### PR TITLE
style: normalize trait-impl syntax via moon fmt

### DIFF
--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -14,14 +14,14 @@ async test "realworld DeepSeek API smoke test" {
     reasoning_effort=Some(High),
   )
   let response = client.chat() <| [
-      ChatMessage(
-        System,
-        content=(
-          #|Reply with exactly this JSON object and no markdown: {"answer":"pong"}
-        ),
+    ChatMessage(
+      System,
+      content=(
+        #|Reply with exactly this JSON object and no markdown: {"answer":"pong"}
       ),
-      ChatMessage(User, content="ping"),
-    ]
+    ),
+    ChatMessage(User, content="ping"),
+  ]
   // It may fail in theory, but in practice it should always work.
   debug_inspect(
     response.content,

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -7,7 +7,7 @@ pub(all) enum Model {
 
 ///|
 /// Returns the DeepSeek wire name for a chat model.
-pub impl Show for Model with to_string(self : Model) -> String {
+pub impl Show for Model with fn to_string(self : Model) -> String {
   match self {
     V4Flash => "deepseek-v4-flash"
     V4Pro => "deepseek-v4-pro"
@@ -33,7 +33,7 @@ pub(all) enum ThinkingMode {
 
 ///|
 /// Returns the DeepSeek wire name for a thinking mode toggle.
-pub impl Show for ThinkingMode with to_string(self : ThinkingMode) -> String {
+pub impl Show for ThinkingMode with fn to_string(self : ThinkingMode) -> String {
   match self {
     Enabled => "enabled"
     Disabled => "disabled"
@@ -49,7 +49,7 @@ pub(all) enum ReasoningEffort {
 
 ///|
 /// Returns the DeepSeek wire name for a reasoning effort.
-pub impl Show for ReasoningEffort with to_string(self : ReasoningEffort) -> String {
+pub impl Show for ReasoningEffort with fn to_string(self : ReasoningEffort) -> String {
   match self {
     High => "high"
     Max => "max"
@@ -70,7 +70,7 @@ pub(all) enum Role {
 
 ///|
 /// Returns the DeepSeek wire name for a chat message role.
-pub impl Show for Role with to_string(self : Role) -> String {
+pub impl Show for Role with fn to_string(self : Role) -> String {
   match self {
     System => "system"
     User => "user"

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -44,12 +44,12 @@ fn[T] json_decode_error(
 }
 
 ///|
-impl FromJson for Usage with from_json(json : Json, _path : @json.JsonPath) -> Usage {
+impl FromJson for Usage with fn from_json(json : Json, _path : @json.JsonPath) -> Usage {
   Usage::from_json(json)
 }
 
 ///|
-impl FromJson for ToolCall with from_json(json : Json, path : @json.JsonPath) -> ToolCall {
+impl FromJson for ToolCall with fn from_json(json : Json, path : @json.JsonPath) -> ToolCall {
   match json {
     {
       "id": String(id),
@@ -102,7 +102,7 @@ impl FromJson for ToolCall with from_json(json : Json, path : @json.JsonPath) ->
 /// Decodes a DeepSeek chat completions JSON response envelope.
 ///
 /// Missing usage information is represented as zero token counts.
-pub impl FromJson for ChatResponse with from_json(
+pub impl FromJson for ChatResponse with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> ChatResponse {

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -3,7 +3,7 @@
 ///
 /// Assistant messages whose `content` is empty but carry tool calls are
 /// encoded with JSON `content: null`, as the API requires.
-impl ToJson for ChatMessage with to_json(message : ChatMessage) -> Json {
+impl ToJson for ChatMessage with fn to_json(message : ChatMessage) -> Json {
   let content = match message.role {
     Assistant if message.tool_calls.length() > 0 && message.content == "" =>
       Json::null()
@@ -35,7 +35,7 @@ impl ToJson for ChatMessage with to_json(message : ChatMessage) -> Json {
 
 ///|
 /// Encodes a `ToolDefinition` as a DeepSeek `tools[]` entry.
-impl ToJson for ToolDefinition with to_json(tool : ToolDefinition) -> Json {
+impl ToJson for ToolDefinition with fn to_json(tool : ToolDefinition) -> Json {
   let function : Json = if tool.strict {
     {
       "name": tool.name,
@@ -55,7 +55,7 @@ impl ToJson for ToolDefinition with to_json(tool : ToolDefinition) -> Json {
 
 ///|
 /// Encodes a `ToolCall` as the DeepSeek assistant `tool_calls[]` entry.
-impl ToJson for ToolCall with to_json(call : ToolCall) -> Json {
+impl ToJson for ToolCall with fn to_json(call : ToolCall) -> Json {
   {
     "id": call.id,
     "type": "function",


### PR DESCRIPTION
## What

Run `moon fmt` with the current toolchain. It rewrites trait method impls from

```moonbit
impl Trait for T with method(...) { ... }
```

to

```moonbit
impl Trait for T with fn method(...) { ... }
```

across the `deepseek` package, and reindents one multi-line block in a test.

## Why

`main` was last formatted with an older MoonBit toolchain, so `moon fmt` now
reports a diff on otherwise-untouched files. This is pure formatting — no
behavior change — split out on its own so feature branches don't carry
unrelated `moon fmt` churn.

## Notes

- 4 files changed, formatting only; `moon check` passes.
- Landing this first lets in-flight feature branches stay free of this drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)