### PR TITLE
[codex] Add Windows native CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   check:
-    name: check (${{ matrix.moonbit-channel }})
-    runs-on: ubuntu-latest
+    name: check (${{ matrix.moonbit-channel }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
@@ -18,22 +18,46 @@ jobs:
           # Temporarily disabled until `<?` is available on stable/latest.
           # - moonbit-channel: stable
           #   moonbit-version: latest
+          #   os: ubuntu-latest
+          # - moonbit-channel: stable
+          #   moonbit-version: latest
+          #   os: windows-latest
           - moonbit-channel: nightly
             moonbit-version: nightly
+            os: ubuntu-latest
+          - moonbit-channel: nightly
+            moonbit-version: nightly
+            os: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up MoonBit (${{ matrix.moonbit-channel }})
+      - name: Set up MoonBit (Unix, ${{ matrix.moonbit-channel }})
+        if: runner.os != 'Windows'
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "${{ matrix.moonbit-version }}"
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: Set up MoonBit (Windows, ${{ matrix.moonbit-channel }})
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $env:MOONBIT_INSTALL_VERSION = "${{ matrix.moonbit-version }}"
+          irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
+          "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: Show MoonBit version
         run: |
           moon version --all
 
       - name: Seed MoonBit registry index
+        shell: bash
         run: |
           mkdir -p "$HOME/.moon/registry"
           for attempt in 1 2 3; do
@@ -54,8 +78,13 @@ jobs:
       - name: Check (deny warnings)
         run: moon check --deny-warn
 
+      - name: Build native
+        run: moon build --target native
+
       - name: Test
+        if: runner.os != 'Windows'
         run: moon test
 
       - name: Cram (offline CLI docs)
+        if: runner.os != 'Windows'
         run: moon cram test tests/cram


### PR DESCRIPTION
## Summary

- extend the current nightly CI job with a Windows runner in the matrix
- install MoonBit nightly on Windows via the PowerShell installer using `MOONBIT_INSTALL_VERSION`
- initialize the Windows MSVC environment with `ilammy/msvc-dev-cmd@v1`
- run `moon fmt --check`, `moon check --deny-warn`, and `moon build --target native` on both Ubuntu and Windows

## Windows Test Coverage

Windows `moon test` and `moon cram test tests/cram` are intentionally skipped for now. The current test suite still has POSIX assumptions such as hard-coded `/tmp/...` paths, `sh -c` shell behavior, and LF/POSIX-path snapshots. Those should be fixed separately before enabling the full test suite on Windows.

## Notes

This PR is based on `main` and intentionally contains only CI workflow changes. `main` still uses the Unix shell prompt generator, so the Windows native build leg may fail until #8 lands.

## Validation

- rebased branch `codex-windows-native-ci` onto latest `main`
- kept the PR diff to `.github/workflows/ci.yml`