### PR TITLE
[codex] Clarify flash prompt checked errors

### DIFF
--- a/prompt/flash_prompt.md
+++ b/prompt/flash_prompt.md
@@ -116,7 +116,9 @@ async fn main {
 ## Checked Error Handling
 
 - MoonBit uses checked raising functions.
-- Declare raising functions with `raise` or a concrete error type.
+- Declare ordinary failing helpers with plain `raise`. Use a concrete error
+  type such as `raise ParseError` only when callers need to match exact error
+  variants.
 - Use checked errors for ordinary parser and CLI control flow. Keep the normal
   return type as the successful value, for example `Json raise`, not a wrapper
   around both success and failure.
@@ -137,6 +139,10 @@ async fn main {
   boundary, such as a CLI path that needs custom stderr text.
 - For custom errors, use `suberror`, not `type Error`, `trait Error`, or
   `type TomlError`.
+- For rare typed-error APIs, declare a `suberror` and mark the function with
+  that exact effect, for example `raise ParseError`. A function marked
+  `raise ParseError` may only let `ParseError` escape; if it calls a broader
+  raising function, catch that error and translate it.
 - To propagate an error from a raising call, call it normally from a function
   marked with `raise`.
 - In success tests, call raising functions directly; if they raise, the test
@@ -148,7 +154,9 @@ async fn main {
 - For invalid-input behavior, prefer a CLI acceptance probe or a simple public
   behavior check unless the task specifically asks for exact error values.
 - If `fn main` calls a raising function, write `fn main raise { ... }`.
-- `async fn main` already can raise; do not write `async fn main raise`.
+- `async fn` can raise by default. Do not write `async fn main raise`.
+- If an async helper must not raise, mark it `noraise`, for example
+  `async fn helper() -> Unit noraise { ... }`.
 - In `async fn main`, prefer calling raising functions directly and let the
   top-level report errors. If you catch for custom user-facing text, print the
   message and return immediately; do not encode failure as `Json::null`, `()`,
@@ -167,11 +175,13 @@ suberror ParseError {
 } derive(Debug)
 
 ///|
-fn parse_count(text : String) -> Int raise {
+fn parse_count(text : String) -> Int raise ParseError {
   if text.trim().is_empty() {
     raise ParseError::InvalidInput("empty input")
   }
-  let n : Int = @string.from_str(text)
+  let n : Int = @string.from_str(text) catch {
+    _ => raise ParseError::InvalidInput("not an integer")
+  }
   n
 }
 

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -120,7 +120,9 @@ fn flash_prompt() -> String {
     #|## Checked Error Handling
     #|
     #|- MoonBit uses checked raising functions.
-    #|- Declare raising functions with `raise` or a concrete error type.
+    #|- Declare ordinary failing helpers with plain `raise`. Use a concrete error
+    #|  type such as `raise ParseError` only when callers need to match exact error
+    #|  variants.
     #|- Use checked errors for ordinary parser and CLI control flow. Keep the normal
     #|  return type as the successful value, for example `Json raise`, not a wrapper
     #|  around both success and failure.
@@ -141,6 +143,10 @@ fn flash_prompt() -> String {
     #|  boundary, such as a CLI path that needs custom stderr text.
     #|- For custom errors, use `suberror`, not `type Error`, `trait Error`, or
     #|  `type TomlError`.
+    #|- For rare typed-error APIs, declare a `suberror` and mark the function with
+    #|  that exact effect, for example `raise ParseError`. A function marked
+    #|  `raise ParseError` may only let `ParseError` escape; if it calls a broader
+    #|  raising function, catch that error and translate it.
     #|- To propagate an error from a raising call, call it normally from a function
     #|  marked with `raise`.
     #|- In success tests, call raising functions directly; if they raise, the test
@@ -152,7 +158,9 @@ fn flash_prompt() -> String {
     #|- For invalid-input behavior, prefer a CLI acceptance probe or a simple public
     #|  behavior check unless the task specifically asks for exact error values.
     #|- If `fn main` calls a raising function, write `fn main raise { ... }`.
-    #|- `async fn main` already can raise; do not write `async fn main raise`.
+    #|- `async fn` can raise by default. Do not write `async fn main raise`.
+    #|- If an async helper must not raise, mark it `noraise`, for example
+    #|  `async fn helper() -> Unit noraise { ... }`.
     #|- In `async fn main`, prefer calling raising functions directly and let the
     #|  top-level report errors. If you catch for custom user-facing text, print the
     #|  message and return immediately; do not encode failure as `Json::null`, `()`,
@@ -171,11 +179,13 @@ fn flash_prompt() -> String {
     #|} derive(Debug)
     #|
     #|///|
-    #|fn parse_count(text : String) -> Int raise {
+    #|fn parse_count(text : String) -> Int raise ParseError {
     #|  if text.trim().is_empty() {
     #|    raise ParseError::InvalidInput("empty input")
     #|  }
-    #|  let n : Int = @string.from_str(text)
+    #|  let n : Int = @string.from_str(text) catch {
+    #|    _ => raise ParseError::InvalidInput("not an integer")
+    #|  }
     #|  n
     #|}
     #|

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -67,6 +67,7 @@ test "flash prompt includes flash addenda" {
   assert_true(prompt.contains("In success tests, call raising functions"))
   assert_true(prompt.contains("fails with the error"))
   assert_true(prompt.contains("Use checked errors for ordinary parser"))
+  assert_true(prompt.contains("Declare ordinary failing helpers"))
   assert_true(prompt.contains("Think of `raise` as a checked effect"))
   assert_true(prompt.contains("different from unchecked exceptions"))
   assert_true(prompt.contains("different from ordinary error\n  return values"))
@@ -75,13 +76,20 @@ test "flash prompt includes flash addenda" {
   assert_true(
     prompt.contains("Let errors travel through internal parser layers"),
   )
+  assert_true(prompt.contains("For rare typed-error APIs"))
+  assert_true(prompt.contains("raise ParseError` may only let `ParseError`"))
+  assert_true(prompt.contains("catch that error and translate it"))
   assert_true(prompt.contains("Do not wrap successful\n  parser tests"))
   assert_true(prompt.contains("wrap raising calls in a manual success/failure"))
   assert_true(prompt.contains("prefer a CLI acceptance probe"))
   assert_true(prompt.contains("suberror ParseError"))
+  assert_true(
+    prompt.contains("fn parse_count(text : String) -> Int raise ParseError"),
+  )
   assert_true(prompt.contains("fn main raise"))
-  assert_true(prompt.contains("async fn main` already can raise"))
-  assert_true(prompt.contains("do not write `async fn main raise`"))
+  assert_true(prompt.contains("async fn` can raise by default"))
+  assert_true(prompt.contains("Do not write `async fn main raise`"))
+  assert_true(prompt.contains("async fn helper() -> Unit noraise"))
   assert_true(prompt.contains("do not encode failure as `Json::null`, `()`"))
   assert_true(prompt.contains("For custom errors, use `suberror`"))
   assert_false(


### PR DESCRIPTION
## Summary
- Clarify that ordinary MoonBit failing helpers should use plain `raise`
- Document rare typed-error APIs with `suberror` plus `raise ParseError`, including translation from broader raising functions
- Update async guidance: async functions can raise by default, and non-raising async helpers use `noraise`
- Regenerate `generated_flash_prompt.mbt` and strengthen prompt regression tests

## Validation
- `moon test prompt`
- `moon info && moon fmt && moon test` (`283/283` passed before commit)
- `git diff --check`