### PR TITLE
[feature] add tui terminal UI primitive packages

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -3,7 +3,10 @@ name = "bobzhang/openseek"
 version = "0.1.3"
 
 import {
-  "moonbitlang/async@0.19.0",
+  "moonbit-community/tty@0.2.4",
+  "moonbitlang/async@0.19.1",
+  "kawaz/grapheme@0.10.2",
+  "rami3l/unicodewidth@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,78 @@
+# bobzhang/openseek/tui
+
+This is the terminal controller for an Agent TUI — the top-level package you
+reach for to build something like the Codex or Claude Code interface: a
+scrolling transcript with a live input box pinned to the bottom.
+
+The central type, `Ui`, is best understood as the **controller** between the
+terminal and your agent loop. It owns the terminal session and does all the
+drawing; your job is the reverse of an event loop — you `read_event()` to get
+what the user did, and call `set_*` / `append_*` to push new output back onto
+the screen. Everything below this package (rendering, editing, scrollback) is an
+implementation detail `Ui` drives for you.
+
+## Usage
+
+`with_ui` opens the terminal, draws the first frame, and hands you a live `Ui`
+for the duration of your loop — restoring the terminal afterwards on both the
+success and error paths.
+
+```mbt
+@tui.with_ui(ui => {
+  for ;; {
+    match ui.read_event() {
+      @tui.Steer(input) => {
+        // The user submitted — echo it into the permanent transcript, then
+        // pretend to do some work.
+        ui.append_item(Input(input))
+        ui.set_activity(Some(@doc.Text::plain("thinking…")))
+        ui.append_item(Response("you said: " + input.text()))
+        ui.set_activity(None)
+      }
+      @tui.Queue(input) =>
+        // Tab queues a follow-up instead of submitting now.
+        ui.set_queued_inputs([input])
+      @tui.Interrupt => ui.set_status(@doc.Text::plain("interrupted"))
+      @tui.Quit => break
+    }
+  }
+})
+```
+
+`Input` is `Prompt(text)` or `Command(text)` (shell mode, entered with a leading
+`!`). `input.text()` is the body; `input.prefix()` is `""` or `! `.
+
+What you can push onto the screen:
+
+- `ui.append_item(TranscriptItem)` — add a permanent line to the scrollback
+  transcript above the live area.
+- `ui.set_activity(@doc.Text?)` — a transient busy line above the composer
+  (`None` clears it); never enters the transcript.
+- `ui.set_queued_inputs(Array[Input])` — render the pending input queue.
+- `ui.set_status(@doc.Text)` — the persistent status line below the composer.
+
+Tune the session with `with_ui(config=Config::new(esc_timeout_ms=…,
+composer_max_rows=…), …)`.
+
+## Key bindings
+
+- `Enter` submits as `Steer`; `Tab` submits as `Queue`.
+- A leading `!` on an empty line switches to shell mode (`Command`); the marker
+  stays out of the editable text.
+- `Shift-Enter` / `Ctrl-J` insert a hard newline; the composer grows up to
+  `composer_max_rows` (default `4`).
+- `Up`/`Down` (or `Ctrl-P`/`Ctrl-N`) move within multiline input, then recall
+  history at the top/bottom edge.
+- Emacs editing: `Ctrl-A`/`Ctrl-E`, `Ctrl-B`/`Ctrl-F`, `Alt-B`/`Alt-F`,
+  `Ctrl-H`, `Ctrl-U`/`Ctrl-K`. `Ctrl-D` deletes forward, or quits when empty.
+- `Ctrl-C` / `Esc` return `Interrupt`.
+
+## How it fits together
+
+`Ui` is a thin façade; the work is spread across the packages it drives:
+[`core`](core/) is the semantic model it produces and re-exports (`Input`,
+`Event`, `TranscriptItem`); [`doc`](doc/) is the styled-text vocabulary;
+[`render`](internal/render/) lays the input area out into a surface;
+[`internal/viewport`](internal/viewport/) draws that surface to the real
+terminal and manages scrollback; [`internal/composer`](internal/composer/) and
+[`internal/history`](internal/history/) are the editing core.

--- a/tui/config.mbt
+++ b/tui/config.mbt
@@ -1,0 +1,33 @@
+///|
+const DefaultEscTimeoutMs : Int = 50
+
+///|
+const DefaultComposerMaxRows : Int = @composer.DefaultMaxTextRows
+
+///|
+struct Config {
+  esc_timeout_ms : Int
+  composer_max_rows : Int
+}
+
+///|
+/// Build a UI `Config`. `esc_timeout_ms` bounds how long the reader waits to
+/// disambiguate a lone `Esc` from a CSI escape sequence, and `composer_max_rows`
+/// caps how tall the editable input area grows. Non-positive values fall back to
+/// the defaults (`50` ms and `@composer.DefaultMaxTextRows`).
+pub fn Config::new(
+  esc_timeout_ms? : Int = DefaultEscTimeoutMs,
+  composer_max_rows? : Int = DefaultComposerMaxRows,
+) -> Config {
+  let esc_timeout_ms = if esc_timeout_ms < 1 {
+    DefaultEscTimeoutMs
+  } else {
+    esc_timeout_ms
+  }
+  let composer_max_rows = if composer_max_rows < 1 {
+    DefaultComposerMaxRows
+  } else {
+    composer_max_rows
+  }
+  { esc_timeout_ms, composer_max_rows }
+}

--- a/tui/core/README.md
+++ b/tui/core/README.md
@@ -1,0 +1,50 @@
+# bobzhang/openseek/tui/core
+
+This package is the **vocabulary** of the Agent TUI — the nouns and verbs of a
+conversation, with no rendering or IO attached. When the user submits something
+it becomes an `Input`; when the loop needs to know what happened it reads an
+`Event`; when a turn is committed to the scrolling history it becomes a
+`TranscriptItem`. These are the types [`tui`](../) re-exports, so you usually
+reach them as `@tui.Input`, `@tui.Event`, and so on.
+
+Each renderable type knows how to project itself into a [`doc`](../doc/) `Doc`
+(via `@doc.ToDoc`), so the UI can draw an item without `core` knowing anything
+about styling or terminals — the meaning lives here, the appearance lives in
+`doc`.
+
+## Usage
+
+What the user submits, and what the loop receives:
+
+```mbt
+// `read_event` hands you one of these:
+Event::Steer(Input::Prompt("hello"))     // submit now
+Event::Queue(Input::Command("ls -la"))   // queue a shell command
+Event::Interrupt                         // Ctrl-C / Esc
+Event::Quit                              // Ctrl-D on empty input
+
+let input = Input::Prompt("hello")
+input.text()    // "hello"
+input.prefix()  // "❯ " for Prompt, "$ " for Command
+```
+
+What you append to the transcript:
+
+```mbt
+TranscriptItem::Input(Input::Prompt("hi"))
+TranscriptItem::Response("the answer")
+TranscriptItem::Error("chat failed")
+TranscriptItem::ToolCall(
+  ToolCall::ToolCall(
+    @doc.Text::plain("read file"),
+    status=ToolStatus::Completed,
+    details=[@doc.Text::plain("config.toml")],
+  ),
+)
+```
+
+`TranscriptItem` carries a `@doc.ToDoc` impl, so the UI renders an item for you
+(`ui.append_item(...)`); to project one yourself, call
+`@doc.ToDoc::to_doc(item)`. A submitted `Input` is rendered by committing it as
+`TranscriptItem::Input(...)`. Tool styling comes from `ToolStatus` (completed,
+failed).

--- a/tui/core/core_test.mbt
+++ b/tui/core/core_test.mbt
@@ -1,0 +1,52 @@
+///|
+test "input doc renders prompt prefixes" {
+  inspect(
+    @doc.ToDoc::to_doc(@core.TranscriptItem::Input(Prompt("hello\nworld")))
+    .layout(width=20)
+    .map(line => line.text())
+    .join("|"),
+    content=(
+      #|❯ hello|  world
+    ),
+  )
+  inspect(
+    @doc.ToDoc::to_doc(@core.TranscriptItem::Input(Command("pwd")))
+    .layout(width=20)
+    .map(line => line.text())
+    .join("|"),
+    content="$ pwd",
+  )
+}
+
+///|
+test "transcript response renders bullet and continuation prefix" {
+  inspect(
+    @doc.ToDoc::to_doc(@core.TranscriptItem::Response("hello\nworld"))
+    .layout(width=20)
+    .map(line => line.text())
+    .join("|"),
+    content=(
+      #|⏺ hello|  world
+    ),
+  )
+}
+
+///|
+test "transcript tool call renders detail texts without caller-side joining" {
+  inspect(
+    @doc.ToDoc::to_doc(
+      @core.TranscriptItem::ToolCall(
+        ToolCall(@doc.Text::plain("Ran moon test"), status=Completed, details=[
+          @doc.Text::plain("one"),
+          @doc.Text::plain("two\nthree"),
+        ]),
+      ),
+    )
+    .layout(width=40)
+    .map(line => line.text())
+    .join("|"),
+    content=(
+      #|⏺ Ran moon test|  └ one|    two|    three
+    ),
+  )
+}

--- a/tui/core/event.mbt
+++ b/tui/core/event.mbt
@@ -1,0 +1,8 @@
+///|
+/// A user-driven UI event handed to the application loop.
+pub(all) enum Event {
+  Queue(Input)
+  Steer(Input)
+  Interrupt
+  Quit
+} derive(Eq, Debug)

--- a/tui/core/input.mbt
+++ b/tui/core/input.mbt
@@ -1,0 +1,53 @@
+// The semantic input the user submits, plus its projection into a `@doc.Doc`.
+
+///|
+/// A submitted input: a prompt for the agent, or a shell command (entered with a
+/// leading `!`).
+pub(all) enum Input {
+  Prompt(String)
+  Command(String)
+} derive(Eq, Debug)
+
+///|
+/// The prefix marker shown before this input (`❯ ` for prompts, `$ ` for shell
+/// commands).
+pub fn Input::prefix(self : Input) -> String {
+  match self {
+    Prompt(_) => "❯ "
+    Command(_) => "$ "
+  }
+}
+
+///|
+/// The raw text of this input, without its prefix.
+pub fn Input::text(self : Input) -> String {
+  match self {
+    Prompt(text) => text
+    Command(command) => command
+  }
+}
+
+///|
+/// Project the input into a renderable `@doc.Doc`: the first line carries the
+/// input's `prefix` and continuation lines are indented two columns, all in the
+/// prompt style.
+impl @doc.ToDoc for Input with fn to_doc(self) {
+  let source = @text.split_lines(self.text())
+  let texts : Array[@doc.Text] = []
+  for index in 0..<source.length() {
+    texts.push(
+      Text([
+        Span(
+          if index == 0 {
+            self.prefix()
+          } else {
+            "  "
+          },
+          style=@doc.Style::prompt(),
+        ),
+        @doc.Span::plain(@text.line_at(source, index)),
+      ]),
+    )
+  }
+  Doc(texts)
+}

--- a/tui/core/moon.pkg
+++ b/tui/core/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "bobzhang/openseek/tui/doc",
+  "bobzhang/openseek/tui/internal/text",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -1,0 +1,48 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/core"
+
+import {
+  "bobzhang/openseek/tui/doc",
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) enum Event {
+  Queue(Input)
+  Steer(Input)
+  Interrupt
+  Quit
+} derive(Eq, @debug.Debug)
+
+pub(all) enum Input {
+  Prompt(String)
+  Command(String)
+} derive(Eq, @debug.Debug)
+pub fn Input::prefix(Self) -> String
+pub fn Input::text(Self) -> String
+
+pub struct ToolCall {
+  // private fields
+}
+pub fn ToolCall::ToolCall(@doc.Text, status? : ToolStatus, details? : Array[@doc.Text]) -> Self
+
+pub(all) enum ToolStatus {
+  Completed
+  Failed
+} derive(Eq, @debug.Debug)
+
+pub(all) enum TranscriptItem {
+  Input(Input)
+  Response(String)
+  ToolCall(ToolCall)
+  Error(String)
+}
+pub impl @doc.ToDoc for TranscriptItem
+
+// Type aliases
+
+// Traits

--- a/tui/core/transcript.mbt
+++ b/tui/core/transcript.mbt
@@ -1,0 +1,114 @@
+// The transcript model — committed conversation items — and its projection into
+// renderable `@doc.Doc` blocks.
+
+///|
+/// The terminal state of a tool call, selecting how its bullet is styled.
+pub(all) enum ToolStatus {
+  Completed
+  Failed
+} derive(Eq, Debug)
+
+///|
+fn ToolStatus::style(self : ToolStatus) -> @doc.Style {
+  match self {
+    Completed => @doc.Style::success()
+    Failed => @doc.Style::error()
+  }
+}
+
+///|
+/// A tool invocation: a `title`, an optional lifecycle `status`, and zero or more
+/// `details` lines shown beneath the title. Opaque — build one with
+/// `ToolCall::ToolCall`.
+struct ToolCall {
+  title : @doc.Text
+  status : ToolStatus?
+  details : Array[@doc.Text]
+}
+
+///|
+/// Build a `ToolCall` from its `title`, an optional `status`, and optional
+/// `details` lines (defaulting to none); the given `details` array is copied.
+pub fn ToolCall::ToolCall(
+  title : @doc.Text,
+  status? : ToolStatus,
+  details? : Array[@doc.Text] = [],
+) -> ToolCall {
+  { title, status, details: details.copy() }
+}
+
+///|
+/// One committed entry in the transcript: a submitted `Input`, an agent
+/// `Response`, a `ToolCall`, or an `Error`.
+pub(all) enum TranscriptItem {
+  Input(Input)
+  Response(String)
+  ToolCall(ToolCall)
+  Error(String)
+}
+
+///|
+/// Prefix each split line of `text` with a bullet/continuation marker in
+/// `style`, producing one `@doc.Text` block per line.
+fn bulleted_lines(
+  text : @doc.Text,
+  first~ : String,
+  rest~ : String,
+  style~ : @doc.Style,
+) -> Array[@doc.Text] {
+  let texts : Array[@doc.Text] = []
+  let lines = text.split_lines()
+  for index in 0..<lines.length() {
+    let marker = if index == 0 { first } else { rest }
+    texts.push(lines[index].prepend_span(Span(marker, style~)))
+  }
+  texts
+}
+
+///|
+/// Project a transcript item into a renderable `@doc.Doc`: inputs use their own
+/// prefixed projection, responses become dim `⏺`-bulleted blocks, tool calls
+/// render a status-styled `⏺` bullet with `└`-indented detail lines, and errors
+/// become an error-styled `■`-bulleted block.
+pub impl @doc.ToDoc for TranscriptItem with fn to_doc(self) {
+  match self {
+    Input(input) => input.to_doc()
+    Response(content) =>
+      Doc(
+        bulleted_lines(
+          @doc.Text::plain(content),
+          first="⏺ ",
+          rest="  ",
+          style=@doc.Style::dim(),
+        ),
+      )
+    ToolCall(call) => {
+      let bullet_style = call.status
+        .map(status => status.style())
+        .unwrap_or(@doc.Style::dim())
+      let texts : Array[@doc.Text] = [
+        call.title.prepend_span(Span("⏺ ", style=bullet_style)),
+      ]
+      let mut has_detail_line = false
+      for detail in call.details {
+        for line in detail.split_lines() {
+          let marker = if has_detail_line { "    " } else { "  └ " }
+          texts.push(line.prepend_span(Span(marker, style=@doc.Style::dim())))
+          has_detail_line = true
+        }
+      }
+      Doc(texts)
+    }
+    Error(message) => {
+      let error_style = @doc.Style::error()
+      Doc(
+        bulleted_lines(
+          Text([Span(message, style=error_style)]),
+          first="■ ",
+          rest="  ",
+          style=error_style,
+        ),
+      )
+    }
+  }
+}

--- a/tui/doc/README.md
+++ b/tui/doc/README.md
@@ -1,0 +1,51 @@
+# bobzhang/openseek/tui/doc
+
+This is the **styled-text vocabulary** of the TUI — the layer where you describe
+what content should look like before anything is drawn. If you've used a rich
+console library, the shape is familiar: a `Span` is a run of text with a style, a
+`Text` is one logical line of spans, and a `Doc` is a block of lines. The one
+thing they all know how to do is **lay themselves out to a width**, producing the
+[`surface`](../internal/surface/) `Line`s the renderer consumes.
+
+It also owns the `ToDoc` trait — the single seam through which a semantic value
+(an `@core.Input`, a tool call) turns into a renderable `Doc`. So `doc` answers
+"how does this look", while [`core`](../core/) supplies "what does this mean".
+
+## Usage
+
+Build a styled block and lay it out:
+
+```mbt
+let doc = Doc::Doc([
+  Text::Text([Span::Span("error: ", style=Style::error()), Span::plain("oops")]),
+  Text::plain("see the log for details"),
+])
+let lines = doc.layout(width=40) // wraps and tab-expands to 40 cols
+```
+
+Shortcuts for the common cases:
+
+```mbt
+Doc::Doc([Text::plain("a\nb")]) // a Doc of one block, wrapped on '\n' at layout
+Text::plain("one line")         // single Text
+dim_text("muted")               // a dim single-line Text
+Style::dim() / Style::prompt() / Style::error() / Style::default()
+```
+
+`Doc::layout(width~)` lays a whole block out into rows; `Text::first_line(width~)`
+gives just the first wrapped row; `Text::split_lines()` splits on hard newlines;
+`Text::prepend_span` glues a prefix (e.g. a prompt marker) onto a line.
+
+## Making your own types renderable
+
+Implement `ToDoc` in the type's home package so the UI can render it:
+
+```mbt
+pub impl @doc.ToDoc for MyEvent with to_doc(self) {
+  @doc.Doc::Doc([@doc.Text::plain(self.message)])
+}
+```
+
+Cross-package callers invoke it as `@doc.ToDoc::to_doc(value)` — the dot-call
+`value.to_doc()` only resolves inside the implementing package. See
+[`core`](../core/) for the `Input` / `TranscriptItem` impls.

--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -1,0 +1,270 @@
+// Styled-text vocabulary for terminal output.
+//
+// `Doc`/`Text`/`Span`/`Style` describe *what* to render as logical, terminal-
+// agnostic blocks of styled text. They are laid out into physical
+// `@surface.Line`s (wrapping by display width, expanding tabs, dropping stray
+// control characters) only when a target width is known. The `tui` package
+// builds these from transcript and input state; the `render` package lays the
+// composer out from them. Nothing here performs IO.
+
+///|
+/// A renderable document made of logical text blocks.
+///
+/// `Doc` is used for committed transcript output. Each `Text` block is wrapped
+/// independently when the document is laid out for the current terminal width.
+struct Doc {
+  texts : Array[Text]
+}
+
+///|
+/// Build a document from a sequence of text blocks.
+pub fn Doc::Doc(texts : Array[Text]) -> Doc {
+  { texts: texts.copy() }
+}
+
+///|
+/// A logical text block made of styled spans.
+///
+/// Text wraps by terminal display width and treats newline characters as forced
+/// row breaks.
+struct Text {
+  spans : Array[Span]
+}
+
+///|
+/// Build a text block from a sequence of styled spans.
+pub fn Text::Text(spans : Array[Span]) -> Text {
+  { spans: spans.copy() }
+}
+
+///|
+/// Build a text block containing one unstyled span.
+pub fn Text::plain(text : String) -> Text {
+  Text([Span::plain(text)])
+}
+
+///|
+/// A copy of this block with `span` inserted before its existing spans.
+///
+/// Used to attach a styled prefix (a bullet, a continuation indent) to existing
+/// content without exposing the span array.
+pub fn Text::prepend_span(self : Text, span : Span) -> Text {
+  Text([span, ..self.spans])
+}
+
+///|
+/// Split this block at line breaks into one block per source line, preserving
+/// each span's style. The returned blocks contain no line-ending characters.
+///
+/// Every line-ending form splits a row: `\r\n` is a single grapheme cluster and
+/// a lone `\r` is its own, so iterating graphemes handles CRLF/CR/LF alike and
+/// never leaves a stray `\r` for `wrap` to turn into an extra blank row.
+pub fn Text::split_lines(self : Text) -> Array[Text] {
+  let lines : Array[Text] = []
+  let mut spans : Array[Span] = []
+  for span in self.spans {
+    let mut current = StringBuilder()
+    for grapheme in @grapheme.grapheme_iter(span.text) {
+      let g = grapheme.to_owned()
+      if g == "\n" || g == "\r\n" || g == "\r" {
+        let part = current.to_string()
+        if part.length() > 0 {
+          spans.push(Span(part, style=span.style))
+        }
+        lines.push(Text(spans))
+        spans = []
+        current = StringBuilder()
+      } else {
+        current.write_string(g)
+      }
+    }
+    let part = current.to_string()
+    if part.length() > 0 {
+      spans.push(Span(part, style=span.style))
+    }
+  }
+  lines.push(Text(spans))
+  lines
+}
+
+///|
+/// A string fragment with an associated terminal style.
+struct Span {
+  text : String
+  style : Style
+}
+
+///|
+/// Build a styled span.
+///
+/// If `style` is omitted, the span uses `Style::default`.
+pub fn Span::Span(text : String, style? : Style = Style::default()) -> Span {
+  { text, style }
+}
+
+///|
+/// Build an unstyled span.
+pub fn Span::plain(text : String) -> Span {
+  Span(text)
+}
+
+///|
+/// Terminal styling applied while a span is written.
+///
+/// A style can set foreground color, background color, and underline. Terminal
+/// styling is reset after each span is emitted.
+struct Style {
+  foreground : @tty/color.Color
+  background : @tty/color.Color
+  underline : Bool
+} derive(Eq)
+
+///|
+/// Return the default terminal style.
+pub fn Style::default() -> Style {
+  { foreground: Default, background: Default, underline: false }
+}
+
+///|
+/// Build a terminal style.
+///
+/// Omitted color arguments use the terminal default, and `underline` defaults
+/// to `false`. Use this to compose ad-hoc colors (e.g. status-line fields)
+/// beyond the named styles below.
+pub fn Style::new(
+  foreground? : @tty/color.Color = Default,
+  background? : @tty/color.Color = Default,
+  underline? : Bool = false,
+) -> Style {
+  { foreground, background, underline }
+}
+
+///|
+/// Return the subdued style used for secondary agentui text.
+pub fn Style::dim() -> Style {
+  Style::new(foreground=Basic(BrightBlack))
+}
+
+///|
+/// Return the prompt style used for submitted and live input prefixes. The
+/// prompt marker is deliberately subdued (gray) so it recedes behind the text.
+pub fn Style::prompt() -> Style {
+  Style::new(foreground=Basic(BrightBlack))
+}
+
+///|
+/// Return the error style used for failed tool calls and error transcript items.
+pub fn Style::error() -> Style {
+  Style::new(foreground=Basic(Red))
+}
+
+///|
+/// Return the success style used for completed tool calls.
+pub fn Style::success() -> Style {
+  Style::new(foreground=Basic(Green))
+}
+
+///|
+/// Project this style onto the lower-level render-data style consumed by the
+/// terminal renderer.
+pub fn Style::to_surface(self : Style) -> @surface.Style {
+  @surface.Style::new(
+    foreground=self.foreground,
+    background=self.background,
+    underline=self.underline,
+  )
+}
+
+///|
+/// Terminal tab stop width. Tabs in transcript content are expanded to spaces
+/// up to the next multiple of this, matching the conventional terminal default.
+const TabWidth : Int = 8
+
+///|
+/// Whether a grapheme is a C0 control character or DEL. `\n` and `\t` are
+/// handled separately by the wrapper, so this only matches the remaining
+/// controls (`\r`, etc.) that must not reach the terminal verbatim.
+fn is_control_grapheme(grapheme : String) -> Bool {
+  match grapheme.get_char(0) {
+    Some(c) => {
+      let code = c.to_int()
+      code < 0x20 || code == 0x7f
+    }
+    None => false
+  }
+}
+
+///|
+/// Lay this block out into physical rows for `width` columns, wrapping by
+/// display width, expanding tabs to the next stop, and dropping stray controls.
+fn Text::wrap(self : Text, width~ : Int) -> Array[@surface.Line] {
+  let rows : Array[@surface.Line] = []
+  let mut spans : Array[@surface.Span] = []
+  let mut used = 0
+  let width = if width < 1 { 1 } else { width }
+  for span in self.spans {
+    let style = span.style.to_surface()
+    for grapheme in @grapheme.grapheme_iter(span.text) {
+      let text = grapheme.to_owned()
+      // `\r\n` is a single grapheme cluster (Unicode CR×LF) and a lone `\r` is
+      // its own; treat all line-ending forms as a row break so CRLF content
+      // (e.g. tool output) keeps its lines instead of being dropped as a control.
+      if text == "\n" || text == "\r\n" || text == "\r" {
+        rows.push(@surface.Line::new(spans))
+        spans = []
+        used = 0
+      } else {
+        // Normalize control characters so the columns we count match what the
+        // terminal draws. A raw `\t` jumps to the terminal's tab stop, which is
+        // not modeled by `used`, so it would shove following text into the wrong
+        // column; every other control is dropped.
+        let pieces : Array[String] = if text == "\t" {
+          Array::make(TabWidth - used % TabWidth, " ")
+        } else if is_control_grapheme(text) {
+          []
+        } else {
+          [text]
+        }
+        for piece in pieces {
+          let next = @unicodewidth.str_width(piece)
+          if used > 0 && used + next > width {
+            rows.push(@surface.Line::new(spans))
+            spans = []
+            used = 0
+          }
+          spans.push(@surface.Span::new(piece, style~))
+          used += next
+        }
+      }
+    }
+  }
+  rows.push(@surface.Line::new(spans))
+  rows
+}
+
+///|
+/// The first wrapped row of this block for `width` columns, or an empty line.
+pub fn Text::first_line(self : Text, width~ : Int) -> @surface.Line {
+  match self.wrap(width~).get(0) {
+    Some(line) => line
+    None => @surface.Line::new([])
+  }
+}
+
+///|
+/// Lay every block out in order into physical rows for `width` columns.
+pub fn Doc::layout(self : Doc, width~ : Int) -> Array[@surface.Line] {
+  let rows : Array[@surface.Line] = []
+  for text in self.texts {
+    for row in text.wrap(width~) {
+      rows.push(row)
+    }
+  }
+  rows
+}
+
+///|
+/// A one-block text in the subdued `Style::dim` style.
+pub fn dim_text(text : String) -> Text {
+  Text([Span(text, style=Style::dim())])
+}

--- a/tui/doc/doc_test.mbt
+++ b/tui/doc/doc_test.mbt
@@ -1,0 +1,83 @@
+///|
+test "doc layout wraps styled text by display width" {
+  inspect(
+    @doc.Doc::Doc([@doc.Text::plain("abcdef")])
+    .layout(width=3)
+    .map(line => line.text())
+    .join("|"),
+    content="abc|def",
+  )
+  inspect(
+    @doc.Doc::Doc([@doc.Text::plain("你好世界")])
+    .layout(width=4)
+    .map(line => line.text())
+    .join("|"),
+    content="你好|世界",
+  )
+}
+
+///|
+test "layout expands tabs to the next stop and drops other control chars" {
+  // `\t` expands to spaces up to the next 8-column tab stop so following text
+  // is not shoved to a terminal tab stop we never accounted for.
+  inspect(
+    @doc.Doc::Doc([@doc.Text::plain("a\tb")])
+    .layout(width=40)
+    .map(line => line.text())
+    .join("|"),
+    content="a       b",
+  )
+  inspect(
+    @doc.Doc::Doc([@doc.Text::plain("abcdef\tg")])
+    .layout(width=40)
+    .map(line => line.text())
+    .join("|"),
+    content="abcdef  g",
+  )
+  // `\r\n` (a single grapheme cluster) and a lone `\r` are line breaks, so they
+  // split rows instead of being dropped — CRLF content keeps its lines.
+  inspect(
+    @doc.Doc::Doc([@doc.Text::plain("x\r\ny")])
+    .layout(width=40)
+    .map(line => line.text())
+    .join("|"),
+    content="x|y",
+  )
+  // Other C0 controls (here `ESC`) are dropped entirely.
+  inspect(
+    @doc.Doc::Doc([@doc.Text::plain("x\u{1b}y")])
+    .layout(width=40)
+    .map(line => line.text())
+    .join("|"),
+    content="xy",
+  )
+}
+
+///|
+test "split_lines splits CRLF and CR so no stray carriage return remains" {
+  // The trailing `\r` the old splitter left on the first block would make
+  // `wrap` emit an extra blank row, so each split block must lay out to exactly
+  // one row.
+  let blocks = @doc.Text::plain("a\r\nb").split_lines()
+  inspect(blocks.length(), content="2")
+  let mut total_rows = 0
+  for block in blocks {
+    total_rows = total_rows + @doc.Doc::Doc([block]).layout(width=40).length()
+  }
+  inspect(total_rows, content="2")
+}
+
+///|
+test "doc constructors copy mutable arrays" {
+  let spans = [@doc.Span::plain("a")]
+  let text = @doc.Text::Text(spans)
+  spans.push(@doc.Span::plain("b"))
+  inspect(
+    @doc.Doc::Doc([text]).layout(width=20).map(line => line.text()).join("|"),
+    content="a",
+  )
+  let texts = [@doc.Text::plain("a")]
+  let doc = @doc.Doc::Doc(texts)
+  texts.push(@doc.Text::plain("b"))
+  inspect(doc.layout(width=20).map(line => line.text()).join("|"), content="a")
+}

--- a/tui/doc/moon.pkg
+++ b/tui/doc/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "bobzhang/openseek/tui/internal/surface",
+  "kawaz/grapheme",
+  "rami3l/unicodewidth",
+  "moonbit-community/tty/color" @tty/color,
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -1,0 +1,51 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/doc"
+
+import {
+  "bobzhang/openseek/tui/internal/surface",
+  "moonbit-community/tty/color",
+}
+
+// Values
+pub fn dim_text(String) -> Text
+
+// Errors
+
+// Types and methods
+pub struct Doc {
+  // private fields
+}
+pub fn Doc::Doc(Array[Text]) -> Self
+pub fn Doc::layout(Self, width~ : Int) -> Array[@surface.Line]
+
+pub struct Span {
+  // private fields
+}
+pub fn Span::Span(String, style? : Style) -> Self
+pub fn Span::plain(String) -> Self
+
+type Style derive(Eq)
+pub fn Style::default() -> Self
+pub fn Style::dim() -> Self
+pub fn Style::error() -> Self
+pub fn Style::new(foreground? : @color.Color, background? : @color.Color, underline? : Bool) -> Self
+pub fn Style::prompt() -> Self
+pub fn Style::success() -> Self
+pub fn Style::to_surface(Self) -> @surface.Style
+
+pub struct Text {
+  // private fields
+}
+pub fn Text::Text(Array[Span]) -> Self
+pub fn Text::first_line(Self, width~ : Int) -> @surface.Line
+pub fn Text::plain(String) -> Self
+pub fn Text::prepend_span(Self, Span) -> Self
+pub fn Text::split_lines(Self) -> Array[Self]
+
+// Type aliases
+
+// Traits
+pub(open) trait ToDoc {
+  fn to_doc(Self) -> Doc
+}
+

--- a/tui/doc/to_doc.mbt
+++ b/tui/doc/to_doc.mbt
@@ -1,0 +1,11 @@
+///|
+/// Projection of a semantic value into a renderable `Doc`.
+///
+/// The styled-text vocabulary lives here, but the values that know how to render
+/// themselves into it (transcript items, inputs) live in higher layers. Defining
+/// the trait here lets those layers attach the projection to their own types —
+/// the orphan rule allows the `impl` in the type's own package — and lets any
+/// importer of `doc` project a value uniformly via `@doc.ToDoc::to_doc(value)`.
+pub(open) trait ToDoc {
+  fn to_doc(Self) -> Doc
+}

--- a/tui/exports.mbt
+++ b/tui/exports.mbt
@@ -1,0 +1,6 @@
+// The semantic model types live in tui/core; re-export them so the tui package
+// remains the single public facade for consumers (e.g. cmd/tui) that construct
+// inputs and transcript items.
+
+///|
+pub using @core {type Input, type Event, type ToolStatus, type TranscriptItem}

--- a/tui/input.mbt
+++ b/tui/input.mbt
@@ -1,0 +1,253 @@
+///|
+fn submitted_input(text : String, mode : @composer.Mode) -> Input {
+  if mode.is_shell() {
+    Command(text.trim().to_owned())
+  } else {
+    Prompt(text)
+  }
+}
+
+///|
+fn Ui::current_history_entry(self : Self) -> @history.Entry {
+  @history.Entry::new(self.composer.text(), self.composer.mode())
+}
+
+///|
+async fn Ui::submit_current_input(self : Self) -> Input? {
+  if self.composer.text().length() == 0 && self.composer.mode().is_input() {
+    self.notice = Some(@doc.dim_text("empty input"))
+    self.redraw()
+    None
+  } else {
+    let text = self.composer.text()
+    let mode = self.composer.mode()
+    self.history.push(@history.Entry::new(text, mode))
+    self.composer.reset()
+    self.notice = None
+    self.redraw()
+    Some(submitted_input(text, mode))
+  }
+}
+
+///|
+/// Readline redraws directly after each branch. Agentui keeps small local
+/// helpers because most input changes also clear transient status text.
+async fn Ui::redraw_after_cursor_move(self : Self) -> Unit {
+  self.notice = None
+  self.redraw()
+}
+
+///|
+async fn Ui::redraw_after_text_change(self : Self) -> Unit {
+  self.history.reset_navigation()
+  self.notice = None
+  self.redraw()
+}
+
+///|
+async fn Ui::redraw_after_history_recall(self : Self) -> Unit {
+  self.notice = None
+  self.redraw()
+}
+
+///|
+async fn Ui::recall_previous_history(self : Self) -> Unit {
+  if self.history.previous(self.current_history_entry()) is Some(entry) {
+    self.composer.replace(entry.text(), mode=entry.mode())
+    self.redraw_after_history_recall()
+  }
+}
+
+///|
+async fn Ui::recall_next_history(self : Self) -> Unit {
+  if self.history.next() is Some(entry) {
+    self.composer.replace(entry.text(), mode=entry.mode())
+    self.redraw_after_history_recall()
+  }
+}
+
+///|
+async fn Ui::move_up_or_recall_history(self : Self) -> Unit {
+  if self.composer.cursor_at_first_visual_row() {
+    self.recall_previous_history()
+  } else {
+    self.composer.move_vertical(-1)
+    self.redraw_after_cursor_move()
+  }
+}
+
+///|
+async fn Ui::move_down_or_recall_history(self : Self) -> Unit {
+  if self.composer.cursor_at_last_visual_row() {
+    self.recall_next_history()
+  } else {
+    self.composer.move_vertical(1)
+    self.redraw_after_cursor_move()
+  }
+}
+
+///|
+async fn Ui::handle_key(self : Self, key : @tty/input.KeyEvent) -> Event? {
+  match key.code {
+    Char('a') if key.modifiers.ctrl() => {
+      self.composer.move_home()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Char('b') if key.modifiers.ctrl() => {
+      self.composer.move_left()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Char('c') if key.modifiers.ctrl() => {
+      self.history.reset_navigation()
+      Some(Interrupt)
+    }
+    Char('d') if key.modifiers.ctrl() =>
+      if self.composer.text().length() == 0 {
+        Some(Quit)
+      } else {
+        self.composer.delete_after()
+        self.redraw_after_text_change()
+        None
+      }
+    Char('e') if key.modifiers.ctrl() => {
+      self.composer.move_end()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Char('f') if key.modifiers.ctrl() => {
+      self.composer.move_right()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Char('f') if key.modifiers.alt() => {
+      self.composer.move_word_right()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Char('b') if key.modifiers.alt() => {
+      self.composer.move_word_left()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Char('h') if key.modifiers.ctrl() => {
+      self.composer.delete_before()
+      self.redraw_after_text_change()
+      None
+    }
+    Enter if key.modifiers.shift() => {
+      self.composer.insert("\n")
+      self.redraw_after_text_change()
+      None
+    }
+    Enter => self.submit_current_input().map(input => Steer(input))
+    Tab => self.submit_current_input().map(input => Queue(input))
+    Escape => {
+      self.history.reset_navigation()
+      Some(Interrupt)
+    }
+    Char('k') if key.modifiers.ctrl() => {
+      self.composer.kill_after()
+      self.redraw_after_text_change()
+      None
+    }
+    Char('n') if key.modifiers.ctrl() => {
+      self.move_down_or_recall_history()
+      None
+    }
+    Char('p') if key.modifiers.ctrl() => {
+      self.move_up_or_recall_history()
+      None
+    }
+    Char('u') if key.modifiers.ctrl() => {
+      self.composer.kill_before()
+      self.redraw_after_text_change()
+      None
+    }
+    Up => {
+      self.move_up_or_recall_history()
+      None
+    }
+    Down => {
+      self.move_down_or_recall_history()
+      None
+    }
+    Left => {
+      self.composer.move_left()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Right => {
+      self.composer.move_right()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Home => {
+      self.composer.move_home()
+      self.redraw_after_cursor_move()
+      None
+    }
+    End => {
+      self.composer.move_end()
+      self.redraw_after_cursor_move()
+      None
+    }
+    Char('j') if key.modifiers.ctrl() => {
+      self.composer.insert("\n")
+      self.redraw_after_text_change()
+      None
+    }
+    Backspace => {
+      self.composer.delete_before()
+      self.redraw_after_text_change()
+      None
+    }
+    Delete => {
+      self.composer.delete_after()
+      self.redraw_after_text_change()
+      None
+    }
+    _ =>
+      if key.text is Some(text) {
+        self.composer.insert_user_text(text)
+        self.redraw_after_text_change()
+        None
+      } else {
+        self.notice = Some(@doc.dim_text("ignored key"))
+        self.redraw()
+        None
+      }
+  }
+}
+
+///|
+async fn Ui::handle_tty_event(self : Self, event : @tty.Event) -> Event? {
+  match event {
+    Input(Key(key)) => self.handle_key(key)
+    Input(Unknown(bytes)) => {
+      self.notice = Some(
+        @doc.dim_text("unknown input: \{bytes.length()} bytes"),
+      )
+      self.redraw()
+      None
+    }
+    Input(Paste(text)) => {
+      self.composer.insert_user_text(text)
+      self.redraw_after_text_change()
+      None
+    }
+    Input(FocusIn | FocusOut | Mouse(_)) => None
+    Resize(_) => {
+      self.redraw_after_resize()
+      None
+    }
+  }
+}
+
+///|
+/// Block until the next semantic `Event` from the input loop. Reraises any error
+/// the tty reader encountered; yields `Quit` once the reader is closed.
+pub async fn Ui::read_event(self : Self) -> Event {
+  self.events.get().unwrap_or_error()
+}

--- a/tui/internal/composer/README.md
+++ b/tui/internal/composer/README.md
@@ -1,0 +1,48 @@
+# bobzhang/openseek/tui/internal/composer
+
+This is the **text editor** behind the input box — the readline-like editing
+core that turns keystrokes into the text the user submits. If you've wired up
+emacs-style editing before, the model is familiar: it owns the buffer and a
+cursor, soft-wraps each logical line to the current width, and exposes editing
+and motion operations (insert, kill-line, word motion, vertical movement across
+wrapped rows).
+
+The central type, `Model`, deliberately knows nothing about colors, surfaces, or
+the terminal. It only produces plain text plus a cursor offset; the
+[`render`](../render/) layer turns that into a styled surface and
+[`viewport`](../viewport/) draws it. That split is what keeps editing logic
+testable without a terminal in the loop.
+
+## Usage
+
+```mbt
+let model = @composer.Model::new(max_text_rows=4)
+model.resize(cols=80)         // relay out for the terminal width
+
+model.insert_user_text("!ls") // leading '!' on empty input → Shell mode ("! ")
+model.insert(" -la")
+model.move_word_left()        // emacs-style motion
+model.delete_before()         // backspace
+
+let text = model.text()                // "ls -l"
+let is_shell = model.mode().is_shell() // true
+```
+
+Reading it back for the renderer:
+
+```mbt
+for row in 0..<model.visible_text_rows() {
+  let prefix = model.input_prefix(row)   // "> ", "! ", or continuation padding
+  let line = model.visible_line(row)     // wrapped row text
+}
+model.cursor_row()    // cursor's visible row
+model.cursor_offset() // cursor's display-cell column
+```
+
+## History handoff
+
+`move_vertical(delta)` moves between *wrapped* rows. When the cursor is already
+at the top/bottom edge, `cursor_at_first_visual_row()` /
+`cursor_at_last_visual_row()` tell the caller to recall from
+[`history`](../history/) instead. Load a recalled entry with
+`replace(text, mode~)`; clear with `reset()`.

--- a/tui/internal/composer/composer.mbt
+++ b/tui/internal/composer/composer.mbt
@@ -1,0 +1,833 @@
+///|
+const MinTextRows : Int = 1
+
+///|
+/// Default cap on how many editable rows the composer grows to before it
+/// scrolls instead of growing further.
+pub const DefaultMaxTextRows : Int = 4
+
+///|
+fn line_count(text : String) -> Int {
+  @text.split_lines(text).length()
+}
+
+///|
+fn normalize_max_text_rows(max_text_rows : Int) -> Int {
+  @cmp.maximum(max_text_rows, MinTextRows)
+}
+
+///|
+fn is_newline_grapheme(grapheme : StringView) -> Bool {
+  grapheme.to_owned() == "\n"
+}
+
+///|
+/// Whether a grapheme counts as part of a word for word-wise cursor motion.
+///
+/// Classification looks at the grapheme's leading scalar: ASCII letters and
+/// digits, and any non-ASCII scalar (CJK, accented letters, emoji), are word
+/// characters; ASCII spaces and punctuation are delimiters.
+fn is_word_grapheme(grapheme : StringView) -> Bool {
+  match grapheme {
+    [c, ..] => c.is_ascii_alphabetic() || c.is_ascii_digit() || !c.is_ascii()
+    [] => false
+  }
+}
+
+///|
+fn line_display_width(lines : Array[String], line : Int) -> Int {
+  @text.display_width(@text.line_at(lines, line))
+}
+
+///|
+/// Display width of the prompt prefix (`> `, `! `, or the `  ` continuation),
+/// which is always two columns. Every wrapped composer row reserves this much.
+const PromptWidth : Int = 2
+
+///|
+/// Editable content width for a composer rendered at `cols` terminal columns,
+/// i.e. the room left once the two-column prompt prefix is reserved.
+fn content_width_for(cols~ : Int) -> Int {
+  @cmp.maximum(cols - PromptWidth, 1)
+}
+
+///|
+/// Content width assumed before the composer has been laid out against a real
+/// terminal. The renderer calls `Model::resize` on every frame, so this only
+/// governs editing that happens before the first draw.
+const DefaultContentWidth : Int = 78
+
+///|
+/// Number of editable rows to render for `total` wrapped rows, clamped between
+/// one and `max_text_rows`.
+fn visible_count(total : Int, max_text_rows : Int) -> Int {
+  total.clamp(min=MinTextRows, max=normalize_max_text_rows(max_text_rows))
+}
+
+///|
+/// A single on-screen composer row produced by soft-wrapping a logical input
+/// line to the editable content width. `start_column` is the grapheme offset
+/// within the logical line where this segment begins, used to map the cursor
+/// onto the correct wrapped row.
+priv struct VisualRow {
+  logical_line : Int
+  start_column : Int
+  text : String
+}
+
+///|
+/// Soft-wrap every logical line of `text` to `content_width` display columns.
+///
+/// Each logical line yields at least one row (an empty line yields one empty
+/// row) so the cursor always has a row to sit on. Wrapping is by grapheme and
+/// display width, matching how each row is later measured on screen.
+fn visual_rows_for(text : String, content_width : Int) -> Array[VisualRow] {
+  let width = @cmp.maximum(content_width, 1)
+  let rows : Array[VisualRow] = []
+  let lines = @text.split_lines(text)
+  for line_index in 0..<lines.length() {
+    let line = lines[line_index]
+    let mut column = 0
+    let mut segment_start = 0
+    let mut segment = StringBuilder()
+    let mut segment_width = 0
+    let mut segment_filled = false
+    for grapheme in @grapheme.grapheme_iter(line) {
+      let grapheme_width = @unicodewidth.str_width(grapheme)
+      if segment_filled && segment_width + grapheme_width > width {
+        rows.push({
+          logical_line: line_index,
+          start_column: segment_start,
+          text: segment.to_string(),
+        })
+        segment = StringBuilder()
+        segment_width = 0
+        segment_filled = false
+        segment_start = column
+      }
+      segment.write_stringview(grapheme)
+      segment_width = segment_width + grapheme_width
+      segment_filled = true
+      column = column + 1
+    }
+    rows.push({
+      logical_line: line_index,
+      start_column: segment_start,
+      text: segment.to_string(),
+    })
+  }
+  rows
+}
+
+///|
+/// Index of the wrapped row that should hold the cursor at `point`.
+///
+/// Within the cursor's logical line this picks the last segment whose
+/// `start_column` is at or before the cursor, so a cursor resting exactly on a
+/// wrap boundary appears at the start of the following row.
+fn cursor_visual_row(rows : Array[VisualRow], point : CursorPoint) -> Int {
+  let mut result = 0
+  for index in 0..<rows.length() {
+    let row = rows[index]
+    if row.logical_line > point.line {
+      break
+    }
+    if row.logical_line == point.line &&
+      row.start_column <= point.grapheme_column {
+      result = index
+    }
+  }
+  result
+}
+
+///|
+/// Grapheme offset within `segment` whose left edge is nearest to but not past
+/// `target` display columns. Used to preserve a preferred column when moving the
+/// cursor vertically between wrapped rows of differing content.
+fn place_display_column(segment : String, target : Int) -> Int {
+  let mut offset = 0
+  let mut width = 0
+  for grapheme in @grapheme.grapheme_iter(segment) {
+    let grapheme_width = @unicodewidth.str_width(grapheme)
+    if width + grapheme_width > target {
+      break
+    }
+    width = width + grapheme_width
+    offset = offset + 1
+  }
+  offset
+}
+
+///|
+/// Resolve the cursor to a wrapped row index and the grapheme offset within that
+/// row's segment.
+///
+/// A cursor sitting exactly on a soft-wrap boundary is ambiguous: the same text
+/// position is both the end of one row and the start of the next. `at_wrap_end`
+/// is the affinity bit set by vertical movement — when true the cursor renders at
+/// the end of the earlier row instead of the start of the following one.
+fn resolve_cursor(
+  rows : Array[VisualRow],
+  point : CursorPoint,
+  at_wrap_end : Bool,
+) -> (Int, Int) {
+  let index = cursor_visual_row(rows, point)
+  if at_wrap_end &&
+    rows[index].start_column == point.grapheme_column &&
+    rows[index].start_column > 0 {
+    let previous = index - 1
+    (previous, point.grapheme_column - rows[previous].start_column)
+  } else {
+    (index, point.grapheme_column - rows[index].start_column)
+  }
+}
+
+///|
+priv struct CursorPoint {
+  line : Int
+  grapheme_column : Int
+}
+
+///|
+/// Semantic mode for the live composer.
+///
+/// `Input` is normal agent-steering text. `Shell` changes the first prompt to
+/// `! ` and makes the submitted text become a shell command.
+enum Mode {
+  Input
+  Shell
+} derive(Eq)
+
+///|
+fn Mode::prompt_prefix(self : Mode) -> String {
+  match self {
+    Input => "❯ "
+    Shell => "! "
+  }
+}
+
+///|
+/// Display width of the prompt prefix — the column where the composer's editable
+/// text begins. Used to indent sibling rows (status, activity) so they line up
+/// with the text, not the prompt glyph.
+pub fn Model::prompt_width(self : Model) -> Int {
+  @text.display_width(self.mode.prompt_prefix())
+}
+
+///|
+/// Whether the composer is in normal agent-steering input mode.
+pub fn Mode::is_input(self : Mode) -> Bool {
+  self == Input
+}
+
+///|
+/// Whether the composer is in shell mode, where submitted text runs as a
+/// shell command and the first prompt shows `! `.
+pub fn Mode::is_shell(self : Mode) -> Bool {
+  self == Shell
+}
+
+///|
+fn cursor_point_for(text : String, cursor : Int) -> CursorPoint {
+  let target = cursor.clamp(min=0, max=@text.grapheme_count(text))
+  let mut index = 0
+  let mut line = 0
+  let mut grapheme_column = 0
+  for grapheme in @grapheme.grapheme_iter(text) {
+    if index >= target {
+      break
+    }
+    if is_newline_grapheme(grapheme) {
+      line = line + 1
+      grapheme_column = 0
+    } else {
+      grapheme_column = grapheme_column + 1
+    }
+    index = index + 1
+  }
+  { line, grapheme_column }
+}
+
+///|
+fn line_start_cursor(text : String, line : Int) -> Int {
+  let line = line.clamp(min=0, max=line_count(text) - 1)
+  if line == 0 {
+    0
+  } else {
+    let mut index = 0
+    let mut current_line = 0
+    for grapheme in @grapheme.grapheme_iter(text) {
+      index = index + 1
+      if is_newline_grapheme(grapheme) {
+        current_line = current_line + 1
+        if current_line == line {
+          break
+        }
+      }
+    }
+    index
+  }
+}
+
+///|
+fn cursor_for_line_display_column(
+  text : String,
+  line : Int,
+  display_column : Int,
+) -> Int {
+  let lines = @text.split_lines(text)
+  let line = line.clamp(min=0, max=lines.length() - 1)
+  let target = display_column.clamp(min=0, max=line_display_width(lines, line))
+  let mut grapheme_column = 0
+  let mut width = 0
+  for grapheme in @grapheme.grapheme_iter(@text.line_at(lines, line)) {
+    let next_width = @unicodewidth.str_width(grapheme)
+    if width + next_width > target {
+      break
+    }
+    width = width + next_width
+    grapheme_column = grapheme_column + 1
+  }
+  line_start_cursor(text, line) + grapheme_column
+}
+
+///|
+/// Mutable state model for the multiline composer.
+///
+/// `Model` owns the user-editable text, cursor position, semantic mode, the
+/// editable content width, the maximum rows the composer may grow to, and the
+/// first visible wrapped row. Because it knows its own width it soft-wraps long
+/// logical lines and navigates by on-screen row like a text editor. It does not
+/// emit terminal sequences; terminal anchoring and rendering belong to `Ui`.
+struct Model {
+  mut text : String
+  mut cursor : Int
+  mut preferred_column : Int?
+  mut view_start : Int
+  // Affinity for a cursor that lands on a soft-wrap boundary: when true the
+  // cursor belongs to the end of the earlier wrapped row, not the start of the
+  // next one. Set by vertical movement, reset by every other edit.
+  mut at_wrap_end : Bool
+  mut content_width : Int
+  // The configured ceiling on visible rows.
+  max_text_rows : Int
+  // The live cap on visible rows, narrowed by `resize` to the terminal's budget
+  // so the composer fits alongside its chrome on a short terminal. Always
+  // `<= max_text_rows`.
+  mut visible_cap : Int
+  mut mode : Mode
+}
+
+///|
+fn make_model(
+  text : String,
+  cursor : Int,
+  preferred_column : Int?,
+  view_start : Int,
+  max_text_rows? : Int = DefaultMaxTextRows,
+  mode? : Mode = Input,
+  content_width? : Int = DefaultContentWidth,
+) -> Model {
+  let max_text_rows = normalize_max_text_rows(max_text_rows)
+  let cursor = cursor.clamp(min=0, max=@text.grapheme_count(text))
+  let content_width = @cmp.maximum(content_width, 1)
+  let model = {
+    text,
+    cursor,
+    preferred_column,
+    view_start: if view_start < 0 {
+      0
+    } else {
+      view_start
+    },
+    at_wrap_end: false,
+    content_width,
+    max_text_rows,
+    visible_cap: max_text_rows,
+    mode,
+  }
+  // The scroll offset depends on how the text wraps, so resolve it once now and
+  // keep it current after every edit and resize.
+  model.reclamp_view()
+  model
+}
+
+///|
+/// Create an empty composer in `Input` mode whose editable area grows to at
+/// most `max_text_rows` wrapped rows.
+pub fn Model::new(max_text_rows? : Int = DefaultMaxTextRows) -> Model {
+  Model::from_text("", max_text_rows~)
+}
+
+///|
+fn Model::from_text(
+  text : String,
+  max_text_rows? : Int = DefaultMaxTextRows,
+) -> Model {
+  make_model(text, @text.grapheme_count(text), None, 0, max_text_rows~)
+}
+
+///|
+/// Clear the composer back to empty `Input` mode, resetting the cursor and
+/// scroll window.
+pub fn Model::reset(self : Model) -> Unit {
+  self.set_state("", 0, None, 0, mode=Input)
+}
+
+///|
+/// Replace the entire buffer with `text` in `mode`, placing the cursor at the
+/// end and scrolling the view back to the top. Used to load history entries.
+pub fn Model::replace(self : Model, text : String, mode~ : Mode) -> Unit {
+  self.set_state(text, @text.grapheme_count(text), None, 0, mode~)
+}
+
+///|
+fn Model::cursor_point(self : Model) -> CursorPoint {
+  cursor_point_for(self.text, self.cursor)
+}
+
+///|
+/// Return the current text that should be submitted to the caller.
+///
+/// In shell mode, the leading `!` prompt marker is not part of this text.
+pub fn Model::text(self : Model) -> String {
+  self.text
+}
+
+///|
+/// Return the semantic mode for the current composer text.
+///
+/// `Input` mode submits normal agent-steering text. `Shell` mode keeps the
+/// leading `!` marker out of editable text and submits a command.
+pub fn Model::mode(self : Model) -> Mode {
+  self.mode
+}
+
+///|
+/// Current number of editable rows that should be rendered.
+///
+/// The composer starts at one row and grows as hard newlines and soft-wrapped
+/// long lines add wrapped rows, stopping at `max_text_rows`. When the text wraps
+/// to more rows than this value, `view_start` scrolls the visible window instead
+/// of growing further.
+pub fn Model::visible_text_rows(self : Model) -> Int {
+  visible_count(
+    visual_rows_for(self.text, self.content_width).length(),
+    self.visible_cap,
+  )
+}
+
+///|
+/// Return the wrapped input segment displayed at a composer row.
+///
+/// `row` is relative to the visible composer text area, not the terminal. A
+/// missing row returns an empty string so renderers can draw a fixed surface for
+/// the current frame without special-casing short buffers.
+pub fn Model::visible_line(self : Model, row : Int) -> String {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let index = self.view_start + row
+  if index < 0 || index >= rows.length() {
+    ""
+  } else {
+    rows[index].text
+  }
+}
+
+///|
+/// Return the prompt prefix for a visible composer row at `cols` columns.
+///
+/// Only the very first wrapped row of the first logical input line gets `❯ ` or
+/// `! `. Every other row — later logical lines and soft-wrapped continuations
+/// alike — uses two spaces so wrapped content lines up with the editable text.
+pub fn Model::input_prefix(self : Model, row : Int) -> String {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let index = self.view_start + row
+  if index >= 0 &&
+    index < rows.length() &&
+    rows[index].logical_line == 0 &&
+    rows[index].start_column == 0 {
+    self.mode.prompt_prefix()
+  } else {
+    "  "
+  }
+}
+
+///|
+/// Cursor row within the visible composer text area.
+///
+/// The row is measured in wrapped rows and clamped to the current visible row
+/// count, so terminal renderers can move relative to the current composer
+/// surface even when the underlying cursor is temporarily outside the window.
+pub fn Model::cursor_row(self : Model) -> Int {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let visible = visible_count(rows.length(), self.visible_cap)
+  let (index, _) = resolve_cursor(rows, self.cursor_point(), self.at_wrap_end)
+  let row = index - self.view_start
+  row.clamp(min=0, max=visible - 1)
+}
+
+///|
+/// Whether the cursor is on the first wrapped row of the composer.
+///
+/// Vertical-up at this row hands off to history recall rather than moving within
+/// the buffer, so wrapped continuation rows count as interior rows here.
+pub fn Model::cursor_at_first_visual_row(self : Model) -> Bool {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let (index, _) = resolve_cursor(rows, self.cursor_point(), self.at_wrap_end)
+  index == 0
+}
+
+///|
+/// Whether the cursor is on the last wrapped row of the composer.
+pub fn Model::cursor_at_last_visual_row(self : Model) -> Bool {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let (index, _) = resolve_cursor(rows, self.cursor_point(), self.at_wrap_end)
+  index == rows.length() - 1
+}
+
+///|
+/// Cursor column offset within the terminal row that contains the cursor.
+///
+/// The result is a display-cell offset from column 1, including the prompt
+/// prefix width, and is measured within the cursor's wrapped segment so it stays
+/// correct when a long line soft-wraps. It is based on grapheme/display-width
+/// measurement, not byte length.
+pub fn Model::cursor_offset(self : Model) -> Int {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let (index, offset) = resolve_cursor(
+    rows,
+    self.cursor_point(),
+    self.at_wrap_end,
+  )
+  let before_cursor = @text.grapheme_slice(rows[index].text, 0, offset)
+  PromptWidth + @text.display_width(before_cursor)
+}
+
+///|
+fn Model::set_state(
+  self : Model,
+  text : String,
+  cursor : Int,
+  preferred_column : Int?,
+  view_start : Int,
+  mode? : Mode = Input,
+  at_wrap_end? : Bool = false,
+) -> Unit {
+  let cursor = cursor.clamp(min=0, max=@text.grapheme_count(text))
+  self.text = text
+  self.cursor = cursor
+  self.preferred_column = preferred_column
+  self.view_start = if view_start < 0 { 0 } else { view_start }
+  self.mode = mode
+  self.at_wrap_end = at_wrap_end
+  // The text or cursor may have moved; pull the scroll window back over the
+  // cursor for the current width.
+  self.reclamp_view()
+}
+
+///|
+/// Re-clamp `view_start` so the cursor's wrapped row stays visible at the
+/// current content width. Called after every edit, move, and resize.
+fn Model::reclamp_view(self : Model) -> Unit {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let total = rows.length()
+  let visible = visible_count(total, self.visible_cap)
+  let max_start = if total - visible > 0 { total - visible } else { 0 }
+  let (cursor_index, _) = resolve_cursor(
+    rows,
+    self.cursor_point(),
+    self.at_wrap_end,
+  )
+  let mut start = self.view_start.clamp(min=0, max=max_start)
+  if cursor_index < start {
+    start = cursor_index
+  } else if cursor_index >= start + visible {
+    start = cursor_index - visible + 1
+  }
+  self.view_start = start.clamp(min=0, max=max_start)
+}
+
+///|
+/// Lay the composer out for a terminal `cols` columns wide. The renderer calls
+/// this each frame so soft-wrapping and vertical movement track the live width.
+/// Re-lay the composer for `cols` columns, capping its visible rows to
+/// `max_rows`. The cap narrows the configured ceiling so the composer fits its
+/// terminal budget; it is floored at one row and never raises the ceiling.
+/// Omitting `max_rows` leaves the configured ceiling in place.
+pub fn Model::resize(
+  self : Model,
+  cols~ : Int,
+  max_rows? : Int = @int.MAX_VALUE,
+) -> Unit {
+  self.content_width = content_width_for(cols~)
+  self.visible_cap = max_rows.clamp(min=MinTextRows, max=self.max_text_rows)
+  self.reclamp_view()
+}
+
+///|
+fn Model::move_to_cursor(
+  self : Model,
+  cursor : Int,
+  preferred_column : Int?,
+) -> Unit {
+  self.set_state(
+    self.text,
+    cursor,
+    preferred_column,
+    self.view_start,
+    mode=self.mode,
+  )
+}
+
+///|
+fn Model::delete_range(self : Model, start : Int, end : Int) -> Unit {
+  let length = @text.grapheme_count(self.text)
+  let start = start.clamp(min=0, max=length)
+  let end = end.clamp(min=start, max=length)
+  let prefix = @text.grapheme_slice(self.text, 0, start)
+  let suffix = @text.grapheme_slice(self.text, end, length)
+  self.set_state(prefix + suffix, start, None, self.view_start, mode=self.mode)
+}
+
+///|
+/// Insert `text` at the cursor and advance the cursor past it. Inserted text is
+/// counted by graphemes, so multi-byte characters move the cursor one step each.
+pub fn Model::insert(self : Model, text : String) -> Unit {
+  let prefix = @text.grapheme_slice(self.text, 0, self.cursor)
+  let suffix = @text.grapheme_slice(
+    self.text,
+    self.cursor,
+    @text.grapheme_count(self.text),
+  )
+  self.set_state(
+    prefix + text + suffix,
+    self.cursor + @text.grapheme_count(text),
+    None,
+    self.view_start,
+    mode=self.mode,
+  )
+}
+
+///|
+/// Insert text typed by the user, applying the shell-mode shortcut.
+///
+/// When the buffer is empty, the cursor is at the start, and the mode is
+/// `Input`, a leading `!` switches the composer into `Shell` mode and is
+/// dropped from the editable text (only the text after it is inserted).
+/// Otherwise this behaves like `insert`.
+pub fn Model::insert_user_text(self : Model, text : String) -> Unit {
+  // Drop terminal-control bytes (pasted ANSI escapes, stray `\r`) before they
+  // reach the model, so the live echo can never mutate the terminal and the
+  // cursor math stays consistent with what is drawn.
+  let text = @text.sanitize(text)
+  if self.mode.is_input() && self.text.length() == 0 && self.cursor == 0 {
+    match text {
+      [.. "!", .. rest] => {
+        let rest_text = rest.to_owned()
+        self.set_state(
+          rest_text,
+          @text.grapheme_count(rest_text),
+          None,
+          self.view_start,
+          mode=Shell,
+        )
+      }
+      _ => self.insert(text)
+    }
+  } else {
+    self.insert(text)
+  }
+}
+
+///|
+/// Delete the one grapheme before the cursor (Backspace). At the start of the
+/// buffer this is a no-op that also normalizes the mode back to `Input`.
+pub fn Model::delete_before(self : Model) -> Unit {
+  if self.cursor <= 0 {
+    self.set_state(self.text, 0, None, self.view_start, mode=Input)
+  } else {
+    let prefix = @text.grapheme_slice(self.text, 0, self.cursor - 1)
+    let suffix = @text.grapheme_slice(
+      self.text,
+      self.cursor,
+      @text.grapheme_count(self.text),
+    )
+    self.set_state(
+      prefix + suffix,
+      self.cursor - 1,
+      None,
+      self.view_start,
+      mode=self.mode,
+    )
+  }
+}
+
+///|
+/// Delete the one grapheme at the cursor (Delete / Ctrl-D). At the end of the
+/// buffer this is a no-op.
+pub fn Model::delete_after(self : Model) -> Unit {
+  let length = @text.grapheme_count(self.text)
+  if self.cursor >= length {
+    self.set_state(
+      self.text,
+      self.cursor,
+      None,
+      self.view_start,
+      mode=self.mode,
+    )
+  } else {
+    let prefix = @text.grapheme_slice(self.text, 0, self.cursor)
+    let suffix = @text.grapheme_slice(self.text, self.cursor + 1, length)
+    self.set_state(
+      prefix + suffix,
+      self.cursor,
+      None,
+      self.view_start,
+      mode=self.mode,
+    )
+  }
+}
+
+///|
+/// Move the cursor one grapheme left, crossing line breaks. Clamped at the
+/// start of the buffer.
+pub fn Model::move_left(self : Model) -> Unit {
+  self.move_to_cursor(self.cursor - 1, None)
+}
+
+///|
+/// Move the cursor one grapheme right, crossing line breaks. Clamped at the end
+/// of the buffer.
+pub fn Model::move_right(self : Model) -> Unit {
+  self.move_to_cursor(self.cursor + 1, None)
+}
+
+///|
+/// Move the cursor to the end of the next word: skip any leading delimiters,
+/// then the run of word graphemes. Matches readline's `forward-word` (Alt-F).
+pub fn Model::move_word_right(self : Model) -> Unit {
+  let graphemes = @grapheme.graphemes(self.text)
+  let length = graphemes.length()
+  let mut cursor = self.cursor
+  while cursor < length && !is_word_grapheme(graphemes[cursor]) {
+    cursor = cursor + 1
+  }
+  while cursor < length && is_word_grapheme(graphemes[cursor]) {
+    cursor = cursor + 1
+  }
+  self.move_to_cursor(cursor, None)
+}
+
+///|
+/// Move the cursor to the start of the previous word: skip any trailing
+/// delimiters, then the run of word graphemes. Matches readline's `backward-word`
+/// (Alt-B).
+pub fn Model::move_word_left(self : Model) -> Unit {
+  let graphemes = @grapheme.graphemes(self.text)
+  let mut cursor = self.cursor
+  while cursor > 0 && !is_word_grapheme(graphemes[cursor - 1]) {
+    cursor = cursor - 1
+  }
+  while cursor > 0 && is_word_grapheme(graphemes[cursor - 1]) {
+    cursor = cursor - 1
+  }
+  self.move_to_cursor(cursor, None)
+}
+
+///|
+/// Move the cursor to the start of its current logical line (Home / Ctrl-A),
+/// not the start of the wrapped row.
+pub fn Model::move_home(self : Model) -> Unit {
+  let point = self.cursor_point()
+  self.move_to_cursor(line_start_cursor(self.text, point.line), None)
+}
+
+///|
+/// Move the cursor to the end of its current logical line (End / Ctrl-E), past
+/// any soft-wrapped rows of that line.
+pub fn Model::move_end(self : Model) -> Unit {
+  let point = self.cursor_point()
+  let lines = @text.split_lines(self.text)
+  self.move_to_cursor(
+    cursor_for_line_display_column(
+      self.text,
+      point.line,
+      line_display_width(lines, point.line),
+    ),
+    None,
+  )
+}
+
+///|
+/// Delete from the start of the current logical line up to the cursor (Ctrl-U).
+pub fn Model::kill_before(self : Model) -> Unit {
+  let point = self.cursor_point()
+  self.delete_range(line_start_cursor(self.text, point.line), self.cursor)
+}
+
+///|
+/// Delete from the cursor to the end of the current logical line (Ctrl-K).
+///
+/// When the cursor is already at the line's end, kill the following line break
+/// so the next line joins up; on a trailing empty line with nothing ahead,
+/// remove the line itself by deleting the preceding break. On a fully empty
+/// buffer this is a no-op.
+pub fn Model::kill_after(self : Model) -> Unit {
+  let point = self.cursor_point()
+  let lines = @text.split_lines(self.text)
+  let line_end = cursor_for_line_display_column(
+    self.text,
+    point.line,
+    line_display_width(lines, point.line),
+  )
+  if self.cursor < line_end {
+    // Kill to the end of the current line's content.
+    self.delete_range(self.cursor, line_end)
+  } else if self.cursor < @text.grapheme_count(self.text) {
+    // Already at the end of the line (an empty line is its own end): kill the
+    // line break so the next line joins up, matching readline/emacs kill-line.
+    self.delete_range(self.cursor, self.cursor + 1)
+  } else if self.cursor > 0 &&
+    line_start_cursor(self.text, point.line) == self.cursor {
+    // A trailing empty line has no forward content to kill; remove the line
+    // itself by deleting the line break that precedes it.
+    self.delete_range(self.cursor - 1, self.cursor)
+  }
+}
+
+///|
+/// Move the cursor one wrapped row up or down, keeping a preferred display
+/// column. Unlike logical-line movement this steps between the soft-wrapped rows
+/// of a single long line, matching how the composer is drawn.
+pub fn Model::move_vertical(self : Model, delta : Int) -> Unit {
+  let rows = visual_rows_for(self.text, self.content_width)
+  let (index, offset) = resolve_cursor(
+    rows,
+    self.cursor_point(),
+    self.at_wrap_end,
+  )
+  let current_column = @text.display_width(
+    @text.grapheme_slice(rows[index].text, 0, offset),
+  )
+  let preferred = self.preferred_column.unwrap_or(current_column)
+  let target_index = (index + delta).clamp(min=0, max=rows.length() - 1)
+  let target = rows[target_index]
+  let target_offset = place_display_column(target.text, preferred)
+  let cursor = line_start_cursor(self.text, target.logical_line) +
+    target.start_column +
+    target_offset
+  // Landing at the far edge of a non-final wrapped row sits on a boundary that
+  // textually equals the next row's start; remember the affinity so it renders
+  // at the end of this row instead of jumping down.
+  let lands_on_wrap_boundary = target_index + 1 < rows.length() &&
+    rows[target_index + 1].logical_line == target.logical_line &&
+    target_offset == @text.grapheme_count(target.text)
+  self.set_state(
+    self.text,
+    cursor,
+    Some(preferred),
+    self.view_start,
+    mode=self.mode,
+    at_wrap_end=lands_on_wrap_boundary,
+  )
+}

--- a/tui/internal/composer/composer_wbtest.mbt
+++ b/tui/internal/composer/composer_wbtest.mbt
@@ -1,0 +1,301 @@
+///|
+test "model starts at end and keeps cursor visible" {
+  let model = Model::from_text("a\nb\nc")
+  let point = model.cursor_point()
+  inspect(point.line, content="2")
+  inspect(point.grapheme_column, content="1")
+  inspect(model.visible_text_rows(), content="3")
+  inspect(model.cursor_row(), content="2")
+  inspect(model.view_start, content="0")
+}
+
+///|
+test "model up down moves cursor and visible line window" {
+  let model = Model::from_text("one\ntwo\nthree")
+  inspect(model.cursor_point().line, content="2")
+  inspect(model.view_start, content="0")
+  model.move_vertical(-1)
+  inspect(model.cursor_point().line, content="1")
+  inspect(model.cursor_point().grapheme_column, content="3")
+  inspect(model.view_start, content="0")
+  model.move_vertical(-1)
+  inspect(model.cursor_point().line, content="0")
+  inspect(model.cursor_point().grapheme_column, content="3")
+  inspect(model.view_start, content="0")
+  model.move_vertical(1)
+  inspect(model.cursor_point().line, content="1")
+  inspect(model.view_start, content="0")
+  model.move_vertical(1)
+  inspect(model.cursor_point().line, content="2")
+  inspect(model.view_start, content="0")
+}
+
+///|
+test "model scrolls visible window after max rows" {
+  let model = Model::from_text("a\nb\nc\nd\ne")
+  inspect(model.visible_text_rows(), content="4")
+  inspect(model.cursor_row(), content="3")
+  inspect(model.view_start, content="1")
+  model.move_vertical(-3)
+  inspect(model.cursor_point().line, content="1")
+  inspect(model.view_start, content="1")
+  model.move_vertical(-1)
+  inspect(model.cursor_point().line, content="0")
+  inspect(model.view_start, content="0")
+}
+
+///|
+test "model inserts and deletes at cursor" {
+  let inserted = Model::from_text("ab")
+  inserted.move_left()
+  inserted.insert("X")
+  inspect(inserted.text, content="aXb")
+  inspect(inserted.cursor, content="2")
+  let deleted_before = Model::from_text("a👨‍👩‍👧‍👦b")
+  deleted_before.move_left()
+  deleted_before.delete_before()
+  inspect(deleted_before.text, content="ab")
+  inspect(deleted_before.cursor_point().grapheme_column, content="1")
+  let deleted_after = Model::from_text("ab")
+  deleted_after.move_home()
+  deleted_after.delete_after()
+  inspect(deleted_after.text, content="b")
+  inspect(deleted_after.cursor, content="0")
+}
+
+///|
+test "model shell mode keeps marker out of text" {
+  let shell = Model::new()
+  shell.insert_user_text("!echo hi")
+  assert_true(shell.mode().is_shell())
+  inspect(shell.text, content="echo hi")
+  inspect(shell.cursor, content="7")
+  let normal = Model::new()
+  normal.insert_user_text("!")
+  normal.delete_before()
+  assert_true(normal.mode().is_input())
+  inspect(normal.text, content="")
+}
+
+///|
+test "model home end moves within logical line" {
+  let model = Model::from_text("ab\ncd")
+  model.move_home()
+  inspect(model.cursor_point().line, content="1")
+  inspect(model.cursor_point().grapheme_column, content="0")
+  model.move_end()
+  inspect(model.cursor_point().line, content="1")
+  inspect(model.cursor_point().grapheme_column, content="2")
+}
+
+///|
+test "model kills before and after cursor within logical line" {
+  let before = Model::from_text("ab\ncd")
+  before.kill_before()
+  inspect(before.text, content="ab\n")
+  inspect(before.cursor_point().line, content="1")
+  inspect(before.cursor_point().grapheme_column, content="0")
+  let after = Model::from_text("ab\ncd")
+  after.move_home()
+  after.kill_after()
+  inspect(after.text, content="ab\n")
+  inspect(after.cursor_point().line, content="1")
+  inspect(after.cursor_point().grapheme_column, content="0")
+}
+
+///|
+test "kill after removes empty lines and joins lines" {
+  // On an empty middle line, kill-line removes the forward line break.
+  let middle = Model::from_text("ab\n\ncd")
+  middle.move_vertical(-1)
+  inspect(middle.cursor_point().line, content="1")
+  inspect(middle.cursor_point().grapheme_column, content="0")
+  middle.kill_after()
+  inspect(middle.text, content="ab\ncd")
+  // At the end of a non-empty line it likewise joins the next line up.
+  let joined = Model::from_text("ab\ncd")
+  joined.move_vertical(-1)
+  joined.move_end()
+  joined.kill_after()
+  inspect(joined.text, content="abcd")
+  // A trailing empty line (e.g. from an extra Shift+Enter) has nothing forward,
+  // so kill-line removes the empty line by deleting the preceding break.
+  let trailing = Model::from_text("ab\n")
+  inspect(trailing.cursor_point().line, content="1")
+  trailing.kill_after()
+  inspect(trailing.text, content="ab")
+}
+
+///|
+test "model kill keeps shell mode active" {
+  let shell = Model::new()
+  shell.insert_user_text("!pwd")
+  shell.kill_before()
+  assert_true(shell.mode().is_shell())
+  inspect(shell.text, content="")
+}
+
+///|
+test "input prefix marks only the first logical input line" {
+  inspect(
+    Model::new().input_prefix(0),
+    content=(
+      #|❯ 
+    ),
+  )
+  let shell = Model::new()
+  shell.insert_user_text("!")
+  inspect(shell.input_prefix(0), content="! ")
+  inspect(Model::new().input_prefix(1), content="  ")
+  inspect(
+    Model::from_text("a\nb\nc", max_text_rows=2).input_prefix(0),
+    content="  ",
+  )
+}
+
+///|
+test "input cursor offset accounts for prompt and display width" {
+  inspect(Model::new().cursor_offset(), content="2")
+  inspect(Model::from_text("abc").cursor_offset(), content="5")
+  inspect(Model::from_text("你好").cursor_offset(), content="6")
+  let moved_left = Model::from_text("abc")
+  moved_left.move_left()
+  inspect(moved_left.cursor_offset(), content="4")
+  inspect(Model::from_text("a\nb").cursor_offset(), content="3")
+  // A long line wrapped to a content width of 3 puts the cursor at the end of
+  // its second wrapped row: prompt (2) + display width of "def" (3).
+  let narrow = Model::from_text("abcdef")
+  narrow.resize(cols=5)
+  inspect(narrow.cursor_offset(), content="5")
+  let shell = Model::new()
+  shell.insert_user_text("!abc")
+  inspect(shell.cursor_offset(), content="5")
+}
+
+///|
+test "long line soft-wraps across visible rows" {
+  // cols 7 leaves a content width of 5, so "abcdefghij" wraps to two rows.
+  let model = Model::from_text("abcdefghij")
+  model.resize(cols=7)
+  inspect(model.visible_text_rows(), content="2")
+  inspect(model.visible_line(0), content="abcde")
+  inspect(model.visible_line(1), content="fghij")
+  // Only the first wrapped row keeps the prompt; the continuation is indented.
+  inspect(
+    model.input_prefix(0),
+    content=(
+      #|❯ 
+    ),
+  )
+  inspect(model.input_prefix(1), content="  ")
+  // The cursor sits at the end of the second wrapped row.
+  inspect(model.cursor_row(), content="1")
+  inspect(model.cursor_offset(), content="7")
+}
+
+///|
+test "soft-wrapped line scrolls when it exceeds max rows" {
+  // cols 3 leaves a content width of 1, so "abcdef" wraps to six rows and the
+  // four-row window scrolls to keep the trailing cursor visible.
+  let model = Model::from_text("abcdef", max_text_rows=4)
+  model.resize(cols=3)
+  inspect(model.visible_text_rows(), content="4")
+  inspect(model.cursor_row(), content="3")
+  inspect(model.view_start, content="2")
+  inspect(model.visible_line(0), content="c")
+  inspect(model.visible_line(3), content="f")
+}
+
+///|
+test "vertical movement steps through wrapped rows of one logical line" {
+  // content width 5 splits "abcdefghij" into "abcde" / "fghij"; the cursor
+  // starts at the end of the second wrapped row.
+  let model = Model::from_text("abcdefghij")
+  model.resize(cols=7)
+  inspect(model.cursor_row(), content="1")
+  // Up moves within the single logical line to the first wrapped row, landing on
+  // the wrap boundary so it renders at the end of that row (offset 2 + 5).
+  model.move_vertical(-1)
+  inspect(model.cursor_row(), content="0")
+  inspect(model.cursor_point().line, content="0")
+  inspect(model.cursor_offset(), content="7")
+  inspect(model.cursor_at_first_visual_row(), content="true")
+  // Down returns to the end of the second wrapped row.
+  model.move_vertical(1)
+  inspect(model.cursor_row(), content="1")
+  inspect(model.cursor_offset(), content="7")
+}
+
+///|
+test "word motion steps across word boundaries" {
+  let model = Model::from_text("foo bar.baz")
+  model.move_home()
+  inspect(model.cursor, content="0")
+  model.move_word_right()
+  inspect(model.cursor, content="3")
+  model.move_word_right()
+  inspect(model.cursor, content="7")
+  model.move_word_right()
+  inspect(model.cursor, content="11")
+  model.move_word_right()
+  inspect(model.cursor, content="11")
+  model.move_word_left()
+  inspect(model.cursor, content="8")
+  model.move_word_left()
+  inspect(model.cursor, content="4")
+  model.move_word_left()
+  inspect(model.cursor, content="0")
+  model.move_word_left()
+  inspect(model.cursor, content="0")
+}
+
+///|
+test "word motion treats non-ascii runs as words" {
+  let model = Model::from_text("你好 world")
+  model.move_home()
+  model.move_word_right()
+  inspect(model.cursor, content="2")
+  model.move_word_right()
+  inspect(model.cursor, content="8")
+}
+
+///|
+test "model replace restores text mode and cursor" {
+  let shell = Model::new()
+  shell.insert_user_text("!pwd")
+  let model = Model::from_text("draft")
+  model.replace(shell.text(), mode=shell.mode())
+  inspect(model.text(), content="pwd")
+  assert_true(model.mode().is_shell())
+  inspect(model.cursor, content="3")
+  inspect(model.input_prefix(0), content="! ")
+}
+
+///|
+test "model reports cursor visual-row boundaries" {
+  let model = Model::from_text("one\ntwo")
+  assert_false(model.cursor_at_first_visual_row())
+  assert_true(model.cursor_at_last_visual_row())
+  model.move_home()
+  assert_false(model.cursor_at_first_visual_row())
+  assert_true(model.cursor_at_last_visual_row())
+  model.move_vertical(-1)
+  assert_true(model.cursor_at_first_visual_row())
+  assert_false(model.cursor_at_last_visual_row())
+}
+
+///|
+test "resize caps visible rows to the terminal budget and keeps the cursor" {
+  let model = Model::from_text("a\nb\nc\nd", max_text_rows=4)
+  model.resize(cols=20)
+  // Four logical lines, no cap below the configured ceiling: all four show.
+  inspect(model.visible_text_rows(), content="4")
+  // A tighter budget narrows the visible window...
+  model.resize(cols=20, max_rows=2)
+  inspect(model.visible_text_rows(), content="2")
+  // ...and the cursor (on the last line) stays inside it.
+  assert_true(model.cursor_row() < 2)
+  // The budget never raises the configured ceiling.
+  model.resize(cols=20, max_rows=10)
+  inspect(model.visible_text_rows(), content="4")
+}

--- a/tui/internal/composer/moon.pkg
+++ b/tui/internal/composer/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "kawaz/grapheme",
+  "rami3l/unicodewidth",
+  "moonbitlang/core/cmp",
+  "moonbitlang/core/int",
+  "bobzhang/openseek/tui/internal/text",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/composer/pkg.generated.mbti
+++ b/tui/internal/composer/pkg.generated.mbti
@@ -1,0 +1,46 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/composer"
+
+// Values
+pub const DefaultMaxTextRows : Int = 4
+
+// Errors
+
+// Types and methods
+type Mode derive(Eq)
+pub fn Mode::is_input(Self) -> Bool
+pub fn Mode::is_shell(Self) -> Bool
+
+type Model
+pub fn Model::cursor_at_first_visual_row(Self) -> Bool
+pub fn Model::cursor_at_last_visual_row(Self) -> Bool
+pub fn Model::cursor_offset(Self) -> Int
+pub fn Model::cursor_row(Self) -> Int
+pub fn Model::delete_after(Self) -> Unit
+pub fn Model::delete_before(Self) -> Unit
+pub fn Model::input_prefix(Self, Int) -> String
+pub fn Model::insert(Self, String) -> Unit
+pub fn Model::insert_user_text(Self, String) -> Unit
+pub fn Model::kill_after(Self) -> Unit
+pub fn Model::kill_before(Self) -> Unit
+pub fn Model::mode(Self) -> Mode
+pub fn Model::move_end(Self) -> Unit
+pub fn Model::move_home(Self) -> Unit
+pub fn Model::move_left(Self) -> Unit
+pub fn Model::move_right(Self) -> Unit
+pub fn Model::move_vertical(Self, Int) -> Unit
+pub fn Model::move_word_left(Self) -> Unit
+pub fn Model::move_word_right(Self) -> Unit
+pub fn Model::new(max_text_rows? : Int) -> Self
+pub fn Model::prompt_width(Self) -> Int
+pub fn Model::replace(Self, String, mode~ : Mode) -> Unit
+pub fn Model::reset(Self) -> Unit
+pub fn Model::resize(Self, cols~ : Int, max_rows? : Int) -> Unit
+pub fn Model::text(Self) -> String
+pub fn Model::visible_line(Self, Int) -> String
+pub fn Model::visible_text_rows(Self) -> Int
+
+// Type aliases
+
+// Traits
+

--- a/tui/internal/geometry/README.md
+++ b/tui/internal/geometry/README.md
@@ -1,0 +1,28 @@
+# bobzhang/openseek/tui/internal/geometry
+
+This is the **pure arithmetic half of [`viewport`](../viewport/)** — all the
+"where does the live area go and which rows does a redraw touch" math, with no
+terminal and no IO. `viewport` does the actual drawing; it delegates every
+placement decision here, so that logic can be unit-tested without a tty.
+
+The central type, `Geometry`, is just a block of terminal rows: a 1-based `top`,
+a `height`, and a derived `bottom`. Coordinates are 1-based to match ANSI cursor
+addressing. Every function here is total and returns a result already clamped to
+the screen, so callers never have to re-validate.
+
+## Usage
+
+```mbt
+let area = @geometry.Geometry::new(top=20, height=4)
+area.bottom() // 23  (== top + height - 1)
+```
+
+Placing an area for a desired height against a terminal size:
+
+```mbt
+let height = @geometry.clamp_height(size, height=4)          // into 1 ..= rows
+let max_top = @geometry.calculate_max_top(size, height)      // lowest fully-on-screen start
+let top = @geometry.clamp_top(size, height~, top=cursor_row) // into 1 ..= max_top
+```
+
+Internal to `tui/` — only importable within the module.

--- a/tui/internal/geometry/geometry.mbt
+++ b/tui/internal/geometry/geometry.mbt
@@ -1,0 +1,106 @@
+// Pure geometry for placing the live input viewport on the terminal.
+//
+// Coordinate model (all rows 1-based, matching ANSI cursor addressing):
+//
+//   row 1          ─┐
+//   ...             │  scrollback: committed transcript, owned by the
+//   top - 1         ─┘  terminal's native scroll history (above the live area)
+//   top            ─┐
+//   ...             │  live area: `height` rows redrawn in place by the app
+//   top+height-1   ─┘  (this row is `bottom`)
+//   ...                blank rows below the live area, if any
+//   size.rows()        last on-screen row
+//
+// `top` is the terminal row where the live area starts, `height` how many rows
+// it occupies, and `bottom = top + height - 1`. The live area must fit on
+// screen, so `top` is clamped to `calculate_max_top` — the lowest start row that
+// still leaves `height` rows above `size.rows()`.
+//
+// Every function here is total and side-effect free: results are clamped into a
+// drawable range so the viewport never has to re-validate geometry. They take an
+// already-normalized `@terminal_size.TerminalSize`, so screen dimensions are always
+// positive; only the app-chosen `top`/`height` are clamped here.
+
+///|
+/// A rectangular block of terminal rows: 1-based start row `top` and row count
+/// `height` (so `bottom = top + height - 1`).
+///
+/// Used for the live area's current placement — which additionally satisfies the
+/// viewport invariant `1 <= height <= size.rows` and `1 <= top <= max_top` — and
+/// for a previous frame's footprint, which is the same shape but may predate a
+/// resize. The type itself enforces no invariant; it is just a row region.
+struct Geometry {
+  top : Int
+  height : Int
+}
+
+///|
+/// Build a row region from a start row and a height.
+pub fn Geometry::new(top~ : Int, height~ : Int) -> Geometry {
+  { top, height }
+}
+
+///|
+/// 1-based start row of the region.
+pub fn Geometry::top(self : Geometry) -> Int {
+  self.top
+}
+
+///|
+/// Number of rows the region spans.
+pub fn Geometry::height(self : Geometry) -> Int {
+  self.height
+}
+
+///|
+/// Bottom-most row the region occupies (`top + height - 1`).
+pub fn Geometry::bottom(self : Geometry) -> Int {
+  self.top + self.height - 1
+}
+
+///|
+/// Clamp a desired live-area height into `1 ..= size.rows()`.
+pub fn clamp_height(size : @terminal_size.TerminalSize, height~ : Int) -> Int {
+  height.clamp(min=1, max=size.rows())
+}
+
+///|
+/// The lowest the live area's `top` may sit and still fit entirely on screen,
+/// floored at row 1 when the live area is taller than the screen.
+///
+/// This is just `bottom <= size.rows()` solved for `top`. The live area spans
+/// `top ..= top + height - 1`, so requiring its last row to land on or above the
+/// last physical row gives:
+///
+///   top + height - 1 <= size.rows()   ⟺   top <= size.rows() - height + 1
+///
+/// Clamping `top` to this bound therefore guarantees the whole `height`-row
+/// block is visible — e.g. `rows=24, height=7` gives `18`, and `bottom = 18 + 7
+/// - 1 = 24` sits exactly on the screen bottom. `height` is pre-clamped to
+/// `<= rows` by `clamp_height`, so the bound is always `>= 1` and the clamp
+/// range stays non-empty.
+pub fn calculate_max_top(
+  size : @terminal_size.TerminalSize,
+  height : Int,
+) -> Int {
+  let top = size.rows() - height + 1
+  if top < 1 {
+    1
+  } else {
+    top
+  }
+}
+
+///|
+/// Clamp an app-desired `top` into `1 ..= calculate_max_top(size, height)`.
+///
+/// The desired `top` comes from outside terminal geometry — the queried cursor
+/// row on the first draw, or the previous frame's `top` afterwards — so it can
+/// sit too low to fit the live area below it; clamping raises it just enough.
+pub fn clamp_top(
+  size : @terminal_size.TerminalSize,
+  height~ : Int,
+  top~ : Int,
+) -> Int {
+  top.clamp(min=1, max=calculate_max_top(size, height))
+}

--- a/tui/internal/geometry/geometry_test.mbt
+++ b/tui/internal/geometry/geometry_test.mbt
@@ -1,0 +1,31 @@
+///|
+test "@geometry.clamp_height clamps into 1..=rows" {
+  let size = @terminal_size.TerminalSize::new(rows=10, cols=80)
+  inspect(@geometry.clamp_height(size, height=0), content="1")
+  inspect(@geometry.clamp_height(size, height=4), content="4")
+  inspect(@geometry.clamp_height(size, height=99), content="10")
+}
+
+///|
+test "@geometry.calculate_max_top leaves room for height and floors at row 1" {
+  let size = @terminal_size.TerminalSize::new(rows=10, cols=80)
+  inspect(@geometry.calculate_max_top(size, 4), content="7")
+  inspect(@geometry.calculate_max_top(size, 10), content="1")
+  // Live area taller than the screen still starts at row 1.
+  inspect(@geometry.calculate_max_top(size, 20), content="1")
+}
+
+///|
+test "@geometry.clamp_top clamps into 1..=@geometry.calculate_max_top" {
+  let size = @terminal_size.TerminalSize::new(rows=10, cols=80)
+  inspect(@geometry.clamp_top(size, height=4, top=0), content="1")
+  inspect(@geometry.clamp_top(size, height=4, top=5), content="5")
+  inspect(@geometry.clamp_top(size, height=4, top=99), content="7")
+  // This is how the live area grows: holding `top` while the taller area still
+  // fits, then raising it by just enough once it would overflow the bottom. On a
+  // 12-row screen with the area at top 8, a height of 5 still fits (stays 8) but
+  // a height of 6 does not (rises to 7).
+  let screen = @terminal_size.TerminalSize::new(rows=12, cols=80)
+  inspect(@geometry.clamp_top(screen, height=5, top=8), content="8")
+  inspect(@geometry.clamp_top(screen, height=6, top=8), content="7")
+}

--- a/tui/internal/geometry/moon.pkg
+++ b/tui/internal/geometry/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "bobzhang/openseek/tui/internal/terminal_size",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/geometry/pkg.generated.mbti
+++ b/tui/internal/geometry/pkg.generated.mbti
@@ -1,0 +1,26 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/geometry"
+
+import {
+  "bobzhang/openseek/tui/internal/terminal_size",
+}
+
+// Values
+pub fn calculate_max_top(@terminal_size.TerminalSize, Int) -> Int
+
+pub fn clamp_height(@terminal_size.TerminalSize, height~ : Int) -> Int
+
+pub fn clamp_top(@terminal_size.TerminalSize, height~ : Int, top~ : Int) -> Int
+
+// Errors
+
+// Types and methods
+type Geometry
+pub fn Geometry::bottom(Self) -> Int
+pub fn Geometry::height(Self) -> Int
+pub fn Geometry::new(top~ : Int, height~ : Int) -> Self
+pub fn Geometry::top(Self) -> Int
+
+// Type aliases
+
+// Traits

--- a/tui/internal/history/README.md
+++ b/tui/internal/history/README.md
@@ -1,0 +1,40 @@
+# bobzhang/openseek/tui/internal/history
+
+This is the **shell-style command history** behind the input box: press Up to
+walk back through what you've submitted, Down to come forward, and your
+in-progress draft is preserved at the boundary so you don't lose it. Same
+behavior you get in bash or a REPL.
+
+The central type, `History`, stores submitted entry *values* — the text plus the
+[`composer`](../composer/) `Mode` it was entered in — and a navigation cursor.
+It does not touch the composer or read keys; the caller drives navigation and
+loads recalled values back into the editor. The cursor ranges over
+`[0, entries.length()]`, where the past-the-end position means "editing the fresh
+draft".
+
+## Usage
+
+Push on submit, then walk back and forth, feeding the current draft in so it can
+be saved and restored at the boundary:
+
+```mbt
+let history = @history.History::new()
+
+// On submit: record it (empty text and adjacent duplicates are skipped).
+history.push(@history.Entry::new(model.text(), model.mode()))
+
+// Up / Ctrl-P: recall the previous entry, saving the live draft on the way back.
+match history.previous(@history.Entry::new(model.text(), model.mode())) {
+  Some(entry) => model.replace(entry.text(), mode=entry.mode())
+  None => () // nothing older
+}
+
+// Down / Ctrl-N: move forward; past the last entry it returns the saved draft.
+match history.next() {
+  Some(entry) => model.replace(entry.text(), mode=entry.mode())
+  None => () // already on the fresh draft
+}
+```
+
+On any edit, submit, or cancel, call `reset_navigation()` to return the cursor
+to the fresh draft.

--- a/tui/internal/history/history.mbt
+++ b/tui/internal/history/history.mbt
@@ -1,0 +1,109 @@
+// Readline-style command history for the input composer.
+//
+// `History` stores submitted `Entry`s and a navigation cursor so Up/Ctrl-P and
+// Down/Ctrl-N can recall previous submissions while preserving the in-progress
+// draft. The cursor lives in the inclusive range `[0, entries.length()]`, where
+// `entries.length()` means "editing the fresh draft" rather than a stored entry.
+
+///|
+/// One recallable submission: the composer text plus the mode it was entered in
+/// (prompt vs. shell), so recall can restore both.
+struct Entry {
+  text : String
+  mode : @composer.Mode
+}
+
+///|
+/// Build a history entry from composer text and its mode.
+pub fn Entry::new(text : String, mode : @composer.Mode) -> Entry {
+  { text, mode }
+}
+
+///|
+/// The recalled text.
+pub fn Entry::text(self : Entry) -> String {
+  self.text
+}
+
+///|
+/// The mode the entry was submitted in.
+pub fn Entry::mode(self : Entry) -> @composer.Mode {
+  self.mode
+}
+
+///|
+fn Entry::same_as(self : Entry, other : Entry) -> Bool {
+  self.text == other.text && self.mode == other.mode
+}
+
+///|
+/// Submitted entries plus the navigation cursor and the saved draft.
+struct History {
+  entries : Array[Entry]
+  // Cursor is in the inclusive range [0, entries.length()].
+  // entries.length() means the user is editing the fresh, not-yet-submitted
+  // draft rather than a stored history entry.
+  mut cursor : Int
+  mut draft : Entry?
+}
+
+///|
+/// An empty history positioned on the fresh draft.
+pub fn History::new() -> History {
+  { entries: [], cursor: 0, draft: None }
+}
+
+///|
+/// Return the cursor to the fresh draft and forget any saved draft. Called when
+/// the user edits, submits, or cancels, so the next recall starts from the end.
+pub fn History::reset_navigation(self : History) -> Unit {
+  self.cursor = self.entries.length()
+  self.draft = None
+}
+
+///|
+/// Append `entry` (unless empty or a duplicate of the most recent one) and reset
+/// navigation to the fresh draft.
+pub fn History::push(self : History, entry : Entry) -> Unit {
+  if entry.text.length() > 0 {
+    if self.entries.last() is Some(last) {
+      if !last.same_as(entry) {
+        self.entries.push(entry)
+      }
+    } else {
+      self.entries.push(entry)
+    }
+  }
+  self.reset_navigation()
+}
+
+///|
+/// Recall the previous entry, saving `current` as the draft on the first step
+/// back. Returns `None` when there is no history to recall.
+pub fn History::previous(self : History, current : Entry) -> Entry? {
+  if self.entries.length() == 0 {
+    return None
+  }
+  if self.cursor == self.entries.length() {
+    self.draft = Some(current)
+  }
+  if self.cursor > 0 {
+    self.cursor -= 1
+  }
+  self.entries.get(self.cursor)
+}
+
+///|
+/// Recall the next entry, returning to the saved draft past the last entry.
+/// Returns `None` when already at the fresh draft.
+pub fn History::next(self : History) -> Entry? {
+  if self.cursor >= self.entries.length() {
+    return None
+  }
+  self.cursor += 1
+  if self.cursor == self.entries.length() {
+    self.draft
+  } else {
+    self.entries.get(self.cursor)
+  }
+}

--- a/tui/internal/history/history_test.mbt
+++ b/tui/internal/history/history_test.mbt
@@ -1,0 +1,79 @@
+///|
+fn prompt_entry(text : String) -> @history.Entry {
+  let composer = @composer.Model::new()
+  @history.Entry::new(text, composer.mode())
+}
+
+///|
+fn shell_entry(text : String) -> @history.Entry {
+  let composer = @composer.Model::new()
+  composer.insert_user_text("!" + text)
+  @history.Entry::new(composer.text(), composer.mode())
+}
+
+///|
+fn recalled_text(entry : @history.Entry?) -> String {
+  match entry {
+    Some(entry) => entry.text()
+    None => "<none>"
+  }
+}
+
+///|
+fn recalled_is_shell(entry : @history.Entry?) -> Bool {
+  match entry {
+    Some(entry) => entry.mode().is_shell()
+    None => false
+  }
+}
+
+///|
+fn recalled_is_input(entry : @history.Entry?) -> Bool {
+  match entry {
+    Some(entry) => entry.mode().is_input()
+    None => false
+  }
+}
+
+///|
+test "history recalls entries and restores draft" {
+  let history = @history.History::new()
+  inspect(history.previous(prompt_entry("draft")) is None, content="true")
+  history.push(prompt_entry("one"))
+  history.push(prompt_entry("two"))
+  let previous = history.previous(prompt_entry("draft"))
+  inspect(recalled_text(previous), content="two")
+  let previous = history.previous(prompt_entry("ignored"))
+  inspect(recalled_text(previous), content="one")
+  let previous = history.previous(prompt_entry("ignored"))
+  inspect(recalled_text(previous), content="one")
+  let next = history.next()
+  inspect(recalled_text(next), content="two")
+  let next = history.next()
+  inspect(recalled_text(next), content="draft")
+  inspect(history.next() is None, content="true")
+}
+
+///|
+test "history skips empty and adjacent duplicate entries" {
+  let history = @history.History::new()
+  history.push(prompt_entry(""))
+  inspect(history.previous(prompt_entry("draft")) is None, content="true")
+  history.push(prompt_entry("same"))
+  history.push(prompt_entry("same"))
+  let previous = history.previous(prompt_entry("draft"))
+  inspect(recalled_text(previous), content="same")
+  let previous = history.previous(prompt_entry("ignored"))
+  inspect(recalled_text(previous), content="same")
+}
+
+///|
+test "history distinguishes shell and prompt entries" {
+  let history = @history.History::new()
+  history.push(prompt_entry("pwd"))
+  history.push(shell_entry("pwd"))
+  let previous = history.previous(prompt_entry("draft"))
+  inspect(recalled_is_shell(previous), content="true")
+  let previous = history.previous(prompt_entry("ignored"))
+  inspect(recalled_is_input(previous), content="true")
+}

--- a/tui/internal/history/moon.pkg
+++ b/tui/internal/history/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "bobzhang/openseek/tui/internal/composer",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/history/pkg.generated.mbti
+++ b/tui/internal/history/pkg.generated.mbti
@@ -1,0 +1,27 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/history"
+
+import {
+  "bobzhang/openseek/tui/internal/composer",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Entry
+pub fn Entry::mode(Self) -> @composer.Mode
+pub fn Entry::new(String, @composer.Mode) -> Self
+pub fn Entry::text(Self) -> String
+
+type History
+pub fn History::new() -> Self
+pub fn History::next(Self) -> Entry?
+pub fn History::previous(Self, Entry) -> Entry?
+pub fn History::push(Self, Entry) -> Unit
+pub fn History::reset_navigation(Self) -> Unit
+
+// Type aliases
+
+// Traits

--- a/tui/internal/render/README.md
+++ b/tui/internal/render/README.md
@@ -1,0 +1,36 @@
+# bobzhang/openseek/tui/internal/render
+
+This is where the core layout logic of the input area resides — the view layer
+that decides what the bottom of an Agent TUI (Codex / Claude Code style) looks
+like on any given frame. It takes the live editing state and the surrounding
+context (status line, activity, queued inputs) and stacks them into a single
+[`surface`](../surface/) `Surface`: the finished picture that
+[`viewport`](../viewport/) then draws to the terminal.
+
+It's one pure function, `composer_surface`. No terminal IO, no input handling —
+given the same state and width it always produces the same surface, which makes
+the whole input area trivial to test and reason about.
+
+## Usage
+
+Hand it the composer model plus the surrounding state and a column width; get
+back a ready-to-draw surface with the cursor already placed on the active input
+row.
+
+```mbt
+let surface = @render.composer_surface(
+  model,                                   // @composer.Model being edited
+  activity=Some(@doc.Text::plain("…")),    // transient busy line, or None
+  queued_inputs=[@core.Input::Prompt("next")],
+  status=@doc.Text::plain("ready"),        // persistent status line
+  notice=None,                             // transient notice, overrides status
+  cols=80,
+)
+```
+
+The surface stacks, top to bottom: the queued-input preview, the optional
+activity block, the bordered composer body, and the status line (`notice` wins
+over `status` when present). The only state it touches is resizing the model to
+`cols` for the draw.
+
+Internal to `tui/` — only importable within the module.

--- a/tui/internal/render/moon.pkg
+++ b/tui/internal/render/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "bobzhang/openseek/tui/core",
+  "bobzhang/openseek/tui/doc",
+  "bobzhang/openseek/tui/internal/composer",
+  "bobzhang/openseek/tui/internal/surface",
+  "bobzhang/openseek/tui/internal/text",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/render/pkg.generated.mbti
+++ b/tui/internal/render/pkg.generated.mbti
@@ -1,0 +1,21 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/render"
+
+import {
+  "bobzhang/openseek/tui/core",
+  "bobzhang/openseek/tui/doc",
+  "bobzhang/openseek/tui/internal/composer",
+  "bobzhang/openseek/tui/internal/surface",
+}
+
+// Values
+pub fn composer_surface(@composer.Model, activity~ : @doc.Text?, queued_inputs~ : Array[@core.Input], status~ : @doc.Text, notice~ : @doc.Text?, cols~ : Int, max_rows~ : Int) -> @surface.Surface
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/tui/internal/render/queued.mbt
+++ b/tui/internal/render/queued.mbt
@@ -1,0 +1,88 @@
+// Render queued follow-up inputs as a compact, numbered preview block drawn
+// above the composer. This is a surface-level rendering (not a logical `Doc`),
+// so it lives here rather than as a `@core` projection.
+
+///|
+fn input_preview_text(input : @core.Input) -> String {
+  // Defense-in-depth: queued previews are written straight to the terminal, so
+  // strip any control bytes the input may carry (composer input is already
+  // sanitized, but other sources — e.g. an initial CLI task — are not).
+  let lines = @text.split_lines(@text.sanitize(input.text()))
+  let first = @text.line_at(lines, 0)
+  if lines.length() > 1 {
+    first + " …"
+  } else {
+    first
+  }
+}
+
+///|
+fn queued_input_line(
+  input : @core.Input,
+  index~ : Int,
+  cols~ : Int,
+  indent~ : Int,
+) -> @surface.Line {
+  let marker = String::make(indent, ' ') + "\{index + 1}. "
+  let prefix = input.prefix()
+  @surface.Line::new([
+    @surface.Span::new(marker, style=@doc.Style::dim().to_surface()),
+    @surface.Span::new(prefix, style=@doc.Style::prompt().to_surface()),
+    @surface.Span::new(
+      @text.truncate_line(
+        input_preview_text(input),
+        cols - @text.display_width(marker) - @text.display_width(prefix),
+      ),
+      style=@doc.Style::dim().to_surface(),
+    ),
+  ])
+}
+
+///|
+fn indented_dim_line(
+  text : String,
+  cols~ : Int,
+  indent~ : Int,
+) -> @surface.Line {
+  @surface.Line::new([
+    @surface.Span::new(
+      String::make(indent, ' ') + @text.truncate_line(text, cols - indent),
+      style=@doc.Style::dim().to_surface(),
+    ),
+  ])
+}
+
+///|
+/// Render the queued-input preview block, bounded to `max_rows` rows so the
+/// composer below it is never clipped on a short terminal.
+///
+/// The block is a header plus one row per input; when the inputs do not all fit
+/// in the budget, the tail is collapsed into a `… N more` line. A budget too
+/// small for even a header and one row drops the block entirely.
+fn queued_input_rows(
+  inputs : Array[@core.Input],
+  cols~ : Int,
+  indent~ : Int,
+  max_rows~ : Int,
+) -> Array[@surface.Line] {
+  let rows : Array[@surface.Line] = []
+  let count = inputs.length()
+  if count == 0 || max_rows < 2 {
+    return rows
+  }
+  rows.push(indented_dim_line("Queued follow-up inputs:", cols~, indent~))
+  let item_budget = max_rows - 1
+  if count <= item_budget {
+    for index in 0..<count {
+      rows.push(queued_input_line(inputs[index], index~, cols~, indent~))
+    }
+  } else {
+    // Reserve the last row for the summary of everything that did not fit.
+    let shown = item_budget - 1
+    for index in 0..<shown {
+      rows.push(queued_input_line(inputs[index], index~, cols~, indent~))
+    }
+    rows.push(indented_dim_line("… \{count - shown} more", cols~, indent~))
+  }
+  rows
+}

--- a/tui/internal/render/render.mbt
+++ b/tui/internal/render/render.mbt
@@ -1,0 +1,192 @@
+// Lay the live composer area out into a render-data `@surface.Surface`.
+//
+// Given the editing `@composer.Model` plus styled status/activity text and any
+// pre-rendered queued-input rows, `composer_surface` stacks the queued rows, an
+// optional activity block, the bordered composer body, and the status line into
+// one surface, and places the cursor on the active input row. It is the view
+// layer for the composer: pure, terminal-agnostic, and performs no IO.
+//
+// Queued follow-up inputs are rendered into their preview block here (see
+// queued.mbt); the editing model and the doc vocabulary cover the rest.
+
+///|
+fn separator_line(cols~ : Int) -> @surface.Line {
+  @surface.Line::new([
+    @surface.Span::new(
+      String::make(cols, '─'),
+      style=@doc.Style::dim().to_surface(),
+    ),
+  ])
+}
+
+///|
+fn input_style() -> @surface.Style {
+  @doc.Style::default().to_surface()
+}
+
+///|
+fn prompt_style() -> @surface.Style {
+  @doc.Style::prompt().to_surface()
+}
+
+///|
+fn prompt_line(prefix~ : String, line~ : String, cols~ : Int) -> @surface.Line {
+  let prefix_width = @text.display_width(prefix)
+  let content = @text.truncate_line(line, cols - prefix_width)
+  let used = prefix_width + @text.display_width(content)
+  let fill_cols = if used < cols { cols - used } else { 0 }
+  @surface.Line::new([
+    @surface.Span::new(prefix, style=prompt_style()),
+    @surface.Span::new(content, style=input_style()),
+    @surface.Span::new(String::make(fill_cols, ' '), style=input_style()),
+  ])
+}
+
+///|
+fn status_line(
+  status : @doc.Text,
+  notice : @doc.Text?,
+  cols~ : Int,
+) -> @surface.Line {
+  notice.unwrap_or(status).first_line(width=cols)
+}
+
+///|
+/// Prepend `indent` blank columns to a line so it lines up with the composer's
+/// editable text (which starts after the prompt prefix), not the left edge.
+fn indent_line(line : @surface.Line, indent~ : Int) -> @surface.Line {
+  if indent <= 0 {
+    return line
+  }
+  let spans : Array[@surface.Span] = [
+    @surface.Span::new(String::make(indent, ' '), style=input_style()),
+  ]
+  for span in line.spans() {
+    spans.push(span)
+  }
+  @surface.Line::new(spans)
+}
+
+///|
+/// The shortest terminal the live area fits in without clipping: a spacer, two
+/// separators, one composer row, and the status line.
+const MinLiveRows : Int = 5
+
+///|
+/// A one-line notice shown in place of the composer when the terminal is too
+/// short to render it without clipping the prompt or status.
+fn too_small_surface(cols~ : Int) -> @surface.Surface {
+  @surface.Surface::new(
+    width=cols,
+    rows=[
+      @surface.Line::new([
+        @surface.Span::new(
+          @text.truncate_line(
+            "Terminal too small — resize to at least \{MinLiveRows} rows",
+            cols,
+          ),
+          style=@doc.Style::error().to_surface(),
+        ),
+      ]),
+    ],
+    cursor=@surface.Cursor::new(row=0, col=0),
+  )
+}
+
+///|
+/// Lay the composer area out for `cols` columns.
+///
+/// `activity` is an optional in-progress block ("Working …") for the current
+/// task; `queued_inputs` are the follow-ups that run after it. They render as one
+/// group above the composer — activity first (present), then the queue (next) —
+/// in temporal order. `status`/`notice` form the bottom status line, with
+/// `notice` taking precedence when present.
+///
+/// `max_rows` is the live area's row budget (the terminal height). The queued
+/// preview is bounded to whatever rows remain after the composer and its chrome,
+/// so a long queue on a short terminal never clips the prompt the user is typing
+/// into; the overflow collapses into a `… N more` line.
+pub fn composer_surface(
+  composer : @composer.Model,
+  activity~ : @doc.Text?,
+  queued_inputs~ : Array[@core.Input],
+  status~ : @doc.Text,
+  notice~ : @doc.Text?,
+  cols~ : Int,
+  max_rows~ : Int,
+) -> @surface.Surface {
+  // Below the minimum the prompt or status would be clipped, so show a notice
+  // instead of a broken frame. This runs on every redraw, so it also covers a
+  // live resize down to (and back up from) a too-short terminal.
+  if max_rows < MinLiveRows {
+    return too_small_surface(cols~)
+  }
+  // Status and activity rows have no prompt prefix, so indent them to the
+  // composer's text column (after `❯ `) instead of the screen's left edge.
+  let indent = composer.prompt_width()
+  // Lay the composer out first, capped to the rows left after its mandatory
+  // chrome (spacer + two separators + status), so a tall multiline draft scrolls
+  // to the cursor instead of overflowing the budget. Its height then bounds the
+  // queued preview below.
+  composer.resize(cols~, max_rows=max_rows - (MinLiveRows - 1))
+  let composer_rows = composer.visible_text_rows()
+  // Rows that must always stay visible — the composer and its chrome: a spacer,
+  // two separators, the composer itself, and the status line. The composer wins
+  // the row budget; the activity line and queue get whatever is left over.
+  let fixed = 1 + composer_rows + 2 + 1
+  // Show the activity line only if it plus its trailing blank still fit, so a
+  // very short terminal drops "Working …" rather than clipping the prompt.
+  let show_activity = activity is Some(_) && max_rows >= fixed + 2
+  // Reserve the activity line + its bracketing blanks (between + trailing) when
+  // shown, otherwise just the queue's trailing blank.
+  let chrome = if show_activity { 3 } else { 1 }
+  let queued = queued_input_rows(
+    queued_inputs,
+    cols~,
+    indent~,
+    max_rows=max_rows - fixed - chrome,
+  )
+  let has_queue = queued.length() > 0
+  let rows : Array[@surface.Line] = []
+  // A blank spacer above the live area so the committed transcript does not butt
+  // directly against the composer's top border — matching the blank that
+  // precedes each transcript item.
+  rows.push(@surface.Line::new([]))
+  if show_activity && activity is Some(activity) {
+    rows.push(indent_line(activity.first_line(width=cols - indent), indent~))
+  }
+  // Blank between the activity line and the queue, when both are present.
+  if show_activity && has_queue {
+    rows.push(@surface.Line::new([]))
+  }
+  for row in queued {
+    rows.push(row)
+  }
+  // Set the live-status group off from the composer border with a blank.
+  if show_activity || has_queue {
+    rows.push(@surface.Line::new([]))
+  }
+  let composer_top = rows.length()
+  rows.push(separator_line(cols~))
+  for row in 0..<composer.visible_text_rows() {
+    rows.push(
+      prompt_line(
+        prefix=composer.input_prefix(row),
+        line=composer.visible_line(row),
+        cols~,
+      ),
+    )
+  }
+  rows.push(separator_line(cols~))
+  rows.push(
+    indent_line(status_line(status, notice, cols=cols - indent), indent~),
+  )
+  @surface.Surface::new(
+    width=cols,
+    rows~,
+    cursor=@surface.Cursor::new(
+      row=composer_top + 1 + composer.cursor_row(),
+      col=composer.cursor_offset(),
+    ),
+  )
+}

--- a/tui/internal/render/render_test.mbt
+++ b/tui/internal/render/render_test.mbt
@@ -1,0 +1,385 @@
+///|
+test "composer surface renders viewport rows and cursor" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=None,
+    queued_inputs=[],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=12,
+    max_rows=24,
+  )
+  inspect(
+    surface.height(),
+    content=(
+      #|5
+    ),
+  )
+  inspect(
+    surface.line_at(0).text(),
+    content=(
+      #|
+    ),
+  )
+  inspect(
+    surface.line_at(1).text().trim(),
+    content=(
+      #|────────────
+    ),
+  )
+  inspect(@text.display_width(surface.line_at(1).text()), content="12")
+  inspect(
+    surface.line_at(2).text(),
+    content=(
+      #|❯           
+    ),
+  )
+  inspect(
+    surface.cursor().row(),
+    content=(
+      #|2
+    ),
+  )
+  inspect(surface.cursor().col(), content="2")
+}
+
+///|
+test "composer surface grows with multiline input up to max rows" {
+  let two_lines = @composer.Model::new()
+  two_lines.insert("a\nb")
+  let two_line_surface = @render.composer_surface(
+    two_lines,
+    activity=None,
+    queued_inputs=[],
+    status=@doc.Text::plain(""),
+    notice=None,
+    cols=12,
+    max_rows=24,
+  )
+  inspect(
+    two_line_surface.height(),
+    content=(
+      #|6
+    ),
+  )
+  inspect(
+    two_line_surface.line_at(1).text().trim(),
+    content=(
+      #|────────────
+    ),
+  )
+  inspect(@text.display_width(two_line_surface.line_at(1).text()), content="12")
+  inspect(
+    @text.grapheme_slice(two_line_surface.line_at(2).text(), 0, 2),
+    content=(
+      #|❯ 
+    ),
+  )
+  inspect(
+    two_line_surface.line_at(2).text().trim(),
+    content=(
+      #|❯ a
+    ),
+  )
+  inspect(@text.display_width(two_line_surface.line_at(2).text()), content="12")
+  let five_lines = @composer.Model::new()
+  five_lines.insert("a\nb\nc\nd\ne")
+  let capped_surface = @render.composer_surface(
+    five_lines,
+    activity=None,
+    queued_inputs=[],
+    status=@doc.Text::plain(""),
+    notice=None,
+    cols=12,
+    max_rows=24,
+  )
+  inspect(
+    capped_surface.height(),
+    content=(
+      #|8
+    ),
+  )
+  inspect(
+    @text.grapheme_slice(capped_surface.line_at(1).text(), 0, 2),
+    content=(
+      #|──
+    ),
+  )
+  inspect(
+    capped_surface.line_at(1).text().trim(),
+    content=(
+      #|────────────
+    ),
+  )
+  inspect(@text.display_width(capped_surface.line_at(1).text()), content="12")
+  inspect(
+    @text.grapheme_slice(capped_surface.line_at(4).text(), 0, 2),
+    content="  ",
+  )
+  inspect(
+    capped_surface.line_at(4).text().trim(),
+    content=(
+      #|d
+    ),
+  )
+  inspect(@text.display_width(capped_surface.line_at(4).text()), content="12")
+}
+
+///|
+test "composer surface renders queued inputs above composer" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=None,
+    queued_inputs=[Prompt("first"), Command("pwd")],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=24,
+  )
+  inspect(
+    surface.height(),
+    content=(
+      #|9
+    ),
+  )
+  inspect(
+    surface.line_at(0).text(),
+    content=(
+      #|
+    ),
+  )
+  inspect(
+    surface.line_at(1).text(),
+    content=(
+      #|  Queued follow-up inputs:
+    ),
+  )
+  inspect(
+    surface.line_at(2).text(),
+    content=(
+      #|  1. ❯ first
+    ),
+  )
+  inspect(
+    @text.display_width(surface.line_at(3).text()),
+    content=(
+      #|10
+    ),
+  )
+  inspect(
+    surface.cursor().row(),
+    content=(
+      #|6
+    ),
+  )
+  inspect(surface.cursor().col(), content="2")
+}
+
+///|
+test "composer surface renders the input viewport" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=None,
+    queued_inputs=[],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=24,
+  )
+  inspect(
+    surface.height(),
+    content=(
+      #|5
+    ),
+  )
+  inspect(
+    surface.line_at(0).text(),
+    content=(
+      #|
+    ),
+  )
+  inspect(
+    surface.line_at(1).text().trim(),
+    content=(
+      #|────────────────────────────────────────
+    ),
+  )
+  inspect(@text.display_width(surface.line_at(1).text()), content="40")
+  inspect(
+    surface.line_at(2).text(),
+    content=(
+      #|❯                                       
+    ),
+  )
+  inspect(
+    surface.cursor().row(),
+    content=(
+      #|2
+    ),
+  )
+  inspect(surface.cursor().col(), content="2")
+}
+
+///|
+test "composer surface renders activity above separator" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=Some(@doc.Text::plain("Working (0s • esc to interrupt)")),
+    queued_inputs=[],
+    status=@doc.Text::plain("gpt-5 · ~/repo · Context 100% left"),
+    notice=None,
+    cols=50,
+    max_rows=24,
+  )
+  inspect(
+    surface.height(),
+    content=(
+      #|7
+    ),
+  )
+  inspect(surface.line_at(0).text(), content="")
+  inspect(
+    surface.line_at(1).text(),
+    content=(
+      #|  Working (0s • esc to interrupt)
+    ),
+  )
+  inspect(
+    surface.line_at(2).text().trim(),
+    content=(
+      #|
+    ),
+  )
+  inspect(
+    @text.display_width(surface.line_at(2).text()),
+    content=(
+      #|0
+    ),
+  )
+  inspect(
+    surface.line_at(3).text(),
+    content=(
+      #|──────────────────────────────────────────────────
+    ),
+  )
+}
+
+///|
+test "composer surface puts activity above queued inputs" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=Some(@doc.Text::plain("Working (3s)")),
+    queued_inputs=[Prompt("next")],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=24,
+  )
+  // Spacer, the current task, a blank, then the indented queue that follows it.
+  inspect(surface.line_at(0).text(), content="")
+  inspect(
+    surface.line_at(1).text(),
+    content=(
+      #|  Working (3s)
+    ),
+  )
+  inspect(surface.line_at(2).text(), content="")
+  inspect(
+    surface.line_at(3).text(),
+    content=(
+      #|  Queued follow-up inputs:
+    ),
+  )
+  inspect(
+    surface.line_at(4).text(),
+    content=(
+      #|  1. ❯ next
+    ),
+  )
+}
+
+///|
+test "composer surface shows a notice when the terminal is below the minimum" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=Some(@doc.Text::plain("Working")),
+    queued_inputs=[Prompt("a")],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=60,
+    max_rows=4,
+  )
+  inspect(surface.height(), content="1")
+  inspect(
+    surface.line_at(0).text(),
+    content="Terminal too small — resize to at least 5 rows",
+  )
+}
+
+///|
+test "composer surface drops activity and queue when the terminal is too short" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=Some(@doc.Text::plain("Working (3s)")),
+    queued_inputs=[Prompt("a"), Prompt("b")],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=6,
+  )
+  // Only the composer + chrome remain (spacer, separators, prompt, status); the
+  // activity line and queue are dropped so the prompt is never clipped.
+  inspect(surface.height(), content="5")
+  inspect(@text.grapheme_slice(surface.line_at(2).text(), 0, 1), content="❯")
+  inspect(surface.cursor().row(), content="2")
+}
+
+///|
+test "composer surface bounds queued previews so the composer stays visible" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=Some(@doc.Text::plain("Working")),
+    queued_inputs=[
+      Prompt("a"),
+      Prompt("b"),
+      Prompt("c"),
+      Prompt("d"),
+      Prompt("e"),
+    ],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=10,
+  )
+  // The live area fits the budget and the overflowing queue collapses to a
+  // single summary line instead of pushing the composer off screen.
+  inspect(surface.height(), content="10")
+  inspect(
+    surface.line_at(4).text(),
+    content=(
+      #|  … 5 more
+    ),
+  )
+  // The composer prompt survives and the cursor stays on it, not on a queue row.
+  inspect(@text.grapheme_slice(surface.line_at(7).text(), 0, 1), content="❯")
+  inspect(surface.cursor().row(), content="7")
+}
+
+///|
+test "composer surface notice overrides persistent status" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(),
+    activity=None,
+    queued_inputs=[],
+    status=@doc.Text::plain("gpt-5 · ~/repo"),
+    notice=Some(@doc.Text::plain("ignored key")),
+    cols=40,
+    max_rows=24,
+  )
+  inspect(
+    surface.line_at(2).text(),
+    content=(
+      #|❯                                       
+    ),
+  )
+}

--- a/tui/internal/surface/README.md
+++ b/tui/internal/surface/README.md
@@ -1,0 +1,38 @@
+# bobzhang/openseek/tui/internal/surface
+
+This is the **picture format** the TUI passes around — an immutable description
+of one frame, with no terminal and no IO attached. A `Span` is styled text, a
+`Line` is a row of spans, and a `Surface` is a full frame: its rows plus a
+`Cursor`. Think of it as the handoff type between the layers that *decide* what
+to draw ([`doc`](../../doc/), [`render`](../render/)) and the layer that
+*draws* it ([`viewport`](../viewport/)).
+
+Because a `Surface` is plain immutable data, the producers are pure and easy to
+test, and the renderer never has to re-validate anything: `Surface::new`
+normalizes the invariants up front — `width >= 1`, and the cursor clamped inside
+the rows and width.
+
+## Usage
+
+```mbt
+let line = Line::new([
+  Span::new("error", style=Style::new(foreground=Red)),
+  Span::new(": failed"),
+])
+let surface = Surface::new(
+  width=80,
+  rows=[line],
+  cursor=Cursor::new(row=0, col=5),
+)
+```
+
+Reading and shaping frames:
+
+```mbt
+surface.height()              // row count
+surface.line_at(2)            // row 2, or an empty Line when out of range
+surface.with_max_rows(10)     // first 10 rows as a new Surface
+line.text()                   // text with styling stripped
+```
+
+Internal to `tui/` — only importable within the module.

--- a/tui/internal/surface/moon.pkg
+++ b/tui/internal/surface/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "moonbit-community/tty/color",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/surface/pkg.generated.mbti
+++ b/tui/internal/surface/pkg.generated.mbti
@@ -1,0 +1,43 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/surface"
+
+import {
+  "moonbit-community/tty/color",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type Cursor
+pub fn Cursor::col(Self) -> Int
+pub fn Cursor::new(row~ : Int, col~ : Int) -> Self
+pub fn Cursor::row(Self) -> Int
+
+type Line derive(Eq)
+pub fn Line::new(Array[Span]) -> Self
+pub fn Line::spans(Self) -> Array[Span]
+pub fn Line::text(Self) -> String
+
+type Span derive(Eq)
+pub fn Span::new(String, style? : Style) -> Self
+pub fn Span::style(Self) -> Style
+pub fn Span::text(Self) -> String
+
+type Style derive(Eq)
+pub fn Style::background(Self) -> @color.Color
+pub fn Style::foreground(Self) -> @color.Color
+pub fn Style::new(foreground? : @color.Color, background? : @color.Color, underline? : Bool) -> Self
+pub fn Style::underline(Self) -> Bool
+
+type Surface
+pub fn Surface::cursor(Self) -> Cursor
+pub fn Surface::height(Self) -> Int
+pub fn Surface::line_at(Self, Int) -> Line
+pub fn Surface::new(width~ : Int, rows~ : Array[Line], cursor~ : Cursor) -> Self
+pub fn Surface::with_max_rows(Self, Int) -> Self
+
+// Type aliases
+
+// Traits

--- a/tui/internal/surface/surface.mbt
+++ b/tui/internal/surface/surface.mbt
@@ -1,0 +1,225 @@
+// The render-data vocabulary shared between the UI and the terminal renderer.
+//
+// These are passive, terminal-agnostic value types describing *what* to draw:
+// styled `Span`s form a `Line`, lines plus a `Cursor` form a `Surface` (one
+// rendered frame). The `Ui` builds them from semantic state; the `viewport`
+// engine consumes them to paint a real terminal. Nothing here performs IO.
+
+///|
+/// Terminal styling applied while a span is written.
+struct Style {
+  foreground : @color.Color
+  background : @color.Color
+  underline : Bool
+} derive(Eq)
+
+///|
+/// A string fragment with an associated style.
+struct Span {
+  text : String
+  style : Style
+} derive(Eq)
+
+///|
+/// One rendered row: a sequence of styled spans.
+struct Line {
+  spans : Array[Span]
+} derive(Eq)
+
+///|
+/// A cursor position within a surface, as a 0-based (row, col) cell offset.
+struct Cursor {
+  row : Int
+  col : Int
+}
+
+///|
+/// Render output for one viewport frame.
+///
+/// `Ui` builds a fresh `Surface` from semantic state such as composer text,
+/// status text, and terminal width, then passes it to `Viewport` for placement
+/// and terminal drawing. `Viewport` does not build surfaces because it should
+/// not own composer/status state, but it does cache the last drawn surface so
+/// redraws can diff physical terminal rows and skip unchanged content.
+///
+/// A `Surface` always has a cursor. `Ui` produces one for the interactive
+/// composer, and `Viewport` places that surface on the terminal.
+///
+/// Invariant: `width >= 1`, `cursor.row` is inside `rows` when any row exists,
+/// and `cursor.col` is inside `width`. Construction normalizes these values so
+/// terminal drawing does not need to defensively adjust them again.
+struct Surface {
+  width : Int
+  rows : Array[Line]
+  cursor : Cursor
+}
+
+///|
+/// Build a style. With no arguments, the unstyled default (terminal default
+/// colors, no underline).
+pub fn Style::new(
+  foreground? : @color.Color = Default,
+  background? : @color.Color = Default,
+  underline? : Bool = false,
+) -> Style {
+  { foreground, background, underline }
+}
+
+///|
+/// Foreground color of the style.
+pub fn Style::foreground(self : Style) -> @color.Color {
+  self.foreground
+}
+
+///|
+/// Background color of the style.
+pub fn Style::background(self : Style) -> @color.Color {
+  self.background
+}
+
+///|
+/// Whether the style underlines its text.
+pub fn Style::underline(self : Style) -> Bool {
+  self.underline
+}
+
+///|
+/// Build a span from text and an optional style (default: unstyled).
+pub fn Span::new(text : String, style? : Style = Style::new()) -> Span {
+  { text, style }
+}
+
+///|
+/// Text of the span.
+pub fn Span::text(self : Span) -> String {
+  self.text
+}
+
+///|
+/// Style of the span.
+pub fn Span::style(self : Span) -> Style {
+  self.style
+}
+
+///|
+/// Build a line from its styled spans, in left-to-right order.
+pub fn Line::new(spans : Array[Span]) -> Line {
+  { spans, }
+}
+
+///|
+/// The styled spans that make up the line, in order.
+pub fn Line::spans(self : Line) -> Array[Span] {
+  self.spans
+}
+
+///|
+/// The line's text content with styling stripped.
+pub fn Line::text(self : Line) -> String {
+  let builder = StringBuilder()
+  for span in self.spans {
+    builder.write_string(span.text)
+  }
+  builder.to_string()
+}
+
+///|
+/// Build a cursor at a 0-based (row, col) cell offset.
+pub fn Cursor::new(row~ : Int, col~ : Int) -> Cursor {
+  { row, col }
+}
+
+///|
+/// The cursor's 0-based row offset.
+pub fn Cursor::row(self : Cursor) -> Int {
+  self.row
+}
+
+///|
+/// The cursor's 0-based column offset.
+pub fn Cursor::col(self : Cursor) -> Int {
+  self.col
+}
+
+///|
+fn normalize_surface_width(width : Int) -> Int {
+  if width < 1 {
+    1
+  } else {
+    width
+  }
+}
+
+///|
+fn normalize_surface_index(value : Int, max_value : Int) -> Int {
+  value.clamp(min=0, max=max_value)
+}
+
+///|
+fn normalize_surface_cursor(
+  rows : Array[Line],
+  width : Int,
+  cursor : Cursor,
+) -> Cursor {
+  let max_row = if rows.length() == 0 { 0 } else { rows.length() - 1 }
+  let max_col = if width <= 1 { 0 } else { width - 1 }
+  {
+    row: normalize_surface_index(cursor.row, max_row),
+    col: normalize_surface_index(cursor.col, max_col),
+  }
+}
+
+///|
+/// Build a surface frame, normalizing invariants: `width` is forced to `>= 1`
+/// and the cursor is clamped inside the rows and width so the renderer never
+/// has to re-validate.
+pub fn Surface::new(
+  width~ : Int,
+  rows~ : Array[Line],
+  cursor~ : Cursor,
+) -> Surface {
+  let width = normalize_surface_width(width)
+  let cursor = normalize_surface_cursor(rows, width, cursor)
+  { width, rows, cursor }
+}
+
+///|
+/// Number of rows in the surface.
+pub fn Surface::height(self : Surface) -> Int {
+  self.rows.length()
+}
+
+///|
+/// The surface's normalized cursor position.
+pub fn Surface::cursor(self : Surface) -> Cursor {
+  self.cursor
+}
+
+///|
+/// Return the first `max_rows` rows of the surface as a new surface, preserving
+/// width and cursor. Used to fit a surface into a bounded terminal region; the
+/// caller decides the bound.
+pub fn Surface::with_max_rows(self : Surface, max_rows : Int) -> Surface {
+  let row_count = if max_rows < 0 {
+    0
+  } else if max_rows > self.rows.length() {
+    self.rows.length()
+  } else {
+    max_rows
+  }
+  let rows : Array[Line] = []
+  for index in 0..<row_count {
+    rows.push(self.rows[index])
+  }
+  Surface::new(width=self.width, rows~, cursor=self.cursor)
+}
+
+///|
+/// The line at `row`, or an empty line when `row` is out of range.
+pub fn Surface::line_at(self : Surface, row : Int) -> Line {
+  if self.rows.get(row) is Some(line) {
+    line
+  } else {
+    Line::new([])
+  }
+}

--- a/tui/internal/surface/surface_test.mbt
+++ b/tui/internal/surface/surface_test.mbt
@@ -1,0 +1,47 @@
+///|
+test "surface cursor is normalized when stored" {
+  let rows = [@surface.Line::new([]), @surface.Line::new([])]
+  let surface = @surface.Surface::new(
+    width=4,
+    rows~,
+    cursor=@surface.Cursor::new(row=9, col=9),
+  )
+  inspect(surface.cursor().row(), content="1")
+  inspect(surface.cursor().col(), content="3")
+}
+
+///|
+test "with_max_rows keeps the leading rows" {
+  let rows = [
+    @surface.Line::new([@surface.Span::new("a")]),
+    @surface.Line::new([@surface.Span::new("b")]),
+    @surface.Line::new([@surface.Span::new("c")]),
+  ]
+  let surface = @surface.Surface::new(
+    width=10,
+    rows~,
+    cursor=@surface.Cursor::new(row=0, col=0),
+  )
+  let capped = surface.with_max_rows(2)
+  inspect(capped.height(), content="2")
+  inspect(capped.line_at(0).text(), content="a")
+  inspect(capped.line_at(1).text(), content="b")
+  // A bound at or above the row count is a no-op.
+  inspect(surface.with_max_rows(9).height(), content="3")
+}
+
+///|
+test "line equality includes span text and style" {
+  let green = @surface.Style::new(foreground=Basic(BrightGreen))
+  let red = @surface.Style::new(foreground=Basic(BrightRed))
+  let left = @surface.Line::new([@surface.Span::new("x", style=green)])
+  let same = @surface.Line::new([@surface.Span::new("x", style=green)])
+  let different_text = @surface.Line::new([@surface.Span::new("y", style=green)])
+  let different_style = @surface.Line::new([@surface.Span::new("x", style=red)])
+  assert_true(left == same)
+  assert_false(left == different_text)
+  assert_false(left == different_style)
+  // Optional lines compare through the derived equality too.
+  assert_true((Some(left) : @surface.Line?) == Some(same))
+  assert_false((Some(left) : @surface.Line?) == None)
+}

--- a/tui/internal/task/README.md
+++ b/tui/internal/task/README.md
@@ -1,0 +1,31 @@
+# bobzhang/openseek/tui/internal/task
+
+This is the **serialization point** for everything the TUI does to the screen.
+Drawing a frame, handling a keystroke, and committing a transcript line all
+mutate the same terminal, so they must never run concurrently. `Queue` is a
+single-slot async queue that guarantees that: one long-lived worker runs
+submitted jobs one at a time, in order.
+
+The mental model is a worker thread with an inbox of size one — you `wait` a job
+onto it from anywhere and get its result back, and the worker drains them
+serially. It's a thin wrapper over `@async/aqueue` with no scheduling policy of
+its own.
+
+## Usage
+
+Spawn the worker loop once, then `wait` jobs onto it; each runs to completion
+before the next starts, and `wait` returns the job's result (or re-raises its
+error).
+
+```mbt
+let queue = @task.Queue::Queue(kind=Blocking(1))
+
+// Background: the worker drains the queue forever.
+g.spawn_bg(no_wait=true, () => queue.run())
+
+// Foreground: submit work and get its result back, serialized against redraws.
+let frame = queue.wait(() => self.build_frame())
+queue.wait(() => self.redraw(frame))
+```
+
+Internal to `tui/` — only importable within the module.

--- a/tui/internal/task/moon.pkg
+++ b/tui/internal/task/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/async/aqueue",
+}
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/task/pkg.generated.mbti
+++ b/tui/internal/task/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/task"
+
+import {
+  "moonbitlang/async/aqueue",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct Queue {
+  // private fields
+}
+pub fn Queue::Queue(kind~ : @aqueue.Kind) -> Self
+pub async fn Queue::run(Self) -> Unit
+pub async fn[T] Queue::wait(Self, async () -> T) -> T
+
+// Type aliases
+
+// Traits

--- a/tui/internal/task/task.mbt
+++ b/tui/internal/task/task.mbt
@@ -1,0 +1,37 @@
+///|
+/// A single-slot async task runner: a `Queue` hands submitted jobs to one
+/// worker loop (`run`) that runs them one at a time, letting the TUI run a
+/// single agent task at a time.
+struct Queue {
+  aq : @aqueue.Queue[async () -> Unit]
+}
+
+///|
+/// Submit `f` to the queue and await its result, propagating any error it
+/// raises. Blocks until the worker loop picks the job up and runs it.
+pub async fn[T] Queue::wait(self : Queue, f : async () -> T) -> T {
+  let result : @aqueue.Queue[Result[T, Error]] = Queue(kind=Blocking(1))
+  self.aq.put(() => {
+    let value : Result[T, Error] = try? f()
+    result.put(value)
+  })
+  result.get().unwrap_or_error()
+}
+
+///|
+/// Build a task queue whose submission slot follows `kind` (for example
+/// `Blocking(1)` to accept at most one in-flight task).
+pub fn Queue::Queue(kind~ : @aqueue.Kind) -> Queue {
+  { aq: Queue(kind~) }
+}
+
+///|
+/// Run the worker loop forever, pulling submitted jobs off the queue one at a
+/// time and running each to completion. Spawn this once alongside the callers
+/// of `wait`.
+pub async fn Queue::run(self : Queue) -> Unit {
+  for ;; {
+    let task = self.aq.get()
+    task()
+  }
+}

--- a/tui/internal/terminal_size/README.md
+++ b/tui/internal/terminal_size/README.md
@@ -1,0 +1,25 @@
+# bobzhang/openseek/tui/internal/terminal_size
+
+This is a one-type, pure value package whose whole job is to make terminal
+dimensions **safe to use without checking**. A reported terminal size can be
+nonsense (0 rows, a closed pipe), and the layout math downstream divides and
+clamps against those numbers. `TerminalSize` is an opaque value that normalizes
+any non-positive dimension to a sane default (24×80), so every consumer can
+treat `rows()` / `cols()` as always `>= 1`.
+
+It deliberately knows nothing about terminals or IO — reading a live tty into a
+`TerminalSize` is `@viewport.read_terminal_size`, which keeps this package a pure
+value type with no `@tty` dependency.
+
+## Usage
+
+```mbt
+let size = @terminal_size.TerminalSize::new(rows=24, cols=80)
+size.rows() // >= 1
+size.cols() // >= 1
+
+@terminal_size.TerminalSize::new(rows=0, cols=120) // rows=0 → default → 24
+@terminal_size.TerminalSize::default()             // the 24×80 fallback
+```
+
+Internal to `tui/` — only importable within the module.

--- a/tui/internal/terminal_size/moon.pkg
+++ b/tui/internal/terminal_size/moon.pkg
@@ -1,0 +1,3 @@
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/terminal_size/pkg.generated.mbti
+++ b/tui/internal/terminal_size/pkg.generated.mbti
@@ -1,0 +1,17 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/terminal_size"
+
+// Values
+
+// Errors
+
+// Types and methods
+type TerminalSize
+pub fn TerminalSize::cols(Self) -> Int
+pub fn TerminalSize::default() -> Self
+pub fn TerminalSize::new(rows~ : Int, cols~ : Int) -> Self
+pub fn TerminalSize::rows(Self) -> Int
+
+// Type aliases
+
+// Traits

--- a/tui/internal/terminal_size/terminal_size.mbt
+++ b/tui/internal/terminal_size/terminal_size.mbt
@@ -1,0 +1,53 @@
+///|
+const DefaultTerminalRows : Int = 24
+
+///|
+const DefaultTerminalCols : Int = 80
+
+///|
+/// On-screen terminal dimensions, guaranteed positive.
+///
+/// The type is opaque and can only be built through `TerminalSize::new` or
+/// `TerminalSize::default`, which replace the non-positive dimensions a terminal
+/// may report (for example a zero size queried before the first `ioctl`) with
+/// sane defaults. Consumers can therefore treat `rows`/`cols` as always `>= 1`
+/// without re-validating.
+struct TerminalSize {
+  rows : Int
+  cols : Int
+}
+
+///|
+/// Build a terminal size, replacing any non-positive dimension with its default.
+pub fn TerminalSize::new(rows~ : Int, cols~ : Int) -> TerminalSize {
+  {
+    rows: if rows < 1 {
+      DefaultTerminalRows
+    } else {
+      rows
+    },
+    cols: if cols < 1 {
+      DefaultTerminalCols
+    } else {
+      cols
+    },
+  }
+}
+
+///|
+/// The fallback size used before a real terminal size is known.
+pub fn TerminalSize::default() -> TerminalSize {
+  { rows: DefaultTerminalRows, cols: DefaultTerminalCols }
+}
+
+///|
+/// Number of on-screen rows.
+pub fn TerminalSize::rows(self : TerminalSize) -> Int {
+  self.rows
+}
+
+///|
+/// Number of on-screen columns.
+pub fn TerminalSize::cols(self : TerminalSize) -> Int {
+  self.cols
+}

--- a/tui/internal/terminal_size/terminal_size_test.mbt
+++ b/tui/internal/terminal_size/terminal_size_test.mbt
@@ -1,0 +1,12 @@
+///|
+test "@terminal_size.TerminalSize::new falls back to defaults for unknown dimensions" {
+  let normalized = @terminal_size.TerminalSize::new(rows=0, cols=-3)
+  inspect(normalized.rows(), content="24")
+  inspect(normalized.cols(), content="80")
+  let kept = @terminal_size.TerminalSize::new(rows=30, cols=100)
+  inspect(kept.rows(), content="30")
+  inspect(kept.cols(), content="100")
+  let fallback = @terminal_size.TerminalSize::default()
+  inspect(fallback.rows(), content="24")
+  inspect(fallback.cols(), content="80")
+}

--- a/tui/internal/text/README.md
+++ b/tui/internal/text/README.md
@@ -1,0 +1,22 @@
+# bobzhang/openseek/tui/internal/text
+
+This is the **terminal-aware string toolbox** the rest of the TUI shares. A
+terminal measures text in display cells, not code points — a CJK character is
+two cells wide, an emoji is one grapheme made of several code points — and
+getting layout right means measuring and slicing the way the terminal sees it.
+These are the small pure functions that do that, with no state and no IO.
+
+## Usage
+
+```mbt
+@text.display_width("日本語")          // 6 — East-Asian wide chars count as 2
+@text.truncate_line("hello world", 8)  // "hello w…" — fits to 8 cells, adds ellipsis
+@text.grapheme_count("a👨‍👩‍👧b")          // 3 — counts clusters, not code points
+@text.grapheme_slice("héllo", 1, 4)    // "éll" — [start, end) by grapheme, clamped
+
+let lines = @text.split_lines("a\nb\nc") // ["a", "b", "c"], always non-empty
+@text.line_at(lines, 9)                // "" — out-of-range is empty, never aborts
+```
+
+Bounds are clamped rather than aborting, so callers can pass loose indices.
+Internal to `tui/` — only importable within the module.

--- a/tui/internal/text/moon.pkg
+++ b/tui/internal/text/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "kawaz/grapheme",
+  "rami3l/unicodewidth",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/text/pkg.generated.mbti
+++ b/tui/internal/text/pkg.generated.mbti
@@ -1,0 +1,26 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/text"
+
+// Values
+pub fn display_width(String) -> Int
+
+pub fn grapheme_count(String) -> Int
+
+pub fn grapheme_slice(String, Int, Int) -> String
+
+pub fn line_at(Array[String], Int) -> String
+
+pub fn sanitize(String) -> String
+
+pub fn split_lines(String) -> Array[String]
+
+pub fn truncate_line(String, Int) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/tui/internal/text/sanitize_test.mbt
+++ b/tui/internal/text/sanitize_test.mbt
@@ -1,0 +1,31 @@
+///|
+test "sanitize drops control bytes and normalizes carriage returns" {
+  // ESC is dropped, so a pasted ANSI sequence degrades to literal text.
+  assert_eq(@text.sanitize("a\u{1b}[31mX"), "a[31mX")
+  // DEL and other C0 controls (here BEL) are dropped.
+  assert_eq(@text.sanitize("a\u{7f}\u{07}b"), "ab")
+  // CRLF and a bare CR both collapse to a single LF.
+  assert_eq(@text.sanitize("x\r\ny"), "x\ny")
+  assert_eq(@text.sanitize("x\ry"), "x\ny")
+  // LF is preserved; the column resets after it.
+  assert_eq(@text.sanitize("x\nz"), "x\nz")
+}
+
+///|
+test "sanitize expands tabs to the next 8-column stop" {
+  // Tab at column 0 fills a whole 8-column stop.
+  assert_eq(@text.sanitize("\tx"), "        x")
+  // From column 2, the tab fills the remaining 6 columns to the next stop.
+  assert_eq(@text.sanitize("ab\tc"), "ab      c")
+  // The column resets on each newline, so the second line's tab is a full stop.
+  assert_eq(@text.sanitize("ab\n\tc"), "ab\n        c")
+}
+
+///|
+test "split_lines splits every line-ending form" {
+  // CRLF, lone CR, and LF all split; no stray `\r` is left on a line.
+  inspect(@text.split_lines("a\r\nb\rc\nd").join("|"), content="a|b|c|d")
+  // Empty input is a single empty line; interior blank lines are preserved.
+  inspect(@text.split_lines("").join("|"), content="")
+  inspect(@text.split_lines("a\n\nb").join("|"), content="a||b")
+}

--- a/tui/internal/text/text.mbt
+++ b/tui/internal/text/text.mbt
@@ -1,0 +1,135 @@
+///|
+/// Display width of `text` in terminal cells, accounting for East-Asian wide
+/// characters.
+pub fn display_width(text : String) -> Int {
+  @unicodewidth.str_width(text)
+}
+
+///|
+/// Truncate `text` to fit within `cols` display cells, appending an ellipsis
+/// (`…`) when content is dropped. Returns `""` for `cols <= 0` and the input
+/// unchanged when it already fits. Breaks on grapheme boundaries.
+pub fn truncate_line(text : String, cols : Int) -> String {
+  if cols <= 0 {
+    ""
+  } else if display_width(text) <= cols {
+    text
+  } else {
+    let suffix = "…"
+    let suffix_width = @unicodewidth.str_width(suffix)
+    let content_cols = cols - suffix_width
+    let builder = StringBuilder()
+    let mut width = 0
+    for grapheme in @grapheme.grapheme_iter(text) {
+      let next_width = @unicodewidth.str_width(grapheme)
+      if width + next_width > content_cols {
+        break
+      }
+      builder.write_stringview(grapheme)
+      width = width + next_width
+    }
+    builder.write_string(suffix)
+    builder.to_string()
+  }
+}
+
+///|
+/// Split `text` into lines on any line-ending form, always returning at least
+/// one element.
+///
+/// `\r\n` is a single grapheme cluster (Unicode CR×LF) and a lone `\r` is its
+/// own, so iterating graphemes splits CRLF/CR/LF alike — no stray `\r` is left
+/// on a line to be mishandled downstream (it would otherwise become an extra
+/// blank row once the doc renderer treats it as a break).
+pub fn split_lines(text : String) -> Array[String] {
+  let lines : Array[String] = []
+  let mut current = StringBuilder()
+  for grapheme in @grapheme.grapheme_iter(text) {
+    let g = grapheme.to_owned()
+    if g == "\n" || g == "\r\n" || g == "\r" {
+      lines.push(current.to_string())
+      current = StringBuilder()
+    } else {
+      current.write_string(g)
+    }
+  }
+  lines.push(current.to_string())
+  lines
+}
+
+///|
+/// Whether a grapheme is a C0 control character or DEL.
+fn is_control(grapheme : String) -> Bool {
+  match grapheme.get_char(0) {
+    Some(c) => {
+      let code = c.to_int()
+      code < 0x20 || code == 0x7f
+    }
+    None => false
+  }
+}
+
+///|
+/// Terminal tab stop width: tabs expand to the next multiple of this.
+const TabWidth : Int = 8
+
+///|
+/// Normalize user-provided text so it can be echoed live — in the composer or
+/// queued previews — without mutating the terminal or confusing the cursor math.
+///
+/// Carriage returns become newlines so pasted line breaks survive; every other
+/// C0 control and `DEL` is dropped — including `ESC`, and therefore every ANSI
+/// escape sequence that could move or clear the cursor. Tabs are expanded to
+/// spaces at the next `TabWidth` stop so the stored width matches what is drawn
+/// (a raw `\t` counts as one column but renders as a jump). `\n` is preserved.
+pub fn sanitize(text : String) -> String {
+  let builder = StringBuilder()
+  // Display column within the current line, used to place tab stops.
+  let mut col = 0
+  for grapheme in @grapheme.grapheme_iter(text) {
+    let g = grapheme.to_owned()
+    // `\r\n` is a single grapheme cluster (Unicode CR×LF); a lone `\r` is its
+    // own cluster. Either way, keep the line break as a plain `\n` and drop the
+    // raw CR, which would otherwise return the cursor to column 1.
+    if g == "\r" || g == "\r\n" || g == "\n" {
+      builder.write_string("\n")
+      col = 0
+    } else if g == "\t" {
+      let spaces = TabWidth - col % TabWidth
+      builder.write_string(String::make(spaces, ' '))
+      col = col + spaces
+    } else if !is_control(g) {
+      builder.write_string(g)
+      col = col + display_width(g)
+    }
+    // else: ESC, DEL, and the remaining C0 controls are dropped.
+  }
+  builder.to_string()
+}
+
+///|
+/// The line at `index`, or `""` when `index` is out of range.
+pub fn line_at(lines : Array[String], index : Int) -> String {
+  if index < 0 || index >= lines.length() {
+    ""
+  } else {
+    lines[index]
+  }
+}
+
+///|
+/// Number of grapheme clusters in `text`.
+pub fn grapheme_count(text : String) -> Int {
+  @grapheme.graphemes(text).length()
+}
+
+///|
+/// Slice `text` by grapheme cluster index over `[start, end)`. Bounds are
+/// clamped into range, so out-of-range indices never error.
+pub fn grapheme_slice(text : String, start : Int, end : Int) -> String {
+  let graphemes = @grapheme.graphemes(text)
+  let length = graphemes.length()
+  let start = start.clamp(min=0, max=length)
+  let end = end.clamp(min=start, max=length)
+  graphemes[start:end].to_string()
+}

--- a/tui/internal/text/text_wbtest.mbt
+++ b/tui/internal/text/text_wbtest.mbt
@@ -1,0 +1,17 @@
+///|
+test "truncate line respects display width and graphemes" {
+  inspect(truncate_line("abcdef", 3), content="ab…")
+  inspect(truncate_line("abcdef", 5), content="abcd…")
+  inspect(truncate_line("abc", 3), content="abc")
+  inspect(truncate_line("你好世界", 5), content="你好…")
+  inspect(
+    truncate_line("x👨‍👩‍👧‍👦yz", 4),
+    content="x👨‍👩‍👧‍👦…",
+  )
+  inspect(truncate_line("abcdef", 1), content="…")
+}
+
+///|
+test "split lines keeps trailing input row" {
+  inspect(split_lines("a\nb\n").join("|"), content="a|b|")
+}

--- a/tui/internal/viewport/README.md
+++ b/tui/internal/viewport/README.md
@@ -1,0 +1,63 @@
+# bobzhang/openseek/tui/internal/viewport
+
+This is where the core layout / rendering logic of the whole Agent TUI lives —
+the bottom-anchored input area with a scrolling transcript above it that you've
+seen in Codex or Claude Code.
+
+The central type, `Viewport`, is best understood as a **renderer**. You hand it
+surfaces (the live input area) and scrollback rows (committed transcript lines);
+it draws them to the `@tty.Tty` and keeps all the bookkeeping — where the input
+composer is anchored, what's currently on screen, the terminal's size — so each
+call knows what to repaint and where.
+
+The defining choice: committed output lives in the terminal's **native
+scrollback** (scroll up with the mouse, select, copy — all the usual things),
+and only the small live area at the bottom is redrawn in place. That's what
+makes the agent feel like a normal terminal program instead of a full-screen app
+like vim.
+
+## Usage
+
+A `Viewport` is created already on screen: `enter` queries the cursor, anchors
+the live area there, and draws the first frame. From then on you call it as
+things change, and `leave` restores the terminal.
+
+```mbt
+let viewport = @viewport.Viewport::enter(
+  tty,
+  size=@viewport.read_terminal_size(tty),
+  surface=first_frame,
+  timeout_ms=100,
+)
+
+// The live area changed (a keystroke, a status update) — repaint it in place,
+// keeping the same anchor:
+viewport.redraw(tty, next_frame)
+
+// Commit a transcript line: insert it above the live area, scrolling older rows
+// into native scrollback.
+viewport.insert_before(tty, committed_rows)
+
+// The terminal was resized — rebuild the screen from the full transcript.
+viewport.refresh_size(tty)
+viewport.replay_scrollback(tty, scrollback=all_rows, surface=current_frame)
+
+viewport.leave(tty) // restore margins/style/autowrap/cursor
+```
+
+Call `refresh_size(tty)` before a draw whenever the terminal may have resized;
+`cols()` is the current width.
+
+## How it works
+
+`Viewport` is the IO half; the row arithmetic (where to anchor, which rows a
+redraw must touch) is pure and lives next door in [`geometry`](../geometry/).
+
+The scrollback trick is a DECSTBM scroll region set *above* the live area: with
+that margin in place, a newline scrolls only the region above, pushing the
+oldest live row up into native scrollback while the live area stays put. Redraws
+diff against the previous frame and repaint only the rows that changed. Autowrap
+is disabled while full-width rows are drawn (so they don't wrap and shove the
+layout down) and restored on `leave`.
+
+Internal to `tui/` — only importable within the module.

--- a/tui/internal/viewport/frame_cache.mbt
+++ b/tui/internal/viewport/frame_cache.mbt
@@ -1,0 +1,49 @@
+///|
+/// Diff/clear state for the live viewport region.
+///
+/// Steady-state redraws diff the new surface against the last one drawn so the
+/// renderer can skip unchanged physical rows. A terminal resize drops that
+/// cached surface. When it does, the old physical *footprint* must still be
+/// remembered so the next redraw can erase rows the moved/shrunken region no
+/// longer covers.
+///
+/// The two states make that lifecycle explicit:
+///
+///   - `Drawn(surface)`: `surface` is on screen at the viewport's current `top`,
+///     so redraws can diff against it row by row.
+///   - `Stale(top, height)`: the cached surface was dropped, but the region it
+///     occupied is remembered so the next redraw clears any rows it vacates.
+priv enum FrameCache {
+  Drawn(@surface.Surface)
+  Stale(top~ : Int, height~ : Int)
+}
+
+///|
+/// The cached surface available for row-level diffing, if any, placed at the
+/// viewport's current live top.
+///
+/// Only `Drawn` carries trustworthy on-screen content; `Stale` has no surface to
+/// diff against, so the next redraw rewrites every covered row.
+fn FrameCache::placed_surface(
+  self : FrameCache,
+  live_top~ : Int,
+) -> PlacedSurface? {
+  match self {
+    Drawn(surface) => Some({ surface, top: live_top })
+    Stale(top=_, height=_) => None
+  }
+}
+
+///|
+/// Drop the cached surface but remember the region it covered so a later redraw
+/// can clear vacated rows. Called when a resize makes the cached physical rows
+/// untrustworthy.
+///
+/// Only `Drawn` has a footprint worth remembering; `Stale` already holds no live
+/// surface, so it is left unchanged.
+fn FrameCache::invalidate(self : FrameCache, live_top~ : Int) -> FrameCache {
+  match self {
+    Drawn(surface) => Stale(top=live_top, height=surface.height())
+    Stale(top=_, height=_) => self
+  }
+}

--- a/tui/internal/viewport/moon.pkg
+++ b/tui/internal/viewport/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbitlang/core/cmp",
+  "bobzhang/openseek/tui/internal/geometry",
+  "bobzhang/openseek/tui/internal/terminal_size",
+  "bobzhang/openseek/tui/internal/surface",
+  "moonbit-community/tty",
+  "moonbit-community/tty/color",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/internal/viewport/pkg.generated.mbti
+++ b/tui/internal/viewport/pkg.generated.mbti
@@ -1,0 +1,29 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/internal/viewport"
+
+import {
+  "bobzhang/openseek/tui/internal/surface",
+  "bobzhang/openseek/tui/internal/terminal_size",
+  "moonbit-community/tty",
+}
+
+// Values
+pub fn read_terminal_size(@tty.Tty) -> @terminal_size.TerminalSize
+
+// Errors
+
+// Types and methods
+type Viewport
+pub fn Viewport::cols(Self) -> Int
+pub async fn Viewport::enter(@tty.Tty, size~ : @terminal_size.TerminalSize, surface~ : @surface.Surface, timeout_ms~ : Int) -> Self
+pub async fn Viewport::insert_before(Self, @tty.Tty, Array[@surface.Line]) -> Unit
+pub async fn Viewport::leave(Self, @tty.Tty) -> Unit
+pub async fn Viewport::redraw(Self, @tty.Tty, @surface.Surface) -> Unit
+pub fn Viewport::refresh_size(Self, @tty.Tty) -> Unit
+pub async fn Viewport::replay_scrollback(Self, @tty.Tty, scrollback~ : Array[@surface.Line], surface~ : @surface.Surface) -> Unit
+pub fn Viewport::rows(Self) -> Int
+
+// Type aliases
+
+// Traits
+

--- a/tui/internal/viewport/surface_placement.mbt
+++ b/tui/internal/viewport/surface_placement.mbt
@@ -1,0 +1,49 @@
+// Mapping a `@surface.Surface` onto physical terminal rows. Placement pairs
+// terminal-agnostic surface content with the first physical row where it is
+// drawn, so it belongs to the renderer rather than the surface vocabulary.
+
+///|
+/// A surface after terminal placement. `top` is the 1-based terminal row where
+/// the surface's row 0 is drawn; height comes from the surface itself.
+priv struct PlacedSurface {
+  surface : @surface.Surface
+  top : Int
+}
+
+///|
+/// The surface line shown at terminal row `row`. `None` when the row falls
+/// outside the placed surface's own rows.
+fn PlacedSurface::line_at_terminal_row(
+  self : PlacedSurface,
+  row~ : Int,
+) -> @surface.Line? {
+  let index = row - self.top
+  if index >= 0 && index < self.surface.height() {
+    Some(self.surface.line_at(index))
+  } else {
+    None
+  }
+}
+
+///|
+/// Whether two surfaces place the cursor on the same physical cell, accounting
+/// for each surface's placement.
+fn PlacedSurface::same_terminal_cursor(
+  self : PlacedSurface,
+  other : PlacedSurface,
+) -> Bool {
+  self.cursor_terminal_row() == other.cursor_terminal_row() &&
+  self.cursor_terminal_col() == other.cursor_terminal_col()
+}
+
+///|
+/// The cursor row in 1-based terminal coordinates.
+fn PlacedSurface::cursor_terminal_row(self : PlacedSurface) -> Int {
+  self.top + self.surface.cursor().row()
+}
+
+///|
+/// The cursor column in 1-based terminal coordinates.
+fn PlacedSurface::cursor_terminal_col(self : PlacedSurface) -> Int {
+  1 + self.surface.cursor().col()
+}

--- a/tui/internal/viewport/viewport.mbt
+++ b/tui/internal/viewport/viewport.mbt
@@ -1,0 +1,648 @@
+///|
+/// Full reset before a from-scratch redraw: drop any scroll region and text
+/// style, then erase both the visible screen and the scrollback, leaving the
+/// cursor at the home position.
+async fn clear_screen_and_scrollback(tty : @tty.Tty) -> Unit {
+  tty.reset_top_bottom_margins()
+  tty.reset_style()
+  tty.set_cursor_position(1, 1)
+  tty.erase_display()
+  tty.erase_scrollback()
+  tty.set_cursor_position(1, 1)
+}
+
+///|
+struct Viewport {
+  mut size : @terminal_size.TerminalSize
+  // The live area's placement. Set once by `enter` (which anchors it at the
+  // terminal cursor) and re-clamped on resize; a `Viewport` only exists once
+  // its area has been placed.
+  mut geometry : @geometry.Geometry
+  // Diff/clear state for the live area: the last drawn surface (for row diffing)
+  // or, once dropped, the footprint it left behind (for clearing). See
+  // `FrameCache`.
+  mut cache : FrameCache
+}
+
+///|
+/// The live area's start row.
+fn Viewport::top(self : Viewport) -> Int {
+  self.geometry.top()
+}
+
+///|
+/// The live area's height in rows.
+fn Viewport::height(self : Viewport) -> Int {
+  self.geometry.height()
+}
+
+///|
+/// Current terminal width in columns, as last read by `refresh_size`.
+pub fn Viewport::cols(self : Viewport) -> Int {
+  self.size.cols()
+}
+
+///|
+/// Current terminal height in rows, as last read by `refresh_size`. The live
+/// area can never exceed this, so the composer view uses it to bound previews.
+pub fn Viewport::rows(self : Viewport) -> Int {
+  self.size.rows()
+}
+
+///|
+fn Viewport::bottom(self : Viewport) -> Int {
+  self.geometry.bottom()
+}
+
+///|
+fn Viewport::set_size(
+  self : Viewport,
+  size : @terminal_size.TerminalSize,
+) -> Unit {
+  if size.rows() != self.size.rows() || size.cols() != self.size.cols() {
+    // Terminal resize can reflow rows away from their old physical footprint.
+    // Resize rebuilds from semantic rows, so the cached frame must be dropped.
+    self.cache = self.cache.invalidate(live_top=self.top())
+  }
+  self.size = size
+  // Re-clamp the live area against the new dimensions so it stays on screen.
+  self.set_geometry(top=self.geometry.top(), height=self.geometry.height())
+}
+
+///|
+fn Viewport::set_geometry(self : Viewport, top~ : Int, height~ : Int) -> Unit {
+  // Store the clamped values, never the caller's desired ones: a desired
+  // `top`/`height` that no longer fits (terminal shrank, composer grew near the
+  // bottom) is raised/shrunk to fit, so `bottom()` stays within `size.rows()`.
+  let clamped_height = @geometry.clamp_height(self.size, height~)
+  let clamped_top = @geometry.clamp_top(self.size, height=clamped_height, top~)
+  self.geometry = @geometry.Geometry::new(
+    top=clamped_top,
+    height=clamped_height,
+  )
+}
+
+///|
+/// Read the terminal window size, falling back to the default if it can't be
+/// queried (for example before the first `ioctl`). This is the one place that
+/// turns a live tty into a `@terminal_size.TerminalSize`; the value type itself
+/// stays free of terminal IO.
+pub fn read_terminal_size(tty : @tty.Tty) -> @terminal_size.TerminalSize {
+  try tty.window_size() catch {
+    _ => @terminal_size.TerminalSize::default()
+  } noraise {
+    size => @terminal_size.TerminalSize::new(rows=size.rows, cols=size.cols)
+  }
+}
+
+///|
+/// Re-query the terminal window size and re-clamp the live area to it.
+///
+/// When the dimensions actually change the cached frame is invalidated (a resize
+/// can reflow rows off their old footprint) and the live area is re-clamped to
+/// stay on screen.
+pub fn Viewport::refresh_size(self : Viewport, tty : @tty.Tty) -> Unit {
+  self.set_size(read_terminal_size(tty))
+}
+
+///|
+async fn erase_cursor_row(tty : @tty.Tty) -> Unit {
+  // `erase_line_all` clears the row but leaves the cursor column unchanged.
+  //
+  // Without the carriage return:
+  //
+  //   before: |old prompt text              |
+  //                         ^
+  //   clear:  |                             |
+  //                         ^
+  //   write:  |                   > new text|
+  //
+  // `\r` moves the cursor to column 1 first, so the next render is anchored at
+  // the left edge:
+  //
+  //   after \r: |                             |
+  //             ^
+  //   write:    |> new text                   |
+  tty.write("\r")
+  tty.erase_line_all()
+}
+
+///|
+async fn apply_style(tty : @tty.Tty, style : @surface.Style) -> Unit {
+  if style.foreground() != Default {
+    tty.set_foreground(style.foreground())
+  }
+  if style.background() != Default {
+    tty.set_background(style.background())
+  }
+  if style.underline() {
+    tty.underline()
+  }
+}
+
+///|
+async fn write_span(tty : @tty.Tty, span : @surface.Span) -> Unit {
+  apply_style(tty, span.style())
+  tty.write(span.text())
+  tty.reset_style()
+}
+
+///|
+/// Run `body` with terminal auto-wrap disabled, restoring it even if drawing
+/// raises.
+async fn without_auto_wrap(tty : @tty.Tty, body : async () -> Unit) -> Unit {
+  tty.disable_auto_wrap()
+  try body() catch {
+    error => {
+      tty.enable_auto_wrap()
+      raise error
+    }
+  } noraise {
+    _ => tty.enable_auto_wrap()
+  }
+}
+
+///|
+/// Draw one surface line at the current cursor. Auto-wrap is controlled by the
+/// caller: live redraw batches disable it around their loops, while scrollback
+/// insertion leaves normal terminal wrapping in place.
+async fn draw_surface_line_at_cursor(
+  tty : @tty.Tty,
+  line : @surface.Line?,
+) -> Unit {
+  erase_cursor_row(tty)
+  if line is Some(line) {
+    for span in line.spans() {
+      write_span(tty, span)
+    }
+  }
+}
+
+///|
+async fn draw_surface_line_at(
+  tty : @tty.Tty,
+  row : Int,
+  line : @surface.Line?,
+) -> Unit {
+  tty.set_cursor_position(row, 1)
+  draw_surface_line_at_cursor(tty, line)
+}
+
+///|
+/// Run `body` with the terminal's scroll region (DECSTBM margins) temporarily
+/// restricted to rows `top..=bottom`, then restore the full-screen region.
+///
+/// Inside the region, line feeds and reverse-indexes scroll only those rows and
+/// leave everything outside the margins fixed. This is the primitive every
+/// scrollback trick below is built on. The margins are always reset, even if
+/// `body` raises, so a failed write can never leave the terminal in a clipped
+/// scroll region.
+async fn with_scroll_region(
+  tty : @tty.Tty,
+  top : Int,
+  bottom : Int,
+  body : async () -> Unit,
+) -> Unit {
+  tty.set_top_bottom_margins(top, bottom)
+  try body() catch {
+    error => {
+      tty.reset_top_bottom_margins()
+      raise error
+    }
+  } noraise {
+    _ => tty.reset_top_bottom_margins()
+  }
+}
+
+///|
+/// Make room for a taller live area by scrolling committed rows up into the
+/// terminal's native scrollback.
+///
+/// With the region restricted to `1..=scrollback_bottom`, writing one newline at
+/// its bottom row pushes the whole region up by one line — the top row leaves
+/// the region into scrollback. Repeating `rows` times frees `rows` rows directly
+/// above the new (higher) live-area top.
+///
+/// Returns whether it scrolled the whole screen (the fallback when there are
+/// fewer than two rows above the live area, where a scroll region is invalid),
+/// which shifts the live frame and so requires the caller to repaint uncached.
+async fn scroll_scrollback_up_for_growth(
+  tty : @tty.Tty,
+  old : @geometry.Geometry,
+  new_top~ : Int,
+  screen_bottom~ : Int,
+) -> Bool {
+  // old:                                     new:
+  //
+  // +------------+                           +------------+
+  // | scrollback |                           | scrollback |
+  // | scrollback |                           | scrollback |
+  // | scrollback |                           +------------+
+  // | scrollback |                new top -> +------------+
+  // +------------+ <- scrollback_bottom      | composer   |
+  // +------------+ <- old.top                | composer   |
+  // | composer   |                           | composer   |
+  // +------------+                           +------------+
+  //
+  // Here we need to make rooms for 2 rows. Since top is 1-based line number from the top
+  // of the terminal, we can obtain the number of rows to make by old.top - new_top.
+  //
+  let rows = old.top() - new_top
+  guard rows > 0 else { return false }
+  let scrollback_bottom = old.top() - 1
+  if scrollback_bottom >= 2 {
+    // At least two rows above: scroll them up within a DECSTBM region so the
+    // oldest spills into native scrollback and the live frame stays put.
+    with_scroll_region(tty, 1, scrollback_bottom, () => {
+      tty.set_cursor_position(scrollback_bottom, 1)
+      tty.write("\r\n".repeat(rows))
+    })
+    false
+  } else {
+    // One row above (a region of < 2 rows is an invalid DECSTBM, silently
+    // ignored): scroll the whole screen up to push that row into native
+    // scrollback. This also shifts the live frame, so report it — the caller
+    // must repaint uncached rather than diff against the old position.
+    tty.set_cursor_position(screen_bottom, 1)
+    tty.write("\r\n".repeat(rows))
+    true
+  }
+}
+
+///|
+/// Paint the first frame: draw every row of the new area (there is nothing on
+/// screen yet to diff against) and place the cursor. The area comes straight
+/// from `set_geometry`, so it already fits the screen — no span clamping needed.
+async fn enter_placed_surface_rows(
+  tty : @tty.Tty,
+  frame : PlacedSurface,
+) -> Unit {
+  let height = frame.surface.height()
+  // No need to hide cursor + show cursor if there is nothing new to draw.
+  guard height > 0 else { return }
+  tty.hide_cursor()
+  // Pair the hide with a guaranteed show. This is the first frame, so a draw
+  // failure here unwinds before any viewport exists for `leave` to restore —
+  // leaving the cursor hidden would break `with_ui`'s restore-on-error promise.
+  try {
+    without_auto_wrap(tty, () => {
+      for row in frame.top..<(frame.top + height) {
+        draw_surface_line_at(tty, row, frame.line_at_terminal_row(row~))
+      }
+    })
+    place_cursor(tty, frame)
+  } catch {
+    error => {
+      tty.show_cursor()
+      raise error
+    }
+  }
+}
+
+///|
+/// Redraw over a previous frame: repaint only the rows that changed within the
+/// union of the old and new footprints, then move the cursor.
+async fn Viewport::redraw_placed_surface_rows(
+  self : Viewport,
+  tty : @tty.Tty,
+  old_frame : PlacedSurface,
+  new_frame : PlacedSurface,
+) -> Unit {
+  let draw_top = @cmp.maximum(@cmp.minimum(old_frame.top, new_frame.top), 1)
+  let old_bottom = old_frame.top + old_frame.surface.height() - 1
+  let new_bottom = new_frame.top + new_frame.surface.height() - 1
+  let draw_bottom = @cmp.minimum(
+    @cmp.maximum(old_bottom, new_bottom),
+    self.size.rows(),
+  )
+  guard draw_top <= draw_bottom else { return }
+  let mut rows_changed = false
+  without_auto_wrap(tty, () => {
+    for row in draw_top..<=draw_bottom {
+      let old_line = old_frame.line_at_terminal_row(row~)
+      let new_line = new_frame.line_at_terminal_row(row~)
+      if old_line != new_line {
+        if !rows_changed {
+          tty.hide_cursor()
+          rows_changed = true
+        }
+        draw_surface_line_at(tty, row, new_line)
+      }
+    }
+  })
+  let cursor_changed = !old_frame.same_terminal_cursor(new_frame)
+  if rows_changed {
+    place_cursor(tty, new_frame)
+  } else if cursor_changed {
+    tty.set_cursor_position(
+      new_frame.cursor_terminal_row(),
+      new_frame.cursor_terminal_col(),
+    )
+  }
+}
+
+///|
+/// Redraw when the previous frame content is unknown: repaint the whole required
+/// span, including rows below the new frame that may still contain stale text.
+async fn Viewport::redraw_uncached_placed_surface_rows(
+  self : Viewport,
+  tty : @tty.Tty,
+  old : @geometry.Geometry,
+  new_frame : PlacedSurface,
+) -> Unit {
+  let draw_top = @cmp.maximum(@cmp.minimum(old.top(), new_frame.top), 1)
+  let draw_bottom = self.size.rows()
+  guard draw_top <= draw_bottom else { return }
+  tty.hide_cursor()
+  without_auto_wrap(tty, () => {
+    for row in draw_top..<=draw_bottom {
+      draw_surface_line_at(tty, row, new_frame.line_at_terminal_row(row~))
+    }
+  })
+  place_cursor(tty, new_frame)
+}
+
+///|
+/// Place the terminal cursor at a placed surface's cursor.
+async fn place_cursor(tty : @tty.Tty, frame : PlacedSurface) -> Unit {
+  tty.show_cursor()
+  tty.set_cursor_position(
+    frame.cursor_terminal_row(),
+    frame.cursor_terminal_col(),
+  )
+}
+
+///|
+/// Rebuilds the DECSTBM screen after resize from semantic transcript rows.
+///
+/// The primary-screen scrollback is treated as a terminal cache here. Resize can
+/// reflow that cache, so this path clears it, draws the live frame at the top,
+/// then lets transcript insertion push it down until the screen is full.
+pub async fn Viewport::replay_scrollback(
+  self : Viewport,
+  tty : @tty.Tty,
+  scrollback~ : Array[@surface.Line],
+  surface~ : @surface.Surface,
+) -> Unit {
+  tty.hide_cursor()
+  clear_screen_and_scrollback(tty)
+  // `set_geometry` clamps the height to the screen itself.
+  self.set_geometry(top=1, height=surface.height())
+  let surface = surface.with_max_rows(self.height())
+  let frame = PlacedSurface::{ surface, top: self.top() }
+  let bottom = self.bottom()
+  without_auto_wrap(tty, () => {
+    for row in self.top()..<=bottom {
+      draw_surface_line_at(tty, row, frame.line_at_terminal_row(row~))
+    }
+    if bottom < self.size.rows() {
+      for row in (bottom + 1)..<=self.size.rows() {
+        draw_surface_line_at(tty, row, None)
+      }
+    }
+  })
+  self.cache = Drawn(frame.surface)
+  self.insert_before(tty, scrollback)
+  // `insert_before` shifts the live area down to open room for the transcript
+  // rows — and when the rebuilt area leaves < 2 rows above it, it scrolls the
+  // live frame off its drawn position and drops the cache. So repaint the frame
+  // at its current position rather than only moving the cursor; `redraw` does a
+  // full repaint when the cache was invalidated and a no-op diff otherwise.
+  self.redraw(tty, surface)
+}
+
+///|
+/// Draw `surface` as the live area for the first time, anchoring it at the
+/// terminal cursor.
+///
+/// Anchor at the row the cursor currently sits on — where the shell left it when
+/// the app started — so committed output above stays put. When the cursor is
+/// near the bottom (say row 23 of 24 while the area needs 7 rows) the live area
+/// would run off the screen, so we first scroll the existing content up into the
+/// terminal's native scrollback to open room beneath the anchor, then place the
+/// area at `calculate_max_top` (here 18). Without that scroll the area would be
+/// drawn straight over the lines above the cursor, destroying them. When the
+/// cursor position can't be queried, assume the worst case (cursor on the last
+/// row). The cursor query is the one blocking read, hence `timeout_ms`.
+pub async fn Viewport::enter(
+  tty : @tty.Tty,
+  size~ : @terminal_size.TerminalSize,
+  surface~ : @surface.Surface,
+  timeout_ms~ : Int,
+) -> Viewport {
+  let height = @geometry.clamp_height(size, height=surface.height())
+  let cursor_row = if tty.query_cursor_position(timeout_ms~) is Some(position) {
+    position.row
+  } else {
+    size.rows()
+  }
+  let top = @geometry.clamp_top(size, height~, top=cursor_row)
+  // The live area spans `cursor_row ..= cursor_row + height - 1`; anything past
+  // the last row must be made by scrolling, not by drawing over the lines above.
+  let overflow = cursor_row + height - 1 - size.rows()
+  if overflow > 0 {
+    tty.set_cursor_position(size.rows(), 1)
+    tty.write("\r\n".repeat(overflow))
+  }
+  let geometry = @geometry.Geometry::new(top~, height~)
+  let surface = surface.with_max_rows(geometry.height())
+  let frame = PlacedSurface::{ surface, top: geometry.top() }
+  enter_placed_surface_rows(tty, frame)
+  { size, geometry, cache: Drawn(surface) }
+}
+
+///|
+/// Redraw `surface` in place over the previous frame, holding the previous `top`.
+///
+/// Readline-style ownership: growth uses the blank rows below first and only
+/// pushes upward once the taller area would overflow the screen bottom;
+/// shrinking holds `top` too. Clamping the old top to `calculate_max_top` is
+/// exactly that — it keeps `top` put while the area fits and raises it by just
+/// enough when it would not.
+pub async fn Viewport::redraw(
+  self : Viewport,
+  tty : @tty.Tty,
+  surface : @surface.Surface,
+) -> Unit {
+  // The previous frame/cache must be read before set_geometry moves the live
+  // area.
+  let old_top = self.top()
+  let old_cache = self.cache
+  let height = @geometry.clamp_height(self.size, height=surface.height())
+  let top = @geometry.clamp_top(self.size, height~, top=self.top())
+  self.set_geometry(top~, height~)
+  let surface = surface.with_max_rows(self.height())
+  let new_frame = PlacedSurface::{ surface, top: self.top() }
+  match old_cache {
+    Drawn(old_surface) => {
+      let old_frame = PlacedSurface::{ surface: old_surface, top: old_top }
+      let old = @geometry.Geometry::new(
+        top=old_top,
+        height=old_surface.height(),
+      )
+      let scrolled_screen = scroll_scrollback_up_for_growth(
+        tty,
+        old,
+        new_top=new_frame.top,
+        screen_bottom=self.size.rows(),
+      )
+      // A whole-screen growth scroll shifts the live frame off its cached
+      // position, so a row-level diff would compare against the wrong screen
+      // contents — repaint uncached in that case.
+      if scrolled_screen {
+        self.redraw_uncached_placed_surface_rows(tty, old, new_frame)
+      } else {
+        self.redraw_placed_surface_rows(tty, old_frame, new_frame)
+      }
+    }
+    Stale(top~, height~) => {
+      let old = @geometry.Geometry::new(top~, height~)
+      let _ = scroll_scrollback_up_for_growth(
+        tty,
+        old,
+        new_top=new_frame.top,
+        screen_bottom=self.size.rows(),
+      )
+      self.redraw_uncached_placed_surface_rows(tty, old, new_frame)
+    }
+  }
+  self.cache = Drawn(new_frame.surface)
+}
+
+///|
+/// Open blank rows directly above the live area by scrolling it down, bounded by
+/// the blank space below it so committed scrollback is never overwritten.
+/// Returns the live-area top from before the shift.
+///
+/// With the region restricted to `top..=size.rows`, a reverse-index at the top
+/// margin scrolls those rows down by one, inserting a blank row at `top`.
+/// Repeating opens the requested space; the live area then sits `shift` rows
+/// lower.
+async fn Viewport::shift_down_for_insert(
+  self : Viewport,
+  tty : @tty.Tty,
+  lines~ : Int,
+) -> Int {
+  let top = self.top()
+  let space = self.size.rows() - self.bottom()
+  let available = if space < 0 { 0 } else { space }
+  let shift = if lines < available { lines } else { available }
+  if shift > 0 {
+    with_scroll_region(tty, top, self.size.rows(), () => {
+      tty.set_cursor_position(top, 1)
+      for _ in 0..<shift {
+        tty.reverse_index()
+      }
+    })
+    self.set_geometry(top=top + shift, height=self.height())
+  }
+  top
+}
+
+///|
+/// Insert rendered transcript rows above the viewport.
+///
+/// `cursor_row` controls where the first line feed starts. Normal append uses
+/// the row above the old viewport so new blank space is filled. Resize replay
+/// uses the row above the rebuilt viewport so transcript rows are bottom-aligned
+/// before the live frame is redrawn.
+async fn Viewport::insert_lines_before(
+  self : Viewport,
+  tty : @tty.Tty,
+  lines : Array[@surface.Line],
+  cursor_row~ : Int,
+) -> Unit {
+  guard lines.length() > 0 else { return }
+  tty.enable_auto_wrap()
+  let scrollback_bottom = self.top() - 1
+  if scrollback_bottom >= 2 {
+    // At least two rows above the live area: draw the rows inside a
+    // `1..=scrollback_bottom` region so each `\r\n` scrolls earlier transcript up
+    // into native scrollback as new rows arrive.
+    with_scroll_region(tty, 1, scrollback_bottom, () => {
+      let start = if cursor_row < 1 {
+        if lines.get(0) is Some(line) {
+          tty.set_cursor_position(1, 1)
+          draw_surface_line_at_cursor(tty, Some(line))
+          1
+        } else {
+          0
+        }
+      } else {
+        tty.set_cursor_position(cursor_row, 1)
+        0
+      }
+      for index in start..<lines.length() {
+        tty.write("\r\n")
+        draw_surface_line_at_cursor(tty, Some(lines[index]))
+      }
+    })
+  } else if scrollback_bottom == 1 {
+    // Exactly one row above the live area (e.g. `shift_down_for_insert` opened a
+    // row and moved the area to row 2). A 1-row scroll region is an invalid
+    // DECSTBM, so scroll the earlier rows off the top of the screen into native
+    // scrollback, but keep the last row drawn at row 1 so the newest appended
+    // item stays visible just above the composer. The displaced live rows are
+    // restored by the caller's redraw (the cache is invalidated for `top <= 2`).
+    for index in 0..<(lines.length() - 1) {
+      draw_surface_line_at(tty, 1, Some(lines[index]))
+      tty.set_cursor_position(self.size.rows(), 1)
+      tty.write("\r\n")
+    }
+    draw_surface_line_at(tty, 1, Some(lines[lines.length() - 1]))
+  } else {
+    // No row above the live area (`top == 1`, the composer fills the screen):
+    // there is nowhere to show a committed row, so draw each at row 1 and scroll
+    // the whole screen up to push it into native scrollback. The caller's redraw
+    // repaints the displaced frame.
+    for line in lines {
+      draw_surface_line_at(tty, 1, Some(line))
+      tty.set_cursor_position(self.size.rows(), 1)
+      tty.write("\r\n")
+    }
+  }
+}
+
+///|
+/// Commit transcript rows above the live area, scrolling earlier rows into
+/// native scrollback.
+///
+/// The area is first shifted down to open blank rows above it, the lines are
+/// drawn into a scroll region so older transcript spills into scrollback, then
+/// the cursor is restored to the live frame.
+pub async fn Viewport::insert_before(
+  self : Viewport,
+  tty : @tty.Tty,
+  lines : Array[@surface.Line],
+) -> Unit {
+  let old_top = self.shift_down_for_insert(tty, lines=lines.length())
+  self.insert_lines_before(tty, lines, cursor_row=old_top - 1)
+  if self.cache.placed_surface(live_top=self.top()) is Some(frame) {
+    place_cursor(tty, frame)
+  }
+  // With fewer than two rows above the live area (`top <= 2`, e.g. a screen
+  // nearly filled by the composer), `insert_lines_before` used the full-screen
+  // scroll path, which shifts the live rows up off their cached positions. The
+  // cached surface no longer matches the screen, so drop it: the next redraw
+  // must repaint the whole span instead of diffing against it, otherwise the
+  // displaced rows are skipped and transcript text stays embedded in the live
+  // area.
+  if self.top() <= 2 && lines.length() > 0 {
+    self.cache = self.cache.invalidate(live_top=self.top())
+  }
+}
+
+///|
+/// Tear down the live area and hand the terminal back to the shell.
+///
+/// Restores the full-screen scroll region, default text style, autowrap, and
+/// cursor visibility, then moves the cursor below the area and emits a newline
+/// so the shell prompt starts on a fresh line beneath the committed output.
+pub async fn Viewport::leave(self : Viewport, tty : @tty.Tty) -> Unit {
+  tty.reset_top_bottom_margins()
+  tty.reset_style()
+  tty.enable_auto_wrap()
+  tty.show_cursor()
+  tty.set_cursor_position(self.bottom(), 1)
+  tty.write("\r\n")
+}

--- a/tui/internal/viewport/viewport_wbtest.mbt
+++ b/tui/internal/viewport/viewport_wbtest.mbt
@@ -1,0 +1,64 @@
+///|
+test "viewport remembers stale frame footprint after resize invalidates frame" {
+  let viewport = Viewport::{
+    size: @terminal_size.TerminalSize::new(rows=10, cols=80),
+    geometry: @geometry.Geometry::new(top=6, height=4),
+    cache: Drawn(
+      @surface.Surface::new(
+        width=80,
+        rows=[
+          @surface.Line::new([]),
+          @surface.Line::new([]),
+          @surface.Line::new([]),
+          @surface.Line::new([]),
+          @surface.Line::new([]),
+        ],
+        cursor=@surface.Cursor::new(row=1, col=0),
+      ),
+    ),
+  }
+  viewport.set_size(@terminal_size.TerminalSize::new(rows=8, cols=40))
+  let (stale_top, stale_height) = match viewport.cache {
+    Stale(top~, height~) => (top, height)
+    _ => (-1, -1)
+  }
+  inspect(stale_top, content="6")
+  inspect(stale_height, content="5")
+  inspect(viewport.top(), content="5")
+  inspect(
+    viewport.cache.placed_surface(live_top=viewport.top()) is None,
+    content="true",
+  )
+}
+
+///|
+test "terminal cursor comparison includes viewport top" {
+  let rows = [@surface.Line::new([]), @surface.Line::new([])]
+  let left = @surface.Surface::new(
+    width=10,
+    rows~,
+    cursor=@surface.Cursor::new(row=1, col=3),
+  )
+  let same = @surface.Surface::new(
+    width=10,
+    rows~,
+    cursor=@surface.Cursor::new(row=0, col=3),
+  )
+  let moved_row = @surface.Surface::new(
+    width=10,
+    rows~,
+    cursor=@surface.Cursor::new(row=1, col=3),
+  )
+  let moved_col = @surface.Surface::new(
+    width=10,
+    rows~,
+    cursor=@surface.Cursor::new(row=0, col=4),
+  )
+  let left = PlacedSurface::{ surface: left, top: 4 }
+  let same = PlacedSurface::{ surface: same, top: 5 }
+  let moved_row = PlacedSurface::{ surface: moved_row, top: 5 }
+  let moved_col = PlacedSurface::{ surface: moved_col, top: 5 }
+  inspect(left.same_terminal_cursor(same), content="true")
+  inspect(left.same_terminal_cursor(moved_row), content="false")
+  inspect(left.same_terminal_cursor(moved_col), content="false")
+}

--- a/tui/moon.pkg
+++ b/tui/moon.pkg
@@ -1,0 +1,20 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/io" @async/io,
+  "moonbitlang/async/aqueue",
+  "bobzhang/openseek/tui/core",
+  "bobzhang/openseek/tui/doc",
+  "bobzhang/openseek/tui/internal/composer",
+  "bobzhang/openseek/tui/internal/history",
+  "bobzhang/openseek/tui/internal/render",
+  "bobzhang/openseek/tui/internal/surface",
+  "bobzhang/openseek/tui/internal/task",
+  "bobzhang/openseek/tui/internal/terminal_size",
+  "bobzhang/openseek/tui/internal/viewport",
+  "moonbit-community/tty",
+  "moonbit-community/tty/input" @tty/input,
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -1,0 +1,34 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui"
+
+import {
+  "bobzhang/openseek/tui/core",
+  "bobzhang/openseek/tui/doc",
+}
+
+// Values
+pub async fn[T] with_ui(config? : Config, async (Ui) -> T) -> T
+
+// Errors
+
+// Types and methods
+type Config
+pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int) -> Self
+
+type Ui
+pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
+pub async fn Ui::read_event(Self) -> @core.Event
+pub async fn Ui::set_activity(Self, @doc.Text?) -> Unit
+pub async fn Ui::set_queued_inputs(Self, Array[@core.Input]) -> Unit
+pub async fn Ui::set_status(Self, @doc.Text) -> Unit
+
+// Type aliases
+pub using @core {type Event}
+
+pub using @core {type Input}
+
+pub using @core {type ToolStatus}
+
+pub using @core {type TranscriptItem}
+
+// Traits

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -1,0 +1,148 @@
+///|
+fn Ui::composer_surface(
+  self : Ui,
+  cols~ : Int,
+  rows~ : Int,
+) -> @surface.Surface {
+  @render.composer_surface(
+    self.composer,
+    activity=self.activity,
+    queued_inputs=self.queued_inputs,
+    status=self.status,
+    notice=self.notice,
+    cols~,
+    max_rows=rows,
+  )
+}
+
+///|
+async fn Ui::redraw_frame(self : Ui, viewport : @viewport.Viewport) -> Unit {
+  viewport.redraw(
+    self.tty,
+    self.composer_surface(cols=viewport.cols(), rows=viewport.rows()),
+  )
+}
+
+///|
+async fn Ui::redraw(self : Self) -> Unit {
+  // Redraws only run inside `with_entered`'s body, so a missing viewport is a
+  // lifecycle bug — surface it rather than silently skipping the draw.
+  guard self.viewport is Some(viewport) else {
+    abort("redraw without an entered UI")
+  }
+  viewport.refresh_size(self.tty)
+  self.redraw_frame(viewport)
+}
+
+///|
+/// Lay out one transcript item, prefixed with a blank separator row so items
+/// are visually spaced apart (matching the Codex TUI). The separator is plain,
+/// outside any item background block.
+fn item_rows(doc : @doc.Doc, cols~ : Int) -> Array[@surface.Line] {
+  let rows : Array[@surface.Line] = [@surface.Line::new([])]
+  for row in doc.layout(width=cols) {
+    rows.push(row)
+  }
+  rows
+}
+
+///|
+fn Ui::transcript_rows(self : Self, cols~ : Int) -> Array[@surface.Line] {
+  let rows : Array[@surface.Line] = []
+  for doc in self.transcript {
+    for row in item_rows(doc, cols~) {
+      rows.push(row)
+    }
+  }
+  rows
+}
+
+///|
+async fn Ui::redraw_after_resize(self : Self) -> Unit {
+  guard self.viewport is Some(viewport) else {
+    abort("resize without an entered UI")
+  }
+  viewport.refresh_size(self.tty)
+  viewport.replay_scrollback(
+    self.tty,
+    scrollback=self.transcript_rows(cols=viewport.cols()),
+    surface=self.composer_surface(cols=viewport.cols(), rows=viewport.rows()),
+  )
+}
+
+///|
+/// Anchor and draw the first frame. `enter` queries the terminal cursor, so this
+/// must run before the tty reader starts (see `with_entered`).
+async fn Ui::enter(self : Self) -> Unit {
+  let size = @viewport.read_terminal_size(self.tty)
+  self.viewport = Some(
+    @viewport.Viewport::enter(
+      self.tty,
+      size~,
+      surface=self.composer_surface(cols=size.cols(), rows=size.rows()),
+      timeout_ms=self.config.esc_timeout_ms,
+    ),
+  )
+}
+
+///|
+/// Append a styled `Doc` to the permanent transcript: insert its rows into the
+/// terminal scrollback above the live area, then redraw the live frame. Runs on
+/// the command queue so it serializes with other redraws.
+async fn Ui::append_transcript(self : Self, doc : @doc.Doc) -> Unit {
+  self.commands.wait(() => {
+    self.transcript.push(doc)
+    guard self.viewport is Some(viewport) else {
+      abort("append without an entered UI")
+    }
+    viewport.refresh_size(self.tty)
+    viewport.insert_before(self.tty, item_rows(doc, cols=viewport.cols()))
+    self.redraw_frame(viewport)
+  })
+}
+
+///|
+/// Project a semantic `TranscriptItem` to a `Doc` and append it to the
+/// transcript via `append_transcript`.
+pub async fn Ui::append_item(self : Self, item : TranscriptItem) -> Unit {
+  self.append_transcript(@doc.ToDoc::to_doc(item))
+}
+
+///|
+/// Set or clear the transient activity label shown above the composer. `Some`
+/// shows a busy/progress line that never enters the transcript; `None` hides it.
+/// Redraws the live frame.
+pub async fn Ui::set_activity(self : Self, activity : @doc.Text?) -> Unit {
+  self.commands.wait(() => {
+    self.activity = activity
+    self.redraw()
+  })
+}
+
+///|
+/// Replace the list of queued inputs shown in the live area (copied defensively)
+/// and redraw the frame.
+pub async fn Ui::set_queued_inputs(self : Self, inputs : Array[Input]) -> Unit {
+  self.commands.wait(() => {
+    self.queued_inputs = inputs.copy()
+    self.redraw()
+  })
+}
+
+///|
+/// Set the persistent status line below the composer and redraw. Transient input
+/// notices may temporarily override its display until the next input event.
+pub async fn Ui::set_status(self : Self, status : @doc.Text) -> Unit {
+  self.commands.wait(() => {
+    self.status = status
+    self.redraw()
+  })
+}
+
+///|
+async fn Ui::leave(self : Self) -> Unit {
+  guard self.viewport is Some(viewport) else { return }
+  self.viewport = None
+  viewport.refresh_size(self.tty)
+  viewport.leave(self.tty)
+}

--- a/tui/ui.mbt
+++ b/tui/ui.mbt
@@ -1,0 +1,132 @@
+///|
+struct Ui {
+  tty : @tty.Tty
+  config : Config
+  // The live viewport, or `None` before `enter` has placed it (and after
+  // `leave`). Present exactly when the UI is entered.
+  mut viewport : @viewport.Viewport?
+  composer : @composer.Model
+  history : @history.History
+  transcript : Array[@doc.Doc]
+  mut activity : @doc.Text?
+  mut queued_inputs : Array[Input]
+  mut status : @doc.Text
+  mut notice : @doc.Text?
+  commands : @task.Queue
+  events : @aqueue.Queue[Result[Event, Error]]
+}
+
+///|
+fn Ui::new(tty : @tty.Tty, config : Config) -> Ui {
+  let composer = @composer.Model::new(max_text_rows=config.composer_max_rows)
+  {
+    tty,
+    config,
+    viewport: None,
+    composer,
+    history: @history.History::new(),
+    transcript: [],
+    activity: None,
+    queued_inputs: [],
+    status: @doc.Text::plain(""),
+    notice: None,
+    commands: Queue(kind=Unbounded),
+    events: Queue(kind=Unbounded),
+  }
+}
+
+///|
+/// Run `body` with the live UI entered: draw the first frame up front and always
+/// restore the terminal afterwards, on both the success and error paths. Enter
+/// and leave run on the command queue so they serialize with redraws.
+async fn[T] Ui::with_entered(self : Self, body : async () -> T) -> T {
+  self.commands.wait(() => self.enter())
+  try body() catch {
+    error => {
+      self.commands.wait(() => self.leave())
+      raise error
+    }
+  } noraise {
+    value => {
+      self.commands.wait(() => self.leave())
+      value
+    }
+  }
+}
+
+///|
+async fn[T] run_ui_session(ui : Ui, body : async (Ui) -> T) -> T {
+  @async.with_task_group() <| g => {
+    g.spawn_bg(no_wait=true) <| () => { ui.commands.run() }
+    ui.with_entered(() => {
+      // `enter` drew the first frame, querying cursor position through tty input.
+      // Start the reader only now, so it cannot consume that response as a key.
+      g.spawn_bg(no_wait=true) <| () => { ui.read_tty_events() }
+      body(ui)
+    })
+  }
+}
+
+///|
+async fn Ui::put_event_result(self : Ui, result : Result[Event, Error]) -> Unit {
+  self.events.put(result) catch {
+    @aqueue.QueueAlreadyClosed => ()
+    error => raise error
+  }
+}
+
+///|
+async fn Ui::read_tty_events(self : Ui) -> Unit {
+  for ;; {
+    let tty_event = self.tty.read_event(
+      esc_timeout_ms=self.config.esc_timeout_ms,
+    ) catch {
+      @async/io.ReaderClosed => {
+        self.put_event_result(Ok(Quit))
+        self.events.close()
+        return
+      }
+      error if @async.is_being_cancelled() => raise error
+      error => {
+        self.put_event_result(Err(error))
+        self.events.close()
+        return
+      }
+    }
+    let event = self.commands.wait(() => self.handle_tty_event(tty_event)) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => {
+        self.put_event_result(Err(error))
+        self.events.close()
+        return
+      }
+    }
+    if event is Some(event) {
+      self.put_event_result(Ok(event))
+    }
+  }
+}
+
+///|
+/// Open a terminal session, run `body` with a live `Ui`, and always restore the
+/// terminal afterwards. Opens the tty in raw mode, requests the kitty keyboard
+/// "disambiguate" enhancement (gracefully ignored where unsupported), draws the
+/// first frame, then spawns the command queue and tty reader for the duration of
+/// `body`.
+pub async fn[T] with_ui(
+  config? : Config = Config::new(),
+  body : async (Ui) -> T,
+) -> T {
+  let tty = @tty.Tty::open()
+  defer tty.close()
+  let ui = Ui::new(tty, config)
+  // Request the kitty keyboard protocol's "disambiguate" level so modified keys
+  // the legacy encoding cannot represent — Shift+Enter, Alt+F/Alt+B — are
+  // reported as distinct CSI-u events. We deliberately avoid the higher levels
+  // that also report key-release events, which would double-fire every key.
+  // Terminals without kitty support ignore the request and degrade gracefully.
+  let flags = @tty.KeyboardEnhancementFlags::disambiguate()
+  tty.with_raw_mode() <| () => {
+    tty.with_keyboard_enhancements(flags) <| () => { run_ui_session(ui, body) }
+  }
+}

--- a/tui/ui_wbtest.mbt
+++ b/tui/ui_wbtest.mbt
@@ -1,0 +1,9 @@
+///|
+test "submitted input marks prompt and shell command" {
+  let input = @composer.Model::new()
+  let shell = @composer.Model::new()
+  shell.insert_user_text("!")
+  assert_true(submitted_input("hello", input.mode()) == Prompt("hello"))
+  assert_true(submitted_input("pwd ", shell.mode()) == Command("pwd"))
+  assert_true(submitted_input("", shell.mode()) == Command(""))
+}


### PR DESCRIPTION
This PR is purely additive: it introduces the `tui` package and its sub-packages — a reusable, inline terminal UI layer for OpenSeek-style agents. The transcript stays in the terminal's native scrollback while a bottom-anchored live area (composer, status, activity) is redrawn in place via a diff-based DECSTBM renderer, rebuilt from semantic rows on resize.

No existing source is modified. The agent integration and the `cmd/tui` binary land in a stacked follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Note:

1. **`kawaz/grapheme` is still added as a dependency**. Since we don't want to break semantics of `char_width` and `str_width` function provided by `moonbit-community/unicodewith` (formally `rami3l/unicodewidth`), I'm currently implementing a separate set of grapheme-aware API alongside with it.
2. Editor is very inefficient as for now - it contains many string copies. This is expected to be resolved by introducing `moonbit-community/unicodewith`, where we will be providing a unified access for both grapheme clusters and display width.