### PR TITLE
Refactor logger sinks to optional values

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -11,7 +11,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek` | Root package and module overview. | `README.mbt.md` |
 | `bobzhang/openseek/deepseek` | Pure DeepSeek chat data, JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
 | `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for DeepSeek chat completions. | `deepseek/client/README.mbt.md` |
-| `bobzhang/openseek/logger` | Native-only async logger with severity-filtered `<+` sinks. | `logger/README.mbt.md` |
+| `bobzhang/openseek/logger` | Native-only async logger with severity-filtered optional `<+` sinks. | `logger/README.mbt.md` |
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/main` | Native-only command-line entry point. | `cmd/main/README.md` |

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -30,8 +30,9 @@ pub async fn run(
   )
   let tools = tool_definitions() catch {
     error => {
-      let error_log = log.error()
-      error_log <+ "agent setup failed: \{error}\n"
+      if log.error() is Some(error_log) {
+        error_log <+ "agent setup failed: \{error}\n"
+      }
       return
     }
   }
@@ -40,15 +41,21 @@ pub async fn run(
     ChatMessage(User, content=task),
   ]
   for step in 0..<max_steps {
-    log <+ "--- step \{step + 1} ---\n"
+    if log.info() is Some(info_log) {
+      info_log <+ "--- step \{step + 1} ---\n"
+    }
     let response = client.chat(messages, tools=tools.function_tools())
     if response.content != "" {
-      log <+ "agent: \{response.content}\n"
+      if log.info() is Some(info_log) {
+        info_log <+ "agent: \{response.content}\n"
+      }
     }
     print_usage(response.usage)
     if response.tool_calls.length() == 0 {
-      log <+ "=== finished ===\n"
-      log <+ "\{response.content}\n"
+      if log.info() is Some(info_log) {
+        info_log <+ "=== finished ===\n"
+        info_log <+ "\{response.content}\n"
+      }
       return
     }
     let reasoning_content = match response.reasoning_content {
@@ -65,8 +72,9 @@ pub async fn run(
     for native_call in response.tool_calls {
       let tool_call = @agent_tool.AgentToolCall(native_call) catch {
         error => {
-          let error_log = log.error()
-          error_log <+ "tool: error: \{error}\n"
+          if log.error() is Some(error_log) {
+            error_log <+ "tool: error: \{error}\n"
+          }
           messages.push(
             ChatMessage(Tool(native_call.id), content="error: \{error}"),
           )
@@ -76,25 +84,31 @@ pub async fn run(
       let result = @agent_tool.execute_tool_call(tool_call, tools)
       let output = match result {
         Control(Finish(answer)) => {
-          log <+ "=== finished ===\n"
-          log <+ "\{answer}\n"
+          if log.info() is Some(info_log) {
+            info_log <+ "=== finished ===\n"
+            info_log <+ "\{answer}\n"
+          }
           return
         }
         Control(Abort(reason)) => {
-          let warn_log = log.warn()
-          warn_log <+ "=== aborted ===\n"
-          warn_log <+ "\{reason}\n"
+          if log.warn() is Some(warn_log) {
+            warn_log <+ "=== aborted ===\n"
+            warn_log <+ "\{reason}\n"
+          }
           return
         }
         Respond(output) => output
       }
       let label = if output.is_error { "tool error" } else { "tool" }
-      log <+ "\{label}: \{output.content}\n"
+      if log.info() is Some(info_log) {
+        info_log <+ "\{label}: \{output.content}\n"
+      }
       messages.push(ChatMessage(Tool(native_call.id), content=output.content))
     }
   }
-  let warn_log = log.warn()
-  warn_log <+ "=== max steps exhausted ===\n"
+  if log.warn() is Some(warn_log) {
+    warn_log <+ "=== max steps exhausted ===\n"
+  }
 }
 
 ///|
@@ -102,6 +116,8 @@ let log : @logger.Logger = @logger.stdout(min_level=INFO)
 
 ///|
 async fn print_usage(usage : @deepseek.Usage) -> Unit {
-  log <+
-    "usage: prompt=\{usage.prompt_tokens} completion=\{usage.completion_tokens} cache_hit=\{usage.prompt_cache_hit_tokens} cache_miss=\{usage.prompt_cache_miss_tokens}\n"
+  if log.info() is Some(info_log) {
+    info_log <+
+      "usage: prompt=\{usage.prompt_tokens} completion=\{usage.completion_tokens} cache_hit=\{usage.prompt_cache_hit_tokens} cache_miss=\{usage.prompt_cache_miss_tokens}\n"
+  }
 }

--- a/logger/README.mbt.md
+++ b/logger/README.mbt.md
@@ -8,9 +8,11 @@ sinks.
 
 - `Level`: `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.
 - `stdout(min_level?)`: build a stdout logger.
-- `Logger::at(level)`: get a level-filtered sink.
-- `Logger::trace/debug/info/warn/error()`: convenience sinks.
-- `Logger` itself supports `<+` as an `INFO` sink.
+- `Logger::at(level)`: get `Some(LogSink)` when `level` is enabled, otherwise
+  `None`.
+- `Logger::trace/debug/info/warn/error()`: convenience optional sinks.
+- `LogSink` supports `<+` and can write JSON object lines with
+  `write_object(Map[String, String])`.
 
 ```moonbit check
 ///|
@@ -18,5 +20,7 @@ test "logger filters by severity" {
   let logger = @logger.Logger(@stdio.stdout, min_level=WARN)
   assert_false(logger.enabled(INFO))
   assert_true(logger.enabled(ERROR))
+  assert_true(logger.debug() is None)
+  assert_true(logger.error() is Some(_))
 }
 ```

--- a/logger/logger.mbt
+++ b/logger/logger.mbt
@@ -56,66 +56,64 @@ pub fn Logger::enabled(self : Logger, level : Level) -> Bool {
 }
 
 ///|
-pub fn Logger::at(self : Logger, level : Level) -> LogSink {
-  { output: self.output, enabled: self.enabled(level) }
+pub fn Logger::at(self : Logger, level : Level) -> LogSink? {
+  if self.enabled(level) {
+    Some({ output: self.output })
+  } else {
+    None
+  }
 }
 
 ///|
-pub fn Logger::trace(self : Logger) -> LogSink {
+pub fn Logger::trace(self : Logger) -> LogSink? {
   self.at(TRACE)
 }
 
 ///|
-pub fn Logger::debug(self : Logger) -> LogSink {
+pub fn Logger::debug(self : Logger) -> LogSink? {
   self.at(DEBUG)
 }
 
 ///|
-pub fn Logger::info(self : Logger) -> LogSink {
+pub fn Logger::info(self : Logger) -> LogSink? {
   self.at(INFO)
 }
 
 ///|
-pub fn Logger::warn(self : Logger) -> LogSink {
+pub fn Logger::warn(self : Logger) -> LogSink? {
   self.at(WARN)
 }
 
 ///|
-pub fn Logger::error(self : Logger) -> LogSink {
+pub fn Logger::error(self : Logger) -> LogSink? {
   self.at(ERROR)
-}
-
-///|
-pub async fn Logger::write_string(self : Logger, text : String) -> Unit {
-  self.info().write_string(text)
-}
-
-///|
-pub async fn[A : Show] Logger::write(self : Logger, value : A) -> Unit {
-  self.info().write(value)
 }
 
 ///|
 pub struct LogSink {
   priv output : @stdio.Output
-  priv enabled : Bool
-}
-
-///|
-pub fn LogSink::enabled(self : LogSink) -> Bool {
-  self.enabled
 }
 
 ///|
 pub async fn LogSink::write_string(self : LogSink, text : String) -> Unit {
-  if self.enabled {
-    self.output.write(text)
-  }
+  self.output.write(text)
 }
 
 ///|
 pub async fn[A : Show] LogSink::write(self : LogSink, value : A) -> Unit {
   self.write_string(value.to_string())
+}
+
+///|
+pub async fn LogSink::write_object(
+  self : LogSink,
+  fields : Map[String, String],
+) -> Unit {
+  let object : Map[String, Json] = Map([])
+  for key, value in fields {
+    object.set(key, Json::string(value))
+  }
+  self.write_string(Json::object(object).stringify() + "\n")
 }
 
 ///|
@@ -143,6 +141,13 @@ test "logger filters below the minimum level" {
   assert_false(logger.enabled(INFO))
   assert_true(logger.enabled(WARN))
   assert_true(logger.enabled(ERROR))
-  assert_false(logger.info().enabled())
-  assert_true(logger.error().enabled())
+  assert_true(logger.info() is None)
+  assert_true(logger.error() is Some(_))
+}
+
+///|
+test "logger level helpers return optional sinks" {
+  let logger = Logger(@stdio.stdout, min_level=INFO)
+  assert_true(logger.debug() is None)
+  assert_true(logger.info() is Some(_))
 }

--- a/logger/moon.pkg
+++ b/logger/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/async/stdio",
+  "moonbitlang/core/json",
 }
 
 warnings = "+unnecessary_annotation"

--- a/logger/pkg.generated.mbti
+++ b/logger/pkg.generated.mbti
@@ -24,23 +24,21 @@ pub fn Level::rank(Self) -> Int
 pub struct LogSink {
   // private fields
 }
-pub fn LogSink::enabled(Self) -> Bool
 pub async fn[A : Show] LogSink::write(Self, A) -> Unit
+pub async fn LogSink::write_object(Self, Map[String, String]) -> Unit
 pub async fn LogSink::write_string(Self, String) -> Unit
 
 pub struct Logger {
   // private fields
 }
 pub fn Logger::Logger(@stdio.Output, min_level? : Level) -> Self
-pub fn Logger::at(Self, Level) -> LogSink
-pub fn Logger::debug(Self) -> LogSink
+pub fn Logger::at(Self, Level) -> LogSink?
+pub fn Logger::debug(Self) -> LogSink?
 pub fn Logger::enabled(Self, Level) -> Bool
-pub fn Logger::error(Self) -> LogSink
-pub fn Logger::info(Self) -> LogSink
-pub fn Logger::trace(Self) -> LogSink
-pub fn Logger::warn(Self) -> LogSink
-pub async fn[A : Show] Logger::write(Self, A) -> Unit
-pub async fn Logger::write_string(Self, String) -> Unit
+pub fn Logger::error(Self) -> LogSink?
+pub fn Logger::info(Self) -> LogSink?
+pub fn Logger::trace(Self) -> LogSink?
+pub fn Logger::warn(Self) -> LogSink?
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

- Change level-specific logger accessors (`trace/debug/info/warn/error` and `at`) to return `LogSink?`, so disabled levels are represented as `None` instead of disabled sink objects.
- Keep `LogSink` as the `<+` writer and add `LogSink::write_object(Map[String, Json])` as the structured logging primitive.
- Update agent logging call sites to unwrap optional sinks before writing.
- Refresh logger docs and generated interface.

## Validation

- `moon check` passes with the existing `deepseek/json_decode.mbt` deprecated `try?` warning from `origin/main`.
- `moon test logger agent` passed: 6 tests.
- `moon info && moon fmt` completed with the same existing warning.