### PR TITLE
Parse JSONL agent logs in eval harnesses

### DIFF
--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -38,6 +38,13 @@ pub struct EvalReport {
 }
 
 ///|
+priv struct AgentLogSummary {
+  steps : Int
+  tool_errors : Int
+  shell_uses : Int
+}
+
+///|
 pub async fn run_suite(config : Config) -> EvalReport {
   prepare_output_dir(config.out_dir)
   let results = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
@@ -160,9 +167,8 @@ async fn evaluate_trial(
 ) -> TrialResult {
   let state_reason = check_expected_state(workspace, case)
   let validation_reason = run_validation(workspace, case.validation)
-  let leading_shell_use = if log_text.has_prefix("tool: exit=") { 1 } else { 0 }
-  let shell_uses = count_occurrences(log_text, "\ntool: exit=") +
-    leading_shell_use
+  let log_summary = summarize_agent_log(log_text)
+  let shell_uses = log_summary.shell_uses
   let marker = "file-edit-eval:\{case.id}"
   let marker_ok = log_text.contains(marker)
   let validation_passed = validation_reason == ""
@@ -197,8 +203,8 @@ async fn evaluate_trial(
     workspace,
     log_path,
     exit_code,
-    steps: count_occurrences(log_text, "--- step "),
-    tool_errors: count_occurrences(log_text, "tool error:"),
+    steps: log_summary.steps,
+    tool_errors: log_summary.tool_errors,
     shell_uses,
     moon_cmd_uses: count_lines_containing_all(log_text, ["command=moon "]),
     moon_run_e_mentions: count_lines_containing_all(log_text, [
@@ -220,6 +226,56 @@ async fn evaluate_trial(
     } else {
       warnings.join("; ")
     },
+  }
+}
+
+///|
+fn summarize_agent_log(log_text : String) -> AgentLogSummary {
+  let mut has_json_events = false
+  let mut steps = 0
+  let mut tool_errors = 0
+  let mut shell_uses = 0
+  for line in log_text.split("\n") {
+    let json = @json.parse(line.trim()) catch { _ => continue }
+    match json {
+      { "event": String("agent_step"), .. } => {
+        has_json_events = true
+        steps += 1
+      }
+      {
+        "event": String("tool_result"),
+        "tool_name": String(tool_name),
+        "is_error": is_error,
+        ..
+      } => {
+        has_json_events = true
+        if tool_name == "shell" {
+          shell_uses += 1
+        }
+        match is_error {
+          True => tool_errors += 1
+          _ => ()
+        }
+      }
+      { "event": String(_), .. } => has_json_events = true
+      _ => ()
+    }
+  }
+  if has_json_events {
+    { steps, tool_errors, shell_uses }
+  } else {
+    let leading_shell_use = if log_text.has_prefix("tool: exit=") {
+      1
+    } else {
+      0
+    }
+    let shell_uses = count_occurrences(log_text, "\ntool: exit=") +
+      leading_shell_use
+    {
+      steps: count_occurrences(log_text, "--- step "),
+      tool_errors: count_occurrences(log_text, "tool error:"),
+      shell_uses,
+    }
   }
 }
 

--- a/eval/file_edit/harness/harness_wbtest.mbt
+++ b/eval/file_edit/harness/harness_wbtest.mbt
@@ -37,6 +37,47 @@ async test "dry run exact replacement oracle" {
 }
 
 ///|
+async test "dry run exact replacement oracle with jsonl agent log" {
+  let case = @cases.case_for_trial(0)
+  let root = @fs.tmpdir(prefix="openseek-file-edit-harness-jsonl")
+  let workspace = root + "/workspace"
+  let log_path = root + "/trial.log"
+  @fs.mkdir(workspace, recursive=true)
+  write_fixture(workspace, case)
+  @vfs.FileSystem({ "src/note.txt": "alpha\ndelta\ngamma\n" }).write_to(
+    workspace,
+  )
+  @fs.write_file(
+    log_path,
+    (
+      $|not json
+      $|{"event":"agent_step","step":1}
+      $|{"event":"tool_result","tool_name":"edit","is_error":false,"content":"ok: replaced 1 occurrence"}
+      $|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
+      $|{"event":"agent_finished","answer":"file-edit-eval:\{case.id}"}
+    ),
+    create_mode=CreateOrTruncate,
+  )
+  let result = evaluate_trial(
+    "builtin",
+    0,
+    case,
+    workspace,
+    log_path,
+    0,
+    @fs.read_file(log_path).text(),
+  )
+  assert_true(result.success)
+  assert_eq(result.steps, 1)
+  assert_eq(result.tool_errors, 0)
+  assert_eq(result.shell_uses, 1)
+  assert_eq(result.edit_successes, 1)
+  assert_true(result.marker_present)
+  assert_eq(result.warnings, "shell tool used 1 time(s)")
+  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+}
+
+///|
 test "count_occurrences counts non-overlapping markers" {
   assert_eq(count_occurrences("tool error: a\ntool error: b", "tool error:"), 2)
   assert_eq(count_occurrences("abc", "z"), 0)

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -58,6 +58,14 @@ pub struct EvalReport {
 }
 
 ///|
+priv struct AgentLogSummary {
+  finished : Bool
+  steps : Int
+  tool_errors : Int
+  shell_uses : Int
+}
+
+///|
 pub async fn run_suite(config : Config) -> EvalReport {
   prepare_output_dir(config.out_dir)
   let task_template = @fs.read_file(config.task_file).text()
@@ -170,7 +178,8 @@ fn evaluate_trial(
   log_text : String,
   validation : ValidationResult,
 ) -> TrialResult {
-  let finished = log_text.contains("=== finished ===")
+  let log_summary = summarize_agent_log(log_text)
+  let finished = log_summary.finished
   let reasons : Array[String] = []
   if exit_code != 0 {
     reasons.push("agent process exited \{exit_code}")
@@ -182,9 +191,8 @@ fn evaluate_trial(
     reasons.push(validation.reason)
   }
   let warnings : Array[String] = []
-  let shell_uses = count_lines_containing_all(log_text, ["tool: exit="])
-  if shell_uses > 0 {
-    warnings.push("shell output observed \{shell_uses} time(s)")
+  if log_summary.shell_uses > 0 {
+    warnings.push("shell output observed \{log_summary.shell_uses} time(s)")
   }
   let success = reasons.length() == 0
   {
@@ -199,8 +207,8 @@ fn evaluate_trial(
     workspace,
     log_path,
     exit_code,
-    steps: count_occurrences(log_text, "--- step "),
-    tool_errors: count_occurrences(log_text, "tool error:"),
+    steps: log_summary.steps,
+    tool_errors: log_summary.tool_errors,
     finished,
     validation,
     moon_check_uses: count_lines_containing_all(log_text, ["command=moon check"]),
@@ -236,6 +244,62 @@ fn evaluate_trial(
     } else {
       warnings.join("; ")
     },
+  }
+}
+
+///|
+fn summarize_agent_log(log_text : String) -> AgentLogSummary {
+  let mut has_json_events = false
+  let mut finished = false
+  let mut steps = 0
+  let mut tool_errors = 0
+  let mut shell_uses = 0
+  for line in log_text.split("\n") {
+    let json = @json.parse(line.trim()) catch { _ => continue }
+    match json {
+      { "event": String("agent_step"), .. } => {
+        has_json_events = true
+        steps += 1
+      }
+      { "event": String("agent_finished"), .. } => {
+        has_json_events = true
+        finished = true
+      }
+      {
+        "event": String("tool_result"),
+        "tool_name": String(tool_name),
+        "is_error": is_error,
+        ..
+      } => {
+        has_json_events = true
+        if tool_name == "shell" {
+          shell_uses += 1
+        }
+        match is_error {
+          True => tool_errors += 1
+          _ => ()
+        }
+      }
+      { "event": String(_), .. } => has_json_events = true
+      _ => ()
+    }
+  }
+  if has_json_events {
+    { finished, steps, tool_errors, shell_uses }
+  } else {
+    let leading_shell_use = if log_text.has_prefix("tool: exit=") {
+      1
+    } else {
+      0
+    }
+    let shell_uses = count_occurrences(log_text, "\ntool: exit=") +
+      leading_shell_use
+    {
+      finished: log_text.contains("=== finished ==="),
+      steps: count_occurrences(log_text, "--- step "),
+      tool_errors: count_occurrences(log_text, "tool error:"),
+      shell_uses,
+    }
   }
 }
 

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -24,6 +24,72 @@ test "json stdout probe accepts valid json only" {
 }
 
 ///|
+test "agent log summary reads jsonl events and ignores process noise" {
+  let summary = summarize_agent_log(
+    (
+      #|Blocking waiting for file lock /tmp/.moon-lock ...
+      #|{"event":"agent_step","step":1}
+      #|{"event":"tool_result","tool_name":"write","is_error":true,"content":"failed"}
+      #|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
+      #|{"event":"agent_finished","answer":"ok"}
+    ),
+  )
+  assert_true(summary.finished)
+  assert_eq(summary.steps, 1)
+  assert_eq(summary.tool_errors, 1)
+  assert_eq(summary.shell_uses, 1)
+}
+
+///|
+test "agent log summary falls back to legacy text markers" {
+  let summary = summarize_agent_log(
+    (
+      #|tool: exit=0
+      #|--- step 1 ---
+      #|tool error: failed
+      #|=== finished ===
+    ),
+  )
+  assert_true(summary.finished)
+  assert_eq(summary.steps, 1)
+  assert_eq(summary.tool_errors, 1)
+  assert_eq(summary.shell_uses, 1)
+}
+
+///|
+test "trial evaluation uses jsonl finish and counters" {
+  let validation : ValidationResult = {
+    passed: true,
+    reason: "ok",
+    moon_check: true,
+    moon_test: true,
+    file_probe: true,
+    stdin_probe: true,
+    duplicate_probe: true,
+  }
+  let result = evaluate_trial(
+    "flash",
+    0,
+    "ws",
+    "log",
+    0,
+    (
+      #|not json
+      #|{"event":"agent_step","step":1}
+      #|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
+      #|{"event":"agent_finished","answer":"ok"}
+    ),
+    validation,
+  )
+  assert_true(result.success)
+  assert_true(result.finished)
+  assert_eq(result.reason, "ok")
+  assert_eq(result.steps, 1)
+  assert_eq(result.tool_errors, 0)
+  assert_eq(result.warnings, "shell output observed 1 time(s)")
+}
+
+///|
 test "markdown report includes concurrency and prompt label" {
   let report : EvalReport = {
     model: "deepseek-v4-flash",


### PR DESCRIPTION
## Summary
- Add JSONL-aware agent log summaries for prompt-task and file-edit eval harnesses.
- Derive steps, tool errors, finish state, and shell usage from structured log events while ignoring non-JSON process noise.
- Keep legacy text-log fallbacks for older logs.
- Add regression tests for JSONL logs and legacy marker logs.

## Validation
- `moon test eval/prompt_task/harness eval/file_edit/harness`
- `moon check` passes with the existing `deepseek/json_decode.mbt` deprecated `try?` warning from `origin/main`
- `moon info && moon fmt`
- `moon test`