### PR TITLE
Tighten logger to structured object API

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -11,7 +11,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek` | Root package and module overview. | `README.mbt.md` |
 | `bobzhang/openseek/deepseek` | Pure DeepSeek chat data, JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
 | `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for DeepSeek chat completions. | `deepseek/client/README.mbt.md` |
-| `bobzhang/openseek/logger` | Native-only async logger with severity-filtered optional `<+` sinks. | `logger/README.mbt.md` |
+| `bobzhang/openseek/logger` | Native-only async JSONL logger with severity-filtered optional sinks. | `logger/README.mbt.md` |
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/main` | Native-only command-line entry point. | `cmd/main/README.md` |

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -30,7 +30,7 @@ pub async fn run(
   )
   let tools = tool_definitions() catch {
     error => {
-      if log.error() is Some(error_log) {
+      if log.at(ERROR) is Some(error_log) {
         error_log.write_object({
           "event": "agent_setup_failed",
           "error": "\{error}",
@@ -44,12 +44,12 @@ pub async fn run(
     ChatMessage(User, content=task),
   ]
   for step in 0..<max_steps {
-    if log.info() is Some(info_log) {
+    if log.at(INFO) is Some(info_log) {
       info_log.write_object({ "event": "agent_step", "step": step + 1 })
     }
     let response = client.chat(messages, tools=tools.function_tools())
     if response.content != "" {
-      if log.info() is Some(info_log) {
+      if log.at(INFO) is Some(info_log) {
         info_log.write_object({
           "event": "assistant_message",
           "content": response.content,
@@ -58,7 +58,7 @@ pub async fn run(
     }
     print_usage(response.usage)
     if response.tool_calls.length() == 0 {
-      if log.info() is Some(info_log) {
+      if log.at(INFO) is Some(info_log) {
         info_log.write_object({
           "event": "agent_finished",
           "answer": response.content,
@@ -80,7 +80,7 @@ pub async fn run(
     for native_call in response.tool_calls {
       let tool_call = @agent_tool.AgentToolCall(native_call) catch {
         error => {
-          if log.error() is Some(error_log) {
+          if log.at(ERROR) is Some(error_log) {
             error_log.write_object({
               "event": "tool_call_decode_error",
               "tool_call_id": native_call.id,
@@ -97,7 +97,7 @@ pub async fn run(
       let result = @agent_tool.execute_tool_call(tool_call, tools)
       let output = match result {
         Control(Finish(answer)) => {
-          if log.info() is Some(info_log) {
+          if log.at(INFO) is Some(info_log) {
             info_log.write_object({
               "event": "agent_finished",
               "answer": answer,
@@ -106,14 +106,14 @@ pub async fn run(
           return
         }
         Control(Abort(reason)) => {
-          if log.warn() is Some(warn_log) {
+          if log.at(WARN) is Some(warn_log) {
             warn_log.write_object({ "event": "agent_aborted", "reason": reason })
           }
           return
         }
         Respond(output) => output
       }
-      if log.info() is Some(info_log) {
+      if log.at(INFO) is Some(info_log) {
         info_log.write_object({
           "event": "tool_result",
           "tool_call_id": native_call.id,
@@ -125,7 +125,7 @@ pub async fn run(
       messages.push(ChatMessage(Tool(native_call.id), content=output.content))
     }
   }
-  if log.warn() is Some(warn_log) {
+  if log.at(WARN) is Some(warn_log) {
     warn_log.write_object({ "event": "max_steps_exhausted" })
   }
 }
@@ -135,7 +135,7 @@ let log : @logger.Logger = @logger.stdout(min_level=INFO)
 
 ///|
 async fn print_usage(usage : @deepseek.Usage) -> Unit {
-  if log.info() is Some(info_log) {
+  if log.at(INFO) is Some(info_log) {
     info_log.write_object({
       "event": "usage",
       "prompt_tokens": usage.prompt_tokens,

--- a/logger/README.mbt.md
+++ b/logger/README.mbt.md
@@ -1,8 +1,7 @@
 # Logger
 
 This package provides a tiny native-only async logger for OpenSeek. It wraps an
-`@stdio.Output`, applies a minimum severity level, and exposes `<+`-compatible
-sinks.
+`@stdio.Output`, applies a minimum severity level, and writes JSONL records.
 
 ## API Shape
 
@@ -10,9 +9,7 @@ sinks.
 - `stdout(min_level?)`: build a stdout logger.
 - `Logger::at(level)`: get `Some(LogSink)` when `level` is enabled, otherwise
   `None`.
-- `Logger::trace/debug/info/warn/error()`: convenience optional sinks.
-- `LogSink` supports `<+` and can write JSON object lines with
-  `write_object(Map[String, Json])`.
+- `LogSink::write_object(fields)`: write one JSON object line.
 
 ```moonbit check
 ///|
@@ -20,7 +17,7 @@ test "logger filters by severity" {
   let logger = @logger.Logger(@stdio.stdout, min_level=WARN)
   assert_false(logger.enabled(INFO))
   assert_true(logger.enabled(ERROR))
-  assert_true(logger.debug() is None)
-  assert_true(logger.error() is Some(_))
+  assert_true(logger.at(DEBUG) is None)
+  assert_true(logger.at(ERROR) is Some(_))
 }
 ```

--- a/logger/logger.mbt
+++ b/logger/logger.mbt
@@ -65,43 +65,8 @@ pub fn Logger::at(self : Logger, level : Level) -> LogSink? {
 }
 
 ///|
-pub fn Logger::trace(self : Logger) -> LogSink? {
-  self.at(TRACE)
-}
-
-///|
-pub fn Logger::debug(self : Logger) -> LogSink? {
-  self.at(DEBUG)
-}
-
-///|
-pub fn Logger::info(self : Logger) -> LogSink? {
-  self.at(INFO)
-}
-
-///|
-pub fn Logger::warn(self : Logger) -> LogSink? {
-  self.at(WARN)
-}
-
-///|
-pub fn Logger::error(self : Logger) -> LogSink? {
-  self.at(ERROR)
-}
-
-///|
 pub struct LogSink {
   priv output : @stdio.Output
-}
-
-///|
-pub async fn LogSink::write_string(self : LogSink, text : String) -> Unit {
-  self.output.write(text)
-}
-
-///|
-pub async fn[A : Show] LogSink::write(self : LogSink, value : A) -> Unit {
-  self.write_string(value.to_string())
 }
 
 ///|
@@ -109,7 +74,7 @@ pub async fn LogSink::write_object(
   self : LogSink,
   fields : Map[String, Json],
 ) -> Unit {
-  self.write_string(Json::object(fields).stringify() + "\n")
+  self.output.write(Json::object(fields).stringify() + "\n")
 }
 
 ///|
@@ -137,13 +102,13 @@ test "logger filters below the minimum level" {
   assert_false(logger.enabled(INFO))
   assert_true(logger.enabled(WARN))
   assert_true(logger.enabled(ERROR))
-  assert_true(logger.info() is None)
-  assert_true(logger.error() is Some(_))
+  assert_true(logger.at(INFO) is None)
+  assert_true(logger.at(ERROR) is Some(_))
 }
 
 ///|
-test "logger level helpers return optional sinks" {
+test "logger returns optional sinks by level" {
   let logger = Logger(@stdio.stdout, min_level=INFO)
-  assert_true(logger.debug() is None)
-  assert_true(logger.info() is Some(_))
+  assert_true(logger.at(DEBUG) is None)
+  assert_true(logger.at(INFO) is Some(_))
 }

--- a/logger/pkg.generated.mbti
+++ b/logger/pkg.generated.mbti
@@ -24,21 +24,14 @@ pub fn Level::rank(Self) -> Int
 pub struct LogSink {
   // private fields
 }
-pub async fn[A : Show] LogSink::write(Self, A) -> Unit
 pub async fn LogSink::write_object(Self, Map[String, Json]) -> Unit
-pub async fn LogSink::write_string(Self, String) -> Unit
 
 pub struct Logger {
   // private fields
 }
 pub fn Logger::Logger(@stdio.Output, min_level? : Level) -> Self
 pub fn Logger::at(Self, Level) -> LogSink?
-pub fn Logger::debug(Self) -> LogSink?
 pub fn Logger::enabled(Self, Level) -> Bool
-pub fn Logger::error(Self) -> LogSink?
-pub fn Logger::info(Self) -> LogSink?
-pub fn Logger::trace(Self) -> LogSink?
-pub fn Logger::warn(Self) -> LogSink?
 
 // Type aliases
 


### PR DESCRIPTION
## Summary
- remove logger level convenience helpers in favor of `Logger::at(level)`
- remove `LogSink::write` and `LogSink::write_string`, leaving `write_object(Map[String, Json])`
- update agent log call sites and logger docs for the structured JSONL-only API

## Validation
- `moon check`
- `moon test logger agent`
- `moon info`
- `moon fmt`
- `moon test`

Note: validation still reports the existing `try?` deprecation warning in `deepseek/json_decode.mbt`, unrelated to this change.