### PR TITLE
Remove deprecated MoonBit try shorthand

### DIFF
--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -150,20 +150,13 @@ pub impl FromJson for ChatResponse with fn from_json(
   }
   let tool_calls = match message_fields {
     { "tool_calls": Array(raw_tool_calls), .. } => {
-      let tool_call_results = [
-        for index, tool_call in raw_tool_calls => {
-          try? FromJson::from_json(
-            tool_call,
-            message_path.add_key("tool_calls").add_index(index),
-          )
-        }
-      ]
       let decoded : Array[ToolCall] = []
-      for result in tool_call_results {
-        match result {
-          Ok(tool_call) => decoded.push(tool_call)
-          Err(error) => raise error
-        }
+      for index, tool_call in raw_tool_calls {
+        let decoded_tool_call : ToolCall = FromJson::from_json(
+          tool_call,
+          message_path.add_key("tool_calls").add_index(index),
+        )
+        decoded.push(decoded_tool_call)
       }
       decoded
     }

--- a/prompt/base_prompt.md
+++ b/prompt/base_prompt.md
@@ -297,7 +297,7 @@ Use snapshot tests as it is easy to update when behavior changes.
 - Black-box by default: Call only public APIs via `@package.fn`. Use white-box tests only when private members matter.
 - Grouping: Combine related checks in one `test "..." { ... }` block for speed and clarity.
 - Panics: Name tests with prefix `test "panic ..." {...}`; if the call returns a value, wrap it with `ignore(...)` to silence warnings.
-- Errors: Use `try? f()` to get `Result[...]` and `inspect` it when a function may raise.
+- Errors: Use `try { ... } catch { ... } noraise { ... }` when a test needs to inspect a function that may raise.
 
 ### Docstring tests
 
@@ -744,7 +744,7 @@ async test "sleep completes" {
 MoonBit uses checked error-throwing functions, not unchecked exceptions. All errors are a subtype of `Error` and you can declare your own error types using `suberror`.
 Use `raise` in signatures to declare error types and let errors propagate by
 default.  `try { } catch { }`
-to handle errors explicitly. Use `try!` to abort if it does raise. Occasionally, use `try?` to convert to `Result[...]` in tests for inspection.
+to handle errors explicitly. In tests, use `try { ... } catch { ... } noraise { ... }` when you need to inspect the raised error.
 
 ```mbt check
 ///|
@@ -787,13 +787,18 @@ fn div(x : Int, y : Int) -> Int raise {
 
 ///|
 test "inspect raise function" {
-  let result : Result[Int, Error] = try? div(1, 0)
-  guard result is Err(Failure::Failure(msg)) && msg.contains("Division by zero") else {
-    fail("Expected error")
+  try {
+    ignore(div(1, 0))
+  } catch {
+    error => {
+      inspect(error)
+    }
+  } noraise {
+    _ => fail("Expected error")
   }
 }
 
-// Three ways to handle errors:
+// Two common ways to handle errors:
 
 ///|
 /// Propagate automatically
@@ -803,13 +808,6 @@ fn use_parse(s : String, position~ : Position) -> Int raise ParseError {
   // Unlike Swift, you do not need to mark `try` for functions that can raise
   // errors; the compiler infers it automatically. This keeps error handling
   // explicit but concise.
-  x * 2
-}
-
-///|
-/// Use try! to abort if it raises, no raise in the signature
-fn use_parse2(position~ : Position) -> Int {
-  let x = try! parse_int("123", position~) // label punning
   x * 2
 }
 
@@ -1030,10 +1028,10 @@ test "map literals and common operations" {
 - `Array[T]`, `FixedArray[T]`, `ReadOnlyArray[T] → `ArrayView[T]` via `a[:]` or `a[start:end]`, etc.
 
 **Important**: StringView slice is slightly different due to unicode safety:
-`s[a:b]` may raise an error at surrogate boundaries (UTF-16 encoding edge case). You have two options:
+`s[a:b]` may raise an error at surrogate boundaries (UTF-16 encoding edge case). Use one of these patterns:
 
-- Use `try! s[a:b]` if you're certain the boundaries are valid (crashes on invalid boundaries)
-- Let the error propagate to the caller for proper handling
+- Let the error propagate from a raising caller when boundaries are valid by construction
+- Catch the slice error locally when invalid boundaries need fallback handling
 
 **When to use views**:
 

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -301,7 +301,7 @@ fn base_prompt() -> String {
     #|- Black-box by default: Call only public APIs via `@package.fn`. Use white-box tests only when private members matter.
     #|- Grouping: Combine related checks in one `test "..." { ... }` block for speed and clarity.
     #|- Panics: Name tests with prefix `test "panic ..." {...}`; if the call returns a value, wrap it with `ignore(...)` to silence warnings.
-    #|- Errors: Use `try? f()` to get `Result[...]` and `inspect` it when a function may raise.
+    #|- Errors: Use `try { ... } catch { ... } noraise { ... }` when a test needs to inspect a function that may raise.
     #|
     #|### Docstring tests
     #|
@@ -748,7 +748,7 @@ fn base_prompt() -> String {
     #|MoonBit uses checked error-throwing functions, not unchecked exceptions. All errors are a subtype of `Error` and you can declare your own error types using `suberror`.
     #|Use `raise` in signatures to declare error types and let errors propagate by
     #|default.  `try { } catch { }`
-    #|to handle errors explicitly. Use `try!` to abort if it does raise. Occasionally, use `try?` to convert to `Result[...]` in tests for inspection.
+    #|to handle errors explicitly. In tests, use `try { ... } catch { ... } noraise { ... }` when you need to inspect the raised error.
     #|
     #|```mbt check
     #|///|
@@ -791,13 +791,18 @@ fn base_prompt() -> String {
     #|
     #|///|
     #|test "inspect raise function" {
-    #|  let result : Result[Int, Error] = try? div(1, 0)
-    #|  guard result is Err(Failure::Failure(msg)) && msg.contains("Division by zero") else {
-    #|    fail("Expected error")
+    #|  try {
+    #|    ignore(div(1, 0))
+    #|  } catch {
+    #|    error => {
+    #|      inspect(error)
+    #|    }
+    #|  } noraise {
+    #|    _ => fail("Expected error")
     #|  }
     #|}
     #|
-    #|// Three ways to handle errors:
+    #|// Two common ways to handle errors:
     #|
     #|///|
     #|/// Propagate automatically
@@ -807,13 +812,6 @@ fn base_prompt() -> String {
     #|  // Unlike Swift, you do not need to mark `try` for functions that can raise
     #|  // errors; the compiler infers it automatically. This keeps error handling
     #|  // explicit but concise.
-    #|  x * 2
-    #|}
-    #|
-    #|///|
-    #|/// Use try! to abort if it raises, no raise in the signature
-    #|fn use_parse2(position~ : Position) -> Int {
-    #|  let x = try! parse_int("123", position~) // label punning
     #|  x * 2
     #|}
     #|
@@ -1034,10 +1032,10 @@ fn base_prompt() -> String {
     #|- `Array[T]`, `FixedArray[T]`, `ReadOnlyArray[T] → `ArrayView[T]` via `a[:]` or `a[start:end]`, etc.
     #|
     #|**Important**: StringView slice is slightly different due to unicode safety:
-    #|`s[a:b]` may raise an error at surrogate boundaries (UTF-16 encoding edge case). You have two options:
+    #|`s[a:b]` may raise an error at surrogate boundaries (UTF-16 encoding edge case). Use one of these patterns:
     #|
-    #|- Use `try! s[a:b]` if you're certain the boundaries are valid (crashes on invalid boundaries)
-    #|- Let the error propagate to the caller for proper handling
+    #|- Let the error propagate from a raising caller when boundaries are valid by construction
+    #|- Catch the slice error locally when invalid boundaries need fallback handling
     #|
     #|**When to use views**:
     #|

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -24,6 +24,8 @@ test "system prompt includes moonbit guide" {
   assert_true(prompt.contains("acceptance probes"))
   assert_true(prompt.contains("file arguments are read as files"))
   assert_true(prompt.contains("OpenSeek DeepSeek Addendum"))
+  assert_false(prompt.contains("try?"))
+  assert_false(prompt.contains("try!"))
 }
 
 ///|


### PR DESCRIPTION
## Summary
- replace deprecated `try?` conversion in chat response tool-call decoding with direct raising propagation
- update the V4 Pro prompt guidance to use `try/catch/noraise` and normal propagation instead of `try?`/`try!`
- add prompt regression assertions so the base prompt does not reintroduce those deprecated shorthands

## Validation
- `moon check`
- `moon test deepseek`
- `moon test deepseek prompt`
- `moon info`
- `moon fmt`
- `moon test`