### PR TITLE
Simplify live test to two imports via jsonl.read_stdin

### DIFF
--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -11,11 +11,12 @@ moon cram test tests/live
 
 The agent streams one JSON object per line (JSONL) to stdout. Instead of an
 external tool such as `jq`, we parse that log with MoonBit itself: the published
-[`bobzhang/jsonl`](https://mooncakes.io/docs/bobzhang/jsonl) package reads the
-stream through `moonbitlang/async/io` and hands back typed `Json` values, so the
-assertions are plain MoonBit pattern matches. The `moon run -e` script below is
-the whole consumer; `grep '='` only drops `moon`'s own dependency-resolution
-chatter, not any log content.
+[`bobzhang/jsonl`](https://mooncakes.io/docs/bobzhang/jsonl) package reads stdin
+and hands back typed `Json` values, so the assertions are plain MoonBit pattern
+matches. Its `read_stdin` helper encapsulates `moonbitlang/async/stdio`, so the
+script imports only `bobzhang/jsonl` plus `moonbitlang/async` — the latter is
+unavoidable because `async fn main` requires it. The `grep '='` only drops
+`moon`'s own dependency-resolution chatter, not any log content.
 
 We give the cheap Flash model a trivial, self-contained task and a tiny step
 budget. The script then proves two things from the real log: that the request
@@ -26,13 +27,12 @@ and that the model invoked the `finish` tool with the requested answer
 ```mooncram
 $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
 >   | moon run --target native -e 'import {
->   "bobzhang/jsonl@0.1.0",
+>   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",
->   "moonbitlang/async/stdio",
 > }
 > 
 > async fn main {
->   let values = @jsonl.read_all(@stdio.stdin)
+>   let values = @jsonl.read_stdin()
 >   let mut tokens_ok = false
 >   let mut finished = false
 >   for value in values {


### PR DESCRIPTION
Follow-up to #20.

`bobzhang/jsonl` 0.2.0 adds `read_stdin()`, which encapsulates `moonbitlang/async/stdio`. The live `moon run -e` script in `tests/live/deepseek.md` now imports only:

```moonbit
import {
  "bobzhang/jsonl@0.2.0",
  "moonbitlang/async",
}
async fn main {
  let values = @jsonl.read_stdin()
  ...
}
```

`moonbitlang/async` stays because `async fn main` requires it (the compiler rejects async main without it, even though jsonl pulls it in transitively) — two imports is the floor while keeping async main. `grep '='` remains only to strip `moon`'s dependency-resolution chatter from stdout.

Docs-only change to the opt-in live suite (not run in CI). Verified end-to-end against the real DeepSeek API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)