### PR TITLE
feat(cmd/tui): render the agent by spawning it and parsing JSONL stdout

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -72,12 +72,15 @@ notes.
 ## Verified CLI Documentation (cram)
 
 The CLI behaviour is documented as executable cram tests under `tests/`, built
-and run with `moon cram test`. The wrapper compiles `cmd/openseek` and exposes it
-on `PATH` as `openseek.exe`.
+and run with `moon cram test`. The wrapper compiles the native `cmd/*` packages
+and exposes each on `PATH` as `<name>.exe` (e.g. `openseek.exe`, `tui.exe`).
 
-- [`tests/cram/cli.md`](tests/cram/cli.md) — offline examples (the full help
-  banner and the missing-API-key error). They make no network calls, use no
-  output-processing tools, and run in CI via `moon cram test tests/cram`.
+- [`tests/cram/cli.md`](tests/cram/cli.md) — offline `cmd/openseek` examples (the
+  full help banner and the missing-API-key error). They make no network calls,
+  use no output-processing tools, and run in CI via `moon cram test tests/cram`.
+- [`tests/cram/tui.md`](tests/cram/tui.md) — offline `cmd/tui` examples (the help
+  banner and the missing-API-key error). The argument parser runs before the
+  terminal UI starts, so these need no API key and no TTY.
 - [`tests/live/deepseek.md`](tests/live/deepseek.md) — a real, non-mock DeepSeek
   round trip. It is opt-in (`DEEPSEEK=sk-... moon cram test tests/live`) and
   parses the agent's JSONL log with MoonBit itself: a `moon run -e` script reads

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -6,11 +6,18 @@ import {
 }
 
 // Values
+pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
+
 pub fn definition() -> @agent_tool.AgentToolDefinition
 
 // Errors
 
 // Types and methods
+pub struct ShellOutput {
+  exit_code : Int?
+  text : String
+  output_limit_reached : Bool
+}
 
 // Type aliases
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -101,10 +101,20 @@ async fn shell(input : @decode.ShellInput) -> @agent_tool.ToolAction {
   let result = match input.timeout_ms {
     Some(timeout_ms) =>
       @async.with_timeout_opt(timeout_ms, () => {
-        collect_shell_output(input.cmd, input.cwd, input.max_output_chars)
+        collect_shell_output(
+          input.cmd,
+          cwd?=input.cwd,
+          max_output_chars=input.max_output_chars,
+        )
       })
     None =>
-      Some(collect_shell_output(input.cmd, input.cwd, input.max_output_chars))
+      Some(
+        collect_shell_output(
+          input.cmd,
+          cwd?=input.cwd,
+          max_output_chars=input.max_output_chars,
+        ),
+      )
   }
   let output = match result {
     Some(result) => result
@@ -124,7 +134,11 @@ async fn shell(input : @decode.ShellInput) -> @agent_tool.ToolAction {
 }
 
 ///|
-priv struct ShellOutput {
+/// The result of running a shell command line: the `exit_code` (`None` if the
+/// command was cancelled or killed before it exited), the merged stdout+stderr
+/// `text` (truncated to the character budget), and whether that truncation
+/// happened.
+pub struct ShellOutput {
   exit_code : Int?
   text : String
   output_limit_reached : Bool
@@ -137,10 +151,16 @@ priv struct ShellResponse {
 }
 
 ///|
-async fn collect_shell_output(
+/// Run `cmd` through the platform shell (`sh -c`, or `pwsh -NoProfile -Command`
+/// on Windows), capturing merged stdout+stderr. This is the execution core
+/// behind the `shell` tool, but it applies NO command policy or safety
+/// filtering — so frontends that run explicit user commands (e.g. the TUI's `!`
+/// command) can reuse it directly. Callers that want the agent guardrails go
+/// through `definition()`/`execute` instead.
+pub async fn collect_shell_output(
   cmd : String,
-  cwd : String?,
-  max_output_chars : Int,
+  cwd? : String,
+  max_output_chars? : Int = @decode.default_max_output_chars,
 ) -> ShellOutput {
   let program = PlatformShellProgram
   let args = platform_shell_args(cmd)

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1,5 +1,6 @@
 ///|
 async fn main {
+  configure_logging()
   let matches = cli_command().parse(env=@env.get_env_vars())
   let api_key = value(matches, "api-key")
   let model = @deepseek.Model::parse(value(matches, "model"))
@@ -7,6 +8,25 @@ async fn main {
   let system_prompt_text = configured_system_prompt(matches, model)
   let task = values(matches, "task").join(" ")
   @agent.run(api_key, model, task, max_steps~, system_prompt_text~)
+}
+
+///|
+/// Mirror every JSONL log event to `OPENSEEK_LOG_FILE` in addition to stdout
+/// when that variable is set.
+///
+/// The TUI parses the JSONL the engine writes to stdout, so stdout is left
+/// exactly as it was (the default `Stdout` handler keeps its `Jsonl` format);
+/// this only adds a second handler that appends the same JSONL to the file. The
+/// file handler flushes per entry, so `tail -f $OPENSEEK_LOG_FILE` shows events
+/// live — useful for inspecting a stuck or headless session. Best-effort: if the
+/// file cannot be opened, logging stays stdout-only rather than failing the run.
+fn configure_logging() -> Unit {
+  guard @env.get_env_var("OPENSEEK_LOG_FILE") is Some(path) && path != "" else {
+    return
+  }
+  let file = @xlog.File::File(path) catch { _ => return }
+  let handlers : Array[&@xlog.Handler] = [@xlog.Stdout(), file]
+  @xlog.global().set_handler(@xlog.Multi(handlers))
 }
 
 ///|

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbitlang/core/argparse",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
+  "tonyfettes/xlog",
 }
 
 warnings = "+unnecessary_annotation"

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -1,0 +1,191 @@
+///|
+fn drain_test_state() -> State {
+  State::new({
+    api_key: "k",
+    model: V4Pro,
+    cwd: ".",
+    max_steps: 10,
+    engine: "openseek",
+  })
+}
+
+///|
+fn start_agent_count(cmds : Array[Cmd]) -> Int {
+  let mut count = 0
+  for cmd in cmds {
+    if cmd is StartAgent(_, ..) {
+      count = count + 1
+    }
+  }
+  count
+}
+
+///|
+fn error_item_count(cmds : Array[Cmd]) -> Int {
+  let mut count = 0
+  for cmd in cmds {
+    if cmd is AppendItem(Error(_)) {
+      count = count + 1
+    }
+  }
+  count
+}
+
+///|
+fn run_command_count(cmds : Array[Cmd]) -> Int {
+  let mut count = 0
+  for cmd in cmds {
+    if cmd is RunCommand(_, ..) {
+      count = count + 1
+    }
+  }
+  count
+}
+
+///|
+test "a submitted shell command runs locally, not via the agent" {
+  let state = drain_test_state()
+  // A `!` command submitted while idle drains to a local RunCommand, never to
+  // the agent engine.
+  let cmds = update(state, UiInput(Steer(Command("ls"))))
+  assert_true(state.run is Running(_))
+  assert_eq(run_command_count(cmds), 1)
+  assert_eq(start_agent_count(cmds), 0)
+}
+
+///|
+test "queued input drains exactly when the agent is idle" {
+  let state = drain_test_state()
+
+  // Submit while idle: starts immediately, nothing left queued.
+  let cmds = update(state, UiInput(Steer(Prompt("a"))))
+  assert_true(state.run is Running(_))
+  assert_eq(state.queued.length(), 0)
+  assert_eq(start_agent_count(cmds), 1)
+
+  // Submit while running: queues, no new agent started.
+  let cmds = update(state, UiInput(Queue(Prompt("b"))))
+  assert_true(state.run is Running(_))
+  assert_eq(state.queued.length(), 1)
+  assert_eq(start_agent_count(cmds), 0)
+
+  // A non-terminal progress event must not drain the queue.
+  let cmds = update(
+    state,
+    AgentProgress(run_id=state.run_id, AssistantMessage("thinking")),
+  )
+  assert_true(state.run is Running(_))
+  assert_eq(state.queued.length(), 1)
+  assert_eq(start_agent_count(cmds), 0)
+
+  // Agent finishes with one queued: drains "b" and starts it.
+  let cmds = update(
+    state,
+    AgentProgress(run_id=state.run_id, AgentFinished("done-a")),
+  )
+  assert_true(state.run is Running(_))
+  assert_eq(state.queued.length(), 0)
+  assert_eq(start_agent_count(cmds), 1)
+
+  // Agent finishes with empty queue: stays idle, nothing started.
+  let cmds = update(
+    state,
+    AgentProgress(run_id=state.run_id, AgentFinished("done-b")),
+  )
+  assert_true(state.run is Idle)
+  assert_eq(state.queued.length(), 0)
+  assert_eq(start_agent_count(cmds), 0)
+}
+
+///|
+test "a stale terminal event from a superseded run is ignored" {
+  let state = drain_test_state()
+
+  // Run A starts, and a second input B is queued behind it.
+  let _ = update(state, UiInput(Steer(Prompt("a"))))
+  let run_a = state.run_id
+  let _ = update(state, UiInput(Queue(Prompt("b"))))
+
+  // A finishes: the queue drains and B starts as a new run with a fresh id.
+  let _ = update(state, AgentProgress(run_id=run_a, AgentFinished("done-a")))
+  assert_true(state.run is Running(_))
+  let run_b = state.run_id
+  assert_true(run_b != run_a)
+
+  // A late terminal from the already-superseded run A (e.g. an `AgentCancelled`
+  // that races a natural finish) must be dropped: it neither finishes B nor
+  // drains the queue again.
+  let cmds = update(state, AgentCancelled(run_id=run_a))
+  assert_eq(cmds.length(), 0)
+  assert_true(state.run is Running(_))
+  assert_eq(state.run_id, run_b)
+}
+
+///|
+fn quit_count(cmds : Array[Cmd]) -> Int {
+  let mut count = 0
+  for cmd in cmds {
+    if cmd is Quit {
+      count = count + 1
+    }
+  }
+  count
+}
+
+///|
+test "Ctrl+C quits when idle and interrupts when a task is running" {
+  let state = drain_test_state()
+
+  // Idle: an interrupt quits the TUI rather than reporting a dead end.
+  let cmds = update(state, UiInput(Interrupt))
+  assert_eq(quit_count(cmds), 1)
+  assert_eq(error_item_count(cmds), 0)
+  assert_true(state.run is Idle)
+
+  // Running: the same interrupt cancels the task instead of quitting.
+  let _ = update(state, UiInput(Steer(Prompt("a"))))
+  assert_true(state.run is Running(_))
+  let cmds = update(state, UiInput(Interrupt))
+  assert_eq(quit_count(cmds), 0)
+  assert_true(cmds.iter().any(cmd => cmd is CancelAgent))
+  assert_true(state.run is Interrupting(_))
+}
+
+///|
+test "a tick while idle never starts an agent" {
+  let state = drain_test_state()
+  let cmds = update(state, Tick)
+  assert_true(state.run is Idle)
+  assert_eq(start_agent_count(cmds), 0)
+}
+
+///|
+test "steering a running agent reports an error and does not queue" {
+  let state = drain_test_state()
+
+  // Idle Steer submits and starts a task.
+  let _ = update(state, UiInput(Steer(Prompt("a"))))
+  assert_true(state.run is Running(_))
+  assert_eq(state.queued.length(), 0)
+
+  // Steer while running: error, nothing queued, nothing started.
+  let cmds = update(state, UiInput(Steer(Prompt("b"))))
+  assert_eq(state.queued.length(), 0)
+  assert_eq(start_agent_count(cmds), 0)
+  assert_eq(error_item_count(cmds), 1)
+
+  // Queue while running still queues without error.
+  let cmds = update(state, UiInput(Queue(Prompt("c"))))
+  assert_eq(state.queued.length(), 1)
+  assert_eq(error_item_count(cmds), 0)
+}
+
+///|
+test "compact_lines strips CRLF so tool output has no stray carriage returns" {
+  inspect(compact_lines("a\r\nb\r\nc", 6).join("|"), content="a|b|c")
+  // Truncation still works and the kept lines carry no `\r`.
+  inspect(
+    compact_lines("a\r\nb\r\nc\r\nd\r\ne", 3).join("|"),
+    content="a|... +3 lines|e",
+  )
+}

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -1,0 +1,45 @@
+// Mapping from the engine's decoded JSONL values to typed `AgentEvent`s. Reading
+// lines, skipping blanks, and parsing each as JSON is `bobzhang/jsonl`'s job
+// (`@jsonl.each` in `cmd/tui`); this module only maps an already-parsed value,
+// keyed by its `"event"` discriminator.
+
+///|
+/// Map one decoded JSONL value from the engine into an `AgentEvent`.
+///
+/// Returns `None` for a non-object value or an unrecognized `"event"` string so
+/// a noisy or newer engine never crashes the UI; the caller simply drops it.
+pub fn decode_event(object : Json) -> AgentEvent? {
+  match @jsonx.string(object, "event") {
+    "agent_step" => Some(AgentStep)
+    "assistant_message" =>
+      Some(AssistantMessage(@jsonx.string(object, "content")))
+    "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))
+    "usage" => {
+      let prompt = @jsonx.int(object, "prompt_tokens")
+      let completion = @jsonx.int(object, "completion_tokens")
+      Some(Usage({ total_tokens: prompt + completion }))
+    }
+    "tool_result" =>
+      Some(
+        ToolResult({
+          name: @jsonx.string(object, "tool_name"),
+          content: @jsonx.string(object, "content"),
+          is_error: @jsonx.bool(object, "is_error"),
+        }),
+      )
+    "tool_call_decode_error" =>
+      Some(
+        ToolResult({
+          name: @jsonx.string(object, "tool_name"),
+          content: "error: \{@jsonx.string(object, "error")}",
+          is_error: true,
+        }),
+      )
+    "agent_finished" => Some(AgentFinished(@jsonx.string(object, "answer")))
+    "agent_aborted" => Some(AgentAborted(@jsonx.string(object, "reason")))
+    "max_steps_exhausted" => Some(MaxStepsExhausted)
+    "agent_setup_failed" =>
+      Some(AgentError("agent setup failed: " + @jsonx.string(object, "error")))
+    _ => None
+  }
+}

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -1,0 +1,67 @@
+///|
+test "decode maps each engine event kind" {
+  assert_true(
+    @event.decode_event(Json::object({ "event": "agent_step", "step": 3 }))
+    is Some(AgentStep),
+  )
+  assert_true(
+    @event.decode_event(Json::object({ "event": "max_steps_exhausted" }))
+    is Some(MaxStepsExhausted),
+  )
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "agent_finished", "answer": "done" }),
+    )
+    is Some(AgentFinished("done")),
+  )
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "runtime_update", "content": "checked: 1 error" }),
+    )
+    is Some(RuntimeUpdate("checked: 1 error")),
+  )
+  match
+    @event.decode_event(
+      Json::object({
+        "event": "tool_result",
+        "tool_call_id": "c1",
+        "tool_name": "bash",
+        "is_error": true,
+        "content": "boom",
+      }),
+    ) {
+    Some(ToolResult(result)) => {
+      assert_eq(result.name, "bash")
+      assert_eq(result.content, "boom")
+      assert_true(result.is_error)
+    }
+    _ => fail("expected ToolResult")
+  }
+}
+
+///|
+test "decode returns None for a non-object value or unknown event" {
+  // `@jsonl` handles blank and malformed lines before decoding; the mapping only
+  // has to tolerate a non-object value and a newer engine's unknown event kind.
+  assert_true(@event.decode_event(Json::string("not an object")) is None)
+  assert_true(
+    @event.decode_event(Json::object({ "event": "future_event_kind" })) is None,
+  )
+}
+
+///|
+test "usage total is derived from prompt and completion tokens" {
+  match
+    @event.decode_event(
+      Json::object({
+        "event": "usage",
+        "prompt_tokens": 100,
+        "completion_tokens": 23,
+        "cache_hit_tokens": 0,
+        "cache_miss_tokens": 100,
+      }),
+    ) {
+    Some(Usage(usage)) => assert_eq(usage.total_tokens, 123)
+    _ => fail("expected Usage")
+  }
+}

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -1,0 +1,45 @@
+// The decoded, in-memory form of the engine's JSONL event stream. The `openseek`
+// engine writes one JSON object per line to stdout; `decode_event` (see
+// `decode.mbt`) maps each into an `AgentEvent`. The `cmd/tui` rendering loop
+// pattern-matches on these types and never touches the wire format.
+
+///|
+/// Token accounting decoded from a `usage` event.
+///
+/// The engine reports prompt/completion/cache counts; only the derived total
+/// (`prompt + completion`) is shown in the status line, so that is all we keep.
+pub(all) struct UsageInfo {
+  total_tokens : Int
+}
+
+///|
+/// The result of a tool call after the engine ran it.
+pub(all) struct ToolResultEvent {
+  name : String
+  content : String
+  is_error : Bool
+}
+
+///|
+/// Decoded agent progress events, one per JSONL line from the engine.
+///
+/// Variant names mirror the engine's wire `event` strings (`agent_step` →
+/// `AgentStep`, `tool_result` → `ToolResult`, …) so decoding is a near-identity
+/// map. `AgentError` is the exception: it carries both the engine's
+/// `agent_setup_failed` and the TUI-synthesized "engine exited without a result"
+/// error, so it stays a general category rather than a single wire event.
+///
+/// Terminal events (`AgentFinished`, `AgentAborted`, `MaxStepsExhausted`,
+/// `AgentError`) leave the agent idle so the message loop can drain the next
+/// queued input.
+pub(all) enum AgentEvent {
+  AgentStep
+  AssistantMessage(String)
+  RuntimeUpdate(String)
+  Usage(UsageInfo)
+  ToolResult(ToolResultEvent)
+  AgentFinished(String)
+  AgentAborted(String)
+  MaxStepsExhausted
+  AgentError(String)
+}

--- a/cmd/tui/internal/event/moon.pkg
+++ b/cmd/tui/internal/event/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "bobzhang/openseek/cmd/tui/internal/jsonx",
+}
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "native"

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -1,0 +1,35 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/tui/internal/event"
+
+// Values
+pub fn decode_event(Json) -> AgentEvent?
+
+// Errors
+
+// Types and methods
+pub(all) enum AgentEvent {
+  AgentStep
+  AssistantMessage(String)
+  RuntimeUpdate(String)
+  Usage(UsageInfo)
+  ToolResult(ToolResultEvent)
+  AgentFinished(String)
+  AgentAborted(String)
+  MaxStepsExhausted
+  AgentError(String)
+}
+
+pub(all) struct ToolResultEvent {
+  name : String
+  content : String
+  is_error : Bool
+}
+
+pub(all) struct UsageInfo {
+  total_tokens : Int
+}
+
+// Type aliases
+
+// Traits
+

--- a/cmd/tui/internal/jsonx/jsonx.mbt
+++ b/cmd/tui/internal/jsonx/jsonx.mbt
@@ -1,0 +1,41 @@
+// Lenient field accessors over a decoded `Json` value. Each returns a benign
+// default (`None` / `""` / `0` / `false`) when the value is not an object, the
+// key is absent, or the value has the wrong shape — so a decoder can read an
+// object field by field without a cascade of nested pattern matches.
+
+///|
+/// The value at `key`, or `None` when `object` is not an object or has no such
+/// key.
+pub fn field(object : Json, key : String) -> Json? {
+  if object is Object(fields) {
+    fields.get(key)
+  } else {
+    None
+  }
+}
+
+///|
+/// The string at `key`, or `""` when it is absent or not a string.
+pub fn string(object : Json, key : String) -> String {
+  if field(object, key) is Some(String(text)) {
+    text
+  } else {
+    ""
+  }
+}
+
+///|
+/// The integer at `key`, or `0` when it is absent or not a number.
+pub fn int(object : Json, key : String) -> Int {
+  if field(object, key) is Some(Number(number, ..)) {
+    number.to_int()
+  } else {
+    0
+  }
+}
+
+///|
+/// Whether `key` is present with the JSON value `true`.
+pub fn bool(object : Json, key : String) -> Bool {
+  field(object, key) is Some(True)
+}

--- a/cmd/tui/internal/jsonx/moon.pkg
+++ b/cmd/tui/internal/jsonx/moon.pkg
@@ -1,0 +1,3 @@
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "native"

--- a/cmd/tui/internal/jsonx/pkg.generated.mbti
+++ b/cmd/tui/internal/jsonx/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/tui/internal/jsonx"
+
+// Values
+pub fn bool(Json, String) -> Bool
+
+pub fn field(Json, String) -> Json?
+
+pub fn int(Json, String) -> Int
+
+pub fn string(Json, String) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -1,0 +1,414 @@
+///|
+/// Decode one engine event and run it through `update`, appending any resulting
+/// transcript items to `items`. Accumulating into a caller-owned array lets a
+/// test replay a whole session and snapshot the rendered transcript at the end.
+fn append_items(
+  state : State,
+  value : Json,
+  items : Array[@ui.TranscriptItem],
+) -> Unit {
+  match @event.decode_event(value) {
+    Some(event) =>
+      for cmd in update(state, AgentProgress(run_id=state.run_id, event)) {
+        if cmd is AppendItem(item) {
+          items.push(item)
+        }
+      }
+    None => ()
+  }
+}
+
+///|
+async test "a shell command runs locally and posts its output" {
+  let messages = @async.Queue(kind=Unbounded)
+  // `echo` is the same on POSIX `sh` and Windows `pwsh`, so the platform shell
+  // `@shell.collect_shell_output` picks runs this on either.
+  run_shell_command(1, "echo hello", messages)
+  // The only message is the local command result: a completed tool item titled
+  // with the command, its stdout as a dimmed detail line. Nothing is sent to the
+  // engine.
+  let item = match messages.get() {
+    CommandResult(item, ..) => item
+    _ => fail("expected a CommandResult")
+  }
+  debug_inspect(
+    item,
+    content=(
+      #|ToolCall(
+      #|  {
+      #|    title: {
+      #|      spans: [
+      #|        {
+      #|          display: {
+      #|            text: "$ echo hello",
+      #|            units: [
+      #|              {
+      #|                text: <StringView: "$">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(1),
+      #|                display_end: DisplayPosition(1),
+      #|              },
+      #|              {
+      #|                text: <StringView: " ">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(2),
+      #|                display_end: DisplayPosition(2),
+      #|              },
+      #|              {
+      #|                text: <StringView: "e">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(3),
+      #|                display_end: DisplayPosition(3),
+      #|              },
+      #|              {
+      #|                text: <StringView: "c">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(4),
+      #|                display_end: DisplayPosition(4),
+      #|              },
+      #|              {
+      #|                text: <StringView: "h">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(5),
+      #|                display_end: DisplayPosition(5),
+      #|              },
+      #|              {
+      #|                text: <StringView: "o">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(6),
+      #|                display_end: DisplayPosition(6),
+      #|              },
+      #|              {
+      #|                text: <StringView: " ">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(7),
+      #|                display_end: DisplayPosition(7),
+      #|              },
+      #|              {
+      #|                text: <StringView: "h">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(8),
+      #|                display_end: DisplayPosition(8),
+      #|              },
+      #|              {
+      #|                text: <StringView: "e">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(9),
+      #|                display_end: DisplayPosition(9),
+      #|              },
+      #|              {
+      #|                text: <StringView: "l">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(10),
+      #|                display_end: DisplayPosition(10),
+      #|              },
+      #|              {
+      #|                text: <StringView: "l">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(11),
+      #|                display_end: DisplayPosition(11),
+      #|              },
+      #|              {
+      #|                text: <StringView: "o">,
+      #|                width: 1,
+      #|                textual_end: TextualPosition(12),
+      #|                display_end: DisplayPosition(12),
+      #|              },
+      #|            ],
+      #|            width: 12,
+      #|            cjk: false,
+      #|          },
+      #|          style: { foreground: Default, background: Default, underline: false },
+      #|        },
+      #|      ],
+      #|    },
+      #|    status: Some(Completed),
+      #|    details: [
+      #|      {
+      #|        spans: [
+      #|          {
+      #|            display: {
+      #|              text: "hello",
+      #|              units: [
+      #|                {
+      #|                  text: <StringView: "h">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(1),
+      #|                  display_end: DisplayPosition(1),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "e">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(2),
+      #|                  display_end: DisplayPosition(2),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "l">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(3),
+      #|                  display_end: DisplayPosition(3),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "l">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(4),
+      #|                  display_end: DisplayPosition(4),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "o">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(5),
+      #|                  display_end: DisplayPosition(5),
+      #|                },
+      #|              ],
+      #|              width: 5,
+      #|              cjk: false,
+      #|            },
+      #|            style: {
+      #|              foreground: Basic(BrightBlack),
+      #|              background: Default,
+      #|              underline: false,
+      #|            },
+      #|          },
+      #|        ],
+      #|      },
+      #|    ],
+      #|  },
+      #|)
+    ),
+  )
+}
+
+///|
+test "a runtime_update event surfaces as a ↻ tool-style notice" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  assert_true(state.run is Running(_))
+  let items : Array[@ui.TranscriptItem] = []
+  // A realistic engine body: the `[moon_check update]` header, the key=value
+  // metadata preamble, then the captured watcher output.
+  append_items(
+    state,
+    Json::object({
+      "event": "runtime_update",
+      "content": "[moon_check update]\nevents=3\nid=moon-check-1\ncwd=.\ncommand=moon check --watch --diagnostic-limit 10\nstatus=running\nseq=3\nWarning: unused variable x\nFinished.",
+    }),
+    items,
+  )
+  // The metadata preamble is stripped: the watcher status is lifted out and only
+  // the captured diagnostics remain (the `↻` tool-style rendering itself is
+  // covered in `tui/core`).
+  let view = parse_runtime_update(
+    "[moon_check update]\nevents=3\nid=moon-check-1\ncwd=.\ncommand=moon check --watch --diagnostic-limit 10\nstatus=running\nseq=3\nWarning: unused variable x\nFinished.",
+  )
+  inspect(view.status, content="running")
+  inspect(
+    view.diagnostics.join("|"),
+    content="Warning: unused variable x|Finished.",
+  )
+  // The event yields exactly one non-terminal `Notice`, and the status bar picks
+  // up the watcher state.
+  guard items is [Notice(_)] else { fail("expected a single Notice item") }
+  assert_eq(state.watcher_status, "running")
+  assert_true(state.run is Running(_))
+
+  // The watcher belongs to the engine process, which exits when the run ends, so
+  // a terminal event must clear the status: no stale `moon_check running` segment
+  // should linger in the status bar while the TUI is idle.
+  let _ = update(
+    state,
+    AgentProgress(run_id=state.run_id, AgentFinished("done")),
+  )
+  assert_true(state.run is Idle)
+  assert_eq(state.watcher_status, "")
+  assert_eq(watcher_segment_text(state.watcher_status), "")
+}
+
+///|
+test "parse_runtime_update aggregates status across watcher sections" {
+  // A single update lists one section per watcher key. When one watcher has
+  // stopped but another is still running — and the stopped one is parsed last —
+  // the status must be `running`, not the last-seen value, so the status bar
+  // does not claim checking is done while a watcher is still active.
+  let view = parse_runtime_update(
+    "[moon_check update]\nevents=2\nid=a\nstatus=running\nseq=1\nchecking a\n\nid=b\nstatus=stopped\nseq=1\ndone b",
+  )
+  inspect(view.status, content="running")
+  inspect(view.diagnostics.join("|"), content="checking a||done b")
+
+  // With every section stopped, the aggregate falls back to the last status.
+  let stopped = parse_runtime_update(
+    "[moon_check update]\nevents=2\nid=a\nstatus=stopped\nseq=1\n\nid=b\nstatus=stopped\nseq=1",
+  )
+  inspect(stopped.status, content="stopped")
+}
+
+///|
+test "replaying a recorded engine session renders the transcript" {
+  let state = drain_test_state()
+  // Submit a task so the agent is running before progress arrives.
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  assert_true(state.run is Running(_))
+
+  // A realistic one-step session: think, report usage, run a tool, finish.
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(state, Json::object({ "event": "agent_step", "step": 1 }), items)
+  append_items(
+    state,
+    Json::object({
+      "event": "assistant_message",
+      "content": "Let me check the project.",
+    }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({
+      "event": "usage",
+      "prompt_tokens": 100,
+      "completion_tokens": 20,
+      "cache_hit_tokens": 0,
+      "cache_miss_tokens": 100,
+    }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({
+      "event": "tool_result",
+      "tool_call_id": "c1",
+      "tool_name": "bash",
+      "is_error": false,
+      "content": "ok",
+    }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({ "event": "agent_finished", "answer": "all done" }),
+    items,
+  )
+
+  // The rendered transcript: the assistant message, the tool result, and the
+  // final answer. `agent_step` and `usage` update state without emitting items.
+  debug_inspect(
+    items,
+    content=(
+      #|[
+      #|  Response("Let me check the project."),
+      #|  ToolCall(
+      #|    {
+      #|      title: {
+      #|        spans: [
+      #|          {
+      #|            display: {
+      #|              text: "Tool bash",
+      #|              units: [
+      #|                {
+      #|                  text: <StringView: "T">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(1),
+      #|                  display_end: DisplayPosition(1),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "o">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(2),
+      #|                  display_end: DisplayPosition(2),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "o">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(3),
+      #|                  display_end: DisplayPosition(3),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "l">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(4),
+      #|                  display_end: DisplayPosition(4),
+      #|                },
+      #|                {
+      #|                  text: <StringView: " ">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(5),
+      #|                  display_end: DisplayPosition(5),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "b">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(6),
+      #|                  display_end: DisplayPosition(6),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "a">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(7),
+      #|                  display_end: DisplayPosition(7),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "s">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(8),
+      #|                  display_end: DisplayPosition(8),
+      #|                },
+      #|                {
+      #|                  text: <StringView: "h">,
+      #|                  width: 1,
+      #|                  textual_end: TextualPosition(9),
+      #|                  display_end: DisplayPosition(9),
+      #|                },
+      #|              ],
+      #|              width: 9,
+      #|              cjk: false,
+      #|            },
+      #|            style: { foreground: Default, background: Default, underline: false },
+      #|          },
+      #|        ],
+      #|      },
+      #|      status: Some(Completed),
+      #|      details: [
+      #|        {
+      #|          spans: [
+      #|            {
+      #|              display: {
+      #|                text: "ok",
+      #|                units: [
+      #|                  {
+      #|                    text: <StringView: "o">,
+      #|                    width: 1,
+      #|                    textual_end: TextualPosition(1),
+      #|                    display_end: DisplayPosition(1),
+      #|                  },
+      #|                  {
+      #|                    text: <StringView: "k">,
+      #|                    width: 1,
+      #|                    textual_end: TextualPosition(2),
+      #|                    display_end: DisplayPosition(2),
+      #|                  },
+      #|                ],
+      #|                width: 2,
+      #|                cjk: false,
+      #|              },
+      #|              style: {
+      #|                foreground: Basic(BrightBlack),
+      #|                background: Default,
+      #|                underline: false,
+      #|              },
+      #|            },
+      #|          ],
+      #|        },
+      #|      ],
+      #|    },
+      #|  ),
+      #|  Response("all done"),
+      #|]
+    ),
+  )
+  match state.usage {
+    Some(usage) => assert_eq(usage.total_tokens, 120)
+    None => fail("usage not recorded")
+  }
+  // The terminal event left the agent idle.
+  assert_true(state.run is Idle)
+}

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -1,0 +1,400 @@
+///|
+async fn read_ui_events(ui : @ui.Ui, messages : @async.Queue[Msg]) -> Unit {
+  for ;; {
+    let event = ui.read_event()
+    messages.put(UiInput(event))
+    if event is Quit {
+      break
+    }
+  }
+}
+
+///|
+async fn tick_ui(messages : @async.Queue[Msg]) -> Unit {
+  for ;; {
+    @async.sleep(1000)
+    messages.put(Tick)
+  }
+}
+
+///|
+/// Cap on the engine stderr we retain to surface in a no-terminal-event error.
+/// We still read past it so the child can never block writing to a full stderr
+/// pipe (which would deadlock the `proc.wait()` below), but only this many bytes
+/// are held in memory and rendered; the overflow is counted and dropped.
+const StderrCaptureLimitBytes : Int = 8192
+
+///|
+/// Per-read size while draining stderr past the cap. The retained bytes are
+/// bounded by the remaining budget so the buffer never overshoots; once full we
+/// keep reading in blocks this size only to drain the pipe, discarding them.
+const StderrDrainChunkBytes : Int = 4096
+
+///|
+/// Drain an engine's stderr `reader` to EOF, retaining at most
+/// `StderrCaptureLimitBytes`. Reading continues past the cap (so the child does
+/// not block on a full pipe), but once the buffer is full further chunks are
+/// discarded and a truncation marker is appended. Bytes are decoded lossily —
+/// stderr is best-effort diagnostics, so a split multi-byte sequence at a chunk
+/// boundary becomes a replacement char rather than failing the whole decode.
+///
+/// A read error ends the drain but is folded into the returned text (after
+/// whatever was captured before it) rather than discarded, so a failure to read
+/// the engine's diagnostics is visible instead of looking like empty stderr.
+/// Cancellation is re-raised so a Ctrl-C still tears the task group down.
+async fn drain_stderr_capped(reader : @process.ReadFromProcess) -> String {
+  let buffer = Buffer()
+  let mut truncated = false
+  let mut read_error : String? = None
+  for ;; {
+    // While there is budget, bound the read by it so a single large `read_some`
+    // can never overshoot the cap; once full, read fixed blocks purely to drain.
+    let remaining = StderrCaptureLimitBytes - buffer.length()
+    let max_len = if remaining > 0 { remaining } else { StderrDrainChunkBytes }
+    let chunk = reader.read_some(max_len~) catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      // Stop on a genuine read error, but keep the prefix already captured and
+      // record the failure so it is surfaced below. `None` ends the loop the
+      // same way EOF does.
+      error => {
+        read_error = Some("\{error}")
+        None
+      }
+    }
+    match chunk {
+      None => break
+      // Under budget the chunk is `<= remaining`, so it fits exactly; once the
+      // buffer is full any further bytes are dropped and flag truncation.
+      Some(chunk) =>
+        if remaining > 0 {
+          buffer.write_bytes(chunk)
+        } else {
+          truncated = true
+        }
+    }
+  }
+  let text = StringBuilder::new()
+  text.write_string(@utf8.decode_lossy(buffer.to_bytes()))
+  if truncated {
+    text.write_string(
+      "\n… (stderr truncated at \{StderrCaptureLimitBytes} bytes)",
+    )
+  }
+  if read_error is Some(message) {
+    text.write_string("\n… (stderr read failed: \{message})")
+  }
+  text.to_string()
+}
+
+///|
+fn is_terminal_event(event : @event.AgentEvent) -> Bool {
+  match event {
+    AgentFinished(_) | AgentAborted(_) | MaxStepsExhausted | AgentError(_) =>
+      true
+    _ => false
+  }
+}
+
+///|
+/// Spawn the agent engine for one input and stream its JSONL stdout into the
+/// message loop.
+///
+/// The engine is a separate process (`config.engine`, default `openseek`): it
+/// runs the task and writes one JSON event per line to stdout. `@jsonl.each`
+/// reads those lines, skips blanks, and parses each as JSON; we map the value to
+/// an `AgentEvent` and forward it as `AgentProgress`. If the engine closes its
+/// stream without a terminal event (it crashed, or exited before answering), we
+/// synthesize an `AgentError` so the loop never hangs waiting for a result that
+/// will not come.
+async fn run_agent_task(
+  config : AppConfig,
+  run_id : Int,
+  task : String,
+  messages : @async.Queue[Msg],
+) -> Unit {
+  @async.with_task_group(group => {
+    let (reader, child_stdout) = @process.read_from_process()
+    let (stderr_reader, child_stderr) = @process.read_from_process()
+    let proc = @process.spawn(
+      group,
+      config.engine,
+      // The TUI accepts hyphen-valued tasks (`allow_hyphen_values`), so a task
+      // can start with `-`/`--` (e.g. the literal text `--help`). Forward it
+      // after a `--` delimiter so the engine's argparse treats it as the task
+      // positional rather than parsing it as one of its own options (which would
+      // exit/print help and never emit a terminal JSONL event).
+      ["--", task],
+      inherit_env=true,
+      extra_env={
+        "DEEPSEEK": config.api_key,
+        "DEEPSEEK_MODEL": config.model.to_string(),
+        "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+      },
+      stdout=child_stdout,
+      stderr=child_stderr,
+    )
+    // Drain the engine's stderr concurrently with stdout. Capturing it (rather
+    // than letting it inherit the terminal) keeps diagnostics from corrupting
+    // the screen `@ui.with_ui` is drawing, and lets us surface them if the
+    // engine dies without a terminal event. The drain is bounded: a misbehaving
+    // engine (crash loop, verbose build log) could write unbounded stderr, so we
+    // keep only a capped prefix in memory while still reading to EOF.
+    // `drain_stderr_capped` folds any read error into its returned text and only
+    // raises on cancellation, which should tear the whole group down — so there
+    // is nothing to swallow here.
+    let stderr_task = group.spawn(no_wait=true) <| () => {
+      drain_stderr_capped(stderr_reader)
+    }
+    let mut saw_terminal = false
+    // A malformed (non-JSON) line raises out of `each`. The only such output is
+    // a runtime crash dump, so rather than surface a parse error we stop reading
+    // and let the exit code below explain the failure. Cancellation is re-raised
+    // to the outer handler so a Ctrl-C still reports `AgentCancelled`.
+    // `each`'s callback is synchronous, so enqueue with `try_put` (the queue
+    // is unbounded, so it never rejects) rather than the async `put`.
+    @jsonl.each(reader, json => {
+      if @event.decode_event(json) is Some(event) {
+        if is_terminal_event(event) {
+          saw_terminal = true
+        }
+        messages.try_put(AgentProgress(run_id~, event)) |> ignore
+      }
+    }) catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      // Protocol violation: stop reading and kill the child instead of waiting
+      // for it. If the engine keeps writing past the bad line, nobody is
+      // draining its stdout, so a plain `proc.wait()` could deadlock on a full
+      // pipe. `cancel()` sends SIGTERM (then SIGKILL) so `wait()` returns.
+      _ => proc.cancel()
+    }
+    // We are done reading; close the read end so the child sees EOF/EPIPE
+    // rather than blocking on a pipe we no longer drain.
+    reader.close()
+    let code = proc.wait()
+    if !saw_terminal {
+      // The engine produced no terminal event. Its stderr is the only clue to
+      // why (a crash, a network/API error), so fold it into the reported error.
+      let diagnostics = stderr_task.wait().trim()
+      let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
+      messages.put(
+        AgentProgress(
+          run_id~,
+          AgentError("engine exited (code \{code}) without a result\{detail}"),
+        ),
+      )
+    }
+  }) catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      messages.put(AgentCancelled(run_id~))
+    error => messages.put(AgentFailed(run_id~, error))
+  }
+}
+
+///|
+/// Run a `!` shell command locally and post its result to the message loop.
+///
+/// Unlike a prompt, a shell command is the TUI's own responsibility: it runs it
+/// through the agent's shell execution (`@shell.collect_shell_output`, which
+/// picks `sh`/`pwsh` per platform and captures merged output but skips the
+/// agent-only command policy), renders the output into the transcript, and never
+/// forwards it to the agent engine or any model. A Ctrl-C cancels the child and
+/// reports the interruption like an aborted task.
+async fn run_shell_command(
+  run_id : Int,
+  command : String,
+  messages : @async.Queue[Msg],
+) -> Unit {
+  let item : @ui.TranscriptItem = command_item(
+    command,
+    @shell.collect_shell_output(command),
+  ) catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) => {
+      messages.put(AgentCancelled(run_id~))
+      return
+    }
+    error => Error("command failed: \{error}")
+  }
+  messages.put(CommandResult(run_id~, item))
+}
+
+///|
+/// Apply one agent progress event to `state`, queueing any transcript updates in
+/// `cmds`. Terminal events call `finish_run`, leaving the agent idle so the
+/// queue drain at the end of `update` can start the next input.
+fn handle_agent_event(
+  state : State,
+  event : @event.AgentEvent,
+  cmds : Array[Cmd],
+) -> Unit {
+  match event {
+    AgentStep => state.step_response = None
+    AssistantMessage(text) => {
+      state.step_response = Some(text)
+      if !text.trim().is_empty() {
+        cmds.push(AppendItem(Response(text)))
+      }
+    }
+    // Out-of-band runtime diagnostics (e.g. `moon check --watch`) the engine fed
+    // back to the model. The model reacts to them, so surface them to the user
+    // too rather than dropping them: lift the watcher status into the status bar
+    // and append the stripped diagnostics as a `↻` tool-style notice.
+    RuntimeUpdate(text) => {
+      let update = parse_runtime_update(text)
+      state.watcher_status = update.status
+      if update.status != "" || update.diagnostics.length() > 0 {
+        cmds.push(AppendItem(runtime_item(update)))
+      }
+    }
+    Usage(usage) => state.usage = Some(usage)
+    ToolResult(result) => cmds.push(AppendItem(tool_item(result)))
+    AgentFinished(answer) => {
+      let already_appended = if state.step_response is Some(response) {
+        response == answer
+      } else {
+        false
+      }
+      // `AgentFinished` follows `AssistantMessage` for normal chat responses,
+      // but tool-controlled finish results may arrive without one.
+      if !already_appended && !answer.trim().is_empty() {
+        cmds.push(AppendItem(Response(answer)))
+      }
+      state.finish_run()
+    }
+    AgentAborted(reason) => {
+      cmds.push(AppendItem(Error("aborted: " + reason)))
+      state.finish_run()
+    }
+    MaxStepsExhausted => {
+      cmds.push(AppendItem(Error("max steps exhausted")))
+      state.finish_run()
+    }
+    AgentError(message) => {
+      cmds.push(AppendItem(Error(message)))
+      state.finish_run()
+    }
+  }
+}
+
+///|
+fn update(state : State, message : Msg) -> Array[Cmd] {
+  let cmds : Array[Cmd] = []
+  // Drop task-originated messages that do not belong to the run currently in
+  // flight. When a task emits a natural terminal event and is then cancelled in
+  // the same window, both messages queue; the first finishes the run and drains
+  // the next queued input, and without this guard the second, stale terminal
+  // would `finish_run` (and possibly start another task) on top of that new run.
+  if message.run_id() is Some(id) && !state.owns_run(id) {
+    return cmds
+  }
+  match message {
+    UiInput(event) =>
+      match event {
+        // Steering (redirecting a task mid-run) is not implementable with the
+        // current agent API. Steer only submits when idle; while a task runs it
+        // reports an error instead of silently queuing. Queue always queues.
+        Steer(input) =>
+          if state.run is Idle {
+            state.queued.push(input)
+          } else {
+            cmds.push(
+              AppendItem(
+                Error(
+                  "Steering is not supported while a task is running. Press Tab to queue this input.",
+                ),
+              ),
+            )
+          }
+        Queue(input) => state.queued.push(input)
+        // Ctrl+C interrupts the running task; when nothing is running it quits
+        // the TUI (the common "press Ctrl+C to get out" expectation), rather than
+        // printing a dead-end "nothing to interrupt" notice.
+        Interrupt =>
+          match state.run {
+            Idle => cmds.push(Quit)
+            Running(started_ms) => {
+              state.run = Interrupting(started_ms)
+              cmds.push(CancelAgent)
+            }
+            Interrupting(_) => cmds.push(CancelAgent)
+          }
+        Quit => cmds.push(Quit)
+      }
+    AgentProgress(event, ..) => handle_agent_event(state, event, cmds)
+    AgentCancelled(..) => {
+      cmds.push(AppendItem(Error("interrupted")))
+      state.finish_run()
+    }
+    AgentFailed(error, ..) => {
+      cmds.push(AppendItem(Error("agent failed: \{error}")))
+      state.finish_run()
+    }
+    CommandResult(item, ..) => {
+      cmds.push(AppendItem(item))
+      state.finish_run()
+    }
+    // No state change: Tick is a 1s heartbeat that just keeps the message loop
+    // turning so the trailing refresh_ui re-runs and the elapsed-time activity
+    // line ("Working (12s)") keeps advancing during quiet stretches.
+    Tick => ()
+  }
+  // One input runs at a time: whenever the TUI is idle and inputs are waiting,
+  // start the next one. A prompt is dispatched to the agent engine; a `!` shell
+  // command is run locally instead. Only submissions and run-ending events can
+  // reach "idle with a non-empty queue", so this never fires spuriously.
+  if state.run is Idle && state.queued.length() > 0 {
+    let input = state.queued.remove(0)
+    cmds.push(AppendItem(Input(input)))
+    let run_id = state.start_run(@async.now())
+    match input {
+      Prompt(text) => cmds.push(StartAgent(run_id~, text))
+      Command(command) => cmds.push(RunCommand(run_id~, command))
+    }
+  }
+  cmds
+}
+
+///|
+async fn[G] run_message_loop(
+  state : State,
+  ui : @ui.Ui,
+  group : @async.TaskGroup[G],
+  messages : @async.Queue[Msg],
+) -> Unit {
+  // The task handle for the run currently in flight, used to cancel it on
+  // interrupt. It is set when a run is dispatched and cleared once `state` goes
+  // back to `Idle` below, so it always tracks the active run and a stale event
+  // (dropped by `update`, leaving `state.run` untouched) can never null it out.
+  let mut running_task : @async.Task[Unit]? = None
+  outer~: for ;; {
+    let message = messages.get()
+    for cmd in update(state, message) {
+      match cmd {
+        AppendItem(item) => ui.append_item(item)
+        StartAgent(run_id~, task) =>
+          running_task = Some(
+            group.spawn(no_wait=true) <| () => {
+              run_agent_task(state.config, run_id, task, messages)
+            },
+          )
+        RunCommand(run_id~, command) =>
+          running_task = Some(
+            group.spawn(no_wait=true) <| () => {
+              run_shell_command(run_id, command, messages)
+            },
+          )
+        CancelAgent => if running_task is Some(task) { task.cancel() }
+        Quit => break outer~
+      }
+    }
+    // A terminal event for the active run leaves `state` idle (unless the queue
+    // drain in `update` immediately started the next run, which re-sets the
+    // handle above); drop the stale handle so an interrupt cannot cancel a task
+    // that has already finished.
+    if state.run is Idle {
+      running_task = None
+    }
+    refresh_ui(ui, state)
+  }
+}

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -1,0 +1,207 @@
+///|
+fn cli_command() -> @argparse.Command {
+  Command(
+    "openseek-tui",
+    about="OpenSeek terminal UI.",
+    options=[
+      OptionArg(
+        "api-key",
+        long="api-key",
+        env="DEEPSEEK",
+        required=true,
+        about="DeepSeek API key.",
+      ),
+      OptionArg(
+        "model",
+        long="model",
+        env="DEEPSEEK_MODEL",
+        default_values=[@deepseek.V4Pro.to_string()],
+        about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
+      ),
+      OptionArg(
+        "max-steps",
+        long="max-steps",
+        env="OPENSEEK_MAX_STEPS",
+        default_values=["1000"],
+        about="Maximum number of agent loop steps before stopping.",
+      ),
+      OptionArg(
+        "engine",
+        long="engine",
+        env="OPENSEEK_ENGINE",
+        default_values=["openseek"],
+        about="Agent engine binary to spawn; reads its JSONL event stream from stdout.",
+      ),
+    ],
+    positionals=[
+      PositionArg(
+        "task",
+        num_args=ValueRange(lower=0),
+        allow_hyphen_values=true,
+        about="Optional initial task description.",
+      ),
+    ],
+  )
+}
+
+///|
+fn value(matches : @argparse.Matches, name : String) -> String raise {
+  match matches.values.get(name) {
+    Some([value]) => value
+    Some(values) if values.length() > 0 => values[0]
+    _ => fail("missing parsed argument: \{name}")
+  }
+}
+
+///|
+fn values(matches : @argparse.Matches, name : String) -> Array[String] {
+  match matches.values.get(name) {
+    Some(values) => values
+    None => []
+  }
+}
+
+///|
+fn parse_positive_int(input : String, label : String) -> Int raise {
+  let parsed = @string.parse_int(input) catch {
+    _ => fail("\{label} must be a positive integer, got: \{input}")
+  }
+  guard parsed > 0 else {
+    fail("\{label} must be a positive integer, got: \{input}")
+  }
+  parsed
+}
+
+///|
+fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
+  let cwd = match @env.current_dir() {
+    Some(cwd) => cwd
+    None => "."
+  }
+  {
+    api_key: value(matches, "api-key"),
+    model: @deepseek.Model::parse(value(matches, "model")),
+    cwd,
+    max_steps: parse_positive_int(value(matches, "max-steps"), "--max-steps"),
+    engine: value(matches, "engine"),
+  }
+}
+
+///|
+fn initial_task(matches : @argparse.Matches) -> String? {
+  let task = values(matches, "task").join(" ").trim().to_owned()
+  if task.is_empty() {
+    None
+  } else {
+    Some(task)
+  }
+}
+
+///|
+async fn run_tui(config : AppConfig, initial : String?) -> Unit {
+  @ui.with_ui(config=@ui.Config::new(composer_max_rows=4), ui => {
+    run_app(config, initial, ui)
+  })
+}
+
+///|
+async fn run_app(config : AppConfig, initial : String?, ui : @ui.Ui) -> Unit {
+  let state = State::new(config)
+  let messages = @async.Queue(kind=Unbounded)
+  ui.append_item(Response("OpenSeek TUI ready"))
+  refresh_ui(ui, state)
+  @async.with_task_group(group => {
+    group.spawn_bg(no_wait=true) <| () => { read_ui_events(ui, messages) }
+    group.spawn_bg(no_wait=true) <| () => { tick_ui(messages) }
+    match initial {
+      Some(task) => messages.put(UiInput(Steer(Prompt(task))))
+      None => ()
+    }
+    run_message_loop(state, ui, group, messages)
+  })
+}
+
+///|
+/// Whether the engine is usable enough to launch. The agent engine is spawned
+/// fresh per task (and only once the user submits one), so a missing, non-
+/// executable, or non-`openseek`-like engine would otherwise surface deep inside
+/// the running UI. We probe it once at startup with `<engine> --help`, which is
+/// part of the engine contract: like `openseek`, any `--engine` replacement must
+/// accept `--help` as a side-effect-free no-op that exits 0 — it makes no API
+/// call, and its output is captured so it never reaches the terminal. The engine
+/// is usable only if that probe spawns and exits 0; `ENOENT`/`EACCES` (not found
+/// / not executable) or a non-zero exit both mean it is not. Any other failure
+/// is unexpected and re-raised rather than mislabeled as a bad engine.
+async fn engine_launchable(engine : String) -> Bool {
+  try {
+    let (code, _) = @process.collect_output_merged(
+      engine,
+      ["--help"],
+      inherit_env=true,
+    )
+    code == 0
+  } catch {
+    @os_error.OSError(_) as err if err.is_ENOENT() || err.is_EACCES() => false
+    err => raise err
+  }
+}
+
+///|
+async fn main {
+  let matches = cli_command().parse(env=@env.get_env_vars())
+  let config = parse_config(matches)
+  // Fail before the terminal UI takes over the screen if the engine is unusable,
+  // rather than dropping the user into a UI that dies on the first task.
+  if !engine_launchable(config.engine) {
+    println(
+      "error: engine '\{config.engine}' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.",
+    )
+    println(
+      "Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.",
+    )
+    @sys.exit(1)
+  }
+  run_tui(config, initial_task(matches))
+}
+
+///|
+test "cli accepts no initial task" {
+  let parsed = cli_command().parse(argv=[], env={ "DEEPSEEK": "test-key" })
+  assert_true(initial_task(parsed) is None)
+  let config = parse_config(parsed)
+  assert_eq(config.api_key, "test-key")
+  assert_eq(config.max_steps, 1000)
+  assert_eq(config.engine, "openseek")
+}
+
+///|
+test "cli accepts initial task and max steps" {
+  let parsed = cli_command().parse(
+    argv=["--max-steps", "5", "inspect", "project"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  assert_true(initial_task(parsed) == Some("inspect project"))
+  assert_eq(parse_config(parsed).max_steps, 5)
+}
+
+///|
+test "cli overrides the engine binary" {
+  let parsed = cli_command().parse(argv=["--engine", "./fake-engine"], env={
+    "DEEPSEEK": "test-key",
+  })
+  assert_eq(parse_config(parsed).engine, "./fake-engine")
+}
+
+///|
+async test "engine_launchable rejects a binary that cannot be exec'd" {
+  assert_false(engine_launchable("openseek-not-a-real-binary-xyz"))
+}
+
+///|
+async test "engine_launchable accepts an engine whose --help exits 0" {
+  // `moon` stands in for an engine that honors the `--help` no-op the probe
+  // requires: `moon --help` exits 0 and, unlike `true`, `moon` is on PATH on
+  // every platform the tests run on (including Windows native), so this stays
+  // cross-platform.
+  assert_true(engine_launchable("moon"))
+}

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -1,0 +1,26 @@
+import {
+  "bobzhang/jsonl",
+  "bobzhang/openseek/agent_tool/shell",
+  "bobzhang/openseek/cmd/tui/internal/event",
+  "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/tui" @ui,
+  "bobzhang/openseek/tui/doc",
+  "bobzhang/openseek/tui/style",
+  "moonbit-community/displaytext",
+  "moonbitlang/async",
+  "moonbitlang/async/os_error",
+  "moonbitlang/async/process",
+  "moonbitlang/core/argparse",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
+  "moonbitlang/core/string",
+  "moonbitlang/x/sys",
+}
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "+native"
+
+options(
+  "is-main": true,
+)

--- a/cmd/tui/pkg.generated.mbti
+++ b/cmd/tui/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/tui"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/cmd/tui/runtime_view.mbt
+++ b/cmd/tui/runtime_view.mbt
@@ -1,0 +1,101 @@
+// Present a `runtime_update` event (the engine's coalesced `moon_check --watch`
+// snapshot) for the human transcript and status bar.
+//
+// The engine emits one model-facing text blob: a `[moon_check update]` header, a
+// `key=value` metadata preamble (events/id/cwd/command/status/seq/…), then the
+// watcher's captured `moon check` output. The model needs all of it; a human
+// reading the TUI does not. So the frontend strips the metadata and renders the
+// watcher status plus the actual diagnostics as a tool-style item (the same
+// `└`-indented detail layout as `tool_item`), flagged with a `↻` marker.
+
+///|
+/// Metadata keys the engine writes one-per-line as `key=value` ahead of the
+/// watcher's captured output. These are dropped from the human view; `status` is
+/// also lifted out for the status bar. Kept in sync with
+/// `@moon_check`'s update-text format.
+let runtime_metadata_keys : Array[String] = [
+  "events", "id", "key", "cwd", "command", "status", "seq", "exit", "truncated",
+  "max_output_chars", "restart_count", "restart_limit", "restart_reason",
+]
+
+///|
+/// A `runtime_update` body parsed for display: the watcher `status` (lifted from
+/// the metadata, `""` if absent) and the `diagnostics` lines that remain once the
+/// `[moon_check update]` header and `key=value` preamble are stripped.
+priv struct RuntimeUpdateView {
+  status : String
+  diagnostics : Array[String]
+}
+
+///|
+/// Strip the model-facing metadata from a `runtime_update` body, keeping the
+/// watcher status and the captured diagnostics. A line is metadata when it is the
+/// `[moon_check update]` header or a `key=value` whose key is a known metadata key
+/// (so a diagnostic line that merely contains `=`, e.g. `let buf = ...`, is kept,
+/// since its key would carry a space and match no metadata key).
+fn parse_runtime_update(content : String) -> RuntimeUpdateView {
+  // A single update can carry several watcher sections (one per key), each with
+  // its own `status=` line. Aggregate as running-if-any-running so a watcher
+  // that is still checking is not masked by another that has stopped; with no
+  // running watcher, keep the last status seen (e.g. "stopped").
+  let mut last_status = ""
+  let mut any_running = false
+  let diagnostics : Array[String] = []
+  for raw in content.split("\n") {
+    let line = raw.to_owned()
+    if line == "[moon_check update]" {
+      continue
+    }
+    let is_metadata = if line.split_once("=") is Some((key, value)) {
+      let key = key.to_owned()
+      if runtime_metadata_keys.contains(key) {
+        if key == "status" {
+          last_status = value.to_owned()
+          if last_status == "running" {
+            any_running = true
+          }
+        }
+        true
+      } else {
+        false
+      }
+    } else {
+      false
+    }
+    if !is_metadata {
+      diagnostics.push(line)
+    }
+  }
+  let status = if any_running { "running" } else { last_status }
+  { status, diagnostics }
+}
+
+///|
+/// Build the tool-style transcript item for a parsed `runtime_update`: a
+/// `moon_check`/status title with the captured diagnostics as compacted detail
+/// lines, rendered under the `↻` notice marker.
+fn runtime_item(update : RuntimeUpdateView) -> @ui.TranscriptItem {
+  let title = if update.status.is_empty() {
+    "moon_check"
+  } else {
+    "moon_check · \{update.status}"
+  }
+  let body = update.diagnostics.join("\n")
+  Notice(
+    ToolCall(
+      @doc.Text::plain(title),
+      details=detail_texts(compact_lines(body, ToolOutputLineLimit)),
+    ),
+  )
+}
+
+///|
+/// The status-bar text for the latest watcher state, or `""` when no watcher
+/// update has been seen yet (so the segment is skipped).
+fn watcher_segment_text(status : String) -> String {
+  if status.is_empty() {
+    ""
+  } else {
+    "moon_check \{status}"
+  }
+}

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -1,0 +1,122 @@
+///|
+priv struct AppConfig {
+  api_key : String
+  model : @deepseek.Model
+  cwd : String
+  max_steps : Int
+  // The agent engine the TUI spawns and reads JSONL events from. Defaults to
+  // the `openseek` binary on `PATH`; override (e.g. to a recorded-stream
+  // replayer) with `--engine` or `OPENSEEK_ENGINE`.
+  engine : String
+}
+
+///|
+priv enum RunState {
+  Idle
+  Running(Int64)
+  Interrupting(Int64)
+}
+
+///|
+priv struct State {
+  config : AppConfig
+  queued : Array[@ui.Input]
+  mut run : RunState
+  // Monotonic id of the most recently started run, bumped each time an input is
+  // dispatched. Task-originated messages carry the id of the run that produced
+  // them; a message whose id is not the active run's is stale (it came from a
+  // task that has since been superseded) and is dropped. See `State::owns_run`.
+  mut run_id : Int
+  mut step_response : String?
+  mut usage : @event.UsageInfo?
+  // Latest background `moon_check` watcher status ("running"/"stopped"), lifted
+  // from the most recent `runtime_update` for the status bar. Empty until the
+  // first watcher update arrives.
+  mut watcher_status : String
+}
+
+///|
+fn State::new(config : AppConfig) -> State {
+  {
+    config,
+    queued: [],
+    run: Idle,
+    run_id: 0,
+    step_response: None,
+    usage: None,
+    watcher_status: "",
+  }
+}
+
+///|
+/// Begin tracking a freshly dispatched run: allocate the next run id and mark the
+/// agent running. Returns the new run id so the caller can tag the spawned task's
+/// messages with it.
+fn State::start_run(self : State, started_ms : Int64) -> Int {
+  self.run_id = self.run_id + 1
+  self.run = Running(started_ms)
+  self.step_response = None
+  self.run_id
+}
+
+///|
+/// Whether `id` identifies the run currently in flight. False once that run has
+/// ended (back to `Idle`) or been replaced by a newer one, so a late or stale
+/// message from a superseded task is recognizable and can be ignored.
+fn State::owns_run(self : State, id : Int) -> Bool {
+  !(self.run is Idle) && id == self.run_id
+}
+
+///|
+/// Reset run tracking after the agent stops (finished, aborted, cancelled, or
+/// failed): no task running, no pending step response. Also clear the watcher
+/// status: `run_agent_task` spawns a fresh engine per prompt and any
+/// `moon_check --watch` process belongs to that engine's runtime, so it is gone
+/// once the engine exits — leaving `watcher_status` set would keep a stale
+/// `moon_check running` segment in the status bar while the TUI sits idle.
+fn State::finish_run(self : State) -> Unit {
+  self.run = Idle
+  self.step_response = None
+  self.watcher_status = ""
+}
+
+///|
+/// Messages feeding the update loop. Task-originated variants carry the `run_id`
+/// of the run that produced them (see `State::run_id`) so the loop can drop the
+/// ones from a superseded run; `UiInput` and `Tick` are loop-intrinsic and
+/// untagged.
+priv enum Msg {
+  UiInput(@ui.Event)
+  AgentProgress(run_id~ : Int, @event.AgentEvent)
+  AgentCancelled(run_id~ : Int)
+  AgentFailed(run_id~ : Int, Error)
+  // A `!` shell command the TUI ran locally finished; carries the run id and the
+  // transcript item to append. Commands run in the TUI and never reach the agent
+  // engine.
+  CommandResult(run_id~ : Int, @ui.TranscriptItem)
+  Tick
+}
+
+///|
+/// The run id carried by a task-originated message, or `None` for the
+/// loop-intrinsic `UiInput`/`Tick` messages that belong to no particular run.
+fn Msg::run_id(self : Msg) -> Int? {
+  match self {
+    AgentProgress(run_id~, _)
+    | AgentCancelled(run_id~)
+    | AgentFailed(run_id~, _) => Some(run_id)
+    CommandResult(run_id~, _) => Some(run_id)
+    UiInput(_) | Tick => None
+  }
+}
+
+///|
+priv enum Cmd {
+  AppendItem(@ui.TranscriptItem)
+  // Start the agent / a local command for a run; carries the run id to tag that
+  // task's messages with.
+  StartAgent(run_id~ : Int, String)
+  RunCommand(run_id~ : Int, String)
+  CancelAgent
+  Quit
+}

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -1,0 +1,110 @@
+///|
+/// A status-bar field: its text and the style it is shown in. Empty-text
+/// segments are skipped so absent fields (e.g. usage before the first response)
+/// leave no dangling separator.
+priv struct Segment {
+  text : String
+  style : @style.Style
+}
+
+///|
+fn format_status_segments(segments : Array[Segment]) -> @doc.Text {
+  let spans : Array[@doc.Span] = []
+  for segment in segments {
+    if segment.text.length() > 0 {
+      if spans.length() > 0 {
+        spans.push(Span(DisplayText(" · "), style=@style.dim))
+      }
+      spans.push(Span(DisplayText(segment.text), style=segment.style))
+    }
+  }
+  Text(spans)
+}
+
+///|
+fn format_usage_segment(usage : @event.UsageInfo?) -> String {
+  match usage {
+    None => ""
+    Some(usage) => "tokens \{usage.total_tokens}"
+  }
+}
+
+///|
+fn status_segments(state : State) -> Array[Segment] {
+  [
+    {
+      text: state.config.model.to_string(),
+      style: Style(foreground=Basic(Yellow)),
+    },
+    { text: state.config.cwd, style: Style(foreground=Basic(Green)) },
+    {
+      text: format_usage_segment(state.usage),
+      style: Style(foreground=Basic(Magenta)),
+    },
+    {
+      text: watcher_segment_text(state.watcher_status),
+      style: Style(foreground=Basic(Cyan)),
+    },
+  ]
+}
+
+///|
+fn format_status_bar_text(state : State) -> @doc.Text {
+  format_status_segments(status_segments(state))
+}
+
+///|
+fn format_two_digits(value : Int64) -> String {
+  if value < 10L {
+    "0" + value.to_string()
+  } else {
+    value.to_string()
+  }
+}
+
+///|
+fn format_elapsed_compact(elapsed_seconds : Int64) -> String {
+  if elapsed_seconds < 60L {
+    "\{elapsed_seconds}s"
+  } else if elapsed_seconds < 3600L {
+    let minutes = elapsed_seconds / 60L
+    let seconds = elapsed_seconds % 60L
+    "\{minutes}m \{format_two_digits(seconds)}s"
+  } else {
+    let hours = elapsed_seconds / 3600L
+    let minutes = elapsed_seconds % 3600L / 60L
+    let seconds = elapsed_seconds % 60L
+    "\{hours}h \{format_two_digits(minutes)}m \{format_two_digits(seconds)}s"
+  }
+}
+
+///|
+fn elapsed_seconds(started_ms : Int64, now_ms : Int64) -> Int64 {
+  let elapsed_ms = if now_ms > started_ms { now_ms - started_ms } else { 0L }
+  elapsed_ms / 1000L
+}
+
+///|
+fn format_activity_text(state : State) -> @doc.Text? {
+  let started_ms = match state.run {
+    Idle => return None
+    Running(started_ms) => started_ms
+    Interrupting(started_ms) => started_ms
+  }
+  let elapsed = format_elapsed_compact(
+    elapsed_seconds(started_ms, @async.now()),
+  )
+  Some(
+    Text([
+      @doc.Span::plain("Working"),
+      Span(DisplayText(" (\{elapsed})"), style=@style.dim),
+    ]),
+  )
+}
+
+///|
+async fn refresh_ui(ui : @ui.Ui, state : State) -> Unit {
+  ui.set_status(format_status_bar_text(state))
+  ui.set_activity(format_activity_text(state))
+  ui.set_queued_inputs(state.queued)
+}

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -1,0 +1,92 @@
+///|
+const ToolOutputLineLimit : Int = 6
+
+///|
+/// Split `source` into trimmed display lines: drop surrounding blank space, then
+/// split on `\n` and strip the trailing `\r` of a CRLF line ending so it does
+/// not become an extra blank row when the transcript re-splits the detail text.
+fn split_output_lines(source : String) -> Array[String] {
+  let trimmed = source.trim()
+  if trimmed.is_empty() {
+    return []
+  }
+  let lines : Array[String] = []
+  for line in trimmed.split("\n") {
+    lines.push(line.trim_end(chars="\r").to_owned())
+  }
+  lines
+}
+
+///|
+fn compact_lines(source : String, limit : Int) -> Array[String] {
+  let lines = split_output_lines(source)
+  if lines.length() <= limit {
+    return lines
+  }
+  if limit <= 1 {
+    return ["... +\{lines.length()} lines"]
+  }
+  let head = limit / 2
+  let tail = limit - head - 1
+  let omitted = lines.length() - head - tail
+  let compacted : Array[String] = []
+  for index in 0..<head {
+    compacted.push(lines[index])
+  }
+  compacted.push("... +\{omitted} lines")
+  for index in (lines.length() - tail)..<lines.length() {
+    compacted.push(lines[index])
+  }
+  compacted
+}
+
+///|
+fn detail_texts(lines : Array[String]) -> Array[@doc.Text] {
+  [
+    for line in lines => @doc.dim_text(line)
+  ]
+}
+
+///|
+fn tool_title(result : @event.ToolResultEvent) -> @doc.Text {
+  let label = if result.is_error { "Tool failed" } else { "Tool" }
+  @doc.Text::plain(label + " " + result.name)
+}
+
+///|
+fn tool_item(result : @event.ToolResultEvent) -> @ui.TranscriptItem {
+  ToolCall(
+    ToolCall(
+      tool_title(result),
+      status=if result.is_error { Failed } else { Completed },
+      details=detail_texts(compact_lines(result.content, ToolOutputLineLimit)),
+    ),
+  )
+}
+
+///|
+/// Render the result of a `!` shell command the TUI ran locally: the command
+/// line as the title (with a non-zero/cancelled marker), and its full captured
+/// output as dimmed detail lines. The output is already character-capped by
+/// `@shell.run`; a truncation note is appended when that cap was hit.
+fn command_item(
+  command : String,
+  result : @shell.ShellOutput,
+) -> @ui.TranscriptItem {
+  let title = match result.exit_code {
+    Some(0) => "$ \{command}"
+    Some(code) => "$ \{command} (exit \{code})"
+    None => "$ \{command} (cancelled)"
+  }
+  let lines = split_output_lines(result.text)
+  if result.output_limit_reached {
+    lines.push("… output truncated")
+  }
+  ToolCall(
+    ToolCall(
+      @doc.Text::plain(title),
+      status=if result.exit_code is Some(0) { Completed } else { Failed },
+      details=detail_texts(lines),
+    ),
+  )
+}

--- a/moon.mod
+++ b/moon.mod
@@ -6,8 +6,9 @@ import {
   "moonbit-community/tty@0.2.4",
   "moonbitlang/async@0.19.1",
   "moonbitlang/x@0.4.45",
-  "moonbit-community/displaytext@0.1.4",
+  "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",
+  "bobzhang/jsonl@0.2.0",
 }
 
 readme = "README.mbt.md"

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -1,0 +1,59 @@
+# Verified OpenSeek TUI CLI Documentation
+
+These examples are executed by `moon cram test tests/cram`. The Moon wrapper
+builds the native package at `cmd/tui` first, then exposes the executable on
+`PATH` as `tui.exe`.
+
+Both commands are offline: they exercise only the argument parser, which runs
+before the terminal UI starts, so the suite needs no API key, no TTY, and makes
+no network calls. The live, API-backed examples live in
+[`tests/live/deepseek.md`](../live/deepseek.md).
+
+## Help Banner
+
+`--help` prints the usage, the available options, and the environment variables
+and defaults behind each one, then exits successfully.
+
+```mooncram
+$ tui.exe --help
+Usage: openseek-tui --api-key <api-key> [options] [task...]
+
+OpenSeek terminal UI.
+
+Arguments:
+  task...  Optional initial task description.
+
+Options:
+  -h, --help               Show help information.
+  --api-key <api-key>      DeepSeek API key. [env: DEEPSEEK]
+  --model <model>          DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>  Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --engine <engine>        Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+```
+
+## A DeepSeek API Key Is Required
+
+With no `--api-key` flag and no `DEEPSEEK` in the environment, the CLI reports
+the missing required argument, prints the usage, and exits non-zero — before the
+terminal UI ever starts.
+
+```mooncram
+$ env -u DEEPSEEK tui.exe "summarize this project"
+error: the following required argument was not provided: 'api-key'
+
+Usage: openseek-tui --api-key <api-key> [options] [task...]
+
+OpenSeek terminal UI.
+
+Arguments:
+  task...  Optional initial task description.
+
+Options:
+  -h, --help               Show help information.
+  --api-key <api-key>      DeepSeek API key. [env: DEEPSEEK]
+  --model <model>          DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>  Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --engine <engine>        Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+
+[1]
+```

--- a/tui/core/core_test.mbt
+++ b/tui/core/core_test.mbt
@@ -32,6 +32,26 @@ test "transcript response renders bullet and continuation prefix" {
 }
 
 ///|
+test "transcript notice renders a ↻ marker with tool-style detail lines" {
+  inspect(
+    @doc.ToDoc::to_doc(
+      @core.TranscriptItem::Notice(
+        ToolCall(@doc.Text::plain("moon_check · running"), details=[
+          @doc.Text::plain("Warning: unused variable"),
+          @doc.Text::plain("ok"),
+        ]),
+      ),
+    )
+    .layout(width=40)
+    .map(line => line.text())
+    .join("|"),
+    content=(
+      #|↻ moon_check · running|  └ Warning: unused variable|    ok
+    ),
+  )
+}
+
+///|
 test "transcript tool call renders detail texts without caller-side joining" {
   inspect(
     @doc.ToDoc::to_doc(

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -29,7 +29,7 @@ pub fn Input::text(Self) -> String
 
 pub struct ToolCall {
   // private fields
-}
+} derive(@debug.Debug)
 pub fn ToolCall::ToolCall(@doc.Text, status? : ToolStatus, details? : Array[@doc.Text]) -> Self
 
 pub(all) enum ToolStatus {
@@ -41,8 +41,9 @@ pub(all) enum TranscriptItem {
   Input(Input)
   Response(String)
   ToolCall(ToolCall)
+  Notice(ToolCall)
   Error(String)
-}
+} derive(@debug.Debug)
 pub impl @doc.ToDoc for TranscriptItem
 
 // Type aliases

--- a/tui/core/transcript.mbt
+++ b/tui/core/transcript.mbt
@@ -24,7 +24,7 @@ struct ToolCall {
   title : @doc.Text
   status : ToolStatus?
   details : Array[@doc.Text]
-}
+} derive(Debug)
 
 ///|
 /// Build a `ToolCall` from its `title`, an optional `status`, and optional
@@ -39,13 +39,16 @@ pub fn ToolCall::ToolCall(
 
 ///|
 /// One committed entry in the transcript: a submitted `Input`, an agent
-/// `Response`, a `ToolCall`, or an `Error`.
+/// `Response`, a `ToolCall`, an out-of-band runtime `Notice` (e.g. background
+/// `moon check --watch` diagnostics the agent was fed — a titled, detail-bearing
+/// block like a tool call but flagged with a `↻` marker), or an `Error`.
 pub(all) enum TranscriptItem {
   Input(Input)
   Response(String)
   ToolCall(ToolCall)
+  Notice(ToolCall)
   Error(String)
-}
+} derive(Debug)
 
 ///|
 /// Prefix each split line of `text` with a bullet/continuation marker in
@@ -75,10 +78,41 @@ let continuation : @displaytext.DisplayText = DisplayText("  ")
 let square : @displaytext.DisplayText = DisplayText("■ ")
 
 ///|
+/// Marker for an out-of-band runtime notice (`Notice`): a `↻` so a background
+/// watcher update reads as a refresh, distinct from a `⏺` agent/tool line.
+let notice : @displaytext.DisplayText = DisplayText("↻ ")
+
+///|
+/// Render a `ToolCall` as a `marker`-bulleted title followed by its detail lines,
+/// each `└`/space-indented and dimmed. Shared by the `⏺` tool-call projection and
+/// the `↻` runtime-notice projection so both lay details out identically.
+fn tool_call_doc(
+  call : ToolCall,
+  marker~ : @displaytext.DisplayText,
+  marker_style~ : @style.Style,
+) -> @doc.Doc {
+  let texts : Array[@doc.Text] = [
+    call.title.prepend_span(Span(marker, style=marker_style)),
+  ]
+  let mut has_detail_line = false
+  for detail in call.details {
+    for line in detail.split_lines() {
+      let detail_marker = if has_detail_line { "    " } else { "  └ " }
+      texts.push(
+        line.prepend_span(Span(DisplayText(detail_marker), style=@style.dim)),
+      )
+      has_detail_line = true
+    }
+  }
+  Doc(texts)
+}
+
+///|
 /// Project a transcript item into a renderable `@doc.Doc`: inputs use their own
 /// prefixed projection, responses become dim `⏺`-bulleted blocks, tool calls
-/// render a status-styled `⏺` bullet with `└`-indented detail lines, and errors
-/// become an error-styled `■`-bulleted block.
+/// render a status-styled `⏺` bullet with `└`-indented detail lines, runtime
+/// notices use the same detail layout under a dim `↻` marker, and errors become
+/// an error-styled `■`-bulleted block.
 pub impl @doc.ToDoc for TranscriptItem with fn to_doc(self) {
   match self {
     Input(input) => input.to_doc()
@@ -95,20 +129,9 @@ pub impl @doc.ToDoc for TranscriptItem with fn to_doc(self) {
       let bullet_style = call.status
         .map(status => status.style())
         .unwrap_or(@style.dim)
-      let texts : Array[@doc.Text] = [
-        call.title.prepend_span(Span(bullet, style=bullet_style)),
-      ]
-      let mut has_detail_line = false
-      for detail in call.details {
-        for line in detail.split_lines() {
-          let marker = if has_detail_line { "    " } else { "  └ " }
-          let marker = @displaytext.DisplayText(marker)
-          texts.push(line.prepend_span(Span(marker, style=@style.dim)))
-          has_detail_line = true
-        }
-      }
-      Doc(texts)
+      tool_call_doc(call, marker=bullet, marker_style=bullet_style)
     }
+    Notice(call) => tool_call_doc(call, marker=notice, marker_style=@style.dim)
     Error(message) => {
       let error_style = @style.error
       Doc(

--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -29,7 +29,7 @@ pub fn Doc::Doc(texts : Array[Text]) -> Doc {
 /// row breaks.
 struct Text {
   spans : Array[Span]
-}
+} derive(Debug)
 
 ///|
 /// Build a text block from a sequence of styled spans.
@@ -80,10 +80,17 @@ pub fn Text::split_lines(self : Text) -> Array[Text] {
 
 ///|
 /// A string fragment with an associated terminal style.
+///
+/// A span normally holds a single display line. Callers split hard line breaks
+/// into separate `Text` blocks with `Text::split_lines` (e.g. to prefix each
+/// line with its own bullet), but a span that reaches layout with an embedded
+/// newline is still handled: `Text::wrap` iterates the span's `DisplayText`
+/// directly and forces a row break on CR/LF/CRLF inline, without re-segmenting
+/// the string.
 struct Span {
   display : @displaytext.DisplayText
   style : @style.Style
-}
+} derive(Debug)
 
 ///|
 /// Build a styled span.
@@ -104,52 +111,86 @@ pub fn Span::plain(text : String) -> Span {
 
 ///|
 /// Lay this block out into physical rows for `width` columns, wrapping by
-/// display width, expanding tabs to the next stop, and dropping stray controls.
+/// display width, expanding tabs to the next stop, forcing a row break on every
+/// hard line break (CR, LF, or CRLF), and dropping other stray controls.
 fn Text::wrap(self : Text, width~ : Int) -> Array[@surface.Line] {
   let rows : Array[@surface.Line] = []
   let mut spans : Array[@surface.Span] = []
   let mut used = 0
   let width = width.max(1)
+  // Accumulate consecutive units into one surface span rather than emitting one
+  // span per grapheme. The renderer writes a style set + reset and an (unbuffered)
+  // terminal write per span, so a per-grapheme line becomes hundreds of syscalls;
+  // coalescing collapses a single-style line into one span. A span's style is
+  // constant, so a run is flushed only when the input span ends or a wrap/line
+  // break splits the physical row.
+  let mut run = StringBuilder()
+  let mut run_empty = true
+  fn flush_run(style : @style.Style) -> Unit {
+    if !run_empty {
+      spans.push(Span(DisplayText(run.to_string()), style~))
+      run = StringBuilder()
+      run_empty = true
+    }
+  }
+
   for span in self.spans {
     let style = span.style
-    let display_lines = @displaytext.split_lines(span.display.text())
-    for line_index, display_line in display_lines {
-      if line_index > 0 {
+    // Iterate the span's precomputed `DisplayText` directly instead of
+    // re-segmenting its string on every layout. Spans are usually newline-free
+    // (callers pre-split with `Text::split_lines`), but a hard line break that
+    // does reach here is honored as a row break inline (below), so layout never
+    // re-runs the grapheme segmentation the `DisplayText` already paid for.
+    let display_line = span.display
+    let mut start = display_line.start()
+    while display_line.next(start) is Some(end) {
+      let unit = display_line.view(start, end)
+      // Normalize control characters so the columns we count match what the
+      // terminal draws. A hard line break ends the current physical row; a raw
+      // `\t` jumps to the terminal's tab stop, which is not modeled by `used`,
+      // so it would shove following text into the wrong column; every other
+      // control is dropped.
+      //
+      // `Text::wrap` honors the documented contract that layout splits on hard
+      // line breaks even for a span that was not pre-split with `split_lines`.
+      // Grapheme segmentation already clusters CRLF into one unit, so "\r\n" is a
+      // single break, matching `Text::split_lines`; a lone CR and lone LF each
+      // arrive as their own unit and break once too.
+      if unit == "\n" || unit == "\r" || unit == "\r\n" {
+        flush_run(style)
         rows.push(@surface.Line::new(spans))
         spans = []
         used = 0
-      }
-      let mut start = display_line.start()
-      while display_line.next(start) is Some(end) {
-        let unit = display_line.view(start, end)
-        // Normalize control characters so the columns we count match what the
-        // terminal draws. A raw `\t` jumps to the terminal's tab stop, which
-        // is not modeled by `used`, so it would shove following text into the
-        // wrong column; every other control is dropped.
-        if unit == "\t" {
-          let spaces = @text.TabWidth - used % @text.TabWidth
-          for _ in 0..<spaces {
-            if used > 0 && used + 1 > width {
-              rows.push(@surface.Line::new(spans))
-              spans = []
-              used = 0
-            }
-            spans.push(Span(DisplayText(" "), style~))
-            used += 1
-          }
-        } else if !@text.is_control_unit(unit) {
-          let next = @text.unit_width(display_line, start~, end~)
-          if used > 0 && used + next > width {
+      } else if unit == "\t" {
+        let spaces = @text.TabWidth - used % @text.TabWidth
+        for _ in 0..<spaces {
+          if used > 0 && used + 1 > width {
+            flush_run(style)
             rows.push(@surface.Line::new(spans))
             spans = []
             used = 0
           }
-          spans.push(Span(DisplayText(unit.to_owned()), style~))
-          used += next
+          run.write_string(" ")
+          run_empty = false
+          used += 1
         }
-        start = end
+      } else if !@text.is_control_unit(unit) {
+        let next = @text.unit_width(display_line, start~, end~)
+        if used > 0 && used + next > width {
+          flush_run(style)
+          rows.push(@surface.Line::new(spans))
+          spans = []
+          used = 0
+        }
+        run.write_stringview(unit)
+        run_empty = false
+        used += next
       }
+      start = end
     }
+    // Flush at the input-span boundary so the next span starts its own run
+    // (its style may differ).
+    flush_run(style)
   }
   rows.push(@surface.Line::new(spans))
   rows

--- a/tui/doc/doc_test.mbt
+++ b/tui/doc/doc_test.mbt
@@ -17,7 +17,7 @@ test "doc layout wraps styled text by display width" {
 }
 
 ///|
-test "layout expands tabs to the next stop and drops other control chars" {
+test "layout expands tabs, breaks rows on hard newlines, and drops other controls" {
   // `\t` expands to spaces up to the next 8-column tab stop so following text
   // is not shoved to a terminal tab stop we never accounted for.
   inspect(
@@ -34,8 +34,10 @@ test "layout expands tabs to the next stop and drops other control chars" {
     .join("|"),
     content="abcdef  g",
   )
-  // `\r\n` (a single grapheme cluster) and a lone `\r` are line breaks, so they
-  // split rows instead of being dropped — CRLF content keeps its lines.
+  // Hard line breaks force a row break at layout time even when the span was not
+  // pre-split with `Text::split_lines` — `Text::plain`/`Text::Text` are public and
+  // the documented contract is that layout splits on '\n'. CRLF and a lone CR
+  // each split exactly once (the LF of a CRLF pair is swallowed, not a second row).
   inspect(
     @doc.Doc::Doc([@doc.Text::plain("x\r\ny")])
     .layout(width=40)
@@ -43,7 +45,14 @@ test "layout expands tabs to the next stop and drops other control chars" {
     .join("|"),
     content="x|y",
   )
-  // Other C0 controls (here `ESC`) are dropped entirely.
+  inspect(
+    @doc.Doc::Doc([@doc.Text::plain("x\ry\nz")])
+    .layout(width=40)
+    .map(line => line.text())
+    .join("|"),
+    content="x|y|z",
+  )
+  // Other C0 controls (here `ESC`) are still dropped, not treated as breaks.
   inspect(
     @doc.Doc::Doc([@doc.Text::plain("x\u{1b}y")])
     .layout(width=40)

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "bobzhang/openseek/tui/internal/surface",
   "bobzhang/openseek/tui/style",
   "moonbit-community/displaytext",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -21,13 +22,13 @@ pub fn Doc::layout(Self, width~ : Int) -> Array[@surface.Line]
 
 pub struct Span {
   // private fields
-}
+} derive(@debug.Debug)
 pub fn Span::Span(@displaytext.DisplayText, style? : @style.Style) -> Self
 pub fn Span::plain(String) -> Self
 
 pub struct Text {
   // private fields
-}
+} derive(@debug.Debug)
 pub fn Text::Text(Array[Span]) -> Self
 pub fn Text::first_line(Self, width~ : Int) -> @surface.Line
 pub fn Text::plain(String) -> Self

--- a/tui/input.mbt
+++ b/tui/input.mbt
@@ -144,8 +144,14 @@ async fn Ui::handle_key(self : Self, key : @tty/input.KeyEvent) -> Event? {
     Enter => self.submit_current_input().map(input => Steer(input))
     Tab => self.submit_current_input().map(input => Queue(input))
     Escape => {
+      // Esc only resets history navigation; it deliberately does NOT interrupt.
+      // Under the kitty keyboard protocol every key is an ESC-prefixed sequence,
+      // and a sequence split across reads (the decoder's esc-timeout firing
+      // before the rest arrives) surfaces as a phantom bare Esc. Routing that to
+      // Interrupt would spuriously cancel a running task or, when idle, quit.
+      // Ctrl+C is the deliberate interrupt/quit key.
       self.history.reset_navigation()
-      Some(Interrupt)
+      None
     }
     Char('k') if key.modifiers.ctrl() => {
       self.composer.kill_after()

--- a/tui/style/pkg.generated.mbti
+++ b/tui/style/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "bobzhang/openseek/tui/style"
 
 import {
   "moonbit-community/tty/color",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -21,7 +22,7 @@ pub struct Style {
   foreground : @color.Color
   background : @color.Color
   underline : Bool
-} derive(Eq)
+} derive(Eq, @debug.Debug)
 pub fn Style::Style(foreground? : @color.Color, background? : @color.Color, underline? : Bool) -> Self
 
 // Type aliases

--- a/tui/style/style.mbt
+++ b/tui/style/style.mbt
@@ -7,7 +7,7 @@ pub struct Style {
   foreground : @tty/color.Color
   background : @tty/color.Color
   underline : Bool
-} derive(Eq)
+} derive(Eq, Debug)
 
 ///|
 pub let default : Style = Style()


### PR DESCRIPTION
Renders the `openseek` agent as a TUI by spawning it as a subprocess and parsing its JSONL stdout. The agent (`agent/`) code is unchanged; the frontend only consumes the engine's existing JSONL event stream.

Running cmd/tui requires there is a `openseek` binary in the `PATH`. Therefore, the ideal development workflow would be:

```bash
moon install cmd/openseek
moon run cmd/tui
```

If you don't want to install `openseek`, you can explicitly pass the path to the openseek binary via `--engine` CLI parameter:

```bash
moon build --release
moon run cmd/tui -- --engine _build/native/release/build/cmd/openseek/openseek.exe
```

## Approach

This supersedes the abandoned in-process design (closed PR #13 / branch `codex/tui-app`): rather than driving the agent loop inside the TUI process, the TUI spawns the engine and renders from its wire events. `AgentEvent` variant names are aligned with the engine's actual JSONL event names.

## Commits

- **render the agent by streaming its JSONL stdout** — spawn the engine via `moonbitlang/async/process`, parse line-delimited JSONL, drive the transcript/composer from typed `AgentEvent`s.
- **dim tool details and color the status line** — gray tool output, colored status fields (model / cwd / tokens).
- **a fake JSONL engine for manual TUI testing** — `scripts/fake-engine.sh` emits canned JSONL so the TUI can be exercised under a real PTY (tmux) without a live model.
- **strip CRLF carriage returns from tool output lines** — split on `\n` and trim a trailing `\r` so CRLF tool output doesn't leave stray blank rows.

## Base

The TUI primitive packages (PR #12, `tui/`) have landed in `main`, so this is now rebased directly onto `main` and is self-contained — just the `cmd/tui/` app on top of the merged library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
