### PR TITLE
[codex] Add live agent tool-use example

### DIFF
--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -100,3 +100,35 @@ $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool imm
 >   | grep '='
 final_answer=DONE
 ```
+
+## Watching The Agent Use A Tool
+
+The point of the agent is that it *acts*. When a task needs work, the model
+calls one of the local tools and a `tool_result` record joins the stream. Here
+the task forces the `shell` tool; we match the `tool_result` event together with
+its `tool_name`, and use a regex on its `content` to confirm the command really
+ran and its output flowed back.
+
+```mooncram
+$ openseek.exe --model deepseek-v4-flash --max-steps 6 "Use the shell tool to run exactly: echo openseek-cram. Then call finish with the word done." 2>/dev/null \
+>   | moon run --target native -e 'import {
+>   "bobzhang/jsonl@0.2.0",
+>   "moonbitlang/async",
+> }
+> 
+> async fn main {
+>   let mut used_shell = false
+>   let mut shell_output_seen = false
+>   for value in @jsonl.read_stdin() {
+>     if value is { "event": String("tool_result"), "tool_name": String("shell"), "content": String(out), .. } {
+>       used_shell = true
+>       if out =~ re"openseek-cram" { shell_output_seen = true }
+>     }
+>   }
+>   println("used_shell=\{used_shell}")
+>   println("shell_output_seen=\{shell_output_seen}")
+> }' 2>/dev/null \
+>   | grep '='
+used_shell=true
+shell_output_seen=true
+```


### PR DESCRIPTION
## Summary

- Add a live DeepSeek documentation example that forces the agent to call the shell tool.
- Parse the JSONL stream and assert the `tool_result` event reports the shell tool and expected command output.

## Impact

- Shows users how to observe real tool-use events in live agent runs.
- Extends the live docs with coverage for streamed tool results.

## Validation

- `moon info && moon fmt`
- `moon test` (288 tests passed)
