### PR TITLE
[codex] Improve shell timeout and policy tests

### DIFF
--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -19,6 +19,10 @@ generated artifacts, dependency listings, or compiler invocations large enough
 to damage the model context. Truncation is treated as a tool error so the agent
 knows it did not receive the full command output.
 
+Callers may also set `timeout_ms` for commands that could wait indefinitely.
+When the timeout expires, the in-flight process collection is cancelled and the
+tool returns an error instead of blocking the agent loop.
+
 ## API Style
 
 Use `cwd` whenever the command is workspace-relative, and keep commands
@@ -42,6 +46,7 @@ features such as pipes.
 | ---- | ------ | -------- | ----- |
 | `cmd` | string | yes | Passed as the single argument to `sh -c`. |
 | `cwd` | string | no  | Working directory. An empty string is treated as missing. |
+| `timeout_ms` | number | no | Positive timeout in milliseconds. Timed-out commands are cancelled and reported as tool errors. |
 | `max_output_chars` | number | no | Defaults to 12000, capped at 50000. Truncated output is a tool error. |
 
 ## Action
@@ -55,6 +60,8 @@ has one of these shapes:
 - `"exit=<code>\n<stdout/stderr merged>"` — normal completion.
 - `"exit=<code>\ntruncated=true\noutput_chars=<n>\nshown_chars=<n>\n<output-prefix>"` —
   the process completed but output was capped before sending it to the model.
+- `"error: shell command timed out after <n>ms"` — `timeout_ms` elapsed before
+  the command completed.
 - `"error running shell: <error>"` — `sh -c` failed to launch (rare; usually
   a process subsystem error).
 - `"error: shell requires arguments.cmd"` — payload was an object but had no
@@ -74,6 +81,7 @@ test "shell tool advertises the expected schema" {
   let JsonSchema(schema) = tool.schema
   let text = schema.stringify()
   assert_true(text.contains("\"cmd\""))
+  assert_true(text.contains("\"timeout_ms\""))
   assert_true(text.contains("\"max_output_chars\""))
   assert_true(text.contains("\"required\""))
 }
@@ -90,7 +98,8 @@ async test "shell tool runs a project-style command through the registry" {
       arguments=(
         #|{
         #|  "cmd": "printf 'alpha beta' | wc -w",
-        #|  "cwd": "/tmp"
+        #|  "cwd": "/tmp",
+        #|  "timeout_ms": 5000
         #|}
       ),
     ),

--- a/agent_tool/shell/TODO.md
+++ b/agent_tool/shell/TODO.md
@@ -1,0 +1,48 @@
+# Shell Tool TODO
+
+Review target: `agent_tool/shell`.
+
+## Bugs And Risks
+
+- [x] Add a hard `timeout_ms` option for shell commands.
+  - Current behavior awaits `@process.collect_output_merged`, so a hung command blocks the whole agent loop.
+  - A timeout should cancel the child process and return a tool error with elapsed time.
+
+- [ ] Enforce output limits while reading, not after full collection.
+  - Current `max_output_chars` caps only after the whole process output has been collected.
+  - Commands such as `yes`, `tail -f`, or huge finite output can still hang or allocate too much before truncation.
+
+- [ ] Harden MoonBit command policy bypass detection.
+  - Current guard is based on simple space splitting and a few string fragments.
+  - Cases to block or route through `moon_cmd`: `env FOO=x moon test`, `PATH=/usr/bin moon check`, `FOO= moon run`, `cd demo;moon test`, subshells, command substitutions, and other executable `moon` tokens.
+
+- [ ] Add tests for guarded-command bypasses.
+  - Include env wrappers, empty env assignments, semicolons without spaces, newlines, subshells, and `moon test --update`.
+
+## Missing Features
+
+- [ ] Support separate stdout and stderr capture.
+  - Current output is always merged, which weakens CLI-contract checks that need parseable stdout and clean stderr.
+  - Consider returning structured sections or adding `merge_output`.
+
+- [ ] Add structured `stdin`.
+  - This avoids shell pipes and heredocs for multiline probes and non-MoonBit commands.
+  - `moon_cmd` already has a working pattern for stdin redirection.
+
+- [ ] Add optional `argv` execution mode.
+  - Keep `cmd` for shell features such as pipes and redirects.
+  - Use `argv` for exact execution when quoting paths, regexes, JSONPath/jq expressions, or generated arguments would be fragile.
+
+- [ ] Echo command context in the result.
+  - Include `cwd=...` and `command=...` like `moon_cmd` so logs remain self-auditing.
+
+## Nice To Have
+
+- [ ] Consider configurable environment handling.
+  - Potential fields: `env`, `inherit_env`, and possibly a denylist for sensitive values in echoed metadata.
+
+- [ ] Document the distinction between `shell`, `moon_cmd`, and `moon_check` in `README.mbt.md` after behavior changes.
+
+- [ ] Re-run targeted validation after changes.
+  - `moon test agent_tool/shell agent_tool/shell/internal/decode --target native`
+  - `moon info && moon fmt`

--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -1,0 +1,93 @@
+# Shell Command Policy
+
+This internal package contains the command-routing policy used by the `shell`
+tool before it runs `sh -c`.
+
+The policy exists for one narrow reason: MoonBit validation commands should use
+the structured MoonBit tools instead of the general shell escape hatch. The
+structured tools preserve arguments, apply MoonBit-specific guardrails, and make
+validation output easier for the agent loop to interpret.
+
+This package is not a security sandbox. It is a local automation guardrail for a
+trusted agent. The shell tool can still run arbitrary non-MoonBit commands, and
+this package only decides whether a shell command should be rejected before
+execution because it looks like a MoonBit command that belongs in `moon_cmd`.
+
+## Enforced Policy
+
+`moonbit_command_policy_error(cmd)` returns `Some(message)` when the command
+should be blocked by `shell`, and `None` when `shell` may continue.
+
+The current policy blocks:
+
+| Command shape | Reason |
+| --- | --- |
+| `moon check` | Use `moon_check` or `moon_cmd` for structured compiler feedback. |
+| `moon test` | Use `moon_cmd` so test output and snapshot-update policy are visible. |
+| `moon run` | Use `moon_cmd` so program args and stdin are structured, not shell-quoted. |
+| `moon info` | Use `moon_cmd` so interface generation is explicit. |
+| `moon fmt` | Use `moon_cmd` so formatting is tracked as a MoonBit command. |
+| `moon build` | Use `moon_cmd` so build output uses the same caps and headers. |
+| `moon_cmd ...` | `moon_cmd` is a tool name, not an executable shell command. |
+| `cd dir && moon check` | Use the shell tool's `cwd` field plus `moon_cmd` instead of embedding `cd`. |
+
+The policy allows:
+
+| Command shape | Reason |
+| --- | --- |
+| `moon --version` | Informational `moon` invocations outside the guarded subcommands. |
+| `git status --short` | Non-MoonBit commands remain in shell. |
+| `printf hi \| wc -c` | Shell-specific pipelines remain in shell unless they embed a guarded `moon` command. |
+
+## Detection Strategy
+
+The implementation is deliberately small and conservative for the cases it
+knows about:
+
+- Split the shell command into rough words.
+- Skip simple leading environment assignments such as `DEEPSEEK_MODEL=x`.
+- Reject a leading `moon_cmd`.
+- Reject a leading `moon` followed by one of the guarded subcommands.
+- Reject a few embedded forms such as `&& moon check`, `; moon test`, or a
+  newline followed by `moon run`.
+
+This is a heuristic parser, not a full POSIX shell parser. It is good enough to
+keep common accidental bypasses from using raw shell, but it does not understand
+every valid shell construct. Known hardening work is tracked in
+`agent_tool/shell/TODO.md`.
+
+## Examples
+
+```moonbit check
+///|
+test "command policy blocks structured MoonBit validation commands" {
+  assert_true(moonbit_command_policy_error("moon check") is Some(_))
+  assert_true(moonbit_command_policy_error("moon test --update") is Some(_))
+  assert_true(
+    moonbit_command_policy_error("DEEPSEEK_MODEL=x moon run cmd/main")
+    is Some(_),
+  )
+  assert_true(moonbit_command_policy_error("cd demo && moon info") is Some(_))
+}
+```
+
+```moonbit check
+///|
+test "command policy allows non guarded shell commands" {
+  assert_true(moonbit_command_policy_error("moon --version") is None)
+  assert_true(moonbit_command_policy_error("git status --short") is None)
+  assert_true(moonbit_command_policy_error("printf hi | wc -c") is None)
+}
+```
+
+## Operational Guidance
+
+When this policy blocks a command, the caller should not try to quote around it
+or rewrite it as a more complex shell string. Use:
+
+- `moon_check` for raw `moon check --output-json` diagnostics.
+- `moon_cmd` for `moon test`, `moon run`, `moon info`, `moon fmt`, and
+  `moon build`.
+- The `cwd` field on those tools instead of `cd ... &&`.
+- `program_args` and `stdin` on `moon_cmd run` instead of shell quoting,
+  heredocs, or pipes.

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -1,0 +1,85 @@
+///|
+pub fn moonbit_command_policy_error(cmd : String) -> String? {
+  let words = shell_words(cmd)
+  let command_index = first_command_word_index(words)
+  match command_index {
+    None => None
+    Some(index) => {
+      let first = words[index]
+      if first == "moon_cmd" {
+        return Some(
+          "error: moon_cmd is a tool, not a shell command; call the moon_cmd tool directly",
+        )
+      }
+      if first == "moon" && index + 1 < words.length() {
+        let subcommand = words[index + 1]
+        if guarded_moon_subcommands().contains(subcommand) {
+          return Some(
+            "error: shell blocked `moon \{subcommand}`; use the moon_cmd tool so MoonBit commands keep structured args, output caps, and guardrails",
+          )
+        }
+      }
+      if contains_guarded_moon_fragment(cmd) {
+        Some(
+          "error: shell blocked an embedded MoonBit command; use cwd plus moon_cmd instead of `cd ... && moon ...`",
+        )
+      } else {
+        None
+      }
+    }
+  }
+}
+
+///|
+fn guarded_moon_subcommands() -> Array[String] {
+  ["check", "test", "run", "info", "fmt", "build"]
+}
+
+///|
+fn shell_words(cmd : String) -> Array[String] {
+  let words : Array[String] = []
+  for piece in cmd.split(" ") {
+    let word = clean_shell_word(piece.to_owned())
+    if word != "" {
+      words.push(word)
+    }
+  }
+  words
+}
+
+///|
+fn clean_shell_word(word : String) -> String {
+  word.trim(chars="\t\r\n ").to_owned().trim(chars=";&|()").to_owned()
+}
+
+///|
+fn first_command_word_index(words : Array[String]) -> Int? {
+  for index, word in words {
+    if !looks_like_env_assignment(word) {
+      return Some(index)
+    }
+  }
+  None
+}
+
+///|
+fn looks_like_env_assignment(word : String) -> Bool {
+  if word.contains("/") || word.contains("-") {
+    return false
+  }
+  let parts = word.split("=").map(part => part.to_owned()).collect()
+  parts.length() == 2 && parts[0] != "" && parts[1] != ""
+}
+
+///|
+fn contains_guarded_moon_fragment(cmd : String) -> Bool {
+  let probes = ["&& moon ", "; moon ", "\nmoon "]
+  for probe in probes {
+    for subcommand in guarded_moon_subcommands() {
+      if cmd.contains(probe + subcommand) {
+        return true
+      }
+    }
+  }
+  false
+}

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -1,0 +1,11 @@
+///|
+test "command policy detects guarded MoonBit commands" {
+  assert_true(moonbit_command_policy_error("moon test") is Some(_))
+  assert_true(
+    moonbit_command_policy_error("DEEPSEEK_MODEL=x moon run cmd/main")
+    is Some(_),
+  )
+  assert_true(moonbit_command_policy_error("cd demo && moon check") is Some(_))
+  assert_true(moonbit_command_policy_error("moon --version") is None)
+  assert_true(moonbit_command_policy_error("git status --short") is None)
+}

--- a/agent_tool/shell/internal/command_policy/moon.pkg
+++ b/agent_tool/shell/internal/command_policy/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/agent_tool/shell/internal/command_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/command_policy/pkg.generated.mbti
@@ -1,0 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell/internal/command_policy"
+
+// Values
+pub fn moonbit_command_policy_error(String) -> String?
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -8,6 +8,7 @@ pub let hard_max_output_chars : Int = 50000
 pub struct ShellInput {
   cmd : String
   cwd : String?
+  timeout_ms : Int?
   max_output_chars : Int
 } derive(Debug)
 
@@ -23,10 +24,16 @@ pub fn decode(arguments : Json) -> ShellInput raise {
 fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
   let cmd = required_string(fields, "cmd")
   let cwd = optional_string(fields, "cwd")
-  let max_output_chars = optional_positive_int(
+  let timeout_ms = optional_positive_int(fields, "timeout_ms")
+  let max_output_chars = optional_positive_int_or_default(
     fields, "max_output_chars", default_max_output_chars,
   )
-  { cmd, cwd, max_output_chars: cap_max_output_chars(max_output_chars) }
+  {
+    cmd,
+    cwd,
+    timeout_ms,
+    max_output_chars: cap_max_output_chars(max_output_chars),
+  }
 }
 
 ///|
@@ -49,6 +56,24 @@ fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
 
 ///|
 fn optional_positive_int(
+  fields : Map[String, Json],
+  name : String,
+) -> Int? raise {
+  match fields.get(name) {
+    Some(Number(value, ..)) => {
+      let int_value = value.to_int()
+      if int_value <= 0 {
+        fail("arguments.\{name} to be a positive number")
+      }
+      Some(int_value)
+    }
+    Some(Null) | None => None
+    _ => fail("arguments.\{name} to be a number")
+  }
+}
+
+///|
+fn optional_positive_int_or_default(
   fields : Map[String, Json],
   name : String,
   default : Int,

--- a/agent_tool/shell/internal/decode/decode_test.mbt
+++ b/agent_tool/shell/internal/decode/decode_test.mbt
@@ -1,9 +1,19 @@
 ///|
 test "decode valid shell input" {
   debug_inspect(
-    decode({ "cmd": "echo hello", "cwd": "/tmp", "max_output_chars": 999999 }),
+    decode({
+      "cmd": "echo hello",
+      "cwd": "/tmp",
+      "timeout_ms": 250,
+      "max_output_chars": 999999,
+    }),
     content=(
-      #|{ cmd: "echo hello", cwd: Some("/tmp"), max_output_chars: 50000 }
+      #|{
+      #|  cmd: "echo hello",
+      #|  cwd: Some("/tmp"),
+      #|  timeout_ms: Some(250),
+      #|  max_output_chars: 50000,
+      #|}
     ),
   )
 }
@@ -13,7 +23,7 @@ test "decode treats empty cwd as absent" {
   debug_inspect(
     decode({ "cmd": "pwd", "cwd": "" }),
     content=(
-      #|{ cmd: "pwd", cwd: None, max_output_chars: 12000 }
+      #|{ cmd: "pwd", cwd: None, timeout_ms: None, max_output_chars: 12000 }
     ),
   )
 }
@@ -38,6 +48,18 @@ test "decode rejects invalid output cap" {
       )
   } noraise {
     _ => fail("invalid output cap decoded")
+  }
+}
+
+///|
+test "decode rejects invalid timeout" {
+  try decode({ "cmd": "echo hello", "timeout_ms": 0 }) catch {
+    error =>
+      assert_true(
+        "\{error}".contains("arguments.timeout_ms to be a positive number"),
+      )
+  } noraise {
+    _ => fail("invalid timeout decoded")
   }
 }
 

--- a/agent_tool/shell/internal/decode/pkg.generated.mbti
+++ b/agent_tool/shell/internal/decode/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub let hard_max_output_chars : Int
 pub struct ShellInput {
   cmd : String
   cwd : String?
+  timeout_ms : Int?
   max_output_chars : Int
 } derive(@debug.Debug)
 

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -1,13 +1,18 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/shell/internal/command_policy",
   "bobzhang/openseek/agent_tool/shell/internal/decode",
-  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/io",
   "moonbitlang/async/process",
   "moonbitlang/core/json",
 }
+
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "test"
 
 warnings = "+unnecessary_annotation"
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -10,6 +10,9 @@
 /// - `max_output_chars` (number, optional): defaults to 12000 and is capped at
 ///   50000. Truncated output is reported as a tool error even when the process
 ///   exits zero.
+/// - `timeout_ms` (number, optional): positive timeout in milliseconds. If the
+///   command is still running after the timeout, the process is cancelled and
+///   reported as a tool error.
 ///
 /// ## Result
 /// - `Respond(ToolOutput("exit=<code>\n<output>", is_error=<code != 0>))`
@@ -28,6 +31,7 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
       "properties": {
         "cmd": { "type": "string" },
         "cwd": { "type": "string" },
+        "timeout_ms": { "type": "number" },
         "max_output_chars": { "type": "number" },
       },
       "required": ["cmd"],
@@ -47,7 +51,7 @@ async fn execute(arguments : Json) -> @agent_tool.ToolAction {
       )
     }
   }
-  match moonbit_command_policy_error(input.cmd) {
+  match @command_policy.moonbit_command_policy_error(input.cmd) {
     Some(message) =>
       return @agent_tool.ToolAction::respond(message, is_error=true)
     None => ()
@@ -59,92 +63,6 @@ async fn execute(arguments : Json) -> @agent_tool.ToolAction {
         is_error=true,
       )
   }
-}
-
-///|
-fn moonbit_command_policy_error(cmd : String) -> String? {
-  let words = shell_words(cmd)
-  let command_index = first_command_word_index(words)
-  match command_index {
-    None => None
-    Some(index) => {
-      let first = words[index]
-      if first == "moon_cmd" {
-        return Some(
-          "error: moon_cmd is a tool, not a shell command; call the moon_cmd tool directly",
-        )
-      }
-      if first == "moon" && index + 1 < words.length() {
-        let subcommand = words[index + 1]
-        if guarded_moon_subcommands().contains(subcommand) {
-          return Some(
-            "error: shell blocked `moon \{subcommand}`; use the moon_cmd tool so MoonBit commands keep structured args, output caps, and guardrails",
-          )
-        }
-      }
-      if contains_guarded_moon_fragment(cmd) {
-        Some(
-          "error: shell blocked an embedded MoonBit command; use cwd plus moon_cmd instead of `cd ... && moon ...`",
-        )
-      } else {
-        None
-      }
-    }
-  }
-}
-
-///|
-fn guarded_moon_subcommands() -> Array[String] {
-  ["check", "test", "run", "info", "fmt", "build"]
-}
-
-///|
-fn shell_words(cmd : String) -> Array[String] {
-  let words : Array[String] = []
-  for piece in cmd.split(" ") {
-    let word = clean_shell_word(piece.to_owned())
-    if word != "" {
-      words.push(word)
-    }
-  }
-  words
-}
-
-///|
-fn clean_shell_word(word : String) -> String {
-  word.trim(chars="\t\r\n ").to_owned().trim(chars=";&|()").to_owned()
-}
-
-///|
-fn first_command_word_index(words : Array[String]) -> Int? {
-  for index, word in words {
-    if !looks_like_env_assignment(word) {
-      return Some(index)
-    }
-  }
-  None
-}
-
-///|
-fn looks_like_env_assignment(word : String) -> Bool {
-  if word.contains("/") || word.contains("-") {
-    return false
-  }
-  let parts = word.split("=").map(part => part.to_owned()).collect()
-  parts.length() == 2 && parts[0] != "" && parts[1] != ""
-}
-
-///|
-fn contains_guarded_moon_fragment(cmd : String) -> Bool {
-  let probes = ["&& moon ", "; moon ", "\nmoon "]
-  for probe in probes {
-    for subcommand in guarded_moon_subcommands() {
-      if cmd.contains(probe + subcommand) {
-        return true
-      }
-    }
-  }
-  false
 }
 
 ///|
@@ -165,9 +83,25 @@ async fn shell(input : @decode.ShellInput) -> @agent_tool.ToolAction {
       )
     }
   }
-  let (code, output) = match input.cwd {
-    Some(cwd) => @process.collect_output_merged("sh", ["-c", input.cmd], cwd~)
-    None => @process.collect_output_merged("sh", ["-c", input.cmd])
+  let result = match input.timeout_ms {
+    Some(timeout_ms) =>
+      @async.with_timeout_opt(timeout_ms, () => {
+        collect_shell_output(input.cmd, input.cwd)
+      })
+    None => Some(collect_shell_output(input.cmd, input.cwd))
+  }
+  let (code, output) = match result {
+    Some(result) => result
+    None => {
+      let timeout_ms = match input.timeout_ms {
+        Some(timeout_ms) => timeout_ms
+        None => 0
+      }
+      return @agent_tool.ToolAction::respond(
+        "error: shell command timed out after \{timeout_ms}ms",
+        is_error=true,
+      )
+    }
   }
   let body = output.text()
   let capped = cap_text(body, input.max_output_chars)
@@ -176,6 +110,14 @@ async fn shell(input : @decode.ShellInput) -> @agent_tool.ToolAction {
     "exit=\{code}\{truncation}\n\{capped}",
     is_error=code != 0 || is_truncated(body, input.max_output_chars),
   )
+}
+
+///|
+async fn collect_shell_output(cmd : String, cwd : String?) -> (Int, &@io.Data) {
+  match cwd {
+    Some(cwd) => @process.collect_output_merged("sh", ["-c", cmd], cwd~)
+    None => @process.collect_output_merged("sh", ["-c", cmd])
+  }
 }
 
 ///|
@@ -206,10 +148,12 @@ test "shell parses and caps output limit" {
   let input = @decode.decode({
     "cmd": "echo hello",
     "cwd": "/tmp",
+    "timeout_ms": 250,
     "max_output_chars": 999999,
   })
   assert_eq(input.cmd, "echo hello")
   assert_true(input.cwd is Some("/tmp"))
+  assert_true(input.timeout_ms is Some(250))
   assert_eq(input.max_output_chars, @decode.hard_max_output_chars)
 }
 
@@ -221,144 +165,4 @@ test "shell records truncation metadata" {
     truncation_header("abcdef", 3),
     "\ntruncated=true\noutput_chars=6\nshown_chars=3",
   )
-}
-
-///|
-async test "shell runs cmd and returns exit code plus output" {
-  let result = execute({ "cmd": "echo hello" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("exit=0"))
-  assert_true(output.content.contains("hello"))
-}
-
-///|
-async test "shell propagates non-zero exit codes" {
-  let result = execute({ "cmd": "exit 7" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("exit=7"))
-}
-
-///|
-async test "shell honors cwd when non-empty" {
-  let result = execute({ "cmd": "pwd", "cwd": "/tmp" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("exit=0"))
-  assert_true(output.content.contains("/tmp"))
-}
-
-///|
-async test "shell reads a virtual filesystem fixture from cwd" {
-  let project = @fs.tmpdir(prefix="openseek-shell-vfs-")
-  @vfs.FileSystem({
-    "data/input.txt": (
-      #|shell-vfs
-      #|
-    ),
-  }).write_to(project)
-  let result = execute({ "cmd": "cat data/input.txt", "cwd": project })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  inspect(
-    output.content.trim(),
-    content=(
-      #|exit=0
-      #|shell-vfs
-    ),
-  )
-}
-
-///|
-async test "shell treats empty cwd as missing" {
-  let result = execute({ "cmd": "echo cwdless", "cwd": "" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("exit=0"))
-  assert_true(output.content.contains("cwdless"))
-}
-
-///|
-async test "shell truncates oversized output and marks it as error" {
-  let result = execute({ "cmd": "printf abcdef", "max_output_chars": 3 })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("exit=0"))
-  assert_true(output.content.contains("truncated=true"))
-  assert_true(output.content.contains("shown_chars=3"))
-  assert_true(output.content.contains("\nabc"))
-  assert_false(output.content.contains("abcdef"))
-}
-
-///|
-async test "shell merges stderr into the captured output" {
-  let result = execute({ "cmd": "echo oops 1>&2" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("oops"))
-}
-
-///|
-test "shell detects moon command policy errors" {
-  assert_true(moonbit_command_policy_error("moon test") is Some(_))
-  assert_true(
-    moonbit_command_policy_error("DEEPSEEK_MODEL=x moon run cmd/main")
-    is Some(_),
-  )
-  assert_true(moonbit_command_policy_error("cd demo && moon check") is Some(_))
-  assert_true(moonbit_command_policy_error("moon --version") is None)
-  assert_true(moonbit_command_policy_error("git status --short") is None)
-}
-
-///|
-async test "shell rejects moon run and points to moon_cmd" {
-  let result = execute({ "cmd": "moon run --target native cmd/main -- .a" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("shell blocked `moon run`"))
-  assert_true(output.content.contains("moon_cmd"))
-}
-
-///|
-async test "shell rejects moon_cmd as a shell command" {
-  let result = execute({ "cmd": "moon_cmd run cmd/main" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("moon_cmd is a tool"))
-}
-
-///|
-async test "shell rejects missing cmd" {
-  let result = execute({ "cwd": "/tmp" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("error: shell requires"))
-  assert_true(output.content.contains("arguments.cmd"))
-}
-
-///|
-async test "shell rejects non-object arguments" {
-  let result = execute(Json::null())
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_eq(output.content, "error: shell requires object arguments")
-}
-
-///|
-async test "shell rejects non-existent cwd" {
-  let result = execute({ "cmd": "echo hello", "cwd": "/nonexistent/path/xyz" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("cwd does not exist"))
-}
-
-///|
-async test "shell rejects cwd that is a file not a directory" {
-  // Use a path that is known to exist and be a file-like entity
-  let result = execute({ "cmd": "echo hello", "cwd": "/dev/null" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("cwd is not a directory"))
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -1,0 +1,138 @@
+///|
+async fn run_shell(arguments : Json) -> @agent_tool.ToolAction {
+  match @shell.definition().execute {
+    Async(execute) => execute(arguments)
+    Sync(_) => fail("shell tool should be async")
+  }
+}
+
+///|
+async test "shell runs cmd and returns exit code plus output" {
+  let result = run_shell({ "cmd": "echo hello" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content =~ re"^exit=0\nhello\n?$")
+}
+
+///|
+async test "shell propagates non-zero exit codes" {
+  let result = run_shell({ "cmd": "exit 7" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content =~ re"^exit=7\n?$")
+}
+
+///|
+async test "shell honors cwd when non-empty" {
+  let result = run_shell({ "cmd": "pwd", "cwd": "/tmp" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content =~ re"^exit=0\n.*/tmp\n?$")
+}
+
+///|
+async test "shell reads a virtual filesystem fixture from cwd" {
+  let project = @fs.tmpdir(prefix="openseek-shell-vfs-")
+  @vfs.FileSystem({
+    "data/input.txt": (
+      #|shell-vfs
+      #|
+    ),
+  }).write_to(project)
+  let result = run_shell({ "cmd": "cat data/input.txt", "cwd": project })
+  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  inspect(
+    output.content.trim(),
+    content=(
+      #|exit=0
+      #|shell-vfs
+    ),
+  )
+}
+
+///|
+async test "shell treats empty cwd as missing" {
+  let result = run_shell({ "cmd": "echo cwdless", "cwd": "" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content =~ re"^exit=0\ncwdless\n?$")
+}
+
+///|
+async test "shell truncates oversized output and marks it as error" {
+  let result = run_shell({ "cmd": "printf abcdef", "max_output_chars": 3 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=0\ntruncated=true\noutput_chars=6\nshown_chars=3\nabc$",
+  )
+  assert_false(output.content.contains("abcdef"))
+}
+
+///|
+async test "shell merges stderr into the captured output" {
+  let result = run_shell({ "cmd": "echo oops 1>&2" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content =~ re"^exit=0\noops\n?$")
+}
+
+///|
+async test "shell times out long running commands" {
+  let result = run_shell({ "cmd": "sleep 2", "timeout_ms": 50 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_eq(output.content, "error: shell command timed out after 50ms")
+}
+
+///|
+async test "shell rejects moon run and points to moon_cmd" {
+  let result = run_shell({ "cmd": "moon run --target native cmd/main -- .a" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("shell blocked `moon run`"))
+  assert_true(output.content.contains("moon_cmd"))
+}
+
+///|
+async test "shell rejects moon_cmd as a shell command" {
+  let result = run_shell({ "cmd": "moon_cmd run cmd/main" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("moon_cmd is a tool"))
+}
+
+///|
+async test "shell rejects missing cmd" {
+  let result = run_shell({ "cwd": "/tmp" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("error: shell requires"))
+  assert_true(output.content.contains("arguments.cmd"))
+}
+
+///|
+async test "shell rejects non-object arguments" {
+  let result = run_shell(Json::null())
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_eq(output.content, "error: shell requires object arguments")
+}
+
+///|
+async test "shell rejects non-existent cwd" {
+  let result = run_shell({ "cmd": "echo hello", "cwd": "/nonexistent/path/xyz" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("cwd does not exist"))
+}
+
+///|
+async test "shell rejects cwd that is a file not a directory" {
+  let result = run_shell({ "cmd": "echo hello", "cwd": "/dev/null" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("cwd is not a directory"))
+}


### PR DESCRIPTION
## Summary

- Add optional `timeout_ms` support to the `shell` tool and report timed-out commands as tool errors.
- Move MoonBit shell-command routing policy into `agent_tool/shell/internal/command_policy` with executable documentation.
- Move most shell behavior tests into `shell_test.mbt` and simplify ordered output assertions with regex where it improves signal.
- Add a shell TODO checklist for remaining output, policy, and API improvements.

## Validation

- `moon test agent_tool/shell agent_tool/shell/internal/decode agent_tool/shell/internal/command_policy --target native`
- `moon test agent_tool/shell/internal/command_policy --target native`
- `moon info && moon fmt`
- `moon test --target native`
