### PR TITLE
[codex] enforce shell output limits while reading

### DIFF
--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -14,10 +14,11 @@ environment variables, and existing scripts all work without inventing a custom
 argument schema for every possible operation.
 
 stdout and stderr are merged so diagnostics appear in the same order a terminal
-would show them. Output is capped because commands can accidentally emit
-generated artifacts, dependency listings, or compiler invocations large enough
-to damage the model context. Truncation is treated as a tool error so the agent
-knows it did not receive the full command output.
+would show them. Output is capped while the process pipe is being read because
+commands can accidentally emit generated artifacts, dependency listings, or
+compiler invocations large enough to damage the model context. When reading
+proves the output exceeds the cap, the tool cancels the child process and treats
+the result as a tool error so the agent knows it received only an output prefix.
 
 Callers may also set `timeout_ms` for commands that could wait indefinitely.
 When the timeout expires, the in-flight process collection is cancelled and the
@@ -47,7 +48,7 @@ features such as pipes.
 | `cmd` | string | yes | Passed as the single argument to `sh -c`. |
 | `cwd` | string | no  | Working directory. An empty string is treated as missing. |
 | `timeout_ms` | number | no | Positive timeout in milliseconds. Timed-out commands are cancelled and reported as tool errors. |
-| `max_output_chars` | number | no | Defaults to 12000, capped at 50000. Truncated output is a tool error. |
+| `max_output_chars` | number | no | Defaults to 12000, capped at 50000. The retained output prefix is bounded while reading; exceeding the limit cancels the command and returns a tool error. |
 
 ## Action
 
@@ -58,8 +59,10 @@ arguments, non-zero shell exit codes, and output truncation. The string body
 has one of these shapes:
 
 - `"exit=<code>\n<stdout/stderr merged>"` — normal completion.
-- `"exit=<code>\ntruncated=true\noutput_chars=<n>\nshown_chars=<n>\n<output-prefix>"` —
-  the process completed but output was capped before sending it to the model.
+- `"exit=<code-or-cancelled>\ntruncated=true\noutput_limit_reached=true\nshown_chars=<n>\nmax_output_chars=<n>\n<output-prefix>"` —
+  output exceeded `max_output_chars` while the process pipe was being read. The
+  command is cancelled if it has not already exited; no full output length is
+  reported because the full output was intentionally not collected.
 - `"error: shell command timed out after <n>ms"` — `timeout_ms` elapsed before
   the command completed.
 - `"error running shell: <error>"` — `sh -c` failed to launch (rare; usually
@@ -68,7 +71,7 @@ has one of these shapes:
   `cmd` field.
 - `"error: shell requires object arguments"` — payload was not a JSON object.
 
-`stderr` is merged into `stdout` via `@process.collect_output_merged` so the
+`stderr` is redirected into the same process output pipe as `stdout` so the
 model sees the same interleaving a developer would see in a terminal.
 
 ## Example

--- a/agent_tool/shell/TODO.md
+++ b/agent_tool/shell/TODO.md
@@ -8,9 +8,9 @@ Review target: `agent_tool/shell`.
   - Current behavior awaits `@process.collect_output_merged`, so a hung command blocks the whole agent loop.
   - A timeout should cancel the child process and return a tool error with elapsed time.
 
-- [ ] Enforce output limits while reading, not after full collection.
-  - Current `max_output_chars` caps only after the whole process output has been collected.
-  - Commands such as `yes`, `tail -f`, or huge finite output can still hang or allocate too much before truncation.
+- [x] Enforce output limits while reading, not after full collection.
+  - `max_output_chars` is enforced on the retained output prefix while the process pipe is read.
+  - Commands such as `yes`, `tail -f`, or huge finite output are cancelled once the limit is reached.
 
 - [ ] Harden MoonBit command policy bypass detection.
   - Current guard is based on simple space splitting and a few string fragments.

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -5,8 +5,8 @@ import {
   "bobzhang/openseek/agent_tool/shell/internal/decode",
   "moonbitlang/async",
   "moonbitlang/async/fs",
-  "moonbitlang/async/io",
   "moonbitlang/async/process",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -8,8 +8,8 @@
 /// - `cwd` (string, optional): working directory the command runs in.
 ///   An empty string is treated the same as a missing field.
 /// - `max_output_chars` (number, optional): defaults to 12000 and is capped at
-///   50000. Truncated output is reported as a tool error even when the process
-///   exits zero.
+///   50000. Once the retained output prefix exceeds this limit, the child
+///   process is cancelled and the result is reported as a tool error.
 /// - `timeout_ms` (number, optional): positive timeout in milliseconds. If the
 ///   command is still running after the timeout, the process is cancelled and
 ///   reported as a tool error.
@@ -18,6 +18,9 @@
 /// - `Respond(ToolOutput("exit=<code>\n<output>", is_error=<code != 0>))`
 ///   when `sh -c` runs. Non-zero exit codes are typed as tool errors while
 ///   preserving the full output for the model.
+/// - `Respond(ToolOutput("exit=<code-or-cancelled>\ntruncated=true\noutput_limit_reached=true\nshown_chars=<n>\nmax_output_chars=<n>\n<output-prefix>", is_error=true))`
+///   when output exceeds `max_output_chars`. The command may be cancelled before
+///   its natural exit code is available.
 /// - `Respond(ToolOutput("error running shell: ...", is_error=true))` when
 ///   launching the process raises.
 /// - `Respond(ToolOutput("error: shell requires ...", is_error=true))` for
@@ -86,11 +89,12 @@ async fn shell(input : @decode.ShellInput) -> @agent_tool.ToolAction {
   let result = match input.timeout_ms {
     Some(timeout_ms) =>
       @async.with_timeout_opt(timeout_ms, () => {
-        collect_shell_output(input.cmd, input.cwd)
+        collect_shell_output(input.cmd, input.cwd, input.max_output_chars)
       })
-    None => Some(collect_shell_output(input.cmd, input.cwd))
+    None =>
+      Some(collect_shell_output(input.cmd, input.cwd, input.max_output_chars))
   }
-  let (code, output) = match result {
+  let output = match result {
     Some(result) => result
     None => {
       let timeout_ms = match input.timeout_ms {
@@ -103,43 +107,162 @@ async fn shell(input : @decode.ShellInput) -> @agent_tool.ToolAction {
       )
     }
   }
-  let body = output.text()
-  let capped = cap_text(body, input.max_output_chars)
-  let truncation = truncation_header(body, input.max_output_chars)
-  @agent_tool.ToolAction::respond(
-    "exit=\{code}\{truncation}\n\{capped}",
-    is_error=code != 0 || is_truncated(body, input.max_output_chars),
-  )
+  let response = shell_response(output, input.max_output_chars)
+  @agent_tool.ToolAction::respond(response.content, is_error=response.is_error)
 }
 
 ///|
-async fn collect_shell_output(cmd : String, cwd : String?) -> (Int, &@io.Data) {
-  match cwd {
-    Some(cwd) => @process.collect_output_merged("sh", ["-c", cmd], cwd~)
-    None => @process.collect_output_merged("sh", ["-c", cmd])
+priv struct ShellOutput {
+  exit_code : Int?
+  text : String
+  output_limit_reached : Bool
+}
+
+///|
+priv struct ShellResponse {
+  content : String
+  is_error : Bool
+}
+
+///|
+async fn collect_shell_output(
+  cmd : String,
+  cwd : String?,
+  max_output_chars : Int,
+) -> ShellOutput {
+  let (reader, writer) = @process.read_from_process()
+  @async.with_task_group() <| group => {
+    defer reader.close()
+    let process = match cwd {
+      Some(cwd) =>
+        @process.spawn(
+          group,
+          "sh",
+          ["-c", cmd],
+          stdout=writer,
+          stderr=writer,
+          cwd~,
+          cancel_handler=@process.hard_cancel(),
+        )
+      None =>
+        @process.spawn(
+          group,
+          "sh",
+          ["-c", cmd],
+          stdout=writer,
+          stderr=writer,
+          cancel_handler=@process.hard_cancel(),
+        )
+    }
+    let prefix = read_output_prefix(reader, max_output_chars)
+    if prefix.output_limit_reached {
+      let exit_code = process.try_wait() catch { _ => None }
+      if exit_code is None {
+        process.cancel()
+        let _ = process.wait() catch { _ => 0 }
+      }
+      { exit_code, text: prefix.text, output_limit_reached: true }
+    } else {
+      {
+        exit_code: Some(process.wait()),
+        text: prefix.text,
+        output_limit_reached: false,
+      }
+    }
   }
 }
 
 ///|
-fn cap_text(content : String, max_chars : Int) -> String {
-  if content.length() <= max_chars {
-    content
-  } else {
-    content[:max_chars].to_owned()
+priv struct OutputPrefix {
+  text : String
+  output_limit_reached : Bool
+}
+
+///|
+async fn read_output_prefix(
+  reader : @process.ReadFromProcess,
+  max_output_chars : Int,
+) -> OutputPrefix {
+  let buffer = Buffer()
+  let byte_budget = max_output_chars * 4 + 4
+  for ;; {
+    let remaining_budget = byte_budget - buffer.length()
+    let chunk_limit = if remaining_budget <= 0 {
+      1
+    } else if remaining_budget < 1024 {
+      remaining_budget
+    } else {
+      1024
+    }
+    match reader.read_some(max_len=chunk_limit) {
+      None =>
+        return {
+          text: @utf8.decode(buffer.to_bytes()),
+          output_limit_reached: false,
+        }
+      Some(chunk) => {
+        buffer.write_bytes(chunk)
+        let text = decode_valid_utf8_prefix(buffer.to_bytes())
+        if text.char_length() > max_output_chars {
+          return {
+            text: text_prefix_by_chars(text, max_output_chars),
+            output_limit_reached: true,
+          }
+        } else {
+          continue
+        }
+      }
+    }
   }
 }
 
 ///|
-fn is_truncated(content : String, max_chars : Int) -> Bool {
-  content.length() > max_chars
+fn text_prefix_by_chars(text : String, max_chars : Int) -> String {
+  match text.offset_of_nth_char(max_chars) {
+    Some(end) => text[:end].to_owned()
+    None => text
+  }
 }
 
 ///|
-fn truncation_header(content : String, max_chars : Int) -> String {
-  if is_truncated(content, max_chars) {
-    "\ntruncated=true\noutput_chars=\{content.length()}\nshown_chars=\{max_chars}"
+fn decode_valid_utf8_prefix(bytes : Bytes) -> String raise {
+  for dropped in 0..<=3 {
+    let end = bytes.length() - dropped
+    if end >= 0 {
+      try {
+        return @utf8.decode(bytes[:end])
+      } catch {
+        _ => ()
+      }
+    }
+  }
+  @utf8.decode(bytes)
+}
+
+///|
+fn shell_response(
+  output : ShellOutput,
+  max_output_chars : Int,
+) -> ShellResponse {
+  if output.output_limit_reached {
+    {
+      content: "\{exit_header(output.exit_code)}\ntruncated=true\noutput_limit_reached=true\nshown_chars=\{output.text.char_length()}\nmax_output_chars=\{max_output_chars}\n\{output.text}",
+      is_error: true,
+    }
   } else {
-    ""
+    let code = match output.exit_code {
+      Some(code) => code
+      None => 0
+    }
+    { content: "exit=\{code}\n\{output.text}", is_error: code != 0 }
+  }
+}
+
+///|
+fn exit_header(exit_code : Int?) -> String {
+  match exit_code {
+    Some(code) => "exit=\{code}"
+    None => "exit=cancelled"
   }
 }
 
@@ -158,11 +281,12 @@ test "shell parses and caps output limit" {
 }
 
 ///|
-test "shell records truncation metadata" {
-  assert_eq(cap_text("abcdef", 3), "abc")
-  assert_true(is_truncated("abcdef", 3))
+test "shell formats output limit metadata" {
   assert_eq(
-    truncation_header("abcdef", 3),
-    "\ntruncated=true\noutput_chars=6\nshown_chars=3",
+    shell_response(
+      { exit_code: Some(0), text: "abc", output_limit_reached: true },
+      3,
+    ).content,
+    "exit=0\ntruncated=true\noutput_limit_reached=true\nshown_chars=3\nmax_output_chars=3\nabc",
   )
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -61,14 +61,99 @@ async test "shell treats empty cwd as missing" {
 }
 
 ///|
-async test "shell truncates oversized output and marks it as error" {
-  let result = run_shell({ "cmd": "printf abcdef", "max_output_chars": 3 })
+async test "shell leaves output at exact limit as a normal result" {
+  let result = run_shell({ "cmd": "printf abc", "max_output_chars": 3 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_eq(output.content, "exit=0\nabc")
+}
+
+///|
+async test "shell counts output limits in characters for non-ascii text" {
+  let result = run_shell({ "cmd": "printf '中中'", "max_output_chars": 2 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_eq(output.content, "exit=0\n中中")
+}
+
+///|
+async test "shell leaves four-byte utf8 output at exact character limit" {
+  let result = run_shell({ "cmd": "printf '😀'", "max_output_chars": 1 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_eq(output.content, "exit=0\n😀")
+}
+
+///|
+async test "shell stops oversized output while the command is still running" {
+  let result = run_shell({
+    "cmd": "printf abcdef; sleep 2",
+    "max_output_chars": 3,
+    "timeout_ms": 1000,
+  })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=0\ntruncated=true\noutput_chars=6\nshown_chars=3\nabc$",
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=3\nmax_output_chars=3\nabc$",
   )
+  assert_false(output.content.contains("timed out"))
   assert_false(output.content.contains("abcdef"))
+}
+
+///|
+async test "shell does not cut multi-byte utf8 output mid-character" {
+  let result = run_shell({
+    "cmd": "printf '中中中'; sleep 2",
+    "max_output_chars": 2,
+    "timeout_ms": 1000,
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=2\nmax_output_chars=2\n中中$",
+  )
+  assert_false(output.content.contains("�"))
+  assert_false(output.content.contains("中中中"))
+}
+
+///|
+async test "shell does not split four-byte utf8 characters" {
+  let result = run_shell({
+    "cmd": "printf '😀😀'; sleep 2",
+    "max_output_chars": 1,
+    "timeout_ms": 1000,
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=1\nmax_output_chars=1\n😀$",
+  )
+  assert_false(output.content.contains("�"))
+  assert_false(output.content.contains("😀😀"))
+}
+
+///|
+async test "shell reports binary output as a tool error" {
+  let result = run_shell({ "cmd": "printf '\\377'" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("error running shell:"))
+  assert_true(output.content.contains("Malformed"))
+}
+
+///|
+async test "shell output limit wins over an unbounded producer" {
+  let result = run_shell({
+    "cmd": "while :; do printf yyyyyyyyyy; done",
+    "max_output_chars": 5,
+    "timeout_ms": 1000,
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=5\nmax_output_chars=5\nyyyyy$",
+  )
+  assert_false(output.content.contains("timed out"))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Replace full-output collection in `shell` with streaming reads from the process pipe.
- Cancel the child process once output exceeds `max_output_chars`, returning explicit `output_limit_reached` metadata with a retained prefix.
- Preserve UTF-8 and Unicode character boundaries when truncating, including four-byte characters.
- Update the shell README/TODO contract and add regression coverage for exact-limit, oversized, unbounded-output, non-ASCII output, and non-UTF-8 binary output cases.

## Why

The previous implementation capped output only after `@process.collect_output_merged` had collected the entire process output. Commands like `yes`, `tail -f`, or huge finite output could still hang or allocate too much before truncation happened.

## Review Notes

A fresh Codex CLI review found a Unicode edge case where byte-safe truncation could still split a decoded surrogate pair. This PR now uses MoonBit character offsets for the retained prefix and includes emoji coverage.

The shell tool remains a strict text tool. Commands that emit invalid UTF-8 return a tool error response instead of crashing the caller; binary output now has an explicit regression test.

## Validation

- `moon check agent_tool/shell --target native --warn-list +73`
- `moon test agent_tool/shell agent_tool/shell/internal/decode agent_tool/shell/internal/command_policy --target native`
- `moon test --target native`
- `moon info && moon fmt`
- `git diff --check`
- GitHub Actions `check (nightly)` passed before the latest test-only amend; re-running on commit `7592aa5`