### PR TITLE
[codex] simplify MoonBit prompt generator

### DIFF
--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -77,20 +77,30 @@ fn generated_source(
   function_name~ : String,
   markdown~ : String,
 ) -> String {
-  let sb = StringBuilder()
-  sb <+ "// Generated from \{base} by moon dev_build. DO NOT EDIT.\n"
-  sb <+ "///|\n"
-  sb <+ "fn \{function_name}() -> String {\n"
-  sb <+ "  (\n"
   let lines = markdown.split("\n").to_array()
   let skip_final_empty = markdown.has_suffix("\n")
+  let sb = StringBuilder()
+  sb <+
+    $|// Generated from \{base} by moon dev_build. DO NOT EDIT.
+    $|///|
+    $|fn \{function_name}() -> String {
+    $|  (
+    $|\{out => write_markdown_lines(out, lines, skip_final_empty)}  )
+    $|}
+    $|
+  sb.to_string()
+}
+
+///|
+fn write_markdown_lines(
+  out : StringBuilder,
+  lines : Array[StringView],
+  skip_final_empty : Bool,
+) -> Unit {
   for index, line in lines {
     if skip_final_empty && index == lines.length() - 1 {
       continue
     }
-    sb <+ "    #|\{line}\n"
+    out <+ "    #|\{line}\n"
   }
-  sb <+ "  )\n"
-  sb <+ "}\n"
-  sb.to_string()
 }


### PR DESCRIPTION
## Summary

Simplify `scripts/md_to_mbt_string/main.mbt` by using multiline `$|` streaming for the generated source skeleton and a builder callback for the Markdown body lines.

The generated prompt files remain byte-identical; this is only a readability cleanup after #30.

## Validation

- `moon -C scripts check md_to_mbt_string --target native --warn-list +73`
- `moon -C scripts test md_to_mbt_string --target native`
- `rm -f prompt/generated_base_prompt.mbt prompt/generated_flash_prompt.mbt; moon check prompt --target native`
- `moon -C scripts info && moon -C scripts fmt`
- `moon check --target native`
- `moon test --target native`
- `git diff --check`