### PR TITLE
[codex] Use pwsh for Windows shell execution

### DIFF
--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -1,17 +1,19 @@
 # Shell Tool
 
-`shell` runs a command line through `sh -c` and returns the exit code together
-with the merged stdout/stderr output. It is the agent's escape hatch for
-running build commands, tests, package managers, version-control operations,
-and any other workspace task the other built-in tools don't cover.
+`shell` runs a command line through the platform shell and returns the exit code
+together with the merged stdout/stderr output. On Windows that shell is
+`pwsh -NoProfile -Command` and callers should use PowerShell syntax; elsewhere
+it is `sh -c` and callers should use POSIX shell syntax. It is the agent's
+escape hatch for running build commands, tests, package managers, version-control
+operations, and any other workspace task the other built-in tools don't cover.
 
 ## Design Rationale
 
 `shell` is the general escape hatch because an agent occasionally needs a real
 workspace command that is not worth modeling as a dedicated tool. It uses
-`sh -c` to match developer command-line ergonomics: pipelines, redirects,
-environment variables, and existing scripts all work without inventing a custom
-argument schema for every possible operation.
+the local platform shell to match developer command-line ergonomics: pipelines,
+redirects, environment variables, and existing scripts all work without
+inventing a custom argument schema for every possible operation.
 
 stdout and stderr are merged so diagnostics appear in the same order a terminal
 would show them. Output is capped while the process pipe is being read because
@@ -45,7 +47,7 @@ features such as pipes.
 
 | Name | Type   | Required | Notes |
 | ---- | ------ | -------- | ----- |
-| `cmd` | string | yes | Passed as the single argument to `sh -c`. |
+| `cmd` | string | yes | Passed as the single command argument to the platform shell. |
 | `cwd` | string | no  | Working directory. An empty string is treated as missing. |
 | `timeout_ms` | number | no | Positive timeout in milliseconds. Timed-out commands are cancelled and reported as tool errors. |
 | `max_output_chars` | number | no | Defaults to 12000, capped at 50000. The retained output prefix is bounded while reading; exceeding the limit cancels the command and returns a tool error. |
@@ -65,8 +67,8 @@ has one of these shapes:
   reported because the full output was intentionally not collected.
 - `"error: shell command timed out after <n>ms"` — `timeout_ms` elapsed before
   the command completed.
-- `"error running shell: <error>"` — `sh -c` failed to launch (rare; usually
-  a process subsystem error).
+- `"error running shell: <error>"` — the platform shell failed to launch
+  (rare; usually a process subsystem error).
 - `"error: shell requires arguments.cmd"` — payload was an object but had no
   `cmd` field.
 - `"error: shell requires object arguments"` — payload was not a JSON object.
@@ -81,6 +83,7 @@ model sees the same interleaving a developer would see in a terminal.
 test "shell tool advertises the expected schema" {
   let tool = @shell.definition()
   assert_eq(tool.name, "shell")
+  assert_true(tool.description.contains("arguments.cmd"))
   let JsonSchema(schema) = tool.schema
   let text = schema.stringify()
   assert_true(text.contains("\"cmd\""))
@@ -93,24 +96,25 @@ test "shell tool advertises the expected schema" {
 ```moonbit check
 ///|
 async test "shell tool runs a project-style command through the registry" {
+  let dir = @fs.tmpdir(prefix="openseek-shell-readme-")
   let tools = @agent_tool.Tools([@shell.definition()])
+  let arguments : Json = {
+    "cmd": "echo 'alpha beta'",
+    "cwd": dir,
+    "timeout_ms": 5000,
+  }
   let call = @agent_tool.AgentToolCall(
     ToolCall(
       id="call_shell_count",
       name="shell",
-      arguments=(
-        #|{
-        #|  "cmd": "printf 'alpha beta' | wc -w",
-        #|  "cwd": "/tmp",
-        #|  "timeout_ms": 5000
-        #|}
-      ),
+      arguments=arguments.stringify(),
     ),
   )
   let result = @agent_tool.execute_tool_call(call, tools)
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_true(output.content.contains("exit=0"))
-  assert_true(output.content.contains("2"))
+  assert_true(output.content.contains("alpha beta"))
 }
 ```

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -12,6 +12,7 @@ import {
 
 import {
   "bobzhang/openseek/testkit/filesystem" @vfs,
+  "moonbitlang/x/path",
 } for "test"
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -1,10 +1,10 @@
 ///|
-/// Tool definition for `shell`: runs `arguments.cmd` through `sh -c`,
-/// optionally in `arguments.cwd`, and returns the exit code plus merged
+/// Tool definition for `shell`: runs `arguments.cmd` through the platform
+/// shell, optionally in `arguments.cwd`, and returns the exit code plus merged
 /// stdout/stderr output.
 ///
 /// ## Arguments
-/// - `cmd` (string, required): shell command line passed to `sh -c`.
+/// - `cmd` (string, required): shell command line passed to the platform shell.
 /// - `cwd` (string, optional): working directory the command runs in.
 ///   An empty string is treated the same as a missing field.
 /// - `max_output_chars` (number, optional): defaults to 12000 and is capped at
@@ -16,8 +16,8 @@
 ///
 /// ## Result
 /// - `Respond(ToolOutput("exit=<code>\n<output>", is_error=<code != 0>))`
-///   when `sh -c` runs. Non-zero exit codes are typed as tool errors while
-///   preserving the full output for the model.
+///   when the platform shell runs. Non-zero exit codes are typed as tool errors
+///   while preserving the full output for the model.
 /// - `Respond(ToolOutput("exit=<code-or-cancelled>\ntruncated=true\noutput_limit_reached=true\nshown_chars=<n>\nmax_output_chars=<n>\n<output-prefix>", is_error=true))`
 ///   when output exceeds `max_output_chars`. The command may be cancelled before
 ///   its natural exit code is available.
@@ -28,7 +28,7 @@
 pub fn definition() -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell",
-    description="Run arguments.cmd through sh -c, optionally in arguments.cwd, and return exit code plus output.",
+    description=shell_description(),
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -41,6 +41,18 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
     }),
     execute=Async(execute),
   )
+}
+
+///|
+#cfg(platform="windows")
+fn shell_description() -> String {
+  "Run arguments.cmd through PowerShell (pwsh -NoProfile -Command), optionally in arguments.cwd, and return exit code plus output. Use PowerShell syntax and cmdlets in arguments.cmd."
+}
+
+///|
+#cfg(not(platform="windows"))
+fn shell_description() -> String {
+  "Run arguments.cmd through the POSIX shell (sh -c), optionally in arguments.cwd, and return exit code plus output. Use POSIX shell syntax in arguments.cmd."
 }
 
 ///|
@@ -130,6 +142,8 @@ async fn collect_shell_output(
   cwd : String?,
   max_output_chars : Int,
 ) -> ShellOutput {
+  let program = PlatformShellProgram
+  let args = platform_shell_args(cmd)
   let (reader, writer) = @process.read_from_process()
   @async.with_task_group() <| group => {
     defer reader.close()
@@ -137,8 +151,8 @@ async fn collect_shell_output(
       Some(cwd) =>
         @process.spawn(
           group,
-          "sh",
-          ["-c", cmd],
+          program,
+          args,
           stdout=writer,
           stderr=writer,
           cwd~,
@@ -147,8 +161,8 @@ async fn collect_shell_output(
       None =>
         @process.spawn(
           group,
-          "sh",
-          ["-c", cmd],
+          program,
+          args,
           stdout=writer,
           stderr=writer,
           cancel_handler=@process.hard_cancel(),
@@ -170,6 +184,26 @@ async fn collect_shell_output(
       }
     }
   }
+}
+
+///|
+#cfg(platform="windows")
+const PlatformShellProgram : String = "pwsh"
+
+///|
+#cfg(not(platform="windows"))
+const PlatformShellProgram : String = "sh"
+
+///|
+#cfg(platform="windows")
+fn platform_shell_args(cmd : String) -> Array[String] {
+  ["-NoProfile", "-Command", cmd]
+}
+
+///|
+#cfg(not(platform="windows"))
+fn platform_shell_args(cmd : String) -> Array[String] {
+  ["-c", cmd]
 }
 
 ///|

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -7,11 +7,30 @@ async fn run_shell(arguments : Json) -> @agent_tool.ToolAction {
 }
 
 ///|
+#cfg(platform="windows")
+test "shell description tells models to use PowerShell on Windows" {
+  let description = @shell.definition().description
+  assert_true(description.contains("PowerShell"))
+  assert_true(description.contains("pwsh -NoProfile -Command"))
+  assert_true(description.contains("PowerShell syntax"))
+}
+
+///|
+#cfg(not(platform="windows"))
+test "shell description tells models to use POSIX shell off Windows" {
+  let description = @shell.definition().description
+  assert_true(description.contains("POSIX shell"))
+  assert_true(description.contains("sh -c"))
+  assert_true(description.contains("POSIX shell syntax"))
+}
+
+///|
 async test "shell runs cmd and returns exit code plus output" {
   let result = run_shell({ "cmd": "echo hello" })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_true(output.content =~ re"^exit=0\nhello\n?$")
+  assert_true(output.content.contains("exit=0"))
+  assert_true(output.content.contains("hello"))
 }
 
 ///|
@@ -19,15 +38,40 @@ async test "shell propagates non-zero exit codes" {
   let result = run_shell({ "cmd": "exit 7" })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
-  assert_true(output.content =~ re"^exit=7\n?$")
+  assert_true(output.content.contains("exit=7"))
+}
+
+///|
+#cfg(platform="windows")
+async test "shell follows PowerShell native Windows exit semantics" {
+  let result = run_shell({ "cmd": "cmd /c exit 7" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("exit=1"))
+}
+
+///|
+#cfg(platform="windows")
+async test "shell follows final successful PowerShell command on Windows" {
+  let result = run_shell({ "cmd": "cmd /c exit 7; Write-Output 'ok'" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content.contains("exit=0"))
+  assert_true(output.content.contains("ok"))
 }
 
 ///|
 async test "shell honors cwd when non-empty" {
-  let result = run_shell({ "cmd": "pwd", "cwd": "/tmp" })
+  let dir = @fs.tmpdir(prefix="openseek-shell-cwd-")
+  let result = run_shell({ "cmd": "echo cwd-ok > marker.txt", "cwd": dir })
+  let dir_path : @path.Path = dir
+  let marker_path = dir_path.join("marker.txt").normalize().to_string()
+  let marker = @fs.read_file(marker_path).text() catch { _ => "" }
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_true(output.content =~ re"^exit=0\n.*/tmp\n?$")
+  assert_true(output.content.contains("exit=0"))
+  assert_eq(marker.trim(), "cwd-ok")
 }
 
 ///|
@@ -40,7 +84,7 @@ async test "shell reads a virtual filesystem fixture from cwd" {
     ),
   }).write_to(project)
   let result = run_shell({ "cmd": "cat data/input.txt", "cwd": project })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   inspect(
@@ -57,37 +101,78 @@ async test "shell treats empty cwd as missing" {
   let result = run_shell({ "cmd": "echo cwdless", "cwd": "" })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_true(output.content =~ re"^exit=0\ncwdless\n?$")
+  assert_true(output.content.contains("exit=0"))
+  assert_true(output.content.contains("cwdless"))
 }
 
 ///|
-async test "shell leaves output at exact limit as a normal result" {
-  let result = run_shell({ "cmd": "printf abc", "max_output_chars": 3 })
+#cfg(platform="windows")
+async test "shell leaves output at exact limit as a normal result on Windows" {
+  let result = run_shell({
+    "cmd": "[Console]::Out.Write('abc')",
+    "max_output_chars": 3,
+  })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_eq(output.content, "exit=0\nabc")
 }
 
 ///|
-async test "shell counts output limits in characters for non-ascii text" {
-  let result = run_shell({ "cmd": "printf '中中'", "max_output_chars": 2 })
+#cfg(not(platform="windows"))
+async test "shell leaves output at exact limit as a normal result on Unix" {
+  let result = run_shell({ "cmd": "printf %s 'abc'", "max_output_chars": 3 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_eq(output.content, "exit=0\nabc")
+}
+
+///|
+#cfg(platform="windows")
+async test "shell counts output limits in characters for non-ascii text on Windows" {
+  let result = run_shell({
+    "cmd": "[Console]::Out.Write('中中')",
+    "max_output_chars": 2,
+  })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_eq(output.content, "exit=0\n中中")
 }
 
 ///|
-async test "shell leaves four-byte utf8 output at exact character limit" {
-  let result = run_shell({ "cmd": "printf '😀'", "max_output_chars": 1 })
+#cfg(not(platform="windows"))
+async test "shell counts output limits in characters for non-ascii text on Unix" {
+  let result = run_shell({ "cmd": "printf %s '中中'", "max_output_chars": 2 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_eq(output.content, "exit=0\n中中")
+}
+
+///|
+#cfg(platform="windows")
+async test "shell leaves four-byte utf8 output at exact character limit on Windows" {
+  let result = run_shell({
+    "cmd": "[Console]::Out.Write('😀')",
+    "max_output_chars": 1,
+  })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_eq(output.content, "exit=0\n😀")
 }
 
 ///|
-async test "shell stops oversized output while the command is still running" {
+#cfg(not(platform="windows"))
+async test "shell leaves four-byte utf8 output at exact character limit on Unix" {
+  let result = run_shell({ "cmd": "printf %s '😀'", "max_output_chars": 1 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_eq(output.content, "exit=0\n😀")
+}
+
+///|
+#cfg(platform="windows")
+async test "shell stops oversized output while the command is still running on Windows" {
   let result = run_shell({
-    "cmd": "printf abcdef; sleep 2",
+    "cmd": "[Console]::Out.Write('abcdef'); Start-Sleep -Seconds 2",
     "max_output_chars": 3,
     "timeout_ms": 1000,
   })
@@ -101,9 +186,27 @@ async test "shell stops oversized output while the command is still running" {
 }
 
 ///|
-async test "shell does not cut multi-byte utf8 output mid-character" {
+#cfg(not(platform="windows"))
+async test "shell stops oversized output while the command is still running on Unix" {
   let result = run_shell({
-    "cmd": "printf '中中中'; sleep 2",
+    "cmd": "printf %s 'abcdef'; sleep 2",
+    "max_output_chars": 3,
+    "timeout_ms": 1000,
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=3\nmax_output_chars=3\nabc$",
+  )
+  assert_false(output.content.contains("timed out"))
+  assert_false(output.content.contains("abcdef"))
+}
+
+///|
+#cfg(platform="windows")
+async test "shell does not cut multi-byte utf8 output mid-character on Windows" {
+  let result = run_shell({
+    "cmd": "[Console]::Out.Write('中中中'); Start-Sleep -Seconds 2",
     "max_output_chars": 2,
     "timeout_ms": 1000,
   })
@@ -117,9 +220,27 @@ async test "shell does not cut multi-byte utf8 output mid-character" {
 }
 
 ///|
-async test "shell does not split four-byte utf8 characters" {
+#cfg(not(platform="windows"))
+async test "shell does not cut multi-byte utf8 output mid-character on Unix" {
   let result = run_shell({
-    "cmd": "printf '😀😀'; sleep 2",
+    "cmd": "printf %s '中中中'; sleep 2",
+    "max_output_chars": 2,
+    "timeout_ms": 1000,
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=2\nmax_output_chars=2\n中中$",
+  )
+  assert_false(output.content.contains("�"))
+  assert_false(output.content.contains("中中中"))
+}
+
+///|
+#cfg(platform="windows")
+async test "shell does not split four-byte utf8 characters on Windows" {
+  let result = run_shell({
+    "cmd": "[Console]::Out.Write('😀😀'); Start-Sleep -Seconds 2",
     "max_output_chars": 1,
     "timeout_ms": 1000,
   })
@@ -133,7 +254,37 @@ async test "shell does not split four-byte utf8 characters" {
 }
 
 ///|
-async test "shell reports binary output as a tool error" {
+#cfg(not(platform="windows"))
+async test "shell does not split four-byte utf8 characters on Unix" {
+  let result = run_shell({
+    "cmd": "printf %s '😀😀'; sleep 2",
+    "max_output_chars": 1,
+    "timeout_ms": 1000,
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=1\nmax_output_chars=1\n😀$",
+  )
+  assert_false(output.content.contains("�"))
+  assert_false(output.content.contains("😀😀"))
+}
+
+///|
+#cfg(platform="windows")
+async test "shell reports binary output as a tool error on Windows" {
+  let result = run_shell({
+    "cmd": "[Console]::OpenStandardOutput().WriteByte(255)",
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("error running shell:"))
+  assert_true(output.content.contains("Malformed"))
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell reports binary output as a tool error on Unix" {
   let result = run_shell({ "cmd": "printf '\\377'" })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
@@ -142,9 +293,10 @@ async test "shell reports binary output as a tool error" {
 }
 
 ///|
-async test "shell output limit wins over an unbounded producer" {
+#cfg(platform="windows")
+async test "shell output limit wins over an unbounded producer on Windows" {
   let result = run_shell({
-    "cmd": "while :; do printf yyyyyyyyyy; done",
+    "cmd": "while ($true) { [Console]::Out.Write('yyyyyyyyyy') }",
     "max_output_chars": 5,
     "timeout_ms": 1000,
   })
@@ -157,15 +309,51 @@ async test "shell output limit wins over an unbounded producer" {
 }
 
 ///|
-async test "shell merges stderr into the captured output" {
-  let result = run_shell({ "cmd": "echo oops 1>&2" })
+#cfg(not(platform="windows"))
+async test "shell output limit wins over an unbounded producer on Unix" {
+  let result = run_shell({
+    "cmd": "while :; do printf %s 'yyyyyyyyyy'; done",
+    "max_output_chars": 5,
+    "timeout_ms": 1000,
+  })
   guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content =~ re"^exit=0\noops\n?$")
+  assert_true(output.is_error)
+  assert_true(
+    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=5\nmax_output_chars=5\nyyyyy$",
+  )
+  assert_false(output.content.contains("timed out"))
 }
 
 ///|
-async test "shell times out long running commands" {
+#cfg(platform="windows")
+async test "shell merges stderr into the captured output on Windows" {
+  let result = run_shell({ "cmd": "[Console]::Error.WriteLine('oops')" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content.contains("oops"))
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell merges stderr into the captured output on Unix" {
+  let result = run_shell({ "cmd": "printf '%s\\n' 'oops' 1>&2" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content.contains("oops"))
+}
+
+///|
+#cfg(platform="windows")
+async test "shell times out long running commands on Windows" {
+  let result = run_shell({ "cmd": "Start-Sleep -Seconds 2", "timeout_ms": 50 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_eq(output.content, "error: shell command timed out after 50ms")
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell times out long running commands on Unix" {
   let result = run_shell({ "cmd": "sleep 2", "timeout_ms": 50 })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
@@ -191,7 +379,7 @@ async test "shell rejects moon_cmd as a shell command" {
 
 ///|
 async test "shell rejects missing cmd" {
-  let result = run_shell({ "cwd": "/tmp" })
+  let result = run_shell({ "cwd": "unused" })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("error: shell requires"))
@@ -208,7 +396,11 @@ async test "shell rejects non-object arguments" {
 
 ///|
 async test "shell rejects non-existent cwd" {
-  let result = run_shell({ "cmd": "echo hello", "cwd": "/nonexistent/path/xyz" })
+  let dir = @fs.tmpdir(prefix="openseek-shell-cwd-")
+  let dir_path : @path.Path = dir
+  let path = dir_path.join("does-not-exist").normalize().to_string()
+  let result = run_shell({ "cmd": "echo hello", "cwd": path })
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("cwd does not exist"))
@@ -216,7 +408,12 @@ async test "shell rejects non-existent cwd" {
 
 ///|
 async test "shell rejects cwd that is a file not a directory" {
-  let result = run_shell({ "cmd": "echo hello", "cwd": "/dev/null" })
+  let dir = @fs.tmpdir(prefix="openseek-shell-cwd-")
+  let dir_path : @path.Path = dir
+  let path = dir_path.join("file.txt").normalize().to_string()
+  @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
+  let result = run_shell({ "cmd": "echo hello", "cwd": path })
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("cwd is not a directory"))

--- a/moon.mod
+++ b/moon.mod
@@ -5,6 +5,7 @@ version = "0.1.4"
 import {
   "moonbit-community/tty@0.2.4",
   "moonbitlang/async@0.19.1",
+  "moonbitlang/x@0.4.45",
   "kawaz/grapheme@0.10.2",
   "rami3l/unicodewidth@0.2.0",
 }


### PR DESCRIPTION
## Summary

- run shell tool commands through `pwsh` on Windows while keeping `sh -c` on non-Windows platforms
- advertise the concrete platform shell in the `shell` tool description so models use PowerShell syntax on Windows and POSIX shell syntax elsewhere
- keep the shell program and shell arguments separate for `@process.spawn`; use a platform `const` for the program name
- pass the user command as a single shell argument instead of interpolating it into a wrapper string
- use `moonbitlang/x/path` in shell tests for path construction and bump `moonbitlang/x` to `0.4.45`
- add Windows-specific shell command fixtures for stdout, stderr, timeout, binary output, cwd, and exit-code behavior

## Validation

- `moon fmt`
- `moon check --deny-warn`
- `moon test agent_tool/shell` (`28/28` passed)
- `moon info`
- `moon fmt`
- GitHub Actions `check (nightly)` passed

## A/B: Tool Description

Lightweight Windows shell probe using `deepseek-v4-flash`, 3 trials per variant, `--max-steps 12`. The task required the agent to use only the `shell` tool to create `result.txt` with exact UTF-8 content `shell-probe-ok` and no trailing newline, then verify it via shell readback.

| Variant | Exact Success | Avg Steps | Tool Errors | Notes |
| --- | ---: | ---: | ---: | --- |
| baseline `a8ecc87` | 2/3 | 8.00 | 8 | one trial wrote a trailing newline and exhausted the 12-step limit |
| candidate `9ea4bf7` | 3/3 | 3.33 | 0 | all trials produced exact 14-byte content |

The heavier prompt-task TOML eval was not used for this comparison because the current eval harness still launches `cmd/main`, while this repo now uses `cmd/openseek`.

## Notes

This PR is independent from #8 and is based directly on `main`. The shell guidance is added to the tool description only; this PR does not add runtime environment context.