### PR TITLE
[codex] Improve edit tool diagnostics

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -9,7 +9,10 @@ code changes where overwriting the whole file would be unnecessarily broad.
 the host can validate the change with simple, deterministic rules. The default
 single-match requirement prevents ambiguous edits in files that contain repeated
 snippets. `replace_all=true` is explicit so broad changes show up in the tool
-call rather than being an accidental consequence of a loose match.
+call rather than being an accidental consequence of a loose match. When a
+single-match edit is ambiguous, the error reports the first matching line
+numbers so the caller can add enough surrounding context to make `old_string`
+unique.
 
 Rejecting empty `old_string` and identical replacements protects against
 no-op or explosive edits. The tool is designed for small surgical changes; if a
@@ -61,7 +64,7 @@ has one of these shapes:
 
 - `"ok: replaced <n> occurrence(s) in <path>"` on success.
 - `"error editing <path>: old_string not found"` — no exact match was found.
-- `"error editing <path>: old_string matched <n> times; set replace_all=true to replace all occurrences"` — the edit was ambiguous.
+- `"error editing <path>: old_string matched <n> times on lines <line>, ...; set replace_all=true to replace all occurrences"` — the edit was ambiguous.
 - `"error editing <path>: moon.pkg content is suspiciously small"` or similar
   manifest-guard messages — the replacement would likely break MoonBit package
   discovery.

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -127,9 +127,9 @@ fn ambiguous_match_message(
   let line_detail = if lines.length() == 0 {
     ""
   } else if occurrences > lines.length() {
-    " on lines " + lines.join(", ") + ", ..."
+    " on lines \{lines.join(", ")}, ..."
   } else {
-    " on lines " + lines.join(", ")
+    " on lines \{lines.join(", ")}"
   }
   "error editing \{path}: old_string matched \{occurrences} times\{line_detail}; set replace_all=true to replace all occurrences"
 }

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -15,7 +15,7 @@
 ///   success.
 /// - `Respond(ToolOutput("error editing <path>: ...", is_error=true))` for
 ///   filesystem failures, empty/no-op edits, missing matches, or ambiguous
-///   matches.
+///   matches. Ambiguous-match errors include the first matching line numbers.
 /// - `Respond(ToolOutput("error: edit requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition() -> @agent_tool.AgentToolDefinition {
@@ -84,7 +84,7 @@ async fn edit_file(input : @decode.EditInput) -> @agent_tool.ToolAction {
   }
   if occurrences > 1 && !input.replace_all {
     return @agent_tool.ToolAction::respond(
-      "error editing \{input.path}: old_string matched \{occurrences} times; set replace_all=true to replace all occurrences",
+      ambiguous_match_message(input.path, occurrences, parts, input.old_string),
       is_error=true,
     )
   }
@@ -114,6 +114,48 @@ async fn edit_file(input : @decode.EditInput) -> @agent_tool.ToolAction {
         is_error=true,
       )
   }
+}
+
+///|
+fn ambiguous_match_message(
+  path : String,
+  occurrences : Int,
+  parts : Array[String],
+  old_string : String,
+) -> String {
+  let lines = occurrence_line_labels(parts, old_string, 5)
+  let line_detail = if lines.length() == 0 {
+    ""
+  } else if occurrences > lines.length() {
+    " on lines " + lines.join(", ") + ", ..."
+  } else {
+    " on lines " + lines.join(", ")
+  }
+  "error editing \{path}: old_string matched \{occurrences} times\{line_detail}; set replace_all=true to replace all occurrences"
+}
+
+///|
+fn occurrence_line_labels(
+  parts : Array[String],
+  old_string : String,
+  max : Int,
+) -> Array[String] {
+  let labels : Array[String] = []
+  let mut current_line = 1
+  let occurrence_count = parts.length() - 1
+  for index in 0..<occurrence_count {
+    current_line = current_line + newline_count(parts[index])
+    if labels.length() < max {
+      labels.push("\{current_line}")
+    }
+    current_line = current_line + newline_count(old_string)
+  }
+  labels
+}
+
+///|
+fn newline_count(text : String) -> Int {
+  text.split("\n").collect().length() - 1
 }
 
 ///|

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -155,7 +155,7 @@ fn occurrence_line_labels(
 
 ///|
 fn newline_count(text : String) -> Int {
-  text.split("\n").collect().length() - 1
+  text.split("\n").count() - 1
 }
 
 ///|

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -139,7 +139,7 @@ async test "edit rejects missing match" {
 ///|
 async test "edit rejects ambiguous match without replace_all" {
   let path = "/tmp/openseek-edit-ambiguous.txt"
-  @fs.write_file(path, "alpha beta beta", create_mode=CreateOrTruncate)
+  @fs.write_file(path, "alpha beta\nmiddle\nbeta", create_mode=CreateOrTruncate)
   let result = run_edit({
     "path": path,
     "old_string": "beta",
@@ -148,10 +148,24 @@ async test "edit rejects ambiguous match without replace_all" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_eq(
     output.content,
-    "error editing \{path}: old_string matched 2 times; set replace_all=true to replace all occurrences",
+    "error editing \{path}: old_string matched 2 times on lines 1, 3; set replace_all=true to replace all occurrences",
   )
   assert_true(output.is_error)
-  assert_eq(@fs.read_file(path).text(), "alpha beta beta")
+  assert_eq(@fs.read_file(path).text(), "alpha beta\nmiddle\nbeta")
+}
+
+///|
+async test "edit reports first ambiguous match lines only" {
+  let path = "/tmp/openseek-edit-many-matches.txt"
+  @fs.write_file(path, "x\nx\nx\nx\nx\nx\n", create_mode=CreateOrTruncate)
+  let result = run_edit({ "path": path, "old_string": "x", "new_string": "y" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_eq(
+    output.content,
+    "error editing \{path}: old_string matched 6 times on lines 1, 2, 3, 4, 5, ...; set replace_all=true to replace all occurrences",
+  )
+  assert_true(output.is_error)
+  assert_eq(@fs.read_file(path).text(), "x\nx\nx\nx\nx\nx\n")
 }
 
 ///|

--- a/agent_tool/edit/internal/decode/README.mbt.md
+++ b/agent_tool/edit/internal/decode/README.mbt.md
@@ -1,0 +1,57 @@
+# Edit Decode
+
+`bobzhang/openseek/agent_tool/edit/internal/decode` converts raw JSON tool
+arguments into the typed `EditInput` record consumed by the `edit` tool.
+
+This package is internal to `agent_tool/edit`. It owns only argument-shape
+decoding: it checks that required fields are present with the expected JSON
+types, supplies the default `replace_all=false`, and raises focused error
+messages for malformed payloads. Filesystem access and edit semantics stay in
+the parent `edit` package.
+
+## API Shape
+
+- `EditInput(path, old_string, new_string, replace_all)`: the normalized edit
+  request.
+- `decode(arguments)`: accepts a JSON object and returns `EditInput`, or raises
+  when required fields are missing or have invalid types.
+
+## Arguments
+
+| Name | Type | Required | Decoder behavior |
+| --- | --- | --- | --- |
+| `path` | string | yes | Missing or non-string values raise `arguments.path`. |
+| `old_string` | string | yes | Missing or non-string values raise `arguments.old_string`. |
+| `new_string` | string | yes | Missing or non-string values raise `arguments.new_string`. |
+| `replace_all` | boolean | no | Defaults to `false`; non-boolean values raise `arguments.replace_all to be a boolean`. |
+
+Extra fields are ignored. Non-object JSON values raise `object arguments`.
+
+The decoder does not reject empty `old_string`, identical replacements, missing
+files, ambiguous matches, or manifest edits. Those checks require file contents
+or tool policy and are handled by `agent_tool/edit`.
+
+## Example
+
+```moonbit check
+///|
+test "decode edit input from tool arguments" {
+  let focused = @decode.decode({
+    "path": "agent_tool/edit/edit.mbt",
+    "old_string": "Replace exact text",
+    "new_string": "Replace one exact text span",
+  })
+  assert_eq(focused.path, "agent_tool/edit/edit.mbt")
+  assert_eq(focused.old_string, "Replace exact text")
+  assert_eq(focused.new_string, "Replace one exact text span")
+  assert_false(focused.replace_all)
+
+  let broad = @decode.decode({
+    "path": "agent_tool/edit/README.mbt.md",
+    "old_string": "moon.mod.json",
+    "new_string": "moon.mod",
+    "replace_all": true,
+  })
+  assert_true(broad.replace_all)
+}
+```


### PR DESCRIPTION
## Summary

This improves the `edit` tool's ambiguous-match diagnostics. When `old_string` matches more than once without `replace_all=true`, the tool now reports the first matching line numbers so callers can make the replacement string unique without an extra read/retry cycle.

It also caps the reported line list at five entries to keep tool output compact, documents the internal edit decoder package with `README.mbt.md`, and replaces the remaining `.collect().length()` count in the edit helper with `Iter::count()`.

## Impact

The edit behavior is unchanged for successful edits, missing matches, `replace_all=true`, and manifest guards. Only ambiguous-match error text becomes more actionable.

## Validation

- `moon test agent_tool/edit --target native`
- `moon test agent_tool/edit/internal/decode --target native`
- `moon fmt`
- `git diff --check`

`moon info` currently crashes in this checkout/toolchain with a Moon CLI panic in `src/db.rs`, so interface files were not regenerated.