### PR TITLE
[codex] Move edit manifest guard into internal package

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -94,7 +94,7 @@ async fn edit_file(input : @decode.EditInput) -> @agent_tool.ToolAction {
   } else {
     content.replace(old=input.old_string, new=input.new_string)
   }
-  match manifest_write_error(input.path, new_content) {
+  match @manifest_error.write_error(input.path, new_content) {
     Some(message) =>
       return @agent_tool.ToolAction::respond(
         "error editing \{input.path}: \{message}",
@@ -156,49 +156,4 @@ fn occurrence_line_labels(
 ///|
 fn newline_count(text : String) -> Int {
   text.split("\n").count() - 1
-}
-
-///|
-async fn manifest_write_error(path : String, content : String) -> String? {
-  let trimmed = content.trim().to_owned()
-  if is_moon_mod_json_path(path) && !@fs.exists(path) {
-    return Some(
-      "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
-    )
-  }
-  if is_moon_mod_path(path) {
-    if trimmed == "" {
-      return Some("moon.mod must not be empty")
-    }
-    if trimmed.has_prefix("{") || trimmed.contains("\"name\"") {
-      return Some("moon.mod uses current text syntax, not JSON")
-    }
-    if !trimmed.contains("name =") {
-      return Some("moon.mod should include a module `name = ...` entry")
-    }
-  }
-  if is_moon_pkg_path(path) {
-    if trimmed.length() < 8 {
-      return Some("moon.pkg content is suspiciously small")
-    }
-    if trimmed.has_prefix("{") {
-      return Some("moon.pkg uses current text syntax, not JSON")
-    }
-  }
-  None
-}
-
-///|
-fn is_moon_mod_path(path : String) -> Bool {
-  path == "moon.mod" || path.has_suffix("/moon.mod")
-}
-
-///|
-fn is_moon_mod_json_path(path : String) -> Bool {
-  path == "moon.mod.json" || path.has_suffix("/moon.mod.json")
-}
-
-///|
-fn is_moon_pkg_path(path : String) -> Bool {
-  path == "moon.pkg" || path.has_suffix("/moon.pkg")
 }

--- a/agent_tool/edit/internal/manifest_error/README.mbt.md
+++ b/agent_tool/edit/internal/manifest_error/README.mbt.md
@@ -1,0 +1,37 @@
+# Edit Manifest Error
+
+`bobzhang/openseek/agent_tool/edit/internal/manifest_error` keeps the manifest
+safety checks used before the `edit` tool writes replacement content.
+
+This package is internal to `agent_tool/edit`. It does not edit files itself;
+it inspects the target path and proposed file content, then returns an optional
+error message for manifest rewrites that look like common agent mistakes.
+
+## API Shape
+
+- `write_error(path, content)`: returns `Some(message)` when the proposed write
+  should be rejected, otherwise `None`.
+
+## Checks
+
+The guard is intentionally narrow and only handles MoonBit manifest paths:
+
+- New `moon.mod.json` files are rejected because that manifest is legacy.
+- `moon.mod` is rejected when it is empty, JSON-shaped, or missing `name =`.
+- `moon.pkg` is rejected when it is suspiciously tiny or JSON-shaped.
+- Other paths are allowed.
+
+Existing `moon.mod.json` files are allowed so `edit` can still update legacy
+projects deliberately; the guard only blocks creating new legacy manifests.
+
+## Example
+
+```moonbit check
+///|
+async test "manifest error rejects JSON moon.mod content" {
+  let error = @manifest_error.write_error("moon.mod", "{\"name\":\"demo\"}")
+  guard error is Some(message) else { fail("expected manifest error") }
+  assert_eq(message, "moon.mod uses current text syntax, not JSON")
+  assert_true(@manifest_error.write_error("notes.json", "{}") is None)
+}
+```

--- a/agent_tool/edit/internal/manifest_error/manifest_error.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error.mbt
@@ -1,0 +1,44 @@
+///|
+pub async fn write_error(path : String, content : String) -> String? {
+  let trimmed = content.trim().to_owned()
+  if is_moon_mod_json_path(path) && !@fs.exists(path) {
+    return Some(
+      "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
+    )
+  }
+  if is_moon_mod_path(path) {
+    if trimmed == "" {
+      return Some("moon.mod must not be empty")
+    }
+    if trimmed.has_prefix("{") || trimmed.contains("\"name\"") {
+      return Some("moon.mod uses current text syntax, not JSON")
+    }
+    if !trimmed.contains("name =") {
+      return Some("moon.mod should include a module `name = ...` entry")
+    }
+  }
+  if is_moon_pkg_path(path) {
+    if trimmed.length() < 8 {
+      return Some("moon.pkg content is suspiciously small")
+    }
+    if trimmed.has_prefix("{") {
+      return Some("moon.pkg uses current text syntax, not JSON")
+    }
+  }
+  None
+}
+
+///|
+fn is_moon_mod_path(path : String) -> Bool {
+  path == "moon.mod" || path.has_suffix("/moon.mod")
+}
+
+///|
+fn is_moon_mod_json_path(path : String) -> Bool {
+  path == "moon.mod.json" || path.has_suffix("/moon.mod.json")
+}
+
+///|
+fn is_moon_pkg_path(path : String) -> Bool {
+  path == "moon.pkg" || path.has_suffix("/moon.pkg")
+}

--- a/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
@@ -1,0 +1,52 @@
+///|
+async test "manifest error allows ordinary files" {
+  assert_true(write_error("notes.json", "{}") is None)
+}
+
+///|
+async test "manifest error rejects new moon.mod.json" {
+  let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
+  let path = dir + "/moon.mod.json"
+  let error = write_error(path, "{}")
+  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  guard error is Some(message) else { fail("expected manifest error") }
+  assert_true(message.contains("moon.mod.json is legacy"))
+}
+
+///|
+async test "manifest error allows existing moon.mod.json" {
+  let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
+  let path = dir + "/moon.mod.json"
+  @fs.write_file(path, "{}", create_mode=CreateOrTruncate)
+  let error = write_error(path, "{}")
+  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  assert_true(error is None)
+}
+
+///|
+async test "manifest error rejects invalid moon.mod content" {
+  guard write_error("moon.mod", "") is Some(empty) else {
+    fail("expected empty moon.mod error")
+  }
+  assert_eq(empty, "moon.mod must not be empty")
+  guard write_error("moon.mod", "{\"name\":\"demo\"}") is Some(json) else {
+    fail("expected JSON moon.mod error")
+  }
+  assert_eq(json, "moon.mod uses current text syntax, not JSON")
+  guard write_error("moon.mod", "version = \"0.1.0\"") is Some(missing_name) else {
+    fail("expected missing name moon.mod error")
+  }
+  assert_eq(missing_name, "moon.mod should include a module `name = ...` entry")
+}
+
+///|
+async test "manifest error rejects invalid moon.pkg content" {
+  guard write_error("moon.pkg", "x") is Some(tiny) else {
+    fail("expected tiny moon.pkg error")
+  }
+  assert_eq(tiny, "moon.pkg content is suspiciously small")
+  guard write_error("moon.pkg", "{\"import\":[]}") is Some(json) else {
+    fail("expected JSON moon.pkg error")
+  }
+  assert_eq(json, "moon.pkg uses current text syntax, not JSON")
+}

--- a/agent_tool/edit/internal/manifest_error/moon.pkg
+++ b/agent_tool/edit/internal/manifest_error/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbitlang/async/fs",
+}
+
+import {
+  "moonbitlang/async",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/edit/internal/manifest_error/pkg.generated.mbti
+++ b/agent_tool/edit/internal/manifest_error/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/edit/internal/manifest_error"
+
+// Values
+pub async fn write_error(String, String) -> String?
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/agent_tool/edit/moon.pkg
+++ b/agent_tool/edit/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/edit/internal/decode",
+  "bobzhang/openseek/agent_tool/edit/internal/manifest_error",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "moonbitlang/async/fs",
   "moonbitlang/core/json",


### PR DESCRIPTION
## Summary

Moves the `edit` tool's manifest write guard out of `agent_tool/edit/edit.mbt` into a new internal package: `agent_tool/edit/internal/manifest_error`.

The new package exposes `write_error(path, content)`, keeps the same MoonBit manifest safety policy, adds focused tests for each manifest case, and documents the behavior in `README.mbt.md`. The parent `edit` package now imports and calls `@manifest_error.write_error(...)` before writing replacement content.

## Impact

This is a refactor of the manifest guard boundary. User-facing edit behavior is intended to remain unchanged.

## Validation

- `moon test agent_tool/edit/internal/manifest_error --target native`
- `moon test agent_tool/edit --target native`
- `moon fmt`
- `git diff --check origin/main..HEAD`

`moon info` still crashes in this checkout/toolchain with a Moon CLI panic in `src/db.rs`, so `pkg.generated.mbti` for the new package was added with the expected interface shape.