### PR TITLE
Propagate rmdir cleanup failures

### DIFF
--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -115,7 +115,7 @@ async test "edit rejects suspicious moon.pkg rewrite" {
     "new_string": "x",
   })
   let read_back = @fs.read_file(path).text()
-  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("moon.pkg content is suspiciously small"))

--- a/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
@@ -8,7 +8,7 @@ async test "manifest error rejects new moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
   let path = dir + "/moon.mod.json"
   let error = write_error(path, "{}")
-  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  @fs.rmdir(dir, recursive=true)
   guard error is Some(message) else { fail("expected manifest error") }
   assert_true(message.contains("moon.mod.json is legacy"))
 }
@@ -19,7 +19,7 @@ async test "manifest error allows existing moon.mod.json" {
   let path = dir + "/moon.mod.json"
   @fs.write_file(path, "{}", create_mode=CreateOrTruncate)
   let error = write_error(path, "{}")
-  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  @fs.rmdir(dir, recursive=true)
   assert_true(error is None)
 }
 

--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -176,7 +176,7 @@ async test "moon_check validates a real fixture project" {
   let project = copy_fixture_project("valid_project")
   let canonical = @fs.realpath(project)
   let result = execute({ "cwd": project })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   inspect(
@@ -195,7 +195,7 @@ async test "moon_check reports diagnostics from a broken fixture project" {
   let project = copy_fixture_project("invalid_project")
   let canonical = @fs.realpath(project)
   let result = execute({ "cwd": project })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   inspect(
@@ -237,7 +237,7 @@ async test "moon_check validates a virtual filesystem package path" {
   }).write_to(project)
   let canonical = @fs.realpath(project)
   let result = execute({ "cwd": project, "path": "math", "target": "native" })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   inspect(

--- a/agent_tool/moon_cmd/moon_cmd.mbt
+++ b/agent_tool/moon_cmd/moon_cmd.mbt
@@ -167,7 +167,7 @@ async fn collect_moon_output(
         None =>
           @process.collect_output_merged("moon", args, stdin=process_input)
       }
-      let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+      @fs.rmdir(dir, recursive=true)
       result
     }
   }
@@ -366,7 +366,7 @@ async test "moon_cmd validates a native fixture CLI when target is explicit" {
     "path": "cmd/main",
     "program_args": ["input.toml"],
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   let stable = stable_moon_cmd_output(output.content, project, canonical)
@@ -390,7 +390,7 @@ async test "moon_cmd passes stdin to native fixture CLI" {
     "program_args": ["--stdin"],
     "stdin": "hello\n",
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   let stable = stable_moon_cmd_output(output.content, project, canonical)
@@ -415,7 +415,7 @@ async test "moon_cmd truncates oversized successful output as a tool error" {
     "program_args": ["input.toml"],
     "max_output_chars": 10,
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   let stable = stable_moon_cmd_output(output.content, project, canonical)
@@ -438,7 +438,7 @@ async test "moon_cmd catches default-target failure for native-only CLI" {
     "path": "cmd/main",
     "program_args": ["input.toml"],
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   let stable = stable_moon_cmd_output(output.content, project, canonical)
@@ -458,7 +458,7 @@ async test "moon_cmd snapshots native fixture test output" {
     "target": "native",
     "path": "cmd/main",
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   inspect(
@@ -492,7 +492,7 @@ async test "moon_cmd reports failing fixture tests as tool errors" {
     "target": "native",
     "path": "cmd/main",
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   let stable = stable_moon_cmd_output(output.content, project, canonical)
@@ -564,7 +564,7 @@ async test "moon_cmd runs a virtual filesystem native CLI fixture" {
     "path": "cmd/main",
     "program_args": ["--probe"],
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   inspect(

--- a/agent_tool/moon_ide/moon_ide.mbt
+++ b/agent_tool/moon_ide/moon_ide.mbt
@@ -286,7 +286,7 @@ async test "moon_ide outlines a real fixture package" {
     "path": ".",
     "no_check": false,
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   inspect(
@@ -319,7 +319,7 @@ async test "moon_ide peeks a definition in a real fixture package" {
     "loc": "lib.mbt",
     "no_check": false,
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   let stable = stable_moon_ide_output(output.content, project, canonical)
@@ -339,7 +339,7 @@ async test "moon_ide hovers a token in a real fixture package" {
     "loc": "lib.mbt:17:24",
     "no_check": false,
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   let stable = stable_moon_ide_output(output.content, project, canonical)
@@ -361,7 +361,7 @@ async test "moon_ide finds references in a real fixture package" {
     "loc": "lib.mbt",
     "no_check": false,
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   let stable = stable_moon_ide_output(output.content, project, canonical)
@@ -429,7 +429,7 @@ async test "moon_ide outlines a virtual filesystem multi-file package" {
     "target": "native",
     "max_output_chars": 4000,
   })
-  let _ = @fs.rmdir(project, recursive=true) catch { _ => () }
+  @fs.rmdir(project, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   inspect(

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -153,7 +153,7 @@ async test "write rejects new legacy moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
   let path = dir + "/moon.mod.json"
   let result = execute({ "path": path, "content": "{\"name\":\"legacy\"}" })
-  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("moon.mod.json is legacy"))
@@ -164,7 +164,7 @@ async test "write rejects json style moon.mod" {
   let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
   let path = dir + "/moon.mod"
   let result = execute({ "path": path, "content": "{\"name\":\"bad\"}" })
-  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("moon.mod uses current text syntax"))
@@ -175,7 +175,7 @@ async test "write rejects suspiciously tiny moon.pkg" {
   let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
   let path = dir + "/moon.pkg"
   let result = execute({ "path": path, "content": "x" })
-  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("moon.pkg content is suspiciously small"))

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -172,7 +172,7 @@ async test "configured system prompt can replace and append files" {
     configured_system_prompt(parsed, V4Flash),
     "base prompt\n\n\naddendum\n",
   )
-  let _ = @fs.rmdir(dir, recursive=true) catch { _ => () }
+  @fs.rmdir(dir, recursive=true)
 }
 
 ///|

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -86,7 +86,9 @@ async fn[X] run_indexed_with_concurrency(
 
 ///|
 async fn prepare_output_dir(out_dir : String) -> Unit {
-  let _ = @fs.rmdir(out_dir, recursive=true) catch { _ => () }
+  if @fs.exists(out_dir) {
+    @fs.rmdir(out_dir, recursive=true)
+  }
   @fs.mkdir(out_dir + "/workspaces", recursive=true)
   @fs.mkdir(out_dir + "/logs", recursive=true)
 }

--- a/eval/file_edit/harness/harness_wbtest.mbt
+++ b/eval/file_edit/harness/harness_wbtest.mbt
@@ -1,4 +1,14 @@
 ///|
+async test "prepare output dir creates a missing output directory" {
+  let root = @fs.tmpdir(prefix="openseek-file-edit-output")
+  let out_dir = root + "/out"
+  prepare_output_dir(out_dir)
+  assert_true(@fs.exists(out_dir + "/workspaces"))
+  assert_true(@fs.exists(out_dir + "/logs"))
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
 async test "dry run exact replacement oracle" {
   let case = @cases.case_for_trial(0)
   let root = @fs.tmpdir(prefix="openseek-file-edit-harness")
@@ -33,7 +43,7 @@ async test "dry run exact replacement oracle" {
   assert_eq(result.prompt_label, "builtin")
   assert_eq(result.edit_successes, 1)
   assert_true(result.marker_present)
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
 }
 
 ///|
@@ -74,7 +84,7 @@ async test "dry run exact replacement oracle with jsonl agent log" {
   assert_eq(result.edit_successes, 1)
   assert_true(result.marker_present)
   assert_eq(result.warnings, "shell tool used 1 time(s)")
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
 }
 
 ///|

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -89,7 +89,9 @@ pub async fn run_suite(config : Config) -> EvalReport {
 
 ///|
 async fn prepare_output_dir(out_dir : String) -> Unit {
-  let _ = @fs.rmdir(out_dir, recursive=true) catch { _ => () }
+  if @fs.exists(out_dir) {
+    @fs.rmdir(out_dir, recursive=true)
+  }
   @fs.mkdir(out_dir + "/workspaces", recursive=true)
   @fs.mkdir(out_dir + "/logs", recursive=true)
 }

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -1,4 +1,14 @@
 ///|
+async test "prepare output dir creates a missing output directory" {
+  let root = @fs.tmpdir(prefix="openseek-prompt-task-output")
+  let out_dir = root + "/out"
+  prepare_output_dir(out_dir)
+  assert_true(@fs.exists(out_dir + "/workspaces"))
+  assert_true(@fs.exists(out_dir + "/logs"))
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
 async test "indexed runner honors concurrency and preserves order" {
   let mut active = 0
   let mut max_active = 0

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -44,5 +44,5 @@ async test "report writes markdown and json files" {
   let json = @fs.read_file(root + "/report.json").text()
   assert_true(markdown.contains("# Tiny Report"))
   assert_true(json.contains("\"title\":\"Tiny Report\""))
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
 }

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -57,7 +57,7 @@ async fn run_read_case(
     "max_lines": 1,
   })
   let reason = expect_respond(action, contains=["hello read"], error=false)
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
   row(index~, name="read", mode="filesystem", action="range read", reason~)
 }
 
@@ -79,7 +79,7 @@ async fn run_write_case(
   if reason == "" {
     reason = @vfs.FileSystem({ "created.txt": content }).mismatch_on_disk(root)
   }
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
   row(
     index~,
     name="write",
@@ -123,7 +123,7 @@ async fn run_edit_case(
       ),
     }).mismatch_on_disk(root)
   }
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
   row(
     index~,
     name="edit",
@@ -168,7 +168,7 @@ async fn run_moon_check_case(
     contains=["command=moon check --output-json --target native", "exit=0"],
     error=false,
   )
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
   row(
     index~,
     name="moon_check",
@@ -194,7 +194,7 @@ async fn run_moon_cmd_case(
     contains=["command=moon test --target native", "exit=0"],
     error=false,
   )
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
   row(
     index~,
     name="moon_cmd",
@@ -222,7 +222,7 @@ async fn run_moon_ide_case(
     contains=["command=moon ide outline --target native .", "exit=0", "answer"],
     error=false,
   )
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
   row(index~, name="moon_ide", mode="moon", action="outline fixture", reason~)
 }
 

--- a/eval/tool_harness/harness_test.mbt
+++ b/eval/tool_harness/harness_test.mbt
@@ -23,5 +23,5 @@ async test "harness report can be written for inspection" {
     ),
   )
   assert_true(json.contains("\"title\":\"Tool Harness\""))
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
 }

--- a/testkit/filesystem/README.mbt.md
+++ b/testkit/filesystem/README.mbt.md
@@ -81,7 +81,7 @@ async test "materialize and compare a fixture" {
 
   @filesystem.write_text(root, "src/note.txt", "changed\n")
   assert_eq(files.mismatch_on_disk(root), "content mismatch in src/note.txt")
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
 }
 ```
 

--- a/testkit/filesystem/filesystem_test.mbt
+++ b/testkit/filesystem/filesystem_test.mbt
@@ -58,5 +58,5 @@ async test "fixture writes to disk and reports mismatches" {
   assert_eq(files.mismatch_on_disk(root), "")
   @filesystem.write_text(root, "src/note.txt", "changed\n")
   assert_eq(files.mismatch_on_disk(root), "content mismatch in src/note.txt")
-  let _ = @fs.rmdir(root, recursive=true) catch { _ => () }
+  @fs.rmdir(root, recursive=true)
 }


### PR DESCRIPTION
Agents may have added these

```moonbit
let _ = @fs.rmdir(...) catch { _ => () }
```

Which is not idiomatic async code b/c it will blocks off propagation of cancellation signal. Generally a catch-all on async code should be avoided unless there is special reason to blocks off cancellation, in which case we should use `@async.protect_from_cancel` instead.

This PR clean ups these usage