### PR TITLE
Document AgentRuntime fields and bump to 0.1.5

### DIFF
--- a/agent_tool/runtime.mbt
+++ b/agent_tool/runtime.mbt
@@ -82,10 +82,23 @@ priv struct MoonCheckRecord {
 }
 
 ///|
+/// Per-agent-loop state shared between the main chat loop and the
+/// side-effectful tools it invokes. Constructed once inside
+/// `@async.with_task_group` and threaded into every tool definition.
 pub struct AgentRuntime[X] {
+  /// Task group the agent runs under; tools spawn background watchers as
+  /// children of this group so their lifetime is bounded by the agent's.
   priv group : @async.TaskGroup[X]
+  /// Bounded event bus (`DiscardOldest`, see `default_agent_event_capacity`)
+  /// that background tools post updates to; the main loop drains it between
+  /// steps to surface fresh tool output into the conversation.
   priv events : @aqueue.Queue[AgentEvent]
+  /// Registry of currently-running `moon check` watchers keyed by their
+  /// assigned id. Each record carries the process handle, latest stdout
+  /// buffer, exit code, and restart bookkeeping.
   priv moon_checks : Map[String, MoonCheckRecord]
+  /// Monotonic counter used by `next_moon_check_id` to mint unique watcher
+  /// ids; only increases for the lifetime of this runtime.
   priv mut next_moon_check_index : Int
 }
 

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/openseek"
 
-version = "0.1.4"
+version = "0.1.5"
 
 import {
   "moonbit-community/tty@0.2.4",


### PR DESCRIPTION
## Summary
- Add doc comments to the `AgentRuntime[X]` struct and each of its four fields (`group`, `events`, `moon_checks`, `next_moon_check_index`) so the role of each is clear from `moon ide analyze`.
- Bump `version` in `moon.mod` from `0.1.4` to `0.1.5` ahead of publishing to mooncakes.io once this lands.

## Test plan
- [x] `moon fmt`
- [x] `moon check agent_tool`
- [ ] CI green