### PR TITLE
Split agent runtime from task scope

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -24,7 +24,8 @@ pub async fn run(
 ) -> Unit {
   @async.with_task_group() <| group => {
     run_with_runtime(
-      AgentRuntime(group),
+      AgentRuntime(),
+      AgentTaskScope(group),
       api_key,
       model,
       task,
@@ -36,7 +37,8 @@ pub async fn run(
 
 ///|
 async fn run_with_runtime(
-  runtime : @agent_runtime.AgentRuntime[Unit],
+  runtime : @agent_runtime.AgentRuntime,
+  scope : @agent_runtime.AgentTaskScope[Unit],
   api_key : String,
   model : @deepseek.Model,
   task : String,
@@ -49,7 +51,7 @@ async fn run_with_runtime(
     thinking=Some(Enabled),
     reasoning_effort=Some(Max),
   )
-  let tools = tool_definitions(runtime) catch {
+  let tools = tool_definitions(runtime, scope) catch {
     error => {
       log.at(ERROR) <? { "event": "agent_setup_failed", "error": "\{error}" }
       return

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -4,14 +4,15 @@
 /// them into the `Tools` value the loop dispatches against. Raises if two
 /// definitions share a name.
 fn tool_definitions(
-  runtime : @agent_runtime.AgentRuntime[Unit],
+  runtime : @agent_runtime.AgentRuntime,
+  scope : @agent_runtime.AgentTaskScope[Unit],
 ) -> @agent_tool.Tools raise {
   Tools([
     @shell.definition(),
     @read.definition(),
     @edit.definition(),
     @write.definition(),
-    @moon_check.definition(runtime),
+    @moon_check.definition(runtime, scope),
     @finish.definition(),
   ])
 }
@@ -19,7 +20,7 @@ fn tool_definitions(
 ///|
 async test "agent registers the expected tool names" {
   @async.with_task_group() <| group => {
-    let tools = tool_definitions(AgentRuntime(group))
+    let tools = tool_definitions(AgentRuntime(), AgentTaskScope(group))
     let function_tools = tools.function_tools()
     assert_eq(function_tools.length(), 6)
     let names = [ for t in function_tools => t.name ]

--- a/agent_runtime/README.mbt.md
+++ b/agent_runtime/README.mbt.md
@@ -1,15 +1,18 @@
 # Agent Runtime
 
-`agent_runtime` owns the generic per-agent-loop runtime: the structured
-concurrency task group and a bounded event queue for background tool updates.
-It deliberately does not know about concrete tools.
+`agent_runtime` owns per-agent-loop infrastructure without knowing about
+concrete tools. `AgentRuntime` carries the bounded event queue for background
+tool updates, while `AgentTaskScope[X]` carries the structured-concurrency task
+group for tools that need bounded background work.
 
 ## API Shape
 
-- `AgentRuntime(group)`: create loop-scoped runtime state inside
-  `@async.with_task_group`.
-- `AgentRuntime::group`: expose the task group to stateful tools that need
-  bounded background tasks.
+- `AgentRuntime()`: create loop-scoped event state.
+- `AgentTaskScope(group)`: wrap a `@async.TaskGroup[X]` inside
+  `@async.with_task_group` for stateful tools that need bounded background
+  tasks.
+- `AgentTaskScope::group`: expose the task group to task-spawning tool
+  implementations.
 - `AgentRuntime::emit_event`: enqueue a typed runtime event.
 - `AgentRuntime::drain_events`: drain pending events for the agent loop.
 - `AgentEvent`: open `extenum` extended by concrete tool packages.

--- a/agent_runtime/pkg.generated.mbti
+++ b/agent_runtime/pkg.generated.mbti
@@ -14,13 +14,18 @@ pub let default_agent_event_capacity : Int
 pub(all) extenum AgentEvent {
 }
 
-pub struct AgentRuntime[X] {
+pub struct AgentRuntime {
   // private fields
 }
-pub fn[X] AgentRuntime::AgentRuntime(@async.TaskGroup[X]) -> Self[X]
-pub fn[X] AgentRuntime::drain_events(Self[X]) -> Array[AgentEvent]
-pub fn[X] AgentRuntime::emit_event(Self[X], AgentEvent) -> Unit
-pub fn[X] AgentRuntime::group(Self[X]) -> @async.TaskGroup[X]
+pub fn AgentRuntime::AgentRuntime() -> Self
+pub fn AgentRuntime::drain_events(Self) -> Array[AgentEvent]
+pub fn AgentRuntime::emit_event(Self, AgentEvent) -> Unit
+
+pub struct AgentTaskScope[X] {
+  // private fields
+}
+pub fn[X] AgentTaskScope::AgentTaskScope(@async.TaskGroup[X]) -> Self[X]
+pub fn[X] AgentTaskScope::group(Self[X]) -> @async.TaskGroup[X]
 
 // Type aliases
 

--- a/agent_runtime/runtime.mbt
+++ b/agent_runtime/runtime.mbt
@@ -8,12 +8,9 @@ pub(all) extenum AgentEvent {}
 
 ///|
 /// Per-agent-loop state shared between the main chat loop and side-effectful
-/// tools. Constructed once inside `@async.with_task_group` and threaded into
-/// tool definitions that need bounded background tasks or runtime updates.
-pub struct AgentRuntime[X] {
-  /// Task group the agent runs under; tools spawn background tasks as children
-  /// of this group so their lifetime is bounded by the agent's.
-  priv group : @async.TaskGroup[X]
+/// tools. It owns runtime updates, while `AgentTaskScope` owns structured
+/// background task lifetime for tools that need it.
+pub struct AgentRuntime {
   /// Bounded event bus (`DiscardOldest`, see `default_agent_event_capacity`)
   /// that background tools post updates to; the main loop drains it between
   /// steps to surface fresh tool output into the conversation.
@@ -21,29 +18,41 @@ pub struct AgentRuntime[X] {
 }
 
 ///|
-pub fn[X] AgentRuntime::AgentRuntime(
-  group : @async.TaskGroup[X],
-) -> AgentRuntime[X] {
-  { group, events: Queue(kind=DiscardOldest(default_agent_event_capacity)) }
+pub fn AgentRuntime::AgentRuntime() -> AgentRuntime {
+  { events: Queue(kind=DiscardOldest(default_agent_event_capacity)) }
 }
 
 ///|
-pub fn[X] AgentRuntime::group(self : AgentRuntime[X]) -> @async.TaskGroup[X] {
+/// Structured-concurrency scope for background work spawned by stateful tools.
+/// The type parameter is the return type of the enclosing `with_task_group`.
+pub struct AgentTaskScope[X] {
+  priv group : @async.TaskGroup[X]
+}
+
+///|
+pub fn[X] AgentTaskScope::AgentTaskScope(
+  group : @async.TaskGroup[X],
+) -> AgentTaskScope[X] {
+  { group, }
+}
+
+///|
+pub fn[X] AgentTaskScope::group(
+  self : AgentTaskScope[X],
+) -> @async.TaskGroup[X] {
   self.group
 }
 
 ///|
-pub fn[X] AgentRuntime::emit_event(
-  self : AgentRuntime[X],
+pub fn AgentRuntime::emit_event(
+  self : AgentRuntime,
   event : AgentEvent,
 ) -> Unit {
   ignore(self.events.try_put(event) catch { _ => false })
 }
 
 ///|
-pub fn[X] AgentRuntime::drain_events(
-  self : AgentRuntime[X],
-) -> Array[AgentEvent] {
+pub fn AgentRuntime::drain_events(self : AgentRuntime) -> Array[AgentEvent] {
   let events : Array[AgentEvent] = []
   for ;; {
     let next = self.events.try_get() catch { _ => None }
@@ -60,16 +69,22 @@ extenum AgentEvent += {
 }
 
 ///|
-async test "runtime drains queued events" {
+test "runtime drains queued events" {
+  let runtime = AgentRuntime()
+  runtime.emit_event(RuntimeTestEvent("ok"))
+  let events = runtime.drain_events()
+  assert_eq(events.length(), 1)
+  guard events[0] is RuntimeTestEvent(value) else {
+    fail("expected RuntimeTestEvent")
+  }
+  assert_eq(value, "ok")
+  assert_eq(runtime.drain_events().length(), 0)
+}
+
+///|
+async test "task scope exposes structured task group" {
   @async.with_task_group() <| group => {
-    let runtime = AgentRuntime(group)
-    runtime.emit_event(RuntimeTestEvent("ok"))
-    let events = runtime.drain_events()
-    assert_eq(events.length(), 1)
-    guard events[0] is RuntimeTestEvent(value) else {
-      fail("expected RuntimeTestEvent")
-    }
-    assert_eq(value, "ok")
-    assert_eq(runtime.drain_events().length(), 0)
+    let scope = AgentTaskScope(group)
+    scope.group().spawn_bg(no_wait=true) <| () => { () }
   }
 }

--- a/agent_tool/moon_check/README.mbt.md
+++ b/agent_tool/moon_check/README.mbt.md
@@ -109,7 +109,7 @@ when the process cannot be launched. The string body has one of these shapes:
 ///|
 async test "moon_check tool advertises the expected schema" {
   @async.with_task_group() <| group => {
-    let tool = @moon_check.definition(AgentRuntime(group))
+    let tool = @moon_check.definition(AgentRuntime(), AgentTaskScope(group))
     assert_eq(tool.name, "moon_check")
     let JsonSchema(schema) = tool.schema
     let text = schema.stringify()

--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -80,23 +80,25 @@ priv struct MoonCheckRecord {
 
 ///|
 priv struct MoonCheckRuntime[X] {
-  runtime : @agent_runtime.AgentRuntime[X]
+  runtime : @agent_runtime.AgentRuntime
+  scope : @agent_runtime.AgentTaskScope[X]
   moon_checks : Map[String, MoonCheckRecord]
   mut next_moon_check_index : Int
 }
 
 ///|
 fn[X] MoonCheckRuntime::MoonCheckRuntime(
-  runtime : @agent_runtime.AgentRuntime[X],
+  runtime : @agent_runtime.AgentRuntime,
+  scope : @agent_runtime.AgentTaskScope[X],
 ) -> MoonCheckRuntime[X] {
-  { runtime, moon_checks: {}, next_moon_check_index: 1 }
+  { runtime, scope, moon_checks: {}, next_moon_check_index: 1 }
 }
 
 ///|
 fn[X] MoonCheckRuntime::group(
   self : MoonCheckRuntime[X],
 ) -> @async.TaskGroup[X] {
-  self.runtime.group()
+  self.scope.group()
 }
 
 ///|
@@ -331,9 +333,10 @@ fn moon_check_run_complete(content : String) -> Bool {
 /// - `Respond(ToolOutput("error: moon_check requires ...", is_error=true))`
 ///   for invalid arguments.
 pub fn[X] definition(
-  runtime : @agent_runtime.AgentRuntime[X],
+  runtime : @agent_runtime.AgentRuntime,
+  scope : @agent_runtime.AgentTaskScope[X],
 ) -> @agent_tool.AgentToolDefinition {
-  let moon_runtime = MoonCheckRuntime(runtime)
+  let moon_runtime = MoonCheckRuntime(runtime, scope)
   AgentToolDefinition(
     name="moon_check",
     description="Start or inspect a persistent `moon check --watch --diagnostic-limit 10` watcher for the given cwd/options. The first call starts the watcher; later calls with the same arguments return the latest snapshot without starting another watcher.",
@@ -828,7 +831,7 @@ fn test_snapshot(
 ///|
 async test "moon_check advertises expected schema" {
   @async.with_task_group() <| group => {
-    let tool = definition(AgentRuntime(group))
+    let tool = definition(AgentRuntime(), AgentTaskScope(group))
     assert_eq(tool.name, "moon_check")
     let JsonSchema(schema) = tool.schema
     let text = schema.stringify()
@@ -924,7 +927,7 @@ test "moon_check auto restart respects exit code and budget" {
 ///|
 async test "moon_check runtime ignores stale watcher id updates" {
   @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(group))
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let key = "cwd=/tmp"
     let (reader1, writer1) = @process.read_from_process()
     let process1 = @process.spawn(
@@ -992,7 +995,7 @@ async test "moon_check runtime ignores stale watcher id updates" {
 ///|
 async test "moon_check keeps crash summary in replacement output" {
   @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(group))
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let key = "cwd=/tmp"
     let (reader, writer) = @process.read_from_process()
     let process = @process.spawn(
@@ -1045,7 +1048,10 @@ async test "moon_check keeps crash summary in replacement output" {
 ///|
 async test "moon_check rejects non-object arguments" {
   @async.with_task_group() <| group => {
-    let result = execute(MoonCheckRuntime(AgentRuntime(group)), Json::null())
+    let result = execute(
+      MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group)),
+      Json::null(),
+    )
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(output.content, "error: moon_check requires object arguments")
     assert_true(output.is_error)
@@ -1057,7 +1063,7 @@ async test "moon_check validates a real fixture project" {
   let project = copy_fixture_project("valid_project")
   let canonical = @fs.realpath(project)
   @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(group))
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let result = execute(runtime, { "cwd": project })
     ignore(
       runtime.stop_moon_check(
@@ -1086,7 +1092,7 @@ async test "moon_check validates a real fixture project" {
 async test "moon_check reuses a running watcher for the same arguments" {
   let project = copy_fixture_project("valid_project")
   @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(group))
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let args : Json = { "cwd": project }
     let first = execute(runtime, args)
     let second = execute(runtime, args)
@@ -1108,7 +1114,7 @@ async test "moon_check reuses a running watcher for the same arguments" {
 async test "moon_check restarts a stopped watcher on explicit next call" {
   let project = copy_fixture_project("valid_project")
   @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(group))
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let args : Json = { "cwd": project }
     let key = moon_check_key(@decode.decode(args))
     let first = execute(runtime, args)
@@ -1135,7 +1141,7 @@ async test "moon_check reports diagnostics from a broken fixture project" {
   let project = copy_fixture_project("invalid_project")
   let canonical = @fs.realpath(project)
   @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(group))
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let result = execute(runtime, { "cwd": project })
     ignore(
       runtime.stop_moon_check(
@@ -1198,7 +1204,7 @@ async test "moon_check validates a virtual filesystem workspace" {
   }).write_to(project)
   let canonical = @fs.realpath(project)
   @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(group))
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let args : Json = { "cwd": project, "target": "native" }
     let result = execute(runtime, args)
     ignore(runtime.stop_moon_check(moon_check_key(@decode.decode(args))))

--- a/agent_tool/moon_check/pkg.generated.mbti
+++ b/agent_tool/moon_check/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn[X] definition(@agent_runtime.AgentRuntime[X]) -> @agent_tool.AgentToolDefinition
+pub fn[X] definition(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X]) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -1,15 +1,16 @@
 ///|
 pub async fn run_harness() -> @report.Report {
   @async.with_task_group() <| group => {
-    run_harness_with_runtime(AgentRuntime(group))
+    run_harness_with_runtime(AgentRuntime(), AgentTaskScope(group))
   }
 }
 
 ///|
 async fn run_harness_with_runtime(
-  runtime : @agent_runtime.AgentRuntime[@report.Report],
+  runtime : @agent_runtime.AgentRuntime,
+  scope : @agent_runtime.AgentTaskScope[@report.Report],
 ) -> @report.Report {
-  let tools = tool_definitions(runtime) catch {
+  let tools = tool_definitions(runtime, scope) catch {
     error =>
       return build_report([
         row(
@@ -35,14 +36,15 @@ async fn run_harness_with_runtime(
 
 ///|
 fn tool_definitions(
-  runtime : @agent_runtime.AgentRuntime[@report.Report],
+  runtime : @agent_runtime.AgentRuntime,
+  scope : @agent_runtime.AgentTaskScope[@report.Report],
 ) -> @agent_tool.Tools raise {
   Tools([
     @read.definition(),
     @write.definition(),
     @edit.definition(),
     @shell.definition(),
-    @moon_check.definition(runtime),
+    @moon_check.definition(runtime, scope),
     @moon_cmd.definition(),
     @moon_ide.definition(),
     @finish.definition(),


### PR DESCRIPTION
Summary:
- Make AgentRuntime non-generic and event-queue only.
- Add AgentTaskScope[X] to carry the structured-concurrency TaskGroup return type separately.
- Thread runtime + task scope through agent, eval harness, and moon_check.
- Update generated interfaces and docs.

Validation:
- moon test agent_runtime --target native
- moon test agent_tool/moon_check --target native
- moon test agent --target native
- moon test eval/tool_harness --target native
- moon info
- moon fmt
- moon fmt --check
- moon check --deny-warn
- moon test (375/375)
- moon cram test tests/cram (3/3)