### PR TITLE
Hide moon_check runtime event internals

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -132,73 +132,7 @@ async fn run_with_runtime(
 
 ///|
 fn runtime_update_message(events : Array[@agent_runtime.AgentEvent]) -> String? {
-  let latest_moon_checks : Map[String, @moon_check.MoonCheckSnapshot] = {}
-  let mut moon_check_count = 0
-  for event in events {
-    match event {
-      @moon_check.MoonCheckUpdate(update) => {
-        latest_moon_checks[update.key] = update
-        moon_check_count += 1
-      }
-      _ => ()
-    }
-  }
-  if moon_check_count == 0 {
-    None
-  } else {
-    let parts = [
-      for update in latest_moon_checks.values() => update.update_text()
-    ]
-    Some(
-      "[moon_check update]\nevents=\{moon_check_count}\n" + parts.join("\n\n"),
-    )
-  }
-}
-
-///|
-test "moon_check update message coalesces by watcher key" {
-  let message = runtime_update_message([
-    @moon_check.MoonCheckUpdate(
-      MoonCheckSnapshot(
-        id="moon-check-1",
-        key="cwd=.",
-        command="moon check --watch --diagnostic-limit 10",
-        cwd=None,
-        status=Running,
-        seq=1,
-        output="old",
-        output_truncated=false,
-        max_output_chars=12000,
-        exit_code=None,
-        restart_count=0,
-        restart_limit=3,
-        restart_reason=None,
-      ),
-    ),
-    @moon_check.MoonCheckUpdate(
-      MoonCheckSnapshot(
-        id="moon-check-1",
-        key="cwd=.",
-        command="moon check --watch --diagnostic-limit 10",
-        cwd=None,
-        status=Running,
-        seq=2,
-        output="new",
-        output_truncated=false,
-        max_output_chars=12000,
-        exit_code=None,
-        restart_count=0,
-        restart_limit=3,
-        restart_reason=None,
-      ),
-    ),
-  ])
-  guard message is Some(text) else { fail("expected message") }
-  assert_true(text.contains("[moon_check update]"))
-  assert_true(text.contains("events=2"))
-  assert_true(text.contains("seq=2"))
-  assert_true(text.contains("new"))
-  assert_false(text.contains("old"))
+  @moon_check.runtime_update_text(events)
 }
 
 ///|

--- a/agent_runtime/README.mbt.md
+++ b/agent_runtime/README.mbt.md
@@ -18,5 +18,5 @@ group for tools that need bounded background work.
 - `AgentEvent`: open `extenum` extended by concrete tool packages.
 
 Tool packages that need typed background updates extend `AgentEvent` from their
-own package. For example, `agent_tool/moon_check` adds `MoonCheckUpdate` without
-making this package depend on `moon_check`.
+own package. They can keep concrete event constructors internal and expose a
+small rendering/query function for the agent loop.

--- a/agent_tool/README.mbt.md
+++ b/agent_tool/README.mbt.md
@@ -48,9 +48,9 @@ has to interpret.
 
 Stateful tools use `agent_runtime` directly when they need loop-scoped
 background work or event updates. For example, `moon_check` owns its watcher
-state in its own package and extends the runtime event type with
-`MoonCheckUpdate`; its direct tool results still follow the normal
-`Respond(ToolOutput(...))` contract.
+state, internal runtime events, and event rendering in its own package; its
+direct tool results still follow the normal `Respond(ToolOutput(...))`
+contract.
 
 ```mermaid
 flowchart LR
@@ -63,7 +63,7 @@ flowchart LR
   Watcher --> Monitor[reader task]
   Monitor --> MoonCheck
   MoonCheck --> Runtime
-  Runtime --> Queue[MoonCheckUpdate queue]
+  Runtime --> Queue[Runtime event queue]
   Agent --> Queue
   Queue --> Message["[moon_check update] user message"]
   Message --> Model

--- a/agent_tool/moon_check/README.mbt.md
+++ b/agent_tool/moon_check/README.mbt.md
@@ -48,10 +48,10 @@ sequenceDiagram
   end
   Watcher-->>Tool: stdout/stderr chunks
   Tool->>State: record latest compact output
-  State->>Runtime: emit MoonCheckUpdate
-  Runtime->>Queue: MoonCheckUpdate
+  State->>Runtime: emit internal update event
+  Runtime->>Queue: runtime update
   Agent->>Queue: drain before next model turn
-  Queue-->>Agent: coalesced [moon_check update]
+  Queue-->>Agent: moon_check renders coalesced update
   alt watcher exits unexpectedly
     Tool->>State: compact crash output
     Tool->>Watcher: restart within budget

--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -1,11 +1,11 @@
 ///|
-pub(all) enum WatcherStatus {
+priv enum WatcherStatus {
   Running
   Stopped
 }
 
 ///|
-pub struct MoonCheckSnapshot {
+priv struct MoonCheckSnapshot {
   id : String
   key : String
   command : String
@@ -22,7 +22,7 @@ pub struct MoonCheckSnapshot {
 }
 
 ///|
-pub fn MoonCheckSnapshot::MoonCheckSnapshot(
+fn MoonCheckSnapshot::MoonCheckSnapshot(
   id~ : String,
   key~ : String,
   command~ : String,
@@ -55,7 +55,7 @@ pub fn MoonCheckSnapshot::MoonCheckSnapshot(
 }
 
 ///|
-pub(all) extenum @agent_runtime.AgentEvent += {
+extenum @agent_runtime.AgentEvent += {
   MoonCheckUpdate(MoonCheckSnapshot)
 }
 
@@ -746,7 +746,7 @@ fn moon_check_status_label(status : WatcherStatus) -> String {
 }
 
 ///|
-pub fn MoonCheckSnapshot::update_text(update : MoonCheckSnapshot) -> String {
+fn MoonCheckSnapshot::update_text(update : MoonCheckSnapshot) -> String {
   let cwd = match update.cwd {
     Some(cwd) => cwd
     None => "."
@@ -771,6 +771,33 @@ pub fn MoonCheckSnapshot::update_text(update : MoonCheckSnapshot) -> String {
     "\n" + update.output
   }
   "id=\{update.id}\ncwd=\{cwd}\ncommand=\{update.command}\nstatus=\{moon_check_status_label(update.status)}\nseq=\{update.seq}\{exit}\{truncated}\{restart}\{output}"
+}
+
+///|
+pub fn runtime_update_text(
+  events : Array[@agent_runtime.AgentEvent],
+) -> String? {
+  let latest_moon_checks : Map[String, MoonCheckSnapshot] = {}
+  let mut moon_check_count = 0
+  for event in events {
+    match event {
+      MoonCheckUpdate(update) => {
+        latest_moon_checks[update.key] = update
+        moon_check_count += 1
+      }
+      _ => ()
+    }
+  }
+  if moon_check_count == 0 {
+    None
+  } else {
+    let parts = [
+      for update in latest_moon_checks.values() => update.update_text()
+    ]
+    Some(
+      "[moon_check update]\nevents=\{moon_check_count}\n" + parts.join("\n\n"),
+    )
+  }
 }
 
 ///|
@@ -826,6 +853,52 @@ fn test_snapshot(
     restart_limit~,
     restart_reason=None,
   )
+}
+
+///|
+test "moon_check update text coalesces by watcher key" {
+  let message = runtime_update_text([
+    MoonCheckUpdate(
+      MoonCheckSnapshot(
+        id="moon-check-1",
+        key="cwd=.",
+        command="moon check --watch --diagnostic-limit 10",
+        cwd=None,
+        status=Running,
+        seq=1,
+        output="old",
+        output_truncated=false,
+        max_output_chars=12000,
+        exit_code=None,
+        restart_count=0,
+        restart_limit=3,
+        restart_reason=None,
+      ),
+    ),
+    MoonCheckUpdate(
+      MoonCheckSnapshot(
+        id="moon-check-1",
+        key="cwd=.",
+        command="moon check --watch --diagnostic-limit 10",
+        cwd=None,
+        status=Running,
+        seq=2,
+        output="new",
+        output_truncated=false,
+        max_output_chars=12000,
+        exit_code=None,
+        restart_count=0,
+        restart_limit=3,
+        restart_reason=None,
+      ),
+    ),
+  ])
+  guard message is Some(text) else { fail("expected message") }
+  assert_true(text.contains("[moon_check update]"))
+  assert_true(text.contains("events=2"))
+  assert_true(text.contains("seq=2"))
+  assert_true(text.contains("new"))
+  assert_false(text.contains("old"))
 }
 
 ///|

--- a/agent_tool/moon_check/pkg.generated.mbti
+++ b/agent_tool/moon_check/pkg.generated.mbti
@@ -9,36 +9,11 @@ import {
 // Values
 pub fn[X] definition(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X]) -> @agent_tool.AgentToolDefinition
 
+pub fn runtime_update_text(Array[@agent_runtime.AgentEvent]) -> String?
+
 // Errors
 
 // Types and methods
-pub struct MoonCheckSnapshot {
-  id : String
-  key : String
-  command : String
-  cwd : String?
-  status : WatcherStatus
-  seq : Int
-  output : String
-  output_truncated : Bool
-  max_output_chars : Int
-  exit_code : Int?
-  restart_count : Int
-  restart_limit : Int
-  restart_reason : String?
-}
-pub fn MoonCheckSnapshot::MoonCheckSnapshot(id~ : String, key~ : String, command~ : String, cwd~ : String?, status~ : WatcherStatus, seq~ : Int, output~ : String, output_truncated~ : Bool, max_output_chars~ : Int, exit_code~ : Int?, restart_count~ : Int, restart_limit~ : Int, restart_reason~ : String?) -> Self
-pub fn MoonCheckSnapshot::update_text(Self) -> String
-
-pub(all) enum WatcherStatus {
-  Running
-  Stopped
-}
-
-// Extensible enum extensions
-pub(all) extenum @agent_runtime.AgentEvent += {
-  MoonCheckUpdate(MoonCheckSnapshot)
-}
 
 // Type aliases
 


### PR DESCRIPTION
Summary:
- Keep MoonCheckUpdate, MoonCheckSnapshot, WatcherStatus, and snapshot rendering internal to agent_tool/moon_check.
- Add runtime_update_text(events) as the small public rendering boundary for the agent loop.
- Move moon_check update coalescing coverage from agent into the moon_check package.
- Update generated interface and docs to match the smaller API.

Validation:
- moon ide analyze agent_tool/moon_check
- moon test agent_tool/moon_check --target native
- moon test agent --target native
- moon fmt --check
- moon check --deny-warn
- moon test (375/375)
- moon cram test tests/cram (3/3)