### PR TITLE
moon_check follow-ups: decode README, .mbti newlines, VFS fixtures

### DIFF
--- a/agent_tool/edit/internal/manifest_error/pkg.generated.mbti
+++ b/agent_tool/edit/internal/manifest_error/pkg.generated.mbti
@@ -11,3 +11,4 @@ pub async fn write_error(String, String) -> String?
 // Type aliases
 
 // Traits
+

--- a/agent_tool/moon_check/README.mbt.md
+++ b/agent_tool/moon_check/README.mbt.md
@@ -121,6 +121,7 @@ async test "moon_check tool advertises the expected schema" {
 
 Process execution is intentionally not exercised from doc tests: running
 `moon check` against the active package from inside `moon test` can contend with
-the active build. The real-world unit tests copy fixture projects into `/tmp`
-and run `moon_check` there, covering both a valid project and a broken project
-that emits compiler diagnostics.
+the active build. The real-world unit tests materialize fixture projects into
+`/tmp` via `testkit/filesystem` (`@vfs.FileSystem(...).write_to(dir)`) and run
+`moon_check` there, covering both a valid project and a broken project that
+emits compiler diagnostics.

--- a/agent_tool/moon_check/fixtures/invalid_project/lib.mbt.fixture
+++ b/agent_tool/moon_check/fixtures/invalid_project/lib.mbt.fixture
@@ -1,4 +1,0 @@
-///|
-pub fn meaning() -> Int {
-  "not an int"
-}

--- a/agent_tool/moon_check/fixtures/invalid_project/moon.mod.fixture
+++ b/agent_tool/moon_check/fixtures/invalid_project/moon.mod.fixture
@@ -1,3 +1,0 @@
-name = "openseek/moon_check_invalid_fixture"
-
-version = "0.1.0"

--- a/agent_tool/moon_check/fixtures/invalid_project/moon.pkg.fixture
+++ b/agent_tool/moon_check/fixtures/invalid_project/moon.pkg.fixture
@@ -1,1 +1,0 @@
-warnings = "+unnecessary_annotation"

--- a/agent_tool/moon_check/fixtures/valid_project/lib.mbt.fixture
+++ b/agent_tool/moon_check/fixtures/valid_project/lib.mbt.fixture
@@ -1,4 +1,0 @@
-///|
-pub fn meaning() -> Int {
-  42
-}

--- a/agent_tool/moon_check/fixtures/valid_project/moon.mod.fixture
+++ b/agent_tool/moon_check/fixtures/valid_project/moon.mod.fixture
@@ -1,3 +1,0 @@
-name = "openseek/moon_check_valid_fixture"
-
-version = "0.1.0"

--- a/agent_tool/moon_check/fixtures/valid_project/moon.pkg.fixture
+++ b/agent_tool/moon_check/fixtures/valid_project/moon.pkg.fixture
@@ -1,1 +1,0 @@
-warnings = "+unnecessary_annotation"

--- a/agent_tool/moon_check/internal/decode/README.mbt.md
+++ b/agent_tool/moon_check/internal/decode/README.mbt.md
@@ -1,0 +1,67 @@
+# Moon Check Decode
+
+`bobzhang/openseek/agent_tool/moon_check/internal/decode` converts raw JSON tool
+arguments into the typed `MoonCheckInput` record consumed by the `moon_check`
+tool.
+
+This package is internal to `agent_tool/moon_check`. It owns only argument-shape
+decoding: it checks each optional field has the expected JSON type, treats
+empty strings and `null` as absent, validates `target` against the moon target
+whitelist, and raises focused error messages for malformed payloads. Watcher
+state, process spawning, and the `moon check --watch` lifecycle stay in the
+parent `moon_check` package.
+
+## API Shape
+
+- `MoonCheckInput(cwd, target, warn_list, deny_warn, fmt, explain)`: the
+  normalized check request. All fields are optional — `cwd`, `target`, and
+  `warn_list` carry `None` when omitted; the booleans default to `false`.
+- `decode(arguments)`: accepts a JSON object and returns `MoonCheckInput`, or
+  raises when fields have invalid types or when `target` is not in the
+  supported set.
+
+## Arguments
+
+| Name | Type | Required | Decoder behavior |
+| --- | --- | --- | --- |
+| `cwd` | string | no | Empty string and `null` are treated as missing; non-string values raise `arguments.cwd to be a string`. |
+| `target` | string | no | Must be one of `wasm`, `wasm-gc`, `js`, `native`, `llvm`, `all`; other strings raise `arguments.target to be one of ...`. Empty and `null` are treated as missing. |
+| `warn_list` | string | no | Forwarded verbatim as `--warn-list`. Empty and `null` are treated as missing; non-string values raise `arguments.warn_list to be a string`. |
+| `deny_warn` | boolean | no | Defaults to `false`; `null` is treated as `false`; non-boolean values raise `arguments.deny_warn to be a boolean`. |
+| `fmt` | boolean | no | Same shape as `deny_warn`. |
+| `explain` | boolean | no | Same shape as `deny_warn`. |
+
+Extra fields are ignored. Non-object JSON values raise `object arguments`.
+
+The decoder does not check that `cwd` points at a real workspace, that the
+workspace has a `moon.mod`, or that the resulting `moon check` command would
+succeed. Those checks happen when the parent `moon_check` package spawns the
+watcher and observes its output.
+
+## Example
+
+```moonbit check
+///|
+test "decode moon_check input from tool arguments" {
+  let focused = @decode.decode({
+    "cwd": "/tmp/example_project",
+    "target": "native",
+    "warn_list": "+unnecessary_annotation",
+    "deny_warn": true,
+    "fmt": true,
+    "explain": true,
+  })
+  assert_true(focused.cwd is Some("/tmp/example_project"))
+  assert_true(focused.target is Some("native"))
+  assert_true(focused.warn_list is Some("+unnecessary_annotation"))
+  assert_true(focused.deny_warn)
+  assert_true(focused.fmt)
+  assert_true(focused.explain)
+
+  let minimal = @decode.decode({ "cwd": "", "deny_warn": false, "fmt": null })
+  assert_true(minimal.cwd is None)
+  assert_true(minimal.target is None)
+  assert_false(minimal.deny_warn)
+  assert_false(minimal.fmt)
+}
+```

--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -154,7 +154,7 @@ async test "moon_check rejects non-object arguments" {
 
 ///|
 async test "moon_check validates a real fixture project" {
-  let project = copy_fixture_project("valid_project")
+  let project = valid_project()
   let canonical = @fs.realpath(project)
   @async.with_task_group() <| group => {
     let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
@@ -184,7 +184,7 @@ async test "moon_check validates a real fixture project" {
 
 ///|
 async test "moon_check reuses a running watcher for the same arguments" {
-  let project = copy_fixture_project("valid_project")
+  let project = valid_project()
   @async.with_task_group() <| group => {
     let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let args : Json = { "cwd": project }
@@ -206,7 +206,7 @@ async test "moon_check reuses a running watcher for the same arguments" {
 
 ///|
 async test "moon_check restarts a stopped watcher on explicit next call" {
-  let project = copy_fixture_project("valid_project")
+  let project = valid_project()
   @async.with_task_group() <| group => {
     let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let args : Json = { "cwd": project }
@@ -232,7 +232,7 @@ async test "moon_check restarts a stopped watcher on explicit next call" {
 
 ///|
 async test "moon_check reports diagnostics from a broken fixture project" {
-  let project = copy_fixture_project("invalid_project")
+  let project = invalid_project()
   let canonical = @fs.realpath(project)
   @async.with_task_group() <| group => {
     let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
@@ -321,24 +321,51 @@ async test "moon_check validates a virtual filesystem workspace" {
 }
 
 ///|
-async fn copy_fixture_project(name : String) -> String {
+/// Materialize a single-package moon workspace into a fresh temp directory
+/// via `@vfs.FileSystem`. The caller passes in the module name (used as the
+/// `moon.mod` `name`) and the `lib.mbt` body; everything else — `moon.pkg`
+/// warning policy, `moon.mod` version — is shared boilerplate. Returns the
+/// temp directory path so the test can pass it to `moon_check` as `cwd` and
+/// later `@fs.rmdir` it.
+async fn write_fixture_project(
+  module_name~ : String,
+  lib_content~ : String,
+) -> String {
   let target = @fs.tmpdir(prefix="openseek-moon-check-")
-  copy_fixture_file(name, "moon.mod.fixture", target + "/moon.mod")
-  copy_fixture_file(name, "moon.pkg.fixture", target + "/moon.pkg")
-  copy_fixture_file(name, "lib.mbt.fixture", target + "/lib.mbt")
+  @vfs.FileSystem({
+    "moon.mod": "name = \"openseek/\{module_name}\"\n\nversion = \"0.1.0\"\n",
+    "moon.pkg": "warnings = \"+unnecessary_annotation\"\n",
+    "lib.mbt": lib_content,
+  }).write_to(target)
   target
 }
 
 ///|
-async fn copy_fixture_file(
-  fixture : String,
-  file : String,
-  target : String,
-) -> Unit {
-  let content = @fs.read_file(
-    "agent_tool/moon_check/fixtures/\{fixture}/\{file}",
-  ).text()
-  @fs.write_file(target, content, create_mode=CreateOrTruncate)
+async fn valid_project() -> String {
+  write_fixture_project(
+    module_name="moon_check_valid_fixture",
+    lib_content=(
+      #|///|
+      #|pub fn meaning() -> Int {
+      #|  42
+      #|}
+      #|
+    ),
+  )
+}
+
+///|
+async fn invalid_project() -> String {
+  write_fixture_project(
+    module_name="moon_check_invalid_fixture",
+    lib_content=(
+      #|///|
+      #|pub fn meaning() -> Int {
+      #|  "not an int"
+      #|}
+      #|
+    ),
+  )
 }
 
 ///|

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -48,3 +48,4 @@ pub impl @doc.ToDoc for TranscriptItem
 // Type aliases
 
 // Traits
+

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -40,3 +40,4 @@ pub fn Text::split_lines(Self) -> Array[Self]
 pub(open) trait ToDoc {
   fn to_doc(Self) -> Doc
 }
+

--- a/tui/internal/composer/pkg.generated.mbti
+++ b/tui/internal/composer/pkg.generated.mbti
@@ -46,3 +46,4 @@ pub fn Model::visible_text_rows(Self) -> Int
 // Type aliases
 
 // Traits
+

--- a/tui/internal/geometry/pkg.generated.mbti
+++ b/tui/internal/geometry/pkg.generated.mbti
@@ -24,3 +24,4 @@ pub fn Geometry::top(Self) -> Int
 // Type aliases
 
 // Traits
+

--- a/tui/internal/history/pkg.generated.mbti
+++ b/tui/internal/history/pkg.generated.mbti
@@ -25,3 +25,4 @@ pub fn History::reset_navigation(Self) -> Unit
 // Type aliases
 
 // Traits
+

--- a/tui/internal/surface/pkg.generated.mbti
+++ b/tui/internal/surface/pkg.generated.mbti
@@ -38,3 +38,4 @@ pub fn Surface::with_max_rows(Self, Int) -> Self
 // Type aliases
 
 // Traits
+

--- a/tui/internal/task/pkg.generated.mbti
+++ b/tui/internal/task/pkg.generated.mbti
@@ -20,3 +20,4 @@ pub async fn[T] Queue::wait(Self, async () -> T) -> T
 // Type aliases
 
 // Traits
+

--- a/tui/internal/terminal_size/pkg.generated.mbti
+++ b/tui/internal/terminal_size/pkg.generated.mbti
@@ -17,3 +17,4 @@ pub fn TerminalSize::rows(Self) -> Int
 // Type aliases
 
 // Traits
+

--- a/tui/internal/text/pkg.generated.mbti
+++ b/tui/internal/text/pkg.generated.mbti
@@ -23,3 +23,4 @@ pub fn unit_width(@displaytext.DisplayText, start~ : @displaytext.TextualPositio
 // Type aliases
 
 // Traits
+

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -32,3 +32,4 @@ pub using @core {type ToolStatus}
 pub using @core {type TranscriptItem}
 
 // Traits
+

--- a/tui/style/pkg.generated.mbti
+++ b/tui/style/pkg.generated.mbti
@@ -27,3 +27,4 @@ pub fn Style::Style(foreground? : @color.Color, background? : @color.Color, unde
 // Type aliases
 
 // Traits
+


### PR DESCRIPTION
Follow-ups to #47.

## Summary
- **docs**: Add `agent_tool/moon_check/internal/decode/README.mbt.md` describing the decoder's API shape, argument table, and a runnable doc-test. Mirrors `agent_tool/edit/internal/decode/README.mbt.md`.
- **chore**: 12 generated `.mbti` files were missing a trailing newline; `moon info` regenerated them. Whitespace-only.
- **test**: Migrate moon_check's valid/invalid fixture tests from on-disk `.fixture` files under `agent_tool/moon_check/fixtures/` to inline `@vfs.FileSystem(...).write_to(dir)` materialization. The broken `"not an int"` source now lives next to the snapshot that asserts on it. 6 fixture files deleted; new shared `write_fixture_project` helper + `valid_project()` / `invalid_project()` wrappers.

## Test plan
- [x] `moon check` clean
- [x] `moon test -p bobzhang/openseek/agent_tool/moon_check` — 16/16 pass
- [x] `moon test -p bobzhang/openseek/agent_tool/moon_check/internal/decode` — 5/5 pass (incl. README doc-test)
- [x] `moon fmt` no further changes