### PR TITLE
[codex] add explicit session support to TUI

### DIFF
--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -5,6 +5,21 @@ fn drain_test_state() -> State {
     model: V4Pro,
     cwd: ".",
     max_steps: 10,
+    session_id: Some(SessionId("test")),
+    session_root: ".openseek",
+    engine: "openseek",
+  })
+}
+
+///|
+fn ephemeral_drain_test_state() -> State {
+  State::new({
+    api_key: "k",
+    model: V4Pro,
+    cwd: ".",
+    max_steps: 10,
+    session_id: None,
+    session_root: ".openseek",
     engine: "openseek",
   })
 }
@@ -40,6 +55,31 @@ fn run_command_count(cmds : Array[Cmd]) -> Int {
     }
   }
   count
+}
+
+///|
+test "agent engine argv stays replay-compatible while session config uses env" {
+  let config = drain_test_state().config
+  let args = engine_args("--literal task")
+  assert_eq(args.length(), 2)
+  assert_eq(args[0], "--")
+  assert_eq(args[1], "--literal task")
+  let env = engine_extra_env(config)
+  guard env.get("OPENSEEK_SESSION") is Some(session_id) else {
+    fail("missing session id env")
+  }
+  guard env.get("OPENSEEK_SESSION_ROOT") is Some(session_root) else {
+    fail("missing session root env")
+  }
+  assert_eq(session_id, "test")
+  assert_eq(session_root, ".openseek")
+}
+
+///|
+test "agent engine env omits session config for fresh runs" {
+  let env = engine_extra_env(ephemeral_drain_test_state().config)
+  assert_true(env.get("OPENSEEK_SESSION") is None)
+  assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -97,6 +97,25 @@ fn is_terminal_event(event : @event.AgentEvent) -> Bool {
 }
 
 ///|
+fn engine_args(task : String) -> Array[String] {
+  ["--", task]
+}
+
+///|
+fn engine_extra_env(config : AppConfig) -> Map[String, String] {
+  let env = {
+    "DEEPSEEK": config.api_key,
+    "DEEPSEEK_MODEL": config.model.to_string(),
+    "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+  }
+  if config.session_id is Some(session_id) {
+    env["OPENSEEK_SESSION"] = session_id.value()
+    env["OPENSEEK_SESSION_ROOT"] = config.session_root
+  }
+  env
+}
+
+///|
 /// Spawn the agent engine for one input and stream its JSONL stdout into the
 /// message loop.
 ///
@@ -123,14 +142,12 @@ async fn run_agent_task(
       // can start with `-`/`--` (e.g. the literal text `--help`). Forward it
       // after a `--` delimiter so the engine's argparse treats it as the task
       // positional rather than parsing it as one of its own options (which would
-      // exit/print help and never emit a terminal JSONL event).
-      ["--", task],
+      // exit/print help and never emit a terminal JSONL event). Session settings
+      // go through environment variables so custom replay engines do not need to
+      // accept OpenSeek-specific flags.
+      engine_args(task),
       inherit_env=true,
-      extra_env={
-        "DEEPSEEK": config.api_key,
-        "DEEPSEEK_MODEL": config.model.to_string(),
-        "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
-      },
+      extra_env=engine_extra_env(config),
       stdout=child_stdout,
       stderr=child_stderr,
     )

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -32,6 +32,19 @@ fn cli_command() -> @argparse.Command {
         default_values=["openseek"],
         about="Agent engine binary to spawn; reads its JSONL event stream from stdout.",
       ),
+      OptionArg(
+        "session",
+        long="session",
+        env="OPENSEEK_SESSION",
+        about="Create or resume this durable session id.",
+      ),
+      OptionArg(
+        "session-root",
+        long="session-root",
+        env="OPENSEEK_SESSION_ROOT",
+        default_values=[".openseek"],
+        about="Directory containing durable OpenSeek sessions.",
+      ),
     ],
     positionals=[
       PositionArg(
@@ -78,11 +91,21 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     Some(cwd) => cwd
     None => "."
   }
+  let session = match values(matches, "session") {
+    [session, ..] => session.trim().to_owned()
+    [] => ""
+  }
   {
     api_key: value(matches, "api-key"),
     model: @deepseek.Model::parse(value(matches, "model")),
     cwd,
     max_steps: parse_positive_int(value(matches, "max-steps"), "--max-steps"),
+    session_id: if session.is_empty() {
+      None
+    } else {
+      Some(SessionId(session))
+    },
+    session_root: value(matches, "session-root"),
     engine: value(matches, "engine"),
   }
 }
@@ -108,6 +131,7 @@ async fn run_tui(config : AppConfig, initial : String?) -> Unit {
 async fn run_app(config : AppConfig, initial : String?, ui : @ui.Ui) -> Unit {
   let state = State::new(config)
   let messages = @async.Queue(kind=Unbounded)
+  append_session_history(state.config, ui)
   ui.append_item(Response("OpenSeek TUI ready"))
   refresh_ui(ui, state)
   @async.with_task_group(group => {
@@ -172,6 +196,8 @@ test "cli accepts no initial task" {
   assert_eq(config.api_key, "test-key")
   assert_eq(config.max_steps, 1000)
   assert_eq(config.engine, "openseek")
+  assert_true(config.session_id is None)
+  assert_eq(config.session_root, ".openseek")
 }
 
 ///|
@@ -182,6 +208,18 @@ test "cli accepts initial task and max steps" {
   )
   assert_true(initial_task(parsed) == Some("inspect project"))
   assert_eq(parse_config(parsed).max_steps, 5)
+}
+
+///|
+test "cli accepts session configuration" {
+  let parsed = cli_command().parse(
+    argv=["--session", "demo", "--session-root", "/tmp/openseek-sessions"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = parse_config(parsed)
+  guard config.session_id is Some(id) else { fail("expected session id") }
+  assert_eq(id.value(), "demo")
+  assert_eq(config.session_root, "/tmp/openseek-sessions")
 }
 
 ///|

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "bobzhang/jsonl",
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/agent_tool/shell",
   "bobzhang/openseek/cmd/tui/internal/event",
   "bobzhang/openseek/deepseek",

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -1,0 +1,76 @@
+///|
+fn session_tool_item(result : @agent_session.ToolResult) -> @ui.TranscriptItem {
+  let event : @event.ToolResultEvent = {
+    name: result.tool_name(),
+    content: result.content(),
+    is_error: result.is_error(),
+  }
+  tool_item(event)
+}
+
+///|
+fn summary_item(summary : @agent_session.SessionSummary) -> @ui.TranscriptItem {
+  Notice(
+    ToolCall(
+      @doc.Text::plain(
+        "conversation summary · events \{summary.from_sequence()}..\{summary.to_sequence()}",
+      ),
+      details=detail_texts(
+        compact_lines(summary.content(), ToolOutputLineLimit),
+      ),
+    ),
+  )
+}
+
+///|
+fn terminal_item(terminal : @agent_session.TurnTerminal) -> @ui.TranscriptItem? {
+  match terminal {
+    Finished(answer) if !answer.trim().is_empty() => Some(Response(answer))
+    Finished(_) => None
+    Aborted(reason) => Some(Error("aborted: " + reason))
+    Interrupted(reason) => Some(Error("interrupted: " + reason))
+    Failed(message) => Some(Error(message))
+  }
+}
+
+///|
+fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
+  match item {
+    User(message) => Some(Input(Prompt(message.content())))
+    Assistant(message) =>
+      if message.content().trim().is_empty() {
+        None
+      } else {
+        Some(Response(message.content()))
+      }
+    Tool(result) => Some(session_tool_item(result))
+    Runtime(notice) =>
+      Some(runtime_item(parse_runtime_update(notice.content())))
+    Summary(summary) => Some(summary_item(summary))
+    Terminal(terminal) => terminal_item(terminal)
+  }
+}
+
+///|
+async fn append_session_history(config : AppConfig, ui : @ui.Ui) -> Unit {
+  guard config.session_id is Some(session_id) else { return }
+  let store = @store.SessionStore(config.session_root)
+  let exists = store.exists(session_id) catch {
+    error => {
+      ui.append_item(Error("failed to inspect session: \{error}"))
+      return
+    }
+  }
+  guard exists else { return }
+  let session = store.load(session_id) catch {
+    error => {
+      ui.append_item(Error("failed to load session: \{error}"))
+      return
+    }
+  }
+  for event in session.events() {
+    if session_item(event.item()) is Some(item) {
+      ui.append_item(item)
+    }
+  }
+}

--- a/cmd/tui/session_view_wbtest.mbt
+++ b/cmd/tui/session_view_wbtest.mbt
@@ -1,0 +1,17 @@
+///|
+test "session items project to transcript items" {
+  guard session_item(User(UserMessage("hello"))) is Some(Input(Prompt(text))) else {
+    fail("expected input")
+  }
+  assert_eq(text, "hello")
+  guard session_item(Terminal(Finished("done"))) is Some(Response(answer)) else {
+    fail("expected response")
+  }
+  assert_eq(answer, "done")
+  guard session_item(
+      Tool(ToolResult(tool_call_id="call_1", tool_name="read", content="ok")),
+    )
+    is Some(ToolCall(_)) else {
+    fail("expected tool")
+  }
+}

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -4,6 +4,8 @@ priv struct AppConfig {
   model : @deepseek.Model
   cwd : String
   max_steps : Int
+  session_id : @agent_session.SessionId?
+  session_root : String
   // The agent engine the TUI spawns and reads JSONL events from. Defaults to
   // the `openseek` binary on `PATH`; override (e.g. to a recorded-stream
   // replayer) with `--engine` or `OPENSEEK_ENGINE`.

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -24,11 +24,13 @@ Arguments:
   task...  Optional initial task description.
 
 Options:
-  -h, --help               Show help information.
-  --api-key <api-key>      DeepSeek API key. [env: DEEPSEEK]
-  --model <model>          DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --max-steps <max-steps>  Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --engine <engine>        Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  -h, --help                     Show help information.
+  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
+  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 ```
 
 ## A DeepSeek API Key Is Required
@@ -49,11 +51,13 @@ Arguments:
   task...  Optional initial task description.
 
 Options:
-  -h, --help               Show help information.
-  --api-key <api-key>      DeepSeek API key. [env: DEEPSEEK]
-  --model <model>          DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --max-steps <max-steps>  Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --engine <engine>        Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  -h, --help                     Show help information.
+  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
+  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 
 [1]
 ```


### PR DESCRIPTION
Stack: 5/5. Depends on #54 (`codex/session-cli`).

This PR is the TUI-only integration layer for durable sessions. The lower PRs define the session model, filesystem store, agent turn API, and `openseek` CLI behavior; this PR wires those capabilities into `openseek-tui` without changing the core session APIs.

What changed:

- Adds `--session` / `OPENSEEK_SESSION` to `openseek-tui` for explicitly choosing a durable session id.
- Adds `--session-root` / `OPENSEEK_SESSION_ROOT` so the TUI and spawned engine agree on where session files live.
- Parses a missing or empty session id as `None`; there is no implicit `default` session.
- Passes session settings to the spawned `openseek` engine through environment variables only when a session id is present.
- Keeps fresh TUI launches fresh: `openseek-tui` without `--session` does not persist or resume conversation state.
- Loads an existing durable session at TUI startup and renders its prior user, assistant, tool, runtime, summary, and terminal events into the transcript.
- Adds focused tests for session config parsing, env propagation to the engine, omitted env for fresh runs, session-history rendering, and prompt draining with durable sessions.
- Updates TUI cram docs so the help output includes the new session flags.

Expected behavior:

```bash
openseek-tui --session parser-fix   # create/resume durable session "parser-fix"
openseek-tui                       # fresh TUI run, no durable session
```

This mirrors the CLI behavior from #54:

```bash
openseek --session parser-fix       # create/resume durable session "parser-fix"
openseek                           # fresh one-shot run
```

Validation:

- `moon test cmd/tui cmd/openseek agent agent_session agent_session/store --warn-list +73 --diagnostic-limit 300`
- `moon info cmd/tui cmd/openseek agent agent_session agent_session/store --target native`
- `moon fmt cmd/tui cmd/openseek agent agent_session tests/cram/tui.md tests/cram/cli.md README.mbt.md`
- `moon cram test tests/cram`
