### PR TITLE
[codex] add DeepSeek streaming agent support

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -150,7 +150,15 @@ async fn run_with_runtime(
         messages.push(ChatMessage(User, content=update))
       }
       @xlog.info() <? { "event": "agent_step", "step": step + 1 }
-      let response = client.chat(messages, tools=tools.function_tools())
+      let response = client.chat_stream(
+        messages,
+        tools=tools.function_tools(),
+        on_content_delta=delta => {
+          if delta != "" {
+            @xlog.info() <? { "event": "assistant_delta", "content": delta }
+          }
+        },
+      )
       if response.content != "" {
         @xlog.info() <?
           { "event": "assistant_message", "content": response.content }

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -11,6 +11,7 @@
 pub fn decode_event(object : Json) -> AgentEvent? {
   match @jsonx.string(object, "event") {
     "agent_step" => Some(AgentStep)
+    "assistant_delta" => Some(AssistantDelta(@jsonx.string(object, "content")))
     "assistant_message" =>
       Some(AssistantMessage(@jsonx.string(object, "content")))
     "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -10,6 +10,12 @@ test "decode maps each engine event kind" {
   )
   assert_true(
     @event.decode_event(
+      Json::object({ "event": "assistant_delta", "content": "tok" }),
+    )
+    is Some(AssistantDelta("tok")),
+  )
+  assert_true(
+    @event.decode_event(
       Json::object({ "event": "agent_finished", "answer": "done" }),
     )
     is Some(AgentFinished("done")),

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -34,6 +34,7 @@ pub(all) struct ToolResultEvent {
 /// queued input.
 pub(all) enum AgentEvent {
   AgentStep
+  AssistantDelta(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -9,6 +9,7 @@ pub fn decode_event(Json) -> AgentEvent?
 // Types and methods
 pub(all) enum AgentEvent {
   AgentStep
+  AssistantDelta(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -244,6 +244,93 @@ test "parse_runtime_update aggregates status across watcher sections" {
 }
 
 ///|
+test "assistant_delta accumulates live text and commits only the final message" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Hel" }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "lo" }),
+    items,
+  )
+  assert_eq(items.length(), 0)
+  assert_true(state.streaming_response is Some("Hello"))
+  assert_true(state.step_response is None)
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Hello" }),
+    items,
+  )
+  assert_true(state.streaming_response is None)
+  assert_true(state.step_response is Some("Hello"))
+  append_items(
+    state,
+    Json::object({ "event": "agent_finished", "answer": "Hello" }),
+    items,
+  )
+  debug_inspect(items, content="[Response(\"Hello\")]")
+}
+
+///|
+test "assistant_message clears live streaming text while tools continue" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Need tool" }),
+    items,
+  )
+  assert_true(state.streaming_response is Some("Need tool"))
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Need tool" }),
+    items,
+  )
+  assert_true(state.run is Running(_))
+  assert_true(state.streaming_response is None)
+  assert_true(state.step_response is Some("Need tool"))
+  assert_eq(items.length(), 1)
+}
+
+///|
+test "assistant_delta live preview is capped" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({
+      "event": "assistant_delta",
+      "content": String::make(StreamingPreviewMaxColumns * 4, 'x'),
+    }),
+    items,
+  )
+  guard state.streaming_response is Some(first) else {
+    fail("expected streaming preview")
+  }
+  assert_true(
+    @displaytext.DisplayText(first).width() <= StreamingPreviewMaxColumns,
+  )
+  assert_true(first.has_suffix("..."))
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "more" }),
+    items,
+  )
+  guard state.streaming_response is Some(second) else {
+    fail("expected streaming preview")
+  }
+  assert_eq(second, first)
+  assert_eq(items.length(), 0)
+}
+
+///|
 test "replaying a recorded engine session renders the transcript" {
   let state = drain_test_state()
   // Submit a task so the agent is running before progress arrives.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -251,6 +251,29 @@ async fn run_shell_command(
 }
 
 ///|
+// The live streaming line is only a transient status preview. The final
+// assistant text is committed later by `assistant_message`, so keep this bounded
+// to avoid quadratic copies during long code-generation streams.
+const StreamingPreviewMaxColumns : Int = 240
+
+///|
+fn capped_streaming_preview(text : String) -> String {
+  @displaytext.DisplayText(text).truncate(
+    StreamingPreviewMaxColumns,
+    suffix="...",
+  )
+}
+
+///|
+fn append_streaming_preview(current : String?, delta : String) -> String {
+  let delta = capped_streaming_preview(delta)
+  match current {
+    Some(response) => capped_streaming_preview(response + delta)
+    None => delta
+  }
+}
+
+///|
 /// Apply one agent progress event to `state`, queueing any transcript updates in
 /// `cmds`. Terminal events call `finish_run`, leaving the agent idle so the
 /// queue drain at the end of `update` can start the next input.
@@ -260,9 +283,19 @@ fn handle_agent_event(
   cmds : Array[Cmd],
 ) -> Unit {
   match event {
-    AgentStep => state.step_response = None
+    AgentStep => {
+      state.step_response = None
+      state.streaming_response = None
+    }
+    AssistantDelta(text) =>
+      if text != "" {
+        state.streaming_response = Some(
+          append_streaming_preview(state.streaming_response, text),
+        )
+      }
     AssistantMessage(text) => {
       state.step_response = Some(text)
+      state.streaming_response = None
       if !text.trim().is_empty() {
         cmds.push(AppendItem(Response(text)))
       }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -29,7 +29,12 @@ priv struct State {
   // them; a message whose id is not the active run's is stale (it came from a
   // task that has since been superseded) and is dropped. See `State::owns_run`.
   mut run_id : Int
+  // Final assistant text for the current step, used to avoid appending the same
+  // answer again when `AgentFinished` follows `AssistantMessage`.
   mut step_response : String?
+  // Incremental assistant text currently arriving from `assistant_delta`
+  // events. Cleared once the final assistant message is committed.
+  mut streaming_response : String?
   mut usage : @event.UsageInfo?
   // Latest background `moon_check` watcher status ("running"/"stopped"), lifted
   // from the most recent `runtime_update` for the status bar. Empty until the
@@ -45,6 +50,7 @@ fn State::new(config : AppConfig) -> State {
     run: Idle,
     run_id: 0,
     step_response: None,
+    streaming_response: None,
     usage: None,
     watcher_status: "",
   }
@@ -58,6 +64,7 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run_id = self.run_id + 1
   self.run = Running(started_ms)
   self.step_response = None
+  self.streaming_response = None
   self.run_id
 }
 
@@ -71,14 +78,15 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 
 ///|
 /// Reset run tracking after the agent stops (finished, aborted, cancelled, or
-/// failed): no task running, no pending step response. Also clear the watcher
-/// status: `run_agent_task` spawns a fresh engine per prompt and any
+/// failed): no task running, no pending final or streaming response. Also clear
+/// the watcher status: `run_agent_task` spawns a fresh engine per prompt and any
 /// `moon_check --watch` process belongs to that engine's runtime, so it is gone
 /// once the engine exits — leaving `watcher_status` set would keep a stale
 /// `moon_check running` segment in the status bar while the TUI sits idle.
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
   self.step_response = None
+  self.streaming_response = None
   self.watcher_status = ""
 }
 

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -91,6 +91,14 @@ fn format_activity_text(state : State) -> @doc.Text? {
     Running(started_ms) => started_ms
     Interrupting(started_ms) => started_ms
   }
+  if state.streaming_response is Some(response) && !response.trim().is_empty() {
+    return Some(
+      Text([
+        Span(DisplayText("Streaming "), style=@style.dim),
+        @doc.Span::plain(response),
+      ]),
+    )
+  }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @async.now()),
   )

--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -17,10 +17,11 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
 - `ChatMessage(role, content=..., tool_calls?, reasoning_content?)`: one typed
   chat message constructor. Use `Assistant` with `tool_calls` for the assistant
   message that must be sent back after DeepSeek requests native tool calls.
-- `encode_chat_request(model, messages, tools?, thinking?, reasoning_effort?)`:
-  builds the full DeepSeek chat completions request body. The per-value
-  encoders for messages, tool definitions, and tool calls are package-private
-  implementation details.
+- `encode_chat_request(model, messages, tools?, thinking?, reasoning_effort?,
+  stream?)`: builds the full DeepSeek chat completions request body. Streaming
+  requests include usage-bearing stream options. The per-value encoders for
+  messages, tool definitions, and tool calls are package-private implementation
+  details.
 - `ToolDefinition(name, description, parameters, strict?)`: a native DeepSeek
   function tool definition with a JSON Schema parameters object.
 - `ToolCall(id~, name~, arguments~)`: a decoded function call request from the

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -14,6 +14,9 @@ The package depends on `moonbitlang/async/http` and is native-only.
   thinking controls.
 - `Client::chat(messages, tools?)`: send typed chat messages in JSON response
   mode, optionally with native DeepSeek function tools, and decode the response.
+- `Client::chat_stream(messages, on_content_delta~, tools?)`: send the same
+  request in SSE streaming mode, emit assistant content fragments through the
+  callback, and return the fully accumulated response.
 
 `Client` implements `Debug` with the API key redacted.
 
@@ -21,7 +24,13 @@ The package depends on `moonbitlang/async/http` and is native-only.
 
 `Client::chat` builds a private request envelope with the client's configured
 model, thinking mode, and reasoning effort, then sends it to `api_url` as JSON.
-It always sends `stream=false` and `response_format={"type":"json_object"}`.
+It sends `stream=false` and `response_format={"type":"json_object"}`.
+
+`Client::chat_stream` sends `stream=true` plus
+`stream_options={"include_usage":true}`. It parses DeepSeek's SSE `data:` events,
+calls `on_content_delta` for each non-empty `delta.content`, accumulates
+reasoning and tool-call fragments, and returns a normal
+`@deepseek.ChatResponse` with final usage when the API supplies it.
 
 Use `tools=[...]` when the model should call native DeepSeek function tools.
 Tool call results should be appended as `@deepseek.ChatMessage(Tool(call.id),

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -61,3 +61,37 @@ pub async fn Client::chat(
   let parsed = @json.parse(text)
   @json.from_json(parsed)
 }
+
+///|
+/// Sends typed chat messages in DeepSeek SSE streaming mode.
+///
+/// `on_content_delta` is called for each assistant content fragment as it arrives.
+/// The returned value is the fully accumulated response, including reasoning,
+/// tool calls, and final token usage when the API sends it.
+pub async fn Client::chat_stream(
+  self : Client,
+  messages : Array[@deepseek.ChatMessage],
+  on_content_delta~ : async (String) -> Unit,
+  tools? : Array[@deepseek.ToolDefinition] = [],
+) -> @deepseek.ChatResponse {
+  let body = @deepseek.encode_chat_request(
+    self.model,
+    messages,
+    tools~,
+    thinking?=self.thinking,
+    reasoning_effort?=self.reasoning_effort,
+    stream=true,
+  )
+  let client = @http.post_stream(self.api_url, headers={
+    "Content-Type": "application/json",
+    "Authorization": "Bearer \{self.api_key}",
+  })
+  defer client.close()
+  client.write(body.stringify())
+  let resp = client.end_request()
+  guard resp.code >= 200 && resp.code < 300 else {
+    let text = client.read_all().text()
+    fail("DeepSeek API error \{resp.code}: \{text}")
+  }
+  read_chat_stream(client, on_content_delta~)
+}

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -1,0 +1,84 @@
+///|
+async fn stream_test_server(
+  group : @async.TaskGroup[Unit],
+  finish? : Bool = true,
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping stream test: \{message}")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        let request_body = body.read_all().text()
+        assert_true(request_body.contains("\"stream\":true"))
+        assert_true(request_body.contains("\"include_usage\":true"))
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+        )
+        conn.flush()
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\" world\",\"reasoning_content\":\"hidden\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n",
+        )
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"moon.mod\\\"}\"}}]}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+        )
+        if finish {
+          conn.write("data: [DONE]\n\n")
+        }
+      },
+      max_connections=1,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "chat_stream accumulates SSE content, tool calls, and usage" {
+  @async.with_task_group() <| group => {
+    guard stream_test_server(group) is Some(url) else { return }
+    let client = @client.Client(api_key="test-key", api_url=url)
+    let deltas : Array[String] = []
+    let response = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=delta => {
+      deltas.push(delta)
+    })
+    assert_eq(deltas.join("|"), "Hello| world")
+    assert_eq(response.content, "Hello world")
+    assert_eq(response.reasoning_content, "hidden")
+    assert_eq(response.tool_calls.length(), 1)
+    assert_eq(response.tool_calls[0].id, "call_1")
+    assert_eq(response.tool_calls[0].name, "read")
+    assert_eq(response.tool_calls[0].arguments, "{\"path\":\"moon.mod\"}")
+    assert_eq(response.usage.prompt_tokens, 3)
+    assert_eq(response.usage.completion_tokens, 5)
+    assert_eq(response.usage.total_tokens, 8)
+    assert_eq(response.usage.prompt_cache_hit_tokens, 1)
+    assert_eq(response.usage.prompt_cache_miss_tokens, 2)
+  }
+}
+
+///|
+async test "chat_stream rejects EOF before done" {
+  @async.with_task_group() <| group => {
+    guard stream_test_server(group, finish=false) is Some(url) else { return }
+    let client = @client.Client(api_key="test-key", api_url=url)
+    try {
+      let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
+        ()
+      })
+      fail("expected truncated stream to fail")
+    } catch {
+      error => assert_true("\{error}".contains("ended before [DONE]"))
+    }
+  }
+}

--- a/deepseek/client/moon.pkg
+++ b/deepseek/client/moon.pkg
@@ -1,11 +1,13 @@
 import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/async/http",
+  "moonbitlang/async/io",
   "moonbitlang/core/json",
 }
 
 import {
   "moonbitlang/async",
+  "moonbitlang/async/socket",
   "moonbitlang/core/env",
 } for "test"
 

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub struct Client {
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode?, reasoning_effort? : @deepseek.ReasoningEffort?) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition]) -> @deepseek.ChatResponse
+pub async fn Client::chat_stream(Self, Array[@deepseek.ChatMessage], on_content_delta~ : async (String) -> Unit, tools? : Array[@deepseek.ToolDefinition]) -> @deepseek.ChatResponse
 
 // Type aliases
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -1,0 +1,238 @@
+///|
+priv struct StreamToolCall {
+  mut id : String
+  mut name : String
+  arguments : StringBuilder
+}
+
+///|
+fn StreamToolCall::StreamToolCall() -> StreamToolCall {
+  { id: "", name: "", arguments: StringBuilder::new() }
+}
+
+///|
+fn StreamToolCall::to_json(self : StreamToolCall) -> Json {
+  {
+    "id": self.id,
+    "type": "function",
+    "function": { "name": self.name, "arguments": self.arguments.to_string() },
+  }
+}
+
+///|
+priv struct StreamAccumulator {
+  content : StringBuilder
+  reasoning_content : StringBuilder
+  tool_calls : Array[StreamToolCall]
+  mut usage : Json?
+}
+
+///|
+fn StreamAccumulator::StreamAccumulator() -> StreamAccumulator {
+  {
+    content: StringBuilder::new(),
+    reasoning_content: StringBuilder::new(),
+    tool_calls: [],
+    usage: None,
+  }
+}
+
+///|
+fn StreamAccumulator::ensure_tool_call(
+  self : StreamAccumulator,
+  index : Int,
+) -> StreamToolCall {
+  while self.tool_calls.length() <= index {
+    self.tool_calls.push(StreamToolCall())
+  }
+  self.tool_calls[index]
+}
+
+///|
+fn StreamAccumulator::response(
+  self : StreamAccumulator,
+) -> @deepseek.ChatResponse raise {
+  let reasoning_content = self.reasoning_content.to_string()
+  let message = Json::object(
+    Map(
+      [
+        ("content", Json::string(self.content.to_string())),
+        ..if reasoning_content != "" {
+          [("reasoning_content", Json::string(reasoning_content))]
+        } else {
+          []
+        },
+        ..if self.tool_calls.length() > 0 {
+          [
+            (
+              "tool_calls",
+              ([ for call in self.tool_calls => call.to_json() ] : Json),
+            ),
+          ]
+        } else {
+          []
+        },
+      ],
+    ),
+  )
+  let envelope = Json::object(
+    Map(
+      [
+        ("choices", ([({ "message": message } : Json)] : Json)),
+        ..match self.usage {
+          Some(usage) => [("usage", usage)]
+          None => []
+        },
+      ],
+    ),
+  )
+  @json.from_json(envelope)
+}
+
+///|
+fn json_string_field(fields : Map[String, Json], key : String) -> String? {
+  match fields.get(key) {
+    Some(String(value)) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn json_int_field(fields : Map[String, Json], key : String) -> Int? {
+  match fields.get(key) {
+    Some(Number(value, ..)) => Some(value.to_int())
+    _ => None
+  }
+}
+
+///|
+fn apply_tool_call_delta(
+  acc : StreamAccumulator,
+  json : Json,
+  fallback_index : Int,
+) -> Unit {
+  let fields = match json {
+    Object(fields) => fields
+    _ => return
+  }
+  let index = json_int_field(fields, "index").unwrap_or(fallback_index)
+  if index < 0 {
+    return
+  }
+  let call = acc.ensure_tool_call(index)
+  if json_string_field(fields, "id") is Some(id) && id != "" {
+    call.id = id
+  }
+  guard fields.get("function") is Some(Object(function)) else { return }
+  if json_string_field(function, "name") is Some(name) && name != "" {
+    call.name = name
+  }
+  if json_string_field(function, "arguments") is Some(arguments) &&
+    arguments != "" {
+    call.arguments.write_string(arguments)
+  }
+}
+
+///|
+async fn apply_stream_delta(
+  acc : StreamAccumulator,
+  delta : Map[String, Json],
+  on_content_delta~ : async (String) -> Unit,
+) -> Unit {
+  if json_string_field(delta, "content") is Some(content) && content != "" {
+    acc.content.write_string(content)
+    on_content_delta(content)
+  }
+  if json_string_field(delta, "reasoning_content") is Some(reasoning) &&
+    reasoning != "" {
+    acc.reasoning_content.write_string(reasoning)
+  }
+  match delta.get("tool_calls") {
+    Some(Array(calls)) =>
+      for index, call in calls {
+        apply_tool_call_delta(acc, call, index)
+      }
+    _ => ()
+  }
+}
+
+///|
+async fn apply_stream_json(
+  acc : StreamAccumulator,
+  json : Json,
+  on_content_delta~ : async (String) -> Unit,
+) -> Unit {
+  match json {
+    { "usage": Null, .. } => ()
+    { "usage": usage_json, .. } => acc.usage = Some(usage_json)
+    _ => ()
+  }
+  match json {
+    { "choices": [{ "delta": Object(delta), .. }, ..], .. } =>
+      apply_stream_delta(acc, delta, on_content_delta~)
+    { "choices": [], .. } => ()
+    _ => ()
+  }
+}
+
+///|
+fn sse_data_fragment(raw : String) -> String? {
+  let line = if raw.has_suffix("\r") {
+    raw[:raw.length() - 1].to_owned()
+  } else {
+    raw
+  }
+  if line.has_prefix("data:") {
+    Some(line[5:].trim().to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+async fn flush_sse_event(
+  acc : StreamAccumulator,
+  data_lines : Array[String],
+  on_content_delta~ : async (String) -> Unit,
+) -> Bool {
+  if data_lines.length() == 0 {
+    return false
+  }
+  let data = data_lines.join("\n").trim().to_owned()
+  data_lines.clear()
+  if data == "[DONE]" {
+    return true
+  }
+  apply_stream_json(acc, @json.parse(data), on_content_delta~)
+  false
+}
+
+///|
+async fn read_chat_stream(
+  reader : @http.Client,
+  on_content_delta~ : async (String) -> Unit,
+) -> @deepseek.ChatResponse {
+  let acc = StreamAccumulator::StreamAccumulator()
+  let data_lines : Array[String] = []
+  for ;; {
+    match reader.read_until("\n") {
+      None => {
+        if flush_sse_event(acc, data_lines, on_content_delta~) {
+          break
+        }
+        fail("DeepSeek stream ended before [DONE]")
+      }
+      Some(raw) => {
+        let trimmed = raw.trim()
+        if trimmed.is_empty() {
+          if flush_sse_event(acc, data_lines, on_content_delta~) {
+            break
+          }
+        } else if sse_data_fragment(raw) is Some(data) {
+          data_lines.push(data)
+        }
+      }
+    }
+  }
+  acc.response()
+}

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -34,6 +34,21 @@ test "encode_chat_request includes tools when present" {
 }
 
 ///|
+test "encode_chat_request enables usage-bearing stream mode" {
+  let body = @deepseek.encode_chat_request(
+    V4Flash,
+    [ChatMessage(User, content="stream this")],
+    stream=true,
+  )
+  let text = body.stringify()
+  assert_true(text.contains("\"stream\":true"))
+  guard body
+    is { "stream": True, "stream_options": { "include_usage": True, .. }, .. } else {
+    fail("wrong stream options")
+  }
+}
+
+///|
 test "encode_chat_request encodes thinking controls" {
   let body = @deepseek.encode_chat_request(
     V4Pro,

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -74,14 +74,20 @@ pub fn encode_chat_request(
   tools? : Array[ToolDefinition] = [],
   thinking? : ThinkingMode,
   reasoning_effort? : ReasoningEffort,
+  stream? : Bool = false,
 ) -> Json {
   Json::object(
     Map(
       [
         ("model", Json::string(model.to_string())),
         ("messages", ([ for message in messages => message ] : Json)),
-        ("stream", Json::boolean(false)),
+        ("stream", Json::boolean(stream)),
         ("response_format", { "type": "json_object" }),
+        ..if stream {
+          [("stream_options", ({ "include_usage": true } : Json))]
+        } else {
+          []
+        },
         ..if tools.length() > 0 {
           [("tools", ([ for tool in tools => tool ] : Json))]
         } else {

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort) -> Json
+pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort, stream? : Bool) -> Json
 
 // Errors
 

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -21,6 +21,11 @@ drops `moon`'s own dependency-resolution chatter, not any log content.
 Every example gives the cheap Flash model a trivial, self-contained task and a
 tiny step budget.
 
+When the model emits assistant text, the stream may include one or more
+`assistant_delta` events before the final `assistant_message`. Tool-only
+responses, such as the forced `finish` examples below, may skip both content
+events and go straight to tool execution.
+
 ## A Real Round Trip That Finishes
 
 This proves two things from the real log: that the request reached DeepSeek and


### PR DESCRIPTION
## Summary

This refreshes the streaming PR on top of current `origin/main`, after the durable session and explicit TUI session slices were merged.

It adds streaming without changing the durable session contract:

- adds DeepSeek SSE streaming through `Client::chat_stream`
- encodes `stream=true` in chat requests when streaming is used
- accumulates streamed assistant content, reasoning, tool-call deltas, and final usage into the same `ChatResponse` shape as the non-streaming client
- rejects stream EOF before `[DONE]`
- switches the agent loop from `client.chat` to `client.chat_stream` while preserving `run_turn_with_append` persistence points
- emits `assistant_delta` JSONL events as content arrives
- renders live streamed text in the TUI activity line while deltas arrive
- clears the live streaming display when the final `assistant_message` is committed, so tool execution after a message falls back to the normal working state instead of showing committed text as still streaming
- caps the transient TUI streaming preview by display width; the full assistant text is still committed from the final `assistant_message`

## Scope

This PR is intentionally limited to model-response streaming. It does not change session storage, session CLI/TUI flags, or the one-turn append API beyond making the model call stream internally.

## Review Follow-Up

- Subal flagged that committed assistant text could remain visible as a live streaming status while tool calls continued. This is addressed by splitting TUI state into `streaming_response` for live deltas and `step_response` for final-message dedupe.
- Subal flagged that live streamed previews were accumulated with repeated unbounded string copies. This is addressed by capping the TUI-only preview and leaving final content to `assistant_message`.

## Validation

- `moon check deepseek/client --target native --warn-list +73 --diagnostic-limit 300`
- `moon check agent --target native --warn-list +73 --diagnostic-limit 300`
- `moon check cmd/tui --target native --warn-list +73 --diagnostic-limit 300`
- `moon test deepseek/client --target native --warn-list +73 --diagnostic-limit 300` - 7/7 passed
- `moon test agent --target native --warn-list +73 --diagnostic-limit 300` - 2/2 passed
- `moon test cmd/tui --target native --warn-list +73 --diagnostic-limit 300` - 26/26 passed
- `moon fmt agent cmd/tui deepseek deepseek/client tests/live`
- `moon fmt cmd/tui`
- `moon info deepseek --target native`
- `moon info deepseek/client --target native`
- `moon info agent --target native`
- `moon info cmd/tui/internal/event --target native`
- `moon info cmd/tui --target native`
- `moon ide analyze deepseek/client --target native`
- `moon ide analyze deepseek --target native`
- `moon ide analyze agent --target native`
- `moon ide analyze cmd/tui/internal/event --target native`
- `moon ide analyze cmd/tui --target native`
- `moon check --target native --warn-list +73 --diagnostic-limit 300`
- `moon test --target native --diagnostic-limit 300` - 455/455 passed
- `moon cram test tests/cram` - 6/6 passed
- `git diff --check`
