### PR TITLE
[codex] add durable session core model

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -12,6 +12,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/deepseek` | Pure DeepSeek chat data, JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
 | `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for DeepSeek chat completions. | `deepseek/client/README.mbt.md` |
 | `bobzhang/openseek/agent_runtime` | Native-only agent task-group and extensible runtime event queue. | `agent_runtime/README.mbt.md` |
+| `bobzhang/openseek/agent_session` | Typed durable conversation state and DeepSeek message projection. | `agent_session/README.mbt.md` |
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
@@ -46,6 +47,11 @@ boundary. Tool executors return `ToolAction`: normal tools use
 
 The `agent_runtime` package owns loop-scoped task-group access and an extensible
 event queue used by stateful tools such as `moon_check`.
+
+The `agent_session` package owns typed durable conversation state, append-only
+session events, JSON round-tripping, and projection from a session into
+DeepSeek chat messages. It is separate from TUI transcript rendering so
+resumable sessions can be type-safe and process-independent.
 
 The `agent` subpackage contains the OpenSeek agent loop, native DeepSeek
 tool-call handling, and local tool dispatch. It depends on `deepseek/client`,

--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -1,0 +1,29 @@
+# OpenSeek Agent Session
+
+`bobzhang/openseek/agent_session` is the typed, provider-aware conversation
+state for resumable OpenSeek agents. It is intentionally separate from the TUI
+transcript model: session values are persisted and projected into DeepSeek chat
+messages, while transcript values are optimized for terminal rendering.
+
+The package exposes:
+
+- `SessionId` and immutable `Session`
+- append-only `SessionEvent` sequence numbers
+- typed `SessionItem` variants for users, assistants, tool results, runtime
+  notices, summaries, and turn terminal states
+- JSON round-tripping for durable storage
+- `Session::chat_messages` for projecting a session into DeepSeek protocol
+  messages
+- `Session::compact` for appending a validated summary that replaces covered
+  source events in model-facing projection while keeping the raw log intact
+
+```mbt check
+///|
+test {
+  let session = @agent_session.Session(
+    SessionId("example"),
+    system_prompt="system",
+  ).append(User(UserMessage("hello")))
+  inspect(session.last_sequence(), content="1")
+}
+```

--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -1,0 +1,198 @@
+///|
+fn[T] json_decode_error(
+  path : @json.JsonPath,
+  message : String,
+) -> T raise @json.JsonDecodeError {
+  raise JsonDecodeError((path, message))
+}
+
+///|
+fn expect_object(
+  json : Json,
+  path : @json.JsonPath,
+) -> Map[String, Json] raise @json.JsonDecodeError {
+  match json {
+    Object(fields) => fields
+    _ => json_decode_error(path, "expected object")
+  }
+}
+
+///|
+fn string_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> String raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(String(value)) => value
+    Some(_) => json_decode_error(path.add_key(key), "expected string")
+    None => json_decode_error(path.add_key(key), "expected string")
+  }
+}
+
+///|
+fn int_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> Int raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(Number(value, ..)) => value.to_int()
+    Some(_) => json_decode_error(path.add_key(key), "expected int")
+    None => json_decode_error(path.add_key(key), "expected int")
+  }
+}
+
+///|
+pub impl ToJson for SessionId with fn to_json(id : SessionId) -> Json {
+  Json::string(id.value())
+}
+
+///|
+pub impl FromJson for SessionId with fn from_json(
+  json : Json,
+  path : @json.JsonPath,
+) -> SessionId {
+  match json {
+    String(value) => SessionId(value)
+    _ => json_decode_error(path, "SessionId: expected string")
+  }
+}
+
+///|
+fn terminal_kind(terminal : TurnTerminal) -> String {
+  match terminal {
+    Finished(_) => "finished"
+    Aborted(_) => "aborted"
+    Interrupted(_) => "interrupted"
+    Failed(_) => "failed"
+  }
+}
+
+///|
+fn terminal_message(terminal : TurnTerminal) -> String {
+  match terminal {
+    Finished(message)
+    | Aborted(message)
+    | Interrupted(message)
+    | Failed(message) => message
+  }
+}
+
+///|
+pub impl ToJson for TurnTerminal with fn to_json(terminal : TurnTerminal) -> Json {
+  { "kind": terminal_kind(terminal), "message": terminal_message(terminal) }
+}
+
+///|
+pub impl FromJson for TurnTerminal with fn from_json(
+  json : Json,
+  path : @json.JsonPath,
+) -> TurnTerminal {
+  let fields = expect_object(json, path)
+  let message = string_field(fields, path, "message")
+  match string_field(fields, path, "kind") {
+    "finished" => Finished(message)
+    "aborted" => Aborted(message)
+    "interrupted" => Interrupted(message)
+    "failed" => Failed(message)
+    other =>
+      json_decode_error(path.add_key("kind"), "unknown terminal kind: \{other}")
+  }
+}
+
+///|
+fn item_payload(item : SessionItem) -> (String, Json) {
+  match item {
+    User(message) => ("user", message.to_json())
+    Assistant(message) => ("assistant", message.to_json())
+    Tool(result) => ("tool_result", result.to_json())
+    Runtime(notice) => ("runtime_notice", notice.to_json())
+    Summary(summary) => ("summary", summary.to_json())
+    Terminal(terminal) => ("terminal", terminal.to_json())
+  }
+}
+
+///|
+pub impl ToJson for SessionItem with fn to_json(item : SessionItem) -> Json {
+  let (kind, payload) = item_payload(item)
+  { "kind": kind, "payload": payload }
+}
+
+///|
+pub impl FromJson for SessionItem with fn from_json(
+  json : Json,
+  path : @json.JsonPath,
+) -> SessionItem {
+  let fields = expect_object(json, path)
+  let payload = match fields.get("payload") {
+    Some(payload) => payload
+    None => json_decode_error(path.add_key("payload"), "expected payload")
+  }
+  match string_field(fields, path, "kind") {
+    "user" => User(@json.from_json(payload, path=path.add_key("payload")))
+    "assistant" =>
+      Assistant(@json.from_json(payload, path=path.add_key("payload")))
+    "tool_result" =>
+      Tool(@json.from_json(payload, path=path.add_key("payload")))
+    "runtime_notice" =>
+      Runtime(@json.from_json(payload, path=path.add_key("payload")))
+    "summary" => Summary(@json.from_json(payload, path=path.add_key("payload")))
+    "terminal" =>
+      Terminal(@json.from_json(payload, path=path.add_key("payload")))
+    other =>
+      json_decode_error(
+        path.add_key("kind"),
+        "unknown session item kind: \{other}",
+      )
+  }
+}
+
+///|
+pub impl ToJson for Session with fn to_json(session : Session) -> Json {
+  {
+    "version": 1,
+    "id": session.id(),
+    "system_prompt": session.system_prompt(),
+    "events": ([ for event in session.events() => event ] : Json),
+  }
+}
+
+///|
+pub impl FromJson for Session with fn from_json(
+  json : Json,
+  path : @json.JsonPath,
+) -> Session {
+  let fields = expect_object(json, path)
+  match int_field(fields, path, "version") {
+    1 => ()
+    other =>
+      json_decode_error(
+        path.add_key("version"),
+        "unsupported session version: \{other}",
+      )
+  }
+  let id : SessionId = match fields.get("id") {
+    Some(id) => @json.from_json(id, path=path.add_key("id"))
+    None => json_decode_error(path.add_key("id"), "expected id")
+  }
+  let events : Array[SessionEvent] = match fields.get("events") {
+    Some(Array(values)) => {
+      let decoded : Array[SessionEvent] = []
+      for index, value in values {
+        decoded.push(
+          @json.from_json(value, path=path.add_key("events").add_index(index)),
+        )
+      }
+      decoded
+    }
+    Some(_) =>
+      json_decode_error(path.add_key("events"), "expected events array")
+    None => []
+  }
+  Session(
+    id,
+    system_prompt=string_field(fields, path, "system_prompt"),
+    events~,
+  )
+}

--- a/agent_session/moon.pkg
+++ b/agent_session/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/json",
+}
+
+warnings = "+unnecessary_annotation"

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -1,0 +1,100 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_session"
+
+import {
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct AssistantMessage {
+  // private fields
+} derive(ToJson, @debug.Debug, @json.FromJson)
+pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.ToolCall], reasoning_content? : String) -> Self
+pub fn AssistantMessage::content(Self) -> String
+
+pub struct RuntimeNotice {
+  // private fields
+} derive(ToJson, @debug.Debug, @json.FromJson)
+pub fn RuntimeNotice::RuntimeNotice(String) -> Self
+pub fn RuntimeNotice::content(Self) -> String
+
+pub struct Session {
+  // private fields
+} derive(@debug.Debug)
+pub fn Session::Session(SessionId, system_prompt~ : String, events? : Array[SessionEvent]) -> Self
+pub fn Session::append(Self, SessionItem) -> Self
+pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
+pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self raise
+pub fn Session::events(Self) -> Array[SessionEvent]
+pub fn Session::id(Self) -> SessionId
+pub fn Session::last_sequence(Self) -> Int
+pub fn Session::system_prompt(Self) -> String
+pub impl ToJson for Session
+pub impl @json.FromJson for Session
+
+pub struct SessionEvent {
+  // private fields
+} derive(ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionEvent::item(Self) -> SessionItem
+pub fn SessionEvent::sequence(Self) -> Int
+
+pub struct SessionId {
+  // private fields
+} derive(@debug.Debug)
+pub fn SessionId::SessionId(String) -> Self
+pub fn SessionId::value(Self) -> String
+pub impl ToJson for SessionId
+pub impl @json.FromJson for SessionId
+
+pub(all) enum SessionItem {
+  User(UserMessage)
+  Assistant(AssistantMessage)
+  Tool(ToolResult)
+  Runtime(RuntimeNotice)
+  Summary(SessionSummary)
+  Terminal(TurnTerminal)
+} derive(@debug.Debug)
+pub impl ToJson for SessionItem
+pub impl @json.FromJson for SessionItem
+
+pub struct SessionSummary {
+  // private fields
+} derive(ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionSummary::SessionSummary(content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self
+pub fn SessionSummary::content(Self) -> String
+pub fn SessionSummary::from_sequence(Self) -> Int
+pub fn SessionSummary::to_sequence(Self) -> Int
+
+pub struct ToolResult {
+  // private fields
+} derive(ToJson, @debug.Debug, @json.FromJson)
+pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool) -> Self
+pub fn ToolResult::content(Self) -> String
+pub fn ToolResult::is_error(Self) -> Bool
+pub fn ToolResult::tool_name(Self) -> String
+
+pub(all) enum TurnTerminal {
+  Finished(String)
+  Aborted(String)
+  Interrupted(String)
+  Failed(String)
+} derive(@debug.Debug)
+pub impl ToJson for TurnTerminal
+pub impl @json.FromJson for TurnTerminal
+
+pub struct UserMessage {
+  // private fields
+} derive(ToJson, @debug.Debug, @json.FromJson)
+pub fn UserMessage::UserMessage(String) -> Self
+pub fn UserMessage::content(Self) -> String
+
+// Type aliases
+
+// Traits
+

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -1,0 +1,144 @@
+///|
+fn summary_model_content(summary : SessionSummary) -> String {
+  (
+    $|[conversation summary]
+    $|source_events=\{summary.from_sequence()}..\{summary.to_sequence()}
+    $|\{summary.content()}
+  )
+}
+
+///|
+fn terminal_model_message(terminal : TurnTerminal) -> String? {
+  match terminal {
+    Finished(answer) if !answer.trim().is_empty() => Some(answer)
+    Finished(_) => None
+    Aborted(reason) if !reason.trim().is_empty() =>
+      Some("[agent aborted]\n\{reason}")
+    Aborted(_) => Some("[agent aborted]")
+    Interrupted(reason) if !reason.trim().is_empty() =>
+      Some("[agent interrupted]\n\{reason}")
+    Interrupted(_) => Some("[agent interrupted]")
+    Failed(message) if !message.trim().is_empty() =>
+      Some("[agent failed]\n\{message}")
+    Failed(_) => Some("[agent failed]")
+  }
+}
+
+///|
+fn append_item_message(
+  item : SessionItem,
+  messages : Array[@deepseek.ChatMessage],
+) -> Unit {
+  match item {
+    User(message) => messages.push(ChatMessage(User, content=message.content()))
+    Runtime(notice) =>
+      messages.push(ChatMessage(User, content=notice.content()))
+    Summary(summary) =>
+      messages.push(ChatMessage(User, content=summary_model_content(summary)))
+    Assistant(message) =>
+      messages.push(
+        ChatMessage(
+          Assistant,
+          content=message.content(),
+          tool_calls=message.tool_calls(),
+          reasoning_content?=message.reasoning_content(),
+        ),
+      )
+    Tool(result) =>
+      messages.push(
+        ChatMessage(Tool(result.tool_call_id()), content=result.content()),
+      )
+    Terminal(terminal) =>
+      if terminal_model_message(terminal) is Some(content) {
+        messages.push(ChatMessage(Assistant, content~))
+      }
+  }
+}
+
+///|
+fn remove_pending_tool_call(
+  pending : Array[@deepseek.ToolCall],
+  tool_call_id : String,
+) -> Bool {
+  for index in 0..<pending.length() {
+    if pending[index].id == tool_call_id {
+      ignore(pending.remove(index))
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn flush_pending_tool_calls(
+  pending : Array[@deepseek.ToolCall],
+  messages : Array[@deepseek.ChatMessage],
+) -> Unit {
+  for call in pending {
+    messages.push(
+      ChatMessage(
+        Tool(call.id),
+        content="error: previous agent process exited before recording a result for tool \{call.name}",
+      ),
+    )
+  }
+  pending.clear()
+}
+
+///|
+fn summary_covers_event(summary_event : SessionEvent, sequence : Int) -> Bool {
+  guard summary_event.item() is Summary(summary) else { return false }
+  summary_event.sequence() > sequence &&
+  summary.from_sequence() <= sequence &&
+  sequence <= summary.to_sequence()
+}
+
+///|
+fn is_covered_by_later_summary(
+  event : SessionEvent,
+  events : Array[SessionEvent],
+) -> Bool {
+  for candidate in events {
+    if summary_covers_event(candidate, event.sequence()) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Project this durable session into the typed DeepSeek chat message array used
+/// by the model client. Summary events compact the model-facing context: any
+/// earlier event in a later summary's source range is skipped, while the raw
+/// event stays in the durable session log.
+pub fn Session::chat_messages(self : Session) -> Array[@deepseek.ChatMessage] {
+  let messages : Array[@deepseek.ChatMessage] = [
+    ChatMessage(System, content=self.system_prompt()),
+  ]
+  let pending_tool_calls : Array[@deepseek.ToolCall] = []
+  let events = self.events()
+  for event in events {
+    if is_covered_by_later_summary(event, events) {
+      continue
+    }
+    match event.item() {
+      Assistant(message) => {
+        flush_pending_tool_calls(pending_tool_calls, messages)
+        append_item_message(Assistant(message), messages)
+        for call in message.tool_calls() {
+          pending_tool_calls.push(call)
+        }
+      }
+      Tool(result) =>
+        if remove_pending_tool_call(pending_tool_calls, result.tool_call_id()) {
+          append_item_message(Tool(result), messages)
+        }
+      item => {
+        flush_pending_tool_calls(pending_tool_calls, messages)
+        append_item_message(item, messages)
+      }
+    }
+  }
+  flush_pending_tool_calls(pending_tool_calls, messages)
+  messages
+}

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -1,0 +1,201 @@
+///|
+fn sample_tool_call() -> @deepseek.ToolCall {
+  ToolCall(id="call_1", name="read", arguments="{\"path\":\"README.md\"}")
+}
+
+///|
+test "session append assigns monotonic sequence numbers immutably" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let next = session.append(User(UserMessage("hello")))
+  assert_eq(session.events().length(), 0)
+  assert_eq(next.events().length(), 1)
+  assert_eq(next.events()[0].sequence(), 1)
+  let after = next.append(Terminal(Finished("done")))
+  assert_eq(after.events()[1].sequence(), 2)
+  assert_eq(after.last_sequence(), 2)
+}
+
+///|
+test "session projects to DeepSeek chat messages" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("inspect")))
+    .append(
+      Assistant(
+        AssistantMessage(
+          "",
+          tool_calls=[sample_tool_call()],
+          reasoning_content="need file",
+        ),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(tool_call_id="call_1", tool_name="read", content="README"),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let messages = session.chat_messages()
+  assert_eq(messages.length(), 5)
+  assert_true(messages[0].role is System)
+  assert_eq(messages[0].content, "system")
+  assert_true(messages[1].role is User)
+  assert_eq(messages[1].content, "inspect")
+  assert_true(messages[2].role is Assistant)
+  assert_eq(messages[2].content, "")
+  assert_true(messages[2].reasoning_content is Some("need file"))
+  assert_eq(messages[2].tool_calls.length(), 1)
+  assert_eq(messages[2].tool_calls[0].id, "call_1")
+  assert_eq(messages[2].tool_calls[0].name, "read")
+  assert_eq(messages[2].tool_calls[0].arguments, "{\"path\":\"README.md\"}")
+  assert_true(messages[3].role is Tool("call_1"))
+  assert_eq(messages[3].content, "README")
+  assert_true(messages[4].role is Assistant)
+  assert_eq(messages[4].content, "done")
+}
+
+///|
+test "session JSON round trips typed events" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("hello")))
+    .append(Runtime(RuntimeNotice("[moon_check update]\nok")))
+    .append(
+      Summary(
+        SessionSummary(
+          content="we inspected files",
+          from_sequence=1,
+          to_sequence=2,
+        ),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let encoded = session.to_json()
+  let decoded : @agent_session.Session = @json.from_json(encoded)
+  assert_eq(decoded.id().value(), "s1")
+  assert_eq(decoded.system_prompt(), "system")
+  assert_eq(decoded.events().length(), 4)
+  assert_eq(decoded.events()[3].sequence(), 4)
+  guard decoded.events()[2].item() is Summary(summary) else {
+    fail("expected summary")
+  }
+  assert_eq(summary.from_sequence(), 1)
+  assert_eq(summary.to_sequence(), 2)
+  assert_eq(summary.content(), "we inspected files")
+}
+
+///|
+test "projection closes unresolved historical tool calls" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(Assistant(AssistantMessage("", tool_calls=[sample_tool_call()])))
+    .append(User(UserMessage("continue")))
+  let messages = session.chat_messages()
+  assert_eq(messages.length(), 4)
+  assert_true(messages[1].role is Assistant)
+  assert_eq(messages[1].tool_calls.length(), 1)
+  assert_true(messages[2].role is Tool("call_1"))
+  assert_true(messages[2].content.contains("previous agent process exited"))
+  assert_true(messages[3].role is User)
+  assert_eq(messages[3].content, "continue")
+}
+
+///|
+test "projection skips compacted assistant tool results" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("inspect")))
+    .append(Assistant(AssistantMessage("", tool_calls=[sample_tool_call()])))
+    .append(
+      Tool(
+        ToolResult(tool_call_id="call_1", tool_name="read", content="README"),
+      ),
+    )
+    .append(
+      Summary(
+        SessionSummary(
+          content="assistant inspected README",
+          from_sequence=2,
+          to_sequence=2,
+        ),
+      ),
+    )
+  let messages = session.chat_messages()
+  assert_eq(messages.length(), 3)
+  assert_true(messages[1].role is User)
+  assert_eq(messages[1].content, "inspect")
+  assert_true(messages[2].role is User)
+  assert_true(messages[2].content.contains("assistant inspected README"))
+}
+
+///|
+test "summary events compact covered model context" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("old user")))
+    .append(Assistant(AssistantMessage("old assistant")))
+    .append(User(UserMessage("recent user")))
+    .append(
+      Summary(
+        SessionSummary(
+          content="old user and assistant discussed README",
+          from_sequence=1,
+          to_sequence=2,
+        ),
+      ),
+    )
+  assert_eq(session.events().length(), 4)
+  let messages = session.chat_messages()
+  assert_eq(messages.length(), 3)
+  assert_true(messages[1].role is User)
+  assert_eq(messages[1].content, "recent user")
+  assert_true(messages[2].role is User)
+  assert_true(messages[2].content.contains("[conversation summary]"))
+  assert_false(messages[2].content.contains("old user\n"))
+  assert_true(messages[2].content.contains("old user and assistant"))
+}
+
+///|
+test "later summary supersedes earlier summary in model context" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(
+      Summary(
+        SessionSummary(content="first summary", from_sequence=1, to_sequence=1),
+      ),
+    )
+    .append(
+      Summary(
+        SessionSummary(
+          content="superseding summary",
+          from_sequence=1,
+          to_sequence=2,
+        ),
+      ),
+    )
+  let messages = session.chat_messages()
+  assert_eq(messages.length(), 2)
+  assert_true(messages[1].content.contains("superseding summary"))
+  assert_false(messages[1].content.contains("first summary"))
+}
+
+///|
+test "compact validates and appends summary event" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(Assistant(AssistantMessage("second")))
+  let compacted = session.compact(
+    content="first two events",
+    from_sequence=1,
+    to_sequence=2,
+  )
+  assert_eq(compacted.events().length(), 3)
+  guard compacted.events()[2].item() is Summary(summary) else {
+    fail("expected summary")
+  }
+  assert_eq(summary.content(), "first two events")
+  assert_eq(summary.from_sequence(), 1)
+  assert_eq(summary.to_sequence(), 2)
+  let _ = session.compact(content="", from_sequence=1, to_sequence=2) catch {
+    error => {
+      assert_true("\{error}".contains("content must not be empty"))
+      return
+    }
+  }
+  fail("empty summary accepted")
+}

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -1,0 +1,311 @@
+///|
+/// Stable identifier for a persisted OpenSeek conversation.
+pub struct SessionId {
+  priv value : String
+} derive(Debug)
+
+///|
+pub fn SessionId::SessionId(value : String) -> SessionId {
+  { value, }
+}
+
+///|
+pub fn SessionId::value(self : SessionId) -> String {
+  self.value
+}
+
+///|
+/// User-authored model input for one conversational turn.
+pub struct UserMessage {
+  priv content : String
+} derive(Debug, ToJson, FromJson)
+
+///|
+priv struct SessionToolCall {
+  id : String
+  name : String
+  arguments : String
+} derive(Debug, ToJson, FromJson)
+
+///|
+fn SessionToolCall::from_deepseek(call : @deepseek.ToolCall) -> SessionToolCall {
+  { id: call.id, name: call.name, arguments: call.arguments }
+}
+
+///|
+fn SessionToolCall::to_deepseek(self : SessionToolCall) -> @deepseek.ToolCall {
+  ToolCall(id=self.id, name=self.name, arguments=self.arguments)
+}
+
+///|
+pub fn UserMessage::UserMessage(content : String) -> UserMessage {
+  { content, }
+}
+
+///|
+pub fn UserMessage::content(self : UserMessage) -> String {
+  self.content
+}
+
+///|
+/// Assistant output returned by the model. Native DeepSeek tool calls are kept
+/// in their typed protocol form so replay can preserve call ids and raw
+/// argument strings exactly.
+pub struct AssistantMessage {
+  priv content : String
+  priv tool_calls : Array[SessionToolCall]
+  priv reasoning_content : String?
+} derive(Debug, ToJson, FromJson)
+
+///|
+pub fn AssistantMessage::AssistantMessage(
+  content : String,
+  tool_calls? : Array[@deepseek.ToolCall] = [],
+  reasoning_content? : String,
+) -> AssistantMessage {
+  {
+    content,
+    tool_calls: [
+      for call in tool_calls => SessionToolCall::from_deepseek(call)
+    ],
+    reasoning_content,
+  }
+}
+
+///|
+pub fn AssistantMessage::content(self : AssistantMessage) -> String {
+  self.content
+}
+
+///|
+fn AssistantMessage::tool_calls(
+  self : AssistantMessage,
+) -> Array[@deepseek.ToolCall] {
+  [
+    for call in self.tool_calls => call.to_deepseek()
+  ]
+}
+
+///|
+fn AssistantMessage::reasoning_content(self : AssistantMessage) -> String? {
+  self.reasoning_content
+}
+
+///|
+/// Result returned by a local tool for one assistant tool call.
+pub struct ToolResult {
+  priv tool_call_id : String
+  priv tool_name : String
+  priv content : String
+  priv is_error : Bool
+} derive(Debug, ToJson, FromJson)
+
+///|
+pub fn ToolResult::ToolResult(
+  tool_call_id~ : String,
+  tool_name~ : String,
+  content~ : String,
+  is_error? : Bool = false,
+) -> ToolResult {
+  { tool_call_id, tool_name, content, is_error }
+}
+
+///|
+fn ToolResult::tool_call_id(self : ToolResult) -> String {
+  self.tool_call_id
+}
+
+///|
+pub fn ToolResult::tool_name(self : ToolResult) -> String {
+  self.tool_name
+}
+
+///|
+pub fn ToolResult::content(self : ToolResult) -> String {
+  self.content
+}
+
+///|
+pub fn ToolResult::is_error(self : ToolResult) -> Bool {
+  self.is_error
+}
+
+///|
+/// Out-of-band runtime update that was surfaced to the model, such as a
+/// `moon_check --watch` diagnostic batch.
+pub struct RuntimeNotice {
+  priv content : String
+} derive(Debug, ToJson, FromJson)
+
+///|
+pub fn RuntimeNotice::RuntimeNotice(content : String) -> RuntimeNotice {
+  { content, }
+}
+
+///|
+pub fn RuntimeNotice::content(self : RuntimeNotice) -> String {
+  self.content
+}
+
+///|
+/// Durable compaction of older session events. The `event_range` names the
+/// inclusive source range summarized so future refactors can verify what was
+/// compacted without depending on string parsing.
+pub struct SessionSummary {
+  priv content : String
+  priv from_sequence : Int
+  priv to_sequence : Int
+} derive(Debug, ToJson, FromJson)
+
+///|
+pub fn SessionSummary::SessionSummary(
+  content~ : String,
+  from_sequence~ : Int,
+  to_sequence~ : Int,
+) -> SessionSummary {
+  { content, from_sequence, to_sequence }
+}
+
+///|
+pub fn SessionSummary::content(self : SessionSummary) -> String {
+  self.content
+}
+
+///|
+pub fn SessionSummary::from_sequence(self : SessionSummary) -> Int {
+  self.from_sequence
+}
+
+///|
+pub fn SessionSummary::to_sequence(self : SessionSummary) -> Int {
+  self.to_sequence
+}
+
+///|
+pub(all) enum TurnTerminal {
+  Finished(String)
+  Aborted(String)
+  Interrupted(String)
+  Failed(String)
+} derive(Debug)
+
+///|
+pub(all) enum SessionItem {
+  User(UserMessage)
+  Assistant(AssistantMessage)
+  Tool(ToolResult)
+  Runtime(RuntimeNotice)
+  Summary(SessionSummary)
+  Terminal(TurnTerminal)
+} derive(Debug)
+
+///|
+/// One append-only session event. Sequence numbers are one-based and monotonic
+/// within a session.
+pub struct SessionEvent {
+  priv sequence : Int
+  priv item : SessionItem
+} derive(Debug, ToJson, FromJson)
+
+///|
+fn SessionEvent::SessionEvent(
+  sequence~ : Int,
+  item~ : SessionItem,
+) -> SessionEvent {
+  { sequence, item }
+}
+
+///|
+pub fn SessionEvent::sequence(self : SessionEvent) -> Int {
+  self.sequence
+}
+
+///|
+pub fn SessionEvent::item(self : SessionEvent) -> SessionItem {
+  self.item
+}
+
+///|
+/// Immutable model of an OpenSeek conversation. Mutating operations return a new
+/// `Session` with copied event storage so callers do not share mutable arrays
+/// across package boundaries.
+pub struct Session {
+  priv id : SessionId
+  priv system_prompt : String
+  priv events : Array[SessionEvent]
+} derive(Debug)
+
+///|
+pub fn Session::Session(
+  id : SessionId,
+  system_prompt~ : String,
+  events? : Array[SessionEvent] = [],
+) -> Session {
+  { id, system_prompt, events: events.copy() }
+}
+
+///|
+pub fn Session::id(self : Session) -> SessionId {
+  self.id
+}
+
+///|
+pub fn Session::system_prompt(self : Session) -> String {
+  self.system_prompt
+}
+
+///|
+pub fn Session::events(self : Session) -> Array[SessionEvent] {
+  self.events.copy()
+}
+
+///|
+pub fn Session::last_sequence(self : Session) -> Int {
+  let mut last = 0
+  for event in self.events {
+    if event.sequence > last {
+      last = event.sequence
+    }
+  }
+  last
+}
+
+///|
+fn Session::next_sequence(self : Session) -> Int {
+  self.last_sequence() + 1
+}
+
+///|
+pub fn Session::append(self : Session, item : SessionItem) -> Session {
+  let events = self.events.copy()
+  events.push(SessionEvent(sequence=self.next_sequence(), item~))
+  Session(self.id, system_prompt=self.system_prompt, events~)
+}
+
+///|
+/// Append a validated summary event that compacts a contiguous range of existing
+/// events in model-facing projection while preserving those events in the
+/// durable append-only log.
+pub fn Session::compact(
+  self : Session,
+  content~ : String,
+  from_sequence~ : Int,
+  to_sequence~ : Int,
+) -> Session raise {
+  if content.trim().is_empty() {
+    fail("summary content must not be empty")
+  }
+  if from_sequence <= 0 {
+    fail("summary from_sequence must be positive")
+  }
+  if to_sequence < from_sequence {
+    fail("summary to_sequence must be >= from_sequence")
+  }
+  let last = self.last_sequence()
+  if to_sequence > last {
+    fail(
+      "summary range \{from_sequence}..\{to_sequence} exceeds last sequence \{last}",
+    )
+  }
+  self.append(Summary(SessionSummary(content~, from_sequence~, to_sequence~)))
+}


### PR DESCRIPTION
Stack: 1/5. Base layer for durable OpenSeek conversations.

This PR adds the pure `agent_session` package:

- typed durable session ids, session items, tool calls, and compaction summaries
- JSON round-tripping for the typed event model
- projection from durable sessions into DeepSeek chat messages
- package docs and blackbox tests

The filesystem store, agent integration, CLI, and TUI changes are intentionally left to later PRs in the stack.

Validation:

- `moon test agent_session --warn-list +73 --diagnostic-limit 300`
- `moon info agent_session --target native`
- `moon fmt agent_session README.mbt.md`
