### PR TITLE
[codex] add filesystem session store

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -13,6 +13,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for DeepSeek chat completions. | `deepseek/client/README.mbt.md` |
 | `bobzhang/openseek/agent_runtime` | Native-only agent task-group and extensible runtime event queue. | `agent_runtime/README.mbt.md` |
 | `bobzhang/openseek/agent_session` | Typed durable conversation state and DeepSeek message projection. | `agent_session/README.mbt.md` |
+| `bobzhang/openseek/agent_session/store` | Native filesystem-backed append-only session store. | `agent_session/store/README.mbt.md` |
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
@@ -51,7 +52,9 @@ event queue used by stateful tools such as `moon_check`.
 The `agent_session` package owns typed durable conversation state, append-only
 session events, JSON round-tripping, and projection from a session into
 DeepSeek chat messages. It is separate from TUI transcript rendering so
-resumable sessions can be type-safe and process-independent.
+resumable sessions can be type-safe and process-independent. The native
+`agent_session/store` package persists those sessions as a small header plus an
+append-only JSONL event log.
 
 The `agent` subpackage contains the OpenSeek agent loop, native DeepSeek
 tool-call handling, and local tool dispatch. It depends on `deepseek/client`,

--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -1,0 +1,22 @@
+# OpenSeek Agent Session Store
+
+`bobzhang/openseek/agent_session/store` is the native filesystem persistence
+layer for typed OpenSeek sessions.
+
+Each session lives under:
+
+```text
+<root>/sessions/<session-id>/
+  session.json
+  events.jsonl
+```
+
+`session.json` stores the small typed header. `events.jsonl` is the append-only
+event log; loading a session replays those typed `SessionEvent` records into an
+immutable `agent_session.Session`.
+
+Use `SessionStore::compact` to append a validated summary event. The covered raw
+events remain in the JSONL log, but `Session::chat_messages` replaces those
+events with the summary when building model context.
+
+Use `SessionStore::list` to enumerate known sessions under the store root.

--- a/agent_session/store/moon.pkg
+++ b/agent_session/store/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "bobzhang/openseek/agent_session",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/os_error",
+  "moonbitlang/core/json",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -1,0 +1,29 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_session/store"
+
+import {
+  "bobzhang/openseek/agent_session",
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct SessionStore {
+  // private fields
+} derive(@debug.Debug)
+pub fn SessionStore::SessionStore(String) -> Self
+pub async fn SessionStore::append(Self, @agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session
+pub async fn SessionStore::compact(Self, @agent_session.Session, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> @agent_session.Session
+pub async fn SessionStore::create(Self, @agent_session.Session) -> Unit
+pub async fn SessionStore::exists(Self, @agent_session.SessionId) -> Bool
+pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]
+pub async fn SessionStore::load(Self, @agent_session.SessionId) -> @agent_session.Session
+pub fn SessionStore::root(Self) -> String
+
+// Type aliases
+
+// Traits
+

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -1,0 +1,337 @@
+///|
+let session_header_version : Int = 1
+
+///|
+let session_dir_name : String = "sessions"
+
+///|
+let header_file_name : String = "session.json"
+
+///|
+let event_log_file_name : String = "events.jsonl"
+
+///|
+priv struct SessionHeader {
+  id : @agent_session.SessionId
+  system_prompt : String
+  last_sequence : Int
+}
+
+///|
+/// Native filesystem-backed store for durable OpenSeek sessions. The store owns
+/// a root directory and keeps each session under `root/sessions/<id>`.
+pub struct SessionStore {
+  priv root : String
+} derive(Debug)
+
+///|
+pub fn SessionStore::SessionStore(root : String) -> SessionStore {
+  { root, }
+}
+
+///|
+pub fn SessionStore::root(self : SessionStore) -> String {
+  self.root
+}
+
+///|
+fn validate_session_id(id : @agent_session.SessionId) -> Unit raise {
+  let value = id.value()
+  if value == "" {
+    fail("session id must not be empty")
+  }
+  if value.contains("/") || value.contains("\\") {
+    fail("session id must not contain path separators: \{value}")
+  }
+  if value == "." || value == ".." {
+    fail("session id must not be `.` or `..`")
+  }
+}
+
+///|
+fn SessionStore::sessions_dir(self : SessionStore) -> String {
+  self.root + "/" + session_dir_name
+}
+
+///|
+fn SessionStore::session_dir(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  validate_session_id(id)
+  self.sessions_dir() + "/" + id.value()
+}
+
+///|
+fn SessionStore::header_path(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  self.session_dir(id) + "/" + header_file_name
+}
+
+///|
+fn SessionStore::event_log_path(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  self.session_dir(id) + "/" + event_log_file_name
+}
+
+///|
+fn session_header_json(session : @agent_session.Session) -> Json {
+  {
+    "version": session_header_version,
+    "id": session.id(),
+    "system_prompt": session.system_prompt(),
+    "last_sequence": session.last_sequence(),
+  }
+}
+
+///|
+fn[T] json_decode_error(
+  path : @json.JsonPath,
+  message : String,
+) -> T raise @json.JsonDecodeError {
+  raise JsonDecodeError((path, message))
+}
+
+///|
+fn header_string_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> String raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(String(value)) => value
+    Some(_) => json_decode_error(path.add_key(key), "expected string")
+    None => json_decode_error(path.add_key(key), "expected string")
+  }
+}
+
+///|
+fn header_int_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> Int raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(Number(value, ..)) => value.to_int()
+    Some(_) => json_decode_error(path.add_key(key), "expected int")
+    None => json_decode_error(path.add_key(key), "expected int")
+  }
+}
+
+///|
+fn decode_session_header(
+  json : Json,
+  path : @json.JsonPath,
+) -> SessionHeader raise @json.JsonDecodeError {
+  let fields = match json {
+    Object(fields) => fields
+    _ => json_decode_error(path, "expected session header object")
+  }
+  match header_int_field(fields, path, "version") {
+    1 => ()
+    other =>
+      json_decode_error(
+        path.add_key("version"),
+        "unsupported session header version: \{other}",
+      )
+  }
+  let id : @agent_session.SessionId = match fields.get("id") {
+    Some(id) => @json.from_json(id, path=path.add_key("id"))
+    None => json_decode_error(path.add_key("id"), "expected id")
+  }
+  {
+    id,
+    system_prompt: header_string_field(fields, path, "system_prompt"),
+    last_sequence: header_int_field(fields, path, "last_sequence"),
+  }
+}
+
+///|
+impl FromJson for SessionHeader with fn from_json(
+  json : Json,
+  path : @json.JsonPath,
+) -> SessionHeader {
+  decode_session_header(json, path)
+}
+
+///|
+fn events_jsonl(events : Array[@agent_session.SessionEvent]) -> String {
+  let builder = StringBuilder::new()
+  for event in events {
+    builder.write_string(event.to_json().stringify())
+    builder.write_string("\n")
+  }
+  builder.to_string()
+}
+
+///|
+fn parse_events_jsonl(
+  text : String,
+) -> Array[@agent_session.SessionEvent] raise {
+  let events : Array[@agent_session.SessionEvent] = []
+  for line in text.split("\n") {
+    if line.trim().is_empty() {
+      continue
+    }
+    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line))
+    events.push(event)
+  }
+  events
+}
+
+///|
+async fn write_header(
+  store : SessionStore,
+  session : @agent_session.Session,
+) -> Unit {
+  @fs.write_file(
+    store.header_path(session.id()),
+    session_header_json(session).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+}
+
+///|
+async fn write_event_log(
+  store : SessionStore,
+  session : @agent_session.Session,
+) -> Unit {
+  @fs.write_file(
+    store.event_log_path(session.id()),
+    events_jsonl(session.events()),
+    create_mode=CreateOrTruncate,
+  )
+}
+
+///|
+async fn append_event(
+  store : SessionStore,
+  session : @agent_session.Session,
+  event : @agent_session.SessionEvent,
+) -> Unit {
+  @fs.write_file(
+    store.event_log_path(session.id()),
+    event.to_json().stringify() + "\n",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+}
+
+///|
+async fn read_event_log_text(path : String) -> String {
+  @fs.read_file(path).text() catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => ""
+    error => raise error
+  }
+}
+
+///|
+async fn ensure_session_dir(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+) -> Unit {
+  let dir = store.session_dir(id)
+  if @fs.exists(dir) {
+    return
+  }
+  @fs.mkdir(dir, recursive=true) catch {
+    error => if @fs.exists(dir) { () } else { raise error }
+  }
+}
+
+///|
+/// Return whether a session directory exists. Invalid session ids raise rather
+/// than being silently treated as absent.
+pub async fn SessionStore::exists(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> Bool {
+  @fs.exists(self.session_dir(id))
+}
+
+///|
+/// List known session ids under this store. Missing stores are treated as empty.
+pub async fn SessionStore::list(
+  self : SessionStore,
+) -> Array[@agent_session.SessionId] {
+  let names = @fs.readdir(self.sessions_dir(), sort=true) catch { _ => [] }
+  [
+    for name in names if name != "." && name != ".." => SessionId(name)
+  ]
+}
+
+///|
+/// Persist a complete session, replacing any previous header and event log for
+/// the same id. Use this for new sessions or deliberate rewrites; ordinary
+/// agent progress should use `append`.
+pub async fn SessionStore::create(
+  self : SessionStore,
+  session : @agent_session.Session,
+) -> Unit {
+  ensure_session_dir(self, session.id())
+  write_header(self, session)
+  write_event_log(self, session)
+}
+
+///|
+/// Load a session by reading its header and replaying the append-only event log.
+pub async fn SessionStore::load(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> @agent_session.Session {
+  let header : SessionHeader = @json.from_json(
+    @json.parse(@fs.read_file(self.header_path(id)).text()),
+  )
+  if header.id.value() != id.value() {
+    fail(
+      "session header id mismatch: requested \{id.value()}, found \{header.id.value()}",
+    )
+  }
+  ignore(header.last_sequence)
+  let events_text = read_event_log_text(self.event_log_path(id))
+  Session(
+    header.id,
+    system_prompt=header.system_prompt,
+    events=parse_events_jsonl(events_text),
+  )
+}
+
+///|
+/// Append one typed item to the session's event log and update the header.
+/// Returns the new in-memory session value.
+pub async fn SessionStore::append(
+  self : SessionStore,
+  session : @agent_session.Session,
+  item : @agent_session.SessionItem,
+) -> @agent_session.Session {
+  let next = session.append(item)
+  let events = next.events()
+  guard events.length() > 0 else { return next }
+  ensure_session_dir(self, next.id())
+  append_event(self, next, events[events.length() - 1])
+  write_header(self, next)
+  next
+}
+
+///|
+/// Append a validated summary event to the durable session log. The raw covered
+/// events remain in `events.jsonl`; model-facing projection compacts them.
+pub async fn SessionStore::compact(
+  self : SessionStore,
+  session : @agent_session.Session,
+  content~ : String,
+  from_sequence~ : Int,
+  to_sequence~ : Int,
+) -> @agent_session.Session {
+  let next = session.compact(content~, from_sequence~, to_sequence~)
+  let events = next.events()
+  guard events.length() > 0 else { return next }
+  ensure_session_dir(self, next.id())
+  append_event(self, next, events[events.length() - 1])
+  write_header(self, next)
+  next
+}

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -1,0 +1,121 @@
+///|
+async fn new_store() -> @store.SessionStore {
+  let root = @fs.tmpdir(prefix="openseek-session-store-")
+  SessionStore(root)
+}
+
+///|
+async test "store creates and loads a session from header and event log" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("hello")))
+    .append(Terminal(Finished("done")))
+  store.create(session)
+  assert_true(store.exists(SessionId("s1")))
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.id().value(), "s1")
+  assert_eq(loaded.system_prompt(), "system")
+  assert_eq(loaded.events().length(), 2)
+  assert_eq(loaded.last_sequence(), 2)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store lists known sessions" {
+  let store = new_store()
+  assert_eq(store.list().length(), 0)
+  store.create(Session(SessionId("b"), system_prompt="system"))
+  store.create(Session(SessionId("a"), system_prompt="system"))
+  let ids = [ for id in store.list() => id.value() ]
+  assert_eq(ids.length(), 2)
+  assert_eq(ids[0], "a")
+  assert_eq(ids[1], "b")
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store appends one event without rewriting the in-memory caller value" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  store.create(session)
+  let next = store.append(session, User(UserMessage("first")))
+  assert_eq(session.events().length(), 0)
+  assert_eq(next.events().length(), 1)
+  let after = store.append(next, Runtime(RuntimeNotice("update")))
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(after.events().length(), 2)
+  assert_eq(loaded.events().length(), 2)
+  guard loaded.events()[1].item() is Runtime(notice) else {
+    fail("expected runtime notice")
+  }
+  assert_eq(notice.content(), "update")
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store loads an empty session when the event log is missing" {
+  let store = new_store()
+  store.create(Session(SessionId("s1"), system_prompt="system"))
+  @fs.remove(store.root() + "/sessions/s1/events.jsonl")
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.events().length(), 0)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store propagates unreadable event logs instead of dropping history" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("hello")),
+  )
+  store.create(session)
+  let event_log = store.root() + "/sessions/s1/events.jsonl"
+  @fs.remove(event_log)
+  @fs.mkdir(event_log)
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}" != "")
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("unreadable event log was silently accepted")
+}
+
+///|
+async test "store rejects path-like session ids" {
+  let store = new_store()
+  let _ = store.exists(SessionId("../bad")) catch {
+    error => {
+      assert_true("\{error}".contains("path separators"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  fail("invalid session id accepted")
+}
+
+///|
+async test "store compacts by appending a durable summary" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(Assistant(AssistantMessage("second")))
+  store.create(session)
+  let compacted = store.compact(
+    session,
+    content="first two events",
+    from_sequence=1,
+    to_sequence=2,
+  )
+  assert_eq(compacted.events().length(), 3)
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.events().length(), 3)
+  guard loaded.events()[2].item() is Summary(summary) else {
+    fail("expected summary")
+  }
+  assert_eq(summary.content(), "first two events")
+  assert_eq(loaded.chat_messages().length(), 2)
+  @fs.rmdir(store.root(), recursive=true)
+}


### PR DESCRIPTION
Stack: 2/5. Depends on #51 (`codex/session-core`).

This PR adds the native filesystem-backed session store:

- append-only `events.jsonl` plus typed `session.json` header
- load/create/list/append helpers for durable sessions
- store package docs and tests
- top-level README entries for the core and store packages

Agent, CLI, and TUI behavior are left to later PRs in the stack.

Validation:

- `moon test agent_session agent_session/store --warn-list +73 --diagnostic-limit 300`
- `moon info agent_session agent_session/store --target native`
- `moon fmt agent_session README.mbt.md`
