### PR TITLE
[codex] use immutable vector for session events

### DIFF
--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -8,10 +8,12 @@ messages, while transcript values are optimized for terminal rendering.
 The package exposes:
 
 - `SessionId` and immutable `Session`
-- append-only `SessionEvent` sequence numbers
+- append-only `SessionEvent` sequence numbers backed by an immutable vector
 - typed `SessionItem` variants for users, assistants, tool results, runtime
   notices, summaries, and turn terminal states
 - JSON round-tripping for durable storage
+- `Session::append_event` for callers that need the new session and appended
+  event without scanning the whole event log
 - `Session::chat_messages` for projecting a session into DeepSeek protocol
   messages
 - `Session::compact` for appending a validated summary that replaces covered

--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -154,7 +154,7 @@ pub impl ToJson for Session with fn to_json(session : Session) -> Json {
     "version": 1,
     "id": session.id(),
     "system_prompt": session.system_prompt(),
-    "events": ([ for event in session.events() => event ] : Json),
+    "events": session.events().to_json(),
   }
 }
 
@@ -176,7 +176,7 @@ pub impl FromJson for Session with fn from_json(
     Some(id) => @json.from_json(id, path=path.add_key("id"))
     None => json_decode_error(path.add_key("id"), "expected id")
   }
-  let events : Array[SessionEvent] = match fields.get("events") {
+  let events = match fields.get("events") {
     Some(Array(values)) => {
       let decoded : Array[SessionEvent] = []
       for index, value in values {
@@ -184,11 +184,11 @@ pub impl FromJson for Session with fn from_json(
           @json.from_json(value, path=path.add_key("events").add_index(index)),
         )
       }
-      decoded
+      @vector.from_array(decoded)
     }
     Some(_) =>
       json_decode_error(path.add_key("events"), "expected events array")
-    None => []
+    None => @vector.new()
   }
   Session(
     id,

--- a/agent_session/moon.pkg
+++ b/agent_session/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/deepseek",
+  "moonbitlang/core/immut/vector",
   "moonbitlang/core/json",
 }
 

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "bobzhang/openseek/agent_session"
 import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/core/debug",
+  "moonbitlang/core/immut/vector",
   "moonbitlang/core/json",
 }
 
@@ -27,11 +28,12 @@ pub fn RuntimeNotice::content(Self) -> String
 pub struct Session {
   // private fields
 } derive(@debug.Debug)
-pub fn Session::Session(SessionId, system_prompt~ : String, events? : Array[SessionEvent]) -> Self
+pub fn Session::Session(SessionId, system_prompt~ : String, events? : @vector.Vector[SessionEvent]) -> Self
 pub fn Session::append(Self, SessionItem) -> Self
+pub fn Session::append_event(Self, SessionItem) -> (Self, SessionEvent)
 pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
 pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self raise
-pub fn Session::events(Self) -> Array[SessionEvent]
+pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int
 pub fn Session::system_prompt(Self) -> String

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -96,7 +96,7 @@ fn summary_covers_event(summary_event : SessionEvent, sequence : Int) -> Bool {
 ///|
 fn is_covered_by_later_summary(
   event : SessionEvent,
-  events : Array[SessionEvent],
+  events : @vector.Vector[SessionEvent],
 ) -> Bool {
   for candidate in events {
     if summary_covers_event(candidate, event.sequence()) {

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -16,6 +16,17 @@ test "session append assigns monotonic sequence numbers immutably" {
 }
 
 ///|
+test "session append_event returns the durable event" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let (next, event) = session.append_event(User(UserMessage("hello")))
+  assert_eq(session.events().length(), 0)
+  assert_eq(next.events().length(), 1)
+  assert_eq(event.sequence(), 1)
+  assert_true(event.item() is User(_))
+  assert_eq(next.events()[0].sequence(), event.sequence())
+}
+
+///|
 test "session projects to DeepSeek chat messages" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("inspect")))

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -227,21 +227,28 @@ pub fn SessionEvent::item(self : SessionEvent) -> SessionItem {
 
 ///|
 /// Immutable model of an OpenSeek conversation. Mutating operations return a new
-/// `Session` with copied event storage so callers do not share mutable arrays
-/// across package boundaries.
+/// `Session` backed by persistent event storage, so appending does not copy the
+/// whole event log.
 pub struct Session {
   priv id : SessionId
   priv system_prompt : String
-  priv events : Array[SessionEvent]
+  priv events : @vector.Vector[SessionEvent]
+  priv last_sequence : Int
 } derive(Debug)
 
 ///|
 pub fn Session::Session(
   id : SessionId,
   system_prompt~ : String,
-  events? : Array[SessionEvent] = [],
+  events? : @vector.Vector[SessionEvent] = @vector.new(),
 ) -> Session {
-  { id, system_prompt, events: events.copy() }
+  let mut last_sequence = 0
+  for event in events {
+    if event.sequence > last_sequence {
+      last_sequence = event.sequence
+    }
+  }
+  { id, system_prompt, events, last_sequence }
 }
 
 ///|
@@ -255,19 +262,13 @@ pub fn Session::system_prompt(self : Session) -> String {
 }
 
 ///|
-pub fn Session::events(self : Session) -> Array[SessionEvent] {
-  self.events.copy()
+pub fn Session::events(self : Session) -> @vector.Vector[SessionEvent] {
+  self.events
 }
 
 ///|
 pub fn Session::last_sequence(self : Session) -> Int {
-  let mut last = 0
-  for event in self.events {
-    if event.sequence > last {
-      last = event.sequence
-    }
-  }
-  last
+  self.last_sequence
 }
 
 ///|
@@ -277,9 +278,28 @@ fn Session::next_sequence(self : Session) -> Int {
 
 ///|
 pub fn Session::append(self : Session, item : SessionItem) -> Session {
-  let events = self.events.copy()
-  events.push(SessionEvent(sequence=self.next_sequence(), item~))
-  Session(self.id, system_prompt=self.system_prompt, events~)
+  let (next, _) = self.append_event(item)
+  next
+}
+
+///|
+/// Append one item and return both the new session value and the event that was
+/// appended. This lets durable stores write the new event without converting the
+/// whole immutable vector back to an array.
+pub fn Session::append_event(
+  self : Session,
+  item : SessionItem,
+) -> (Session, SessionEvent) {
+  let event = SessionEvent(sequence=self.next_sequence(), item~)
+  (
+    {
+      id: self.id,
+      system_prompt: self.system_prompt,
+      events: self.events.push(event),
+      last_sequence: event.sequence,
+    },
+    event,
+  )
 }
 
 ///|


### PR DESCRIPTION
This PR changes `agent_session.Session` to use persistent immutable event storage.

What changed:

- Adds `moonbitlang/core/immut/vector` to `agent_session`.
- Stores session events as `@vector.Vector[SessionEvent]` instead of copying `Array[SessionEvent]` on every append.
- Changes the visible `Session::events()` API to return `@vector.Vector[SessionEvent]`.
- Changes the `Session` constructor `events?` parameter to accept a vector.
- Caches `last_sequence` inside `Session` so sequence lookup stays O(1) after construction.
- Adds `Session::append_event`, which returns both the updated session and the appended event for future durable stores that need to write the new event without scanning/converting the full event log.
- Keeps the JSON wire format unchanged: sessions still encode/decode the same `events` JSON array.

Why:

The old implementation was API-immutable but copied the entire event array on every append. Continuous/resumable dialogs are append-heavy, so that shape becomes O(n^2) over long sessions. A persistent vector preserves immutable session semantics while making appends suitable for long-lived conversations.

Compatibility:

This is an intentional API change. There are no third-party users yet, so it is better to expose the vector-native API before the session package gets wider use.

Validation:

- `moon test agent_session --warn-list +73 --diagnostic-limit 300`
- `moon info agent_session --target native`
- `moon fmt agent_session`
- `moon ide analyze agent_session --target native`
