### PR TITLE
[codex] harden session store durability

### DIFF
--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -11,10 +11,16 @@ let header_file_name : String = "session.json"
 let event_log_file_name : String = "events.jsonl"
 
 ///|
+let lock_file_name : String = "session.lock"
+
+///|
 priv struct SessionHeader {
   id : @agent_session.SessionId
   system_prompt : String
   last_sequence : Int
+  event_log_length : Int?
+  event_log_hash : Int?
+  allow_event_log_ahead : Bool?
 }
 
 ///|
@@ -79,12 +85,32 @@ fn SessionStore::event_log_path(
 }
 
 ///|
-fn session_header_json(session : @agent_session.Session) -> Json {
+fn SessionStore::lock_path(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  self.session_dir(id) + "/" + lock_file_name
+}
+
+///|
+fn event_log_hash(text : StringView) -> Int {
+  Hash::hash(text)
+}
+
+///|
+fn session_header_json(
+  session : @agent_session.Session,
+  events_text : String,
+  allow_event_log_ahead : Bool,
+) -> Json {
   {
     "version": session_header_version,
     "id": session.id(),
     "system_prompt": session.system_prompt(),
     "last_sequence": session.last_sequence(),
+    "event_log_length": events_text.length(),
+    "event_log_hash": event_log_hash(events_text),
+    "allow_event_log_ahead": allow_event_log_ahead,
   }
 }
 
@@ -123,6 +149,33 @@ fn header_int_field(
 }
 
 ///|
+fn header_optional_int_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> Int? raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(Number(value, ..)) => Some(value.to_int())
+    Some(_) => json_decode_error(path.add_key(key), "expected int")
+    None => None
+  }
+}
+
+///|
+fn header_optional_bool_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> Bool? raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(True) => Some(true)
+    Some(False) => Some(false)
+    Some(_) => json_decode_error(path.add_key(key), "expected bool")
+    None => None
+  }
+}
+
+///|
 fn decode_session_header(
   json : Json,
   path : @json.JsonPath,
@@ -147,6 +200,13 @@ fn decode_session_header(
     id,
     system_prompt: header_string_field(fields, path, "system_prompt"),
     last_sequence: header_int_field(fields, path, "last_sequence"),
+    event_log_length: header_optional_int_field(
+      fields, path, "event_log_length",
+    ),
+    event_log_hash: header_optional_int_field(fields, path, "event_log_hash"),
+    allow_event_log_ahead: header_optional_bool_field(
+      fields, path, "allow_event_log_ahead",
+    ),
   }
 }
 
@@ -184,14 +244,153 @@ fn parse_events_jsonl(
 }
 
 ///|
-async fn write_header(
+fn checked_last_sequence_in_events(
+  events : @vector.Vector[@agent_session.SessionEvent],
+) -> Int raise {
+  let mut expected = 1
+  for event in events {
+    if event.sequence() != expected {
+      fail(
+        "session event log sequence mismatch: expected \{expected}, found \{event.sequence()}",
+      )
+    }
+    expected += 1
+  }
+  expected - 1
+}
+
+///|
+async fn durable_last_sequence(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+) -> Int {
+  let events_text = read_event_log_text(store.event_log_path(id))
+  checked_last_sequence_in_events(parse_events_jsonl(events_text))
+}
+
+///|
+async fn read_session_header(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+) -> SessionHeader {
+  @json.from_json(@json.parse(@fs.read_file(store.header_path(id)).text()))
+}
+
+///|
+fn validate_loaded_header(
+  header : SessionHeader,
+  requested_id : @agent_session.SessionId,
+) -> Unit raise {
+  if header.id.value() != requested_id.value() {
+    fail(
+      "session header id mismatch: requested \{requested_id.value()}, found \{header.id.value()}",
+    )
+  }
+}
+
+///|
+fn validate_event_log_fingerprint(
+  header : SessionHeader,
+  events_text : String,
+) -> Unit raise {
+  match (header.event_log_length, header.event_log_hash) {
+    (Some(length), Some(hash)) => {
+      if events_text.length() < length ||
+        event_log_hash(events_text[:length]) != hash {
+        fail("session event log fingerprint mismatch for \{header.id.value()}")
+      }
+      if header.allow_event_log_ahead == Some(false) &&
+        events_text.length() != length {
+        fail(
+          "session event log stale tail after replacement for \{header.id.value()}",
+        )
+      }
+      let prefix_last_sequence = checked_last_sequence_in_events(
+        parse_events_jsonl(events_text[:length].to_owned()),
+      )
+      if prefix_last_sequence != header.last_sequence {
+        fail(
+          "session header fingerprint tail mismatch: header last sequence \{header.last_sequence}, fingerprint last sequence \{prefix_last_sequence}",
+        )
+      }
+    }
+    (None, None) => ()
+    _ => fail("session header event log fingerprint is incomplete")
+  }
+}
+
+///|
+fn session_from_replayed_events(
+  header : SessionHeader,
+  events_text : String,
+  events : @vector.Vector[@agent_session.SessionEvent],
+) -> @agent_session.Session raise {
+  validate_event_log_fingerprint(header, events_text)
+  let replayed_last_sequence = checked_last_sequence_in_events(events)
+  if replayed_last_sequence < header.last_sequence {
+    fail(
+      "session event log tail mismatch: header last sequence \{header.last_sequence}, replayed last sequence \{replayed_last_sequence}",
+    )
+  }
+  Session(header.id, system_prompt=header.system_prompt, events~)
+}
+
+///|
+async fn load_persisted_session(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+) -> @agent_session.Session {
+  let header = read_session_header(store, id)
+  validate_loaded_header(header, id)
+  let events_text = read_event_log_text(store.event_log_path(id))
+  session_from_replayed_events(
+    header,
+    events_text,
+    parse_events_jsonl(events_text),
+  )
+}
+
+///|
+async fn ensure_empty_missing_session(
   store : SessionStore,
   session : @agent_session.Session,
 ) -> Unit {
-  @fs.write_file(
+  let durable_last = durable_last_sequence(store, session.id())
+  if durable_last != 0 || session.last_sequence() != 0 {
+    fail(
+      "stale session snapshot for \{session.id().value()}: no persisted header, in-memory last sequence \{session.last_sequence()}, durable last sequence \{durable_last}",
+    )
+  }
+}
+
+///|
+async fn ensure_session_is_current(
+  store : SessionStore,
+  session : @agent_session.Session,
+) -> Unit {
+  let persisted = load_persisted_session(store, session.id()) catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => {
+      ensure_empty_missing_session(store, session)
+      return
+    }
+    error => raise error
+  }
+  if persisted.system_prompt() != session.system_prompt() ||
+    events_jsonl(persisted.events()) != events_jsonl(session.events()) {
+    fail("stale session snapshot for \{session.id().value()}")
+  }
+}
+
+///|
+async fn write_header(
+  store : SessionStore,
+  session : @agent_session.Session,
+  allow_event_log_ahead : Bool,
+) -> Unit {
+  let events_text = events_jsonl(session.events())
+  write_text_atomic(
     store.header_path(session.id()),
-    session_header_json(session).stringify(),
-    create_mode=CreateOrTruncate,
+    session_header_json(session, events_text, allow_event_log_ahead).stringify(),
   )
 }
 
@@ -200,10 +399,9 @@ async fn write_event_log(
   store : SessionStore,
   session : @agent_session.Session,
 ) -> Unit {
-  @fs.write_file(
+  write_text_atomic(
     store.event_log_path(session.id()),
     events_jsonl(session.events()),
-    create_mode=CreateOrTruncate,
   )
 }
 
@@ -230,6 +428,13 @@ async fn read_event_log_text(path : String) -> String {
 }
 
 ///|
+async fn write_text_atomic(path : String, text : String) -> Unit {
+  let tmp_path = path + ".tmp"
+  @fs.write_file(tmp_path, text, create_mode=CreateOrTruncate)
+  @fs.rename(tmp_path, path, replace=true)
+}
+
+///|
 async fn ensure_session_dir(
   store : SessionStore,
   id : @agent_session.SessionId,
@@ -241,6 +446,38 @@ async fn ensure_session_dir(
   @fs.mkdir(dir, recursive=true) catch {
     error => if @fs.exists(dir) { () } else { raise error }
   }
+}
+
+///|
+async fn[T] with_session_lock(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+  kind : @fs.Lock,
+  body : async () -> T,
+) -> T {
+  let file = @fs.open(
+    store.lock_path(id),
+    mode=ReadWrite,
+    create_mode=OpenOrCreate,
+  )
+  defer file.close()
+  file.lock(kind)
+  defer file.unlock()
+  body()
+}
+
+///|
+async fn[T] with_existing_session_lock(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+  kind : @fs.Lock,
+  body : async () -> T,
+) -> T {
+  let dir = store.session_dir(id)
+  if !@fs.exists(dir) {
+    return body()
+  }
+  with_session_lock(store, id, kind, body)
 }
 
 ///|
@@ -258,7 +495,10 @@ pub async fn SessionStore::exists(
 pub async fn SessionStore::list(
   self : SessionStore,
 ) -> Array[@agent_session.SessionId] {
-  let names = @fs.readdir(self.sessions_dir(), sort=true) catch { _ => [] }
+  let names = @fs.readdir(self.sessions_dir(), sort=true) catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => []
+    error => raise error
+  }
   [
     for name in names if name != "." && name != ".." => SessionId(name)
   ]
@@ -273,8 +513,12 @@ pub async fn SessionStore::create(
   session : @agent_session.Session,
 ) -> Unit {
   ensure_session_dir(self, session.id())
-  write_header(self, session)
-  write_event_log(self, session)
+  with_session_lock(self, session.id(), Exclusive, () => {
+    // Exact header-first rewrites fail closed on stale old-log tails.
+    write_header(self, session, false)
+    write_event_log(self, session)
+    write_header(self, session, true)
+  })
 }
 
 ///|
@@ -283,21 +527,9 @@ pub async fn SessionStore::load(
   self : SessionStore,
   id : @agent_session.SessionId,
 ) -> @agent_session.Session {
-  let header : SessionHeader = @json.from_json(
-    @json.parse(@fs.read_file(self.header_path(id)).text()),
-  )
-  if header.id.value() != id.value() {
-    fail(
-      "session header id mismatch: requested \{id.value()}, found \{header.id.value()}",
-    )
-  }
-  ignore(header.last_sequence)
-  let events_text = read_event_log_text(self.event_log_path(id))
-  Session(
-    header.id,
-    system_prompt=header.system_prompt,
-    events=parse_events_jsonl(events_text),
-  )
+  with_existing_session_lock(self, id, Shared, () => {
+    load_persisted_session(self, id)
+  })
 }
 
 ///|
@@ -308,11 +540,14 @@ pub async fn SessionStore::append(
   session : @agent_session.Session,
   item : @agent_session.SessionItem,
 ) -> @agent_session.Session {
-  let (next, event) = session.append_event(item)
-  ensure_session_dir(self, next.id())
-  append_event(self, next, event)
-  write_header(self, next)
-  next
+  ensure_session_dir(self, session.id())
+  with_session_lock(self, session.id(), Exclusive, () => {
+    ensure_session_is_current(self, session)
+    let (next, event) = session.append_event(item)
+    append_event(self, next, event)
+    write_header(self, next, true)
+    next
+  })
 }
 
 ///|
@@ -325,13 +560,16 @@ pub async fn SessionStore::compact(
   from_sequence~ : Int,
   to_sequence~ : Int,
 ) -> @agent_session.Session {
-  let next = session.compact(content~, from_sequence~, to_sequence~)
-  let event = match next.events().peek() {
-    Some(event) => event
-    None => fail("compacted session did not append a summary event")
-  }
-  ensure_session_dir(self, next.id())
-  append_event(self, next, event)
-  write_header(self, next)
-  next
+  ensure_session_dir(self, session.id())
+  with_session_lock(self, session.id(), Exclusive, () => {
+    ensure_session_is_current(self, session)
+    let next = session.compact(content~, from_sequence~, to_sequence~)
+    let event = match next.events().peek() {
+      Some(event) => event
+      None => fail("compacted session did not append a summary event")
+    }
+    append_event(self, next, event)
+    write_header(self, next, true)
+    next
+  })
 }

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -5,6 +5,34 @@ async fn new_store() -> @store.SessionStore {
 }
 
 ///|
+fn session_events_jsonl(session : @agent_session.Session) -> String {
+  let builder = StringBuilder::new()
+  for event in session.events() {
+    builder.write_string(event.to_json().stringify())
+    builder.write_string("\n")
+  }
+  builder.to_string()
+}
+
+///|
+fn session_header_jsonl(
+  session : @agent_session.Session,
+  allow_event_log_ahead? : Bool = true,
+) -> String {
+  let events_text = session_events_jsonl(session)
+  let header : Json = {
+    "version": 1,
+    "id": session.id(),
+    "system_prompt": session.system_prompt(),
+    "last_sequence": session.last_sequence(),
+    "event_log_length": events_text.length(),
+    "event_log_hash": Hash::hash(events_text[:]),
+    "allow_event_log_ahead": allow_event_log_ahead,
+  }
+  header.stringify()
+}
+
+///|
 async test "store creates and loads a session from header and event log" {
   let store = new_store()
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
@@ -34,6 +62,25 @@ async test "store lists known sessions" {
 }
 
 ///|
+async test "store propagates non-missing list errors" {
+  let store = new_store()
+  @fs.write_file(
+    store.root() + "/sessions",
+    "not a directory",
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.list() catch {
+    error => {
+      assert_true("\{error}" != "")
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("list error was silently treated as empty")
+}
+
+///|
 async test "store appends one event without rewriting the in-memory caller value" {
   let store = new_store()
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
@@ -53,6 +100,192 @@ async test "store appends one event without rewriting the in-memory caller value
 }
 
 ///|
+async test "store rejects stale snapshots before appending" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  store.create(session)
+  ignore(store.append(session, User(UserMessage("first"))))
+  let _ = store.append(session, Runtime(RuntimeNotice("stale"))) catch {
+    error => {
+      assert_true("\{error}".contains("stale session snapshot"))
+      let loaded = store.load(SessionId("s1"))
+      assert_eq(loaded.events().length(), 1)
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("stale append was accepted")
+}
+
+///|
+async test "store rejects divergent snapshots with the same sequence" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("first")),
+  )
+  let divergent = @agent_session.Session(
+    SessionId("s1"),
+    system_prompt="changed system",
+    events=session.events(),
+  )
+  store.create(session)
+  let _ = store.append(divergent, Runtime(RuntimeNotice("stale"))) catch {
+    error => {
+      assert_true("\{error}".contains("stale session snapshot"))
+      let loaded = store.load(SessionId("s1"))
+      assert_eq(loaded.system_prompt(), "system")
+      assert_eq(loaded.events().length(), 1)
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("divergent same-sequence append was accepted")
+}
+
+///|
+async test "store rejects mixed header and event log from interrupted rewrites" {
+  let store = new_store()
+  let original = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("old")),
+  )
+  let rewrite = @agent_session.Session(
+    SessionId("s1"),
+    system_prompt="rewritten system",
+  ).append(User(UserMessage("new")))
+  store.create(original)
+  @fs.write_file(
+    store.root() + "/sessions/s1/session.json",
+    session_header_jsonl(rewrite),
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}".contains("fingerprint mismatch"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("mixed rewrite header and event log was accepted")
+}
+
+///|
+async test "store rejects stale tails after interrupted prefix rewrites" {
+  let store = new_store()
+  let original = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(Runtime(RuntimeNotice("stale tail")))
+  let rewrite = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  store.create(original)
+  @fs.write_file(
+    store.root() + "/sessions/s1/session.json",
+    session_header_jsonl(rewrite, allow_event_log_ahead=false),
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}".contains("stale tail after replacement"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("stale tail from interrupted prefix rewrite was accepted")
+}
+
+///|
+async test "store serializes concurrent appends from the same snapshot" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let results : Array[String] = []
+  store.create(session)
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
+      try store.append(session, User(UserMessage("first"))) catch {
+        error => {
+          assert_true("\{error}".contains("stale session snapshot"))
+          results.push("stale")
+        }
+      } noraise {
+        _ => results.push("ok")
+      }
+    }
+    group.spawn_bg() <| () => {
+      try store.append(session, Runtime(RuntimeNotice("second"))) catch {
+        error => {
+          assert_true("\{error}".contains("stale session snapshot"))
+          results.push("stale")
+        }
+      } noraise {
+        _ => results.push("ok")
+      }
+    }
+  }
+  let mut ok = 0
+  let mut stale = 0
+  for result in results {
+    if result == "ok" {
+      ok += 1
+    } else if result == "stale" {
+      stale += 1
+    }
+  }
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(ok, 1)
+  assert_eq(stale, 1)
+  assert_eq(loaded.events().length(), 1)
+  assert_eq(loaded.last_sequence(), 1)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store rejects stale snapshots before compacting" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(Assistant(AssistantMessage("second")))
+  store.create(session)
+  ignore(store.append(session, Runtime(RuntimeNotice("new durable tail"))))
+  let _ = store.compact(
+    session,
+    content="first two events",
+    from_sequence=1,
+    to_sequence=2,
+  ) catch {
+    error => {
+      assert_true("\{error}".contains("stale session snapshot"))
+      let loaded = store.load(SessionId("s1"))
+      assert_eq(loaded.events().length(), 3)
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("stale compact was accepted")
+}
+
+///|
+async test "store loads when the append-only log is ahead of the header" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let (_, event) = session.append_event(User(UserMessage("first")))
+  store.create(session)
+  @fs.write_file(
+    store.root() + "/sessions/s1/events.jsonl",
+    event.to_json().stringify() + "\n",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.system_prompt(), "system")
+  assert_eq(loaded.events().length(), 1)
+  assert_eq(loaded.last_sequence(), 1)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
 async test "store loads an empty session when the event log is missing" {
   let store = new_store()
   store.create(Session(SessionId("s1"), system_prompt="system"))
@@ -60,6 +293,25 @@ async test "store loads an empty session when the event log is missing" {
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 0)
   @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store rejects missing event logs for non-empty sessions" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("hello")),
+  )
+  store.create(session)
+  @fs.remove(store.root() + "/sessions/s1/events.jsonl")
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}".contains("fingerprint mismatch"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("missing non-empty event log was accepted")
 }
 
 ///|


### PR DESCRIPTION
## Summary

Follow-up to #58. The initial store PR was merged before the Subal review fixes landed on the branch, so this PR contains only the durability fixes relative to current `main`.

The original filesystem store was intentionally small and happy-path oriented: write `session.json`, write `events.jsonl`, and load by trusting both files. This PR makes the same two-file layout explicit about crash and concurrency behavior, which is why the implementation is noticeably longer.

This hardens the filesystem session store by:

- rejecting stale session snapshots before `append` and `compact`
- serializing `load`, `create`, `append`, and `compact` with per-session advisory locks so concurrent appends cannot both pass the stale check and write duplicate sequence numbers
- replacing full session rewrites through temp-file rename and exact replacement headers, then publishing a final stable header once the replacement log is in place
- binding new headers to the event-log prefix they were written against, with an `allow_event_log_ahead` flag so append-ahead recovery is allowed but interrupted prefix rewrites cannot resurrect stale tails
- validating replayed JSONL event sequence continuity
- rejecting divergent same-sequence snapshots, including changed system prompts or event prefixes
- rejecting truncated or missing non-empty event logs when the header expects events
- propagating non-ENOENT `SessionStore::list` filesystem errors instead of silently returning an empty list

## Durability Rules

The header and event log can disagree if the process exits between writes. The store now treats those states as follows:

- header behind log after append: allowed, because replaying the longer log recovers the durable tail
- header ahead of log or fingerprint mismatch: rejected, because the log is truncated or mixed with another write
- exact replacement in progress: old stale tails are rejected until the replacement log and final stable header are both published
- concurrent stale append/compact: rejected after taking the session lock and reloading the current durable session

The on-disk header extension is backward-compatible: old headers without a fingerprint still load, and newly written headers get the stricter validation.

## Validation

- `moon fmt agent_session/store`
- `moon check --target native --diagnostic-limit 300`
- `moon test agent_session/store --target native --warn-list +73 --diagnostic-limit 300`
- `moon info agent_session/store --target native`
- `moon ide analyze agent_session/store --target native`
- `git diff --check`
- `moon test --target native --diagnostic-limit 300`
- Subal rerun: concurrent store stress test passed; full `moon test` inside Subal only hit the network-dependent real-world DeepSeek DNS smoke test
