### PR TITLE
chore(prompt): use named warning categories in moon.pkg

### DIFF
--- a/prompt/moon.pkg
+++ b/prompt/moon.pkg
@@ -18,6 +18,6 @@ dev_build(
   output: "generated_flash_prompt.mbt",
 )
 
-warnings = "+unnecessary_annotation-1-2-3-6-7-28-68"
+warnings = "+unnecessary_annotation-unused_value-unused_type_declaration-unused_constructor-unused_field-todo-declaration_unimplemented"
 
 supported_targets = "+native"


### PR DESCRIPTION
## Summary

Follow-up to #60. The suppression list in `prompt/moon.pkg` was numeric (`-1-2-3-6-7-28-68`); switch it to the names `moon explain --diagnostic N` reports, so the intent is obvious without a lookup:

| code | name |
| ---- | ---- |
| 1, 2 | `unused_value` (covers both function and variable) |
| 3    | `unused_type_declaration` |
| 6    | `unused_constructor` |
| 7    | `unused_field` |
| 28   | `todo` |
| 68   | `declaration_unimplemented` |
| 73   | `unnecessary_annotation` (kept enabled as error) |

## Test plan

- [x] `moon check --deny-warn` → 0 errors, 0 warnings
- [x] `moon test` → 393/393 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)