### PR TITLE
refactor(prompt): convert three pedagogical blocks from nocheck to check

### DIFF
--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -706,7 +706,7 @@ import {
 } for "test"
 ```
 
-```mbt nocheck
+```mbt check
 ///|
 async test "sleep completes" {
   @async.sleep(1)

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -143,7 +143,7 @@ options(
 - Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
 - Match arms are separated by newlines or semicolons, not `|`:
 
-```mbt nocheck
+```mbt check
 ///|
 test {
   let n : Int = @string.from_str("123")
@@ -257,7 +257,7 @@ test {
 - Multi-line raw strings use `#|`. Multi-line interpolated strings use `$|` and
   interpolation as `\{...}`:
 
-```mbt nocheck
+```mbt check
 ///|
 fn message(name : String, line : Int) -> String {
   (

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -710,7 +710,7 @@ fn base_prompt() -> String {
     #|} for "test"
     #|```
     #|
-    #|```mbt nocheck
+    #|```mbt check
     #|///|
     #|async test "sleep completes" {
     #|  @async.sleep(1)

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -147,7 +147,7 @@ fn flash_prompt() -> String {
     #|- Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
     #|- Match arms are separated by newlines or semicolons, not `|`:
     #|
-    #|```mbt nocheck
+    #|```mbt check
     #|///|
     #|test {
     #|  let n : Int = @string.from_str("123")
@@ -261,7 +261,7 @@ fn flash_prompt() -> String {
     #|- Multi-line raw strings use `#|`. Multi-line interpolated strings use `$|` and
     #|  interpolation as `\{...}`:
     #|
-    #|```mbt nocheck
+    #|```mbt check
     #|///|
     #|fn message(name : String, line : Int) -> String {
     #|  (

--- a/prompt/moon.pkg
+++ b/prompt/moon.pkg
@@ -4,6 +4,8 @@ import {
 
 import {
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/string",
+  "moonbitlang/async",
 } for "test"
 
 dev_build(


### PR DESCRIPTION
## Summary

Converts three `mbt nocheck` example blocks to `mbt check` so MoonBit type-checks them in CI:

| file | block | added test-import |
| ---- | ----- | ----------------- |
| `base_prompt.mbt.md` L709 | `async test "sleep completes"` (uses `@async.sleep`) | `moonbitlang/async` |
| `flash_prompt.mbt.md` L146 | `test { @string.from_str("123") ... }` | `moonbitlang/core/string` |
| `flash_prompt.mbt.md` L260 | string-interpolation `fn message` | none |

Five `mbt nocheck` blocks remain — each defines a top-level `fn main` (forbidden in this non-main package) or is a syntactic fragment depending on a `writer` / `x` from outside the snippet, so they cannot stand alone.

## Test plan

- [x] `moon check --deny-warn` → 0 errors, 0 warnings
- [x] `moon test` → 395/395 pass (393 → 395; the two new test blocks add coverage)
- [x] `moon fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)