### PR TITLE
refactor(prompt): convert nocheck->check and self-document mbt.md verification

### DIFF
--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -5,10 +5,6 @@ About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit bl
 
 ```
 import {
-  "bobzhang/openseek/deepseek",
-}
-
-import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/string",
   "moonbitlang/async",

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -1,7 +1,21 @@
 You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
 Use finish when the task is complete.
 
-> About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
+
+```
+import {
+  "bobzhang/openseek/deepseek",
+}
+
+import {
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/string",
+  "moonbitlang/async",
+} for "test"
+```
+
+Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
 
 # Agent Workflow
 

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -1,6 +1,8 @@
 You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
 Use finish when the task is complete.
 
+> About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+
 # Agent Workflow
 
 For fast, reliable task execution, follow this order:

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -3,7 +3,21 @@ You are OpenSeek, a MoonBit coding agent optimized for DeepSeek V4 Flash.
 Use the native tools to inspect, create, edit, validate, and finish work. If
 work is needed, call a tool. When the task is complete, call `finish`.
 
-> About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
+
+```
+import {
+  "bobzhang/openseek/deepseek",
+}
+
+import {
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/string",
+  "moonbitlang/async",
+} for "test"
+```
+
+Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
 
 ## Tool Protocol
 

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -7,10 +7,6 @@ About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit b
 
 ```
 import {
-  "bobzhang/openseek/deepseek",
-}
-
-import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/string",
   "moonbitlang/async",

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -3,6 +3,8 @@ You are OpenSeek, a MoonBit coding agent optimized for DeepSeek V4 Flash.
 Use the native tools to inspect, create, edit, validate, and finish work. If
 work is needed, call a tool. When the task is complete, call `finish`.
 
+> About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+
 ## Tool Protocol
 
 - Do not emit JSON action plans as assistant text, such as `{"tool":"shell"}`.

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -9,10 +9,6 @@ fn base_prompt() -> String {
     #|
     #|```
     #|import {
-    #|  "bobzhang/openseek/deepseek",
-    #|}
-    #|
-    #|import {
     #|  "moonbitlang/core/encoding/utf8",
     #|  "moonbitlang/core/string",
     #|  "moonbitlang/async",

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -5,6 +5,8 @@ fn base_prompt() -> String {
     #|You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
     #|Use finish when the task is complete.
     #|
+    #|> About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+    #|
     #|# Agent Workflow
     #|
     #|For fast, reliable task execution, follow this order:

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -5,7 +5,21 @@ fn base_prompt() -> String {
     #|You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
     #|Use finish when the task is complete.
     #|
-    #|> About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+    #|About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
+    #|
+    #|```
+    #|import {
+    #|  "bobzhang/openseek/deepseek",
+    #|}
+    #|
+    #|import {
+    #|  "moonbitlang/core/encoding/utf8",
+    #|  "moonbitlang/core/string",
+    #|  "moonbitlang/async",
+    #|} for "test"
+    #|```
+    #|
+    #|Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
     #|
     #|# Agent Workflow
     #|

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -7,7 +7,21 @@ fn flash_prompt() -> String {
     #|Use the native tools to inspect, create, edit, validate, and finish work. If
     #|work is needed, call a tool. When the task is complete, call `finish`.
     #|
-    #|> About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+    #|About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
+    #|
+    #|```
+    #|import {
+    #|  "bobzhang/openseek/deepseek",
+    #|}
+    #|
+    #|import {
+    #|  "moonbitlang/core/encoding/utf8",
+    #|  "moonbitlang/core/string",
+    #|  "moonbitlang/async",
+    #|} for "test"
+    #|```
+    #|
+    #|Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
     #|
     #|## Tool Protocol
     #|

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -11,10 +11,6 @@ fn flash_prompt() -> String {
     #|
     #|```
     #|import {
-    #|  "bobzhang/openseek/deepseek",
-    #|}
-    #|
-    #|import {
     #|  "moonbitlang/core/encoding/utf8",
     #|  "moonbitlang/core/string",
     #|  "moonbitlang/async",

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -7,6 +7,8 @@ fn flash_prompt() -> String {
     #|Use the native tools to inspect, create, edit, validate, and finish work. If
     #|work is needed, call a tool. When the task is complete, call `finish`.
     #|
+    #|> About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every fenced ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. To make the example blocks check, `prompt/moon.pkg` adds the following test-imports: `moonbitlang/core/encoding/utf8`, `moonbitlang/core/string`, and `moonbitlang/async`. Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+    #|
     #|## Tool Protocol
     #|
     #|- Do not emit JSON action plans as assistant text, such as `{"tool":"shell"}`.


### PR DESCRIPTION
## Summary

Now targets `main` (no longer stacked). Supersedes #63 — if you take this one, close #63 unmerged.

Two related changes:

### 1. nocheck -> check (from the original #63)

Convert three `mbt nocheck` example blocks to `mbt check` and add the supporting test-imports to `prompt/moon.pkg`:

| file | block | added test-import |
| ---- | ----- | ----------------- |
| `base_prompt.mbt.md` L709 | `async test "sleep completes"` | `moonbitlang/async` |
| `flash_prompt.mbt.md` L146 | `test { @string.from_str("123") ... }` | `moonbitlang/core/string` |
| `flash_prompt.mbt.md` L260 | string-interpolation `fn message` | none |

Five `mbt nocheck` blocks remain — each defines a top-level `fn main` (forbidden in this non-main package) or is a syntactic fragment depending on identifiers from outside the snippet.

### 2. Self-documenting note

Add an `About this guide` paragraph near the top of both prompt files showing:

- The file itself is a MoonBit blackbox-test file.
- ```` ```mbt check ```` blocks are exercised by `moon check --deny-warn` and `moon test`.
- The literal `import { ... }` and `import { ... } for "test"` blocks from `prompt/moon.pkg` (so the agent can copy the exact syntax).
- Why ```` ```mbt nocheck ```` blocks stay illustrative.

## Test plan

- [x] `moon check --deny-warn` -> 0 errors, 0 warnings
- [x] `moon test` -> 395/395 pass (393 -> 395; the two converted test blocks add coverage)
- [x] `moon fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)