### PR TITLE
[codex] add explicit session CLI commands

### DIFF
--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -2,24 +2,41 @@
 
 This package is the native-only command-line entry point for OpenSeek. It parses
 arguments with `moonbitlang/core/argparse`, reads defaults from environment
-variables, and calls `bobzhang/openseek/agent.run`.
+variables, and calls `bobzhang/openseek/agent.run` for one-shot tasks or
+`agent.run_turn_with_append` for durable sessions.
 
 ## Command
 
 ```bash
-moon run cmd/openseek -- [--api-key sk-...] [--model deepseek-v4-pro] [--max-steps 1000] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] "task text"
+moon run cmd/openseek -- [--api-key sk-...] [--model deepseek-v4-pro] [--max-steps 1000] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
 ```
 
-`--api-key` can also be supplied with `DEEPSEEK`. `--model` can also be supplied
-with `DEEPSEEK_MODEL`; it defaults to `deepseek-v4-pro`. `--max-steps` can also
-be supplied with `OPENSEEK_MAX_STEPS`; it defaults to `1000`.
+Agent runs require `--api-key` or `DEEPSEEK`. `--model` can also be supplied with
+`DEEPSEEK_MODEL`; it defaults to `deepseek-v4-pro`. `--max-steps` can also be
+supplied with `OPENSEEK_MAX_STEPS`; it defaults to `1000`.
 `--system-prompt-file` and `--system-prompt-addendum-file` can also be supplied
 with `OPENSEEK_SYSTEM_PROMPT_FILE` and
-`OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`.
+`OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`. `--session` can also be supplied with
+`OPENSEEK_SESSION`; when set, the CLI creates or resumes that session under
+`--session-root` / `OPENSEEK_SESSION_ROOT` (default `.openseek`).
 
 Without an explicit prompt file, the CLI selects the built-in prompt by model:
 `deepseek-v4-flash` uses `prompt/flash_prompt.md`; `deepseek-v4-pro` uses
 `prompt/base_prompt.md`.
+
+## Session Management
+
+The session-management commands are offline and do not require `--api-key`:
+
+```bash
+moon run cmd/openseek -- --session-list --session-root .openseek
+moon run cmd/openseek -- --session-show --session parser-fix --session-root .openseek
+moon run cmd/openseek -- --session parser-fix --session-compact-file summary.txt --session-compact-from 1 --session-compact-to 120
+```
+
+`--session-compact-file` appends a typed summary event. It does not delete raw
+events from `events.jsonl`; `agent_session.Session::chat_messages` uses the
+summary to compact model context on replay.
 
 ## Examples
 
@@ -36,12 +53,16 @@ DEEPSEEK_MODEL=deepseek-v4-flash moon run cmd/openseek -- "inspect the package d
 moon run cmd/openseek -- --max-steps 200 "write tests, fix failures, and summarize"
 ```
 
+```bash
+moon run cmd/openseek -- --session parser-fix "continue from the last run"
+```
+
 ## Package Boundary
 
 This package should stay thin: argument parsing, environment-backed defaults,
-model parsing, prompt override file loading, and delegation to `@agent.run`.
-The prompt package owns built-in prompt selection; the agent package owns tool
-definitions and the execution loop.
+model parsing, prompt override file loading, session-store setup, and
+delegation to the agent package. The prompt package owns built-in prompt
+selection; the agent package owns tool definitions and the execution loop.
 
 Run the package tests with:
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1,13 +1,64 @@
 ///|
 async fn main {
+  run_cli() catch {
+    error => {
+      @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
+        _ => ()
+      }
+      @sys.exit(1)
+    }
+  }
+}
+
+///|
+async fn run_cli() -> Unit {
   configure_logging()
   let matches = cli_command().parse(env=@env.get_env_vars())
-  let api_key = value(matches, "api-key")
+  if handle_session_command(matches) {
+    return
+  }
+  let api_key = api_key(matches)
   let model = @deepseek.Model::parse(value(matches, "model"))
   let max_steps = max_steps(matches)
-  let system_prompt_text = configured_system_prompt(matches, model)
-  let task = values(matches, "task").join(" ")
-  @agent.run(api_key, model, task, max_steps~, system_prompt_text~)
+  let task = task_text(matches)
+  match session_id(matches) {
+    None => {
+      let system_prompt_text = configured_system_prompt(matches, model)
+      @agent.run(api_key, model, task, max_steps~, system_prompt_text~)
+    }
+    Some(id) => {
+      let store = @store.SessionStore(session_root(matches))
+      let session = load_or_new_session(store, id, matches, model)
+      ignore(
+        @agent.run_turn_with_append(
+          api_key,
+          model,
+          session,
+          task,
+          append_item=(session, item) => store.append(session, item),
+          max_steps~,
+        ),
+      )
+    }
+  }
+}
+
+///|
+fn failure_message(error_text : String) -> String {
+  let marker = " FAILED: "
+  let pieces : Array[String] = error_text
+    .split(marker)
+    .map(piece => piece.to_owned())
+    .collect()
+  if pieces.length() < 2 {
+    return error_text
+  }
+  let message = pieces[pieces.length() - 1]
+  if message.has_suffix(")") {
+    message[:message.length() - 1].to_owned()
+  } else {
+    message
+  }
 }
 
 ///|
@@ -39,7 +90,7 @@ fn cli_command() -> @argparse.Command {
         "api-key",
         long="api-key",
         env="DEEPSEEK",
-        required=true,
+        default_values=[""],
         about="DeepSeek API key.",
       ),
       OptionArg(
@@ -70,11 +121,55 @@ fn cli_command() -> @argparse.Command {
         default_values=[""],
         about="Append this file to the selected system prompt for prompt experiments.",
       ),
+      OptionArg(
+        "session",
+        long="session",
+        env="OPENSEEK_SESSION",
+        default_values=[""],
+        about="Create or resume this durable session id.",
+      ),
+      OptionArg(
+        "session-root",
+        long="session-root",
+        env="OPENSEEK_SESSION_ROOT",
+        default_values=[".openseek"],
+        about="Directory containing durable OpenSeek sessions.",
+      ),
+      OptionArg(
+        "session-compact-file",
+        long="session-compact-file",
+        default_values=[""],
+        about="Read summary text from this file, append it to --session, and exit.",
+      ),
+      OptionArg(
+        "session-compact-from",
+        long="session-compact-from",
+        default_values=[""],
+        about="First event sequence covered by --session-compact-file.",
+      ),
+      OptionArg(
+        "session-compact-to",
+        long="session-compact-to",
+        default_values=[""],
+        about="Last event sequence covered by --session-compact-file.",
+      ),
+    ],
+    flags=[
+      FlagArg(
+        "session-list",
+        long="session-list",
+        about="List durable session ids and exit.",
+      ),
+      FlagArg(
+        "session-show",
+        long="session-show",
+        about="Print the durable session JSON for --session and exit.",
+      ),
     ],
     positionals=[
       PositionArg(
         "task",
-        num_args=ValueRange(lower=1),
+        num_args=ValueRange(lower=0),
         allow_hyphen_values=true,
         about="Task description.",
       ),
@@ -92,16 +187,142 @@ fn value(matches : @argparse.Matches, name : String) -> String raise {
 }
 
 ///|
-fn values(matches : @argparse.Matches, name : String) -> Array[String] raise {
+fn values(matches : @argparse.Matches, name : String) -> Array[String] {
   match matches.values.get(name) {
     Some(values) => values
-    None => fail("missing parsed argument: \{name}")
+    None => []
   }
+}
+
+///|
+fn flag(matches : @argparse.Matches, name : String) -> Bool {
+  match matches.flags.get(name) {
+    Some(value) => value
+    None => false
+  }
+}
+
+///|
+fn api_key(matches : @argparse.Matches) -> String raise {
+  let key = value(matches, "api-key").trim().to_owned()
+  if key.is_empty() {
+    fail("--api-key or DEEPSEEK is required for agent runs")
+  }
+  key
 }
 
 ///|
 fn max_steps(matches : @argparse.Matches) -> Int raise {
   parse_positive_int(value(matches, "max-steps"), "--max-steps")
+}
+
+///|
+fn task_text(matches : @argparse.Matches) -> String raise {
+  let task = values(matches, "task").join(" ").trim().to_owned()
+  if task.is_empty() {
+    fail("task description is required for agent runs")
+  }
+  task
+}
+
+///|
+fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? raise {
+  let id = value(matches, "session").trim().to_owned()
+  if id.is_empty() {
+    None
+  } else {
+    Some(SessionId(id))
+  }
+}
+
+///|
+fn session_root(matches : @argparse.Matches) -> String raise {
+  let root = value(matches, "session-root").trim().to_owned()
+  if root.is_empty() {
+    fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
+  }
+  root
+}
+
+///|
+async fn handle_session_command(matches : @argparse.Matches) -> Bool {
+  let list_sessions = flag(matches, "session-list")
+  let show_session = flag(matches, "session-show")
+  let compact_file = value(matches, "session-compact-file").trim().to_owned()
+  let compact_from = value(matches, "session-compact-from").trim().to_owned()
+  let compact_to = value(matches, "session-compact-to").trim().to_owned()
+  let compact_session = !compact_file.is_empty() ||
+    !compact_from.is_empty() ||
+    !compact_to.is_empty()
+  let command_count = (if list_sessions { 1 } else { 0 }) +
+    (if show_session { 1 } else { 0 }) +
+    (if compact_session { 1 } else { 0 })
+  if command_count == 0 {
+    return false
+  }
+  if command_count > 1 {
+    fail(
+      "choose only one of --session-list, --session-show, or --session-compact-file",
+    )
+  }
+  let store = @store.SessionStore(session_root(matches))
+  if list_sessions {
+    for id in store.list() {
+      println(id.value())
+    }
+    return true
+  }
+  let id = required_session_id(matches)
+  if show_session {
+    println(store.load(id).to_json().stringify())
+    return true
+  }
+  if compact_file.is_empty() {
+    fail("--session-compact-file is required for session compaction")
+  }
+  let from_sequence = required_positive_int(
+    compact_from, "--session-compact-from",
+  )
+  let to_sequence = required_positive_int(compact_to, "--session-compact-to")
+  let summary = @fs.read_file(compact_file).text()
+  let compacted = store.compact(
+    store.load(id),
+    content=summary,
+    from_sequence~,
+    to_sequence~,
+  )
+  println(
+    "compacted session \{id.value()} events \{from_sequence}..\{to_sequence}; last_sequence=\{compacted.last_sequence()}",
+  )
+  true
+}
+
+///|
+fn required_session_id(
+  matches : @argparse.Matches,
+) -> @agent_session.SessionId raise {
+  match session_id(matches) {
+    Some(id) => id
+    None => fail("--session is required for this session management command")
+  }
+}
+
+///|
+async fn load_or_new_session(
+  store : @store.SessionStore,
+  id : @agent_session.SessionId,
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+) -> @agent_session.Session {
+  if store.exists(id) {
+    store.load(id) catch {
+      @os_error.OSError(_) as error if error.is_ENOENT() =>
+        Session(id, system_prompt=configured_system_prompt(matches, model))
+      error => raise error
+    }
+  } else {
+    Session(id, system_prompt=configured_system_prompt(matches, model))
+  }
 }
 
 ///|
@@ -140,6 +361,15 @@ fn parse_positive_int(input : String, label : String) -> Int raise {
 }
 
 ///|
+fn required_positive_int(input : String, label : String) -> Int raise {
+  let trimmed = input.trim().to_owned()
+  if trimmed.is_empty() {
+    fail("\{label} is required")
+  }
+  parse_positive_int(trimmed, label)
+}
+
+///|
 test "cli parses env backed options and task" {
   let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
@@ -147,13 +377,18 @@ test "cli parses env backed options and task" {
     "OPENSEEK_MAX_STEPS": "120",
     "OPENSEEK_SYSTEM_PROMPT_FILE": "/tmp/prompt-a.md",
     "OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE": "/tmp/prompt-b.md",
+    "OPENSEEK_SESSION": "demo",
+    "OPENSEEK_SESSION_ROOT": "/tmp/openseek-sessions",
   })
-  assert_eq(value(parsed, "api-key"), "test-key")
+  assert_eq(api_key(parsed), "test-key")
   assert_eq(value(parsed, "model"), "deepseek-v4-pro")
   assert_eq(max_steps(parsed), 120)
   assert_eq(value(parsed, "system-prompt-file"), "/tmp/prompt-a.md")
   assert_eq(value(parsed, "system-prompt-addendum-file"), "/tmp/prompt-b.md")
-  assert_eq(values(parsed, "task").join(" "), "write MoonBit")
+  guard session_id(parsed) is Some(id) else { fail("expected session id") }
+  assert_eq(id.value(), "demo")
+  assert_eq(session_root(parsed), "/tmp/openseek-sessions")
+  assert_eq(task_text(parsed), "write MoonBit")
 }
 
 ///|
@@ -161,8 +396,58 @@ test "cli defaults model and max steps" {
   let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
+  assert_eq(api_key(parsed), "test-key")
   assert_eq(value(parsed, "model"), "deepseek-v4-pro")
   assert_eq(max_steps(parsed), 1000)
+  assert_true(session_id(parsed) is None)
+  assert_eq(session_root(parsed), ".openseek")
+}
+
+///|
+test "cli allows session management without api key or task" {
+  let parsed = cli_command().parse(argv=["--session-list"], env={})
+  assert_true(flag(parsed, "session-list"))
+  assert_eq(value(parsed, "api-key"), "")
+  assert_eq(values(parsed, "task").length(), 0)
+}
+
+///|
+async test "session commands reject empty session root" {
+  let parsed = cli_command().parse(
+    argv=["--session-root", "", "--session-list"],
+    env={},
+  )
+  let _ = handle_session_command(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("--session-root"))
+      return
+    }
+  }
+  fail("empty session root accepted")
+}
+
+///|
+test "agent runs require api key" {
+  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={})
+  let _ = api_key(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("--api-key or DEEPSEEK is required"))
+      return
+    }
+  }
+  fail("missing api key accepted")
+}
+
+///|
+test "agent runs require task text" {
+  let parsed = cli_command().parse(argv=[], env={ "DEEPSEEK": "test-key" })
+  let _ = task_text(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("task description is required"))
+      return
+    }
+  }
+  fail("missing task accepted")
 }
 
 ///|
@@ -206,6 +491,124 @@ async test "configured system prompt defaults by model" {
   assert_false(
     configured_system_prompt(parsed, V4Pro).contains("DeepSeek V4 Flash"),
   )
+}
+
+///|
+async test "load_or_new_session defers first durable write until append" {
+  let root = @fs.tmpdir(prefix="openseek-cli-session-")
+  let store = @store.SessionStore(root)
+  let id : @agent_session.SessionId = SessionId("cli-test")
+  let prompt_path = root + "/prompt.md"
+  @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
+  let parsed = cli_command().parse(
+    argv=[
+      "--session-root", root, "--session", "cli-test", "--system-prompt-file", prompt_path,
+      "write", "MoonBit",
+    ],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let created = load_or_new_session(store, id, parsed, V4Pro)
+  assert_eq(created.system_prompt(), "system")
+  assert_eq(created.events().length(), 0)
+  assert_false(store.exists(id))
+  let with_event = store.append(created, User(UserMessage("hello")))
+  assert_eq(with_event.events().length(), 1)
+  @fs.remove(prompt_path)
+  let loaded = load_or_new_session(store, id, parsed, V4Pro)
+  assert_eq(loaded.system_prompt(), "system")
+  assert_eq(loaded.events().length(), 1)
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "load_or_new_session recovers empty interrupted session directory" {
+  let root = @fs.tmpdir(prefix="openseek-cli-session-empty-dir-")
+  let id : @agent_session.SessionId = SessionId("cli-test")
+  @fs.mkdir(root + "/sessions/" + id.value(), recursive=true)
+  let prompt_path = root + "/prompt.md"
+  @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
+  let parsed = cli_command().parse(
+    argv=[
+      "--session-root",
+      root,
+      "--session",
+      id.value(),
+      "--system-prompt-file",
+      prompt_path,
+      "write",
+      "MoonBit",
+    ],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let store = @store.SessionStore(root)
+  let session = load_or_new_session(store, id, parsed, V4Pro)
+  assert_eq(session.system_prompt(), "system")
+  assert_eq(session.events().length(), 0)
+  let with_event = store.append(session, User(UserMessage("hello")))
+  assert_eq(with_event.events().length(), 1)
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "session list command does not require deepseek setup" {
+  let root = @fs.tmpdir(prefix="openseek-cli-session-list-")
+  let store = @store.SessionStore(root)
+  store.create(Session(SessionId("b"), system_prompt="system"))
+  store.create(Session(SessionId("a"), system_prompt="system"))
+  let parsed = cli_command().parse(
+    argv=["--session-root", root, "--session-list"],
+    env={},
+  )
+  assert_true(handle_session_command(parsed))
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "session compact command appends summary without api key" {
+  let root = @fs.tmpdir(prefix="openseek-cli-session-compact-")
+  let store = @store.SessionStore(root)
+  let session = @agent_session.Session(
+      SessionId("cli-test"),
+      system_prompt="system",
+    )
+    .append(User(UserMessage("hello")))
+    .append(Assistant(AssistantMessage("answer")))
+  store.create(session)
+  let summary_path = root + "/summary.txt"
+  @fs.write_file(summary_path, "summarized turn", create_mode=CreateOrTruncate)
+  let parsed = cli_command().parse(
+    argv=[
+      "--session-root", root, "--session", "cli-test", "--session-compact-file",
+      summary_path, "--session-compact-from", "1", "--session-compact-to", "2",
+    ],
+    env={},
+  )
+  assert_true(handle_session_command(parsed))
+  let loaded = store.load(SessionId("cli-test"))
+  assert_eq(loaded.events().length(), 3)
+  guard loaded.events()[2].item() is Summary(summary) else {
+    fail("expected summary")
+  }
+  assert_eq(summary.content(), "summarized turn")
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "session compaction rejects missing summary file" {
+  let parsed = cli_command().parse(
+    argv=[
+      "--session", "cli-test", "--session-compact-from", "1", "--session-compact-to",
+      "2", "write", "MoonBit",
+    ],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let _ = handle_session_command(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("--session-compact-file is required"))
+      return
+    }
+  }
+  fail("partial session compaction accepted")
 }
 
 ///|

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -1,12 +1,18 @@
 import {
   "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/prompt",
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/io",
+  "moonbitlang/async/os_error",
+  "moonbitlang/async/stdio",
   "moonbitlang/core/argparse",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
+  "moonbitlang/x/sys",
   "tonyfettes/xlog",
 }
 

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -16,7 +16,7 @@ variables and defaults behind each one, then exits successfully.
 
 ```mooncram
 $ openseek.exe --help
-Usage: openseek --api-key <api-key> [options] <task...>
+Usage: openseek [options] [task...]
 
 DeepSeek-backed MoonBit coding agent.
 
@@ -25,39 +25,64 @@ Arguments:
 
 Options:
   -h, --help                                                   Show help information.
-  --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK]
+  --session-list                                               List durable session ids and exit.
+  --session-show                                               Print the durable session JSON for --session and exit.
+  --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
   --model <model>                                              DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
+  --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION] [default: ]
+  --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  --session-compact-file <session-compact-file>                Read summary text from this file, append it to --session, and exit. [default: ]
+  --session-compact-from <session-compact-from>                First event sequence covered by --session-compact-file. [default: ]
+  --session-compact-to <session-compact-to>                    Last event sequence covered by --session-compact-file. [default: ]
 ```
 
-## A DeepSeek API Key Is Required
+## A DeepSeek API Key Is Required For Agent Runs
 
-With no `--api-key` flag and no `DEEPSEEK` in the environment, the CLI reports
-the missing required argument, prints the usage to help the caller, and exits
-non-zero.
+With no `--api-key` flag and no `DEEPSEEK` in the environment, an agent run
+reports the missing key and exits non-zero.
 
 ```mooncram
-$ env -u DEEPSEEK openseek.exe "summarize this project"
-error: the following required argument was not provided: 'api-key'
+$ sh <<'EOF'
+> stdout=$(mktemp)
+> stderr=$(mktemp)
+> if env -u DEEPSEEK openseek.exe "summarize this project" > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> cat "$stderr"
+> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
+> rm -f "$stdout" "$stderr"
+> EOF
+exit-non-zero
+error: --api-key or DEEPSEEK is required for agent runs
+stdout-empty
+```
 
-Usage: openseek --api-key <api-key> [options] <task...>
+## Session Management Is Offline
 
-DeepSeek-backed MoonBit coding agent.
+Session inspection and compaction operate on typed session files and do not
+require a DeepSeek API key.
 
-Arguments:
-  task...  Task description.
-
-Options:
-  -h, --help                                                   Show help information.
-  --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK]
-  --model <model>                                              DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
-  --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
-
-[1]
+```mooncram
+$ sh <<'EOF'
+> tmp=$(mktemp -d)
+> mkdir -p "$tmp/sessions/demo"
+> printf '{"version":1,"id":"demo","system_prompt":"system","last_sequence":2}' > "$tmp/sessions/demo/session.json"
+> cat > "$tmp/sessions/demo/events.jsonl" <<'JSONL'
+> {"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}}
+> {"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
+> JSONL
+> printf 'hello and answer' > "$tmp/summary.txt"
+> env -u DEEPSEEK openseek.exe --session-list --session-root "$tmp"
+> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp"
+> env -u DEEPSEEK openseek.exe --session demo --session-root "$tmp" --session-compact-file "$tmp/summary.txt" --session-compact-from 1 --session-compact-to 2
+> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp"
+> rm -rf "$tmp"
+> EOF
+demo
+{"version":1,"id":"demo","system_prompt":"system","events":[{"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}},{"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}]}
+compacted session demo events 1..2; last_sequence=3
+{"version":1,"id":"demo","system_prompt":"system","events":[{"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}},{"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}},{"sequence":3,"item":{"kind":"summary","payload":{"content":"hello and answer","from_sequence":1,"to_sequence":2}}}]}
 ```
 
 ## MoonBit CLI Argument Parsing Pattern


### PR DESCRIPTION
## Summary

This is the next focused slice after the agent turn API reached `main`.

It wires durable sessions into `cmd/openseek` while preserving one-shot behavior by default:

- `openseek ...` runs a new one-shot in-memory session, as before
- `openseek --session <id> ...` creates or resumes that explicit durable session
- `--session-list`, `--session-show`, and `--session-compact-file` provide offline session-management commands
- `--api-key` is no longer an argparse-required option so offline session commands can run without DeepSeek credentials; agent runs still validate `--api-key` / `DEEPSEEK` before calling the model
- CLI errors are reported cleanly to stderr with exit code 1

The new-session path deliberately does not eagerly create an empty session file. It returns an in-memory session and lets the first `SessionStore::append` write under the store lock, so concurrent first writers cannot clobber each other with an empty `create` rewrite.

Subal review feedback is addressed in this version:

- resuming an existing durable session no longer reads `--system-prompt-file` / addendum files before load, so stale prompt-file paths do not block resume
- an interrupted first session creation that left `sessions/<id>/` without a header is recovered as a fresh session and repaired on first append
- partial compaction flags are validated as a session-management command instead of falling through to an agent run
- empty `--session-root` / `OPENSEEK_SESSION_ROOT` values are rejected before constructing store paths

## Scope

This PR only updates the `cmd/openseek` CLI. TUI session display/control remains a later separate PR.

## Validation

- `moon check cmd/openseek --target native --warn-list +73 --diagnostic-limit 300`
- `moon test cmd/openseek --target native --warn-list +73 --diagnostic-limit 300` - 15/15 passed
- `moon fmt cmd/openseek`
- `moon info cmd/openseek --target native`
- `moon ide analyze cmd/openseek --target native`
- `moon check --target native --diagnostic-limit 300`
- `git diff --check -- cmd/openseek/main.mbt cmd/openseek/moon.pkg cmd/openseek/README.md tests/cram/cli.md`
- `moon test --target native --diagnostic-limit 300` - 442/442 passed
- `moon cram test tests/cram` - 6/6 passed
