### PR TITLE
[codex] add explicit TUI session support

### DIFF
--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -5,6 +5,21 @@ fn drain_test_state() -> State {
     model: V4Pro,
     cwd: ".",
     max_steps: 10,
+    session_id: Some(SessionId("test")),
+    session_root: ".openseek",
+    engine: "openseek",
+  })
+}
+
+///|
+fn ephemeral_drain_test_state() -> State {
+  State::new({
+    api_key: "k",
+    model: V4Pro,
+    cwd: ".",
+    max_steps: 10,
+    session_id: None,
+    session_root: ".openseek",
     engine: "openseek",
   })
 }
@@ -40,6 +55,57 @@ fn run_command_count(cmds : Array[Cmd]) -> Int {
     }
   }
   count
+}
+
+///|
+test "agent engine argv stays replay-compatible while session config uses env" {
+  let config = drain_test_state().config
+  let args = engine_args("--literal task")
+  assert_eq(args.length(), 2)
+  assert_eq(args[0], "--")
+  assert_eq(args[1], "--literal task")
+  let env = engine_extra_env(config)
+  guard env.get("OPENSEEK_SESSION") is Some(session_id) else {
+    fail("missing session id env")
+  }
+  guard env.get("OPENSEEK_SESSION_ROOT") is Some(session_root) else {
+    fail("missing session root env")
+  }
+  assert_eq(session_id, "test")
+  assert_eq(session_root, ".openseek")
+}
+
+///|
+test "agent engine env omits session config for fresh runs" {
+  let env = engine_env(ephemeral_drain_test_state().config, {})
+  assert_true(env.get("OPENSEEK_SESSION") is None)
+  assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
+}
+
+///|
+test "agent engine env overrides inherited session config" {
+  let inherited = {
+    "OPENSEEK_SESSION": "parent",
+    "OPENSEEK_SESSION_ROOT": "/tmp/parent",
+    "PATH": "/bin",
+  }
+  let env = engine_env(drain_test_state().config, inherited)
+  assert_true(env.get("PATH") == Some("/bin"))
+  assert_true(env.get("OPENSEEK_SESSION") == Some("test"))
+  assert_true(env.get("OPENSEEK_SESSION_ROOT") == Some(".openseek"))
+  assert_true(inherited.get("OPENSEEK_SESSION") == Some("parent"))
+}
+
+///|
+test "agent engine env clears inherited session config for fresh runs" {
+  let env = engine_env(ephemeral_drain_test_state().config, {
+    "OPENSEEK_SESSION": "parent",
+    "OPENSEEK_SESSION_ROOT": "/tmp/parent",
+    "PATH": "/bin",
+  })
+  assert_true(env.get("PATH") == Some("/bin"))
+  assert_true(env.get("OPENSEEK_SESSION") is None)
+  assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -97,6 +97,37 @@ fn is_terminal_event(event : @event.AgentEvent) -> Bool {
 }
 
 ///|
+fn engine_args(task : String) -> Array[String] {
+  ["--", task]
+}
+
+///|
+fn engine_extra_env(config : AppConfig) -> Map[String, String] {
+  let env = {
+    "DEEPSEEK": config.api_key,
+    "DEEPSEEK_MODEL": config.model.to_string(),
+    "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+  }
+  if config.session_id is Some(session_id) {
+    env["OPENSEEK_SESSION"] = session_id.value()
+    env["OPENSEEK_SESSION_ROOT"] = config.session_root
+  }
+  env
+}
+
+///|
+fn engine_env(
+  config : AppConfig,
+  inherited : Map[String, String],
+) -> Map[String, String] {
+  let env = inherited.copy()
+  env.remove("OPENSEEK_SESSION")
+  env.remove("OPENSEEK_SESSION_ROOT")
+  env.merge_in_place(engine_extra_env(config))
+  env
+}
+
+///|
 /// Spawn the agent engine for one input and stream its JSONL stdout into the
 /// message loop.
 ///
@@ -116,6 +147,7 @@ async fn run_agent_task(
   @async.with_task_group(group => {
     let (reader, child_stdout) = @process.read_from_process()
     let (stderr_reader, child_stderr) = @process.read_from_process()
+    let child_env = engine_env(config, @env.get_env_vars())
     let proc = @process.spawn(
       group,
       config.engine,
@@ -123,14 +155,13 @@ async fn run_agent_task(
       // can start with `-`/`--` (e.g. the literal text `--help`). Forward it
       // after a `--` delimiter so the engine's argparse treats it as the task
       // positional rather than parsing it as one of its own options (which would
-      // exit/print help and never emit a terminal JSONL event).
-      ["--", task],
-      inherit_env=true,
-      extra_env={
-        "DEEPSEEK": config.api_key,
-        "DEEPSEEK_MODEL": config.model.to_string(),
-        "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
-      },
+      // exit/print help and never emit a terminal JSONL event). Session settings
+      // go through a fully materialized environment so custom replay engines do
+      // not need to accept OpenSeek-specific flags, and inherited session vars
+      // cannot shadow explicit TUI config.
+      engine_args(task),
+      inherit_env=false,
+      extra_env=child_env,
       stdout=child_stdout,
       stderr=child_stderr,
     )

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -32,6 +32,19 @@ fn cli_command() -> @argparse.Command {
         default_values=["openseek"],
         about="Agent engine binary to spawn; reads its JSONL event stream from stdout.",
       ),
+      OptionArg(
+        "session",
+        long="session",
+        env="OPENSEEK_SESSION",
+        about="Create or resume this durable session id.",
+      ),
+      OptionArg(
+        "session-root",
+        long="session-root",
+        env="OPENSEEK_SESSION_ROOT",
+        default_values=[".openseek"],
+        about="Directory containing durable OpenSeek sessions.",
+      ),
     ],
     positionals=[
       PositionArg(
@@ -73,16 +86,51 @@ fn parse_positive_int(input : String, label : String) -> Int raise {
 }
 
 ///|
+fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? {
+  let session = match values(matches, "session") {
+    [session, ..] => session.trim().to_owned()
+    [] => ""
+  }
+  if session.is_empty() {
+    None
+  } else {
+    Some(SessionId(session))
+  }
+}
+
+///|
+fn session_root(matches : @argparse.Matches) -> String raise {
+  let root = value(matches, "session-root").trim().to_owned()
+  if root.is_empty() {
+    fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
+  }
+  root
+}
+
+///|
 fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   let cwd = match @env.current_dir() {
     Some(cwd) => cwd
     None => "."
+  }
+  let session_id = session_id(matches)
+  let session_root_value = if session_id is Some(_) {
+    session_root(matches)
+  } else {
+    let root = value(matches, "session-root").trim().to_owned()
+    if root.is_empty() {
+      ".openseek"
+    } else {
+      root
+    }
   }
   {
     api_key: value(matches, "api-key"),
     model: @deepseek.Model::parse(value(matches, "model")),
     cwd,
     max_steps: parse_positive_int(value(matches, "max-steps"), "--max-steps"),
+    session_id,
+    session_root: session_root_value,
     engine: value(matches, "engine"),
   }
 }
@@ -108,6 +156,7 @@ async fn run_tui(config : AppConfig, initial : String?) -> Unit {
 async fn run_app(config : AppConfig, initial : String?, ui : @ui.Ui) -> Unit {
   let state = State::new(config)
   let messages = @async.Queue(kind=Unbounded)
+  append_session_history(state.config, ui)
   ui.append_item(Response("OpenSeek TUI ready"))
   refresh_ui(ui, state)
   @async.with_task_group(group => {
@@ -172,6 +221,8 @@ test "cli accepts no initial task" {
   assert_eq(config.api_key, "test-key")
   assert_eq(config.max_steps, 1000)
   assert_eq(config.engine, "openseek")
+  assert_true(config.session_id is None)
+  assert_eq(config.session_root, ".openseek")
 }
 
 ///|
@@ -182,6 +233,33 @@ test "cli accepts initial task and max steps" {
   )
   assert_true(initial_task(parsed) == Some("inspect project"))
   assert_eq(parse_config(parsed).max_steps, 5)
+}
+
+///|
+test "cli accepts session configuration" {
+  let parsed = cli_command().parse(
+    argv=["--session", "demo", "--session-root", "/tmp/openseek-sessions"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = parse_config(parsed)
+  guard config.session_id is Some(id) else { fail("expected session id") }
+  assert_eq(id.value(), "demo")
+  assert_eq(config.session_root, "/tmp/openseek-sessions")
+}
+
+///|
+test "cli rejects empty session root when session is active" {
+  let parsed = cli_command().parse(
+    argv=["--session", "demo", "--session-root", ""],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let _ = parse_config(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("--session-root"))
+      return
+    }
+  }
+  fail("empty session root accepted")
 }
 
 ///|

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "bobzhang/jsonl",
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/agent_tool/shell",
   "bobzhang/openseek/cmd/tui/internal/event",
   "bobzhang/openseek/deepseek",

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -1,0 +1,76 @@
+///|
+fn session_tool_item(result : @agent_session.ToolResult) -> @ui.TranscriptItem {
+  let event : @event.ToolResultEvent = {
+    name: result.tool_name(),
+    content: result.content(),
+    is_error: result.is_error(),
+  }
+  tool_item(event)
+}
+
+///|
+fn summary_item(summary : @agent_session.SessionSummary) -> @ui.TranscriptItem {
+  Notice(
+    ToolCall(
+      @doc.Text::plain(
+        "conversation summary · events \{summary.from_sequence()}..\{summary.to_sequence()}",
+      ),
+      details=detail_texts(
+        compact_lines(summary.content(), ToolOutputLineLimit),
+      ),
+    ),
+  )
+}
+
+///|
+fn terminal_item(terminal : @agent_session.TurnTerminal) -> @ui.TranscriptItem? {
+  match terminal {
+    Finished(answer) if !answer.trim().is_empty() => Some(Response(answer))
+    Finished(_) => None
+    Aborted(reason) => Some(Error("aborted: " + reason))
+    Interrupted(reason) => Some(Error("interrupted: " + reason))
+    Failed(message) => Some(Error(message))
+  }
+}
+
+///|
+fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
+  match item {
+    User(message) => Some(Input(Prompt(message.content())))
+    Assistant(message) =>
+      if message.content().trim().is_empty() {
+        None
+      } else {
+        Some(Response(message.content()))
+      }
+    Tool(result) => Some(session_tool_item(result))
+    Runtime(notice) =>
+      Some(runtime_item(parse_runtime_update(notice.content())))
+    Summary(summary) => Some(summary_item(summary))
+    Terminal(terminal) => terminal_item(terminal)
+  }
+}
+
+///|
+async fn append_session_history(config : AppConfig, ui : @ui.Ui) -> Unit {
+  guard config.session_id is Some(session_id) else { return }
+  let store = @store.SessionStore(config.session_root)
+  let exists = store.exists(session_id) catch {
+    error => {
+      ui.append_item(Error("failed to inspect session: \{error}"))
+      return
+    }
+  }
+  guard exists else { return }
+  let session = store.load(session_id) catch {
+    error => {
+      ui.append_item(Error("failed to load session: \{error}"))
+      return
+    }
+  }
+  for event in session.events() {
+    if session_item(event.item()) is Some(item) {
+      ui.append_item(item)
+    }
+  }
+}

--- a/cmd/tui/session_view_wbtest.mbt
+++ b/cmd/tui/session_view_wbtest.mbt
@@ -1,0 +1,17 @@
+///|
+test "session items project to transcript items" {
+  guard session_item(User(UserMessage("hello"))) is Some(Input(Prompt(text))) else {
+    fail("expected input")
+  }
+  assert_eq(text, "hello")
+  guard session_item(Terminal(Finished("done"))) is Some(Response(answer)) else {
+    fail("expected response")
+  }
+  assert_eq(answer, "done")
+  guard session_item(
+      Tool(ToolResult(tool_call_id="call_1", tool_name="read", content="ok")),
+    )
+    is Some(ToolCall(_)) else {
+    fail("expected tool")
+  }
+}

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -4,6 +4,8 @@ priv struct AppConfig {
   model : @deepseek.Model
   cwd : String
   max_steps : Int
+  session_id : @agent_session.SessionId?
+  session_root : String
   // The agent engine the TUI spawns and reads JSONL events from. Defaults to
   // the `openseek` binary on `PATH`; override (e.g. to a recorded-stream
   // replayer) with `--engine` or `OPENSEEK_ENGINE`.

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -24,11 +24,13 @@ Arguments:
   task...  Optional initial task description.
 
 Options:
-  -h, --help               Show help information.
-  --api-key <api-key>      DeepSeek API key. [env: DEEPSEEK]
-  --model <model>          DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --max-steps <max-steps>  Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --engine <engine>        Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  -h, --help                     Show help information.
+  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
+  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 ```
 
 ## A DeepSeek API Key Is Required
@@ -49,11 +51,13 @@ Arguments:
   task...  Optional initial task description.
 
 Options:
-  -h, --help               Show help information.
-  --api-key <api-key>      DeepSeek API key. [env: DEEPSEEK]
-  --model <model>          DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --max-steps <max-steps>  Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --engine <engine>        Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  -h, --help                     Show help information.
+  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
+  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 
 [1]
 ```

--- a/tui/style/style.mbt
+++ b/tui/style/style.mbt
@@ -18,7 +18,7 @@ pub fn Style::Style(
   background? : @tty/color.Color = Default,
   underline? : Bool = false,
 ) -> Style {
-  Style::{ foreground, background, underline }
+  { foreground, background, underline }
 }
 
 ///|


### PR DESCRIPTION
## Summary

This is the next focused slice after the CLI durable-session commands reached `main`.

It wires explicit durable sessions into `cmd/tui` without changing the default one-shot TUI behavior:

- `openseek-tui ...` still starts without a durable session by default
- `openseek-tui --session <id> ...` creates/resumes that explicit durable session through the spawned `openseek` engine
- the TUI forwards session configuration through a fully materialized child environment, using `OPENSEEK_SESSION` / `OPENSEEK_SESSION_ROOT` only when an explicit session is active
- inherited session environment values are cleared/overridden before spawning the engine, so CLI/env parsing and engine persistence cannot diverge
- when an existing session is present, the TUI loads its typed history and renders user, assistant, tool, runtime, summary, and terminal events into the transcript before new input
- empty `--session-root` / `OPENSEEK_SESSION_ROOT` values are rejected when a durable session is active
- removes a redundant `Style::` constructor annotation surfaced by warning 73 while validating the TUI packages

## Scope

This PR only updates TUI integration and display. The underlying session model, store, agent turn API, and `cmd/openseek` CLI commands are already in `main` from earlier focused PRs.

## Validation

- `moon check cmd/tui --target native --warn-list +73 --diagnostic-limit 300`
- `moon test cmd/tui --target native --warn-list +73 --diagnostic-limit 300` - 23/23 passed
- `moon fmt cmd/tui tui/style`
- `moon info cmd/tui --target native`
- `moon ide analyze cmd/tui --target native`
- `moon check --target native --warn-list +73 --diagnostic-limit 300`
- `git diff --check`
- `moon test --target native --diagnostic-limit 300` - 449/449 passed
- `moon cram test tests/cram` - 6/6 passed
- `subal exec review --base origin/main` - no actionable regressions found; its full `moon test --target native` hit the existing opt-in DeepSeek real-world smoke test DNS failure in the Subal environment
- GitHub CI `check (nightly)` passed
