### PR TITLE
Stream assistant and reasoning deltas live in the TUI

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -150,7 +150,20 @@ async fn run_with_runtime(
         messages.push(ChatMessage(User, content=update))
       }
       @xlog.info() <? { "event": "agent_step", "step": step + 1 }
-      let response = client.chat(messages, tools=tools.function_tools())
+      let response = client.chat_stream(
+        messages,
+        tools=tools.function_tools(),
+        on_content_delta=delta => {
+          if delta != "" {
+            @xlog.info() <? { "event": "assistant_delta", "content": delta }
+          }
+        },
+        on_reasoning_delta=delta => {
+          if delta != "" {
+            @xlog.info() <? { "event": "reasoning_delta", "content": delta }
+          }
+        },
+      )
       if response.content != "" {
         @xlog.info() <?
           { "event": "assistant_message", "content": response.content }

--- a/cmd/openseek/flushed_stdout.c
+++ b/cmd/openseek/flushed_stdout.c
@@ -1,0 +1,26 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+#include "moonbit.h"
+
+MOONBIT_FFI_EXPORT int
+openseek_write_flushed_stdout_line(moonbit_bytes_t data) {
+  int len = Moonbit_array_length(data);
+  if (len > 0) {
+    size_t written = fwrite(data, 1, (size_t)len, stdout);
+    if (written != (size_t)len) {
+      return -1;
+    }
+  }
+  if (fputc('\n', stdout) == EOF) {
+    return -1;
+  }
+  return fflush(stdout) == 0 ? 0 : -1;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/cmd/openseek/logging.mbt
+++ b/cmd/openseek/logging.mbt
@@ -1,0 +1,34 @@
+///|
+priv struct FlushedStdout {
+  format : @xlog.Format
+}
+
+///|
+fn FlushedStdout::FlushedStdout(
+  format? : @xlog.Format = Jsonl,
+) -> FlushedStdout {
+  { format, }
+}
+
+///|
+#borrow(data)
+extern "C" fn write_flushed_stdout_line_ffi(data : Bytes) -> Int = "openseek_write_flushed_stdout_line"
+
+///|
+fn write_flushed_stdout_line(text : String) -> Unit raise {
+  guard write_flushed_stdout_line_ffi(@utf8.encode(text)) == 0 else {
+    fail("failed to write stdout")
+  }
+}
+
+///|
+impl @xlog.Handler for FlushedStdout with fn handle(
+  self : FlushedStdout,
+  entry : @xlog.Entry,
+) -> Unit raise {
+  let line = match self.format {
+    Text => entry.to_string()
+    Jsonl => entry.to_json().stringify()
+  }
+  write_flushed_stdout_line(line)
+}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -62,21 +62,29 @@ fn failure_message(error_text : String) -> String {
 }
 
 ///|
-/// Mirror every JSONL log event to `OPENSEEK_LOG_FILE` in addition to stdout
-/// when that variable is set.
+/// Write every JSONL log event to stdout with a per-entry flush. When
+/// `OPENSEEK_LOG_FILE` is set, mirror each event there as well.
 ///
-/// The TUI parses the JSONL the engine writes to stdout, so stdout is left
-/// exactly as it was (the default `Stdout` handler keeps its `Jsonl` format);
-/// this only adds a second handler that appends the same JSONL to the file. The
-/// file handler flushes per entry, so `tail -f $OPENSEEK_LOG_FILE` shows events
-/// live — useful for inspecting a stuck or headless session. Best-effort: if the
-/// file cannot be opened, logging stays stdout-only rather than failing the run.
+/// The TUI parses the JSONL the engine writes to stdout through a pipe. Plain
+/// `println` can be block-buffered in that setup, which makes streaming deltas
+/// arrive all at once. `FlushedStdout` preserves the JSONL wire format but calls
+/// `fflush(stdout)` after each line so assistant deltas are visible promptly.
+/// The file handler already flushes per entry, so `tail -f $OPENSEEK_LOG_FILE`
+/// also shows events live. Best-effort: if the file cannot be opened, logging
+/// stays flushed-stdout-only rather than failing the run.
 fn configure_logging() -> Unit {
+  let stdout = FlushedStdout()
   guard @env.get_env_var("OPENSEEK_LOG_FILE") is Some(path) && path != "" else {
+    @xlog.global().set_handler(stdout)
     return
   }
-  let file = @xlog.File::File(path) catch { _ => return }
-  let handlers : Array[&@xlog.Handler] = [@xlog.Stdout(), file]
+  let file = @xlog.File::File(path) catch {
+    _ => {
+      @xlog.global().set_handler(stdout)
+      return
+    }
+  }
+  let handlers : Array[&@xlog.Handler] = [stdout, file]
   @xlog.global().set_handler(@xlog.Multi(handlers))
 }
 

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -10,6 +10,7 @@ import {
   "moonbitlang/async/os_error",
   "moonbitlang/async/stdio",
   "moonbitlang/core/argparse",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/x/sys",
@@ -22,4 +23,5 @@ supported_targets = "+native"
 
 options(
   "is-main": true,
+  "native-stub": [ "flushed_stdout.c" ],
 )

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -11,6 +11,8 @@
 pub fn decode_event(object : Json) -> AgentEvent? {
   match @jsonx.string(object, "event") {
     "agent_step" => Some(AgentStep)
+    "assistant_delta" => Some(AssistantDelta(@jsonx.string(object, "content")))
+    "reasoning_delta" => Some(ReasoningDelta(@jsonx.string(object, "content")))
     "assistant_message" =>
       Some(AssistantMessage(@jsonx.string(object, "content")))
     "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -10,6 +10,18 @@ test "decode maps each engine event kind" {
   )
   assert_true(
     @event.decode_event(
+      Json::object({ "event": "assistant_delta", "content": "tok" }),
+    )
+    is Some(AssistantDelta("tok")),
+  )
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "reasoning_delta", "content": "hmm" }),
+    )
+    is Some(ReasoningDelta("hmm")),
+  )
+  assert_true(
+    @event.decode_event(
       Json::object({ "event": "agent_finished", "answer": "done" }),
     )
     is Some(AgentFinished("done")),

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -34,6 +34,8 @@ pub(all) struct ToolResultEvent {
 /// queued input.
 pub(all) enum AgentEvent {
   AgentStep
+  AssistantDelta(String)
+  ReasoningDelta(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -9,6 +9,8 @@ pub fn decode_event(Json) -> AgentEvent?
 // Types and methods
 pub(all) enum AgentEvent {
   AgentStep
+  AssistantDelta(String)
+  ReasoningDelta(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -244,6 +244,150 @@ test "parse_runtime_update aggregates status across watcher sections" {
 }
 
 ///|
+test "assistant_delta accumulates live text and commits only the final message" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Hel" }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "lo" }),
+    items,
+  )
+  assert_eq(items.length(), 0)
+  assert_true(state.streaming_response is Some("Hello"))
+  assert_true(state.step_response is None)
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Hello" }),
+    items,
+  )
+  assert_true(state.streaming_response is None)
+  assert_true(state.step_response is Some("Hello"))
+  append_items(
+    state,
+    Json::object({ "event": "agent_finished", "answer": "Hello" }),
+    items,
+  )
+  debug_inspect(items, content="[Response(\"Hello\")]")
+}
+
+///|
+test "assistant_message clears live streaming text while tools continue" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Need tool" }),
+    items,
+  )
+  assert_true(state.streaming_response is Some("Need tool"))
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Need tool" }),
+    items,
+  )
+  assert_true(state.run is Running(_))
+  assert_true(state.streaming_response is None)
+  assert_true(state.step_response is Some("Need tool"))
+  assert_eq(items.length(), 1)
+}
+
+///|
+test "assistant_delta live preview keeps the newest tail within the cap" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({
+      "event": "assistant_delta",
+      "content": String::make(StreamingPreviewMaxColumns * 4, 'x'),
+    }),
+    items,
+  )
+  guard state.streaming_response is Some(first) else {
+    fail("expected streaming preview")
+  }
+  assert_true(
+    @displaytext.DisplayText(first).width() <= StreamingPreviewMaxColumns,
+  )
+  assert_true(first.has_prefix("…"))
+  // The preview is a tail window: new deltas keep showing up at its end
+  // (instead of freezing once the cap is reached, as a head truncation would).
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "more" }),
+    items,
+  )
+  guard state.streaming_response is Some(second) else {
+    fail("expected streaming preview")
+  }
+  assert_true(second.has_suffix("more"))
+  assert_true(
+    @displaytext.DisplayText(second).width() <= StreamingPreviewMaxColumns,
+  )
+  assert_eq(items.length(), 0)
+}
+
+///|
+test "streamed newlines collapse so the preview stays one line" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "fn main {\n" }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "  println(1)\n}" }),
+    items,
+  )
+  // The run of newline + indentation spanning the two deltas collapses to a
+  // single space; the preview holds no control characters.
+  assert_true(state.streaming_response is Some("fn main { println(1) }"))
+}
+
+///|
+test "reasoning_delta drives the thinking preview until content arrives" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "reasoning_delta", "content": "Let me think" }),
+    items,
+  )
+  assert_true(state.streaming_reasoning is Some("Let me think"))
+  assert_true(state.streaming_response is None)
+  assert_eq(items.length(), 0)
+  // The first content delta ends the thinking phase: the content preview
+  // replaces the reasoning one.
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Answer" }),
+    items,
+  )
+  assert_true(state.streaming_reasoning is None)
+  assert_true(state.streaming_response is Some("Answer"))
+  // The committed message clears both previews.
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Answer" }),
+    items,
+  )
+  assert_true(state.streaming_response is None)
+  assert_true(state.streaming_reasoning is None)
+}
+
+///|
 test "replaying a recorded engine session renders the transcript" {
   let state = drain_test_state()
   // Submit a task so the agent is running before progress arrives.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -251,6 +251,71 @@ async fn run_shell_command(
 }
 
 ///|
+// The live streaming line is only a transient status preview: it keeps the
+// *tail* of the stream (the newest text) so the line visibly moves while the
+// model types. The final assistant text is committed later by
+// `assistant_message`, so the buffer only needs to cover the widest plausible
+// terminal row; the bound keeps per-delta work constant during long
+// code-generation streams.
+const StreamingPreviewMaxColumns : Int = 240
+
+///|
+/// Keep the last `max_cols` display columns of `text`, marking an elided front
+/// with a leading `…`. The inverse of `DisplayText::truncate`, which keeps the
+/// front — a streaming preview must keep the end, where the new text arrives.
+fn tail_columns(text : String, max_cols : Int) -> String {
+  let display = @displaytext.DisplayText(text)
+  if display.width() <= max_cols {
+    return text
+  }
+  // Reserve one column for the `…` marker; `at_or_after` lands past a wide
+  // char straddling the cut, so the kept tail never exceeds the budget.
+  let keep_from = display.textual_position_at_or_after(
+    @displaytext.DisplayPosition::new(
+      column=display.width() - max_cols + 1,
+    ),
+  )
+  "…" + display.view(keep_from, display.end()).to_owned()
+}
+
+///|
+/// Collapse whitespace runs (newline, CR, tab, space) to a single space so a
+/// streamed fragment stays renderable on the one-row activity line — streamed
+/// code is mostly newlines and indentation, which would otherwise hit the
+/// renderer as control characters.
+fn collapse_preview_whitespace(text : String) -> String {
+  let out = StringBuilder::new()
+  let mut last_was_space = false
+  for ch in text {
+    if ch is (' ' | '\t' | '\n' | '\r') {
+      if !last_was_space {
+        out.write_char(' ')
+      }
+      last_was_space = true
+    } else {
+      out.write_char(ch)
+      last_was_space = false
+    }
+  }
+  out.to_string()
+}
+
+///|
+fn append_streaming_preview(current : String?, delta : String) -> String {
+  let combined = match current {
+    Some(text) => text + delta
+    None => delta
+  }
+  // Re-collapsing the bounded buffer keeps a whitespace run that spans two
+  // deltas collapsed too; the buffer is at most a few hundred chars, so the
+  // rescan is constant work per delta.
+  tail_columns(
+    collapse_preview_whitespace(combined),
+    StreamingPreviewMaxColumns,
+  )
+}
+
+///|
 /// Apply one agent progress event to `state`, queueing any transcript updates in
 /// `cmds`. Terminal events call `finish_run`, leaving the agent idle so the
 /// queue drain at the end of `update` can start the next input.
@@ -260,9 +325,30 @@ fn handle_agent_event(
   cmds : Array[Cmd],
 ) -> Unit {
   match event {
-    AgentStep => state.step_response = None
+    AgentStep => {
+      state.step_response = None
+      state.streaming_response = None
+      state.streaming_reasoning = None
+    }
+    AssistantDelta(text) =>
+      if text != "" {
+        state.streaming_response = Some(
+          append_streaming_preview(state.streaming_response, text),
+        )
+        // Content starting means the thinking phase is over; the content
+        // preview replaces the reasoning one.
+        state.streaming_reasoning = None
+      }
+    ReasoningDelta(text) =>
+      if text != "" {
+        state.streaming_reasoning = Some(
+          append_streaming_preview(state.streaming_reasoning, text),
+        )
+      }
     AssistantMessage(text) => {
       state.step_response = Some(text)
+      state.streaming_response = None
+      state.streaming_reasoning = None
       if !text.trim().is_empty() {
         cmds.push(AppendItem(Response(text)))
       }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -29,7 +29,17 @@ priv struct State {
   // them; a message whose id is not the active run's is stale (it came from a
   // task that has since been superseded) and is dropped. See `State::owns_run`.
   mut run_id : Int
+  // Final assistant text for the current step, used to avoid appending the same
+  // answer again when `AgentFinished` follows `AssistantMessage`.
   mut step_response : String?
+  // Incremental assistant text currently arriving from `assistant_delta`
+  // events. Cleared once the final assistant message is committed.
+  mut streaming_response : String?
+  // Incremental thinking-mode text arriving from `reasoning_delta` events.
+  // Shown only until the first content delta arrives, so the activity line
+  // moves during the (often long) reasoning phase instead of sitting on
+  // "Working (Ns)".
+  mut streaming_reasoning : String?
   mut usage : @event.UsageInfo?
   // Latest background `moon_check` watcher status ("running"/"stopped"), lifted
   // from the most recent `runtime_update` for the status bar. Empty until the
@@ -45,6 +55,8 @@ fn State::new(config : AppConfig) -> State {
     run: Idle,
     run_id: 0,
     step_response: None,
+    streaming_response: None,
+    streaming_reasoning: None,
     usage: None,
     watcher_status: "",
   }
@@ -58,6 +70,8 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run_id = self.run_id + 1
   self.run = Running(started_ms)
   self.step_response = None
+  self.streaming_response = None
+  self.streaming_reasoning = None
   self.run_id
 }
 
@@ -71,14 +85,16 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 
 ///|
 /// Reset run tracking after the agent stops (finished, aborted, cancelled, or
-/// failed): no task running, no pending step response. Also clear the watcher
-/// status: `run_agent_task` spawns a fresh engine per prompt and any
+/// failed): no task running, no pending final or streaming response. Also clear
+/// the watcher status: `run_agent_task` spawns a fresh engine per prompt and any
 /// `moon_check --watch` process belongs to that engine's runtime, so it is gone
 /// once the engine exits — leaving `watcher_status` set would keep a stale
 /// `moon_check running` segment in the status bar while the TUI sits idle.
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
   self.step_response = None
+  self.streaming_response = None
+  self.streaming_reasoning = None
   self.watcher_status = ""
 }
 

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -85,11 +85,48 @@ fn elapsed_seconds(started_ms : Int64, now_ms : Int64) -> Int64 {
 }
 
 ///|
-fn format_activity_text(state : State) -> @doc.Text? {
+/// Columns of the activity row not available to the streaming preview: the
+/// composer indent the renderer prepends (2), the widest label ("Streaming ",
+/// 10), and one column of slack. The preview is tail-clipped to what remains so
+/// its newest characters are never cut by the renderer's own width clip, which
+/// keeps the line's *front* — the oldest text — on overflow.
+const ActivityPreviewReservedColumns : Int = 13
+
+///|
+fn activity_preview(text : String, cols~ : Int) -> String {
+  let budget = cols - ActivityPreviewReservedColumns
+  tail_columns(text, if budget < 16 { 16 } else { budget })
+}
+
+///|
+fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
   let started_ms = match state.run {
     Idle => return None
     Running(started_ms) => started_ms
     Interrupting(started_ms) => started_ms
+  }
+  if state.streaming_response is Some(response) && !response.trim().is_empty() {
+    return Some(
+      Text([
+        Span(DisplayText("Streaming "), style=@style.dim),
+        @doc.Span::plain(activity_preview(response, cols~)),
+      ]),
+    )
+  }
+  // Thinking-mode runs spend their first (often long) stretch emitting only
+  // reasoning deltas; show their tail dimmed so the line moves from the first
+  // token rather than sitting on "Working (Ns)" until content starts.
+  if state.streaming_reasoning is Some(reasoning) &&
+    !reasoning.trim().is_empty() {
+    return Some(
+      Text([
+        Span(DisplayText("Thinking "), style=@style.dim),
+        Span(
+          DisplayText(activity_preview(reasoning, cols~)),
+          style=@style.dim,
+        ),
+      ]),
+    )
   }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @async.now()),
@@ -105,6 +142,6 @@ fn format_activity_text(state : State) -> @doc.Text? {
 ///|
 async fn refresh_ui(ui : @ui.Ui, state : State) -> Unit {
   ui.set_status(format_status_bar_text(state))
-  ui.set_activity(format_activity_text(state))
+  ui.set_activity(format_activity_text(state, cols=ui.columns()))
   ui.set_queued_inputs(state.queued)
 }

--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -17,8 +17,12 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
 - `ChatMessage(role, content=..., tool_calls?, reasoning_content?)`: one typed
   chat message constructor. Use `Assistant` with `tool_calls` for the assistant
   message that must be sent back after DeepSeek requests native tool calls.
-- `encode_chat_request(model, messages, tools?, thinking?, reasoning_effort?)`:
-  builds the full DeepSeek chat completions request body. The per-value
+- `ResponseFormat`: optional assistant content constraint. Leave absent for
+  normal text; pass `JsonObject` only when the assistant content must be a JSON
+  object.
+- `encode_chat_request(model, messages, tools?, thinking?, reasoning_effort?,
+  stream?, response_format?)`: builds the full DeepSeek chat completions request
+  body. Streaming requests include usage-bearing stream options. The per-value
   encoders for messages, tool definitions, and tool calls are package-private
   implementation details.
 - `ToolDefinition(name, description, parameters, strict?)`: a native DeepSeek
@@ -68,6 +72,7 @@ test "encode chat request values" {
   let body = @deepseek.encode_chat_request(model, [message]).stringify()
   assert_true(body.contains("\"role\":\"user\""))
   assert_true(body.contains("\"model\":\"deepseek-v4-flash\""))
+  assert_false(body.contains("\"response_format\""))
 }
 ```
 
@@ -94,6 +99,19 @@ test "encode tool-enabled chat request" {
   ).stringify()
   assert_true(body.contains("\"type\":\"function\""))
   assert_true(body.contains("\"tool_calls\""))
+}
+```
+
+```moonbit check
+///|
+test "encode json-object response request" {
+  let body = @deepseek.encode_chat_request(
+    V4Flash,
+    [ChatMessage(User, content="return {\"ok\":true}")],
+    response_format=JsonObject,
+  ).stringify()
+  assert_true(body.contains("\"response_format\""))
+  assert_true(body.contains("\"json_object\""))
 }
 ```
 

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -12,8 +12,12 @@ The package depends on `moonbitlang/async/http` and is native-only.
 - `Client(api_key~, model?, api_url?, thinking?, reasoning_effort?)`: configure
   the API key, typed model, optional endpoint override, and optional DeepSeek V4
   thinking controls.
-- `Client::chat(messages, tools?)`: send typed chat messages in JSON response
-  mode, optionally with native DeepSeek function tools, and decode the response.
+- `Client::chat(messages, tools?, response_format?)`: send typed chat messages,
+  optionally with native DeepSeek function tools, and decode the response.
+- `Client::chat_stream(messages, on_content_delta~, on_reasoning_delta?,
+  tools?, response_format?)`: send the same request in SSE streaming mode, emit
+  assistant content (and, when thinking is on, reasoning) fragments through the
+  callbacks, and return the fully accumulated response.
 
 `Client` implements `Debug` with the API key redacted.
 
@@ -21,7 +25,18 @@ The package depends on `moonbitlang/async/http` and is native-only.
 
 `Client::chat` builds a private request envelope with the client's configured
 model, thinking mode, and reasoning effort, then sends it to `api_url` as JSON.
-It always sends `stream=false` and `response_format={"type":"json_object"}`.
+It sends `stream=false` and leaves assistant content unconstrained by default.
+Pass `response_format=JsonObject` only for callers that explicitly want the
+assistant content constrained to a JSON object.
+
+`Client::chat_stream` sends `stream=true` plus
+`stream_options={"include_usage":true}`. It parses DeepSeek's SSE `data:` events,
+calls `on_content_delta` for each non-empty `delta.content` (and
+`on_reasoning_delta` for each non-empty `delta.reasoning_content`), accumulates
+reasoning and tool-call fragments, and returns a normal
+`@deepseek.ChatResponse` with final usage when the API supplies it. The request
+pins `Accept-Encoding: identity` so no gzip-compressing intermediary can buffer
+and re-batch the delta stream.
 
 Use `tools=[...]` when the model should call native DeepSeek function tools.
 Tool call results should be appended as `@deepseek.ChatMessage(Tool(call.id),

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -36,12 +36,14 @@ pub fn Client::Client(
 ///|
 /// Sends typed chat messages to DeepSeek and decodes the response.
 ///
-/// The client always requests a JSON object response. Pass `tools` to enable
-/// native DeepSeek function tool calls.
+/// Pass `tools` to enable native DeepSeek function tool calls. Pass
+/// `response_format=JsonObject` only when the assistant content itself should
+/// be constrained to a JSON object.
 pub async fn Client::chat(
   self : Client,
   messages : Array[@deepseek.ChatMessage],
   tools? : Array[@deepseek.ToolDefinition] = [],
+  response_format? : @deepseek.ResponseFormat,
 ) -> @deepseek.ChatResponse {
   let body = @deepseek.encode_chat_request(
     self.model,
@@ -49,6 +51,7 @@ pub async fn Client::chat(
     tools~,
     thinking?=self.thinking,
     reasoning_effort?=self.reasoning_effort,
+    response_format?,
   )
   let (resp, data) = @http.post(self.api_url, body, headers={
     "Content-Type": "application/json",
@@ -60,4 +63,48 @@ pub async fn Client::chat(
   }
   let parsed = @json.parse(text)
   @json.from_json(parsed)
+}
+
+///|
+/// Sends typed chat messages in DeepSeek SSE streaming mode.
+///
+/// `on_content_delta` is called for each assistant content fragment as it
+/// arrives; `on_reasoning_delta` likewise for each thinking-mode reasoning
+/// fragment (it is simply not called when thinking is off). The returned value
+/// is the fully accumulated response, including reasoning, tool calls, and
+/// final token usage when the API sends it.
+pub async fn Client::chat_stream(
+  self : Client,
+  messages : Array[@deepseek.ChatMessage],
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta? : async (String) -> Unit = _ => (),
+  tools? : Array[@deepseek.ToolDefinition] = [],
+  response_format? : @deepseek.ResponseFormat,
+) -> @deepseek.ChatResponse {
+  let body = @deepseek.encode_chat_request(
+    self.model,
+    messages,
+    tools~,
+    thinking?=self.thinking,
+    reasoning_effort?=self.reasoning_effort,
+    stream=true,
+    response_format?,
+  )
+  let client = @http.post_stream(self.api_url, headers={
+    "Content-Type": "application/json",
+    "Authorization": "Bearer \{self.api_key}",
+    // Without an explicit Accept-Encoding the HTTP client advertises gzip and
+    // transparently decompresses. A gzip-compressing intermediary buffers
+    // whole compression blocks, which would re-batch the SSE deltas this
+    // request exists to stream — so pin the identity encoding.
+    "Accept-Encoding": "identity",
+  })
+  defer client.close()
+  client.write(body.stringify())
+  let resp = client.end_request()
+  guard resp.code >= 200 && resp.code < 300 else {
+    let text = client.read_all().text()
+    fail("DeepSeek API error \{resp.code}: \{text}")
+  }
+  read_chat_stream(client, on_content_delta~, on_reasoning_delta~)
 }

--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -13,15 +13,18 @@ async test "realworld DeepSeek API smoke test" {
     thinking=Some(Enabled),
     reasoning_effort=Some(High),
   )
-  let response = client.chat() <| [
-    ChatMessage(
-      System,
-      content=(
-        #|Reply with exactly this JSON object and no markdown: {"answer":"pong"}
+  let response = client.chat(
+    [
+      ChatMessage(
+        System,
+        content=(
+          #|Reply with exactly this JSON object and no markdown: {"answer":"pong"}
+        ),
       ),
-    ),
-    ChatMessage(User, content="ping"),
-  ]
+      ChatMessage(User, content="ping"),
+    ],
+    response_format=JsonObject,
+  )
   // It may fail in theory, but in practice it should always work.
   debug_inspect(
     response.content,

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -1,0 +1,93 @@
+///|
+async fn stream_test_server(
+  group : @async.TaskGroup[Unit],
+  finish? : Bool = true,
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping stream test: \{message}")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        // The streaming request pins the identity encoding: a gzip-compressing
+        // intermediary would buffer compression blocks and re-batch the SSE
+        // deltas.
+        assert_true(request.headers.get("accept-encoding") is Some("identity"))
+        let request_body = body.read_all().text()
+        assert_true(request_body.contains("\"stream\":true"))
+        assert_true(request_body.contains("\"include_usage\":true"))
+        assert_false(request_body.contains("\"response_format\""))
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+        )
+        conn.flush()
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\" world\",\"reasoning_content\":\"hidden\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n",
+        )
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"moon.mod\\\"}\"}}]}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+        )
+        if finish {
+          conn.write("data: [DONE]\n\n")
+        }
+      },
+      max_connections=1,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "chat_stream accumulates SSE content, tool calls, and usage" {
+  @async.with_task_group() <| group => {
+    guard stream_test_server(group) is Some(url) else { return }
+    let client = @client.Client(api_key="test-key", api_url=url)
+    let deltas : Array[String] = []
+    let reasoning_deltas : Array[String] = []
+    let response = client.chat_stream(
+      [ChatMessage(User, content="hello")],
+      on_content_delta=delta => deltas.push(delta),
+      on_reasoning_delta=delta => reasoning_deltas.push(delta),
+    )
+    assert_eq(deltas.join("|"), "Hello| world")
+    assert_eq(reasoning_deltas.join("|"), "hidden")
+    assert_eq(response.content, "Hello world")
+    assert_eq(response.reasoning_content, "hidden")
+    assert_eq(response.tool_calls.length(), 1)
+    assert_eq(response.tool_calls[0].id, "call_1")
+    assert_eq(response.tool_calls[0].name, "read")
+    assert_eq(response.tool_calls[0].arguments, "{\"path\":\"moon.mod\"}")
+    assert_eq(response.usage.prompt_tokens, 3)
+    assert_eq(response.usage.completion_tokens, 5)
+    assert_eq(response.usage.total_tokens, 8)
+    assert_eq(response.usage.prompt_cache_hit_tokens, 1)
+    assert_eq(response.usage.prompt_cache_miss_tokens, 2)
+  }
+}
+
+///|
+async test "chat_stream rejects EOF before done" {
+  @async.with_task_group() <| group => {
+    guard stream_test_server(group, finish=false) is Some(url) else { return }
+    let client = @client.Client(api_key="test-key", api_url=url)
+    try {
+      let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
+        ()
+      })
+      fail("expected truncated stream to fail")
+    } catch {
+      error => assert_true("\{error}".contains("ended before [DONE]"))
+    }
+  }
+}

--- a/deepseek/client/moon.pkg
+++ b/deepseek/client/moon.pkg
@@ -1,11 +1,13 @@
 import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/async/http",
+  "moonbitlang/async/io",
   "moonbitlang/core/json",
 }
 
 import {
   "moonbitlang/async",
+  "moonbitlang/async/socket",
   "moonbitlang/core/env",
 } for "test"
 

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -19,7 +19,8 @@ pub struct Client {
   // private fields
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode?, reasoning_effort? : @deepseek.ReasoningEffort?) -> Self
-pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition]) -> @deepseek.ChatResponse
+pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
+pub async fn Client::chat_stream(Self, Array[@deepseek.ChatMessage], on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
 
 // Type aliases
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -1,0 +1,245 @@
+///|
+priv struct StreamToolCall {
+  mut id : String
+  mut name : String
+  arguments : StringBuilder
+}
+
+///|
+fn StreamToolCall::StreamToolCall() -> StreamToolCall {
+  { id: "", name: "", arguments: StringBuilder::new() }
+}
+
+///|
+fn StreamToolCall::to_json(self : StreamToolCall) -> Json {
+  {
+    "id": self.id,
+    "type": "function",
+    "function": { "name": self.name, "arguments": self.arguments.to_string() },
+  }
+}
+
+///|
+priv struct StreamAccumulator {
+  content : StringBuilder
+  reasoning_content : StringBuilder
+  tool_calls : Array[StreamToolCall]
+  mut usage : Json?
+}
+
+///|
+fn StreamAccumulator::StreamAccumulator() -> StreamAccumulator {
+  {
+    content: StringBuilder::new(),
+    reasoning_content: StringBuilder::new(),
+    tool_calls: [],
+    usage: None,
+  }
+}
+
+///|
+fn StreamAccumulator::ensure_tool_call(
+  self : StreamAccumulator,
+  index : Int,
+) -> StreamToolCall {
+  while self.tool_calls.length() <= index {
+    self.tool_calls.push(StreamToolCall())
+  }
+  self.tool_calls[index]
+}
+
+///|
+fn StreamAccumulator::response(
+  self : StreamAccumulator,
+) -> @deepseek.ChatResponse raise {
+  let reasoning_content = self.reasoning_content.to_string()
+  let message = Json::object(
+    Map(
+      [
+        ("content", Json::string(self.content.to_string())),
+        ..if reasoning_content != "" {
+          [("reasoning_content", Json::string(reasoning_content))]
+        } else {
+          []
+        },
+        ..if self.tool_calls.length() > 0 {
+          [
+            (
+              "tool_calls",
+              ([ for call in self.tool_calls => call.to_json() ] : Json),
+            ),
+          ]
+        } else {
+          []
+        },
+      ],
+    ),
+  )
+  let envelope = Json::object(
+    Map(
+      [
+        ("choices", ([({ "message": message } : Json)] : Json)),
+        ..match self.usage {
+          Some(usage) => [("usage", usage)]
+          None => []
+        },
+      ],
+    ),
+  )
+  @json.from_json(envelope)
+}
+
+///|
+fn json_string_field(fields : Map[String, Json], key : String) -> String? {
+  match fields.get(key) {
+    Some(String(value)) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn json_int_field(fields : Map[String, Json], key : String) -> Int? {
+  match fields.get(key) {
+    Some(Number(value, ..)) => Some(value.to_int())
+    _ => None
+  }
+}
+
+///|
+fn apply_tool_call_delta(
+  acc : StreamAccumulator,
+  json : Json,
+  fallback_index : Int,
+) -> Unit {
+  let fields = match json {
+    Object(fields) => fields
+    _ => return
+  }
+  let index = json_int_field(fields, "index").unwrap_or(fallback_index)
+  if index < 0 {
+    return
+  }
+  let call = acc.ensure_tool_call(index)
+  if json_string_field(fields, "id") is Some(id) && id != "" {
+    call.id = id
+  }
+  guard fields.get("function") is Some(Object(function)) else { return }
+  if json_string_field(function, "name") is Some(name) && name != "" {
+    call.name = name
+  }
+  if json_string_field(function, "arguments") is Some(arguments) &&
+    arguments != "" {
+    call.arguments.write_string(arguments)
+  }
+}
+
+///|
+async fn apply_stream_delta(
+  acc : StreamAccumulator,
+  delta : Map[String, Json],
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> Unit {
+  if json_string_field(delta, "content") is Some(content) && content != "" {
+    acc.content.write_string(content)
+    on_content_delta(content)
+  }
+  if json_string_field(delta, "reasoning_content") is Some(reasoning) &&
+    reasoning != "" {
+    acc.reasoning_content.write_string(reasoning)
+    on_reasoning_delta(reasoning)
+  }
+  match delta.get("tool_calls") {
+    Some(Array(calls)) =>
+      for index, call in calls {
+        apply_tool_call_delta(acc, call, index)
+      }
+    _ => ()
+  }
+}
+
+///|
+async fn apply_stream_json(
+  acc : StreamAccumulator,
+  json : Json,
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> Unit {
+  match json {
+    { "usage": Null, .. } => ()
+    { "usage": usage_json, .. } => acc.usage = Some(usage_json)
+    _ => ()
+  }
+  match json {
+    { "choices": [{ "delta": Object(delta), .. }, ..], .. } =>
+      apply_stream_delta(acc, delta, on_content_delta~, on_reasoning_delta~)
+    { "choices": [], .. } => ()
+    _ => ()
+  }
+}
+
+///|
+fn sse_data_fragment(raw : String) -> String? {
+  let line = if raw.has_suffix("\r") {
+    raw[:raw.length() - 1].to_owned()
+  } else {
+    raw
+  }
+  if line.has_prefix("data:") {
+    Some(line[5:].trim().to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+async fn flush_sse_event(
+  acc : StreamAccumulator,
+  data_lines : Array[String],
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> Bool {
+  if data_lines.length() == 0 {
+    return false
+  }
+  let data = data_lines.join("\n").trim().to_owned()
+  data_lines.clear()
+  if data == "[DONE]" {
+    return true
+  }
+  apply_stream_json(acc, @json.parse(data), on_content_delta~, on_reasoning_delta~)
+  false
+}
+
+///|
+async fn read_chat_stream(
+  reader : @http.Client,
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> @deepseek.ChatResponse {
+  let acc = StreamAccumulator::StreamAccumulator()
+  let data_lines : Array[String] = []
+  for ;; {
+    match reader.read_until("\n") {
+      None => {
+        if flush_sse_event(acc, data_lines, on_content_delta~, on_reasoning_delta~) {
+          break
+        }
+        fail("DeepSeek stream ended before [DONE]")
+      }
+      Some(raw) => {
+        let trimmed = raw.trim()
+        if trimmed.is_empty() {
+          if flush_sse_event(
+              acc, data_lines, on_content_delta~, on_reasoning_delta~,
+            ) {
+            break
+          }
+        } else if sse_data_fragment(raw) is Some(data) {
+          data_lines.push(data)
+        }
+      }
+    }
+  }
+  acc.response()
+}

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -57,6 +57,23 @@ pub impl Show for ReasoningEffort with fn to_string(self : ReasoningEffort) -> S
 }
 
 ///|
+/// Optional structured response format for DeepSeek chat completions.
+///
+/// Leave absent for normal assistant text. Use `JsonObject` only when a caller
+/// explicitly wants the model's assistant content constrained to a JSON object.
+pub(all) enum ResponseFormat {
+  JsonObject
+} derive(Eq, Debug)
+
+///|
+/// Returns the DeepSeek wire name for a response format.
+pub impl Show for ResponseFormat with fn to_string(self : ResponseFormat) -> String {
+  match self {
+    JsonObject => "json_object"
+  }
+}
+
+///|
 /// DeepSeek chat message roles.
 ///
 /// `Tool(tool_call_id)` represents a tool response message and carries the

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -1,12 +1,24 @@
 ///|
-test "encode_chat_request always asks for json output" {
+test "encode_chat_request omits response format by default" {
   let body = @deepseek.encode_chat_request(V4Flash, [
-    ChatMessage(System, content="json only"),
+    ChatMessage(System, content="plain text is fine"),
     ChatMessage(User, content="ping"),
   ])
   let text = body.stringify()
   assert_true(text.contains("\"stream\":false"))
-  assert_true(text.contains("\"response_format\""))
+  assert_false(text.contains("\"response_format\""))
+}
+
+///|
+test "encode_chat_request can ask for json output explicitly" {
+  let body = @deepseek.encode_chat_request(
+    V4Flash,
+    [
+      ChatMessage(System, content="json only"),
+      ChatMessage(User, content="ping"),
+    ],
+    response_format=JsonObject,
+  )
   guard body is { "response_format": { "type": String("json_object"), .. }, .. } else {
     fail("wrong response_format")
   }
@@ -31,6 +43,21 @@ test "encode_chat_request includes tools when present" {
   assert_true(text.contains("\"type\":\"function\""))
   assert_true(text.contains("\"name\":\"shell\""))
   assert_true(text.contains("\"required\""))
+}
+
+///|
+test "encode_chat_request enables usage-bearing stream mode" {
+  let body = @deepseek.encode_chat_request(
+    V4Flash,
+    [ChatMessage(User, content="stream this")],
+    stream=true,
+  )
+  let text = body.stringify()
+  assert_true(text.contains("\"stream\":true"))
+  guard body
+    is { "stream": True, "stream_options": { "include_usage": True, .. }, .. } else {
+    fail("wrong stream options")
+  }
 }
 
 ///|

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -66,22 +66,33 @@ impl ToJson for ToolCall with fn to_json(call : ToolCall) -> Json {
 ///|
 /// Encodes a DeepSeek chat completions request body.
 ///
-/// The request always asks for a JSON object response. `tools`, `thinking`,
-/// and `reasoning_effort` are omitted when empty / `None`.
+/// `response_format`, `tools`, `thinking`, and `reasoning_effort` are omitted
+/// when empty / `None`.
 pub fn encode_chat_request(
   model : Model,
   messages : Array[ChatMessage],
   tools? : Array[ToolDefinition] = [],
   thinking? : ThinkingMode,
   reasoning_effort? : ReasoningEffort,
+  stream? : Bool = false,
+  response_format? : ResponseFormat,
 ) -> Json {
   Json::object(
     Map(
       [
         ("model", Json::string(model.to_string())),
         ("messages", ([ for message in messages => message ] : Json)),
-        ("stream", Json::boolean(false)),
-        ("response_format", { "type": "json_object" }),
+        ("stream", Json::boolean(stream)),
+        ..match response_format {
+          Some(format) =>
+            [("response_format", ({ "type": format.to_string() } : Json))]
+          None => []
+        },
+        ..if stream {
+          [("stream_options", ({ "include_usage": true } : Json))]
+        } else {
+          []
+        },
         ..if tools.length() > 0 {
           [("tools", ([ for tool in tools => tool ] : Json))]
         } else {

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort) -> Json
+pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort, stream? : Bool, response_format? : ResponseFormat) -> Json
 
 // Errors
 
@@ -40,6 +40,11 @@ pub(all) enum ReasoningEffort {
   Max
 } derive(Eq, @debug.Debug)
 pub impl Show for ReasoningEffort
+
+pub(all) enum ResponseFormat {
+  JsonObject
+} derive(Eq, @debug.Debug)
+pub impl Show for ResponseFormat
 
 pub(all) enum Role {
   System

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -21,6 +21,12 @@ drops `moon`'s own dependency-resolution chatter, not any log content.
 Every example gives the cheap Flash model a trivial, self-contained task and a
 tiny step budget.
 
+When the model emits assistant text, the stream may include one or more
+`assistant_delta` events before the final `assistant_message`; thinking-mode
+runs may also interleave `reasoning_delta` events before the content starts.
+Tool-only responses, such as the forced `finish` examples below, may skip these
+content events and go straight to tool execution.
+
 ## A Real Round Trip That Finishes
 
 This proves two things from the real log: that the request reached DeepSeek and
@@ -57,7 +63,9 @@ A minimal run emits an `agent_step`, a `usage` record once DeepSeek answers, and
 an `agent_finished`. We collect the `"event"` values into a `Set`, which dedupes
 and preserves insertion order — so printing it yields the lifecycle in the order
 it occurred, the same `{agent_step, usage, agent_finished}` no matter how many
-steps the run takes.
+steps the run takes. Streaming `assistant_delta`/`reasoning_delta` events are
+filtered out: whether and how often they appear varies per run (thinking mode
+streams its reasoning live), while the lifecycle events are stable.
 
 ```mooncram
 $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
@@ -69,7 +77,9 @@ $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool imm
 > async fn main {
 >   let events = Set::new()
 >   for value in @jsonl.read_stdin() {
->     if value is { "event": String(event), .. } { events.add(event) }
+>     if value is { "event": String(event), .. } && !event.has_suffix("_delta") {
+>       events.add(event)
+>     }
 >   }
 >   println("events=\{events}")
 > }' 2>/dev/null \

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int) -> Self
 
 type Ui
 pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
+pub fn Ui::columns(Self) -> Int
 pub async fn Ui::read_event(Self) -> @core.Event
 pub async fn Ui::set_activity(Self, @doc.Text?) -> Unit
 pub async fn Ui::set_queued_inputs(Self, Array[@core.Input]) -> Unit

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -109,6 +109,18 @@ pub async fn Ui::append_item(self : Self, item : TranscriptItem) -> Unit {
 }
 
 ///|
+/// The terminal width in columns as of the last redraw, or a conservative 80
+/// before the UI has entered the live screen. Lets callers fit transient
+/// content (e.g. a streaming tail preview) to the row the renderer will clip
+/// it to.
+pub fn Ui::columns(self : Self) -> Int {
+  match self.viewport {
+    Some(viewport) => viewport.cols()
+    None => 80
+  }
+}
+
+///|
 /// Set or clear the transient activity label shown above the composer. `Some`
 /// shows a busy/progress line that never enters the transcript; `None` hides it.
 /// Redraws the live frame.


### PR DESCRIPTION
## Summary

Streaming previously "worked" in the client but the TUI still showed answers landing in one batch. This PR completes the end-to-end streaming experience:

- **`deepseek/client`**: new `Client::chat_stream` parses the SSE stream, fires `on_content_delta` / `on_reasoning_delta` per fragment, and returns the fully accumulated `ChatResponse`. The request pins `Accept-Encoding: identity` so no gzip-compressing intermediary can buffer and re-batch the deltas. `encode_chat_request` now sends `response_format` only when explicitly asked for `JsonObject` (previously every response was constrained to a JSON object), and gains the `stream` flag.
- **`agent` / `cmd/openseek`**: the loop streams each turn and logs `assistant_delta` / `reasoning_delta` JSONL events as fragments arrive. The engine's JSONL goes through a per-line `fflush(stdout)` handler — stdout is a pipe under the TUI, where plain `println` is block-buffered and was the root cause of the batchy output.
- **`cmd/tui` / `tui`**: the activity line shows a live **tail** preview fitted to the terminal width (`Ui::columns()`), with whitespace collapsed to keep it one row and a leading `…` marking the elided front. The old head-truncation froze the line after 240 columns. Thinking-mode runs show the dimmed reasoning tail (`Thinking …`) until content starts (`Streaming …`), so the line moves from the first token instead of sitting on `Working (Ns)` through the reasoning phase.

## Verification (live, real API)

- Engine → pipe: 76 `reasoning_delta` lines spread over 6.6s and 51 `assistant_delta` lines over 0.7s, each line flushed on arrival — incremental, not one burst.
- TUI in a pty (100×30): 207 distinct activity-line frames — `Thinking The` → `Thinking The user wants…` → `…Let me compose that.` → `Streaming A terminal multiplex…` → `…happens to your connection.` — then the full response committed to the transcript.
- Probes: Ctrl-C mid-stream commits `interrupted` and leaves a live idle composer; a 44-column terminal clamps the tail without breaking the frame.
- `moon check` clean, 431/431 unit tests, 6/6 offline cram, 4/4 live cram (the lifecycle example now filters `*_delta` events, whose count varies per run by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)