### PR TITLE
deepseek: make JSON response format opt-in

### DIFF
--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -17,10 +17,13 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
 - `ChatMessage(role, content=..., tool_calls?, reasoning_content?)`: one typed
   chat message constructor. Use `Assistant` with `tool_calls` for the assistant
   message that must be sent back after DeepSeek requests native tool calls.
-- `encode_chat_request(model, messages, tools?, thinking?, reasoning_effort?)`:
-  builds the full DeepSeek chat completions request body. The per-value
-  encoders for messages, tool definitions, and tool calls are package-private
-  implementation details.
+- `ResponseFormat`: optional assistant content constraint. Leave absent for
+  normal text; pass `JsonObject` only when the assistant content must be a JSON
+  object.
+- `encode_chat_request(model, messages, tools?, thinking?, reasoning_effort?,
+  response_format?)`: builds the full DeepSeek chat completions request body.
+  The per-value encoders for messages, tool definitions, and tool calls are
+  package-private implementation details.
 - `ToolDefinition(name, description, parameters, strict?)`: a native DeepSeek
   function tool definition with a JSON Schema parameters object.
 - `ToolCall(id~, name~, arguments~)`: a decoded function call request from the
@@ -68,6 +71,7 @@ test "encode chat request values" {
   let body = @deepseek.encode_chat_request(model, [message]).stringify()
   assert_true(body.contains("\"role\":\"user\""))
   assert_true(body.contains("\"model\":\"deepseek-v4-flash\""))
+  assert_false(body.contains("\"response_format\""))
 }
 ```
 
@@ -94,6 +98,19 @@ test "encode tool-enabled chat request" {
   ).stringify()
   assert_true(body.contains("\"type\":\"function\""))
   assert_true(body.contains("\"tool_calls\""))
+}
+```
+
+```moonbit check
+///|
+test "encode json-object response request" {
+  let body = @deepseek.encode_chat_request(
+    V4Flash,
+    [ChatMessage(User, content="return {\"ok\":true}")],
+    response_format=JsonObject,
+  ).stringify()
+  assert_true(body.contains("\"response_format\""))
+  assert_true(body.contains("\"json_object\""))
 }
 ```
 

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -12,8 +12,8 @@ The package depends on `moonbitlang/async/http` and is native-only.
 - `Client(api_key~, model?, api_url?, thinking?, reasoning_effort?)`: configure
   the API key, typed model, optional endpoint override, and optional DeepSeek V4
   thinking controls.
-- `Client::chat(messages, tools?)`: send typed chat messages in JSON response
-  mode, optionally with native DeepSeek function tools, and decode the response.
+- `Client::chat(messages, tools?, response_format?)`: send typed chat messages,
+  optionally with native DeepSeek function tools, and decode the response.
 
 `Client` implements `Debug` with the API key redacted.
 
@@ -21,7 +21,9 @@ The package depends on `moonbitlang/async/http` and is native-only.
 
 `Client::chat` builds a private request envelope with the client's configured
 model, thinking mode, and reasoning effort, then sends it to `api_url` as JSON.
-It always sends `stream=false` and `response_format={"type":"json_object"}`.
+It sends `stream=false` and leaves assistant content unconstrained by default.
+Pass `response_format=JsonObject` only for callers that explicitly want the
+assistant content constrained to a JSON object.
 
 Use `tools=[...]` when the model should call native DeepSeek function tools.
 Tool call results should be appended as `@deepseek.ChatMessage(Tool(call.id),

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -36,12 +36,14 @@ pub fn Client::Client(
 ///|
 /// Sends typed chat messages to DeepSeek and decodes the response.
 ///
-/// The client always requests a JSON object response. Pass `tools` to enable
-/// native DeepSeek function tool calls.
+/// Pass `tools` to enable native DeepSeek function tool calls. Pass
+/// `response_format=JsonObject` only when the assistant content itself should
+/// be constrained to a JSON object.
 pub async fn Client::chat(
   self : Client,
   messages : Array[@deepseek.ChatMessage],
   tools? : Array[@deepseek.ToolDefinition] = [],
+  response_format? : @deepseek.ResponseFormat,
 ) -> @deepseek.ChatResponse {
   let body = @deepseek.encode_chat_request(
     self.model,
@@ -49,6 +51,7 @@ pub async fn Client::chat(
     tools~,
     thinking?=self.thinking,
     reasoning_effort?=self.reasoning_effort,
+    response_format?,
   )
   let (resp, data) = @http.post(self.api_url, body, headers={
     "Content-Type": "application/json",

--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -13,15 +13,18 @@ async test "realworld DeepSeek API smoke test" {
     thinking=Some(Enabled),
     reasoning_effort=Some(High),
   )
-  let response = client.chat() <| [
-    ChatMessage(
-      System,
-      content=(
-        #|Reply with exactly this JSON object and no markdown: {"answer":"pong"}
+  let response = client.chat(
+    [
+      ChatMessage(
+        System,
+        content=(
+          #|Reply with exactly this JSON object and no markdown: {"answer":"pong"}
+        ),
       ),
-    ),
-    ChatMessage(User, content="ping"),
-  ]
+      ChatMessage(User, content="ping"),
+    ],
+    response_format=JsonObject,
+  )
   // It may fail in theory, but in practice it should always work.
   debug_inspect(
     response.content,

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -19,7 +19,7 @@ pub struct Client {
   // private fields
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode?, reasoning_effort? : @deepseek.ReasoningEffort?) -> Self
-pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition]) -> @deepseek.ChatResponse
+pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
 
 // Type aliases
 

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -57,6 +57,23 @@ pub impl Show for ReasoningEffort with fn to_string(self : ReasoningEffort) -> S
 }
 
 ///|
+/// Optional structured response format for DeepSeek chat completions.
+///
+/// Leave absent for normal assistant text. Use `JsonObject` only when a caller
+/// explicitly wants the model's assistant content constrained to a JSON object.
+pub(all) enum ResponseFormat {
+  JsonObject
+} derive(Eq, Debug)
+
+///|
+/// Returns the DeepSeek wire name for a response format.
+pub impl Show for ResponseFormat with fn to_string(self : ResponseFormat) -> String {
+  match self {
+    JsonObject => "json_object"
+  }
+}
+
+///|
 /// DeepSeek chat message roles.
 ///
 /// `Tool(tool_call_id)` represents a tool response message and carries the

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -1,12 +1,24 @@
 ///|
-test "encode_chat_request always asks for json output" {
+test "encode_chat_request omits response format by default" {
   let body = @deepseek.encode_chat_request(V4Flash, [
-    ChatMessage(System, content="json only"),
+    ChatMessage(System, content="plain text is fine"),
     ChatMessage(User, content="ping"),
   ])
   let text = body.stringify()
   assert_true(text.contains("\"stream\":false"))
-  assert_true(text.contains("\"response_format\""))
+  assert_false(text.contains("\"response_format\""))
+}
+
+///|
+test "encode_chat_request can ask for json output explicitly" {
+  let body = @deepseek.encode_chat_request(
+    V4Flash,
+    [
+      ChatMessage(System, content="json only"),
+      ChatMessage(User, content="ping"),
+    ],
+    response_format=JsonObject,
+  )
   guard body is { "response_format": { "type": String("json_object"), .. }, .. } else {
     fail("wrong response_format")
   }

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -66,14 +66,15 @@ impl ToJson for ToolCall with fn to_json(call : ToolCall) -> Json {
 ///|
 /// Encodes a DeepSeek chat completions request body.
 ///
-/// The request always asks for a JSON object response. `tools`, `thinking`,
-/// and `reasoning_effort` are omitted when empty / `None`.
+/// `response_format`, `tools`, `thinking`, and `reasoning_effort` are omitted
+/// when empty / `None`.
 pub fn encode_chat_request(
   model : Model,
   messages : Array[ChatMessage],
   tools? : Array[ToolDefinition] = [],
   thinking? : ThinkingMode,
   reasoning_effort? : ReasoningEffort,
+  response_format? : ResponseFormat,
 ) -> Json {
   Json::object(
     Map(
@@ -81,7 +82,11 @@ pub fn encode_chat_request(
         ("model", Json::string(model.to_string())),
         ("messages", ([ for message in messages => message ] : Json)),
         ("stream", Json::boolean(false)),
-        ("response_format", { "type": "json_object" }),
+        ..match response_format {
+          Some(format) =>
+            [("response_format", ({ "type": format.to_string() } : Json))]
+          None => []
+        },
         ..if tools.length() > 0 {
           [("tools", ([ for tool in tools => tool ] : Json))]
         } else {

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort) -> Json
+pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort, response_format? : ResponseFormat) -> Json
 
 // Errors
 
@@ -40,6 +40,11 @@ pub(all) enum ReasoningEffort {
   Max
 } derive(Eq, @debug.Debug)
 pub impl Show for ReasoningEffort
+
+pub(all) enum ResponseFormat {
+  JsonObject
+} derive(Eq, @debug.Debug)
+pub impl Show for ResponseFormat
 
 pub(all) enum Role {
   System


### PR DESCRIPTION
**PR 1 of 4** in the live-streaming stack (1 → #71 → #72 → #73; each PR diffs only against its predecessor).

`encode_chat_request` previously constrained every assistant response to a JSON object via an unconditional `response_format` — plain-text replies, the normal agent case, were forced through JSON mode. This adds a typed `ResponseFormat` and sends `response_format` only when a caller explicitly asks for `JsonObject`; `Client::chat` gains the matching optional parameter, and the realworld smoke test now opts in explicitly.

No behavior change for callers that want JSON — they pass `response_format=JsonObject`. Everyone else gets unconstrained text.

Tested: `moon check`, `moon test` green at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)