### PR TITLE
openseek: stream agent turns as flushed JSONL delta events

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -150,7 +150,20 @@ async fn run_with_runtime(
         messages.push(ChatMessage(User, content=update))
       }
       @xlog.info() <? { "event": "agent_step", "step": step + 1 }
-      let response = client.chat(messages, tools=tools.function_tools())
+      let response = client.chat_stream(
+        messages,
+        tools=tools.function_tools(),
+        on_content_delta=delta => {
+          if delta != "" {
+            @xlog.info() <? { "event": "assistant_delta", "content": delta }
+          }
+        },
+        on_reasoning_delta=delta => {
+          if delta != "" {
+            @xlog.info() <? { "event": "reasoning_delta", "content": delta }
+          }
+        },
+      )
       if response.content != "" {
         @xlog.info() <?
           { "event": "assistant_message", "content": response.content }

--- a/cmd/openseek/logging.mbt
+++ b/cmd/openseek/logging.mbt
@@ -1,0 +1,84 @@
+///|
+/// Bridge from `@xlog`'s synchronous `Handler` to unbuffered stdout writes.
+///
+/// The TUI parses the JSONL the engine writes to stdout through a pipe. Plain
+/// `println` goes through C stdio, which is block-buffered on a pipe, so
+/// streaming deltas would all arrive at once. `@stdio.stdout` writes the fd
+/// directly through the event loop instead — one write per line, no userspace
+/// buffer — but it is asynchronous while `Handler::handle` is not. The handler
+/// therefore enqueues each formatted line, and `drain` (spawned for the run by
+/// `run_cli`) writes them out in order.
+///
+/// The queue is unbounded, so `try_put` only fails once the queue is closed —
+/// that is, for an entry logged after the run already ended — and dropping
+/// such an entry matches the process being on its way out.
+priv struct FlushedStdout {
+  format : @xlog.Format
+  lines : @async.Queue[String]
+}
+
+///|
+fn FlushedStdout::FlushedStdout(
+  format? : @xlog.Format = Jsonl,
+) -> FlushedStdout {
+  { format, lines: Queue(kind=Unbounded) }
+}
+
+///|
+impl @xlog.Handler for FlushedStdout with fn handle(
+  self : FlushedStdout,
+  entry : @xlog.Entry,
+) -> Unit raise {
+  let line = match self.format {
+    Text => entry.to_string()
+    Jsonl => entry.to_json().stringify()
+  }
+  self.lines.try_put(line) |> ignore
+}
+
+///|
+/// Write queued log lines to stdout until the queue is closed and drained.
+/// `Queue::get` keeps returning buffered lines after `close`, so closing never
+/// loses events that were logged before it.
+async fn FlushedStdout::drain(self : FlushedStdout) -> Unit {
+  for ;; {
+    let line = self.lines.get() catch {
+      error if @async.is_cancellation_error(error) => raise error
+      // The queue is closed and empty: every logged line has been written.
+      // This must not test `is_being_cancelled`: when the run body fails, the
+      // `defer` close and the group's cancellation race, and re-raising the
+      // close error here would replace the run's real failure with
+      // `QueueAlreadyClosed` in the report the user sees.
+      _ => return
+    }
+    @stdio.stdout.write(line + "\n")
+  }
+}
+
+///|
+fn FlushedStdout::close(self : FlushedStdout) -> Unit {
+  self.lines.close()
+}
+
+///|
+/// Route every JSONL log event to the flushed-stdout queue. When
+/// `OPENSEEK_LOG_FILE` is set, mirror each event there as well; the file
+/// handler flushes per entry, so `tail -f $OPENSEEK_LOG_FILE` shows events
+/// live. Best-effort: if the file cannot be opened, logging stays
+/// stdout-only rather than failing the run.
+fn configure_logging() -> FlushedStdout {
+  let stdout = FlushedStdout()
+  guard @env.get_env_var("OPENSEEK_LOG_FILE") is Some(path) && path != "" else {
+    @xlog.global().set_handler(stdout)
+    return stdout
+  }
+  let file = @xlog.File::File(path) catch {
+    _ => {
+      @xlog.global().set_handler(stdout)
+      return stdout
+    }
+  }
+  let handlers : Array[&@xlog.Handler] = [stdout, file]
+  @xlog.global().set_handler(@xlog.Multi(handlers))
+  stdout
+}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -12,35 +12,44 @@ async fn main {
 
 ///|
 async fn run_cli() -> Unit {
-  configure_logging()
-  let matches = cli_command().parse(env=@env.get_env_vars())
-  if handle_session_command(matches) {
-    return
-  }
-  let api_key = api_key(matches)
-  let model = @deepseek.Model::parse(value(matches, "model"))
-  let max_steps = max_steps(matches)
-  let task = task_text(matches)
-  match session_id(matches) {
-    None => {
-      let system_prompt_text = configured_system_prompt(matches, model)
-      @agent.run(api_key, model, task, max_steps~, system_prompt_text~)
+  let stdout_log = configure_logging()
+  @async.with_task_group(group => {
+    // The drain owns all stdout JSONL writes for the run. It is spawned
+    // without `no_wait`, so the group only completes once the queue — closed
+    // by the `defer` when this body exits, on success and error alike — has
+    // been written out in full; the terminal event is never lost to an early
+    // process exit.
+    group.spawn_bg() <| () => { stdout_log.drain() }
+    defer stdout_log.close()
+    let matches = cli_command().parse(env=@env.get_env_vars())
+    if handle_session_command(matches) {
+      return
     }
-    Some(id) => {
-      let store = @store.SessionStore(session_root(matches))
-      let session = load_or_new_session(store, id, matches, model)
-      ignore(
-        @agent.run_turn_with_append(
-          api_key,
-          model,
-          session,
-          task,
-          append_item=(session, item) => store.append(session, item),
-          max_steps~,
-        ),
-      )
+    let api_key = api_key(matches)
+    let model = @deepseek.Model::parse(value(matches, "model"))
+    let max_steps = max_steps(matches)
+    let task = task_text(matches)
+    match session_id(matches) {
+      None => {
+        let system_prompt_text = configured_system_prompt(matches, model)
+        @agent.run(api_key, model, task, max_steps~, system_prompt_text~)
+      }
+      Some(id) => {
+        let store = @store.SessionStore(session_root(matches))
+        let session = load_or_new_session(store, id, matches, model)
+        ignore(
+          @agent.run_turn_with_append(
+            api_key,
+            model,
+            session,
+            task,
+            append_item=(session, item) => store.append(session, item),
+            max_steps~,
+          ),
+        )
+      }
     }
-  }
+  })
 }
 
 ///|
@@ -59,25 +68,6 @@ fn failure_message(error_text : String) -> String {
   } else {
     message
   }
-}
-
-///|
-/// Mirror every JSONL log event to `OPENSEEK_LOG_FILE` in addition to stdout
-/// when that variable is set.
-///
-/// The TUI parses the JSONL the engine writes to stdout, so stdout is left
-/// exactly as it was (the default `Stdout` handler keeps its `Jsonl` format);
-/// this only adds a second handler that appends the same JSONL to the file. The
-/// file handler flushes per entry, so `tail -f $OPENSEEK_LOG_FILE` shows events
-/// live — useful for inspecting a stuck or headless session. Best-effort: if the
-/// file cannot be opened, logging stays stdout-only rather than failing the run.
-fn configure_logging() -> Unit {
-  guard @env.get_env_var("OPENSEEK_LOG_FILE") is Some(path) && path != "" else {
-    return
-  }
-  let file = @xlog.File::File(path) catch { _ => return }
-  let handlers : Array[&@xlog.Handler] = [@xlog.Stdout(), file]
-  @xlog.global().set_handler(@xlog.Multi(handlers))
 }
 
 ///|

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -10,6 +10,7 @@ import {
   "moonbitlang/async/os_error",
   "moonbitlang/async/stdio",
   "moonbitlang/core/argparse",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/x/sys",

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -21,6 +21,12 @@ drops `moon`'s own dependency-resolution chatter, not any log content.
 Every example gives the cheap Flash model a trivial, self-contained task and a
 tiny step budget.
 
+When the model emits assistant text, the stream may include one or more
+`assistant_delta` events before the final `assistant_message`; thinking-mode
+runs may also interleave `reasoning_delta` events before the content starts.
+Tool-only responses, such as the forced `finish` examples below, may skip these
+content events and go straight to tool execution.
+
 ## A Real Round Trip That Finishes
 
 This proves two things from the real log: that the request reached DeepSeek and
@@ -57,7 +63,9 @@ A minimal run emits an `agent_step`, a `usage` record once DeepSeek answers, and
 an `agent_finished`. We collect the `"event"` values into a `Set`, which dedupes
 and preserves insertion order — so printing it yields the lifecycle in the order
 it occurred, the same `{agent_step, usage, agent_finished}` no matter how many
-steps the run takes.
+steps the run takes. Streaming `assistant_delta`/`reasoning_delta` events are
+filtered out: whether and how often they appear varies per run (thinking mode
+streams its reasoning live), while the lifecycle events are stable.
 
 ```mooncram
 $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
@@ -69,7 +77,9 @@ $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool imm
 > async fn main {
 >   let events = Set::new()
 >   for value in @jsonl.read_stdin() {
->     if value is { "event": String(event), .. } { events.add(event) }
+>     if value is { "event": String(event), .. } && !event.has_suffix("_delta") {
+>       events.add(event)
+>     }
 >   }
 >   println("events=\{events}")
 > }' 2>/dev/null \


### PR DESCRIPTION
**PR 3 of 4** in the live-streaming stack (#70 → #71 → 3 → 4). Based on #71; this diff is only the engine.

The agent loop now uses `chat_stream` and logs `assistant_delta` / `reasoning_delta` JSONL events as fragments arrive, instead of a single `assistant_message` after the full response. Existing consumers are unaffected: unknown events are skipped by the TUI's decoder, and the final `assistant_message` / `agent_finished` events are unchanged.

The interesting part is flushing. Delta events are only as live as stdout lets them be: under the TUI, stdout is a pipe, where `println`'s C-stdio buffer is block-buffered and held every event back until ~the process exited. The JSONL now goes through an unbounded queue drained by a task that writes `@stdio.stdout` directly — one unbuffered write per line, **no C stub** (an earlier draft used an `fflush` native stub; this replaces it before it ever lands). The drain is awaited by the run's task group after a deferred queue close, so the terminal event is always written before exit, on success and error paths alike.

`tests/live/deepseek.md`'s lifecycle example now filters `*_delta` events, whose count varies per run by design.

Verified live: 76 `reasoning_delta` lines spread over 6.6s and 51 `assistant_delta` lines over 0.7s through a pipe, each line arriving on flush; offline cram 6/6, live cram 4/4, `moon test` 426/426 at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)