### PR TITLE
tui: render the engine's delta stream as a live tail preview

### DIFF
--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -11,6 +11,8 @@
 pub fn decode_event(object : Json) -> AgentEvent? {
   match @jsonx.string(object, "event") {
     "agent_step" => Some(AgentStep)
+    "assistant_delta" => Some(AssistantDelta(@jsonx.string(object, "content")))
+    "reasoning_delta" => Some(ReasoningDelta(@jsonx.string(object, "content")))
     "assistant_message" =>
       Some(AssistantMessage(@jsonx.string(object, "content")))
     "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -10,6 +10,18 @@ test "decode maps each engine event kind" {
   )
   assert_true(
     @event.decode_event(
+      Json::object({ "event": "assistant_delta", "content": "tok" }),
+    )
+    is Some(AssistantDelta("tok")),
+  )
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "reasoning_delta", "content": "hmm" }),
+    )
+    is Some(ReasoningDelta("hmm")),
+  )
+  assert_true(
+    @event.decode_event(
       Json::object({ "event": "agent_finished", "answer": "done" }),
     )
     is Some(AgentFinished("done")),

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -34,6 +34,8 @@ pub(all) struct ToolResultEvent {
 /// queued input.
 pub(all) enum AgentEvent {
   AgentStep
+  AssistantDelta(String)
+  ReasoningDelta(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -9,6 +9,8 @@ pub fn decode_event(Json) -> AgentEvent?
 // Types and methods
 pub(all) enum AgentEvent {
   AgentStep
+  AssistantDelta(String)
+  ReasoningDelta(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -244,6 +244,150 @@ test "parse_runtime_update aggregates status across watcher sections" {
 }
 
 ///|
+test "assistant_delta accumulates live text and commits only the final message" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Hel" }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "lo" }),
+    items,
+  )
+  assert_eq(items.length(), 0)
+  assert_true(state.streaming_response is Some("Hello"))
+  assert_true(state.step_response is None)
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Hello" }),
+    items,
+  )
+  assert_true(state.streaming_response is None)
+  assert_true(state.step_response is Some("Hello"))
+  append_items(
+    state,
+    Json::object({ "event": "agent_finished", "answer": "Hello" }),
+    items,
+  )
+  debug_inspect(items, content="[Response(\"Hello\")]")
+}
+
+///|
+test "assistant_message clears live streaming text while tools continue" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Need tool" }),
+    items,
+  )
+  assert_true(state.streaming_response is Some("Need tool"))
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Need tool" }),
+    items,
+  )
+  assert_true(state.run is Running(_))
+  assert_true(state.streaming_response is None)
+  assert_true(state.step_response is Some("Need tool"))
+  assert_eq(items.length(), 1)
+}
+
+///|
+test "assistant_delta live preview keeps the newest tail within the cap" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({
+      "event": "assistant_delta",
+      "content": String::make(StreamingPreviewMaxColumns * 4, 'x'),
+    }),
+    items,
+  )
+  guard state.streaming_response is Some(first) else {
+    fail("expected streaming preview")
+  }
+  assert_true(
+    @displaytext.DisplayText(first).width() <= StreamingPreviewMaxColumns,
+  )
+  assert_true(first.has_prefix("…"))
+  // The preview is a tail window: new deltas keep showing up at its end
+  // (instead of freezing once the cap is reached, as a head truncation would).
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "more" }),
+    items,
+  )
+  guard state.streaming_response is Some(second) else {
+    fail("expected streaming preview")
+  }
+  assert_true(second.has_suffix("more"))
+  assert_true(
+    @displaytext.DisplayText(second).width() <= StreamingPreviewMaxColumns,
+  )
+  assert_eq(items.length(), 0)
+}
+
+///|
+test "streamed newlines collapse so the preview stays one line" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "fn main {\n" }),
+    items,
+  )
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "  println(1)\n}" }),
+    items,
+  )
+  // The run of newline + indentation spanning the two deltas collapses to a
+  // single space; the preview holds no control characters.
+  assert_true(state.streaming_response is Some("fn main { println(1) }"))
+}
+
+///|
+test "reasoning_delta drives the thinking preview until content arrives" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "reasoning_delta", "content": "Let me think" }),
+    items,
+  )
+  assert_true(state.streaming_reasoning is Some("Let me think"))
+  assert_true(state.streaming_response is None)
+  assert_eq(items.length(), 0)
+  // The first content delta ends the thinking phase: the content preview
+  // replaces the reasoning one.
+  append_items(
+    state,
+    Json::object({ "event": "assistant_delta", "content": "Answer" }),
+    items,
+  )
+  assert_true(state.streaming_reasoning is None)
+  assert_true(state.streaming_response is Some("Answer"))
+  // The committed message clears both previews.
+  append_items(
+    state,
+    Json::object({ "event": "assistant_message", "content": "Answer" }),
+    items,
+  )
+  assert_true(state.streaming_response is None)
+  assert_true(state.streaming_reasoning is None)
+}
+
+///|
 test "replaying a recorded engine session renders the transcript" {
   let state = drain_test_state()
   // Submit a task so the agent is running before progress arrives.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -251,6 +251,69 @@ async fn run_shell_command(
 }
 
 ///|
+// The live streaming line is only a transient status preview: it keeps the
+// *tail* of the stream (the newest text) so the line visibly moves while the
+// model types. The final assistant text is committed later by
+// `assistant_message`, so the buffer only needs to cover the widest plausible
+// terminal row; the bound keeps per-delta work constant during long
+// code-generation streams.
+const StreamingPreviewMaxColumns : Int = 240
+
+///|
+/// Keep the last `max_cols` display columns of `text`, marking an elided front
+/// with a leading `…`. The inverse of `DisplayText::truncate`, which keeps the
+/// front — a streaming preview must keep the end, where the new text arrives.
+fn tail_columns(text : String, max_cols : Int) -> String {
+  let display = @displaytext.DisplayText(text)
+  if display.width() <= max_cols {
+    return text
+  }
+  // Reserve one column for the `…` marker; `at_or_after` lands past a wide
+  // char straddling the cut, so the kept tail never exceeds the budget.
+  let keep_from = display.textual_position_at_or_after(
+    @displaytext.DisplayPosition::new(column=display.width() - max_cols + 1),
+  )
+  "…" + display.view(keep_from, display.end()).to_owned()
+}
+
+///|
+/// Collapse whitespace runs (newline, CR, tab, space) to a single space so a
+/// streamed fragment stays renderable on the one-row activity line — streamed
+/// code is mostly newlines and indentation, which would otherwise hit the
+/// renderer as control characters.
+fn collapse_preview_whitespace(text : String) -> String {
+  let out = StringBuilder::new()
+  let mut last_was_space = false
+  for ch in text {
+    if ch is (' ' | '\t' | '\n' | '\r') {
+      if !last_was_space {
+        out.write_char(' ')
+      }
+      last_was_space = true
+    } else {
+      out.write_char(ch)
+      last_was_space = false
+    }
+  }
+  out.to_string()
+}
+
+///|
+fn append_streaming_preview(current : String?, delta : String) -> String {
+  let combined = match current {
+    Some(text) => text + delta
+    None => delta
+  }
+  // Re-collapsing the bounded buffer keeps a whitespace run that spans two
+  // deltas collapsed too; the buffer is at most a few hundred chars, so the
+  // rescan is constant work per delta.
+  tail_columns(
+    collapse_preview_whitespace(combined),
+    StreamingPreviewMaxColumns,
+  )
+}
+
+///|
 /// Apply one agent progress event to `state`, queueing any transcript updates in
 /// `cmds`. Terminal events call `finish_run`, leaving the agent idle so the
 /// queue drain at the end of `update` can start the next input.
@@ -260,9 +323,30 @@ fn handle_agent_event(
   cmds : Array[Cmd],
 ) -> Unit {
   match event {
-    AgentStep => state.step_response = None
+    AgentStep => {
+      state.step_response = None
+      state.streaming_response = None
+      state.streaming_reasoning = None
+    }
+    AssistantDelta(text) =>
+      if text != "" {
+        state.streaming_response = Some(
+          append_streaming_preview(state.streaming_response, text),
+        )
+        // Content starting means the thinking phase is over; the content
+        // preview replaces the reasoning one.
+        state.streaming_reasoning = None
+      }
+    ReasoningDelta(text) =>
+      if text != "" {
+        state.streaming_reasoning = Some(
+          append_streaming_preview(state.streaming_reasoning, text),
+        )
+      }
     AssistantMessage(text) => {
       state.step_response = Some(text)
+      state.streaming_response = None
+      state.streaming_reasoning = None
       if !text.trim().is_empty() {
         cmds.push(AppendItem(Response(text)))
       }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -29,7 +29,17 @@ priv struct State {
   // them; a message whose id is not the active run's is stale (it came from a
   // task that has since been superseded) and is dropped. See `State::owns_run`.
   mut run_id : Int
+  // Final assistant text for the current step, used to avoid appending the same
+  // answer again when `AgentFinished` follows `AssistantMessage`.
   mut step_response : String?
+  // Incremental assistant text currently arriving from `assistant_delta`
+  // events. Cleared once the final assistant message is committed.
+  mut streaming_response : String?
+  // Incremental thinking-mode text arriving from `reasoning_delta` events.
+  // Shown only until the first content delta arrives, so the activity line
+  // moves during the (often long) reasoning phase instead of sitting on
+  // "Working (Ns)".
+  mut streaming_reasoning : String?
   mut usage : @event.UsageInfo?
   // Latest background `moon_check` watcher status ("running"/"stopped"), lifted
   // from the most recent `runtime_update` for the status bar. Empty until the
@@ -45,6 +55,8 @@ fn State::new(config : AppConfig) -> State {
     run: Idle,
     run_id: 0,
     step_response: None,
+    streaming_response: None,
+    streaming_reasoning: None,
     usage: None,
     watcher_status: "",
   }
@@ -58,6 +70,8 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run_id = self.run_id + 1
   self.run = Running(started_ms)
   self.step_response = None
+  self.streaming_response = None
+  self.streaming_reasoning = None
   self.run_id
 }
 
@@ -71,14 +85,16 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 
 ///|
 /// Reset run tracking after the agent stops (finished, aborted, cancelled, or
-/// failed): no task running, no pending step response. Also clear the watcher
-/// status: `run_agent_task` spawns a fresh engine per prompt and any
+/// failed): no task running, no pending final or streaming response. Also clear
+/// the watcher status: `run_agent_task` spawns a fresh engine per prompt and any
 /// `moon_check --watch` process belongs to that engine's runtime, so it is gone
 /// once the engine exits — leaving `watcher_status` set would keep a stale
 /// `moon_check running` segment in the status bar while the TUI sits idle.
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
   self.step_response = None
+  self.streaming_response = None
+  self.streaming_reasoning = None
   self.watcher_status = ""
 }
 

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -85,11 +85,45 @@ fn elapsed_seconds(started_ms : Int64, now_ms : Int64) -> Int64 {
 }
 
 ///|
-fn format_activity_text(state : State) -> @doc.Text? {
+/// Columns of the activity row not available to the streaming preview: the
+/// composer indent the renderer prepends (2), the widest label ("Streaming ",
+/// 10), and one column of slack. The preview is tail-clipped to what remains so
+/// its newest characters are never cut by the renderer's own width clip, which
+/// keeps the line's *front* — the oldest text — on overflow.
+const ActivityPreviewReservedColumns : Int = 13
+
+///|
+fn activity_preview(text : String, cols~ : Int) -> String {
+  let budget = cols - ActivityPreviewReservedColumns
+  tail_columns(text, if budget < 16 { 16 } else { budget })
+}
+
+///|
+fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
   let started_ms = match state.run {
     Idle => return None
     Running(started_ms) => started_ms
     Interrupting(started_ms) => started_ms
+  }
+  if state.streaming_response is Some(response) && !response.trim().is_empty() {
+    return Some(
+      Text([
+        Span(DisplayText("Streaming "), style=@style.dim),
+        @doc.Span::plain(activity_preview(response, cols~)),
+      ]),
+    )
+  }
+  // Thinking-mode runs spend their first (often long) stretch emitting only
+  // reasoning deltas; show their tail dimmed so the line moves from the first
+  // token rather than sitting on "Working (Ns)" until content starts.
+  if state.streaming_reasoning is Some(reasoning) &&
+    !reasoning.trim().is_empty() {
+    return Some(
+      Text([
+        Span(DisplayText("Thinking "), style=@style.dim),
+        Span(DisplayText(activity_preview(reasoning, cols~)), style=@style.dim),
+      ]),
+    )
   }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @async.now()),
@@ -105,6 +139,6 @@ fn format_activity_text(state : State) -> @doc.Text? {
 ///|
 async fn refresh_ui(ui : @ui.Ui, state : State) -> Unit {
   ui.set_status(format_status_bar_text(state))
-  ui.set_activity(format_activity_text(state))
+  ui.set_activity(format_activity_text(state, cols=ui.columns()))
   ui.set_queued_inputs(state.queued)
 }

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int) -> Self
 
 type Ui
 pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
+pub fn Ui::columns(Self) -> Int
 pub async fn Ui::read_event(Self) -> @core.Event
 pub async fn Ui::set_activity(Self, @doc.Text?) -> Unit
 pub async fn Ui::set_queued_inputs(Self, Array[@core.Input]) -> Unit

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -109,6 +109,18 @@ pub async fn Ui::append_item(self : Self, item : TranscriptItem) -> Unit {
 }
 
 ///|
+/// The terminal width in columns as of the last redraw, or a conservative 80
+/// before the UI has entered the live screen. Lets callers fit transient
+/// content (e.g. a streaming tail preview) to the row the renderer will clip
+/// it to.
+pub fn Ui::columns(self : Self) -> Int {
+  match self.viewport {
+    Some(viewport) => viewport.cols()
+    None => 80
+  }
+}
+
+///|
 /// Set or clear the transient activity label shown above the composer. `Some`
 /// shows a busy/progress line that never enters the transcript; `None` hides it.
 /// Redraws the live frame.


### PR DESCRIPTION
**PR 4 of 4** in the live-streaming stack (#70 → #71 → #72 → 4). Based on #72; this diff is only the TUI.

Decodes `assistant_delta` / `reasoning_delta` events and shows the stream on the activity line as a **tail window**: the newest text fitted to the terminal width (via the new `Ui::columns()`), whitespace runs collapsed so streamed code stays on one row, and a leading `…` marking the elided front. A head truncation would freeze the line once the cap filled — the preview must keep the end, where new text arrives.

Thinking-mode runs spend their first (often long) stretch emitting only reasoning deltas; their tail shows dimmed (`Thinking …`) until content starts (`Streaming …`), so the line moves from the first token instead of sitting on `Working (Ns)`. The committed transcript is unchanged: the full response still lands once `assistant_message` arrives.

Verified in a pty against the real API (100×30): 207 distinct activity frames across one answer —

```
frame   1: Thinking The
frame  30: Thinking …xt explanation of what a terminal multiplexer is, then call finish with "done". Let me
frame  45: Streaming A terminal multiplexer is a program that lets you run multiple
frame 207: Streaming …istent, flexible workspace that stays alive no matter what happens to your connection.
```

Probes: Ctrl-C mid-stream commits `interrupted` and leaves a live idle composer; a 44-column terminal clamps the tail (min budget 16) without breaking the frame. `moon test` 431/431 at this commit; the stack's final tree is byte-identical to the live-verified integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)