### PR TITLE
deepseek/client: add SSE streaming chat

### DIFF
--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -21,9 +21,10 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
   normal text; pass `JsonObject` only when the assistant content must be a JSON
   object.
 - `encode_chat_request(model, messages, tools?, thinking?, reasoning_effort?,
-  response_format?)`: builds the full DeepSeek chat completions request body.
-  The per-value encoders for messages, tool definitions, and tool calls are
-  package-private implementation details.
+  stream?, response_format?)`: builds the full DeepSeek chat completions request
+  body. Streaming requests include usage-bearing stream options. The per-value
+  encoders for messages, tool definitions, and tool calls are package-private
+  implementation details.
 - `ToolDefinition(name, description, parameters, strict?)`: a native DeepSeek
   function tool definition with a JSON Schema parameters object.
 - `ToolCall(id~, name~, arguments~)`: a decoded function call request from the

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -14,6 +14,10 @@ The package depends on `moonbitlang/async/http` and is native-only.
   thinking controls.
 - `Client::chat(messages, tools?, response_format?)`: send typed chat messages,
   optionally with native DeepSeek function tools, and decode the response.
+- `Client::chat_stream(messages, on_content_delta~, on_reasoning_delta?,
+  tools?, response_format?)`: send the same request in SSE streaming mode, emit
+  assistant content (and, when thinking is on, reasoning) fragments through the
+  callbacks, and return the fully accumulated response.
 
 `Client` implements `Debug` with the API key redacted.
 
@@ -24,6 +28,15 @@ model, thinking mode, and reasoning effort, then sends it to `api_url` as JSON.
 It sends `stream=false` and leaves assistant content unconstrained by default.
 Pass `response_format=JsonObject` only for callers that explicitly want the
 assistant content constrained to a JSON object.
+
+`Client::chat_stream` sends `stream=true` plus
+`stream_options={"include_usage":true}`. It parses DeepSeek's SSE `data:` events,
+calls `on_content_delta` for each non-empty `delta.content` (and
+`on_reasoning_delta` for each non-empty `delta.reasoning_content`), accumulates
+reasoning and tool-call fragments, and returns a normal
+`@deepseek.ChatResponse` with final usage when the API supplies it. The request
+pins `Accept-Encoding: identity` so no gzip-compressing intermediary can buffer
+and re-batch the delta stream.
 
 Use `tools=[...]` when the model should call native DeepSeek function tools.
 Tool call results should be appended as `@deepseek.ChatMessage(Tool(call.id),

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -64,3 +64,47 @@ pub async fn Client::chat(
   let parsed = @json.parse(text)
   @json.from_json(parsed)
 }
+
+///|
+/// Sends typed chat messages in DeepSeek SSE streaming mode.
+///
+/// `on_content_delta` is called for each assistant content fragment as it
+/// arrives; `on_reasoning_delta` likewise for each thinking-mode reasoning
+/// fragment (it is simply not called when thinking is off). The returned value
+/// is the fully accumulated response, including reasoning, tool calls, and
+/// final token usage when the API sends it.
+pub async fn Client::chat_stream(
+  self : Client,
+  messages : Array[@deepseek.ChatMessage],
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta? : async (String) -> Unit = _ => (),
+  tools? : Array[@deepseek.ToolDefinition] = [],
+  response_format? : @deepseek.ResponseFormat,
+) -> @deepseek.ChatResponse {
+  let body = @deepseek.encode_chat_request(
+    self.model,
+    messages,
+    tools~,
+    thinking?=self.thinking,
+    reasoning_effort?=self.reasoning_effort,
+    stream=true,
+    response_format?,
+  )
+  let client = @http.post_stream(self.api_url, headers={
+    "Content-Type": "application/json",
+    "Authorization": "Bearer \{self.api_key}",
+    // Without an explicit Accept-Encoding the HTTP client advertises gzip and
+    // transparently decompresses. A gzip-compressing intermediary buffers
+    // whole compression blocks, which would re-batch the SSE deltas this
+    // request exists to stream — so pin the identity encoding.
+    "Accept-Encoding": "identity",
+  })
+  defer client.close()
+  client.write(body.stringify())
+  let resp = client.end_request()
+  guard resp.code >= 200 && resp.code < 300 else {
+    let text = client.read_all().text()
+    fail("DeepSeek API error \{resp.code}: \{text}")
+  }
+  read_chat_stream(client, on_content_delta~, on_reasoning_delta~)
+}

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -1,0 +1,93 @@
+///|
+async fn stream_test_server(
+  group : @async.TaskGroup[Unit],
+  finish? : Bool = true,
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping stream test: \{message}")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        // The streaming request pins the identity encoding: a gzip-compressing
+        // intermediary would buffer compression blocks and re-batch the SSE
+        // deltas.
+        assert_true(request.headers.get("accept-encoding") is Some("identity"))
+        let request_body = body.read_all().text()
+        assert_true(request_body.contains("\"stream\":true"))
+        assert_true(request_body.contains("\"include_usage\":true"))
+        assert_false(request_body.contains("\"response_format\""))
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+        )
+        conn.flush()
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\" world\",\"reasoning_content\":\"hidden\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n",
+        )
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"moon.mod\\\"}\"}}]}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+        )
+        if finish {
+          conn.write("data: [DONE]\n\n")
+        }
+      },
+      max_connections=1,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "chat_stream accumulates SSE content, tool calls, and usage" {
+  @async.with_task_group() <| group => {
+    guard stream_test_server(group) is Some(url) else { return }
+    let client = @client.Client(api_key="test-key", api_url=url)
+    let deltas : Array[String] = []
+    let reasoning_deltas : Array[String] = []
+    let response = client.chat_stream(
+      [ChatMessage(User, content="hello")],
+      on_content_delta=delta => deltas.push(delta),
+      on_reasoning_delta=delta => reasoning_deltas.push(delta),
+    )
+    assert_eq(deltas.join("|"), "Hello| world")
+    assert_eq(reasoning_deltas.join("|"), "hidden")
+    assert_eq(response.content, "Hello world")
+    assert_eq(response.reasoning_content, "hidden")
+    assert_eq(response.tool_calls.length(), 1)
+    assert_eq(response.tool_calls[0].id, "call_1")
+    assert_eq(response.tool_calls[0].name, "read")
+    assert_eq(response.tool_calls[0].arguments, "{\"path\":\"moon.mod\"}")
+    assert_eq(response.usage.prompt_tokens, 3)
+    assert_eq(response.usage.completion_tokens, 5)
+    assert_eq(response.usage.total_tokens, 8)
+    assert_eq(response.usage.prompt_cache_hit_tokens, 1)
+    assert_eq(response.usage.prompt_cache_miss_tokens, 2)
+  }
+}
+
+///|
+async test "chat_stream rejects EOF before done" {
+  @async.with_task_group() <| group => {
+    guard stream_test_server(group, finish=false) is Some(url) else { return }
+    let client = @client.Client(api_key="test-key", api_url=url)
+    try {
+      let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
+        ()
+      })
+      fail("expected truncated stream to fail")
+    } catch {
+      error => assert_true("\{error}".contains("ended before [DONE]"))
+    }
+  }
+}

--- a/deepseek/client/moon.pkg
+++ b/deepseek/client/moon.pkg
@@ -1,11 +1,13 @@
 import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/async/http",
+  "moonbitlang/async/io",
   "moonbitlang/core/json",
 }
 
 import {
   "moonbitlang/async",
+  "moonbitlang/async/socket",
   "moonbitlang/core/env",
 } for "test"
 

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub struct Client {
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode?, reasoning_effort? : @deepseek.ReasoningEffort?) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
+pub async fn Client::chat_stream(Self, Array[@deepseek.ChatMessage], on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
 
 // Type aliases
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -1,0 +1,258 @@
+///|
+priv struct StreamToolCall {
+  mut id : String
+  mut name : String
+  arguments : StringBuilder
+}
+
+///|
+fn StreamToolCall::StreamToolCall() -> StreamToolCall {
+  { id: "", name: "", arguments: StringBuilder::new() }
+}
+
+///|
+fn StreamToolCall::to_json(self : StreamToolCall) -> Json {
+  {
+    "id": self.id,
+    "type": "function",
+    "function": { "name": self.name, "arguments": self.arguments.to_string() },
+  }
+}
+
+///|
+priv struct StreamAccumulator {
+  content : StringBuilder
+  reasoning_content : StringBuilder
+  tool_calls : Array[StreamToolCall]
+  mut usage : Json?
+}
+
+///|
+fn StreamAccumulator::StreamAccumulator() -> StreamAccumulator {
+  {
+    content: StringBuilder::new(),
+    reasoning_content: StringBuilder::new(),
+    tool_calls: [],
+    usage: None,
+  }
+}
+
+///|
+fn StreamAccumulator::ensure_tool_call(
+  self : StreamAccumulator,
+  index : Int,
+) -> StreamToolCall {
+  while self.tool_calls.length() <= index {
+    self.tool_calls.push(StreamToolCall())
+  }
+  self.tool_calls[index]
+}
+
+///|
+fn StreamAccumulator::response(
+  self : StreamAccumulator,
+) -> @deepseek.ChatResponse raise {
+  let reasoning_content = self.reasoning_content.to_string()
+  let message = Json::object(
+    Map(
+      [
+        ("content", Json::string(self.content.to_string())),
+        ..if reasoning_content != "" {
+          [("reasoning_content", Json::string(reasoning_content))]
+        } else {
+          []
+        },
+        ..if self.tool_calls.length() > 0 {
+          [
+            (
+              "tool_calls",
+              ([ for call in self.tool_calls => call.to_json() ] : Json),
+            ),
+          ]
+        } else {
+          []
+        },
+      ],
+    ),
+  )
+  let envelope = Json::object(
+    Map(
+      [
+        ("choices", ([({ "message": message } : Json)] : Json)),
+        ..match self.usage {
+          Some(usage) => [("usage", usage)]
+          None => []
+        },
+      ],
+    ),
+  )
+  @json.from_json(envelope)
+}
+
+///|
+fn json_string_field(fields : Map[String, Json], key : String) -> String? {
+  match fields.get(key) {
+    Some(String(value)) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn json_int_field(fields : Map[String, Json], key : String) -> Int? {
+  match fields.get(key) {
+    Some(Number(value, ..)) => Some(value.to_int())
+    _ => None
+  }
+}
+
+///|
+fn apply_tool_call_delta(
+  acc : StreamAccumulator,
+  json : Json,
+  fallback_index : Int,
+) -> Unit {
+  let fields = match json {
+    Object(fields) => fields
+    _ => return
+  }
+  let index = json_int_field(fields, "index").unwrap_or(fallback_index)
+  if index < 0 {
+    return
+  }
+  let call = acc.ensure_tool_call(index)
+  if json_string_field(fields, "id") is Some(id) && id != "" {
+    call.id = id
+  }
+  guard fields.get("function") is Some(Object(function)) else { return }
+  if json_string_field(function, "name") is Some(name) && name != "" {
+    call.name = name
+  }
+  if json_string_field(function, "arguments") is Some(arguments) &&
+    arguments != "" {
+    call.arguments.write_string(arguments)
+  }
+}
+
+///|
+async fn apply_stream_delta(
+  acc : StreamAccumulator,
+  delta : Map[String, Json],
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> Unit {
+  if json_string_field(delta, "content") is Some(content) && content != "" {
+    acc.content.write_string(content)
+    on_content_delta(content)
+  }
+  if json_string_field(delta, "reasoning_content") is Some(reasoning) &&
+    reasoning != "" {
+    acc.reasoning_content.write_string(reasoning)
+    on_reasoning_delta(reasoning)
+  }
+  match delta.get("tool_calls") {
+    Some(Array(calls)) =>
+      for index, call in calls {
+        apply_tool_call_delta(acc, call, index)
+      }
+    _ => ()
+  }
+}
+
+///|
+async fn apply_stream_json(
+  acc : StreamAccumulator,
+  json : Json,
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> Unit {
+  match json {
+    { "usage": Null, .. } => ()
+    { "usage": usage_json, .. } => acc.usage = Some(usage_json)
+    _ => ()
+  }
+  match json {
+    { "choices": [{ "delta": Object(delta), .. }, ..], .. } =>
+      apply_stream_delta(acc, delta, on_content_delta~, on_reasoning_delta~)
+    { "choices": [], .. } => ()
+    _ => ()
+  }
+}
+
+///|
+fn sse_data_fragment(raw : String) -> String? {
+  let line = if raw.has_suffix("\r") {
+    raw[:raw.length() - 1].to_owned()
+  } else {
+    raw
+  }
+  if line.has_prefix("data:") {
+    Some(line[5:].trim().to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+async fn flush_sse_event(
+  acc : StreamAccumulator,
+  data_lines : Array[String],
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> Bool {
+  if data_lines.length() == 0 {
+    return false
+  }
+  let data = data_lines.join("\n").trim().to_owned()
+  data_lines.clear()
+  if data == "[DONE]" {
+    return true
+  }
+  apply_stream_json(
+    acc,
+    @json.parse(data),
+    on_content_delta~,
+    on_reasoning_delta~,
+  )
+  false
+}
+
+///|
+async fn read_chat_stream(
+  reader : @http.Client,
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> @deepseek.ChatResponse {
+  let acc = StreamAccumulator::StreamAccumulator()
+  let data_lines : Array[String] = []
+  for ;; {
+    match reader.read_until("\n") {
+      None => {
+        if flush_sse_event(
+            acc,
+            data_lines,
+            on_content_delta~,
+            on_reasoning_delta~,
+          ) {
+          break
+        }
+        fail("DeepSeek stream ended before [DONE]")
+      }
+      Some(raw) => {
+        let trimmed = raw.trim()
+        if trimmed.is_empty() {
+          if flush_sse_event(
+              acc,
+              data_lines,
+              on_content_delta~,
+              on_reasoning_delta~,
+            ) {
+            break
+          }
+        } else if sse_data_fragment(raw) is Some(data) {
+          data_lines.push(data)
+        }
+      }
+    }
+  }
+  acc.response()
+}

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -46,6 +46,21 @@ test "encode_chat_request includes tools when present" {
 }
 
 ///|
+test "encode_chat_request enables usage-bearing stream mode" {
+  let body = @deepseek.encode_chat_request(
+    V4Flash,
+    [ChatMessage(User, content="stream this")],
+    stream=true,
+  )
+  let text = body.stringify()
+  assert_true(text.contains("\"stream\":true"))
+  guard body
+    is { "stream": True, "stream_options": { "include_usage": True, .. }, .. } else {
+    fail("wrong stream options")
+  }
+}
+
+///|
 test "encode_chat_request encodes thinking controls" {
   let body = @deepseek.encode_chat_request(
     V4Pro,

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -74,6 +74,7 @@ pub fn encode_chat_request(
   tools? : Array[ToolDefinition] = [],
   thinking? : ThinkingMode,
   reasoning_effort? : ReasoningEffort,
+  stream? : Bool = false,
   response_format? : ResponseFormat,
 ) -> Json {
   Json::object(
@@ -81,11 +82,16 @@ pub fn encode_chat_request(
       [
         ("model", Json::string(model.to_string())),
         ("messages", ([ for message in messages => message ] : Json)),
-        ("stream", Json::boolean(false)),
+        ("stream", Json::boolean(stream)),
         ..match response_format {
           Some(format) =>
             [("response_format", ({ "type": format.to_string() } : Json))]
           None => []
+        },
+        ..if stream {
+          [("stream_options", ({ "include_usage": true } : Json))]
+        } else {
+          []
         },
         ..if tools.length() > 0 {
           [("tools", ([ for tool in tools => tool ] : Json))]

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort, response_format? : ResponseFormat) -> Json
+pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, reasoning_effort? : ReasoningEffort, stream? : Bool, response_format? : ResponseFormat) -> Json
 
 // Errors
 


### PR DESCRIPTION
**PR 2 of 4** in the live-streaming stack (#70 ✅ → 2 → #72 → #73). Replaces #71, which GitHub closed when #70's base branch was deleted; same content, now rebased onto main.

Adds `Client::chat_stream`:

- sends `stream=true` plus `stream_options={"include_usage":true}` (new `stream` flag on `encode_chat_request`),
- parses DeepSeek's SSE `data:` events incrementally (`stream.mbt`),
- fires `on_content_delta` per non-empty `delta.content` and `on_reasoning_delta` per non-empty `delta.reasoning_content`,
- accumulates content, reasoning, and indexed tool-call fragments, returning a normal `ChatResponse` with final usage,
- pins `Accept-Encoding: identity` — the HTTP library otherwise advertises gzip, and a compressing intermediary would buffer whole blocks and re-batch the delta stream.

Tested: mock SSE server test covers content/reasoning deltas, tool-call fragment assembly, usage, the identity-encoding header, and EOF-before-`[DONE]` rejection. Verified live against the real API: 71 content deltas arrived spread over 1.1s through a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)