### PR TITLE
tui: converse in a durable session by default

### DIFF
--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -5,20 +5,7 @@ fn drain_test_state() -> State {
     model: V4Pro,
     cwd: ".",
     max_steps: 10,
-    session_id: Some(SessionId("test")),
-    session_root: ".openseek",
-    engine: "openseek",
-  })
-}
-
-///|
-fn ephemeral_drain_test_state() -> State {
-  State::new({
-    api_key: "k",
-    model: V4Pro,
-    cwd: ".",
-    max_steps: 10,
-    session_id: None,
+    session_id: SessionId("test"),
     session_root: ".openseek",
     engine: "openseek",
   })
@@ -76,13 +63,6 @@ test "agent engine argv stays replay-compatible while session config uses env" {
 }
 
 ///|
-test "agent engine env omits session config for fresh runs" {
-  let env = engine_env(ephemeral_drain_test_state().config, {})
-  assert_true(env.get("OPENSEEK_SESSION") is None)
-  assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
-}
-
-///|
 test "agent engine env overrides inherited session config" {
   let inherited = {
     "OPENSEEK_SESSION": "parent",
@@ -94,18 +74,6 @@ test "agent engine env overrides inherited session config" {
   assert_true(env.get("OPENSEEK_SESSION") == Some("test"))
   assert_true(env.get("OPENSEEK_SESSION_ROOT") == Some(".openseek"))
   assert_true(inherited.get("OPENSEEK_SESSION") == Some("parent"))
-}
-
-///|
-test "agent engine env clears inherited session config for fresh runs" {
-  let env = engine_env(ephemeral_drain_test_state().config, {
-    "OPENSEEK_SESSION": "parent",
-    "OPENSEEK_SESSION_ROOT": "/tmp/parent",
-    "PATH": "/bin",
-  })
-  assert_true(env.get("PATH") == Some("/bin"))
-  assert_true(env.get("OPENSEEK_SESSION") is None)
-  assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -103,16 +103,13 @@ fn engine_args(task : String) -> Array[String] {
 
 ///|
 fn engine_extra_env(config : AppConfig) -> Map[String, String] {
-  let env = {
+  {
     "DEEPSEEK": config.api_key,
     "DEEPSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+    "OPENSEEK_SESSION": config.session_id.value(),
+    "OPENSEEK_SESSION_ROOT": config.session_root,
   }
-  if config.session_id is Some(session_id) {
-    env["OPENSEEK_SESSION"] = session_id.value()
-    env["OPENSEEK_SESSION_ROOT"] = config.session_root
-  }
-  env
 }
 
 ///|
@@ -120,9 +117,9 @@ fn engine_env(
   config : AppConfig,
   inherited : Map[String, String],
 ) -> Map[String, String] {
+  // The merge overwrites every OpenSeek setting — including the always-present
+  // session id — so inherited session vars can never shadow this TUI's config.
   let env = inherited.copy()
-  env.remove("OPENSEEK_SESSION")
-  env.remove("OPENSEEK_SESSION_ROOT")
   env.merge_in_place(engine_extra_env(config))
   env
 }

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -108,13 +108,53 @@ fn session_root(matches : @argparse.Matches) -> String raise {
 }
 
 ///|
+/// Session id for a TUI launch that did not pick one: a UTC wall-clock stamp,
+/// `tui-YYYYMMDD-HHMMSS-mmm`.
+///
+/// Conversation continuity is the TUI's default. The engine runs once per
+/// prompt, so context only carries between prompts through the durable session
+/// store — without a session, telling the assistant something and asking about
+/// it in the next prompt would hit a fresh one-shot that never saw the first
+/// message. The timestamp form keeps generated ids unique per launch, sorted
+/// chronologically in `--session-list`, and valid as a directory name on every
+/// platform.
+fn generated_session_id(now_ms : Int64) -> @agent_session.SessionId {
+  fn pad2(value : Int) -> String {
+    if value < 10 {
+      "0\{value}"
+    } else {
+      "\{value}"
+    }
+  }
+
+  fn pad3(value : Int) -> String {
+    if value < 10 {
+      "00\{value}"
+    } else if value < 100 {
+      "0\{value}"
+    } else {
+      "\{value}"
+    }
+  }
+
+  let time = @time.unix(now_ms / 1000) catch {
+    // A wall clock unrepresentable as a date (absurd system time): the raw
+    // millisecond count still yields a unique, valid directory name.
+    _ => return SessionId("tui-\{now_ms}")
+  }
+  SessionId(
+    "tui-\{time.year()}\{pad2(time.month())}\{pad2(time.day())}-\{pad2(time.hour())}\{pad2(time.minute())}\{pad2(time.second())}-\{pad3((now_ms % 1000).to_int())}",
+  )
+}
+
+///|
 fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   let cwd = match @env.current_dir() {
     Some(cwd) => cwd
     None => "."
   }
-  let session_id = session_id(matches)
-  let session_root_value = if session_id is Some(_) {
+  let explicit_session = session_id(matches)
+  let session_root_value = if explicit_session is Some(_) {
     session_root(matches)
   } else {
     let root = value(matches, "session-root").trim().to_owned()
@@ -129,7 +169,10 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     model: @deepseek.Model::parse(value(matches, "model")),
     cwd,
     max_steps: parse_positive_int(value(matches, "max-steps"), "--max-steps"),
-    session_id,
+    session_id: match explicit_session {
+      Some(id) => id
+      None => generated_session_id(@env.now().reinterpret_as_int64())
+    },
     session_root: session_root_value,
     engine: value(matches, "engine"),
   }
@@ -157,7 +200,12 @@ async fn run_app(config : AppConfig, initial : String?, ui : @ui.Ui) -> Unit {
   let state = State::new(config)
   let messages = @async.Queue(kind=Unbounded)
   append_session_history(state.config, ui)
-  ui.append_item(Response("OpenSeek TUI ready"))
+  // Name the session so the conversation is resumable later with
+  // `--session <id>` — for generated ids this line is the only place the user
+  // ever sees one.
+  ui.append_item(
+    Response("OpenSeek TUI ready · session \{config.session_id.value()}"),
+  )
   refresh_ui(ui, state)
   @async.with_task_group(group => {
     group.spawn_bg(no_wait=true) <| () => { read_ui_events(ui, messages) }
@@ -221,8 +269,21 @@ test "cli accepts no initial task" {
   assert_eq(config.api_key, "test-key")
   assert_eq(config.max_steps, 1000)
   assert_eq(config.engine, "openseek")
-  assert_true(config.session_id is None)
+  // No --session still converses in a session: a generated per-launch id, so
+  // consecutive prompts share context instead of running amnesiac one-shots.
+  assert_true(config.session_id.value().has_prefix("tui-"))
   assert_eq(config.session_root, ".openseek")
+}
+
+///|
+test "generated session ids are timestamped and directory-safe" {
+  assert_eq(generated_session_id(0).value(), "tui-19700101-000000-000")
+  assert_eq(generated_session_id(86_399_999).value(), "tui-19700101-235959-999")
+  // 2026-06-10T03:14:07.089Z
+  assert_eq(
+    generated_session_id(1_781_061_247_089).value(),
+    "tui-20260610-031407-089",
+  )
 }
 
 ///|
@@ -242,8 +303,7 @@ test "cli accepts session configuration" {
     env={ "DEEPSEEK": "test-key" },
   )
   let config = parse_config(parsed)
-  guard config.session_id is Some(id) else { fail("expected session id") }
-  assert_eq(id.value(), "demo")
+  assert_eq(config.session_id.value(), "demo")
   assert_eq(config.session_root, "/tmp/openseek-sessions")
 }
 

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -17,6 +17,7 @@ import {
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/x/sys",
+  "moonbitlang/x/time",
 }
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -53,7 +53,7 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
 
 ///|
 async fn append_session_history(config : AppConfig, ui : @ui.Ui) -> Unit {
-  guard config.session_id is Some(session_id) else { return }
+  let session_id = config.session_id
   let store = @store.SessionStore(config.session_root)
   let exists = store.exists(session_id) catch {
     error => {

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -4,7 +4,12 @@ priv struct AppConfig {
   model : @deepseek.Model
   cwd : String
   max_steps : Int
-  session_id : @agent_session.SessionId?
+  // The durable session every prompt of this TUI run converses in. The engine
+  // is spawned fresh per prompt, so context only carries between prompts
+  // through the session store: without one, each prompt would be an amnesiac
+  // one-shot. `--session` picks (or resumes) an id; otherwise one is generated
+  // per launch.
+  session_id : @agent_session.SessionId
   session_root : String
   // The agent engine the TUI spawns and reads JSONL events from. Defaults to
   // the `openseek` binary on `PATH`; override (e.g. to a recorded-stream


### PR DESCRIPTION
## Problem

Tell the TUI your name, then ask for it in the next prompt — it has no idea. The TUI spawns a fresh `openseek` engine process per prompt, so conversation context can only carry between prompts through the durable session store. Without `--session`, every prompt ran as an amnesiac one-shot. (Engine-level session memory itself works: two `--session demo` runs recall the name correctly.)

## Fix

Every TUI launch now converses in its own durable session by default:

- no `--session` → a generated per-launch id, `tui-YYYYMMDD-HHMMSS-mmm` (UTC; unique per launch, sorts chronologically in `--session-list`, valid as a directory name on every platform),
- the startup banner names it (`OpenSeek TUI ready · session tui-…`) so the conversation is resumable later with `--session <id>`,
- explicit `--session` resumes/creates that id exactly as before.

`AppConfig.session_id` becomes non-optional, the engine environment always carries `OPENSEEK_SESSION`/`OPENSEEK_SESSION_ROOT`, and the session-less code paths and their tests are gone.

## Verification

- Live pty run (real API, flash): prompt 1 "Remember this: my name is Hongbo." → prompt 2 "What is my name?" — the thinking preview read *"The user's name is Hongbo, as they told me earlier."* and the transcript committed **Hongbo**. One session directory (`.openseek/sessions/tui-20260610-031529-831`) holds both turns.
- `generated_session_id` is pure and unit-tested against fixed timestamps (epoch, day boundary, a 2026 date).
- `moon test` 430/430, offline cram 6/6, `moon fmt --check` clean.
- A scripted pty run initially looked like the TUI quit on its own ~30s in; a `waitpid`-instrumented rerun showed the TUI alive 42s+ idle — the harness pty had died under it, and the TUI correctly treated the vanished terminal (`ReaderClosed`) as Quit. Test-harness artifact; app behavior is by design and unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)