### PR TITLE
docs: enforce missing_doc and document every public symbol

### DIFF
--- a/agent_runtime/runtime.mbt
+++ b/agent_runtime/runtime.mbt
@@ -1,4 +1,8 @@
 ///|
+/// Capacity of an `AgentRuntime`'s event bus. The bus discards oldest on
+/// overflow: runtime updates are progress feedback for the model, so when a
+/// noisy watcher outpaces the agent loop, dropping stale updates beats
+/// blocking the tool that posts them.
 pub let default_agent_event_capacity : Int = 32
 
 ///|
@@ -18,6 +22,8 @@ pub struct AgentRuntime {
 }
 
 ///|
+/// Create a runtime with an empty event bus of
+/// `default_agent_event_capacity`.
 pub fn AgentRuntime::AgentRuntime() -> AgentRuntime {
   { events: Queue(kind=DiscardOldest(default_agent_event_capacity)) }
 }
@@ -30,6 +36,9 @@ pub struct AgentTaskScope[X] {
 }
 
 ///|
+/// Wrap the agent loop's task group so stateful tools can spawn background
+/// work whose lifetime is bounded by the loop, without taking a dependency on
+/// the loop's own types.
 pub fn[X] AgentTaskScope::AgentTaskScope(
   group : @async.TaskGroup[X],
 ) -> AgentTaskScope[X] {
@@ -37,6 +46,8 @@ pub fn[X] AgentTaskScope::AgentTaskScope(
 }
 
 ///|
+/// The underlying task group, for spawning background work that must not
+/// outlive the agent loop.
 pub fn[X] AgentTaskScope::group(
   self : AgentTaskScope[X],
 ) -> @async.TaskGroup[X] {
@@ -44,6 +55,9 @@ pub fn[X] AgentTaskScope::group(
 }
 
 ///|
+/// Post one runtime update for the agent loop to pick up on its next step.
+/// Never blocks and never fails: on overflow the oldest queued event is
+/// discarded, because a fresh update is worth more than a stale one.
 pub fn AgentRuntime::emit_event(
   self : AgentRuntime,
   event : AgentEvent,
@@ -52,6 +66,9 @@ pub fn AgentRuntime::emit_event(
 }
 
 ///|
+/// Take every queued runtime update, oldest first, leaving the bus empty.
+/// The agent loop calls this between steps to fold fresh background tool
+/// output into the conversation.
 pub fn AgentRuntime::drain_events(self : AgentRuntime) -> Array[AgentEvent] {
   let events : Array[AgentEvent] = []
   for ;; {

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -31,11 +31,15 @@ pub struct SessionStore {
 } derive(Debug)
 
 ///|
+/// Open a store rooted at `root`. Nothing is touched on disk until the first
+/// session is created or appended to, so constructing a store is free and
+/// never fails.
 pub fn SessionStore::SessionStore(root : String) -> SessionStore {
   { root, }
 }
 
 ///|
+/// The root directory this store keeps its `sessions/` tree under.
 pub fn SessionStore::root(self : SessionStore) -> String {
   self.root
 }

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -5,11 +5,14 @@ pub struct SessionId {
 } derive(Debug)
 
 ///|
+/// Wrap a raw id string. The id doubles as the session's directory name in a
+/// `SessionStore`, so it should be filesystem-safe on every platform.
 pub fn SessionId::SessionId(value : String) -> SessionId {
   { value, }
 }
 
 ///|
+/// The raw id string, e.g. for display or for building a store path.
 pub fn SessionId::value(self : SessionId) -> String {
   self.value
 }
@@ -38,11 +41,13 @@ fn SessionToolCall::to_deepseek(self : SessionToolCall) -> @deepseek.ToolCall {
 }
 
 ///|
+/// Wrap one user prompt as it was submitted, verbatim.
 pub fn UserMessage::UserMessage(content : String) -> UserMessage {
   { content, }
 }
 
 ///|
+/// The prompt text exactly as the user submitted it.
 pub fn UserMessage::content(self : UserMessage) -> String {
   self.content
 }
@@ -58,6 +63,11 @@ pub struct AssistantMessage {
 } derive(Debug, ToJson, FromJson)
 
 ///|
+/// Build an assistant message from the model's response parts: the visible
+/// `content`, any native `tool_calls` it requested, and the thinking-mode
+/// `reasoning_content` when the API returned one. Tool calls are converted to
+/// the session's own storage form so the event log has no wire-type
+/// dependency.
 pub fn AssistantMessage::AssistantMessage(
   content : String,
   tool_calls? : Array[@deepseek.ToolCall] = [],
@@ -73,6 +83,8 @@ pub fn AssistantMessage::AssistantMessage(
 }
 
 ///|
+/// The assistant's visible text — empty for turns that only requested tool
+/// calls.
 pub fn AssistantMessage::content(self : AssistantMessage) -> String {
   self.content
 }
@@ -101,6 +113,10 @@ pub struct ToolResult {
 } derive(Debug, ToJson, FromJson)
 
 ///|
+/// Record the outcome of one tool execution: which assistant call it answers
+/// (`tool_call_id`), which tool ran (`tool_name`), what it returned
+/// (`content`), and whether that content is an error report rather than a
+/// normal result.
 pub fn ToolResult::ToolResult(
   tool_call_id~ : String,
   tool_name~ : String,
@@ -116,16 +132,21 @@ fn ToolResult::tool_call_id(self : ToolResult) -> String {
 }
 
 ///|
+/// Name of the tool that produced this result (e.g. `shell`, `edit`).
 pub fn ToolResult::tool_name(self : ToolResult) -> String {
   self.tool_name
 }
 
 ///|
+/// The tool's output as it was fed back to the model — an error description
+/// when `is_error` is true.
 pub fn ToolResult::content(self : ToolResult) -> String {
   self.content
 }
 
 ///|
+/// Whether `content` reports a failure (bad arguments, command error) rather
+/// than a normal result.
 pub fn ToolResult::is_error(self : ToolResult) -> Bool {
   self.is_error
 }
@@ -138,11 +159,13 @@ pub struct RuntimeNotice {
 } derive(Debug, ToJson, FromJson)
 
 ///|
+/// Wrap one runtime update exactly as it was injected into the conversation.
 pub fn RuntimeNotice::RuntimeNotice(content : String) -> RuntimeNotice {
   { content, }
 }
 
 ///|
+/// The update text the model saw, including any watcher metadata preamble.
 pub fn RuntimeNotice::content(self : RuntimeNotice) -> String {
   self.content
 }
@@ -158,6 +181,9 @@ pub struct SessionSummary {
 } derive(Debug, ToJson, FromJson)
 
 ///|
+/// Build a summary of the events `from_sequence..to_sequence` (inclusive).
+/// Prefer `Session::compact`, which validates the range against the session
+/// before appending.
 pub fn SessionSummary::SessionSummary(
   content~ : String,
   from_sequence~ : Int,
@@ -167,21 +193,30 @@ pub fn SessionSummary::SessionSummary(
 }
 
 ///|
+/// The summary text that stands in for the compacted events in the
+/// model-facing projection.
 pub fn SessionSummary::content(self : SessionSummary) -> String {
   self.content
 }
 
 ///|
+/// First event sequence (inclusive) this summary covers.
 pub fn SessionSummary::from_sequence(self : SessionSummary) -> Int {
   self.from_sequence
 }
 
 ///|
+/// Last event sequence (inclusive) this summary covers.
 pub fn SessionSummary::to_sequence(self : SessionSummary) -> Int {
   self.to_sequence
 }
 
 ///|
+/// How a turn ended, with the payload a consumer shows for it: the final
+/// answer for `Finished`, the reason for `Aborted` (the agent's own abort
+/// tool) and `Interrupted` (cancelled from outside), or the failure message
+/// for `Failed`. Every turn closes with exactly one of these, so a session
+/// whose last event is not a `Terminal` was cut off mid-turn.
 pub(all) enum TurnTerminal {
   Finished(String)
   Aborted(String)
@@ -190,6 +225,10 @@ pub(all) enum TurnTerminal {
 } derive(Debug)
 
 ///|
+/// One kind of session event payload — the conversation's vocabulary: the
+/// user spoke (`User`), the model answered (`Assistant`), a tool returned
+/// (`Tool`), the runtime injected diagnostics (`Runtime`), older events were
+/// compacted (`Summary`), or the turn ended (`Terminal`).
 pub(all) enum SessionItem {
   User(UserMessage)
   Assistant(AssistantMessage)
@@ -216,11 +255,13 @@ fn SessionEvent::SessionEvent(
 }
 
 ///|
+/// This event's position in the session's append-only log (one-based).
 pub fn SessionEvent::sequence(self : SessionEvent) -> Int {
   self.sequence
 }
 
 ///|
+/// The event's payload.
 pub fn SessionEvent::item(self : SessionEvent) -> SessionItem {
   self.item
 }
@@ -237,6 +278,9 @@ pub struct Session {
 } derive(Debug)
 
 ///|
+/// Build a session from its identity, system prompt, and (when loading from
+/// storage) its existing event log. `last_sequence` is recovered from the
+/// highest sequence present, so appending continues where the log left off.
 pub fn Session::Session(
   id : SessionId,
   system_prompt~ : String,
@@ -252,21 +296,25 @@ pub fn Session::Session(
 }
 
 ///|
+/// The session's stable identifier.
 pub fn Session::id(self : Session) -> SessionId {
   self.id
 }
 
 ///|
+/// The system prompt this conversation runs under, fixed at creation.
 pub fn Session::system_prompt(self : Session) -> String {
   self.system_prompt
 }
 
 ///|
+/// The full append-only event log, oldest first.
 pub fn Session::events(self : Session) -> @vector.Vector[SessionEvent] {
   self.events
 }
 
 ///|
+/// Sequence of the newest event, or `0` for a session with no events yet.
 pub fn Session::last_sequence(self : Session) -> Int {
   self.last_sequence
 }
@@ -277,6 +325,9 @@ fn Session::next_sequence(self : Session) -> Int {
 }
 
 ///|
+/// Append one item as the next event and return the new session value; the
+/// receiver is unchanged. Callers that also need the assigned event (e.g. to
+/// persist it) should use `append_event`.
 pub fn Session::append(self : Session, item : SessionItem) -> Session {
   let (next, _) = self.append_event(item)
   next

--- a/agent_tool/edit/internal/decode/decode.mbt
+++ b/agent_tool/edit/internal/decode/decode.mbt
@@ -1,4 +1,7 @@
 ///|
+/// Decoded arguments of the `edit` tool: replace `old_string` with
+/// `new_string` in the file at `path` — every occurrence when `replace_all`,
+/// otherwise exactly one.
 pub struct EditInput {
   path : String
   old_string : String
@@ -7,6 +10,12 @@ pub struct EditInput {
 } derive(Debug)
 
 ///|
+/// Decode `edit` tool-call arguments.
+///
+/// `path`, `old_string`, and `new_string` are required strings;
+/// `replace_all` is an optional boolean defaulting to `false`. Failures name
+/// the first offending field (e.g. `arguments.old_string`) so the error fed
+/// back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> EditInput raise {
   match arguments {
     {

--- a/agent_tool/edit/internal/manifest_error/manifest_error.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error.mbt
@@ -1,4 +1,13 @@
 ///|
+/// Guard rail for writes to MoonBit manifests: returns the error to feed back
+/// to the model when writing `content` to `path` would produce a known-bad
+/// manifest, or `None` when the write may proceed.
+///
+/// Models trained on older MoonBit emit legacy shapes — `moon.mod.json`
+/// files, JSON syntax inside `moon.mod`/`moon.pkg` — that the toolchain no
+/// longer accepts. Rejecting the write with a corrective message at the tool
+/// boundary fixes the mistake in one round trip, instead of letting a broken
+/// manifest fail every later build step.
 pub async fn write_error(path : String, content : String) -> String? {
   let trimmed = content.trim().to_owned()
   if is_moon_mod_json_path(path) && !@fs.exists(path) {

--- a/agent_tool/finish/internal/decode/decode.mbt
+++ b/agent_tool/finish/internal/decode/decode.mbt
@@ -1,9 +1,16 @@
 ///|
+/// Decoded arguments of the `finish` control tool: the final answer the agent
+/// ends its run with.
 pub struct FinishInput {
   answer : String
 } derive(Debug)
 
 ///|
+/// Decode `finish` tool-call arguments.
+///
+/// Lenient by design: `finish` ends the run, so a missing or non-string
+/// `answer` becomes an empty answer rather than an error that would keep an
+/// otherwise completed run alive.
 pub fn decode(arguments : Json) -> FinishInput {
   let answer = match arguments {
     { "answer": String(answer), .. } => answer

--- a/agent_tool/moon_check/internal/decode/decode.mbt
+++ b/agent_tool/moon_check/internal/decode/decode.mbt
@@ -1,4 +1,8 @@
 ///|
+/// Decoded arguments of the `moon_check` tool: where to run the persistent
+/// `moon check` watcher (`cwd`), which backend to check (`target`), and the
+/// pass-through diagnostics switches (`warn_list`, `deny_warn`, `fmt`,
+/// `explain`).
 pub struct MoonCheckInput {
   cwd : String?
   target : String?
@@ -9,6 +13,12 @@ pub struct MoonCheckInput {
 } derive(Debug)
 
 ///|
+/// Decode `moon_check` tool-call arguments.
+///
+/// Every field is optional: strings default to absent, booleans to `false`.
+/// A present `target` must be one of moon's backends (`wasm`, `wasm-gc`,
+/// `js`, `native`, `llvm`, `all`). Failures name the offending field so the
+/// error fed back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> MoonCheckInput raise {
   match arguments {
     Object(fields) => parse_fields(fields)

--- a/agent_tool/moon_cmd/internal/decode/decode.mbt
+++ b/agent_tool/moon_cmd/internal/decode/decode.mbt
@@ -1,10 +1,19 @@
 ///|
+/// Characters of captured `moon` output one `moon_cmd` call returns when the
+/// model does not pick a `max_output_chars` budget itself.
 pub let default_max_output_chars : Int = 12000
 
 ///|
+/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
+/// `moon` invocation's output can never flood the conversation.
 pub let hard_max_output_chars : Int = 50000
 
 ///|
+/// Decoded arguments of the `moon_cmd` tool: the `moon` subcommand to run
+/// (`command`), where (`cwd`) and for which backend (`target`), its
+/// flag-style `args`, positional `paths`, post-`--` `program_args`, optional
+/// `stdin` text, the snapshot-update audit fields (`test_update_kind`,
+/// `test_update_reason`), and the output budget.
 pub struct MoonCommandInput {
   command : String
   cwd : String?
@@ -19,6 +28,13 @@ pub struct MoonCommandInput {
 } derive(Debug)
 
 ///|
+/// Decode `moon_cmd` tool-call arguments.
+///
+/// `command` is required and validated against the supported subcommand set;
+/// `target` is only accepted for subcommands that take one. The array fields
+/// default to empty, `max_output_chars` to `default_max_output_chars` clamped
+/// to `hard_max_output_chars`. Failures name the offending field so the error
+/// fed back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> MoonCommandInput raise {
   match arguments {
     Object(fields) => parse_fields(fields)

--- a/agent_tool/moon_ide/internal/decode/decode.mbt
+++ b/agent_tool/moon_ide/internal/decode/decode.mbt
@@ -1,10 +1,18 @@
 ///|
+/// Characters of IDE query output one `moon_ide` call returns when the model
+/// does not pick a `max_output_chars` budget itself.
 pub let default_max_output_chars : Int = 12000
 
 ///|
+/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
+/// IDE query can never flood the conversation.
 pub let hard_max_output_chars : Int = 50000
 
 ///|
+/// Decoded arguments of the `moon_ide` tool: which IDE `action` to run
+/// (symbol search, goto-definition, hover, …) and its inputs — the free-text
+/// `query`, the `path`/`loc` position, the backend `target` — plus `no_check`
+/// to skip the pre-query type check and the output budget.
 pub struct MoonIdeInput {
   action : String
   cwd : String?
@@ -17,6 +25,15 @@ pub struct MoonIdeInput {
 } derive(Debug)
 
 ///|
+/// Decode `moon_ide` tool-call arguments.
+///
+/// `action` is required and validated against the supported set; which other
+/// fields are required depends on the action and is checked by the tool
+/// itself, so this stays a pure shape decode. A present `target` must be one
+/// of moon's backends. `max_output_chars` defaults to
+/// `default_max_output_chars`, clamped to `hard_max_output_chars`. Failures
+/// name the offending field so the error fed back to the model says exactly
+/// which argument to fix.
 pub fn decode(arguments : Json) -> MoonIdeInput raise {
   match arguments {
     Object(fields) => parse_fields(fields)

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -1,10 +1,17 @@
 ///|
+/// Characters of file content one `read` call returns when the model does not
+/// pick a `max_output_chars` budget itself.
 pub let default_max_output_chars : Int = 12000
 
 ///|
+/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
+/// tool call can never flood the conversation with an arbitrarily large file.
 pub let hard_max_output_chars : Int = 50000
 
 ///|
+/// Decoded arguments of the `read` tool: the file at `path`, starting from
+/// the 1-based `start_line`, at most `max_lines` lines (unbounded when
+/// `None`), truncated to `max_output_chars` characters.
 pub struct ReadInput {
   path : String
   start_line : Int
@@ -13,6 +20,13 @@ pub struct ReadInput {
 } derive(Debug)
 
 ///|
+/// Decode `read` tool-call arguments.
+///
+/// Only `path` is required; the numeric fields must be positive when present
+/// and otherwise default (`start_line` 1, `max_lines` unbounded,
+/// `max_output_chars` `default_max_output_chars` clamped to
+/// `hard_max_output_chars`). Failures name the offending field so the error
+/// fed back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> ReadInput raise {
   match arguments {
     Object(fields) => parse_fields(fields)

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -1,4 +1,13 @@
 ///|
+/// Policy gate for agent shell commands: returns the error to feed back to
+/// the model when `cmd` must not run, or `None` when it may.
+///
+/// The blocked commands are not dangerous — they are redirections. `moon
+/// check` (bare, behind `cd`, or embedded in a compound command) is pushed to
+/// the `moon_check` tool so the agent gets persistent watcher feedback
+/// instead of a one-shot run, and the tool name `moon_cmd` typed as a shell
+/// command is pointed back at the real tools. Each error's wording tells the
+/// model what to do instead, because the model is the caller who reads it.
 pub fn moonbit_command_policy_error(cmd : String) -> String? {
   let words = shell_words(cmd)
   let command_index = first_command_word_index(words)

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -1,10 +1,17 @@
 ///|
+/// Characters of captured command output one `shell` call returns when the
+/// model does not pick a `max_output_chars` budget itself.
 pub let default_max_output_chars : Int = 12000
 
 ///|
+/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
+/// command's output can never flood the conversation.
 pub let hard_max_output_chars : Int = 50000
 
 ///|
+/// Decoded arguments of the `shell` tool: run `cmd` through the platform
+/// shell, in `cwd` when given, killed after `timeout_ms` when given, with
+/// captured output truncated to `max_output_chars` characters.
 pub struct ShellInput {
   cmd : String
   cwd : String?
@@ -13,6 +20,13 @@ pub struct ShellInput {
 } derive(Debug)
 
 ///|
+/// Decode `shell` tool-call arguments.
+///
+/// Only `cmd` is required (and must be non-empty). `cwd` defaults to the
+/// process working directory, `timeout_ms` to no timeout, and
+/// `max_output_chars` to `default_max_output_chars`, clamped to
+/// `hard_max_output_chars`. Failures name the offending field so the error
+/// fed back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> ShellInput raise {
   match arguments {
     Object(fields) => parse_fields(fields)

--- a/agent_tool/write/internal/decode/decode.mbt
+++ b/agent_tool/write/internal/decode/decode.mbt
@@ -1,10 +1,17 @@
 ///|
+/// Decoded arguments of the `write` tool: create or overwrite the file at
+/// `path` with exactly `content`.
 pub struct WriteInput {
   path : String
   content : String
 } derive(Debug)
 
 ///|
+/// Decode `write` tool-call arguments.
+///
+/// Both fields are required strings. Failures name the first offending field
+/// (e.g. `arguments.content`) so the error fed back to the model says exactly
+/// which argument to fix.
 pub fn decode(arguments : Json) -> WriteInput raise {
   match arguments {
     { "path": String(path), "content": String(content), .. } =>

--- a/eval/file_edit/cases/cases.mbt
+++ b/eval/file_edit/cases/cases.mbt
@@ -1,4 +1,8 @@
 ///|
+/// One file-editing scenario: the `instructions` given to the agent, the
+/// `initial` workspace to stage, the `expected` workspace afterwards, the
+/// `unchanged_files` that must survive byte-for-byte, and extra `validation`
+/// marker strings the agent must produce. `id` names the case in reports.
 pub struct EvalCase {
   id : String
   instructions : String
@@ -9,6 +13,9 @@ pub struct EvalCase {
 }
 
 ///|
+/// The fixed case suite, ordered: exact replace, ambiguous replace,
+/// multiline replace, file creation, and a compile fix — one case per
+/// editing skill the `edit`/`write` tools must get right.
 pub fn eval_cases() -> Array[EvalCase] {
   [
     exact_replace_case(),
@@ -20,12 +27,17 @@ pub fn eval_cases() -> Array[EvalCase] {
 }
 
 ///|
+/// The case trial `index` runs, cycling through `eval_cases()` so any trial
+/// count covers the suite evenly.
 pub fn case_for_trial(index : Int) -> EvalCase {
   let cases = eval_cases()
   cases[index % cases.length()]
 }
 
 ///|
+/// Render the full task prompt for a trial running in `workspace`: the
+/// shared editing rules (absolute paths, no shell-based file mutation,
+/// preserve unrelated files) followed by this case's instructions.
 pub fn EvalCase::task(self : EvalCase, workspace : String) -> String {
   (
     $|You are running a file-editing eval.

--- a/eval/file_edit/harness/config.mbt
+++ b/eval/file_edit/harness/config.mbt
@@ -1,4 +1,11 @@
 ///|
+/// Configuration of one file-edit eval run: DeepSeek access (`api_key`,
+/// `model`), trial shape (`runs`, `concurrency`, `min_successes`,
+/// `max_steps`), artifact and workspace locations (`out_dir`, `repo_root`),
+/// and the prompt variant under test (`prompt_label`,
+/// `system_prompt_file`, `system_prompt_addendum_file` — empty paths mean
+/// the built-in prompt). The cases themselves come from the sibling `cases`
+/// package.
 pub struct Config {
   api_key : String
   model : @deepseek.Model
@@ -14,6 +21,8 @@ pub struct Config {
 }
 
 ///|
+/// Build a config; every field is explicit because eval runs must be
+/// reproducible from their recorded parameters alone.
 pub fn Config::Config(
   api_key~ : String,
   model~ : @deepseek.Model,

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -1,4 +1,11 @@
 ///|
+/// Everything recorded about one file-edit trial: identity (`index`, the
+/// eval `case_id`, `prompt_label`), the verdict (`success`/`reason`), where
+/// it ran (`workspace`, `log_path`, `exit_code`), agent-loop measurements
+/// (`steps`, `tool_errors`), per-tool usage counters (how the agent split
+/// its work across shell, moon_cmd, edit, write, …), and the case's two
+/// gates — the workspace matched the expected files (`validation_passed`)
+/// and the required marker text was produced (`marker_present`).
 pub struct TrialResult {
   index : Int
   case_id : String
@@ -26,6 +33,9 @@ pub struct TrialResult {
 }
 
 ///|
+/// One file-edit eval run's outcome: the configuration that defined it, the
+/// success tally against `min_successes`, where artifacts were written, and
+/// every trial's result.
 pub struct EvalReport {
   model : String
   prompt_label : String
@@ -45,6 +55,11 @@ priv struct AgentLogSummary {
 }
 
 ///|
+/// Run the whole file-edit eval: `config.runs` agent trials cycling through
+/// the eval cases, `config.concurrency` at a time, each in a fresh staged
+/// workspace checked against the case's expected files. Returns the
+/// aggregated report; rendering and exit-status decisions stay with the
+/// caller.
 pub async fn run_suite(config : Config) -> EvalReport {
   prepare_output_dir(config.out_dir)
   let results = run_indexed_with_concurrency(config.runs, config.concurrency, index => {

--- a/eval/file_edit/harness/report.mbt
+++ b/eval/file_edit/harness/report.mbt
@@ -48,16 +48,22 @@ fn TrialResult::to_json(self : TrialResult) -> Json {
 }
 
 ///|
+/// Whether the run met its success threshold. Thresholded rather than
+/// all-or-nothing because agent trials are stochastic: the tooling is judged
+/// on its success rate, not on a single unlucky trial.
 pub fn EvalReport::passed(self : EvalReport) -> Bool {
   self.successes >= self.min_successes
 }
 
 ///|
+/// The one-line failure summary a runner prints (and exits non-zero with)
+/// when the threshold was missed, stating tally and threshold.
 pub fn EvalReport::failure_message(self : EvalReport) -> String {
   "file edit eval failed: \{self.successes}/\{self.runs} below threshold \{self.min_successes}/\{self.runs}"
 }
 
 ///|
+/// Render this run as the standard markdown report document.
 pub fn EvalReport::markdown(self : EvalReport) -> String {
   self.as_report().markdown()
 }

--- a/eval/prompt_task/harness/config.mbt
+++ b/eval/prompt_task/harness/config.mbt
@@ -1,4 +1,10 @@
 ///|
+/// Configuration of one prompt eval run: DeepSeek access (`api_key`,
+/// `model`), trial shape (`runs`, `concurrency`, `min_successes`,
+/// `max_steps`), artifact and workspace locations (`out_dir`, `repo_root`),
+/// and the prompt variant under test (`prompt_label`, `task_file`,
+/// `system_prompt_file`, `system_prompt_addendum_file` — empty paths mean
+/// the built-in prompt).
 pub struct Config {
   api_key : String
   model : @deepseek.Model
@@ -15,6 +21,8 @@ pub struct Config {
 }
 
 ///|
+/// Build a config; every field is explicit because eval runs must be
+/// reproducible from their recorded parameters alone.
 pub fn Config::Config(
   api_key~ : String,
   model~ : @deepseek.Model,

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -1,10 +1,16 @@
 ///|
+/// Verdict of one behavioral probe run against a trial's workspace, with the
+/// `reason` it failed ("ok" when it passed).
 pub struct ProbeResult {
   passed : Bool
   reason : String
 }
 
 ///|
+/// Validation verdict for one trial's finished workspace: the overall
+/// `passed`/`reason` plus each individual gate — the project must type-check
+/// (`moon_check`), pass its tests (`moon_test`), and behave correctly on the
+/// file, stdin, and duplicate-handling probes.
 pub struct ValidationResult {
   passed : Bool
   reason : String
@@ -16,6 +22,12 @@ pub struct ValidationResult {
 }
 
 ///|
+/// Everything recorded about one trial: identity (`index`, `prompt_label`),
+/// the verdict (`success`/`reason`), where it ran (`workspace`, `log_path`,
+/// `exit_code`), agent-loop measurements (`steps`, `tool_errors`,
+/// `finished`), the workspace `validation`, and the `*_mentions`/`*_uses`
+/// counters that track how often the transcript touches APIs and idioms the
+/// prompt under test tries to encourage or ban.
 pub struct TrialResult {
   index : Int
   prompt_label : String
@@ -45,6 +57,9 @@ pub struct TrialResult {
 }
 
 ///|
+/// One prompt-eval run's outcome: the configuration that defined it (model,
+/// prompt label, task file, trial counts), the success tally against
+/// `min_successes`, where artifacts were written, and every trial's result.
 pub struct EvalReport {
   model : String
   prompt_label : String
@@ -66,6 +81,10 @@ priv struct AgentLogSummary {
 }
 
 ///|
+/// Run the whole prompt eval: `config.runs` agent trials of the task file,
+/// `config.concurrency` at a time, each in a fresh workspace and validated
+/// end-to-end. Returns the aggregated report; rendering and exit-status
+/// decisions stay with the caller.
 pub async fn run_suite(config : Config) -> EvalReport {
   prepare_output_dir(config.out_dir)
   let task_template = @fs.read_file(config.task_file).text()

--- a/eval/prompt_task/harness/report.mbt
+++ b/eval/prompt_task/harness/report.mbt
@@ -64,16 +64,22 @@ fn ValidationResult::to_json(self : ValidationResult) -> Json {
 }
 
 ///|
+/// Whether the run met its success threshold. Thresholded rather than
+/// all-or-nothing because agent trials are stochastic: a prompt is judged on
+/// its success rate, not on a single unlucky trial.
 pub fn EvalReport::passed(self : EvalReport) -> Bool {
   self.successes >= self.min_successes
 }
 
 ///|
+/// The one-line failure summary a runner prints (and exits non-zero with)
+/// when the threshold was missed, stating tally and threshold.
 pub fn EvalReport::failure_message(self : EvalReport) -> String {
   "prompt task eval failed: \{self.successes}/\{self.runs} below threshold \{self.min_successes}/\{self.runs}"
 }
 
 ///|
+/// Render this run as the standard markdown report document.
 pub fn EvalReport::markdown(self : EvalReport) -> String {
   self.as_report().markdown()
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -1,15 +1,23 @@
 ///|
+/// One named measurement, already rendered to display text — the shared cell
+/// format for report summaries and per-row metric columns.
 pub struct Metric {
   name : String
   value : String
 }
 
 ///|
+/// Build a metric. `value` is display text: format numbers before
+/// constructing so the report layer never guesses precision.
 pub fn Metric::Metric(name~ : String, value~ : String) -> Metric {
   { name, value }
 }
 
 ///|
+/// One trial's row in an eval report: which case (`name`) and repetition
+/// (`index`), whether it passed, the failure `reason` ("ok" when it passed),
+/// non-fatal `warnings`, its `metrics` cells, and the path of its full
+/// transcript log when one was kept.
 pub struct ReportRow {
   index : Int
   name : String
@@ -21,6 +29,8 @@ pub struct ReportRow {
 }
 
 ///|
+/// Build a report row; everything beyond identity and the verdict is
+/// optional. `reason` defaults to "ok" so passing rows read uniformly.
 pub fn ReportRow::ReportRow(
   index~ : Int,
   name~ : String,
@@ -34,6 +44,9 @@ pub fn ReportRow::ReportRow(
 }
 
 ///|
+/// A complete eval run's results: a `title`, run-level `summary` metrics, the
+/// ordered `metric_columns` every row renders under, and one `ReportRow` per
+/// trial. Renders to markdown for humans and JSON for tooling.
 pub struct Report {
   title : String
   summary : Array[Metric]
@@ -42,6 +55,8 @@ pub struct Report {
 }
 
 ///|
+/// Build a report. `metric_columns` names and orders the per-row metric
+/// cells; rows supply values for those names via their `metrics`.
 pub fn Report::Report(
   title~ : String,
   summary? : Array[Metric] = [],
@@ -52,6 +67,7 @@ pub fn Report::Report(
 }
 
 ///|
+/// How many rows passed.
 pub fn Report::successes(self : Report) -> Int {
   let mut count = 0
   for row in self.rows {
@@ -63,11 +79,15 @@ pub fn Report::successes(self : Report) -> Int {
 }
 
 ///|
+/// Whether every row passed — the run's exit-status verdict. Vacuously true
+/// for a report with no rows.
 pub fn Report::all_passed(self : Report) -> Bool {
   self.successes() == self.rows.length()
 }
 
 ///|
+/// Render the report as a human-facing markdown document: title, summary
+/// bullets, the trial table, and a log-paths section when any row kept one.
 pub fn Report::markdown(self : Report) -> String {
   let lines : Array[String] = ["# \{self.title}", ""]
   for metric in self.summary {
@@ -94,6 +114,8 @@ pub fn Report::markdown(self : Report) -> String {
 }
 
 ///|
+/// Render the report as JSON for tooling (diffing runs, dashboards), with
+/// the success count precomputed alongside the raw rows.
 pub fn Report::to_json(self : Report) -> Json {
   {
     "title": self.title,
@@ -105,11 +127,16 @@ pub fn Report::to_json(self : Report) -> Json {
 }
 
 ///|
+/// Write both renderings of this report under `out_dir` — the standard
+/// artifact layout eval runners leave behind.
 pub async fn Report::write_files(self : Report, out_dir : String) -> Unit {
   write_files(out_dir, self.markdown(), self.to_json())
 }
 
 ///|
+/// Write already-rendered report artifacts as `report.md` and `report.json`
+/// under `out_dir`, creating it as needed — for runners that build their
+/// renderings separately.
 pub async fn write_files(
   out_dir : String,
   markdown : String,
@@ -208,6 +235,9 @@ fn log_section_lines(rows : Array[ReportRow]) -> Array[String] {
 }
 
 ///|
+/// Make free text safe inside a markdown table cell: escape `|` and flatten
+/// newlines to spaces. Failure reasons quote arbitrary model and tool
+/// output, which would otherwise break the table layout.
 pub fn escape_table_cell(text : String) -> String {
   text
   |> String::replace_all(old="|", new="\\|")

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -1,4 +1,9 @@
 ///|
+/// Exercise every agent tool once through the real registry — decode,
+/// dispatch, execute, and check each tool's happy path plus a
+/// representative failure — and return the per-case report. This is the
+/// offline tool smoke test: no model involved, so a failure localizes to
+/// the tool layer itself.
 pub async fn run_harness() -> @report.Report {
   @async.with_task_group() <| group => {
     run_harness_with_runtime(AgentRuntime(), AgentTaskScope(group))

--- a/improvement.md
+++ b/improvement.md
@@ -1,0 +1,93 @@
+# Improvement Checklist
+
+Observations collected while working on streaming, sessions, and documentation
+(June 2026). Each item is small enough to land as its own PR; none blocks
+current functionality. Check items off as they land, and add new ones at the
+bottom of the matching section.
+
+## TUI
+
+- [ ] **Collapse the triple redraw per message.** `refresh_ui` calls
+  `set_status`, `set_activity`, and `set_queued_inputs`, each of which queues
+  its own full-frame redraw — three repaints per message-loop iteration.
+  During delta bursts this triples render work. Add a single
+  "set view state + one redraw" command on `Ui`.
+- [ ] **Keep reasoning visible after the turn.** Thinking-mode reasoning only
+  ever exists as the transient `Thinking …` tail and is discarded once
+  content starts. Surface it as a dimmed/collapsible transcript item so a
+  user can review *why* the model did something.
+- [ ] **Measure the activity label instead of reserving 13 columns.**
+  `ActivityPreviewReservedColumns` hardcodes indent + widest label + slack;
+  computing it from the actual label keeps the preview honest if labels
+  change.
+- [ ] **Session management inside the TUI.** A `--continue` flag for the most
+  recent session, and a way to list/switch sessions without restarting.
+  Generated ids (`tui-YYYYMMDD-HHMMSS-mmm`) are only discoverable via the
+  startup banner or `openseek --session-list` today.
+- [ ] **Steering a running task.** `Steer` while running is rejected ("press
+  Tab to queue") because the engine cannot accept mid-turn input. Needs an
+  engine-side protocol (e.g. a control channel on stdin) before the TUI can
+  offer it.
+- [ ] **Persistent engine per session.** The TUI spawns a fresh engine per
+  prompt, so `moon_check --watch` restarts (and re-warms) every turn and its
+  watcher state is lost between prompts. A long-lived engine process per
+  session — with prompts delivered over a channel — would keep watchers warm
+  and is also the prerequisite for steering.
+
+## Engine / agent
+
+- [ ] **Expose thinking controls.** `run_with_runtime` hardcodes
+  `thinking=Enabled, reasoning_effort=Max`; make them engine flags
+  (`--thinking`, `--reasoning-effort`) and TUI pass-throughs.
+- [ ] **Auto-compaction.** Compaction exists only as the manual
+  `--session-compact-*` flow. Long-lived sessions (now the TUI default)
+  grow without bound; trigger summarization when the projected context
+  passes a threshold.
+- [ ] **Richer `--session-list`.** Bare ids are hard to recognize; include
+  last-activity time and the first user prompt as a label.
+- [ ] **Stale `session.lock` recovery.** Verify what happens when an engine
+  crashes while holding the lock, and document (or implement) the recovery
+  path.
+- [ ] **Flush the JSONL queue on hard crash.** The stdout drain trades
+  crash-tail durability for purity (no C stub): lines queued but unwritten
+  when the process aborts are lost. A panic hook that drains synchronously
+  would close the gap.
+- [ ] **Cheapen the engine probe.** `engine_launchable` spawns
+  `<engine> --help` on every TUI launch; cache the result per engine path
+  (mtime-keyed) or accept the first spawn failing fast instead.
+
+## DeepSeek client
+
+- [ ] **Unify `chat` and `chat_stream`.** They share request encoding but
+  duplicate response and error handling. Implementing `chat` as
+  streaming-with-no-callbacks leaves one wire path to maintain.
+- [ ] **Retry transient HTTP failures.** Both entry points are single-shot;
+  a bounded retry with backoff on connect/5xx errors would remove the most
+  common spurious turn failures.
+
+## Testing / CI
+
+- [ ] **More CI platforms.** CI is a single `check (nightly)` job; the TUI's
+  pty handling and the engine's stdio behavior are platform-sensitive
+  (macOS pty quirks surfaced during verification). Add macOS, then Windows.
+- [ ] **Make the live cram lifecycle test extension-proof.** It asserts an
+  exact event-name set and broke when `*_delta` events were added (now
+  filtered). Assert the stable lifecycle subset is *present* instead of
+  asserting the full set.
+- [ ] **Checked-in TUI integration harness.** The pty driver used to verify
+  streaming and session memory lives outside the repo. Pair a small pty
+  driver with a recorded-stream replay engine (the TUI already accepts
+  `--engine <replayer>`) for deterministic offline TUI tests.
+- [ ] **Run `moon fmt --check` before push.** Two consecutive PRs hit
+  CI-only formatting failures; a pre-push hook or documented `moon` alias
+  would catch them locally.
+
+## Docs / prompts
+
+- [ ] **Doc-exemplary prompt examples.** `prompt/moon.pkg` opts the system
+  prompt out of `missing_doc` because its example code blocks are
+  model-facing text. Consider documenting those examples *as a prompt
+  change* (with an eval run) so the model also learns the doc convention.
+- [ ] **Document the TUI session default.** The root README does not yet
+  mention that every TUI launch converses in a durable session and how to
+  resume one (`--session <id>` from the startup banner).

--- a/moon.mod
+++ b/moon.mod
@@ -23,6 +23,8 @@ description = "DeepSeek-backed MoonBit coding agent"
 
 preferred_target = "native"
 
+warnings = "+missing_doc"
+
 rule(
   name: "md_to_mbt_string",
   command: "moon run --quiet --target native scripts/md_to_mbt_string -- \"$input\" \"$output\"",

--- a/prompt/moon.pkg
+++ b/prompt/moon.pkg
@@ -20,6 +20,10 @@ dev_build(
   output: "generated_flash_prompt.mbt",
 )
 
-warnings = "+unnecessary_annotation-unused_value-unused_type_declaration-unused_constructor-unused_field-todo-declaration_unimplemented"
+// -missing_doc: the flagged symbols live in the system prompt's example code
+// blocks; doc comments there would change the prompt text the model sees,
+// which is an eval'd prompt change, not a documentation change.
+
+warnings = "+unnecessary_annotation-unused_value-unused_type_declaration-unused_constructor-unused_field-todo-declaration_unimplemented-missing_doc"
 
 supported_targets = "+native"

--- a/testkit/filesystem/filesystem.mbt
+++ b/testkit/filesystem/filesystem.mbt
@@ -1,4 +1,6 @@
 ///|
+/// One file of a `FileSystem`: its slash-separated relative `path` and full
+/// text `content`.
 pub struct FileEntry {
   path : String
   content : String
@@ -12,6 +14,9 @@ pub struct FileEntry {
 pub(all) struct FileSystem(Json)
 
 ///|
+/// Wrap an already-encoded JSON filesystem, validating the convention up
+/// front (object shape, relative string paths, string contents) so later
+/// reads cannot fail on malformed fixture data.
 pub fn FileSystem::from_json(json : Json) -> FileSystem raise {
   let filesystem = FileSystem(json)
   filesystem.validate()
@@ -19,6 +24,8 @@ pub fn FileSystem::from_json(json : Json) -> FileSystem raise {
 }
 
 ///|
+/// Build a filesystem from `(path, content)` pairs — the convenient form for
+/// literal fixtures in test code. Rejects invalid paths and duplicates.
 pub fn FileSystem::from_pairs(
   files : Array[(String, String)],
 ) -> FileSystem raise {
@@ -35,17 +42,23 @@ pub fn FileSystem::from_pairs(
 }
 
 ///|
+/// The underlying JSON object, e.g. for embedding the fixture in a larger
+/// eval-case document.
 pub fn FileSystem::to_json(self : FileSystem) -> Json {
   let FileSystem(json) = self
   json
 }
 
 ///|
+/// Check the whole filesystem against the convention, raising on the first
+/// violation. Equivalent to `entries()` with the result discarded.
 pub fn FileSystem::validate(self : FileSystem) -> Unit raise {
   let _ = self.entries()
 }
 
 ///|
+/// Every file as a `FileEntry`, sorted by path for deterministic iteration.
+/// Raises when the JSON violates the filesystem convention.
 pub fn FileSystem::entries(self : FileSystem) -> Array[FileEntry] raise {
   let FileSystem(json) = self
   guard json is Object(fields) else {
@@ -65,6 +78,7 @@ pub fn FileSystem::entries(self : FileSystem) -> Array[FileEntry] raise {
 }
 
 ///|
+/// Every file path, sorted — the entries without their contents.
 pub fn FileSystem::paths(self : FileSystem) -> Array[String] raise {
   [
     for entry in self.entries() => entry.path
@@ -72,6 +86,9 @@ pub fn FileSystem::paths(self : FileSystem) -> Array[String] raise {
 }
 
 ///|
+/// Content of the file at `path`, or `None` when absent. Raises on an
+/// invalid `path` or malformed stored content rather than hiding either as
+/// "absent".
 pub fn FileSystem::get(self : FileSystem, path : String) -> String? raise {
   validate_relative_path(path)
   let FileSystem(json) = self
@@ -86,6 +103,8 @@ pub fn FileSystem::get(self : FileSystem, path : String) -> String? raise {
 }
 
 ///|
+/// Materialize every file under the `root` directory, creating parent
+/// directories as needed — how an eval trial stages its starting workspace.
 pub async fn FileSystem::write_to(self : FileSystem, root : String) -> Unit {
   for entry in self.entries() {
     write_text(root, entry.path, entry.content)
@@ -93,6 +112,10 @@ pub async fn FileSystem::write_to(self : FileSystem, root : String) -> Unit {
 }
 
 ///|
+/// Compare this filesystem against the files under `root` and describe the
+/// first difference — a missing file or a content mismatch — or return `""`
+/// when everything matches. A description rather than a `Bool` so an eval
+/// report can say what went wrong, not just that something did.
 pub async fn FileSystem::mismatch_on_disk(
   self : FileSystem,
   root : String,
@@ -113,6 +136,8 @@ pub async fn FileSystem::mismatch_on_disk(
 }
 
 ///|
+/// Write one text file at `root`/`path` (relative, validated), creating
+/// parent directories and truncating any existing file.
 pub async fn write_text(root : String, path : String, content : String) -> Unit {
   validate_relative_path(path)
   ensure_parent_dir(root, path)

--- a/tui/style/style.mbt
+++ b/tui/style/style.mbt
@@ -10,9 +10,12 @@ pub struct Style {
 } derive(Eq, Debug)
 
 ///|
+/// The terminal's own colors, no underline — text with no styling applied.
 pub let default : Style = Style()
 
 ///|
+/// Build a style; omitted fields keep the terminal default. Pass only what
+/// the span should change, e.g. `Style(foreground=Basic(Yellow))`.
 pub fn Style::Style(
   foreground? : @tty/color.Color = Default,
   background? : @tty/color.Color = Default,
@@ -22,10 +25,13 @@ pub fn Style::Style(
 }
 
 ///|
+/// De-emphasized text (bright black): labels, separators, secondary detail.
 pub let dim : Style = Style(foreground=Basic(BrightBlack))
 
 ///|
+/// Success accent (green): completed statuses and confirmations.
 pub let ok : Style = Style(foreground=Basic(Green))
 
 ///|
+/// Failure accent (red): error items and failed statuses.
 pub let error : Style = Style(foreground=Basic(Red))


### PR DESCRIPTION
## What

Two commits, both documentation:

1. **`moon.mod` gains `warnings = "+missing_doc"`** — an undocumented public symbol now fails `moon check` module-wide, so the docs can't rot silently. All 115 flagged symbols are documented:
   - `agent_session`: the session domain model — constructors/accessors now state the append-only log semantics, sequence numbering, and what each `SessionItem`/`TurnTerminal` variant means for consumers.
   - `agent_tool/*/internal/decode` (8 packages): each input struct documents its tool's argument contract; each `decode` documents required vs defaulted fields, clamping (`default_max_output_chars` → `hard_max_output_chars`), and why failures name the offending field (the model is the caller who reads the error).
   - `agent_tool` policy/manifest guards: documented as *redirections aimed at the model*, not safety blocks — e.g. why `moon check` is pushed to the `moon_check` tool, and why manifest writes reject legacy `moon.mod.json`/JSON shapes in one round trip.
   - `agent_runtime`: the discard-oldest event-bus rationale (a fresh update beats a stale one; never block the posting tool).
   - `eval/*` harnesses + `eval/report`: threshold semantics (`passed` is a success-*rate* judgment because agent trials are stochastic), what each `TrialResult` counter tracks, and the report artifact layout.
   - `testkit/filesystem`, `tui/style`: fixture conventions and style palette roles.

   One deliberate opt-out: **`prompt/`** keeps `-missing_doc` (with an explanatory comment) because its flagged symbols are example code blocks *inside the model-facing system prompt* — documenting them would change the prompt the model sees, which is an eval'd prompt change, not a documentation change. (Tracked in `improvement.md`.)

2. **`improvement.md`** — a backlog checklist of improvements observed while working on streaming, sessions, and docs, grouped by area (TUI, engine/agent, DeepSeek client, testing/CI, docs/prompts), each with enough context to be picked up cold as its own PR.

## Verification

`moon check` clean (0 warnings), `moon fmt --check` clean, `moon test` 430/430, offline cram 6/6. No code behavior changes — doc comments, one warning flag, one markdown file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)