### PR TITLE
feat(tui): keep the turn's reasoning as a transcript thought aside

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -164,6 +164,15 @@ async fn run_with_runtime(
           }
         },
       )
+      // Reasoning first, so a consumer appending events in order shows the
+      // thinking above the answer it led to.
+      if response.reasoning_content != "" {
+        @xlog.info() <?
+          {
+            "event": "reasoning_message",
+            "content": response.reasoning_content,
+          }
+      }
       if response.content != "" {
         @xlog.info() <?
           { "event": "assistant_message", "content": response.content }

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -13,6 +13,8 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "agent_step" => Some(AgentStep)
     "assistant_delta" => Some(AssistantDelta(@jsonx.string(object, "content")))
     "reasoning_delta" => Some(ReasoningDelta(@jsonx.string(object, "content")))
+    "reasoning_message" =>
+      Some(ReasoningMessage(@jsonx.string(object, "content")))
     "assistant_message" =>
       Some(AssistantMessage(@jsonx.string(object, "content")))
     "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -22,6 +22,12 @@ test "decode maps each engine event kind" {
   )
   assert_true(
     @event.decode_event(
+      Json::object({ "event": "reasoning_message", "content": "full thought" }),
+    )
+    is Some(ReasoningMessage("full thought")),
+  )
+  assert_true(
+    @event.decode_event(
       Json::object({ "event": "agent_finished", "answer": "done" }),
     )
     is Some(AgentFinished("done")),

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -36,6 +36,7 @@ pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
   ReasoningDelta(String)
+  ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -11,6 +11,7 @@ pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
   ReasoningDelta(String)
+  ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -356,6 +356,38 @@ test "streamed newlines collapse so the preview stays one line" {
 }
 
 ///|
+test "reasoning_message commits a thought item and clears the preview" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    Json::object({ "event": "reasoning_delta", "content": "Let me think" }),
+    items,
+  )
+  assert_true(state.streaming_reasoning is Some("Let me think"))
+  // The full reasoning lands as one `✻` thought item, and the live preview
+  // is finished with.
+  append_items(
+    state,
+    Json::object({
+      "event": "reasoning_message",
+      "content": "Let me think about names.\nThe user said Hongbo.",
+    }),
+    items,
+  )
+  assert_true(state.streaming_reasoning is None)
+  guard items is [Thought(_)] else { fail("expected a single Thought item") }
+  // Blank reasoning never appends an empty aside.
+  append_items(
+    state,
+    Json::object({ "event": "reasoning_message", "content": "  " }),
+    items,
+  )
+  assert_eq(items.length(), 1)
+}
+
+///|
 test "reasoning_delta drives the thinking preview until content arrives" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -340,6 +340,14 @@ fn handle_agent_event(
           append_streaming_preview(state.streaming_reasoning, text),
         )
       }
+    // The turn's full reasoning, emitted once streaming ends and before the
+    // assistant message commits — so the transcript reads thought → answer.
+    ReasoningMessage(text) => {
+      state.streaming_reasoning = None
+      if !text.trim().is_empty() {
+        cmds.push(AppendItem(reasoning_item(text)))
+      }
+    }
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -65,6 +65,21 @@ fn tool_item(result : @event.ToolResultEvent) -> @ui.TranscriptItem {
 }
 
 ///|
+/// Render a turn's completed thinking as a `✻` transcript aside: a dim
+/// "thought" title over the reasoning's first and last lines. The full text
+/// already streamed through the activity line; the transcript keeps a
+/// compact trace the user can scroll back to, so the *why* of an answer
+/// survives the moment it was streamed.
+fn reasoning_item(text : String) -> @ui.TranscriptItem {
+  Thought(
+    ToolCall(
+      @doc.dim_text("thought"),
+      details=detail_texts(compact_lines(text, ToolOutputLineLimit)),
+    ),
+  )
+}
+
+///|
 /// Render the result of a `!` shell command the TUI ran locally: the command
 /// line as the title (with a non-zero/cancelled marker), and its full captured
 /// output as dimmed detail lines. The output is already character-capped by

--- a/improvement.md
+++ b/improvement.md
@@ -13,10 +13,13 @@ bottom of the matching section.
   During delta bursts this triples render work. Add a single
   "set view state + one redraw" command on `Ui`. *(Done: `Ui::set_live_view`
   replaces the three setters; one command, one redraw per loop turn.)*
-- [ ] **Keep reasoning visible after the turn.** Thinking-mode reasoning only
+- [x] **Keep reasoning visible after the turn.** Thinking-mode reasoning only
   ever exists as the transient `Thinking …` tail and is discarded once
   content starts. Surface it as a dimmed/collapsible transcript item so a
-  user can review *why* the model did something.
+  user can review *why* the model did something. *(Done: the engine emits
+  `reasoning_message` after streaming; the TUI commits a `✻` thought aside
+  above the answer. Resume does not replay thoughts — sessions do not store
+  reasoning for no-tool turns; see the auto-compaction/session items.)*
 - [ ] **Measure the activity label instead of reserving 13 columns.**
   `ActivityPreviewReservedColumns` hardcodes indent + widest label + slack;
   computing it from the actual label keeps the preview honest if labels
@@ -71,10 +74,11 @@ bottom of the matching section.
 - [ ] **More CI platforms.** CI is a single `check (nightly)` job; the TUI's
   pty handling and the engine's stdio behavior are platform-sensitive
   (macOS pty quirks surfaced during verification). Add macOS, then Windows.
-- [ ] **Make the live cram lifecycle test extension-proof.** It asserts an
+- [x] **Make the live cram lifecycle test extension-proof.** It asserts an
   exact event-name set and broke when `*_delta` events were added (now
   filtered). Assert the stable lifecycle subset is *present* instead of
-  asserting the full set.
+  asserting the full set. *(Done: the example whitelists the lifecycle
+  events, so new payload event kinds cannot break it.)*
 - [ ] **Checked-in TUI integration harness.** The pty driver used to verify
   streaming and session memory lives outside the repo. Pair a small pty
   driver with a recorded-stream replay engine (the TUI already accepts

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -63,9 +63,11 @@ A minimal run emits an `agent_step`, a `usage` record once DeepSeek answers, and
 an `agent_finished`. We collect the `"event"` values into a `Set`, which dedupes
 and preserves insertion order — so printing it yields the lifecycle in the order
 it occurred, the same `{agent_step, usage, agent_finished}` no matter how many
-steps the run takes. Streaming `assistant_delta`/`reasoning_delta` events are
-filtered out: whether and how often they appear varies per run (thinking mode
-streams its reasoning live), while the lifecycle events are stable.
+steps the run takes. The filter is a whitelist of exactly those lifecycle
+events: the stream also carries content/reasoning payload events
+(`assistant_delta`, `reasoning_message`, …) whose presence and count vary per
+run, and asserting the full set would break every time the engine grows a new
+event kind.
 
 ```mooncram
 $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
@@ -75,9 +77,10 @@ $ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool imm
 > }
 > 
 > async fn main {
+>   let lifecycle = ["agent_step", "usage", "agent_finished"]
 >   let events = Set::new()
 >   for value in @jsonl.read_stdin() {
->     if value is { "event": String(event), .. } && !event.has_suffix("_delta") {
+>     if value is { "event": String(event), .. } && lifecycle.contains(event) {
 >       events.add(event)
 >     }
 >   }

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -42,6 +42,7 @@ pub(all) enum TranscriptItem {
   Response(String)
   ToolCall(ToolCall)
   Notice(ToolCall)
+  Thought(ToolCall)
   Error(String)
 } derive(@debug.Debug)
 pub impl @doc.ToDoc for TranscriptItem

--- a/tui/core/transcript.mbt
+++ b/tui/core/transcript.mbt
@@ -41,12 +41,15 @@ pub fn ToolCall::ToolCall(
 /// One committed entry in the transcript: a submitted `Input`, an agent
 /// `Response`, a `ToolCall`, an out-of-band runtime `Notice` (e.g. background
 /// `moon check --watch` diagnostics the agent was fed — a titled, detail-bearing
-/// block like a tool call but flagged with a `↻` marker), or an `Error`.
+/// block like a tool call but flagged with a `↻` marker), a `Thought` (the
+/// model's completed thinking for a turn, same titled block under a `✻`
+/// marker), or an `Error`.
 pub(all) enum TranscriptItem {
   Input(Input)
   Response(String)
   ToolCall(ToolCall)
   Notice(ToolCall)
+  Thought(ToolCall)
   Error(String)
 } derive(Debug)
 
@@ -83,6 +86,11 @@ let square : @displaytext.DisplayText = DisplayText("■ ")
 let notice : @displaytext.DisplayText = DisplayText("↻ ")
 
 ///|
+/// Marker for a completed thinking block (`Thought`): a `✻` so the model's
+/// own reasoning reads as an aside, distinct from tool output and answers.
+let thought : @displaytext.DisplayText = DisplayText("✻ ")
+
+///|
 /// Render a `ToolCall` as a `marker`-bulleted title followed by its detail lines,
 /// each `└`/space-indented and dimmed. Shared by the `⏺` tool-call projection and
 /// the `↻` runtime-notice projection so both lay details out identically.
@@ -111,8 +119,8 @@ fn tool_call_doc(
 /// Project a transcript item into a renderable `@doc.Doc`: inputs use their own
 /// prefixed projection, responses become dim `⏺`-bulleted blocks, tool calls
 /// render a status-styled `⏺` bullet with `└`-indented detail lines, runtime
-/// notices use the same detail layout under a dim `↻` marker, and errors become
-/// an error-styled `■`-bulleted block.
+/// notices and thoughts use the same detail layout under dim `↻` and `✻`
+/// markers, and errors become an error-styled `■`-bulleted block.
 pub impl @doc.ToDoc for TranscriptItem with fn to_doc(self) {
   match self {
     Input(input) => input.to_doc()
@@ -132,6 +140,8 @@ pub impl @doc.ToDoc for TranscriptItem with fn to_doc(self) {
       tool_call_doc(call, marker=bullet, marker_style=bullet_style)
     }
     Notice(call) => tool_call_doc(call, marker=notice, marker_style=@style.dim)
+    Thought(call) =>
+      tool_call_doc(call, marker=thought, marker_style=@style.dim)
     Error(message) => {
       let error_style = @style.error
       Doc(


### PR DESCRIPTION
Second item off the `improvement.md` checklist (plus the live-cram hardening it required).

## Problem

Thinking-mode reasoning only ever existed as the transient `Thinking …` activity tail and was discarded once content started — the *why* behind an answer never survived the moment it streamed.

## Change

- **Engine**: emits one `reasoning_message` event per turn — the full accumulated reasoning, ordered before `assistant_message` so consumers appending events in order show the thought above the answer it led to.
- **TUI**: new `Thought` transcript variant (dim `✻` marker, same titled-block layout as tool calls/notices); the reasoning lands as a compact aside (first/last lines via the shared `compact_lines` limit) and the live preview clears.
- **Live cram**: the lifecycle example now *whitelists* `{agent_step, usage, agent_finished}` instead of blacklisting payload suffixes — new event kinds (like this one) can no longer break it. Ticks that checklist item too, since this change is exactly what would have broken it.

Scope note: resume does not replay thoughts — sessions store no reasoning for no-tool turns; recorded in `improvement.md` alongside the session items.

## Verification

- `moon check` 0 warnings, fmt clean, 431/431 tests, 6/6 offline cram.
- Live pty run (real API): transcript reads
  ```
  ✻ thought
    └ Let me calculate 17 times 23.
      17 * 23 = 17 * (20 + 3) = 17*20 + 17*3 = 340 + 51 = 391.
      Let me verify: 17 * 23 = 391.
  ⏺ 391
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)