### PR TITLE
feat: expose thinking controls as engine and TUI flags

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -21,12 +21,24 @@ pub async fn run(
   task : String,
   max_steps? : Int = default_max_steps,
   system_prompt_text? : String = default_system_prompt_for_model(model),
+  thinking? : @deepseek.ThinkingMode = Enabled,
+  reasoning_effort? : @deepseek.ReasoningEffort = Max,
 ) -> Unit {
   let session = @agent_session.Session(
     SessionId("one-shot"),
     system_prompt=system_prompt_text,
   )
-  ignore(run_turn(api_key, model, session, task, max_steps~))
+  ignore(
+    run_turn(
+      api_key,
+      model,
+      session,
+      task,
+      max_steps~,
+      thinking~,
+      reasoning_effort~,
+    ),
+  )
 }
 
 ///|
@@ -39,6 +51,8 @@ pub async fn run_turn(
   session : @agent_session.Session,
   task : String,
   max_steps? : Int = default_max_steps,
+  thinking? : @deepseek.ThinkingMode = Enabled,
+  reasoning_effort? : @deepseek.ReasoningEffort = Max,
 ) -> @agent_session.Session {
   run_turn_with_append(
     api_key,
@@ -47,6 +61,8 @@ pub async fn run_turn(
     task,
     append_item=(session, item) => session.append(item),
     max_steps~,
+    thinking~,
+    reasoning_effort~,
   )
 }
 
@@ -61,6 +77,8 @@ pub async fn run_turn_with_append(
   task : String,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = default_max_steps,
+  thinking? : @deepseek.ThinkingMode = Enabled,
+  reasoning_effort? : @deepseek.ReasoningEffort = Max,
 ) -> @agent_session.Session {
   @async.with_task_group() <| group => {
     run_with_runtime(
@@ -72,6 +90,8 @@ pub async fn run_turn_with_append(
       task,
       append_item~,
       max_steps~,
+      thinking~,
+      reasoning_effort~,
     )
   }
 }
@@ -123,12 +143,20 @@ async fn run_with_runtime(
   task : String,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps~ : Int,
+  thinking~ : @deepseek.ThinkingMode,
+  reasoning_effort~ : @deepseek.ReasoningEffort,
 ) -> @agent_session.Session {
   let client = @client.Client(
     api_key~,
     model~,
-    thinking=Some(Enabled),
-    reasoning_effort=Some(Max),
+    thinking=Some(thinking),
+    // The API rejects a request that sets reasoning_effort while thinking is
+    // disabled — effort only means something during thinking — so the effort
+    // rides along only when thinking is on.
+    reasoning_effort=match thinking {
+      Enabled => Some(reasoning_effort)
+      Disabled => None
+    },
   )
   let mut session = append_item(session, User(UserMessage(task)))
   try {

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -11,11 +11,11 @@ pub fn default_system_prompt() -> String
 
 pub fn default_system_prompt_for_model(@deepseek.Model) -> String
 
-pub async fn run(String, @deepseek.Model, String, max_steps? : Int, system_prompt_text? : String) -> Unit
+pub async fn run(String, @deepseek.Model, String, max_steps? : Int, system_prompt_text? : String, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort) -> Unit
 
-pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int) -> @agent_session.Session
+pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort) -> @agent_session.Session
 
-pub async fn run_turn_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int) -> @agent_session.Session
+pub async fn run_turn_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort) -> @agent_session.Session
 
 // Errors
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -28,11 +28,23 @@ async fn run_cli() -> Unit {
     let api_key = api_key(matches)
     let model = @deepseek.Model::parse(value(matches, "model"))
     let max_steps = max_steps(matches)
+    let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
+    let reasoning_effort = @deepseek.ReasoningEffort::parse(
+      value(matches, "reasoning-effort"),
+    )
     let task = task_text(matches)
     match session_id(matches) {
       None => {
         let system_prompt_text = configured_system_prompt(matches, model)
-        @agent.run(api_key, model, task, max_steps~, system_prompt_text~)
+        @agent.run(
+          api_key,
+          model,
+          task,
+          max_steps~,
+          system_prompt_text~,
+          thinking~,
+          reasoning_effort~,
+        )
       }
       Some(id) => {
         let store = @store.SessionStore(session_root(matches))
@@ -45,6 +57,8 @@ async fn run_cli() -> Unit {
             task,
             append_item=(session, item) => store.append(session, item),
             max_steps~,
+            thinking~,
+            reasoning_effort~,
           ),
         )
       }
@@ -96,6 +110,20 @@ fn cli_command() -> @argparse.Command {
         env="OPENSEEK_MAX_STEPS",
         default_values=["1000"],
         about="Maximum number of agent loop steps before stopping.",
+      ),
+      OptionArg(
+        "thinking",
+        long="thinking",
+        env="OPENSEEK_THINKING",
+        default_values=["enabled"],
+        about="DeepSeek thinking mode: enabled or disabled.",
+      ),
+      OptionArg(
+        "reasoning-effort",
+        long="reasoning-effort",
+        env="OPENSEEK_REASONING_EFFORT",
+        default_values=["max"],
+        about="DeepSeek reasoning effort in thinking mode: high or max.",
       ),
       OptionArg(
         "system-prompt-file",

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -5,6 +5,8 @@ fn drain_test_state() -> State {
     model: V4Pro,
     cwd: ".",
     max_steps: 10,
+    thinking: Enabled,
+    reasoning_effort: Max,
     session_id: SessionId("test"),
     session_root: ".openseek",
     engine: "openseek",
@@ -60,6 +62,8 @@ test "agent engine argv stays replay-compatible while session config uses env" {
   }
   assert_eq(session_id, "test")
   assert_eq(session_root, ".openseek")
+  assert_true(env.get("OPENSEEK_THINKING") == Some("enabled"))
+  assert_true(env.get("OPENSEEK_REASONING_EFFORT") == Some("max"))
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -107,6 +107,8 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
     "DEEPSEEK": config.api_key,
     "DEEPSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+    "OPENSEEK_THINKING": config.thinking.to_string(),
+    "OPENSEEK_REASONING_EFFORT": config.reasoning_effort.to_string(),
     "OPENSEEK_SESSION": config.session_id.value(),
     "OPENSEEK_SESSION_ROOT": config.session_root,
   }

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -26,6 +26,20 @@ fn cli_command() -> @argparse.Command {
         about="Maximum number of agent loop steps before stopping.",
       ),
       OptionArg(
+        "thinking",
+        long="thinking",
+        env="OPENSEEK_THINKING",
+        default_values=["enabled"],
+        about="DeepSeek thinking mode: enabled or disabled.",
+      ),
+      OptionArg(
+        "reasoning-effort",
+        long="reasoning-effort",
+        env="OPENSEEK_REASONING_EFFORT",
+        default_values=["max"],
+        about="DeepSeek reasoning effort in thinking mode: high or max.",
+      ),
+      OptionArg(
         "engine",
         long="engine",
         env="OPENSEEK_ENGINE",
@@ -210,6 +224,12 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     model: @deepseek.Model::parse(value(matches, "model")),
     cwd,
     max_steps: parse_positive_int(value(matches, "max-steps"), "--max-steps"),
+    // Parsed eagerly so a typo fails at launch with a CLI error instead of
+    // inside the first turn's engine run.
+    thinking: @deepseek.ThinkingMode::parse(value(matches, "thinking")),
+    reasoning_effort: @deepseek.ReasoningEffort::parse(
+      value(matches, "reasoning-effort"),
+    ),
     session_id: match explicit_session {
       Some(id) => id
       None => generated_session_id(@env.now().reinterpret_as_int64())
@@ -328,6 +348,27 @@ test "generated session ids are timestamped and directory-safe" {
     generated_session_id(1_781_061_247_089).value(),
     "tui-20260610-031407-089",
   )
+}
+
+///|
+test "cli parses and validates thinking controls" {
+  let parsed = cli_command().parse(
+    argv=["--thinking", "disabled", "--reasoning-effort", "high"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = parse_config(parsed)
+  assert_true(config.thinking is Disabled)
+  assert_true(config.reasoning_effort is High)
+  let bad = cli_command().parse(argv=["--thinking", "sometimes"], env={
+    "DEEPSEEK": "test-key",
+  })
+  let _ = parse_config(bad) catch {
+    error => {
+      assert_true("\{error}".contains("unknown thinking mode"))
+      return
+    }
+  }
+  fail("invalid thinking mode accepted")
 }
 
 ///|

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -4,6 +4,8 @@ priv struct AppConfig {
   model : @deepseek.Model
   cwd : String
   max_steps : Int
+  thinking : @deepseek.ThinkingMode
+  reasoning_effort : @deepseek.ReasoningEffort
   // The durable session every prompt of this TUI run converses in. The engine
   // is spawned fresh per prompt, so context only carries between prompts
   // through the session store: without one, each prompt would be an amnesiac

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -41,6 +41,17 @@ pub impl Show for ThinkingMode with fn to_string(self : ThinkingMode) -> String 
 }
 
 ///|
+/// Parses a thinking mode from its wire name (`enabled`/`disabled`), raising
+/// on anything else — the inverse of `Show`, for CLI flags and config.
+pub fn ThinkingMode::parse(input : String) -> ThinkingMode raise {
+  match input {
+    "enabled" => Enabled
+    "disabled" => Disabled
+    other => fail("unknown thinking mode: \{other} (use enabled or disabled)")
+  }
+}
+
+///|
 /// DeepSeek reasoning effort for thinking mode.
 pub(all) enum ReasoningEffort {
   High
@@ -53,6 +64,17 @@ pub impl Show for ReasoningEffort with fn to_string(self : ReasoningEffort) -> S
   match self {
     High => "high"
     Max => "max"
+  }
+}
+
+///|
+/// Parses a reasoning effort from its wire name (`high`/`max`), raising on
+/// anything else — the inverse of `Show`, for CLI flags and config.
+pub fn ReasoningEffort::parse(input : String) -> ReasoningEffort raise {
+  match input {
+    "high" => High
+    "max" => Max
+    other => fail("unknown reasoning effort: \{other} (use high or max)")
   }
 }
 

--- a/deepseek/deepseek_test.mbt
+++ b/deepseek/deepseek_test.mbt
@@ -51,3 +51,24 @@ test "thinking controls stringify" {
   assert_eq(high.to_string(), "high")
   assert_eq(max.to_string(), "max")
 }
+
+///|
+test "thinking controls parse their wire names and reject others" {
+  assert_true(@deepseek.ThinkingMode::parse("enabled") is Enabled)
+  assert_true(@deepseek.ThinkingMode::parse("disabled") is Disabled)
+  assert_true(@deepseek.ReasoningEffort::parse("high") is High)
+  assert_true(@deepseek.ReasoningEffort::parse("max") is Max)
+  let _ = @deepseek.ThinkingMode::parse("on") catch {
+    error => {
+      assert_true("\{error}".contains("unknown thinking mode"))
+      let _ = @deepseek.ReasoningEffort::parse("ultra") catch {
+        error => {
+          assert_true("\{error}".contains("unknown reasoning effort"))
+          return
+        }
+      }
+      fail("bad reasoning effort accepted")
+    }
+  }
+  fail("bad thinking mode accepted")
+}

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -39,6 +39,7 @@ pub(all) enum ReasoningEffort {
   High
   Max
 } derive(Eq, @debug.Debug)
+pub fn ReasoningEffort::parse(String) -> Self raise
 pub impl Show for ReasoningEffort
 
 pub(all) enum ResponseFormat {
@@ -58,6 +59,7 @@ pub(all) enum ThinkingMode {
   Enabled
   Disabled
 } derive(Eq, @debug.Debug)
+pub fn ThinkingMode::parse(String) -> Self raise
 pub impl Show for ThinkingMode
 
 pub struct ToolCall {

--- a/improvement.md
+++ b/improvement.md
@@ -44,9 +44,12 @@ bottom of the matching section.
 
 ## Engine / agent
 
-- [ ] **Expose thinking controls.** `run_with_runtime` hardcodes
+- [x] **Expose thinking controls.** `run_with_runtime` hardcodes
   `thinking=Enabled, reasoning_effort=Max`; make them engine flags
-  (`--thinking`, `--reasoning-effort`) and TUI pass-throughs.
+  (`--thinking`, `--reasoning-effort`) and TUI pass-throughs. *(Done:
+  `OPENSEEK_THINKING` / `OPENSEEK_REASONING_EFFORT` env-backed flags on both
+  binaries, threaded through `@agent.run*` as optional params with the old
+  hardcoded values as defaults.)*
 - [ ] **Auto-compaction.** Compaction exists only as the manual
   `--session-compact-*` flow. Long-lived sessions (now the TUI default)
   grow without bound; trigger summarization when the projected context

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -30,6 +30,8 @@ Options:
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
   --model <model>                                              DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --thinking <thinking>                                        DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
+  --reasoning-effort <reasoning-effort>                        DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
   --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION] [default: ]

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -24,14 +24,16 @@ Arguments:
   task...  Optional initial task description.
 
 Options:
-  -h, --help                     Show help information.
-  --continue                     Resume the most recently active session in --session-root.
-  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
-  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
-  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  -h, --help                             Show help information.
+  --continue                             Resume the most recently active session in --session-root.
+  --api-key <api-key>                    DeepSeek API key. [env: DEEPSEEK]
+  --model <model>                        DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>                Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --thinking <thinking>                  DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
+  --reasoning-effort <reasoning-effort>  DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]
+  --engine <engine>                      Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --session <session>                    Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session-root <session-root>          Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 ```
 
 ## A DeepSeek API Key Is Required
@@ -52,14 +54,16 @@ Arguments:
   task...  Optional initial task description.
 
 Options:
-  -h, --help                     Show help information.
-  --continue                     Resume the most recently active session in --session-root.
-  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
-  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
-  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  -h, --help                             Show help information.
+  --continue                             Resume the most recently active session in --session-root.
+  --api-key <api-key>                    DeepSeek API key. [env: DEEPSEEK]
+  --model <model>                        DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --max-steps <max-steps>                Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
+  --thinking <thinking>                  DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
+  --reasoning-effort <reasoning-effort>  DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]
+  --engine <engine>                      Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --session <session>                    Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session-root <session-root>          Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 
 [1]
 ```


### PR DESCRIPTION
Fifth item off the `improvement.md` checklist.

## Change

- `--thinking enabled|disabled` (`OPENSEEK_THINKING`) and `--reasoning-effort high|max` (`OPENSEEK_REASONING_EFFORT`) on **both** `openseek` and `openseek-tui`; the TUI forwards them through the engine environment like its other settings, and the TUI parses eagerly so a typo fails at launch rather than inside the first turn.
- Threaded through `@agent.run` / `run_turn` / `run_turn_with_append` as optional params defaulting to the previously hardcoded `Enabled`/`Max` — no behavior change for existing callers.
- `ThinkingMode::parse` / `ReasoningEffort::parse` added to the pure `deepseek` package as the `Show` inverses.
- **Live-verified API constraint**: DeepSeek 400s (`thinking options type cannot be disabled when reasoning_effort is set`) if effort rides along while thinking is off — caught in live verification of the new flag, fixed by omitting effort when thinking is disabled.
- Help-output cram snapshots regenerated from the real binaries (the long new flag re-padded the whole option column).

## Verification

- `moon check` 0 warnings, fmt clean, 439/439 tests (parse round-trips + rejection, TUI config validation, engine-env forwarding), 6/6 offline cram.
- Live: `--thinking disabled` streams 27 content deltas with **zero** reasoning events and finishes cleanly; the default run still emits reasoning deltas as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)