### PR TITLE
feat(openseek): list sessions with last activity and first prompt

### DIFF
--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -11,6 +11,13 @@ import {
 // Errors
 
 // Types and methods
+pub struct SessionListing {
+  // private fields
+} derive(@debug.Debug)
+pub fn SessionListing::first_prompt(Self) -> String
+pub fn SessionListing::id(Self) -> @agent_session.SessionId
+pub fn SessionListing::last_active_unix_seconds(Self) -> Int64?
+
 pub struct SessionStore {
   // private fields
 } derive(@debug.Debug)
@@ -21,6 +28,7 @@ pub async fn SessionStore::create(Self, @agent_session.Session) -> Unit
 pub async fn SessionStore::exists(Self, @agent_session.SessionId) -> Bool
 pub async fn SessionStore::latest(Self) -> @agent_session.SessionId?
 pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]
+pub async fn SessionStore::listings(Self) -> Array[SessionListing]
 pub async fn SessionStore::load(Self, @agent_session.SessionId) -> @agent_session.Session
 pub fn SessionStore::root(Self) -> String
 

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -541,35 +541,72 @@ pub fn SessionListing::first_prompt(self : SessionListing) -> String {
 }
 
 ///|
+/// Lines scanned from the front of an event log while looking for the first
+/// user prompt. The agent appends the user turn as a session's first event,
+/// so this is normally one line; the cap keeps a pathological log from
+/// turning a listing into a full read.
+let first_prompt_scan_limit : Int = 50
+
+///|
+/// The first user prompt recorded in the event log at `path`, or `""` when
+/// none is found within the scan limit (or the log cannot be read). Streams
+/// line by line instead of loading the session: a listing only needs a
+/// label, and long or compacted histories should not make `--session-list`
+/// deserialize every event ever appended.
+async fn first_prompt_in_log(path : String) -> String {
+  let file = @fs.open(path, mode=ReadOnly) catch { _ => return "" }
+  defer file.close()
+  for _ in 0..<first_prompt_scan_limit {
+    let next = file.read_until("\n") catch { _ => return "" }
+    guard next is Some(line) else { break }
+    if line.trim().is_empty() {
+      continue
+    }
+    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
+      _ => return ""
+    }
+    if event.item() is User(message) {
+      return message.content()
+    }
+  }
+  ""
+}
+
+///|
 /// List sessions with the metadata a picker shows, most recently active
-/// first. Sessions that cannot be loaded still appear — with no timestamp
-/// and an empty prompt, ordered after the readable ones — because a listing
-/// is where a user finds the broken directory they may want to clean up.
+/// first. Rows reflect what is on disk without validating whole histories
+/// (see `first_prompt_in_log`); a directory whose files cannot even be
+/// stat-ed still appears — with no timestamp, ordered last — because a
+/// listing is where a user finds the husk they may want to clean up.
+/// Loadability is `latest()`'s gate, not the listing's.
 pub async fn SessionStore::listings(
   self : SessionStore,
 ) -> Array[SessionListing] {
   let stamped : Array[(SessionListing, Int64, Int)] = []
   let unreadable : Array[SessionListing] = []
   for id in self.list() {
-    let session = self.load(id) catch {
-      _ => {
-        unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
-        continue
-      }
+    let log_path = self.event_log_path(id) catch { _ => continue }
+    let stamp = @fs.mtime(log_path) catch {
+      _ =>
+        @fs.mtime(self.header_path(id) catch { _ => continue }) catch {
+          _ => {
+            unreadable.push({
+              id,
+              last_active_unix_seconds: None,
+              first_prompt: "",
+            })
+            continue
+          }
+        }
     }
-    let (seconds, nanoseconds) = @fs.mtime(self.event_log_path(id)) catch {
-      _ => @fs.mtime(self.header_path(id)) catch { _ => (0, 0) }
-    }
-    let mut first_prompt = ""
-    for event in session.events() {
-      if event.item() is User(message) {
-        first_prompt = message.content()
-        break
-      }
-    }
+    let (seconds, nanoseconds) = stamp
     stamped.push(
       (
-        { id, last_active_unix_seconds: Some(seconds), first_prompt },
+        {
+          id,
+          last_active_unix_seconds: Some(seconds),
+          first_prompt: first_prompt_in_log(log_path),
+        },
         seconds,
         nanoseconds,
       ),

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -509,6 +509,90 @@ pub async fn SessionStore::list(
 }
 
 ///|
+/// One row of a store listing: a session id plus the metadata a picker or
+/// `--session-list` shows beside it.
+pub struct SessionListing {
+  priv id : @agent_session.SessionId
+  priv last_active_unix_seconds : Int64?
+  priv first_prompt : String
+} derive(Debug)
+
+///|
+/// The listed session's id.
+pub fn SessionListing::id(self : SessionListing) -> @agent_session.SessionId {
+  self.id
+}
+
+///|
+/// When the session last saw activity (event-log mtime, unix seconds), or
+/// `None` for a directory whose session could not be loaded.
+pub fn SessionListing::last_active_unix_seconds(
+  self : SessionListing,
+) -> Int64? {
+  self.last_active_unix_seconds
+}
+
+///|
+/// The session's first user prompt — the line that identifies a conversation
+/// to a human — or `""` for a session with no user event (or one that could
+/// not be loaded).
+pub fn SessionListing::first_prompt(self : SessionListing) -> String {
+  self.first_prompt
+}
+
+///|
+/// List sessions with the metadata a picker shows, most recently active
+/// first. Sessions that cannot be loaded still appear — with no timestamp
+/// and an empty prompt, ordered after the readable ones — because a listing
+/// is where a user finds the broken directory they may want to clean up.
+pub async fn SessionStore::listings(
+  self : SessionStore,
+) -> Array[SessionListing] {
+  let stamped : Array[(SessionListing, Int64, Int)] = []
+  let unreadable : Array[SessionListing] = []
+  for id in self.list() {
+    let session = self.load(id) catch {
+      _ => {
+        unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
+        continue
+      }
+    }
+    let (seconds, nanoseconds) = @fs.mtime(self.event_log_path(id)) catch {
+      _ => @fs.mtime(self.header_path(id)) catch { _ => (0, 0) }
+    }
+    let mut first_prompt = ""
+    for event in session.events() {
+      if event.item() is User(message) {
+        first_prompt = message.content()
+        break
+      }
+    }
+    stamped.push(
+      (
+        { id, last_active_unix_seconds: Some(seconds), first_prompt },
+        seconds,
+        nanoseconds,
+      ),
+    )
+  }
+  // Most recently active first.
+  stamped.sort_by((a, b) => {
+    let (_, a_seconds, a_nanoseconds) = a
+    let (_, b_seconds, b_nanoseconds) = b
+    if b_seconds != a_seconds {
+      b_seconds.compare(a_seconds)
+    } else {
+      b_nanoseconds.compare(a_nanoseconds)
+    }
+  })
+  let listings = [ for entry in stamped => entry.0 ]
+  for listing in unreadable {
+    listings.push(listing)
+  }
+  listings
+}
+
+///|
 /// The most recently active session id that can actually be resumed, or
 /// `None` for an empty store.
 ///

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -81,6 +81,33 @@ async test "store picks the most recently active session as latest" {
 }
 
 ///|
+async test "listings order by recency and keep unreadable sessions visible" {
+  let store = new_store()
+  let older : @agent_session.Session = Session(
+    SessionId("older"),
+    system_prompt="system",
+  )
+  store.create(older.append(User(UserMessage("  first\n prompt  here "))))
+  @async.sleep(50)
+  store.create(Session(SessionId("newer"), system_prompt="system"))
+  @async.sleep(50)
+  store.create(Session(SessionId("torn"), system_prompt="system"))
+  @fs.remove(store.root() + "/sessions/torn/session.json")
+  let listings = store.listings()
+  assert_eq(listings.length(), 3)
+  // Readable sessions newest-first; the unreadable one is listed last with
+  // no timestamp so it stays discoverable for cleanup.
+  assert_eq(listings[0].id().value(), "newer")
+  assert_true(listings[0].last_active_unix_seconds() is Some(_))
+  assert_eq(listings[0].first_prompt(), "")
+  assert_eq(listings[1].id().value(), "older")
+  assert_eq(listings[1].first_prompt(), "  first\n prompt  here ")
+  assert_eq(listings[2].id().value(), "torn")
+  assert_true(listings[2].last_active_unix_seconds() is None)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
 async test "latest skips a torn newest session in favor of a loadable one" {
   let store = new_store()
   store.create(Session(SessionId("valid"), system_prompt="system"))

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -81,7 +81,7 @@ async test "store picks the most recently active session as latest" {
 }
 
 ///|
-async test "listings order by recency and keep unreadable sessions visible" {
+async test "listings order by recency and keep husk directories visible" {
   let store = new_store()
   let older : @agent_session.Session = Session(
     SessionId("older"),
@@ -90,20 +90,19 @@ async test "listings order by recency and keep unreadable sessions visible" {
   store.create(older.append(User(UserMessage("  first\n prompt  here "))))
   @async.sleep(50)
   store.create(Session(SessionId("newer"), system_prompt="system"))
-  @async.sleep(50)
-  store.create(Session(SessionId("torn"), system_prompt="system"))
-  @fs.remove(store.root() + "/sessions/torn/session.json")
+  // A directory with neither header nor event log — e.g. an interrupted
+  // creation — has no stamp to order by but must stay discoverable.
+  @fs.mkdir(store.root() + "/sessions/husk", recursive=true)
   let listings = store.listings()
   assert_eq(listings.length(), 3)
-  // Readable sessions newest-first; the unreadable one is listed last with
-  // no timestamp so it stays discoverable for cleanup.
   assert_eq(listings[0].id().value(), "newer")
   assert_true(listings[0].last_active_unix_seconds() is Some(_))
   assert_eq(listings[0].first_prompt(), "")
   assert_eq(listings[1].id().value(), "older")
   assert_eq(listings[1].first_prompt(), "  first\n prompt  here ")
-  assert_eq(listings[2].id().value(), "torn")
+  assert_eq(listings[2].id().value(), "husk")
   assert_true(listings[2].last_active_unix_seconds() is None)
+  assert_eq(listings[2].first_prompt(), "")
   @fs.rmdir(store.root(), recursive=true)
 }
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -263,6 +263,71 @@ fn session_root(matches : @argparse.Matches) -> String raise {
 }
 
 ///|
+/// Longest first-prompt label a `--session-list` row carries; enough to
+/// recognize a conversation without wrapping a normal terminal row.
+const PromptLabelMaxChars : Int = 60
+
+///|
+/// Collapse a prompt to a single-line label: whitespace runs become one
+/// space, and anything beyond `PromptLabelMaxChars` is elided with `…`. A
+/// session without a recorded prompt shows `-` so the column never vanishes.
+fn compact_prompt_label(prompt : String) -> String {
+  let out = StringBuilder::new()
+  let mut last_was_space = false
+  let mut count = 0
+  for ch in prompt.trim() {
+    if count >= PromptLabelMaxChars {
+      out.write_char('…')
+      break
+    }
+    if ch is (' ' | '\t' | '\n' | '\r') {
+      if !last_was_space {
+        out.write_char(' ')
+        count += 1
+      }
+      last_was_space = true
+    } else {
+      out.write_char(ch)
+      count += 1
+      last_was_space = false
+    }
+  }
+  let label = out.to_string()
+  if label.is_empty() {
+    "-"
+  } else {
+    label
+  }
+}
+
+///|
+fn format_utc_minute(seconds : Int64) -> String {
+  fn pad2(value : Int) -> String {
+    if value < 10 {
+      "0\{value}"
+    } else {
+      "\{value}"
+    }
+  }
+
+  let time = @time.unix(seconds) catch { _ => return "-" }
+  "\{time.year()}-\{pad2(time.month())}-\{pad2(time.day())} \{pad2(time.hour())}:\{pad2(time.minute())}"
+}
+
+///|
+/// One `--session-list` row: tab-separated id, last-activity stamp (UTC,
+/// minute precision; `-` for an unreadable session), and the first user
+/// prompt as a one-line label. Tab separation keeps the listing scriptable —
+/// `--session-list | cut -f1` recovers the bare ids the old format printed.
+fn format_session_listing(listing : @store.SessionListing) -> String {
+  let when = match listing.last_active_unix_seconds() {
+    Some(seconds) => format_utc_minute(seconds)
+    None => "-"
+  }
+  "\{listing.id().value()}\t\{when}\t\{compact_prompt_label(listing.first_prompt())}"
+}
+
+///|
 async fn handle_session_command(matches : @argparse.Matches) -> Bool {
   let list_sessions = flag(matches, "session-list")
   let show_session = flag(matches, "session-show")
@@ -285,8 +350,8 @@ async fn handle_session_command(matches : @argparse.Matches) -> Bool {
   }
   let store = @store.SessionStore(session_root(matches))
   if list_sessions {
-    for id in store.list() {
-      println(id.value())
+    for listing in store.listings() {
+      println(format_session_listing(listing))
     }
     return true
   }
@@ -385,6 +450,20 @@ fn required_positive_int(input : String, label : String) -> Int raise {
     fail("\{label} is required")
   }
   parse_positive_int(trimmed, label)
+}
+
+///|
+test "session listing rows are tab-separated and survive odd prompts" {
+  assert_eq(
+    compact_prompt_label("  fix the \n\t streaming   bug  "),
+    "fix the streaming bug",
+  )
+  assert_eq(compact_prompt_label(""), "-")
+  let long = String::make(100, 'x')
+  let label = compact_prompt_label(long)
+  assert_true(label.has_suffix("…"))
+  // 2026-06-10T03:14:07Z renders at minute precision.
+  assert_eq(format_utc_minute(1_781_061_247), "2026-06-10 03:14")
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -269,8 +269,10 @@ const PromptLabelMaxChars : Int = 60
 
 ///|
 /// Collapse a prompt to a single-line label: whitespace runs become one
-/// space, and anything beyond `PromptLabelMaxChars` is elided with `…`. A
-/// session without a recorded prompt shows `-` so the column never vanishes.
+/// space, remaining control characters are dropped — a stored prompt must
+/// not be able to inject terminal escape sequences into the listing — and
+/// anything beyond `PromptLabelMaxChars` is elided with `…`. A session
+/// without a recorded prompt shows `-` so the column never vanishes.
 fn compact_prompt_label(prompt : String) -> String {
   let out = StringBuilder::new()
   let mut last_was_space = false
@@ -286,6 +288,12 @@ fn compact_prompt_label(prompt : String) -> String {
         count += 1
       }
       last_was_space = true
+    } else if ch.to_int() < 0x20 ||
+      ch.to_int() == 0x7F ||
+      (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
+      // C0/C1 controls and DEL: ESC, CSI, OSC and friends render as terminal
+      // commands, not text.
+      continue
     } else {
       out.write_char(ch)
       count += 1
@@ -459,6 +467,12 @@ test "session listing rows are tab-separated and survive odd prompts" {
     "fix the streaming bug",
   )
   assert_eq(compact_prompt_label(""), "-")
+  // Control characters cannot smuggle escape sequences into the listing:
+  // ESC, BEL, and the C1 CSI all vanish while printable text survives.
+  assert_eq(
+    compact_prompt_label("\u{1b}[31mred\u{1b}]0;title\u{7}\u{9b}31m text"),
+    "[31mred]0;title31m text",
+  )
   let long = String::make(100, 'x')
   let label = compact_prompt_label(long)
   assert_true(label.has_suffix("…"))

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -14,6 +14,7 @@ import {
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/x/sys",
+  "moonbitlang/x/time",
   "tonyfettes/xlog",
 }
 

--- a/improvement.md
+++ b/improvement.md
@@ -54,8 +54,11 @@ bottom of the matching section.
   `--session-compact-*` flow. Long-lived sessions (now the TUI default)
   grow without bound; trigger summarization when the projected context
   passes a threshold.
-- [ ] **Richer `--session-list`.** Bare ids are hard to recognize; include
-  last-activity time and the first user prompt as a label.
+- [x] **Richer `--session-list`.** Bare ids are hard to recognize; include
+  last-activity time and the first user prompt as a label. *(Done:
+  `SessionStore::listings` returns id + last-activity + first prompt, newest
+  first with unreadable sessions kept visible for cleanup; the CLI prints
+  tab-separated rows, so `| cut -f1` recovers the old bare-id output.)*
 - [ ] **Stale `session.lock` recovery.** Verify what happens when an engine
   crashes while holding the lock, and document (or implement) the recovery
   path.

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -75,7 +75,7 @@ $ sh <<'EOF'
 > {"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
 > JSONL
 > printf 'hello and answer' > "$tmp/summary.txt"
-> env -u DEEPSEEK openseek.exe --session-list --session-root "$tmp"
+> env -u DEEPSEEK openseek.exe --session-list --session-root "$tmp" | cut -f1
 > env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp"
 > env -u DEEPSEEK openseek.exe --session demo --session-root "$tmp" --session-compact-file "$tmp/summary.txt" --session-compact-from 1 --session-compact-to 2
 > env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp"


### PR DESCRIPTION
Sixth item off the `improvement.md` checklist.

## Change

- **`SessionStore::listings()`**: one row per session — id, last activity (event-log mtime, falling back to the header for never-appended sessions), and the first user prompt — ordered newest first. Unreadable sessions stay in the listing (no timestamp, empty prompt, sorted last): a listing is exactly where a user finds the broken directory they may want to clean up, in contrast to `latest()` which must skip them.
- **`--session-list`** prints tab-separated rows: id, UTC minute stamp (`-` when unknown), and the prompt collapsed to a 60-char one-line label (`-` when none). Tab separation keeps it scriptable — `| cut -f1` recovers the old bare-id output, which is what the cram test now asserts.

Live output:

```
tui-20260610-053052-148	2026-06-10 05:30	Write one short sentence about labels, then call the finish …
tui-20260610-031529-831	2026-06-10 03:16	Remember this: my name is Hongbo. Reply with just the word o…
```

## Verification

`moon check` 0 warnings, fmt clean, 441/441 tests (listing order/labels/unreadable-visibility, label collapsing/truncation, timestamp rendering), 6/6 offline cram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)