### PR TITLE
docs: document the TUI and its durable-session default in the README

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -17,7 +17,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
-| `bobzhang/openseek/cmd/tui` | Native-only terminal UI that drives the engine per prompt. | `tui/README.md` |
+| `bobzhang/openseek/cmd/tui` | Native-only terminal UI that drives the engine per prompt. | `cmd/tui/README.md` |
 | `bobzhang/openseek/testkit/filesystem` | JSON-backed virtual filesystem for tests and eval fixtures. | `testkit/filesystem/README.mbt.md` |
 | `bobzhang/openseek/eval/report` | Shared Markdown/JSON report primitive for deterministic and model evals. | `eval/report/README.mbt.md` |
 | `bobzhang/openseek/eval/tool_harness` | Deterministic host-side harness that dispatches every built-in tool. | `eval/tool_harness/README.mbt.md` |
@@ -98,10 +98,11 @@ and stores the conversation under `--session-root` (default `.openseek/`).
 Follow-up prompts remember earlier ones, and a conversation outlives the
 process:
 
-- `openseek-tui --continue` resumes the most recently active session.
-- `openseek-tui --session <id>` resumes (or creates) a specific one.
-- `openseek --session-list` shows what is resumable — tab-separated id,
-  last-activity time, and the session's first prompt, newest first.
+- `moon run cmd/tui -- --continue` resumes the most recently active session.
+- `moon run cmd/tui -- --session <id>` resumes (or creates) a specific one.
+- `moon run cmd/openseek -- --session-list` shows what is resumable —
+  tab-separated id, last-activity time, and the session's first prompt,
+  newest first.
 
 See each package README for API boundaries, examples, and package-specific test
 notes.

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -17,6 +17,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
+| `bobzhang/openseek/cmd/tui` | Native-only terminal UI that drives the engine per prompt. | `tui/README.md` |
 | `bobzhang/openseek/testkit/filesystem` | JSON-backed virtual filesystem for tests and eval fixtures. | `testkit/filesystem/README.mbt.md` |
 | `bobzhang/openseek/eval/report` | Shared Markdown/JSON report primitive for deterministic and model evals. | `eval/report/README.mbt.md` |
 | `bobzhang/openseek/eval/tool_harness` | Deterministic host-side harness that dispatches every built-in tool. | `eval/tool_harness/README.mbt.md` |
@@ -73,7 +74,34 @@ moon run cmd/openseek -- "inspect this project and finish with a short summary"
 
 `DEEPSEEK_MODEL` is optional and defaults to `deepseek-v4-pro`.
 `OPENSEEK_MAX_STEPS` is optional and defaults to `1000`; pass `--max-steps` on
-the CLI to override it for one run.
+the CLI to override it for one run. `--thinking enabled|disabled` and
+`--reasoning-effort high|max` control DeepSeek thinking mode (defaults:
+enabled, max).
+
+## Terminal UI
+
+The `cmd/tui` package is the interactive interface: a scrolling transcript with
+a live composer. It spawns the `openseek` engine binary fresh for every prompt
+and renders its JSONL event stream — streamed thinking and answer text appear
+live on the activity line, and each turn's reasoning is kept as a dim `✻`
+transcript aside above its answer.
+
+```bash
+export DEEPSEEK=sk-...
+moon run cmd/tui
+```
+
+**Every launch converses in a durable session.** The engine only carries
+context between prompts through the session store, so the TUI generates a
+session id per launch (`tui-YYYYMMDD-HHMMSS-mmm`, named in the startup banner)
+and stores the conversation under `--session-root` (default `.openseek/`).
+Follow-up prompts remember earlier ones, and a conversation outlives the
+process:
+
+- `openseek-tui --continue` resumes the most recently active session.
+- `openseek-tui --session <id>` resumes (or creates) a specific one.
+- `openseek --session-list` shows what is resumable — tab-separated id,
+  last-activity time, and the session's first prompt, newest first.
 
 See each package README for API boundaries, examples, and package-specific test
 notes.

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -1,0 +1,33 @@
+# bobzhang/openseek/cmd/tui
+
+The OpenSeek terminal UI: a scrolling transcript with a live composer, built
+on the reusable [`tui`](../../tui/README.md) controller package.
+
+The TUI runs no agent code itself. For every submitted prompt it spawns the
+engine binary (`openseek` from `PATH`; override with `--engine` or
+`OPENSEEK_ENGINE`) and renders the engine's JSONL event stream: streamed
+thinking and answer text move live on the activity line, each turn's reasoning
+is kept as a dim `✻` transcript aside above its answer, and tool results land
+as `⏺` blocks.
+
+## Sessions
+
+Every launch converses in a durable session — the engine only carries context
+between prompts through the session store, so without one each prompt would be
+an amnesiac one-shot. A generated id (`tui-YYYYMMDD-HHMMSS-mmm`, named in the
+startup banner) stores the conversation under `--session-root` (default
+`.openseek/`).
+
+- `--continue` resumes the most recently active session.
+- `--session <id>` resumes (or creates) a specific one; combining it with
+  `--continue` is rejected.
+- `openseek --session-list` (on the engine CLI) lists what is resumable.
+
+## Configuration
+
+`--api-key` (env `DEEPSEEK`) is required. `--model`, `--max-steps`,
+`--thinking`, and `--reasoning-effort` mirror the engine's flags and are
+forwarded to it through the environment, alongside the session settings.
+
+The full flag reference lives in the executable help — verified verbatim in
+[`tests/cram/tui.md`](../../tests/cram/tui.md).

--- a/improvement.md
+++ b/improvement.md
@@ -103,6 +103,9 @@ bottom of the matching section.
   prompt out of `missing_doc` because its example code blocks are
   model-facing text. Consider documenting those examples *as a prompt
   change* (with an eval run) so the model also learns the doc convention.
-- [ ] **Document the TUI session default.** The root README does not yet
+- [x] **Document the TUI session default.** The root README does not yet
   mention that every TUI launch converses in a durable session and how to
-  resume one (`--session <id>` from the startup banner).
+  resume one (`--session <id>` from the startup banner). *(Done: the README
+  gains a Terminal UI section covering default sessions, `--continue`,
+  `--session`, and the enriched `--session-list`, plus a `cmd/tui` row in
+  the packages table.)*


### PR DESCRIPTION
Seventh item off the `improvement.md` checklist.

The root README never mentioned `cmd/tui`. This adds the packages-table row and a **Terminal UI** section: how the TUI drives the engine per prompt and renders its event stream (live streaming line, `✻` thought asides), why every launch converses in a generated durable session, and the resume surface (`--continue`, `--session <id>`, enriched `--session-list`). The Agent CLI section also gains a line for the new thinking flags.

Docs-only; `moon check`/`moon test` green (the README's code blocks are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)