### PR TITLE
feat(agent): steerable turns in a caller-owned scope

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -2,24 +2,34 @@
 let default_max_steps : Int = 1000
 
 ///|
-/// Mid-turn user input riding the shared runtime event bus. Queued by
-/// `steer` and folded into the conversation by the agent loop at its next
-/// step boundary.
-extenum @agent_runtime.AgentEvent += {
-  SteerInput(String)
-}
-
-///|
 /// Queue `text` as steering input for the turn running on `runtime`.
 ///
 /// Steering lands at the next step boundary — after the in-flight model call
 /// and its tool batch complete, where the loop already folds in runtime
 /// updates — so completed work is never thrown away. The text is appended to
 /// the session as a user message and a `steer_applied` event is emitted when
-/// it takes effect. Steering an idle runtime is harmless: the input waits on
-/// the bus for the next turn.
+/// it takes effect. Steering an idle runtime is harmless: the input waits in
+/// the queue for the next turn. The channel is lossless (unlike the runtime
+/// event bus, which discards under flood), so a steer can never be pushed
+/// out by noisy watcher updates.
 pub fn steer(runtime : @agent_runtime.AgentRuntime, text : String) -> Unit {
-  runtime.emit_event(SteerInput(text))
+  runtime.queue_steer(text)
+}
+
+///|
+/// Build the agent's standard tool registry bound to `runtime` and `scope`.
+///
+/// Stateful tools live in the registry value itself: `moon_check` keeps its
+/// watcher records in the closure this builds, not in `AgentRuntime`. A
+/// serve-mode caller that wants watchers to survive from one turn to the
+/// next must therefore build the registry once and pass it to every
+/// `run_turn_in_scope` call — rebuilding it each turn would orphan the old
+/// watchers and start duplicates.
+pub fn[X] build_tools(
+  runtime : @agent_runtime.AgentRuntime,
+  scope : @agent_runtime.AgentTaskScope[X],
+) -> @agent_tool.Tools raise {
+  tool_definitions(runtime, scope)
 }
 
 ///|
@@ -164,12 +174,15 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// Runs one user turn inside a caller-owned runtime and task scope.
 ///
 /// This is the building block for callers that keep an engine alive across
-/// turns (serve mode): a shared `runtime` preserves stateful tools — a
-/// `moon_check` watcher started in one turn keeps reporting in the next —
-/// and is also the bus `steer` feeds mid-turn input through. `scope` bounds
-/// background work the turn's tools spawn, so it must outlive the turn.
-/// One-shot callers should prefer `run_turn`/`run_turn_with_append`, which
-/// own both for the duration of a single turn.
+/// turns (serve mode): the shared `runtime` carries steering input and
+/// runtime updates across the turn boundary, and a `tools` registry built
+/// once with `build_tools` preserves stateful tools — a `moon_check` watcher
+/// started in one turn keeps reporting in the next. When `tools` is omitted
+/// a fresh registry is built for this turn only. `scope` bounds background
+/// work the turn's tools spawn, so it must outlive every turn that may have
+/// spawned some. One-shot callers should prefer
+/// `run_turn`/`run_turn_with_append`, which own everything for the duration
+/// of a single turn.
 pub async fn[X] run_turn_in_scope(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[X],
@@ -182,6 +195,7 @@ pub async fn[X] run_turn_in_scope(
   thinking? : @deepseek.ThinkingMode = Enabled,
   reasoning_effort? : @deepseek.ReasoningEffort = Max,
   api_url? : String,
+  tools? : @agent_tool.Tools,
 ) -> @agent_session.Session {
   let client = @client.Client(
     api_key~,
@@ -198,29 +212,33 @@ pub async fn[X] run_turn_in_scope(
   )
   let mut session = append_item(session, User(UserMessage(task)))
   try {
-    let tools = tool_definitions(runtime, scope) catch {
-      error => {
-        let next = append_item(
-          session,
-          Terminal(Failed("agent setup failed: \{error}")),
-        )
-        @xlog.error() <? { "event": "agent_setup_failed", "error": "\{error}" }
-        return next
-      }
+    let tools = match tools {
+      Some(tools) => tools
+      None =>
+        tool_definitions(runtime, scope) catch {
+          error => {
+            let next = append_item(
+              session,
+              Terminal(Failed("agent setup failed: \{error}")),
+            )
+            @xlog.error() <?
+              { "event": "agent_setup_failed", "error": "\{error}" }
+            return next
+          }
+        }
     }
     let messages = session.chat_messages()
     for step in 0..<max_steps {
-      let drained = runtime.drain_events()
       // Steering first: a user's mid-turn redirection should precede the
       // runtime chatter the model reads alongside it.
-      for event in drained {
-        if event is SteerInput(text) && !text.trim().is_empty() {
+      for text in runtime.drain_steers() {
+        if !text.trim().is_empty() {
           @xlog.info() <? { "event": "steer_applied", "content": text }
           session = append_item(session, User(UserMessage(text)))
           messages.push(ChatMessage(User, content=text))
         }
       }
-      if runtime_update_message(drained) is Some(update) {
+      if runtime_update_message(runtime.drain_events()) is Some(update) {
         @xlog.info() <? { "event": "runtime_update", "content": update }
         session = append_item(session, Runtime(RuntimeNotice(update)))
         messages.push(ChatMessage(User, content=update))

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -6,12 +6,17 @@ let default_max_steps : Int = 1000
 ///
 /// Steering lands at the next step boundary — after the in-flight model call
 /// and its tool batch complete, where the loop already folds in runtime
-/// updates — so completed work is never thrown away. The text is appended to
-/// the session as a user message and a `steer_applied` event is emitted when
-/// it takes effect. Steering an idle runtime is harmless: the input waits in
-/// the queue for the next turn. The channel is lossless (unlike the runtime
-/// event bus, which discards under flood), so a steer can never be pushed
-/// out by noisy watcher updates.
+/// updates — so completed work is never thrown away. User input also wins
+/// over model-initiated completion: a steer that arrives while the final
+/// call is in flight keeps the turn alive (the would-be answer becomes an
+/// ordinary assistant message, or the finish call's batch is closed out)
+/// and the conversation continues with the steer. Only error terminals
+/// (abort, failure, exhausted steps) still end the turn; a steer queued
+/// then applies to the next one. The text is appended to the session as a
+/// user message and a `steer_applied` event is emitted when it takes
+/// effect. The channel is lossless (unlike the runtime event bus, which
+/// discards under flood), so a steer can never be pushed out by noisy
+/// watcher updates.
 pub fn steer(runtime : @agent_runtime.AgentRuntime, text : String) -> Unit {
   runtime.queue_steer(text)
 }
@@ -228,16 +233,15 @@ pub async fn[X] run_turn_in_scope(
         }
     }
     let messages = session.chat_messages()
-    for step in 0..<max_steps {
+    steps~: for step in 0..<max_steps {
       // Steering first: a user's mid-turn redirection should precede the
       // runtime chatter the model reads alongside it.
-      for text in runtime.drain_steers() {
-        if !text.trim().is_empty() {
-          @xlog.info() <? { "event": "steer_applied", "content": text }
-          session = append_item(session, User(UserMessage(text)))
-          messages.push(ChatMessage(User, content=text))
-        }
-      }
+      session = apply_steer_texts(
+        pending_steers(runtime),
+        session,
+        messages,
+        append_item~,
+      )
       if runtime_update_message(runtime.drain_events()) is Some(update) {
         @xlog.info() <? { "event": "runtime_update", "content": update }
         session = append_item(session, Runtime(RuntimeNotice(update)))
@@ -272,15 +276,31 @@ pub async fn[X] run_turn_in_scope(
           { "event": "assistant_message", "content": response.content }
       }
       print_usage(response.usage)
-      if response.tool_calls.length() == 0 {
-        let next = append_item(session, Terminal(Finished(response.content)))
-        @xlog.info() <?
-          { "event": "agent_finished", "answer": response.content }
-        return next
-      }
       let reasoning_content = match response.reasoning_content {
         "" => None
         content => Some(content)
+      }
+      if response.tool_calls.length() == 0 {
+        let pending = pending_steers(runtime)
+        if pending.length() == 0 {
+          let next = append_item(session, Terminal(Finished(response.content)))
+          @xlog.info() <?
+            { "event": "agent_finished", "answer": response.content }
+          return next
+        }
+        // The model considers itself done, but the user redirected while the
+        // final call was in flight: user input wins over model-initiated
+        // completion. The would-be answer stays as an ordinary assistant
+        // message and the turn continues with the steers folded in.
+        messages.push(
+          ChatMessage(Assistant, content=response.content, reasoning_content?),
+        )
+        session = append_item(
+          session,
+          Assistant(AssistantMessage(response.content, reasoning_content?)),
+        )
+        session = apply_steer_texts(pending, session, messages, append_item~)
+        continue steps~
       }
       let assistant_message : @deepseek.ChatMessage = ChatMessage(
         Assistant,
@@ -299,7 +319,7 @@ pub async fn[X] run_turn_in_scope(
           ),
         ),
       )
-      for native_call in response.tool_calls {
+      for call_index, native_call in response.tool_calls {
         let tool_call = @agent_tool.AgentToolCall(native_call) catch {
           error => {
             @xlog.error() <?
@@ -339,9 +359,51 @@ pub async fn[X] run_turn_in_scope(
                 ),
               ),
             )
-            let next = append_item(session, Terminal(Finished(answer)))
-            @xlog.info() <? { "event": "agent_finished", "answer": answer }
-            return next
+            let pending = pending_steers(runtime)
+            if pending.length() == 0 {
+              let next = append_item(session, Terminal(Finished(answer)))
+              @xlog.info() <? { "event": "agent_finished", "answer": answer }
+              return next
+            }
+            // User input wins over the finish tool as well. Continuing the
+            // turn must keep the conversation API-valid: every call in the
+            // assistant's batch needs a result message, so the finish call's
+            // result and skipped notes for the unexecuted remainder are
+            // pushed before the steers.
+            messages.push(
+              ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
+            )
+            for rest_index in (call_index + 1)..<response.tool_calls.length() {
+              let skipped = response.tool_calls[rest_index]
+              let note = "skipped: the user steered the turn before this call ran"
+              @xlog.info() <?
+                {
+                  "event": "tool_result",
+                  "tool_call_id": skipped.id,
+                  "tool_name": skipped.name,
+                  "is_error": true,
+                  "content": note,
+                }
+              messages.push(ChatMessage(Tool(skipped.id), content=note))
+              session = append_item(
+                session,
+                Tool(
+                  ToolResult(
+                    tool_call_id=skipped.id,
+                    tool_name=skipped.name,
+                    content=note,
+                    is_error=true,
+                  ),
+                ),
+              )
+            }
+            session = apply_steer_texts(
+              pending,
+              session,
+              messages,
+              append_item~,
+            )
+            continue steps~
           }
           Control(Abort(reason)) => {
             session = append_item(
@@ -409,6 +471,32 @@ pub async fn[X] run_turn_in_scope(
 ///|
 fn runtime_update_message(events : Array[@agent_runtime.AgentEvent]) -> String? {
   @moon_check.runtime_update_text(events)
+}
+
+///|
+/// Queued steering input worth applying: drained losslessly, blanks dropped.
+fn pending_steers(runtime : @agent_runtime.AgentRuntime) -> Array[String] {
+  [
+    for text in runtime.drain_steers() if !text.trim().is_empty() => text
+  ]
+}
+
+///|
+/// Fold steering texts into the conversation: each becomes a durable user
+/// message, a model-visible chat message, and a `steer_applied` event.
+async fn apply_steer_texts(
+  texts : Array[String],
+  session : @agent_session.Session,
+  messages : Array[@deepseek.ChatMessage],
+  append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
+) -> @agent_session.Session {
+  let mut current = session
+  for text in texts {
+    @xlog.info() <? { "event": "steer_applied", "content": text }
+    current = append_item(current, User(UserMessage(text)))
+    messages.push(ChatMessage(User, content=text))
+  }
+  current
 }
 
 ///|

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -2,6 +2,27 @@
 let default_max_steps : Int = 1000
 
 ///|
+/// Mid-turn user input riding the shared runtime event bus. Queued by
+/// `steer` and folded into the conversation by the agent loop at its next
+/// step boundary.
+extenum @agent_runtime.AgentEvent += {
+  SteerInput(String)
+}
+
+///|
+/// Queue `text` as steering input for the turn running on `runtime`.
+///
+/// Steering lands at the next step boundary — after the in-flight model call
+/// and its tool batch complete, where the loop already folds in runtime
+/// updates — so completed work is never thrown away. The text is appended to
+/// the session as a user message and a `steer_applied` event is emitted when
+/// it takes effect. Steering an idle runtime is harmless: the input waits on
+/// the bus for the next turn.
+pub fn steer(runtime : @agent_runtime.AgentRuntime, text : String) -> Unit {
+  runtime.emit_event(SteerInput(text))
+}
+
+///|
 /// Returns the base built-in system prompt.
 pub fn default_system_prompt() -> String {
   @prompt.system_prompt_for_model(V4Pro)
@@ -23,6 +44,7 @@ pub async fn run(
   system_prompt_text? : String = default_system_prompt_for_model(model),
   thinking? : @deepseek.ThinkingMode = Enabled,
   reasoning_effort? : @deepseek.ReasoningEffort = Max,
+  api_url? : String,
 ) -> Unit {
   let session = @agent_session.Session(
     SessionId("one-shot"),
@@ -37,6 +59,7 @@ pub async fn run(
       max_steps~,
       thinking~,
       reasoning_effort~,
+      api_url?,
     ),
   )
 }
@@ -53,6 +76,7 @@ pub async fn run_turn(
   max_steps? : Int = default_max_steps,
   thinking? : @deepseek.ThinkingMode = Enabled,
   reasoning_effort? : @deepseek.ReasoningEffort = Max,
+  api_url? : String,
 ) -> @agent_session.Session {
   run_turn_with_append(
     api_key,
@@ -63,6 +87,7 @@ pub async fn run_turn(
     max_steps~,
     thinking~,
     reasoning_effort~,
+    api_url?,
   )
 }
 
@@ -79,9 +104,10 @@ pub async fn run_turn_with_append(
   max_steps? : Int = default_max_steps,
   thinking? : @deepseek.ThinkingMode = Enabled,
   reasoning_effort? : @deepseek.ReasoningEffort = Max,
+  api_url? : String,
 ) -> @agent_session.Session {
   @async.with_task_group() <| group => {
-    run_with_runtime(
+    run_turn_in_scope(
       AgentRuntime(),
       AgentTaskScope(group),
       api_key,
@@ -92,6 +118,7 @@ pub async fn run_turn_with_append(
       max_steps~,
       thinking~,
       reasoning_effort~,
+      api_url?,
     )
   }
 }
@@ -134,17 +161,27 @@ async test "run_turn_with_append closes failed persisted turns" {
 }
 
 ///|
-async fn run_with_runtime(
+/// Runs one user turn inside a caller-owned runtime and task scope.
+///
+/// This is the building block for callers that keep an engine alive across
+/// turns (serve mode): a shared `runtime` preserves stateful tools — a
+/// `moon_check` watcher started in one turn keeps reporting in the next —
+/// and is also the bus `steer` feeds mid-turn input through. `scope` bounds
+/// background work the turn's tools spawn, so it must outlive the turn.
+/// One-shot callers should prefer `run_turn`/`run_turn_with_append`, which
+/// own both for the duration of a single turn.
+pub async fn[X] run_turn_in_scope(
   runtime : @agent_runtime.AgentRuntime,
-  scope : @agent_runtime.AgentTaskScope[@agent_session.Session],
+  scope : @agent_runtime.AgentTaskScope[X],
   api_key : String,
   model : @deepseek.Model,
   session : @agent_session.Session,
   task : String,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
-  max_steps~ : Int,
-  thinking~ : @deepseek.ThinkingMode,
-  reasoning_effort~ : @deepseek.ReasoningEffort,
+  max_steps? : Int = default_max_steps,
+  thinking? : @deepseek.ThinkingMode = Enabled,
+  reasoning_effort? : @deepseek.ReasoningEffort = Max,
+  api_url? : String,
 ) -> @agent_session.Session {
   let client = @client.Client(
     api_key~,
@@ -157,6 +194,7 @@ async fn run_with_runtime(
       Enabled => Some(reasoning_effort)
       Disabled => None
     },
+    api_url?,
   )
   let mut session = append_item(session, User(UserMessage(task)))
   try {
@@ -172,7 +210,17 @@ async fn run_with_runtime(
     }
     let messages = session.chat_messages()
     for step in 0..<max_steps {
-      if runtime_update_message(runtime.drain_events()) is Some(update) {
+      let drained = runtime.drain_events()
+      // Steering first: a user's mid-turn redirection should precede the
+      // runtime chatter the model reads alongside it.
+      for event in drained {
+        if event is SteerInput(text) && !text.trim().is_empty() {
+          @xlog.info() <? { "event": "steer_applied", "content": text }
+          session = append_item(session, User(UserMessage(text)))
+          messages.push(ChatMessage(User, content=text))
+        }
+      }
+      if runtime_update_message(drained) is Some(update) {
         @xlog.info() <? { "event": "runtime_update", "content": update }
         session = append_item(session, Runtime(RuntimeNotice(update)))
         messages.push(ChatMessage(User, content=update))

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -16,6 +16,14 @@ import {
   "tonyfettes/xlog",
 }
 
+import {
+  "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_session",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+} for "test"
+
 warnings = "+unnecessary_annotation"
 
 supported_targets = "+native"

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -4,10 +4,13 @@ package "bobzhang/openseek/agent"
 import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/deepseek",
 }
 
 // Values
+pub fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X]) -> @agent_tool.Tools raise
+
 pub fn default_system_prompt() -> String
 
 pub fn default_system_prompt_for_model(@deepseek.Model) -> String
@@ -16,7 +19,7 @@ pub async fn run(String, @deepseek.Model, String, max_steps? : Int, system_promp
 
 pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String) -> @agent_session.Session
 
-pub async fn[X] run_turn_in_scope(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String, tools? : @agent_tool.Tools) -> @agent_session.Session
 
 pub async fn run_turn_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String) -> @agent_session.Session
 

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/agent"
 
 import {
+  "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/deepseek",
 }
@@ -11,11 +12,15 @@ pub fn default_system_prompt() -> String
 
 pub fn default_system_prompt_for_model(@deepseek.Model) -> String
 
-pub async fn run(String, @deepseek.Model, String, max_steps? : Int, system_prompt_text? : String, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort) -> Unit
+pub async fn run(String, @deepseek.Model, String, max_steps? : Int, system_prompt_text? : String, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String) -> Unit
 
-pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort) -> @agent_session.Session
+pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String) -> @agent_session.Session
 
-pub async fn run_turn_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String) -> @agent_session.Session
+
+pub async fn run_turn_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, reasoning_effort? : @deepseek.ReasoningEffort, api_url? : String) -> @agent_session.Session
+
+pub fn steer(@agent_runtime.AgentRuntime, String) -> Unit
 
 // Errors
 

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -1,0 +1,101 @@
+///|
+/// A one-request DeepSeek stand-in for steering tests: asserts the request
+/// carries both the original task and the steered text as user messages, then
+/// streams a plain content answer so the turn finishes without tool calls.
+async fn steer_test_server(group : @async.TaskGroup[Unit]) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping steer test: \{message}")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        let request_body = body.read_all().text()
+        assert_true(request_body.contains("do the task"))
+        assert_true(request_body.contains("also rename the file"))
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=1,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "queued steering is folded in at the next step boundary" {
+  @async.with_task_group() <| group => {
+    guard steer_test_server(group) is Some(url) else { return }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    // Steer before the turn starts: the loop drains the bus at its first
+    // step boundary, so the steered text must reach the model alongside the
+    // task (the mock server asserts both are in the request body).
+    @agent.steer(runtime, "also rename the file")
+    let session = @agent_session.Session(
+      SessionId("steer-test"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "do the task",
+      append_item=(session, item) => session.append(item),
+      max_steps=2,
+      api_url=url,
+    )
+    // The steered text is durably part of the conversation: task, steer,
+    // then the finished terminal.
+    let events = result.events()
+    assert_eq(events.length(), 3)
+    guard events[0].item() is User(task) else { fail("expected task event") }
+    assert_eq(task.content(), "do the task")
+    guard events[1].item() is User(steer) else { fail("expected steer event") }
+    assert_eq(steer.content(), "also rename the file")
+    guard events[2].item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "ok")
+  }
+}
+
+///|
+async test "blank steering input is dropped at the boundary" {
+  @async.with_task_group() <| group => {
+    guard steer_test_server(group) is Some(url) else { return }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    @agent.steer(runtime, "   ")
+    @agent.steer(runtime, "also rename the file")
+    let session = @agent_session.Session(
+      SessionId("steer-blank"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "do the task",
+      append_item=(session, item) => session.append(item),
+      max_steps=2,
+      api_url=url,
+    )
+    // The blank steer left no trace; only the real one was applied.
+    assert_eq(result.events().length(), 3)
+  }
+}

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -20,6 +20,9 @@ async fn steer_test_server(group : @async.TaskGroup[Unit]) -> String? {
         let request_body = body.read_all().text()
         assert_true(request_body.contains("do the task"))
         assert_true(request_body.contains("also rename the file"))
+        // The prebuilt registry reached the request: the standard tools ride
+        // along even though the caller, not the turn, constructed them.
+        assert_true(request_body.contains("\"name\":\"moon_check\""))
         conn.send_response(200, "OK", extra_headers={
           "Content-Type": "text/event-stream",
         })
@@ -38,14 +41,17 @@ async test "queued steering is folded in at the next step boundary" {
     guard steer_test_server(group) is Some(url) else { return }
     let runtime = @agent_runtime.AgentRuntime()
     let scope = @agent_runtime.AgentTaskScope(group)
-    // Steer before the turn starts: the loop drains the bus at its first
-    // step boundary, so the steered text must reach the model alongside the
-    // task (the mock server asserts both are in the request body).
+    // Steer before the turn starts: the loop drains the steering queue at
+    // its first step boundary, so the steered text must reach the model
+    // alongside the task (the mock server asserts both are in the body).
     @agent.steer(runtime, "also rename the file")
     let session = @agent_session.Session(
       SessionId("steer-test"),
       system_prompt="system",
     )
+    // The registry is built once by the caller, the way a serve-mode engine
+    // shares it across turns.
+    let tools = @agent.build_tools(runtime, scope)
     let result = @agent.run_turn_in_scope(
       runtime,
       scope,
@@ -56,6 +62,7 @@ async test "queued steering is folded in at the next step boundary" {
       append_item=(session, item) => session.append(item),
       max_steps=2,
       api_url=url,
+      tools~,
     )
     // The steered text is durably part of the conversation: task, steer,
     // then the finished terminal.

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -80,6 +80,95 @@ async test "queued steering is folded in at the next step boundary" {
 }
 
 ///|
+/// A two-request stand-in for the override path: while handling the first
+/// request it steers the running turn, then answers content-only — which
+/// without the pending steer would have finished the turn. The second
+/// request must carry the steer and gets the real final answer.
+async fn override_test_server(
+  group : @async.TaskGroup[Unit],
+  runtime : @agent_runtime.AgentRuntime,
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping override test")
+        return None
+      }
+      raise error
+    }
+  }
+  let mut requests = 0
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        requests += 1
+        let request_body = body.read_all().text()
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        if requests == 1 {
+          // The steer arrives while this "final" call is in flight.
+          @agent.steer(runtime, "actually, make it rhyme")
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"draft answer\"}}]}\n\n",
+          )
+        } else {
+          assert_true(request_body.contains("actually, make it rhyme"))
+          assert_true(request_body.contains("draft answer"))
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"rhymed answer\"}}]}\n\n",
+          )
+        }
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=2,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "a steer racing the final call keeps the turn alive" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    guard override_test_server(group, runtime) is Some(url) else { return }
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("steer-override"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "write a poem",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+    )
+    // User input beat the model's completion: the draft stayed an ordinary
+    // assistant message, the steer follows it, and the turn finished on the
+    // second answer.
+    let events = result.events()
+    assert_eq(events.length(), 4)
+    assert_true(events[0].item() is User(_))
+    guard events[1].item() is Assistant(draft) else {
+      fail("expected the draft as an assistant message")
+    }
+    assert_eq(draft.content(), "draft answer")
+    guard events[2].item() is User(steer) else { fail("expected steer event") }
+    assert_eq(steer.content(), "actually, make it rhyme")
+    guard events[3].item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "rhymed answer")
+  }
+}
+
+///|
 async test "blank steering input is dropped at the boundary" {
   @async.with_task_group() <| group => {
     guard steer_test_server(group) is Some(url) else { return }

--- a/agent_runtime/pkg.generated.mbti
+++ b/agent_runtime/pkg.generated.mbti
@@ -19,7 +19,9 @@ pub struct AgentRuntime {
 }
 pub fn AgentRuntime::AgentRuntime() -> Self
 pub fn AgentRuntime::drain_events(Self) -> Array[AgentEvent]
+pub fn AgentRuntime::drain_steers(Self) -> Array[String]
 pub fn AgentRuntime::emit_event(Self, AgentEvent) -> Unit
+pub fn AgentRuntime::queue_steer(Self, String) -> Unit
 
 pub struct AgentTaskScope[X] {
   // private fields

--- a/agent_runtime/runtime.mbt
+++ b/agent_runtime/runtime.mbt
@@ -12,20 +12,28 @@ pub(all) extenum AgentEvent {}
 
 ///|
 /// Per-agent-loop state shared between the main chat loop and side-effectful
-/// tools. It owns runtime updates, while `AgentTaskScope` owns structured
-/// background task lifetime for tools that need it.
+/// tools. It owns runtime updates and queued steering input, while
+/// `AgentTaskScope` owns structured background task lifetime for tools that
+/// need it.
 pub struct AgentRuntime {
   /// Bounded event bus (`DiscardOldest`, see `default_agent_event_capacity`)
   /// that background tools post updates to; the main loop drains it between
   /// steps to surface fresh tool output into the conversation.
   priv events : @aqueue.Queue[AgentEvent]
+  /// Unbounded queue of mid-turn user input. Deliberately separate from the
+  /// lossy event bus: a noisy watcher may flood `events` and push old
+  /// updates out, but a user's steering text must never be the casualty.
+  priv steers : @aqueue.Queue[String]
 }
 
 ///|
 /// Create a runtime with an empty event bus of
-/// `default_agent_event_capacity`.
+/// `default_agent_event_capacity` and an empty steering queue.
 pub fn AgentRuntime::AgentRuntime() -> AgentRuntime {
-  { events: Queue(kind=DiscardOldest(default_agent_event_capacity)) }
+  {
+    events: Queue(kind=DiscardOldest(default_agent_event_capacity)),
+    steers: Queue(kind=Unbounded),
+  }
 }
 
 ///|
@@ -66,6 +74,27 @@ pub fn AgentRuntime::emit_event(
 }
 
 ///|
+/// Queue mid-turn user input for the loop's next step boundary. Lossless:
+/// the steering queue is unbounded and never closed, so unlike `emit_event`
+/// nothing can push a queued steer out.
+pub fn AgentRuntime::queue_steer(self : AgentRuntime, text : String) -> Unit {
+  ignore(self.steers.try_put(text) catch { _ => false })
+}
+
+///|
+/// Take every queued steering input, oldest first, leaving the queue empty.
+pub fn AgentRuntime::drain_steers(self : AgentRuntime) -> Array[String] {
+  let texts : Array[String] = []
+  for ;; {
+    let next = self.steers.try_get() catch { _ => None }
+    match next {
+      None => return texts
+      Some(text) => texts.push(text)
+    }
+  }
+}
+
+///|
 /// Take every queued runtime update, oldest first, leaving the bus empty.
 /// The agent loop calls this between steps to fold fresh background tool
 /// output into the conversation.
@@ -96,6 +125,21 @@ test "runtime drains queued events" {
   }
   assert_eq(value, "ok")
   assert_eq(runtime.drain_events().length(), 0)
+}
+
+///|
+test "steering input survives an event-bus flood" {
+  let runtime = AgentRuntime()
+  runtime.queue_steer("turn left")
+  // Flood the lossy event bus far past its capacity: updates may be
+  // discarded, but the steering queue is a separate lossless channel.
+  for index in 0..<(default_agent_event_capacity * 3) {
+    runtime.emit_event(RuntimeTestEvent("noise \{index}"))
+  }
+  runtime.queue_steer("turn right")
+  assert_eq(runtime.drain_steers().join("|"), "turn left|turn right")
+  assert_eq(runtime.drain_steers().length(), 0)
+  assert_eq(runtime.drain_events().length(), default_agent_event_capacity)
 }
 
 ///|


### PR DESCRIPTION
**PR 1 of 3** for the persistent-engine design (approved in review discussion; targets the "persistent engine per session" + "steering" items in `improvement.md`). PR 2 adds the engine's `--serve` command loop; PR 3 the TUI client.

## Change

- **`run_turn_in_scope`** (was private `run_with_runtime`): one turn inside a **caller-owned** `AgentRuntime` + task scope, generic over the scope's result type. A serve-mode engine holds both across turns — that's what keeps `moon_check` watchers warm between prompts, and what makes steering reachable.
- **`steer(runtime, text)`**: queues mid-turn user input on the existing runtime event bus (`extenum AgentEvent += SteerInput`). The loop folds it in at the **next step boundary** — the same place runtime updates land, ordered before them so the user's redirection reads first — appends it durably as a `User` message, and emits a `steer_applied` JSONL event. Blank input is dropped. Steering an idle runtime parks the input for the next turn.
- **`api_url?`** threaded through all run entry points, making agent turns testable against the mock SSE server pattern from `deepseek/client`.

## Verification

- New blackbox tests run a **full agent turn** against a scripted SSE server: the server asserts the steered text arrives in the request body alongside the task, and the session ends `[User(task), User(steer), Terminal(Finished)]`; a second test pins that blank steers leave no trace.
- `moon check` 0 warnings, fmt clean, 443/443 tests, 6/6 offline cram. No behavior change for existing callers (all new params optional, defaults preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)