### PR TITLE
feat(openseek): add --serve, a long-lived session server on stdio

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -25,6 +25,13 @@ async fn run_cli() -> Unit {
     if handle_session_command(matches) {
       return
     }
+    if flag(matches, "serve") {
+      if values(matches, "task").length() > 0 {
+        fail("--serve reads commands from stdin; it does not take a task")
+      }
+      run_serve(matches)
+      return
+    }
     let api_key = api_key(matches)
     let model = @deepseek.Model::parse(value(matches, "model"))
     let max_steps = max_steps(matches)
@@ -173,6 +180,11 @@ fn cli_command() -> @argparse.Command {
       ),
     ],
     flags=[
+      FlagArg(
+        "serve",
+        long="serve",
+        about="Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.",
+      ),
       FlagArg(
         "session-list",
         long="session-list",

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -1,5 +1,7 @@
 import {
+  "bobzhang/jsonl",
   "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/deepseek",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -8,6 +8,17 @@ priv enum ServeCommand {
 }
 
 ///|
+/// One unit of work for the serve loop's single consumer: a wire command in
+/// arrival order, the completion of the active turn, or the stdin-EOF
+/// shutdown marker. Funneling all three through one queue is what makes
+/// command handling race-free against turn lifecycle.
+priv enum ServeStep {
+  Wire(ServeCommand)
+  TurnDone
+  Shutdown
+}
+
+///|
 /// Decode one JSONL command line from the controller.
 ///
 /// `prompt` starts a turn, `steer` injects input into the running one,
@@ -100,24 +111,17 @@ async fn run_serve(matches : @argparse.Matches) -> Unit {
     // rebuilding it per turn would orphan running watchers (see
     // @agent.build_tools).
     let tools = @agent.build_tools(runtime, scope)
-    let prompts : @async.Queue[String] = Queue(kind=Unbounded)
-    let turn_done : @async.Queue[Unit] = Queue(kind=Unbounded)
-    let mut active_turn : @async.Task[Unit]? = None
-    // Command reader: steer and cancel act immediately — that is the whole
-    // point of a persistent process — while prompts queue for the serve
-    // loop below. Runs concurrently with turns; `no_wait` because it ends
-    // only at stdin EOF.
+    // All scheduling flows through one ordered queue with one consumer:
+    // wire commands from the reader, plus the internal turn-completion and
+    // shutdown markers. A second scheduler (e.g. acting on commands inside
+    // the reader) would race the consumer's view of the active turn — a
+    // controller writing `prompt\nsteer\n` in one buffer must have its
+    // steer land in that prompt's turn, exactly as the wire order says.
+    let steps : @async.Queue[ServeStep] = Queue(kind=Unbounded)
     group.spawn_bg(no_wait=true) <| () => {
       @jsonl.each(@stdio.stdin, json => {
         match decode_serve_command(json) {
-          Ok(Prompt(text)) => prompts.try_put(text) |> ignore
-          Ok(Steer(text)) =>
-            match active_turn {
-              Some(_) => @agent.steer(runtime, text)
-              // Steering an idle engine means "this is my next message".
-              None => prompts.try_put(text) |> ignore
-            }
-          Ok(Cancel) => if active_turn is Some(task) { task.cancel() }
+          Ok(command) => steps.try_put(Wire(command)) |> ignore
           Err(message) =>
             @xlog.error() <? { "event": "command_error", "error": message }
         }
@@ -130,16 +134,13 @@ async fn run_serve(matches : @argparse.Matches) -> Unit {
           @xlog.error() <?
             { "event": "command_error", "error": "command stream: \{error}" }
       }
-      prompts.close()
+      steps.try_put(Shutdown) |> ignore
     }
-    for ;; {
-      let task_text = prompts.get() catch {
-        error if @async.is_being_cancelled() ||
-          @async.is_cancellation_error(error) => raise error
-        // Closed and drained: stdin ended, every queued prompt ran.
-        _ => break
-      }
-      let turn = group.spawn(no_wait=true) <| () => {
+    let pending : Array[String] = []
+    let mut active_turn : @async.Task[Unit]? = None
+    let mut shutting_down = false
+    fn start_turn(task_text : String) -> @async.Task[Unit] {
+      group.spawn() <| () => {
         let _ = @agent.run_turn_in_scope(
           runtime,
           scope,
@@ -172,15 +173,62 @@ async fn run_serve(matches : @argparse.Matches) -> Unit {
             } else {
               @xlog.error() <? { "event": "turn_failed", "error": "\{error}" }
             }
-            ignore(turn_done.try_put(()) catch { _ => false })
+            ignore(steps.try_put(TurnDone) catch { _ => false })
             return
           }
         }
-        ignore(turn_done.try_put(()) catch { _ => false })
+        ignore(steps.try_put(TurnDone) catch { _ => false })
       }
-      active_turn = Some(turn)
-      turn_done.get()
-      active_turn = None
+    }
+
+    serve~: for ;; {
+      let step = steps.get() catch {
+        error if @async.is_being_cancelled() ||
+          @async.is_cancellation_error(error) => raise error
+        _ => break serve~
+      }
+      match step {
+        Wire(Prompt(text)) =>
+          match active_turn {
+            // One turn at a time: extra prompts wait their wire-order turn.
+            Some(_) => pending.push(text)
+            None => active_turn = Some(start_turn(text))
+          }
+        Wire(Steer(text)) =>
+          if active_turn is Some(_) || pending.length() > 0 {
+            // A turn is running or already submitted ahead of this steer:
+            // the lossless steering queue delivers it at that turn's next
+            // step boundary (or its first, if it has not started yet).
+            @agent.steer(runtime, text)
+          } else {
+            // Steering an idle engine means "this is my next message".
+            active_turn = Some(start_turn(text))
+          }
+        Wire(Cancel) =>
+          match active_turn {
+            Some(task) => task.cancel()
+            None =>
+              // No active turn: in wire order the cancel targets the next
+              // submitted prompt, so withdraw it before it starts.
+              if pending.length() > 0 {
+                let _ = pending.remove(0)
+              }
+          }
+        TurnDone => {
+          active_turn = None
+          if pending.length() > 0 {
+            active_turn = Some(start_turn(pending.remove(0)))
+          } else if shutting_down {
+            break serve~
+          }
+        }
+        Shutdown => {
+          shutting_down = true
+          if active_turn is None && pending.length() == 0 {
+            break serve~
+          }
+        }
+      }
     }
   })
 }

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -1,0 +1,186 @@
+///|
+/// One decoded command from the serve-mode controller (e.g. the TUI) on
+/// stdin.
+priv enum ServeCommand {
+  Prompt(String)
+  Steer(String)
+  Cancel
+}
+
+///|
+/// Decode one JSONL command line from the controller.
+///
+/// `prompt` starts a turn, `steer` injects input into the running one,
+/// `cancel` interrupts it. Anything else is an `Err` whose text is emitted
+/// as a `command_error` event — a controller bug must be visible on the
+/// wire, not silently swallowed, but it must not kill the session either.
+fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
+  match json {
+    { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text))
+    { "command": "steer", "text": String(text), .. } => Ok(Steer(text))
+    { "command": "prompt", .. } | { "command": "steer", .. } =>
+      Err("expected a string \"text\" field")
+    { "command": "cancel", .. } => Ok(Cancel)
+    { "command": String(other), .. } => Err("unknown command: \{other}")
+    _ => Err("expected a {\"command\": ...} object")
+  }
+}
+
+///|
+test "serve commands decode and reject with actionable errors" {
+  assert_true(
+    decode_serve_command({ "command": "prompt", "text": "hi" })
+    is Ok(Prompt("hi")),
+  )
+  assert_true(
+    decode_serve_command({ "command": "steer", "text": "left" })
+    is Ok(Steer("left")),
+  )
+  assert_true(decode_serve_command({ "command": "cancel" }) is Ok(Cancel))
+  guard decode_serve_command({ "command": "prompt" }) is Err(message) else {
+    fail("textless prompt accepted")
+  }
+  assert_true(message.contains("text"))
+  guard decode_serve_command({ "command": "reboot" }) is Err(message) else {
+    fail("unknown command accepted")
+  }
+  assert_true(message.contains("unknown command: reboot"))
+  guard decode_serve_command("nonsense") is Err(message) else {
+    fail("non-object accepted")
+  }
+  assert_true(message.contains("command"))
+}
+
+///|
+/// Run the engine as a long-lived session server: read JSONL commands from
+/// stdin, run turns sequentially against one shared session, and write the
+/// usual JSONL event stream to stdout. This is the engine half of the
+/// persistent-engine design — one process per conversation instead of one
+/// per prompt.
+///
+/// The runtime and the tool registry are built once and shared by every
+/// turn, so stateful tools survive turn boundaries (a `moon_check` watcher
+/// started in turn 1 keeps reporting in turn 5). `steer` rides the
+/// runtime's lossless steering queue into the running turn; when no turn is
+/// running it simply becomes the next prompt. `cancel` interrupts the
+/// current turn but never the process. stdin EOF is the shutdown signal:
+/// the running turn finishes first, then the loop drains and exits.
+async fn run_serve(matches : @argparse.Matches) -> Unit {
+  let api_key = api_key(matches)
+  let model = @deepseek.Model::parse(value(matches, "model"))
+  let max_steps = max_steps(matches)
+  let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
+  let reasoning_effort = @deepseek.ReasoningEffort::parse(
+    value(matches, "reasoning-effort"),
+  )
+  let (store, initial_session) = match session_id(matches) {
+    Some(id) => {
+      let store = @store.SessionStore(session_root(matches))
+      (Some(store), load_or_new_session(store, id, matches, model))
+    }
+    // No durable session requested: the conversation still spans every
+    // prompt of this process's lifetime, it just leaves nothing behind.
+    None =>
+      (
+        None,
+        Session(
+          SessionId("serve"),
+          system_prompt=configured_system_prompt(matches, model),
+        ),
+      )
+  }
+  // The live conversation value. `append_item` updates it on every appended
+  // event, so even a turn that raises leaves `session` reflecting all the
+  // events it durably recorded before failing.
+  let mut session = initial_session
+  @async.with_task_group(group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    // Built once: stateful tool records live in this registry, and
+    // rebuilding it per turn would orphan running watchers (see
+    // @agent.build_tools).
+    let tools = @agent.build_tools(runtime, scope)
+    let prompts : @async.Queue[String] = Queue(kind=Unbounded)
+    let turn_done : @async.Queue[Unit] = Queue(kind=Unbounded)
+    let mut active_turn : @async.Task[Unit]? = None
+    // Command reader: steer and cancel act immediately — that is the whole
+    // point of a persistent process — while prompts queue for the serve
+    // loop below. Runs concurrently with turns; `no_wait` because it ends
+    // only at stdin EOF.
+    group.spawn_bg(no_wait=true) <| () => {
+      @jsonl.each(@stdio.stdin, json => {
+        match decode_serve_command(json) {
+          Ok(Prompt(text)) => prompts.try_put(text) |> ignore
+          Ok(Steer(text)) =>
+            match active_turn {
+              Some(_) => @agent.steer(runtime, text)
+              // Steering an idle engine means "this is my next message".
+              None => prompts.try_put(text) |> ignore
+            }
+          Ok(Cancel) => if active_turn is Some(task) { task.cancel() }
+          Err(message) =>
+            @xlog.error() <? { "event": "command_error", "error": message }
+        }
+      }) catch {
+        error if @async.is_being_cancelled() ||
+          @async.is_cancellation_error(error) => raise error
+        // A malformed (non-JSON) line is a controller bug: report it and
+        // stop reading commands, which shuts the server down gracefully.
+        error =>
+          @xlog.error() <?
+            { "event": "command_error", "error": "command stream: \{error}" }
+      }
+      prompts.close()
+    }
+    for ;; {
+      let task_text = prompts.get() catch {
+        error if @async.is_being_cancelled() ||
+          @async.is_cancellation_error(error) => raise error
+        // Closed and drained: stdin ended, every queued prompt ran.
+        _ => break
+      }
+      let turn = group.spawn(no_wait=true) <| () => {
+        let _ = @agent.run_turn_in_scope(
+          runtime,
+          scope,
+          api_key,
+          model,
+          session,
+          task_text,
+          append_item=(current, item) => {
+            let next = match store {
+              Some(store) => store.append(current, item)
+              None => current.append(item)
+            }
+            session = next
+            next
+          },
+          max_steps~,
+          thinking~,
+          reasoning_effort~,
+          tools~,
+        ) catch {
+          error => {
+            // The turn died but the session server must not: a cancelled
+            // turn already appended its Interrupted terminal inside the
+            // loop, and any other failure is reported as a terminal wire
+            // event so the controller can close the run.
+            if @async.is_being_cancelled() ||
+              @async.is_cancellation_error(error) {
+              @xlog.warn() <?
+                { "event": "agent_aborted", "reason": "interrupted" }
+            } else {
+              @xlog.error() <? { "event": "turn_failed", "error": "\{error}" }
+            }
+            ignore(turn_done.try_put(()) catch { _ => false })
+            return
+          }
+        }
+        ignore(turn_done.try_put(()) catch { _ => false })
+      }
+      active_turn = Some(turn)
+      turn_done.get()
+      active_turn = None
+    }
+  })
+}

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -44,6 +44,10 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "max_steps_exhausted" => Some(MaxStepsExhausted)
     "agent_setup_failed" =>
       Some(AgentError("agent setup failed: " + @jsonx.string(object, "error")))
+    // A serve-mode turn that died with a non-cancellation error. Terminal for
+    // the run even though the engine process lives on.
+    "turn_failed" =>
+      Some(AgentError("turn failed: " + @jsonx.string(object, "error")))
     _ => None
   }
 }

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -58,6 +58,16 @@ test "decode maps each engine event kind" {
 }
 
 ///|
+test "a failed serve turn decodes to a terminal agent error" {
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "turn_failed", "error": "DeepSeek API error" }),
+    )
+    is Some(AgentError("turn failed: DeepSeek API error")),
+  )
+}
+
+///|
 test "decode returns None for a non-object value or unknown event" {
   // `@jsonl` handles blank and malformed lines before decoding; the mapping only
   // has to tolerate a non-object value and a newer engine's unknown event kind.

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -25,6 +25,7 @@ Arguments:
 
 Options:
   -h, --help                                                   Show help information.
+  --serve                                                      Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.
   --session-list                                               List durable session ids and exit.
   --session-show                                               Print the durable session JSON for --session and exit.
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
@@ -85,6 +86,30 @@ demo
 {"version":1,"id":"demo","system_prompt":"system","events":[{"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}},{"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}]}
 compacted session demo events 1..2; last_sequence=3
 {"version":1,"id":"demo","system_prompt":"system","events":[{"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}},{"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}},{"sequence":3,"item":{"kind":"summary","payload":{"content":"hello and answer","from_sequence":1,"to_sequence":2}}}]}
+```
+
+## Serve Mode Speaks JSONL Commands On Stdin
+
+`--serve` turns the engine into a long-lived session server: prompts, steers,
+and cancels arrive as JSONL commands on stdin, and the usual event stream
+leaves on stdout. The command surface is testable offline — a malformed
+command is reported as a `command_error` event rather than killing the
+server, an idle `cancel` is a no-op, and stdin EOF shuts the server down
+cleanly (exit 0) without ever touching the network. The `grep -o` keeps only
+the stable event tag, since event lines carry timestamps.
+
+```mooncram
+$ printf '{"command":"reboot"}\n{"command":"cancel"}\n' | env DEEPSEEK=test-key openseek.exe --serve 2>/dev/null | grep -o '"event":"command_error"'
+"event":"command_error"
+```
+
+A task positional contradicts serve mode and is rejected before anything
+runs.
+
+```mooncram
+$ env DEEPSEEK=test-key openseek.exe --serve "do something" 2>&1
+error: --serve reads commands from stdin; it does not take a task
+[1]
 ```
 
 ## MoonBit CLI Argument Parsing Pattern


### PR DESCRIPTION
**PR 2 of 3** for the persistent-engine design (PR 1: #85, merged). PR 3 wires the TUI to this.

## Change

`openseek --serve` turns the engine into a session server speaking line-delimited JSON on its standard streams:

- **stdin commands**: `{"command":"prompt","text":…}` starts a turn; `steer` injects input into the running turn via the lossless steering channel (idle steer = next prompt); `cancel` interrupts the turn — never the process. Malformed commands surface as `command_error` events instead of killing the session. stdin EOF = graceful shutdown (running turn finishes, queue drains, exit 0).
- **stdout**: the existing JSONL event stream, plus `turn_failed` for a turn that died with an error (so a controller can close the run without the process exiting; cancelled turns emit `agent_aborted`).
- One `AgentRuntime` + one `build_tools` registry span every turn — the PR-1 plumbing that keeps `moon_check` watchers warm across prompts. The session value updates on every durable append, so even a failing turn leaves the in-memory conversation consistent with the store.

## Verification

- Live, real API, **one process** for all of: turn 1 stores a name → turn 2 recalls it (`Hongbo`) → turn 3 is steered mid-run (`steer_applied` emitted, answer ends with the steered `BANANA`) → turn 4 is cancelled (`agent_aborted`, process alive) → turn 5 still serves → EOF exits 0.
- Offline cram covers the command surface without network: malformed command → `command_error`, idle cancel no-op, EOF exit 0, and the task-positional rejection.
- `moon check` 0 warnings, fmt clean, 449/449 tests (command decode), 8/8 offline cram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)