### PR TITLE
feat(session): record the conversation working directory in durable sessions

### DIFF
--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -44,6 +44,19 @@ fn int_field(
 }
 
 ///|
+fn optional_string_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> String? raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(String(value)) => Some(value)
+    None | Some(Null) => None
+    Some(_) => json_decode_error(path.add_key(key), "expected string")
+  }
+}
+
+///|
 pub impl ToJson for SessionId with fn to_json(id : SessionId) -> Json {
   Json::string(id.value())
 }
@@ -150,12 +163,18 @@ pub impl FromJson for SessionItem with fn from_json(
 
 ///|
 pub impl ToJson for Session with fn to_json(session : Session) -> Json {
-  {
-    "version": 1,
-    "id": session.id(),
-    "system_prompt": session.system_prompt(),
+  let fields : Map[String, Json] = {
+    "version": Json::number(1),
+    "id": session.id().to_json(),
+    "system_prompt": Json::string(session.system_prompt()),
     "events": session.events().to_json(),
   }
+  // Absent (not `null`) when unrecorded, so legacy sessions round-trip to the
+  // same shape they were written in.
+  if session.cwd() is Some(cwd) {
+    fields["cwd"] = Json::string(cwd)
+  }
+  Json::object(fields)
 }
 
 ///|
@@ -193,6 +212,7 @@ pub impl FromJson for Session with fn from_json(
   Session(
     id,
     system_prompt=string_field(fields, path, "system_prompt"),
+    cwd?=optional_string_field(fields, path, "cwd"),
     events~,
   )
 }

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -28,11 +28,12 @@ pub fn RuntimeNotice::content(Self) -> String
 pub struct Session {
   // private fields
 } derive(@debug.Debug)
-pub fn Session::Session(SessionId, system_prompt~ : String, events? : @vector.Vector[SessionEvent]) -> Self
+pub fn Session::Session(SessionId, system_prompt~ : String, cwd? : String, events? : @vector.Vector[SessionEvent]) -> Self
 pub fn Session::append(Self, SessionItem) -> Self
 pub fn Session::append_event(Self, SessionItem) -> (Self, SessionEvent)
 pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
 pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self raise
+pub fn Session::cwd(Self) -> String?
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -94,6 +94,27 @@ test "session JSON round trips typed events" {
 }
 
 ///|
+test "session JSON round trips the working directory" {
+  let session = @agent_session.Session(
+    SessionId("s1"),
+    system_prompt="system",
+    cwd="/work/project",
+  ).append(User(UserMessage("hello")))
+  assert_true(session.cwd() is Some("/work/project"))
+  let decoded : @agent_session.Session = @json.from_json(session.to_json())
+  assert_true(decoded.cwd() is Some("/work/project"))
+  // A session persisted before directories were recorded has no `cwd` key and
+  // decodes to `None` — and re-encodes without inventing one.
+  let legacy : @agent_session.Session = @json.from_json(
+    @json.parse(
+      "{\"version\":1,\"id\":\"s1\",\"system_prompt\":\"system\",\"events\":[]}",
+    ),
+  )
+  assert_true(legacy.cwd() is None)
+  assert_false(legacy.to_json().stringify().contains("cwd"))
+}
+
+///|
 test "projection closes unresolved historical tool calls" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(Assistant(AssistantMessage("", tool_calls=[sample_tool_call()])))

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub fn SessionStore::SessionStore(String) -> Self
 pub async fn SessionStore::append(Self, @agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session
 pub async fn SessionStore::compact(Self, @agent_session.Session, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> @agent_session.Session
 pub async fn SessionStore::create(Self, @agent_session.Session) -> Unit
+pub async fn SessionStore::cwd(Self, @agent_session.SessionId) -> String?
 pub async fn SessionStore::exists(Self, @agent_session.SessionId) -> Bool
 pub async fn SessionStore::latest(Self) -> @agent_session.SessionId?
 pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -17,6 +17,7 @@ let lock_file_name : String = "session.lock"
 priv struct SessionHeader {
   id : @agent_session.SessionId
   system_prompt : String
+  cwd : String?
   last_sequence : Int
   event_log_length : Int?
   event_log_hash : Int?
@@ -107,15 +108,21 @@ fn session_header_json(
   events_text : String,
   allow_event_log_ahead : Bool,
 ) -> Json {
-  {
-    "version": session_header_version,
-    "id": session.id(),
-    "system_prompt": session.system_prompt(),
-    "last_sequence": session.last_sequence(),
-    "event_log_length": events_text.length(),
-    "event_log_hash": event_log_hash(events_text),
-    "allow_event_log_ahead": allow_event_log_ahead,
+  let fields : Map[String, Json] = {
+    "version": session_header_version.to_json(),
+    "id": session.id().to_json(),
+    "system_prompt": Json::string(session.system_prompt()),
+    "last_sequence": session.last_sequence().to_json(),
+    "event_log_length": events_text.length().to_json(),
+    "event_log_hash": event_log_hash(events_text).to_json(),
+    "allow_event_log_ahead": allow_event_log_ahead.to_json(),
   }
+  // Absent (not `null`) when unrecorded, so legacy headers keep their shape
+  // across rewrites.
+  if session.cwd() is Some(cwd) {
+    fields["cwd"] = Json::string(cwd)
+  }
+  Json::object(fields)
 }
 
 ///|
@@ -166,6 +173,19 @@ fn header_optional_int_field(
 }
 
 ///|
+fn header_optional_string_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> String? raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(String(value)) => Some(value)
+    None | Some(Null) => None
+    Some(_) => json_decode_error(path.add_key(key), "expected string")
+  }
+}
+
+///|
 fn header_optional_bool_field(
   fields : Map[String, Json],
   path : @json.JsonPath,
@@ -203,6 +223,7 @@ fn decode_session_header(
   {
     id,
     system_prompt: header_string_field(fields, path, "system_prompt"),
+    cwd: header_optional_string_field(fields, path, "cwd"),
     last_sequence: header_int_field(fields, path, "last_sequence"),
     event_log_length: header_optional_int_field(
       fields, path, "event_log_length",
@@ -336,7 +357,12 @@ fn session_from_replayed_events(
       "session event log tail mismatch: header last sequence \{header.last_sequence}, replayed last sequence \{replayed_last_sequence}",
     )
   }
-  Session(header.id, system_prompt=header.system_prompt, events~)
+  Session(
+    header.id,
+    system_prompt=header.system_prompt,
+    cwd?=header.cwd,
+    events~,
+  )
 }
 
 ///|
@@ -686,6 +712,22 @@ pub async fn SessionStore::create(
     write_header(self, session, false)
     write_event_log(self, session)
     write_header(self, session, true)
+  })
+}
+
+///|
+/// The working directory recorded in the session's header, or `None` for a
+/// session persisted before directories were recorded. Reads only the header:
+/// resolving a resume directory must not replay a long event log. Raises when
+/// the session does not exist or its header cannot be read.
+pub async fn SessionStore::cwd(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String? {
+  with_existing_session_lock(self, id, Shared, () => {
+    let header = read_session_header(self, id)
+    validate_loaded_header(header, id)
+    header.cwd
   })
 }
 

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -49,6 +49,39 @@ async test "store creates and loads a session from header and event log" {
 }
 
 ///|
+async test "store persists the session working directory in the header" {
+  let store = new_store()
+  let session = @agent_session.Session(
+    SessionId("cwd"),
+    system_prompt="system",
+    cwd="/work/project",
+  ).append(User(UserMessage("hello")))
+  store.create(session)
+  assert_true(store.load(SessionId("cwd")).cwd() is Some("/work/project"))
+  // Appending rewrites the header without losing the recorded directory.
+  let appended = store.append(
+    store.load(SessionId("cwd")),
+    Terminal(Finished("done")),
+  )
+  assert_true(appended.cwd() is Some("/work/project"))
+  assert_true(store.load(SessionId("cwd")).cwd() is Some("/work/project"))
+  // The header-only read agrees with the full load without replaying events.
+  assert_true(store.cwd(SessionId("cwd")) is Some("/work/project"))
+  // A header written before directories were recorded loads as `None`.
+  store.create(Session(SessionId("legacy"), system_prompt="system"))
+  assert_true(store.load(SessionId("legacy")).cwd() is None)
+  assert_true(store.cwd(SessionId("legacy")) is None)
+  // A missing session raises rather than masquerading as "no directory".
+  let _ = store.cwd(SessionId("missing")) catch {
+    _ => {
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  fail("missing session yielded a working directory")
+}
+
+///|
 async test "store lists known sessions" {
   let store = new_store()
   assert_eq(store.list().length(), 0)

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -273,17 +273,22 @@ pub fn SessionEvent::item(self : SessionEvent) -> SessionItem {
 pub struct Session {
   priv id : SessionId
   priv system_prompt : String
+  priv cwd : String?
   priv events : @vector.Vector[SessionEvent]
   priv last_sequence : Int
 } derive(Debug)
 
 ///|
 /// Build a session from its identity, system prompt, and (when loading from
-/// storage) its existing event log. `last_sequence` is recovered from the
-/// highest sequence present, so appending continues where the log left off.
+/// storage) its existing event log. `cwd` records the working directory the
+/// conversation runs in, fixed at creation; omit it only when loading a
+/// session persisted before directories were recorded. `last_sequence` is
+/// recovered from the highest sequence present, so appending continues where
+/// the log left off.
 pub fn Session::Session(
   id : SessionId,
   system_prompt~ : String,
+  cwd? : String,
   events? : @vector.Vector[SessionEvent] = @vector.new(),
 ) -> Session {
   let mut last_sequence = 0
@@ -292,7 +297,7 @@ pub fn Session::Session(
       last_sequence = event.sequence
     }
   }
-  { id, system_prompt, events, last_sequence }
+  { id, system_prompt, cwd, events, last_sequence }
 }
 
 ///|
@@ -305,6 +310,13 @@ pub fn Session::id(self : Session) -> SessionId {
 /// The system prompt this conversation runs under, fixed at creation.
 pub fn Session::system_prompt(self : Session) -> String {
   self.system_prompt
+}
+
+///|
+/// The working directory the conversation runs in, fixed at creation, or
+/// `None` for a session persisted before directories were recorded.
+pub fn Session::cwd(self : Session) -> String? {
+  self.cwd
 }
 
 ///|
@@ -346,6 +358,7 @@ pub fn Session::append_event(
     {
       id: self.id,
       system_prompt: self.system_prompt,
+      cwd: self.cwd,
       events: self.events.push(event),
       last_sequence: event.sequence,
     },

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -411,6 +411,21 @@ fn required_session_id(
 }
 
 ///|
+/// A fresh durable session, recording the engine's working directory so a
+/// later resume can re-root the conversation where it started.
+async fn new_session(
+  id : @agent_session.SessionId,
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+) -> @agent_session.Session {
+  Session(
+    id,
+    system_prompt=configured_system_prompt(matches, model),
+    cwd?=@env.current_dir(),
+  )
+}
+
+///|
 async fn load_or_new_session(
   store : @store.SessionStore,
   id : @agent_session.SessionId,
@@ -420,11 +435,11 @@ async fn load_or_new_session(
   if store.exists(id) {
     store.load(id) catch {
       @os_error.OSError(_) as error if error.is_ENOENT() =>
-        Session(id, system_prompt=configured_system_prompt(matches, model))
+        new_session(id, matches, model)
       error => raise error
     }
   } else {
-    Session(id, system_prompt=configured_system_prompt(matches, model))
+    new_session(id, matches, model)
   }
 }
 
@@ -633,6 +648,8 @@ async test "load_or_new_session defers first durable write until append" {
   let created = load_or_new_session(store, id, parsed, V4Pro)
   assert_eq(created.system_prompt(), "system")
   assert_eq(created.events().length(), 0)
+  // A fresh session records the engine's working directory for later resumes.
+  assert_true(created.cwd() == @env.current_dir())
   assert_false(store.exists(id))
   let with_event = store.append(created, User(UserMessage("hello")))
   assert_eq(with_event.events().length(), 1)
@@ -640,6 +657,7 @@ async test "load_or_new_session defers first durable write until append" {
   let loaded = load_or_new_session(store, id, parsed, V4Pro)
   assert_eq(loaded.system_prompt(), "system")
   assert_eq(loaded.events().length(), 1)
+  assert_true(loaded.cwd() == @env.current_dir())
   @fs.rmdir(root, recursive=true)
 }
 

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -23,7 +23,7 @@ async test "a shell command runs locally and posts its output" {
   let messages = @async.Queue(kind=Unbounded)
   // `echo` is the same on POSIX `sh` and Windows `pwsh`, so the platform shell
   // `@shell.collect_shell_output` picks runs this on either.
-  run_shell_command(1, "echo hello", messages)
+  run_shell_command(1, "echo hello", cwd=".", messages)
   // The only message is the local command result: a completed tool item titled
   // with the command, its stdout as a dimmed detail line. Nothing is sent to the
   // engine.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -161,6 +161,9 @@ async fn run_agent_task(
       engine_args(task),
       inherit_env=false,
       extra_env=child_env,
+      // The conversation's directory, not the TUI's: a resumed session runs
+      // where it was created (see `with_session_cwd`).
+      cwd=config.cwd,
       stdout=child_stdout,
       stderr=child_stderr,
     )
@@ -234,11 +237,12 @@ async fn run_agent_task(
 async fn run_shell_command(
   run_id : Int,
   command : String,
+  cwd~ : String,
   messages : @async.Queue[Msg],
 ) -> Unit {
   let item : @ui.TranscriptItem = command_item(
     command,
-    @shell.collect_shell_output(command),
+    @shell.collect_shell_output(command, cwd~),
   ) catch {
     error if @async.is_being_cancelled() || @async.is_cancellation_error(error) => {
       messages.put(AgentCancelled(run_id~))
@@ -503,7 +507,7 @@ async fn[G] run_message_loop(
         RunCommand(run_id~, command) =>
           running_task = Some(
             group.spawn(no_wait=true) <| () => {
-              run_shell_command(run_id, command, messages)
+              run_shell_command(run_id, command, cwd=state.config.cwd, messages)
             },
           )
         CancelAgent => if running_task is Some(task) { task.cancel() }

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -106,9 +106,51 @@ fn continue_requested(matches : @argparse.Matches) -> Bool raise {
 /// empty store the generated fresh session stands: there is nothing to
 /// continue, and starting a new conversation beats refusing to launch.
 async fn with_latest_session(config : AppConfig) -> AppConfig {
-  match @store.SessionStore(config.session_root).latest() {
-    Some(id) => { ..config, session_id: id }
-    None => config
+  if @store.SessionStore(config.session_root).latest() is Some(id) {
+    { ..config, session_id: id }
+  } else {
+    config
+  }
+}
+
+///|
+/// The user's home directory: `HOME`, or `USERPROFILE` where `HOME` is unset
+/// (Windows).
+fn home_dir() -> String? {
+  if @env.get_env_var("HOME") is Some(home) && !home.trim().is_empty() {
+    Some(home)
+  } else {
+    @env.get_env_var("USERPROFILE")
+  }
+}
+
+///|
+/// Re-root a resumed conversation in its recorded working directory. A
+/// session persisted before directories were recorded — or whose recorded
+/// directory has since disappeared — falls back to the home directory, so
+/// resuming is deterministic instead of inheriting whatever directory the
+/// relaunch happened to come from. A fresh session keeps the launch
+/// directory (the engine records it on the session's first append), and an
+/// unreadable session or a missing home also keep it rather than failing
+/// the launch.
+async fn with_session_cwd(config : AppConfig) -> AppConfig {
+  // A missing or unreadable session keeps the launch directory rather than
+  // failing the launch: `append_session_history` inspects the same session
+  // right after the UI starts and reports its errors in the transcript, so
+  // swallowing here hides nothing.
+  let stored = @store.SessionStore(config.session_root).cwd(config.session_id) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return config
+  }
+  let resolved = if stored is Some(cwd) && @fs.exists(cwd) {
+    Some(cwd)
+  } else {
+    home_dir()
+  }
+  if resolved is Some(cwd) {
+    { ..config, cwd, }
+  } else {
+    config
   }
 }
 
@@ -160,6 +202,34 @@ fn session_root(matches : @argparse.Matches) -> String raise {
     fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
   }
   root
+}
+
+///|
+/// Whether `path` names a fixed location on any supported platform: a POSIX
+/// root, a UNC `\\server` path, a Windows rooted `\dir`, or a drive-qualified
+/// `C:/` / `C:\` path. Deliberately broader than `@path.Path::is_absolute`,
+/// whose win32 semantics call a drive-relative `/tmp` not absolute — a root
+/// the user wrote as rooted must pass through verbatim on every platform,
+/// never be re-anchored under the launch directory.
+fn is_rooted_path(path : String) -> Bool {
+  path.has_prefix("/") ||
+  path.has_prefix("\\") ||
+  path is [_, ':', '/' | '\\', ..]
+}
+
+///|
+/// Pin a relative session root to the launch directory. The engine is
+/// spawned in the conversation's directory, which `with_session_cwd` may
+/// re-root away from the launch directory; a relative `--session-root`
+/// passed along as-is would then resolve inside that other directory —
+/// a different store entirely — and the next turn would silently start a
+/// same-named session there instead of continuing this one.
+fn absolute_session_root(root : String, cwd : String) -> String {
+  if is_rooted_path(root) {
+    root
+  } else {
+    @path.Path(cwd).join(Path(root)).0
+  }
 }
 
 ///|
@@ -234,7 +304,7 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
       Some(id) => id
       None => generated_session_id(@env.now().reinterpret_as_int64())
     },
-    session_root: session_root_value,
+    session_root: absolute_session_root(session_root_value, cwd),
     engine: value(matches, "engine"),
   }
 }
@@ -311,6 +381,7 @@ async fn main {
   if continue_requested(matches) {
     config = with_latest_session(config)
   }
+  config = with_session_cwd(config)
   // Fail before the terminal UI takes over the screen if the engine is unusable,
   // rather than dropping the user into a UI that dies on the first task.
   if !engine_launchable(config.engine) {
@@ -336,7 +407,25 @@ test "cli accepts no initial task" {
   // No --session still converses in a session: a generated per-launch id, so
   // consecutive prompts share context instead of running amnesiac one-shots.
   assert_true(config.session_id.value().has_prefix("tui-"))
-  assert_eq(config.session_root, ".openseek")
+  // The default relative root is pinned to the launch directory so the
+  // engine sees the same store wherever it is spawned.
+  assert_true(config.session_root.has_suffix(".openseek"))
+  assert_eq(config.session_root, absolute_session_root(".openseek", config.cwd))
+}
+
+///|
+test "relative session roots pin to the launch directory" {
+  let pinned = absolute_session_root(".openseek", "/launch")
+  assert_true(pinned.has_prefix("/launch"))
+  assert_true(pinned.has_suffix(".openseek"))
+  // Rooted roots pass through verbatim on every platform.
+  assert_eq(absolute_session_root("/abs/store", "/launch"), "/abs/store")
+  assert_eq(absolute_session_root("C:\\store", "/launch"), "C:\\store")
+  assert_eq(absolute_session_root("C:/store", "/launch"), "C:/store")
+  assert_eq(
+    absolute_session_root("\\\\server\\share", "/launch"),
+    "\\\\server\\share",
+  )
 }
 
 ///|

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -10,19 +10,17 @@ import {
   "bobzhang/openseek/tui/style",
   "moonbit-community/displaytext",
   "moonbitlang/async",
+  "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
   "moonbitlang/async/process",
   "moonbitlang/core/argparse",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
+  "moonbitlang/x/path",
   "moonbitlang/x/sys",
   "moonbitlang/x/time",
 }
-
-import {
-  "moonbitlang/async/fs",
-} for "wbtest"
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 

--- a/cmd/tui/session_cwd_wbtest.mbt
+++ b/cmd/tui/session_cwd_wbtest.mbt
@@ -1,0 +1,62 @@
+///|
+async test "resume re-roots the conversation in the session's recorded directory" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-")
+  let recorded = @fs.tmpdir(prefix="openseek-tui-recorded-cwd-")
+  let store = @store.SessionStore(root)
+  store.create(
+    Session(SessionId("with-cwd"), system_prompt="system", cwd=recorded),
+  )
+  let parsed = cli_command().parse(
+    argv=["--session", "with-cwd", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(parse_config(parsed))
+  assert_eq(config.cwd, recorded)
+  @fs.rmdir(root, recursive=true)
+  @fs.rmdir(recorded, recursive=true)
+}
+
+///|
+async test "resume falls back to home for sessions without a recorded directory" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-legacy-")
+  let store = @store.SessionStore(root)
+  store.create(Session(SessionId("legacy"), system_prompt="system"))
+  let parsed = cli_command().parse(
+    argv=["--session", "legacy", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(parse_config(parsed))
+  guard home_dir() is Some(home) else { fail("expected a home directory") }
+  assert_eq(config.cwd, home)
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "resume falls back to home when the recorded directory is gone" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-stale-")
+  let gone = @fs.tmpdir(prefix="openseek-tui-gone-cwd-")
+  @fs.rmdir(gone, recursive=true)
+  let store = @store.SessionStore(root)
+  store.create(Session(SessionId("stale"), system_prompt="system", cwd=gone))
+  let parsed = cli_command().parse(
+    argv=["--session", "stale", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(parse_config(parsed))
+  guard home_dir() is Some(home) else { fail("expected a home directory") }
+  assert_eq(config.cwd, home)
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "a fresh session keeps the launch directory" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-fresh-")
+  let parsed = cli_command().parse(
+    argv=["--session", "brand-new", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let before = parse_config(parsed)
+  let config = with_session_cwd(before)
+  assert_eq(config.cwd, before.cwd)
+  @fs.rmdir(root, recursive=true)
+}


### PR DESCRIPTION
For desktop app, it might be better associate a session with a cwd, so that we can list out all sessions, group by cwd to show user a project view, like this:

```
project-1/
  - session 1
  - session 2
  - ...
project-2/
  - session a
  - session b
  - ...
```

This is not a big problem for TUI b/c terminal program always have a cwd, but for a desktop application, the only sensible choice for cwd is the home directory.