### PR TITLE
feat(tui): drive one persistent serve-mode engine per session

### DIFF
--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -72,10 +72,13 @@ test "serve commands decode and reject with actionable errors" {
 /// The runtime and the tool registry are built once and shared by every
 /// turn, so stateful tools survive turn boundaries (a `moon_check` watcher
 /// started in turn 1 keeps reporting in turn 5). `steer` rides the
-/// runtime's lossless steering queue into the running turn; when no turn is
-/// running it simply becomes the next prompt. `cancel` interrupts the
-/// current turn but never the process. stdin EOF is the shutdown signal:
-/// the running turn finishes first, then the loop drains and exits.
+/// runtime's lossless steering queue into the running (or already
+/// submitted) turn; with no turn to land in it is rejected with a
+/// `steer_dropped` event — that only happens by racing the terminal event
+/// through the pipes, and an engine must never start a turn the controller
+/// did not ask for. `cancel` interrupts the current turn but never the
+/// process. stdin EOF is the shutdown signal: the running turn finishes
+/// first, then the loop drains and exits.
 async fn run_serve(matches : @argparse.Matches) -> Unit {
   let api_key = api_key(matches)
   let model = @deepseek.Model::parse(value(matches, "model"))
@@ -201,8 +204,12 @@ async fn run_serve(matches : @argparse.Matches) -> Unit {
             // step boundary (or its first, if it has not started yet).
             @agent.steer(runtime, text)
           } else {
-            // Steering an idle engine means "this is my next message".
-            active_turn = Some(start_turn(text))
+            // An idle engine never converts a steer into a prompt: the only
+            // way a steer arrives idle is racing the turn's terminal event
+            // through the pipes, and silently starting a turn the controller
+            // never asked for would mutate the session behind its back.
+            // Reject it on the wire so the controller can ask for a resubmit.
+            @xlog.warn() <? { "event": "steer_dropped", "content": text }
           }
         Wire(Cancel) =>
           match active_turn {

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -222,6 +222,13 @@ async fn run_serve(matches : @argparse.Matches) -> Unit {
               }
           }
         TurnDone => {
+          // A steer that raced the turn's end (or was queued while it was
+          // dying) may still sit in the runtime's steering queue; the next
+          // turn must not inherit input the user aimed at this one. Reject
+          // leftovers on the wire like any other undeliverable steer.
+          for text in runtime.drain_steers() {
+            @xlog.warn() <? { "event": "steer_dropped", "content": text }
+          }
           active_turn = None
           if pending.length() > 0 {
             active_turn = Some(start_turn(pending.remove(0)))

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -3,12 +3,19 @@
 The OpenSeek terminal UI: a scrolling transcript with a live composer, built
 on the reusable [`tui`](../../tui/README.md) controller package.
 
-The TUI runs no agent code itself. For every submitted prompt it spawns the
-engine binary (`openseek` from `PATH`; override with `--engine` or
-`OPENSEEK_ENGINE`) and renders the engine's JSONL event stream: streamed
-thinking and answer text move live on the activity line, each turn's reasoning
-is kept as a dim `✻` transcript aside above its answer, and tool results land
-as `⏺` blocks.
+The TUI runs no agent code itself. It spawns the engine binary (`openseek`
+from `PATH`; override with `--engine` or `OPENSEEK_ENGINE`) **once per
+session** in `--serve` mode and drives it over stdin commands, rendering the
+engine's JSONL event stream: streamed thinking and answer text move live on
+the activity line, each turn's reasoning is kept as a dim `✻` transcript
+aside above its answer, and tool results land as `⏺` blocks. Pressing Enter
+while a task runs steers it mid-turn; Ctrl-C cancels the turn (a second
+Ctrl-C kills the engine, and the next prompt respawns it on the same
+session).
+
+A custom or recorded-stream engine that only speaks the original
+one-process-per-prompt protocol still works with `--engine-mode oneshot`
+(env `OPENSEEK_ENGINE_MODE`); steering is unavailable there.
 
 ## Sessions
 

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -10,6 +10,7 @@ fn drain_test_state() -> State {
     session_id: SessionId("test"),
     session_root: ".openseek",
     engine: "openseek",
+    engine_mode: Serve,
   })
 }
 
@@ -228,6 +229,29 @@ test "steering a running agent sends a steer command" {
   let cmds = update(state, UiInput(Queue(Prompt("c"))))
   assert_eq(state.queued.length(), 1)
   assert_eq(error_item_count(cmds), 0)
+}
+
+///|
+test "oneshot engines reject steering with the legacy notice" {
+  let state = State::new({
+    api_key: "k",
+    model: V4Pro,
+    cwd: ".",
+    max_steps: 10,
+    thinking: Enabled,
+    reasoning_effort: Max,
+    session_id: SessionId("test"),
+    session_root: ".openseek",
+    engine: "./replayer",
+    engine_mode: OneShot,
+  })
+  let _ = update(state, UiInput(Steer(Prompt("a"))))
+  assert_true(state.run is Running(_))
+  // No command channel into a one-shot process: steering errors instead of
+  // emitting a steer command.
+  let cmds = update(state, UiInput(Steer(Prompt("b"))))
+  assert_eq(error_item_count(cmds), 1)
+  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
 }
 
 ///|

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -231,6 +231,34 @@ test "steering a running agent sends a steer command" {
 }
 
 ///|
+test "a running shell command is never steered and never kills the engine" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Command("sleep 5"))))
+  assert_true(state.run is Running(_))
+  assert_true(state.run_is_command)
+
+  // Steering a local command run errors instead of poking the idle engine.
+  let cmds = update(state, UiInput(Steer(Prompt("change of plan"))))
+  assert_eq(error_item_count(cmds), 1)
+  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+
+  // Interrupt escalation stays on the local task: a second Ctrl-C cancels
+  // again rather than killing the bystander engine process.
+  let _ = update(state, UiInput(Interrupt))
+  assert_true(state.run is Interrupting(_))
+  let cmds = update(state, UiInput(Interrupt))
+  assert_true(cmds.iter().any(cmd => cmd is CancelAgent))
+  assert_true(cmds.iter().all(cmd => !(cmd is KillEngine)))
+
+  // Finishing the command clears the flag.
+  let _ = update(
+    state,
+    CommandResult(run_id=state.run_id, Error("interrupted")),
+  )
+  assert_false(state.run_is_command)
+}
+
+///|
 test "a steer_applied event echoes the input into the transcript" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -47,12 +47,8 @@ fn run_command_count(cmds : Array[Cmd]) -> Int {
 }
 
 ///|
-test "agent engine argv stays replay-compatible while session config uses env" {
+test "engine configuration travels through the environment" {
   let config = drain_test_state().config
-  let args = engine_args("--literal task")
-  assert_eq(args.length(), 2)
-  assert_eq(args[0], "--")
-  assert_eq(args[1], "--literal task")
   let env = engine_extra_env(config)
   guard env.get("OPENSEEK_SESSION") is Some(session_id) else {
     fail("missing session id env")
@@ -187,6 +183,12 @@ test "Ctrl+C quits when idle and interrupts when a task is running" {
   assert_eq(quit_count(cmds), 0)
   assert_true(cmds.iter().any(cmd => cmd is CancelAgent))
   assert_true(state.run is Interrupting(_))
+
+  // A second interrupt escalates from the polite cancel command to killing
+  // the engine process.
+  let cmds = update(state, UiInput(Interrupt))
+  assert_true(cmds.iter().any(cmd => cmd is KillEngine))
+  assert_eq(quit_count(cmds), 0)
 }
 
 ///|
@@ -198,7 +200,7 @@ test "a tick while idle never starts an agent" {
 }
 
 ///|
-test "steering a running agent reports an error and does not queue" {
+test "steering a running agent sends a steer command" {
   let state = drain_test_state()
 
   // Idle Steer submits and starts a task.
@@ -206,16 +208,42 @@ test "steering a running agent reports an error and does not queue" {
   assert_true(state.run is Running(_))
   assert_eq(state.queued.length(), 0)
 
-  // Steer while running: error, nothing queued, nothing started.
+  // Steer while running: a steer command for the engine — no queueing, no
+  // new run, no error. The transcript echo comes later, from the engine's
+  // steer_applied event at the boundary where the model actually saw it.
   let cmds = update(state, UiInput(Steer(Prompt("b"))))
   assert_eq(state.queued.length(), 0)
   assert_eq(start_agent_count(cmds), 0)
+  assert_eq(error_item_count(cmds), 0)
+  guard cmds is [SteerAgent(text)] else { fail("expected a steer command") }
+  assert_eq(text, "b")
+  assert_true(state.run is Running(_))
+
+  // A shell command cannot steer a model turn: error, nothing sent.
+  let cmds = update(state, UiInput(Steer(Command("ls"))))
   assert_eq(error_item_count(cmds), 1)
+  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
 
   // Queue while running still queues without error.
   let cmds = update(state, UiInput(Queue(Prompt("c"))))
   assert_eq(state.queued.length(), 1)
   assert_eq(error_item_count(cmds), 0)
+}
+
+///|
+test "a steer_applied event echoes the input into the transcript" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let cmds = update(
+    state,
+    AgentProgress(run_id=state.run_id, SteerApplied("make it rhyme")),
+  )
+  guard cmds is [AppendItem(Input(Prompt(text)))] else {
+    fail("expected the steered input echoed as a transcript item")
+  }
+  assert_eq(text, "make it rhyme")
+  // The run keeps going: a steer is not a terminal event.
+  assert_true(state.run is Running(_))
 }
 
 ///|

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -190,6 +190,13 @@ test "Ctrl+C quits when idle and interrupts when a task is running" {
   let cmds = update(state, UiInput(Interrupt))
   assert_true(cmds.iter().any(cmd => cmd is KillEngine))
   assert_eq(quit_count(cmds), 0)
+
+  // Steering a turn that is being cancelled is refused: the text could
+  // outlive the dying turn in the engine's queue and contaminate a later
+  // prompt.
+  let cmds = update(state, UiInput(Steer(Prompt("late idea"))))
+  assert_eq(error_item_count(cmds), 1)
+  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
 }
 
 ///|

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -259,6 +259,14 @@ test "oneshot engines reject steering with the legacy notice" {
   let cmds = update(state, UiInput(Steer(Prompt("b"))))
   assert_eq(error_item_count(cmds), 1)
   assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  // A oneshot engine dies with its turn — its watcher status must not
+  // outlive the run the way serve mode's deliberately does.
+  state.watcher_status = "running"
+  let _ = update(
+    state,
+    AgentProgress(run_id=state.run_id, AgentFinished("done")),
+  )
+  assert_eq(state.watcher_status, "")
 }
 
 ///|

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -77,11 +77,24 @@ async fn[G] EngineClient::start(
     }
     @jsonl.each(reader, json => {
       if @event.decode_event(json) is Some(event) {
-        if is_terminal_event(event) {
-          engine.run_open = false
+        match event {
+          // A wire-level drop races the turn's terminal event by
+          // construction (the engine only rejects steers once idle), so a
+          // run-tagged message would arrive after finish_run and be eaten
+          // by the stale-run guard. Post it untagged so the resubmit notice
+          // always reaches the user.
+          SteerDropped(text) =>
+            self.messages.try_put(SteerDropped(text)) |> ignore
+          _ => {
+            if is_terminal_event(event) {
+              engine.run_open = false
+            }
+            self.messages.try_put(
+              AgentProgress(run_id=engine.latest_run, event),
+            )
+            |> ignore
+          }
         }
-        self.messages.try_put(AgentProgress(run_id=engine.latest_run, event))
-        |> ignore
       }
     }) catch {
       error if @async.is_being_cancelled() ||

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -1,0 +1,191 @@
+///|
+/// A live serve-mode engine process: the stdin command channel and the
+/// process handle for escalation.
+priv struct EngineProcess {
+  writer : @process.WriteToProcess
+  proc : @process.Process
+}
+
+///|
+/// The TUI's connection to one long-lived `--serve` engine process — the
+/// client half of the persistent-engine design.
+///
+/// One engine serves every prompt of a TUI session: prompts, steers, and
+/// cancels are written as JSONL commands to its stdin, and its stdout event
+/// stream feeds the message loop continuously. Turns are strictly
+/// sequential on the wire, so decoded events are stamped with the run id of
+/// the most recently submitted input — by the time a new prompt is written,
+/// the previous turn's terminal event has already been emitted ahead of it
+/// in the stream.
+///
+/// The engine is spawned on first use and respawned on the next prompt
+/// after it dies: the durable session is the source of truth, so a fresh
+/// process resumes the same conversation. Death with a run in flight is
+/// reported into the message loop as that run's failure, with the captured
+/// stderr prefix as the diagnostic.
+priv struct EngineClient {
+  config : AppConfig
+  messages : @async.Queue[Msg]
+  mut live : EngineProcess?
+  mut latest_run : Int
+  // Whether a prompt has been sent whose terminal event has not come back.
+  // Owned here rather than inferred from the stream so an engine that dies
+  // before emitting anything still gets its run reported as failed.
+  mut run_open : Bool
+}
+
+///|
+fn EngineClient::EngineClient(
+  config : AppConfig,
+  messages : @async.Queue[Msg],
+) -> EngineClient {
+  { config, messages, live: None, latest_run: 0, run_open: false }
+}
+
+///|
+/// Spawn the serve-mode engine and its stream readers inside `group`.
+///
+/// The stdout reader runs for the engine's lifetime, decoding events and
+/// stamping them with the current run id; the stderr drain keeps the capped
+/// diagnostics prefix. When stdout ends the engine is gone: the client is
+/// marked dead (so the next prompt respawns) and, if a run was in flight,
+/// its failure is reported with the exit code and stderr.
+async fn[G] EngineClient::start(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+) -> Unit {
+  let (child_stdin, writer) = @process.write_to_process()
+  let (reader, child_stdout) = @process.read_from_process()
+  let (stderr_reader, child_stderr) = @process.read_from_process()
+  let child_env = engine_env(self.config, @env.get_env_vars())
+  let proc = @process.spawn(
+    group,
+    self.config.engine,
+    ["--serve"],
+    inherit_env=false,
+    extra_env=child_env,
+    stdin=child_stdin,
+    stdout=child_stdout,
+    stderr=child_stderr,
+    no_wait=true,
+  )
+  self.live = Some({ writer, proc })
+  group.spawn_bg(no_wait=true) <| () => {
+    let stderr_task = group.spawn(no_wait=true) <| () => {
+      drain_stderr_capped(stderr_reader)
+    }
+    @jsonl.each(reader, json => {
+      if @event.decode_event(json) is Some(event) {
+        if is_terminal_event(event) {
+          self.run_open = false
+        }
+        self.messages.try_put(AgentProgress(run_id=self.latest_run, event))
+        |> ignore
+      }
+    }) catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      // Protocol violation (a non-JSON line is a crash dump): stop reading
+      // and kill the engine so `wait` below returns and reports it.
+      _ => proc.cancel()
+    }
+    reader.close()
+    self.live = None
+    let code = proc.wait()
+    // EOF with a run still open means the engine died mid-turn: close that
+    // run with its only available diagnostics. A terminal event followed by
+    // a clean exit (TUI shutdown, graceful EOF) reports nothing.
+    if self.run_open {
+      let diagnostics = stderr_task.wait().trim()
+      let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
+      self.run_open = false
+      self.messages.put(
+        AgentProgress(
+          run_id=self.latest_run,
+          AgentError("engine exited (code \{code}) without a result\{detail}"),
+        ),
+      )
+    }
+  }
+}
+
+///|
+/// Write one JSONL command line to the engine, starting it first when
+/// needed. A write failure means the engine just died: the client is marked
+/// dead for respawn and the error is reported against `run_id`.
+async fn[G] EngineClient::send(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+  run_id : Int,
+  command : Json,
+) -> Unit {
+  if self.live is None {
+    self.start(group) catch {
+      error => {
+        self.messages.put(AgentFailed(run_id~, error))
+        return
+      }
+    }
+  }
+  guard self.live is Some(live) else {
+    self.messages.put(
+      AgentFailed(run_id~, Failure::Failure("engine is not running")),
+    )
+    return
+  }
+  live.writer.write(command.stringify() + "\n") catch {
+    error => {
+      self.live = None
+      self.messages.put(AgentFailed(run_id~, error))
+    }
+  }
+}
+
+///|
+async fn[G] EngineClient::prompt(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+  run_id : Int,
+  text : String,
+) -> Unit {
+  self.latest_run = run_id
+  self.run_open = true
+  self.send(group, run_id, { "command": "prompt", "text": text })
+}
+
+///|
+async fn[G] EngineClient::steer(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+  text : String,
+) -> Unit {
+  self.send(group, self.latest_run, { "command": "steer", "text": text })
+}
+
+///|
+async fn[G] EngineClient::cancel_turn(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+) -> Unit {
+  self.send(group, self.latest_run, { "command": "cancel" })
+}
+
+///|
+/// Hard escalation: kill the engine process outright. The stdout reader
+/// observes the EOF and reports the in-flight run's failure; the next
+/// prompt respawns a fresh engine on the same durable session.
+fn EngineClient::kill(self : EngineClient) -> Unit {
+  if self.live is Some(live) {
+    live.proc.cancel()
+  }
+}
+
+///|
+/// Graceful shutdown for TUI exit: closing the engine's stdin is the serve
+/// protocol's EOF signal, letting it finish draining and exit 0. Any
+/// straggler is reaped by task-group teardown.
+fn EngineClient::shutdown(self : EngineClient) -> Unit {
+  if self.live is Some(live) {
+    live.writer.close()
+  }
+}

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -113,6 +113,9 @@ async fn[G] EngineClient::start(
         ),
       )
     }
+    // The watchers this engine owned died with it: let the loop reset
+    // engine-scoped status, whatever the exit reason.
+    self.messages.put(EngineExited)
   }
 }
 

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -117,23 +117,16 @@ async fn[G] EngineClient::start(
 }
 
 ///|
-/// Write one JSONL command line to the engine, starting it first when
-/// needed. A write failure means the engine just died: the client is marked
-/// dead for respawn and the error is reported against `run_id`.
-async fn[G] EngineClient::send(
+/// Write one JSONL command line to the live engine. Never spawns one:
+/// `prompt` owns engine startup, while mid-turn controls must not — a steer
+/// reaching a freshly spawned idle engine would become a phantom prompt. A
+/// write failure means the engine just died: the client is marked dead for
+/// respawn and the error is reported against `run_id`.
+async fn EngineClient::send(
   self : EngineClient,
-  group : @async.TaskGroup[G],
   run_id : Int,
   command : Json,
 ) -> Unit {
-  if self.live is None {
-    self.start(group) catch {
-      error => {
-        self.messages.put(AgentFailed(run_id~, error))
-        return
-      }
-    }
-  }
   guard self.live is Some(live) else {
     self.messages.put(
       AgentFailed(run_id~, Failure::Failure("engine is not running")),
@@ -171,32 +164,30 @@ async fn[G] EngineClient::prompt(
   }
   live.latest_run = run_id
   live.run_open = true
-  self.send(group, run_id, { "command": "prompt", "text": text })
+  self.send(run_id, { "command": "prompt", "text": text })
 }
 
 ///|
-async fn[G] EngineClient::steer(
-  self : EngineClient,
-  group : @async.TaskGroup[G],
-  text : String,
-) -> Unit {
-  let run_id = match self.live {
-    Some(live) => live.latest_run
-    None => 0
+/// Steer the running turn, or report the input as undeliverable when there
+/// is no live engine with an open run (e.g. the engine died an instant
+/// before the user pressed Enter). Steering must never spawn an engine: an
+/// idle serve process treats steer as a prompt, which would mutate the
+/// session behind the TUI's back under a run id nobody owns.
+async fn EngineClient::steer(self : EngineClient, text : String) -> Unit {
+  match self.live {
+    Some(live) if live.run_open =>
+      self.send(live.latest_run, { "command": "steer", "text": text })
+    _ => self.messages.put(SteerDropped(text))
   }
-  self.send(group, run_id, { "command": "steer", "text": text })
 }
 
 ///|
-async fn[G] EngineClient::cancel_turn(
-  self : EngineClient,
-  group : @async.TaskGroup[G],
-) -> Unit {
-  let run_id = match self.live {
-    Some(live) => live.latest_run
-    None => 0
+/// Cancel the running turn. With no live engine or open run this is a
+/// silent no-op — the turn the user wanted dead is already gone.
+async fn EngineClient::cancel_turn(self : EngineClient) -> Unit {
+  if self.live is Some(live) && live.run_open {
+    self.send(live.latest_run, { "command": "cancel" })
   }
-  self.send(group, run_id, { "command": "cancel" })
 }
 
 ///|

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -4,6 +4,11 @@
 priv struct EngineProcess {
   writer : @process.WriteToProcess
   proc : @process.Process
+  // Run bookkeeping is owned by the process whose stream produced it: a
+  // reader at EOF must report the run that was open on *its* engine, never
+  // one a respawned successor has since started.
+  mut latest_run : Int
+  mut run_open : Bool
 }
 
 ///|
@@ -27,11 +32,6 @@ priv struct EngineClient {
   config : AppConfig
   messages : @async.Queue[Msg]
   mut live : EngineProcess?
-  mut latest_run : Int
-  // Whether a prompt has been sent whose terminal event has not come back.
-  // Owned here rather than inferred from the stream so an engine that dies
-  // before emitting anything still gets its run reported as failed.
-  mut run_open : Bool
 }
 
 ///|
@@ -39,7 +39,7 @@ fn EngineClient::EngineClient(
   config : AppConfig,
   messages : @async.Queue[Msg],
 ) -> EngineClient {
-  { config, messages, live: None, latest_run: 0, run_open: false }
+  { config, messages, live: None }
 }
 
 ///|
@@ -69,7 +69,8 @@ async fn[G] EngineClient::start(
     stderr=child_stderr,
     no_wait=true,
   )
-  self.live = Some({ writer, proc })
+  let engine : EngineProcess = { writer, proc, latest_run: 0, run_open: false }
+  self.live = Some(engine)
   group.spawn_bg(no_wait=true) <| () => {
     let stderr_task = group.spawn(no_wait=true) <| () => {
       drain_stderr_capped(stderr_reader)
@@ -77,9 +78,9 @@ async fn[G] EngineClient::start(
     @jsonl.each(reader, json => {
       if @event.decode_event(json) is Some(event) {
         if is_terminal_event(event) {
-          self.run_open = false
+          engine.run_open = false
         }
-        self.messages.try_put(AgentProgress(run_id=self.latest_run, event))
+        self.messages.try_put(AgentProgress(run_id=engine.latest_run, event))
         |> ignore
       }
     }) catch {
@@ -90,18 +91,24 @@ async fn[G] EngineClient::start(
       _ => proc.cancel()
     }
     reader.close()
-    self.live = None
+    // A respawn may already have replaced this engine (e.g. after a failed
+    // write); only clear the slot if it is still ours.
+    if self.live is Some(current) && physical_equal(current, engine) {
+      self.live = None
+    }
     let code = proc.wait()
-    // EOF with a run still open means the engine died mid-turn: close that
+    // EOF with a run still open means this engine died mid-turn: close that
     // run with its only available diagnostics. A terminal event followed by
-    // a clean exit (TUI shutdown, graceful EOF) reports nothing.
-    if self.run_open {
+    // a clean exit (TUI shutdown, graceful EOF) reports nothing — and a
+    // successor's runs are out of reach by construction, since this reader
+    // only ever sees its own process's bookkeeping.
+    if engine.run_open {
       let diagnostics = stderr_task.wait().trim()
       let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
-      self.run_open = false
+      engine.run_open = false
       self.messages.put(
         AgentProgress(
-          run_id=self.latest_run,
+          run_id=engine.latest_run,
           AgentError("engine exited (code \{code}) without a result\{detail}"),
         ),
       )
@@ -148,8 +155,22 @@ async fn[G] EngineClient::prompt(
   run_id : Int,
   text : String,
 ) -> Unit {
-  self.latest_run = run_id
-  self.run_open = true
+  if self.live is None {
+    self.start(group) catch {
+      error => {
+        self.messages.put(AgentFailed(run_id~, error))
+        return
+      }
+    }
+  }
+  guard self.live is Some(live) else {
+    self.messages.put(
+      AgentFailed(run_id~, Failure::Failure("engine is not running")),
+    )
+    return
+  }
+  live.latest_run = run_id
+  live.run_open = true
   self.send(group, run_id, { "command": "prompt", "text": text })
 }
 
@@ -159,7 +180,11 @@ async fn[G] EngineClient::steer(
   group : @async.TaskGroup[G],
   text : String,
 ) -> Unit {
-  self.send(group, self.latest_run, { "command": "steer", "text": text })
+  let run_id = match self.live {
+    Some(live) => live.latest_run
+    None => 0
+  }
+  self.send(group, run_id, { "command": "steer", "text": text })
 }
 
 ///|
@@ -167,7 +192,11 @@ async fn[G] EngineClient::cancel_turn(
   self : EngineClient,
   group : @async.TaskGroup[G],
 ) -> Unit {
-  self.send(group, self.latest_run, { "command": "cancel" })
+  let run_id = match self.live {
+    Some(live) => live.latest_run
+    None => 0
+  }
+  self.send(group, run_id, { "command": "cancel" })
 }
 
 ///|

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -15,6 +15,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "reasoning_delta" => Some(ReasoningDelta(@jsonx.string(object, "content")))
     "reasoning_message" =>
       Some(ReasoningMessage(@jsonx.string(object, "content")))
+    "steer_applied" => Some(SteerApplied(@jsonx.string(object, "content")))
     "assistant_message" =>
       Some(AssistantMessage(@jsonx.string(object, "content")))
     "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -16,6 +16,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "reasoning_message" =>
       Some(ReasoningMessage(@jsonx.string(object, "content")))
     "steer_applied" => Some(SteerApplied(@jsonx.string(object, "content")))
+    "steer_dropped" => Some(SteerDropped(@jsonx.string(object, "content")))
     "assistant_message" =>
       Some(AssistantMessage(@jsonx.string(object, "content")))
     "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -58,6 +58,22 @@ test "decode maps each engine event kind" {
 }
 
 ///|
+test "steer wire events decode to their applied and dropped forms" {
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "steer_applied", "content": "go left" }),
+    )
+    is Some(SteerApplied("go left")),
+  )
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "steer_dropped", "content": "too late" }),
+    )
+    is Some(SteerDropped("too late")),
+  )
+}
+
+///|
 test "a failed serve turn decodes to a terminal agent error" {
   assert_true(
     @event.decode_event(

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -38,6 +38,7 @@ pub(all) enum AgentEvent {
   ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(String)
+  SteerDropped(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -37,6 +37,7 @@ pub(all) enum AgentEvent {
   AssistantDelta(String)
   ReasoningDelta(String)
   ReasoningMessage(String)
+  SteerApplied(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -13,6 +13,7 @@ pub(all) enum AgentEvent {
   ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(String)
+  SteerDropped(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -12,6 +12,7 @@ pub(all) enum AgentEvent {
   AssistantDelta(String)
   ReasoningDelta(String)
   ReasoningMessage(String)
+  SteerApplied(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
   Usage(UsageInfo)

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -212,14 +212,16 @@ test "a runtime_update event surfaces as a ↻ tool-style notice" {
   assert_eq(state.watcher_status, "running")
   assert_true(state.run is Running(_))
 
-  // The watcher belongs to the engine process, which exits when the run ends, so
-  // a terminal event must clear the status: no stale `moon_check running` segment
-  // should linger in the status bar while the TUI is idle.
+  // The watcher belongs to the persistent engine, which outlives the turn:
+  // the status survives the terminal event and only clears when the engine
+  // process itself exits.
   let _ = update(
     state,
     AgentProgress(run_id=state.run_id, AgentFinished("done")),
   )
   assert_true(state.run is Idle)
+  assert_eq(state.watcher_status, "running")
+  let _ = update(state, EngineExited)
   assert_eq(state.watcher_status, "")
   assert_eq(watcher_segment_text(state.watcher_status), "")
 }

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -133,6 +133,107 @@ fn engine_env(
 }
 
 ///|
+fn engine_args(task : String) -> Array[String] {
+  ["--", task]
+}
+
+///|
+/// Spawn the agent engine for one input and stream its JSONL stdout into the
+/// message loop.
+///
+/// The engine is a separate process (`config.engine`, default `openseek`): it
+/// runs the task and writes one JSON event per line to stdout. `@jsonl.each`
+/// reads those lines, skips blanks, and parses each as JSON; we map the value to
+/// an `AgentEvent` and forward it as `AgentProgress`. If the engine closes its
+/// stream without a terminal event (it crashed, or exited before answering), we
+/// synthesize an `AgentError` so the loop never hangs waiting for a result that
+/// will not come.
+async fn run_agent_task(
+  config : AppConfig,
+  run_id : Int,
+  task : String,
+  messages : @async.Queue[Msg],
+) -> Unit {
+  @async.with_task_group(group => {
+    let (reader, child_stdout) = @process.read_from_process()
+    let (stderr_reader, child_stderr) = @process.read_from_process()
+    let child_env = engine_env(config, @env.get_env_vars())
+    let proc = @process.spawn(
+      group,
+      config.engine,
+      // The TUI accepts hyphen-valued tasks (`allow_hyphen_values`), so a task
+      // can start with `-`/`--` (e.g. the literal text `--help`). Forward it
+      // after a `--` delimiter so the engine's argparse treats it as the task
+      // positional rather than parsing it as one of its own options (which would
+      // exit/print help and never emit a terminal JSONL event). Session settings
+      // go through a fully materialized environment so custom replay engines do
+      // not need to accept OpenSeek-specific flags, and inherited session vars
+      // cannot shadow explicit TUI config.
+      engine_args(task),
+      inherit_env=false,
+      extra_env=child_env,
+      stdout=child_stdout,
+      stderr=child_stderr,
+    )
+    // Drain the engine's stderr concurrently with stdout. Capturing it (rather
+    // than letting it inherit the terminal) keeps diagnostics from corrupting
+    // the screen `@ui.with_ui` is drawing, and lets us surface them if the
+    // engine dies without a terminal event. The drain is bounded: a misbehaving
+    // engine (crash loop, verbose build log) could write unbounded stderr, so we
+    // keep only a capped prefix in memory while still reading to EOF.
+    // `drain_stderr_capped` folds any read error into its returned text and only
+    // raises on cancellation, which should tear the whole group down — so there
+    // is nothing to swallow here.
+    let stderr_task = group.spawn(no_wait=true) <| () => {
+      drain_stderr_capped(stderr_reader)
+    }
+    let mut saw_terminal = false
+    // A malformed (non-JSON) line raises out of `each`. The only such output is
+    // a runtime crash dump, so rather than surface a parse error we stop reading
+    // and let the exit code below explain the failure. Cancellation is re-raised
+    // to the outer handler so a Ctrl-C still reports `AgentCancelled`.
+    // `each`'s callback is synchronous, so enqueue with `try_put` (the queue
+    // is unbounded, so it never rejects) rather than the async `put`.
+    @jsonl.each(reader, json => {
+      if @event.decode_event(json) is Some(event) {
+        if is_terminal_event(event) {
+          saw_terminal = true
+        }
+        messages.try_put(AgentProgress(run_id~, event)) |> ignore
+      }
+    }) catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      // Protocol violation: stop reading and kill the child instead of waiting
+      // for it. If the engine keeps writing past the bad line, nobody is
+      // draining its stdout, so a plain `proc.wait()` could deadlock on a full
+      // pipe. `cancel()` sends SIGTERM (then SIGKILL) so `wait()` returns.
+      _ => proc.cancel()
+    }
+    // We are done reading; close the read end so the child sees EOF/EPIPE
+    // rather than blocking on a pipe we no longer drain.
+    reader.close()
+    let code = proc.wait()
+    if !saw_terminal {
+      // The engine produced no terminal event. Its stderr is the only clue to
+      // why (a crash, a network/API error), so fold it into the reported error.
+      let diagnostics = stderr_task.wait().trim()
+      let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
+      messages.put(
+        AgentProgress(
+          run_id~,
+          AgentError("engine exited (code \{code}) without a result\{detail}"),
+        ),
+      )
+    }
+  }) catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      messages.put(AgentCancelled(run_id~))
+    error => messages.put(AgentFailed(run_id~, error))
+  }
+}
+
+///|
 /// Run a `!` shell command locally and post its result to the message loop.
 ///
 /// Unlike a prompt, a shell command is the TUI's own responsibility: it runs it
@@ -349,6 +450,16 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
                 ),
               ),
             )
+          } else if state.config.engine_mode is OneShot {
+            // One-shot engines have no command channel into a running
+            // process — the original pre-serve limitation.
+            cmds.push(
+              AppendItem(
+                Error(
+                  "Steering is not supported by a oneshot engine. Press Tab to queue this input.",
+                ),
+              ),
+            )
           } else {
             match input {
               Prompt(text) => cmds.push(SteerAgent(text))
@@ -449,15 +560,26 @@ async fn[G] run_message_loop(
     for cmd in update(state, message) {
       match cmd {
         AppendItem(item) => ui.append_item(item)
-        StartAgent(run_id~, task) => {
-          // An engine turn has no local task. A queued prompt can start in
-          // the same update that finished a `!` command (state never passes
-          // through Idle, so the cleanup below never runs); clear the stale
-          // handle here or the next Ctrl-C would cancel a dead command task
-          // instead of the engine turn.
-          running_task = None
-          engine.prompt(group, run_id, task)
-        }
+        StartAgent(run_id~, task) =>
+          match state.config.engine_mode {
+            Serve => {
+              // An engine turn has no local task. A queued prompt can start
+              // in the same update that finished a `!` command (state never
+              // passes through Idle, so the cleanup below never runs); clear
+              // the stale handle here or the next Ctrl-C would cancel a dead
+              // command task instead of the engine turn.
+              running_task = None
+              engine.prompt(group, run_id, task)
+            }
+            // The escape hatch for engines that only speak the original
+            // protocol: one process per prompt, cancelled like a local task.
+            OneShot =>
+              running_task = Some(
+                group.spawn(no_wait=true) <| () => {
+                  run_agent_task(state.config, run_id, task, messages)
+                },
+              )
+          }
         RunCommand(run_id~, command) =>
           running_task = Some(
             group.spawn(no_wait=true) <| () => {
@@ -467,11 +589,18 @@ async fn[G] run_message_loop(
         SteerAgent(text) => engine.steer(text)
         CancelAgent =>
           match running_task {
-            // A local shell command in flight: cancel its task directly.
+            // A local shell command (or a one-shot engine run) in flight:
+            // cancel its task directly.
             Some(task) => task.cancel()
             None => engine.cancel_turn()
           }
-        KillEngine => engine.kill()
+        KillEngine =>
+          match running_task {
+            // One-shot runs and local commands have no separate process to
+            // escalate to beyond cancelling the task again.
+            Some(task) => task.cancel()
+            None => engine.kill()
+          }
         Quit => {
           // Closing the engine's stdin is the serve protocol's shutdown
           // signal; any straggler is reaped by task-group teardown.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -97,11 +97,6 @@ fn is_terminal_event(event : @event.AgentEvent) -> Bool {
 }
 
 ///|
-fn engine_args(task : String) -> Array[String] {
-  ["--", task]
-}
-
-///|
 fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   {
     "DEEPSEEK": config.api_key,
@@ -124,102 +119,6 @@ fn engine_env(
   let env = inherited.copy()
   env.merge_in_place(engine_extra_env(config))
   env
-}
-
-///|
-/// Spawn the agent engine for one input and stream its JSONL stdout into the
-/// message loop.
-///
-/// The engine is a separate process (`config.engine`, default `openseek`): it
-/// runs the task and writes one JSON event per line to stdout. `@jsonl.each`
-/// reads those lines, skips blanks, and parses each as JSON; we map the value to
-/// an `AgentEvent` and forward it as `AgentProgress`. If the engine closes its
-/// stream without a terminal event (it crashed, or exited before answering), we
-/// synthesize an `AgentError` so the loop never hangs waiting for a result that
-/// will not come.
-async fn run_agent_task(
-  config : AppConfig,
-  run_id : Int,
-  task : String,
-  messages : @async.Queue[Msg],
-) -> Unit {
-  @async.with_task_group(group => {
-    let (reader, child_stdout) = @process.read_from_process()
-    let (stderr_reader, child_stderr) = @process.read_from_process()
-    let child_env = engine_env(config, @env.get_env_vars())
-    let proc = @process.spawn(
-      group,
-      config.engine,
-      // The TUI accepts hyphen-valued tasks (`allow_hyphen_values`), so a task
-      // can start with `-`/`--` (e.g. the literal text `--help`). Forward it
-      // after a `--` delimiter so the engine's argparse treats it as the task
-      // positional rather than parsing it as one of its own options (which would
-      // exit/print help and never emit a terminal JSONL event). Session settings
-      // go through a fully materialized environment so custom replay engines do
-      // not need to accept OpenSeek-specific flags, and inherited session vars
-      // cannot shadow explicit TUI config.
-      engine_args(task),
-      inherit_env=false,
-      extra_env=child_env,
-      stdout=child_stdout,
-      stderr=child_stderr,
-    )
-    // Drain the engine's stderr concurrently with stdout. Capturing it (rather
-    // than letting it inherit the terminal) keeps diagnostics from corrupting
-    // the screen `@ui.with_ui` is drawing, and lets us surface them if the
-    // engine dies without a terminal event. The drain is bounded: a misbehaving
-    // engine (crash loop, verbose build log) could write unbounded stderr, so we
-    // keep only a capped prefix in memory while still reading to EOF.
-    // `drain_stderr_capped` folds any read error into its returned text and only
-    // raises on cancellation, which should tear the whole group down — so there
-    // is nothing to swallow here.
-    let stderr_task = group.spawn(no_wait=true) <| () => {
-      drain_stderr_capped(stderr_reader)
-    }
-    let mut saw_terminal = false
-    // A malformed (non-JSON) line raises out of `each`. The only such output is
-    // a runtime crash dump, so rather than surface a parse error we stop reading
-    // and let the exit code below explain the failure. Cancellation is re-raised
-    // to the outer handler so a Ctrl-C still reports `AgentCancelled`.
-    // `each`'s callback is synchronous, so enqueue with `try_put` (the queue
-    // is unbounded, so it never rejects) rather than the async `put`.
-    @jsonl.each(reader, json => {
-      if @event.decode_event(json) is Some(event) {
-        if is_terminal_event(event) {
-          saw_terminal = true
-        }
-        messages.try_put(AgentProgress(run_id~, event)) |> ignore
-      }
-    }) catch {
-      error if @async.is_being_cancelled() ||
-        @async.is_cancellation_error(error) => raise error
-      // Protocol violation: stop reading and kill the child instead of waiting
-      // for it. If the engine keeps writing past the bad line, nobody is
-      // draining its stdout, so a plain `proc.wait()` could deadlock on a full
-      // pipe. `cancel()` sends SIGTERM (then SIGKILL) so `wait()` returns.
-      _ => proc.cancel()
-    }
-    // We are done reading; close the read end so the child sees EOF/EPIPE
-    // rather than blocking on a pipe we no longer drain.
-    reader.close()
-    let code = proc.wait()
-    if !saw_terminal {
-      // The engine produced no terminal event. Its stderr is the only clue to
-      // why (a crash, a network/API error), so fold it into the reported error.
-      let diagnostics = stderr_task.wait().trim()
-      let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
-      messages.put(
-        AgentProgress(
-          run_id~,
-          AgentError("engine exited (code \{code}) without a result\{detail}"),
-        ),
-      )
-    }
-  }) catch {
-    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
-      messages.put(AgentCancelled(run_id~))
-    error => messages.put(AgentFailed(run_id~, error))
-  }
 }
 
 ///|
@@ -350,6 +249,10 @@ fn handle_agent_event(
         cmds.push(AppendItem(reasoning_item(text)))
       }
     }
+    // A steer took effect at the engine's step boundary: echo the input into
+    // the transcript at its true conversational position, the way the model
+    // actually saw it.
+    SteerApplied(text) => cmds.push(AppendItem(Input(Prompt(text))))
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None
@@ -413,25 +316,31 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
   match message {
     UiInput(event) =>
       match event {
-        // Steering (redirecting a task mid-run) is not implementable with the
-        // current agent API. Steer only submits when idle; while a task runs it
-        // reports an error instead of silently queuing. Queue always queues.
+        // Enter while idle submits; Enter while a task runs steers it — the
+        // text is folded into the running turn at its next step boundary.
+        // Shell commands cannot steer a model turn, so they still queue.
         Steer(input) =>
           if state.run is Idle {
             state.queued.push(input)
           } else {
-            cmds.push(
-              AppendItem(
-                Error(
-                  "Steering is not supported while a task is running. Press Tab to queue this input.",
-                ),
-              ),
-            )
+            match input {
+              Prompt(text) => cmds.push(SteerAgent(text))
+              Command(_) =>
+                cmds.push(
+                  AppendItem(
+                    Error(
+                      "A shell command cannot steer the running task. Press Tab to queue it.",
+                    ),
+                  ),
+                )
+            }
           }
         Queue(input) => state.queued.push(input)
         // Ctrl+C interrupts the running task; when nothing is running it quits
         // the TUI (the common "press Ctrl+C to get out" expectation), rather than
-        // printing a dead-end "nothing to interrupt" notice.
+        // printing a dead-end "nothing to interrupt" notice. A second Ctrl+C
+        // while already interrupting escalates from the polite cancel command
+        // to killing the engine process.
         Interrupt =>
           match state.run {
             Idle => cmds.push(Quit)
@@ -439,7 +348,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
               state.run = Interrupting(started_ms)
               cmds.push(CancelAgent)
             }
-            Interrupting(_) => cmds.push(CancelAgent)
+            Interrupting(_) => cmds.push(KillEngine)
           }
         Quit => cmds.push(Quit)
       }
@@ -484,36 +393,44 @@ async fn[G] run_message_loop(
   group : @async.TaskGroup[G],
   messages : @async.Queue[Msg],
 ) -> Unit {
-  // The task handle for the run currently in flight, used to cancel it on
-  // interrupt. It is set when a run is dispatched and cleared once `state` goes
-  // back to `Idle` below, so it always tracks the active run and a stale event
-  // (dropped by `update`, leaving `state.run` untouched) can never null it out.
+  // The persistent serve-mode engine connection: one process serves every
+  // prompt of this TUI session. Prompts, steers, and cancels are commands on
+  // its stdin; a `!` shell command remains a local task, tracked by
+  // `running_task` so an interrupt can cancel it directly.
+  let engine = EngineClient(state.config, messages)
   let mut running_task : @async.Task[Unit]? = None
   outer~: for ;; {
     let message = messages.get()
     for cmd in update(state, message) {
       match cmd {
         AppendItem(item) => ui.append_item(item)
-        StartAgent(run_id~, task) =>
-          running_task = Some(
-            group.spawn(no_wait=true) <| () => {
-              run_agent_task(state.config, run_id, task, messages)
-            },
-          )
+        StartAgent(run_id~, task) => engine.prompt(group, run_id, task)
         RunCommand(run_id~, command) =>
           running_task = Some(
             group.spawn(no_wait=true) <| () => {
               run_shell_command(run_id, command, messages)
             },
           )
-        CancelAgent => if running_task is Some(task) { task.cancel() }
-        Quit => break outer~
+        SteerAgent(text) => engine.steer(group, text)
+        CancelAgent =>
+          match running_task {
+            // A local shell command in flight: cancel its task directly.
+            Some(task) => task.cancel()
+            None => engine.cancel_turn(group)
+          }
+        KillEngine => engine.kill()
+        Quit => {
+          // Closing the engine's stdin is the serve protocol's shutdown
+          // signal; any straggler is reaped by task-group teardown.
+          engine.shutdown()
+          break outer~
+        }
       }
     }
-    // A terminal event for the active run leaves `state` idle (unless the queue
-    // drain in `update` immediately started the next run, which re-sets the
-    // handle above); drop the stale handle so an interrupt cannot cancel a task
-    // that has already finished.
+    // A terminal event for the active run leaves `state` idle (unless the
+    // queue drain in `update` immediately started the next run); drop the
+    // stale local task handle so an interrupt cannot cancel a command that
+    // already finished.
     if state.run is Idle {
       running_task = None
     }

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -88,6 +88,17 @@ async fn drain_stderr_capped(reader : @process.ReadFromProcess) -> String {
 }
 
 ///|
+/// The transcript item for steering input that never reached a turn —
+/// whether the client dropped it (no live engine) or the engine rejected it
+/// (the steer raced the terminal event through the pipes). Either way the
+/// text must not vanish silently.
+fn steer_dropped_item(text : String) -> @ui.TranscriptItem {
+  Error(
+    "Input was not delivered (the task ended as you sent it) — submit it again: \{text}",
+  )
+}
+
+///|
 fn is_terminal_event(event : @event.AgentEvent) -> Bool {
   match event {
     AgentFinished(_) | AgentAborted(_) | MaxStepsExhausted | AgentError(_) =>
@@ -253,6 +264,9 @@ fn handle_agent_event(
     // the transcript at its true conversational position, the way the model
     // actually saw it.
     SteerApplied(text) => cmds.push(AppendItem(Input(Prompt(text))))
+    // The engine rejected a steer that raced the turn's terminal event
+    // through the pipes — same surfacing as the client-side drop.
+    SteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None
@@ -387,14 +401,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // The steer never reached a turn; the text would otherwise vanish
     // silently. Run state is untouched — the run's own death report (or
     // terminal event) settles it.
-    SteerDropped(text) =>
-      cmds.push(
-        AppendItem(
-          Error(
-            "Input was not delivered (the task ended as you sent it) — submit it again: \{text}",
-          ),
-        ),
-      )
+    SteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
     // No state change: Tick is a 1s heartbeat that just keeps the message loop
     // turning so the trailing refresh_ui re-runs and the elapsed-time activity
     // line ("Working (12s)") keeps advancing during quiet stretches.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -437,7 +437,15 @@ async fn[G] run_message_loop(
     for cmd in update(state, message) {
       match cmd {
         AppendItem(item) => ui.append_item(item)
-        StartAgent(run_id~, task) => engine.prompt(group, run_id, task)
+        StartAgent(run_id~, task) => {
+          // An engine turn has no local task. A queued prompt can start in
+          // the same update that finished a `!` command (state never passes
+          // through Idle, so the cleanup below never runs); clear the stale
+          // handle here or the next Ctrl-C would cancel a dead command task
+          // instead of the engine turn.
+          running_task = None
+          engine.prompt(group, run_id, task)
+        }
         RunCommand(run_id~, command) =>
           running_task = Some(
             group.spawn(no_wait=true) <| () => {

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -322,6 +322,17 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
         Steer(input) =>
           if state.run is Idle {
             state.queued.push(input)
+          } else if state.run_is_command {
+            // The active run is a local shell command: there is no engine
+            // turn to steer, and steering the idle engine would start a
+            // phantom turn behind the command's back.
+            cmds.push(
+              AppendItem(
+                Error(
+                  "A local shell command is running and cannot be steered. Press Tab to queue this input.",
+                ),
+              ),
+            )
           } else {
             match input {
               Prompt(text) => cmds.push(SteerAgent(text))
@@ -348,7 +359,15 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
               state.run = Interrupting(started_ms)
               cmds.push(CancelAgent)
             }
-            Interrupting(_) => cmds.push(KillEngine)
+            Interrupting(_) =>
+              // Escalation only makes sense for an engine turn; a stuck
+              // local shell command has nothing harder than another cancel,
+              // and killing the engine would punish an innocent bystander.
+              if state.run_is_command {
+                cmds.push(CancelAgent)
+              } else {
+                cmds.push(KillEngine)
+              }
           }
         Quit => cmds.push(Quit)
       }
@@ -380,7 +399,10 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     let run_id = state.start_run(@async.now())
     match input {
       Prompt(text) => cmds.push(StartAgent(run_id~, text))
-      Command(command) => cmds.push(RunCommand(run_id~, command))
+      Command(command) => {
+        state.run_is_command = true
+        cmds.push(RunCommand(run_id~, command))
+      }
     }
   }
   cmds

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -439,6 +439,17 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
         Steer(input) =>
           if state.run is Idle {
             state.queued.push(input)
+          } else if state.run is Interrupting(_) {
+            // The turn is being cancelled: a steer sent now could outlive
+            // the dying turn in the engine's queue and contaminate a later
+            // prompt. Refuse rather than race.
+            cmds.push(
+              AppendItem(
+                Error(
+                  "The task is being interrupted and cannot be steered. Press Tab to queue this input.",
+                ),
+              ),
+            )
           } else if state.run_is_command {
             // The active run is a local shell command: there is no engine
             // turn to steer, and steering the idle engine would start a

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -264,8 +264,10 @@ fn handle_agent_event(
     // the transcript at its true conversational position, the way the model
     // actually saw it.
     SteerApplied(text) => cmds.push(AppendItem(Input(Prompt(text))))
-    // The engine rejected a steer that raced the turn's terminal event
-    // through the pipes — same surfacing as the client-side drop.
+    // Normally unreachable from the wire: the engine client routes
+    // steer_dropped events to the untagged message (they always trail the
+    // racing turn's terminal, so a run-tagged copy would be stale-filtered).
+    // Kept as defense in depth for any future in-run emitter.
     SteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
     AssistantMessage(text) => {
       state.step_response = Some(text)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -402,6 +402,9 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // silently. Run state is untouched — the run's own death report (or
     // terminal event) settles it.
     SteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
+    // The engine process is gone, and its watchers with it: an old
+    // `moon_check running` segment would be a lie on the status bar.
+    EngineExited => state.watcher_status = ""
     // No state change: Tick is a 1s heartbeat that just keeps the message loop
     // turning so the trailing refresh_ui re-runs and the elapsed-time activity
     // line ("Working (12s)") keeps advancing during quiet stretches.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -384,6 +384,17 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
       cmds.push(AppendItem(item))
       state.finish_run()
     }
+    // The steer never reached a turn; the text would otherwise vanish
+    // silently. Run state is untouched — the run's own death report (or
+    // terminal event) settles it.
+    SteerDropped(text) =>
+      cmds.push(
+        AppendItem(
+          Error(
+            "Input was not delivered (the task ended as you sent it) — submit it again: \{text}",
+          ),
+        ),
+      )
     // No state change: Tick is a 1s heartbeat that just keeps the message loop
     // turning so the trailing refresh_ui re-runs and the elapsed-time activity
     // line ("Working (12s)") keeps advancing during quiet stretches.
@@ -433,12 +444,12 @@ async fn[G] run_message_loop(
               run_shell_command(run_id, command, messages)
             },
           )
-        SteerAgent(text) => engine.steer(group, text)
+        SteerAgent(text) => engine.steer(text)
         CancelAgent =>
           match running_task {
             // A local shell command in flight: cancel its task directly.
             Some(task) => task.cancel()
-            None => engine.cancel_turn(group)
+            None => engine.cancel_turn()
           }
         KillEngine => engine.kill()
         Quit => {

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -47,6 +47,13 @@ fn cli_command() -> @argparse.Command {
         about="Agent engine binary to spawn; reads its JSONL event stream from stdout.",
       ),
       OptionArg(
+        "engine-mode",
+        long="engine-mode",
+        env="OPENSEEK_ENGINE_MODE",
+        default_values=["serve"],
+        about="Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines).",
+      ),
+      OptionArg(
         "session",
         long="session",
         env="OPENSEEK_SESSION",
@@ -236,6 +243,7 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     },
     session_root: session_root_value,
     engine: value(matches, "engine"),
+    engine_mode: EngineMode::parse(value(matches, "engine-mode")),
   }
 }
 

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -17,6 +17,27 @@ priv struct AppConfig {
   // the `openseek` binary on `PATH`; override (e.g. to a recorded-stream
   // replayer) with `--engine` or `OPENSEEK_ENGINE`.
   engine : String
+  engine_mode : EngineMode
+}
+
+///|
+/// How the TUI talks to its engine. `Serve` (the default) keeps one
+/// persistent `--serve` process per session — warm watchers, steering,
+/// polite cancel. `OneShot` spawns the engine once per prompt with the task
+/// as an argument: the escape hatch for replay or custom engines that only
+/// speak the original protocol; steering is unavailable there.
+priv enum EngineMode {
+  Serve
+  OneShot
+}
+
+///|
+fn EngineMode::parse(input : String) -> EngineMode raise {
+  match input {
+    "serve" => Serve
+    "oneshot" => OneShot
+    other => fail("unknown engine mode: \{other} (use serve or oneshot)")
+  }
 }
 
 ///|

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -97,18 +97,17 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 
 ///|
 /// Reset run tracking after the agent stops (finished, aborted, cancelled, or
-/// failed): no task running, no pending final or streaming response. Also clear
-/// the watcher status: `run_agent_task` spawns a fresh engine per prompt and any
-/// `moon_check --watch` process belongs to that engine's runtime, so it is gone
-/// once the engine exits — leaving `watcher_status` set would keep a stale
-/// `moon_check running` segment in the status bar while the TUI sits idle.
+/// failed): no task running, no pending final or streaming response. The
+/// watcher status survives a turn ending: the persistent engine keeps its
+/// `moon_check --watch` processes alive between prompts, so the segment only
+/// clears when the engine itself exits (`EngineExited`) or a runtime update
+/// reports the watcher stopped.
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
   self.run_is_command = false
   self.step_response = None
   self.streaming_response = None
   self.streaming_reasoning = None
-  self.watcher_status = ""
 }
 
 ///|
@@ -128,6 +127,9 @@ priv enum Msg {
   // A steer had no live turn to land in (the engine died an instant before
   // Enter): surface the lost text so the user can resubmit it.
   SteerDropped(String)
+  // The persistent engine process exited (for any reason): its background
+  // watchers died with it, so engine-scoped status must reset.
+  EngineExited
   Tick
 }
 
@@ -140,7 +142,7 @@ fn Msg::run_id(self : Msg) -> Int? {
     | AgentCancelled(run_id~)
     | AgentFailed(run_id~, _) => Some(run_id)
     CommandResult(run_id~, _) => Some(run_id)
-    UiInput(_) | SteerDropped(_) | Tick => None
+    UiInput(_) | SteerDropped(_) | EngineExited | Tick => None
   }
 }
 

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -118,17 +118,21 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 
 ///|
 /// Reset run tracking after the agent stops (finished, aborted, cancelled, or
-/// failed): no task running, no pending final or streaming response. The
-/// watcher status survives a turn ending: the persistent engine keeps its
-/// `moon_check --watch` processes alive between prompts, so the segment only
-/// clears when the engine itself exits (`EngineExited`) or a runtime update
-/// reports the watcher stopped.
+/// failed): no task running, no pending final or streaming response. In serve
+/// mode the watcher status survives a turn ending — the persistent engine
+/// keeps its `moon_check --watch` processes alive between prompts, so the
+/// segment only clears when the engine itself exits (`EngineExited`) or a
+/// runtime update reports the watcher stopped. A oneshot engine dies with its
+/// turn, and its watchers with it, so there the status clears here as before.
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
   self.run_is_command = false
   self.step_response = None
   self.streaming_response = None
   self.streaming_reasoning = None
+  if self.config.engine_mode is OneShot {
+    self.watcher_status = ""
+  }
 }
 
 ///|

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -142,6 +142,12 @@ priv enum Cmd {
   // task's messages with.
   StartAgent(run_id~ : Int, String)
   RunCommand(run_id~ : Int, String)
+  // Redirect the running turn: the text rides the engine's steer command and
+  // lands at the turn's next step boundary.
+  SteerAgent(String)
   CancelAgent
+  // Second Ctrl-C while already interrupting: the cancel command was not
+  // enough, so kill the engine process outright.
+  KillEngine
   Quit
 }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -125,6 +125,9 @@ priv enum Msg {
   // transcript item to append. Commands run in the TUI and never reach the agent
   // engine.
   CommandResult(run_id~ : Int, @ui.TranscriptItem)
+  // A steer had no live turn to land in (the engine died an instant before
+  // Enter): surface the lost text so the user can resubmit it.
+  SteerDropped(String)
   Tick
 }
 
@@ -137,7 +140,7 @@ fn Msg::run_id(self : Msg) -> Int? {
     | AgentCancelled(run_id~)
     | AgentFailed(run_id~, _) => Some(run_id)
     CommandResult(run_id~, _) => Some(run_id)
-    UiInput(_) | Tick => None
+    UiInput(_) | SteerDropped(_) | Tick => None
   }
 }
 

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -36,6 +36,10 @@ priv struct State {
   // them; a message whose id is not the active run's is stale (it came from a
   // task that has since been superseded) and is dropped. See `State::owns_run`.
   mut run_id : Int
+  // Whether the active run is a local `!` shell command rather than an
+  // engine turn. Steering and interrupt escalation must not touch the
+  // persistent engine while the work in flight is a local task.
+  mut run_is_command : Bool
   // Final assistant text for the current step, used to avoid appending the same
   // answer again when `AgentFinished` follows `AssistantMessage`.
   mut step_response : String?
@@ -61,6 +65,7 @@ fn State::new(config : AppConfig) -> State {
     queued: [],
     run: Idle,
     run_id: 0,
+    run_is_command: false,
     step_response: None,
     streaming_response: None,
     streaming_reasoning: None,
@@ -99,6 +104,7 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 /// `moon_check running` segment in the status bar while the TUI sits idle.
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
+  self.run_is_command = false
   self.step_response = None
   self.streaming_response = None
   self.streaming_reasoning = None

--- a/improvement.md
+++ b/improvement.md
@@ -32,15 +32,21 @@ bottom of the matching section.
 - [ ] **Session switching inside the TUI.** A way to list and switch sessions
   without restarting. Generated ids (`tui-YYYYMMDD-HHMMSS-mmm`) are only
   discoverable via the startup banner or `openseek --session-list` today.
-- [ ] **Steering a running task.** `Steer` while running is rejected ("press
+- [x] **Steering a running task.** `Steer` while running is rejected ("press
   Tab to queue") because the engine cannot accept mid-turn input. Needs an
   engine-side protocol (e.g. a control channel on stdin) before the TUI can
-  offer it.
-- [ ] **Persistent engine per session.** The TUI spawns a fresh engine per
+  offer it. *(Done: Enter while running steers — the text rides the serve
+  protocol's lossless channel, lands at the turn's next step boundary, wins
+  over model-initiated completion, and is echoed into the transcript at the
+  position the model actually saw it.)*
+- [x] **Persistent engine per session.** The TUI spawns a fresh engine per
   prompt, so `moon_check --watch` restarts (and re-warms) every turn and its
   watcher state is lost between prompts. A long-lived engine process per
   session — with prompts delivered over a channel — would keep watchers warm
-  and is also the prerequisite for steering.
+  and is also the prerequisite for steering. *(Done: one `--serve` engine per
+  TUI session — JSONL commands on stdin, shared runtime and tool registry
+  across turns, Ctrl-C cancel → kill escalation, respawn on death from the
+  durable session.)*
 
 ## Engine / agent
 

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -103,6 +103,18 @@ $ printf '{"command":"reboot"}\n{"command":"cancel"}\n' | env DEEPSEEK=test-key 
 "event":"command_error"
 ```
 
+A steer with no turn to land in is rejected rather than converted into a
+prompt: it can only arrive idle by racing a turn's terminal event through
+the pipes, and an engine must never start a turn the controller did not ask
+for. The rejection carries a `steer_dropped` event so the controller can
+ask the user to resubmit — and, usefully for this offline test, no turn
+means no network.
+
+```mooncram
+$ printf '{"command":"steer","text":"too late"}\n' | env DEEPSEEK=test-key openseek.exe --serve 2>/dev/null | grep -o '"event":"steer_dropped"'
+"event":"steer_dropped"
+```
+
 A task positional contradicts serve mode and is rejected before anything
 runs.
 

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -32,6 +32,7 @@ Options:
   --thinking <thinking>                  DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
   --reasoning-effort <reasoning-effort>  DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]
   --engine <engine>                      Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --engine-mode <engine-mode>            Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]
   --session <session>                    Create or resume this durable session id. [env: OPENSEEK_SESSION]
   --session-root <session-root>          Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 ```
@@ -62,6 +63,7 @@ Options:
   --thinking <thinking>                  DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
   --reasoning-effort <reasoning-effort>  DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]
   --engine <engine>                      Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --engine-mode <engine-mode>            Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]
   --session <session>                    Create or resume this durable session id. [env: OPENSEEK_SESSION]
   --session-root <session-root>          Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 


### PR DESCRIPTION
**PR 3 of 3** for the persistent-engine design (PR 1: #85, PR 2: #86 — both merged). Completes the feature and ticks the "persistent engine per session" and "steering a running task" checklist items.

## Change

- **`EngineClient`**: spawns `openseek --serve` on first use and keeps it for the session. Commands ride stdin (`prompt`/`steer`/`cancel`); one long-lived reader decodes the event stream and stamps events with the run id of the most recently submitted input — sound because turns are strictly sequential on the wire (a new prompt is only written after the previous terminal event already precedes it in the stream). A `run_open` flag owned by the client (not inferred from the stream) ensures an engine that dies before emitting anything still fails its run, with the capped stderr prefix as diagnostics. Next prompt respawns from the durable session.
- **Steering UX**: Enter while a task runs steers it (previously a "not supported" error). The transcript echo comes from the engine's `steer_applied` event, so the input appears at the conversational position the model actually saw it. Shell commands can't steer and say so.
- **Ctrl-C ladder**: first press sends the polite `cancel` command (turn dies, engine lives); second press kills the engine process. TUI exit closes the engine's stdin — the serve protocol's graceful EOF.

## Verification (live pty, real API — one TUI session)

- Engine PID **15223 constant** across two prompts, a mid-run steer, and a cancel — one process for everything.
- Turn 2 recalled turn 1's name (`Hongbo`) through the shared engine.
- A steer typed in the composer mid-run was echoed into the transcript at its true position and honored — the answer ended with the steered `PAPAYA`.
- Ctrl-C cancelled the turn (`aborted` in transcript), TUI and engine both survived, and the next prompt answered normally.
- `moon check` 0 warnings, fmt clean, 451/451 tests (steer command dispatch, steer_applied echo, interrupt escalation), 8/8 offline cram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)