### PR TITLE
feat(tui): index workspaces under ~/.openseek, sessions stay in the project

### DIFF
--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -44,6 +44,7 @@ test "append leaves the original session unchanged" {
       #|{
       #|  id: { value: "example" },
       #|  system_prompt: "system",
+      #|  cwd: None,
       #|  events: <Vector: [{ sequence: 1, ts: 0, item: User({ content: "hello" }) }]>,
       #|  last_sequence: 1,
       #|}
@@ -176,6 +177,7 @@ test "summary replaces covered events in model projection only" {
       #|{
       #|  id: { value: "s1" },
       #|  system_prompt: "system",
+      #|  cwd: None,
       #|  events: <Vector:
       #|    [
       #|      { sequence: 1, ts: 0, item: User({ content: "old user" }) },
@@ -292,6 +294,7 @@ test "session JSON round-trips events" {
       #|{
       #|  id: { value: "s1" },
       #|  system_prompt: "system",
+      #|  cwd: None,
       #|  events: <Vector:
       #|    [
       #|      { sequence: 1, ts: 0, item: User({ content: "hello" }) },

--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -44,6 +44,19 @@ fn int_field(
 }
 
 ///|
+fn optional_string_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> String? raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(String(value)) => Some(value)
+    None | Some(Null) => None
+    Some(_) => json_decode_error(path.add_key(key), "expected string")
+  }
+}
+
+///|
 /// Encode a `SessionId` as its raw string value.
 ///
 /// No escaping beyond normal JSON string encoding is applied, and no filesystem
@@ -182,12 +195,18 @@ pub impl FromJson for SessionItem with fn from_json(
 /// complete `events` vector. `last_sequence` is intentionally not stored; it is
 /// recomputed by `Session::Session` from event sequence numbers when decoded.
 pub impl ToJson for Session with fn to_json(session : Session) -> Json {
-  {
-    "version": 1,
-    "id": session.id(),
-    "system_prompt": session.system_prompt(),
+  let fields : Map[String, Json] = {
+    "version": Json::number(1),
+    "id": session.id().to_json(),
+    "system_prompt": Json::string(session.system_prompt()),
     "events": session.events().to_json(),
   }
+  // Absent (not `null`) when unrecorded, so legacy sessions round-trip to the
+  // same shape they were written in.
+  if session.cwd() is Some(cwd) {
+    fields["cwd"] = Json::string(cwd)
+  }
+  Json::object(fields)
 }
 
 ///|
@@ -231,6 +250,7 @@ pub impl FromJson for Session with fn from_json(
   Session(
     id,
     system_prompt=string_field(fields, path, "system_prompt"),
+    cwd?=optional_string_field(fields, path, "cwd"),
     events~,
   )
 }

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -30,11 +30,12 @@ pub fn RuntimeNotice::content(Self) -> String
 pub struct Session {
   // private fields
 } derive(@debug.Debug)
-pub fn Session::Session(SessionId, system_prompt~ : String, events? : @vector.Vector[SessionEvent]) -> Self
+pub fn Session::Session(SessionId, system_prompt~ : String, cwd? : String, events? : @vector.Vector[SessionEvent]) -> Self
 pub fn Session::append(Self, SessionItem, unix_ms? : Int64) -> Self
 pub fn Session::append_event(Self, SessionItem, unix_ms? : Int64) -> (Self, SessionEvent)
 pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
 pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int, unix_ms? : Int64) -> Self raise
+pub fn Session::cwd(Self) -> String?
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -119,6 +119,27 @@ test "session JSON round trips typed events" {
 }
 
 ///|
+test "session JSON round trips the working directory" {
+  let session = @agent_session.Session(
+    SessionId("s1"),
+    system_prompt="system",
+    cwd="/work/project",
+  ).append(User(UserMessage("hello")))
+  assert_true(session.cwd() is Some("/work/project"))
+  let decoded : @agent_session.Session = @json.from_json(session.to_json())
+  assert_true(decoded.cwd() is Some("/work/project"))
+  // A session persisted before directories were recorded has no `cwd` key and
+  // decodes to `None` — and re-encodes without inventing one.
+  let legacy : @agent_session.Session = @json.from_json(
+    @json.parse(
+      "{\"version\":1,\"id\":\"s1\",\"system_prompt\":\"system\",\"events\":[]}",
+    ),
+  )
+  assert_true(legacy.cwd() is None)
+  assert_false(legacy.to_json().stringify().contains("cwd"))
+}
+
+///|
 test "projection closes unresolved historical tool calls" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(Assistant(AssistantMessage("", tool_calls=[sample_tool_call()])))

--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -99,6 +99,7 @@ async test "create and load a complete session" {
       #|{
       #|  id: { value: "demo" },
       #|  system_prompt: "system",
+      #|  cwd: None,
       #|  events: <Vector:
       #|    [
       #|      { sequence: 1, ts: 0, item: User({ content: "hello" }) },

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -25,6 +25,7 @@ pub fn SessionStore::SessionStore(String) -> Self
 pub async fn SessionStore::append(Self, @agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session
 pub async fn SessionStore::compact(Self, @agent_session.Session, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> @agent_session.Session
 pub async fn SessionStore::create(Self, @agent_session.Session) -> Unit
+pub async fn SessionStore::cwd(Self, @agent_session.SessionId) -> String?
 pub fn SessionStore::event_log_file(Self, @agent_session.SessionId) -> String raise
 pub async fn SessionStore::exists(Self, @agent_session.SessionId) -> Bool
 pub fn SessionStore::header_file(Self, @agent_session.SessionId) -> String raise

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -17,6 +17,7 @@ let lock_file_name : String = "session.lock"
 priv struct SessionHeader {
   id : @agent_session.SessionId
   system_prompt : String
+  cwd : String?
   last_sequence : Int
   event_log_length : Int?
   event_log_hash : Int?
@@ -119,15 +120,21 @@ fn session_header_json(
   events_text : String,
   allow_event_log_ahead : Bool,
 ) -> Json {
-  {
-    "version": session_header_version,
-    "id": session.id(),
-    "system_prompt": session.system_prompt(),
-    "last_sequence": session.last_sequence(),
-    "event_log_length": events_text.length(),
-    "event_log_hash": event_log_hash(events_text),
-    "allow_event_log_ahead": allow_event_log_ahead,
+  let fields : Map[String, Json] = {
+    "version": session_header_version.to_json(),
+    "id": session.id().to_json(),
+    "system_prompt": Json::string(session.system_prompt()),
+    "last_sequence": session.last_sequence().to_json(),
+    "event_log_length": events_text.length().to_json(),
+    "event_log_hash": event_log_hash(events_text).to_json(),
+    "allow_event_log_ahead": allow_event_log_ahead.to_json(),
   }
+  // Absent (not `null`) when unrecorded, so legacy headers keep their shape
+  // across rewrites.
+  if session.cwd() is Some(cwd) {
+    fields["cwd"] = Json::string(cwd)
+  }
+  Json::object(fields)
 }
 
 ///|
@@ -178,6 +185,19 @@ fn header_optional_int_field(
 }
 
 ///|
+fn header_optional_string_field(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+  key : String,
+) -> String? raise @json.JsonDecodeError {
+  match fields.get(key) {
+    Some(String(value)) => Some(value)
+    None | Some(Null) => None
+    Some(_) => json_decode_error(path.add_key(key), "expected string")
+  }
+}
+
+///|
 fn header_optional_bool_field(
   fields : Map[String, Json],
   path : @json.JsonPath,
@@ -215,6 +235,7 @@ fn decode_session_header(
   {
     id,
     system_prompt: header_string_field(fields, path, "system_prompt"),
+    cwd: header_optional_string_field(fields, path, "cwd"),
     last_sequence: header_int_field(fields, path, "last_sequence"),
     event_log_length: header_optional_int_field(
       fields, path, "event_log_length",
@@ -347,7 +368,12 @@ fn session_from_replayed_events(
       "session event log tail mismatch: header last sequence \{header.last_sequence}, replayed last sequence \{replayed_last_sequence}",
     )
   }
-  Session(header.id, system_prompt=header.system_prompt, events~)
+  Session(
+    header.id,
+    system_prompt=header.system_prompt,
+    cwd?=header.cwd,
+    events~,
+  )
 }
 
 ///|
@@ -390,7 +416,12 @@ async fn ensure_session_is_current(
     }
     error => raise error
   }
+  // `cwd` is part of the durable state the header carries: a snapshot that
+  // disagrees (say, rebuilt without it) must be rejected here, or the
+  // header rewrite after an append would silently replace the recorded
+  // resume directory.
   if persisted.system_prompt() != session.system_prompt() ||
+    persisted.cwd() != session.cwd() ||
     events_jsonl(persisted.events()) != events_jsonl(session.events()) {
     fail("stale session snapshot for \{session.id().value()}")
   }
@@ -767,6 +798,22 @@ pub async fn SessionStore::create(
     write_header(self, session, false)
     write_event_log(self, session)
     write_header(self, session, true)
+  })
+}
+
+///|
+/// The working directory recorded in the session's header, or `None` for a
+/// session persisted before directories were recorded. Reads only the header:
+/// resolving a resume directory must not replay a long event log. Raises when
+/// the session does not exist or its header cannot be read.
+pub async fn SessionStore::cwd(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String? {
+  with_existing_session_lock(self, id, Shared, () => {
+    let header = read_session_header(self, id)
+    validate_loaded_header(header, id)
+    header.cwd
   })
 }
 

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -100,6 +100,67 @@ async test "store validates invalid ids before creating directories" {
 }
 
 ///|
+async test "store persists the session working directory in the header" {
+  let store = new_store()
+  let session = @agent_session.Session(
+    SessionId("cwd"),
+    system_prompt="system",
+    cwd="/work/project",
+  ).append(User(UserMessage("hello")))
+  store.create(session)
+  assert_true(store.load(SessionId("cwd")).cwd() is Some("/work/project"))
+  // Appending rewrites the header without losing the recorded directory.
+  let appended = store.append(
+    store.load(SessionId("cwd")),
+    Terminal(Finished("done")),
+  )
+  assert_true(appended.cwd() is Some("/work/project"))
+  assert_true(store.load(SessionId("cwd")).cwd() is Some("/work/project"))
+  // The header-only read agrees with the full load without replaying events.
+  assert_true(store.cwd(SessionId("cwd")) is Some("/work/project"))
+  // A header written before directories were recorded loads as `None`.
+  store.create(Session(SessionId("legacy"), system_prompt="system"))
+  assert_true(store.load(SessionId("legacy")).cwd() is None)
+  assert_true(store.cwd(SessionId("legacy")) is None)
+  // A missing session raises rather than masquerading as "no directory".
+  let _ = store.cwd(SessionId("missing")) catch {
+    _ => {
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  fail("missing session yielded a working directory")
+}
+
+///|
+async test "a snapshot disagreeing on cwd is stale, not a silent rewrite" {
+  let store = new_store()
+  let session = @agent_session.Session(
+    SessionId("cwd-guard"),
+    system_prompt="system",
+    cwd="/work/project",
+  ).append(User(UserMessage("hello")))
+  store.create(session)
+  // Same id, prompt, and events — but rebuilt without the recorded
+  // directory. Appending through it must fail closed instead of rewriting
+  // the header with `cwd` dropped.
+  let forgetful = @agent_session.Session(
+    SessionId("cwd-guard"),
+    system_prompt="system",
+    events=session.events(),
+  )
+  let _ = store.append(forgetful, Terminal(Finished("done"))) catch {
+    error => {
+      assert_true("\{error}".contains("stale session snapshot"))
+      assert_true(store.cwd(SessionId("cwd-guard")) is Some("/work/project"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  fail("a cwd-less snapshot rewrote the session header")
+}
+
+///|
 async test "store lists known sessions" {
   let store = new_store()
   assert_eq(store.list().length(), 0)

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -411,6 +411,7 @@ pub fn SessionEvent::unix_ms(self : SessionEvent) -> Int64 {
 pub struct Session {
   priv id : SessionId
   priv system_prompt : String
+  priv cwd : String?
   priv events : @vector.Vector[SessionEvent]
   priv last_sequence : Int
 } derive(Debug)
@@ -419,13 +420,16 @@ pub struct Session {
 /// Build a session from identity, system prompt, and an optional event log.
 ///
 /// `id` is stored exactly as supplied. `system_prompt` becomes the first system
-/// message in `chat_messages` and is not changed by append operations. `events`
-/// is used as-is; this constructor does not check contiguity or sort events.
-/// `last_sequence` is recovered as the highest sequence number present, so the
-/// next append uses `last_sequence + 1`.
+/// message in `chat_messages` and is not changed by append operations. `cwd`
+/// records the working directory the conversation runs in, fixed at creation;
+/// omit it only when loading a session persisted before directories were
+/// recorded. `events` is used as-is; this constructor does not check contiguity
+/// or sort events. `last_sequence` is recovered as the highest sequence number
+/// present, so the next append uses `last_sequence + 1`.
 pub fn Session::Session(
   id : SessionId,
   system_prompt~ : String,
+  cwd? : String,
   events? : @vector.Vector[SessionEvent] = @vector.new(),
 ) -> Session {
   let mut last_sequence = 0
@@ -434,7 +438,7 @@ pub fn Session::Session(
       last_sequence = event.sequence
     }
   }
-  { id, system_prompt, events, last_sequence }
+  { id, system_prompt, cwd, events, last_sequence }
 }
 
 ///|
@@ -447,6 +451,13 @@ pub fn Session::id(self : Session) -> SessionId {
 /// Return the fixed system prompt for this conversation.
 pub fn Session::system_prompt(self : Session) -> String {
   self.system_prompt
+}
+
+///|
+/// The working directory the conversation runs in, fixed at creation, or
+/// `None` for a session persisted before directories were recorded.
+pub fn Session::cwd(self : Session) -> String? {
+  self.cwd
 }
 
 ///|
@@ -505,6 +516,7 @@ pub fn Session::append_event(
     {
       id: self.id,
       system_prompt: self.system_prompt,
+      cwd: self.cwd,
       events: self.events.push(event),
       last_sequence: event.sequence,
     },

--- a/agent_session/workspace/README.md
+++ b/agent_session/workspace/README.md
@@ -1,0 +1,31 @@
+# bobzhang/openseek/agent_session/workspace
+
+Workspace indexing for durable sessions. A *workspace* is a project
+directory; its sessions live in the project's own `.openseek/` — exactly
+where the pre-workspace TUI kept them, so existing stores need no migration —
+while the global OpenSeek home (`~/.openseek`) only indexes which workspaces
+exist, so they can be found again from anywhere.
+
+```text
+<home>/
+  workspaces/
+    <key>/                 # FNV-1a-64 of the canonical project path
+      workspace.json       # { version, path, last_opened_unix }
+      workspace.lock
+
+<project>/
+  .openseek/
+    sessions/...           # an ordinary agent_session/store tree
+```
+
+`WorkspaceHome::open(path, now_unix~)` canonicalizes `path`, claims (or
+revisits) its index entry, and returns the `Workspace` whose `store_root()`
+(`<path>/.openseek`) is passed to `SessionStore`. `workspace.json` carries
+the real path, so the key never needs to be reversible; key collisions are
+kept apart by probing `<key>-1`, `<key>-2`, …. There is no single registry
+file: `WorkspaceHome::listings()` derives "recent workspaces" by scanning
+`workspaces/*/workspace.json`, which is cheap, self-healing, and free of
+write contention.
+
+Only front-ends (the TUI, a future GUI) speak workspace; the engine keeps its
+dumb `--session-root` contract and never resolves workspaces itself.

--- a/agent_session/workspace/moon.pkg
+++ b/agent_session/workspace/moon.pkg
@@ -1,0 +1,19 @@
+import {
+  "moonbitlang/async/fs",
+  "moonbitlang/async/os_error",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/json",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+} for "test"
+
+import {
+  "moonbitlang/async",
+} for "wbtest"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_session/workspace/pkg.generated.mbti
+++ b/agent_session/workspace/pkg.generated.mbti
@@ -1,0 +1,31 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_session/workspace"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct Workspace {
+  // private fields
+} derive(@debug.Debug)
+pub fn Workspace::path(Self) -> String
+pub fn Workspace::store_root(Self) -> String
+
+pub(all) struct WorkspaceHome(String) derive(@debug.Debug)
+pub async fn WorkspaceHome::listings(Self) -> Array[WorkspaceListing]
+pub async fn WorkspaceHome::open(Self, String, now_unix~ : Int64) -> Workspace
+
+type WorkspaceListing derive(@debug.Debug)
+pub fn WorkspaceListing::last_opened_unix(Self) -> Int64
+pub fn WorkspaceListing::path(Self) -> String
+pub fn WorkspaceListing::store_root(Self) -> String
+
+// Type aliases
+
+// Traits
+

--- a/agent_session/workspace/workspace.mbt
+++ b/agent_session/workspace/workspace.mbt
@@ -1,0 +1,273 @@
+///|
+const WorkspacesDirName : String = "workspaces"
+
+///|
+const WorkspaceFileName : String = "workspace.json"
+
+///|
+const WorkspaceLockFileName : String = "workspace.lock"
+
+///|
+const WorkspaceFileVersion : Int = 1
+
+///|
+/// Where a workspace keeps its durable sessions: `.openseek` inside the
+/// project directory.
+const StoreDirName : String = ".openseek"
+
+///|
+/// The global OpenSeek home (`~/.openseek` unless overridden). The home only
+/// *indexes* workspaces — one `workspaces/<key>/workspace.json` per project
+/// directory ever opened — so they can be found again from anywhere; the
+/// sessions themselves stay in each project's `.openseek`, traveling (and
+/// dying) with the project. Constructing a home touches nothing on disk;
+/// index entries appear when the first workspace is opened.
+pub(all) struct WorkspaceHome(String) derive(Debug)
+
+///|
+/// One opened workspace: a project directory, indexed under the OpenSeek
+/// home.
+pub struct Workspace {
+  priv path : String
+} derive(Debug)
+
+///|
+/// The workspace's project directory, canonicalized.
+pub fn Workspace::path(self : Workspace) -> String {
+  self.path
+}
+
+///|
+/// The directory holding this workspace's durable sessions — the root to
+/// open a `SessionStore` at: `.openseek` inside the project, exactly where
+/// the pre-workspace TUI kept them, so existing stores need no migration.
+pub fn Workspace::store_root(self : Workspace) -> String {
+  self.path + "/" + StoreDirName
+}
+
+///|
+fn WorkspaceHome::workspaces_dir(self : WorkspaceHome) -> String {
+  self.0 + "/" + WorkspacesDirName
+}
+
+///|
+/// FNV-1a-64 of the canonical workspace path, as 16 hex chars. The key only
+/// needs to be stable and filesystem-safe — `workspace.json` carries the real
+/// path, and `open` probes past collisions — but stable means stable across
+/// releases: the key names directories on disk, and changing the function
+/// would orphan every existing workspace. Hence a fixed local hash instead of
+/// `Hash::hash`, whose algorithm the core library is free to change.
+fn workspace_key(path : String) -> String {
+  let mut hash : UInt64 = 0xcbf29ce484222325
+  for byte in @utf8.encode(path) {
+    hash = (hash ^ byte.to_uint64()) * 0x100000001b3
+  }
+  let hex = hash.to_string(radix=16)
+  "0".repeat(16 - hex.length()) + hex
+}
+
+///|
+priv struct WorkspaceFile {
+  path : String
+  last_opened_unix : Int64
+}
+
+///|
+fn workspace_file_json(path : String, last_opened_unix : Int64) -> Json {
+  Json::object({
+    "version": WorkspaceFileVersion.to_json(),
+    "path": Json::string(path),
+    // Unix seconds fit a double exactly; `Json::number` keeps the field an
+    // ordinary JSON number instead of Int64's string encoding.
+    "last_opened_unix": Json::number(last_opened_unix.to_double()),
+  })
+}
+
+///|
+fn decode_workspace_file(
+  json : Json,
+  json_path : @json.JsonPath,
+) -> WorkspaceFile raise @json.JsonDecodeError {
+  let fields = match json {
+    Object(fields) => fields
+    _ => raise JsonDecodeError((json_path, "expected workspace object"))
+  }
+  match fields.get("version") {
+    Some(Number(version, ..)) =>
+      if version.to_int() != WorkspaceFileVersion {
+        raise JsonDecodeError(
+          (
+            json_path.add_key("version"),
+            "unsupported workspace version: \{version.to_int()}",
+          ),
+        )
+      }
+    _ => raise JsonDecodeError((json_path.add_key("version"), "expected int"))
+  }
+  let path = match fields.get("path") {
+    Some(String(path)) => path
+    _ => raise JsonDecodeError((json_path.add_key("path"), "expected string"))
+  }
+  let last_opened_unix = match fields.get("last_opened_unix") {
+    Some(Number(value, ..)) => value.to_int64()
+    _ =>
+      raise JsonDecodeError(
+        (json_path.add_key("last_opened_unix"), "expected int"),
+      )
+  }
+  { path, last_opened_unix }
+}
+
+///|
+impl @json.FromJson for WorkspaceFile with fn from_json(
+  json : Json,
+  json_path : @json.JsonPath,
+) -> WorkspaceFile {
+  decode_workspace_file(json, json_path)
+}
+
+///|
+fn decode_workspace_text(text : String) -> WorkspaceFile raise {
+  @json.from_json(@json.parse(text))
+}
+
+///|
+/// The raw `workspace.json` under `dir`, or `None` when absent.
+async fn read_workspace_text(dir : String) -> String? {
+  Some(@fs.read_file(dir + "/" + WorkspaceFileName).text()) catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => None
+    error => raise error
+  }
+}
+
+///|
+async fn write_workspace_file(
+  dir : String,
+  path : String,
+  last_opened_unix : Int64,
+) -> Unit {
+  let file_path = dir + "/" + WorkspaceFileName
+  let tmp_path = file_path + ".tmp"
+  @fs.write_file(
+    tmp_path,
+    workspace_file_json(path, last_opened_unix).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  @fs.rename(tmp_path, file_path, replace=true)
+}
+
+///|
+async fn ensure_dir(dir : String) -> Unit {
+  @fs.mkdir(dir, recursive=true) catch {
+    // Already present — whether from an earlier open or a concurrent one —
+    // is exactly the state this function ensures.
+    @os_error.OSError(_) as error if error.is_EEXIST() => ()
+    error => raise error
+  }
+}
+
+///|
+async fn[T] with_workspace_lock(dir : String, body : async () -> T) -> T {
+  let file = @fs.open(
+    dir + "/" + WorkspaceLockFileName,
+    mode=ReadWrite,
+    create_mode=OpenOrCreate,
+  )
+  defer file.close()
+  file.lock(Exclusive)
+  defer file.unlock()
+  body()
+}
+
+///|
+/// Open the workspace for the project directory at `path`, indexing it under
+/// the home on first open and bumping its last-opened stamp otherwise.
+/// `path` must name an existing directory and is canonicalized (symlinks
+/// resolved), so every spelling of a directory opens the same workspace.
+/// Distinct directories whose keys collide are kept apart by probing
+/// `<key>-1`, `<key>-2`, … until the stored path matches or a free slot
+/// claims the new entry. A `workspace.json` that exists but cannot be
+/// decoded raises rather than being silently reclaimed: the slot belongs to
+/// a workspace this function can no longer identify.
+pub async fn WorkspaceHome::open(
+  self : WorkspaceHome,
+  path : String,
+  now_unix~ : Int64,
+) -> Workspace {
+  let canonical = @fs.realpath(path)
+  let key = workspace_key(canonical)
+  let mut probe = 0
+  for ;; {
+    let dir = if probe == 0 {
+      self.workspaces_dir() + "/" + key
+    } else {
+      self.workspaces_dir() + "/" + key + "-\{probe}"
+    }
+    ensure_dir(dir)
+    let claimed = with_workspace_lock(dir, () => {
+      if read_workspace_text(dir) is Some(text) &&
+        decode_workspace_text(text).path != canonical {
+        // Another workspace's slot (key collision): probe the next one.
+        false
+      } else {
+        write_workspace_file(dir, canonical, now_unix)
+        true
+      }
+    })
+    if claimed {
+      return { path: canonical }
+    }
+    probe += 1
+  }
+}
+
+///|
+/// One row of a workspace listing: the project path plus when it was last
+/// opened.
+struct WorkspaceListing {
+  path : String
+  last_opened_unix : Int64
+} derive(Debug)
+
+///|
+/// The listed workspace's project directory.
+pub fn WorkspaceListing::path(self : WorkspaceListing) -> String {
+  self.path
+}
+
+///|
+/// The directory holding the listed workspace's durable sessions — see
+/// `Workspace::store_root`.
+pub fn WorkspaceListing::store_root(self : WorkspaceListing) -> String {
+  self.path + "/" + StoreDirName
+}
+
+///|
+/// When the listed workspace was last opened, unix seconds.
+pub fn WorkspaceListing::last_opened_unix(self : WorkspaceListing) -> Int64 {
+  self.last_opened_unix
+}
+
+///|
+/// Known workspaces, most recently opened first. Derived by scanning
+/// `workspaces/*/workspace.json` — there is no single registry file to
+/// maintain (or corrupt), and a deleted index entry simply disappears from
+/// the listing. An entry whose `workspace.json` is missing or undecodable is
+/// skipped: without it there is no path to show.
+pub async fn WorkspaceHome::listings(
+  self : WorkspaceHome,
+) -> Array[WorkspaceListing] {
+  let names = @fs.readdir(self.workspaces_dir(), sort=true) catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => []
+    error => raise error
+  }
+  let listings : Array[WorkspaceListing] = []
+  for name in names {
+    let dir = self.workspaces_dir() + "/" + name
+    guard read_workspace_text(dir) is Some(text) else { continue }
+    let file = decode_workspace_text(text) catch { _ => continue }
+    listings.push({ path: file.path, last_opened_unix: file.last_opened_unix })
+  }
+  listings.sort_by((a, b) => b.last_opened_unix.compare(a.last_opened_unix))
+  listings
+}

--- a/agent_session/workspace/workspace_test.mbt
+++ b/agent_session/workspace/workspace_test.mbt
@@ -1,0 +1,61 @@
+///|
+async test "opening a directory creates its workspace and reopening reuses it" {
+  let home_root = @fs.tmpdir(prefix="openseek-workspace-home-")
+  let project = @fs.tmpdir(prefix="openseek-workspace-project-")
+  let home = @workspace.WorkspaceHome(home_root)
+  let first = home.open(project, now_unix=100)
+  assert_eq(first.path(), @fs.realpath(project))
+  // Sessions stay with the project; the home only indexes the workspace.
+  assert_eq(first.store_root(), first.path() + "/.openseek")
+  let again = home.open(project, now_unix=200)
+  assert_eq(again.store_root(), first.store_root())
+  assert_eq(again.path(), first.path())
+  let listings = home.listings()
+  assert_eq(listings.length(), 1)
+  assert_eq(listings[0].path(), first.path())
+  assert_eq(listings[0].store_root(), first.store_root())
+  // Reopening bumped the stamp.
+  assert_eq(listings[0].last_opened_unix(), 200)
+  @fs.rmdir(home_root, recursive=true)
+  @fs.rmdir(project, recursive=true)
+}
+
+///|
+async test "distinct directories get distinct stores, listed most recent first" {
+  let home_root = @fs.tmpdir(prefix="openseek-workspace-home-")
+  let older = @fs.tmpdir(prefix="openseek-workspace-older-")
+  let newer = @fs.tmpdir(prefix="openseek-workspace-newer-")
+  let home = @workspace.WorkspaceHome(home_root)
+  let older_workspace = home.open(older, now_unix=100)
+  let newer_workspace = home.open(newer, now_unix=200)
+  assert_true(older_workspace.store_root() != newer_workspace.store_root())
+  let listings = home.listings()
+  assert_eq(listings.length(), 2)
+  assert_eq(listings[0].path(), newer_workspace.path())
+  assert_eq(listings[1].path(), older_workspace.path())
+  @fs.rmdir(home_root, recursive=true)
+  @fs.rmdir(older, recursive=true)
+  @fs.rmdir(newer, recursive=true)
+}
+
+///|
+async test "a home that was never opened lists no workspaces" {
+  let home_root = @fs.tmpdir(prefix="openseek-workspace-home-")
+  // The `workspaces/` tree does not exist yet; listing treats that as empty.
+  assert_true(@workspace.WorkspaceHome(home_root).listings().is_empty())
+  @fs.rmdir(home_root, recursive=true)
+}
+
+///|
+async test "opening a missing directory raises" {
+  let home_root = @fs.tmpdir(prefix="openseek-workspace-home-")
+  let gone = @fs.tmpdir(prefix="openseek-workspace-gone-")
+  @fs.rmdir(gone, recursive=true)
+  let _ = @workspace.WorkspaceHome(home_root).open(gone, now_unix=100) catch {
+    _ => {
+      @fs.rmdir(home_root, recursive=true)
+      return
+    }
+  }
+  fail("opening a missing directory succeeded")
+}

--- a/agent_session/workspace/workspace_wbtest.mbt
+++ b/agent_session/workspace/workspace_wbtest.mbt
@@ -1,0 +1,64 @@
+///|
+async test "colliding keys probe to the next slot" {
+  let home_root = @fs.tmpdir(prefix="openseek-workspace-home-")
+  let project = @fs.tmpdir(prefix="openseek-workspace-project-")
+  let canonical = @fs.realpath(project)
+  // Pre-claim the project's slot for a different path, simulating a key
+  // collision.
+  let taken = home_root +
+    "/" +
+    WorkspacesDirName +
+    "/" +
+    workspace_key(canonical)
+  ensure_dir(taken)
+  write_workspace_file(taken, "/somewhere/else", 50)
+  let home = WorkspaceHome(home_root)
+  let workspace = home.open(project, now_unix=100)
+  assert_eq(workspace.path(), canonical)
+  // The project landed in the probed slot, leaving the claimed one intact.
+  guard read_workspace_text(taken + "-1") is Some(text) else {
+    fail("expected the probed slot to be claimed")
+  }
+  assert_eq(decode_workspace_text(text).path, canonical)
+  let listings = home.listings()
+  assert_eq(listings.length(), 2)
+  assert_eq(listings[0].path(), canonical)
+  assert_eq(listings[1].path(), "/somewhere/else")
+  // Reopening keeps landing on the probed slot.
+  let _ = home.open(project, now_unix=200)
+  guard read_workspace_text(taken + "-1") is Some(text) else {
+    fail("expected the probed slot to be claimed")
+  }
+  assert_eq(decode_workspace_text(text).last_opened_unix, 200)
+  @fs.rmdir(home_root, recursive=true)
+  @fs.rmdir(project, recursive=true)
+}
+
+///|
+async test "a corrupt workspace file fails open and is skipped by listings" {
+  let home_root = @fs.tmpdir(prefix="openseek-workspace-home-")
+  let project = @fs.tmpdir(prefix="openseek-workspace-project-")
+  let home = WorkspaceHome(home_root)
+  let _ = home.open(project, now_unix=100)
+  let entry = home_root +
+    "/" +
+    WorkspacesDirName +
+    "/" +
+    workspace_key(@fs.realpath(project))
+  @fs.write_file(
+    entry + "/" + WorkspaceFileName,
+    "not json",
+    create_mode=CreateOrTruncate,
+  )
+  // Opening must not silently reclaim a slot it can no longer identify.
+  let _ = home.open(project, now_unix=200) catch {
+    _ => {
+      // A listing has no path to show for the slot, so it is skipped.
+      assert_true(home.listings().is_empty())
+      @fs.rmdir(home_root, recursive=true)
+      @fs.rmdir(project, recursive=true)
+      return
+    }
+  }
+  fail("a corrupt workspace file was silently reclaimed")
+}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -623,6 +623,30 @@ fn required_session_id(
 }
 
 ///|
+/// A fresh durable session, recording the engine's working directory so a
+/// later resume can re-root the conversation where it started.
+async fn new_session(
+  id : @agent_session.SessionId,
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+  workspace_root~ : String,
+) -> @agent_session.Session {
+  let cwd = if workspace_root == "." || workspace_root == "" {
+    match @env.current_dir() {
+      Some(cwd) => cwd
+      None => "."
+    }
+  } else {
+    workspace_root
+  }
+  Session(
+    id,
+    system_prompt=configured_system_prompt(matches, model, workspace_root~),
+    cwd~,
+  )
+}
+
+///|
 async fn load_or_new_session(
   store : @store.SessionStore,
   id : @agent_session.SessionId,
@@ -633,21 +657,11 @@ async fn load_or_new_session(
   if store.exists(id) {
     store.load(id) catch {
       @os_error.OSError(_) as error if error.is_ENOENT() =>
-        Session(
-          id,
-          system_prompt=configured_system_prompt(
-            matches,
-            model,
-            workspace_root~,
-          ),
-        )
+        new_session(id, matches, model, workspace_root~)
       error => raise error
     }
   } else {
-    Session(
-      id,
-      system_prompt=configured_system_prompt(matches, model, workspace_root~),
-    )
+    new_session(id, matches, model, workspace_root~)
   }
 }
 
@@ -1221,6 +1235,8 @@ async test "load_or_new_session defers first durable write until append" {
   let grounded_prompt = "system\n\n\{environment_prompt_section()}"
   assert_eq(created.system_prompt(), grounded_prompt)
   assert_eq(created.events().length(), 0)
+  // A fresh session records the engine's working directory for later resumes.
+  assert_true(created.cwd() == @env.current_dir())
   assert_false(store.exists(id))
   let with_event = store.append(created, User(UserMessage("hello")))
   assert_eq(with_event.events().length(), 1)
@@ -1228,6 +1244,7 @@ async test "load_or_new_session defers first durable write until append" {
   let loaded = load_or_new_session(store, id, parsed, V4Pro)
   assert_eq(loaded.system_prompt(), grounded_prompt)
   assert_eq(loaded.events().length(), 1)
+  assert_true(loaded.cwd() == @env.current_dir())
   @fs.rmdir(root, recursive=true)
 }
 

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -17,18 +17,29 @@ A custom or recorded-stream engine that only speaks the original
 one-process-per-prompt protocol still works with `--engine-mode oneshot`
 (env `OPENSEEK_ENGINE_MODE`); steering is unavailable there.
 
-## Sessions
+## Workspaces and sessions
+
+Launching the TUI in a directory opens that directory's *workspace*, the way
+`code .` does. A workspace's sessions live in the project's own `.openseek/`
+— they travel (and die) with the project — while the global OpenSeek home at
+`~/.openseek` (override with `OPENSEEK_HOME`) only *indexes* which workspaces
+exist, so conversations are found again from anywhere, not only from the
+directory that created them. To open another project's workspace, launch the
+TUI there; `--workspace-list` prints known workspaces, most recently opened
+first.
 
 Every launch converses in a durable session — the engine only carries context
 between prompts through the session store, so without one each prompt would be
 an amnesiac one-shot. A generated id (`tui-YYYYMMDD-HHMMSS-mmm`, named in the
-startup banner) stores the conversation under `--session-root` (default
-`.openseek/`).
+startup banner) stores the conversation in the workspace's store.
 
-- `--continue` resumes the most recently active session.
+- `--continue` resumes the workspace's most recently active session.
 - `--session <id>` resumes (or creates) a specific one; combining it with
   `--continue` is rejected.
-- `openseek --session-list` (on the engine CLI) lists what is resumable.
+- `openseek --session-list --session-root <store>` (on the engine CLI) lists
+  what is resumable.
+- `--session-root <dir>` bypasses the workspace layer entirely and uses the
+  given store as-is (nothing is indexed under the home).
 
 ## Configuration
 

--- a/cmd/tui/continue_wbtest.mbt
+++ b/cmd/tui/continue_wbtest.mbt
@@ -10,7 +10,9 @@ async test "--continue resolves the most recently active session" {
     argv=["--continue", "--session-root", root],
     env={ "DEEPSEEK": "test-key" },
   )
-  let config = with_latest_session(parse_config(parsed))
+  let config = with_latest_session(
+    parse_config(parsed, cwd=launch_cwd(), session_root=root),
+  )
   assert_eq(config.session_id.value(), "newer")
   // An empty store keeps the generated fresh session: nothing to continue,
   // so the TUI starts a new conversation instead of refusing to launch.
@@ -19,7 +21,9 @@ async test "--continue resolves the most recently active session" {
     argv=["--continue", "--session-root", empty_root],
     env={ "DEEPSEEK": "test-key" },
   )
-  let fresh = with_latest_session(parse_config(parsed))
+  let fresh = with_latest_session(
+    parse_config(parsed, cwd=launch_cwd(), session_root=empty_root),
+  )
   assert_true(fresh.session_id.value().has_prefix("tui-"))
   @fs.rmdir(root, recursive=true)
   @fs.rmdir(empty_root, recursive=true)

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -64,6 +64,9 @@ async fn[G] EngineClient::start(
     ["--serve"],
     inherit_env=false,
     extra_env=child_env,
+    // The conversation's directory, not the TUI's: a resumed session runs
+    // where it was created (see `with_session_cwd`).
+    cwd=self.config.cwd,
     stdin=child_stdin,
     stdout=child_stdout,
     stderr=child_stderr,

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -23,7 +23,7 @@ async test "a shell command runs locally and posts its output" {
   let messages = @async.Queue(kind=Unbounded)
   // `echo` is the same on POSIX `sh` and Windows `pwsh`, so the platform shell
   // `@shell.collect_shell_output` picks runs this on either.
-  run_shell_command(1, "echo hello", messages)
+  run_shell_command(1, "echo hello", cwd=".", messages)
   // The only message is the local command result: a completed tool item titled
   // with the command, its stdout as a dimmed detail line. Nothing is sent to the
   // engine.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -186,6 +186,9 @@ async fn run_agent_task(
       engine_args(task),
       inherit_env=false,
       extra_env=child_env,
+      // The conversation's directory, not the TUI's: a resumed session runs
+      // where it was created (see `with_session_cwd`).
+      cwd=config.cwd,
       stdout=child_stdout,
       stderr=child_stderr,
     )
@@ -259,11 +262,12 @@ async fn run_agent_task(
 async fn run_shell_command(
   run_id : Int,
   command : String,
+  cwd~ : String,
   messages : @async.Queue[Msg],
 ) -> Unit {
   let item : @ui.TranscriptItem = command_item(
     command,
-    @shell.collect_shell_output(command),
+    @shell.collect_shell_output(command, cwd~),
   ) catch {
     error if @async.is_being_cancelled() || @async.is_cancellation_error(error) => {
       messages.put(AgentCancelled(run_id~))
@@ -634,7 +638,7 @@ async fn[G] run_message_loop(
         RunCommand(run_id~, command) =>
           running_task = Some(
             group.spawn(no_wait=true) <| () => {
-              run_shell_command(run_id, command, messages)
+              run_shell_command(run_id, command, cwd=state.config.cwd, messages)
             },
           )
         SteerAgent(text) => engine.steer(text)

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -167,8 +167,24 @@ async fn with_session_cwd(config : AppConfig) -> AppConfig {
     error if @async.is_being_cancelled() => raise error
     _ => return config
   }
-  if stored is Some(cwd) && within_directory(cwd, config.cwd) && @fs.exists(cwd) {
-    { ..config, cwd, }
+  if stored is Some(cwd) {
+    let workspace = @fs.realpath(config.cwd) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => return config
+    }
+    let cwd = @fs.realpath(cwd) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => return config
+    }
+    let kind = @fs.kind(cwd) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => return config
+    }
+    if within_directory(cwd, workspace) && kind == Directory {
+      { ..config, cwd, }
+    } else {
+      config
+    }
   } else {
     config
   }

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -63,15 +63,19 @@ fn cli_command() -> @argparse.Command {
         "session-root",
         long="session-root",
         env="OPENSEEK_SESSION_ROOT",
-        default_values=[".openseek"],
-        about="Directory containing durable OpenSeek sessions.",
+        about="Directory containing durable OpenSeek sessions; bypasses the workspace store.",
       ),
     ],
     flags=[
       FlagArg(
         "continue",
         long="continue",
-        about="Resume the most recently active session in --session-root.",
+        about="Resume this workspace's most recently active session.",
+      ),
+      FlagArg(
+        "workspace-list",
+        long="workspace-list",
+        about="List known workspaces, most recently opened first, then exit.",
       ),
     ],
     positionals=[
@@ -112,9 +116,61 @@ fn continue_requested(matches : @argparse.Matches) -> Bool raise {
 /// empty store the generated fresh session stands: there is nothing to
 /// continue, and starting a new conversation beats refusing to launch.
 async fn with_latest_session(config : AppConfig) -> AppConfig {
-  match @store.SessionStore(config.session_root).latest() {
-    Some(id) => { ..config, session_id: id }
-    None => config
+  if @store.SessionStore(config.session_root).latest() is Some(id) {
+    { ..config, session_id: id }
+  } else {
+    config
+  }
+}
+
+///|
+/// The user's home directory: `HOME`, or `USERPROFILE` where `HOME` is unset
+/// (Windows).
+fn home_dir() -> String? {
+  if @env.get_env_var("HOME") is Some(home) && !home.trim().is_empty() {
+    Some(home)
+  } else {
+    @env.get_env_var("USERPROFILE")
+  }
+}
+
+///|
+/// Whether `dir` is `root` itself or a subdirectory of it. A plain prefix is
+/// not enough: `/work/project2` starts with `/work/project` without being
+/// inside it, so the prefix must end exactly at a separator.
+fn within_directory(dir : String, root : String) -> Bool {
+  dir == root ||
+  (
+    dir.has_prefix(root) &&
+    dir.view(start_offset=root.length()) is ['/' | '\\', ..]
+  )
+}
+
+///|
+/// Re-root a resumed conversation in its recorded working directory. The
+/// recorded directory is a refinement *within* the workspace: a session
+/// recorded in a subdirectory resumes there, but one pointing outside
+/// `config.cwd` is ignored — sessions travel with the project, so when a
+/// project is copied or moved (with the old path still existing), or a
+/// session was written into this store from elsewhere via `--session-root`,
+/// resuming must run in the workspace being opened, not in the unrelated
+/// directory the header remembers. Sessions persisted before directories
+/// were recorded — or whose directory has since vanished — also keep
+/// `config.cwd`, the workspace path (or the launch directory when
+/// `--session-root` bypasses the workspace store).
+async fn with_session_cwd(config : AppConfig) -> AppConfig {
+  // A missing or unreadable session keeps the configured directory rather
+  // than failing the launch: `append_session_history` inspects the same
+  // session right after the UI starts and reports its errors in the
+  // transcript, so swallowing here hides nothing.
+  let stored = @store.SessionStore(config.session_root).cwd(config.session_id) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return config
+  }
+  if stored is Some(cwd) && within_directory(cwd, config.cwd) && @fs.exists(cwd) {
+    { ..config, cwd, }
+  } else {
+    config
   }
 }
 
@@ -170,12 +226,110 @@ fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? {
 }
 
 ///|
-fn session_root(matches : @argparse.Matches) -> String raise {
-  let root = value(matches, "session-root").trim().to_owned()
+/// The explicit `--session-root`, or `None` to use the workspace store.
+fn explicit_session_root(matches : @argparse.Matches) -> String? raise {
+  guard values(matches, "session-root") is [root, ..] else { return None }
+  let root = root.trim().to_owned()
   if root.is_empty() {
     fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
   }
-  root
+  Some(root)
+}
+
+///|
+/// The OpenSeek home indexing known workspaces: `OPENSEEK_HOME`, else
+/// `.openseek` under the home directory.
+fn openseek_home() -> String raise {
+  if @env.get_env_var("OPENSEEK_HOME") is Some(home) && !home.trim().is_empty() {
+    return home
+  }
+  guard home_dir() is Some(home) else {
+    fail(
+      "cannot locate the OpenSeek home: set OPENSEEK_HOME, HOME, or USERPROFILE",
+    )
+  }
+  home + "/.openseek"
+}
+
+///|
+fn launch_cwd() -> String {
+  match @env.current_dir() {
+    Some(cwd) => cwd
+    None => "."
+  }
+}
+
+///|
+/// Resolve where this launch stores sessions and build the launch config.
+/// The launch directory is the workspace, `code .` style: its sessions live
+/// in `./.openseek` (canonicalized to an absolute root), and opening it
+/// indexes the workspace under `home` for `--workspace-list`. An explicit
+/// `--session-root` bypasses the workspace layer — the given store is used
+/// as-is and nothing is indexed — with relative roots pinned to the launch
+/// directory.
+async fn launch_config(
+  matches : @argparse.Matches,
+  home~ : String,
+) -> AppConfig {
+  let cwd = launch_cwd()
+  if explicit_session_root(matches) is Some(root) {
+    parse_config(matches, cwd~, session_root=absolute_session_root(root, cwd))
+  } else {
+    let workspace = @workspace.WorkspaceHome(home).open(
+      cwd,
+      now_unix=@env.now().reinterpret_as_int64() / 1000,
+    )
+    parse_config(
+      matches,
+      cwd=workspace.path(),
+      session_root=workspace.store_root(),
+    )
+  }
+}
+
+///|
+/// Whether `path` names a fixed location on any supported platform: a POSIX
+/// root, a UNC `\\server` path, a Windows rooted `\dir`, or a drive-qualified
+/// `C:/` / `C:\` path. Deliberately broader than `@path.Path::is_absolute`,
+/// whose win32 semantics call a drive-relative `/tmp` not absolute — a root
+/// the user wrote as rooted must pass through verbatim on every platform,
+/// never be re-anchored under the launch directory.
+fn is_rooted_path(path : String) -> Bool {
+  path.has_prefix("/") ||
+  path.has_prefix("\\") ||
+  path is [_, ':', '/' | '\\', ..]
+}
+
+///|
+/// Pin a relative session root to the launch directory. The engine is
+/// spawned in the conversation's directory, which `with_session_cwd` may
+/// re-root away from the launch directory; a relative `--session-root`
+/// passed along as-is would then resolve inside that other directory —
+/// a different store entirely — and the next turn would silently start a
+/// same-named session there instead of continuing this one.
+fn absolute_session_root(root : String, cwd : String) -> String {
+  if is_rooted_path(root) {
+    root
+  } else {
+    @path.Path(cwd).join(Path(root)).0
+  }
+}
+
+///|
+/// Pin a relative engine path to the launch directory. The engine is spawned
+/// in the conversation's directory, which `with_session_cwd` may re-root away
+/// from where the TUI was launched; a relative `--engine ./fake-engine`
+/// resolved there would exec a different file than the one the user pointed
+/// at — and than the one `engine_launchable` probed. A bare name is left
+/// alone: it is a PATH lookup, and the probe runs in the same directory as
+/// the spawn, so even a pathological relative `PATH` entry resolves both
+/// the same way.
+fn absolute_engine(engine : String, cwd : String) -> String {
+  if engine.contains("/") || engine.contains("\\") {
+    absolute_session_root(engine, cwd)
+  } else {
+    engine
+  }
 }
 
 ///|
@@ -192,22 +346,11 @@ fn generated_session_id(now_ms : Int64) -> @agent_session.SessionId {
 }
 
 ///|
-fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
-  let cwd = match @env.current_dir() {
-    Some(cwd) => cwd
-    None => "."
-  }
-  let explicit_session = session_id(matches)
-  let session_root_value = if explicit_session is Some(_) {
-    session_root(matches)
-  } else {
-    let root = value(matches, "session-root").trim().to_owned()
-    if root.is_empty() {
-      ".openseek"
-    } else {
-      root
-    }
-  }
+fn parse_config(
+  matches : @argparse.Matches,
+  cwd~ : String,
+  session_root~ : String,
+) -> AppConfig raise {
   {
     api_key: value(matches, "api-key"),
     api_url: api_url(matches),
@@ -217,12 +360,12 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     // Parsed eagerly so a typo fails at launch with a CLI error instead of
     // inside the first turn's engine run.
     thinking: @deepseek.ThinkingMode::parse(value(matches, "thinking")),
-    session_id: match explicit_session {
+    session_id: match session_id(matches) {
       Some(id) => id
       None => generated_session_id(@env.now().reinterpret_as_int64())
     },
-    session_root: session_root_value,
-    engine: value(matches, "engine"),
+    session_root,
+    engine: absolute_engine(value(matches, "engine"), cwd),
     engine_mode: EngineMode::parse(value(matches, "engine-mode")),
   }
 }
@@ -278,12 +421,18 @@ async fn run_app(config : AppConfig, initial : String?, ui : @ui.Ui) -> Unit {
 /// is usable only if that probe spawns and exits 0; `ENOENT`/`EACCES` (not found
 /// / not executable) or a non-zero exit both mean it is not. Any other failure
 /// is unexpected and re-raised rather than mislabeled as a bad engine.
-async fn engine_launchable(engine : String) -> Bool {
+///
+/// The probe runs in `cwd~` — the conversation's directory, the same one the
+/// real engine is spawned in — so the two resolve the executable identically
+/// even when a relative `PATH` entry (`.`, `bin`, an empty segment) makes a
+/// bare engine name cwd-dependent.
+async fn engine_launchable(engine : String, cwd~ : String) -> Bool {
   try {
     let (code, _) = @process.collect_output_merged(
       engine,
       ["--help"],
       inherit_env=true,
+      cwd~,
     )
     code == 0
   } catch {
@@ -293,15 +442,53 @@ async fn engine_launchable(engine : String) -> Bool {
 }
 
 ///|
+fn format_utc_minute(seconds : Int64) -> String {
+  fn pad2(value : Int) -> String {
+    if value < 10 {
+      "0\{value}"
+    } else {
+      "\{value}"
+    }
+  }
+
+  let time = @time.unix(seconds) catch { _ => return "-" }
+  "\{time.year()}-\{pad2(time.month())}-\{pad2(time.day())} \{pad2(time.hour())}:\{pad2(time.minute())}"
+}
+
+///|
+/// `--workspace-list`: one workspace per row, tab-separated path and
+/// last-opened stamp (UTC, minute precision), most recently opened first —
+/// the same scriptable shape as the engine's `--session-list`.
+///
+/// Listing contacts no API, yet still sits behind the parser's required
+/// `--api-key` — deliberately. Exempting it would take a second, permissive
+/// parse pass or hand-rolled key validation that duplicates the argparse
+/// error text pinned in the cram suite, and every real TUI launch needs the
+/// key anyway: one uniform parse contract is worth more than sparing a
+/// listing-only invocation one environment variable.
+async fn print_workspace_listings(home~ : String) -> Unit {
+  for listing in @workspace.WorkspaceHome(home).listings() {
+    println(
+      "\{listing.path()}\t\{format_utc_minute(listing.last_opened_unix())}",
+    )
+  }
+}
+
+///|
 async fn main {
   let matches = cli_command().parse(env=@env.get_env_vars())
-  let mut config = parse_config(matches)
+  if flag(matches, "workspace-list") {
+    print_workspace_listings(home=openseek_home())
+    return
+  }
+  let mut config = launch_config(matches, home=openseek_home())
   if continue_requested(matches) {
     config = with_latest_session(config)
   }
+  config = with_session_cwd(config)
   // Fail before the terminal UI takes over the screen if the engine is unusable,
   // rather than dropping the user into a UI that dies on the first task.
-  if !engine_launchable(config.engine) {
+  if !engine_launchable(config.engine, cwd=config.cwd) {
     println(
       "error: engine '\{config.engine}' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.",
     )
@@ -317,7 +504,7 @@ async fn main {
 test "cli accepts no initial task" {
   let parsed = cli_command().parse(argv=[], env={ "DEEPSEEK": "test-key" })
   assert_true(initial_task(parsed) is None)
-  let config = parse_config(parsed)
+  let config = parse_config(parsed, cwd="/launch", session_root="/store")
   assert_eq(config.api_key, "test-key")
   assert_true(config.api_url is None)
   assert_eq(config.max_steps, 1000)
@@ -325,7 +512,31 @@ test "cli accepts no initial task" {
   // No --session still converses in a session: a generated per-launch id, so
   // consecutive prompts share context instead of running amnesiac one-shots.
   assert_true(config.session_id.value().has_prefix("tui-"))
-  assert_eq(config.session_root, ".openseek")
+  // No --session-root: the launch directory is the workspace, like `code .`.
+  assert_true(explicit_session_root(parsed) is None)
+}
+
+///|
+test "explicit --session-root bypasses the workspace store" {
+  let parsed = cli_command().parse(argv=["--session-root", "/abs/store"], env={
+    "DEEPSEEK": "test-key",
+  })
+  assert_true(explicit_session_root(parsed) is Some("/abs/store"))
+}
+
+///|
+test "relative session roots pin to the launch directory" {
+  let pinned = absolute_session_root(".openseek", "/launch")
+  assert_true(pinned.has_prefix("/launch"))
+  assert_true(pinned.has_suffix(".openseek"))
+  // Rooted roots pass through verbatim on every platform.
+  assert_eq(absolute_session_root("/abs/store", "/launch"), "/abs/store")
+  assert_eq(absolute_session_root("C:\\store", "/launch"), "C:\\store")
+  assert_eq(absolute_session_root("C:/store", "/launch"), "C:/store")
+  assert_eq(
+    absolute_session_root("\\\\server\\share", "/launch"),
+    "\\\\server\\share",
+  )
 }
 
 ///|
@@ -334,7 +545,8 @@ test "cli parses api url" {
     "DEEPSEEK": "test-key",
     "OPENSEEK_API_URL": " https://proxy.example/v1/chat/completions ",
   })
-  guard parse_config(parsed).api_url is Some(url) else {
+  guard parse_config(parsed, cwd="/launch", session_root="/store").api_url
+    is Some(url) else {
     fail("expected api url")
   }
   assert_eq(url, "https://proxy.example/v1/chat/completions")
@@ -356,12 +568,12 @@ test "cli parses and validates thinking controls" {
   let parsed = cli_command().parse(argv=["--thinking", "high"], env={
     "DEEPSEEK": "test-key",
   })
-  let config = parse_config(parsed)
+  let config = parse_config(parsed, cwd="/launch", session_root="/store")
   assert_true(config.thinking is High)
   let bad = cli_command().parse(argv=["--thinking", "sometimes"], env={
     "DEEPSEEK": "test-key",
   })
-  let _ = parse_config(bad) catch {
+  let _ = parse_config(bad, cwd="/launch", session_root="/store") catch {
     error => {
       assert_true("\{error}".contains("unknown thinking mode"))
       return
@@ -377,7 +589,10 @@ test "cli accepts initial task and max steps" {
     env={ "DEEPSEEK": "test-key" },
   )
   assert_true(initial_task(parsed) == Some("inspect project"))
-  assert_eq(parse_config(parsed).max_steps, 5)
+  assert_eq(
+    parse_config(parsed, cwd="/launch", session_root="/store").max_steps,
+    5,
+  )
 }
 
 ///|
@@ -407,18 +622,25 @@ test "cli accepts session configuration" {
     argv=["--session", "demo", "--session-root", "/tmp/openseek-sessions"],
     env={ "DEEPSEEK": "test-key" },
   )
-  let config = parse_config(parsed)
+  guard explicit_session_root(parsed) is Some(root) else {
+    fail("expected an explicit root")
+  }
+  let config = parse_config(
+    parsed,
+    cwd="/launch",
+    session_root=absolute_session_root(root, "/launch"),
+  )
   assert_eq(config.session_id.value(), "demo")
   assert_eq(config.session_root, "/tmp/openseek-sessions")
 }
 
 ///|
-test "cli rejects empty session root when session is active" {
+test "cli rejects an empty explicit session root" {
   let parsed = cli_command().parse(
     argv=["--session", "demo", "--session-root", ""],
     env={ "DEEPSEEK": "test-key" },
   )
-  let _ = parse_config(parsed) catch {
+  let _ = explicit_session_root(parsed) catch {
     error => {
       assert_true("\{error}".contains("--session-root"))
       return
@@ -451,12 +673,40 @@ test "cli overrides the engine binary" {
   let parsed = cli_command().parse(argv=["--engine", "./fake-engine"], env={
     "DEEPSEEK": "test-key",
   })
-  assert_eq(parse_config(parsed).engine, "./fake-engine")
+  // Pinned to the launch directory, so spawning in the conversation's
+  // directory still execs the binary the user pointed at.
+  let engine = parse_config(parsed, cwd="/launch", session_root="/store").engine
+  assert_true(is_rooted_path(engine))
+  assert_true(engine.has_prefix("/launch"))
+  assert_true(engine.has_suffix("fake-engine"))
+}
+
+///|
+test "within_directory accepts the root and its subdirectories only" {
+  assert_true(within_directory("/work/project", "/work/project"))
+  assert_true(within_directory("/work/project/sub/dir", "/work/project"))
+  assert_true(within_directory("C:\\proj\\sub", "C:\\proj"))
+  // A sibling sharing the prefix is not inside.
+  assert_false(within_directory("/work/project2", "/work/project"))
+  assert_false(within_directory("/elsewhere", "/work/project"))
+}
+
+///|
+test "relative engine paths pin to the launch directory, bare names stay" {
+  // A bare name is a PATH lookup and passes through untouched.
+  assert_eq(absolute_engine("openseek", "/launch"), "openseek")
+  // Rooted paths pass through verbatim.
+  assert_eq(absolute_engine("/abs/engine", "/launch"), "/abs/engine")
+  assert_eq(absolute_engine("C:\\engine.exe", "/launch"), "C:\\engine.exe")
+  // Separator-bearing relative paths are anchored to the launch directory.
+  let pinned = absolute_engine("./fake-engine", "/launch")
+  assert_true(pinned.has_prefix("/launch"))
+  assert_true(pinned.has_suffix("fake-engine"))
 }
 
 ///|
 async test "engine_launchable rejects a binary that cannot be exec'd" {
-  assert_false(engine_launchable("openseek-not-a-real-binary-xyz"))
+  assert_false(engine_launchable("openseek-not-a-real-binary-xyz", cwd="."))
 }
 
 ///|
@@ -465,5 +715,5 @@ async test "engine_launchable accepts an engine whose --help exits 0" {
   // requires: `moon --help` exits 0 and, unlike `true`, `moon` is on PATH on
   // every platform the tests run on (including Windows native), so this stays
   // cross-platform.
-  assert_true(engine_launchable("moon"))
+  assert_true(engine_launchable("moon", cwd="."))
 }

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/jsonl",
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/agent_session/workspace",
   "bobzhang/openseek/agent_tool/shell",
   "bobzhang/openseek/cmd/tui/internal/event",
   "bobzhang/openseek/deepseek",
@@ -10,18 +11,17 @@ import {
   "bobzhang/openseek/tui/style",
   "moonbit-community/displaytext",
   "moonbitlang/async",
+  "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
   "moonbitlang/async/process",
   "moonbitlang/core/argparse",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
   "moonbitlang/core/string",
+  "moonbitlang/x/path",
   "moonbitlang/x/sys",
+  "moonbitlang/x/time",
 }
-
-import {
-  "moonbitlang/async/fs",
-} for "wbtest"
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 

--- a/cmd/tui/session_cwd_wbtest.mbt
+++ b/cmd/tui/session_cwd_wbtest.mbt
@@ -16,7 +16,7 @@ async test "resume re-roots the conversation in the session's recorded directory
   let config = with_session_cwd(
     parse_config(parsed, cwd=project, session_root=root),
   )
-  assert_eq(config.cwd, recorded)
+  assert_eq(config.cwd, @fs.realpath(recorded))
   @fs.rmdir(root, recursive=true)
   @fs.rmdir(project, recursive=true)
 }
@@ -34,6 +34,30 @@ async test "a recorded directory outside the workspace is ignored" {
   )
   let parsed = cli_command().parse(
     argv=["--session", "outside", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(
+    parse_config(parsed, cwd=project, session_root=root),
+  )
+  assert_eq(config.cwd, project)
+  @fs.rmdir(root, recursive=true)
+  @fs.rmdir(project, recursive=true)
+  @fs.rmdir(elsewhere, recursive=true)
+}
+
+///|
+async test "a recorded directory that canonicalizes outside the workspace is ignored" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-escape-")
+  let project = @fs.tmpdir(prefix="openseek-tui-project-")
+  let elsewhere = project + "-elsewhere"
+  @fs.mkdir(elsewhere)
+  let escaped = "\{project}/../\{@path.Path(elsewhere).basename()}"
+  let store = @store.SessionStore(root)
+  store.create(
+    Session(SessionId("escaped"), system_prompt="system", cwd=escaped),
+  )
+  let parsed = cli_command().parse(
+    argv=["--session", "escaped", "--session-root", root],
     env={ "DEEPSEEK": "test-key" },
   )
   let config = with_session_cwd(

--- a/cmd/tui/session_cwd_wbtest.mbt
+++ b/cmd/tui/session_cwd_wbtest.mbt
@@ -1,0 +1,93 @@
+///|
+async test "resume re-roots the conversation in the session's recorded directory" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-")
+  let project = @fs.tmpdir(prefix="openseek-tui-project-")
+  // The recorded directory refines the workspace: a subdirectory of it.
+  let recorded = project + "/sub"
+  @fs.mkdir(recorded)
+  let store = @store.SessionStore(root)
+  store.create(
+    Session(SessionId("with-cwd"), system_prompt="system", cwd=recorded),
+  )
+  let parsed = cli_command().parse(
+    argv=["--session", "with-cwd", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(
+    parse_config(parsed, cwd=project, session_root=root),
+  )
+  assert_eq(config.cwd, recorded)
+  @fs.rmdir(root, recursive=true)
+  @fs.rmdir(project, recursive=true)
+}
+
+///|
+async test "a recorded directory outside the workspace is ignored" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-outside-")
+  let project = @fs.tmpdir(prefix="openseek-tui-project-")
+  // Exists, but is not within the workspace being opened — e.g. the
+  // original location of a project that was copied, sessions and all.
+  let elsewhere = @fs.tmpdir(prefix="openseek-tui-elsewhere-")
+  let store = @store.SessionStore(root)
+  store.create(
+    Session(SessionId("outside"), system_prompt="system", cwd=elsewhere),
+  )
+  let parsed = cli_command().parse(
+    argv=["--session", "outside", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(
+    parse_config(parsed, cwd=project, session_root=root),
+  )
+  assert_eq(config.cwd, project)
+  @fs.rmdir(root, recursive=true)
+  @fs.rmdir(project, recursive=true)
+  @fs.rmdir(elsewhere, recursive=true)
+}
+
+///|
+async test "a session without a recorded directory keeps the configured one" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-legacy-")
+  let store = @store.SessionStore(root)
+  store.create(Session(SessionId("legacy"), system_prompt="system"))
+  let parsed = cli_command().parse(
+    argv=["--session", "legacy", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(
+    parse_config(parsed, cwd="/configured", session_root=root),
+  )
+  assert_eq(config.cwd, "/configured")
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "a vanished recorded directory keeps the configured one" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-stale-")
+  let gone = @fs.tmpdir(prefix="openseek-tui-gone-cwd-")
+  @fs.rmdir(gone, recursive=true)
+  let store = @store.SessionStore(root)
+  store.create(Session(SessionId("stale"), system_prompt="system", cwd=gone))
+  let parsed = cli_command().parse(
+    argv=["--session", "stale", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let config = with_session_cwd(
+    parse_config(parsed, cwd="/configured", session_root=root),
+  )
+  assert_eq(config.cwd, "/configured")
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "a fresh session keeps the configured directory" {
+  let root = @fs.tmpdir(prefix="openseek-tui-session-cwd-fresh-")
+  let parsed = cli_command().parse(
+    argv=["--session", "brand-new", "--session-root", root],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let before = parse_config(parsed, cwd=launch_cwd(), session_root=root)
+  let config = with_session_cwd(before)
+  assert_eq(config.cwd, before.cwd)
+  @fs.rmdir(root, recursive=true)
+}

--- a/cmd/tui/workspace_wbtest.mbt
+++ b/cmd/tui/workspace_wbtest.mbt
@@ -1,0 +1,33 @@
+///|
+async test "by default the launch directory is the workspace" {
+  let home = @fs.tmpdir(prefix="openseek-tui-home-")
+  let parsed = cli_command().parse(argv=[], env={ "DEEPSEEK": "test-key" })
+  let config = launch_config(parsed, home~)
+  // The conversation runs in the (canonicalized) launch directory and its
+  // sessions live inside it. Nothing touches that store at launch, so
+  // asserting against the real cwd leaves no droppings behind.
+  assert_eq(config.cwd, @fs.realpath(launch_cwd()))
+  assert_eq(config.session_root, config.cwd + "/.openseek")
+  // Opening indexed the workspace under the home for --workspace-list.
+  let listings = @workspace.WorkspaceHome(home).listings()
+  assert_eq(listings.length(), 1)
+  assert_eq(listings[0].path(), config.cwd)
+  assert_eq(listings[0].store_root(), config.session_root)
+  @fs.rmdir(home, recursive=true)
+}
+
+///|
+async test "an explicit --session-root bypasses the workspace layer" {
+  let home = @fs.tmpdir(prefix="openseek-tui-home-")
+  let root = @fs.tmpdir(prefix="openseek-tui-root-")
+  let parsed = cli_command().parse(argv=["--session-root", root], env={
+    "DEEPSEEK": "test-key",
+  })
+  let config = launch_config(parsed, home~)
+  assert_eq(config.session_root, root)
+  assert_eq(config.cwd, launch_cwd())
+  // Nothing was indexed under the home: the workspace layer never ran.
+  assert_true(@workspace.WorkspaceHome(home).listings().is_empty())
+  @fs.rmdir(home, recursive=true)
+  @fs.rmdir(root, recursive=true)
+}

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,3 +1,22 @@
 # OpenSeek Plans
 
 - [Custom API URL](plans/custom-api-url.md)
+
+## Checkpoint: TUI Session cwd Realpath Guard
+
+- Goal: address PR review feedback that a stored session cwd like
+  `/workspace/project/../other` could pass raw string containment checks while
+  spawning outside the current workspace.
+- Accepted design: before accepting a stored cwd, resolve both the configured
+  workspace cwd and the stored cwd with `moonbitlang/async/fs.realpath`, then
+  accept only a canonical stored cwd that is the canonical workspace itself or a
+  subdirectory and is a directory.
+- Target surfaces: `cmd/tui/main.mbt` resume cwd selection and
+  `cmd/tui/session_cwd_wbtest.mbt` regression coverage.
+- API/interface diff: no public API changes expected; generated `.mbti` files
+  should remain semantically unchanged.
+- Open questions: none.
+- Next implementation step: update `with_session_cwd` and add a test for a raw
+  prefix path that canonicalizes outside the workspace.
+- Validation plan: `moon check`, targeted TUI tests, `moon info`, `moon fmt`,
+  and full `moon test`.

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -25,7 +25,8 @@ Arguments:
 
 Options:
   -h, --help                     Show help information.
-  --continue                     Resume the most recently active session in --session-root.
+  --continue                     Resume this workspace's most recently active session.
+  --workspace-list               List known workspaces, most recently opened first, then exit.
   --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
   --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
@@ -34,7 +35,7 @@ Options:
   --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
   --engine-mode <engine-mode>    Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]
   --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions; bypasses the workspace store. [env: OPENSEEK_SESSION_ROOT]
 ```
 
 ## A DeepSeek API Key Is Required
@@ -56,7 +57,8 @@ Arguments:
 
 Options:
   -h, --help                     Show help information.
-  --continue                     Resume the most recently active session in --session-root.
+  --continue                     Resume this workspace's most recently active session.
+  --workspace-list               List known workspaces, most recently opened first, then exit.
   --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
   --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
@@ -65,7 +67,7 @@ Options:
   --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
   --engine-mode <engine-mode>    Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]
   --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions; bypasses the workspace store. [env: OPENSEEK_SESSION_ROOT]
 
 [1]
 ```


### PR DESCRIPTION
**TL;DR**: In order to have workspace support in desktop app (like in Codex App), we need to maintain a global registry to all possible workspaces. This PR add workspace support to the cmd/openseek.

Supersedes #87 (which stays draft until this lands, then closes unmerged). Background: the durable store's default root was a **relative** `.openseek`, so sessions were findable only from the directory that created them, and a relative root resolves to a different store per process — the bug class behind #87's P1 review.

## The model

A *workspace* is a project directory, opened implicitly by launching the TUI in it (`code .` mental model; to open another project, launch there). **Sessions stay in the project's own `./.openseek`** — exactly where the pre-workspace TUI kept them, so existing stores need no migration and conversations travel (and die) with their project. The global home only **indexes** which workspaces exist:

```
~/.openseek/                      # OPENSEEK_HOME overrides
  workspaces/
    <key>/                        # FNV-1a-64 of the canonical project path
      workspace.json              # { version, path, last_opened_unix }
      workspace.lock

<project>/
  .openseek/
    sessions/<id>/…               # an ordinary agent_session/store tree
```

The TUI's CLI surface stays minimal: no new mode flags, just `--workspace-list` (recents) on top of the existing `--session-root`.

## What changes

- **New `agent_session/workspace` package**: `WorkspaceHome::open` canonicalizes the path (symlinks resolved via `realpath`), claims or revisits its index entry under an exclusive lock, and bumps `last_opened_unix` atomically (temp+rename). The key never needs to be reversible — `workspace.json` carries the real path — but must stay stable across releases (it names directories on disk), hence a fixed local FNV-1a-64 instead of core's `Hash::hash`. Collisions probe `<key>-1`, `<key>-2`, …. No single registry file: `--workspace-list` recents are derived by scanning, so there is nothing to corrupt and deleted entries self-heal out of the list.
- **TUI**: the store root handed to the engine is the workspace's `.openseek` canonicalized to an absolute path, eliminating the relative-root bug structurally. The first half of the commit carries over #87's reviewed pieces (`Session.cwd` field + codec, engine-side cwd recording, `SessionStore::cwd`, `spawn(cwd=…)`); #87's home-directory fallback is **gone** — the workspace path is the always-known fallback, and a session's recorded cwd remains a refinement within it.
- **`--session-root` keeps its old meaning**: pass it and the workspace layer is bypassed entirely (nothing gets indexed) — the store is used as-is, relative roots pinned to the launch directory. Same contract as the engine's flag; what scripts and tmpdir-based tests use.
- **Engine contract unchanged**: `openseek` still takes `--session-root` and knows nothing about workspaces.

## Testing

- `agent_session/workspace`: open/reopen/bump, recency-ordered listings, missing-dir raise, collision probing, corrupt-workspace.json behavior (open fails loudly, listings skip).
- `cmd/tui`: default workspace launch config (sessions in the project, index under the home), `--session-root` bypass, session-cwd refinement without home fallback.
- `moon check` clean, `moon test` 483/483, `moon cram test tests/cram` 9/9 (help banner updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)