### PR TITLE
feat(tui): acknowledge a sent steer on the activity line

### DIFF
--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -298,6 +298,44 @@ test "a running shell command is never steered and never kills the engine" {
 }
 
 ///|
+test "a sent steer is acknowledged until the engine settles it" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  assert_eq(state.pending_steers.length(), 0)
+
+  // Enter mid-run: acknowledged immediately, before any engine round trip —
+  // this is the only feedback between the keypress and the transcript echo.
+  let _ = update(state, UiInput(Steer(Prompt("make it rhyme"))))
+  assert_eq(state.pending_steers.length(), 1)
+  guard pending_steer_segment(state.pending_steers) is [_, _] else {
+    fail("expected an activity-line acknowledgment")
+  }
+
+  // The engine confirms: acknowledgment clears, transcript echo appends.
+  let _ = update(
+    state,
+    AgentProgress(run_id=state.run_id, SteerApplied("make it rhyme")),
+  )
+  assert_eq(state.pending_steers.length(), 0)
+  assert_eq(pending_steer_segment(state.pending_steers).length(), 0)
+
+  // A dropped steer also clears the acknowledgment (and shows its notice).
+  let _ = update(state, UiInput(Steer(Prompt("too late"))))
+  assert_eq(state.pending_steers.length(), 1)
+  let _ = update(state, SteerDropped("too late"))
+  assert_eq(state.pending_steers.length(), 0)
+
+  // A turn ending sweeps anything still unconfirmed.
+  let _ = update(state, UiInput(Steer(Prompt("orphaned"))))
+  assert_eq(state.pending_steers.length(), 1)
+  let _ = update(
+    state,
+    AgentProgress(run_id=state.run_id, AgentFinished("done")),
+  )
+  assert_eq(state.pending_steers.length(), 0)
+}
+
+///|
 test "a steer_applied event echoes the input into the transcript" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -350,8 +350,11 @@ test "a trailing drop from a dead turn never steals a fresh acknowledgment" {
   let _ = update(state, UiInput(Steer(Prompt("task b"))))
   let _ = update(state, UiInput(Steer(Prompt("fresh steer"))))
   assert_eq(state.pending_steers.length(), 1)
-  // The old turn's drop settles nothing of B's — matched by text, no hit.
-  let _ = update(state, SteerDropped("old steer"))
+  // The old turn's wire drop settles nothing of B's — even with identical
+  // text, a wire drop's own entries are swept before it is processed.
+  let _ = update(state, EngineSteerDropped("old steer"))
+  assert_eq(state.pending_steers.length(), 1)
+  let _ = update(state, EngineSteerDropped("fresh steer"))
   assert_eq(state.pending_steers.length(), 1)
   assert_eq(state.pending_steers[0], "fresh steer")
 }

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -336,6 +336,38 @@ test "a sent steer is acknowledged until the engine settles it" {
 }
 
 ///|
+test "a trailing drop from a dead turn never steals a fresh acknowledgment" {
+  let state = drain_test_state()
+  // Turn A is steered, then ends (sweeping its pending entry).
+  let _ = update(state, UiInput(Steer(Prompt("task a"))))
+  let _ = update(state, UiInput(Steer(Prompt("old steer"))))
+  let _ = update(
+    state,
+    AgentProgress(run_id=state.run_id, AgentFinished("done-a")),
+  )
+  assert_eq(state.pending_steers.length(), 0)
+  // Turn B starts and is steered before A's untagged drop arrives.
+  let _ = update(state, UiInput(Steer(Prompt("task b"))))
+  let _ = update(state, UiInput(Steer(Prompt("fresh steer"))))
+  assert_eq(state.pending_steers.length(), 1)
+  // The old turn's drop settles nothing of B's — matched by text, no hit.
+  let _ = update(state, SteerDropped("old steer"))
+  assert_eq(state.pending_steers.length(), 1)
+  assert_eq(state.pending_steers[0], "fresh steer")
+}
+
+///|
+test "blank steers are neither sent nor acknowledged" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("task"))))
+  let cmds = update(state, UiInput(Steer(Prompt("   "))))
+  // The engine would filter it without any settling event, so the TUI must
+  // not create an acknowledgment that can never clear.
+  assert_eq(state.pending_steers.length(), 0)
+  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+}
+
+///|
 test "a steer_applied event echoes the input into the transcript" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -84,7 +84,7 @@ async fn[G] EngineClient::start(
           // by the stale-run guard. Post it untagged so the resubmit notice
           // always reaches the user.
           SteerDropped(text) =>
-            self.messages.try_put(SteerDropped(text)) |> ignore
+            self.messages.try_put(EngineSteerDropped(text)) |> ignore
           _ => {
             if is_terminal_event(event) {
               engine.run_open = false

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -560,6 +560,10 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
       confirm_pending_steer(state, text)
       cmds.push(AppendItem(steer_dropped_item(text)))
     }
+    // Settles nothing by construction: the rejecting turn's terminal already
+    // swept its acknowledgments, and a text match here could only steal a
+    // fresh identical-text steer's entry from the next turn.
+    EngineSteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
     // The engine process is gone, and its watchers with it: an old
     // `moon_check running` segment would be a lie on the status bar.
     EngineExited => state.watcher_status = ""

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -99,6 +99,16 @@ fn steer_dropped_item(text : String) -> @ui.TranscriptItem {
 }
 
 ///|
+/// One pending steer was settled (applied or dropped): stop acknowledging
+/// it on the activity line. Confirmations arrive in send order, so the
+/// oldest entry is the settled one.
+fn confirm_pending_steer(state : State) -> Unit {
+  if state.pending_steers.length() > 0 {
+    let _ = state.pending_steers.remove(0)
+  }
+}
+
+///|
 fn is_terminal_event(event : @event.AgentEvent) -> Bool {
   match event {
     AgentFinished(_) | AgentAborted(_) | MaxStepsExhausted | AgentError(_) =>
@@ -364,12 +374,18 @@ fn handle_agent_event(
     // A steer took effect at the engine's step boundary: echo the input into
     // the transcript at its true conversational position, the way the model
     // actually saw it.
-    SteerApplied(text) => cmds.push(AppendItem(Input(Prompt(text))))
+    SteerApplied(text) => {
+      confirm_pending_steer(state)
+      cmds.push(AppendItem(Input(Prompt(text))))
+    }
     // Normally unreachable from the wire: the engine client routes
     // steer_dropped events to the untagged message (they always trail the
     // racing turn's terminal, so a run-tagged copy would be stale-filtered).
     // Kept as defense in depth for any future in-run emitter.
-    SteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
+    SteerDropped(text) => {
+      confirm_pending_steer(state)
+      cmds.push(AppendItem(steer_dropped_item(text)))
+    }
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None
@@ -473,7 +489,12 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
             )
           } else {
             match input {
-              Prompt(text) => cmds.push(SteerAgent(text))
+              Prompt(text) => {
+                // Acknowledge immediately: the transcript echo only comes at
+                // the step boundary, but the user pressed Enter *now*.
+                state.pending_steers.push(text)
+                cmds.push(SteerAgent(text))
+              }
               Command(_) =>
                 cmds.push(
                   AppendItem(
@@ -525,7 +546,10 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // The steer never reached a turn; the text would otherwise vanish
     // silently. Run state is untouched — the run's own death report (or
     // terminal event) settles it.
-    SteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
+    SteerDropped(text) => {
+      confirm_pending_steer(state)
+      cmds.push(AppendItem(steer_dropped_item(text)))
+    }
     // The engine process is gone, and its watchers with it: an old
     // `moon_check running` segment would be a lie on the status bar.
     EngineExited => state.watcher_status = ""

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -100,11 +100,17 @@ fn steer_dropped_item(text : String) -> @ui.TranscriptItem {
 
 ///|
 /// One pending steer was settled (applied or dropped): stop acknowledging
-/// it on the activity line. Confirmations arrive in send order, so the
-/// oldest entry is the settled one.
-fn confirm_pending_steer(state : State) -> Unit {
-  if state.pending_steers.length() > 0 {
-    let _ = state.pending_steers.remove(0)
+/// it on the activity line. Settlement is matched by text, not position —
+/// an untagged drop from a finished turn can trail into the next turn's
+/// lifetime, and it must never consume an acknowledgment belonging to a
+/// fresh steer it has nothing to do with. No match (the old turn's list
+/// was already swept) is a no-op.
+fn confirm_pending_steer(state : State, text : String) -> Unit {
+  for index, pending in state.pending_steers {
+    if pending == text {
+      let _ = state.pending_steers.remove(index)
+      return
+    }
   }
 }
 
@@ -375,7 +381,7 @@ fn handle_agent_event(
     // the transcript at its true conversational position, the way the model
     // actually saw it.
     SteerApplied(text) => {
-      confirm_pending_steer(state)
+      confirm_pending_steer(state, text)
       cmds.push(AppendItem(Input(Prompt(text))))
     }
     // Normally unreachable from the wire: the engine client routes
@@ -383,7 +389,7 @@ fn handle_agent_event(
     // racing turn's terminal, so a run-tagged copy would be stale-filtered).
     // Kept as defense in depth for any future in-run emitter.
     SteerDropped(text) => {
-      confirm_pending_steer(state)
+      confirm_pending_steer(state, text)
       cmds.push(AppendItem(steer_dropped_item(text)))
     }
     AssistantMessage(text) => {
@@ -489,12 +495,16 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
             )
           } else {
             match input {
-              Prompt(text) => {
-                // Acknowledge immediately: the transcript echo only comes at
-                // the step boundary, but the user pressed Enter *now*.
-                state.pending_steers.push(text)
-                cmds.push(SteerAgent(text))
-              }
+              Prompt(text) =>
+                // A blank steer would be filtered engine-side without any
+                // settling event, leaving a phantom acknowledgment; there is
+                // nothing to say to the model anyway, so drop it here.
+                if !text.trim().is_empty() {
+                  // Acknowledge immediately: the transcript echo only comes
+                  // at the step boundary, but the user pressed Enter *now*.
+                  state.pending_steers.push(text)
+                  cmds.push(SteerAgent(text))
+                }
               Command(_) =>
                 cmds.push(
                   AppendItem(
@@ -547,7 +557,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // silently. Run state is untouched — the run's own death report (or
     // terminal event) settles it.
     SteerDropped(text) => {
-      confirm_pending_steer(state)
+      confirm_pending_steer(state, text)
       cmds.push(AppendItem(steer_dropped_item(text)))
     }
     // The engine process is gone, and its watchers with it: an old

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -161,9 +161,16 @@ priv enum Msg {
   // transcript item to append. Commands run in the TUI and never reach the agent
   // engine.
   CommandResult(run_id~ : Int, @ui.TranscriptItem)
-  // A steer had no live turn to land in (the engine died an instant before
-  // Enter): surface the lost text so the user can resubmit it.
+  // A steer the client could not deliver (no live engine/turn): show the
+  // resubmit notice and settle its acknowledgment — the entry was created an
+  // instant ago and cannot have been swept.
   SteerDropped(String)
+  // A steer the engine rejected on the wire. Its turn's terminal event
+  // always precedes it in the stream, so by the time this is processed the
+  // acknowledgment it belonged to is already swept: notice only, settling
+  // nothing — a fresh identical-text steer of the next turn keeps its own
+  // acknowledgment.
+  EngineSteerDropped(String)
   // The persistent engine process exited (for any reason): its background
   // watchers died with it, so engine-scoped status must reset.
   EngineExited
@@ -179,7 +186,11 @@ fn Msg::run_id(self : Msg) -> Int? {
     | AgentCancelled(run_id~)
     | AgentFailed(run_id~, _) => Some(run_id)
     CommandResult(run_id~, _) => Some(run_id)
-    UiInput(_) | SteerDropped(_) | EngineExited | Tick => None
+    UiInput(_)
+    | SteerDropped(_)
+    | EngineSteerDropped(_)
+    | EngineExited
+    | Tick => None
   }
 }
 

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -72,6 +72,13 @@ priv struct State {
   // moves during the (often long) reasoning phase instead of sitting on
   // "Working (Ns)".
   mut streaming_reasoning : String?
+  // Steering input sent to the engine but not yet confirmed (no
+  // steer_applied/steer_dropped back). Shown on the activity line so the
+  // moment of pressing Enter is acknowledged immediately — the transcript
+  // echo only comes at the step boundary where the model actually sees it,
+  // which during a long tool call can be many seconds later, and a silent
+  // gap reads as "my keystroke was eaten".
+  pending_steers : Array[String]
   mut usage : @event.UsageInfo?
   // Latest background `moon_check` watcher status ("running"/"stopped"), lifted
   // from the most recent `runtime_update` for the status bar. Empty until the
@@ -87,6 +94,7 @@ fn State::new(config : AppConfig) -> State {
     run: Idle,
     run_id: 0,
     run_is_command: false,
+    pending_steers: [],
     step_response: None,
     streaming_response: None,
     streaming_reasoning: None,
@@ -127,6 +135,10 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
   self.run_is_command = false
+  // Anything still unconfirmed died with the turn; the engine sweeps its
+  // queue at turn end and reports each leftover as steer_dropped, which
+  // arrives untagged and renders its own resubmit notice.
+  self.pending_steers.clear()
   self.step_response = None
   self.streaming_response = None
   self.streaming_reasoning = None

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -92,28 +92,60 @@ fn elapsed_seconds(started_ms : Int64, now_ms : Int64) -> Int64 {
 const ActivityChromeColumns : Int = 3
 
 ///|
+/// Most columns the pending-steer acknowledgment may take on the activity
+/// row, so it never starves the streaming preview it shares the line with.
+const SteerSegmentMaxColumns : Int = 44
+
+///|
+/// The acknowledgment that steering input was sent and awaits its step
+/// boundary: ` · steering: <tail of the latest text>` (with a count when
+/// several are in flight). This is the only feedback between pressing Enter
+/// and the transcript echo — which during a long tool call can be many
+/// seconds — so without it a steer reads as an eaten keystroke.
+fn pending_steer_segment(steers : Array[String]) -> Array[@doc.Span] {
+  guard steers.length() > 0 else { return [] }
+  let label = if steers.length() > 1 {
+    " · steering ×\{steers.length()}: "
+  } else {
+    " · steering: "
+  }
+  let latest = collapse_preview_whitespace(steers[steers.length() - 1])
+  let budget = SteerSegmentMaxColumns - @displaytext.DisplayText(label).width()
+  [
+    Span(DisplayText(label), style=@style.dim),
+    Span(
+      DisplayText(tail_columns(latest, if budget < 8 { 8 } else { budget })),
+      style=@style.dim,
+    ),
+  ]
+}
+
+///|
 /// A streaming activity line: the dim `label` followed by the tail of `text`
-/// clipped to the columns the label leaves free, so the newest characters
-/// always fit the row. The preview dims with `dim_preview` (reasoning reads
-/// as an aside; content reads at full strength).
-fn streaming_activity_line(
+/// clipped to the columns the label (and any pending-steer acknowledgment)
+/// leaves free, so the newest characters always fit the row. The preview
+/// dims with `dim_preview` (reasoning reads as an aside; content reads at
+/// full strength).
+fn streaming_activity_spans(
   label : String,
   text : String,
   cols~ : Int,
   dim_preview~ : Bool,
-) -> @doc.Text {
+  reserved~ : Int,
+) -> Array[@doc.Span] {
   let budget = cols -
     ActivityChromeColumns -
+    reserved -
     @displaytext.DisplayText(label).width()
   let preview = tail_columns(text, if budget < 16 { 16 } else { budget })
-  Text([
+  [
     Span(DisplayText(label), style=@style.dim),
     if dim_preview {
       Span(DisplayText(preview), style=@style.dim)
     } else {
       @doc.Span::plain(preview)
     },
-  ])
+  ]
 }
 
 ///|
@@ -123,29 +155,47 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
     Running(started_ms) => started_ms
     Interrupting(started_ms) => started_ms
   }
+  let steer_segment = pending_steer_segment(state.pending_steers)
+  // The acknowledgment sits at the row's end, where the renderer clips on
+  // overflow — so the preview must cede exactly its width to keep it
+  // visible.
+  let reserved = if steer_segment.length() > 0 {
+    SteerSegmentMaxColumns
+  } else {
+    0
+  }
   if state.streaming_response is Some(response) && !response.trim().is_empty() {
-    return Some(
-      streaming_activity_line("Streaming ", response, cols~, dim_preview=false),
+    let spans = streaming_activity_spans(
+      "Streaming ",
+      response,
+      cols~,
+      dim_preview=false,
+      reserved~,
     )
+    return Some(Text(spans + steer_segment))
   }
   // Thinking-mode runs spend their first (often long) stretch emitting only
   // reasoning deltas; show their tail dimmed so the line moves from the first
   // token rather than sitting on "Working (Ns)" until content starts.
   if state.streaming_reasoning is Some(reasoning) &&
     !reasoning.trim().is_empty() {
-    return Some(
-      streaming_activity_line("Thinking ", reasoning, cols~, dim_preview=true),
+    let spans = streaming_activity_spans(
+      "Thinking ",
+      reasoning,
+      cols~,
+      dim_preview=true,
+      reserved~,
     )
+    return Some(Text(spans + steer_segment))
   }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @async.now()),
   )
-  Some(
-    Text([
-      @doc.Span::plain("Working"),
-      Span(DisplayText(" (\{elapsed})"), style=@style.dim),
-    ]),
-  )
+  let spans : Array[@doc.Span] = [
+    @doc.Span::plain("Working"),
+    Span(DisplayText(" (\{elapsed})"), style=@style.dim),
+  ]
+  Some(Text(spans + steer_segment))
 }
 
 ///|

--- a/cmd/tui/status_view_wbtest.mbt
+++ b/cmd/tui/status_view_wbtest.mbt
@@ -6,7 +6,15 @@ test "streaming activity line fits the label and preview to the row" {
   let long = String::make(300, 'x') + " tail-end"
   for label in ["Streaming ", "Thinking "] {
     let cols = 60
-    let line = streaming_activity_line(label, long, cols~, dim_preview=false)
+    let line : @doc.Text = Text(
+      streaming_activity_spans(
+        label,
+        long,
+        cols~,
+        dim_preview=false,
+        reserved=0,
+      ),
+    )
     let rendered = line.split_lines()
     assert_eq(rendered.length(), 1)
     // Reconstruct the row's display width from its spans: label + preview.


### PR DESCRIPTION
UX follow-up to #88, from user feedback: after pressing Enter to steer, the composer cleared and **nothing confirmed the input was sent** until the step-boundary echo — many seconds later during a long tool call. A steer read as an eaten keystroke.

## Change

- `State.pending_steers` tracks input sent but not yet settled. The activity line immediately grows a dim ` · steering: <tail>` segment (with `×N` when several are in flight): `Thinking …project layout · steering: "…add a unit test"`.
- The segment clears exactly when the engine settles the steer: `steer_applied` (transcript echo), `steer_dropped` (resubmit notice), or turn end (engine sweeps leftovers).
- The segment has a bounded width (44 cols) and the streaming preview cedes exactly that much — the renderer clips the row's *end* on overflow, so without the reservation the acknowledgment would be the first thing cut.

## Verification

- Live pty (real API): the acknowledgment appeared **within 1.5s of Enter** — while the steered turn was still mid-`sleep` — the steer echoed later at its true transcript position, the segment cleared on echo, and the answer honored the steered word.
- Full persistent-engine pty suite re-passed (PID stability, memory, steer, cancel).
- 455/455 tests (pending-steer lifecycle: ack on send, clear on applied/dropped/turn-end), 9/9 cram, fmt clean.

Side discovery while verifying, recorded for posterity: `cp` over the executed `~/.moon/bin/openseek` corrupts the macOS per-inode signature cache — the binary gets SIGKILLed at exec (exit 137) with no stderr, masquerading as an engine protocol bug. Install with `rm` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)