### PR TITLE
feat(viz): events.jsonl session visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ _build/
 .mooncakes/
 .moonagent/
 .repos/
+web/viz_app.js
 eval/*
 !eval/README.md
 !eval/prompts/

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -18,6 +18,8 @@ pub struct AssistantMessage {
 } derive(ToJson, @debug.Debug, @json.FromJson)
 pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.ToolCall], reasoning_content? : String) -> Self
 pub fn AssistantMessage::content(Self) -> String
+pub fn AssistantMessage::reasoning_content(Self) -> String?
+pub fn AssistantMessage::tool_calls(Self) -> Array[@deepseek.ToolCall]
 
 pub struct RuntimeNotice {
   // private fields

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -25,7 +25,9 @@ pub fn SessionStore::SessionStore(String) -> Self
 pub async fn SessionStore::append(Self, @agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session
 pub async fn SessionStore::compact(Self, @agent_session.Session, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> @agent_session.Session
 pub async fn SessionStore::create(Self, @agent_session.Session) -> Unit
+pub fn SessionStore::event_log_file(Self, @agent_session.SessionId) -> String raise
 pub async fn SessionStore::exists(Self, @agent_session.SessionId) -> Bool
+pub fn SessionStore::header_file(Self, @agent_session.SessionId) -> String raise
 pub async fn SessionStore::latest(Self) -> @agent_session.SessionId?
 pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]
 pub async fn SessionStore::listings(Self) -> Array[SessionListing]

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -495,6 +495,28 @@ pub async fn SessionStore::exists(
 }
 
 ///|
+/// Absolute path to a session's append-only `events.jsonl` log. Exposed so a
+/// read-only consumer (such as the visualizer web server) can stream the raw
+/// log without the store reconstructing the on-disk layout for it.
+pub fn SessionStore::event_log_file(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  self.event_log_path(id)
+}
+
+///|
+/// Absolute path to a session's `session.json` header file. The file may not
+/// exist for a session whose first event has not yet been flushed; callers
+/// should check existence before reading.
+pub fn SessionStore::header_file(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  self.header_path(id)
+}
+
+///|
 /// List known session ids under this store. Missing stores are treated as empty.
 pub async fn SessionStore::list(
   self : SessionStore,

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -90,7 +90,9 @@ pub fn AssistantMessage::content(self : AssistantMessage) -> String {
 }
 
 ///|
-fn AssistantMessage::tool_calls(
+/// The native tool calls the model requested this turn, in protocol form
+/// (call id, name, raw argument string). Empty for a text-only response.
+pub fn AssistantMessage::tool_calls(
   self : AssistantMessage,
 ) -> Array[@deepseek.ToolCall] {
   [
@@ -99,7 +101,9 @@ fn AssistantMessage::tool_calls(
 }
 
 ///|
-fn AssistantMessage::reasoning_content(self : AssistantMessage) -> String? {
+/// The thinking-mode reasoning the model returned alongside its answer, or
+/// `None` when the response carried no reasoning content.
+pub fn AssistantMessage::reasoning_content(self : AssistantMessage) -> String? {
   self.reasoning_content
 }
 

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -19,8 +19,28 @@ struct Model {
   system_prompt : String
   header_present : Bool
   view_mode : @viz.ViewMode
+  theme : Theme
   loading : Bool
   status : String
+}
+
+///|
+/// Colour theme. `Light` is the default; `System` follows the OS via a CSS
+/// `prefers-color-scheme` media query (so it tracks live OS changes without any
+/// listener). The choice is applied by setting `data-theme` on `<html>`.
+enum Theme {
+  Light
+  Dark
+  System
+} derive(Eq)
+
+///|
+fn Theme::value(self : Theme) -> String {
+  match self {
+    Light => "light"
+    Dark => "dark"
+    System => "system"
+  }
 }
 
 ///|
@@ -33,6 +53,7 @@ enum Msg {
   Select(String)
   SessionFetched(String, Result[String, Error])
   SetMode(@viz.ViewMode)
+  SetTheme(Theme)
 }
 
 ///|
@@ -54,6 +75,7 @@ fn init_model() -> Model {
     system_prompt: "",
     header_present: false,
     view_mode: RawLog,
+    theme: Light,
     loading: false,
     status: "loading sessions…",
   }
@@ -142,7 +164,21 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
         }
       }
     SetMode(mode) => (@cmd.none, { ..model, view_mode: mode })
+    SetTheme(theme) =>
+      // Apply the theme as a side effect (set `data-theme` on <html>) so the CSS
+      // variable blocks take over; the model tracks it for button highlighting.
+      (apply_theme(theme), { ..model, theme, })
   }
+}
+
+///|
+/// Set `data-theme` on the document root. `light`/`dark` pick a fixed palette;
+/// `system` defers to the OS via the stylesheet's `prefers-color-scheme` query.
+extern "js" fn set_document_theme(theme : String) -> Unit = "(t) => document.documentElement.setAttribute('data-theme', t)"
+
+///|
+fn apply_theme(theme : Theme) -> @cmd.Cmd {
+  @cmd.effect(() => set_document_theme(theme.value()))
 }
 
 ///|
@@ -180,12 +216,39 @@ fn events_status(parsed : @viz.ParsedLog) -> String {
 fn view(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
   @html.div(class="app", [
     @html.aside(class="sidebar", [
-      @html.h1(class="brand", "OpenSeek sessions"),
-      @html.div(class="status", model.status),
+      @html.div(class="sidebar-head", [
+        @html.h1(class="brand", "OpenSeek sessions"),
+        @html.div(class="status", model.status),
+      ]),
       sidebar_list(emit, model),
+      theme_toggle(emit, model),
     ]),
     @html.section(class="main", [main_pane(emit, model)]),
   ])
+}
+
+///|
+fn theme_toggle(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  @html.div(class="theme-toggle", [
+    theme_button(emit, model, Light, "Light"),
+    theme_button(emit, model, Dark, "Dark"),
+    theme_button(emit, model, System, "System"),
+  ])
+}
+
+///|
+fn theme_button(
+  emit : @cmd.Emit[Msg],
+  model : Model,
+  theme : Theme,
+  label : String,
+) -> @html.Html {
+  let classes = if model.theme == theme {
+    "theme-button active"
+  } else {
+    "theme-button"
+  }
+  @html.button(class=classes, on_click=emit(SetTheme(theme)), label)
 }
 
 ///|

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1,0 +1,352 @@
+///|
+/// One row of the `/api/sessions` listing shown in the sidebar. The server
+/// already returns rows most-recently-active first, so the row only needs an id
+/// and a human label.
+struct SessionRow {
+  id : String
+  first_prompt : String
+}
+
+///|
+/// The whole viewer state. The current session is kept as the parsed log plus a
+/// system prompt fetched from `session.json`; the typed `Session` and its model
+/// projection are rebuilt in `view` so the two view modes always agree with the
+/// bytes on disk.
+struct Model {
+  sessions : Array[SessionRow]
+  selected : String?
+  parsed : @viz.ParsedLog?
+  system_prompt : String
+  header_present : Bool
+  view_mode : @viz.ViewMode
+  loading : Bool
+  status : String
+}
+
+///|
+/// Messages driving the update loop. The `String` in the fetch results carries
+/// the session id the request was issued for, so a slow response for a session
+/// the user already navigated away from is discarded instead of clobbering the
+/// pane.
+enum Msg {
+  SessionsFetched(Result[String, Error])
+  Select(String)
+  SessionFetched(String, Result[String, Error])
+  SetMode(@viz.ViewMode)
+}
+
+///|
+/// Outcome of decoding the `/api/sessions/<id>` envelope. `rabbita/http` reports
+/// any completed response as `Ok`, so absence and malformed payloads are
+/// distinguished here from the body, not the HTTP status.
+enum LoadOutcome {
+  Loaded(@viz.ParsedLog, String, Bool)
+  NotFound
+  Malformed
+}
+
+///|
+fn init_model() -> Model {
+  {
+    sessions: [],
+    selected: None,
+    parsed: None,
+    system_prompt: "",
+    header_present: false,
+    view_mode: RawLog,
+    loading: false,
+    status: "loading sessions…",
+  }
+}
+
+// ---- update ----------------------------------------------------------------
+
+///|
+fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) {
+  match msg {
+    SessionsFetched(Ok(text)) =>
+      match parse_session_rows(text) {
+        Some(sessions) =>
+          (
+            @cmd.none,
+            { ..model, sessions, status: "\{sessions.length()} session(s)" },
+          )
+        None =>
+          (@cmd.none, { ..model, status: "could not read the session list" })
+      }
+    SessionsFetched(Err(error)) =>
+      (@cmd.none, { ..model, status: "failed to list sessions: \{error}" })
+    Select(id) => {
+      let command = fetch_text(emit, session_url(id), result => {
+        SessionFetched(id, result)
+      })
+      (
+        command,
+        {
+          ..model,
+          selected: Some(id),
+          parsed: None,
+          system_prompt: "",
+          header_present: false,
+          loading: true,
+          status: "loading \{id}…",
+        },
+      )
+    }
+    SessionFetched(id, result) =>
+      // Drop a response for a session the user already navigated away from.
+      if model.selected != Some(id) {
+        (@cmd.none, model)
+      } else {
+        match result {
+          Err(error) =>
+            (
+              @cmd.none,
+              { ..model, loading: false, status: "request failed: \{error}" },
+            )
+          Ok(text) =>
+            match parse_load(text) {
+              Loaded(parsed, system_prompt, header_present) =>
+                (
+                  @cmd.none,
+                  {
+                    ..model,
+                    parsed: Some(parsed),
+                    system_prompt,
+                    header_present,
+                    loading: false,
+                    status: events_status(parsed),
+                  },
+                )
+              NotFound =>
+                (
+                  @cmd.none,
+                  {
+                    ..model,
+                    parsed: None,
+                    loading: false,
+                    status: "session not found: \{id}",
+                  },
+                )
+              Malformed =>
+                (
+                  @cmd.none,
+                  {
+                    ..model,
+                    parsed: None,
+                    loading: false,
+                    status: "malformed response for \{id}",
+                  },
+                )
+            }
+        }
+      }
+    SetMode(mode) => (@cmd.none, { ..model, view_mode: mode })
+  }
+}
+
+///|
+fn fetch_text(
+  emit : @cmd.Emit[Msg],
+  url : String,
+  to_msg : (Result[String, Error]) -> Msg,
+) -> @cmd.Cmd {
+  @http.get(url).expect_text(emit.map(to_msg))
+}
+
+///|
+/// Percent-encode the id so session ids containing URL-reserved characters
+/// (spaces, `?`, `#`) reach the server intact; it percent-decodes the segment.
+extern "js" fn encode_uri_component(value : String) -> String = "encodeURIComponent"
+
+///|
+fn session_url(id : String) -> String {
+  "/api/sessions/\{encode_uri_component(id)}"
+}
+
+///|
+fn events_status(parsed : @viz.ParsedLog) -> String {
+  let base = "\{parsed.events.length()} event(s)"
+  if parsed.errors.is_empty() && !parsed.partial_tail {
+    base
+  } else {
+    "\{base} · \{parsed.errors.length()} bad line(s)\{if parsed.partial_tail { " · truncated tail" } else { "" }}"
+  }
+}
+
+// ---- view ------------------------------------------------------------------
+
+///|
+fn view(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  @html.div(class="app", [
+    @html.aside(class="sidebar", [
+      @html.h1(class="brand", "OpenSeek sessions"),
+      @html.div(class="status", model.status),
+      sidebar_list(emit, model),
+    ]),
+    @html.section(class="main", [main_pane(emit, model)]),
+  ])
+}
+
+///|
+fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  if model.sessions.is_empty() {
+    return @html.div(class="sidebar-empty", "no sessions found")
+  }
+  let rows : Array[@html.Html] = [
+    for row in model.sessions => sidebar_row(emit, model, row)
+  ]
+  @html.ul(class="session-list", rows)
+}
+
+///|
+fn sidebar_row(
+  emit : @cmd.Emit[Msg],
+  model : Model,
+  row : SessionRow,
+) -> @html.Html {
+  let selected = model.selected == Some(row.id)
+  let label = if row.first_prompt.trim().is_empty() {
+    row.id
+  } else {
+    row.first_prompt
+  }
+  let classes = if selected { "session-item selected" } else { "session-item" }
+  @html.li(class=classes, on_click=emit(Select(row.id)), [
+    @html.div(class="session-item-label", label),
+    @html.div(class="session-item-id", row.id),
+  ])
+}
+
+///|
+fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  match model.selected {
+    None =>
+      @html.div(
+        class="placeholder",
+        "Select a session from the left to view it.",
+      )
+    Some(id) =>
+      match model.parsed {
+        None =>
+          if model.loading {
+            @html.div(class="placeholder", "Loading \{id}…")
+          } else {
+            @html.div(class="placeholder", model.status)
+          }
+        Some(parsed) => {
+          let session = @viz.session_from_parse(
+            parsed,
+            id~,
+            system_prompt=model.system_prompt,
+          )
+          @html.div(class="session-view", [
+            header_strip(model, id),
+            mode_toggle(emit, model),
+            @viz.render_notices(parsed),
+            @viz.render_session(session, model.view_mode),
+          ])
+        }
+      }
+  }
+}
+
+///|
+fn header_strip(model : Model, id : String) -> @html.Html {
+  let prompt_note = if model.header_present {
+    "session.json loaded"
+  } else {
+    "no session.json (events only)"
+  }
+  @html.header(class="header-strip", [
+    @html.div(class="header-id", id),
+    @html.div(class="header-meta", "\{model.status} · \{prompt_note}"),
+  ])
+}
+
+///|
+fn mode_toggle(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  @html.div(class="mode-toggle", [
+    mode_button(emit, model, RawLog, "Raw log"),
+    mode_button(emit, model, ModelView, "Model view"),
+  ])
+}
+
+///|
+fn mode_button(
+  emit : @cmd.Emit[Msg],
+  model : Model,
+  mode : @viz.ViewMode,
+  label : String,
+) -> @html.Html {
+  let classes = if model.view_mode == mode {
+    "mode-button active"
+  } else {
+    "mode-button"
+  }
+  @html.button(class=classes, on_click=emit(SetMode(mode)), label)
+}
+
+// ---- JSON helpers ----------------------------------------------------------
+
+///|
+/// Decode the `/api/sessions` listing. Returns `None` when the body is not a
+/// JSON array (e.g. a server error body that `rabbita/http` still delivers as
+/// `Ok`), so the caller can surface the failure instead of conflating it with a
+/// genuinely empty `[]`.
+fn parse_session_rows(text : String) -> Array[SessionRow]? {
+  let json = @json.parse(text) catch { _ => return None }
+  guard json is Array(items) else { return None }
+  let rows : Array[SessionRow] = []
+  for item in items {
+    if session_row_of(item) is Some(row) {
+      rows.push(row)
+    }
+  }
+  Some(rows)
+}
+
+///|
+fn session_row_of(json : Json) -> SessionRow? {
+  guard json is Object(fields) else { return None }
+  guard fields.get("id") is Some(String(id)) else { return None }
+  let first_prompt = match fields.get("first_prompt") {
+    Some(String(value)) => value
+    _ => ""
+  }
+  Some({ id, first_prompt })
+}
+
+///|
+/// Decode the `/api/sessions/<id>` envelope into a `LoadOutcome`. `header` is
+/// the parsed `session.json` (or null); its `system_prompt` is lifted out when
+/// present so the viewer can label the header strip and seed the model view.
+fn parse_load(text : String) -> LoadOutcome {
+  let json = @json.parse(text) catch { _ => return Malformed }
+  guard json is Object(fields) else { return Malformed }
+  let found = match fields.get("found") {
+    Some(True) => true
+    Some(False) => false
+    _ => return Malformed
+  }
+  if !found {
+    return NotFound
+  }
+  let events_text = match fields.get("events") {
+    Some(String(value)) => value
+    _ => return Malformed
+  }
+  let parsed = @viz.parse_events(events_text)
+  let (system_prompt, header_present) = match fields.get("header") {
+    Some(Object(header)) =>
+      (
+        match header.get("system_prompt") {
+          Some(String(prompt)) => prompt
+          _ => ""
+        },
+        true,
+      )
+    _ => ("", false)
+  }
+  Loaded(parsed, system_prompt, header_present)
+}

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -65,3 +65,10 @@ test "parse_session_rows distinguishes empty list from a non-array body" {
 test "session_url percent-encodes the id" {
   inspect(session_url("a b/c"), content="/api/sessions/a%20b%2Fc")
 }
+
+///|
+test "theme values map to the data-theme attribute" {
+  inspect(Theme::value(Light), content="light")
+  inspect(Theme::value(Dark), content="dark")
+  inspect(Theme::value(System), content="system")
+}

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -1,0 +1,67 @@
+///|
+test "parse_load reads a found envelope with header" {
+  let text =
+    #|{"found":true,"events":"{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","header":{"version":1,"system_prompt":"SYS"}}
+  match parse_load(text) {
+    Loaded(parsed, system_prompt, header_present) => {
+      inspect(parsed.events.length(), content="1")
+      inspect(system_prompt, content="SYS")
+      inspect(header_present, content="true")
+    }
+    _ => fail("expected Loaded")
+  }
+}
+
+///|
+test "parse_load treats a null header as events-only" {
+  let text =
+    #|{"found":true,"events":"","header":null}
+  match parse_load(text) {
+    Loaded(_, system_prompt, header_present) => {
+      inspect(system_prompt, content="")
+      inspect(header_present, content="false")
+    }
+    _ => fail("expected Loaded")
+  }
+}
+
+///|
+test "parse_load distinguishes not-found from malformed" {
+  guard parse_load("{\"found\":false}") is NotFound else {
+    fail("expected NotFound")
+  }
+  guard parse_load("not json") is Malformed else { fail("expected Malformed") }
+  guard parse_load("{\"events\":\"x\"}") is Malformed else {
+    fail("expected Malformed when found is missing")
+  }
+}
+
+///|
+test "parse_session_rows reads the listing, skipping malformed rows" {
+  let text =
+    #|[{"id":"a","last_active":1,"first_prompt":"hello"},{"first_prompt":"no id"},{"id":"b","first_prompt":""}]
+  guard parse_session_rows(text) is Some(rows) else { fail("expected Some") }
+  inspect(rows.length(), content="2")
+  inspect(rows[0].id, content="a")
+  inspect(rows[0].first_prompt, content="hello")
+  inspect(rows[1].id, content="b")
+}
+
+///|
+test "parse_session_rows distinguishes empty list from a non-array body" {
+  guard parse_session_rows("[]") is Some(empty) else {
+    fail("expected Some([])")
+  }
+  inspect(empty.length(), content="0")
+  guard parse_session_rows("oops 500") is None else {
+    fail("expected None for a non-JSON body")
+  }
+  guard parse_session_rows("{\"error\":\"x\"}") is None else {
+    fail("expected None for a non-array body")
+  }
+}
+
+///|
+test "session_url percent-encodes the id" {
+  inspect(session_url("a b/c"), content="/api/sessions/a%20b%2Fc")
+}

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -1,0 +1,17 @@
+///|
+/// Mount the visualizer onto `#app` and kick off the initial session-list fetch.
+/// The frontend talks only to the read-only viz server's JSON/raw-file API.
+fn main {
+  let (emit, app_cell) = @rabbita.cell_with_emit(
+    model=init_model(),
+    update~,
+    view~,
+  )
+  let app = @rabbita.new(app_cell)
+  app.with_init(
+    @http.get("/api/sessions").expect_text(
+      emit.map(result => SessionsFetched(result)),
+    ),
+  )
+  app.mount("app")
+}

--- a/cmd/viz_app/moon.pkg
+++ b/cmd/viz_app/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "bobzhang/openseek/viz",
+  "moonbit-community/rabbita",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/http",
+  "moonbitlang/core/json",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "js"
+
+options(
+  "is-main": true,
+)

--- a/cmd/viz_app/pkg.generated.mbti
+++ b/cmd/viz_app/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/viz_app"
+
+// Values
+
+// Errors
+
+// Types and methods
+type LoadOutcome
+
+type Model
+
+type Msg
+
+type SessionRow
+
+// Type aliases
+
+// Traits
+

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -1,0 +1,375 @@
+///|
+/// Read-only web server for the events.jsonl visualizer. Serves the static
+/// frontend bundle plus a tiny JSON/raw-file API over a `SessionStore`:
+///
+/// - `GET /`                                  → the viewer shell (web/index.html)
+/// - `GET /viz_app.js`                        → the compiled frontend bundle
+/// - `GET /api/sessions`                      → JSON listing of known sessions
+/// - `GET /api/sessions/<id>`                 → `{found, events, header}` envelope
+/// - `GET /api/sessions/<id>/events.jsonl`    → raw append-only event log
+/// - `GET /api/sessions/<id>/session.json`    → raw header (404 when absent)
+///
+/// It never writes to the store, so pointing it at a live session root is safe.
+async fn main {
+  let matches = cli_command().parse(env=@env.get_env_vars())
+  let port = parse_port(value(matches, "port"))
+  let session_root = value(matches, "session-root").trim().to_owned()
+  if session_root.is_empty() {
+    fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
+  }
+  let web_dir = value(matches, "web-dir")
+  let bundle = value(matches, "bundle")
+  let store = @store.SessionStore(session_root)
+  let addr = @socket.Addr::parse("127.0.0.1:\{port}")
+  println("openseek viz: serving sessions under '\{session_root}'")
+  println("openseek viz: shell from '\{web_dir}/index.html'")
+  println("openseek viz: open http://127.0.0.1:\{port}")
+  let server = @http.Server(addr)
+  server.run_forever((request, _body, conn) => {
+    handle(request, conn, store, web_dir, bundle)
+  })
+}
+
+///|
+/// A fully-computed HTTP reply. Building it does no socket I/O, so the single
+/// send in `handle` is the only place a response is written — there is no way to
+/// start a second response (which would panic `send_response`).
+struct Reply {
+  code : Int
+  reason : String
+  content_type : String
+  body : String
+}
+
+///|
+/// Handle one request: compute the reply (catching any failure as a 500), then
+/// send it exactly once. A failure during the send — e.g. the client closed the
+/// connection mid-body — is swallowed: the response was already started, so
+/// retrying would double-send. `run_forever` keeps serving other connections.
+async fn handle(
+  request : @http.Request,
+  conn : @http.ServerConnection,
+  store : @store.SessionStore,
+  web_dir : String,
+  bundle : String,
+) -> Unit {
+  let reply = build_reply(request, store, web_dir, bundle) catch {
+    error => text_reply(500, "Internal Server Error", "error: \{error}")
+  }
+  send_reply(conn, reply) catch {
+    // The send already started, so a mid-body failure (client hung up) must not
+    // trigger a second send_response. Swallow it; run_forever keeps serving.
+    _ => ()
+  }
+}
+
+///|
+async fn send_reply(conn : @http.ServerConnection, reply : Reply) -> Unit {
+  conn.send_response(reply.code, reply.reason, extra_headers={
+    "Content-Type": reply.content_type,
+  })
+  conn.write_string(reply.body)
+  conn.end_response()
+}
+
+///|
+async fn build_reply(
+  request : @http.Request,
+  store : @store.SessionStore,
+  web_dir : String,
+  bundle : String,
+) -> Reply {
+  guard request.meth is Get else {
+    return text_reply(405, "Method Not Allowed", "only GET is supported")
+  }
+  let path = strip_query(request.path)
+  match path {
+    "/" | "/index.html" =>
+      asset_reply(web_dir + "/index.html", "text/html; charset=utf-8")
+    "/viz_app.js" => bundle_reply(web_dir, bundle)
+    "/api/sessions" => session_list_reply(store)
+    _ =>
+      if path.has_prefix("/api/sessions/") {
+        session_path_reply(store, path)
+      } else {
+        text_reply(404, "Not Found", "no route for \{path}")
+      }
+  }
+}
+
+///|
+/// Resolve `/api/sessions/<id>` (envelope) or `/api/sessions/<id>/<file>` (raw).
+/// The `<id>` segment is percent-decoded, so an id containing URL-reserved
+/// characters (spaces, `?`, `#`) still resolves to the right session. The
+/// store's own id validation rejects path separators and `..`, so a crafted id
+/// cannot escape the session directory.
+async fn session_path_reply(
+  store : @store.SessionStore,
+  path : String,
+) -> Reply {
+  let rest = slice_from(path, "/api/sessions/".length())
+  let (id_value, file) = match rest.find("/") {
+    None => (percent_decode(rest), None)
+    Some(index) =>
+      (percent_decode(slice(rest, 0, index)), Some(slice_from(rest, index + 1)))
+  }
+  // Validate the id ourselves so a malformed request is a 400, not a 500 from
+  // the store's path-building assertion. These are the store's own id rules.
+  guard valid_session_id(id_value) else {
+    return text_reply(400, "Bad Request", "invalid session id")
+  }
+  let id = @agent_session.SessionId(id_value)
+  match file {
+    None => session_envelope_reply(store, id)
+    Some("events.jsonl") =>
+      asset_reply(
+        store.event_log_file(id),
+        "application/x-ndjson; charset=utf-8",
+      )
+    Some("session.json") =>
+      asset_reply(store.header_file(id), "application/json; charset=utf-8")
+    Some(other) =>
+      text_reply(404, "Not Found", "no such session file: \{other}")
+  }
+}
+
+///|
+/// Mirror `SessionStore`'s id validation so a bad URL id is rejected as a client
+/// error before any store path is built (which would otherwise raise → 500).
+fn valid_session_id(value : String) -> Bool {
+  value != "" &&
+  !value.contains("/") &&
+  !value.contains("\\") &&
+  value != "." &&
+  value != ".."
+}
+
+///|
+/// Serve one session as a single JSON envelope:
+/// `{ "found": Bool, "events": String, "header": Json|null }`.
+///
+/// The frontend's HTTP client (`rabbita/http`) resolves any completed response
+/// as success regardless of status code, so absence and content must be encoded
+/// in the body rather than signalled by 404. `events` is the raw `events.jsonl`
+/// text; `header` is the parsed `session.json` or `null` when it is absent.
+async fn session_envelope_reply(
+  store : @store.SessionStore,
+  id : @agent_session.SessionId,
+) -> Reply {
+  let events_path = store.event_log_file(id)
+  let header_path = store.header_file(id)
+  let events_exists = @fs.exists(events_path)
+  let header_exists = @fs.exists(header_path)
+  // A session with only a header (e.g. a crash between the first header write
+  // and the empty-log write) is still loadable — `SessionStore::load` treats a
+  // missing log as empty — and `listings()` can surface it, so treat either
+  // file existing as found rather than reporting a listed session as missing.
+  if !events_exists && !header_exists {
+    return json_reply({ "found": false })
+  }
+  let events_text = if events_exists {
+    read_text_lossy(events_path)
+  } else {
+    ""
+  }
+  let header : Json = if header_exists {
+    @json.parse(read_text_lossy(header_path)) catch {
+      _ => Json::null()
+    }
+  } else {
+    Json::null()
+  }
+  json_reply({ "found": true, "events": events_text, "header": header })
+}
+
+///|
+async fn session_list_reply(store : @store.SessionStore) -> Reply {
+  let rows : Array[Json] = []
+  for listing in store.listings() {
+    let last_active : Json = match listing.last_active_unix_seconds() {
+      Some(seconds) => Json::number(seconds.to_double())
+      None => Json::null()
+    }
+    rows.push({
+      "id": listing.id().value(),
+      "last_active": last_active,
+      "first_prompt": listing.first_prompt(),
+    })
+  }
+  json_reply(rows.to_json())
+}
+
+///|
+/// Locate the compiled frontend bundle. Searches, in order: an explicit
+/// `--bundle` path, `<web-dir>/viz_app.js`, then moon's release and debug build
+/// outputs. This lets `moon build cmd/viz_app --target js` followed by
+/// `moon run cmd/viz_server` work with no copy step.
+async fn bundle_reply(web_dir : String, bundle : String) -> Reply {
+  let candidates = [
+    bundle,
+    web_dir + "/viz_app.js",
+    "_build/js/release/build/cmd/viz_app/viz_app.js",
+    "_build/js/debug/build/cmd/viz_app/viz_app.js",
+  ]
+  for candidate in candidates {
+    if candidate != "" && @fs.exists(candidate) {
+      return asset_reply(candidate, "text/javascript; charset=utf-8")
+    }
+  }
+  text_reply(
+    404, "Not Found", "viz_app.js not found; build it with: moon build cmd/viz_app --target js",
+  )
+}
+
+///|
+/// Read a file into a reply, or a 404 reply when it does not exist.
+async fn asset_reply(path : String, content_type : String) -> Reply {
+  if !@fs.exists(path) {
+    return text_reply(404, "Not Found", "missing file: \{path}")
+  }
+  { code: 200, reason: "OK", content_type, body: read_text_lossy(path) }
+}
+
+///|
+/// Read a file as text, decoding invalid UTF-8 lossily rather than raising. A
+/// live `events.jsonl` can be torn mid-codepoint by a concurrent append; strict
+/// decoding would 500 the whole fetch, hiding the valid prefix. Lossy decoding
+/// keeps that prefix, and the torn final line then fails to parse client-side
+/// and is reported as a benign truncated tail.
+async fn read_text_lossy(path : String) -> String {
+  @utf8.decode_lossy(@fs.read_file(path).binary()[:])
+}
+
+///|
+fn json_reply(body : Json) -> Reply {
+  {
+    code: 200,
+    reason: "OK",
+    content_type: "application/json; charset=utf-8",
+    body: body.stringify(),
+  }
+}
+
+///|
+fn text_reply(code : Int, reason : String, message : String) -> Reply {
+  { code, reason, content_type: "text/plain; charset=utf-8", body: message }
+}
+
+///|
+/// The path without any `?query` suffix.
+fn strip_query(path : String) -> String {
+  match path.find("?") {
+    Some(index) => slice(path, 0, index)
+    None => path
+  }
+}
+
+///|
+/// Code-unit slice `s[start:end]` as an owned `String`. Indices here always come
+/// from `find`/`length`, so they are in range.
+fn slice(s : String, start : Int, end : Int) -> String {
+  s[start:end].to_owned()
+}
+
+///|
+/// Code-unit slice `s[start:]` as an owned `String`.
+fn slice_from(s : String, start : Int) -> String {
+  s[start:].to_owned()
+}
+
+///|
+/// Percent-decode a URL path segment (`%XX` → byte), assembling the decoded
+/// bytes and interpreting them as UTF-8. Non-`%` characters pass through as
+/// their own UTF-8 bytes. `+` is left as-is (it is literal in path segments).
+/// A malformed `%` escape is left verbatim, and undecodable bytes fall back to
+/// the original string.
+fn percent_decode(s : String) -> String {
+  let chars = s.to_array()
+  let bytes : Array[Byte] = []
+  let mut i = 0
+  while i < chars.length() {
+    let c = chars[i]
+    if c == '%' &&
+      i + 2 < chars.length() &&
+      hex_val(chars[i + 1]) is Some(high) &&
+      hex_val(chars[i + 2]) is Some(low) {
+      bytes.push(((high * 16 + low) & 0xff).to_byte())
+      i = i + 3
+    } else {
+      for byte in @utf8.encode(c.to_string()) {
+        bytes.push(byte)
+      }
+      i = i + 1
+    }
+  }
+  @utf8.decode(Bytes::from_array(bytes)) catch {
+    _ => s
+  }
+}
+
+///|
+fn hex_val(c : Char) -> Int? {
+  if c >= '0' && c <= '9' {
+    Some(c.to_int() - '0'.to_int())
+  } else if c >= 'a' && c <= 'f' {
+    Some(c.to_int() - 'a'.to_int() + 10)
+  } else if c >= 'A' && c <= 'F' {
+    Some(c.to_int() - 'A'.to_int() + 10)
+  } else {
+    None
+  }
+}
+
+///|
+fn cli_command() -> @argparse.Command {
+  Command(
+    "openseek-viz",
+    about="Read-only web server for the OpenSeek events.jsonl visualizer.",
+    options=[
+      OptionArg(
+        "port",
+        long="port",
+        env="OPENSEEK_VIZ_PORT",
+        default_values=["8080"],
+        about="TCP port to listen on (127.0.0.1).",
+      ),
+      OptionArg(
+        "session-root",
+        long="session-root",
+        env="OPENSEEK_SESSION_ROOT",
+        default_values=[".openseek"],
+        about="Directory containing durable OpenSeek sessions.",
+      ),
+      OptionArg(
+        "web-dir",
+        long="web-dir",
+        env="OPENSEEK_VIZ_WEB_DIR",
+        default_values=["web"],
+        about="Directory holding the index.html shell.",
+      ),
+      OptionArg(
+        "bundle",
+        long="bundle",
+        env="OPENSEEK_VIZ_BUNDLE",
+        default_values=[""],
+        about="Path to the compiled viz_app.js; defaults to auto-locating the moon build output.",
+      ),
+    ],
+  )
+}
+
+///|
+fn value(matches : @argparse.Matches, name : String) -> String raise {
+  match matches.values.get(name) {
+    Some([value]) => value
+    Some(values) if values.length() > 0 => values[0]
+    _ => fail("missing parsed argument: \{name}")
+  }
+}
+
+///|
+fn parse_port(text : String) -> Int raise {
+  @string.parse_int(text) catch {
+    _ => fail("--port or OPENSEEK_VIZ_PORT must be an integer, got: \{text}")
+  }
+}

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -1,0 +1,38 @@
+///|
+test "percent_decode passes plain segments through" {
+  inspect(
+    percent_decode("tui-20260610-124146-251"),
+    content="tui-20260610-124146-251",
+  )
+}
+
+///|
+test "percent_decode resolves ASCII escapes" {
+  inspect(percent_decode("with%20space"), content="with space")
+  inspect(percent_decode("100%25"), content="100%")
+  inspect(percent_decode("a%3Fb%23c"), content="a?b#c")
+}
+
+///|
+test "percent_decode handles lowercase hex and UTF-8 byte sequences" {
+  inspect(percent_decode("a%2fb"), content="a/b")
+  inspect(percent_decode("%E4%B8%AD"), content="中")
+}
+
+///|
+test "percent_decode leaves malformed escapes verbatim" {
+  inspect(percent_decode("%zz"), content="%zz")
+  inspect(percent_decode("tail%2"), content="tail%2")
+  inspect(percent_decode("bare%"), content="bare%")
+}
+
+///|
+test "valid_session_id mirrors the store's id rules" {
+  inspect(valid_session_id("tui-20260610-124146-251"), content="true")
+  inspect(valid_session_id("with space"), content="true")
+  inspect(valid_session_id(""), content="false")
+  inspect(valid_session_id("."), content="false")
+  inspect(valid_session_id(".."), content="false")
+  inspect(valid_session_id("a/b"), content="false")
+  inspect(valid_session_id("a\\b"), content="false")
+}

--- a/cmd/viz_server/moon.pkg
+++ b/cmd/viz_server/moon.pkg
@@ -1,0 +1,19 @@
+import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/argparse",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbitlang/core/string",
+}
+
+supported_targets = "native"
+
+options(
+  "is-main": true,
+)

--- a/cmd/viz_server/pkg.generated.mbti
+++ b/cmd/viz_server/pkg.generated.mbti
@@ -1,0 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/viz_server"
+
+// Values
+
+// Errors
+
+// Types and methods
+type Reply
+
+// Type aliases
+
+// Traits
+

--- a/moon.mod
+++ b/moon.mod
@@ -9,6 +9,7 @@ import {
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",
+  "moonbit-community/rabbita@0.12.4",
 }
 
 readme = "README.mbt.md"

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -1,0 +1,54 @@
+# OpenSeek session visualizer
+
+A browser viewer for OpenSeek's durable session logs. It renders the
+`events.jsonl` append-only log of a session two ways, side by side behind a
+toggle:
+
+- **Raw log** — every event in file order, grouped into turns (user prompt →
+  assistant messages, tool results, runtime notices, terminal).
+- **Model view** — exactly what `Session::chat_messages` feeds the model:
+  summaries replace the events they cover, and tool calls left dangling by a
+  crashed process show the synthesized "previous agent process exited…" marker.
+
+## Pieces
+
+| Package          | Target | Role                                                                 |
+|------------------|--------|---------------------------------------------------------------------|
+| `viz`            | js     | Pure parse + render: `events.jsonl` text → typed events → `@html.Html`. Reuses `agent_session` decoders and projection, so it stays correct as the format evolves. |
+| `cmd/viz_app`    | js     | The rabbita (TEA) frontend: session browser, fetch, mode toggle.    |
+| `cmd/viz_server` | native | Read-only web server (`moonbitlang/async/http`) exposing a JSON/raw-file API over a `SessionStore`. It never writes, so pointing it at a live session root is safe. |
+
+The `viz` library is headless-testable: `render_session` returns `@html.Html`,
+which `@rabbita.render_to_string` turns into a string for snapshot assertions —
+no browser needed in CI.
+
+## Server API
+
+- `GET /` → the viewer shell (`web/index.html`)
+- `GET /viz_app.js` → the compiled frontend bundle (auto-located from the moon build output)
+- `GET /api/sessions` → `[{id, last_active, first_prompt}, …]`, most recent first
+- `GET /api/sessions/<id>/events.jsonl` → raw append-only log
+- `GET /api/sessions/<id>/session.json` → raw header (404 when absent; the frontend degrades to events-only)
+
+## Running it
+
+```bash
+# 1. Build the frontend bundle (JS backend)
+moon build cmd/viz_app --target js
+
+# 2. Serve a session root (the server finds the bundle from the build output)
+moon run cmd/viz_server --target native -- --session-root .openseek --port 8080
+
+# 3. Open http://127.0.0.1:8080
+```
+
+`--session-root`, `--port`, `--web-dir`, and `--bundle` all have env-var
+fallbacks (`OPENSEEK_SESSION_ROOT`, `OPENSEEK_VIZ_PORT`, …); run with `--help`
+for the full list.
+
+## Resilient parsing
+
+`parse_events` tolerates a half-written log: a truncated final line (a process
+that exited between writing an event and its newline) is reported as a benign
+truncated tail, and any single line that fails to decode becomes an inline error
+card while the rest of the conversation still renders.

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -10,6 +10,9 @@ toggle:
   summaries replace the events they cover, and tool calls left dangling by a
   crashed process show the synthesized "previous agent process exited…" marker.
 
+A Light / Dark / System theme toggle sits in the sidebar (default Light;
+System follows the OS via `prefers-color-scheme`).
+
 ## Pieces
 
 | Package          | Target | Role                                                                 |

--- a/viz/README.md
+++ b/viz/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/viz/group_wbtest.mbt
+++ b/viz/group_wbtest.mbt
@@ -1,0 +1,31 @@
+///|
+/// Turns are delimited by `Terminal` events, so a turn that contains mid-turn
+/// steering (extra `User` events before the terminal) stays a single turn.
+test "group_turns keeps steering messages within one turn" {
+  let s = @agent_session.Session(SessionId("g"), system_prompt="")
+    .append(User(UserMessage("do the thing")))
+    .append(Assistant(AssistantMessage("working")))
+    .append(User(UserMessage("actually, also this")))
+    .append(Assistant(AssistantMessage("ok")))
+    .append(Terminal(Finished("done")))
+  let turns = group_turns(s.events())
+  inspect(turns.length(), content="1")
+  inspect(turns[0].length(), content="5")
+}
+
+///|
+/// Two complete turns produce two groups; a trailing turn with no terminal
+/// (cut off mid-flight) becomes its own final group.
+test "group_turns splits on terminals and keeps an unterminated tail" {
+  let s = @agent_session.Session(SessionId("g"), system_prompt="")
+    .append(User(UserMessage("one")))
+    .append(Terminal(Finished("first")))
+    .append(User(UserMessage("two")))
+    .append(Terminal(Finished("second")))
+    .append(User(UserMessage("three (still running)")))
+  let turns = group_turns(s.events())
+  inspect(turns.length(), content="3")
+  inspect(turns[0].length(), content="2")
+  inspect(turns[1].length(), content="2")
+  inspect(turns[2].length(), content="1")
+}

--- a/viz/moon.pkg
+++ b/viz/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/deepseek",
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/immut/vector",
+  "moonbitlang/core/json",
+}
+
+import {
+  "moonbit-community/rabbita",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "js"

--- a/viz/parse.mbt
+++ b/viz/parse.mbt
@@ -1,0 +1,72 @@
+///|
+/// One JSONL line that could not be decoded into a `SessionEvent`. Kept so the
+/// viewer can surface the offending line instead of silently dropping it or
+/// aborting the whole load.
+pub(all) struct LineError {
+  line_number : Int
+  content : String
+  message : String
+} derive(Debug)
+
+///|
+/// The result of parsing an `events.jsonl` log line by line. `events` are the
+/// records that decoded cleanly (in file order); `errors` are individual lines
+/// that failed to decode; `partial_tail` is true when the final line looked
+/// like a half-written record from a process that exited mid-append (no
+/// trailing newline and the last segment failed to decode), which the viewer
+/// reports as a benign truncation rather than corruption.
+pub(all) struct ParsedLog {
+  events : Array[@agent_session.SessionEvent]
+  errors : Array[LineError]
+  partial_tail : Bool
+} derive(Debug)
+
+///|
+/// Parse an `events.jsonl` log into typed `SessionEvent`s, tolerating a
+/// truncated trailing line and per-line decode failures. Blank lines are
+/// ignored. A decode failure on any line other than an unterminated final line
+/// is recorded as a `LineError` and parsing continues, so one bad record never
+/// hides the rest of the conversation.
+pub fn parse_events(text : String) -> ParsedLog {
+  let events : Array[@agent_session.SessionEvent] = []
+  let errors : Array[LineError] = []
+  let ends_with_newline = text.has_suffix("\n")
+  let lines = text.split("\n").map(line => line.to_owned()).collect()
+  let mut partial_tail = false
+  for index, line in lines {
+    let line_number = index + 1
+    if line.trim().is_empty() {
+      continue
+    }
+    let is_last_segment = index == lines.length() - 1
+    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
+      error => {
+        // A failed final line with no terminating newline is the classic
+        // signature of a crash between `write(line)` and `write("\n")`; treat
+        // it as a truncated tail, not a corrupt record.
+        if is_last_segment && !ends_with_newline {
+          partial_tail = true
+        } else {
+          errors.push({ line_number, content: line, message: "\{error}" })
+        }
+        continue
+      }
+    }
+    events.push(event)
+  }
+  { events, errors, partial_tail }
+}
+
+///|
+/// Build an immutable `Session` from parsed events plus an optional header.
+/// When the header is absent (no `session.json`), a placeholder id and an empty
+/// system prompt are used so the viewer can still render the event log. The
+/// header's id and system prompt win when present.
+pub fn session_from_parse(
+  parsed : ParsedLog,
+  id~ : String,
+  system_prompt~ : String,
+) -> @agent_session.Session {
+  let session_id : @agent_session.SessionId = SessionId(id)
+  Session(session_id, system_prompt~, events=@vector.from_array(parsed.events))
+}

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -1,0 +1,42 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/viz"
+
+import {
+  "bobzhang/openseek/agent_session",
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn parse_events(String) -> ParsedLog
+
+pub fn render_notices(ParsedLog) -> @html.Html
+
+pub fn render_session(@agent_session.Session, ViewMode) -> @html.Html
+
+pub fn session_from_parse(ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
+
+// Errors
+
+// Types and methods
+pub(all) struct LineError {
+  line_number : Int
+  content : String
+  message : String
+} derive(@debug.Debug)
+
+pub(all) struct ParsedLog {
+  events : Array[@agent_session.SessionEvent]
+  errors : Array[LineError]
+  partial_tail : Bool
+} derive(@debug.Debug)
+
+pub(all) enum ViewMode {
+  RawLog
+  ModelView
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1,0 +1,337 @@
+///|
+/// Which projection of a session to render: the full append-only `RawLog` (every
+/// event in file order, grouped into turns) or `ModelView` — exactly the
+/// messages `Session::chat_messages` feeds the model, with summaries substituted
+/// for the events they cover and dangling tool calls healed.
+pub(all) enum ViewMode {
+  RawLog
+  ModelView
+} derive(Eq, Debug)
+
+///|
+/// Render a session under the chosen view mode.
+pub fn render_session(
+  session : @agent_session.Session,
+  mode : ViewMode,
+) -> @html.Html {
+  match mode {
+    RawLog => render_raw(session)
+    ModelView => render_model(session)
+  }
+}
+
+///|
+/// Banners for anything the parser flagged: decode failures on individual lines
+/// and a truncated final record. Returns `@html.nothing` for a clean log so the
+/// caller can stack it unconditionally.
+pub fn render_notices(parsed : ParsedLog) -> @html.Html {
+  let notices : Array[@html.Html] = []
+  if parsed.partial_tail {
+    notices.push(
+      @html.div(class="notice notice-warn", [
+        @html.text(
+          "⚠ trailing partial line ignored (process likely exited mid-append)",
+        ),
+      ]),
+    )
+  }
+  for error in parsed.errors {
+    notices.push(
+      @html.div(class="notice notice-error", [
+        @html.div(class="notice-head", [
+          @html.text(
+            "⚠ line \{error.line_number} could not be decoded: \{error.message}",
+          ),
+        ]),
+        @html.pre(class="notice-body", error.content),
+      ]),
+    )
+  }
+  if notices.is_empty() {
+    @html.nothing
+  } else {
+    @html.div(class="notices", notices)
+  }
+}
+
+// ---- raw log view ----------------------------------------------------------
+
+///|
+fn render_raw(session : @agent_session.Session) -> @html.Html {
+  let turns = group_turns(session.events())
+  let blocks : Array[@html.Html] = []
+  for index, turn in turns {
+    blocks.push(turn_block(index + 1, turn))
+  }
+  if blocks.is_empty() {
+    return empty_state("This session has no events yet.")
+  }
+  @html.div(class="log raw-log", blocks)
+}
+
+///|
+/// Split the flat event log into turns. Every turn closes with exactly one
+/// `Terminal` event, so a turn runs up to and including the next `Terminal` —
+/// keying off terminals rather than `User` events keeps mid-turn steering
+/// (extra `User` events the engine appends before the terminal) inside the same
+/// turn. A trailing group with no terminal is a turn cut off mid-flight.
+fn group_turns(
+  events : @vector.Vector[@agent_session.SessionEvent],
+) -> Array[Array[@agent_session.SessionEvent]] {
+  let turns : Array[Array[@agent_session.SessionEvent]] = []
+  let mut current : Array[@agent_session.SessionEvent] = []
+  for event in events {
+    current.push(event)
+    if event.item() is Terminal(_) {
+      turns.push(current)
+      current = []
+    }
+  }
+  if !current.is_empty() {
+    turns.push(current)
+  }
+  turns
+}
+
+///|
+fn turn_block(
+  number : Int,
+  turn : Array[@agent_session.SessionEvent],
+) -> @html.Html {
+  let cards : Array[@html.Html] = [ for event in turn => event_card(event) ]
+  let label = "Turn \{number} · \{turn_preview(turn)}"
+  @html.details(open=true, class="turn", [
+    @html.summary(class="turn-summary", label),
+    @html.div(class="turn-body", cards),
+  ])
+}
+
+///|
+fn turn_preview(turn : Array[@agent_session.SessionEvent]) -> String {
+  for event in turn {
+    if event.item() is User(message) {
+      return truncate(one_line(message.content()), 80)
+    }
+  }
+  "\{turn.length()} events"
+}
+
+///|
+fn event_card(event : @agent_session.SessionEvent) -> @html.Html {
+  let seq = event.sequence()
+  match event.item() {
+    User(message) => card("user", "User", seq, [text_block(message.content())])
+    Assistant(message) => assistant_card(seq, message)
+    Tool(result) => tool_card(seq, result)
+    Runtime(notice) =>
+      card("runtime", "Runtime notice", seq, [text_block(notice.content())])
+    Summary(summary) => summary_card(seq, summary)
+    Terminal(terminal) => terminal_card(seq, terminal)
+  }
+}
+
+///|
+fn assistant_card(
+  seq : Int,
+  message : @agent_session.AssistantMessage,
+) -> @html.Html {
+  let body : Array[@html.Html] = []
+  if message.reasoning_content() is Some(reasoning) &&
+    !reasoning.trim().is_empty() {
+    body.push(
+      @html.details(class="reasoning", [
+        @html.summary("reasoning"),
+        text_block(reasoning),
+      ]),
+    )
+  }
+  if !message.content().trim().is_empty() {
+    body.push(text_block(message.content()))
+  }
+  let calls = message.tool_calls()
+  if !calls.is_empty() {
+    let call_views : Array[@html.Html] = [
+      for call in calls => tool_call_view(call)
+    ]
+    body.push(@html.div(class="tool-calls", call_views))
+  }
+  card("assistant", "Assistant", seq, body)
+}
+
+///|
+fn tool_call_view(call : @deepseek.ToolCall) -> @html.Html {
+  @html.div(class="tool-call", [
+    @html.div(class="tool-call-name", [
+      @html.text("→ "),
+      @html.strong(call.name),
+    ]),
+    @html.pre(class="tool-call-args", pretty_json(call.arguments)),
+  ])
+}
+
+///|
+fn tool_card(seq : Int, result : @agent_session.ToolResult) -> @html.Html {
+  let kind = if result.is_error() { "tool error" } else { "tool" }
+  let label = if result.is_error() {
+    "Tool error · \{result.tool_name()}"
+  } else {
+    "Tool result · \{result.tool_name()}"
+  }
+  card(kind, label, seq, [text_block(result.content())])
+}
+
+///|
+fn summary_card(
+  seq : Int,
+  summary : @agent_session.SessionSummary,
+) -> @html.Html {
+  let label = "Summary · covers events \{summary.from_sequence()}..\{summary.to_sequence()}"
+  card("summary", label, seq, [text_block(summary.content())])
+}
+
+///|
+fn terminal_card(
+  seq : Int,
+  terminal : @agent_session.TurnTerminal,
+) -> @html.Html {
+  let (kind, message) = match terminal {
+    Finished(answer) => ("finished", answer)
+    Aborted(reason) => ("aborted", reason)
+    Interrupted(reason) => ("interrupted", reason)
+    Failed(message) => ("failed", message)
+  }
+  let body : Array[@html.Html] = [@html.span(class="badge badge-\{kind}", kind)]
+  if !message.trim().is_empty() {
+    body.push(text_block(message))
+  }
+  card("terminal", "Turn ended", seq, body)
+}
+
+// ---- model projection view -------------------------------------------------
+
+///|
+fn render_model(session : @agent_session.Session) -> @html.Html {
+  let messages = session.chat_messages()
+  let cards : Array[@html.Html] = [
+    for message in messages => message_card(message)
+  ]
+  if cards.is_empty() {
+    return empty_state("The model projection is empty.")
+  }
+  @html.div(class="log model-log", cards)
+}
+
+///|
+fn message_card(message : @deepseek.ChatMessage) -> @html.Html {
+  match message.role {
+    System =>
+      @html.section(class="card system", [
+        @html.details(open=false, [
+          @html.summary(class="card-label", "System prompt"),
+          text_block(message.content),
+        ]),
+      ])
+    User => model_card("user", "User", message)
+    Assistant => model_card("assistant", "Assistant", message)
+    Tool(_) => model_card("tool", "Tool result", message)
+  }
+}
+
+///|
+fn model_card(
+  kind : String,
+  label : String,
+  message : @deepseek.ChatMessage,
+) -> @html.Html {
+  let body : Array[@html.Html] = []
+  if message.reasoning_content is Some(reasoning) &&
+    !reasoning.trim().is_empty() {
+    body.push(
+      @html.details(class="reasoning", [
+        @html.summary("reasoning"),
+        text_block(reasoning),
+      ]),
+    )
+  }
+  if !message.content.trim().is_empty() {
+    body.push(text_block(message.content))
+  }
+  if !message.tool_calls.is_empty() {
+    let call_views : Array[@html.Html] = [
+      for call in message.tool_calls => tool_call_view(call)
+    ]
+    body.push(@html.div(class="tool-calls", call_views))
+  }
+  @html.section(class="card \{kind}", [
+    @html.div(class="card-label", label),
+    @html.div(class="card-body", body),
+  ])
+}
+
+// ---- shared helpers --------------------------------------------------------
+
+///|
+fn card(
+  kind : String,
+  label : String,
+  seq : Int,
+  body : Array[@html.Html],
+) -> @html.Html {
+  @html.section(class="card \{kind}", [
+    @html.div(class="card-label", [
+      @html.span(class="card-seq", "#\{seq}"),
+      @html.text(label),
+    ]),
+    @html.div(class="card-body", body),
+  ])
+}
+
+///|
+/// A whitespace-preserving text block. Empty content renders an explicit
+/// placeholder so a card never collapses to nothing.
+fn text_block(content : String) -> @html.Html {
+  if content.trim().is_empty() {
+    @html.span(class="empty", "(empty)")
+  } else {
+    @html.pre(class="content", content)
+  }
+}
+
+///|
+fn empty_state(message : String) -> @html.Html {
+  @html.div(class="empty-state", [@html.text(message)])
+}
+
+///|
+/// Pretty-print a tool call's raw argument string when it is valid JSON; fall
+/// back to the raw string otherwise, since the model can emit malformed
+/// arguments and the viewer should show them as-is.
+fn pretty_json(raw : String) -> String {
+  @json.parse(raw).stringify(indent=2) catch {
+    _ => raw
+  }
+}
+
+///|
+fn one_line(text : String) -> String {
+  text.replace_all(old="\n", new=" ").trim().to_owned()
+}
+
+///|
+/// Keep the first `limit` characters, appending an ellipsis when text is cut.
+/// Iterates by character so it never splits a surrogate pair.
+fn truncate(text : String, limit : Int) -> String {
+  if text.length() <= limit {
+    return text
+  }
+  let kept = StringBuilder::new()
+  let mut count = 0
+  for char in text {
+    if count >= limit {
+      break
+    }
+    kept.write_char(char)
+    count += 1
+  }
+  kept.to_string() + "…"
+}

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1,0 +1,132 @@
+///|
+/// Build a session that exercises every event kind, then serialize it back to
+/// the on-disk `events.jsonl` form so the parser is tested against exactly what
+/// the store writes.
+fn sample_session() -> @agent_session.Session {
+  let s0 = @agent_session.Session(
+    SessionId("demo"),
+    system_prompt="You are a helpful agent.",
+  )
+  let s1 = s0.append(User(UserMessage("list the files")))
+  let s2 = s1.append(
+    Assistant(
+      AssistantMessage(
+        "I'll run ls.",
+        tool_calls=[
+          ToolCall(id="call_1", name="shell", arguments="{\"cmd\":\"ls\"}"),
+        ],
+        reasoning_content="The user wants a directory listing.",
+      ),
+    ),
+  )
+  let s3 = s2.append(
+    Tool(
+      ToolResult(
+        tool_call_id="call_1",
+        tool_name="shell",
+        content="README.md\nsrc",
+      ),
+    ),
+  )
+  let s4 = s3.append(Runtime(RuntimeNotice("moon check: 0 errors")))
+  s4.append(Terminal(Finished("Here are your files: README.md, src.")))
+}
+
+///|
+/// Serialize a session to the append-only JSONL text the store persists.
+fn events_jsonl(session : @agent_session.Session) -> String {
+  let out = StringBuilder::new()
+  for event in session.events() {
+    out.write_string(event.to_json().stringify())
+    out.write_char('\n')
+  }
+  out.to_string()
+}
+
+///|
+fn render(html : @html.Html) -> String {
+  @rabbita.render_to_string(@rabbita.static_cell(html))
+}
+
+///|
+test "parse round-trips every event kind" {
+  let text = events_jsonl(sample_session())
+  let parsed = @viz.parse_events(text)
+  inspect(parsed.events.length(), content="5")
+  inspect(parsed.errors.length(), content="0")
+  inspect(parsed.partial_tail, content="false")
+}
+
+///|
+test "parse tolerates a truncated final line" {
+  let text = "{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"item\":{\"kind\":\"assi"
+  let parsed = @viz.parse_events(text)
+  inspect(parsed.events.length(), content="1")
+  inspect(parsed.errors.length(), content="0")
+  inspect(parsed.partial_tail, content="true")
+}
+
+///|
+test "parse records a bad interior line without aborting" {
+  let text = "{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\nnot json at all\n{\"sequence\":2,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n"
+  let parsed = @viz.parse_events(text)
+  inspect(parsed.events.length(), content="2")
+  inspect(parsed.errors.length(), content="1")
+  inspect(parsed.errors[0].line_number, content="2")
+  inspect(parsed.partial_tail, content="false")
+}
+
+///|
+test "raw view renders each event kind" {
+  let session = @viz.session_from_parse(
+    @viz.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="You are a helpful agent.",
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("Turn 1"))
+  assert_true(html.contains("class=\"card user\""))
+  assert_true(html.contains("class=\"card assistant\""))
+  assert_true(html.contains("reasoning"))
+  assert_true(html.contains("shell"))
+  assert_true(html.contains("Tool result"))
+  assert_true(html.contains("Runtime notice"))
+  assert_true(html.contains("badge-finished"))
+}
+
+///|
+test "model view substitutes a summary for the events it covers" {
+  // A session whose summary covers the first two events: the model projection
+  // should show the summary text and drop the covered user/assistant content.
+  let base = @viz.session_from_parse(
+    @viz.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="SYS-PROMPT-MARKER",
+  )
+  let compacted = base.compact(
+    content="SUMMARY-MARKER: user asked for files; agent planned ls.",
+    from_sequence=1,
+    to_sequence=2,
+  )
+  let model_html = render(@viz.render_session(compacted, ModelView))
+  assert_true(model_html.contains("System prompt"))
+  assert_true(model_html.contains("SYS-PROMPT-MARKER"))
+  assert_true(model_html.contains("SUMMARY-MARKER"))
+  // The assistant's planning line is covered by the summary, so the model view
+  // must not replay it.
+  assert_true(!model_html.contains("I'll run ls."))
+  // The raw view still shows everything, including the covered line.
+  let raw_html = render(@viz.render_session(compacted, RawLog))
+  assert_true(raw_html.contains("I'll run ls."))
+  assert_true(raw_html.contains("Summary"))
+}
+
+///|
+test "notices surface partial tails and bad lines" {
+  let parsed = @viz.parse_events(
+    "garbage line\n{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{bad tail",
+  )
+  let html = render(@viz.render_notices(parsed))
+  assert_true(html.contains("could not be decoded"))
+  assert_true(html.contains("trailing partial line"))
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,11 +1,40 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>OpenSeek session viewer</title>
   <style>
-    :root {
+    /* Light is the default. `data-theme="dark"` forces dark; `data-theme="system"`
+       follows the OS via prefers-color-scheme (tracked live, no JS listener). */
+    :root,
+    :root[data-theme="light"] {
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --panel-2: #eef1f5;
+      --border: #d7dce3;
+      --text: #1c2027;
+      --muted: #5b6472;
+      --accent: #2563eb;
+      --on-accent: #ffffff;
+      --user: #2f5bd6;
+      --assistant: #1a8f63;
+      --tool: #8a6d10;
+      --error: #c2334a;
+      --runtime: #6d4fb0;
+      --summary: #b5701f;
+      --terminal: #2b7e9e;
+      --summary-bg: #fbf3e6;
+      --notice-warn-bg: #fdf3e0;
+      --notice-error-bg: #fbe9ec;
+      --badge-finished-bg: #dff3e6; --badge-finished-fg: #1a7a45;
+      --badge-aborted-bg: #fbeed1; --badge-aborted-fg: #8a6d10;
+      --badge-interrupted-bg: #e6e9ef; --badge-interrupted-fg: #4a5263;
+      --badge-failed-bg: #fbe0e5; --badge-failed-fg: #b02a43;
+    }
+    :root[data-theme="dark"] {
+      color-scheme: dark;
       --bg: #0f1117;
       --panel: #161922;
       --panel-2: #1d212c;
@@ -13,13 +42,48 @@
       --text: #d7dbe4;
       --muted: #8a92a4;
       --accent: #6ea8fe;
-      --user: #4f7cff;
+      --on-accent: #0b0d12;
+      --user: #6f93ff;
       --assistant: #36c08a;
       --tool: #c9a227;
       --error: #e0556b;
       --runtime: #9a7bd6;
       --summary: #d98a3a;
       --terminal: #5fa8c7;
+      --summary-bg: #1c1812;
+      --notice-warn-bg: #3a2f12;
+      --notice-error-bg: #3a1620;
+      --badge-finished-bg: #14361f; --badge-finished-fg: #5fd08a;
+      --badge-aborted-bg: #3a2f12; --badge-aborted-fg: #e0b257;
+      --badge-interrupted-bg: #2a2f3a; --badge-interrupted-fg: #9fb0c9;
+      --badge-failed-bg: #3a1620; --badge-failed-fg: #ef8098;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root[data-theme="system"] {
+        color-scheme: dark;
+        --bg: #0f1117;
+        --panel: #161922;
+        --panel-2: #1d212c;
+        --border: #2a2f3a;
+        --text: #d7dbe4;
+        --muted: #8a92a4;
+        --accent: #6ea8fe;
+        --on-accent: #0b0d12;
+        --user: #6f93ff;
+        --assistant: #36c08a;
+        --tool: #c9a227;
+        --error: #e0556b;
+        --runtime: #9a7bd6;
+        --summary: #d98a3a;
+        --terminal: #5fa8c7;
+        --summary-bg: #1c1812;
+        --notice-warn-bg: #3a2f12;
+        --notice-error-bg: #3a1620;
+        --badge-finished-bg: #14361f; --badge-finished-fg: #5fd08a;
+        --badge-aborted-bg: #3a2f12; --badge-aborted-fg: #e0b257;
+        --badge-interrupted-bg: #2a2f3a; --badge-interrupted-fg: #9fb0c9;
+        --badge-failed-bg: #3a1620; --badge-failed-fg: #ef8098;
+      }
     }
     * { box-sizing: border-box; }
     body {
@@ -27,20 +91,23 @@
       font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       background: var(--bg);
       color: var(--text);
+      transition: background .15s ease, color .15s ease;
     }
     .app { display: grid; grid-template-columns: 320px 1fr; height: 100vh; }
 
-    /* sidebar */
+    /* sidebar: fixed head, scrolling list, pinned theme footer */
     .sidebar {
+      display: flex;
+      flex-direction: column;
       border-right: 1px solid var(--border);
       background: var(--panel);
-      overflow-y: auto;
-      padding: 16px;
+      overflow: hidden;
     }
+    .sidebar-head { padding: 16px 16px 8px; }
     .brand { font-size: 15px; margin: 0 0 4px; letter-spacing: .2px; }
-    .status { color: var(--muted); font-size: 12px; margin-bottom: 12px; }
-    .sidebar-empty { color: var(--muted); font-style: italic; }
-    .session-list { list-style: none; margin: 0; padding: 0; }
+    .status { color: var(--muted); font-size: 12px; }
+    .sidebar-empty { padding: 8px 16px; color: var(--muted); font-style: italic; }
+    .session-list { flex: 1 1 auto; overflow-y: auto; list-style: none; margin: 0; padding: 8px 12px; }
     .session-item {
       padding: 9px 10px;
       border: 1px solid transparent;
@@ -50,10 +117,19 @@
     }
     .session-item:hover { background: var(--panel-2); }
     .session-item.selected { background: var(--panel-2); border-color: var(--accent); }
-    .session-item-label {
-      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-    }
+    .session-item-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .session-item-id { color: var(--muted); font-size: 11px; font-family: ui-monospace, monospace; }
+
+    /* theme switcher */
+    .theme-toggle { display: flex; gap: 6px; padding: 10px 14px; border-top: 1px solid var(--border); }
+    .theme-button {
+      flex: 1;
+      background: var(--panel); color: var(--text);
+      border: 1px solid var(--border); border-radius: 7px;
+      padding: 5px 0; cursor: pointer; font-size: 12px;
+    }
+    .theme-button:hover { border-color: var(--accent); }
+    .theme-button.active { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
 
     /* main */
     .main { overflow-y: auto; padding: 20px 28px; }
@@ -74,13 +150,13 @@
       padding: 5px 14px; cursor: pointer; font-size: 13px;
     }
     .mode-button:hover { border-color: var(--accent); }
-    .mode-button.active { background: var(--accent); color: #0b0d12; border-color: var(--accent); }
+    .mode-button.active { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
 
     /* notices */
     .notices { margin-bottom: 16px; }
     .notice { border-radius: 8px; padding: 8px 12px; margin-bottom: 8px; font-size: 13px; }
-    .notice-warn { background: #3a2f12; border: 1px solid var(--summary); }
-    .notice-error { background: #3a1620; border: 1px solid var(--error); }
+    .notice-warn { background: var(--notice-warn-bg); border: 1px solid var(--summary); }
+    .notice-error { background: var(--notice-error-bg); border: 1px solid var(--error); }
     .notice-head { font-weight: 600; }
     .notice-body { margin: 6px 0 0; font-size: 12px; opacity: .85; white-space: pre-wrap; }
 
@@ -104,7 +180,7 @@
     .card.tool { border-left-color: var(--tool); }
     .card.tool.error { border-left-color: var(--error); }
     .card.runtime { border-left-color: var(--runtime); }
-    .card.summary { border-left-color: var(--summary); background: #1c1812; }
+    .card.summary { border-left-color: var(--summary); background: var(--summary-bg); }
     .card.terminal { border-left-color: var(--terminal); }
     .card.system { border-left-color: var(--muted); }
     .card-label {
@@ -132,10 +208,10 @@
       display: inline-block; padding: 2px 9px; border-radius: 999px;
       font-size: 11px; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 6px;
     }
-    .badge-finished { background: #14361f; color: #5fd08a; }
-    .badge-aborted { background: #3a2f12; color: #e0b257; }
-    .badge-interrupted { background: #2a2f3a; color: #9fb0c9; }
-    .badge-failed { background: #3a1620; color: #ef8098; }
+    .badge-finished { background: var(--badge-finished-bg); color: var(--badge-finished-fg); }
+    .badge-aborted { background: var(--badge-aborted-bg); color: var(--badge-aborted-fg); }
+    .badge-interrupted { background: var(--badge-interrupted-bg); color: var(--badge-interrupted-fg); }
+    .badge-failed { background: var(--badge-failed-bg); color: var(--badge-failed-fg); }
 
     .empty-state { color: var(--muted); margin-top: 24px; }
   </style>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenSeek session viewer</title>
+  <style>
+    :root {
+      --bg: #0f1117;
+      --panel: #161922;
+      --panel-2: #1d212c;
+      --border: #2a2f3a;
+      --text: #d7dbe4;
+      --muted: #8a92a4;
+      --accent: #6ea8fe;
+      --user: #4f7cff;
+      --assistant: #36c08a;
+      --tool: #c9a227;
+      --error: #e0556b;
+      --runtime: #9a7bd6;
+      --summary: #d98a3a;
+      --terminal: #5fa8c7;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }
+    .app { display: grid; grid-template-columns: 320px 1fr; height: 100vh; }
+
+    /* sidebar */
+    .sidebar {
+      border-right: 1px solid var(--border);
+      background: var(--panel);
+      overflow-y: auto;
+      padding: 16px;
+    }
+    .brand { font-size: 15px; margin: 0 0 4px; letter-spacing: .2px; }
+    .status { color: var(--muted); font-size: 12px; margin-bottom: 12px; }
+    .sidebar-empty { color: var(--muted); font-style: italic; }
+    .session-list { list-style: none; margin: 0; padding: 0; }
+    .session-item {
+      padding: 9px 10px;
+      border: 1px solid transparent;
+      border-radius: 8px;
+      cursor: pointer;
+      margin-bottom: 4px;
+    }
+    .session-item:hover { background: var(--panel-2); }
+    .session-item.selected { background: var(--panel-2); border-color: var(--accent); }
+    .session-item-label {
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .session-item-id { color: var(--muted); font-size: 11px; font-family: ui-monospace, monospace; }
+
+    /* main */
+    .main { overflow-y: auto; padding: 20px 28px; }
+    .placeholder { color: var(--muted); margin-top: 40px; text-align: center; }
+    .header-strip {
+      display: flex; justify-content: space-between; align-items: baseline;
+      gap: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--border);
+      margin-bottom: 14px;
+    }
+    .header-id { font-family: ui-monospace, monospace; font-size: 16px; }
+    .header-meta { color: var(--muted); font-size: 12px; }
+
+    /* mode toggle */
+    .mode-toggle { display: flex; gap: 8px; margin-bottom: 16px; }
+    .mode-button {
+      background: var(--panel); color: var(--text);
+      border: 1px solid var(--border); border-radius: 999px;
+      padding: 5px 14px; cursor: pointer; font-size: 13px;
+    }
+    .mode-button:hover { border-color: var(--accent); }
+    .mode-button.active { background: var(--accent); color: #0b0d12; border-color: var(--accent); }
+
+    /* notices */
+    .notices { margin-bottom: 16px; }
+    .notice { border-radius: 8px; padding: 8px 12px; margin-bottom: 8px; font-size: 13px; }
+    .notice-warn { background: #3a2f12; border: 1px solid var(--summary); }
+    .notice-error { background: #3a1620; border: 1px solid var(--error); }
+    .notice-head { font-weight: 600; }
+    .notice-body { margin: 6px 0 0; font-size: 12px; opacity: .85; white-space: pre-wrap; }
+
+    /* turns + cards */
+    .turn { margin-bottom: 14px; }
+    .turn-summary {
+      cursor: pointer; color: var(--muted); font-size: 12px;
+      text-transform: uppercase; letter-spacing: .5px; padding: 4px 0;
+    }
+    .turn-body { padding-left: 4px; }
+    .card {
+      border: 1px solid var(--border);
+      border-left-width: 3px;
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 10px 14px;
+      margin: 8px 0;
+    }
+    .card.user { border-left-color: var(--user); }
+    .card.assistant { border-left-color: var(--assistant); }
+    .card.tool { border-left-color: var(--tool); }
+    .card.tool.error { border-left-color: var(--error); }
+    .card.runtime { border-left-color: var(--runtime); }
+    .card.summary { border-left-color: var(--summary); background: #1c1812; }
+    .card.terminal { border-left-color: var(--terminal); }
+    .card.system { border-left-color: var(--muted); }
+    .card-label {
+      font-size: 11px; text-transform: uppercase; letter-spacing: .6px;
+      color: var(--muted); margin-bottom: 6px; cursor: default;
+    }
+    .card-seq { font-family: ui-monospace, monospace; margin-right: 8px; opacity: .7; }
+    .content {
+      margin: 0; white-space: pre-wrap; word-break: break-word;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px;
+    }
+    .empty { color: var(--muted); font-style: italic; }
+
+    /* assistant reasoning + tool calls */
+    .reasoning { margin: 0 0 8px; }
+    .reasoning > summary { cursor: pointer; color: var(--muted); font-size: 12px; }
+    .reasoning .content { color: var(--muted); }
+    .tool-calls { margin-top: 8px; }
+    .tool-call { border: 1px dashed var(--border); border-radius: 6px; padding: 6px 10px; margin-top: 6px; }
+    .tool-call-name { font-size: 13px; margin-bottom: 4px; }
+    .tool-call-args { margin: 0; white-space: pre-wrap; font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); }
+
+    /* badges */
+    .badge {
+      display: inline-block; padding: 2px 9px; border-radius: 999px;
+      font-size: 11px; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 6px;
+    }
+    .badge-finished { background: #14361f; color: #5fd08a; }
+    .badge-aborted { background: #3a2f12; color: #e0b257; }
+    .badge-interrupted { background: #2a2f3a; color: #9fb0c9; }
+    .badge-failed { background: #3a1620; color: #ef8098; }
+
+    .empty-state { color: var(--muted); margin-top: 24px; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="/viz_app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What

A browser viewer for OpenSeek's durable session logs (`events.jsonl` + `session.json`), built as a monorepo feature: a JS frontend backed by a native MoonBit web server, sharing the existing `agent_session` types as the contract.

## Pieces

| Package | Target | Role |
|---|---|---|
| `viz/` | js | Pure parse + render. Reuses `agent_session` decoders and the real `Session::chat_messages` projection. Renders a **Raw log** (turn-grouped by terminal) and a **Model view**; tolerant of truncated/corrupt logs. |
| `cmd/viz_server/` | native | Read-only web server (`moonbitlang/async/http`) exposing a JSON/raw-file API over a `SessionStore`. Never writes. |
| `cmd/viz_app/` | js | rabbita (TEA) frontend: session browser + Raw/Model toggle. |
| `web/index.html` | — | The viewer shell (server auto-locates the built bundle). |

## UX

- Left sidebar lists sessions (most-recent first); click to load.
- Header strip shows id, event count, `session.json` status, and any parse warnings.
- **Raw log**: every event grouped into turns (delimited by `Terminal`, so mid-turn steering stays in one turn), with per-kind cards (user / assistant + reasoning + tool calls / tool result / runtime / summary / terminal badge).
- **Model view**: exactly what `chat_messages` feeds the model — summaries substitute covered events, dangling tool calls show the synthesized marker.

## API additions

- `AssistantMessage::{reasoning_content, tool_calls}` (read accessors)
- `SessionStore::{event_log_file, header_file}` (paths for the read-only server)

## Running

```
moon build cmd/viz_app --target js
moon run cmd/viz_server --target native -- --session-root .openseek
# open http://127.0.0.1:8080
```

## Testing

- Unit/snapshot tests in `viz`, `cmd/viz_app`, `cmd/viz_server` (parsing, both render modes, turn grouping, percent-decode, id validation, envelope decoding).
- Verified end-to-end against a real 355-event session via headless Chrome (sidebar → load → both view modes; rendered counts match the on-disk data).
- Hardened against early client disconnect, invalid/encoded ids, empty session root, bad port, header-only sessions, and torn-UTF-8 tails.

> Note: CI is native-only and skips the JS packages (`viz`, `cmd/viz_app`); those are covered by the local unit tests and the browser E2E above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)