### PR TITLE
feat(session): stamp every appended event with wall-clock ts

### DIFF
--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -31,10 +31,10 @@ pub struct Session {
   // private fields
 } derive(@debug.Debug)
 pub fn Session::Session(SessionId, system_prompt~ : String, events? : @vector.Vector[SessionEvent]) -> Self
-pub fn Session::append(Self, SessionItem) -> Self
-pub fn Session::append_event(Self, SessionItem) -> (Self, SessionEvent)
+pub fn Session::append(Self, SessionItem, unix_ms? : Int64) -> Self
+pub fn Session::append_event(Self, SessionItem, unix_ms? : Int64) -> (Self, SessionEvent)
 pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
-pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self raise
+pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int, unix_ms? : Int64) -> Self raise
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int
@@ -47,6 +47,7 @@ pub struct SessionEvent {
 } derive(ToJson, @debug.Debug, @json.FromJson)
 pub fn SessionEvent::item(Self) -> SessionItem
 pub fn SessionEvent::sequence(Self) -> Int
+pub fn SessionEvent::unix_ms(Self) -> Int64
 
 pub struct SessionId {
   // private fields

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -27,6 +27,31 @@ test "session append_event returns the durable event" {
 }
 
 ///|
+test "event timestamps round trip through JSON" {
+  // Key order is pinned because the store's event_log_length/hash markers
+  // cover the exact serialized text.
+  let stamped = @agent_session.Session(SessionId("s1"), system_prompt="p").append(
+    User(UserMessage("hello")),
+    unix_ms=1781144351123L,
+  )
+  let line = stamped.events()[0].to_json().stringify()
+  assert_eq(
+    line,
+    (
+      #|{"sequence":1,"ts":1781144351123,"item":{"kind":"user","payload":{"content":"hello"}}}
+    ),
+  )
+  let decoded : @agent_session.SessionEvent = @json.from_json(@json.parse(line))
+  assert_eq(decoded.unix_ms(), 1781144351123L)
+
+  // Without a clock (purely in-memory appends), the stamp is the 0 sentinel.
+  let unstamped = @agent_session.Session(SessionId("s2"), system_prompt="p").append(
+    User(UserMessage("hi")),
+  )
+  assert_eq(unstamped.events()[0].unix_ms(), 0L)
+}
+
+///|
 test "session projects to DeepSeek chat messages" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("inspect")))

--- a/agent_session/store/moon.pkg
+++ b/agent_session/store/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_session",
   "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
+  "moonbitlang/core/env",
   "moonbitlang/core/immut/vector",
   "moonbitlang/core/json",
 }

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -733,7 +733,10 @@ pub async fn SessionStore::append(
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
     ensure_session_is_current(self, session)
-    let (next, event) = session.append_event(item)
+    let (next, event) = session.append_event(
+      item,
+      unix_ms=@env.now().reinterpret_as_int64(),
+    )
     append_event(self, next, event)
     write_header(self, next, true)
     next
@@ -753,7 +756,12 @@ pub async fn SessionStore::compact(
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
     ensure_session_is_current(self, session)
-    let next = session.compact(content~, from_sequence~, to_sequence~)
+    let next = session.compact(
+      content~,
+      from_sequence~,
+      to_sequence~,
+      unix_ms=@env.now().reinterpret_as_int64(),
+    )
     let event = match next.events().peek() {
       Some(event) => event
       None => fail("compacted session did not append a summary event")

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -155,6 +155,9 @@ async test "store appends one event without rewriting the in-memory caller value
     fail("expected runtime notice")
   }
   assert_eq(notice.content(), "update")
+  // The store stamps each appended event with the wall clock, and the stamp
+  // survives a reload.
+  assert_true(loaded.events()[0].unix_ms() > 0)
   @fs.rmdir(store.root(), recursive=true)
 }
 

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -247,6 +247,12 @@ pub(all) enum SessionItem {
 /// within a session.
 pub struct SessionEvent {
   priv sequence : Int
+  // Wall-clock stamp (unix milliseconds) of when the event was appended; 0
+  // for purely in-memory sessions appended without a clock (the durable
+  // store always stamps). The field is named for its wire key, and typed
+  // Double so it serializes as a JSON number (core encodes Int64 as a
+  // string); milliseconds are exactly representable until year ~2255.
+  priv ts : Double
   priv item : SessionItem
 } derive(Debug, ToJson, FromJson)
 
@@ -254,8 +260,9 @@ pub struct SessionEvent {
 fn SessionEvent::SessionEvent(
   sequence~ : Int,
   item~ : SessionItem,
+  unix_ms? : Int64 = 0,
 ) -> SessionEvent {
-  { sequence, item }
+  { sequence, ts: unix_ms.to_double(), item }
 }
 
 ///|
@@ -268,6 +275,14 @@ pub fn SessionEvent::sequence(self : SessionEvent) -> Int {
 /// The event's payload.
 pub fn SessionEvent::item(self : SessionEvent) -> SessionItem {
   self.item
+}
+
+///|
+/// When the event was appended (unix milliseconds), or 0 when it was created
+/// without a clock (purely in-memory sessions; the durable store always
+/// stamps).
+pub fn SessionEvent::unix_ms(self : SessionEvent) -> Int64 {
+  self.ts.to_int64()
 }
 
 ///|
@@ -332,8 +347,12 @@ fn Session::next_sequence(self : Session) -> Int {
 /// Append one item as the next event and return the new session value; the
 /// receiver is unchanged. Callers that also need the assigned event (e.g. to
 /// persist it) should use `append_event`.
-pub fn Session::append(self : Session, item : SessionItem) -> Session {
-  let (next, _) = self.append_event(item)
+pub fn Session::append(
+  self : Session,
+  item : SessionItem,
+  unix_ms? : Int64 = 0,
+) -> Session {
+  let (next, _) = self.append_event(item, unix_ms~)
   next
 }
 
@@ -344,8 +363,9 @@ pub fn Session::append(self : Session, item : SessionItem) -> Session {
 pub fn Session::append_event(
   self : Session,
   item : SessionItem,
+  unix_ms? : Int64 = 0,
 ) -> (Session, SessionEvent) {
-  let event = SessionEvent(sequence=self.next_sequence(), item~)
+  let event = SessionEvent(sequence=self.next_sequence(), item~, unix_ms~)
   (
     {
       id: self.id,
@@ -366,6 +386,7 @@ pub fn Session::compact(
   content~ : String,
   from_sequence~ : Int,
   to_sequence~ : Int,
+  unix_ms? : Int64 = 0,
 ) -> Session raise {
   if content.trim().is_empty() {
     fail("summary content must not be empty")
@@ -382,5 +403,8 @@ pub fn Session::compact(
       "summary range \{from_sequence}..\{to_sequence} exceeds last sequence \{last}",
     )
   }
-  self.append(Summary(SessionSummary(content~, from_sequence~, to_sequence~)))
+  self.append(
+    Summary(SessionSummary(content~, from_sequence~, to_sequence~)),
+    unix_ms~,
+  )
 }

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -1,7 +1,7 @@
 ///|
 test "parse_load reads a found envelope with header" {
   let text =
-    #|{"found":true,"events":"{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","header":{"version":1,"system_prompt":"SYS"}}
+    #|{"found":true,"events":"{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","header":{"version":1,"system_prompt":"SYS"}}
   match parse_load(text) {
     Loaded(parsed, system_prompt, header_present) => {
       inspect(parsed.events.length(), content="1")

--- a/improvement.md
+++ b/improvement.md
@@ -81,10 +81,13 @@ shows where steps and tokens went to waste):
   exactly one tool call; the model proved it can batch (it opened with two
   parallel reads). A system-prompt nudge for batching independent
   reads/checks would cut round trips — at ~7s a step, real minutes.
-- [ ] **Timestamps on session events.** `events.jsonl` lines carry no
+- [x] **Timestamps on session events.** `events.jsonl` lines carry no
   timestamps, so per-step latency and where wall-clock went cannot be
   reconstructed from the log (this analysis had to infer duration from
   file mtimes). One `ts` field per event line fixes it and feeds the viz.
+  *(Done: the store stamps every appended event with `ts` (unix ms,
+  required field — no external users, so old logs are simply re-created;
+  in-memory appends without a clock carry the 0 sentinel).)*
 
 - [x] **Expose thinking controls.** `run_with_runtime` hardcodes
   `thinking=Enabled, reasoning_effort=Max`; make them engine flags

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -64,7 +64,9 @@ stdout-empty
 ## Session Management Is Offline
 
 Session inspection and compaction operate on typed session files and do not
-require a DeepSeek API key.
+require a DeepSeek API key. Hand-written log lines carry the 0 sentinel
+stamp; the summary event the compaction *appends* is stamped with the wall
+clock, so both `--session-show` calls strip `ts` to stay deterministic.
 
 ```mooncram
 $ sh <<'EOF'
@@ -72,14 +74,14 @@ $ sh <<'EOF'
 > mkdir -p "$tmp/sessions/demo"
 > printf '{"version":1,"id":"demo","system_prompt":"system","last_sequence":2}' > "$tmp/sessions/demo/session.json"
 > cat > "$tmp/sessions/demo/events.jsonl" <<'JSONL'
-> {"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}}
-> {"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
+> {"sequence":1,"ts":0,"item":{"kind":"user","payload":{"content":"hello"}}}
+> {"sequence":2,"ts":0,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
 > JSONL
 > printf 'hello and answer' > "$tmp/summary.txt"
 > env -u DEEPSEEK openseek.exe --session-list --session-root "$tmp" | cut -f1
-> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp"
+> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
 > env -u DEEPSEEK openseek.exe --session demo --session-root "$tmp" --session-compact-file "$tmp/summary.txt" --session-compact-from 1 --session-compact-to 2
-> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp"
+> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
 > rm -rf "$tmp"
 > EOF
 demo

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -98,12 +98,73 @@ fn turn_block(
   number : Int,
   turn : Array[@agent_session.SessionEvent],
 ) -> @html.Html {
-  let cards : Array[@html.Html] = [ for event in turn => event_card(event) ]
-  let label = "Turn \{number} · \{turn_preview(turn)}"
+  // Offsets are relative to the turn's first stamped event: for reading a
+  // log, "how far into the turn" answers latency questions directly, where
+  // absolute wall clock would force mental subtraction (and a timezone).
+  let base = turn_base_ms(turn)
+  let cards : Array[@html.Html] = [
+    for event in turn => event_card(event, time=offset_label(base, event))
+  ]
+  let label = match turn_duration_label(turn) {
+    Some(duration) => "Turn \{number} · \{turn_preview(turn)} · \{duration}"
+    None => "Turn \{number} · \{turn_preview(turn)}"
+  }
   @html.details(open=true, class="turn", [
     @html.summary(class="turn-summary", label),
     @html.div(class="turn-body", cards),
   ])
+}
+
+///|
+/// The turn's first wall-clock stamp (unix ms), or 0 when no event carries
+/// one (events appended without a clock keep the 0 sentinel).
+fn turn_base_ms(turn : Array[@agent_session.SessionEvent]) -> Int64 {
+  for event in turn {
+    if event.unix_ms() > 0 {
+      return event.unix_ms()
+    }
+  }
+  0
+}
+
+///|
+fn offset_label(base : Int64, event : @agent_session.SessionEvent) -> String {
+  if base == 0 || event.unix_ms() == 0 {
+    return ""
+  }
+  "+" + format_span_seconds(event.unix_ms() - base)
+}
+
+///|
+fn turn_duration_label(turn : Array[@agent_session.SessionEvent]) -> String? {
+  let base = turn_base_ms(turn)
+  guard base > 0 else { return None }
+  let mut last = base
+  for event in turn {
+    if event.unix_ms() > 0 {
+      last = event.unix_ms()
+    }
+  }
+  if last > base {
+    Some(format_span_seconds(last - base))
+  } else {
+    None
+  }
+}
+
+///|
+/// A millisecond span as a compact human duration: `3.4s`, `2m 05.1s`.
+fn format_span_seconds(span_ms : Int64) -> String {
+  let tenths = span_ms / 100
+  if tenths < 600 {
+    "\{tenths / 10}.\{tenths % 10}s"
+  } else {
+    let minutes = tenths / 600
+    let rest = tenths % 600
+    let seconds = rest / 10
+    let pad = if seconds < 10 { "0" } else { "" }
+    "\{minutes}m \{pad}\{seconds}.\{rest % 10}s"
+  }
 }
 
 ///|
@@ -117,22 +178,29 @@ fn turn_preview(turn : Array[@agent_session.SessionEvent]) -> String {
 }
 
 ///|
-fn event_card(event : @agent_session.SessionEvent) -> @html.Html {
+fn event_card(
+  event : @agent_session.SessionEvent,
+  time~ : String,
+) -> @html.Html {
   let seq = event.sequence()
   match event.item() {
-    User(message) => card("user", "User", seq, [text_block(message.content())])
-    Assistant(message) => assistant_card(seq, message)
-    Tool(result) => tool_card(seq, result)
+    User(message) =>
+      card("user", "User", seq, time~, [text_block(message.content())])
+    Assistant(message) => assistant_card(seq, time, message)
+    Tool(result) => tool_card(seq, time, result)
     Runtime(notice) =>
-      card("runtime", "Runtime notice", seq, [text_block(notice.content())])
-    Summary(summary) => summary_card(seq, summary)
-    Terminal(terminal) => terminal_card(seq, terminal)
+      card("runtime", "Runtime notice", seq, time~, [
+        text_block(notice.content()),
+      ])
+    Summary(summary) => summary_card(seq, time, summary)
+    Terminal(terminal) => terminal_card(seq, time, terminal)
   }
 }
 
 ///|
 fn assistant_card(
   seq : Int,
+  time : String,
   message : @agent_session.AssistantMessage,
 ) -> @html.Html {
   let body : Array[@html.Html] = []
@@ -155,7 +223,7 @@ fn assistant_card(
     ]
     body.push(@html.div(class="tool-calls", call_views))
   }
-  card("assistant", "Assistant", seq, body)
+  card("assistant", "Assistant", seq, time~, body)
 }
 
 ///|
@@ -170,28 +238,34 @@ fn tool_call_view(call : @deepseek.ToolCall) -> @html.Html {
 }
 
 ///|
-fn tool_card(seq : Int, result : @agent_session.ToolResult) -> @html.Html {
+fn tool_card(
+  seq : Int,
+  time : String,
+  result : @agent_session.ToolResult,
+) -> @html.Html {
   let kind = if result.is_error() { "tool error" } else { "tool" }
   let label = if result.is_error() {
     "Tool error · \{result.tool_name()}"
   } else {
     "Tool result · \{result.tool_name()}"
   }
-  card(kind, label, seq, [text_block(result.content())])
+  card(kind, label, seq, time~, [text_block(result.content())])
 }
 
 ///|
 fn summary_card(
   seq : Int,
+  time : String,
   summary : @agent_session.SessionSummary,
 ) -> @html.Html {
   let label = "Summary · covers events \{summary.from_sequence()}..\{summary.to_sequence()}"
-  card("summary", label, seq, [text_block(summary.content())])
+  card("summary", label, seq, time~, [text_block(summary.content())])
 }
 
 ///|
 fn terminal_card(
   seq : Int,
+  time : String,
   terminal : @agent_session.TurnTerminal,
 ) -> @html.Html {
   let (kind, message) = match terminal {
@@ -204,7 +278,7 @@ fn terminal_card(
   if !message.trim().is_empty() {
     body.push(text_block(message))
   }
-  card("terminal", "Turn ended", seq, body)
+  card("terminal", "Turn ended", seq, time~, body)
 }
 
 // ---- model projection view -------------------------------------------------
@@ -275,13 +349,18 @@ fn card(
   kind : String,
   label : String,
   seq : Int,
+  time~ : String,
   body : Array[@html.Html],
 ) -> @html.Html {
+  let head : Array[@html.Html] = [
+    @html.span(class="card-seq", "#\{seq}"),
+    @html.text(label),
+  ]
+  if !time.is_empty() {
+    head.push(@html.span(class="card-ts", time))
+  }
   @html.section(class="card \{kind}", [
-    @html.div(class="card-label", [
-      @html.span(class="card-seq", "#\{seq}"),
-      @html.text(label),
-    ]),
+    @html.div(class="card-label", head),
     @html.div(class="card-body", body),
   ])
 }

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -59,7 +59,7 @@ test "parse round-trips every event kind" {
 
 ///|
 test "parse tolerates a truncated final line" {
-  let text = "{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"item\":{\"kind\":\"assi"
+  let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi"
   let parsed = @viz.parse_events(text)
   inspect(parsed.events.length(), content="1")
   inspect(parsed.errors.length(), content="0")
@@ -68,7 +68,7 @@ test "parse tolerates a truncated final line" {
 
 ///|
 test "parse records a bad interior line without aborting" {
-  let text = "{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\nnot json at all\n{\"sequence\":2,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n"
+  let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\nnot json at all\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n"
   let parsed = @viz.parse_events(text)
   inspect(parsed.events.length(), content="2")
   inspect(parsed.errors.length(), content="1")
@@ -129,4 +129,24 @@ test "notices surface partial tails and bad lines" {
   let html = render(@viz.render_notices(parsed))
   assert_true(html.contains("could not be decoded"))
   assert_true(html.contains("trailing partial line"))
+}
+
+///|
+/// Stamped events render relative offsets and a turn duration; unstamped
+/// events (the 0 sentinel) render no time chips at all.
+test "raw view shows per-event offsets and turn duration from ts" {
+  let stamped = @agent_session.Session(SessionId("t"), system_prompt="")
+    .append(User(UserMessage("go")), unix_ms=1781151318110L)
+    .append(Runtime(RuntimeNotice("working")), unix_ms=1781151319242L)
+    .append(Terminal(Finished("done")), unix_ms=1781151443650L)
+  let html = render(@viz.render_session(stamped, RawLog))
+  assert_true(html.contains("+0.0s"))
+  assert_true(html.contains("+1.1s"))
+  assert_true(html.contains("+2m 05.5s"))
+  assert_true(html.contains("· 2m 05.5s"))
+  let unstamped = @agent_session.Session(SessionId("u"), system_prompt="")
+    .append(User(UserMessage("go")))
+    .append(Terminal(Finished("done")))
+  let plain = render(@viz.render_session(unstamped, RawLog))
+  assert_false(plain.contains("card-ts"))
 }

--- a/web/index.html
+++ b/web/index.html
@@ -188,6 +188,7 @@
       color: var(--muted); margin-bottom: 6px; cursor: default;
     }
     .card-seq { font-family: ui-monospace, monospace; margin-right: 8px; opacity: .7; }
+    .card-ts { font-family: ui-monospace, monospace; margin-left: 8px; opacity: .55; font-weight: normal; }
     .content {
       margin: 0; white-space: pre-wrap; word-break: break-word;
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px;


### PR DESCRIPTION
Checklist item from the [156-step log analysis](https://github.com/moonbitlang/openseek/pull/93#issuecomment-4676980288): session event logs carry no timestamps, so per-step latency can't be reconstructed (the analysis had to infer a 19-minute duration from file mtimes).

## Change

- `SessionEvent` gains a **required** `ts` stamp (unix milliseconds); `SessionStore::append`/`compact` set it from the wall clock. Lines become `{"sequence":N,"ts":<unix-ms>,"item":…}`. In-memory appends without a clock (serve's ephemeral sessions, unit tests) carry the 0 sentinel.
- **Why on the event, not the write path**: the header's `event_log_length`/`event_log_hash` durability markers cover the exact serialized log text, so the appended line and every reserialization (`write_header`, stale-snapshot comparison, compaction rewrite) must agree byte-for-byte.
- **Why required, not optional**: there are no external users, so pre-stamp logs aren't worth a compatibility codec — old local sessions are simply re-created (explicit owner decision). Required keeps the derived codec; `ts` is `Double` so it serializes as a JSON number (core encodes `Int64` as a string), exact for milliseconds until ~2255.
- **Visualizer**: each raw-log card now shows its offset into the turn (`+0.0s`, `+1.1s`, `+2m 05.5s`) and each turn summary its total duration — relative offsets answer "where did the time go" directly, without timezone mental math. Sentinel (unstamped) events render no time chips. Model view is untouched (the projection carries no timestamps).

## Verification

- Live engine run: every appended line stamped — the turn's 1.1s is measurable from the log alone — and the viz server serves the stamped envelope (`/`, `/viz_app.js`, `/api/sessions/<id>` all green against the new log).
- 465/465 native tests (JSON round trip pins the exact line shape; store stamp survives reload) and 114/114 js tests (offset and duration rendering, sentinel suppression), 9/9 cram (the compact demo writes sentinel stamps and `sed`-strips the live one), fmt clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)