### PR TITLE
fix(deepseek): never send reasoning_content back to the API

### DIFF
--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -3,6 +3,12 @@
 ///
 /// Assistant messages whose `content` is empty but carry tool calls are
 /// encoded with JSON `content: null`, as the API requires.
+///
+/// `reasoning_content` is deliberately never encoded: it is response-side
+/// data the model does not read back (DeepSeek's docs say not to return it),
+/// and resending it grows every request — a real 156-step run accumulated
+/// 64KB of dead reasoning, 11% of its final 141K-token context. Sessions
+/// still store it for the TUI transcript and the visualizer.
 impl ToJson for ChatMessage with fn to_json(message : ChatMessage) -> Json {
   let content = match message.role {
     Assistant if message.tool_calls.length() > 0 && message.content == "" =>
@@ -22,11 +28,6 @@ impl ToJson for ChatMessage with fn to_json(message : ChatMessage) -> Json {
           [("tool_calls", ([ for call in message.tool_calls => call ] : Json))]
         } else {
           []
-        },
-        ..match message.reasoning_content {
-          Some(reasoning_content) =>
-            [("reasoning_content", Json::string(reasoning_content))]
-          None => []
         },
       ],
     ),
@@ -151,7 +152,9 @@ test "tool definitions encode as native DeepSeek tools" {
 }
 
 ///|
-test "assistant tool call messages encode tool_calls" {
+test "assistant tool call messages encode tool_calls, never reasoning" {
+  // reasoning_content is response-side data: it must not reach the wire even
+  // when the in-memory message carries it (see the codec doc comment).
   let body = ChatMessage(
     Assistant,
     content="",
@@ -177,7 +180,6 @@ test "assistant tool call messages encode tool_calls" {
         },
       },
     ],
-    "reasoning_content": "checked available tools",
   })
 }
 

--- a/improvement.md
+++ b/improvement.md
@@ -61,11 +61,15 @@ shows where steps and tokens went to waste):
   produced stale results, and the model ended up running `pkill -9 -f
   "moon check"` mid-task to recover. Same cwd + new options should replace
   (stop) the old watcher.
-- [ ] **Stop resending historical `reasoning_content`.** The request encoder
+- [x] **Stop resending historical `reasoning_content`.** The request encoder
   sends stored reasoning back on every historical assistant message — 11%
   of a 141K-token final context was old reasoning the model never needs
   again (DeepSeek's own docs say not to pass it back). Drop it when
-  projecting session history to API messages.
+  projecting session history to API messages. *(Done: the wire encoder
+  never emits `reasoning_content` — the right chokepoint, since the 11%
+  accrued within a single 156-step turn via the agent's incremental
+  pushes, not only across turns. Sessions still store reasoning for the
+  TUI transcript and the visualizer.)*
 - [ ] **Deduplicate watcher notices.** 61 `[moon_check update]` runtime
   notices (11% of final context) were appended, mostly identical
   re-reports from the duplicate watchers. Coalesce per watcher: a new


### PR DESCRIPTION
Checklist item from the [156-step log analysis](https://github.com/moonbitlang/openseek/pull/93#issuecomment-4676980288): stored reasoning was echoed on every resent assistant message — 64KB of dead context (11% of the final 141K tokens) the model never reads back, and DeepSeek's docs say not to return it.

## Change

One central removal in the **wire encoder** (`deepseek/json_encode.mbt`): `ChatMessage::to_json` never emits `reasoning_content`. The encoder is the right chokepoint rather than the session→messages projection: the measured waste accrued *within* a single 156-step turn through the agent loop's incremental message pushes, not only across turn boundaries — fixing only the projection would have left the dominant path leaking.

Responses still parse `reasoning_content`, sessions still store it, and the TUI transcript (`✻` asides) and the visualizer still display it — it is response-side data end to end now.

## Verification

- Live, thinking mode, multi-step tool turn (the risky case — steps 2–3 resend prior assistant messages now stripped of reasoning mid-loop): 3 steps, `agent_finished`, reasoning still streamed to the UI, still stored in the session log.
- Encoder test updated to pin the absence: an assistant message carrying reasoning in memory encodes without it on the wire.
- 465/465 native + 114/114 js tests, 9/9 cram, fmt clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)