### PR TITLE
fix(moon_check): one watcher per directory, replace on option change

### DIFF
--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -101,7 +101,14 @@ async fn[X] moon_check(
           is_error=moon_check_snapshot_is_error(snapshot),
         )
       } else {
+        let exit_signal = runtime.moon_check_exit_signal(key)
         ignore(runtime.stop_moon_check(key))
+        // `Process.cancel()` is asynchronous: wait until the old watcher's
+        // monitor has reaped it before spawning the replacement, or the two
+        // would briefly contend for the same build lock.
+        if exit_signal is Some(signal) {
+          signal.get()
+        }
         start_moon_check(
           runtime,
           input,

--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -29,7 +29,7 @@ pub fn[X] definition(
   let moon_runtime = MoonCheckRuntime(runtime, scope)
   AgentToolDefinition(
     name="moon_check",
-    description="Start or inspect a persistent `moon check --watch --diagnostic-limit 10` watcher for the given cwd/options. The first call starts the watcher; later calls with the same arguments return the latest snapshot without starting another watcher.",
+    description="Start or inspect a persistent `moon check --watch --diagnostic-limit 10` watcher for the given cwd. One watcher runs per directory: the first call starts it, later calls with the same arguments return the latest snapshot, and calling with different options replaces the watcher instead of stacking a second one.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -78,10 +78,15 @@ async fn[X] execute(
 }
 
 ///|
-/// Dispatch by watcher key:
-/// - A running record for `key` → reuse (`watcher=reused`), no new process.
-/// - A stopped record for `key` → restart (`watcher=restarted`) carrying the
-///   prior `restart_count` forward.
+/// Dispatch by watcher key (one watcher per cwd):
+/// - A running record with the same command → reuse (`watcher=reused`), no
+///   new process.
+/// - A running record whose command differs (the options changed) → stop it
+///   and start fresh (`watcher=replaced`). Stacking a second watcher on the
+///   same directory would make the two compete for moon's build lock and
+///   report stale results.
+/// - A stopped record for `key` → restart (`watcher=restarted`) with the
+///   *new* options, carrying the prior `restart_count` forward.
 /// - No record for `key` → fresh start (`watcher=started`).
 async fn[X] moon_check(
   runtime : MoonCheckRuntime[X],
@@ -90,10 +95,22 @@ async fn[X] moon_check(
   let key = moon_check_key(input)
   match runtime.moon_check_snapshot(key) {
     Some(snapshot) if snapshot.status is Running =>
-      @agent_tool.ToolAction::respond(
-        moon_check_response("reused", snapshot),
-        is_error=moon_check_snapshot_is_error(snapshot),
-      )
+      if snapshot.command == moon_check_command_line(input) {
+        @agent_tool.ToolAction::respond(
+          moon_check_response("reused", snapshot),
+          is_error=moon_check_snapshot_is_error(snapshot),
+        )
+      } else {
+        ignore(runtime.stop_moon_check(key))
+        start_moon_check(
+          runtime,
+          input,
+          key,
+          action="replaced",
+          restart_count=snapshot.restart_count,
+          restart_reason=Some("options changed; replaced \{snapshot.command}"),
+        )
+      }
     Some(snapshot) =>
       start_moon_check(
         runtime,
@@ -200,6 +217,40 @@ async test "moon_check reuses a running watcher for the same arguments" {
     assert_true(second_output.content.contains("watcher=reused"))
     assert_true(second_output.content.contains("id=moon-check-1"))
     assert_false(second_output.content.contains("id=moon-check-2"))
+  }
+  @fs.rmdir(project, recursive=true)
+}
+
+///|
+async test "changed options replace the cwd's watcher instead of stacking" {
+  let project = valid_project()
+  @async.with_task_group() <| group => {
+    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
+    let first = execute(runtime, { "cwd": project })
+    // Same cwd, different options: the running watcher is stopped and
+    // replaced — never a second concurrent watcher fighting it for moon's
+    // build lock.
+    let second = execute(runtime, { "cwd": project, "deny_warn": true })
+    let key = moon_check_key(@decode.decode({ "cwd": project }))
+    guard first is Respond(first_output) else { fail("expected Respond") }
+    guard second is Respond(second_output) else { fail("expected Respond") }
+    assert_true(first_output.content.contains("watcher=started"))
+    assert_true(first_output.content.contains("id=moon-check-1"))
+    assert_true(second_output.content.contains("watcher=replaced"))
+    assert_true(second_output.content.contains("id=moon-check-2"))
+    assert_true(second_output.content.contains("--deny-warn"))
+    // One record per cwd: the replacement owns the key, with the new
+    // command, and a same-options follow-up reuses it.
+    guard runtime.moon_check_snapshot(key) is Some(snapshot) else {
+      fail("expected a registry record")
+    }
+    assert_true(snapshot.status is Running)
+    assert_true(snapshot.command.contains("--deny-warn"))
+    let third = execute(runtime, { "cwd": project, "deny_warn": true })
+    guard third is Respond(third_output) else { fail("expected Respond") }
+    assert_true(third_output.content.contains("watcher=reused"))
+    assert_true(third_output.content.contains("id=moon-check-2"))
+    ignore(runtime.stop_moon_check(key))
   }
   @fs.rmdir(project, recursive=true)
 }

--- a/agent_tool/moon_check/runtime.mbt
+++ b/agent_tool/moon_check/runtime.mbt
@@ -87,6 +87,11 @@ priv struct MoonCheckRecord {
   restart_count : Int
   restart_limit : Int
   restart_reason : String?
+  // Signalled (once) when this spawn's monitor task has reaped the child
+  // process. `Process.cancel()` is asynchronous, so a replacement must wait
+  // on this before spawning, or old and new watchers would briefly contend
+  // for the same build lock — the exact failure replacement exists to fix.
+  exited : @async.Queue[Unit]
 }
 
 ///|
@@ -191,6 +196,7 @@ fn[X] MoonCheckRuntime::register_moon_check(
   restart_count~ : Int,
   restart_limit~ : Int,
   restart_reason~ : String?,
+  exited~ : @async.Queue[Unit],
 ) -> MoonCheckSnapshot {
   let record = {
     id,
@@ -208,6 +214,7 @@ fn[X] MoonCheckRuntime::register_moon_check(
     restart_count,
     restart_limit,
     restart_reason,
+    exited,
   }
   self.moon_checks[record.key] = record
   record.to_snapshot()
@@ -323,6 +330,19 @@ fn[X] MoonCheckRuntime::stop_moon_check(
 }
 
 ///|
+/// The current record's reaped-child signal (see `MoonCheckRecord::exited`),
+/// captured by the replace path before it stops the watcher.
+fn[X] MoonCheckRuntime::moon_check_exit_signal(
+  self : MoonCheckRuntime[X],
+  key : String,
+) -> @async.Queue[Unit]? {
+  match self.moon_checks.get(key) {
+    Some(record) => Some(record.exited)
+    None => None
+  }
+}
+
+///|
 fn[X] MoonCheckRuntime::emit_moon_check(
   self : MoonCheckRuntime[X],
   snapshot : MoonCheckSnapshot,
@@ -380,6 +400,7 @@ async test "moon_check runtime ignores stale watcher id updates" {
         restart_count=0,
         restart_limit=3,
         restart_reason=None,
+        exited=Queue(kind=Unbounded),
       ),
     )
     ignore(
@@ -393,6 +414,7 @@ async test "moon_check runtime ignores stale watcher id updates" {
         restart_count=0,
         restart_limit=3,
         restart_reason=None,
+        exited=Queue(kind=Unbounded),
       ),
     )
     assert_true(
@@ -439,6 +461,7 @@ async test "moon_check keeps crash summary in replacement output" {
         restart_count=1,
         restart_limit=3,
         restart_reason=Some("auto restart after exit 101"),
+        exited=Queue(kind=Unbounded),
       ),
     )
     let summary =

--- a/agent_tool/moon_check/runtime.mbt
+++ b/agent_tool/moon_check/runtime.mbt
@@ -132,14 +132,14 @@ priv struct MoonCheckRuntime[X] {
   /// session ends — there are no orphan `moon` processes after a session
   /// exit.
   scope : @agent_runtime.AgentTaskScope[X]
-  /// Watcher registry keyed by `moon_check_key(input)` — a stable
-  /// serialization of `cwd` + all check options. One entry per
-  /// `(cwd, options)` tuple is the core invariant: a `moon_check` call with
-  /// the same key as an existing **running** record reuses it; the same key
-  /// matching a **stopped** record triggers a manual restart that overwrites
-  /// the entry. Different options → different key → independent watcher.
-  /// Records are never removed, only superseded — a stopped record stays in
-  /// the map until either a restart replaces it or the agent session ends.
+  /// Watcher registry keyed by `moon_check_key(input)` — the watcher's
+  /// `cwd`. One entry per directory is the core invariant: a `moon_check`
+  /// call whose command matches an existing **running** record reuses it; a
+  /// running record with a *different* command (the options changed) is
+  /// stopped and replaced; a **stopped** record triggers a manual restart
+  /// that overwrites the entry. Records are never removed, only
+  /// superseded — a stopped record stays in the map until either a restart
+  /// replaces it or the agent session ends.
   moon_checks : Map[String, MoonCheckRecord]
   /// Monotonic counter for assigning watcher ids. Each
   /// `next_moon_check_id()` call produces `moon-check-<N>` and bumps the
@@ -331,23 +331,19 @@ fn[X] MoonCheckRuntime::emit_moon_check(
 }
 
 ///|
-/// Stable string used to deduplicate watchers per `(cwd, options)` tuple.
-/// Two calls with the same key reuse a live watcher; a stopped record under
-/// the same key is restarted on the next call.
+/// Stable string identifying a watcher by its directory — one watcher per
+/// cwd is the invariant. A call with the same cwd reuses the running
+/// watcher when its command matches and *replaces* it (stopping the old
+/// process) when the options changed. Keying on the full option set instead
+/// used to stack concurrent watchers on one directory; they competed for
+/// moon's build lock with each other and with the agent's own `moon test`
+/// runs, reported stale results, and a real session ended with the model
+/// running `pkill -9 -f "moon check"` to recover.
 fn moon_check_key(input : @decode.MoonCheckInput) -> String {
-  let cwd = match input.cwd {
-    Some(cwd) => cwd
-    None => "."
+  match input.cwd {
+    Some(cwd) => "cwd=\{cwd}"
+    None => "cwd=."
   }
-  let target = match input.target {
-    Some(target) => target
-    None => ""
-  }
-  let warn_list = match input.warn_list {
-    Some(warn_list) => warn_list
-    None => ""
-  }
-  "cwd=\{cwd}\ntarget=\{target}\nwarn_list=\{warn_list}\ndeny_warn=\{input.deny_warn}\nfmt=\{input.fmt}\nexplain=\{input.explain}"
 }
 
 ///|

--- a/agent_tool/moon_check/watcher.mbt
+++ b/agent_tool/moon_check/watcher.mbt
@@ -97,6 +97,15 @@ async fn[X] start_moon_check(
 }
 
 ///|
+/// The exact command line a `moon_check` input runs. Doubles as the option
+/// fingerprint: a running watcher whose command equals the incoming input's
+/// is reusable; any difference means the options changed and the watcher is
+/// replaced.
+fn moon_check_command_line(input : @decode.MoonCheckInput) -> String {
+  "moon \{command_args(input, watch=true).join(" ")}"
+}
+
+///|
 /// Spawn `moon check --watch ...` with combined stdout/stderr piped back to
 /// `monitor_moon_check`. Returns the freshly assigned watcher id. The caller
 /// can pre-populate the recorded output via `initial_output` — used when an
@@ -126,7 +135,7 @@ async fn[X] spawn_moon_check_watch(
     runtime.register_moon_check(
       key~,
       id~,
-      command="moon \{args.join(" ")}",
+      command=moon_check_command_line(input),
       cwd=input.cwd,
       process~,
       max_output_chars=default_max_output_chars,

--- a/agent_tool/moon_check/watcher.mbt
+++ b/agent_tool/moon_check/watcher.mbt
@@ -120,6 +120,7 @@ async fn[X] spawn_moon_check_watch(
 ) -> String {
   let args = command_args(input, watch=true)
   let id = runtime.next_moon_check_id()
+  let exited : @async.Queue[Unit] = Queue(kind=Unbounded)
   let (reader, writer) = @process.read_from_process()
   let process = @process.spawn(
     runtime.group(),
@@ -142,12 +143,17 @@ async fn[X] spawn_moon_check_watch(
       restart_count~,
       restart_limit=default_restart_limit,
       restart_reason~,
+      exited~,
     ),
   )
   if initial_output != "" {
     ignore(runtime.replace_moon_check_output(key, id, initial_output))
   }
   runtime.group().spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    // Every monitor exit path has reaped (or failed to read) the child by
+    // the time it returns; signal regardless of which path ran so a waiting
+    // replacement can never hang.
+    defer ignore(exited.try_put(()) catch { _ => false })
     monitor_moon_check(runtime, input, key, id, reader, process)
   }
   id

--- a/improvement.md
+++ b/improvement.md
@@ -54,13 +54,16 @@ Findings from a real 156-step session log (seek-toml, 2026-06-11: "Write a
 toml parser in MoonBit with high quality tests" — succeeded, but the log
 shows where steps and tokens went to waste):
 
-- [ ] **One watcher per directory, not per option set.** The `moon_check`
+- [x] **One watcher per directory, not per option set.** The `moon_check`
   registry keys watchers by the full option set, so toggling `deny_warn`
   stacked three concurrent watchers on one cwd. They competed for moon's
   build lock with each other and with the model's own `moon test` runs,
   produced stale results, and the model ended up running `pkill -9 -f
   "moon check"` mid-task to recover. Same cwd + new options should replace
-  (stop) the old watcher.
+  (stop) the old watcher. *(Done: the registry keys by cwd; a running
+  watcher is reused when the incoming command matches and stopped+replaced
+  (`watcher=replaced`) when the options changed, with the tool description
+  telling the model so.)*
 - [x] **Stop resending historical `reasoning_content`.** The request encoder
   sends stored reasoning back on every historical assistant message — 11%
   of a 141K-token final context was old reasoning the model never needs


### PR DESCRIPTION
Top item from the [156-step log analysis](https://github.com/moonbitlang/openseek/pull/93#issuecomment-4676980288) — the one failure that made the agent fight its own tooling: keying watchers by the full option set let a `deny_warn` toggle stack **three concurrent watchers on one cwd**, which fought each other (and the model's own `moon test` runs) for moon's build lock until results went stale and the model ran `pkill -9 -f "moon check"` mid-task to recover.

## Change

- The registry keys by **cwd** — one watcher per directory is the invariant.
- A call whose rendered command (`moon_check_command_line`, also used at spawn time so the fingerprint can't drift from reality) matches the running watcher **reuses** it, exactly as before.
- A call with different options **stops the old process and starts a fresh one** — `watcher=replaced`, with the superseded command recorded in the restart reason so the transcript shows what changed.
- Stopped records restart with the new options (unchanged behavior), and the tool description now tells the model about the replacement semantics.

## Verification

- New regression test drives real `moon check --watch` processes through started → replaced → reused on one fixture cwd: the replacement owns the key with the new command (`--deny-warn`), gets a fresh id, and the registry holds exactly one record throughout.
- 466/466 native + 114/114 js tests, 9/9 cram, fmt clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)