### PR TITLE
[codex] expose custom API endpoint

### DIFF
--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -8,12 +8,14 @@ variables, and calls `bobzhang/openseek/agent.run` for one-shot tasks or
 ## Command
 
 ```bash
-moon run cmd/openseek -- [--api-key sk-...] [--model deepseek-v4-pro] [--max-steps 1000] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
+moon run cmd/openseek -- [--api-key sk-...] [--model deepseek-v4-pro] [--api-url https://api.deepseek.com/chat/completions] [--max-steps 1000] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
 ```
 
 Agent runs require `--api-key` or `DEEPSEEK`. `--model` can also be supplied with
 `DEEPSEEK_MODEL`; it defaults to `deepseek-v4-pro`. `--max-steps` can also be
 supplied with `OPENSEEK_MAX_STEPS`; it defaults to `1000`.
+`--api-url` can also be supplied with `OPENSEEK_API_URL`; when omitted, OpenSeek
+uses the default DeepSeek chat completions endpoint.
 `--system-prompt-file` and `--system-prompt-addendum-file` can also be supplied
 with `OPENSEEK_SYSTEM_PROMPT_FILE` and
 `OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`. `--session` can also be supplied with

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -33,6 +33,7 @@ async fn run_cli() -> Unit {
       return
     }
     let api_key = api_key(matches)
+    let api_url = api_url(matches)
     let model = @deepseek.Model::parse(value(matches, "model"))
     let max_steps = max_steps(matches)
     let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
@@ -51,6 +52,7 @@ async fn run_cli() -> Unit {
           system_prompt_text~,
           thinking~,
           reasoning_effort~,
+          api_url?,
         )
       }
       Some(id) => {
@@ -66,6 +68,7 @@ async fn run_cli() -> Unit {
             max_steps~,
             thinking~,
             reasoning_effort~,
+            api_url?,
           ),
         )
       }
@@ -110,6 +113,13 @@ fn cli_command() -> @argparse.Command {
         env="DEEPSEEK_MODEL",
         default_values=[@deepseek.V4Pro.to_string()],
         about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
+      ),
+      OptionArg(
+        "api-url",
+        long="api-url",
+        env="OPENSEEK_API_URL",
+        default_values=[""],
+        about="DeepSeek-compatible chat completions endpoint.",
       ),
       OptionArg(
         "max-steps",
@@ -239,6 +249,16 @@ fn api_key(matches : @argparse.Matches) -> String raise {
     fail("--api-key or DEEPSEEK is required for agent runs")
   }
   key
+}
+
+///|
+fn api_url(matches : @argparse.Matches) -> String? raise {
+  let url = value(matches, "api-url").trim().to_owned()
+  if url.is_empty() {
+    None
+  } else {
+    Some(url)
+  }
 }
 
 ///|
@@ -497,6 +517,7 @@ test "cli parses env backed options and task" {
   let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
     "DEEPSEEK_MODEL": "deepseek-v4-pro",
+    "OPENSEEK_API_URL": "https://proxy.example/v1/chat/completions",
     "OPENSEEK_MAX_STEPS": "120",
     "OPENSEEK_SYSTEM_PROMPT_FILE": "/tmp/prompt-a.md",
     "OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE": "/tmp/prompt-b.md",
@@ -505,6 +526,8 @@ test "cli parses env backed options and task" {
   })
   assert_eq(api_key(parsed), "test-key")
   assert_eq(value(parsed, "model"), "deepseek-v4-pro")
+  guard api_url(parsed) is Some(url) else { fail("expected api url") }
+  assert_eq(url, "https://proxy.example/v1/chat/completions")
   assert_eq(max_steps(parsed), 120)
   assert_eq(value(parsed, "system-prompt-file"), "/tmp/prompt-a.md")
   assert_eq(value(parsed, "system-prompt-addendum-file"), "/tmp/prompt-b.md")
@@ -521,6 +544,7 @@ test "cli defaults model and max steps" {
   })
   assert_eq(api_key(parsed), "test-key")
   assert_eq(value(parsed, "model"), "deepseek-v4-pro")
+  assert_true(api_url(parsed) is None)
   assert_eq(max_steps(parsed), 1000)
   assert_true(session_id(parsed) is None)
   assert_eq(session_root(parsed), ".openseek")

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -81,6 +81,7 @@ test "serve commands decode and reject with actionable errors" {
 /// first, then the loop drains and exits.
 async fn run_serve(matches : @argparse.Matches) -> Unit {
   let api_key = api_key(matches)
+  let api_url = api_url(matches)
   let model = @deepseek.Model::parse(value(matches, "model"))
   let max_steps = max_steps(matches)
   let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
@@ -162,6 +163,7 @@ async fn run_serve(matches : @argparse.Matches) -> Unit {
           max_steps~,
           thinking~,
           reasoning_effort~,
+          api_url?,
           tools~,
         ) catch {
           error => {

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -32,9 +32,9 @@ startup banner) stores the conversation under `--session-root` (default
 
 ## Configuration
 
-`--api-key` (env `DEEPSEEK`) is required. `--model`, `--max-steps`,
-`--thinking`, and `--reasoning-effort` mirror the engine's flags and are
-forwarded to it through the environment, alongside the session settings.
+`--api-key` (env `DEEPSEEK`) is required. `--model`, `--api-url`,
+`--max-steps`, `--thinking`, and `--reasoning-effort` mirror the engine's flags
+and are forwarded to it through the environment, alongside the session settings.
 
 The full flag reference lives in the executable help — verified verbatim in
 [`tests/cram/tui.md`](../../tests/cram/tui.md).

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -2,6 +2,7 @@
 fn drain_test_state() -> State {
   State::new({
     api_key: "k",
+    api_url: Some("https://proxy.example/v1/chat/completions"),
     model: V4Pro,
     cwd: ".",
     max_steps: 10,
@@ -61,6 +62,10 @@ test "engine configuration travels through the environment" {
   assert_eq(session_root, ".openseek")
   assert_true(env.get("OPENSEEK_THINKING") == Some("enabled"))
   assert_true(env.get("OPENSEEK_REASONING_EFFORT") == Some("max"))
+  assert_true(
+    env.get("OPENSEEK_API_URL") ==
+    Some("https://proxy.example/v1/chat/completions"),
+  )
 }
 
 ///|
@@ -68,13 +73,27 @@ test "agent engine env overrides inherited session config" {
   let inherited = {
     "OPENSEEK_SESSION": "parent",
     "OPENSEEK_SESSION_ROOT": "/tmp/parent",
+    "OPENSEEK_API_URL": "https://parent.example/chat/completions",
     "PATH": "/bin",
   }
   let env = engine_env(drain_test_state().config, inherited)
   assert_true(env.get("PATH") == Some("/bin"))
   assert_true(env.get("OPENSEEK_SESSION") == Some("test"))
   assert_true(env.get("OPENSEEK_SESSION_ROOT") == Some(".openseek"))
+  assert_true(
+    env.get("OPENSEEK_API_URL") ==
+    Some("https://proxy.example/v1/chat/completions"),
+  )
   assert_true(inherited.get("OPENSEEK_SESSION") == Some("parent"))
+}
+
+///|
+test "agent engine env clears inherited api url without override" {
+  let config = { ..drain_test_state().config, api_url: None }
+  let env = engine_env(config, {
+    "OPENSEEK_API_URL": "https://parent.example/chat/completions",
+  })
+  assert_true(env.get("OPENSEEK_API_URL") == Some(""))
 }
 
 ///|
@@ -242,6 +261,7 @@ test "steering a running agent sends a steer command" {
 test "oneshot engines reject steering with the legacy notice" {
   let state = State::new({
     api_key: "k",
+    api_url: None,
     model: V4Pro,
     cwd: ".",
     max_steps: 10,

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -127,6 +127,7 @@ fn is_terminal_event(event : @event.AgentEvent) -> Bool {
 fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   {
     "DEEPSEEK": config.api_key,
+    "OPENSEEK_API_URL": config.api_url.unwrap_or(""),
     "DEEPSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
     "OPENSEEK_THINKING": config.thinking.to_string(),

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -19,6 +19,13 @@ fn cli_command() -> @argparse.Command {
         about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
       ),
       OptionArg(
+        "api-url",
+        long="api-url",
+        env="OPENSEEK_API_URL",
+        default_values=[""],
+        about="DeepSeek-compatible chat completions endpoint.",
+      ),
+      OptionArg(
         "max-steps",
         long="max-steps",
         env="OPENSEEK_MAX_STEPS",
@@ -148,6 +155,16 @@ fn parse_positive_int(input : String, label : String) -> Int raise {
 }
 
 ///|
+fn api_url(matches : @argparse.Matches) -> String? raise {
+  let url = value(matches, "api-url").trim().to_owned()
+  if url.is_empty() {
+    None
+  } else {
+    Some(url)
+  }
+}
+
+///|
 fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? {
   let session = match values(matches, "session") {
     [session, ..] => session.trim().to_owned()
@@ -228,6 +245,7 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   }
   {
     api_key: value(matches, "api-key"),
+    api_url: api_url(matches),
     model: @deepseek.Model::parse(value(matches, "model")),
     cwd,
     max_steps: parse_positive_int(value(matches, "max-steps"), "--max-steps"),
@@ -339,12 +357,25 @@ test "cli accepts no initial task" {
   assert_true(initial_task(parsed) is None)
   let config = parse_config(parsed)
   assert_eq(config.api_key, "test-key")
+  assert_true(config.api_url is None)
   assert_eq(config.max_steps, 1000)
   assert_eq(config.engine, "openseek")
   // No --session still converses in a session: a generated per-launch id, so
   // consecutive prompts share context instead of running amnesiac one-shots.
   assert_true(config.session_id.value().has_prefix("tui-"))
   assert_eq(config.session_root, ".openseek")
+}
+
+///|
+test "cli parses api url" {
+  let parsed = cli_command().parse(argv=[], env={
+    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_URL": " https://proxy.example/v1/chat/completions ",
+  })
+  guard parse_config(parsed).api_url is Some(url) else {
+    fail("expected api url")
+  }
+  assert_eq(url, "https://proxy.example/v1/chat/completions")
 }
 
 ///|

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -1,6 +1,7 @@
 ///|
 priv struct AppConfig {
   api_key : String
+  api_url : String?
   model : @deepseek.Model
   cwd : String
   max_steps : Int

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,3 @@
+# OpenSeek Plans
+
+- [Custom API URL](plans/custom-api-url.md)

--- a/docs/plans/custom-api-url.md
+++ b/docs/plans/custom-api-url.md
@@ -1,0 +1,60 @@
+# Custom API URL
+
+## Goal
+
+Expose the already-supported DeepSeek client `api_url` override through the
+OpenSeek CLI and TUI entry points, so users can point OpenSeek at a compatible
+custom endpoint without changing application code.
+
+## Accepted Design
+
+- Add `--api-url` to `cmd/openseek` and `cmd/tui`.
+- Add `OPENSEEK_API_URL` as the environment variable for the same setting.
+- Treat an empty value as "use the default DeepSeek endpoint" by passing no
+  `api_url` override.
+- Pass a non-empty value unchanged to the existing `@agent` `api_url?` optional
+  argument.
+- Forward `OPENSEEK_API_URL` from TUI configuration into spawned engine
+  processes.
+- Keep the current typed DeepSeek model enum unchanged; this change does not add
+  arbitrary model names.
+- Keep the request schema unchanged; only the transport endpoint becomes
+  configurable.
+
+## Target Files And Surfaces
+
+- `cmd/openseek/main.mbt`: parse `--api-url` / `OPENSEEK_API_URL`, pass it to
+  one-shot and durable session runs, and cover parsing in tests.
+- `cmd/openseek/serve.mbt`: pass the same parsed endpoint into serve-mode turns.
+- `cmd/openseek/README.md`: document CLI usage and environment variable.
+- `cmd/tui/main.mbt`: parse the endpoint setting into TUI config.
+- `cmd/tui/state.mbt`: store the endpoint override in `AppConfig`.
+- `cmd/tui/loop.mbt`: forward `OPENSEEK_API_URL` to spawned engines.
+- TUI tests around config/env propagation.
+
+## API And Interface Diff
+
+- New CLI flag: `--api-url <url>`.
+- New environment variable: `OPENSEEK_API_URL`.
+- `agent/pkg.generated.mbti` should remain unchanged because `api_url?` already
+  exists on the public agent APIs.
+- `cmd/*` generated interfaces should not expose new public library APIs.
+
+## Open Questions
+
+- None for this implementation. Supporting arbitrary model strings is explicitly
+  out of scope.
+
+## Next Implementation Step
+
+Create the small parsing helper for optional API URLs, wire it through
+`cmd/openseek`, then mirror the same config field through the TUI engine
+environment.
+
+## Validation Plan
+
+- Run targeted tests for `cmd/openseek` and `cmd/tui` where practical.
+- Run `moon check`.
+- Run `moon test`.
+- Run `moon info && moon fmt`.
+- Review generated `.mbti` diffs and ensure only expected files changed.

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -30,6 +30,7 @@ Options:
   --session-show                                               Print the durable session JSON for --session and exit.
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
   --model <model>                                              DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>                                        DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
   --reasoning-effort <reasoning-effort>                        DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -28,6 +28,7 @@ Options:
   --continue                             Resume the most recently active session in --session-root.
   --api-key <api-key>                    DeepSeek API key. [env: DEEPSEEK]
   --model <model>                        DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>                    DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>                  DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
   --reasoning-effort <reasoning-effort>  DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]
@@ -59,6 +60,7 @@ Options:
   --continue                             Resume the most recently active session in --session-root.
   --api-key <api-key>                    DeepSeek API key. [env: DEEPSEEK]
   --model <model>                        DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>                    DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>                  DeepSeek thinking mode: enabled or disabled. [env: OPENSEEK_THINKING] [default: enabled]
   --reasoning-effort <reasoning-effort>  DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]


### PR DESCRIPTION
## Summary

Expose the existing DeepSeek client `api_url` override through the OpenSeek CLI and TUI entry points.

## Changes

- Add `--api-url` / `OPENSEEK_API_URL` to `cmd/openseek`.
- Pass the configured endpoint through one-shot, durable session, and serve-mode agent runs.
- Add the same setting to `cmd/tui` and forward it to spawned engine processes.
- Document the new flag and update cram help snapshots.
- Persist the approved design checkpoint under `docs/plans/custom-api-url.md`.

## Impact

Users can point OpenSeek at a DeepSeek-compatible chat completions endpoint without code changes. The model enum and request schema remain unchanged.

## Validation

- `moon check`
- `moon test cmd/openseek`
- `moon test cmd/tui`
- `moon test`
- `moon cram test tests/cram`
- `moon info && moon fmt`