### PR TITLE
feat(openseek): ground the model in its working directory

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -440,16 +440,48 @@ async fn configured_system_prompt(
   } else {
     @fs.read_file(base_path).text()
   }
+  let grounded =
+    $|\{base}
+    $|
+    $|\{environment_prompt_section()}
   if addendum_path == "" {
-    base
+    grounded
   } else {
     let addendum = @fs.read_file(addendum_path).text()
     (
-      $|\{base}
+      $|\{grounded}
       $|
       $|\{addendum}
     )
   }
+}
+
+///|
+/// The runtime environment block appended to every system prompt — including
+/// a `--system-prompt-file` override, since grounding describes the process,
+/// not the prompt content. Without it the model has no idea where it is and
+/// guesses: in a five-run benchmark batch one agent passed
+/// `cwd="/workspace"` on its very first call, then explored the parent
+/// directory, found a concurrent sibling run's files, and adopted that
+/// workspace wholesale. A durable session stores the prompt at creation, so
+/// the recorded directory is where the session was started — resume it from
+/// the same project root.
+async fn environment_prompt_section() -> String {
+  let cwd = @fs.realpath(".") catch { _ => "." }
+  (
+    $|## Environment
+    $|
+    $|Working directory: \{cwd}
+    $|Relative paths resolve against it; treat it as the workspace root and stay inside it. Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
+  )
+}
+
+///|
+async test "environment section names the real working directory" {
+  let section = environment_prompt_section()
+  let cwd = @fs.realpath(".")
+  assert_true(section.contains("Working directory: \{cwd}"))
+  assert_true(section.contains("stay inside it"))
 }
 
 ///|
@@ -598,7 +630,7 @@ async test "configured system prompt can replace and append files" {
   )
   assert_eq(
     configured_system_prompt(parsed, V4Flash),
-    "base prompt\n\n\naddendum\n",
+    "base prompt\n\n\n\{environment_prompt_section()}\n\naddendum\n",
   )
   @fs.rmdir(dir, recursive=true)
 }
@@ -631,14 +663,15 @@ async test "load_or_new_session defers first durable write until append" {
     env={ "DEEPSEEK": "test-key" },
   )
   let created = load_or_new_session(store, id, parsed, V4Pro)
-  assert_eq(created.system_prompt(), "system")
+  let grounded_prompt = "system\n\n\{environment_prompt_section()}"
+  assert_eq(created.system_prompt(), grounded_prompt)
   assert_eq(created.events().length(), 0)
   assert_false(store.exists(id))
   let with_event = store.append(created, User(UserMessage("hello")))
   assert_eq(with_event.events().length(), 1)
   @fs.remove(prompt_path)
   let loaded = load_or_new_session(store, id, parsed, V4Pro)
-  assert_eq(loaded.system_prompt(), "system")
+  assert_eq(loaded.system_prompt(), grounded_prompt)
   assert_eq(loaded.events().length(), 1)
   @fs.rmdir(root, recursive=true)
 }
@@ -665,7 +698,10 @@ async test "load_or_new_session recovers empty interrupted session directory" {
   )
   let store = @store.SessionStore(root)
   let session = load_or_new_session(store, id, parsed, V4Pro)
-  assert_eq(session.system_prompt(), "system")
+  assert_eq(
+    session.system_prompt(),
+    "system\n\n\{environment_prompt_section()}",
+  )
   assert_eq(session.events().length(), 0)
   let with_event = store.append(session, User(UserMessage("hello")))
   assert_eq(with_event.events().length(), 1)

--- a/eval/file_edit/cmd/main/main.mbt
+++ b/eval/file_edit/cmd/main/main.mbt
@@ -60,7 +60,7 @@ fn cli_command() -> @argparse.Command {
         "repo-root",
         long="repo-root",
         default_values=["."],
-        about="OpenSeek repository root used to run cmd/main.",
+        about="OpenSeek repository root used to run the cmd/openseek engine.",
       ),
       OptionArg(
         "prompt-label",

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -118,10 +118,15 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
     case.id
   @fs.mkdir(workspace, recursive=true)
   write_fixture(workspace, case)
-  let task = case.task(@fs.realpath(workspace))
+  let real_workspace = @fs.realpath(workspace)
+  let task = case.task(real_workspace)
+  // Run the engine in the trial workspace so environment grounding names it
+  // (see the prompt_task harness for the same pattern).
   let args = [
     "run",
-    "cmd/main",
+    // cmd/openseek is the engine package (the pre-rename cmd/main no longer
+    // exists, so the old invocation could not have launched at all).
+    config.repo_root + "/cmd/openseek",
     "--",
     "--max-steps",
     config.max_steps.to_string(),
@@ -146,7 +151,7 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
       "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
     },
     inherit_env=true,
-    cwd=config.repo_root,
+    cwd=real_workspace,
   )
   let log_text = output.text()
   let log_path = config.out_dir +

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -122,11 +122,14 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
   let task = case.task(real_workspace)
   // Run the engine in the trial workspace so environment grounding names it
   // (see the prompt_task harness for the same pattern).
+  // Canonicalize launcher-relative paths (the default --repo-root ".",
+  // prompt files) before the child cwd changes their meaning.
+  let repo_root = @fs.realpath(config.repo_root)
   let args = [
     "run",
     // cmd/openseek is the engine package (the pre-rename cmd/main no longer
     // exists, so the old invocation could not have launched at all).
-    config.repo_root + "/cmd/openseek",
+    repo_root + "/cmd/openseek",
     "--",
     "--max-steps",
     config.max_steps.to_string(),
@@ -135,11 +138,11 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
   ]
   if config.system_prompt_file != "" {
     args.push("--system-prompt-file")
-    args.push(config.system_prompt_file)
+    args.push(@fs.realpath(config.system_prompt_file))
   }
   if config.system_prompt_addendum_file != "" {
     args.push("--system-prompt-addendum-file")
-    args.push(config.system_prompt_addendum_file)
+    args.push(@fs.realpath(config.system_prompt_addendum_file))
   }
   args.push(task)
   let (exit_code, output) = @process.collect_output_merged(

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -148,10 +148,13 @@ async fn run_trial(
   // The engine runs *in* the trial workspace (moon resolves the module from
   // the absolute package path), so the prompt's environment grounding names
   // the workspace rather than the OpenSeek checkout — and relative paths in
-  // the model's tool calls land in the right tree.
+  // the model's tool calls land in the right tree. Launcher-relative paths
+  // (the default --repo-root ".", prompt files) must be canonicalized
+  // before the child cwd changes their meaning.
+  let repo_root = @fs.realpath(config.repo_root)
   let args = [
     "run",
-    config.repo_root + "/cmd/openseek",
+    repo_root + "/cmd/openseek",
     "--",
     "--max-steps",
     config.max_steps.to_string(),
@@ -160,11 +163,11 @@ async fn run_trial(
   ]
   if config.system_prompt_file != "" {
     args.push("--system-prompt-file")
-    args.push(config.system_prompt_file)
+    args.push(@fs.realpath(config.system_prompt_file))
   }
   if config.system_prompt_addendum_file != "" {
     args.push("--system-prompt-addendum-file")
-    args.push(config.system_prompt_addendum_file)
+    args.push(@fs.realpath(config.system_prompt_addendum_file))
   }
   args.push(task)
   let (exit_code, output) = @process.collect_output_merged(

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -145,9 +145,13 @@ async fn run_trial(
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
   let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
+  // The engine runs *in* the trial workspace (moon resolves the module from
+  // the absolute package path), so the prompt's environment grounding names
+  // the workspace rather than the OpenSeek checkout — and relative paths in
+  // the model's tool calls land in the right tree.
   let args = [
     "run",
-    "cmd/openseek",
+    config.repo_root + "/cmd/openseek",
     "--",
     "--max-steps",
     config.max_steps.to_string(),
@@ -172,7 +176,7 @@ async fn run_trial(
       "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
     },
     inherit_env=true,
-    cwd=config.repo_root,
+    cwd=real_workspace,
   )
   let log_text = output.text()
   let log_path = config.out_dir + "/logs/" + padded_index(index + 1) + ".log"


### PR DESCRIPTION
Checklist item from the [batch benchmark findings](https://github.com/moonbitlang/openseek/pull/98#issuecomment-4677851061): the prompt never states the working directory, so models guess on step 1 — one agent hallucinated `cwd="/workspace"`, then explored the parent directory and **adopted a concurrent sibling run's workspace** (two agents co-editing one project); another opened with `read /home/user`.

## Change

`configured_system_prompt` appends an `## Environment` section: the engine's realpath cwd, "treat it as the workspace root and stay inside it", "parent and sibling directories belong to other projects", and "never pass a cwd you have not verified exists". It rides every prompt source including `--system-prompt-file` (grounding describes the process, not the prompt content). Durable sessions record the prompt at creation, so the named directory is where the session started.

## Verification plan (merge gated on the experiment)

**Held unmerged pending a concurrency-5 benchmark with this engine** — judging on: zero hallucinated step-1 paths (vs 2/5 pre-fix), zero cross-workspace writes (vs one hijack in 5), artifacts in their own directories, plus the usual cost metrics. Results will be posted here.

Unit coverage: the section names the real cwd; the prompt-file replace/append composition and session creation tests pin the grounded form. 468/468 tests, 9/9 cram, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)