### PR TITLE
perf(openseek): order the prompt for prefix caching, environment last

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -460,20 +460,27 @@ async fn configured_system_prompt(
   } else {
     @fs.read_file(base_path).text()
   }
-  let grounded =
-    $|\{base}
-    $|
-    $|\{environment_prompt_section()}
-  if addendum_path == "" {
-    grounded
+  // The environment section goes LAST: DeepSeek's context cache matches on
+  // request prefixes, and the cwd is the only per-project variable in the
+  // prompt. Base and addendum are byte-identical across projects (and across
+  // an eval harness's N concurrent trial workspaces testing one addendum),
+  // so ordering them first keeps the whole shared text cache-hittable; the
+  // end position also gives the grounding instruction recency weight.
+  let with_addendum = if addendum_path == "" {
+    base
   } else {
     let addendum = @fs.read_file(addendum_path).text()
     (
-      $|\{grounded}
+      $|\{base}
       $|
       $|\{addendum}
     )
   }
+  (
+    $|\{with_addendum}
+    $|
+    $|\{environment_prompt_section()}
+  )
 }
 
 ///|
@@ -652,9 +659,11 @@ async test "configured system prompt can replace and append files" {
     ],
     env={ "DEEPSEEK": "test-key" },
   )
+  // Environment last: base and addendum form the cache-shared prefix; the
+  // per-project cwd is the only divergence point.
   assert_eq(
     configured_system_prompt(parsed, V4Flash),
-    "base prompt\n\n\n\{environment_prompt_section()}\n\naddendum\n",
+    "base prompt\n\n\naddendum\n\n\n\{environment_prompt_section()}",
   )
   @fs.rmdir(dir, recursive=true)
 }


### PR DESCRIPTION
Follow-up to #100 from review discussion: DeepSeek's context cache matches on request *prefixes* (64-token blocks), so prompt layout should put most-shared content first and per-run variables last.

## Change

The system prompt composes as `base → addendum → environment` instead of `base → environment → addendum`. The environment section's cwd is the only per-project variable in the prompt; with it last, the entire `base + addendum` text is a byte-identical, cache-hittable prefix across projects — which matters most in the eval harnesses, where N concurrent trial workspaces test one addendum and previously re-paid full price for the addendum region on every request. Bonus: the grounding instruction now sits at the prompt's end, where recency weighting helps it.

The addendum-composition test pins the new order; the no-addendum form is unchanged (`base → environment` as before).

## Verification

470/470 native tests, 9/9 cram, fmt clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)