### PR TITLE
feat(deepseek/client): retry transient failures with backoff

### DIFF
--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -15,6 +15,8 @@ pub struct Client {
   api_url : String
   thinking : @deepseek.ThinkingMode?
   reasoning_effort : @deepseek.ReasoningEffort?
+  retry_attempts : Int
+  retry_backoff_ms : Int
 } derive(Debug(ignore=API_KEY))
 
 ///|
@@ -23,14 +25,82 @@ pub struct Client {
 /// `model` defaults to `deepseek-v4-pro`; `api_url` defaults to the DeepSeek
 /// chat completions endpoint. Pass `thinking` and `reasoning_effort` to control
 /// DeepSeek V4 thinking mode explicitly.
+///
+/// Transient failures — transport errors, HTTP 429, and 5xx — are retried up
+/// to `retry_attempts` total tries with exponential backoff starting at
+/// `retry_backoff_ms` (doubling per retry). Client errors other than 429
+/// never retry, and a streaming call never retries once a delta has been
+/// delivered.
 pub fn Client::Client(
   api_key~ : String,
   model? : @deepseek.Model = default_model,
   api_url? : String = default_api_url,
   thinking? : @deepseek.ThinkingMode? = None,
   reasoning_effort? : @deepseek.ReasoningEffort? = None,
+  retry_attempts? : Int = 3,
+  retry_backoff_ms? : Int = 500,
 ) -> Client {
-  { api_key, model, api_url, thinking, reasoning_effort }
+  {
+    api_key,
+    model,
+    api_url,
+    thinking,
+    reasoning_effort,
+    retry_attempts,
+    retry_backoff_ms,
+  }
+}
+
+///|
+/// A response status worth retrying: rate limiting or a server-side failure.
+/// Other 4xx are caller errors (bad key, malformed request) that a retry
+/// cannot fix.
+fn retryable_status(code : Int) -> Bool {
+  code == 429 || (code >= 500 && code < 600)
+}
+
+///|
+/// Marks an attempt failure the retry loop may absorb. Carries the
+/// already-formatted public failure message so the final attempt re-raises
+/// the same text a non-retrying client would have produced.
+priv suberror RetryableApiError {
+  RetryableApiError(String)
+}
+
+///|
+/// Run `attempt` up to `retry_attempts` times. `RetryableApiError` and
+/// transport errors back off and retry; cancellations and everything else
+/// (including non-retryable HTTP statuses, raised as plain failures by the
+/// attempt) propagate immediately. `bail` lets an attempt declare later
+/// retries pointless — chat_stream sets it once deltas were delivered, since
+/// replaying a half-consumed stream would duplicate content downstream.
+async fn[T] Client::with_retries(
+  self : Client,
+  attempt : async () -> T,
+  bail : () -> Bool,
+) -> T {
+  for tries = 1; ; tries = tries + 1 {
+    return attempt() catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      RetryableApiError(message) if tries >= self.retry_attempts || bail() =>
+        fail(message)
+      RetryableApiError(_) => {
+        @async.sleep(self.retry_backoff_ms << (tries - 1))
+        continue
+      }
+      // A plain Failure is one of our own final verdicts (non-retryable
+      // status, malformed response body, truncated stream): never retry it.
+      Failure::Failure(_) as error => raise error
+      error if bail() || tries >= self.retry_attempts => raise error
+      // Anything else is transport-shaped (connect refused, reset, DNS):
+      // retry within budget.
+      _ => {
+        @async.sleep(self.retry_backoff_ms << (tries - 1))
+        continue
+      }
+    }
+  }
 }
 
 ///|
@@ -53,13 +123,25 @@ pub async fn Client::chat(
     reasoning_effort?=self.reasoning_effort,
     response_format?,
   )
+  self.with_retries(() => self.chat_attempt(body), () => false)
+}
+
+///|
+async fn Client::chat_attempt(
+  self : Client,
+  body : Json,
+) -> @deepseek.ChatResponse {
   let (resp, data) = @http.post(self.api_url, body, headers={
     "Content-Type": "application/json",
     "Authorization": "Bearer \{self.api_key}",
   })
   let text = data.text()
   guard resp.code >= 200 && resp.code < 300 else {
-    fail("DeepSeek API error \{resp.code}: \{text}")
+    let message = "DeepSeek API error \{resp.code}: \{text}"
+    if retryable_status(resp.code) {
+      raise RetryableApiError(message)
+    }
+    fail(message)
   }
   let parsed = @json.parse(text)
   @json.from_json(parsed)
@@ -90,6 +172,35 @@ pub async fn Client::chat_stream(
     stream=true,
     response_format?,
   )
+  // Once any delta reached a callback the consumer has observed partial
+  // output; a retry would replay it from the top. Bail out of the retry
+  // loop at that point and surface the failure instead.
+  let mut streamed = false
+  self.with_retries(
+    () => {
+      self.chat_stream_attempt(
+        body,
+        on_content_delta=delta => {
+          streamed = true
+          on_content_delta(delta)
+        },
+        on_reasoning_delta=delta => {
+          streamed = true
+          on_reasoning_delta(delta)
+        },
+      )
+    },
+    () => streamed,
+  )
+}
+
+///|
+async fn Client::chat_stream_attempt(
+  self : Client,
+  body : Json,
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta~ : async (String) -> Unit,
+) -> @deepseek.ChatResponse {
   let client = @http.post_stream(self.api_url, headers={
     "Content-Type": "application/json",
     "Authorization": "Bearer \{self.api_key}",
@@ -104,7 +215,11 @@ pub async fn Client::chat_stream(
   let resp = client.end_request()
   guard resp.code >= 200 && resp.code < 300 else {
     let text = client.read_all().text()
-    fail("DeepSeek API error \{resp.code}: \{text}")
+    let message = "DeepSeek API error \{resp.code}: \{text}"
+    if retryable_status(resp.code) {
+      raise RetryableApiError(message)
+    }
+    fail(message)
   }
   read_chat_stream(client, on_content_delta~, on_reasoning_delta~)
 }

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -29,8 +29,8 @@ pub struct Client {
 /// Transient failures — transport errors, HTTP 429, and 5xx — are retried up
 /// to `retry_attempts` total tries with exponential backoff starting at
 /// `retry_backoff_ms` (doubling per retry, capped at 60s). Client errors
-/// other than 429 never retry, and a streaming call never retries once a
-/// delta has been delivered.
+/// other than 429 never retry, and a streaming call never retries once the
+/// stream has produced any event — text, tool-call, or usage alike.
 pub fn Client::Client(
   api_key~ : String,
   model? : @deepseek.Model = default_model,
@@ -84,8 +84,9 @@ let max_backoff_ms : Int = 60_000
 /// identically every time, before any network I/O) propagate immediately;
 /// anything else is transport-shaped (connect refused, reset, DNS) and
 /// retries within budget. `bail` lets an attempt declare later retries
-/// pointless — chat_stream sets it once deltas were delivered, since
-/// replaying a half-consumed stream would duplicate content downstream.
+/// pointless — chat_stream sets it once the stream has produced any event,
+/// since replaying a half-consumed completion would duplicate content (or
+/// regenerate tool calls) downstream.
 ///
 /// A `RetryableApiError` that survives the budget (or bail) re-raises as a
 /// plain failure carrying the same text a non-retrying client would have
@@ -193,22 +194,20 @@ pub async fn Client::chat_stream(
     stream=true,
     response_format?,
   )
-  // Once any delta reached a callback the consumer has observed partial
-  // output; a retry would replay it from the top. Bail out of the retry
-  // loop at that point and surface the failure instead.
+  // Once the server has produced any complete SSE event the completion is
+  // running and billed — text deltas, tool-call deltas, and usage alike,
+  // even though only text reaches the callbacks. A retry past that point
+  // could duplicate content or generate a different tool call, so the
+  // first event (not just the first text delta) bails the retry loop and
+  // failures surface instead (Codex review).
   let mut streamed = false
   self.with_retries(
     () => {
       self.chat_stream_attempt(
         body,
-        on_content_delta=delta => {
-          streamed = true
-          on_content_delta(delta)
-        },
-        on_reasoning_delta=delta => {
-          streamed = true
-          on_reasoning_delta(delta)
-        },
+        on_stream_event=() => streamed = true,
+        on_content_delta~,
+        on_reasoning_delta~,
       )
     },
     () => streamed,
@@ -219,6 +218,7 @@ pub async fn Client::chat_stream(
 async fn Client::chat_stream_attempt(
   self : Client,
   body : Json,
+  on_stream_event~ : () -> Unit,
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> @deepseek.ChatResponse {
@@ -244,7 +244,12 @@ async fn Client::chat_stream_attempt(
   }
   // The stream reader finalizes malformed SSE payloads at its parse site
   // (see decode_sse_data in stream.mbt), so a mid-stream transport error
-  // reaches the retry loop with its own type and the delivered-delta bail
+  // reaches the retry loop with its own type and the delivered-event bail
   // decides whether retrying is allowed.
-  read_chat_stream(client, on_content_delta~, on_reasoning_delta~)
+  read_chat_stream(
+    client,
+    on_stream_event~,
+    on_content_delta~,
+    on_reasoning_delta~,
+  )
 }

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -143,8 +143,16 @@ async fn Client::chat_attempt(
     }
     fail(message)
   }
-  let parsed = @json.parse(text)
-  @json.from_json(parsed)
+  // A 2xx body that fails to parse or decode is a final verdict, not a
+  // transport error: the completion already ran (and billed), so retrying
+  // would duplicate it for the same bad payload.
+  @json.from_json(
+    @json.parse(text) catch {
+      error => fail("DeepSeek response is not JSON: \{error}; body: \{text}")
+    },
+  ) catch {
+    error => fail("DeepSeek response decode error: \{error}; body: \{text}")
+  }
 }
 
 ///|
@@ -221,5 +229,16 @@ async fn Client::chat_stream_attempt(
     }
     fail(message)
   }
-  read_chat_stream(client, on_content_delta~, on_reasoning_delta~)
+  // Same finality rule as chat_attempt: once the server answered 2xx, a
+  // malformed SSE payload must not re-run the completion. Only the JSON
+  // error classes are finalized — a mid-stream transport error keeps its
+  // type so the retry loop can still classify it (and the delivered-delta
+  // bail decides whether retrying is allowed).
+  read_chat_stream(client, on_content_delta~, on_reasoning_delta~) catch {
+    @json.ParseError(_) as error =>
+      fail("DeepSeek stream decode error: \{error}")
+    @json.JsonDecodeError(_) as error =>
+      fail("DeepSeek stream decode error: \{error}")
+    error => raise error
+  }
 }

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -229,16 +229,9 @@ async fn Client::chat_stream_attempt(
     }
     fail(message)
   }
-  // Same finality rule as chat_attempt: once the server answered 2xx, a
-  // malformed SSE payload must not re-run the completion. Only the JSON
-  // error classes are finalized — a mid-stream transport error keeps its
-  // type so the retry loop can still classify it (and the delivered-delta
-  // bail decides whether retrying is allowed).
-  read_chat_stream(client, on_content_delta~, on_reasoning_delta~) catch {
-    @json.ParseError(_) as error =>
-      fail("DeepSeek stream decode error: \{error}")
-    @json.JsonDecodeError(_) as error =>
-      fail("DeepSeek stream decode error: \{error}")
-    error => raise error
-  }
+  // The stream reader finalizes malformed SSE payloads at its parse site
+  // (see decode_sse_data in stream.mbt), so a mid-stream transport error
+  // reaches the retry loop with its own type and the delivered-delta bail
+  // decides whether retrying is allowed.
+  read_chat_stream(client, on_content_delta~, on_reasoning_delta~)
 }

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -28,9 +28,9 @@ pub struct Client {
 ///
 /// Transient failures — transport errors, HTTP 429, and 5xx — are retried up
 /// to `retry_attempts` total tries with exponential backoff starting at
-/// `retry_backoff_ms` (doubling per retry). Client errors other than 429
-/// never retry, and a streaming call never retries once a delta has been
-/// delivered.
+/// `retry_backoff_ms` (doubling per retry, capped at 60s). Client errors
+/// other than 429 never retry, and a streaming call never retries once a
+/// delta has been delivered.
 pub fn Client::Client(
   api_key~ : String,
   model? : @deepseek.Model = default_model,
@@ -68,42 +68,51 @@ priv suberror RetryableApiError {
 }
 
 ///|
-/// Run `attempt` up to `retry_attempts` times. `RetryableApiError` and
-/// transport errors back off and retry; cancellations and everything else
-/// (including non-retryable HTTP statuses, raised as plain failures by the
-/// attempt) propagate immediately. `bail` lets an attempt declare later
-/// retries pointless — chat_stream sets it once deltas were delivered, since
+/// Ceiling on a single backoff sleep. The doubling sequence from
+/// `retry_backoff_ms` stops growing here, so a generous retry budget cannot
+/// accumulate minutes-long sleeps between attempts.
+let max_backoff_ms : Int = 60_000
+
+///|
+/// Run `attempt` up to `retry_attempts` total tries via `@async.retry`
+/// (exponential backoff doubling from `retry_backoff_ms`, capped at
+/// `max_backoff_ms`; `max_retry` counts restarts, hence the -1).
+///
+/// The `fatal_error` classification: cancellations, plain failures (our own
+/// final verdicts — non-retryable HTTP statuses, malformed response bodies,
+/// truncated streams), and malformed-api_url parse errors (which fail
+/// identically every time, before any network I/O) propagate immediately;
+/// anything else is transport-shaped (connect refused, reset, DNS) and
+/// retries within budget. `bail` lets an attempt declare later retries
+/// pointless — chat_stream sets it once deltas were delivered, since
 /// replaying a half-consumed stream would duplicate content downstream.
+///
+/// A `RetryableApiError` that survives the budget (or bail) re-raises as a
+/// plain failure carrying the same text a non-retrying client would have
+/// produced, so the private marker type never escapes the package.
 async fn[T] Client::with_retries(
   self : Client,
   attempt : async () -> T,
   bail : () -> Bool,
 ) -> T {
-  for tries = 1; ; tries = tries + 1 {
-    return attempt() catch {
-      error if @async.is_being_cancelled() ||
-        @async.is_cancellation_error(error) => raise error
-      RetryableApiError(message) if tries >= self.retry_attempts || bail() =>
-        fail(message)
-      RetryableApiError(_) => {
-        @async.sleep(self.retry_backoff_ms << (tries - 1))
-        continue
-      }
-      // A plain Failure is one of our own final verdicts (non-retryable
-      // status, malformed response body, truncated stream): never retry it.
-      Failure::Failure(_) as error => raise error
-      // A malformed api_url fails identically every time, before any
-      // network I/O — retrying only repeats the configuration error.
-      @http.URIParseError::InvalidFormat as error => raise error
-      @http.URIParseError::UnsupportedProtocol(_) as error => raise error
-      error if bail() || tries >= self.retry_attempts => raise error
-      // Anything else is transport-shaped (connect refused, reset, DNS):
-      // retry within budget.
-      _ => {
-        @async.sleep(self.retry_backoff_ms << (tries - 1))
-        continue
-      }
-    }
+  @async.retry(
+    ExponentialDelay(
+      initial=self.retry_backoff_ms,
+      factor=2.0,
+      maximum=max_backoff_ms,
+    ),
+    max_retry=self.retry_attempts - 1,
+    fatal_error=error => {
+      bail() ||
+      @async.is_cancellation_error(error) ||
+      error is Failure::Failure(_) ||
+      error is @http.URIParseError::InvalidFormat ||
+      error is @http.URIParseError::UnsupportedProtocol(_)
+    },
+    attempt,
+  ) catch {
+    RetryableApiError(message) => fail(message)
+    error => raise error
   }
 }
 

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -92,6 +92,10 @@ async fn[T] Client::with_retries(
       // A plain Failure is one of our own final verdicts (non-retryable
       // status, malformed response body, truncated stream): never retry it.
       Failure::Failure(_) as error => raise error
+      // A malformed api_url fails identically every time, before any
+      // network I/O — retrying only repeats the configuration error.
+      @http.URIParseError::InvalidFormat as error => raise error
+      @http.URIParseError::UnsupportedProtocol(_) as error => raise error
       error if bail() || tries >= self.retry_attempts => raise error
       // Anything else is transport-shaped (connect refused, reset, DNS):
       // retry within budget.

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -244,3 +244,57 @@ async test "chat_stream never retries after the first delta" {
     fail("expected truncated stream error")
   }
 }
+
+///|
+/// Tool-call deltas carry no text, so the content callbacks never fire —
+/// but they are model output all the same. A stream that emits only a
+/// tool-call delta and then drops must surface the failure rather than
+/// retry: a replay could generate (and bill) a different call. (Codex
+/// review: the bail flag used to track callback-delivered text only.)
+async test "chat_stream never retries after a tool-call-only delta" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+      error => {
+        let message = "\{error}"
+        if message.contains("Operation not permitted") {
+          println("local TCP bind unavailable; skipping retry test")
+          return
+        }
+        raise error
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val = hits.val + 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read\",\"arguments\":\"{}\"}}]}}]}\n\n",
+          )
+        },
+        max_connections=8,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
+      ()
+    }) catch {
+      error => {
+        assert_true("\{error}".contains("ended before [DONE]"))
+        assert_eq(hits.val, 1)
+        return
+      }
+    }
+    fail("expected truncated stream error")
+  }
+}

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -1,0 +1,196 @@
+///|
+/// A server whose first `failures` responses are `status`, after which it
+/// serves a minimal valid chat completion (or an SSE stream when `sse`).
+/// Returns the endpoint URL and a counter of requests actually received.
+async fn flaky_server(
+  group : @async.TaskGroup[Unit],
+  failures~ : Int,
+  status~ : Int,
+  sse? : Bool = false,
+) -> (String, Ref[Int])? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping retry test: \{message}")
+        return None
+      }
+      raise error
+    }
+  }
+  let hits : Ref[Int] = { val: 0 }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        let _ = body.read_all()
+        hits.val = hits.val + 1
+        if hits.val <= failures {
+          conn.send_response(status, "Error", extra_headers={
+            "Content-Type": "text/plain",
+          })
+          conn.write("synthetic failure")
+        } else if sse {
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+          )
+          conn.write("data: [DONE]\n\n")
+        } else {
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "application/json",
+          })
+          conn.write(
+            "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}",
+          )
+        }
+      },
+      max_connections=8,
+    )
+  }
+  Some(("http://127.0.0.1:\{server.addr.port()}/chat/completions", hits))
+}
+
+///|
+async test "chat retries transient 5xx and succeeds" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=2, status=503) is Some((url, hits)) else {
+      return
+    }
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let response = client.chat([ChatMessage(User, content="hello")])
+    assert_eq(response.content, "ok")
+    assert_eq(hits.val, 3)
+  }
+}
+
+///|
+async test "chat gives up after the retry budget with the API error" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=99, status=500) is Some((url, hits)) else {
+      return
+    }
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=2,
+      retry_backoff_ms=1,
+    )
+    let _ = client.chat([ChatMessage(User, content="hello")]) catch {
+      error => {
+        assert_true("\{error}".contains("DeepSeek API error 500"))
+        assert_eq(hits.val, 2)
+        return
+      }
+    }
+    fail("expected exhausted retries")
+  }
+}
+
+///|
+async test "chat never retries a non-429 client error" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=99, status=400) is Some((url, hits)) else {
+      return
+    }
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let _ = client.chat([ChatMessage(User, content="hello")]) catch {
+      error => {
+        assert_true("\{error}".contains("DeepSeek API error 400"))
+        assert_eq(hits.val, 1)
+        return
+      }
+    }
+    fail("expected immediate failure")
+  }
+}
+
+///|
+async test "chat_stream retries a pre-stream 429 and then streams" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=1, status=429, sse=true)
+      is Some((url, hits)) else {
+      return
+    }
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let deltas : Array[String] = []
+    let response = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=delta => {
+      deltas.push(delta)
+    })
+    assert_eq(response.content, "ok")
+    assert_eq(deltas.join("|"), "ok")
+    assert_eq(hits.val, 2)
+  }
+}
+
+///|
+/// Once a delta has been delivered, a failure must surface instead of
+/// retrying — replaying the stream would hand the consumer duplicate
+/// content. The server streams one delta then ends without [DONE] on every
+/// request, so a retry (if one wrongly happened) would be observable as a
+/// second hit.
+async test "chat_stream never retries after the first delta" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+      error => {
+        let message = "\{error}"
+        if message.contains("Operation not permitted") {
+          println("local TCP bind unavailable; skipping retry test")
+          return
+        }
+        raise error
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val = hits.val + 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+          )
+        },
+        max_connections=8,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let deltas : Array[String] = []
+    let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=delta => {
+      deltas.push(delta)
+    }) catch {
+      error => {
+        assert_true("\{error}".contains("ended before [DONE]"))
+        assert_eq(deltas.join("|"), "partial")
+        assert_eq(hits.val, 1)
+        return
+      }
+    }
+    fail("expected truncated stream error")
+  }
+}

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -140,6 +140,56 @@ async test "chat_stream retries a pre-stream 429 and then streams" {
 }
 
 ///|
+/// A 2xx connection that dies before any event is transport-shaped: with no
+/// delta delivered, the stream call retries and the second connection
+/// serves the full stream.
+async test "chat_stream retries a pre-delta stream drop" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+      error => {
+        let message = "\{error}"
+        if message.contains("Operation not permitted") {
+          println("local TCP bind unavailable; skipping retry test")
+          return
+        }
+        raise error
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val = hits.val + 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          if hits.val > 1 {
+            conn.write(
+              "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+            )
+            conn.write("data: [DONE]\n\n")
+          }
+        },
+        max_connections=8,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let response = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
+      ()
+    })
+    assert_eq(response.content, "ok")
+    assert_eq(hits.val, 2)
+  }
+}
+
+///|
 /// Once a delta has been delivered, a failure must surface instead of
 /// retrying — replaying the stream would hand the consumer duplicate
 /// content. The server streams one delta then ends without [DONE] on every

--- a/deepseek/client/client_test.mbt
+++ b/deepseek/client/client_test.mbt
@@ -21,6 +21,8 @@ test "client debug redacts api key" {
       #|  api_url: "https://api.deepseek.com/chat/completions",
       #|  thinking: Some(Enabled),
       #|  reasoning_effort: Some(Max),
+      #|  retry_attempts: 3,
+      #|  retry_backoff_ms: 500,
       #|}
     ),
   )

--- a/deepseek/client/moon.pkg
+++ b/deepseek/client/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/deepseek",
+  "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/async/io",
   "moonbitlang/core/json",

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -16,9 +16,11 @@ pub struct Client {
   api_url : String
   thinking : @deepseek.ThinkingMode?
   reasoning_effort : @deepseek.ReasoningEffort?
+  retry_attempts : Int
+  retry_backoff_ms : Int
   // private fields
 } derive(@debug.Debug)
-pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode?, reasoning_effort? : @deepseek.ReasoningEffort?) -> Self
+pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode?, reasoning_effort? : @deepseek.ReasoningEffort?, retry_attempts? : Int, retry_backoff_ms? : Int) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
 pub async fn Client::chat_stream(Self, Array[@deepseek.ChatMessage], on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -240,7 +240,11 @@ async fn read_chat_stream(
           ) {
           break
         }
-        fail("DeepSeek stream ended before [DONE]")
+        // A connection that dies before [DONE] is transport-shaped; raise
+        // the retryable class so the client's retry loop may re-run the
+        // request — its delivered-delta bail makes this final whenever any
+        // output already reached the consumer.
+        raise RetryableApiError("DeepSeek stream ended before [DONE]")
       }
       Some(raw) => {
         let trimmed = raw.trim()

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -196,6 +196,7 @@ fn sse_data_fragment(raw : String) -> String? {
 async fn flush_sse_event(
   acc : StreamAccumulator,
   data_lines : Array[String],
+  on_stream_event~ : () -> Unit,
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> Bool {
@@ -204,6 +205,11 @@ async fn flush_sse_event(
   }
   let data = data_lines.join("\n").trim().to_owned()
   data_lines.clear()
+  // A complete event means the completion is producing output server-side
+  // — text, tool-call deltas, usage, or the terminal marker — even when
+  // nothing reaches the text callbacks. Signal before parsing: the retry
+  // decision must not depend on whether the payload decodes.
+  on_stream_event()
   if data == "[DONE]" {
     return true
   }
@@ -224,6 +230,7 @@ async fn flush_sse_event(
 ///|
 async fn read_chat_stream(
   reader : @http.Client,
+  on_stream_event~ : () -> Unit,
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> @deepseek.ChatResponse {
@@ -235,6 +242,7 @@ async fn read_chat_stream(
         if flush_sse_event(
             acc,
             data_lines,
+            on_stream_event~,
             on_content_delta~,
             on_reasoning_delta~,
           ) {
@@ -252,6 +260,7 @@ async fn read_chat_stream(
           if flush_sse_event(
               acc,
               data_lines,
+              on_stream_event~,
               on_content_delta~,
               on_reasoning_delta~,
             ) {

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -205,10 +205,17 @@ async fn flush_sse_event(
   }
   let data = data_lines.join("\n").trim().to_owned()
   data_lines.clear()
-  // A complete event means the completion is producing output server-side
-  // — text, tool-call deltas, usage, or the terminal marker — even when
-  // nothing reaches the text callbacks. Signal before parsing: the retry
-  // decision must not depend on whether the payload decodes.
+  // A flushed data payload means the completion is producing output
+  // server-side — text, tool-call deltas, usage, or the terminal marker —
+  // even when nothing reaches the text callbacks. Signal before parsing:
+  // the retry decision must not depend on whether the payload decodes.
+  //
+  // Deliberately, this also fires for the EOF flush of an event whose
+  // blank-line terminator never arrived: the data line itself is model
+  // output (a text payload is even delivered to the callbacks below), so
+  // replaying the request would duplicate or regenerate it — the missing
+  // terminator does not change that. Only a drop with no data line at all
+  // (caught by the emptiness guard above) leaves the request retryable.
   on_stream_event()
   if data == "[DONE]" {
     return true

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -209,7 +209,12 @@ async fn flush_sse_event(
   }
   apply_stream_json(
     acc,
-    @json.parse(data),
+    // A malformed payload on an established 2xx stream is a final verdict:
+    // the completion already ran (and billed), so the retry loop must not
+    // re-run it. fail() converts the parse error to the non-retryable class.
+    @json.parse(data) catch {
+      error => fail("DeepSeek stream decode error: \{error}; data: \{data}")
+    },
     on_content_delta~,
     on_reasoning_delta~,
   )

--- a/moon.mod
+++ b/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.5"
 
 import {
   "moonbit-community/tty@0.2.4",
-  "moonbitlang/async@0.19.1",
+  "moonbitlang/async@0.19.4",
   "moonbitlang/x@0.4.45",
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",


### PR DESCRIPTION
Checklist item: both chat entry points were single-shot, making connect resets / 429 / transient 5xx the most common spurious `turn_failed` class.

## Change

- Up to `retry_attempts` total tries (default 3), exponential backoff from `retry_backoff_ms` (default 500ms, doubling, capped at 60s).
- **Built on `@async.retry`** (after upgrading moonbitlang/async 0.19.1 → 0.19.4): the runtime's `ExponentialDelay` strategy and `max_retry` budget replace the hand-rolled loop; the never-retry taxonomy lives in its `fatal_error` predicate. A thin catch keeps the public failure text identical — the private retryable marker never escapes the package.
- Explicit taxonomy: **retry** 429, 5xx, transport-shaped errors; **never retry** other 4xx, the client's own final verdicts (malformed body, truncated stream), or anything after the stream has produced an event; **always propagate** cancellation immediately.
- **Stream bail covers all output, not just text** (Codex review): the bail flag now flips on every complete SSE event — tool-call deltas and usage included — so a stream that emitted only a tool-call delta before dropping surfaces the failure instead of re-billing the completion (and possibly generating a different call) on retry.
- The retryable marker carries the already-formatted public failure message, so an exhausted budget surfaces exactly the text a non-retrying client would have produced.

## Verification

Six mock flaky-server tests (local `@http.Server`, counted hits): 503×2→200 succeeds in 3 hits; always-500 with budget 2 fails with `DeepSeek API error 500` after exactly 2 hits; 400 fails after exactly 1 hit; pre-stream 429 retries into a clean SSE stream (2 hits); mid-stream truncation after a delivered text delta fails with no second request; tool-call-only delta then drop fails with no second request. 477/477 tests, fmt clean, 0 warnings.

## Codex review

- Round 1 flagged the tool-call-only stream bail gap — fixed in 41f01ac with a regression test.
- Round 2 asked to keep a drop *between a data line and its blank-line terminator* retryable. **Declined** (rationale documented at the signal site in stream.mbt, 2e0f306): the data line itself is model output — a text payload is delivered to the callbacks in that same EOF flush, and a tool-call-only payload is exactly the replay-divergence case round 1 closed; the missing terminator changes neither. A drop with *no* data line at all remains retryable (pinned by the pre-delta-drop test).

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)