### PR TITLE
feat(agent): skills support — workspace + global libraries advertised to the model

### DIFF
--- a/agent_skill/README.mbt.md
+++ b/agent_skill/README.mbt.md
@@ -1,0 +1,24 @@
+# agent_skill
+
+Workspace skills: markdown playbooks the agent pulls into context on demand.
+
+A skill is a markdown file under `.openseek/skills/` — either `<name>.md` or
+`<name>/SKILL.md` for skills that ship companion files — with optional
+frontmatter:
+
+```markdown
+---
+name: release
+description: How to cut a release of this project.
+---
+1. Bump the version in moon.mod
+2. ...
+```
+
+The engine discovers skills at startup and appends a `## Skills` section to
+the system prompt listing each skill's name, description, and path, with the
+instruction to `read` the file before doing matching work. The body stays
+out of the prompt until the model decides it is relevant, so a large skill
+library costs a few listing lines per request, not its full text. Missing
+frontmatter falls back to the file stem and an empty description; a missing
+directory is simply an empty library.

--- a/agent_skill/README.mbt.md
+++ b/agent_skill/README.mbt.md
@@ -22,3 +22,10 @@ out of the prompt until the model decides it is relevant, so a large skill
 library costs a few listing lines per request, not its full text. Missing
 frontmatter falls back to the file stem and an empty description; a missing
 directory is simply an empty library.
+
+Two libraries feed the listing: the user-level (global) one under
+`$HOME/.openseek/skills` (override with `--global-skills-dir` /
+`OPENSEEK_GLOBAL_SKILLS_DIR`) and the workspace one under
+`.openseek/skills`. `merge_skills` combines them with workspace skills
+shadowing same-named global ones, so a project can specialize a shared
+playbook without renaming it.

--- a/agent_skill/moon.pkg
+++ b/agent_skill/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbitlang/async/fs",
+}
+
+import {
+  "moonbitlang/async",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_skill/pkg.generated.mbti
+++ b/agent_skill/pkg.generated.mbti
@@ -1,0 +1,26 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_skill"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub async fn discover_skills(String) -> Array[Skill]
+
+pub fn skills_prompt_section(Array[Skill]) -> String?
+
+// Errors
+
+// Types and methods
+pub struct Skill {
+  // private fields
+} derive(@debug.Debug)
+pub fn Skill::description(Self) -> String
+pub fn Skill::name(Self) -> String
+pub fn Skill::path(Self) -> String
+
+// Type aliases
+
+// Traits
+

--- a/agent_skill/pkg.generated.mbti
+++ b/agent_skill/pkg.generated.mbti
@@ -8,6 +8,8 @@ import {
 // Values
 pub async fn discover_skills(String) -> Array[Skill]
 
+pub fn merge_skills(Array[Skill], overrides~ : Array[Skill]) -> Array[Skill]
+
 pub fn skills_prompt_section(Array[Skill]) -> String?
 
 // Errors

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -165,7 +165,7 @@ pub fn skills_prompt_section(skills : Array[Skill]) -> String? {
   lines.push("## Skills")
   lines.push("")
   lines.push(
-    "This workspace defines reusable skills. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it.",
+    "Reusable skills are available. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it. Listed skill files are pre-approved reads even when they sit outside the working directory.",
   )
   for skill in skills {
     let description = if skill.description() == "" {

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -131,6 +131,31 @@ async fn add_skill_file(skills : Array[Skill], path : String) -> Unit {
 }
 
 ///|
+/// Combine a base skill library with an overriding one: an override skill
+/// shadows a same-named base skill, so a workspace can specialize a
+/// user-level (global) playbook without renaming it. The result is
+/// re-sorted by name, keeping the prompt listing deterministic regardless
+/// of which library each skill came from.
+pub fn merge_skills(
+  base : Array[Skill],
+  overrides~ : Array[Skill],
+) -> Array[Skill] {
+  let merged : Array[Skill] = []
+  let taken : Set[String] = Set([])
+  for skill in overrides {
+    taken.add(skill.name)
+    merged.push(skill)
+  }
+  for skill in base {
+    if !taken.contains(skill.name) {
+      merged.push(skill)
+    }
+  }
+  merged.sort_by((a, b) => a.name.compare(b.name))
+  merged
+}
+
+///|
 /// The prompt block advertising `skills`, or `None` for an empty library so
 /// callers can skip the section entirely. Tells the model exactly how to
 /// use a skill: read the listed file first, then follow it.

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -1,0 +1,150 @@
+///|
+/// One workspace skill: a markdown playbook the model can pull into context
+/// when its task matches. Skills are advertised to the model as a name, a
+/// one-line description, and the file path to `read` — the body itself stays
+/// out of the prompt until the model decides it is relevant, so a large
+/// skill library costs a few listing lines, not its full text.
+pub struct Skill {
+  priv name : String
+  priv description : String
+  priv path : String
+} derive(Debug)
+
+///|
+fn Skill::Skill(name~ : String, description~ : String, path~ : String) -> Skill {
+  { name, description, path }
+}
+
+///|
+/// The skill's short identifier, from frontmatter `name:` or the file stem.
+pub fn Skill::name(self : Skill) -> String {
+  self.name
+}
+
+///|
+/// One-line summary the model uses to decide relevance, from frontmatter
+/// `description:` (empty when the file declares none).
+pub fn Skill::description(self : Skill) -> String {
+  self.description
+}
+
+///|
+/// Path of the markdown file holding the full skill body.
+pub fn Skill::path(self : Skill) -> String {
+  self.path
+}
+
+///|
+/// Parse `name:` and `description:` from a markdown frontmatter block — the
+/// lines between a leading `---` and the next `---`. Anything missing falls
+/// back to `fallback_name` / empty: a malformed header demotes the skill's
+/// listing quality, it never hides the skill.
+fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) {
+  let mut name = fallback_name
+  let mut description = ""
+  let lines = text.split("\n").map(line => line.to_owned()).collect()
+  guard lines is [first, .. rest] && first.trim() == "---" else {
+    return (name, description)
+  }
+  for line in rest {
+    if line.trim() == "---" {
+      break
+    }
+    match line.find(":") {
+      Some(index) => {
+        let key = line[0:index].to_owned().trim().to_owned()
+        let value = line[index + 1:].to_owned().trim().to_owned()
+        match key {
+          "name" => if value != "" { name = value }
+          "description" => description = value
+          _ => ()
+        }
+      }
+      None => ()
+    }
+  }
+  (name, description)
+}
+
+///|
+/// The markdown file's stem (`foo` for `dir/foo.md`), used as the fallback
+/// skill name.
+fn file_stem(path : String) -> String {
+  let base = match path.rev_find("/") {
+    Some(index) => path[index + 1:].to_owned()
+    None => path
+  }
+  match base.rev_find(".") {
+    Some(index) => base[0:index].to_owned()
+    None => base
+  }
+}
+
+///|
+/// Discover the skills under `dir`: every `<dir>/<name>.md`, plus every
+/// `<dir>/<name>/SKILL.md` for skills that ship companion files. A missing
+/// or unreadable directory is an empty library, never an error — most
+/// workspaces define no skills. Results are sorted by name (MoonBit's
+/// String order: length first, then code units) so the prompt listing is
+/// deterministic — and therefore prefix-cache stable — across runs.
+pub async fn discover_skills(dir : String) -> Array[Skill] {
+  let skills : Array[Skill] = []
+  let entries = @fs.readdir(dir) catch { _ => return skills }
+  for entry in entries {
+    let entry_path = dir + "/" + entry
+    if entry.has_suffix(".md") {
+      add_skill_file(skills, entry_path)
+    } else {
+      let nested = entry_path + "/SKILL.md"
+      // exists() raises ENOTDIR when entry_path is a plain file; either way
+      // there is no nested skill here.
+      let has_nested = @fs.exists(nested) catch { _ => false }
+      if has_nested {
+        add_skill_file(skills, nested)
+      }
+    }
+  }
+  skills.sort_by((a, b) => a.name.compare(b.name))
+  skills
+}
+
+///|
+async fn add_skill_file(skills : Array[Skill], path : String) -> Unit {
+  let text = @fs.read_file(path).text() catch { _ => return }
+  let fallback = match file_stem(path) {
+    "SKILL" =>
+      // For <name>/SKILL.md layouts the directory carries the name.
+      file_stem(
+        match path.rev_find("/") {
+          Some(index) => path[0:index].to_owned()
+          None => path
+        },
+      )
+    stem => stem
+  }
+  let (name, description) = parse_frontmatter(text, fallback)
+  skills.push(Skill(name~, description~, path~))
+}
+
+///|
+/// The prompt block advertising `skills`, or `None` for an empty library so
+/// callers can skip the section entirely. Tells the model exactly how to
+/// use a skill: read the listed file first, then follow it.
+pub fn skills_prompt_section(skills : Array[Skill]) -> String? {
+  guard skills.length() > 0 else { return None }
+  let lines : Array[String] = []
+  lines.push("## Skills")
+  lines.push("")
+  lines.push(
+    "This workspace defines reusable skills. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it.",
+  )
+  for skill in skills {
+    let description = if skill.description() == "" {
+      "(no description)"
+    } else {
+      skill.description()
+    }
+    lines.push("- \{skill.name()} — \{description} (file: \{skill.path()})")
+  }
+  Some(lines.join("\n"))
+}

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -112,14 +112,18 @@ pub async fn discover_skills(dir : String) -> Array[Skill] {
 async fn add_skill_file(skills : Array[Skill], path : String) -> Unit {
   let text = @fs.read_file(path).text() catch { _ => return }
   let fallback = match file_stem(path) {
-    "SKILL" =>
-      // For <name>/SKILL.md layouts the directory carries the name.
-      file_stem(
-        match path.rev_find("/") {
-          Some(index) => path[0:index].to_owned()
-          None => path
-        },
-      )
+    "SKILL" => {
+      // For <name>/SKILL.md layouts the directory carries the name — its
+      // full basename, dots included ("node.js" stays "node.js").
+      let parent = match path.rev_find("/") {
+        Some(index) => path[0:index].to_owned()
+        None => path
+      }
+      match parent.rev_find("/") {
+        Some(index) => parent[index + 1:].to_owned()
+        None => parent
+      }
+    }
     stem => stem
   }
   let (name, description) = parse_frontmatter(text, fallback)

--- a/agent_skill/skill_test.mbt
+++ b/agent_skill/skill_test.mbt
@@ -68,6 +68,45 @@ async test "a malformed frontmatter never hides the skill" {
 }
 
 ///|
+async test "workspace skills shadow same-named global skills on merge" {
+  let global_dir = @fs.tmpdir(prefix="openseek-skills-global-")
+  let workspace_dir = @fs.tmpdir(prefix="openseek-skills-workspace-")
+  write_skill(
+    global_dir + "/deploy.md",
+    (
+      #|---
+      #|description: Generic deploy steps.
+      #|---
+    ),
+  )
+  write_skill(global_dir + "/lint.md", "Global lint steps.")
+  write_skill(
+    workspace_dir + "/deploy.md",
+    (
+      #|---
+      #|description: This project's deploy steps.
+      #|---
+    ),
+  )
+  write_skill(workspace_dir + "/triage.md", "Workspace triage steps.")
+  let merged = @agent_skill.merge_skills(
+    @agent_skill.discover_skills(global_dir),
+    overrides=@agent_skill.discover_skills(workspace_dir),
+  )
+  // "deploy" appears once — the workspace copy; "lint" survives from the
+  // global library; everything stays name-sorted across both sources.
+  assert_eq(merged.length(), 3)
+  assert_eq(merged[0].name(), "lint")
+  assert_eq(merged[0].path(), global_dir + "/lint.md")
+  assert_eq(merged[1].name(), "deploy")
+  assert_eq(merged[1].description(), "This project's deploy steps.")
+  assert_eq(merged[1].path(), workspace_dir + "/deploy.md")
+  assert_eq(merged[2].name(), "triage")
+  @fs.rmdir(global_dir, recursive=true)
+  @fs.rmdir(workspace_dir, recursive=true)
+}
+
+///|
 async test "a missing skills directory is an empty library" {
   let skills = @agent_skill.discover_skills("/nonexistent/openseek-skills")
   assert_eq(skills.length(), 0)

--- a/agent_skill/skill_test.mbt
+++ b/agent_skill/skill_test.mbt
@@ -28,11 +28,14 @@ async test "discovery reads flat files and SKILL.md directories, sorted" {
   )
   // No frontmatter at all: still listed under its file stem.
   write_skill(dir + "/bare.md", "Just instructions, no header.")
+  // A dotted directory name survives intact ("node.js", not "node").
+  @fs.mkdir(dir + "/node.js", recursive=true)
+  write_skill(dir + "/node.js/SKILL.md", "Node skill body.")
   // A non-skill directory and a stray file are ignored.
   @fs.mkdir(dir + "/not-a-skill", recursive=true)
   write_skill(dir + "/notes.txt", "not markdown")
   let skills = @agent_skill.discover_skills(dir)
-  assert_eq(skills.length(), 3)
+  assert_eq(skills.length(), 4)
   // Sorted by name (String order is length-first, so "bare" precedes
   // "alpha"); the SKILL.md layout names itself after its directory.
   assert_eq(skills[0].name(), "bare")
@@ -40,8 +43,9 @@ async test "discovery reads flat files and SKILL.md directories, sorted" {
   assert_eq(skills[1].name(), "alpha")
   assert_eq(skills[1].description(), "Alpha steps.")
   assert_eq(skills[1].path(), dir + "/alpha/SKILL.md")
-  assert_eq(skills[2].name(), "zeta-protocol")
-  assert_eq(skills[2].description(), "How to zeta.")
+  assert_eq(skills[2].name(), "node.js")
+  assert_eq(skills[3].name(), "zeta-protocol")
+  assert_eq(skills[3].description(), "How to zeta.")
   @fs.rmdir(dir, recursive=true)
 }
 

--- a/agent_skill/skill_test.mbt
+++ b/agent_skill/skill_test.mbt
@@ -1,0 +1,98 @@
+///|
+async fn write_skill(path : String, text : String) -> Unit {
+  @fs.write_file(path, text, create_mode=CreateOrTruncate)
+}
+
+///|
+async test "discovery reads flat files and SKILL.md directories, sorted" {
+  let dir = @fs.tmpdir(prefix="openseek-skills-")
+  write_skill(
+    dir + "/zeta.md",
+    (
+      #|---
+      #|name: zeta-protocol
+      #|description: How to zeta.
+      #|---
+      #|Body text.
+    ),
+  )
+  @fs.mkdir(dir + "/alpha", recursive=true)
+  write_skill(
+    dir + "/alpha/SKILL.md",
+    (
+      #|---
+      #|description: Alpha steps.
+      #|---
+      #|Steps.
+    ),
+  )
+  // No frontmatter at all: still listed under its file stem.
+  write_skill(dir + "/bare.md", "Just instructions, no header.")
+  // A non-skill directory and a stray file are ignored.
+  @fs.mkdir(dir + "/not-a-skill", recursive=true)
+  write_skill(dir + "/notes.txt", "not markdown")
+  let skills = @agent_skill.discover_skills(dir)
+  assert_eq(skills.length(), 3)
+  // Sorted by name (String order is length-first, so "bare" precedes
+  // "alpha"); the SKILL.md layout names itself after its directory.
+  assert_eq(skills[0].name(), "bare")
+  assert_eq(skills[0].description(), "")
+  assert_eq(skills[1].name(), "alpha")
+  assert_eq(skills[1].description(), "Alpha steps.")
+  assert_eq(skills[1].path(), dir + "/alpha/SKILL.md")
+  assert_eq(skills[2].name(), "zeta-protocol")
+  assert_eq(skills[2].description(), "How to zeta.")
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+async test "a malformed frontmatter never hides the skill" {
+  let dir = @fs.tmpdir(prefix="openseek-skills-malformed-")
+  // Opening --- with no closing fence: keys still parse until EOF.
+  write_skill(
+    dir + "/open.md",
+    (
+      #|---
+      #|name: still-found
+      #|no colon line
+    ),
+  )
+  let skills = @agent_skill.discover_skills(dir)
+  assert_eq(skills.length(), 1)
+  assert_eq(skills[0].name(), "still-found")
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+async test "a missing skills directory is an empty library" {
+  let skills = @agent_skill.discover_skills("/nonexistent/openseek-skills")
+  assert_eq(skills.length(), 0)
+  assert_true(@agent_skill.skills_prompt_section(skills) is None)
+}
+
+///|
+async test "the prompt section lists usage, names, and paths" {
+  let dir = @fs.tmpdir(prefix="openseek-skills-prompt-")
+  write_skill(
+    dir + "/release.md",
+    (
+      #|---
+      #|name: release
+      #|description: Cut a release of this project.
+      #|---
+      #|1. bump version
+    ),
+  )
+  let skills = @agent_skill.discover_skills(dir)
+  guard @agent_skill.skills_prompt_section(skills) is Some(section) else {
+    fail("expected a section")
+  }
+  assert_true(section.contains("## Skills"))
+  assert_true(section.contains("read its file with the read tool"))
+  assert_true(
+    section.contains(
+      "- release — Cut a release of this project. (file: \{dir}/release.md)",
+    ),
+  )
+  @fs.rmdir(dir, recursive=true)
+}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -476,11 +476,10 @@ async fn configured_system_prompt(
       $|\{addendum}
     )
   }
-  let tail = (
+  let tail =
     $|\{with_addendum}
     $|
     $|\{environment_prompt_section()}
-  )
   // Workspace skills join the per-project tail after the environment
   // section: like the cwd they vary per project (and change when skills are
   // edited), so they must sit after all globally shared text to keep it
@@ -501,7 +500,9 @@ async fn configured_system_prompt(
 /// the working directory, listing `<name>.md` files and `<name>/SKILL.md`
 /// layouts. Empty or absent directories advertise nothing.
 async fn skills_prompt_section_for_cwd() -> String? {
-  @agent_skill.skills_prompt_section(@agent_skill.discover_skills(".openseek/skills"))
+  @agent_skill.skills_prompt_section(
+    @agent_skill.discover_skills(".openseek/skills"),
+  )
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -710,13 +710,53 @@ async test "configured system prompt can replace and append files" {
       "--system-prompt-file", prompt_path, "--system-prompt-addendum-file", addendum_path,
       "write", "MoonBit",
     ],
-    env={ "DEEPSEEK": "test-key" },
+    // The pinned global-skills dir keeps the exact-text assertion below
+    // machine-independent: without it, a developer's ~/.openseek/skills
+    // would append a ## Skills section (Codex review).
+    env={
+      "DEEPSEEK": "test-key",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": dir + "/no-global-skills",
+    },
   )
   // Environment last: base and addendum form the cache-shared prefix; the
   // per-project cwd is the only divergence point.
   assert_eq(
     configured_system_prompt(parsed, V4Flash),
     "base prompt\n\n\naddendum\n\n\n\{environment_prompt_section()}",
+  )
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+async test "configured system prompt advertises global skills" {
+  let dir = @fs.tmpdir(prefix="openseek-global-skills-")
+  @fs.mkdir(dir + "/skills", recursive=true)
+  @fs.write_file(
+    dir + "/skills/release.md",
+    (
+      #|---
+      #|name: release
+      #|description: Cut a release.
+      #|---
+      #|steps
+    ),
+    create_mode=CreateOrTruncate,
+  )
+  let prompt_path = dir + "/prompt.md"
+  @fs.write_file(prompt_path, "base\n", create_mode=CreateOrTruncate)
+  let parsed = cli_command().parse(
+    argv=["--system-prompt-file", prompt_path, "write", "MoonBit"],
+    env={
+      "DEEPSEEK": "test-key",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": dir + "/skills",
+    },
+  )
+  let prompt = configured_system_prompt(parsed, V4Flash)
+  assert_true(prompt.contains("## Skills"))
+  assert_true(
+    prompt.contains(
+      "release — Cut a release. (file: \{dir}/skills/release.md)",
+    ),
   )
   @fs.rmdir(dir, recursive=true)
 }
@@ -746,7 +786,11 @@ async test "load_or_new_session defers first durable write until append" {
       "--session-root", root, "--session", "cli-test", "--system-prompt-file", prompt_path,
       "write", "MoonBit",
     ],
-    env={ "DEEPSEEK": "test-key" },
+    // Pinned so the exact-prompt assertions stay machine-independent.
+    env={
+      "DEEPSEEK": "test-key",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": root + "/no-global-skills",
+    },
   )
   let created = load_or_new_session(store, id, parsed, V4Pro)
   let grounded_prompt = "system\n\n\{environment_prompt_section()}"
@@ -780,7 +824,11 @@ async test "load_or_new_session recovers empty interrupted session directory" {
       "write",
       "MoonBit",
     ],
-    env={ "DEEPSEEK": "test-key" },
+    // Pinned so the exact-prompt assertion stays machine-independent.
+    env={
+      "DEEPSEEK": "test-key",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": root + "/no-global-skills",
+    },
   )
   let store = @store.SessionStore(root)
   let session = load_or_new_session(store, id, parsed, V4Pro)

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -157,6 +157,13 @@ fn cli_command() -> @argparse.Command {
         about="Append this file to the selected system prompt for prompt experiments.",
       ),
       OptionArg(
+        "global-skills-dir",
+        long="global-skills-dir",
+        env="OPENSEEK_GLOBAL_SKILLS_DIR",
+        default_values=[""],
+        about="User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills.",
+      ),
+      OptionArg(
         "session",
         long="session",
         env="OPENSEEK_SESSION",
@@ -484,7 +491,10 @@ async fn configured_system_prompt(
   // section: like the cwd they vary per project (and change when skills are
   // edited), so they must sit after all globally shared text to keep it
   // prefix-cache hittable.
-  match skills_prompt_section_for_cwd() {
+  match
+    skills_prompt_section_for_cwd(
+      global_dir=value(matches, "global-skills-dir"),
+    ) {
     Some(section) =>
       (
         $|\{tail}
@@ -496,12 +506,33 @@ async fn configured_system_prompt(
 }
 
 ///|
-/// The skills directory advertised to the model: `.openseek/skills` under
-/// the working directory, listing `<name>.md` files and `<name>/SKILL.md`
-/// layouts. Empty or absent directories advertise nothing.
-async fn skills_prompt_section_for_cwd() -> String? {
+/// The skills advertised to the model: the user-level library (`global_dir`,
+/// defaulting to `$HOME/.openseek/skills` when empty) merged with the
+/// workspace library under `.openseek/skills`, listing `<name>.md` files and
+/// `<name>/SKILL.md` layouts. Workspace skills shadow same-named global ones
+/// so a project can specialize a shared playbook. Empty or absent
+/// directories advertise nothing — and eval harnesses point `global_dir` at
+/// a path inside the trial workspace so the developer's own library never
+/// leaks into trials.
+async fn skills_prompt_section_for_cwd(global_dir~ : String) -> String? {
+  let resolved_global_dir = if global_dir != "" {
+    global_dir
+  } else {
+    match @env.get_env_var("HOME") {
+      Some(home) if home != "" => home + "/.openseek/skills"
+      _ => ""
+    }
+  }
+  let global_skills = if resolved_global_dir == "" {
+    []
+  } else {
+    @agent_skill.discover_skills(resolved_global_dir)
+  }
   @agent_skill.skills_prompt_section(
-    @agent_skill.discover_skills(".openseek/skills"),
+    @agent_skill.merge_skills(
+      global_skills,
+      overrides=@agent_skill.discover_skills(".openseek/skills"),
+    ),
   )
 }
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -476,11 +476,32 @@ async fn configured_system_prompt(
       $|\{addendum}
     )
   }
-  (
+  let tail = (
     $|\{with_addendum}
     $|
     $|\{environment_prompt_section()}
   )
+  // Workspace skills join the per-project tail after the environment
+  // section: like the cwd they vary per project (and change when skills are
+  // edited), so they must sit after all globally shared text to keep it
+  // prefix-cache hittable.
+  match skills_prompt_section_for_cwd() {
+    Some(section) =>
+      (
+        $|\{tail}
+        $|
+        $|\{section}
+      )
+    None => tail
+  }
+}
+
+///|
+/// The skills directory advertised to the model: `.openseek/skills` under
+/// the working directory, listing `<name>.md` files and `<name>/SKILL.md`
+/// layouts. Empty or absent directories advertise nothing.
+async fn skills_prompt_section_for_cwd() -> String? {
+  @agent_skill.skills_prompt_section(@agent_skill.discover_skills(".openseek/skills"))
 }
 
 ///|

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/jsonl",
   "bobzhang/openseek/agent",
   "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_skill",
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/deepseek",

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -152,6 +152,10 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
       "DEEPSEEK": config.api_key,
       "DEEPSEEK_MODEL": config.model.to_string(),
       "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+      // Trials inherit the developer's env, so point the global skills
+      // lookup at a workspace path that does not exist — the developer's
+      // own ~/.openseek/skills must never reach a trial prompt.
+      "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
     },
     inherit_env=true,
     cwd=real_workspace,

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -177,6 +177,10 @@ async fn run_trial(
       "DEEPSEEK": config.api_key,
       "DEEPSEEK_MODEL": config.model.to_string(),
       "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+      // Trials inherit the developer's env, so point the global skills
+      // lookup at a workspace path that does not exist — the developer's
+      // own ~/.openseek/skills must never reach a trial prompt.
+      "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
     },
     inherit_env=true,
     cwd=real_workspace,

--- a/improvement.md
+++ b/improvement.md
@@ -156,6 +156,21 @@ shows where steps and tokens went to waste):
 - [ ] **Cheapen the engine probe.** `engine_launchable` spawns
   `<engine> --help` on every TUI launch; cache the result per engine path
   (mtime-keyed) or accept the first spawn failing fast instead.
+- [x] **Skills: advertise markdown playbooks, load on demand.** *(Done:
+  workspace `.openseek/skills` plus a user-level library — default
+  `$HOME/.openseek/skills`, override `--global-skills-dir` /
+  `OPENSEEK_GLOBAL_SKILLS_DIR`, workspace shadows global by name — are
+  listed name/description/path in a `## Skills` prompt section; bodies load
+  through the existing `read` tool. Effectiveness A/B (2026-06-11, 5 flash
+  trials per arm, marketplace `anthropics/skills` brand-guidelines skill,
+  "branded landing page" task): skill arm read the skill unprompted 5/5 and
+  shipped the exact brand palette 5/5 (7–36 hex occurrences); no-skill
+  control hit the palette 0/5; negative control — skill advertised, haiku
+  task — read it 0/5, so the listing does not pollute unrelated tasks.
+  Listing cost ~1 line/skill; the matched read added one step. Eval
+  harnesses pin `OPENSEEK_GLOBAL_SKILLS_DIR` into the trial workspace so a
+  developer's personal library never leaks into trials.)* Follow-ups: TUI
+  surfacing of available skills, multi-skill libraries under noisier tasks.
 
 ## DeepSeek client
 

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -36,6 +36,7 @@ Options:
   --reasoning-effort <reasoning-effort>                        DeepSeek reasoning effort in thinking mode: high or max. [env: OPENSEEK_REASONING_EFFORT] [default: max]
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
+  --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
   --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION] [default: ]
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
   --session-compact-file <session-compact-file>                Read summary text from this file, append it to --session, and exit. [default: ]


### PR DESCRIPTION
Owner-requested feature: skills support.

## Design

- **Skill** = markdown playbook (`<name>.md` or `<name>/SKILL.md`), optional `name:`/`description:` frontmatter; malformed headers degrade to the file stem, never hide a skill; missing directory = empty library.
- **Two libraries**: workspace `.openseek/skills/` plus a user-level (global) one — default `$HOME/.openseek/skills`, override with `--global-skills-dir` / `OPENSEEK_GLOBAL_SKILLS_DIR`. `merge_skills` lets workspace skills shadow same-named global ones, so a project can specialize a shared playbook without renaming it.
- **Advertisement, not injection**: the engine appends a `## Skills` section (name — description — path, plus "read the file BEFORE doing matching work"; listed files are pre-approved reads even outside the workspace, since global skills live under `$HOME`). Bodies stay out of context until the model judges relevance — a library costs listing lines per request, not its text.
- **Zero new tool surface**: loading rides the existing `read` tool.
- **Cache placement** (per #102's ordering rule): the section joins the per-project tail *after* the environment block, keeping all globally shared prompt text prefix-cache hittable; listings sort deterministically.
- **Hermetic evals**: both eval harnesses pin `OPENSEEK_GLOBAL_SKILLS_DIR` into the trial workspace, so a developer's personal library never leaks into trials; exact-prompt unit tests pin it the same way.

## Verification

- **Effectiveness A/B** (2026-06-11, deepseek-v4-flash, 5 trials per arm, real marketplace skill: `anthropics/skills` brand-guidelines; task: "create a branded landing page", skill never named):
  - *skill arm*: 5/5 read the SKILL.md unprompted (first tool call), 5/5 shipped the exact mandated palette (7–36 brand-hex occurrences in `index.html`);
  - *no-skill control*: 0/5 produced any brand hex — the palette never appears by chance;
  - *negative control* (skill advertised, haiku task): 0/5 read the skill — the listing does not pollute unrelated tasks. Matched tasks cost one extra step (the read); unmatched tasks cost zero.
- Unit tests: flat + `SKILL.md` discovery and deterministic ordering, frontmatter fallbacks, malformed-header tolerance, missing-directory emptiness, global/workspace merge shadowing, prompt-section content, env-var wiring end to end. Exact-prompt tests verified against a booby-trapped `$HOME` skills library. 476/476 native tests, 9/9 cram, fmt clean.
- Codex review: round 1 flagged the dotted-directory-name bug (fixed in 5f6fcd8) and the HOME-dependent exact-prompt tests (fixed in 3520ccc); round 2 clean.

Natural follow-ups (not in this PR): TUI surfacing of available skills, multi-skill libraries under noisier tasks.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)