### PR TITLE
feat(agent): verified moon-ide-doc ergonomics + multi-file read

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -1,9 +1,9 @@
 # Read Tool
 
-`read` returns text from a file at `arguments.path`. By default it returns the
-whole file when it fits within the output cap. For larger files, or when the
-agent only needs a focused region, pass `start_line`, `max_lines`, or
-`max_output_chars`.
+`read` returns text from a file at `arguments.path`, or from several files in
+one call via `arguments.paths`. By default it returns whole files when they
+fit within the output cap. For larger files, or when the agent only needs a
+focused region, pass `start_line`, `max_lines`, or `max_output_chars`.
 
 ## Design Rationale
 
@@ -17,6 +17,14 @@ Ranged or capped reads include a metadata header so the model knows what it saw
 and what it did not see. Automatic character truncation is marked as a tool
 error even when the file was read successfully; that makes lossy context visible
 to the loop instead of silently pretending the returned prefix is complete.
+
+Multi-file reads exist because agent traces show models reading related files
+one round trip at a time — each a full model turn. `paths` collapses those
+into one call: every file returns as its own headered block, a file that
+fails to read reports inline while the others still land (mirroring how
+`moon ide doc` reports per-query misses), and the `max_output_chars` budget
+is shared across the call in argument order. Line-range options stay
+single-file: a range only means something against one file.
 
 ## API Style
 
@@ -40,10 +48,11 @@ Prefer a range plus a cap over reading a large file and relying on truncation.
 
 | Name | Type | Required | Notes |
 | ---- | ---- | -------- | ----- |
-| `path` | string | yes | Filesystem path. Relative paths resolve against the agent process's current working directory. |
-| `start_line` | number | no | 1-based first line to return. Defaults to `1`. |
-| `max_lines` | number | no | Maximum number of lines to return. |
-| `max_output_chars` | number | no | Maximum content chars to return. Defaults to `12000` and is capped at `50000`. |
+| `path` | string | one of `path`/`paths` | Filesystem path. Relative paths resolve against the agent process's current working directory. |
+| `paths` | string array | one of `path`/`paths` | Several files in one call, each returned as a headered block; per-file errors report inline. |
+| `start_line` | number | no | 1-based first line to return. Defaults to `1`. Single-file calls only. |
+| `max_lines` | number | no | Maximum number of lines to return. Single-file calls only. |
+| `max_output_chars` | number | no | Maximum content chars to return across the call. Defaults to `12000` and is capped at `50000`. |
 
 ## Action
 
@@ -56,11 +65,15 @@ character truncation. The string body has one of these shapes:
 - A metadata header followed by `---` and the selected content for ranged reads
   or capped reads. The header includes line and character counts plus
   `truncated=true` when `max_output_chars` cut the selected content.
-- `"error reading <path>: <error>"` — the read failed. Common causes: the
-  file is missing, the agent doesn't have read permissions, or the bytes
-  aren't valid UTF-8.
-- `"error: read requires arguments.path"` — payload was an object but had no
-  `path` field.
+- Headered blocks separated by blank lines for multi-file reads. A failed
+  file contributes an inline `error reading <path>: <error>` block;
+  `is_error` only flips when every file failed or the shared budget
+  truncated or skipped content.
+- `"error reading <path>: <error>"` — a single-file read failed. Common
+  causes: the file is missing, the agent doesn't have read permissions, or
+  the bytes aren't valid UTF-8.
+- `"error: read requires arguments.path or arguments.paths"` — payload was an
+  object but named no file.
 - `"error: read requires object arguments"` — payload was not a JSON object.
 
 ## Example
@@ -73,10 +86,10 @@ test "read tool advertises the expected schema" {
   let JsonSchema(schema) = tool.schema
   let text = schema.stringify()
   assert_true(text.contains("\"path\""))
+  assert_true(text.contains("\"paths\""))
   assert_true(text.contains("\"start_line\""))
   assert_true(text.contains("\"max_lines\""))
   assert_true(text.contains("\"max_output_chars\""))
-  assert_true(text.contains("\"required\""))
 }
 ```
 

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -23,8 +23,11 @@ one round trip at a time — each a full model turn. `paths` collapses those
 into one call: every file returns as its own headered block, a file that
 fails to read reports inline while the others still land (mirroring how
 `moon ide doc` reports per-query misses), and the `max_output_chars` budget
-is shared across the call in argument order. Line-range options stay
-single-file: a range only means something against one file.
+is shared across the call in argument order — headers, separators, and error
+blocks count against it too, and an exhausted budget collapses the unread
+tail into one bounded skipped-files marker, so output stays near the cap no
+matter how many paths the call names. Line-range options stay single-file: a
+range only means something against one file.
 
 ## API Style
 

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -9,11 +9,13 @@ pub let default_max_output_chars : Int = 12000
 pub let hard_max_output_chars : Int = 50000
 
 ///|
-/// Decoded arguments of the `read` tool: the file at `path`, starting from
-/// the 1-based `start_line`, at most `max_lines` lines (unbounded when
-/// `None`), truncated to `max_output_chars` characters.
+/// Decoded arguments of the `read` tool: one or more files (`paths` holds a
+/// single element for a `path` call), starting from the 1-based `start_line`,
+/// at most `max_lines` lines (unbounded when `None`), truncated to
+/// `max_output_chars` characters across the whole call. Line-range options
+/// only combine with a single file.
 pub struct ReadInput {
-  path : String
+  paths : Array[String]
   start_line : Int
   max_lines : Int?
   max_output_chars : Int
@@ -22,11 +24,13 @@ pub struct ReadInput {
 ///|
 /// Decode `read` tool-call arguments.
 ///
-/// Only `path` is required; the numeric fields must be positive when present
-/// and otherwise default (`start_line` 1, `max_lines` unbounded,
-/// `max_output_chars` `default_max_output_chars` clamped to
-/// `hard_max_output_chars`). Failures name the offending field so the error
-/// fed back to the model says exactly which argument to fix.
+/// Exactly one of `path` (string) or `paths` (non-empty string array) is
+/// required; the numeric fields must be positive when present and otherwise
+/// default (`start_line` 1, `max_lines` unbounded, `max_output_chars`
+/// `default_max_output_chars` clamped to `hard_max_output_chars`).
+/// `start_line`/`max_lines` are single-file affairs and are rejected for a
+/// multi-file call. Failures name the offending field so the error fed back
+/// to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> ReadInput raise {
   match arguments {
     Object(fields) => parse_fields(fields)
@@ -36,14 +40,27 @@ pub fn decode(arguments : Json) -> ReadInput raise {
 
 ///|
 fn parse_fields(fields : Map[String, Json]) -> ReadInput raise {
-  let path = required_string(fields, "path")
+  let single = optional_string(fields, "path")
+  let multi = optional_path_array(fields, "paths")
+  let paths = match (single, multi) {
+    (Some(path), None) => [path]
+    (None, Some(paths)) => paths
+    (Some(_), Some(_)) =>
+      fail("arguments.path or arguments.paths, not both at once")
+    (None, None) => fail("arguments.path or arguments.paths")
+  }
   let start_line = optional_positive_int(fields, "start_line", 1)
   let max_lines = optional_positive_int_option(fields, "max_lines")
+  if paths.length() > 1 && (start_line != 1 || max_lines is Some(_)) {
+    fail(
+      "arguments.start_line and arguments.max_lines to be combined with a single file only",
+    )
+  }
   let max_output_chars = optional_positive_int(
     fields, "max_output_chars", default_max_output_chars,
   )
   {
-    path,
+    paths,
     start_line,
     max_lines,
     max_output_chars: cap_max_output_chars(max_output_chars),
@@ -51,11 +68,36 @@ fn parse_fields(fields : Map[String, Json]) -> ReadInput raise {
 }
 
 ///|
-fn required_string(fields : Map[String, Json], name : String) -> String raise {
+fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
   match fields.get(name) {
-    Some(String(value)) if value != "" => value
-    Some(String(_)) | Some(Null) | None => fail("arguments.\{name}")
+    Some(String(value)) if value != "" => Some(value)
+    Some(String(_)) => fail("arguments.\{name} to be a non-empty string")
+    Some(Null) | None => None
     _ => fail("arguments.\{name} to be a string")
+  }
+}
+
+///|
+fn optional_path_array(
+  fields : Map[String, Json],
+  name : String,
+) -> Array[String]? raise {
+  match fields.get(name) {
+    Some(Array(items)) => {
+      guard items.length() > 0 else {
+        fail("arguments.\{name} to be a non-empty array")
+      }
+      let paths : Array[String] = []
+      for item in items {
+        guard item is String(value) && value != "" else {
+          fail("arguments.\{name} to be an array of non-empty path strings")
+        }
+        paths.push(value)
+      }
+      Some(paths)
+    }
+    Some(Null) | None => None
+    _ => fail("arguments.\{name} to be an array of paths")
   }
 }
 

--- a/agent_tool/read/internal/decode/decode_test.mbt
+++ b/agent_tool/read/internal/decode/decode_test.mbt
@@ -14,7 +14,6 @@ test "decode valid read input" {
       #|  max_lines: Some(4),
       #|  max_output_chars: 50000,
       #|}
-
     ),
   )
 }
@@ -30,7 +29,6 @@ test "decode defaults optional limits" {
       #|  max_lines: None,
       #|  max_output_chars: 12000,
       #|}
-
     ),
   )
 }

--- a/agent_tool/read/internal/decode/decode_test.mbt
+++ b/agent_tool/read/internal/decode/decode_test.mbt
@@ -9,11 +9,12 @@ test "decode valid read input" {
     }),
     content=(
       #|{
-      #|  path: "file.mbt",
+      #|  paths: ["file.mbt"],
       #|  start_line: 3,
       #|  max_lines: Some(4),
       #|  max_output_chars: 50000,
       #|}
+
     ),
   )
 }
@@ -24,11 +25,12 @@ test "decode defaults optional limits" {
     decode({ "path": "file.mbt" }),
     content=(
       #|{
-      #|  path: "file.mbt",
+      #|  paths: ["file.mbt"],
       #|  start_line: 1,
       #|  max_lines: None,
       #|  max_output_chars: 12000,
       #|}
+
     ),
   )
 }

--- a/agent_tool/read/internal/decode/pkg.generated.mbti
+++ b/agent_tool/read/internal/decode/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub let hard_max_output_chars : Int
 
 // Types and methods
 pub struct ReadInput {
-  path : String
+  paths : Array[String]
   start_line : Int
   max_lines : Int?
   max_output_chars : Int

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -106,25 +106,32 @@ async fn read_file(input : @decode.ReadInput) -> @agent_tool.ToolAction {
 /// lines, sharing the call's `max_output_chars` budget in argument order. A
 /// file that fails to read contributes an inline error block — the other
 /// files still return, mirroring how `moon ide doc` reports per-query misses
-/// — and `is_error` only flips when every file failed or the budget
-/// truncated content (so the model knows to re-read the tail individually).
+/// — and `is_error` only flips when every file failed or the budget cut
+/// content (so the model knows to re-read the tail individually).
+///
+/// Every emitted block — header, error text, separators — counts against the
+/// budget, not just file content: otherwise a long paths list of headers or
+/// missing-file errors would outgrow the cap that exists to protect the
+/// context (Codex review). Once the budget is exhausted the unread tail
+/// collapses into a single skipped-files marker, so output stays bounded no
+/// matter how many paths the call names.
 async fn read_files(input : @decode.ReadInput) -> @agent_tool.ToolAction {
   let blocks : Array[String] = []
   let mut remaining = input.max_output_chars
   let mut failures = 0
   let mut truncated_any = false
+  let skipped : Array[String] = []
   for path in input.paths {
     if remaining <= 0 {
-      truncated_any = true
-      blocks.push(
-        "path=\{path}\nskipped=true (max_output_chars budget exhausted; read this file individually)",
-      )
+      skipped.push(path)
       continue
     }
     let content = @fs.read_file(path).text() catch {
       error => {
         failures = failures + 1
-        blocks.push("error reading \{path}: \{error}")
+        let block = "error reading \{path}: \{error}"
+        remaining = remaining - block.length() - 2
+        blocks.push(block)
         continue
       }
     }
@@ -134,9 +141,24 @@ async fn read_files(input : @decode.ReadInput) -> @agent_tool.ToolAction {
     if char_truncated {
       truncated_any = true
     }
-    remaining = remaining - capped.length()
+    let block = read_header(path, content, selection, capped, char_truncated) +
+      capped
+    remaining = remaining - block.length() - 2
+    blocks.push(block)
+  }
+  if skipped.length() > 0 {
+    truncated_any = true
+    // Preview only a handful of names: the marker itself must stay bounded
+    // or a thousand-path call would flood the context through its skip list.
+    let preview_count = if skipped.length() < 5 { skipped.length() } else { 5 }
+    let preview = skipped[0:preview_count].join(", ")
+    let rest = if skipped.length() > 5 {
+      " and \{skipped.length() - 5} more"
+    } else {
+      ""
+    }
     blocks.push(
-      read_header(path, content, selection, capped, char_truncated) + capped,
+      "skipped \{skipped.length()} file(s), max_output_chars budget exhausted — read them individually: \{preview}\{rest}",
     )
   }
   @agent_tool.ToolAction::respond(
@@ -384,8 +406,28 @@ async test "the output budget is shared and exhaustion is reported" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("0123456789"))
-  assert_true(output.content.contains("skipped=true"))
+  assert_true(output.content.contains("skipped 1 file(s)"))
+  assert_true(output.content.contains(b))
   assert_false(output.content.contains("abcdefghij"))
+}
+
+///|
+async test "headers and error blocks count against the budget" {
+  // 40 missing paths with a small budget: error blocks consume the budget,
+  // the tail collapses into one bounded marker, and the total output stays
+  // near the cap instead of growing per path (Codex review).
+  let paths : Array[Json] = []
+  for i in 0..<40 {
+    paths.push(Json::string("/tmp/openseek-read-flood-\{i}"))
+  }
+  let result = execute({ "paths": Json::array(paths), "max_output_chars": 300 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("skipped"))
+  assert_true(output.content.contains("and"))
+  // Bounded: the budget plus one overshooting block plus the skip marker,
+  // far below what 40 unbudgeted error blocks (~70 chars each) would emit.
+  assert_true(output.content.length() < 1200)
 }
 
 ///|

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -1,37 +1,49 @@
 ///|
-/// Tool definition for `read`: returns text from `arguments.path`, optionally
-/// restricted to a line range and capped to avoid flooding the agent context.
+/// Tool definition for `read`: returns text from `arguments.path` (or several
+/// files via `arguments.paths`), optionally restricted to a line range and
+/// capped to avoid flooding the agent context.
 ///
 /// ## Arguments
-/// - `path` (string, required): filesystem path to read.
+/// - `path` (string): filesystem path to read. Exactly one of `path`/`paths`
+///   is required.
+/// - `paths` (string array): several files in one call; per-file read errors
+///   report inline while the other files still return.
 /// - `start_line` (number, optional): 1-based first line to return. Defaults
-///   to 1.
+///   to 1. Single-file calls only.
 /// - `max_lines` (number, optional): maximum number of lines to return.
-/// - `max_output_chars` (number, optional): maximum returned content chars.
-///   Defaults to 12000 and is capped at 50000.
+///   Single-file calls only.
+/// - `max_output_chars` (number, optional): maximum returned content chars
+///   for the whole call. Defaults to 12000 and is capped at 50000.
 ///
 /// ## Result
 /// - `Respond(ToolOutput(<file contents>))` on success for uncapped whole-file
-///   reads.
+///   single reads.
 /// - `Respond(ToolOutput(<metadata header + content>))` for ranged reads or
-///   capped reads.
+///   capped reads, and per file for multi-file reads (blocks separated by a
+///   blank line; a failed file contributes an inline `error reading ...`
+///   block and only flips `is_error` when every file failed).
 /// - `Respond(ToolOutput("error reading <path>: <error>", is_error=true))`
-///   if the read fails (missing file, permission denied, invalid UTF-8, etc.).
+///   if a single-file read fails (missing file, permission denied, invalid
+///   UTF-8, etc.).
 /// - `Respond(ToolOutput("error: read requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition() -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text. Supports optional start_line, max_lines, and max_output_chars for focused reads.",
+    description="Read arguments.path as text — or several independent files in ONE call via arguments.paths (per-file errors report inline; cheaper than one call per file). Supports optional start_line, max_lines, and max_output_chars for focused single-file reads.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
         "path": { "type": "string" },
+        "paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Read several files in one call instead of one call per file. Exactly one of path/paths is required.",
+        },
         "start_line": { "type": "number" },
         "max_lines": { "type": "number" },
         "max_output_chars": { "type": "number" },
       },
-      "required": ["path"],
     }),
     execute=Async(execute),
   )
@@ -48,7 +60,11 @@ async fn execute(arguments : Json) -> @agent_tool.ToolAction {
       )
     }
   }
-  read_file(input)
+  if input.paths.length() == 1 {
+    read_file(input)
+  } else {
+    read_files(input)
+  }
 }
 
 ///|
@@ -63,10 +79,11 @@ priv struct ReadSelection {
 
 ///|
 async fn read_file(input : @decode.ReadInput) -> @agent_tool.ToolAction {
-  let content = @fs.read_file(input.path).text() catch {
+  let path = input.paths[0]
+  let content = @fs.read_file(path).text() catch {
     error =>
       return @agent_tool.ToolAction::respond(
-        "error reading \{input.path}: \{error}",
+        "error reading \{path}: \{error}",
         is_error=true,
       )
   }
@@ -77,11 +94,55 @@ async fn read_file(input : @decode.ReadInput) -> @agent_tool.ToolAction {
     input.max_lines is Some(_) ||
     char_truncated
   let output = if include_header {
-    read_header(input.path, content, selection, capped, char_truncated) + capped
+    read_header(path, content, selection, capped, char_truncated) + capped
   } else {
     capped
   }
   @agent_tool.ToolAction::respond(output, is_error=char_truncated)
+}
+
+///|
+/// Render a multi-file read: one headered block per file, separated by blank
+/// lines, sharing the call's `max_output_chars` budget in argument order. A
+/// file that fails to read contributes an inline error block — the other
+/// files still return, mirroring how `moon ide doc` reports per-query misses
+/// — and `is_error` only flips when every file failed or the budget
+/// truncated content (so the model knows to re-read the tail individually).
+async fn read_files(input : @decode.ReadInput) -> @agent_tool.ToolAction {
+  let blocks : Array[String] = []
+  let mut remaining = input.max_output_chars
+  let mut failures = 0
+  let mut truncated_any = false
+  for path in input.paths {
+    if remaining <= 0 {
+      truncated_any = true
+      blocks.push(
+        "path=\{path}\nskipped=true (max_output_chars budget exhausted; read this file individually)",
+      )
+      continue
+    }
+    let content = @fs.read_file(path).text() catch {
+      error => {
+        failures = failures + 1
+        blocks.push("error reading \{path}: \{error}")
+        continue
+      }
+    }
+    let selection = select_lines(content, 1, None)
+    let capped = cap_text(selection.content, remaining)
+    let char_truncated = selection.content.length() > remaining
+    if char_truncated {
+      truncated_any = true
+    }
+    remaining = remaining - capped.length()
+    blocks.push(
+      read_header(path, content, selection, capped, char_truncated) + capped,
+    )
+  }
+  @agent_tool.ToolAction::respond(
+    blocks.join("\n\n"),
+    is_error=failures == input.paths.length() || truncated_any,
+  )
 }
 
 ///|
@@ -264,11 +325,91 @@ test "read parses and caps optional limits" {
     "max_lines": 4,
     "max_output_chars": 999999,
   })
-  assert_eq(input.path, "file.mbt")
+  assert_eq(input.paths.length(), 1)
+  assert_eq(input.paths[0], "file.mbt")
   assert_eq(input.start_line, 3)
   guard input.max_lines is Some(max_lines) else { fail("missing max_lines") }
   assert_eq(max_lines, 4)
   assert_eq(input.max_output_chars, @decode.hard_max_output_chars)
+}
+
+///|
+async test "read returns several files as headered blocks" {
+  let a = "/tmp/openseek-read-multi-a.txt"
+  let b = "/tmp/openseek-read-multi-b.txt"
+  @fs.write_file(a, "alpha", create_mode=CreateOrTruncate)
+  @fs.write_file(b, "beta", create_mode=CreateOrTruncate)
+  let result = execute({ "paths": [a, b] })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content.contains("path=\{a}"))
+  assert_true(output.content.contains("alpha"))
+  assert_true(output.content.contains("path=\{b}"))
+  assert_true(output.content.contains("beta"))
+}
+
+///|
+async test "a missing file reports inline while the others return" {
+  let a = "/tmp/openseek-read-multi-ok.txt"
+  @fs.write_file(a, "still here", create_mode=CreateOrTruncate)
+  let result = execute({ "paths": [a, "/tmp/openseek-read-multi-missing.txt"] })
+  guard result is Respond(output) else { fail("expected Respond") }
+  // Partial failure is not a tool error: the good file landed and the bad
+  // path's error block tells the model exactly which read to fix.
+  assert_false(output.is_error)
+  assert_true(output.content.contains("still here"))
+  assert_true(
+    output.content.contains(
+      "error reading /tmp/openseek-read-multi-missing.txt",
+    ),
+  )
+}
+
+///|
+async test "every file missing is a tool error" {
+  let result = execute({
+    "paths": ["/tmp/openseek-read-none-1", "/tmp/openseek-read-none-2"],
+  })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+}
+
+///|
+async test "the output budget is shared and exhaustion is reported" {
+  let a = "/tmp/openseek-read-budget-a.txt"
+  let b = "/tmp/openseek-read-budget-b.txt"
+  @fs.write_file(a, "0123456789", create_mode=CreateOrTruncate)
+  @fs.write_file(b, "abcdefghij", create_mode=CreateOrTruncate)
+  let result = execute({ "paths": [a, b], "max_output_chars": 10 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("0123456789"))
+  assert_true(output.content.contains("skipped=true"))
+  assert_false(output.content.contains("abcdefghij"))
+}
+
+///|
+async test "read rejects path and paths together" {
+  let result = execute({ "path": "/tmp/x", "paths": ["/tmp/y"] })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("not both"))
+}
+
+///|
+async test "read rejects line ranges on multi-file calls" {
+  let result = execute({ "paths": ["/tmp/x", "/tmp/y"], "start_line": 2 })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("single file"))
+}
+
+///|
+async test "read rejects an empty paths array" {
+  let result = execute({ "paths": [] })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("non-empty array"))
 }
 
 ///|

--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -18,6 +18,7 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
     max_steps=parse_positive_int(value(matches, "max-steps"), "--max-steps"),
     out_dir=value(matches, "out"),
     repo_root=value(matches, "repo-root"),
+    engine=value(matches, "engine"),
     prompt_label=value(matches, "prompt-label"),
     task_file=value(matches, "task-file"),
     system_prompt_file=value(matches, "system-prompt-file"),

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -69,6 +69,12 @@ fn cli_command() -> @argparse.Command {
         about="OpenSeek repository root used to run cmd/main.",
       ),
       OptionArg(
+        "engine",
+        long="engine",
+        default_values=[""],
+        about="Prebuilt openseek binary to exec per trial; empty falls back to `moon run <repo-root>/cmd/openseek` (which breaks when the repo defines dev_build rules, since their paths resolve against the trial cwd).",
+      ),
+      OptionArg(
         "prompt-label",
         long="prompt-label",
         default_values=["builtin"],

--- a/eval/prompt_task/harness/config.mbt
+++ b/eval/prompt_task/harness/config.mbt
@@ -4,7 +4,11 @@
 /// `max_steps`), artifact and workspace locations (`out_dir`, `repo_root`),
 /// and the prompt variant under test (`prompt_label`, `task_file`,
 /// `system_prompt_file`, `system_prompt_addendum_file` — empty paths mean
-/// the built-in prompt).
+/// the built-in prompt). A non-empty `engine` is a prebuilt openseek binary
+/// trials exec directly; empty falls back to `moon run <repo>/cmd/openseek`,
+/// which only works when the repo's build rules resolve from the trial
+/// workspace (a dev_build rule path resolves against the cwd, so prefer the
+/// prebuilt binary).
 pub struct Config {
   api_key : String
   model : @deepseek.Model
@@ -14,6 +18,7 @@ pub struct Config {
   max_steps : Int
   out_dir : String
   repo_root : String
+  engine : String
   prompt_label : String
   task_file : String
   system_prompt_file : String
@@ -32,6 +37,7 @@ pub fn Config::Config(
   max_steps~ : Int,
   out_dir~ : String,
   repo_root~ : String,
+  engine? : String = "",
   prompt_label~ : String,
   task_file~ : String,
   system_prompt_file~ : String,
@@ -46,6 +52,7 @@ pub fn Config::Config(
     max_steps,
     out_dir,
     repo_root,
+    engine,
     prompt_label,
     task_file,
     system_prompt_file,

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -145,22 +145,26 @@ async fn run_trial(
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
   let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
-  // The engine runs *in* the trial workspace (moon resolves the module from
-  // the absolute package path), so the prompt's environment grounding names
-  // the workspace rather than the OpenSeek checkout — and relative paths in
-  // the model's tool calls land in the right tree. Launcher-relative paths
-  // (the default --repo-root ".", prompt files) must be canonicalized
-  // before the child cwd changes their meaning.
+  // The engine runs *in* the trial workspace, so the prompt's environment
+  // grounding names the workspace rather than the OpenSeek checkout — and
+  // relative paths in the model's tool calls land in the right tree.
+  // Launcher-relative paths (the default --repo-root ".", the engine
+  // binary, prompt files) must be canonicalized before the child cwd
+  // changes their meaning. Prefer a prebuilt --engine binary: `moon run`
+  // resolves the repo's dev_build rule paths against the cwd — the trial
+  // workspace, not the checkout — and fails before the engine starts.
   let repo_root = @fs.realpath(config.repo_root)
-  let args = [
-    "run",
-    repo_root + "/cmd/openseek",
-    "--",
+  let (program, args) = if config.engine != "" {
+    (@fs.realpath(config.engine), [])
+  } else {
+    ("moon", ["run", repo_root + "/cmd/openseek", "--"])
+  }
+  args.append([
     "--max-steps",
     config.max_steps.to_string(),
     "--model",
     config.model.to_string(),
-  ]
+  ])
   if config.system_prompt_file != "" {
     args.push("--system-prompt-file")
     args.push(@fs.realpath(config.system_prompt_file))
@@ -171,7 +175,7 @@ async fn run_trial(
   }
   args.push(task)
   let (exit_code, output) = @process.collect_output_merged(
-    "moon",
+    program,
     args,
     extra_env={
       "DEEPSEEK": config.api_key,

--- a/eval/prompt_task/harness/pkg.generated.mbti
+++ b/eval/prompt_task/harness/pkg.generated.mbti
@@ -20,12 +20,13 @@ pub struct Config {
   max_steps : Int
   out_dir : String
   repo_root : String
+  engine : String
   prompt_label : String
   task_file : String
   system_prompt_file : String
   system_prompt_addendum_file : String
 }
-pub fn Config::Config(api_key~ : String, model~ : @deepseek.Model, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, repo_root~ : String, prompt_label~ : String, task_file~ : String, system_prompt_file~ : String, system_prompt_addendum_file~ : String) -> Self
+pub fn Config::Config(api_key~ : String, model~ : @deepseek.Model, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, repo_root~ : String, engine? : String, prompt_label~ : String, task_file~ : String, system_prompt_file~ : String, system_prompt_addendum_file~ : String) -> Self
 
 pub struct EvalReport {
   model : String

--- a/improvement.md
+++ b/improvement.md
@@ -94,6 +94,20 @@ shows where steps and tokens went to waste):
   `@strconv`, and one `moon ide` OCaml assertion crash. Better query
   ergonomics (or a documented snippet-eval recipe) converts that tail of
   failures into one or two steps.
+  *Second A/B (2026-06-12, 5 pro trials per arm, TOML task): verified
+  glob/multi-query/miss-recovery guidance folded into the prompts' tool
+  docs (the placement the first result pointed at) — successes 1/5 →
+  5/5, no 160-step cap overruns (was 2), doc calls 25 → 37 while misses
+  fell 23 → 17 (miss rate 0.92 → 0.46), package-listing exploration up
+  17 → 25. Promoted: every statement is CLI-verified and the trace
+  improved across the board. Attribution caveats recorded: n=5; the
+  taught glob (1 use) and multi-query (0 uses) forms themselves were
+  barely adopted — the absorbed lesson looks like "trust doc lookups,
+  recover by listing the package"; baseline's failures were step-cap
+  finish discipline and project misplacement, not lookup tails. A
+  dedicated lookup tool with query rewriting stays open as the
+  zero-adoption-risk endgame; schema-level cues beat prose (see the
+  multi-path read tool).*
 - [x] **Ground the model in its environment.** The system prompt never
   states the working directory, so models guess on step 1: in a 5-run
   batch, one agent passed `cwd="/workspace"` (rejected: does not exist),

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -390,9 +390,20 @@ These tools save tokens and are more precise than grepping (`grep` displays resu
   - Example: `moon ide doc "@json"` - explore entire `@json` package
   - Example: `moon ide doc "@encoding/utf8"` - explore nested package
 - **Multiple queries**: `moon ide doc "query1" "query2" ...`
-  - Run multiple queries in one invocation and combine results
+  - Run multiple queries in one invocation and combine results; a query that
+    misses reports `No results found` inline while the others still return
   - Example: `moon ide doc "String" "Array" "@json"` to explore multiple types and a package at once
-- **Globbing**: Use `*` wildcard for partial matches, e.g. `moon ide doc "String::*rev*"` to find all String methods with "rev" in their name
+  - When unsure of a name, batch the candidate spellings plus a bare glob in
+    ONE call instead of probing one guess per step:
+    `moon ide doc "parse_float" "*parse*" "@strconv"`
+- **Globbing**: Use `*` wildcard for partial matches, e.g. `moon ide doc "String::*rev*"` to find all String methods with "rev" in their name, or `moon ide doc "*parse*"` to search every package for a partial name
+  - Globs only match in bare-symbol or `Type::method` position; they silently
+    match nothing after a package qualifier — query `"*parse*"`, never
+    `"@strconv.*parse*"`
+- **On `No results found`**: the exact name exists nowhere, so do not retry
+  near-identical spellings one call at a time or fall back to compile-probe
+  guessing. Re-query once with a bare glob (`"*fragment*"`) or list the
+  package (`moon ide doc "@pkg"`) and read the real names
 
 #### `moon ide doc` Examples
 

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -396,14 +396,18 @@ These tools save tokens and are more precise than grepping (`grep` displays resu
   - When unsure of a name, batch the candidate spellings plus a bare glob in
     ONE call instead of probing one guess per step:
     `moon ide doc "parse_float" "*parse*" "@strconv"`
-- **Globbing**: Use `*` wildcard for partial matches, e.g. `moon ide doc "String::*rev*"` to find all String methods with "rev" in their name, or `moon ide doc "*parse*"` to search every package for a partial name
-  - Globs only match in bare-symbol or `Type::method` position; they silently
-    match nothing after a package qualifier — query `"*parse*"`, never
-    `"@strconv.*parse*"`
-- **On `No results found`**: the exact name exists nowhere, so do not retry
-  near-identical spellings one call at a time or fall back to compile-probe
-  guessing. Re-query once with a bare glob (`"*fragment*"`) or list the
-  package (`moon ide doc "@pkg"`) and read the real names
+- **Globbing**: Use `*` wildcard for partial matches in any position:
+  `moon ide doc "String::*rev*"` for methods, `moon ide doc "@string.*parse*"`
+  within a package, `moon ide doc "*parse*"` to search every package
+  - Glob results can omit deprecated symbols and aliases that an exact
+    lookup would still show — `"@strconv.*parse*"` returns nothing even
+    though a deprecated `@strconv.parse_double` exists (the live API moved
+    to `@string`). An empty glob within one package does not prove the
+    name exists nowhere: widen to a bare glob across packages
+- **On `No results found`**: do not retry near-identical spellings one call
+  at a time or fall back to compile-probe guessing. Re-query once with a
+  bare glob (`"*fragment*"`) across all packages, or list the package
+  (`moon ide doc "@pkg"`) and read the real names
 
 #### `moon ide doc` Examples
 

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -134,11 +134,13 @@ options(
   `moon ide doc "StringView::split"` for methods,
   `moon ide doc "@json.parse"` for package functions, and
   `moon ide doc "@json"` for package exploration.
-- `moon ide doc` accepts several queries per call and `*` globs in
-  bare-symbol or `Type::method` position (never after `@pkg.`). When unsure
-  of a name, batch candidates with a bare glob in one call —
+- `moon ide doc` accepts several queries per call and `*` globs in any
+  position (`"String::*rev*"`, `"@string.*parse*"`, `"*parse*"`). When
+  unsure of a name, batch candidates with a bare glob in one call —
   `moon ide doc "parse_float" "*parse*" "@strconv"` — misses report
-  `No results found` inline while the others return. On a miss, never retry
+  `No results found` inline while the others return. Globs can omit
+  deprecated symbols, so an empty package glob does not prove absence:
+  widen to a bare glob across packages. On a miss, never retry
   near-identical spellings or compile-probe blindly: re-query once with a
   bare glob or list the package and read the real names. Use
   `moon ide outline <dir-or-file>` for package symbols,

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -133,7 +133,14 @@ options(
   methods, types, or imported package aliases, not broad English terms:
   `moon ide doc "StringView::split"` for methods,
   `moon ide doc "@json.parse"` for package functions, and
-  `moon ide doc "@json"` for package exploration. Use
+  `moon ide doc "@json"` for package exploration.
+- `moon ide doc` accepts several queries per call and `*` globs in
+  bare-symbol or `Type::method` position (never after `@pkg.`). When unsure
+  of a name, batch candidates with a bare glob in one call —
+  `moon ide doc "parse_float" "*parse*" "@strconv"` — misses report
+  `No results found` inline while the others return. On a miss, never retry
+  near-identical spellings or compile-probe blindly: re-query once with a
+  bare glob or list the package and read the real names. Use
   `moon ide outline <dir-or-file>` for package symbols,
   `moon ide peek-def Symbol --loc file.mbt:line:col` for definitions,
   `moon ide find-references Symbol`, and `moon ide hover Symbol --loc

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -394,9 +394,20 @@ fn base_prompt() -> String {
     #|  - Example: `moon ide doc "@json"` - explore entire `@json` package
     #|  - Example: `moon ide doc "@encoding/utf8"` - explore nested package
     #|- **Multiple queries**: `moon ide doc "query1" "query2" ...`
-    #|  - Run multiple queries in one invocation and combine results
+    #|  - Run multiple queries in one invocation and combine results; a query that
+    #|    misses reports `No results found` inline while the others still return
     #|  - Example: `moon ide doc "String" "Array" "@json"` to explore multiple types and a package at once
-    #|- **Globbing**: Use `*` wildcard for partial matches, e.g. `moon ide doc "String::*rev*"` to find all String methods with "rev" in their name
+    #|  - When unsure of a name, batch the candidate spellings plus a bare glob in
+    #|    ONE call instead of probing one guess per step:
+    #|    `moon ide doc "parse_float" "*parse*" "@strconv"`
+    #|- **Globbing**: Use `*` wildcard for partial matches, e.g. `moon ide doc "String::*rev*"` to find all String methods with "rev" in their name, or `moon ide doc "*parse*"` to search every package for a partial name
+    #|  - Globs only match in bare-symbol or `Type::method` position; they silently
+    #|    match nothing after a package qualifier — query `"*parse*"`, never
+    #|    `"@strconv.*parse*"`
+    #|- **On `No results found`**: the exact name exists nowhere, so do not retry
+    #|  near-identical spellings one call at a time or fall back to compile-probe
+    #|  guessing. Re-query once with a bare glob (`"*fragment*"`) or list the
+    #|  package (`moon ide doc "@pkg"`) and read the real names
     #|
     #|#### `moon ide doc` Examples
     #|

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -400,14 +400,18 @@ fn base_prompt() -> String {
     #|  - When unsure of a name, batch the candidate spellings plus a bare glob in
     #|    ONE call instead of probing one guess per step:
     #|    `moon ide doc "parse_float" "*parse*" "@strconv"`
-    #|- **Globbing**: Use `*` wildcard for partial matches, e.g. `moon ide doc "String::*rev*"` to find all String methods with "rev" in their name, or `moon ide doc "*parse*"` to search every package for a partial name
-    #|  - Globs only match in bare-symbol or `Type::method` position; they silently
-    #|    match nothing after a package qualifier — query `"*parse*"`, never
-    #|    `"@strconv.*parse*"`
-    #|- **On `No results found`**: the exact name exists nowhere, so do not retry
-    #|  near-identical spellings one call at a time or fall back to compile-probe
-    #|  guessing. Re-query once with a bare glob (`"*fragment*"`) or list the
-    #|  package (`moon ide doc "@pkg"`) and read the real names
+    #|- **Globbing**: Use `*` wildcard for partial matches in any position:
+    #|  `moon ide doc "String::*rev*"` for methods, `moon ide doc "@string.*parse*"`
+    #|  within a package, `moon ide doc "*parse*"` to search every package
+    #|  - Glob results can omit deprecated symbols and aliases that an exact
+    #|    lookup would still show — `"@strconv.*parse*"` returns nothing even
+    #|    though a deprecated `@strconv.parse_double` exists (the live API moved
+    #|    to `@string`). An empty glob within one package does not prove the
+    #|    name exists nowhere: widen to a bare glob across packages
+    #|- **On `No results found`**: do not retry near-identical spellings one call
+    #|  at a time or fall back to compile-probe guessing. Re-query once with a
+    #|  bare glob (`"*fragment*"`) across all packages, or list the package
+    #|  (`moon ide doc "@pkg"`) and read the real names
     #|
     #|#### `moon ide doc` Examples
     #|

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -137,7 +137,14 @@ fn flash_prompt() -> String {
     #|  methods, types, or imported package aliases, not broad English terms:
     #|  `moon ide doc "StringView::split"` for methods,
     #|  `moon ide doc "@json.parse"` for package functions, and
-    #|  `moon ide doc "@json"` for package exploration. Use
+    #|  `moon ide doc "@json"` for package exploration.
+    #|- `moon ide doc` accepts several queries per call and `*` globs in
+    #|  bare-symbol or `Type::method` position (never after `@pkg.`). When unsure
+    #|  of a name, batch candidates with a bare glob in one call —
+    #|  `moon ide doc "parse_float" "*parse*" "@strconv"` — misses report
+    #|  `No results found` inline while the others return. On a miss, never retry
+    #|  near-identical spellings or compile-probe blindly: re-query once with a
+    #|  bare glob or list the package and read the real names. Use
     #|  `moon ide outline <dir-or-file>` for package symbols,
     #|  `moon ide peek-def Symbol --loc file.mbt:line:col` for definitions,
     #|  `moon ide find-references Symbol`, and `moon ide hover Symbol --loc

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -138,11 +138,13 @@ fn flash_prompt() -> String {
     #|  `moon ide doc "StringView::split"` for methods,
     #|  `moon ide doc "@json.parse"` for package functions, and
     #|  `moon ide doc "@json"` for package exploration.
-    #|- `moon ide doc` accepts several queries per call and `*` globs in
-    #|  bare-symbol or `Type::method` position (never after `@pkg.`). When unsure
-    #|  of a name, batch candidates with a bare glob in one call —
+    #|- `moon ide doc` accepts several queries per call and `*` globs in any
+    #|  position (`"String::*rev*"`, `"@string.*parse*"`, `"*parse*"`). When
+    #|  unsure of a name, batch candidates with a bare glob in one call —
     #|  `moon ide doc "parse_float" "*parse*" "@strconv"` — misses report
-    #|  `No results found` inline while the others return. On a miss, never retry
+    #|  `No results found` inline while the others return. Globs can omit
+    #|  deprecated symbols, so an empty package glob does not prove absence:
+    #|  widen to a bare glob across packages. On a miss, never retry
     #|  near-identical spellings or compile-probe blindly: re-query once with a
     #|  bare glob or list the package and read the real names. Use
     #|  `moon ide outline <dir-or-file>` for package symbols,


### PR DESCRIPTION
Follow-up to the negative API-lookup addendum A/B: move the lookup technique out of tail prose and into the two places models actually take cues — the prompts' tool docs and the tool schema.

## Changes

- **Verified `moon ide doc` guidance in both prompts**: `*` globs work in any query position (`"String::*rev*"`, `"@string.*parse*"`, bare `"*parse*"` across all packages); several queries batch into one invocation with per-query misses reported inline; on `No results found`, recover with one bare glob or a package listing instead of spelling-walking or compile-probing. Every statement was verified against the real CLI — including the subtle one found during owner review: glob output can omit deprecated symbols/aliases that exact lookup still shows (`"@strconv.*parse*"` is empty although deprecated `@strconv.parse_double` exists; the live API moved to `@string`), so an empty package glob does not prove absence.
- **`read` accepts a `paths` array**: several files in one call, per-file headered blocks, per-file errors inline while other files still return, shared `max_output_chars` budget with explicit `skipped=` markers. Single-path calls are byte-identical to before. Attacks the one-tool-call-per-step round-trip waste at the schema level, where adoption doesn't depend on prose.
- **Eval harness fix**: every `prompt_task` trial had been dying at step 0 — `moon run <repo>/cmd/openseek` from a trial workspace resolves the prompt dev_build rule path against the cwd. Trials now exec a prebuilt `--engine` binary.

## A/B (deepseek-v4-pro, 5 trials/arm, TOML task, prompt injected via --system-prompt-file against one engine build)

| metric | baseline | enhanced docs |
|---|---|---|
| successes | 1/5 | **5/5** |
| 160-step cap overruns | 2 | 0 |
| `moon ide doc` calls | 25 | 37 |
| doc misses ("No results found") | 23 | 17 |
| miss rate | 0.92 | 0.46 |
| package-listing queries | 17 | 25 |

Attribution caveats recorded in improvement.md: n=5; the taught glob (1 use) and multi-query (0 uses) forms were barely adopted — the absorbed lesson reads as "trust doc lookups, recover by listing the package"; baseline's failures were step-cap finish discipline and project misplacement. A dedicated lookup tool with query rewriting stays open as the zero-adoption-risk endgame.

490/490 native tests, 9/9 cram, fmt clean; the only API surface change is the read tool's optional `paths`.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Post-review updates

- **Codex round 1** flagged that the multi-read budget only counted file content — headers, separators, and missing-file error blocks rode free, so a call naming many empty/missing paths could outgrow the cap. Fixed in c19c735: whole blocks deduct from the budget and an exhausted budget collapses the unread tail into one bounded skipped-files marker (regression test: 40 missing paths under a 300-char budget stay bounded).
- **Adoption probe** (5 fresh trials, "explain this project and its package dependencies", no read-mechanics hints): deepseek-v4-pro passed all six project files in a single `paths` call in 1 of 2 trials — organic, schema-cue-only, first exposure. Flash (0/3) kept single reads but parallel-batched up to 7 read calls inside 2 steps, getting similar round-trip economy via the other mechanism.
