### PR TITLE
feat(cli): one-shot runs record a durable session by default

### DIFF
--- a/agent_session/moon.pkg
+++ b/agent_session/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/core/immut/vector",
   "moonbitlang/core/json",
+  "moonbitlang/x/time",
 }
 
 warnings = "+unnecessary_annotation"

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -53,6 +53,7 @@ pub struct SessionId {
   // private fields
 } derive(@debug.Debug)
 pub fn SessionId::SessionId(String) -> Self
+pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64) -> Self
 pub fn SessionId::value(Self) -> String
 pub impl ToJson for SessionId
 pub impl @json.FromJson for SessionId

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -53,7 +53,7 @@ pub struct SessionId {
   // private fields
 } derive(@debug.Debug)
 pub fn SessionId::SessionId(String) -> Self
-pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64) -> Self
+pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64, salt? : String) -> Self
 pub fn SessionId::value(Self) -> String
 pub impl ToJson for SessionId
 pub impl @json.FromJson for SessionId

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -235,3 +235,16 @@ test "compact validates and appends summary event" {
   }
   fail("empty summary accepted")
 }
+
+///|
+test "generated session ids stamp the launcher prefix and UTC wall clock" {
+  assert_eq(
+    @agent_session.SessionId::generated(prefix="cli", now_ms=0).value(),
+    "cli-19700101-000000-000",
+  )
+  // 2026-06-11T08:15:00.042Z, cross-checked against python datetime
+  assert_eq(
+    @agent_session.SessionId::generated(prefix="tui", now_ms=1781165700042).value(),
+    "tui-20260611-081500-042",
+  )
+}

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -247,4 +247,13 @@ test "generated session ids stamp the launcher prefix and UTC wall clock" {
     @agent_session.SessionId::generated(prefix="tui", now_ms=1781165700042).value(),
     "tui-20260611-081500-042",
   )
+  // A salt keeps two same-millisecond launches apart.
+  assert_eq(
+    @agent_session.SessionId::generated(
+      prefix="cli",
+      now_ms=1781165700042,
+      salt="1a2b3c4d",
+    ).value(),
+    "cli-20260611-081500-042-1a2b3c4d",
+  )
 }

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -19,13 +19,21 @@ pub fn SessionId::value(self : SessionId) -> String {
 
 ///|
 /// Session id for a run that did not pick one: a UTC wall-clock stamp,
-/// `<prefix>-YYYYMMDD-HHMMSS-mmm` (e.g. `cli-20260612-081500-042`).
+/// `<prefix>-YYYYMMDD-HHMMSS-mmm` (e.g. `cli-20260612-081500-042`), plus an
+/// optional `-<salt>` tail.
 ///
 /// The timestamp form keeps generated ids unique per launch, sorted
 /// chronologically in `--session-list`, and valid as a directory name on
 /// every platform. Launchers pass their own `prefix` ("tui", "cli") so a
-/// listing shows where each conversation came from.
-pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64) -> SessionId {
+/// listing shows where each conversation came from. A launcher that can
+/// start several times in the same millisecond under one session root (the
+/// headless CLI under a parallel driver) supplies `salt` — entropy that
+/// keeps simultaneous runs from appending to each other's session.
+pub fn SessionId::generated(
+  prefix~ : String,
+  now_ms~ : Int64,
+  salt? : String = "",
+) -> SessionId {
   fn pad2(value : Int) -> String {
     if value < 10 {
       "0\{value}"
@@ -44,13 +52,14 @@ pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64) -> SessionId {
     }
   }
 
+  let tail = if salt == "" { "" } else { "-\{salt}" }
   let time = @time.unix(now_ms / 1000) catch {
     // A wall clock unrepresentable as a date (absurd system time): the raw
     // millisecond count still yields a unique, valid directory name.
-    _ => return SessionId("\{prefix}-\{now_ms}")
+    _ => return SessionId("\{prefix}-\{now_ms}\{tail}")
   }
   SessionId(
-    "\{prefix}-\{time.year()}\{pad2(time.month())}\{pad2(time.day())}-\{pad2(time.hour())}\{pad2(time.minute())}\{pad2(time.second())}-\{pad3((now_ms % 1000).to_int())}",
+    "\{prefix}-\{time.year()}\{pad2(time.month())}\{pad2(time.day())}-\{pad2(time.hour())}\{pad2(time.minute())}\{pad2(time.second())}-\{pad3((now_ms % 1000).to_int())}\{tail}",
   )
 }
 

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -18,6 +18,43 @@ pub fn SessionId::value(self : SessionId) -> String {
 }
 
 ///|
+/// Session id for a run that did not pick one: a UTC wall-clock stamp,
+/// `<prefix>-YYYYMMDD-HHMMSS-mmm` (e.g. `cli-20260612-081500-042`).
+///
+/// The timestamp form keeps generated ids unique per launch, sorted
+/// chronologically in `--session-list`, and valid as a directory name on
+/// every platform. Launchers pass their own `prefix` ("tui", "cli") so a
+/// listing shows where each conversation came from.
+pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64) -> SessionId {
+  fn pad2(value : Int) -> String {
+    if value < 10 {
+      "0\{value}"
+    } else {
+      "\{value}"
+    }
+  }
+
+  fn pad3(value : Int) -> String {
+    if value < 10 {
+      "00\{value}"
+    } else if value < 100 {
+      "0\{value}"
+    } else {
+      "\{value}"
+    }
+  }
+
+  let time = @time.unix(now_ms / 1000) catch {
+    // A wall clock unrepresentable as a date (absurd system time): the raw
+    // millisecond count still yields a unique, valid directory name.
+    _ => return SessionId("\{prefix}-\{now_ms}")
+  }
+  SessionId(
+    "\{prefix}-\{time.year()}\{pad2(time.month())}\{pad2(time.day())}-\{pad2(time.hour())}\{pad2(time.minute())}\{pad2(time.second())}-\{pad3((now_ms % 1000).to_int())}",
+  )
+}
+
+///|
 /// User-authored model input for one conversational turn.
 pub struct UserMessage {
   priv content : String

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -22,6 +22,13 @@ with `OPENSEEK_SYSTEM_PROMPT_FILE` and
 `OPENSEEK_SESSION`; when set, the CLI creates or resumes that session under
 `--session-root` / `OPENSEEK_SESSION_ROOT` (default `.openseek`).
 
+Every run records a durable session: without `--session`, a generated
+`cli-YYYYMMDD-HHMMSS-mmm` id is used and announced by a `session_started`
+event on stdout, so the conversation is reviewable afterwards with
+`--session-list` / `--session-show` (or the viz server) and resumable with
+`--session <id>`. Pass `--no-session` to run ephemerally; combining it with
+`--session` is rejected.
+
 Without an explicit prompt file, the CLI selects the built-in prompt by model:
 `deepseek-v4-flash` uses `prompt/flash_prompt.md`; `deepseek-v4-pro` uses
 `prompt/base_prompt.md`.

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -22,6 +22,13 @@ async fn run_cli() -> Unit {
     group.spawn_bg() <| () => { stdout_log.drain() }
     defer stdout_log.close()
     let matches = cli_command().parse(env=@env.get_env_vars())
+    // --no-session contradicts an explicit --session in every mode. Checked
+    // before the session-command and serve branches: serve loads its store
+    // on its own path, so a later check could not stop it from recording
+    // anyway (Codex review).
+    if flag(matches, "no-session") && session_id(matches) is Some(_) {
+      fail("--no-session contradicts --session; pick one behavior")
+    }
     if handle_session_command(matches) {
       return
     }
@@ -87,7 +94,7 @@ async fn run_cli() -> Unit {
 
 ///|
 /// The session this run records to: the explicit `--session` id, a generated
-/// `cli-<stamp>` id by default, or `None` under `--no-session`.
+/// `cli-<stamp>-<salt>` id by default, or `None` under `--no-session`.
 ///
 /// One-shot runs record by default because "what did the agent actually do?"
 /// is asked after the run, when an unrecorded answer is gone for good; the
@@ -95,10 +102,16 @@ async fn run_cli() -> Unit {
 /// deferred first write means a run that fails before its first event still
 /// leaves nothing behind. `--no-session` restores the ephemeral behavior for
 /// callers that must not write to the workspace; combining it with an
-/// explicit `--session` is a contradiction and fails fast.
-fn resolved_session_id(
+/// explicit `--session` is a contradiction that `run_cli` rejects up front
+/// for every mode (this helper repeats the check as defense in depth).
+///
+/// The generated id carries a random salt: two timestamp-only ids collide
+/// when a parallel driver launches two bare CLI runs in the same
+/// millisecond under one session root, and the colliding runs would append
+/// to each other's conversation (Codex review).
+async fn resolved_session_id(
   matches : @argparse.Matches,
-) -> @agent_session.SessionId? raise {
+) -> @agent_session.SessionId? {
   match (session_id(matches), flag(matches, "no-session")) {
     (Some(_), true) =>
       fail("--no-session contradicts --session; pick one behavior")
@@ -109,9 +122,40 @@ fn resolved_session_id(
         @agent_session.SessionId::generated(
           prefix="cli",
           now_ms=@env.now().reinterpret_as_int64(),
+          salt=random_salt(),
         ),
       )
   }
+}
+
+///|
+/// A short random token, or "" where none can be produced (the timestamp
+/// alone then still names the session, as before).
+///
+/// The entropy comes from `mkdtemp` via `@fs.tmpdir`: the kernel arbitrates
+/// the random suffix to be unique across concurrent processes — exactly the
+/// guarantee two same-millisecond launches need — and the async runtime
+/// cannot read `/dev/urandom` directly (character devices are not
+/// pollable). The probe directory is removed immediately, and the suffix is
+/// filtered to alphanumerics (platforms decorate it with pid and dots).
+async fn random_salt() -> String {
+  let prefix = "openseek-salt-"
+  let dir = @fs.tmpdir(prefix~) catch { _ => return "" }
+  @fs.rmdir(dir) catch {
+    _ => ()
+  }
+  let basename = match dir.rev_find("/") {
+    Some(index) => dir[index + 1:].to_owned()
+    None => dir
+  }
+  guard basename.has_prefix(prefix) else { return "" }
+  let salt = StringBuilder()
+  for ch in basename[prefix.length():] {
+    if ch is ('0'..='9' | 'a'..='z' | 'A'..='Z') {
+      salt.write_char(ch)
+    }
+  }
+  salt.to_string()
 }
 
 ///|
@@ -733,7 +777,7 @@ test "agent runs require task text" {
 }
 
 ///|
-test "one-shot runs record to a generated cli session by default" {
+async test "one-shot runs record to a generated salted cli session by default" {
   let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
@@ -741,10 +785,14 @@ test "one-shot runs record to a generated cli session by default" {
     fail("expected a generated session id")
   }
   assert_true(id.value().has_prefix("cli-"))
+  // cli- + YYYYMMDD-HHMMSS-mmm is 23 chars; anything beyond is the random
+  // salt that keeps two same-millisecond launches under one session root
+  // apart (mkdtemp-arbitrated, so its exact length is platform-defined).
+  assert_true(id.value().length() > 24)
 }
 
 ///|
-test "--no-session restores the ephemeral one-shot" {
+async test "--no-session restores the ephemeral one-shot" {
   let parsed = cli_command().parse(argv=["--no-session", "write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
@@ -752,7 +800,7 @@ test "--no-session restores the ephemeral one-shot" {
 }
 
 ///|
-test "an explicit --session id is used verbatim" {
+async test "an explicit --session id is used verbatim" {
   let parsed = cli_command().parse(
     argv=["--session", "demo", "write", "MoonBit"],
     env={ "DEEPSEEK": "test-key" },
@@ -764,7 +812,7 @@ test "an explicit --session id is used verbatim" {
 }
 
 ///|
-test "--session with --no-session is a contradiction" {
+async test "--session with --no-session is a contradiction" {
   let parsed = cli_command().parse(
     argv=["--session", "demo", "--no-session", "write", "MoonBit"],
     env={ "DEEPSEEK": "test-key" },

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -41,7 +41,7 @@ async fn run_cli() -> Unit {
       value(matches, "reasoning-effort"),
     )
     let task = task_text(matches)
-    match session_id(matches) {
+    match resolved_session_id(matches) {
       None => {
         let system_prompt_text = configured_system_prompt(matches, model)
         @agent.run(
@@ -56,6 +56,15 @@ async fn run_cli() -> Unit {
         )
       }
       Some(id) => {
+        // Name the recording up front so a user scanning the event stream —
+        // or its OPENSEEK_LOG_FILE mirror — knows where to find this run
+        // later (--session-show, the viz server, or resuming by id).
+        @xlog.info() <?
+          {
+            "event": "session_started",
+            "session": id.value(),
+            "session_root": session_root(matches),
+          }
         let store = @store.SessionStore(session_root(matches))
         let session = load_or_new_session(store, id, matches, model)
         ignore(
@@ -74,6 +83,35 @@ async fn run_cli() -> Unit {
       }
     }
   })
+}
+
+///|
+/// The session this run records to: the explicit `--session` id, a generated
+/// `cli-<stamp>` id by default, or `None` under `--no-session`.
+///
+/// One-shot runs record by default because "what did the agent actually do?"
+/// is asked after the run, when an unrecorded answer is gone for good; the
+/// recording is a small JSONL directory under --session-root, and the
+/// deferred first write means a run that fails before its first event still
+/// leaves nothing behind. `--no-session` restores the ephemeral behavior for
+/// callers that must not write to the workspace; combining it with an
+/// explicit `--session` is a contradiction and fails fast.
+fn resolved_session_id(
+  matches : @argparse.Matches,
+) -> @agent_session.SessionId? raise {
+  match (session_id(matches), flag(matches, "no-session")) {
+    (Some(_), true) =>
+      fail("--no-session contradicts --session; pick one behavior")
+    (Some(id), false) => Some(id)
+    (None, true) => None
+    (None, false) =>
+      Some(
+        @agent_session.SessionId::generated(
+          prefix="cli",
+          now_ms=@env.now().reinterpret_as_int64(),
+        ),
+      )
+  }
 }
 
 ///|
@@ -201,6 +239,11 @@ fn cli_command() -> @argparse.Command {
         "serve",
         long="serve",
         about="Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.",
+      ),
+      FlagArg(
+        "no-session",
+        long="no-session",
+        about="Run ephemerally: do not record this run to a durable session.",
       ),
       FlagArg(
         "session-list",
@@ -687,6 +730,52 @@ test "agent runs require task text" {
     }
   }
   fail("missing task accepted")
+}
+
+///|
+test "one-shot runs record to a generated cli session by default" {
+  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+  })
+  guard resolved_session_id(parsed) is Some(id) else {
+    fail("expected a generated session id")
+  }
+  assert_true(id.value().has_prefix("cli-"))
+}
+
+///|
+test "--no-session restores the ephemeral one-shot" {
+  let parsed = cli_command().parse(argv=["--no-session", "write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+  })
+  assert_true(resolved_session_id(parsed) is None)
+}
+
+///|
+test "an explicit --session id is used verbatim" {
+  let parsed = cli_command().parse(
+    argv=["--session", "demo", "write", "MoonBit"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  guard resolved_session_id(parsed) is Some(id) else {
+    fail("expected the explicit id")
+  }
+  assert_eq(id.value(), "demo")
+}
+
+///|
+test "--session with --no-session is a contradiction" {
+  let parsed = cli_command().parse(
+    argv=["--session", "demo", "--no-session", "write", "MoonBit"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let _ = resolved_session_id(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("--no-session contradicts --session"))
+      return
+    }
+  }
+  fail("expected a contradiction failure")
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -144,13 +144,12 @@ async fn random_salt() -> String {
   @fs.rmdir(dir) catch {
     _ => ()
   }
-  let basename = match dir.rev_find("/") {
-    Some(index) => dir[index + 1:].to_owned()
-    None => dir
-  }
-  guard basename.has_prefix(prefix) else { return "" }
+  // Locate the prefix instead of splitting on a path separator: Windows
+  // paths use backslashes, and a `/`-only basename split would drop the
+  // salt there entirely (Codex review).
+  guard dir.rev_find(prefix) is Some(index) else { return "" }
   let salt = StringBuilder()
-  for ch in basename[prefix.length():] {
+  for ch in dir[index + prefix.length():] {
     if ch is ('0'..='9' | 'a'..='z' | 'A'..='Z') {
       salt.write_char(ch)
     }

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -187,43 +187,16 @@ fn session_root(matches : @argparse.Matches) -> String raise {
 }
 
 ///|
-/// Session id for a TUI launch that did not pick one: a UTC wall-clock stamp,
-/// `tui-YYYYMMDD-HHMMSS-mmm`.
+/// Session id for a TUI launch that did not pick one.
 ///
 /// Conversation continuity is the TUI's default. The engine runs once per
 /// prompt, so context only carries between prompts through the durable session
 /// store — without a session, telling the assistant something and asking about
 /// it in the next prompt would hit a fresh one-shot that never saw the first
-/// message. The timestamp form keeps generated ids unique per launch, sorted
-/// chronologically in `--session-list`, and valid as a directory name on every
-/// platform.
+/// message. The stamp format lives in `SessionId::generated`, shared with the
+/// engine CLI's default recording.
 fn generated_session_id(now_ms : Int64) -> @agent_session.SessionId {
-  fn pad2(value : Int) -> String {
-    if value < 10 {
-      "0\{value}"
-    } else {
-      "\{value}"
-    }
-  }
-
-  fn pad3(value : Int) -> String {
-    if value < 10 {
-      "00\{value}"
-    } else if value < 100 {
-      "0\{value}"
-    } else {
-      "\{value}"
-    }
-  }
-
-  let time = @time.unix(now_ms / 1000) catch {
-    // A wall clock unrepresentable as a date (absurd system time): the raw
-    // millisecond count still yields a unique, valid directory name.
-    _ => return SessionId("tui-\{now_ms}")
-  }
-  SessionId(
-    "tui-\{time.year()}\{pad2(time.month())}\{pad2(time.day())}-\{pad2(time.hour())}\{pad2(time.minute())}\{pad2(time.second())}-\{pad3((now_ms % 1000).to_int())}",
-  )
+  @agent_session.SessionId::generated(prefix="tui", now_ms~)
 }
 
 ///|

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -17,7 +17,6 @@ import {
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbitlang/x/sys",
-  "moonbitlang/x/time",
 }
 
 import {

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -26,6 +26,7 @@ Arguments:
 Options:
   -h, --help                                                   Show help information.
   --serve                                                      Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.
+  --no-session                                                 Run ephemerally: do not record this run to a durable session.
   --session-list                                               List durable session ids and exit.
   --session-show                                               Print the durable session JSON for --session and exit.
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
@@ -90,6 +91,58 @@ demo
 {"version":1,"id":"demo","system_prompt":"system","events":[{"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}},{"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}]}
 compacted session demo events 1..2; last_sequence=3
 {"version":1,"id":"demo","system_prompt":"system","events":[{"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}},{"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}},{"sequence":3,"item":{"kind":"summary","payload":{"content":"hello and answer","from_sequence":1,"to_sequence":2}}}]}
+```
+
+## One-Shot Runs Record A Session By Default
+
+A bare `openseek "task"` records its conversation to a generated
+`cli-YYYYMMDD-HHMMSS-mmm` session under `--session-root` (default
+`.openseek`), exactly as if `--session` had been passed — "what did the agent
+do?" is usually asked after the run, when an unrecorded answer is gone for
+good. The run announces the recording with a `session_started` event on
+stdout, so the id is in the log stream (and any `OPENSEEK_LOG_FILE` mirror);
+afterwards the run is visible to `--session-list`, `--session-show`, the viz
+server, and `--session <id>` resumption.
+
+This example stays offline by pointing `--api-url` at a closed local port:
+the engine names its session, durably records the user prompt, and only then
+fails to reach the API. The generated id's timestamp is normalized for
+determinism.
+
+```mooncram
+$ sh <<'EOF'
+> tmp=$(mktemp -d)
+> cd "$tmp"
+> if env DEEPSEEK=test-key openseek.exe --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> grep -c '"event":"session_started"' out.jsonl
+> env -u DEEPSEEK openseek.exe --session-list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}/cli-<stamp>/'
+> rm -rf "$tmp"
+> EOF
+exit-non-zero
+1
+cli-<stamp>
+```
+
+`--no-session` turns recording off: the same failing run leaves no session
+root behind.
+
+```mooncram
+$ sh <<'EOF'
+> tmp=$(mktemp -d)
+> cd "$tmp"
+> env DEEPSEEK=test-key openseek.exe --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" >/dev/null 2>&1
+> if test -d .openseek; then echo recorded; else echo ephemeral; fi
+> rm -rf "$tmp"
+> EOF
+ephemeral
+```
+
+Asking for both behaviors at once is rejected before any work happens.
+
+```mooncram
+$ env DEEPSEEK=test-key openseek.exe --session demo --no-session "say hi" 2>&1
+error: --no-session contradicts --session; pick one behavior
+[1]
 ```
 
 ## Serve Mode Speaks JSONL Commands On Stdin

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -115,7 +115,7 @@ $ sh <<'EOF'
 > cd "$tmp"
 > if env DEEPSEEK=test-key openseek.exe --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > grep -c '"event":"session_started"' out.jsonl
-> env -u DEEPSEEK openseek.exe --session-list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}/cli-<stamp>/'
+> env -u DEEPSEEK openseek.exe --session-list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
 > rm -rf "$tmp"
 > EOF
 exit-non-zero
@@ -141,6 +141,15 @@ Asking for both behaviors at once is rejected before any work happens.
 
 ```mooncram
 $ env DEEPSEEK=test-key openseek.exe --session demo --no-session "say hi" 2>&1
+error: --no-session contradicts --session; pick one behavior
+[1]
+```
+
+The same contradiction is caught in every mode — including `--serve`, which
+loads its session store on its own code path.
+
+```mooncram
+$ printf '' | env DEEPSEEK=test-key openseek.exe --serve --session demo --no-session 2>&1
 error: --no-session contradicts --session; pick one behavior
 [1]
 ```


### PR DESCRIPTION
Owner-requested: `openseek "task"` should save its log by default — the headless one-shot was the only entry point that forgot everything, while "what did the agent do?" is asked after the run, when an unrecorded answer is gone for good.

## Behavior

- A bare `openseek "task"` records to a generated `cli-YYYYMMDD-HHMMSS-mmm` session under `--session-root` (default `.openseek`), exactly as if `--session` had been passed.
- The run announces the recording with a `session_started` event (id + root) on stdout, so the id is in the event stream and any `OPENSEEK_LOG_FILE` mirror; afterwards the run is visible to `--session-list` / `--session-show` / the viz server and resumable via `--session <id>`.
- **Off switch**: `--no-session` runs ephemerally. Combining it with an explicit `--session` is rejected as a contradiction before any work happens.
- The store's deferred first write still guarantees a run that fails before its first event (missing key, bad flags) leaves nothing behind.
- The id generator moved to `SessionId::generated(prefix~, now_ms~)`, shared with the TUI's `tui-` stamps (TUI behavior unchanged).

## Documentation

Per owner request, the cram suite documents the new behavior offline: pointing `--api-url` at a closed local port shows the engine naming its session and durably recording the prompt before the API fails (generated stamp normalized for determinism); a second case shows `--no-session` leaving no session root; a third pins the contradiction error. `cmd/openseek/README.md` updated to match.

## Verification

488/488 native tests (4 new: generated-id default, `--no-session`, explicit id, contradiction; plus a stamp test cross-checked against python datetime), 12/12 cram (3 new documentation cases), fmt clean. Side effect recorded in the commit: eval-harness trials now leave a durable session per trial workspace, making failed trials replayable in the visualizer.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Codex review (4 rounds)

1. Flagged two real issues: timestamp-only generated ids collide across same-millisecond parallel launches under one session root, and the `--session`/`--no-session` contradiction was bypassed by `--serve` (which loads its store on its own path). Fixed in 7b237fa: `SessionId::generated` takes an optional salt filled with kernel-arbitrated mkdtemp entropy (the async runtime cannot poll `/dev/urandom`), and the contradiction is rejected immediately after argument parsing in every mode, with a serve-mode cram case.
2. Flagged the salt's `/`-only basename split dropping the salt on Windows backslash paths. Fixed in 998c3af by locating the prefix instead.
3. Final pass clean: "no discrete regressions were identified in the diff."
