### PR TITLE
fix: use $mod_dir in md_to_mbt_string

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -28,5 +28,5 @@ warnings = "+missing_doc"
 
 rule(
   name: "md_to_mbt_string",
-  command: "moon run --quiet --target native scripts/md_to_mbt_string -- \"$input\" \"$output\"",
+  command: "moon run --quiet --target native \"$mod_dir/scripts/md_to_mbt_string\" -- \"$input\" \"$output\"",
 )


### PR DESCRIPTION
This fix allow user to moon install openseek via git.

Previously, `moon install https://github.com/moonbitlang/openseek cmd/openseek` errors:

```
Error: failed to resolve path `scripts/md_to_mbt_string`
Caused by:
    No such file or directory (os error 2)
Error: failed to resolve path `scripts/md_to_mbt_string`
Caused by:
    No such file or directory (os error 2)
```

By using `$mod_dir`, now user are expected to `moon install` a openseek executable properly via git.

Thanks @peter-jerry-ye for reporting this.