### PR TITLE
feat(cli): --upload collects finished sessions for experiment datasets

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -74,19 +74,32 @@ async fn run_cli() -> Unit {
           }
         let store = @store.SessionStore(session_root(matches))
         let session = load_or_new_session(store, id, matches, model)
-        ignore(
-          @agent.run_turn_with_append(
-            api_key,
-            model,
-            session,
-            task,
-            append_item=(session, item) => store.append(session, item),
-            max_steps~,
-            thinking~,
-            reasoning_effort~,
-            api_url?,
-          ),
-        )
+        // Collection runs on success AND failure — failed runs are the
+        // diagnostically interesting ones. `defer` cannot call async
+        // functions, so the turn's outcome is held while the upload runs,
+        // then re-raised.
+        let turn_error : Error? = try {
+          ignore(
+            @agent.run_turn_with_append(
+              api_key,
+              model,
+              session,
+              task,
+              append_item=(session, item) => store.append(session, item),
+              max_steps~,
+              thinking~,
+              reasoning_effort~,
+              api_url?,
+            ),
+          )
+          None
+        } catch {
+          error => Some(error)
+        }
+        upload_session(matches, model, id)
+        if turn_error is Some(error) {
+          raise error
+        }
       }
     }
   })
@@ -243,6 +256,13 @@ fn cli_command() -> @argparse.Command {
         env="OPENSEEK_GLOBAL_SKILLS_DIR",
         default_values=[""],
         about="User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills.",
+      ),
+      OptionArg(
+        "upload",
+        long="upload",
+        env="OPENSEEK_UPLOAD",
+        default_values=[""],
+        about="Copy the finished run's session for collection: 'local' ($HOME/.openseek/sessions) or a directory. Off by default; failed runs upload too.",
       ),
       OptionArg(
         "session",

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -15,6 +15,7 @@ import {
   "moonbitlang/core/argparse",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
+  "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbitlang/x/sys",
   "moonbitlang/x/time",

--- a/cmd/openseek/upload.mbt
+++ b/cmd/openseek/upload.mbt
@@ -1,0 +1,163 @@
+///|
+/// Copy a finished run's durable session somewhere a data-collection effort
+/// can find it, per `--upload` / `OPENSEEK_UPLOAD`:
+///
+/// - `""` (default): nowhere — nothing ever leaves the workspace.
+/// - `"local"`: `$HOME/.openseek/sessions/<id>/`.
+/// - any other value: `<dir>/sessions/<id>/` — the target works as a
+///   `--session-root` for the viz server and `--session-list`.
+///
+/// Runs after the turn ends, success and failure alike — failed runs are
+/// the diagnostically interesting ones. Strictly best-effort: a collection
+/// problem must never fail the run that produced the data, so every failure
+/// is logged and swallowed. Each copy gains a `meta.json` sidecar carrying
+/// provenance the session format itself does not store (model, run
+/// settings, source workspace, outcome, upload time).
+async fn upload_session(
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+  id : @agent_session.SessionId,
+) -> Unit noraise {
+  // `defer` only accepts non-raising calls, and even logging can raise, so
+  // the entire collection attempt — including its failure logging — lives
+  // behind one swallow-everything boundary.
+  run_upload(matches, model, id) catch {
+    _ => ()
+  }
+}
+
+///|
+async fn run_upload(
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+  id : @agent_session.SessionId,
+) -> Unit {
+  let target = value(matches, "upload")
+  if target == "" {
+    return
+  }
+  upload_session_to(target, matches, model, id) catch {
+    error =>
+      @xlog.warn() <?
+        {
+          "event": "session_uploaded",
+          "ok": false,
+          "session": id.value(),
+          "target": target,
+          "error": "\{error}",
+        }
+  }
+}
+
+///|
+async fn upload_session_to(
+  target : String,
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+  id : @agent_session.SessionId,
+) -> Unit {
+  let store = @store.SessionStore(session_root(matches))
+  let events_path = store.event_log_file(id)
+  guard @fs.exists(events_path) else {
+    // Deferred first write never happened: the run failed before any event,
+    // so there is no session on disk and nothing to collect.
+    @xlog.info() <?
+      {
+        "event": "session_uploaded",
+        "ok": false,
+        "session": id.value(),
+        "target": target,
+        "error": "no durable session was written",
+      }
+    return
+  }
+  let events = @fs.read_file(events_path).text()
+  let header_path = store.header_file(id)
+  let header = if @fs.exists(header_path) {
+    @fs.read_file(header_path).text()
+  } else {
+    ""
+  }
+  let workspace = @fs.realpath(".") catch { _ => "." }
+  let meta : Json = {
+    "session": id.value(),
+    "model": model.to_string(),
+    "thinking": value(matches, "thinking"),
+    "reasoning_effort": value(matches, "reasoning-effort"),
+    "max_steps": value(matches, "max-steps"),
+    "workspace": workspace,
+    "outcome": terminal_outcome(events),
+    "uploaded_unix_ms": @env.now().reinterpret_as_int64().to_double(),
+  }
+  let base = if target == "local" {
+    guard @env.get_env_var("HOME") is Some(home) && home != "" else {
+      fail("--upload local needs HOME to locate ~/.openseek")
+    }
+    home + "/.openseek"
+  } else {
+    target
+  }
+  let dest = base + "/sessions/" + id.value()
+  @fs.mkdir(dest, recursive=true)
+  @fs.write_file(dest + "/events.jsonl", events, create_mode=CreateOrTruncate)
+  if header != "" {
+    @fs.write_file(dest + "/session.json", header, create_mode=CreateOrTruncate)
+  }
+  @fs.write_file(
+    dest + "/meta.json",
+    meta.stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  @xlog.info() <?
+    {
+      "event": "session_uploaded",
+      "ok": true,
+      "session": id.value(),
+      "target": dest,
+    }
+}
+
+///|
+/// The run's terminal state as recorded in the event log — "finished",
+/// "failed", or "missing" when the run ended without a terminal event (step
+/// cap, crash). Scans from the end since the terminal event, when present,
+/// is the last line.
+fn terminal_outcome(events : String) -> String {
+  let lines = events.split("\n").to_array()
+  for i = lines.length() - 1; i >= 0; i = i - 1 {
+    let line = lines[i].trim()
+    if line.is_empty() {
+      continue
+    }
+    let parsed = @json.parse(line.to_owned()) catch { _ => continue }
+    if parsed
+      is {
+        "item": {
+          "kind": "terminal",
+          "payload": { "kind": String(kind), .. },
+          ..
+        },
+        ..
+      } {
+      return kind
+    }
+    // The last non-empty line is not a terminal event: the run was cut off.
+    return "missing"
+  }
+  "missing"
+}
+
+///|
+test "terminal_outcome reads the last event's verdict" {
+  let finished =
+    #|{"sequence":1,"ts":0,"item":{"kind":"user","payload":{"content":"hi"}}}
+    #|{"sequence":2,"ts":0,"item":{"kind":"terminal","payload":{"kind":"finished","message":"done"}}}
+  assert_eq(terminal_outcome(finished), "finished")
+  let failed =
+    #|{"sequence":1,"ts":0,"item":{"kind":"terminal","payload":{"kind":"failed","message":"boom"}}}
+  assert_eq(terminal_outcome(failed), "failed")
+  let cut_off =
+    #|{"sequence":1,"ts":0,"item":{"kind":"user","payload":{"content":"hi"}}}
+  assert_eq(terminal_outcome(cut_off), "missing")
+  assert_eq(terminal_outcome(""), "missing")
+}

--- a/improvement.md
+++ b/improvement.md
@@ -163,6 +163,14 @@ shows where steps and tokens went to waste):
 - [ ] **Stale `session.lock` recovery.** Verify what happens when an engine
   crashes while holding the lock, and document (or implement) the recovery
   path.
+- [ ] **Failing runs lose their stdout log tail.** Observed while
+  verifying --upload (2026-06-12): on a turn that raises (e.g. transport
+  failure), stdout JSONL ends at the last agent_step — no error event, no
+  session_uploaded event — although the durable session does record the
+  terminal event. The drain comment claims the close/drain pair never loses
+  the terminal event, but a raising body appears to cancel the drain before
+  the queued tail flushes. The durable session compensates for diagnostics,
+  but the live stream should not go silent exactly when things break.
 - [ ] **Flush the JSONL queue on hard crash.** The stdout drain trades
   crash-tail durability for purity (no C stub): lines queued but unwritten
   when the process aborts are lost. A panic hook that drains synchronously

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -38,6 +38,7 @@ Options:
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
   --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
+  --upload <upload>                                            Copy the finished run's session for collection: 'local' ($HOME/.openseek/sessions) or a directory. Off by default; failed runs upload too. [env: OPENSEEK_UPLOAD] [default: ]
   --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION] [default: ]
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
   --session-compact-file <session-compact-file>                Read summary text from this file, append it to --session, and exit. [default: ]
@@ -135,6 +136,37 @@ $ sh <<'EOF'
 > rm -rf "$tmp"
 > EOF
 ephemeral
+```
+
+## Collecting Sessions With --upload
+
+For data collection across many runs, `--upload local` copies the finished
+run's session — failed runs included, since those are the diagnostically
+interesting ones — into the central `$HOME/.openseek/sessions/` archive,
+alongside a `meta.json` sidecar recording provenance the session format
+itself does not store: model, thinking/effort settings, source workspace,
+and the run's terminal outcome. Any other value is treated as a target
+directory (`<dir>/sessions/<id>/`), so an experiment can collect all its
+trials into one place; either target then works directly as a
+`--session-root` for the viz server and `--session-list`. Collection is off
+by default and best-effort: an upload problem never fails the run.
+
+```mooncram
+$ sh <<'EOF'
+> tmp=$(mktemp -d)
+> mkdir -p "$tmp/home" "$tmp/ws"
+> cd "$tmp/ws"
+> env HOME="$tmp/home" DEEPSEEK=test-key openseek.exe --api-url "http://127.0.0.1:9/chat/completions" --upload local "say hi" >/dev/null 2>&1
+> ls "$tmp/home/.openseek/sessions" | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
+> find "$tmp/home/.openseek/sessions" -type f | sed 's|.*/||' | sort
+> grep -o '"outcome":"[a-z]*"' "$tmp/home/.openseek/sessions"/*/meta.json
+> rm -rf "$tmp"
+> EOF
+cli-<stamp>
+events.jsonl
+meta.json
+session.json
+"outcome":"failed"
 ```
 
 Asking for both behaviors at once is rejected before any work happens.


### PR DESCRIPTION
Data-collection groundwork for upcoming experiments: a one-shot run can archive its session to a central place.

## Behavior

- `openseek --upload local "task"` → after the run ends, the session is **copied** (workspace copy stays, so resume keeps working) to `$HOME/.openseek/sessions/<id>/`.
- `--upload <dir>` → `<dir>/sessions/<id>/` — an experiment pools all its trials into one directory, which then works directly as a `--session-root` for the viz server and `--session-list`.
- **Failed runs upload too** — they are the diagnostically interesting ones. `defer` cannot call async functions, so the turn's outcome is held while the upload runs, then re-raised.
- Each copy gains a `meta.json` sidecar with provenance the session format does not store: model, thinking/effort settings, max steps, source workspace, the run's **terminal outcome** (finished/failed/missing, parsed from the event log tail), and upload time.
- **Off by default, strictly best-effort**: nothing leaves the workspace unless asked; a collection failure logs a `session_uploaded ok=false` event and never fails the run. `OPENSEEK_UPLOAD` env-backs the flag so an eval harness can switch on collection for every trial.

Scope note: a server mode (`--upload <url>` to a viz-server ingest endpoint) was prototyped and deliberately cut per owner direction — local collection only for now.

## Verification

End-to-end offline: failed runs against a closed port archived events.jsonl + session.json + meta.json to a pinned `$HOME` and to a custom directory, with `outcome:"failed"` recorded. Cram documents the workflow (new `Collecting Sessions With --upload` section, stamp-normalized). Unit test pins `terminal_outcome` on finished/failed/cut-off/empty logs. 496/496 native tests (the lone failure is the known network-dependent realworld smoke test, 401 in this environment), 14/14 cram, fmt clean.

Also ledgered (pre-existing, found during verification): a raising turn loses its stdout JSONL tail — the drain is cancelled before flushing, so the live stream goes silent exactly when things break; the durable session compensates.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)