### PR TITLE
chore(warnings): enable unnecessary_view_op module-wide

### DIFF
--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -299,7 +299,7 @@ async fn asset_reply(path : String, content_type : String) -> Reply {
 /// keeps that prefix, and the torn final line then fails to parse client-side
 /// and is reported as a benign truncated tail.
 async fn read_text_lossy(path : String) -> String {
-  @utf8.decode_lossy(@fs.read_file(path).binary()[:])
+  @utf8.decode_lossy(@fs.read_file(path).binary())
 }
 
 ///|

--- a/moon.mod
+++ b/moon.mod
@@ -24,7 +24,7 @@ description = "DeepSeek-backed MoonBit coding agent"
 
 preferred_target = "native"
 
-warnings = "+missing_doc"
+warnings = "+missing_doc+unnecessary_view_op"
 
 rule(
   name: "md_to_mbt_string",


### PR DESCRIPTION
Part 1 of the warning-enablement series from `moon check --warn-list +a`: one warning class per PR, each enabled module-wide in `moon.mod` so the class stays at zero after the fix.

`unnecessary_view_op` (E0075) had exactly one instance: a redundant `[:]` in the viz server's lossy file read, where the expected parameter type is already a view and MoonBit inserts the conversion automatically. One-character fix; `cmd/tui` already enabled this warning locally.

495/495 native tests (the lone failure is the known network-dependent realworld smoke test), fmt clean.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)