### PR TITLE
chore(warnings): enable unused_optional_argument module-wide

### DIFF
--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1018,7 +1018,8 @@ async fn refusal_guidance(
 ) -> String? {
   async fn shows(reports : (String) -> Bool) -> Bool {
     match log_path {
-      Some(path) => log_shows_denial(path, reports)
+      Some(path) =>
+        log_shows_denial(path, reports, budget_bytes=DenialScanBudgetBytes)
       None => reports(head)
     }
   }
@@ -1096,16 +1097,17 @@ const DenialScanBudgetBytes : Int = 16_777_216
 /// one. Detection must not be bounded by the 48KB display cap (a snippet can
 /// flood past it before the denied access), but it must stay bounded in bytes
 /// and time: a log larger
-/// than twice `DenialScanBudgetBytes` is scanned at its head and tail only. An
+/// than twice `budget_bytes` is scanned at its head and tail only. An
 /// uncaught denial crashes the snippet, so its OSError line is the log's tail;
 /// a caught-and-printed denial lands where it happened, inside the head for
 /// realistic probes. Only a denial buried in the MIDDLE of a >32MB flood is
-/// missed — the price of a bounded scan. `budget_bytes` is parameterized for
-/// tests only.
+/// missed — the price of a bounded scan. Production passes
+/// `DenialScanBudgetBytes` as `budget_bytes`; tests pass a small budget to
+/// exercise the head/tail split.
 async fn log_shows_denial(
   path : String,
   reports_denial : (String) -> Bool,
-  budget_bytes? : Int = DenialScanBudgetBytes,
+  budget_bytes~ : Int,
 ) -> Bool {
   let file = @fs.open(path, mode=ReadOnly) catch { _ => return false }
   defer file.close()

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -199,17 +199,16 @@ async fn assert_answer_main_unchanged(
 }
 
 ///|
-/// Assert `result` is the pre-execution source-write refusal: an error
-/// Respond carrying the `marker` phrase plus the shared feedback line (and,
-/// when `line_anchored`, the edit-tool redirection hint).
+/// Assert `output` is the pre-execution source-write refusal: an error
+/// Respond carrying the blocked-operation marker plus the shared feedback line
+/// (and, when `line_anchored`, the edit-tool redirection hint).
 #cfg(not(platform="windows"))
 fn expect_source_write_blocked(
   output : @agent_tool.ToolOutput,
-  marker? : String = "source tree operation is blocked",
   line_anchored? : Bool = false,
 ) -> Unit raise {
   assert_true(output.is_error)
-  assert_true(output.content.contains(marker))
+  assert_true(output.content.contains("source tree operation is blocked"))
   assert_true(
     output.content.contains("source file writes from shell are blocked"),
   )

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -413,10 +413,10 @@ pub fn ShellExecution::seq(self : ShellExecution) -> Int {
 
 ///|
 /// Poll an execution until it reaches a terminal status, failing after a bounded
-/// deadline so a hung child can never hang the test.
+/// deadline (200 ticks of 25ms) so a hung child can never hang the test.
 #cfg(not(platform="windows"))
-async fn poll_exec_terminal(exec : ShellExecution, ticks? : Int = 200) -> Unit {
-  for _ in 0..<ticks {
+async fn poll_exec_terminal(exec : ShellExecution) -> Unit {
+  for _ in 0..<200 {
     if exec.status().is_terminal() {
       return
     }

--- a/moon.mod
+++ b/moon.mod
@@ -25,7 +25,7 @@ description = "DeepSeek-backed MoonBit coding agent"
 
 preferred_target = "native"
 
-warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method"
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method+unused_optional_argument"
 
 rule(
   name: "md_to_mbt_string",


### PR DESCRIPTION
Part 2 of the warning-enablement series (one warning class per PR, enabled module-wide after fixing).

Enables `unused_optional_argument` (E0031) in the root module's `moon.mod`.

**Rebased 2026-09-03 onto main.** The original composer fix (`preferred_column?` / `at_wrap_end?` on `set_logical_lines`) is gone with the terminal UI's move to moonbitlang/openseek_tui (71cf04be2). Since June three new never-supplied optional arguments appeared in the root module, so a second commit clears them before the flag lands:

- `agent_tool/mbtx/mbtx.mbt`: `log_shows_denial`'s `budget_bytes?` is only supplied by the white-box test, which the non-test build never sees. It becomes a required labeled argument; the production caller passes `DenialScanBudgetBytes` explicitly.
- `agent_tool/shell/shell_test.mbt`: `expect_source_write_blocked`'s `marker?` is never supplied; the default string is inlined.
- `agent_tool/shell_exec/execution.mbt`: `poll_exec_terminal`'s `ticks?` is never supplied; the 200-tick bound is inlined.

Scope stays the root module. Enabling the same flag in the other workspace members would surface 4 sites in `desktop` and 45 in `editor` (mostly `_wbtest` helpers); those are left for their own PRs.

Verification: `moon check --deny-warn` clean on native and js (CI's stable matrix), `moon test --target native` for the three touched packages (215/215), `moon fmt` and `moon info` produce no further changes (no public `.mbti` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XT7dsfETcRugdG9uhU4pq
