### PR TITLE
chore(warnings): enable unused_default_value module-wide

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -24,7 +24,7 @@ description = "DeepSeek-backed MoonBit coding agent"
 
 preferred_target = "native"
 
-warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package"
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value"
 
 rule(
   name: "md_to_mbt_string",

--- a/prompt/moon.pkg
+++ b/prompt/moon.pkg
@@ -20,10 +20,13 @@ dev_build(
   output: "generated_flash_prompt.mbt",
 )
 
+// -unused_default_value: the Label and Optional Parameters section
+// demonstrates the f_misuse anti-pattern on purpose; "fixing" the example
+// would change the prompt text the model sees.
 // -missing_doc: the flagged symbols live in the system prompt's example code
 // blocks; doc comments there would change the prompt text the model sees,
 // which is an eval'd prompt change, not a documentation change.
 
-warnings = "+unnecessary_annotation-unused_value-unused_type_declaration-unused_constructor-unused_field-todo-declaration_unimplemented-missing_doc"
+warnings = "+unnecessary_annotation-unused_value-unused_type_declaration-unused_constructor-unused_field-todo-declaration_unimplemented-missing_doc-unused_default_value"
 
 supported_targets = "+native"

--- a/tui/internal/composer/composer.mbt
+++ b/tui/internal/composer/composer.mbt
@@ -302,7 +302,7 @@ fn Model::set_logical_lines(
   cursor~ : TextCursor,
   view_start~ : Int,
   preferred_column? : Int,
-  mode? : Mode = Input,
+  mode~ : Mode,
   at_wrap_end? : Bool = false,
 ) -> Unit {
   let logical_lines = if logical_lines is [] {


### PR DESCRIPTION
Part 3 of the warning-enablement series (one warning class per PR, enabled module-wide after fixing).

`unused_default_value` (E0032) had two instances:

- **composer**: `set_logical_lines`'s `mode? : Mode = Input` — every caller supplies `mode` explicitly, so it becomes a required labelled argument per the diagnostic's own guidance.
- **base prompt**: the `f_misuse(a? : Int?, b? : Int = 1)` example demonstrates the anti-pattern *on purpose*. The prompt package opts out of this warning (same precedent as its existing `-missing_doc` opt-out, documented in `prompt/moon.pkg`): changing the example would silently change the prompt text the model sees, and this repo ships prompt changes with evals, not as warning-fix riders.

Note: PR #114 touches the same composer signature (different parameters); whichever lands second rebases with a one-line conflict.

495/495 native tests (known realworld network test excepted), fmt clean.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)