### PR TITLE
chore(warnings): enable test_unqualified_package module-wide

### DIFF
--- a/agent_tool/edit/internal/decode/decode_test.mbt
+++ b/agent_tool/edit/internal/decode/decode_test.mbt
@@ -1,7 +1,11 @@
 ///|
 test "decode valid edit input" {
   debug_inspect(
-    decode({ "path": "file.mbt", "old_string": "old", "new_string": "new" }),
+    @decode.decode({
+      "path": "file.mbt",
+      "old_string": "old",
+      "new_string": "new",
+    }),
     content=(
       #|{
       #|  path: "file.mbt",
@@ -16,7 +20,7 @@ test "decode valid edit input" {
 ///|
 test "decode replace_all flag" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
@@ -36,7 +40,7 @@ test "decode replace_all flag" {
 ///|
 test "decode rejects invalid replace_all" {
   try
-    decode({
+    @decode.decode({
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
@@ -51,12 +55,12 @@ test "decode rejects invalid replace_all" {
 
 ///|
 test "decode rejects missing required fields" {
-  try decode({ "path": "file.mbt" }) catch {
+  try @decode.decode({ "path": "file.mbt" }) catch {
     error => assert_true("\{error}".contains("arguments.old_string"))
   } noraise {
     _ => fail("missing old_string decoded")
   }
-  try decode({ "path": "file.mbt", "old_string": "old" }) catch {
+  try @decode.decode({ "path": "file.mbt", "old_string": "old" }) catch {
     error => assert_true("\{error}".contains("arguments.new_string"))
   } noraise {
     _ => fail("missing new_string decoded")
@@ -65,7 +69,7 @@ test "decode rejects missing required fields" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try decode(Json::null()) catch {
+  try @decode.decode(Json::null()) catch {
     error => assert_true("\{error}".contains("object arguments"))
   } noraise {
     _ => fail("non-object decoded")

--- a/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
@@ -1,13 +1,13 @@
 ///|
 async test "manifest error allows ordinary files" {
-  assert_true(write_error("notes.json", "{}") is None)
+  assert_true(@manifest_error.write_error("notes.json", "{}") is None)
 }
 
 ///|
 async test "manifest error rejects new moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
   let path = dir + "/moon.mod.json"
-  let error = write_error(path, "{}")
+  let error = @manifest_error.write_error(path, "{}")
   @fs.rmdir(dir, recursive=true)
   guard error is Some(message) else { fail("expected manifest error") }
   assert_true(message.contains("moon.mod.json is legacy"))
@@ -18,22 +18,24 @@ async test "manifest error allows existing moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
   let path = dir + "/moon.mod.json"
   @fs.write_file(path, "{}", create_mode=CreateOrTruncate)
-  let error = write_error(path, "{}")
+  let error = @manifest_error.write_error(path, "{}")
   @fs.rmdir(dir, recursive=true)
   assert_true(error is None)
 }
 
 ///|
 async test "manifest error rejects invalid moon.mod content" {
-  guard write_error("moon.mod", "") is Some(empty) else {
+  guard @manifest_error.write_error("moon.mod", "") is Some(empty) else {
     fail("expected empty moon.mod error")
   }
   assert_eq(empty, "moon.mod must not be empty")
-  guard write_error("moon.mod", "{\"name\":\"demo\"}") is Some(json) else {
+  guard @manifest_error.write_error("moon.mod", "{\"name\":\"demo\"}")
+    is Some(json) else {
     fail("expected JSON moon.mod error")
   }
   assert_eq(json, "moon.mod uses current text syntax, not JSON")
-  guard write_error("moon.mod", "version = \"0.1.0\"") is Some(missing_name) else {
+  guard @manifest_error.write_error("moon.mod", "version = \"0.1.0\"")
+    is Some(missing_name) else {
     fail("expected missing name moon.mod error")
   }
   assert_eq(missing_name, "moon.mod should include a module `name = ...` entry")
@@ -41,11 +43,11 @@ async test "manifest error rejects invalid moon.mod content" {
 
 ///|
 async test "manifest error rejects invalid moon.pkg content" {
-  guard write_error("moon.pkg", "x") is Some(tiny) else {
+  guard @manifest_error.write_error("moon.pkg", "x") is Some(tiny) else {
     fail("expected tiny moon.pkg error")
   }
   assert_eq(tiny, "moon.pkg content is suspiciously small")
-  guard write_error("moon.pkg", "{\"import\":[]}") is Some(json) else {
+  guard @manifest_error.write_error("moon.pkg", "{\"import\":[]}") is Some(json) else {
     fail("expected JSON moon.pkg error")
   }
   assert_eq(json, "moon.pkg uses current text syntax, not JSON")

--- a/agent_tool/finish/internal/decode/decode_test.mbt
+++ b/agent_tool/finish/internal/decode/decode_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "decode keeps answer" {
   debug_inspect(
-    decode({ "answer": "all done" }),
+    @decode.decode({ "answer": "all done" }),
     content=(
       #|{ answer: "all done" }
     ),
@@ -11,7 +11,7 @@ test "decode keeps answer" {
 ///|
 test "decode preserves multiline answer" {
   debug_inspect(
-    decode({ "answer": "line one\nline two" }),
+    @decode.decode({ "answer": "line one\nline two" }),
     content=(
       #|{ answer: "line one\nline two" }
     ),
@@ -21,7 +21,7 @@ test "decode preserves multiline answer" {
 ///|
 test "decode ignores extra fields" {
   debug_inspect(
-    decode({ "answer": "done", "extra": "ignored" }),
+    @decode.decode({ "answer": "done", "extra": "ignored" }),
     content=(
       #|{ answer: "done" }
     ),
@@ -31,19 +31,19 @@ test "decode ignores extra fields" {
 ///|
 test "decode falls back to empty answer" {
   debug_inspect(
-    decode({}),
+    @decode.decode({}),
     content=(
       #|{ answer: "" }
     ),
   )
   debug_inspect(
-    decode({ "answer": 42 }),
+    @decode.decode({ "answer": 42 }),
     content=(
       #|{ answer: "" }
     ),
   )
   debug_inspect(
-    decode(Json::null()),
+    @decode.decode(Json::null()),
     content=(
       #|{ answer: "" }
     ),

--- a/agent_tool/moon_check/internal/decode/decode_test.mbt
+++ b/agent_tool/moon_check/internal/decode/decode_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "decode direct moon_check arguments" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "cwd": "/tmp",
       "target": "native",
       "warn_list": "+unnecessary_annotation",
@@ -25,7 +25,7 @@ test "decode direct moon_check arguments" {
 ///|
 test "decode ignores empty optional strings and false flags" {
   debug_inspect(
-    decode({ "cwd": "", "deny_warn": false, "fmt": null }),
+    @decode.decode({ "cwd": "", "deny_warn": false, "fmt": null }),
     content=(
       #|{
       #|  cwd: None,
@@ -41,7 +41,7 @@ test "decode ignores empty optional strings and false flags" {
 
 ///|
 test "decode rejects invalid target" {
-  try decode({ "target": "browser" }) catch {
+  try @decode.decode({ "target": "browser" }) catch {
     error => assert_true("\{error}".contains("arguments.target"))
   } noraise {
     _ => fail("invalid target decoded")
@@ -50,7 +50,7 @@ test "decode rejects invalid target" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try decode(Json::null()) catch {
+  try @decode.decode(Json::null()) catch {
     error => assert_true("\{error}".contains("object arguments"))
   } noraise {
     _ => fail("non-object decoded")

--- a/agent_tool/moon_cmd/internal/decode/decode_test.mbt
+++ b/agent_tool/moon_cmd/internal/decode/decode_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "decode direct moon command arguments" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "command": "run",
       "cwd": "/tmp",
       "target": "native",
@@ -30,7 +30,7 @@ test "decode direct moon command arguments" {
 ///|
 test "decode singular and plural argument fields" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "command": "test",
       "arg": "--filter",
       "args": ["parser::*", "--quiet"],
@@ -56,7 +56,7 @@ test "decode singular and plural argument fields" {
 
 ///|
 test "decode rejects invalid command" {
-  try decode({ "command": "new" }) catch {
+  try @decode.decode({ "command": "new" }) catch {
     error => assert_true("\{error}".contains("arguments.command"))
   } noraise {
     _ => fail("invalid command decoded")
@@ -65,7 +65,7 @@ test "decode rejects invalid command" {
 
 ///|
 test "decode rejects program args outside run" {
-  try decode({ "command": "test", "program_args": ["ignored"] }) catch {
+  try @decode.decode({ "command": "test", "program_args": ["ignored"] }) catch {
     error => assert_true("\{error}".contains("arguments.program_args"))
   } noraise {
     _ => fail("invalid program args decoded")
@@ -74,7 +74,7 @@ test "decode rejects program args outside run" {
 
 ///|
 test "decode rejects stdin outside run" {
-  try decode({ "command": "test", "stdin": "input" }) catch {
+  try @decode.decode({ "command": "test", "stdin": "input" }) catch {
     error => assert_true("\{error}".contains("arguments.stdin"))
   } noraise {
     _ => fail("invalid stdin decoded")
@@ -83,7 +83,7 @@ test "decode rejects stdin outside run" {
 
 ///|
 test "decode rejects target for fmt" {
-  try decode({ "command": "fmt", "target": "native" }) catch {
+  try @decode.decode({ "command": "fmt", "target": "native" }) catch {
     error => assert_true("\{error}".contains("arguments.target"))
   } noraise {
     _ => fail("invalid fmt target decoded")
@@ -92,7 +92,7 @@ test "decode rejects target for fmt" {
 
 ///|
 test "decode rejects moon test update without classification" {
-  try decode({ "command": "test", "arg": "--update" }) catch {
+  try @decode.decode({ "command": "test", "arg": "--update" }) catch {
     error => assert_true("\{error}".contains("arguments.test_update_kind"))
   } noraise {
     _ => fail("unclassified test update decoded")
@@ -102,7 +102,7 @@ test "decode rejects moon test update without classification" {
 ///|
 test "decode rejects moon test update without reason" {
   try
-    decode({
+    @decode.decode({
       "command": "test",
       "arg": "--update",
       "test_update_kind": "stale_snapshot",
@@ -117,7 +117,7 @@ test "decode rejects moon test update without reason" {
 ///|
 test "decode accepts classified moon test update" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "command": "test",
       "arg": "--update",
       "test_update_kind": "stale_snapshot",
@@ -143,7 +143,7 @@ test "decode accepts classified moon test update" {
 ///|
 test "decode parses and caps output limit" {
   debug_inspect(
-    decode({ "command": "check", "max_output_chars": 999999 }),
+    @decode.decode({ "command": "check", "max_output_chars": 999999 }),
     content=(
       #|{
       #|  command: "check",
@@ -163,7 +163,7 @@ test "decode parses and caps output limit" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try decode(Json::null()) catch {
+  try @decode.decode(Json::null()) catch {
     error => assert_true("\{error}".contains("object arguments"))
   } noraise {
     _ => fail("non-object decoded")

--- a/agent_tool/moon_ide/internal/decode/decode_test.mbt
+++ b/agent_tool/moon_ide/internal/decode/decode_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "decode doc action arguments" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "action": "doc",
       "cwd": "/tmp",
       "query": "String::replace_all",
@@ -25,7 +25,7 @@ test "decode doc action arguments" {
 ///|
 test "decode loc-aware navigation arguments" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "action": "peek_def",
       "query": "render",
       "loc": "lib.mbt:14:8",
@@ -49,7 +49,7 @@ test "decode loc-aware navigation arguments" {
 ///|
 test "decode outline path" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "action": "outline",
       "path": "agent_tool/moon_ide",
       "max_output_chars": 42,
@@ -72,7 +72,11 @@ test "decode outline path" {
 ///|
 test "decode caps oversized output limit" {
   debug_inspect(
-    decode({ "action": "doc", "query": "String", "max_output_chars": 999999 }),
+    @decode.decode({
+      "action": "doc",
+      "query": "String",
+      "max_output_chars": 999999,
+    }),
     content=(
       #|{
       #|  action: "doc",
@@ -90,7 +94,7 @@ test "decode caps oversized output limit" {
 
 ///|
 test "decode rejects invalid action" {
-  try decode({ "action": "rename", "query": "old_name" }) catch {
+  try @decode.decode({ "action": "rename", "query": "old_name" }) catch {
     error => assert_true("\{error}".contains("arguments.action"))
   } noraise {
     _ => fail("invalid action decoded")
@@ -99,7 +103,7 @@ test "decode rejects invalid action" {
 
 ///|
 test "decode rejects missing required fields" {
-  try decode({ "action": "hover", "query": "Widget" }) catch {
+  try @decode.decode({ "action": "hover", "query": "Widget" }) catch {
     error => assert_true("\{error}".contains("arguments.loc"))
   } noraise {
     _ => fail("hover without loc decoded")
@@ -108,7 +112,7 @@ test "decode rejects missing required fields" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try decode(Json::null()) catch {
+  try @decode.decode(Json::null()) catch {
     error => assert_true("\{error}".contains("object arguments"))
   } noraise {
     _ => fail("non-object decoded")

--- a/agent_tool/read/internal/decode/decode_test.mbt
+++ b/agent_tool/read/internal/decode/decode_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "decode valid read input" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "path": "file.mbt",
       "start_line": 3,
       "max_lines": 4,
@@ -21,7 +21,7 @@ test "decode valid read input" {
 ///|
 test "decode defaults optional limits" {
   debug_inspect(
-    decode({ "path": "file.mbt" }),
+    @decode.decode({ "path": "file.mbt" }),
     content=(
       #|{
       #|  paths: ["file.mbt"],
@@ -35,7 +35,7 @@ test "decode defaults optional limits" {
 
 ///|
 test "decode rejects missing path" {
-  try decode({}) catch {
+  try @decode.decode({}) catch {
     error => assert_true("\{error}".contains("arguments.path"))
   } noraise {
     _ => fail("missing path decoded")
@@ -44,7 +44,7 @@ test "decode rejects missing path" {
 
 ///|
 test "decode rejects invalid limits" {
-  try decode({ "path": "file.mbt", "max_lines": 0 }) catch {
+  try @decode.decode({ "path": "file.mbt", "max_lines": 0 }) catch {
     error =>
       assert_true(
         "\{error}".contains("arguments.max_lines to be a positive number"),
@@ -56,7 +56,7 @@ test "decode rejects invalid limits" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try decode(Json::null()) catch {
+  try @decode.decode(Json::null()) catch {
     error => assert_true("\{error}".contains("object arguments"))
   } noraise {
     _ => fail("non-object decoded")

--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -56,21 +56,37 @@ every valid shell construct. Known hardening work is tracked in
 ```moonbit check
 ///|
 test "command policy blocks structured MoonBit validation commands" {
-  assert_true(moonbit_command_policy_error("moon check") is Some(_))
-  assert_true(moonbit_command_policy_error("moon test --update") is None)
   assert_true(
-    moonbit_command_policy_error("DEEPSEEK_MODEL=x moon run cmd/main") is None,
+    @command_policy.moonbit_command_policy_error("moon check") is Some(_),
   )
-  assert_true(moonbit_command_policy_error("cd demo && moon check") is Some(_))
+  assert_true(
+    @command_policy.moonbit_command_policy_error("moon test --update") is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error(
+      "DEEPSEEK_MODEL=x moon run cmd/main",
+    )
+    is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error("cd demo && moon check")
+    is Some(_),
+  )
 }
 ```
 
 ```moonbit check
 ///|
 test "command policy allows non guarded shell commands" {
-  assert_true(moonbit_command_policy_error("moon --version") is None)
-  assert_true(moonbit_command_policy_error("git status --short") is None)
-  assert_true(moonbit_command_policy_error("printf hi | wc -c") is None)
+  assert_true(
+    @command_policy.moonbit_command_policy_error("moon --version") is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error("git status --short") is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error("printf hi | wc -c") is None,
+  )
 }
 ```
 

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -1,15 +1,31 @@
 ///|
 test "command policy detects guarded MoonBit commands" {
-  assert_true(moonbit_command_policy_error("moon check") is Some(_))
-  assert_true(moonbit_command_policy_error("moon test") is None)
-  assert_true(moonbit_command_policy_error("moon run cmd/main") is None)
-  assert_true(moonbit_command_policy_error("moon info") is None)
-  assert_true(moonbit_command_policy_error("moon fmt") is None)
-  assert_true(moonbit_command_policy_error("moon build") is None)
   assert_true(
-    moonbit_command_policy_error("DEEPSEEK_MODEL=x moon run cmd/main") is None,
+    @command_policy.moonbit_command_policy_error("moon check") is Some(_),
   )
-  assert_true(moonbit_command_policy_error("cd demo && moon check") is Some(_))
-  assert_true(moonbit_command_policy_error("moon --version") is None)
-  assert_true(moonbit_command_policy_error("git status --short") is None)
+  assert_true(@command_policy.moonbit_command_policy_error("moon test") is None)
+  assert_true(
+    @command_policy.moonbit_command_policy_error("moon run cmd/main") is None,
+  )
+  assert_true(@command_policy.moonbit_command_policy_error("moon info") is None)
+  assert_true(@command_policy.moonbit_command_policy_error("moon fmt") is None)
+  assert_true(
+    @command_policy.moonbit_command_policy_error("moon build") is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error(
+      "DEEPSEEK_MODEL=x moon run cmd/main",
+    )
+    is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error("cd demo && moon check")
+    is Some(_),
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error("moon --version") is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error("git status --short") is None,
+  )
 }

--- a/agent_tool/shell/internal/decode/decode_test.mbt
+++ b/agent_tool/shell/internal/decode/decode_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "decode valid shell input" {
   debug_inspect(
-    decode({
+    @decode.decode({
       "cmd": "echo hello",
       "cwd": "/tmp",
       "timeout_ms": 250,
@@ -21,7 +21,7 @@ test "decode valid shell input" {
 ///|
 test "decode treats empty cwd as absent" {
   debug_inspect(
-    decode({ "cmd": "pwd", "cwd": "" }),
+    @decode.decode({ "cmd": "pwd", "cwd": "" }),
     content=(
       #|{ cmd: "pwd", cwd: None, timeout_ms: None, max_output_chars: 12000 }
     ),
@@ -30,7 +30,7 @@ test "decode treats empty cwd as absent" {
 
 ///|
 test "decode rejects missing command" {
-  try decode({ "cwd": "/tmp" }) catch {
+  try @decode.decode({ "cwd": "/tmp" }) catch {
     error => assert_true("\{error}".contains("arguments.cmd"))
   } noraise {
     _ => fail("missing command decoded")
@@ -39,7 +39,7 @@ test "decode rejects missing command" {
 
 ///|
 test "decode rejects invalid output cap" {
-  try decode({ "cmd": "echo hello", "max_output_chars": 0 }) catch {
+  try @decode.decode({ "cmd": "echo hello", "max_output_chars": 0 }) catch {
     error =>
       assert_true(
         "\{error}".contains(
@@ -53,7 +53,7 @@ test "decode rejects invalid output cap" {
 
 ///|
 test "decode rejects invalid timeout" {
-  try decode({ "cmd": "echo hello", "timeout_ms": 0 }) catch {
+  try @decode.decode({ "cmd": "echo hello", "timeout_ms": 0 }) catch {
     error =>
       assert_true(
         "\{error}".contains("arguments.timeout_ms to be a positive number"),
@@ -65,7 +65,7 @@ test "decode rejects invalid timeout" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try decode(Json::null()) catch {
+  try @decode.decode(Json::null()) catch {
     error => assert_true("\{error}".contains("object arguments"))
   } noraise {
     _ => fail("non-object decoded")

--- a/agent_tool/write/internal/decode/decode_test.mbt
+++ b/agent_tool/write/internal/decode/decode_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "decode valid write input" {
   debug_inspect(
-    decode({ "path": "/tmp/file.txt", "content": "hello" }),
+    @decode.decode({ "path": "/tmp/file.txt", "content": "hello" }),
     content=(
       #|{ path: "/tmp/file.txt", content: "hello" }
     ),
@@ -11,7 +11,7 @@ test "decode valid write input" {
 ///|
 test "decode accepts empty content" {
   debug_inspect(
-    decode({ "path": "/tmp/file.txt", "content": "" }),
+    @decode.decode({ "path": "/tmp/file.txt", "content": "" }),
     content=(
       #|{ path: "/tmp/file.txt", content: "" }
     ),
@@ -20,7 +20,7 @@ test "decode accepts empty content" {
 
 ///|
 test "decode rejects missing content" {
-  try decode({ "path": "/tmp/file.txt" }) catch {
+  try @decode.decode({ "path": "/tmp/file.txt" }) catch {
     error => assert_true("\{error}".contains("arguments.content"))
   } noraise {
     _ => fail("missing content decoded")
@@ -29,7 +29,7 @@ test "decode rejects missing content" {
 
 ///|
 test "decode rejects missing path" {
-  try decode({ "content": "hello" }) catch {
+  try @decode.decode({ "content": "hello" }) catch {
     error => assert_true("\{error}".contains("arguments.path"))
   } noraise {
     _ => fail("missing path decoded")
@@ -38,7 +38,7 @@ test "decode rejects missing path" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try decode(Json::null()) catch {
+  try @decode.decode(Json::null()) catch {
     error => assert_true("\{error}".contains("object arguments"))
   } noraise {
     _ => fail("non-object decoded")

--- a/eval/tool_harness/harness_test.mbt
+++ b/eval/tool_harness/harness_test.mbt
@@ -1,6 +1,6 @@
 ///|
 async test "deterministic harness exercises every tool" {
-  let report = run_harness()
+  let report = @tool_harness.run_harness()
   assert_eq(report.rows.length(), 8)
   assert_eq(report.successes(), 8)
   assert_true(report.all_passed())
@@ -14,7 +14,7 @@ async test "deterministic harness exercises every tool" {
 ///|
 async test "harness report can be written for inspection" {
   let root = @fs.tmpdir(prefix="openseek-tool-harness-report-")
-  let report = run_harness()
+  let report = @tool_harness.run_harness()
   report.write_files(root)
   let markdown = @fs.read_file(root + "/report.md").text()
   let json = @fs.read_file(root + "/report.json").text()

--- a/moon.mod
+++ b/moon.mod
@@ -24,7 +24,7 @@ description = "DeepSeek-backed MoonBit coding agent"
 
 preferred_target = "native"
 
-warnings = "+missing_doc+unnecessary_view_op"
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package"
 
 rule(
   name: "md_to_mbt_string",


### PR DESCRIPTION
Part 4 (final) of the warning-enablement series (one warning class per PR, enabled module-wide after fixing).

`test_unqualified_package` (E0025) was by far the largest class: 77 test references across 12 files calling the package under test via its implicit import (`decode(...)`, `write_error(...)`) instead of the qualified `@pkg.fn` form the repo's own conventions prefer. All 77 were rewritten mechanically from the diagnostics' exact spans and suggested replacements (no hand-typed edits), then `moon fmt`'d. `cmd/tui` already enforced this locally; `moon.mod` now enables it module-wide.

With this series merged, `moon check --warn-list +a-38-39` is clean — every warning class except the proof-invariant pair (0038/0039) is at zero and pinned on.

495/495 native tests (known realworld network test excepted), no public API changes.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)