### PR TITLE
refactor(agent_runtime): drain loops via while-is-Some

### DIFF
--- a/agent_runtime/runtime.mbt
+++ b/agent_runtime/runtime.mbt
@@ -85,13 +85,10 @@ pub fn AgentRuntime::queue_steer(self : AgentRuntime, text : String) -> Unit {
 /// Take every queued steering input, oldest first, leaving the queue empty.
 pub fn AgentRuntime::drain_steers(self : AgentRuntime) -> Array[String] {
   let texts : Array[String] = []
-  for ;; {
-    let next = self.steers.try_get() catch { _ => None }
-    match next {
-      None => return texts
-      Some(text) => texts.push(text)
-    }
+  while (self.steers.try_get() catch { _ => None }) is Some(text) {
+    texts.push(text)
   }
+  texts
 }
 
 ///|
@@ -100,13 +97,10 @@ pub fn AgentRuntime::drain_steers(self : AgentRuntime) -> Array[String] {
 /// output into the conversation.
 pub fn AgentRuntime::drain_events(self : AgentRuntime) -> Array[AgentEvent] {
   let events : Array[AgentEvent] = []
-  for ;; {
-    let next = self.events.try_get() catch { _ => None }
-    match next {
-      None => return events
-      Some(event) => events.push(event)
-    }
+  while (self.events.try_get() catch { _ => None }) is Some(event) {
+    events.push(event)
   }
+  events
 }
 
 ///|


### PR DESCRIPTION
Readability refactoring series, part 2 (no semantic changes, one scoped package per PR).

Owner suggestion on `runtime.mbt:88`: rather than `for ;;` + match-on-Option with a mid-loop `return`, bind the next queue item in the loop condition — `while (self.steers.try_get() catch { _ => None }) is Some(text)`. Applied to both `drain_steers` and `drain_events`: each collapses from eight lines to three, the exit condition reads at the top, and two of the `missing_invariant`/`missing_reasoning` (0038/0039) `for ;;` sites disappear as a side effect.

Behavior identical (drain until empty, oldest first; queue failure treated as empty). 495/495 native tests (known realworld network test excepted), fmt clean, zero `.mbti` drift.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)