### PR TITLE
refactor(agent_session): search_by and any() in projection helpers

### DIFF
--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -60,13 +60,13 @@ fn remove_pending_tool_call(
   pending : Array[@deepseek.ToolCall],
   tool_call_id : String,
 ) -> Bool {
-  for index in 0..<pending.length() {
-    if pending[index].id == tool_call_id {
+  match pending.search_by(call => call.id == tool_call_id) {
+    Some(index) => {
       ignore(pending.remove(index))
-      return true
+      true
     }
+    None => false
   }
-  false
 }
 
 ///|
@@ -98,12 +98,9 @@ fn is_covered_by_later_summary(
   event : SessionEvent,
   events : @vector.Vector[SessionEvent],
 ) -> Bool {
-  for candidate in events {
-    if summary_covers_event(candidate, event.sequence()) {
-      return true
-    }
-  }
-  false
+  events
+  .iter()
+  .any(candidate => summary_covers_event(candidate, event.sequence()))
 }
 
 ///|


### PR DESCRIPTION
Readability refactoring series, part 6 (no semantic changes, one scoped package per PR).

Deliberately narrow: only the two leaf helpers of the `chat_messages` projection are touched — the stateful projection loop itself (pending tool-call ordering, summary skipping) is semantics-critical and left exactly as is.

- `remove_pending_tool_call`: index scan + mid-loop `remove`/`return` → `pending.search_by(call => call.id == tool_call_id)` then one `remove`, the find-and-act split made explicit.
- `is_covered_by_later_summary`: early-return loop → `events.iter().any(candidate => summary_covers_event(...))`.

Behavior pinned by the existing projection tests (compaction, summary supersession, unresolved historical tool calls, compacted tool results). Full native suite unchanged (known realworld network test excepted), fmt clean, zero `.mbti` drift.

**Awaiting owner signoff to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)