### PR TITLE
[codex] Improve DeepSeek request examples and call shape

### DIFF
--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -45,10 +45,10 @@ tool-call message, execute each local function, then append
 
 `ToolDefinition` and `ToolCall` are opposite sides of the same protocol step:
 
-| Type | Direction | Meaning |
-| --- | --- | --- |
+| Type             | Direction                                                                | Meaning                                                                                                                    |
+| ---------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | `ToolDefinition` | Your code sends it to DeepSeek through `Client::chat(..., tools=[...])`. | A tool definition: name, description, and JSON Schema for arguments. It advertises a function the model may request later. |
-| `ToolCall` | DeepSeek returns it in `ChatResponse.tool_calls`. | A concrete tool invocation request: generated call id, function name, and raw JSON argument string. |
+| `ToolCall`       | DeepSeek returns it in `ChatResponse.tool_calls`.                        | A concrete tool invocation request: generated call id, function name, and raw JSON argument string.                        |
 
 The usual sequence is:
 
@@ -64,41 +64,75 @@ The usual sequence is:
 ```moonbit check
 ///|
 test "encode chat request values" {
-  let message = @deepseek.ChatMessage(User, content="write a MoonBit test")
-  let model : @deepseek.Model = V4Flash
-  inspect(model, content="deepseek-v4-flash")
-  inspect(message.role, content="user")
-  assert_eq(message.content, "write a MoonBit test")
-  let body = @deepseek.encode_chat_request(model, [message]).stringify()
-  assert_true(body.contains("\"role\":\"user\""))
-  assert_true(body.contains("\"model\":\"deepseek-v4-flash\""))
-  assert_false(body.contains("\"response_format\""))
+  let body = @deepseek.encode_chat_request(V4Flash, [
+    ChatMessage(User, content="write a MoonBit test"),
+  ])
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [{ "role": "user", "content": "write a MoonBit test" }],
+    "stream": false,
+  })
 }
 ```
 
 ```moonbit check
 ///|
 test "encode tool-enabled chat request" {
-  let tool = @deepseek.ToolDefinition("read", "Read a file.", {
-    "type": "object",
-    "properties": { "path": { "type": "string" } },
-    "required": ["path"],
-  })
-  let call = @deepseek.ToolCall(
-    id="call_1",
-    name="read",
-    arguments="{\"path\":\"README.mbt.md\"}",
-  )
   let body = @deepseek.encode_chat_request(
     V4Flash,
     [
       ChatMessage(User, content="read README.mbt.md"),
-      ChatMessage(Assistant, content="", tool_calls=[call]),
+      ChatMessage(Assistant, content="", tool_calls=[
+        ToolCall(
+          id="call_1",
+          name="read",
+          arguments="{\"path\":\"README.mbt.md\"}",
+        ),
+      ]),
     ],
-    tools=[tool],
-  ).stringify()
-  assert_true(body.contains("\"type\":\"function\""))
-  assert_true(body.contains("\"tool_calls\""))
+    tools=[
+      ToolDefinition("read", "Read a file.", {
+        "type": "object",
+        "properties": { "path": { "type": "string" } },
+        "required": ["path"],
+      }),
+    ],
+  )
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [
+      { "role": "user", "content": "read README.mbt.md" },
+      {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+              "name": "read",
+              "arguments": "{\"path\":\"README.mbt.md\"}",
+            },
+          },
+        ],
+      },
+    ],
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file.",
+          "parameters": {
+            "type": "object",
+            "properties": { "path": { "type": "string" } },
+            "required": ["path"],
+          },
+        },
+      },
+    ],
+  })
 }
 ```
 
@@ -109,9 +143,13 @@ test "encode json-object response request" {
     V4Flash,
     [ChatMessage(User, content="return {\"ok\":true}")],
     response_format=JsonObject,
-  ).stringify()
-  assert_true(body.contains("\"response_format\""))
-  assert_true(body.contains("\"json_object\""))
+  )
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [{ "role": "user", "content": "return {\"ok\":true}" }],
+    "stream": false,
+    "response_format": { "type": "json_object" },
+  })
 }
 ```
 
@@ -125,8 +163,23 @@ test "decode chat response values" {
       ),
     ),
   )
-  assert_eq(response.content, "ok")
-  assert_eq(response.usage.total_tokens, 0)
+  debug_inspect(
+    response,
+    content=(
+      #|{
+      #|  content: "ok",
+      #|  reasoning_content: "",
+      #|  tool_calls: [],
+      #|  usage: {
+      #|    prompt_tokens: 0,
+      #|    completion_tokens: 0,
+      #|    total_tokens: 0,
+      #|    prompt_cache_hit_tokens: 0,
+      #|    prompt_cache_miss_tokens: 0,
+      #|  },
+      #|}
+    ),
+  )
 }
 ```
 
@@ -140,8 +193,28 @@ test "decode native tool call values" {
       ),
     ),
   )
-  assert_eq(response.tool_calls.length(), 1)
-  assert_eq(response.tool_calls[0].id, "call_1")
-  assert_eq(response.tool_calls[0].name, "read")
+  debug_inspect(
+    response,
+    content=(
+      #|{
+      #|  content: "",
+      #|  reasoning_content: "",
+      #|  tool_calls: [
+      #|    {
+      #|      id: "call_1",
+      #|      name: "read",
+      #|      arguments: "{\"path\":\"README.mbt.md\"}",
+      #|    },
+      #|  ],
+      #|  usage: {
+      #|    prompt_tokens: 0,
+      #|    completion_tokens: 0,
+      #|    total_tokens: 0,
+      #|    prompt_cache_hit_tokens: 0,
+      #|    prompt_cache_miss_tokens: 0,
+      #|  },
+      #|}
+    ),
+  )
 }
 ```

--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -20,8 +20,8 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
 - `ResponseFormat`: optional assistant content constraint. Leave absent for
   normal text; pass `JsonObject` only when the assistant content must be a JSON
   object.
-- `encode_chat_request(model, messages, tools?, thinking?, stream?,
-  response_format?)`: builds the full DeepSeek chat completions request
+- `encode_chat_request(tools?, thinking?, stream?, response_format?,
+  model?=V4Pro) <| messages`: builds the full DeepSeek chat completions request
   body. Streaming requests include usage-bearing stream options. The per-value
   encoders for messages, tool definitions, and tool calls are package-private
   implementation details.
@@ -64,9 +64,9 @@ The usual sequence is:
 ```moonbit check
 ///|
 test "encode chat request values" {
-  let body = @deepseek.encode_chat_request(V4Flash, [
+  let body = @deepseek.encode_chat_request(model=V4Flash) <| [
     ChatMessage(User, content="write a MoonBit test"),
-  ])
+  ]
   json_inspect(body, content={
     "model": "deepseek-v4-flash",
     "messages": [{ "role": "user", "content": "write a MoonBit test" }],
@@ -79,17 +79,7 @@ test "encode chat request values" {
 ///|
 test "encode tool-enabled chat request" {
   let body = @deepseek.encode_chat_request(
-    V4Flash,
-    [
-      ChatMessage(User, content="read README.mbt.md"),
-      ChatMessage(Assistant, content="", tool_calls=[
-        ToolCall(
-          id="call_1",
-          name="read",
-          arguments="{\"path\":\"README.mbt.md\"}",
-        ),
-      ]),
-    ],
+    model=V4Flash,
     tools=[
       ToolDefinition("read", "Read a file.", {
         "type": "object",
@@ -97,7 +87,16 @@ test "encode tool-enabled chat request" {
         "required": ["path"],
       }),
     ],
-  )
+  ) <| [
+    ChatMessage(User, content="read README.mbt.md"),
+    ChatMessage(Assistant, content="", tool_calls=[
+      ToolCall(
+        id="call_1",
+        name="read",
+        arguments="{\"path\":\"README.mbt.md\"}",
+      ),
+    ]),
+  ]
   json_inspect(body, content={
     "model": "deepseek-v4-flash",
     "messages": [
@@ -140,10 +139,11 @@ test "encode tool-enabled chat request" {
 ///|
 test "encode json-object response request" {
   let body = @deepseek.encode_chat_request(
-    V4Flash,
-    [ChatMessage(User, content="return {\"ok\":true}")],
+    model=V4Flash,
     response_format=JsonObject,
-  )
+  ) <| [
+    ChatMessage(User, content="return {\"ok\":true}"),
+  ]
   json_inspect(body, content={
     "model": "deepseek-v4-flash",
     "messages": [{ "role": "user", "content": "return {\"ok\":true}" }],
@@ -156,13 +156,9 @@ test "encode json-object response request" {
 ```moonbit check
 ///|
 test "decode chat response values" {
-  let response : @deepseek.ChatResponse = @json.from_json(
-    @json.parse(
-      (
-        #|{"choices":[{"message":{"content":"ok"}}]}
-      ),
-    ),
-  )
+  let response : @deepseek.ChatResponse = @json.from_json({
+    "choices": [{ "message": { "content": "ok" } }],
+  })
   debug_inspect(
     response,
     content=(
@@ -186,13 +182,25 @@ test "decode chat response values" {
 ```moonbit check
 ///|
 test "decode native tool call values" {
-  let response : @deepseek.ChatResponse = @json.from_json(
-    @json.parse(
-      (
-        #|{"choices":[{"message":{"content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"read","arguments":"{\"path\":\"README.mbt.md\"}"}}]}}]}
-      ),
-    ),
-  )
+  let response : @deepseek.ChatResponse = @json.from_json({
+    "choices": [
+      {
+        "message": {
+          "content": null,
+          "tool_calls": [
+            {
+              "id": "call_1",
+              "type": "function",
+              "function": {
+                "name": "read",
+                "arguments": "{\"path\":\"README.mbt.md\"}",
+              },
+            },
+          ],
+        },
+      },
+    ],
+  })
   debug_inspect(
     response,
     content=(

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -78,10 +78,11 @@ test "prepare tool-enabled client request values" {
     "required": ["path"],
   })
   let messages = [@deepseek.ChatMessage(User, content="read README.mbt.md")]
-  let body = @deepseek.encode_chat_request(V4Flash, messages, tools=[tool]).stringify()
+  let body = @deepseek.encode_chat_request(model=V4Flash, tools=[tool]) <| messages
+  let text = body.stringify()
   assert_eq(messages.length(), 1)
-  assert_true(body.contains("\"type\":\"function\""))
-  assert_true(body.contains("\"name\":\"read\""))
+  assert_true(text.contains("\"type\":\"function\""))
+  assert_true(text.contains("\"name\":\"read\""))
 }
 ```
 

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -120,12 +120,11 @@ pub async fn Client::chat(
   response_format? : @deepseek.ResponseFormat,
 ) -> @deepseek.ChatResponse {
   let body = @deepseek.encode_chat_request(
-    self.model,
-    messages,
+    model=self.model,
     tools~,
     thinking?=self.thinking,
     response_format?,
-  )
+  ) <| messages
   self.with_retries(() => self.chat_attempt(body), () => false)
 }
 
@@ -175,13 +174,12 @@ pub async fn Client::chat_stream(
   response_format? : @deepseek.ResponseFormat,
 ) -> @deepseek.ChatResponse {
   let body = @deepseek.encode_chat_request(
-    self.model,
-    messages,
+    model=self.model,
     tools~,
     thinking?=self.thinking,
     stream=true,
     response_format?,
-  )
+  ) <| messages
   // Once the server has produced any complete SSE event the completion is
   // running and billed — text deltas, tool-call deltas, and usage alike,
   // even though only text reaches the callbacks. A retry past that point

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -1,24 +1,31 @@
 ///|
 test "encode_chat_request omits response format by default" {
-  let body = @deepseek.encode_chat_request(V4Flash, [
+  let body = @deepseek.encode_chat_request(model=V4Flash) <| [
     ChatMessage(System, content="plain text is fine"),
     ChatMessage(User, content="ping"),
-  ])
+  ]
   let text = body.stringify()
   assert_true(text.contains("\"stream\":false"))
   assert_false(text.contains("\"response_format\""))
 }
 
 ///|
+test "encode_chat_request defaults to V4Pro" {
+  let body = @deepseek.encode_chat_request() <| [
+    ChatMessage(User, content="ping"),
+  ]
+  assert_true(body.stringify().contains("\"model\":\"deepseek-v4-pro\""))
+}
+
+///|
 test "encode_chat_request can ask for json output explicitly" {
   let body = @deepseek.encode_chat_request(
-    V4Flash,
-    [
-      ChatMessage(System, content="json only"),
-      ChatMessage(User, content="ping"),
-    ],
+    model=V4Flash,
     response_format=JsonObject,
-  )
+  ) <| [
+    ChatMessage(System, content="json only"),
+    ChatMessage(User, content="ping"),
+  ]
   guard body is { "response_format": { "type": String("json_object"), .. }, .. } else {
     fail("wrong response_format")
   }
@@ -31,11 +38,9 @@ test "encode_chat_request includes tools when present" {
     "properties": { "cmd": { "type": "string" } },
     "required": ["cmd"],
   })
-  let body = @deepseek.encode_chat_request(
-    V4Flash,
-    [ChatMessage(User, content="run tests")],
-    tools=[tool],
-  )
+  let body = @deepseek.encode_chat_request(model=V4Flash, tools=[tool]) <| [
+    ChatMessage(User, content="run tests"),
+  ]
   let text = body.stringify()
   assert_true(text.contains("\"model\":\"deepseek-v4-flash\""))
   assert_true(text.contains("\"messages\""))
@@ -47,11 +52,9 @@ test "encode_chat_request includes tools when present" {
 
 ///|
 test "encode_chat_request enables usage-bearing stream mode" {
-  let body = @deepseek.encode_chat_request(
-    V4Flash,
-    [ChatMessage(User, content="stream this")],
-    stream=true,
-  )
+  let body = @deepseek.encode_chat_request(model=V4Flash, stream=true) <| [
+    ChatMessage(User, content="stream this"),
+  ]
   let text = body.stringify()
   assert_true(text.contains("\"stream\":true"))
   guard body
@@ -62,28 +65,22 @@ test "encode_chat_request enables usage-bearing stream mode" {
 
 ///|
 test "encode_chat_request encodes thinking controls" {
-  let high = @deepseek.encode_chat_request(
-    V4Pro,
-    [ChatMessage(User, content="solve")],
-    thinking=High,
-  )
+  let high = @deepseek.encode_chat_request(model=V4Pro, thinking=High) <| [
+    ChatMessage(User, content="solve"),
+  ]
   let high_text = high.stringify()
   assert_true(high_text.contains("\"thinking\""))
   assert_true(high_text.contains("\"type\":\"enabled\""))
   assert_true(high_text.contains("\"reasoning_effort\":\"high\""))
 
-  let max = @deepseek.encode_chat_request(
-    V4Pro,
-    [ChatMessage(User, content="solve")],
-    thinking=Max,
-  )
+  let max = @deepseek.encode_chat_request(model=V4Pro, thinking=Max) <| [
+    ChatMessage(User, content="solve"),
+  ]
   assert_true(max.stringify().contains("\"reasoning_effort\":\"max\""))
 
-  let no = @deepseek.encode_chat_request(
-    V4Pro,
-    [ChatMessage(User, content="solve")],
-    thinking=No,
-  )
+  let no = @deepseek.encode_chat_request(model=V4Pro, thinking=No) <| [
+    ChatMessage(User, content="solve"),
+  ]
   let no_text = no.stringify()
   assert_true(no_text.contains("\"type\":\"disabled\""))
   assert_false(no_text.contains("\"reasoning_effort\""))
@@ -91,9 +88,9 @@ test "encode_chat_request encodes thinking controls" {
 
 ///|
 test "encode_chat_request omits tools and thinking when absent" {
-  let body = @deepseek.encode_chat_request(V4Flash, [
+  let body = @deepseek.encode_chat_request(model=V4Flash) <| [
     ChatMessage(User, content="hi"),
-  ])
+  ]
   let text = body.stringify()
   assert_false(text.contains("\"tools\""))
   assert_false(text.contains("\"thinking\""))
@@ -107,12 +104,12 @@ test "encode_chat_request rounds-trips assistant tool call echo and tool result"
     name="shell",
     arguments="{\"cmd\":\"moon test\"}",
   )
-  let body = @deepseek.encode_chat_request(V4Flash, [
+  let body = @deepseek.encode_chat_request(model=V4Flash) <| [
     ChatMessage(System, content="be terse"),
     ChatMessage(User, content="run the tests"),
     ChatMessage(Assistant, content="", tool_calls=[call]),
     ChatMessage(Tool("call_42"), content="exit=0\nok"),
-  ])
+  ]
   let text = body.stringify()
   assert_true(text.contains("\"role\":\"system\""))
   assert_true(text.contains("\"role\":\"user\""))
@@ -138,10 +135,11 @@ test "encode_chat_request encodes multiple tool definitions" {
     "required": ["path"],
   })
   let body = @deepseek.encode_chat_request(
-    V4Flash,
-    [ChatMessage(User, content="look around")],
+    model=V4Flash,
     tools=[shell, read_tool],
-  )
+  ) <| [
+    ChatMessage(User, content="look around"),
+  ]
   let text = body.stringify()
   assert_true(text.contains("\"name\":\"shell\""))
   assert_true(text.contains("\"name\":\"read\""))

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -69,12 +69,12 @@ impl ToJson for ToolCall with fn to_json(call : ToolCall) -> Json {
 ///
 /// `response_format`, `tools`, and `thinking` are omitted when empty / `None`.
 pub fn encode_chat_request(
-  model : Model,
-  messages : Array[ChatMessage],
   tools? : Array[ToolDefinition] = [],
   thinking? : ThinkingMode,
   stream? : Bool = false,
   response_format? : ResponseFormat,
+  model? : Model = V4Pro,
+  messages : Array[ChatMessage],
 ) -> Json {
   Json::object(
     Map(

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn encode_chat_request(Model, Array[ChatMessage], tools? : Array[ToolDefinition], thinking? : ThinkingMode, stream? : Bool, response_format? : ResponseFormat) -> Json
+pub fn encode_chat_request(tools? : Array[ToolDefinition], thinking? : ThinkingMode, stream? : Bool, response_format? : ResponseFormat, model? : Model, Array[ChatMessage]) -> Json
 
 // Errors
 


### PR DESCRIPTION
## Summary

- Refresh the DeepSeek README examples to read like documentation, using structured `json_inspect` / `debug_inspect` assertions.
- Use direct JSON literals with `@json.from_json({...})` in README response-decoding examples.
- Change `encode_chat_request` so request options are labeled, `model` defaults to `V4Pro`, and `messages` is the trailing argument, enabling `encode_chat_request(model=...) <| [...]`.
- Update the DeepSeek client, request tests, client README, and generated interface for the new call shape.

## Validation

- `moon info && moon fmt`
- `moon check`
- `moon test`
- `moon cram test tests/cram`
- `git diff --check`