### PR TITLE
[codex] Unify DeepSeek streaming chat handler

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -244,19 +244,21 @@ pub async fn[X] run_turn_in_scope(
         messages.push(ChatMessage(User, content=notice))
       }
       @xlog.info() <? { "event": "agent_step", "step": step + 1 }
-      let response = client.chat_stream(
+      let response = client.chat(
         messages,
         tools=tools.function_tools(),
-        on_content_delta=delta => {
-          if delta != "" {
-            @xlog.info() <? { "event": "assistant_delta", "content": delta }
-          }
-        },
-        on_reasoning_delta=delta => {
-          if delta != "" {
-            @xlog.info() <? { "event": "reasoning_delta", "content": delta }
-          }
-        },
+        stream=StreamHandler(
+          on_content_delta=delta => {
+            if delta != "" {
+              @xlog.info() <? { "event": "assistant_delta", "content": delta }
+            }
+          },
+          on_reasoning_delta=delta => {
+            if delta != "" {
+              @xlog.info() <? { "event": "reasoning_delta", "content": delta }
+            }
+          },
+        ),
       )
       // Reasoning first, so a consumer appending events in order shows the
       // thinking above the answer it led to.

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -15,20 +15,20 @@ The package depends on `moonbitlang/async/http` and is native-only.
 - `Client(api_key~, model?, api_url?, thinking?, retry_attempts?,
   retry_backoff_ms?)`: configure the API key, endpoint, model, thinking mode,
   and retry budget.
-- `Client::chat(messages, tools?, response_format?)`: send a non-streaming
-  request and decode the response as `@deepseek.ChatResponse`.
-- `Client::chat_stream(messages, on_content_delta~, on_reasoning_delta?,
-  tools?, response_format?)`: send the same request in SSE streaming mode,
-  deliver non-empty content/reasoning deltas through callbacks, and return the
-  fully accumulated `@deepseek.ChatResponse`.
+- `Client::chat(messages, tools?, response_format?, stream?)`: send a request
+  and decode the response as `@deepseek.ChatResponse`. Without `stream`, this
+  is a normal JSON response. With `stream=StreamHandler(...)`, it uses SSE and
+  still returns the accumulated response.
+- `StreamHandler(on_content_delta~, on_reasoning_delta?)`: receive non-empty
+  content and reasoning deltas while a streaming chat request is in progress.
 
 `Client` implements `Debug` with the API key redacted.
 
 ## Configuration
 
 The default endpoint is `https://api.deepseek.com/chat/completions`, the default
-model is `deepseek-v4-pro`, and `thinking=No` is sent unless a different mode is provided. Pass `thinking=Max` for explicit max-effort thinking-mode
-requests.
+model is `deepseek-v4-pro`, and `thinking=No` is sent unless a different mode is
+provided. Pass `thinking=Max` for explicit max-effort thinking-mode requests.
 
 Retries cover transient failures: transport errors, HTTP 429, and HTTP 5xx.
 Other HTTP 4xx responses fail immediately. `retry_attempts` counts total tries;
@@ -63,9 +63,10 @@ test "construct DeepSeek client configuration" {
 
 ## Non-Streaming Chat
 
-`Client::chat` builds the same JSON body as `@deepseek.encode_chat_request`,
-using the client's `model` and `thinking` configuration, then posts it to
-`api_url` with `Content-Type: application/json` and bearer authorization.
+Without `stream`, `Client::chat` builds the same JSON body as
+`@deepseek.encode_chat_request`, using the client's `model` and `thinking`
+configuration, then posts it to `api_url` with `Content-Type:
+application/json` and bearer authorization.
 
 Use `tools=[...]` when the model may request native DeepSeek function calls.
 Use `response_format=JsonObject` only when the assistant content itself must be
@@ -133,10 +134,10 @@ then append one `Tool(call.id)` result message per call before the next request.
 
 ## Streaming Chat
 
-`Client::chat_stream` sends `stream=true` plus
-`stream_options={"include_usage":true}`. The transport pins
-`Accept-Encoding: identity` so a gzip-compressing intermediary cannot buffer and
-re-batch SSE deltas.
+Pass `stream=StreamHandler(...)` to `Client::chat` to send `stream=true` plus
+`stream_options={"include_usage":true}`. The transport pins `Accept-Encoding:
+identity` so a gzip-compressing intermediary cannot buffer and re-batch SSE
+deltas.
 
 The stream reader:
 
@@ -153,10 +154,14 @@ At runtime:
 
 ```moonbit nocheck
 ///|
-let response = client.chat_stream(
+let stream = @client.StreamHandler(on_content_delta=delta => print(delta), on_reasoning_delta=reasoning => {
+  log_reasoning(reasoning)
+})
+
+///|
+let response = client.chat(
   [@deepseek.ChatMessage(User, content="Explain this briefly.")],
-  on_content_delta=delta => print(delta),
-  on_reasoning_delta=reasoning => log_reasoning(reasoning),
+  stream~,
 )
 ```
 
@@ -164,7 +169,7 @@ The request body has this shape:
 
 ```moonbit check
 ///|
-test "Client::chat_stream request body shape" {
+test "Client::chat streaming request body shape" {
   let client = @client.Client(api_key="test-key")
   let body = @deepseek.encode_chat_request(
     model=client.model,

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -42,6 +42,27 @@ pub fn Client::Client(
 }
 
 ///|
+/// Callback hooks for a streaming DeepSeek chat request.
+///
+/// `on_content_delta` is called for each assistant content fragment as it
+/// arrives; `on_reasoning_delta` likewise for each thinking-mode reasoning
+/// fragment (it is simply not called when thinking is off). `Client::chat`
+/// returns the fully accumulated response after the stream reaches `[DONE]`.
+pub struct StreamHandler {
+  priv on_content_delta : async (String) -> Unit
+  priv on_reasoning_delta : async (String) -> Unit
+}
+
+///|
+/// Constructs callbacks for `Client::chat(..., stream=...)`.
+pub fn StreamHandler::StreamHandler(
+  on_content_delta~ : async (String) -> Unit,
+  on_reasoning_delta? : async (String) -> Unit = _ => (),
+) -> StreamHandler {
+  { on_content_delta, on_reasoning_delta }
+}
+
+///|
 /// A response status worth retrying: rate limiting or a server-side failure.
 /// Other 4xx are caller errors (bad key, malformed request) that a retry
 /// cannot fix.
@@ -74,7 +95,7 @@ let max_backoff_ms : Int = 60_000
 /// identically every time, before any network I/O) propagate immediately;
 /// anything else is transport-shaped (connect refused, reset, DNS) and
 /// retries within budget. `bail` lets an attempt declare later retries
-/// pointless — chat_stream sets it once the stream has produced any event,
+/// pointless — streaming chat sets it once the stream has produced any event,
 /// since replaying a half-consumed completion would duplicate content (or
 /// regenerate tool calls) downstream.
 ///
@@ -112,20 +133,28 @@ async fn[T] Client::with_retries(
 ///
 /// Pass `tools` to enable native DeepSeek function tool calls. Pass
 /// `response_format=JsonObject` only when the assistant content itself should
-/// be constrained to a JSON object.
+/// be constrained to a JSON object. Pass `stream=StreamHandler(...)` to send
+/// the request in SSE streaming mode while still receiving the accumulated
+/// response as the return value.
 pub async fn Client::chat(
   self : Client,
   messages : Array[@deepseek.ChatMessage],
   tools? : Array[@deepseek.ToolDefinition] = [],
   response_format? : @deepseek.ResponseFormat,
+  stream? : StreamHandler,
 ) -> @deepseek.ChatResponse {
+  let is_streaming = stream is Some(_)
   let body = @deepseek.encode_chat_request(
     model=self.model,
     tools~,
     thinking=self.thinking,
+    stream=is_streaming,
     response_format?,
   ) <| messages
-  self.with_retries(() => self.chat_attempt(body), () => false)
+  match stream {
+    None => self.with_retries(() => self.chat_attempt(body), () => false)
+    Some(stream) => self.chat_stream_body(body, stream)
+  }
 }
 
 ///|
@@ -158,28 +187,11 @@ async fn Client::chat_attempt(
 }
 
 ///|
-/// Sends typed chat messages in DeepSeek SSE streaming mode.
-///
-/// `on_content_delta` is called for each assistant content fragment as it
-/// arrives; `on_reasoning_delta` likewise for each thinking-mode reasoning
-/// fragment (it is simply not called when thinking is off). The returned value
-/// is the fully accumulated response, including reasoning, tool calls, and
-/// final token usage when the API sends it.
-pub async fn Client::chat_stream(
+async fn Client::chat_stream_body(
   self : Client,
-  messages : Array[@deepseek.ChatMessage],
-  on_content_delta~ : async (String) -> Unit,
-  on_reasoning_delta? : async (String) -> Unit = _ => (),
-  tools? : Array[@deepseek.ToolDefinition] = [],
-  response_format? : @deepseek.ResponseFormat,
+  body : Json,
+  stream : StreamHandler,
 ) -> @deepseek.ChatResponse {
-  let body = @deepseek.encode_chat_request(
-    model=self.model,
-    tools~,
-    thinking=self.thinking,
-    stream=true,
-    response_format?,
-  ) <| messages
   // Once the server has produced any complete SSE event the completion is
   // running and billed — text deltas, tool-call deltas, and usage alike,
   // even though only text reaches the callbacks. A retry past that point
@@ -192,8 +204,7 @@ pub async fn Client::chat_stream(
       self.chat_stream_attempt(
         body,
         on_stream_event=() => streamed = true,
-        on_content_delta~,
-        on_reasoning_delta~,
+        stream,
       )
     },
     () => streamed,
@@ -205,8 +216,7 @@ async fn Client::chat_stream_attempt(
   self : Client,
   body : Json,
   on_stream_event~ : () -> Unit,
-  on_content_delta~ : async (String) -> Unit,
-  on_reasoning_delta~ : async (String) -> Unit,
+  stream : StreamHandler,
 ) -> @deepseek.ChatResponse {
   let client = @http.post_stream(self.api_url, headers={
     "Content-Type": "application/json",
@@ -235,7 +245,7 @@ async fn Client::chat_stream_attempt(
   read_chat_stream(
     client,
     on_stream_event~,
-    on_content_delta~,
-    on_reasoning_delta~,
+    on_content_delta=stream.on_content_delta,
+    on_reasoning_delta=stream.on_reasoning_delta,
   )
 }

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -117,7 +117,7 @@ async test "chat never retries a non-429 client error" {
 }
 
 ///|
-async test "chat_stream retries a pre-stream 429 and then streams" {
+async test "streaming chat retries a pre-stream 429 and then streams" {
   @async.with_task_group() <| group => {
     guard flaky_server(group, failures=1, status=429, sse=true)
       is Some((url, hits)) else {
@@ -130,9 +130,10 @@ async test "chat_stream retries a pre-stream 429 and then streams" {
       retry_backoff_ms=1,
     )
     let deltas : Array[String] = []
-    let response = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=delta => {
-      deltas.push(delta)
-    })
+    let response = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta)),
+    )
     assert_eq(response.content, "ok")
     assert_eq(deltas.join("|"), "ok")
     assert_eq(hits.val, 2)
@@ -143,7 +144,7 @@ async test "chat_stream retries a pre-stream 429 and then streams" {
 /// A 2xx connection that dies before any event is transport-shaped: with no
 /// delta delivered, the stream call retries and the second connection
 /// serves the full stream.
-async test "chat_stream retries a pre-delta stream drop" {
+async test "streaming chat retries a pre-delta stream drop" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
       error => {
@@ -181,9 +182,10 @@ async test "chat_stream retries a pre-delta stream drop" {
       retry_attempts=3,
       retry_backoff_ms=1,
     )
-    let response = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
-      ()
-    })
+    let response = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    )
     assert_eq(response.content, "ok")
     assert_eq(hits.val, 2)
   }
@@ -195,7 +197,7 @@ async test "chat_stream retries a pre-delta stream drop" {
 /// content. The server streams one delta then ends without [DONE] on every
 /// request, so a retry (if one wrongly happened) would be observable as a
 /// second hit.
-async test "chat_stream never retries after the first delta" {
+async test "streaming chat never retries after the first delta" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
       error => {
@@ -231,9 +233,10 @@ async test "chat_stream never retries after the first delta" {
       retry_backoff_ms=1,
     )
     let deltas : Array[String] = []
-    let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=delta => {
-      deltas.push(delta)
-    }) catch {
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta)),
+    ) catch {
       error => {
         assert_true("\{error}".contains("ended before [DONE]"))
         assert_eq(deltas.join("|"), "partial")
@@ -251,7 +254,7 @@ async test "chat_stream never retries after the first delta" {
 /// tool-call delta and then drops must surface the failure rather than
 /// retry: a replay could generate (and bill) a different call. (Codex
 /// review: the bail flag used to track callback-delivered text only.)
-async test "chat_stream never retries after a tool-call-only delta" {
+async test "streaming chat never retries after a tool-call-only delta" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
       error => {
@@ -286,9 +289,10 @@ async test "chat_stream never retries after a tool-call-only delta" {
       retry_attempts=3,
       retry_backoff_ms=1,
     )
-    let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
-      ()
-    }) catch {
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    ) catch {
       error => {
         assert_true("\{error}".contains("ended before [DONE]"))
         assert_eq(hits.val, 1)

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -49,16 +49,17 @@ async fn stream_test_server(
 }
 
 ///|
-async test "chat_stream accumulates SSE content, tool calls, and usage" {
+async test "chat stream handler accumulates SSE content, tool calls, and usage" {
   @async.with_task_group() <| group => {
     guard stream_test_server(group) is Some(url) else { return }
     let client = @client.Client(api_key="test-key", api_url=url)
     let deltas : Array[String] = []
     let reasoning_deltas : Array[String] = []
-    let response = client.chat_stream(
+    let response = client.chat(
       [ChatMessage(User, content="hello")],
-      on_content_delta=delta => deltas.push(delta),
-      on_reasoning_delta=delta => reasoning_deltas.push(delta),
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_reasoning_delta=delta => {
+        reasoning_deltas.push(delta)
+      }),
     )
     assert_eq(deltas.join("|"), "Hello| world")
     assert_eq(reasoning_deltas.join("|"), "hidden")
@@ -77,14 +78,15 @@ async test "chat_stream accumulates SSE content, tool calls, and usage" {
 }
 
 ///|
-async test "chat_stream rejects EOF before done" {
+async test "chat stream handler rejects EOF before done" {
   @async.with_task_group() <| group => {
     guard stream_test_server(group, finish=false) is Some(url) else { return }
     let client = @client.Client(api_key="test-key", api_url=url)
     try {
-      let _ = client.chat_stream([ChatMessage(User, content="hello")], on_content_delta=_ => {
-        ()
-      })
+      let _ = client.chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
       fail("expected truncated stream to fail")
     } catch {
       error => assert_true("\{error}".contains("ended before [DONE]"))

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -20,8 +20,12 @@ pub struct Client {
   // private fields
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int) -> Self
-pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
-pub async fn Client::chat_stream(Self, Array[@deepseek.ChatMessage], on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat) -> @deepseek.ChatResponse
+pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
+
+pub struct StreamHandler {
+  // private fields
+}
+pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit) -> Self
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

- Add a public `StreamHandler` callback holder for DeepSeek streaming deltas.
- Route streaming through `Client::chat(..., stream=StreamHandler(...))` and remove the public `Client::chat_stream` API.
- Update the agent, DeepSeek client docs, tests, and generated interface to use the unified chat API.

## Validation

- `moon info && moon fmt`
- `moon test deepseek/client`
- `moon test`
- `moon check --deny-warn`
- `moon cram test tests/cram`
- `zsh -lc 'source ~/.zshrc >/dev/null 2>&1 || true; moon test deepseek/client'`