### PR TITLE
[codex] Add viz session root discovery

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -3,7 +3,9 @@
 /// already returns rows most-recently-active first, so the row only needs an id
 /// and a human label.
 struct SessionRow {
+  key : String
   id : String
+  root_label : String
   first_prompt : String
 }
 
@@ -98,28 +100,30 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
       }
     SessionsFetched(Err(error)) =>
       (@cmd.none, { ..model, status: "failed to list sessions: \{error}" })
-    Select(id) => {
-      let command = fetch_text(emit, session_url(id), result => {
-        SessionFetched(id, result)
+    Select(key) => {
+      let label = session_label(model, key)
+      let command = fetch_text(emit, session_url(key), result => {
+        SessionFetched(key, result)
       })
       (
         command,
         {
           ..model,
-          selected: Some(id),
+          selected: Some(key),
           parsed: None,
           system_prompt: "",
           header_present: false,
           loading: true,
-          status: "loading \{id}…",
+          status: "loading \{label}…",
         },
       )
     }
-    SessionFetched(id, result) =>
+    SessionFetched(key, result) =>
       // Drop a response for a session the user already navigated away from.
-      if model.selected != Some(id) {
+      if model.selected != Some(key) {
         (@cmd.none, model)
       } else {
+        let label = session_label(model, key)
         match result {
           Err(error) =>
             (
@@ -147,7 +151,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
                     ..model,
                     parsed: None,
                     loading: false,
-                    status: "session not found: \{id}",
+                    status: "session not found: \{label}",
                   },
                 )
               Malformed =>
@@ -157,7 +161,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
                     ..model,
                     parsed: None,
                     loading: false,
-                    status: "malformed response for \{id}",
+                    status: "malformed response for \{label}",
                   },
                 )
             }
@@ -198,6 +202,24 @@ extern "js" fn encode_uri_component(value : String) -> String = "encodeURICompon
 ///|
 fn session_url(id : String) -> String {
   "/api/sessions/\{encode_uri_component(id)}"
+}
+
+///|
+fn session_label(model : Model, key : String) -> String {
+  match session_row(model, key) {
+    Some(row) => row.id
+    None => key
+  }
+}
+
+///|
+fn session_row(model : Model, key : String) -> SessionRow? {
+  for row in model.sessions {
+    if row.key == key {
+      return Some(row)
+    }
+  }
+  None
 }
 
 ///|
@@ -256,10 +278,32 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
   if model.sessions.is_empty() {
     return @html.div(class="sidebar-empty", "no sessions found")
   }
-  let rows : Array[@html.Html] = [
-    for row in model.sessions => sidebar_row(emit, model, row)
-  ]
-  @html.ul(class="session-list", rows)
+  let sections : Array[@html.Html] = []
+  for root in sidebar_roots(model.sessions) {
+    let rows : Array[@html.Html] = [
+      for row in model.sessions if row.root_label == root => {
+        sidebar_row(emit, model, row)
+      }
+    ]
+    sections.push(
+      @html.div(class="session-root", [
+        @html.div(class="session-root-label", root),
+        @html.ul(class="session-root-sessions", rows),
+      ]),
+    )
+  }
+  @html.div(class="session-list", sections)
+}
+
+///|
+fn sidebar_roots(rows : Array[SessionRow]) -> Array[String] {
+  let roots : Array[String] = []
+  for row in rows {
+    if !roots.contains(row.root_label) {
+      roots.push(row.root_label)
+    }
+  }
+  roots
 }
 
 ///|
@@ -268,14 +312,14 @@ fn sidebar_row(
   model : Model,
   row : SessionRow,
 ) -> @html.Html {
-  let selected = model.selected == Some(row.id)
+  let selected = model.selected == Some(row.key)
   let label = if row.first_prompt.trim().is_empty() {
     row.id
   } else {
     row.first_prompt
   }
   let classes = if selected { "session-item selected" } else { "session-item" }
-  @html.li(class=classes, on_click=emit(Select(row.id)), [
+  @html.li(class=classes, on_click=emit(Select(row.key)), [
     @html.div(class="session-item-label", label),
     @html.div(class="session-item-id", row.id),
   ])
@@ -289,22 +333,30 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
         class="placeholder",
         "Select a session from the left to view it.",
       )
-    Some(id) =>
+    Some(key) =>
       match model.parsed {
         None =>
           if model.loading {
-            @html.div(class="placeholder", "Loading \{id}…")
+            @html.div(
+              class="placeholder",
+              "Loading \{session_label(model, key)}…",
+            )
           } else {
             @html.div(class="placeholder", model.status)
           }
         Some(parsed) => {
+          let row = session_row(model, key)
+          let id = match row {
+            Some(row) => row.id
+            None => key
+          }
           let session = @viz.session_from_parse(
             parsed,
             id~,
             system_prompt=model.system_prompt,
           )
           @html.div(class="session-view", [
-            header_strip(model, id),
+            header_strip(model, id, row.map(row => row.root_label)),
             mode_toggle(emit, model),
             @viz.render_notices(parsed),
             @viz.render_session(session, model.view_mode),
@@ -315,15 +367,22 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
 }
 
 ///|
-fn header_strip(model : Model, id : String) -> @html.Html {
+fn header_strip(model : Model, id : String, root_label : String?) -> @html.Html {
   let prompt_note = if model.header_present {
     "session.json loaded"
   } else {
     "no session.json (events only)"
   }
+  let root_note = match root_label {
+    Some(root) => " · \{root}"
+    None => ""
+  }
   @html.header(class="header-strip", [
     @html.div(class="header-id", id),
-    @html.div(class="header-meta", "\{model.status} · \{prompt_note}"),
+    @html.div(
+      class="header-meta",
+      "\{model.status} · \{prompt_note}\{root_note}",
+    ),
   ])
 }
 
@@ -373,11 +432,23 @@ fn parse_session_rows(text : String) -> Array[SessionRow]? {
 fn session_row_of(json : Json) -> SessionRow? {
   guard json is Object(fields) else { return None }
   guard fields.get("id") is Some(String(id)) else { return None }
+  let key = match fields.get("key") {
+    Some(String(value)) => value
+    _ => id
+  }
+  let root_label = match fields.get("root_label") {
+    Some(String(value)) => value
+    _ =>
+      match fields.get("root") {
+        Some(String(value)) => value
+        _ => ""
+      }
+  }
   let first_prompt = match fields.get("first_prompt") {
     Some(String(value)) => value
     _ => ""
   }
-  Some({ id, first_prompt })
+  Some({ key, id, root_label, first_prompt })
 }
 
 ///|

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -39,12 +39,16 @@ test "parse_load distinguishes not-found from malformed" {
 ///|
 test "parse_session_rows reads the listing, skipping malformed rows" {
   let text =
-    #|[{"id":"a","last_active":1,"first_prompt":"hello"},{"first_prompt":"no id"},{"id":"b","first_prompt":""}]
+    #|[{"key":"0|a","id":"a","root_label":"app/.openseek","last_active":1,"first_prompt":"hello"},{"first_prompt":"no id"},{"id":"b","root":"lib/.openseek","first_prompt":""}]
   guard parse_session_rows(text) is Some(rows) else { fail("expected Some") }
   inspect(rows.length(), content="2")
+  inspect(rows[0].key, content="0|a")
   inspect(rows[0].id, content="a")
+  inspect(rows[0].root_label, content="app/.openseek")
   inspect(rows[0].first_prompt, content="hello")
+  inspect(rows[1].key, content="b")
   inspect(rows[1].id, content="b")
+  inspect(rows[1].root_label, content="lib/.openseek")
 }
 
 ///|
@@ -63,7 +67,22 @@ test "parse_session_rows distinguishes empty list from a non-array body" {
 
 ///|
 test "session_url percent-encodes the id" {
-  inspect(session_url("a b/c"), content="/api/sessions/a%20b%2Fc")
+  inspect(session_url("0|a b/c"), content="/api/sessions/0%7Ca%20b%2Fc")
+}
+
+///|
+test "sidebar_roots preserves listing order without duplicates" {
+  let rows = [
+    { key: "0|a", id: "a", root_label: "app/.openseek", first_prompt: "" },
+    { key: "0|b", id: "b", root_label: "app/.openseek", first_prompt: "" },
+    { key: "1|c", id: "c", root_label: "lib/.openseek", first_prompt: "" },
+  ]
+  @debug.debug_inspect(
+    sidebar_roots(rows),
+    content=(
+      #|["app/.openseek", "lib/.openseek"]
+    ),
+  )
 }
 
 ///|

--- a/cmd/viz_app/moon.pkg
+++ b/cmd/viz_app/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/http",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -4,12 +4,12 @@
 ///
 /// - `GET /`                                  → the viewer shell (web/index.html)
 /// - `GET /viz_app.js`                        → the compiled frontend bundle
-/// - `GET /api/sessions`                      → JSON listing of known sessions
-/// - `GET /api/sessions/<id>`                 → `{found, events, header}` envelope
-/// - `GET /api/sessions/<id>/events.jsonl`    → raw append-only event log
-/// - `GET /api/sessions/<id>/session.json`    → raw header (404 when absent)
+/// - `GET /api/sessions`                      → JSON listing across known roots
+/// - `GET /api/sessions/<key>`                → `{found, events, header}` envelope
+/// - `GET /api/sessions/<key>/events.jsonl`   → raw append-only event log
+/// - `GET /api/sessions/<key>/session.json`   → raw header (404 when absent)
 ///
-/// It never writes to the store, so pointing it at a live session root is safe.
+/// It never writes to the stores, so pointing it at live session roots is safe.
 async fn main {
   let matches = cli_command().parse(env=@env.get_env_vars())
   let port = parse_port(value(matches, "port"))
@@ -17,6 +17,13 @@ async fn main {
   if session_root.is_empty() {
     fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
   }
+  let session_root_name = value(matches, "session-root-name").trim().to_owned()
+  if session_root_name.is_empty() {
+    fail(
+      "--session-root-name or OPENSEEK_VIZ_SESSION_ROOT_NAME must not be empty",
+    )
+  }
+  let search_dirs = non_empty_values(matches, "search-dir")
   let web_dir = value(matches, "web-dir")
   let bundle = value(matches, "bundle")
   let module_root = match @env.args() {
@@ -25,14 +32,17 @@ async fn main {
   }
   let shell = shell_candidates(web_dir, module_root)
   let bundle_paths = bundle_candidates(bundle, web_dir, module_root)
-  let store = @store.SessionStore(session_root)
+  let catalog = session_catalog(session_root, search_dirs, session_root_name)
   let addr = @socket.Addr::parse("127.0.0.1:\{port}")
-  println("openseek viz: serving sessions under '\{session_root}'")
+  println("openseek viz: serving \{catalog.roots.length()} session root(s)")
+  for root in catalog.roots {
+    println("openseek viz: sessions under '\{root.path}'")
+  }
   println("openseek viz: shell from '\{shell[0]}'")
   println("openseek viz: open http://127.0.0.1:\{port}")
   let server = @http.Server(addr)
   server.run_forever((request, _body, conn) => {
-    handle(request, conn, store, shell, bundle_paths)
+    handle(request, conn, catalog, shell, bundle_paths)
   })
 }
 
@@ -55,11 +65,11 @@ struct Reply {
 async fn handle(
   request : @http.Request,
   conn : @http.ServerConnection,
-  store : @store.SessionStore,
+  catalog : SessionCatalog,
   shell : Array[String],
   bundle : Array[String],
 ) -> Unit {
-  let reply = build_reply(request, store, shell, bundle) catch {
+  let reply = build_reply(request, catalog, shell, bundle) catch {
     error => text_reply(500, "Internal Server Error", "error: \{error}")
   }
   send_reply(conn, reply) catch {
@@ -81,7 +91,7 @@ async fn send_reply(conn : @http.ServerConnection, reply : Reply) -> Unit {
 ///|
 async fn build_reply(
   request : @http.Request,
-  store : @store.SessionStore,
+  catalog : SessionCatalog,
   shell : Array[String],
   bundle : Array[String],
 ) -> Reply {
@@ -98,10 +108,10 @@ async fn build_reply(
       search_reply(
         bundle, "text/javascript; charset=utf-8", "viz_app.js not found; build it with: moon build cmd/viz_app --target js",
       )
-    "/api/sessions" => session_list_reply(store)
+    "/api/sessions" => session_list_reply(catalog)
     _ =>
       if path.has_prefix("/api/sessions/") {
-        session_path_reply(store, path)
+        session_path_reply(catalog, path)
       } else {
         text_reply(404, "Not Found", "no route for \{path}")
       }
@@ -109,20 +119,22 @@ async fn build_reply(
 }
 
 ///|
-/// Resolve `/api/sessions/<id>` (envelope) or `/api/sessions/<id>/<file>` (raw).
-/// The `<id>` segment is percent-decoded, so an id containing URL-reserved
-/// characters (spaces, `?`, `#`) still resolves to the right session. The
-/// store's own id validation rejects path separators and `..`, so a crafted id
-/// cannot escape the session directory.
-async fn session_path_reply(
-  store : @store.SessionStore,
-  path : String,
-) -> Reply {
+/// Resolve `/api/sessions/<key>` (envelope) or `/api/sessions/<key>/<file>`
+/// (raw). A key is either legacy `<id>` for the first root, or `<root>|<id>`
+/// for a discovered root. The segment is percent-decoded, so ids containing
+/// URL-reserved characters (spaces, `?`, `#`) still resolve to the right
+/// session. The store's own id validation rejects path separators and `..`, so
+/// a crafted id cannot escape the session directory.
+async fn session_path_reply(catalog : SessionCatalog, path : String) -> Reply {
   let rest = slice_from(path, "/api/sessions/".length())
-  let (id_value, file) = match rest.find("/") {
+  let (key, file) = match rest.find("/") {
     None => (percent_decode(rest), None)
     Some(index) =>
       (percent_decode(slice(rest, 0, index)), Some(slice_from(rest, index + 1)))
+  }
+  let (root, id_value) = match catalog.lookup(key) {
+    Some(found) => found
+    None => return text_reply(404, "Not Found", "session root not found")
   }
   // Validate the id ourselves so a malformed request is a 400, not a 500 from
   // the store's path-building assertion. These are the store's own id rules.
@@ -131,14 +143,14 @@ async fn session_path_reply(
   }
   let id = @agent_session.SessionId(id_value)
   match file {
-    None => session_envelope_reply(store, id)
+    None => session_envelope_reply(root.store, id)
     Some("events.jsonl") =>
       asset_reply(
-        store.event_log_file(id),
+        root.store.event_log_file(id),
         "application/x-ndjson; charset=utf-8",
       )
     Some("session.json") =>
-      asset_reply(store.header_file(id), "application/json; charset=utf-8")
+      asset_reply(root.store.header_file(id), "application/json; charset=utf-8")
     Some(other) =>
       text_reply(404, "Not Found", "no such session file: \{other}")
   }
@@ -194,20 +206,261 @@ async fn session_envelope_reply(
 }
 
 ///|
-async fn session_list_reply(store : @store.SessionStore) -> Reply {
-  let rows : Array[Json] = []
-  for listing in store.listings() {
-    let last_active : Json = match listing.last_active_unix_seconds() {
-      Some(seconds) => Json::number(seconds.to_double())
-      None => Json::null()
+async fn session_list_reply(catalog : SessionCatalog) -> Reply {
+  let rows : Array[SessionListRow] = []
+  for root in catalog.roots {
+    for listing in root.store.listings() {
+      let id = listing.id().value()
+      rows.push({
+        key: session_key(root.key, id),
+        id,
+        root: root.path,
+        root_label: root.label,
+        last_active: listing.last_active_unix_seconds(),
+        first_prompt: listing.first_prompt(),
+      })
     }
-    rows.push({
-      "id": listing.id().value(),
-      "last_active": last_active,
-      "first_prompt": listing.first_prompt(),
+  }
+  rows.sort_by(compare_session_list_rows)
+  json_reply(Array::map(rows, row => row.to_json()).to_json())
+}
+
+///|
+priv struct SessionRoot {
+  key : String
+  path : String
+  label : String
+  store : @store.SessionStore
+}
+
+///|
+priv struct SessionCatalog {
+  roots : Array[SessionRoot]
+}
+
+///|
+priv struct SessionListRow {
+  key : String
+  id : String
+  root : String
+  root_label : String
+  last_active : Int64?
+  first_prompt : String
+}
+
+///|
+fn SessionListRow::to_json(self : SessionListRow) -> Json {
+  let last_active : Json = match self.last_active {
+    Some(seconds) => Json::number(seconds.to_double())
+    None => Json::null()
+  }
+  {
+    "key": self.key,
+    "id": self.id,
+    "root": self.root,
+    "root_label": self.root_label,
+    "last_active": last_active,
+    "first_prompt": self.first_prompt,
+  }
+}
+
+///|
+fn compare_session_list_rows(a : SessionListRow, b : SessionListRow) -> Int {
+  match (a.last_active, b.last_active) {
+    (Some(a_time), Some(b_time)) =>
+      if a_time == b_time {
+        compare_session_list_row_labels(a, b)
+      } else if a_time > b_time {
+        -1
+      } else {
+        1
+      }
+    (Some(_), None) => -1
+    (None, Some(_)) => 1
+    (None, None) => compare_session_list_row_labels(a, b)
+  }
+}
+
+///|
+fn compare_session_list_row_labels(
+  a : SessionListRow,
+  b : SessionListRow,
+) -> Int {
+  let root_order = a.root_label.compare(b.root_label)
+  if root_order != 0 {
+    root_order
+  } else {
+    a.id.compare(b.id)
+  }
+}
+
+///|
+async fn session_catalog(
+  session_root : String,
+  search_dirs : Array[String],
+  session_root_name : String,
+) -> SessionCatalog {
+  let paths : Array[String] = []
+  paths.push(session_root)
+  for root in discover_session_roots(search_dirs, session_root_name) {
+    paths.push(root)
+  }
+  let unique = unique_paths(paths)
+  let roots : Array[SessionRoot] = []
+  for index, path in unique {
+    roots.push({
+      key: index.to_string(),
+      path,
+      label: root_label(path),
+      store: @store.SessionStore(path),
     })
   }
-  json_reply(rows.to_json())
+  { roots, }
+}
+
+///|
+async fn discover_session_roots(
+  search_dirs : Array[String],
+  session_root_name : String,
+) -> Array[String] {
+  let roots : Array[String] = []
+  for dir in search_dirs {
+    scan_session_roots(dir, session_root_name, roots)
+  }
+  roots
+}
+
+///|
+async fn scan_session_roots(
+  dir : String,
+  session_root_name : String,
+  roots : Array[String],
+) -> Unit {
+  guard is_directory(dir) else { return }
+  if path_tail(dir) == session_root_name {
+    roots.push(dir)
+    return
+  }
+  let direct = join_path(dir, session_root_name)
+  if is_directory(direct) {
+    roots.push(direct)
+  }
+  let names = @fs.readdir(dir, sort=true) catch { _ => return }
+  for name in names {
+    if should_skip_scan_dir(name, session_root_name) {
+      continue
+    }
+    let child = join_path(dir, name)
+    if is_directory(child) {
+      scan_session_roots(child, session_root_name, roots)
+    }
+  }
+}
+
+///|
+async fn is_directory(path : String) -> Bool {
+  (@fs.kind(path, follow_symlink=false) catch { _ => return false }) ==
+  Directory
+}
+
+///|
+fn should_skip_scan_dir(name : String, session_root_name : String) -> Bool {
+  name == session_root_name ||
+  name == ".git" ||
+  name == "node_modules" ||
+  name == ".mooncakes" ||
+  name == "_build"
+}
+
+///|
+async fn unique_paths(paths : Array[String]) -> Array[String] {
+  let seen : Array[String] = []
+  let unique : Array[String] = []
+  for path in paths {
+    let key = @fs.realpath(path) catch { _ => path }
+    if !seen.contains(key) {
+      seen.push(key)
+      unique.push(path)
+    }
+  }
+  unique
+}
+
+///|
+fn session_key(root_key : String, id : String) -> String {
+  "\{root_key}|\{id}"
+}
+
+///|
+fn SessionCatalog::lookup(
+  self : SessionCatalog,
+  key : String,
+) -> (SessionRoot, String)? {
+  match key.find("|") {
+    Some(index) => {
+      let root_key = slice(key, 0, index)
+      let id = slice_from(key, index + 1)
+      for root in self.roots {
+        if root.key == root_key {
+          return Some((root, id))
+        }
+      }
+      None
+    }
+    None =>
+      match self.roots {
+        [root, ..] => Some((root, key))
+        [] => None
+      }
+  }
+}
+
+///|
+fn root_label(path : String) -> String {
+  let trimmed = trim_trailing_path_separators(path)
+  if trimmed.is_empty() {
+    path
+  } else {
+    trimmed
+  }
+}
+
+///|
+fn path_tail(path : String) -> String {
+  let trimmed = trim_trailing_path_separators(path)
+  match last_path_separator(trimmed) {
+    Some(index) => slice_from(trimmed, index + 1)
+    None => trimmed
+  }
+}
+
+///|
+fn last_path_separator(path : String) -> Int? {
+  match (path.rev_find("/"), path.rev_find("\\")) {
+    (Some(a), Some(b)) => Some(if a > b { a } else { b })
+    (Some(a), None) => Some(a)
+    (None, Some(b)) => Some(b)
+    (None, None) => None
+  }
+}
+
+///|
+fn trim_trailing_path_separators(path : String) -> String {
+  let mut result = path
+  while result.length() > 1 &&
+        (result.has_suffix("/") || result.has_suffix("\\")) {
+    result = result[:result.length() - 1].to_owned()
+  }
+  result
+}
+
+///|
+fn join_path(parent : String, child : String) -> String {
+  if parent.is_empty() || parent.has_suffix("/") || parent.has_suffix("\\") {
+    parent + child
+  } else {
+    parent + "/" + child
+  }
 }
 
 ///|
@@ -401,7 +654,22 @@ fn cli_command() -> @argparse.Command {
         long="session-root",
         env="OPENSEEK_SESSION_ROOT",
         default_values=[".openseek"],
-        about="Directory containing durable OpenSeek sessions.",
+        about="Compatibility session root to serve in addition to discovered roots.",
+      ),
+      OptionArg(
+        "search-dir",
+        long="search-dir",
+        env="OPENSEEK_VIZ_SEARCH_DIR",
+        action=Append,
+        default_values=["."],
+        about="Directory to scan recursively for session roots; repeat to scan several trees.",
+      ),
+      OptionArg(
+        "session-root-name",
+        long="session-root-name",
+        env="OPENSEEK_VIZ_SESSION_ROOT_NAME",
+        default_values=[".openseek"],
+        about="Directory name treated as an OpenSeek session root during recursive scan.",
       ),
       OptionArg(
         "web-dir",
@@ -427,6 +695,22 @@ fn value(matches : @argparse.Matches, name : String) -> String raise {
     Some([value]) => value
     Some(values) if values.length() > 0 => values[0]
     _ => fail("missing parsed argument: \{name}")
+  }
+}
+
+///|
+fn non_empty_values(
+  matches : @argparse.Matches,
+  name : String,
+) -> Array[String] {
+  match matches.values.get(name) {
+    Some(values) =>
+      [
+        for value in values if !value.trim().is_empty() => {
+          value.trim().to_owned()
+        }
+      ]
+    None => []
   }
 }
 

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -115,3 +115,106 @@ test "valid_session_id mirrors the store's id rules" {
   inspect(valid_session_id("a/b"), content="false")
   inspect(valid_session_id("a\\b"), content="false")
 }
+
+///|
+async test "discover_session_roots scans recursively and skips heavy dirs" {
+  let root = @fs.tmpdir(prefix="openseek-viz-scan-")
+  @fs.mkdir(root + "/app/.openseek/sessions", recursive=true)
+  @fs.mkdir(root + "/packages/lib/.openseek/sessions", recursive=true)
+  @fs.mkdir(root + "/.git/ignored/.openseek/sessions", recursive=true)
+  @fs.mkdir(root + "/node_modules/ignored/.openseek/sessions", recursive=true)
+  @fs.mkdir(root + "/.mooncakes/ignored/.openseek/sessions", recursive=true)
+  @fs.mkdir(root + "/_build/ignored/.openseek/sessions", recursive=true)
+  let roots = discover_session_roots([root], ".openseek").map(path => {
+    path.replace_all(old=root, new="<root>")
+  })
+  @debug.debug_inspect(
+    roots,
+    content=(
+      #|["<root>/app/.openseek", "<root>/packages/lib/.openseek"]
+    ),
+  )
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "discover_session_roots supports a custom root marker" {
+  let root = @fs.tmpdir(prefix="openseek-viz-openroot-")
+  @fs.mkdir(root + "/app/.openroot/sessions", recursive=true)
+  @fs.mkdir(root + "/app/.openseek/sessions", recursive=true)
+  let roots = discover_session_roots([root], ".openroot").map(path => {
+    path.replace_all(old=root, new="<root>")
+  })
+  @debug.debug_inspect(
+    roots,
+    content=(
+      #|["<root>/app/.openroot"]
+    ),
+  )
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+test "session catalog lookup supports composite and legacy keys" {
+  let catalog : SessionCatalog = {
+    roots: [
+      {
+        key: "0",
+        path: "app/.openseek",
+        label: "app/.openseek",
+        store: @store.SessionStore("app/.openseek"),
+      },
+      {
+        key: "1",
+        path: "lib/.openseek",
+        label: "lib/.openseek",
+        store: @store.SessionStore("lib/.openseek"),
+      },
+    ],
+  }
+  guard catalog.lookup("1|demo") is Some((root, id)) else {
+    fail("expected composite lookup")
+  }
+  inspect(root.path, content="lib/.openseek")
+  inspect(id, content="demo")
+  guard catalog.lookup("legacy") is Some((root, id)) else {
+    fail("expected legacy lookup")
+  }
+  inspect(root.path, content="app/.openseek")
+  inspect(id, content="legacy")
+  guard catalog.lookup("9|missing") is None else {
+    fail("unexpected missing root lookup")
+  }
+}
+
+///|
+async test "session_list_reply includes root metadata and composite keys" {
+  let root = @fs.tmpdir(prefix="openseek-viz-list-")
+  let app_store = @store.SessionStore(root + "/app/.openseek")
+  let lib_store = @store.SessionStore(root + "/lib/.openseek")
+  app_store.create(@agent_session.Session(SessionId("same"), system_prompt="a"))
+  lib_store.create(@agent_session.Session(SessionId("same"), system_prompt="b"))
+  let catalog : SessionCatalog = {
+    roots: [
+      {
+        key: "0",
+        path: root + "/app/.openseek",
+        label: "app/.openseek",
+        store: app_store,
+      },
+      {
+        key: "1",
+        path: root + "/lib/.openseek",
+        label: "lib/.openseek",
+        store: lib_store,
+      },
+    ],
+  }
+  let reply = session_list_reply(catalog)
+  let text = reply.body
+  assert_true(text.contains("\"key\":\"0|same\""))
+  assert_true(text.contains("\"key\":\"1|same\""))
+  assert_true(text.contains("\"root_label\":\"app/.openseek\""))
+  assert_true(text.contains("\"root_label\":\"lib/.openseek\""))
+  @fs.rmdir(root, recursive=true)
+}

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -29,9 +29,9 @@ no browser needed in CI.
 
 - `GET /` → the viewer shell (`web/index.html`)
 - `GET /viz_app.js` → the compiled frontend bundle (auto-located from the moon build output)
-- `GET /api/sessions` → `[{id, last_active, first_prompt}, …]`, most recent first
-- `GET /api/sessions/<id>/events.jsonl` → raw append-only log
-- `GET /api/sessions/<id>/session.json` → raw header (404 when absent; the frontend degrades to events-only)
+- `GET /api/sessions` → `[{key, id, root, root_label, last_active, first_prompt}, …]`, most recent first across all roots
+- `GET /api/sessions/<key>/events.jsonl` → raw append-only log
+- `GET /api/sessions/<key>/session.json` → raw header (404 when absent; the frontend degrades to events-only)
 
 ## Running it
 
@@ -39,14 +39,22 @@ no browser needed in CI.
 # 1. Build the frontend bundle (JS backend)
 moon build cmd/viz_app --target js
 
-# 2. Serve a session root (the server finds the bundle from the build output)
-moon run cmd/viz_server --target native -- --session-root .openseek --port 8080
+# 2. Serve sessions discovered under the current tree
+moon run cmd/viz_server --target native -- --search-dir . --port 8080
 
 # 3. Open http://127.0.0.1:8080
 ```
 
-`--session-root`, `--port`, `--web-dir`, and `--bundle` all have env-var
-fallbacks (`OPENSEEK_SESSION_ROOT`, `OPENSEEK_VIZ_PORT`, …); run with `--help`
+By default the server scans `.` recursively for `.openseek` directories and
+also includes the compatibility `--session-root` (default `.openseek`). The
+scanner skips `.git`, `node_modules`, `.mooncakes`, and `_build`. Repeat
+`--search-dir` to scan several trees, and use `--session-root-name` when a
+different marker such as `.openroot` should be treated as the session root.
+
+`--session-root`, `--search-dir`, `--session-root-name`, `--port`,
+`--web-dir`, and `--bundle` all have env-var fallbacks
+(`OPENSEEK_SESSION_ROOT`, `OPENSEEK_VIZ_SEARCH_DIR`,
+`OPENSEEK_VIZ_SESSION_ROOT_NAME`, `OPENSEEK_VIZ_PORT`, …); run with `--help`
 for the full list.
 
 ## Resilient parsing

--- a/web/index.html
+++ b/web/index.html
@@ -107,7 +107,23 @@
     .brand { font-size: 15px; margin: 0 0 4px; letter-spacing: .2px; }
     .status { color: var(--muted); font-size: 12px; }
     .sidebar-empty { padding: 8px 16px; color: var(--muted); font-style: italic; }
-    .session-list { flex: 1 1 auto; overflow-y: auto; list-style: none; margin: 0; padding: 8px 12px; }
+    .session-list { flex: 1 1 auto; overflow-y: auto; margin: 0; padding: 8px 12px; }
+    .session-root { margin-bottom: 10px; }
+    .session-root-label {
+      padding: 6px 4px 5px;
+      color: var(--muted);
+      font-size: 11px;
+      font-family: ui-monospace, monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .session-root-sessions {
+      list-style: none;
+      margin: 0;
+      padding: 0 0 0 10px;
+      border-left: 1px solid var(--border);
+    }
     .session-item {
       padding: 9px 10px;
       border: 1px solid transparent;


### PR DESCRIPTION
## Summary

- Add recursive visualizer discovery for session roots under `--search-dir`.
- Skip expensive generated/dependency directories while scanning: `.git`, `node_modules`, `.mooncakes`, and `_build`.
- Return root metadata and composite session keys from the server so duplicate session ids across roots remain addressable.
- Group the visualizer sidebar by root path and document the new options, including custom markers such as `.openroot`.

## Impact

The visualizer can now scan a project tree and show sessions from nested packages without manually restarting it per `.openseek` directory. Existing single-root usage remains available through `--session-root`.

## Validation

- `moon check --target native cmd/viz_server`
- `moon check --target js cmd/viz_app`
- `moon test --target native cmd/viz_server`
- `moon test --target js cmd/viz_app`
- `moon check --target native --deny-warn`
- `DEEPSEEK= moon test --target native`
- `moon info && moon fmt`
- Local Chrome smoke test against a fixture with two discovered roots and an ignored `_build` root