### PR TITLE
[codex] Reject unknown openseek CLI options

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -172,6 +172,10 @@ async fn random_salt() -> String {
 
 ///|
 fn failure_message(error_text : String) -> String {
+  match error_text.strip_prefix("error: ") {
+    Some(message) => return message.to_owned()
+    None => ()
+  }
   let marker = " FAILED: "
   let pieces : Array[String] = error_text
     .split(marker)
@@ -186,6 +190,16 @@ fn failure_message(error_text : String) -> String {
   } else {
     message
   }
+}
+
+///|
+test "failure_message avoids duplicating argparse error prefix" {
+  assert_eq(
+    failure_message(
+      "error: unexpected argument '--xxy' found\n\nUsage: openseek",
+    ),
+    "unexpected argument '--xxy' found\n\nUsage: openseek",
+  )
 }
 
 ///|
@@ -316,7 +330,6 @@ fn cli_command() -> @argparse.Command {
       PositionArg(
         "task",
         num_args=ValueRange(lower=0),
-        allow_hyphen_values=true,
         about="Task description.",
       ),
     ],
@@ -843,6 +856,23 @@ test "cli defaults model and max steps" {
   assert_eq(max_steps(parsed), 1000)
   assert_true(session_id(parsed) is None)
   assert_eq(session_root(parsed), ".openseek")
+}
+
+///|
+test "cli rejects unknown options before task text" {
+  let _ = cli_command().parse(argv=["--xxy", "he"], env={}) catch {
+    error => {
+      assert_true("\{error}".contains("unexpected argument '--xxy' found"))
+      return
+    }
+  }
+  fail("unknown option accepted as task text")
+}
+
+///|
+test "cli accepts hyphen-leading task text after option delimiter" {
+  let parsed = cli_command().parse(argv=["--", "--xxy", "he"], env={})
+  assert_eq(task_text(parsed), "--xxy he")
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -178,14 +178,13 @@ async fn run_agent_task(
     let proc = @process.spawn(
       group,
       config.engine,
-      // The TUI accepts hyphen-valued tasks (`allow_hyphen_values`), so a task
-      // can start with `-`/`--` (e.g. the literal text `--help`). Forward it
-      // after a `--` delimiter so the engine's argparse treats it as the task
-      // positional rather than parsing it as one of its own options (which would
-      // exit/print help and never emit a terminal JSONL event). Session settings
-      // go through a fully materialized environment so custom replay engines do
-      // not need to accept OpenSeek-specific flags, and inherited session vars
-      // cannot shadow explicit TUI config.
+      // The queued task is already prompt text here. Forward it after a `--`
+      // delimiter so the engine's argparse treats any leading `-`/`--` as the
+      // task positional rather than parsing it as one of its own options (which
+      // would exit/print help and never emit a terminal JSONL event). Session
+      // settings go through a fully materialized environment so custom replay
+      // engines do not need to accept OpenSeek-specific flags, and inherited
+      // session vars cannot shadow explicit TUI config.
       engine_args(task),
       inherit_env=false,
       extra_env=child_env,

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -78,7 +78,6 @@ fn cli_command() -> @argparse.Command {
       PositionArg(
         "task",
         num_args=ValueRange(lower=0),
-        allow_hyphen_values=true,
         about="Optional initial task description.",
       ),
     ],
@@ -379,6 +378,27 @@ test "cli accepts initial task and max steps" {
   )
   assert_true(initial_task(parsed) == Some("inspect project"))
   assert_eq(parse_config(parsed).max_steps, 5)
+}
+
+///|
+test "cli rejects unknown option before initial task" {
+  let _ = cli_command().parse(argv=["--xxy", "he"], env={
+    "DEEPSEEK": "test-key",
+  }) catch {
+    error => {
+      assert_true("\{error}".contains("unexpected argument '--xxy' found"))
+      return
+    }
+  }
+  fail("unknown option accepted as initial task")
+}
+
+///|
+test "cli accepts hyphen-leading initial task after option delimiter" {
+  let parsed = cli_command().parse(argv=["--", "--xxy", "he"], env={
+    "DEEPSEEK": "test-key",
+  })
+  assert_true(initial_task(parsed) == Some("--xxy he"))
 }
 
 ///|

--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -1,24 +1,26 @@
 ///|
-async fn main {
-  let command : @argparse.Command = Command(
+fn cli_command() -> @argparse.Command {
+  Command(
     "md_to_mbt_string",
     about="Generate a MoonBit string source file from Markdown.",
     positionals=[
       PositionArg(
         "input",
         num_args=@argparse.ValueRange::single(),
-        allow_hyphen_values=true,
         about="Input Markdown path.",
       ),
       PositionArg(
         "output",
         num_args=@argparse.ValueRange::single(),
-        allow_hyphen_values=true,
         about="Output MoonBit source path.",
       ),
     ],
   )
-  guard command.parse().values is { "input": [input, ..], "output": [output, ..], .. } else {
+}
+
+///|
+async fn main {
+  guard cli_command().parse().values is { "input": [input, ..], "output": [output, ..], .. } else {
     fail("missing parsed arguments")
   }
   let base = @path.Path(input).basename()

--- a/scripts/md_to_mbt_string/main_wbtest.mbt
+++ b/scripts/md_to_mbt_string/main_wbtest.mbt
@@ -25,6 +25,25 @@ test "function name rejects invalid MoonBit identifier" {
 }
 
 ///|
+test "cli rejects unknown option-looking input path" {
+  let _ = cli_command().parse(argv=["--xxy", "out.mbt"]) catch {
+    error => {
+      assert_true("\{error}".contains("unexpected argument '--xxy' found"))
+      return
+    }
+  }
+  fail("unknown option accepted as input path")
+}
+
+///|
+test "cli accepts hyphen-leading paths after option delimiter" {
+  let parsed = cli_command().parse(argv=["--", "-input.md", "-output.mbt"])
+  guard parsed.values is { "input": ["-input.md", ..], "output": ["-output.mbt", ..], .. } else {
+    fail("expected delimiter to allow hyphen-leading paths")
+  }
+}
+
+///|
 test "generated source matches dev_build output shape" {
   let source = generated_source(
     base="base_prompt.md",

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -64,6 +64,43 @@ error: --api-key or DEEPSEEK is required for agent runs
 stdout-empty
 ```
 
+## Unknown Options Are Rejected Before Task Text
+
+The task is free-form after option parsing has stopped, but a leading
+option-looking token is still an option. This catches stale or misspelled flags
+instead of silently turning them into prompt text.
+
+```mooncram
+$ sh <<'EOF'
+> stdout=$(mktemp)
+> stderr=$(mktemp)
+> if env -u DEEPSEEK openseek.exe --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' "$stderr"
+> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
+> rm -f "$stdout" "$stderr"
+> EOF
+exit-non-zero
+error: unexpected argument '--xxy' found
+stdout-empty
+```
+
+When the task itself must start with `-`, use the normal option delimiter.
+Here parsing succeeds and the run reaches the later API-key validation.
+
+```mooncram
+$ sh <<'EOF'
+> stdout=$(mktemp)
+> stderr=$(mktemp)
+> if env -u DEEPSEEK openseek.exe -- '--xxy he' > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> cat "$stderr"
+> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
+> rm -f "$stdout" "$stderr"
+> EOF
+exit-non-zero
+error: --api-key or DEEPSEEK is required for agent runs
+stdout-empty
+```
+
 ## Session Management Is Offline
 
 Session inspection and compaction operate on typed session files and do not

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -69,3 +69,33 @@ Options:
 
 [1]
 ```
+
+## Unknown Options Are Rejected Before Initial Task Text
+
+Like the one-shot CLI, the TUI treats option-looking tokens as options until
+the normal `--` delimiter stops option parsing.
+
+```mooncram
+$ sh <<'EOF'
+> stdout=$(mktemp)
+> stderr=$(mktemp)
+> if env DEEPSEEK=test-key tui.exe --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' "$stdout"
+> if test -s "$stderr"; then echo stderr-not-empty; else echo stderr-empty; fi
+> rm -f "$stdout" "$stderr"
+> EOF
+exit-non-zero
+error: unexpected argument '--xxy' found
+stderr-empty
+```
+
+When the initial task itself must start with `-`, use `--`. This gets past
+argument parsing; the fake engine then fails the preflight check before the TUI
+takes over the terminal.
+
+```mooncram
+$ env DEEPSEEK=test-key tui.exe --engine openseek-not-a-real-binary -- '--xxy he'
+error: engine 'openseek-not-a-real-binary' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
+Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
+[1]
+```


### PR DESCRIPTION
## Summary

Fixes #132.

- Remove `allow_hyphen_values=true` from the variadic `task` positional so unknown option-looking tokens are reported by argparse.
- Keep the standard `--` delimiter path for prompts that intentionally start with `-`.
- Avoid printing `error: error: ...` when an argparse error already includes the `error:` prefix.
- Add unit and cram coverage for unknown-option rejection and delimiter behavior.

## Why

Before this change, a stale or mistyped flag such as:

```bash
openseek --xxy he
```

was silently parsed as task text. That made a stale checkout of PR #130 confusing: `--dir ./harness/hi2 'how are you'` could run as a prompt and record under the default session root instead of failing fast.

This is the same class of ambiguity seen in other CLIs when option values or arguments start with `-`. For example, on this machine:

```bash
node -e '-3'
# node: -e requires an argument

node --eval=-3
# exits 0
```

Shell quotes do not survive into argv, so the parser needs a clear rule. OpenSeek now follows the usual CLI behavior: unknown leading options fail, and users can pass a hyphen-leading prompt with the explicit delimiter:

```bash
openseek -- '--xxy he'
```

## Validation

- `moon test --target native cmd/openseek`
- `moon cram test tests/cram`
- `moon check --target native --deny-warn`
- `DEEPSEEK= moon test --target native`
- `moon info && moon fmt`
- `git diff --check`