### PR TITLE
[codex] Add viz sidebar folding controls

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -22,6 +22,8 @@ struct Model {
   header_present : Bool
   view_mode : @viz.ViewMode
   theme : Theme
+  sidebar_visible : Bool
+  collapsed_roots : Array[String]
   loading : Bool
   status : String
 }
@@ -56,6 +58,8 @@ enum Msg {
   SessionFetched(String, Result[String, Error])
   SetMode(@viz.ViewMode)
   SetTheme(Theme)
+  ToggleSidebar
+  ToggleRoot(String)
 }
 
 ///|
@@ -78,6 +82,8 @@ fn init_model() -> Model {
     header_present: false,
     view_mode: RawLog,
     theme: Light,
+    sidebar_visible: true,
+    collapsed_roots: [],
     loading: false,
     status: "loading sessions…",
   }
@@ -93,7 +99,15 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
         Some(sessions) =>
           (
             @cmd.none,
-            { ..model, sessions, status: "\{sessions.length()} session(s)" },
+            {
+              ..model,
+              sessions,
+              collapsed_roots: prune_collapsed_roots(
+                model.collapsed_roots,
+                sessions,
+              ),
+              status: "\{sessions.length()} session(s)",
+            },
           )
         None =>
           (@cmd.none, { ..model, status: "could not read the session list" })
@@ -172,6 +186,16 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
       // Apply the theme as a side effect (set `data-theme` on <html>) so the CSS
       // variable blocks take over; the model tracks it for button highlighting.
       (apply_theme(theme), { ..model, theme, })
+    ToggleSidebar =>
+      (@cmd.none, { ..model, sidebar_visible: !model.sidebar_visible })
+    ToggleRoot(root) =>
+      (
+        @cmd.none,
+        {
+          ..model,
+          collapsed_roots: toggle_collapsed_root(model.collapsed_roots, root),
+        },
+      )
   }
 }
 
@@ -236,16 +260,59 @@ fn events_status(parsed : @viz.ParsedLog) -> String {
 
 ///|
 fn view(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
-  @html.div(class="app", [
-    @html.aside(class="sidebar", [
-      @html.div(class="sidebar-head", [
-        @html.h1(class="brand", "OpenSeek sessions"),
-        @html.div(class="status", model.status),
-      ]),
-      sidebar_list(emit, model),
-      theme_toggle(emit, model),
+  @html.div(class=app_class(model), [
+    sidebar_pane(emit, model),
+    @html.section(class="main", [
+      main_toolbar(emit, model),
+      main_pane(emit, model),
     ]),
-    @html.section(class="main", [main_pane(emit, model)]),
+  ])
+}
+
+///|
+fn app_class(model : Model) -> String {
+  if model.sidebar_visible {
+    "app"
+  } else {
+    "app sidebar-hidden"
+  }
+}
+
+///|
+fn sidebar_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  if !model.sidebar_visible {
+    return @html.nothing
+  }
+  @html.aside(class="sidebar", [
+    @html.div(class="sidebar-head", [
+      @html.div(class="sidebar-title-row", [
+        @html.h1(class="brand", "OpenSeek sessions"),
+        @html.button(
+          class="sidebar-hide-button",
+          title="Hide sessions",
+          on_click=emit(ToggleSidebar),
+          "Hide",
+        ),
+      ]),
+      @html.div(class="status", model.status),
+    ]),
+    sidebar_list(emit, model),
+    theme_toggle(emit, model),
+  ])
+}
+
+///|
+fn main_toolbar(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  if model.sidebar_visible {
+    return @html.nothing
+  }
+  @html.div(class="main-toolbar", [
+    @html.button(
+      class="sidebar-show-button",
+      title="Show sessions",
+      on_click=emit(ToggleSidebar),
+      "Show sessions",
+    ),
   ])
 }
 
@@ -285,14 +352,44 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
         sidebar_row(emit, model, row)
       }
     ]
+    let collapsed = root_collapsed(model, root)
     sections.push(
-      @html.div(class="session-root", [
-        @html.div(class="session-root-label", root),
-        @html.ul(class="session-root-sessions", rows),
+      @html.div(class=session_root_class(collapsed), [
+        @html.button(
+          class="session-root-toggle",
+          title=if collapsed { "Expand \{root}" } else { "Collapse \{root}" },
+          on_click=emit(ToggleRoot(root)),
+          [
+            @html.span(
+              class="session-root-caret",
+              if collapsed {
+                "▸"
+              } else {
+                "▾"
+              },
+            ),
+            @html.span(class="session-root-name", root),
+            @html.span(class="session-root-count", rows.length().to_string()),
+          ],
+        ),
+        if collapsed {
+          @html.nothing
+        } else {
+          @html.ul(class="session-root-sessions", rows)
+        },
       ]),
     )
   }
   @html.div(class="session-list", sections)
+}
+
+///|
+fn session_root_class(collapsed : Bool) -> String {
+  if collapsed {
+    "session-root collapsed"
+  } else {
+    "session-root"
+  }
 }
 
 ///|
@@ -304,6 +401,31 @@ fn sidebar_roots(rows : Array[SessionRow]) -> Array[String] {
     }
   }
   roots
+}
+
+///|
+fn root_collapsed(model : Model, root : String) -> Bool {
+  model.collapsed_roots.contains(root)
+}
+
+///|
+fn toggle_collapsed_root(roots : Array[String], root : String) -> Array[String] {
+  if roots.contains(root) {
+    roots.filter(value => value != root)
+  } else {
+    let next = roots.copy()
+    next.push(root)
+    next
+  }
+}
+
+///|
+fn prune_collapsed_roots(
+  collapsed_roots : Array[String],
+  rows : Array[SessionRow],
+) -> Array[String] {
+  let roots = sidebar_roots(rows)
+  collapsed_roots.filter(root => roots.contains(root))
 }
 
 ///|
@@ -331,7 +453,11 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
     None =>
       @html.div(
         class="placeholder",
-        "Select a session from the left to view it.",
+        if model.sidebar_visible {
+          "Select a session from the left to view it."
+        } else {
+          "Show sessions to select a session."
+        },
       )
     Some(key) =>
       match model.parsed {

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -86,6 +86,30 @@ test "sidebar_roots preserves listing order without duplicates" {
 }
 
 ///|
+test "collapsed root helpers toggle and prune stale roots" {
+  let rows = [
+    { key: "0|a", id: "a", root_label: "app/.openseek", first_prompt: "" },
+    { key: "1|b", id: "b", root_label: "lib/.openseek", first_prompt: "" },
+  ]
+  let collapsed = toggle_collapsed_root([], "app/.openseek")
+  @debug.debug_inspect(collapsed, content="[\"app/.openseek\"]")
+  let expanded = toggle_collapsed_root(collapsed, "app/.openseek")
+  @debug.debug_inspect(expanded, content="[]")
+  @debug.debug_inspect(
+    prune_collapsed_roots(["app/.openseek", "stale/.openseek"], rows),
+    content="[\"app/.openseek\"]",
+  )
+}
+
+///|
+test "app class tracks sidebar visibility" {
+  let visible = { ..init_model(), sidebar_visible: true }
+  let hidden = { ..init_model(), sidebar_visible: false }
+  inspect(app_class(visible), content="app")
+  inspect(app_class(hidden), content="app sidebar-hidden")
+}
+
+///|
 test "theme values map to the data-theme attribute" {
   inspect(Theme::value(Light), content="light")
   inspect(Theme::value(Dark), content="dark")

--- a/web/index.html
+++ b/web/index.html
@@ -94,6 +94,7 @@
       transition: background .15s ease, color .15s ease;
     }
     .app { display: grid; grid-template-columns: 320px 1fr; height: 100vh; }
+    .app.sidebar-hidden { grid-template-columns: minmax(0, 1fr); }
 
     /* sidebar: fixed head, scrolling list, pinned theme footer */
     .sidebar {
@@ -104,19 +105,59 @@
       overflow: hidden;
     }
     .sidebar-head { padding: 16px 16px 8px; }
+    .sidebar-title-row { display: flex; align-items: center; gap: 8px; }
     .brand { font-size: 15px; margin: 0 0 4px; letter-spacing: .2px; }
     .status { color: var(--muted); font-size: 12px; }
+    .sidebar-hide-button,
+    .sidebar-show-button {
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 7px;
+      cursor: pointer;
+      font-size: 12px;
+      line-height: 1.2;
+    }
+    .sidebar-hide-button {
+      margin-left: auto;
+      padding: 4px 9px;
+    }
+    .sidebar-show-button { padding: 6px 12px; }
+    .sidebar-hide-button:hover,
+    .sidebar-show-button:hover { border-color: var(--accent); }
     .sidebar-empty { padding: 8px 16px; color: var(--muted); font-style: italic; }
     .session-list { flex: 1 1 auto; overflow-y: auto; margin: 0; padding: 8px 12px; }
     .session-root { margin-bottom: 10px; }
-    .session-root-label {
+    .session-root-toggle {
+      width: 100%;
+      display: grid;
+      grid-template-columns: 14px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 6px;
       padding: 6px 4px 5px;
+      background: transparent;
+      border: 0;
       color: var(--muted);
       font-size: 11px;
       font-family: ui-monospace, monospace;
+      cursor: pointer;
+      text-align: left;
+    }
+    .session-root-toggle:hover { color: var(--text); }
+    .session-root-caret {
+      text-align: center;
+      font-size: 10px;
+    }
+    .session-root-name {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+    .session-root-count {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 0 6px;
+      font-size: 10px;
     }
     .session-root-sessions {
       list-style: none;
@@ -149,6 +190,13 @@
 
     /* main */
     .main { overflow-y: auto; padding: 20px 28px; }
+    .main-toolbar {
+      min-height: 34px;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      margin-bottom: 6px;
+    }
     .placeholder { color: var(--muted); margin-top: 40px; text-align: center; }
     .header-strip {
       display: flex; justify-content: space-between; align-items: baseline;


### PR DESCRIPTION
## Summary

- Add a hide/show sessions control so the log pane can use the full viewport width.
- Add collapsible session-root groups in the sidebar with per-root session counts.
- Preserve collapsed root state across sidebar hide/show and prune stale collapsed roots after session list refreshes.
- Add white-box coverage for sidebar visibility and collapsed-root helpers.

## Validation

- `moon test --target js cmd/viz_app`
- `moon test --target native cmd/viz_server`
- `moon check --target native --deny-warn`
- `moon build --target all`
- `moon info && moon fmt`
- Local Chrome smoke test against a fixture with two discovered roots: collapse root, hide sessions, show sessions again, verify DOM state preserved.