### PR TITLE
[codex] Split prompt task runner and analyzer reports

### DIFF
--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -1,0 +1,65 @@
+///|
+/// One JSONL line that could not be decoded into a `SessionEvent`. Kept so
+/// downstream tools can surface the offending line instead of silently
+/// dropping it or aborting the whole load.
+pub(all) struct LineError {
+  line_number : Int
+  content : String
+  message : String
+} derive(Debug)
+
+///|
+/// The result of parsing an `events.jsonl` log line by line. `events` are the
+/// records that decoded cleanly (in file order); `errors` are individual lines
+/// that failed to decode; `partial_tail` is true when the final line looked
+/// like a half-written record from a process that exited mid-append.
+pub(all) struct ParsedLog {
+  events : Array[@agent_session.SessionEvent]
+  errors : Array[LineError]
+  partial_tail : Bool
+} derive(Debug)
+
+///|
+/// Parse an `events.jsonl` log into typed `SessionEvent`s, tolerating a
+/// truncated trailing line and per-line decode failures. Blank lines are
+/// ignored. A decode failure on any line other than an unterminated final line
+/// is recorded as a `LineError` and parsing continues.
+pub fn parse_events(text : String) -> ParsedLog {
+  let events : Array[@agent_session.SessionEvent] = []
+  let errors : Array[LineError] = []
+  let ends_with_newline = text.has_suffix("\n")
+  let lines = text.split("\n").map(line => line.to_owned()).collect()
+  let mut partial_tail = false
+  for index, line in lines {
+    let line_number = index + 1
+    if line.trim().is_empty() {
+      continue
+    }
+    let is_last_segment = index == lines.length() - 1
+    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
+      error => {
+        if is_last_segment && !ends_with_newline {
+          partial_tail = true
+        } else {
+          errors.push({ line_number, content: line, message: "\{error}" })
+        }
+        continue
+      }
+    }
+    events.push(event)
+  }
+  { events, errors, partial_tail }
+}
+
+///|
+/// Build an immutable `Session` from parsed events plus the header values the
+/// caller wants to use. When no `session.json` header is available, pass a
+/// placeholder id and an empty system prompt.
+pub fn session_from_parse(
+  parsed : ParsedLog,
+  id~ : String,
+  system_prompt~ : String,
+) -> @agent_session.Session {
+  let session_id : @agent_session.SessionId = SessionId(id)
+  Session(session_id, system_prompt~, events=@vector.from_array(parsed.events))
+}

--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -1,0 +1,79 @@
+///|
+fn sample_session() -> @agent_session.Session {
+  let s0 = @agent_session.Session(
+    SessionId("demo"),
+    system_prompt="You are a helpful agent.",
+  )
+  let s1 = s0.append(User(UserMessage("list the files")))
+  let s2 = s1.append(
+    Assistant(
+      AssistantMessage(
+        "I'll run ls.",
+        tool_calls=[
+          ToolCall(id="call_1", name="shell", arguments="{\"cmd\":\"ls\"}"),
+        ],
+        reasoning_content="The user wants a directory listing.",
+      ),
+    ),
+  )
+  let s3 = s2.append(
+    Tool(
+      ToolResult(
+        tool_call_id="call_1",
+        tool_name="shell",
+        content="README.md\nsrc",
+      ),
+    ),
+  )
+  let s4 = s3.append(Runtime(RuntimeNotice("moon check: 0 errors")))
+  s4.append(Terminal(Finished("Here are your files: README.md, src.")))
+}
+
+///|
+fn events_jsonl(session : @agent_session.Session) -> String {
+  let out = StringBuilder::new()
+  for event in session.events() {
+    out.write_string(event.to_json().stringify())
+    out.write_char('\n')
+  }
+  out.to_string()
+}
+
+///|
+test "parse round-trips every event kind" {
+  let parsed = @log.parse_events(events_jsonl(sample_session()))
+  inspect(parsed.events.length(), content="5")
+  inspect(parsed.errors.length(), content="0")
+  inspect(parsed.partial_tail, content="false")
+}
+
+///|
+test "parse tolerates a truncated final line" {
+  let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi"
+  let parsed = @log.parse_events(text)
+  inspect(parsed.events.length(), content="1")
+  inspect(parsed.errors.length(), content="0")
+  inspect(parsed.partial_tail, content="true")
+}
+
+///|
+test "parse records a bad interior line without aborting" {
+  let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\nnot json at all\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n"
+  let parsed = @log.parse_events(text)
+  inspect(parsed.events.length(), content="2")
+  inspect(parsed.errors.length(), content="1")
+  inspect(parsed.errors[0].line_number, content="2")
+  inspect(parsed.partial_tail, content="false")
+}
+
+///|
+test "session from parse uses supplied header values" {
+  let session = @log.session_from_parse(
+    @log.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="system",
+  )
+  assert_eq(session.id().value(), "demo")
+  assert_eq(session.system_prompt(), "system")
+  assert_eq(session.events().length(), 5)
+}

--- a/agent_session/log/moon.pkg
+++ b/agent_session/log/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "bobzhang/openseek/agent_session",
+  "moonbitlang/core/immut/vector",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/deepseek",
+} for "test"
+
+warnings = "+unnecessary_annotation"

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -1,0 +1,32 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_session/log"
+
+import {
+  "bobzhang/openseek/agent_session",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn parse_events(String) -> ParsedLog
+
+pub fn session_from_parse(ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
+
+// Errors
+
+// Types and methods
+pub(all) struct LineError {
+  line_number : Int
+  content : String
+  message : String
+} derive(@debug.Debug)
+
+pub(all) struct ParsedLog {
+  events : Array[@agent_session.SessionEvent]
+  errors : Array[LineError]
+  partial_tail : Bool
+} derive(@debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -450,17 +450,23 @@ async fn write_text_atomic(path : String, text : String) -> Unit {
 }
 
 ///|
-async fn ensure_session_dir(
-  store : SessionStore,
-  id : @agent_session.SessionId,
-) -> Unit {
-  let dir = store.session_dir(id)
+async fn ensure_dir_exists(dir : String) -> Unit {
   if @fs.exists(dir) {
     return
   }
   @fs.mkdir(dir, recursive=true) catch {
     error => if @fs.exists(dir) { () } else { raise error }
   }
+}
+
+///|
+async fn ensure_session_dir(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+) -> Unit {
+  ensure_dir_exists(store.sessions_dir())
+  let dir = store.session_dir(id)
+  ensure_dir_exists(dir)
 }
 
 ///|

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -48,6 +48,23 @@ async test "store creates and loads a session from header and event log" {
 }
 
 ///|
+async test "store creates different sessions concurrently under one root" {
+  let store = new_store()
+  ignore(
+    @async.all(
+      [
+        for id in ["a", "b", "c", "d"] => {
+          () => store.create(Session(SessionId(id), system_prompt="system"))
+        }
+      ],
+    ),
+  )
+  let ids = [ for id in store.list() => id.value() ]
+  json_inspect(ids, content=["a", "b", "c", "d"])
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
 async test "store lists known sessions" {
   let store = new_store()
   assert_eq(store.list().length(), 0)

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -17,7 +17,7 @@ struct SessionRow {
 struct Model {
   sessions : Array[SessionRow]
   selected : String?
-  parsed : @viz.ParsedLog?
+  parsed : @session_log.ParsedLog?
   system_prompt : String
   header_present : Bool
   view_mode : @viz.ViewMode
@@ -67,7 +67,7 @@ enum Msg {
 /// any completed response as `Ok`, so absence and malformed payloads are
 /// distinguished here from the body, not the HTTP status.
 enum LoadOutcome {
-  Loaded(@viz.ParsedLog, String, Bool)
+  Loaded(@session_log.ParsedLog, String, Bool)
   NotFound
   Malformed
 }
@@ -247,7 +247,7 @@ fn session_row(model : Model, key : String) -> SessionRow? {
 }
 
 ///|
-fn events_status(parsed : @viz.ParsedLog) -> String {
+fn events_status(parsed : @session_log.ParsedLog) -> String {
   let base = "\{parsed.events.length()} event(s)"
   if parsed.errors.is_empty() && !parsed.partial_tail {
     base

--- a/cmd/viz_app/moon.pkg
+++ b/cmd/viz_app/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/viz",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/html",

--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -7,9 +7,12 @@ be regenerated without rerunning model/API trials.
 
 The default task is `eval/prompt_tasks/toml_parser_cli.md`. The runner replaces
 `{{WORKSPACE}}` in the task template with each trial workspace path and starts
-the agent with an explicit per-trial session id. The analyzer loads the run
-manifest and session logs, then independently validates the final TOML project
-with:
+the agent with `openseek --dir <trial-workspace>` and an explicit per-trial
+session id. Each session log stays under the trial workspace's `.openseek`
+directory. The analyzer loads the run manifest, recursively resolves the
+workspace-local session logs, evaluates each loaded agent session independently,
+then combines those eval results into a run-level report. Workspace validation
+for the TOML task checks:
 
 - `moon check --target native`
 - `moon test --target native`
@@ -39,8 +42,6 @@ moon run eval/prompt_task/cmd/main -- \
   --out .moonagent/eval_runs/toml_flash_current_5x
 ```
 
-For the old one-step behavior, add `--run-and-analyze` to the run command.
-
 Run an A/B comparison by using different output directories and prompt labels:
 
 ```bash
@@ -56,7 +57,10 @@ moon run eval/prompt_task/cmd/main -- \
   --out .moonagent/eval_runs/toml_flash_candidate_5x
 ```
 
-The runner writes `run_manifest.json`, `workspaces/`, `logs/`, and
-`session_store/`. The analyzer writes `report.md`, `report.json`, and
-`report.html`; the report records success rate, typed-session metrics,
+The runner writes `run_manifest.json`, `workspaces/`, and `logs/`. Agent
+session logs remain in each workspace at `.openseek/sessions/<session>/`.
+The analyzer writes aggregate `report.md`, `report.json`, and `report.html`
+files under the run output directory. It also writes one independently
+renderable eval result under `eval_results/<trial>/` with its own markdown,
+JSON, and HTML report. The reports record success rate, typed-session metrics,
 validation pass/fail, prompt-sensitive counters, and paths to each raw log.

--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -1,12 +1,15 @@
 # Prompt Task Eval
 
 This harness runs a MoonBit prompt task through the real OpenSeek agent with
-isolated workspaces, per-trial logs, independent validation probes, and bounded
-parallelism.
+isolated workspaces, per-trial raw logs, durable session `events.jsonl` logs,
+and bounded parallelism. Reporting is a separate analyzer pass, so reports can
+be regenerated without rerunning model/API trials.
 
 The default task is `eval/prompt_tasks/toml_parser_cli.md`. The runner replaces
-`{{WORKSPACE}}` in the task template with each trial workspace path, starts the
-agent, then independently validates the final TOML project with:
+`{{WORKSPACE}}` in the task template with each trial workspace path and starts
+the agent with an explicit per-trial session id. The analyzer loads the run
+manifest and session logs, then independently validates the final TOML project
+with:
 
 - `moon check --target native`
 - `moon test --target native`
@@ -28,6 +31,16 @@ moon run eval/prompt_task/cmd/main -- \
   --out .moonagent/eval_runs/toml_flash_current_5x
 ```
 
+Analyze the finished run later:
+
+```bash
+moon run eval/prompt_task/cmd/main -- \
+  --analyze-only \
+  --out .moonagent/eval_runs/toml_flash_current_5x
+```
+
+For the old one-step behavior, add `--run-and-analyze` to the run command.
+
 Run an A/B comparison by using different output directories and prompt labels:
 
 ```bash
@@ -43,5 +56,7 @@ moon run eval/prompt_task/cmd/main -- \
   --out .moonagent/eval_runs/toml_flash_candidate_5x
 ```
 
-The report records success rate, steps, tool errors, validation pass/fail,
-prompt-sensitive log counters, and paths to each raw log.
+The runner writes `run_manifest.json`, `workspaces/`, `logs/`, and
+`session_store/`. The analyzer writes `report.md`, `report.json`, and
+`report.html`; the report records success rate, typed-session metrics,
+validation pass/fail, prompt-sensitive counters, and paths to each raw log.

--- a/eval/prompt_task/analyzer/analyzer.mbt
+++ b/eval/prompt_task/analyzer/analyzer.mbt
@@ -1,0 +1,477 @@
+///|
+/// Verdict of one behavioral probe run against a trial's workspace, with the
+/// `reason` it failed ("ok" when it passed).
+pub struct ProbeResult {
+  passed : Bool
+  reason : String
+}
+
+///|
+/// Validation verdict for one trial's finished workspace.
+pub struct ValidationResult {
+  passed : Bool
+  reason : String
+  moon_check : Bool
+  moon_test : Bool
+  file_probe : Bool
+  stdin_probe : Bool
+  duplicate_probe : Bool
+}
+
+///|
+/// Everything recorded about one analyzed prompt-task trial.
+pub struct TrialResult {
+  index : Int
+  prompt_label : String
+  success : Bool
+  reason : String
+  workspace : String
+  log_path : String
+  session_id : String
+  events_path : String
+  exit_code : Int
+  steps : Int
+  tool_errors : Int
+  finished : Bool
+  validation : ValidationResult
+  parse_errors : Int
+  partial_tail : Bool
+  moon_check_uses : Int
+  moon_test_uses : Int
+  moon_run_e_mentions : Int
+  moon_run_c_mentions : Int
+  bad_run_e_mentions : Int
+  from_str_mentions : Int
+  parse_int_mentions : Int
+  argparse_mentions : Int
+  old_argparse_mentions : Int
+  c_ffi_mentions : Int
+  env_args_mentions : Int
+  result_style_mentions : Int
+  try_mentions : Int
+  warnings : String
+}
+
+///|
+/// One prompt-task eval analysis report.
+pub struct EvalReport {
+  model : String
+  prompt_label : String
+  task_file : String
+  runs : Int
+  concurrency : Int
+  min_successes : Int
+  successes : Int
+  out_dir : String
+  results : Array[TrialResult]
+}
+
+///|
+priv struct SessionMetrics {
+  finished : Bool
+  steps : Int
+  tool_errors : Int
+  shell_uses : Int
+  text : String
+}
+
+///|
+/// Analyze an existing prompt-task run directory.
+pub async fn analyze_run(out_dir : String) -> EvalReport {
+  analyze_manifest(@manifest.read_manifest(out_dir))
+}
+
+///|
+/// Analyze a prompt-task run manifest and write report artifacts.
+pub async fn analyze_manifest(manifest : @manifest.RunManifest) -> EvalReport {
+  let results : Array[TrialResult] = []
+  for trial in manifest.trials {
+    results.push(analyze_trial(manifest, trial))
+  }
+  let report : EvalReport = {
+    model: manifest.model,
+    prompt_label: manifest.prompt_label,
+    task_file: manifest.task_file,
+    runs: manifest.runs,
+    concurrency: manifest.concurrency,
+    min_successes: manifest.min_successes,
+    successes: count_successes(results),
+    out_dir: manifest.out_dir,
+    results,
+  }
+  write_report_files(report)
+  report
+}
+
+///|
+async fn analyze_trial(
+  manifest : @manifest.RunManifest,
+  trial : @manifest.TrialArtifact,
+) -> TrialResult {
+  let events_missing = !@fs.exists(trial.events_path)
+  let events_text = if events_missing {
+    ""
+  } else {
+    @fs.read_file(trial.events_path).text()
+  }
+  let parsed = @session_log.parse_events(events_text)
+  let session = @session_log.session_from_parse(
+    parsed,
+    id=trial.session_id,
+    system_prompt="",
+  )
+  let session_summary = summarize_session(session)
+  let validation = validate_toml_workspace(trial.workspace)
+  let reasons : Array[String] = []
+  if trial.exit_code != 0 {
+    reasons.push("agent process exited \{trial.exit_code}")
+  }
+  if events_missing {
+    reasons.push("events log missing")
+  }
+  if parsed.errors.length() > 0 {
+    reasons.push("events decode errors \{parsed.errors.length()}")
+  }
+  if !session_summary.finished {
+    reasons.push("finish marker missing")
+  }
+  if !validation.passed {
+    reasons.push(validation.reason)
+  }
+  let warnings : Array[String] = []
+  if parsed.partial_tail {
+    warnings.push("trailing partial event ignored")
+  }
+  if session_summary.shell_uses > 0 {
+    warnings.push("shell output observed \{session_summary.shell_uses} time(s)")
+  }
+  let success = reasons.length() == 0
+  let text = session_summary.text
+  {
+    index: trial.index,
+    prompt_label: manifest.prompt_label,
+    success,
+    reason: if success {
+      "ok"
+    } else {
+      reasons.join("; ")
+    },
+    workspace: trial.workspace,
+    log_path: trial.log_path,
+    session_id: trial.session_id,
+    events_path: trial.events_path,
+    exit_code: trial.exit_code,
+    steps: session_summary.steps,
+    tool_errors: session_summary.tool_errors,
+    finished: session_summary.finished,
+    validation,
+    parse_errors: parsed.errors.length(),
+    partial_tail: parsed.partial_tail,
+    moon_check_uses: count_occurrences(text, "moon check"),
+    moon_test_uses: count_occurrences(text, "moon test"),
+    moon_run_e_mentions: count_lines_containing_all(text, ["moon run", " -e"]),
+    moon_run_c_mentions: count_lines_containing_all(text, ["moon run", " -c"]),
+    bad_run_e_mentions: count_occurrences(
+      text, "a value is required for `-e <SCRIPT>`",
+    ),
+    from_str_mentions: count_occurrences(text, "@string.from_str"),
+    parse_int_mentions: count_occurrences(text, "@string.parse_int"),
+    argparse_mentions: count_occurrences(text, "@argparse.parse") +
+    count_occurrences(text, ".parse("),
+    old_argparse_mentions: count_occurrences(text, "@argparse.command") +
+    count_occurrences(text, "@argparse.flag") +
+    count_occurrences(text, "@argparse.argument") +
+    count_occurrences(text, ".is_present") +
+    count_occurrences(text, ".value("),
+    c_ffi_mentions: count_occurrences(text, "extern \"c\"") +
+    count_occurrences(text, "native-stub"),
+    env_args_mentions: count_occurrences(text, "@env.args"),
+    result_style_mentions: count_occurrences(text, "Result[") +
+    count_occurrences(text, "Ok(") +
+    count_occurrences(text, "Err("),
+    try_mentions: count_occurrences(text, "try?") +
+    count_occurrences(text, "try!"),
+    warnings: if warnings.length() == 0 {
+      ""
+    } else {
+      warnings.join("; ")
+    },
+  }
+}
+
+///|
+fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
+  let text = StringBuilder::new()
+  let mut finished = false
+  let mut steps = 0
+  let mut tool_errors = 0
+  let mut shell_uses = 0
+  for event in session.events() {
+    append_item_text(text, event.item())
+    match event.item() {
+      Assistant(_) => steps += 1
+      Tool(result) => {
+        if result.tool_name() == "shell" {
+          shell_uses += 1
+        }
+        if result.is_error() {
+          tool_errors += 1
+        }
+      }
+      Terminal(Finished(_)) => finished = true
+      _ => ()
+    }
+  }
+  { finished, steps, tool_errors, shell_uses, text: text.to_string() }
+}
+
+///|
+fn append_item_text(
+  out : StringBuilder,
+  item : @agent_session.SessionItem,
+) -> Unit {
+  match item {
+    User(message) => write_line(out, message.content())
+    Assistant(message) => {
+      if message.reasoning_content() is Some(reasoning) {
+        write_line(out, reasoning)
+      }
+      write_line(out, message.content())
+      for call in message.tool_calls() {
+        write_line(out, call.name)
+        write_line(out, call.arguments)
+      }
+    }
+    Tool(result) => {
+      write_line(out, result.tool_name())
+      write_line(out, result.content())
+    }
+    Runtime(notice) => write_line(out, notice.content())
+    Summary(summary) => write_line(out, summary.content())
+    Terminal(terminal) =>
+      match terminal {
+        Finished(message)
+        | Aborted(message)
+        | Interrupted(message)
+        | Failed(message) => write_line(out, message)
+      }
+  }
+}
+
+///|
+fn write_line(out : StringBuilder, value : String) -> Unit {
+  out.write_string(value)
+  out.write_char('\n')
+}
+
+///|
+async fn validate_toml_workspace(workspace : String) -> ValidationResult {
+  if !@fs.exists(workspace) || @fs.kind(workspace) != Directory {
+    return {
+      passed: false,
+      reason: "workspace missing: \{workspace}",
+      moon_check: false,
+      moon_test: false,
+      file_probe: false,
+      stdin_probe: false,
+      duplicate_probe: false,
+    }
+  }
+  let check = run_command(workspace, ["moon", "check", "--target", "native"])
+  let test_probe = run_command(workspace, ["moon", "test", "--target", "native"])
+  let file_probe = run_file_probe(workspace)
+  let stdin_probe = run_stdin_probe(workspace)
+  let duplicate_probe = run_duplicate_probe(workspace)
+  let failures : Array[String] = []
+  if !check.passed {
+    failures.push("moon check: " + check.reason)
+  }
+  if !test_probe.passed {
+    failures.push("moon test: " + test_probe.reason)
+  }
+  if !file_probe.passed {
+    failures.push("file probe: " + file_probe.reason)
+  }
+  if !stdin_probe.passed {
+    failures.push("stdin probe: " + stdin_probe.reason)
+  }
+  if !duplicate_probe.passed {
+    failures.push("duplicate probe: " + duplicate_probe.reason)
+  }
+  {
+    passed: failures.length() == 0,
+    reason: if failures.length() == 0 {
+      "ok"
+    } else {
+      failures.join("; ")
+    },
+    moon_check: check.passed,
+    moon_test: test_probe.passed,
+    file_probe: file_probe.passed,
+    stdin_probe: stdin_probe.passed,
+    duplicate_probe: duplicate_probe.passed,
+  }
+}
+
+///|
+async fn run_command(
+  workspace : String,
+  command : Array[String],
+) -> ProbeResult {
+  let args = [ for i in 1..<command.length() => command[i] ]
+  let (code, output) = @process.collect_output_merged(
+    command[0],
+    args,
+    cwd=workspace,
+  )
+  if code == 0 {
+    { passed: true, reason: "ok" }
+  } else {
+    { passed: false, reason: "exit \{code}: " + summarize(output.text()) }
+  }
+}
+
+///|
+async fn run_file_probe(workspace : String) -> ProbeResult {
+  let path = workspace + "/.openseek-file-probe.toml"
+  @fs.write_file(
+    path,
+    (
+      #|[owner]
+      #|name = "Alice"
+      #|age = 30
+      #|[database]
+      #|host = "localhost"
+      #|ports = [8000, 8001]
+      #|
+    ),
+    create_mode=CreateOrTruncate,
+  )
+  let (code, stdout, stderr) = @process.collect_output(
+    "moon",
+    ["run", "--target", "native", "cmd/tomljson", "--", path],
+    cwd=workspace,
+  )
+  json_stdout_probe(code, stdout.text(), stderr.text())
+}
+
+///|
+async fn run_stdin_probe(workspace : String) -> ProbeResult {
+  let path = workspace + "/.openseek-stdin-probe.toml"
+  @fs.write_file(path, "a.b.c = 42\nx.y = true\n", create_mode=CreateOrTruncate)
+  let (code, stdout, stderr) = @process.collect_output(
+    "moon",
+    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
+    stdin=@process.redirect_from_file(path),
+    cwd=workspace,
+  )
+  json_stdout_probe(code, stdout.text(), stderr.text())
+}
+
+///|
+async fn run_duplicate_probe(workspace : String) -> ProbeResult {
+  let path = workspace + "/.openseek-duplicate-probe.toml"
+  @fs.write_file(path, "key = 1\nkey = 2\n", create_mode=CreateOrTruncate)
+  let (code, stdout, stderr) = @process.collect_output(
+    "moon",
+    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
+    stdin=@process.redirect_from_file(path),
+    cwd=workspace,
+  )
+  let combined = stdout.text() + stderr.text()
+  if combined.contains("RUNTIME ERROR") || combined.contains("panic") {
+    return { passed: false, reason: "debug/panic output leaked" }
+  }
+  if !combined.contains("duplicate") && !combined.contains("Duplicate") {
+    return {
+      passed: false,
+      reason: "missing duplicate-key message, exit \{code}: " +
+      summarize(combined),
+    }
+  }
+  { passed: true, reason: "ok" }
+}
+
+///|
+fn json_stdout_probe(
+  code : Int,
+  stdout : String,
+  stderr : String,
+) -> ProbeResult {
+  if code != 0 {
+    return {
+      passed: false,
+      reason: "exit \{code}: " + summarize(stdout + stderr),
+    }
+  }
+  let trimmed = stdout.trim().to_owned()
+  let _ = @json.parse(trimmed) catch {
+    error =>
+      return {
+        passed: false,
+        reason: "stdout is not JSON: \{error}; stdout=" + summarize(stdout),
+      }
+  }
+  { passed: true, reason: "ok" }
+}
+
+///|
+fn count_successes(results : Array[TrialResult]) -> Int {
+  let mut count = 0
+  for result in results {
+    if result.success {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+fn count_occurrences(content : String, needle : String) -> Int {
+  if needle == "" {
+    return 0
+  }
+  let pieces = content.split(needle).collect()
+  pieces.length() - 1
+}
+
+///|
+fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
+  let mut count = 0
+  for piece in content.split("\n") {
+    let line = piece.to_owned()
+    let mut matched = true
+    for needle in needles {
+      if !line.contains(needle) {
+        matched = false
+      }
+    }
+    if matched {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+fn summarize(text : String) -> String {
+  let one_line = text
+    .replace_all(old="\r\n", new="\n")
+    .replace_all(old="\n", new=" ")
+    .trim()
+    .to_owned()
+  if one_line.length() <= 240 {
+    one_line
+  } else {
+    one_line.sub(start=0, end=240).to_owned() + "..."
+  }
+}
+
+///|
+fn padded_index(value : Int) -> String {
+  if value < 10 {
+    "0" + value.to_string()
+  } else {
+    value.to_string()
+  }
+}

--- a/eval/prompt_task/analyzer/analyzer.mbt
+++ b/eval/prompt_task/analyzer/analyzer.mbt
@@ -31,8 +31,15 @@ pub struct TrialResult {
   events_path : String
   exit_code : Int
   steps : Int
+  tool_results : Int
   tool_errors : Int
+  shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
   finished : Bool
+  finish_message : String
+  terminal_status : String
+  terminal_message : String
   validation : ValidationResult
   parse_errors : Int
   partial_tail : Bool
@@ -69,9 +76,15 @@ pub struct EvalReport {
 ///|
 priv struct SessionMetrics {
   finished : Bool
+  finish_message : String
   steps : Int
+  tool_results : Int
   tool_errors : Int
   shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
+  terminal_status : String
+  terminal_message : String
   text : String
 }
 
@@ -132,7 +145,14 @@ async fn analyze_trial(
   if parsed.errors.length() > 0 {
     reasons.push("events decode errors \{parsed.errors.length()}")
   }
-  if !session_summary.finished {
+  if !session_summary.finished && session_summary.terminal_status != "" {
+    reasons.push(
+      "agent terminal " +
+      session_summary.terminal_status +
+      ": " +
+      session_summary.terminal_message,
+    )
+  } else if !session_summary.finished {
     reasons.push("finish marker missing")
   }
   if !validation.passed {
@@ -162,8 +182,15 @@ async fn analyze_trial(
     events_path: trial.events_path,
     exit_code: trial.exit_code,
     steps: session_summary.steps,
+    tool_results: session_summary.tool_results,
     tool_errors: session_summary.tool_errors,
+    shell_uses: session_summary.shell_uses,
+    shell_failures: session_summary.shell_failures,
+    runtime_notices: session_summary.runtime_notices,
     finished: session_summary.finished,
+    finish_message: session_summary.finish_message,
+    terminal_status: session_summary.terminal_status,
+    terminal_message: session_summary.terminal_message,
     validation,
     parse_errors: parsed.errors.length(),
     partial_tail: parsed.partial_tail,
@@ -203,26 +230,77 @@ async fn analyze_trial(
 fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
   let text = StringBuilder::new()
   let mut finished = false
+  let mut finish_message = ""
   let mut steps = 0
+  let mut tool_results = 0
   let mut tool_errors = 0
   let mut shell_uses = 0
+  let mut shell_failures = 0
+  let mut runtime_notices = 0
+  let mut terminal_status = ""
+  let mut terminal_message = ""
   for event in session.events() {
     append_item_text(text, event.item())
     match event.item() {
       Assistant(_) => steps += 1
       Tool(result) => {
+        tool_results += 1
         if result.tool_name() == "shell" {
           shell_uses += 1
+          if shell_result_failed(result.content()) {
+            shell_failures += 1
+          }
         }
         if result.is_error() {
           tool_errors += 1
         }
       }
-      Terminal(Finished(_)) => finished = true
+      Runtime(_) => runtime_notices += 1
+      Terminal(Finished(message)) => {
+        finished = true
+        finish_message = message
+        terminal_status = "finished"
+        terminal_message = message
+      }
+      Terminal(Aborted(message)) => {
+        terminal_status = "aborted"
+        terminal_message = message
+      }
+      Terminal(Interrupted(message)) => {
+        terminal_status = "interrupted"
+        terminal_message = message
+      }
+      Terminal(Failed(message)) => {
+        terminal_status = "failed"
+        terminal_message = message
+      }
       _ => ()
     }
   }
-  { finished, steps, tool_errors, shell_uses, text: text.to_string() }
+  {
+    finished,
+    finish_message,
+    steps,
+    tool_results,
+    tool_errors,
+    shell_uses,
+    shell_failures,
+    runtime_notices,
+    terminal_status,
+    terminal_message,
+    text: text.to_string(),
+  }
+}
+
+///|
+fn shell_result_failed(content : String) -> Bool {
+  for piece in content.split("\n") {
+    let line = piece.to_owned().trim().to_owned()
+    if line.has_prefix("exit=") && line != "exit=0" {
+      return true
+    }
+  }
+  false
 }
 
 ///|
@@ -277,6 +355,18 @@ async fn validate_toml_workspace(workspace : String) -> ValidationResult {
       duplicate_probe: false,
     }
   }
+  let readiness = toml_workspace_readiness(workspace)
+  if !readiness.passed {
+    return {
+      passed: false,
+      reason: readiness.reason,
+      moon_check: false,
+      moon_test: false,
+      file_probe: false,
+      stdin_probe: false,
+      duplicate_probe: false,
+    }
+  }
   let check = run_command(workspace, ["moon", "check", "--target", "native"])
   let test_probe = run_command(workspace, ["moon", "test", "--target", "native"])
   let file_probe = run_file_probe(workspace)
@@ -311,6 +401,20 @@ async fn validate_toml_workspace(workspace : String) -> ValidationResult {
     stdin_probe: stdin_probe.passed,
     duplicate_probe: duplicate_probe.passed,
   }
+}
+
+///|
+async fn toml_workspace_readiness(workspace : String) -> ProbeResult {
+  if !@fs.exists(workspace + "/moon.mod") {
+    return { passed: false, reason: "moon.mod missing" }
+  }
+  if !@fs.exists(workspace + "/cmd/tomljson/moon.pkg") {
+    return {
+      passed: false,
+      reason: "expected CLI package missing: cmd/tomljson/moon.pkg",
+    }
+  }
+  { passed: true, reason: "ok" }
 }
 
 ///|

--- a/eval/prompt_task/analyzer/analyzer.mbt
+++ b/eval/prompt_task/analyzer/analyzer.mbt
@@ -9,6 +9,7 @@ pub struct ProbeResult {
 ///|
 /// Validation verdict for one trial's finished workspace.
 pub struct ValidationResult {
+  ran : Bool
   passed : Bool
   reason : String
   moon_check : Bool
@@ -19,8 +20,10 @@ pub struct ValidationResult {
 }
 
 ///|
-/// Everything recorded about one analyzed prompt-task trial.
-pub struct TrialResult {
+/// Everything recorded about one analyzed agent session. Harness metadata and
+/// workspace validation are attached when the session came from a prompt-task
+/// trial.
+pub struct EvalResult {
   index : Int
   prompt_label : String
   success : Bool
@@ -70,7 +73,7 @@ pub struct EvalReport {
   min_successes : Int
   successes : Int
   out_dir : String
-  results : Array[TrialResult]
+  results : Array[EvalResult]
 }
 
 ///|
@@ -89,6 +92,21 @@ priv struct SessionMetrics {
 }
 
 ///|
+priv struct EvalContext {
+  index : Int
+  prompt_label : String
+  workspace : String
+  log_path : String
+  events_path : String
+  exit_code : Int
+  validation : ValidationResult
+  parse_errors : Int
+  partial_tail : Bool
+  extra_reasons : Array[String]
+  extra_warnings : Array[String]
+}
+
+///|
 /// Analyze an existing prompt-task run directory.
 pub async fn analyze_run(out_dir : String) -> EvalReport {
   analyze_manifest(@manifest.read_manifest(out_dir))
@@ -97,11 +115,22 @@ pub async fn analyze_run(out_dir : String) -> EvalReport {
 ///|
 /// Analyze a prompt-task run manifest and write report artifacts.
 pub async fn analyze_manifest(manifest : @manifest.RunManifest) -> EvalReport {
-  let results : Array[TrialResult] = []
+  let results : Array[EvalResult] = []
   for trial in manifest.trials {
     results.push(analyze_trial(manifest, trial))
   }
-  let report : EvalReport = {
+  let report = combine_results(manifest, results)
+  write_report_files(report)
+  report
+}
+
+///|
+/// Combine independently evaluated sessions into one run-level report.
+pub fn combine_results(
+  manifest : @manifest.RunManifest,
+  results : Array[EvalResult],
+) -> EvalReport {
+  {
     model: manifest.model,
     prompt_label: manifest.prompt_label,
     task_file: manifest.task_file,
@@ -112,20 +141,39 @@ pub async fn analyze_manifest(manifest : @manifest.RunManifest) -> EvalReport {
     out_dir: manifest.out_dir,
     results,
   }
-  write_report_files(report)
-  report
+}
+
+///|
+/// Evaluate one loaded agent session without depending on the prompt-task
+/// harness. Workspace validation is deliberately not run for this pure
+/// session pass.
+pub fn eval_session(session : @agent_session.Session) -> EvalResult {
+  eval_session_with_context(session, {
+    index: 0,
+    prompt_label: "",
+    workspace: "",
+    log_path: "",
+    events_path: "",
+    exit_code: 0,
+    validation: validation_not_run(),
+    parse_errors: 0,
+    partial_tail: false,
+    extra_reasons: [],
+    extra_warnings: [],
+  })
 }
 
 ///|
 async fn analyze_trial(
   manifest : @manifest.RunManifest,
   trial : @manifest.TrialArtifact,
-) -> TrialResult {
-  let events_missing = !@fs.exists(trial.events_path)
+) -> EvalResult {
+  let events_path = resolve_events_path(trial)
+  let events_missing = !@fs.exists(events_path)
   let events_text = if events_missing {
     ""
   } else {
-    @fs.read_file(trial.events_path).text()
+    @fs.read_file(events_path).text()
   }
   let parsed = @session_log.parse_events(events_text)
   let session = @session_log.session_from_parse(
@@ -133,7 +181,6 @@ async fn analyze_trial(
     id=trial.session_id,
     system_prompt="",
   )
-  let session_summary = summarize_session(session)
   let validation = validate_toml_workspace(trial.workspace)
   let reasons : Array[String] = []
   if trial.exit_code != 0 {
@@ -145,6 +192,35 @@ async fn analyze_trial(
   if parsed.errors.length() > 0 {
     reasons.push("events decode errors \{parsed.errors.length()}")
   }
+  let warnings : Array[String] = []
+  if parsed.partial_tail {
+    warnings.push("trailing partial event ignored")
+  }
+  eval_session_with_context(session, {
+    index: trial.index,
+    prompt_label: manifest.prompt_label,
+    workspace: trial.workspace,
+    log_path: trial.log_path,
+    events_path,
+    exit_code: trial.exit_code,
+    validation,
+    parse_errors: parsed.errors.length(),
+    partial_tail: parsed.partial_tail,
+    extra_reasons: reasons,
+    extra_warnings: warnings,
+  })
+}
+
+///|
+fn eval_session_with_context(
+  session : @agent_session.Session,
+  context : EvalContext,
+) -> EvalResult {
+  let session_summary = summarize_session(session)
+  let reasons : Array[String] = []
+  for reason in context.extra_reasons {
+    reasons.push(reason)
+  }
   if !session_summary.finished && session_summary.terminal_status != "" {
     reasons.push(
       "agent terminal " +
@@ -155,12 +231,12 @@ async fn analyze_trial(
   } else if !session_summary.finished {
     reasons.push("finish marker missing")
   }
-  if !validation.passed {
-    reasons.push(validation.reason)
+  if context.validation.ran && !context.validation.passed {
+    reasons.push(context.validation.reason)
   }
   let warnings : Array[String] = []
-  if parsed.partial_tail {
-    warnings.push("trailing partial event ignored")
+  for warning in context.extra_warnings {
+    warnings.push(warning)
   }
   if session_summary.shell_uses > 0 {
     warnings.push("shell output observed \{session_summary.shell_uses} time(s)")
@@ -168,19 +244,19 @@ async fn analyze_trial(
   let success = reasons.length() == 0
   let text = session_summary.text
   {
-    index: trial.index,
-    prompt_label: manifest.prompt_label,
+    index: context.index,
+    prompt_label: context.prompt_label,
     success,
     reason: if success {
       "ok"
     } else {
       reasons.join("; ")
     },
-    workspace: trial.workspace,
-    log_path: trial.log_path,
-    session_id: trial.session_id,
-    events_path: trial.events_path,
-    exit_code: trial.exit_code,
+    workspace: context.workspace,
+    log_path: context.log_path,
+    session_id: session.id().value(),
+    events_path: context.events_path,
+    exit_code: context.exit_code,
     steps: session_summary.steps,
     tool_results: session_summary.tool_results,
     tool_errors: session_summary.tool_errors,
@@ -191,9 +267,9 @@ async fn analyze_trial(
     finish_message: session_summary.finish_message,
     terminal_status: session_summary.terminal_status,
     terminal_message: session_summary.terminal_message,
-    validation,
-    parse_errors: parsed.errors.length(),
-    partial_tail: parsed.partial_tail,
+    validation: context.validation,
+    parse_errors: context.parse_errors,
+    partial_tail: context.partial_tail,
     moon_check_uses: count_occurrences(text, "moon check"),
     moon_test_uses: count_occurrences(text, "moon test"),
     moon_run_e_mentions: count_lines_containing_all(text, ["moon run", " -e"]),
@@ -343,9 +419,74 @@ fn write_line(out : StringBuilder, value : String) -> Unit {
 }
 
 ///|
+async fn resolve_events_path(trial : @manifest.TrialArtifact) -> String {
+  if trial.events_path != "" && @fs.exists(trial.events_path) {
+    return trial.events_path
+  }
+  let matches : Array[String] = []
+  collect_session_events(trial.workspace, trial.session_id, matches)
+  if matches.length() > 0 {
+    matches[0]
+  } else {
+    trial.events_path
+  }
+}
+
+///|
+async fn collect_session_events(
+  dir : String,
+  session_id : String,
+  matches : Array[String],
+) -> Unit {
+  guard is_directory(dir) else { return }
+  let names = @fs.readdir(dir, sort=true) catch { _ => return }
+  for name in names {
+    if should_skip_scan_dir(name) {
+      continue
+    }
+    let path = dir + "/" + name
+    if is_directory(path) {
+      collect_session_events(path, session_id, matches)
+    } else if name == "events.jsonl" &&
+      path.contains("/sessions/" + session_id + "/") {
+      matches.push(path)
+    }
+  }
+}
+
+///|
+async fn is_directory(path : String) -> Bool {
+  (@fs.kind(path, follow_symlink=false) catch { _ => return false }) ==
+  Directory
+}
+
+///|
+fn should_skip_scan_dir(name : String) -> Bool {
+  name == ".git" ||
+  name == "node_modules" ||
+  name == ".mooncakes" ||
+  name == "_build"
+}
+
+///|
+fn validation_not_run() -> ValidationResult {
+  {
+    ran: false,
+    passed: true,
+    reason: "not run",
+    moon_check: false,
+    moon_test: false,
+    file_probe: false,
+    stdin_probe: false,
+    duplicate_probe: false,
+  }
+}
+
+///|
 async fn validate_toml_workspace(workspace : String) -> ValidationResult {
   if !@fs.exists(workspace) || @fs.kind(workspace) != Directory {
     return {
+      ran: true,
       passed: false,
       reason: "workspace missing: \{workspace}",
       moon_check: false,
@@ -358,6 +499,7 @@ async fn validate_toml_workspace(workspace : String) -> ValidationResult {
   let readiness = toml_workspace_readiness(workspace)
   if !readiness.passed {
     return {
+      ran: true,
       passed: false,
       reason: readiness.reason,
       moon_check: false,
@@ -389,6 +531,7 @@ async fn validate_toml_workspace(workspace : String) -> ValidationResult {
     failures.push("duplicate probe: " + duplicate_probe.reason)
   }
   {
+    ran: true,
     passed: failures.length() == 0,
     reason: if failures.length() == 0 {
       "ok"
@@ -520,7 +663,7 @@ fn json_stdout_probe(
 }
 
 ///|
-fn count_successes(results : Array[TrialResult]) -> Int {
+fn count_successes(results : Array[EvalResult]) -> Int {
   let mut count = 0
   for result in results {
     if result.success {

--- a/eval/prompt_task/analyzer/analyzer_wbtest.mbt
+++ b/eval/prompt_task/analyzer/analyzer_wbtest.mbt
@@ -50,6 +50,23 @@ test "session summary counts typed events" {
 }
 
 ///|
+test "eval session produces standalone result" {
+  let parsed = @session_log.parse_events(sample_events())
+  let session = @session_log.session_from_parse(
+    parsed,
+    id="trial-01",
+    system_prompt="",
+  )
+  let result = eval_session(session)
+  assert_true(result.success)
+  assert_eq(result.session_id, "trial-01")
+  assert_eq(result.steps, 1)
+  assert_false(result.validation.ran)
+  assert_true(result.markdown().contains("Prompt Task Eval Result"))
+  assert_true(result.html().contains("<html"))
+}
+
+///|
 test "shell result failure detection reads exit markers" {
   assert_false(shell_result_failed("exit=0\nok"))
   assert_true(shell_result_failed("exit=2\nfailed"))
@@ -96,6 +113,7 @@ test "markdown report includes prompt label and parser metrics" {
         terminal_status: "finished",
         terminal_message: "done",
         validation: {
+          ran: true,
           passed: true,
           reason: "ok",
           moon_check: true,

--- a/eval/prompt_task/analyzer/analyzer_wbtest.mbt
+++ b/eval/prompt_task/analyzer/analyzer_wbtest.mbt
@@ -1,0 +1,114 @@
+///|
+fn sample_events() -> String {
+  let session = @agent_session.Session(SessionId("trial-01"), system_prompt="")
+    .append(User(UserMessage("build a toml cli")))
+    .append(
+      Assistant(
+        AssistantMessage("I will run moon check", tool_calls=[
+          ToolCall(
+            id="call_1",
+            name="moon_cmd",
+            arguments="{\"command\":\"moon check\"}",
+          ),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="call_1",
+          tool_name="moon_cmd",
+          content="moon check passed",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let out = StringBuilder::new()
+  for event in session.events() {
+    out.write_string(event.to_json().stringify())
+    out.write_char('\n')
+  }
+  out.to_string()
+}
+
+///|
+test "session summary counts typed events" {
+  let parsed = @session_log.parse_events(sample_events())
+  let session = @session_log.session_from_parse(
+    parsed,
+    id="trial-01",
+    system_prompt="",
+  )
+  let summary = summarize_session(session)
+  assert_true(summary.finished)
+  assert_eq(summary.steps, 1)
+  assert_eq(summary.tool_errors, 0)
+  assert_true(summary.text.contains("moon check"))
+}
+
+///|
+test "json stdout probe accepts valid json only" {
+  assert_true(json_stdout_probe(0, "{\"a\":1}\n", "").passed)
+  let invalid = json_stdout_probe(0, "not-json\n", "")
+  assert_false(invalid.passed)
+  assert_true(invalid.reason.contains("stdout is not JSON"))
+}
+
+///|
+test "markdown report includes prompt label and parser metrics" {
+  let report : EvalReport = {
+    model: "deepseek-v4-flash",
+    prompt_label: "flash",
+    task_file: "eval/prompt_tasks/toml_parser_cli.md",
+    runs: 1,
+    concurrency: 1,
+    min_successes: 1,
+    successes: 1,
+    out_dir: "out",
+    results: [
+      {
+        index: 1,
+        prompt_label: "flash",
+        success: true,
+        reason: "ok",
+        workspace: "ws",
+        log_path: "log",
+        session_id: "trial-01",
+        events_path: "events",
+        exit_code: 0,
+        steps: 1,
+        tool_errors: 0,
+        finished: true,
+        validation: {
+          passed: true,
+          reason: "ok",
+          moon_check: true,
+          moon_test: true,
+          file_probe: true,
+          stdin_probe: true,
+          duplicate_probe: true,
+        },
+        parse_errors: 0,
+        partial_tail: false,
+        moon_check_uses: 1,
+        moon_test_uses: 1,
+        moon_run_e_mentions: 1,
+        moon_run_c_mentions: 0,
+        bad_run_e_mentions: 0,
+        from_str_mentions: 1,
+        parse_int_mentions: 0,
+        argparse_mentions: 1,
+        old_argparse_mentions: 0,
+        c_ffi_mentions: 0,
+        env_args_mentions: 0,
+        result_style_mentions: 0,
+        try_mentions: 0,
+        warnings: "",
+      },
+    ],
+  }
+  let text = report.markdown()
+  assert_true(text.contains("flash"))
+  assert_true(text.contains("Parse Errors"))
+  assert_true(report.html().contains("<html"))
+}

--- a/eval/prompt_task/analyzer/analyzer_wbtest.mbt
+++ b/eval/prompt_task/analyzer/analyzer_wbtest.mbt
@@ -42,8 +42,17 @@ test "session summary counts typed events" {
   let summary = summarize_session(session)
   assert_true(summary.finished)
   assert_eq(summary.steps, 1)
+  assert_eq(summary.tool_results, 1)
   assert_eq(summary.tool_errors, 0)
+  assert_eq(summary.shell_uses, 0)
+  assert_eq(summary.runtime_notices, 0)
   assert_true(summary.text.contains("moon check"))
+}
+
+///|
+test "shell result failure detection reads exit markers" {
+  assert_false(shell_result_failed("exit=0\nok"))
+  assert_true(shell_result_failed("exit=2\nfailed"))
 }
 
 ///|
@@ -77,8 +86,15 @@ test "markdown report includes prompt label and parser metrics" {
         events_path: "events",
         exit_code: 0,
         steps: 1,
+        tool_results: 1,
         tool_errors: 0,
+        shell_uses: 0,
+        shell_failures: 0,
+        runtime_notices: 0,
         finished: true,
+        finish_message: "done",
+        terminal_status: "finished",
+        terminal_message: "done",
         validation: {
           passed: true,
           reason: "ok",
@@ -110,5 +126,7 @@ test "markdown report includes prompt label and parser metrics" {
   let text = report.markdown()
   assert_true(text.contains("flash"))
   assert_true(text.contains("Parse Errors"))
+  assert_true(text.contains("## Trial Details"))
   assert_true(report.html().contains("<html"))
+  assert_true(report.html().contains("trial-card"))
 }

--- a/eval/prompt_task/analyzer/moon.pkg
+++ b/eval/prompt_task/analyzer/moon.pkg
@@ -2,15 +2,13 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/deepseek",
-  "moonbit-community/rabbita/html",
-  "moonbitlang/core/immut/vector",
+  "bobzhang/openseek/eval/prompt_task/manifest",
+  "bobzhang/openseek/eval/report",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/process",
   "moonbitlang/core/json",
 }
 
-import {
-  "moonbit-community/rabbita",
-} for "test"
-
 warnings = "+unnecessary_annotation"
 
-supported_targets = "js"
+supported_targets = "+native"

--- a/eval/prompt_task/analyzer/pkg.generated.mbti
+++ b/eval/prompt_task/analyzer/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/eval/prompt_task/analyzer"
 
 import {
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/eval/prompt_task/manifest",
 }
 
@@ -9,6 +10,10 @@ import {
 pub async fn analyze_manifest(@manifest.RunManifest) -> EvalReport
 
 pub async fn analyze_run(String) -> EvalReport
+
+pub fn combine_results(@manifest.RunManifest, Array[EvalResult]) -> EvalReport
+
+pub fn eval_session(@agent_session.Session) -> EvalResult
 
 // Errors
 
@@ -22,19 +27,14 @@ pub struct EvalReport {
   min_successes : Int
   successes : Int
   out_dir : String
-  results : Array[TrialResult]
+  results : Array[EvalResult]
 }
 pub fn EvalReport::failure_message(Self) -> String
 pub fn EvalReport::html(Self) -> String
 pub fn EvalReport::markdown(Self) -> String
 pub fn EvalReport::passed(Self) -> Bool
 
-pub struct ProbeResult {
-  passed : Bool
-  reason : String
-}
-
-pub struct TrialResult {
+pub struct EvalResult {
   index : Int
   prompt_label : String
   success : Bool
@@ -45,8 +45,15 @@ pub struct TrialResult {
   events_path : String
   exit_code : Int
   steps : Int
+  tool_results : Int
   tool_errors : Int
+  shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
   finished : Bool
+  finish_message : String
+  terminal_status : String
+  terminal_message : String
   validation : ValidationResult
   parse_errors : Int
   partial_tail : Bool
@@ -65,8 +72,16 @@ pub struct TrialResult {
   try_mentions : Int
   warnings : String
 }
+pub fn EvalResult::html(Self) -> String
+pub fn EvalResult::markdown(Self) -> String
+
+pub struct ProbeResult {
+  passed : Bool
+  reason : String
+}
 
 pub struct ValidationResult {
+  ran : Bool
   passed : Bool
   reason : String
   moon_check : Bool

--- a/eval/prompt_task/analyzer/pkg.generated.mbti
+++ b/eval/prompt_task/analyzer/pkg.generated.mbti
@@ -1,0 +1,82 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/eval/prompt_task/analyzer"
+
+import {
+  "bobzhang/openseek/eval/prompt_task/manifest",
+}
+
+// Values
+pub async fn analyze_manifest(@manifest.RunManifest) -> EvalReport
+
+pub async fn analyze_run(String) -> EvalReport
+
+// Errors
+
+// Types and methods
+pub struct EvalReport {
+  model : String
+  prompt_label : String
+  task_file : String
+  runs : Int
+  concurrency : Int
+  min_successes : Int
+  successes : Int
+  out_dir : String
+  results : Array[TrialResult]
+}
+pub fn EvalReport::failure_message(Self) -> String
+pub fn EvalReport::html(Self) -> String
+pub fn EvalReport::markdown(Self) -> String
+pub fn EvalReport::passed(Self) -> Bool
+
+pub struct ProbeResult {
+  passed : Bool
+  reason : String
+}
+
+pub struct TrialResult {
+  index : Int
+  prompt_label : String
+  success : Bool
+  reason : String
+  workspace : String
+  log_path : String
+  session_id : String
+  events_path : String
+  exit_code : Int
+  steps : Int
+  tool_errors : Int
+  finished : Bool
+  validation : ValidationResult
+  parse_errors : Int
+  partial_tail : Bool
+  moon_check_uses : Int
+  moon_test_uses : Int
+  moon_run_e_mentions : Int
+  moon_run_c_mentions : Int
+  bad_run_e_mentions : Int
+  from_str_mentions : Int
+  parse_int_mentions : Int
+  argparse_mentions : Int
+  old_argparse_mentions : Int
+  c_ffi_mentions : Int
+  env_args_mentions : Int
+  result_style_mentions : Int
+  try_mentions : Int
+  warnings : String
+}
+
+pub struct ValidationResult {
+  passed : Bool
+  reason : String
+  moon_check : Bool
+  moon_test : Bool
+  file_probe : Bool
+  stdin_probe : Bool
+  duplicate_probe : Bool
+}
+
+// Type aliases
+
+// Traits
+

--- a/eval/prompt_task/analyzer/report.mbt
+++ b/eval/prompt_task/analyzer/report.mbt
@@ -6,6 +6,19 @@ async fn write_report_files(report : EvalReport) -> Unit {
     report.to_json(),
     html=report.html(),
   )
+  for result in report.results {
+    write_eval_result_files(report.out_dir, result)
+  }
+}
+
+///|
+async fn write_eval_result_files(out_dir : String, result : EvalResult) -> Unit {
+  @report.write_files(
+    out_dir + "/eval_results/" + eval_result_artifact_name(result),
+    result.markdown(),
+    result.to_json(),
+    html=result.html(),
+  )
 }
 
 ///|
@@ -25,7 +38,7 @@ fn EvalReport::to_json(self : EvalReport) -> Json {
 }
 
 ///|
-fn TrialResult::to_json(self : TrialResult) -> Json {
+fn EvalResult::to_json(self : EvalResult) -> Json {
   {
     "index": self.index,
     "prompt_label": self.prompt_label,
@@ -69,6 +82,7 @@ fn TrialResult::to_json(self : TrialResult) -> Json {
 ///|
 fn ValidationResult::to_json(self : ValidationResult) -> Json {
   {
+    "ran": self.ran,
     "passed": self.passed,
     "reason": self.reason,
     "moon_check": self.moon_check,
@@ -104,6 +118,18 @@ pub fn EvalReport::html(self : EvalReport) -> String {
 }
 
 ///|
+/// Render this single-session eval result as Markdown.
+pub fn EvalResult::markdown(self : EvalResult) -> String {
+  self.as_report(out_dir="").markdown()
+}
+
+///|
+/// Render this single-session eval result as standalone HTML.
+pub fn EvalResult::html(self : EvalResult) -> String {
+  self.as_report(out_dir="").html()
+}
+
+///|
 fn EvalReport::as_report(self : EvalReport) -> @report.Report {
   Report(
     title="Prompt Task Eval",
@@ -123,51 +149,85 @@ fn EvalReport::as_report(self : EvalReport) -> @report.Report {
     ],
     rows=[
       for result in self.results => {
-        ReportRow(
-          index=result.index,
-          name="trial-\{padded_index(result.index)}",
-          success=result.success,
-          reason=result.reason,
-          warnings=result.warnings,
-          metrics=[
-            Metric(name="Steps", value=result.steps.to_string()),
-            Metric(name="Tool Results", value=result.tool_results.to_string()),
-            Metric(name="Tool Errors", value=result.tool_errors.to_string()),
-            Metric(
-              name="Shell Failures",
-              value=result.shell_failures.to_string(),
-            ),
-            Metric(name="Finished", value=result.finished.to_string()),
-            Metric(
-              name="Validation",
-              value=result.validation.passed.to_string(),
-            ),
-            Metric(name="Exit Code", value=result.exit_code.to_string()),
-          ],
-          details=trial_details(result),
-          log_path=relative_artifact_path(self.out_dir, result.log_path),
-        )
+        eval_result_row(result, out_dir=self.out_dir, include_eval_link=true)
       }
     ],
   )
 }
 
 ///|
-fn trial_details(result : TrialResult) -> Array[@report.Metric] {
-  [
+fn EvalResult::as_report(
+  self : EvalResult,
+  out_dir~ : String,
+) -> @report.Report {
+  Report(
+    title="Prompt Task Eval Result: " + eval_result_name(self),
+    summary=[
+      Metric(name="session", value=empty_dash(self.session_id)),
+      Metric(name="prompt", value=empty_dash(self.prompt_label)),
+      Metric(name="result", value=if self.success { "pass" } else { "fail" }),
+      Metric(name="reason", value=self.reason),
+      Metric(name="workspace", value=empty_dash(self.workspace)),
+      Metric(name="events", value=empty_dash(self.events_path)),
+    ],
+    metric_columns=[
+      "Steps", "Tool Results", "Tool Errors", "Shell Failures", "Finished", "Validation",
+      "Exit Code",
+    ],
+    rows=[eval_result_row(self, out_dir~, include_eval_link=false)],
+  )
+}
+
+///|
+fn eval_result_row(
+  result : EvalResult,
+  out_dir~ : String,
+  include_eval_link~ : Bool,
+) -> @report.ReportRow {
+  ReportRow(
+    index=display_index(result),
+    name=eval_result_name(result),
+    success=result.success,
+    reason=result.reason,
+    warnings=result.warnings,
+    metrics=[
+      Metric(name="Steps", value=result.steps.to_string()),
+      Metric(name="Tool Results", value=result.tool_results.to_string()),
+      Metric(name="Tool Errors", value=result.tool_errors.to_string()),
+      Metric(name="Shell Failures", value=result.shell_failures.to_string()),
+      Metric(name="Finished", value=result.finished.to_string()),
+      Metric(name="Validation", value=validation_status(result.validation)),
+      Metric(name="Exit Code", value=result.exit_code.to_string()),
+    ],
+    details=eval_details(result, out_dir~, include_eval_link~),
+    log_path=relative_artifact_path(out_dir, result.log_path),
+  )
+}
+
+///|
+fn eval_details(
+  result : EvalResult,
+  out_dir~ : String,
+  include_eval_link~ : Bool,
+) -> Array[@report.Metric] {
+  let details : Array[@report.Metric] = [
     Metric(name="Session", value=result.session_id),
-    Metric(name="Workspace", value="workspaces/" + padded_index(result.index)),
+    Metric(
+      name="Workspace",
+      value=relative_artifact_path(out_dir, result.workspace),
+    ),
     Metric(
       name="Events",
-      value="session_store/sessions/" + result.session_id + "/events.jsonl",
+      value=relative_artifact_path(out_dir, result.events_path),
     ),
-    Metric(name="Log", value="logs/" + padded_index(result.index) + ".log"),
+    Metric(name="Log", value=relative_artifact_path(out_dir, result.log_path)),
     Metric(name="Terminal Status", value=empty_dash(result.terminal_status)),
     Metric(
       name="Terminal Message",
       value=empty_dash(summarize(result.terminal_message)),
     ),
     Metric(name="Validation Reason", value=result.validation.reason),
+    Metric(name="Validation Ran", value=result.validation.ran.to_string()),
     Metric(name="Moon Check", value=result.validation.moon_check.to_string()),
     Metric(name="Moon Test", value=result.validation.moon_test.to_string()),
     Metric(name="File Probe", value=result.validation.file_probe.to_string()),
@@ -215,15 +275,67 @@ fn trial_details(result : TrialResult) -> Array[@report.Metric] {
     ),
     Metric(name="try mentions", value=result.try_mentions.to_string()),
   ]
+  if include_eval_link {
+    details.push(
+      Metric(
+        name="Eval Result Report",
+        value="eval_results/" +
+          eval_result_artifact_name(result) +
+          "/report.html",
+      ),
+    )
+  }
+  details
 }
 
 ///|
 fn relative_artifact_path(out_dir : String, path : String) -> String {
+  if out_dir == "" || path == "" {
+    return path
+  }
   let prefix = out_dir + "/"
   if path.has_prefix(prefix) {
     path.sub(start=prefix.length(), end=path.length()).to_owned()
   } else {
     path
+  }
+}
+
+///|
+fn eval_result_name(result : EvalResult) -> String {
+  if result.index > 0 {
+    "trial-\{padded_index(result.index)}"
+  } else if result.session_id != "" {
+    result.session_id
+  } else {
+    "session"
+  }
+}
+
+///|
+fn eval_result_artifact_name(result : EvalResult) -> String {
+  eval_result_name(result)
+  .replace_all(old="/", new="_")
+  .replace_all(old="\\", new="_")
+  .replace_all(old=":", new="_")
+  .replace_all(old=" ", new="_")
+}
+
+///|
+fn display_index(result : EvalResult) -> Int {
+  if result.index > 0 {
+    result.index
+  } else {
+    1
+  }
+}
+
+///|
+fn validation_status(validation : ValidationResult) -> String {
+  if !validation.ran {
+    "not run"
+  } else {
+    validation.passed.to_string()
   }
 }
 

--- a/eval/prompt_task/analyzer/report.mbt
+++ b/eval/prompt_task/analyzer/report.mbt
@@ -37,8 +37,15 @@ fn TrialResult::to_json(self : TrialResult) -> Json {
     "events_path": self.events_path,
     "exit_code": self.exit_code,
     "steps": self.steps,
+    "tool_results": self.tool_results,
     "tool_errors": self.tool_errors,
+    "shell_uses": self.shell_uses,
+    "shell_failures": self.shell_failures,
+    "runtime_notices": self.runtime_notices,
     "finished": self.finished,
+    "finish_message": self.finish_message,
+    "terminal_status": self.terminal_status,
+    "terminal_message": self.terminal_message,
     "validation": self.validation.to_json(),
     "parse_errors": self.parse_errors,
     "partial_tail": self.partial_tail,
@@ -111,10 +118,8 @@ fn EvalReport::as_report(self : EvalReport) -> @report.Report {
       Metric(name="output", value=self.out_dir),
     ],
     metric_columns=[
-      "Steps", "Tool Errors", "Finished", "Validation", "Check", "Test", "File Probe",
-      "Stdin Probe", "Dup Probe", "Parse Errors", "Partial Tail", "Run -e", "Run -c",
-      "Bad -e", "from_str", "parse_int", "argparse", "old argparse", "C FFI", "env args",
-      "containers", "try", "Exit Code",
+      "Steps", "Tool Results", "Tool Errors", "Shell Failures", "Finished", "Validation",
+      "Exit Code",
     ],
     rows=[
       for result in self.results => {
@@ -126,53 +131,107 @@ fn EvalReport::as_report(self : EvalReport) -> @report.Report {
           warnings=result.warnings,
           metrics=[
             Metric(name="Steps", value=result.steps.to_string()),
+            Metric(name="Tool Results", value=result.tool_results.to_string()),
             Metric(name="Tool Errors", value=result.tool_errors.to_string()),
+            Metric(
+              name="Shell Failures",
+              value=result.shell_failures.to_string(),
+            ),
             Metric(name="Finished", value=result.finished.to_string()),
             Metric(
               name="Validation",
               value=result.validation.passed.to_string(),
             ),
-            Metric(name="Check", value=result.validation.moon_check.to_string()),
-            Metric(name="Test", value=result.validation.moon_test.to_string()),
-            Metric(
-              name="File Probe",
-              value=result.validation.file_probe.to_string(),
-            ),
-            Metric(
-              name="Stdin Probe",
-              value=result.validation.stdin_probe.to_string(),
-            ),
-            Metric(
-              name="Dup Probe",
-              value=result.validation.duplicate_probe.to_string(),
-            ),
-            Metric(name="Parse Errors", value=result.parse_errors.to_string()),
-            Metric(name="Partial Tail", value=result.partial_tail.to_string()),
-            Metric(name="Run -e", value=result.moon_run_e_mentions.to_string()),
-            Metric(name="Run -c", value=result.moon_run_c_mentions.to_string()),
-            Metric(name="Bad -e", value=result.bad_run_e_mentions.to_string()),
-            Metric(name="from_str", value=result.from_str_mentions.to_string()),
-            Metric(
-              name="parse_int",
-              value=result.parse_int_mentions.to_string(),
-            ),
-            Metric(name="argparse", value=result.argparse_mentions.to_string()),
-            Metric(
-              name="old argparse",
-              value=result.old_argparse_mentions.to_string(),
-            ),
-            Metric(name="C FFI", value=result.c_ffi_mentions.to_string()),
-            Metric(name="env args", value=result.env_args_mentions.to_string()),
-            Metric(
-              name="containers",
-              value=result.result_style_mentions.to_string(),
-            ),
-            Metric(name="try", value=result.try_mentions.to_string()),
             Metric(name="Exit Code", value=result.exit_code.to_string()),
           ],
-          log_path=result.log_path,
+          details=trial_details(result),
+          log_path=relative_artifact_path(self.out_dir, result.log_path),
         )
       }
     ],
   )
+}
+
+///|
+fn trial_details(result : TrialResult) -> Array[@report.Metric] {
+  [
+    Metric(name="Session", value=result.session_id),
+    Metric(name="Workspace", value="workspaces/" + padded_index(result.index)),
+    Metric(
+      name="Events",
+      value="session_store/sessions/" + result.session_id + "/events.jsonl",
+    ),
+    Metric(name="Log", value="logs/" + padded_index(result.index) + ".log"),
+    Metric(name="Terminal Status", value=empty_dash(result.terminal_status)),
+    Metric(
+      name="Terminal Message",
+      value=empty_dash(summarize(result.terminal_message)),
+    ),
+    Metric(name="Validation Reason", value=result.validation.reason),
+    Metric(name="Moon Check", value=result.validation.moon_check.to_string()),
+    Metric(name="Moon Test", value=result.validation.moon_test.to_string()),
+    Metric(name="File Probe", value=result.validation.file_probe.to_string()),
+    Metric(name="Stdin Probe", value=result.validation.stdin_probe.to_string()),
+    Metric(
+      name="Duplicate Probe",
+      value=result.validation.duplicate_probe.to_string(),
+    ),
+    Metric(name="Parse Errors", value=result.parse_errors.to_string()),
+    Metric(name="Partial Tail", value=result.partial_tail.to_string()),
+    Metric(name="Shell Uses", value=result.shell_uses.to_string()),
+    Metric(name="Runtime Notices", value=result.runtime_notices.to_string()),
+    Metric(name="moon check mentions", value=result.moon_check_uses.to_string()),
+    Metric(name="moon test mentions", value=result.moon_test_uses.to_string()),
+    Metric(
+      name="moon run -e mentions",
+      value=result.moon_run_e_mentions.to_string(),
+    ),
+    Metric(
+      name="moon run -c mentions",
+      value=result.moon_run_c_mentions.to_string(),
+    ),
+    Metric(name="bad -e mentions", value=result.bad_run_e_mentions.to_string()),
+    Metric(
+      name="@string.from_str mentions",
+      value=result.from_str_mentions.to_string(),
+    ),
+    Metric(
+      name="@string.parse_int mentions",
+      value=result.parse_int_mentions.to_string(),
+    ),
+    Metric(name="argparse mentions", value=result.argparse_mentions.to_string()),
+    Metric(
+      name="old argparse mentions",
+      value=result.old_argparse_mentions.to_string(),
+    ),
+    Metric(name="C FFI mentions", value=result.c_ffi_mentions.to_string()),
+    Metric(
+      name="@env.args mentions",
+      value=result.env_args_mentions.to_string(),
+    ),
+    Metric(
+      name="Result container mentions",
+      value=result.result_style_mentions.to_string(),
+    ),
+    Metric(name="try mentions", value=result.try_mentions.to_string()),
+  ]
+}
+
+///|
+fn relative_artifact_path(out_dir : String, path : String) -> String {
+  let prefix = out_dir + "/"
+  if path.has_prefix(prefix) {
+    path.sub(start=prefix.length(), end=path.length()).to_owned()
+  } else {
+    path
+  }
+}
+
+///|
+fn empty_dash(value : String) -> String {
+  if value == "" {
+    "-"
+  } else {
+    value
+  }
 }

--- a/eval/prompt_task/analyzer/report.mbt
+++ b/eval/prompt_task/analyzer/report.mbt
@@ -1,6 +1,11 @@
 ///|
 async fn write_report_files(report : EvalReport) -> Unit {
-  @report.write_files(report.out_dir, report.markdown(), report.to_json())
+  @report.write_files(
+    report.out_dir,
+    report.markdown(),
+    report.to_json(),
+    html=report.html(),
+  )
 }
 
 ///|
@@ -28,11 +33,15 @@ fn TrialResult::to_json(self : TrialResult) -> Json {
     "reason": self.reason,
     "workspace": self.workspace,
     "log_path": self.log_path,
+    "session_id": self.session_id,
+    "events_path": self.events_path,
     "exit_code": self.exit_code,
     "steps": self.steps,
     "tool_errors": self.tool_errors,
     "finished": self.finished,
     "validation": self.validation.to_json(),
+    "parse_errors": self.parse_errors,
+    "partial_tail": self.partial_tail,
     "moon_check_uses": self.moon_check_uses,
     "moon_test_uses": self.moon_test_uses,
     "moon_run_e_mentions": self.moon_run_e_mentions,
@@ -64,24 +73,27 @@ fn ValidationResult::to_json(self : ValidationResult) -> Json {
 }
 
 ///|
-/// Whether the run met its success threshold. Thresholded rather than
-/// all-or-nothing because agent trials are stochastic: a prompt is judged on
-/// its success rate, not on a single unlucky trial.
+/// Whether the analysis met its configured success threshold.
 pub fn EvalReport::passed(self : EvalReport) -> Bool {
   self.successes >= self.min_successes
 }
 
 ///|
-/// The one-line failure summary a runner prints (and exits non-zero with)
-/// when the threshold was missed, stating tally and threshold.
+/// One-line failure summary for CLIs that exit non-zero on a missed threshold.
 pub fn EvalReport::failure_message(self : EvalReport) -> String {
   "prompt task eval failed: \{self.successes}/\{self.runs} below threshold \{self.min_successes}/\{self.runs}"
 }
 
 ///|
-/// Render this run as the standard markdown report document.
+/// Render this prompt-task analysis report as Markdown.
 pub fn EvalReport::markdown(self : EvalReport) -> String {
   self.as_report().markdown()
+}
+
+///|
+/// Render this prompt-task analysis report as standalone HTML.
+pub fn EvalReport::html(self : EvalReport) -> String {
+  self.as_report().html()
 }
 
 ///|
@@ -100,8 +112,9 @@ fn EvalReport::as_report(self : EvalReport) -> @report.Report {
     ],
     metric_columns=[
       "Steps", "Tool Errors", "Finished", "Validation", "Check", "Test", "File Probe",
-      "Stdin Probe", "Dup Probe", "Run -e", "Run -c", "Bad -e", "from_str", "parse_int",
-      "argparse", "old argparse", "C FFI", "env args", "containers", "try", "Exit Code",
+      "Stdin Probe", "Dup Probe", "Parse Errors", "Partial Tail", "Run -e", "Run -c",
+      "Bad -e", "from_str", "parse_int", "argparse", "old argparse", "C FFI", "env args",
+      "containers", "try", "Exit Code",
     ],
     rows=[
       for result in self.results => {
@@ -133,6 +146,8 @@ fn EvalReport::as_report(self : EvalReport) -> @report.Report {
               name="Dup Probe",
               value=result.validation.duplicate_probe.to_string(),
             ),
+            Metric(name="Parse Errors", value=result.parse_errors.to_string()),
+            Metric(name="Partial Tail", value=result.partial_tail.to_string()),
             Metric(name="Run -e", value=result.moon_run_e_mentions.to_string()),
             Metric(name="Run -c", value=result.moon_run_c_mentions.to_string()),
             Metric(name="Bad -e", value=result.bad_run_e_mentions.to_string()),

--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -6,8 +6,10 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
     "--min-successes",
   )
   guard min_successes <= runs else { fail("--min-successes must be <= --runs") }
+  let api_key = value(matches, "api-key")
+  guard api_key != "" else { fail("--api-key is required for running trials") }
   Config(
-    api_key=value(matches, "api-key"),
+    api_key~,
     model=@deepseek.Model::parse(value(matches, "model")),
     runs~,
     concurrency=parse_positive_int(
@@ -24,6 +26,14 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
     system_prompt_file=value(matches, "system-prompt-file"),
     system_prompt_addendum_file=value(matches, "system-prompt-addendum-file"),
   )
+}
+
+///|
+fn flag(matches : @argparse.Matches, name : String) -> Bool {
+  match matches.flags.get(name) {
+    Some(value) => value
+    None => false
+  }
 }
 
 ///|

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -1,10 +1,29 @@
 ///|
 async fn main {
-  let config = @argparse.parse(cli_command()) |> config_from_matches
-  let report = @harness.run_suite(config)
-  println(report.markdown())
-  if !report.passed() {
-    fail(report.failure_message())
+  let matches = @argparse.parse(cli_command())
+  if flag(matches, "analyze-only") && flag(matches, "run-and-analyze") {
+    fail("--analyze-only contradicts --run-and-analyze")
+  }
+  if flag(matches, "analyze-only") {
+    let report = @analyzer.analyze_run(value(matches, "out"))
+    println(report.markdown())
+    if !report.passed() {
+      fail(report.failure_message())
+    }
+    return
+  }
+  let config = config_from_matches(matches)
+  if flag(matches, "run-and-analyze") {
+    let report = @harness.run_suite(config)
+    println(report.markdown())
+    if !report.passed() {
+      fail(report.failure_message())
+    }
+  } else {
+    let manifest = @harness.run_experiments(config)
+    println(
+      "prompt task run manifest: \{@manifest.manifest_path(manifest.out_dir)}",
+    )
   }
 }
 
@@ -17,7 +36,7 @@ fn cli_command() -> @argparse.Command {
       OptionArg(
         "api-key",
         long="api-key",
-        required=true,
+        default_values=[""],
         about="DeepSeek API key.",
       ),
       OptionArg(
@@ -91,6 +110,18 @@ fn cli_command() -> @argparse.Command {
         long="system-prompt-addendum-file",
         default_values=[""],
         about="Pass a system prompt addendum file through to OpenSeek.",
+      ),
+    ],
+    flags=[
+      FlagArg(
+        "analyze-only",
+        long="analyze-only",
+        about="Analyze an existing --out directory without running agent trials.",
+      ),
+      FlagArg(
+        "run-and-analyze",
+        long="run-and-analyze",
+        about="Run trials and immediately analyze them, preserving the old one-shot behavior.",
       ),
     ],
   )

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -1,9 +1,6 @@
 ///|
 async fn main {
   let matches = @argparse.parse(cli_command())
-  if flag(matches, "analyze-only") && flag(matches, "run-and-analyze") {
-    fail("--analyze-only contradicts --run-and-analyze")
-  }
   if flag(matches, "analyze-only") {
     let report = @analyzer.analyze_run(value(matches, "out"))
     println(report.markdown())
@@ -13,18 +10,10 @@ async fn main {
     return
   }
   let config = config_from_matches(matches)
-  if flag(matches, "run-and-analyze") {
-    let report = @harness.run_suite(config)
-    println(report.markdown())
-    if !report.passed() {
-      fail(report.failure_message())
-    }
-  } else {
-    let manifest = @harness.run_experiments(config)
-    println(
-      "prompt task run manifest: \{@manifest.manifest_path(manifest.out_dir)}",
-    )
-  }
+  let manifest = @harness.run_experiments(config)
+  println(
+    "prompt task run manifest: \{@manifest.manifest_path(manifest.out_dir)}",
+  )
 }
 
 ///|
@@ -117,11 +106,6 @@ fn cli_command() -> @argparse.Command {
         "analyze-only",
         long="analyze-only",
         about="Analyze an existing --out directory without running agent trials.",
-      ),
-      FlagArg(
-        "run-and-analyze",
-        long="run-and-analyze",
-        about="Run trials and immediately analyze them, preserving the old one-shot behavior.",
       ),
     ],
   )

--- a/eval/prompt_task/cmd/main/main_wbtest.mbt
+++ b/eval/prompt_task/cmd/main/main_wbtest.mbt
@@ -27,6 +27,25 @@ test "cli parses prompt and task options" {
 }
 
 ///|
+test "analyze-only mode does not require an api key" {
+  let matches = cli_command().parse(argv=["--analyze-only", "--out", "existing"])
+  assert_true(flag(matches, "analyze-only"))
+  assert_eq(value(matches, "out"), "existing")
+}
+
+///|
+test "running trials requires an api key" {
+  let matches = cli_command().parse(argv=[])
+  let _ = config_from_matches(matches) catch {
+    error => {
+      assert_true("\{error}".contains("--api-key is required"))
+      return
+    }
+  }
+  fail("missing api key parsed")
+}
+
+///|
 test "cli rejects impossible threshold" {
   let matches = cli_command().parse(argv=[
     "--api-key", "test-key", "--runs", "3", "--min-successes", "4",

--- a/eval/prompt_task/cmd/main/moon.pkg
+++ b/eval/prompt_task/cmd/main/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/eval/prompt_task/analyzer",
   "bobzhang/openseek/eval/prompt_task/harness",
+  "bobzhang/openseek/eval/prompt_task/manifest",
   "moonbitlang/async",
   "moonbitlang/core/argparse",
   "moonbitlang/core/string",

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -1,109 +1,39 @@
 ///|
-/// Verdict of one behavioral probe run against a trial's workspace, with the
-/// `reason` it failed ("ok" when it passed).
-pub struct ProbeResult {
-  passed : Bool
-  reason : String
+/// Run prompt-task experiments and immediately analyze them. This keeps the
+/// previous one-call API available; new callers that want a pure experiment
+/// phase should call `run_experiments` and run the analyzer separately.
+pub async fn run_suite(config : Config) -> @analyzer.EvalReport {
+  let manifest = run_experiments(config)
+  @analyzer.analyze_manifest(manifest)
 }
 
 ///|
-/// Validation verdict for one trial's finished workspace: the overall
-/// `passed`/`reason` plus each individual gate — the project must type-check
-/// (`moon_check`), pass its tests (`moon_test`), and behave correctly on the
-/// file, stdin, and duplicate-handling probes.
-pub struct ValidationResult {
-  passed : Bool
-  reason : String
-  moon_check : Bool
-  moon_test : Bool
-  file_probe : Bool
-  stdin_probe : Bool
-  duplicate_probe : Bool
-}
-
-///|
-/// Everything recorded about one trial: identity (`index`, `prompt_label`),
-/// the verdict (`success`/`reason`), where it ran (`workspace`, `log_path`,
-/// `exit_code`), agent-loop measurements (`steps`, `tool_errors`,
-/// `finished`), the workspace `validation`, and the `*_mentions`/`*_uses`
-/// counters that track how often the transcript touches APIs and idioms the
-/// prompt under test tries to encourage or ban.
-pub struct TrialResult {
-  index : Int
-  prompt_label : String
-  success : Bool
-  reason : String
-  workspace : String
-  log_path : String
-  exit_code : Int
-  steps : Int
-  tool_errors : Int
-  finished : Bool
-  validation : ValidationResult
-  moon_check_uses : Int
-  moon_test_uses : Int
-  moon_run_e_mentions : Int
-  moon_run_c_mentions : Int
-  bad_run_e_mentions : Int
-  from_str_mentions : Int
-  parse_int_mentions : Int
-  argparse_mentions : Int
-  old_argparse_mentions : Int
-  c_ffi_mentions : Int
-  env_args_mentions : Int
-  result_style_mentions : Int
-  try_mentions : Int
-  warnings : String
-}
-
-///|
-/// One prompt-eval run's outcome: the configuration that defined it (model,
-/// prompt label, task file, trial counts), the success tally against
-/// `min_successes`, where artifacts were written, and every trial's result.
-pub struct EvalReport {
-  model : String
-  prompt_label : String
-  task_file : String
-  runs : Int
-  concurrency : Int
-  min_successes : Int
-  successes : Int
-  out_dir : String
-  results : Array[TrialResult]
-}
-
-///|
-priv struct AgentLogSummary {
-  finished : Bool
-  steps : Int
-  tool_errors : Int
-  shell_uses : Int
-}
-
-///|
-/// Run the whole prompt eval: `config.runs` agent trials of the task file,
-/// `config.concurrency` at a time, each in a fresh workspace and validated
-/// end-to-end. Returns the aggregated report; rendering and exit-status
-/// decisions stay with the caller.
-pub async fn run_suite(config : Config) -> EvalReport {
+/// Run the prompt task `config.runs` times, `config.concurrency` at a time,
+/// writing only durable artifacts: workspaces, raw process logs, recorded
+/// session `events.jsonl` files, and a run manifest. No validation or report
+/// analysis is performed in this phase.
+pub async fn run_experiments(config : Config) -> @manifest.RunManifest {
+  if config.api_key == "" {
+    fail("api_key is required for running trials")
+  }
   prepare_output_dir(config.out_dir)
   let task_template = @fs.read_file(config.task_file).text()
-  let results = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
+  let trials = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
     run_trial(config, task_template, index)
   })
-  let report : EvalReport = {
-    model: config.model.to_string(),
-    prompt_label: config.prompt_label,
-    task_file: config.task_file,
-    runs: config.runs,
-    concurrency: config.concurrency,
-    min_successes: config.min_successes,
-    successes: count_successes(results),
-    out_dir: config.out_dir,
-    results,
-  }
-  write_report_files(report)
-  report
+  let manifest = @manifest.RunManifest(
+    model=config.model.to_string(),
+    prompt_label=config.prompt_label,
+    task_file=config.task_file,
+    runs=config.runs,
+    concurrency=config.concurrency,
+    min_successes=config.min_successes,
+    max_steps=config.max_steps,
+    out_dir=config.out_dir,
+    trials~,
+  )
+  @manifest.write_manifest(manifest)
+  manifest
 }
 
 ///|
@@ -113,6 +43,7 @@ async fn prepare_output_dir(out_dir : String) -> Unit {
   }
   @fs.mkdir(out_dir + "/workspaces", recursive=true)
   @fs.mkdir(out_dir + "/logs", recursive=true)
+  @fs.mkdir(out_dir + "/session_store", recursive=true)
 }
 
 ///|
@@ -140,19 +71,22 @@ async fn run_trial(
   config : Config,
   task_template : String,
   index : Int,
-) -> TrialResult {
-  let workspace = config.out_dir + "/workspaces/" + padded_index(index + 1)
+) -> @manifest.TrialArtifact {
+  let trial_name = padded_index(index + 1)
+  let workspace = config.out_dir + "/workspaces/" + trial_name
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
+  let real_out_dir = @fs.realpath(config.out_dir)
+  let session_root = real_out_dir + "/session_store"
+  let session_id = "trial-" + trial_name
+  let events_path = session_root + "/sessions/" + session_id + "/events.jsonl"
   let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
   // The engine runs *in* the trial workspace, so the prompt's environment
   // grounding names the workspace rather than the OpenSeek checkout — and
   // relative paths in the model's tool calls land in the right tree.
   // Launcher-relative paths (the default --repo-root ".", the engine
   // binary, prompt files) must be canonicalized before the child cwd
-  // changes their meaning. Prefer a prebuilt --engine binary: `moon run`
-  // resolves the repo's dev_build rule paths against the cwd — the trial
-  // workspace, not the checkout — and fails before the engine starts.
+  // changes their meaning.
   let repo_root = @fs.realpath(config.repo_root)
   let (program, args) = if config.engine != "" {
     (@fs.realpath(config.engine), [])
@@ -164,6 +98,10 @@ async fn run_trial(
     config.max_steps.to_string(),
     "--model",
     config.model.to_string(),
+    "--session-root",
+    session_root,
+    "--session",
+    session_id,
   ])
   if config.system_prompt_file != "" {
     args.push("--system-prompt-file")
@@ -181,354 +119,22 @@ async fn run_trial(
       "DEEPSEEK": config.api_key,
       "DEEPSEEK_MODEL": config.model.to_string(),
       "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
-      // Trials inherit the developer's env, so point the global skills
-      // lookup at a workspace path that does not exist — the developer's
-      // own ~/.openseek/skills must never reach a trial prompt.
       "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
     },
     inherit_env=true,
     cwd=real_workspace,
   )
-  let log_text = output.text()
-  let log_path = config.out_dir + "/logs/" + padded_index(index + 1) + ".log"
-  @fs.write_file(log_path, log_text, create_mode=CreateOrTruncate)
-  let validation = validate_toml_workspace(real_workspace)
-  evaluate_trial(
-    config.prompt_label,
-    index,
-    real_workspace,
-    log_path,
-    exit_code,
-    log_text,
-    validation,
+  let log_path = config.out_dir + "/logs/" + trial_name + ".log"
+  @fs.write_file(log_path, output.text(), create_mode=CreateOrTruncate)
+  TrialArtifact(
+    index=index + 1,
+    workspace=real_workspace,
+    log_path~,
+    session_root~,
+    session_id~,
+    events_path~,
+    exit_code~,
   )
-}
-
-///|
-fn evaluate_trial(
-  prompt_label : String,
-  index : Int,
-  workspace : String,
-  log_path : String,
-  exit_code : Int,
-  log_text : String,
-  validation : ValidationResult,
-) -> TrialResult {
-  let log_summary = summarize_agent_log(log_text)
-  let finished = log_summary.finished
-  let reasons : Array[String] = []
-  if exit_code != 0 {
-    reasons.push("agent process exited \{exit_code}")
-  }
-  if !finished {
-    reasons.push("finish marker missing")
-  }
-  if !validation.passed {
-    reasons.push(validation.reason)
-  }
-  let warnings : Array[String] = []
-  if log_summary.shell_uses > 0 {
-    warnings.push("shell output observed \{log_summary.shell_uses} time(s)")
-  }
-  let success = reasons.length() == 0
-  {
-    index: index + 1,
-    prompt_label,
-    success,
-    reason: if success {
-      "ok"
-    } else {
-      reasons.join("; ")
-    },
-    workspace,
-    log_path,
-    exit_code,
-    steps: log_summary.steps,
-    tool_errors: log_summary.tool_errors,
-    finished,
-    validation,
-    moon_check_uses: count_lines_containing_all(log_text, ["command=moon check"]),
-    moon_test_uses: count_lines_containing_all(log_text, ["command=moon test"]),
-    moon_run_e_mentions: count_lines_containing_all(log_text, [
-      "moon run", " -e",
-    ]),
-    moon_run_c_mentions: count_lines_containing_all(log_text, [
-      "moon run", " -c",
-    ]),
-    bad_run_e_mentions: count_occurrences(
-      log_text, "a value is required for `-e <SCRIPT>`",
-    ),
-    from_str_mentions: count_occurrences(log_text, "@string.from_str"),
-    parse_int_mentions: count_occurrences(log_text, "@string.parse_int"),
-    argparse_mentions: count_occurrences(log_text, "@argparse.parse") +
-    count_occurrences(log_text, ".parse("),
-    old_argparse_mentions: count_occurrences(log_text, "@argparse.command") +
-    count_occurrences(log_text, "@argparse.flag") +
-    count_occurrences(log_text, "@argparse.argument") +
-    count_occurrences(log_text, ".is_present") +
-    count_occurrences(log_text, ".value("),
-    c_ffi_mentions: count_occurrences(log_text, "extern \"c\"") +
-    count_occurrences(log_text, "native-stub"),
-    env_args_mentions: count_occurrences(log_text, "@env.args"),
-    result_style_mentions: count_occurrences(log_text, "Result[") +
-    count_occurrences(log_text, "Ok(") +
-    count_occurrences(log_text, "Err("),
-    try_mentions: count_occurrences(log_text, "try?") +
-    count_occurrences(log_text, "try!"),
-    warnings: if warnings.length() == 0 {
-      ""
-    } else {
-      warnings.join("; ")
-    },
-  }
-}
-
-///|
-fn summarize_agent_log(log_text : String) -> AgentLogSummary {
-  let mut has_json_events = false
-  let mut finished = false
-  let mut steps = 0
-  let mut tool_errors = 0
-  let mut shell_uses = 0
-  for line in log_text.split("\n") {
-    let json = @json.parse(line.trim()) catch { _ => continue }
-    match json {
-      { "event": String("agent_step"), .. } => {
-        has_json_events = true
-        steps += 1
-      }
-      { "event": String("agent_finished"), .. } => {
-        has_json_events = true
-        finished = true
-      }
-      {
-        "event": String("tool_result"),
-        "tool_name": String(tool_name),
-        "is_error": is_error,
-        ..
-      } => {
-        has_json_events = true
-        if tool_name == "shell" {
-          shell_uses += 1
-        }
-        match is_error {
-          True => tool_errors += 1
-          _ => ()
-        }
-      }
-      { "event": String(_), .. } => has_json_events = true
-      _ => ()
-    }
-  }
-  if has_json_events {
-    { finished, steps, tool_errors, shell_uses }
-  } else {
-    let leading_shell_use = if log_text.has_prefix("tool: exit=") {
-      1
-    } else {
-      0
-    }
-    let shell_uses = count_occurrences(log_text, "\ntool: exit=") +
-      leading_shell_use
-    {
-      finished: log_text.contains("=== finished ==="),
-      steps: count_occurrences(log_text, "--- step "),
-      tool_errors: count_occurrences(log_text, "tool error:"),
-      shell_uses,
-    }
-  }
-}
-
-///|
-async fn validate_toml_workspace(workspace : String) -> ValidationResult {
-  let check = run_command(workspace, ["moon", "check", "--target", "native"])
-  let test_probe = run_command(workspace, ["moon", "test", "--target", "native"])
-  let file_probe = run_file_probe(workspace)
-  let stdin_probe = run_stdin_probe(workspace)
-  let duplicate_probe = run_duplicate_probe(workspace)
-  let failures : Array[String] = []
-  if !check.passed {
-    failures.push("moon check: " + check.reason)
-  }
-  if !test_probe.passed {
-    failures.push("moon test: " + test_probe.reason)
-  }
-  if !file_probe.passed {
-    failures.push("file probe: " + file_probe.reason)
-  }
-  if !stdin_probe.passed {
-    failures.push("stdin probe: " + stdin_probe.reason)
-  }
-  if !duplicate_probe.passed {
-    failures.push("duplicate probe: " + duplicate_probe.reason)
-  }
-  {
-    passed: failures.length() == 0,
-    reason: if failures.length() == 0 {
-      "ok"
-    } else {
-      failures.join("; ")
-    },
-    moon_check: check.passed,
-    moon_test: test_probe.passed,
-    file_probe: file_probe.passed,
-    stdin_probe: stdin_probe.passed,
-    duplicate_probe: duplicate_probe.passed,
-  }
-}
-
-///|
-async fn run_command(
-  workspace : String,
-  command : Array[String],
-) -> ProbeResult {
-  let args = [ for i in 1..<command.length() => command[i] ]
-  let (code, output) = @process.collect_output_merged(
-    command[0],
-    args,
-    cwd=workspace,
-  )
-  if code == 0 {
-    { passed: true, reason: "ok" }
-  } else {
-    { passed: false, reason: "exit \{code}: " + summarize(output.text()) }
-  }
-}
-
-///|
-async fn run_file_probe(workspace : String) -> ProbeResult {
-  let path = workspace + "/.openseek-file-probe.toml"
-  @fs.write_file(
-    path,
-    (
-      #|[owner]
-      #|name = "Alice"
-      #|age = 30
-      #|[database]
-      #|host = "localhost"
-      #|ports = [8000, 8001]
-      #|
-    ),
-    create_mode=CreateOrTruncate,
-  )
-  let (code, stdout, stderr) = @process.collect_output(
-    "moon",
-    ["run", "--target", "native", "cmd/tomljson", "--", path],
-    cwd=workspace,
-  )
-  json_stdout_probe(code, stdout.text(), stderr.text())
-}
-
-///|
-async fn run_stdin_probe(workspace : String) -> ProbeResult {
-  let path = workspace + "/.openseek-stdin-probe.toml"
-  @fs.write_file(path, "a.b.c = 42\nx.y = true\n", create_mode=CreateOrTruncate)
-  let (code, stdout, stderr) = @process.collect_output(
-    "moon",
-    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
-    stdin=@process.redirect_from_file(path),
-    cwd=workspace,
-  )
-  json_stdout_probe(code, stdout.text(), stderr.text())
-}
-
-///|
-async fn run_duplicate_probe(workspace : String) -> ProbeResult {
-  let path = workspace + "/.openseek-duplicate-probe.toml"
-  @fs.write_file(path, "key = 1\nkey = 2\n", create_mode=CreateOrTruncate)
-  let (code, stdout, stderr) = @process.collect_output(
-    "moon",
-    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
-    stdin=@process.redirect_from_file(path),
-    cwd=workspace,
-  )
-  let combined = stdout.text() + stderr.text()
-  if combined.contains("RUNTIME ERROR") || combined.contains("panic") {
-    return { passed: false, reason: "debug/panic output leaked" }
-  }
-  if !combined.contains("duplicate") && !combined.contains("Duplicate") {
-    return {
-      passed: false,
-      reason: "missing duplicate-key message, exit \{code}: " +
-      summarize(combined),
-    }
-  }
-  { passed: true, reason: "ok" }
-}
-
-///|
-fn json_stdout_probe(
-  code : Int,
-  stdout : String,
-  stderr : String,
-) -> ProbeResult {
-  if code != 0 {
-    return {
-      passed: false,
-      reason: "exit \{code}: " + summarize(stdout + stderr),
-    }
-  }
-  let trimmed = stdout.trim().to_owned()
-  let _ = @json.parse(trimmed) catch {
-    error =>
-      return {
-        passed: false,
-        reason: "stdout is not JSON: \{error}; stdout=" + summarize(stdout),
-      }
-  }
-  { passed: true, reason: "ok" }
-}
-
-///|
-fn count_successes(results : Array[TrialResult]) -> Int {
-  let mut count = 0
-  for result in results {
-    if result.success {
-      count += 1
-    }
-  }
-  count
-}
-
-///|
-fn count_occurrences(content : String, needle : String) -> Int {
-  if needle == "" {
-    return 0
-  }
-  let pieces = content.split(needle).collect()
-  pieces.length() - 1
-}
-
-///|
-fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
-  let mut count = 0
-  for piece in content.split("\n") {
-    let line = piece.to_owned()
-    let mut matched = true
-    for needle in needles {
-      if !line.contains(needle) {
-        matched = false
-      }
-    }
-    if matched {
-      count += 1
-    }
-  }
-  count
-}
-
-///|
-fn summarize(text : String) -> String {
-  let one_line = text
-    .replace_all(old="\r\n", new="\n")
-    .replace_all(old="\n", new=" ")
-    .trim()
-    .to_owned()
-  if one_line.length() <= 240 {
-    one_line
-  } else {
-    one_line.sub(start=0, end=240).to_owned() + "..."
-  }
 }
 
 ///|

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -99,12 +99,7 @@ async fn run_trial(
   let (exit_code, output) = @process.collect_output_merged(
     program,
     args,
-    extra_env={
-      "DEEPSEEK": config.api_key,
-      "DEEPSEEK_MODEL": config.model.to_string(),
-      "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
-      "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
-    },
+    extra_env=trial_extra_env(config, real_workspace),
     inherit_env=true,
     cwd=repo_root,
   )
@@ -126,6 +121,20 @@ async fn run_trial(
     events_path~,
     exit_code~,
   )
+}
+
+///|
+fn trial_extra_env(
+  config : Config,
+  real_workspace : String,
+) -> Map[String, String] {
+  {
+    "DEEPSEEK": config.api_key,
+    "DEEPSEEK_MODEL": config.model.to_string(),
+    "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+    "OPENSEEK_SESSION_ROOT": ".openseek",
+    "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
+  }
 }
 
 ///|

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -1,13 +1,4 @@
 ///|
-/// Run prompt-task experiments and immediately analyze them. This keeps the
-/// previous one-call API available; new callers that want a pure experiment
-/// phase should call `run_experiments` and run the analyzer separately.
-pub async fn run_suite(config : Config) -> @analyzer.EvalReport {
-  let manifest = run_experiments(config)
-  @analyzer.analyze_manifest(manifest)
-}
-
-///|
 /// Run the prompt task `config.runs` times, `config.concurrency` at a time,
 /// writing only durable artifacts: workspaces, raw process logs, recorded
 /// session `events.jsonl` files, and a run manifest. No validation or report
@@ -43,7 +34,6 @@ async fn prepare_output_dir(out_dir : String) -> Unit {
   }
   @fs.mkdir(out_dir + "/workspaces", recursive=true)
   @fs.mkdir(out_dir + "/logs", recursive=true)
-  @fs.mkdir(out_dir + "/session_store", recursive=true)
 }
 
 ///|
@@ -76,17 +66,11 @@ async fn run_trial(
   let workspace = config.out_dir + "/workspaces/" + trial_name
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
-  let real_out_dir = @fs.realpath(config.out_dir)
-  let session_root = real_out_dir + "/session_store"
   let session_id = "trial-" + trial_name
-  let events_path = session_root + "/sessions/" + session_id + "/events.jsonl"
   let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
-  // The engine runs *in* the trial workspace, so the prompt's environment
-  // grounding names the workspace rather than the OpenSeek checkout — and
-  // relative paths in the model's tool calls land in the right tree.
-  // Launcher-relative paths (the default --repo-root ".", the engine
-  // binary, prompt files) must be canonicalized before the child cwd
-  // changes their meaning.
+  // The engine runs from the OpenSeek checkout and receives --dir for the
+  // isolated trial workspace. This keeps launcher-relative paths stable while
+  // ensuring the agent's session store and tool cwd live under the workspace.
   let repo_root = @fs.realpath(config.repo_root)
   let (program, args) = if config.engine != "" {
     (@fs.realpath(config.engine), [])
@@ -98,8 +82,8 @@ async fn run_trial(
     config.max_steps.to_string(),
     "--model",
     config.model.to_string(),
-    "--session-root",
-    session_root,
+    "--dir",
+    real_workspace,
     "--session",
     session_id,
   ])
@@ -122,19 +106,77 @@ async fn run_trial(
       "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
     },
     inherit_env=true,
-    cwd=real_workspace,
+    cwd=repo_root,
   )
   let log_path = config.out_dir + "/logs/" + trial_name + ".log"
   @fs.write_file(log_path, output.text(), create_mode=CreateOrTruncate)
+  let events_path = discover_session_events(
+    real_workspace,
+    session_id,
+    fallback=real_workspace +
+      "/.openseek/sessions/" +
+      session_id +
+      "/events.jsonl",
+  )
   TrialArtifact(
     index=index + 1,
     workspace=real_workspace,
     log_path~,
-    session_root~,
     session_id~,
     events_path~,
     exit_code~,
   )
+}
+
+///|
+async fn discover_session_events(
+  workspace : String,
+  session_id : String,
+  fallback~ : String,
+) -> String {
+  let matches : Array[String] = []
+  collect_session_events(workspace, session_id, matches)
+  if matches.length() > 0 {
+    matches[0]
+  } else {
+    fallback
+  }
+}
+
+///|
+async fn collect_session_events(
+  dir : String,
+  session_id : String,
+  matches : Array[String],
+) -> Unit {
+  guard is_directory(dir) else { return }
+  let names = @fs.readdir(dir, sort=true) catch { _ => return }
+  for name in names {
+    if should_skip_scan_dir(name) {
+      continue
+    }
+    let path = dir + "/" + name
+    if is_directory(path) {
+      collect_session_events(path, session_id, matches)
+    } else if name == "events.jsonl" &&
+      path.contains("/sessions/" + session_id + "/") {
+      matches.push(path)
+    }
+  }
+}
+
+///|
+async fn is_directory(path : String) -> Bool {
+  (@fs.kind(path, follow_symlink=false) catch { _ => return false }) ==
+  Directory
+}
+
+///|
+fn should_skip_scan_dir(name : String) -> Bool {
+  name == ".git" ||
+  name == "node_modules" ||
+  name == ".mooncakes" ||
+  name == "_build"
 }
 
 ///|

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -24,3 +24,30 @@ async test "indexed runner honors concurrency and preserves order" {
   json_inspect(results, content=[0, 1, 2, 3, 4])
   assert_eq(max_active, 2)
 }
+
+///|
+test "trial environment pins workspace-local session root" {
+  let config = Config(
+    api_key="key",
+    model=V4Flash,
+    runs=1,
+    concurrency=1,
+    min_successes=1,
+    max_steps=12,
+    out_dir="out",
+    repo_root=".",
+    prompt_label="label",
+    task_file="task.md",
+    system_prompt_file="",
+    system_prompt_addendum_file="",
+  )
+  let env = trial_extra_env(config, "/tmp/workspace")
+  guard env.get("OPENSEEK_SESSION_ROOT") is Some(root) else {
+    fail("expected OPENSEEK_SESSION_ROOT")
+  }
+  assert_eq(root, ".openseek")
+  guard env.get("OPENSEEK_GLOBAL_SKILLS_DIR") is Some(skills_dir) else {
+    fail("expected OPENSEEK_GLOBAL_SKILLS_DIR")
+  }
+  assert_eq(skills_dir, "/tmp/workspace/.no-global-skills")
+}

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -1,10 +1,11 @@
 ///|
-async test "prepare output dir creates a missing output directory" {
+async test "prepare output dir creates runner artifact directories" {
   let root = @fs.tmpdir(prefix="openseek-prompt-task-output")
   let out_dir = root + "/out"
   prepare_output_dir(out_dir)
   assert_true(@fs.exists(out_dir + "/workspaces"))
   assert_true(@fs.exists(out_dir + "/logs"))
+  assert_true(@fs.exists(out_dir + "/session_store"))
   @fs.rmdir(root, recursive=true)
 }
 
@@ -23,133 +24,4 @@ async test "indexed runner honors concurrency and preserves order" {
   })
   json_inspect(results, content=[0, 1, 2, 3, 4])
   assert_eq(max_active, 2)
-}
-
-///|
-test "json stdout probe accepts valid json only" {
-  assert_true(json_stdout_probe(0, "{\"a\":1}\n", "").passed)
-  let invalid = json_stdout_probe(0, "not-json\n", "")
-  assert_false(invalid.passed)
-  assert_true(invalid.reason.contains("stdout is not JSON"))
-}
-
-///|
-test "agent log summary reads jsonl events and ignores process noise" {
-  let summary = summarize_agent_log(
-    (
-      #|Blocking waiting for file lock /tmp/.moon-lock ...
-      #|{"event":"agent_step","step":1}
-      #|{"event":"tool_result","tool_name":"write","is_error":true,"content":"failed"}
-      #|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
-      #|{"event":"agent_finished","answer":"ok"}
-    ),
-  )
-  assert_true(summary.finished)
-  assert_eq(summary.steps, 1)
-  assert_eq(summary.tool_errors, 1)
-  assert_eq(summary.shell_uses, 1)
-}
-
-///|
-test "agent log summary falls back to legacy text markers" {
-  let summary = summarize_agent_log(
-    (
-      #|tool: exit=0
-      #|--- step 1 ---
-      #|tool error: failed
-      #|=== finished ===
-    ),
-  )
-  assert_true(summary.finished)
-  assert_eq(summary.steps, 1)
-  assert_eq(summary.tool_errors, 1)
-  assert_eq(summary.shell_uses, 1)
-}
-
-///|
-test "trial evaluation uses jsonl finish and counters" {
-  let validation : ValidationResult = {
-    passed: true,
-    reason: "ok",
-    moon_check: true,
-    moon_test: true,
-    file_probe: true,
-    stdin_probe: true,
-    duplicate_probe: true,
-  }
-  let result = evaluate_trial(
-    "flash",
-    0,
-    "ws",
-    "log",
-    0,
-    (
-      #|not json
-      #|{"event":"agent_step","step":1}
-      #|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
-      #|{"event":"agent_finished","answer":"ok"}
-    ),
-    validation,
-  )
-  assert_true(result.success)
-  assert_true(result.finished)
-  assert_eq(result.reason, "ok")
-  assert_eq(result.steps, 1)
-  assert_eq(result.tool_errors, 0)
-  assert_eq(result.warnings, "shell output observed 1 time(s)")
-}
-
-///|
-test "markdown report includes concurrency and prompt label" {
-  let report : EvalReport = {
-    model: "deepseek-v4-flash",
-    prompt_label: "flash",
-    task_file: "eval/prompt_tasks/toml_parser_cli.md",
-    runs: 1,
-    concurrency: 1,
-    min_successes: 1,
-    successes: 1,
-    out_dir: "out",
-    results: [
-      {
-        index: 1,
-        prompt_label: "flash",
-        success: true,
-        reason: "ok",
-        workspace: "ws",
-        log_path: "log",
-        exit_code: 0,
-        steps: 10,
-        tool_errors: 0,
-        finished: true,
-        validation: {
-          passed: true,
-          reason: "ok",
-          moon_check: true,
-          moon_test: true,
-          file_probe: true,
-          stdin_probe: true,
-          duplicate_probe: true,
-        },
-        moon_check_uses: 1,
-        moon_test_uses: 1,
-        moon_run_e_mentions: 1,
-        moon_run_c_mentions: 0,
-        bad_run_e_mentions: 0,
-        from_str_mentions: 1,
-        parse_int_mentions: 0,
-        argparse_mentions: 1,
-        old_argparse_mentions: 0,
-        c_ffi_mentions: 0,
-        env_args_mentions: 0,
-        result_style_mentions: 0,
-        try_mentions: 0,
-        warnings: "",
-      },
-    ],
-  }
-  let text = report.markdown()
-  assert_true(text.contains("flash"))
-  assert_true(text.contains("concurrency"))
-  assert_true(text.contains("File Probe"))
 }

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -5,7 +5,6 @@ async test "prepare output dir creates runner artifact directories" {
   prepare_output_dir(out_dir)
   assert_true(@fs.exists(out_dir + "/workspaces"))
   assert_true(@fs.exists(out_dir + "/logs"))
-  assert_true(@fs.exists(out_dir + "/session_store"))
   @fs.rmdir(root, recursive=true)
 }
 

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "bobzhang/openseek/eval/prompt_task/analyzer",
   "bobzhang/openseek/eval/prompt_task/manifest",
   "bobzhang/openseek/deepseek",
   "moonbitlang/async",

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -1,10 +1,10 @@
 import {
+  "bobzhang/openseek/eval/prompt_task/analyzer",
+  "bobzhang/openseek/eval/prompt_task/manifest",
   "bobzhang/openseek/deepseek",
-  "bobzhang/openseek/eval/report",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
-  "moonbitlang/core/json",
 }
 
 warnings = "+unnecessary_annotation"

--- a/eval/prompt_task/harness/pkg.generated.mbti
+++ b/eval/prompt_task/harness/pkg.generated.mbti
@@ -3,14 +3,11 @@ package "bobzhang/openseek/eval/prompt_task/harness"
 
 import {
   "bobzhang/openseek/deepseek",
-  "bobzhang/openseek/eval/prompt_task/analyzer",
   "bobzhang/openseek/eval/prompt_task/manifest",
 }
 
 // Values
 pub async fn run_experiments(Config) -> @manifest.RunManifest
-
-pub async fn run_suite(Config) -> @analyzer.EvalReport
 
 // Errors
 

--- a/eval/prompt_task/harness/pkg.generated.mbti
+++ b/eval/prompt_task/harness/pkg.generated.mbti
@@ -3,10 +3,14 @@ package "bobzhang/openseek/eval/prompt_task/harness"
 
 import {
   "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/eval/prompt_task/analyzer",
+  "bobzhang/openseek/eval/prompt_task/manifest",
 }
 
 // Values
-pub async fn run_suite(Config) -> EvalReport
+pub async fn run_experiments(Config) -> @manifest.RunManifest
+
+pub async fn run_suite(Config) -> @analyzer.EvalReport
 
 // Errors
 
@@ -27,64 +31,6 @@ pub struct Config {
   system_prompt_addendum_file : String
 }
 pub fn Config::Config(api_key~ : String, model~ : @deepseek.Model, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, repo_root~ : String, engine? : String, prompt_label~ : String, task_file~ : String, system_prompt_file~ : String, system_prompt_addendum_file~ : String) -> Self
-
-pub struct EvalReport {
-  model : String
-  prompt_label : String
-  task_file : String
-  runs : Int
-  concurrency : Int
-  min_successes : Int
-  successes : Int
-  out_dir : String
-  results : Array[TrialResult]
-}
-pub fn EvalReport::failure_message(Self) -> String
-pub fn EvalReport::markdown(Self) -> String
-pub fn EvalReport::passed(Self) -> Bool
-
-pub struct ProbeResult {
-  passed : Bool
-  reason : String
-}
-
-pub struct TrialResult {
-  index : Int
-  prompt_label : String
-  success : Bool
-  reason : String
-  workspace : String
-  log_path : String
-  exit_code : Int
-  steps : Int
-  tool_errors : Int
-  finished : Bool
-  validation : ValidationResult
-  moon_check_uses : Int
-  moon_test_uses : Int
-  moon_run_e_mentions : Int
-  moon_run_c_mentions : Int
-  bad_run_e_mentions : Int
-  from_str_mentions : Int
-  parse_int_mentions : Int
-  argparse_mentions : Int
-  old_argparse_mentions : Int
-  c_ffi_mentions : Int
-  env_args_mentions : Int
-  result_style_mentions : Int
-  try_mentions : Int
-  warnings : String
-}
-
-pub struct ValidationResult {
-  passed : Bool
-  reason : String
-  moon_check : Bool
-  moon_test : Bool
-  file_probe : Bool
-  stdin_probe : Bool
-  duplicate_probe : Bool
-}
 
 // Type aliases
 

--- a/eval/prompt_task/manifest/manifest.mbt
+++ b/eval/prompt_task/manifest/manifest.mbt
@@ -1,0 +1,193 @@
+///|
+let manifest_file_name : String = "run_manifest.json"
+
+///|
+/// Durable artifact record for one prompt-task trial. The runner writes these
+/// fields once; analyzers can replay report generation from them without
+/// rerunning the agent.
+pub struct TrialArtifact {
+  index : Int
+  workspace : String
+  log_path : String
+  session_root : String
+  session_id : String
+  events_path : String
+  exit_code : Int
+}
+
+///|
+/// Build a trial artifact entry for a completed prompt-task experiment trial.
+pub fn TrialArtifact::TrialArtifact(
+  index~ : Int,
+  workspace~ : String,
+  log_path~ : String,
+  session_root~ : String,
+  session_id~ : String,
+  events_path~ : String,
+  exit_code~ : Int,
+) -> TrialArtifact {
+  {
+    index,
+    workspace,
+    log_path,
+    session_root,
+    session_id,
+    events_path,
+    exit_code,
+  }
+}
+
+///|
+/// Manifest for one prompt-task experiment run.
+pub struct RunManifest {
+  model : String
+  prompt_label : String
+  task_file : String
+  runs : Int
+  concurrency : Int
+  min_successes : Int
+  max_steps : Int
+  out_dir : String
+  trials : Array[TrialArtifact]
+}
+
+///|
+/// Build a manifest for a completed prompt-task experiment run.
+pub fn RunManifest::RunManifest(
+  model~ : String,
+  prompt_label~ : String,
+  task_file~ : String,
+  runs~ : Int,
+  concurrency~ : Int,
+  min_successes~ : Int,
+  max_steps~ : Int,
+  out_dir~ : String,
+  trials~ : Array[TrialArtifact],
+) -> RunManifest {
+  {
+    model,
+    prompt_label,
+    task_file,
+    runs,
+    concurrency,
+    min_successes,
+    max_steps,
+    out_dir,
+    trials,
+  }
+}
+
+///|
+/// Path to the run manifest under an eval output directory.
+pub fn manifest_path(out_dir : String) -> String {
+  out_dir + "/" + manifest_file_name
+}
+
+///|
+/// Write the run manifest to `run_manifest.json`.
+pub async fn write_manifest(manifest : RunManifest) -> Unit {
+  @fs.write_file(
+    manifest_path(manifest.out_dir),
+    manifest.to_json().stringify(),
+    create_mode=CreateOrTruncate,
+  )
+}
+
+///|
+/// Read a run manifest from `run_manifest.json` under `out_dir`.
+pub async fn read_manifest(out_dir : String) -> RunManifest {
+  let text = @fs.read_file(manifest_path(out_dir)).text()
+  RunManifest::from_json(@json.parse(text))
+}
+
+///|
+fn RunManifest::to_json(self : RunManifest) -> Json {
+  {
+    "model": self.model,
+    "prompt_label": self.prompt_label,
+    "task_file": self.task_file,
+    "runs": self.runs,
+    "concurrency": self.concurrency,
+    "min_successes": self.min_successes,
+    "max_steps": self.max_steps,
+    "out_dir": self.out_dir,
+    "trials": ([ for trial in self.trials => trial.to_json() ] : Json),
+  }
+}
+
+///|
+fn TrialArtifact::to_json(self : TrialArtifact) -> Json {
+  {
+    "index": self.index,
+    "workspace": self.workspace,
+    "log_path": self.log_path,
+    "session_root": self.session_root,
+    "session_id": self.session_id,
+    "events_path": self.events_path,
+    "exit_code": self.exit_code,
+  }
+}
+
+///|
+fn RunManifest::from_json(json : Json) -> RunManifest raise {
+  let fields = object_fields(json, "manifest")
+  let trials : Array[TrialArtifact] = match fields.get("trials") {
+    Some(Array(items)) =>
+      [
+        for item in items => TrialArtifact::from_json(item)
+      ]
+    Some(_) => fail("manifest.trials must be an array")
+    None => fail("manifest.trials is missing")
+  }
+  {
+    model: string_field(fields, "model"),
+    prompt_label: string_field(fields, "prompt_label"),
+    task_file: string_field(fields, "task_file"),
+    runs: int_field(fields, "runs"),
+    concurrency: int_field(fields, "concurrency"),
+    min_successes: int_field(fields, "min_successes"),
+    max_steps: int_field(fields, "max_steps"),
+    out_dir: string_field(fields, "out_dir"),
+    trials,
+  }
+}
+
+///|
+fn TrialArtifact::from_json(json : Json) -> TrialArtifact raise {
+  let fields = object_fields(json, "trial")
+  {
+    index: int_field(fields, "index"),
+    workspace: string_field(fields, "workspace"),
+    log_path: string_field(fields, "log_path"),
+    session_root: string_field(fields, "session_root"),
+    session_id: string_field(fields, "session_id"),
+    events_path: string_field(fields, "events_path"),
+    exit_code: int_field(fields, "exit_code"),
+  }
+}
+
+///|
+fn object_fields(json : Json, label : String) -> Map[String, Json] raise {
+  match json {
+    Object(fields) => fields
+    _ => fail("\{label} must be a JSON object")
+  }
+}
+
+///|
+fn string_field(fields : Map[String, Json], key : String) -> String raise {
+  match fields.get(key) {
+    Some(String(value)) => value
+    Some(_) => fail("\{key} must be a string")
+    None => fail("\{key} is missing")
+  }
+}
+
+///|
+fn int_field(fields : Map[String, Json], key : String) -> Int raise {
+  match fields.get(key) {
+    Some(Number(value, ..)) => value.to_int()
+    Some(_) => fail("\{key} must be an int")
+    None => fail("\{key} is missing")
+  }
+}

--- a/eval/prompt_task/manifest/manifest.mbt
+++ b/eval/prompt_task/manifest/manifest.mbt
@@ -9,7 +9,6 @@ pub struct TrialArtifact {
   index : Int
   workspace : String
   log_path : String
-  session_root : String
   session_id : String
   events_path : String
   exit_code : Int
@@ -21,20 +20,11 @@ pub fn TrialArtifact::TrialArtifact(
   index~ : Int,
   workspace~ : String,
   log_path~ : String,
-  session_root~ : String,
   session_id~ : String,
   events_path~ : String,
   exit_code~ : Int,
 ) -> TrialArtifact {
-  {
-    index,
-    workspace,
-    log_path,
-    session_root,
-    session_id,
-    events_path,
-    exit_code,
-  }
+  { index, workspace, log_path, session_id, events_path, exit_code }
 }
 
 ///|
@@ -121,7 +111,6 @@ fn TrialArtifact::to_json(self : TrialArtifact) -> Json {
     "index": self.index,
     "workspace": self.workspace,
     "log_path": self.log_path,
-    "session_root": self.session_root,
     "session_id": self.session_id,
     "events_path": self.events_path,
     "exit_code": self.exit_code,
@@ -159,7 +148,6 @@ fn TrialArtifact::from_json(json : Json) -> TrialArtifact raise {
     index: int_field(fields, "index"),
     workspace: string_field(fields, "workspace"),
     log_path: string_field(fields, "log_path"),
-    session_root: string_field(fields, "session_root"),
     session_id: string_field(fields, "session_id"),
     events_path: string_field(fields, "events_path"),
     exit_code: int_field(fields, "exit_code"),

--- a/eval/prompt_task/manifest/manifest_wbtest.mbt
+++ b/eval/prompt_task/manifest/manifest_wbtest.mbt
@@ -16,9 +16,9 @@ async test "manifest round trips run artifacts" {
         index: 1,
         workspace: root + "/workspaces/01",
         log_path: root + "/logs/01.log",
-        session_root: root + "/session_store",
         session_id: "trial-01",
-        events_path: root + "/session_store/sessions/trial-01/events.jsonl",
+        events_path: root +
+        "/workspaces/01/.openseek/sessions/trial-01/events.jsonl",
         exit_code: 0,
       },
     ],

--- a/eval/prompt_task/manifest/manifest_wbtest.mbt
+++ b/eval/prompt_task/manifest/manifest_wbtest.mbt
@@ -1,0 +1,32 @@
+///|
+async test "manifest round trips run artifacts" {
+  @async.sleep(0)
+  let root = @fs.tmpdir(prefix="openseek-prompt-task-manifest")
+  let manifest : RunManifest = {
+    model: "deepseek-v4-flash",
+    prompt_label: "flash",
+    task_file: "eval/prompt_tasks/toml_parser_cli.md",
+    runs: 1,
+    concurrency: 1,
+    min_successes: 1,
+    max_steps: 160,
+    out_dir: root,
+    trials: [
+      {
+        index: 1,
+        workspace: root + "/workspaces/01",
+        log_path: root + "/logs/01.log",
+        session_root: root + "/session_store",
+        session_id: "trial-01",
+        events_path: root + "/session_store/sessions/trial-01/events.jsonl",
+        exit_code: 0,
+      },
+    ],
+  }
+  write_manifest(manifest)
+  let loaded = read_manifest(root)
+  assert_eq(loaded.model, "deepseek-v4-flash")
+  assert_eq(loaded.trials.length(), 1)
+  assert_eq(loaded.trials[0].session_id, "trial-01")
+  @fs.rmdir(root, recursive=true)
+}

--- a/eval/prompt_task/manifest/moon.pkg
+++ b/eval/prompt_task/manifest/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/json",
+}
+
+warnings = "+unnecessary_annotation-unused_package"
+
+supported_targets = "+native"

--- a/eval/prompt_task/manifest/pkg.generated.mbti
+++ b/eval/prompt_task/manifest/pkg.generated.mbti
@@ -1,0 +1,41 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/eval/prompt_task/manifest"
+
+// Values
+pub fn manifest_path(String) -> String
+
+pub async fn read_manifest(String) -> RunManifest
+
+pub async fn write_manifest(RunManifest) -> Unit
+
+// Errors
+
+// Types and methods
+pub struct RunManifest {
+  model : String
+  prompt_label : String
+  task_file : String
+  runs : Int
+  concurrency : Int
+  min_successes : Int
+  max_steps : Int
+  out_dir : String
+  trials : Array[TrialArtifact]
+}
+pub fn RunManifest::RunManifest(model~ : String, prompt_label~ : String, task_file~ : String, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, trials~ : Array[TrialArtifact]) -> Self
+
+pub struct TrialArtifact {
+  index : Int
+  workspace : String
+  log_path : String
+  session_root : String
+  session_id : String
+  events_path : String
+  exit_code : Int
+}
+pub fn TrialArtifact::TrialArtifact(index~ : Int, workspace~ : String, log_path~ : String, session_root~ : String, session_id~ : String, events_path~ : String, exit_code~ : Int) -> Self
+
+// Type aliases
+
+// Traits
+

--- a/eval/prompt_task/manifest/pkg.generated.mbti
+++ b/eval/prompt_task/manifest/pkg.generated.mbti
@@ -28,12 +28,11 @@ pub struct TrialArtifact {
   index : Int
   workspace : String
   log_path : String
-  session_root : String
   session_id : String
   events_path : String
   exit_code : Int
 }
-pub fn TrialArtifact::TrialArtifact(index~ : Int, workspace~ : String, log_path~ : String, session_root~ : String, session_id~ : String, events_path~ : String, exit_code~ : Int) -> Self
+pub fn TrialArtifact::TrialArtifact(index~ : Int, workspace~ : String, log_path~ : String, session_id~ : String, events_path~ : String, exit_code~ : Int) -> Self
 
 // Type aliases
 

--- a/eval/report/README.mbt.md
+++ b/eval/report/README.mbt.md
@@ -1,8 +1,8 @@
 # Eval Report
 
 `bobzhang/openseek/eval/report` provides the small report primitive shared by
-local harnesses. It renders a title, summary metrics, dynamic table columns,
-rows, and optional log links to both Markdown and JSON.
+local harnesses. It renders a title, summary metrics, dynamic overview columns,
+per-row detail metrics, and optional log links to Markdown, HTML, and JSON.
 
 It is intentionally simple: individual harnesses still own their domain result
 types, then convert to `Report` at the output boundary.
@@ -10,11 +10,12 @@ types, then convert to `Report` at the output boundary.
 ## API Shape
 
 - `Metric(name~, value~)`: a string metric used in summaries or rows.
-- `ReportRow(index~, name~, success~, reason?, warnings?, metrics?, log_path?)`:
-  one case/tool row.
+- `ReportRow(index~, name~, success~, reason?, warnings?, metrics?, details?,
+  log_path?)`: one case/tool row. `metrics` appear in the overview table;
+  `details` appear in the per-row details section.
 - `Report(title~, summary?, metric_columns?, rows?)`: the renderable report.
 - `Report::markdown()`: Markdown table plus optional log section.
-- `Report::html()`: standalone HTML table plus optional log section.
+- `Report::html()`: standalone HTML overview plus per-row detail cards.
 - `Report::to_json()`: JSON representation for automated inspection.
 - `Report::write_files(out_dir)`: writes `report.md`, `report.json`, and
   `report.html`.
@@ -31,9 +32,13 @@ test "render a tiny report" {
     summary=[Metric(name="passed", value="true")],
     metric_columns=["Mode"],
     rows=[
-      ReportRow(index=1, name="read", success=true, metrics=[
-        Metric(name="Mode", value="filesystem"),
-      ]),
+      ReportRow(
+        index=1,
+        name="read",
+        success=true,
+        metrics=[Metric(name="Mode", value="filesystem")],
+        details=[Metric(name="Log", value="logs/read.log")],
+      ),
     ],
   )
   let markdown = report.markdown()
@@ -42,5 +47,7 @@ test "render a tiny report" {
     markdown.contains("| # | Case | Result | Mode | Reason | Warnings |"),
   )
   assert_true(markdown.contains("| 1 | `read` | pass | filesystem | ok |  |"))
+  assert_true(markdown.contains("## Trial Details"))
+  assert_true(markdown.contains("- Log: `logs/read.log`"))
 }
 ```

--- a/eval/report/README.mbt.md
+++ b/eval/report/README.mbt.md
@@ -14,10 +14,12 @@ types, then convert to `Report` at the output boundary.
   one case/tool row.
 - `Report(title~, summary?, metric_columns?, rows?)`: the renderable report.
 - `Report::markdown()`: Markdown table plus optional log section.
+- `Report::html()`: standalone HTML table plus optional log section.
 - `Report::to_json()`: JSON representation for automated inspection.
-- `Report::write_files(out_dir)`: writes `report.md` and `report.json`.
-- `write_files(out_dir, markdown, json)`: shared writer for harnesses that keep
-  their own richer JSON schema but reuse the Markdown renderer.
+- `Report::write_files(out_dir)`: writes `report.md`, `report.json`, and
+  `report.html`.
+- `write_files(out_dir, markdown, json, html?)`: shared writer for harnesses
+  that keep their own richer JSON schema but reuse the renderers.
 
 ## Example
 

--- a/eval/report/pkg.generated.mbti
+++ b/eval/report/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "bobzhang/openseek/eval/report"
 // Values
 pub fn escape_table_cell(String) -> String
 
-pub async fn write_files(String, String, Json) -> Unit
+pub async fn write_files(String, String, Json, html? : String) -> Unit
 
 // Errors
 
@@ -23,6 +23,7 @@ pub struct Report {
 }
 pub fn Report::Report(title~ : String, summary? : Array[Metric], metric_columns? : Array[String], rows? : Array[ReportRow]) -> Self
 pub fn Report::all_passed(Self) -> Bool
+pub fn Report::html(Self) -> String
 pub fn Report::markdown(Self) -> String
 pub fn Report::successes(Self) -> Int
 pub fn Report::to_json(Self) -> Json

--- a/eval/report/pkg.generated.mbti
+++ b/eval/report/pkg.generated.mbti
@@ -36,9 +36,10 @@ pub struct ReportRow {
   reason : String
   warnings : String
   metrics : Array[Metric]
+  details : Array[Metric]
   log_path : String
 }
-pub fn ReportRow::ReportRow(index~ : Int, name~ : String, success~ : Bool, reason? : String, warnings? : String, metrics? : Array[Metric], log_path? : String) -> Self
+pub fn ReportRow::ReportRow(index~ : Int, name~ : String, success~ : Bool, reason? : String, warnings? : String, metrics? : Array[Metric], details? : Array[Metric], log_path? : String) -> Self
 
 // Type aliases
 

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -127,20 +127,102 @@ pub fn Report::to_json(self : Report) -> Json {
 }
 
 ///|
-/// Write both renderings of this report under `out_dir` — the standard
-/// artifact layout eval runners leave behind.
-pub async fn Report::write_files(self : Report, out_dir : String) -> Unit {
-  write_files(out_dir, self.markdown(), self.to_json())
+/// Render the report as a standalone HTML document for browser inspection.
+pub fn Report::html(self : Report) -> String {
+  let out = StringBuilder::new()
+  out.write_string("<!doctype html>\n<html><head><meta charset=\"utf-8\">")
+  out.write_string("<title>")
+  out.write_string(escape_html(self.title))
+  out.write_string("</title>")
+  out.write_string(
+    "<style>body{font-family:system-ui,sans-serif;margin:24px;color:#202124}table{border-collapse:collapse;width:100%;font-size:13px}th,td{border:1px solid #d0d7de;padding:6px 8px;text-align:left;vertical-align:top}th{background:#f6f8fa}.pass{color:#116329;font-weight:600}.fail{color:#cf222e;font-weight:600}code{background:#f6f8fa;padding:1px 4px;border-radius:4px}.summary{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0 20px}.metric{border:1px solid #d0d7de;border-radius:6px;padding:6px 8px}.metric-name{color:#57606a;font-size:12px}.logs{margin-top:24px}</style>",
+  )
+  out.write_string("</head><body>")
+  out.write_string("<h1>")
+  out.write_string(escape_html(self.title))
+  out.write_string("</h1>")
+  if self.summary.length() > 0 {
+    out.write_string("<div class=\"summary\">")
+    for metric in self.summary {
+      out.write_string("<div class=\"metric\"><div class=\"metric-name\">")
+      out.write_string(escape_html(metric.name))
+      out.write_string("</div><code>")
+      out.write_string(escape_html(metric.value))
+      out.write_string("</code></div>")
+    }
+    out.write_string("</div>")
+  }
+  out.write_string("<table><thead><tr>")
+  let columns : Array[String] = ["#", "Case", "Result"]
+  for column in self.metric_columns {
+    columns.push(column)
+  }
+  columns.push("Reason")
+  columns.push("Warnings")
+  for column in columns {
+    out.write_string("<th>")
+    out.write_string(escape_html(column))
+    out.write_string("</th>")
+  }
+  out.write_string("</tr></thead><tbody>")
+  for row in self.rows {
+    out.write_string("<tr><td>")
+    out.write_string(row.index.to_string())
+    out.write_string("</td><td><code>")
+    out.write_string(escape_html(row.name))
+    out.write_string("</code></td><td class=\"")
+    out.write_string(if row.success { "pass" } else { "fail" })
+    out.write_string("\">")
+    out.write_string(if row.success { "pass" } else { "fail" })
+    out.write_string("</td>")
+    for column in self.metric_columns {
+      out.write_string("<td>")
+      out.write_string(escape_html(row.metric_value(column)))
+      out.write_string("</td>")
+    }
+    out.write_string("<td>")
+    out.write_string(escape_html(row.reason))
+    out.write_string("</td><td>")
+    out.write_string(escape_html(row.warnings))
+    out.write_string("</td></tr>")
+  }
+  out.write_string("</tbody></table>")
+  let log_lines = log_section_lines(self.rows)
+  if log_lines.length() > 0 {
+    out.write_string("<section class=\"logs\"><h2>Logs</h2><ul>")
+    for row in self.rows {
+      if row.log_path != "" {
+        out.write_string("<li><code>")
+        out.write_string(escape_html(row.name))
+        out.write_string("</code> trial ")
+        out.write_string(row.index.to_string())
+        out.write_string(": <code>")
+        out.write_string(escape_html(row.log_path))
+        out.write_string("</code></li>")
+      }
+    }
+    out.write_string("</ul></section>")
+  }
+  out.write_string("</body></html>\n")
+  out.to_string()
 }
 
 ///|
-/// Write already-rendered report artifacts as `report.md` and `report.json`
-/// under `out_dir`, creating it as needed — for runners that build their
-/// renderings separately.
+/// Write both renderings of this report under `out_dir` — the standard
+/// artifact layout eval runners leave behind.
+pub async fn Report::write_files(self : Report, out_dir : String) -> Unit {
+  write_files(out_dir, self.markdown(), self.to_json(), html=self.html())
+}
+
+///|
+/// Write already-rendered report artifacts under `out_dir`, creating it as
+/// needed. `html` is optional for older runners that only render markdown and
+/// JSON.
 pub async fn write_files(
   out_dir : String,
   markdown : String,
   json : Json,
+  html? : String = "",
 ) -> Unit {
   let _ = @fs.mkdir(out_dir, recursive=true) catch { _ => () }
   @fs.write_file(
@@ -149,6 +231,9 @@ pub async fn write_files(
     create_mode=CreateOrTruncate,
   )
   @fs.write_file(out_dir + "/report.md", markdown, create_mode=CreateOrTruncate)
+  if html != "" {
+    @fs.write_file(out_dir + "/report.html", html, create_mode=CreateOrTruncate)
+  }
 }
 
 ///|
@@ -242,4 +327,13 @@ pub fn escape_table_cell(text : String) -> String {
   text
   |> String::replace_all(old="|", new="\\|")
   |> String::replace_all(old="\n", new=" ")
+}
+
+///|
+fn escape_html(text : String) -> String {
+  text
+  |> String::replace_all(old="&", new="&amp;")
+  |> String::replace_all(old="<", new="&lt;")
+  |> String::replace_all(old=">", new="&gt;")
+  |> String::replace_all(old="\"", new="&quot;")
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -25,6 +25,7 @@ pub struct ReportRow {
   reason : String
   warnings : String
   metrics : Array[Metric]
+  details : Array[Metric]
   log_path : String
 }
 
@@ -38,9 +39,10 @@ pub fn ReportRow::ReportRow(
   reason? : String = "ok",
   warnings? : String = "",
   metrics? : Array[Metric] = [],
+  details? : Array[Metric] = [],
   log_path? : String = "",
 ) -> ReportRow {
-  { index, name, success, reason, warnings, metrics, log_path }
+  { index, name, success, reason, warnings, metrics, details, log_path }
 }
 
 ///|
@@ -101,6 +103,15 @@ pub fn Report::markdown(self : Report) -> String {
   for row in self.rows {
     lines.push(row.markdown_row(self.metric_columns))
   }
+  let detail_lines = detail_section_lines(self.rows)
+  if detail_lines.length() > 0 {
+    lines.push("")
+    lines.push("## Trial Details")
+    lines.push("")
+    for line in detail_lines {
+      lines.push(line)
+    }
+  }
   let log_lines = log_section_lines(self.rows)
   if log_lines.length() > 0 {
     lines.push("")
@@ -131,13 +142,16 @@ pub fn Report::to_json(self : Report) -> Json {
 pub fn Report::html(self : Report) -> String {
   let out = StringBuilder::new()
   out.write_string("<!doctype html>\n<html><head><meta charset=\"utf-8\">")
+  out.write_string(
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+  )
   out.write_string("<title>")
   out.write_string(escape_html(self.title))
   out.write_string("</title>")
   out.write_string(
-    "<style>body{font-family:system-ui,sans-serif;margin:24px;color:#202124}table{border-collapse:collapse;width:100%;font-size:13px}th,td{border:1px solid #d0d7de;padding:6px 8px;text-align:left;vertical-align:top}th{background:#f6f8fa}.pass{color:#116329;font-weight:600}.fail{color:#cf222e;font-weight:600}code{background:#f6f8fa;padding:1px 4px;border-radius:4px}.summary{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0 20px}.metric{border:1px solid #d0d7de;border-radius:6px;padding:6px 8px}.metric-name{color:#57606a;font-size:12px}.logs{margin-top:24px}</style>",
+    "<style>:root{color-scheme:light;--bg:#f7f9fb;--panel:#fff;--text:#1f2328;--muted:#59636e;--line:#d0d7de;--line-soft:#eaeef2;--good:#116329;--bad:#cf222e;--accent:#0969da;--warn:#9a6700}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,\"Segoe UI\",sans-serif;font-size:14px;line-height:1.45}main{max-width:1440px;margin:0 auto;padding:28px 24px 44px}h1{margin:0 0 16px;font-size:28px;line-height:1.15}h2{margin:28px 0 12px;font-size:18px}.summary{display:flex;flex-wrap:wrap;align-items:flex-start;gap:10px;margin:12px 0 20px}.metric,.trial-card{background:var(--panel);border:1px solid var(--line);border-radius:8px}.metric{padding:9px 10px;min-width:140px;max-width:420px}.summary>.metric{flex:1 1 150px}.summary>.metric:last-child{flex-basis:320px}.metric-name{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}.metric code,.detail-list code,td code,.logs code{background:#f6f8fa;border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px;white-space:pre-wrap;overflow-wrap:anywhere}.table-wrap{overflow-x:auto;background:var(--panel);border:1px solid var(--line);border-radius:8px}table{border-collapse:separate;border-spacing:0;width:100%;font-size:13px}th,td{border-bottom:1px solid var(--line-soft);padding:8px 10px;text-align:left;vertical-align:top}th{background:#f6f8fa;color:#3f4852;font-weight:650;white-space:nowrap}tbody tr:last-child td{border-bottom:0}.pass{color:var(--good);font-weight:700}.fail{color:var(--bad);font-weight:700}.reason-cell,.warning-cell{max-width:360px;overflow-wrap:anywhere}.trial-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:12px}.trial-card{padding:14px}.trial-card header{display:flex;gap:10px;align-items:center;justify-content:space-between;margin-bottom:10px}.trial-card h3{margin:0;font-size:16px}.badge{border-radius:999px;padding:2px 9px;font-size:12px;font-weight:700}.badge.pass{background:#dafbe1}.badge.fail{background:#ffebe9}.detail-list{display:grid;grid-template-columns:minmax(120px,180px) 1fr;gap:6px 12px;margin:0}.detail-list dt{color:var(--muted);font-weight:650}.detail-list dd{margin:0;min-width:0}.detail-list dd.long{white-space:pre-wrap;overflow-wrap:anywhere}.detail-list dd.long code{display:block;max-height:180px;overflow:auto}.logs{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:12px 16px}.logs ul{margin:8px 0 0;padding-left:20px}@media(max-width:720px){main{padding:20px 14px}.summary>.metric{flex-basis:100%;max-width:none}.trial-grid{grid-template-columns:1fr}.detail-list{grid-template-columns:1fr}.detail-list dt{margin-top:6px}}</style>",
   )
-  out.write_string("</head><body>")
+  out.write_string("</head><body><main>")
   out.write_string("<h1>")
   out.write_string(escape_html(self.title))
   out.write_string("</h1>")
@@ -152,7 +166,7 @@ pub fn Report::html(self : Report) -> String {
     }
     out.write_string("</div>")
   }
-  out.write_string("<table><thead><tr>")
+  out.write_string("<div class=\"table-wrap\"><table><thead><tr>")
   let columns : Array[String] = ["#", "Case", "Result"]
   for column in self.metric_columns {
     columns.push(column)
@@ -180,13 +194,43 @@ pub fn Report::html(self : Report) -> String {
       out.write_string(escape_html(row.metric_value(column)))
       out.write_string("</td>")
     }
-    out.write_string("<td>")
-    out.write_string(escape_html(row.reason))
-    out.write_string("</td><td>")
-    out.write_string(escape_html(row.warnings))
+    out.write_string("<td class=\"reason-cell\">")
+    out.write_string(escape_html(short_cell(row.reason)))
+    out.write_string("</td><td class=\"warning-cell\">")
+    out.write_string(escape_html(short_cell(row.warnings)))
     out.write_string("</td></tr>")
   }
-  out.write_string("</tbody></table>")
+  out.write_string("</tbody></table></div>")
+  if has_detail_section(self.rows) {
+    out.write_string(
+      "<section><h2>Trial Details</h2><div class=\"trial-grid\">",
+    )
+    for row in self.rows {
+      if row.has_details() {
+        out.write_string("<article class=\"trial-card\"><header><h3><code>")
+        out.write_string(escape_html(row.name))
+        out.write_string("</code></h3><span class=\"badge ")
+        out.write_string(if row.success { "pass" } else { "fail" })
+        out.write_string("\">")
+        out.write_string(if row.success { "pass" } else { "fail" })
+        out.write_string("</span></header><dl class=\"detail-list\">")
+        write_html_detail(out, "Reason", row.reason, long=true)
+        if row.warnings != "" {
+          write_html_detail(out, "Warnings", row.warnings, long=true)
+        }
+        for detail in row.details {
+          write_html_detail(
+            out,
+            detail.name,
+            detail.value,
+            long=detail.value.length() > 80,
+          )
+        }
+        out.write_string("</dl></article>")
+      }
+    }
+    out.write_string("</div></section>")
+  }
   let log_lines = log_section_lines(self.rows)
   if log_lines.length() > 0 {
     out.write_string("<section class=\"logs\"><h2>Logs</h2><ul>")
@@ -203,7 +247,7 @@ pub fn Report::html(self : Report) -> String {
     }
     out.write_string("</ul></section>")
   }
-  out.write_string("</body></html>\n")
+  out.write_string("</main></body></html>\n")
   out.to_string()
 }
 
@@ -250,6 +294,7 @@ fn ReportRow::to_json(self : ReportRow) -> Json {
     "reason": self.reason,
     "warnings": self.warnings,
     "metrics": ([ for metric in self.metrics => metric.to_json() ] : Json),
+    "details": ([ for metric in self.details => metric.to_json() ] : Json),
     "log_path": self.log_path,
   }
 }
@@ -293,8 +338,8 @@ fn ReportRow::markdown_row(
   for column in metric_columns {
     cells.push(escape_table_cell(self.metric_value(column)))
   }
-  cells.push(escape_table_cell(self.reason))
-  cells.push(escape_table_cell(self.warnings))
+  cells.push(escape_table_cell(short_cell(self.reason)))
+  cells.push(escape_table_cell(short_cell(self.warnings)))
   "| " + cells.join(" | ") + " |"
 }
 
@@ -317,6 +362,86 @@ fn log_section_lines(rows : Array[ReportRow]) -> Array[String] {
     }
   }
   lines
+}
+
+///|
+fn detail_section_lines(rows : Array[ReportRow]) -> Array[String] {
+  let lines : Array[String] = []
+  for row in rows {
+    if row.has_details() {
+      if lines.length() > 0 {
+        lines.push("")
+      }
+      lines.push("### `\{row.name}`")
+      lines.push("")
+      lines.push("- result: `\{if row.success { "pass" } else { "fail" }}`")
+      lines.push("- reason: \{markdown_text(row.reason)}")
+      if row.warnings != "" {
+        lines.push("- warnings: \{markdown_text(row.warnings)}")
+      }
+      for detail in row.details {
+        lines.push("- \{detail.name}: `\{escape_backticks(detail.value)}`")
+      }
+    }
+  }
+  lines
+}
+
+///|
+fn has_detail_section(rows : Array[ReportRow]) -> Bool {
+  for row in rows {
+    if row.has_details() {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn ReportRow::has_details(self : ReportRow) -> Bool {
+  self.details.length() > 0 || self.reason != "ok" || self.warnings != ""
+}
+
+///|
+fn write_html_detail(
+  out : StringBuilder,
+  name : String,
+  value : String,
+  long~ : Bool,
+) -> Unit {
+  out.write_string("<dt>")
+  out.write_string(escape_html(name))
+  out.write_string("</dt><dd")
+  if long {
+    out.write_string(" class=\"long\"")
+  }
+  out.write_string("><code>")
+  out.write_string(escape_html(value))
+  out.write_string("</code></dd>")
+}
+
+///|
+fn short_cell(text : String) -> String {
+  let squashed = text
+    .replace_all(old="\r\n", new="\n")
+    .replace_all(old="\n", new=" ")
+    .trim()
+    .to_owned()
+  if squashed.length() <= 96 {
+    squashed
+  } else {
+    squashed.sub(start=0, end=96).to_owned() + "..."
+  }
+}
+
+///|
+fn markdown_text(text : String) -> String {
+  "`\{escape_backticks(short_cell(text))}`"
+}
+
+///|
+fn escape_backticks(text : String) -> String {
+  text.replace_all(old="`", new="\\`")
 }
 
 ///|

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -8,10 +8,16 @@ test "markdown renders summary metrics and dynamic columns" {
     ],
     metric_columns=["Mode", "Steps"],
     rows=[
-      ReportRow(index=1, name="read", success=true, metrics=[
-        Metric(name="Mode", value="filesystem"),
-        Metric(name="Steps", value="1"),
-      ]),
+      ReportRow(
+        index=1,
+        name="read",
+        success=true,
+        metrics=[
+          Metric(name="Mode", value="filesystem"),
+          Metric(name="Steps", value="1"),
+        ],
+        details=[Metric(name="Log", value="logs/read.log")],
+      ),
       ReportRow(
         index=2,
         name="shell",
@@ -28,6 +34,8 @@ test "markdown renders summary metrics and dynamic columns" {
   assert_true(
     text.contains("| # | Case | Result | Mode | Steps | Reason | Warnings |"),
   )
+  assert_true(text.contains("## Trial Details"))
+  assert_true(text.contains("- Log: `logs/read.log`"))
   assert_true(text.contains("contains \\| pipe and newline"))
   assert_eq(report.successes(), 1)
   assert_false(report.all_passed())
@@ -46,5 +54,6 @@ async test "report writes markdown json and html files" {
   assert_true(markdown.contains("# Tiny Report"))
   assert_true(json.contains("\"title\":\"Tiny Report\""))
   assert_true(html.contains("<title>Tiny Report</title>"))
+  assert_true(html.contains("table-wrap"))
   @fs.rmdir(root, recursive=true)
 }

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -34,7 +34,7 @@ test "markdown renders summary metrics and dynamic columns" {
 }
 
 ///|
-async test "report writes markdown and json files" {
+async test "report writes markdown json and html files" {
   let root = @fs.tmpdir(prefix="openseek-eval-report")
   let report = @report.Report(title="Tiny Report", rows=[
     ReportRow(index=1, name="finish", success=true),
@@ -42,7 +42,9 @@ async test "report writes markdown and json files" {
   report.write_files(root)
   let markdown = @fs.read_file(root + "/report.md").text()
   let json = @fs.read_file(root + "/report.json").text()
+  let html = @fs.read_file(root + "/report.html").text()
   assert_true(markdown.contains("# Tiny Report"))
   assert_true(json.contains("\"title\":\"Tiny Report\""))
+  assert_true(html.contains("<title>Tiny Report</title>"))
   @fs.rmdir(root, recursive=true)
 }

--- a/improvement.md
+++ b/improvement.md
@@ -210,6 +210,12 @@ shows where steps and tokens went to waste):
 - [ ] **Run `moon fmt --check` before push.** Two consecutive PRs hit
   CI-only formatting failures; a pre-push hook or documented `moon` alias
   would catch them locally.
+- [ ] **CI does not exercise the JS packages.** `ci.yml` runs `moon check` /
+  `moon test` on the default (native) target only, so the visualizer's
+  js-only packages (`viz`, `cmd/viz_app`) are silently skipped — they
+  compile and pass locally but a regression there would not fail CI today.
+  Add a `--target js` check/test step (or a target matrix). Their logic is
+  currently covered only by local unit tests + a headless-browser run.
 
 ## Docs / prompts
 
@@ -223,3 +229,74 @@ shows where steps and tokens went to waste):
   gains a Terminal UI section covering default sessions, `--continue`,
   `--session`, and the enriched `--session-list`, plus a `cmd/tui` row in
   the packages table.)*
+
+## Visualizer (viz)
+
+Follow-ups for the `events.jsonl` web viewer (`viz`, `cmd/viz_server`,
+`cmd/viz_app`, `web/`).
+
+- [ ] **Smarter `--session-root` default discovery.** The default is the
+  relative `.openseek`, resolved against the server's cwd; `moon run
+  cmd/viz_server` uses the module root as cwd (no `.openseek` there), so the
+  no-arg case shows nothing. Walk up from cwd to the nearest `.openseek`
+  (like git finds `.git`) so the default "just works" from a subdirectory.
+- [ ] **Optional self-contained binary for distribution.** Today the server
+  serves `web/index.html` from disk and auto-locates the built `viz_app.js`
+  from `_build/`. If we ever want to *ship* the viewer as one binary, embed
+  both via the `md_to_mbt_string`-style `rule` and accept the js→embed→native
+  build order. Not worth it for a local dev tool; embedding only the HTML is
+  a half-measure (the binary still needs the JS), so it is all-or-nothing.
+- [ ] **UI polish.** Sidebar: show the last-active timestamp (the server
+  already returns it; the frontend ignores it). Turn headers: show a per-turn
+  summary (tool count, terminal status) on the collapsed `<details>` line.
+  Tool cards: collapse long output by default with an expand toggle.
+  Navigation: jump-to-errors, text search/filter, expand/collapse all.
+- [ ] **Persist the theme choice.** The Light/Dark/System toggle resets to
+  Light on reload; persist it (localStorage) so the choice sticks.
+
+## MoonBit toolchain & DX
+
+Observations from building the visualizer (native server + JS frontend in
+one module). These are toolchain/language ergonomics — several are likely
+upstream `moon`/MoonBit items rather than openseek changes — but they cost
+real time and are worth tracking.
+
+- [ ] **`moon info` does not generate `.mbti` for js-only packages.** In a
+  module whose canonical backend is native, `moon info` writes no
+  `pkg.generated.mbti` for `supported_targets = "js"` packages — it only
+  prints a perpetual "requested interfaces different from canonical backend
+  Native" diff. I had to hand-copy the generated interface out of `_build/`.
+  A per-package canonical backend (or `moon info --target js` writing the
+  files) would fix it.
+- [ ] **No cross-target build dependency.** `moon build` is per-target, so
+  there is no way to express "build the JS bundle, then embed it into the
+  native binary" in one invocation — it forces a manual two-step. This is
+  the root reason the viz bundle is served from disk rather than embedded.
+- [ ] **Library aborts are invisible and uncontainable.** A second
+  `send_response` on a connection hit a `guard … else`-less panic (abort) in
+  `@async/http` that tore down `run_forever`; neither `catch` (handles
+  `Error`, not panics) nor `allow_failure` contained it. Checked errors are
+  tracked in signatures, but panics/aborts are not — so you cannot tell which
+  library calls can kill the process. Surfacing "can abort", or a task
+  boundary that contains aborts, would make robust server code tractable.
+  *(Worked around in viz by computing each reply before a single send.)*
+- [ ] **Default trait methods are not callable through a trait object.**
+  `@fs.read_file` returns `&@io.Data`; the *required* `binary()`/`text()`
+  dispatch fine, but the *default* `to_bytes()`/`to_bytesview()` fail with
+  `[4039] Cannot use method … of abstract trait`. The required-vs-default
+  rule through `&Trait` is non-obvious and cost compile cycles.
+- [ ] **A `moon fix` autofixer for deprecations.** A lot of small edit cycles
+  came from deprecation warnings with mechanical rewrites: `not(x)`→`!x`,
+  `StringView::to_string`→`to_owned`, `String::substring`→view slicing,
+  `@strconv.parse_int`→`@string.parse_int`, `derive(Show)`→`derive(Debug)`,
+  plus `+unnecessary_annotation` cascading. An autofix (à la `moon fmt`)
+  would erase most of these.
+- [ ] **Lint a `..` cascade that discards a non-unit return.** `session..append(x)`
+  on an immutable builder (where `append` returns a *new* `Session`) compiles
+  and silently no-ops — it caused a real test bug. Warn when `..` drops a
+  non-`Unit` result.
+- [ ] **Surface dependency examples/APIs in `moon ide doc`.** Learning
+  third-party APIs (rabbita's callable `Emit`, `@async/http.Server::Server`,
+  `@utf8.decode_lossy`, `&Data::binary`) meant grepping `.mooncakes`/`.repos`.
+  Examples like `http_file_server` were invaluable once found; surfacing dep
+  docs/examples through `moon ide doc` would shortcut discovery.

--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/openseek"
 
-version = "0.1.5"
+version = "0.2.0"
 
 import {
   "moonbit-community/tty@0.2.4",

--- a/viz/parse.mbt
+++ b/viz/parse.mbt
@@ -1,60 +1,8 @@
 ///|
-/// One JSONL line that could not be decoded into a `SessionEvent`. Kept so the
-/// viewer can surface the offending line instead of silently dropping it or
-/// aborting the whole load.
-pub(all) struct LineError {
-  line_number : Int
-  content : String
-  message : String
-} derive(Debug)
-
-///|
-/// The result of parsing an `events.jsonl` log line by line. `events` are the
-/// records that decoded cleanly (in file order); `errors` are individual lines
-/// that failed to decode; `partial_tail` is true when the final line looked
-/// like a half-written record from a process that exited mid-append (no
-/// trailing newline and the last segment failed to decode), which the viewer
-/// reports as a benign truncation rather than corruption.
-pub(all) struct ParsedLog {
-  events : Array[@agent_session.SessionEvent]
-  errors : Array[LineError]
-  partial_tail : Bool
-} derive(Debug)
-
-///|
 /// Parse an `events.jsonl` log into typed `SessionEvent`s, tolerating a
-/// truncated trailing line and per-line decode failures. Blank lines are
-/// ignored. A decode failure on any line other than an unterminated final line
-/// is recorded as a `LineError` and parsing continues, so one bad record never
-/// hides the rest of the conversation.
-pub fn parse_events(text : String) -> ParsedLog {
-  let events : Array[@agent_session.SessionEvent] = []
-  let errors : Array[LineError] = []
-  let ends_with_newline = text.has_suffix("\n")
-  let lines = text.split("\n").map(line => line.to_owned()).collect()
-  let mut partial_tail = false
-  for index, line in lines {
-    let line_number = index + 1
-    if line.trim().is_empty() {
-      continue
-    }
-    let is_last_segment = index == lines.length() - 1
-    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
-      error => {
-        // A failed final line with no terminating newline is the classic
-        // signature of a crash between `write(line)` and `write("\n")`; treat
-        // it as a truncated tail, not a corrupt record.
-        if is_last_segment && !ends_with_newline {
-          partial_tail = true
-        } else {
-          errors.push({ line_number, content: line, message: "\{error}" })
-        }
-        continue
-      }
-    }
-    events.push(event)
-  }
-  { events, errors, partial_tail }
+/// truncated trailing line and per-line decode failures.
+pub fn parse_events(text : String) -> @session_log.ParsedLog {
+  @session_log.parse_events(text)
 }
 
 ///|
@@ -63,10 +11,9 @@ pub fn parse_events(text : String) -> ParsedLog {
 /// system prompt are used so the viewer can still render the event log. The
 /// header's id and system prompt win when present.
 pub fn session_from_parse(
-  parsed : ParsedLog,
+  parsed : @session_log.ParsedLog,
   id~ : String,
   system_prompt~ : String,
 ) -> @agent_session.Session {
-  let session_id : @agent_session.SessionId = SessionId(id)
-  Session(session_id, system_prompt~, events=@vector.from_array(parsed.events))
+  @session_log.session_from_parse(parsed, id~, system_prompt~)
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -24,7 +24,7 @@ pub fn render_session(
 /// Banners for anything the parser flagged: decode failures on individual lines
 /// and a truncated final record. Returns `@html.nothing` for a clean log so the
 /// caller can stack it unconditionally.
-pub fn render_notices(parsed : ParsedLog) -> @html.Html {
+pub fn render_notices(parsed : @session_log.ParsedLog) -> @html.Html {
   let notices : Array[@html.Html] = []
   if parsed.partial_tail {
     notices.push(


### PR DESCRIPTION
## Summary

- Split prompt-task evaluation into a runner phase that writes durable artifacts and an analyzer phase that can be rerun independently.
- Reuse the shared `events.jsonl` parser/session loading path for analyzer input.
- Add manifest/analyzer packages and report rendering to Markdown, JSON, and standalone HTML.
- Improve report output with compact overview tables, per-trial details, terminal status, validation probes, and scrollable long diagnostics.
- Fix concurrent session-store creation discovered by running concurrent DeepSeek experiments.

## Validation

- `moon test eval/report eval/prompt_task/analyzer --target native`
- `moon test agent_session/store --target native`
- `moon check --target all`
- Ran DeepSeek smoke experiments:
  - 2 concurrent trials: `1/2` success, analyzer rerendered previous artifacts.
  - 5 concurrent trials: `3/5` successes, analyzer report generated Markdown/JSON/HTML and HTML screenshot inspected.

## Notes

The local branch had diverged from `origin/viz/events-jsonl-viewer`, so this was pushed to a new review branch: `codex/prompt-task-analyzer-report`.