### PR TITLE
refactor(agent_session): more aggressive pattern matching and functional combinators

### DIFF
--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -23,10 +23,12 @@ fn string_field(
   path : @json.JsonPath,
   key : String,
 ) -> String raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(String(value)) => value
-    Some(_) => json_decode_error(path.add_key(key), "expected string")
-    None => json_decode_error(path.add_key(key), "expected string")
+  guard fields.get(key) is Some(json) else {
+    json_decode_error(path.add_key(key), "expected string")
+  }
+  match json {
+    String(value) => value
+    _ => json_decode_error(path.add_key(key), "expected string")
   }
 }
 
@@ -36,10 +38,12 @@ fn int_field(
   path : @json.JsonPath,
   key : String,
 ) -> Int raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(Number(value, ..)) => value.to_int()
-    Some(_) => json_decode_error(path.add_key(key), "expected int")
-    None => json_decode_error(path.add_key(key), "expected int")
+  guard fields.get(key) is Some(json) else {
+    json_decode_error(path.add_key(key), "expected int")
+  }
+  match json {
+    Number(value, ..) => value.to_int()
+    _ => json_decode_error(path.add_key(key), "expected int")
   }
 }
 
@@ -202,28 +206,24 @@ pub impl FromJson for Session with fn from_json(
   path : @json.JsonPath,
 ) -> Session {
   let fields = expect_object(json, path)
-  match int_field(fields, path, "version") {
-    1 => ()
-    other =>
-      json_decode_error(
-        path.add_key("version"),
-        "unsupported session version: \{other}",
-      )
+  let version = int_field(fields, path, "version")
+  guard version is 1 else {
+    json_decode_error(
+      path.add_key("version"),
+      "unsupported session version: \{version}",
+    )
   }
   let id : SessionId = match fields.get("id") {
     Some(id) => @json.from_json(id, path=path.add_key("id"))
     None => json_decode_error(path.add_key("id"), "expected id")
   }
   let events = match fields.get("events") {
-    Some(Array(values)) => {
-      let decoded : Array[SessionEvent] = []
-      for index, value in values {
-        decoded.push(
-          @json.from_json(value, path=path.add_key("events").add_index(index)),
-        )
-      }
-      @vector.from_array(decoded)
-    }
+    Some(Array(values)) =>
+      @vector.from_array(
+        values.mapi((index, value) => {
+          @json.from_json(value, path=path.add_key("events").add_index(index))
+        }),
+      )
     Some(_) =>
       json_decode_error(path.add_key("events"), "expected events array")
     None => @vector.new()

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -60,13 +60,13 @@ fn remove_pending_tool_call(
   pending : Array[@deepseek.ToolCall],
   tool_call_id : String,
 ) -> Bool {
-  for index in 0..<pending.length() {
-    if pending[index].id == tool_call_id {
+  match pending.search_by(fn(call) { call.id == tool_call_id }) {
+    Some(index) => {
       ignore(pending.remove(index))
-      return true
+      true
     }
+    None => false
   }
-  false
 }
 
 ///|
@@ -140,9 +140,7 @@ pub fn Session::chat_messages(self : Session) -> Array[@deepseek.ChatMessage] {
       Assistant(message) => {
         flush_pending_tool_calls(pending_tool_calls, messages)
         append_item_message(Assistant(message), messages)
-        for call in message.tool_calls() {
-          pending_tool_calls.push(call)
-        }
+        pending_tool_calls.append(message.tool_calls())
       }
       Tool(result) =>
         if remove_pending_tool_call(pending_tool_calls, result.tool_call_id()) {

--- a/agent_session/session_wbtest.mbt
+++ b/agent_session/session_wbtest.mbt
@@ -1,0 +1,11 @@
+///|
+test "session constructor recovers highest sequence from unordered events" {
+  let events = @vector.from_array([
+    SessionEvent(sequence=3, item=User(UserMessage("third"))),
+    SessionEvent(sequence=1, item=User(UserMessage("first"))),
+    SessionEvent(sequence=2, item=User(UserMessage("second"))),
+  ])
+  let session = Session(SessionId("unordered"), system_prompt="system", events~)
+  assert_eq(session.last_sequence(), 3)
+  assert_eq(session.next_sequence(), 4)
+}

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -65,8 +65,9 @@ fn validate_session_id(id : @agent_session.SessionId) -> Unit raise {
   if value.contains("/") || value.contains("\\") {
     fail("session id must not contain path separators: \{value}")
   }
-  if value == "." || value == ".." {
-    fail("session id must not be `.` or `..`")
+  match value {
+    "." | ".." => fail("session id must not be `.` or `..`")
+    _ => ()
   }
 }
 
@@ -144,10 +145,12 @@ fn header_string_field(
   path : @json.JsonPath,
   key : String,
 ) -> String raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(String(value)) => value
-    Some(_) => json_decode_error(path.add_key(key), "expected string")
-    None => json_decode_error(path.add_key(key), "expected string")
+  guard fields.get(key) is Some(json) else {
+    json_decode_error(path.add_key(key), "expected string")
+  }
+  match json {
+    String(value) => value
+    _ => json_decode_error(path.add_key(key), "expected string")
   }
 }
 
@@ -157,10 +160,12 @@ fn header_int_field(
   path : @json.JsonPath,
   key : String,
 ) -> Int raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(Number(value, ..)) => value.to_int()
-    Some(_) => json_decode_error(path.add_key(key), "expected int")
-    None => json_decode_error(path.add_key(key), "expected int")
+  guard fields.get(key) is Some(json) else {
+    json_decode_error(path.add_key(key), "expected int")
+  }
+  match json {
+    Number(value, ..) => value.to_int()
+    _ => json_decode_error(path.add_key(key), "expected int")
   }
 }
 
@@ -170,10 +175,10 @@ fn header_optional_int_field(
   path : @json.JsonPath,
   key : String,
 ) -> Int? raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(Number(value, ..)) => Some(value.to_int())
-    Some(_) => json_decode_error(path.add_key(key), "expected int")
-    None => None
+  guard fields.get(key) is Some(json) else { return None }
+  match json {
+    Number(value, ..) => Some(value.to_int())
+    _ => json_decode_error(path.add_key(key), "expected int")
   }
 }
 
@@ -183,11 +188,11 @@ fn header_optional_bool_field(
   path : @json.JsonPath,
   key : String,
 ) -> Bool? raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(True) => Some(true)
-    Some(False) => Some(false)
-    Some(_) => json_decode_error(path.add_key(key), "expected bool")
-    None => None
+  guard fields.get(key) is Some(json) else { return None }
+  match json {
+    True => Some(true)
+    False => Some(false)
+    _ => json_decode_error(path.add_key(key), "expected bool")
   }
 }
 
@@ -200,13 +205,12 @@ fn decode_session_header(
     Object(fields) => fields
     _ => json_decode_error(path, "expected session header object")
   }
-  match header_int_field(fields, path, "version") {
-    1 => ()
-    other =>
-      json_decode_error(
-        path.add_key("version"),
-        "unsupported session header version: \{other}",
-      )
+  let version = header_int_field(fields, path, "version")
+  guard version is 1 else {
+    json_decode_error(
+      path.add_key("version"),
+      "unsupported session header version: \{version}",
+    )
   }
   let id : @agent_session.SessionId = match fields.get("id") {
     Some(id) => @json.from_json(id, path=path.add_key("id"))
@@ -262,16 +266,15 @@ fn parse_events_jsonl(
 fn checked_last_sequence_in_events(
   events : @vector.Vector[@agent_session.SessionEvent],
 ) -> Int raise {
-  let mut expected = 1
-  for event in events {
+  events.fold(init=1, (expected, event) => {
     if event.sequence() != expected {
       fail(
         "session event log sequence mismatch: expected \{expected}, found \{event.sequence()}",
       )
     }
-    expected += 1
-  }
-  expected - 1
+    expected + 1
+  }) -
+  1
 }
 
 ///|

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -56,20 +56,17 @@ pub fn SessionId::generated(
   salt? : String = "",
 ) -> SessionId {
   fn pad2(value : Int) -> String {
-    if value < 10 {
-      "0\{value}"
-    } else {
-      "\{value}"
+    match value {
+      0..=9 => "0\{value}"
+      _ => "\{value}"
     }
   }
 
   fn pad3(value : Int) -> String {
-    if value < 10 {
-      "00\{value}"
-    } else if value < 100 {
-      "0\{value}"
-    } else {
-      "\{value}"
+    match value {
+      0..=9 => "00\{value}"
+      10..=99 => "0\{value}"
+      _ => "\{value}"
     }
   }
 
@@ -153,9 +150,7 @@ pub fn AssistantMessage::AssistantMessage(
 ) -> AssistantMessage {
   {
     content,
-    tool_calls: [
-      for call in tool_calls => SessionToolCall::from_deepseek(call)
-    ],
+    tool_calls: tool_calls.map(SessionToolCall::from_deepseek),
     reasoning_content,
   }
 }
@@ -178,9 +173,7 @@ pub fn AssistantMessage::content(self : AssistantMessage) -> String {
 pub fn AssistantMessage::tool_calls(
   self : AssistantMessage,
 ) -> Array[@deepseek.ToolCall] {
-  [
-    for call in self.tool_calls => call.to_deepseek()
-  ]
+  self.tool_calls.map(fn(call) { call.to_deepseek() })
 }
 
 ///|
@@ -428,12 +421,13 @@ pub fn Session::Session(
   system_prompt~ : String,
   events? : @vector.Vector[SessionEvent] = @vector.new(),
 ) -> Session {
-  let mut last_sequence = 0
-  for event in events {
-    if event.sequence > last_sequence {
-      last_sequence = event.sequence
+  let last_sequence = events.fold(init=0, fn(max, event) {
+    if event.sequence > max {
+      event.sequence
+    } else {
+      max
     }
-  }
+  })
   { id, system_prompt, events, last_sequence }
 }
 


### PR DESCRIPTION
This PR applies local refactoring in `agent_session` to make the code more declarative and pattern-matching oriented, following the MoonBit refactoring guidelines.

## Changes

- `agent_session/types.mbt`
  - Replaced the mutable loop in `Session::Session` with `Vector::fold`.
  - Used Int range patterns in `SessionId::generated` padding helpers.
  - Replaced array comprehensions with `Array::map` in `AssistantMessage`.

- `agent_session/projection.mbt`
  - Used `Array::search_by` + pattern match in `remove_pending_tool_call`.
  - Replaced a manual push loop with `Array::append` in `Session::chat_messages`.

- `agent_session/json.mbt`
  - Switched JSON field decoders to `guard ... is Some(json)` + inner `match`.
  - Used `guard version is 1` for the version check.
  - Replaced the mutable decode loop with `Array::mapi`.

- `agent_session/store/store.mbt`
  - Same guard+match style for header field decoders.
  - Replaced mutable sequence check with `Vector::fold`.
  - Used pattern match for `"." | ".."` session id validation.

- Added `agent_session/session_wbtest.mbt` to cover out-of-order event sequence recovery.

## Verification

- `moon check` passes.
- `moon test` passes: **536 tests** (was 535).
- `moon info` produced no `.mbti` changes; public API is unchanged.
- `moon fmt` applied.

No behavioral changes are intended; this is a pure refactoring.