### PR TITLE
Fix concurrent session store creation

### DIFF
--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -451,10 +451,17 @@ async fn write_text_atomic(path : String, text : String) -> Unit {
 
 ///|
 async fn ensure_dir_exists(dir : String) -> Unit {
+  ensure_dir_exists_with_retry(dir, attempts=4)
+}
+
+///|
+async fn ensure_dir_exists_with_retry(dir : String, attempts~ : Int) -> Unit {
   if @fs.exists(dir) {
     return
   }
   @fs.mkdir(dir, recursive=true) catch {
+    @os_error.OSError(_) as error if error.is_EEXIST() && attempts > 0 =>
+      ensure_dir_exists_with_retry(dir, attempts=attempts - 1)
     error => if @fs.exists(dir) { () } else { raise error }
   }
 }
@@ -464,7 +471,6 @@ async fn ensure_session_dir(
   store : SessionStore,
   id : @agent_session.SessionId,
 ) -> Unit {
-  ensure_dir_exists(store.sessions_dir())
   let dir = store.session_dir(id)
   ensure_dir_exists(dir)
 }

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -450,17 +450,23 @@ async fn write_text_atomic(path : String, text : String) -> Unit {
 }
 
 ///|
-async fn ensure_session_dir(
-  store : SessionStore,
-  id : @agent_session.SessionId,
-) -> Unit {
-  let dir = store.session_dir(id)
+async fn ensure_dir_exists(dir : String) -> Unit {
   if @fs.exists(dir) {
     return
   }
   @fs.mkdir(dir, recursive=true) catch {
     error => if @fs.exists(dir) { () } else { raise error }
   }
+}
+
+///|
+async fn ensure_session_dir(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+) -> Unit {
+  ensure_dir_exists(store.sessions_dir())
+  let dir = store.session_dir(id)
+  ensure_dir_exists(dir)
 }
 
 ///|

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -48,6 +48,23 @@ async test "store creates and loads a session from header and event log" {
 }
 
 ///|
+async test "store creates different sessions concurrently under one root" {
+  let store = new_store()
+  ignore(
+    @async.all(
+      [
+        for id in ["a", "b", "c", "d"] => {
+          () => store.create(Session(SessionId(id), system_prompt="system"))
+        }
+      ],
+    ),
+  )
+  let ids = [ for id in store.list() => id.value() ]
+  json_inspect(ids, content=["a", "b", "c", "d"])
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
 async test "store lists known sessions" {
   let store = new_store()
   assert_eq(store.list().length(), 0)

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -65,6 +65,41 @@ async test "store creates different sessions concurrently under one root" {
 }
 
 ///|
+async test "store creates different sessions concurrently under a missing root" {
+  let parent = @fs.tmpdir(prefix="openseek-session-store-race-")
+  let store : @store.SessionStore = SessionStore("\{parent}/missing-root")
+  ignore(
+    @async.all(
+      [
+        for id in ["a", "b", "c", "d", "e", "f", "g", "h"] => {
+          () => store.create(Session(SessionId(id), system_prompt="system"))
+        }
+      ],
+    ),
+  )
+  let ids = [ for id in store.list() => id.value() ]
+  json_inspect(ids, content=["a", "b", "c", "d", "e", "f", "g", "h"])
+  @fs.rmdir(parent, recursive=true)
+}
+
+///|
+async test "store validates invalid ids before creating directories" {
+  let parent = @fs.tmpdir(prefix="openseek-session-store-invalid-")
+  let root = "\{parent}/missing-root"
+  let store : @store.SessionStore = SessionStore(root)
+  let _ = store.create(Session(SessionId("../bad"), system_prompt="system")) catch {
+    error => {
+      assert_true("\{error}".contains("path separators"))
+      assert_true(!@fs.exists("\{root}/sessions"))
+      @fs.rmdir(parent, recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(parent, recursive=true)
+  fail("invalid session id accepted")
+}
+
+///|
 async test "store lists known sessions" {
   let store = new_store()
   assert_eq(store.list().length(), 0)


### PR DESCRIPTION
## Summary
- Make session-store creation safe under concurrent writers.
- Add regression coverage for concurrent session creation.

## Validation
- `moon check --target all`
- `moon test agent_session/store --target native`

This PR is independent and can be reviewed or merged separately.