### PR TITLE
Add reusable session log parser for viz

### DIFF
--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -1,0 +1,65 @@
+///|
+/// One JSONL line that could not be decoded into a `SessionEvent`. Kept so
+/// downstream tools can surface the offending line instead of silently
+/// dropping it or aborting the whole load.
+pub(all) struct LineError {
+  line_number : Int
+  content : String
+  message : String
+} derive(Debug)
+
+///|
+/// The result of parsing an `events.jsonl` log line by line. `events` are the
+/// records that decoded cleanly (in file order); `errors` are individual lines
+/// that failed to decode; `partial_tail` is true when the final line looked
+/// like a half-written record from a process that exited mid-append.
+pub(all) struct ParsedLog {
+  events : Array[@agent_session.SessionEvent]
+  errors : Array[LineError]
+  partial_tail : Bool
+} derive(Debug)
+
+///|
+/// Parse an `events.jsonl` log into typed `SessionEvent`s, tolerating a
+/// truncated trailing line and per-line decode failures. Blank lines are
+/// ignored. A decode failure on any line other than an unterminated final line
+/// is recorded as a `LineError` and parsing continues.
+pub fn parse_events(text : String) -> ParsedLog {
+  let events : Array[@agent_session.SessionEvent] = []
+  let errors : Array[LineError] = []
+  let ends_with_newline = text.has_suffix("\n")
+  let lines = text.split("\n").map(line => line.to_owned()).collect()
+  let mut partial_tail = false
+  for index, line in lines {
+    let line_number = index + 1
+    if line.trim().is_empty() {
+      continue
+    }
+    let is_last_segment = index == lines.length() - 1
+    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
+      error => {
+        if is_last_segment && !ends_with_newline {
+          partial_tail = true
+        } else {
+          errors.push({ line_number, content: line, message: "\{error}" })
+        }
+        continue
+      }
+    }
+    events.push(event)
+  }
+  { events, errors, partial_tail }
+}
+
+///|
+/// Build an immutable `Session` from parsed events plus the header values the
+/// caller wants to use. When no `session.json` header is available, pass a
+/// placeholder id and an empty system prompt.
+pub fn session_from_parse(
+  parsed : ParsedLog,
+  id~ : String,
+  system_prompt~ : String,
+) -> @agent_session.Session {
+  let session_id : @agent_session.SessionId = SessionId(id)
+  Session(session_id, system_prompt~, events=@vector.from_array(parsed.events))
+}

--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -1,0 +1,79 @@
+///|
+fn sample_session() -> @agent_session.Session {
+  let s0 = @agent_session.Session(
+    SessionId("demo"),
+    system_prompt="You are a helpful agent.",
+  )
+  let s1 = s0.append(User(UserMessage("list the files")))
+  let s2 = s1.append(
+    Assistant(
+      AssistantMessage(
+        "I'll run ls.",
+        tool_calls=[
+          ToolCall(id="call_1", name="shell", arguments="{\"cmd\":\"ls\"}"),
+        ],
+        reasoning_content="The user wants a directory listing.",
+      ),
+    ),
+  )
+  let s3 = s2.append(
+    Tool(
+      ToolResult(
+        tool_call_id="call_1",
+        tool_name="shell",
+        content="README.md\nsrc",
+      ),
+    ),
+  )
+  let s4 = s3.append(Runtime(RuntimeNotice("moon check: 0 errors")))
+  s4.append(Terminal(Finished("Here are your files: README.md, src.")))
+}
+
+///|
+fn events_jsonl(session : @agent_session.Session) -> String {
+  let out = StringBuilder::new()
+  for event in session.events() {
+    out.write_string(event.to_json().stringify())
+    out.write_char('\n')
+  }
+  out.to_string()
+}
+
+///|
+test "parse round-trips every event kind" {
+  let parsed = @log.parse_events(events_jsonl(sample_session()))
+  inspect(parsed.events.length(), content="5")
+  inspect(parsed.errors.length(), content="0")
+  inspect(parsed.partial_tail, content="false")
+}
+
+///|
+test "parse tolerates a truncated final line" {
+  let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi"
+  let parsed = @log.parse_events(text)
+  inspect(parsed.events.length(), content="1")
+  inspect(parsed.errors.length(), content="0")
+  inspect(parsed.partial_tail, content="true")
+}
+
+///|
+test "parse records a bad interior line without aborting" {
+  let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\nnot json at all\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n"
+  let parsed = @log.parse_events(text)
+  inspect(parsed.events.length(), content="2")
+  inspect(parsed.errors.length(), content="1")
+  inspect(parsed.errors[0].line_number, content="2")
+  inspect(parsed.partial_tail, content="false")
+}
+
+///|
+test "session from parse uses supplied header values" {
+  let session = @log.session_from_parse(
+    @log.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="system",
+  )
+  assert_eq(session.id().value(), "demo")
+  assert_eq(session.system_prompt(), "system")
+  assert_eq(session.events().length(), 5)
+}

--- a/agent_session/log/moon.pkg
+++ b/agent_session/log/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "bobzhang/openseek/agent_session",
+  "moonbitlang/core/immut/vector",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/deepseek",
+} for "test"
+
+warnings = "+unnecessary_annotation"

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -1,0 +1,32 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_session/log"
+
+import {
+  "bobzhang/openseek/agent_session",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn parse_events(String) -> ParsedLog
+
+pub fn session_from_parse(ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
+
+// Errors
+
+// Types and methods
+pub(all) struct LineError {
+  line_number : Int
+  content : String
+  message : String
+} derive(@debug.Debug)
+
+pub(all) struct ParsedLog {
+  events : Array[@agent_session.SessionEvent]
+  errors : Array[LineError]
+  partial_tail : Bool
+} derive(@debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -17,7 +17,7 @@ struct SessionRow {
 struct Model {
   sessions : Array[SessionRow]
   selected : String?
-  parsed : @viz.ParsedLog?
+  parsed : @session_log.ParsedLog?
   system_prompt : String
   header_present : Bool
   view_mode : @viz.ViewMode
@@ -67,7 +67,7 @@ enum Msg {
 /// any completed response as `Ok`, so absence and malformed payloads are
 /// distinguished here from the body, not the HTTP status.
 enum LoadOutcome {
-  Loaded(@viz.ParsedLog, String, Bool)
+  Loaded(@session_log.ParsedLog, String, Bool)
   NotFound
   Malformed
 }
@@ -247,7 +247,7 @@ fn session_row(model : Model, key : String) -> SessionRow? {
 }
 
 ///|
-fn events_status(parsed : @viz.ParsedLog) -> String {
+fn events_status(parsed : @session_log.ParsedLog) -> String {
   let base = "\{parsed.events.length()} event(s)"
   if parsed.errors.is_empty() && !parsed.partial_tail {
     base

--- a/cmd/viz_app/moon.pkg
+++ b/cmd/viz_app/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/viz",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/html",

--- a/viz/moon.pkg
+++ b/viz/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/deepseek",
   "moonbit-community/rabbita/html",
   "moonbitlang/core/immut/vector",

--- a/viz/parse.mbt
+++ b/viz/parse.mbt
@@ -1,60 +1,8 @@
 ///|
-/// One JSONL line that could not be decoded into a `SessionEvent`. Kept so the
-/// viewer can surface the offending line instead of silently dropping it or
-/// aborting the whole load.
-pub(all) struct LineError {
-  line_number : Int
-  content : String
-  message : String
-} derive(Debug)
-
-///|
-/// The result of parsing an `events.jsonl` log line by line. `events` are the
-/// records that decoded cleanly (in file order); `errors` are individual lines
-/// that failed to decode; `partial_tail` is true when the final line looked
-/// like a half-written record from a process that exited mid-append (no
-/// trailing newline and the last segment failed to decode), which the viewer
-/// reports as a benign truncation rather than corruption.
-pub(all) struct ParsedLog {
-  events : Array[@agent_session.SessionEvent]
-  errors : Array[LineError]
-  partial_tail : Bool
-} derive(Debug)
-
-///|
 /// Parse an `events.jsonl` log into typed `SessionEvent`s, tolerating a
-/// truncated trailing line and per-line decode failures. Blank lines are
-/// ignored. A decode failure on any line other than an unterminated final line
-/// is recorded as a `LineError` and parsing continues, so one bad record never
-/// hides the rest of the conversation.
-pub fn parse_events(text : String) -> ParsedLog {
-  let events : Array[@agent_session.SessionEvent] = []
-  let errors : Array[LineError] = []
-  let ends_with_newline = text.has_suffix("\n")
-  let lines = text.split("\n").map(line => line.to_owned()).collect()
-  let mut partial_tail = false
-  for index, line in lines {
-    let line_number = index + 1
-    if line.trim().is_empty() {
-      continue
-    }
-    let is_last_segment = index == lines.length() - 1
-    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
-      error => {
-        // A failed final line with no terminating newline is the classic
-        // signature of a crash between `write(line)` and `write("\n")`; treat
-        // it as a truncated tail, not a corrupt record.
-        if is_last_segment && !ends_with_newline {
-          partial_tail = true
-        } else {
-          errors.push({ line_number, content: line, message: "\{error}" })
-        }
-        continue
-      }
-    }
-    events.push(event)
-  }
-  { events, errors, partial_tail }
+/// truncated trailing line and per-line decode failures.
+pub fn parse_events(text : String) -> @session_log.ParsedLog {
+  @session_log.parse_events(text)
 }
 
 ///|
@@ -63,10 +11,9 @@ pub fn parse_events(text : String) -> ParsedLog {
 /// system prompt are used so the viewer can still render the event log. The
 /// header's id and system prompt win when present.
 pub fn session_from_parse(
-  parsed : ParsedLog,
+  parsed : @session_log.ParsedLog,
   id~ : String,
   system_prompt~ : String,
 ) -> @agent_session.Session {
-  let session_id : @agent_session.SessionId = SessionId(id)
-  Session(session_id, system_prompt~, events=@vector.from_array(parsed.events))
+  @session_log.session_from_parse(parsed, id~, system_prompt~)
 }

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -3,34 +3,23 @@ package "bobzhang/openseek/viz"
 
 import {
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/log",
   "moonbit-community/rabbita/html",
   "moonbitlang/core/debug",
 }
 
 // Values
-pub fn parse_events(String) -> ParsedLog
+pub fn parse_events(String) -> @log.ParsedLog
 
-pub fn render_notices(ParsedLog) -> @html.Html
+pub fn render_notices(@log.ParsedLog) -> @html.Html
 
 pub fn render_session(@agent_session.Session, ViewMode) -> @html.Html
 
-pub fn session_from_parse(ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
+pub fn session_from_parse(@log.ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
 
 // Errors
 
 // Types and methods
-pub(all) struct LineError {
-  line_number : Int
-  content : String
-  message : String
-} derive(@debug.Debug)
-
-pub(all) struct ParsedLog {
-  events : Array[@agent_session.SessionEvent]
-  errors : Array[LineError]
-  partial_tail : Bool
-} derive(@debug.Debug)
-
 pub(all) enum ViewMode {
   RawLog
   ModelView
@@ -39,4 +28,3 @@ pub(all) enum ViewMode {
 // Type aliases
 
 // Traits
-

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -24,7 +24,7 @@ pub fn render_session(
 /// Banners for anything the parser flagged: decode failures on individual lines
 /// and a truncated final record. Returns `@html.nothing` for a clean log so the
 /// caller can stack it unconditionally.
-pub fn render_notices(parsed : ParsedLog) -> @html.Html {
+pub fn render_notices(parsed : @session_log.ParsedLog) -> @html.Html {
   let notices : Array[@html.Html] = []
   if parsed.partial_tail {
     notices.push(


### PR DESCRIPTION
## Summary
- Add `agent_session/log` for parsing recorded `events.jsonl` into typed `agent_session.Session` values.
- Reuse that parser from the viz package and viz app.

## Validation
- `moon check --target all`
- `moon test agent_session/log viz cmd/viz_app --target native`

## Stack
This is the first PR in the analyzer stack. Merge before the report renderer and prompt-task analyzer workflow PRs.