### PR TITLE
Improve shared eval report rendering

### DIFF
--- a/eval/report/README.mbt.md
+++ b/eval/report/README.mbt.md
@@ -1,8 +1,8 @@
 # Eval Report
 
 `bobzhang/openseek/eval/report` provides the small report primitive shared by
-local harnesses. It renders a title, summary metrics, dynamic table columns,
-rows, and optional log links to both Markdown and JSON.
+local harnesses. It renders a title, summary metrics, dynamic overview columns,
+per-row detail metrics, and optional log links to Markdown, HTML, and JSON.
 
 It is intentionally simple: individual harnesses still own their domain result
 types, then convert to `Report` at the output boundary.
@@ -10,14 +10,17 @@ types, then convert to `Report` at the output boundary.
 ## API Shape
 
 - `Metric(name~, value~)`: a string metric used in summaries or rows.
-- `ReportRow(index~, name~, success~, reason?, warnings?, metrics?, log_path?)`:
-  one case/tool row.
+- `ReportRow(index~, name~, success~, reason?, warnings?, metrics?, details?,
+  log_path?)`: one case/tool row. `metrics` appear in the overview table;
+  `details` appear in the per-row details section.
 - `Report(title~, summary?, metric_columns?, rows?)`: the renderable report.
 - `Report::markdown()`: Markdown table plus optional log section.
+- `Report::html()`: standalone HTML overview plus per-row detail cards.
 - `Report::to_json()`: JSON representation for automated inspection.
-- `Report::write_files(out_dir)`: writes `report.md` and `report.json`.
-- `write_files(out_dir, markdown, json)`: shared writer for harnesses that keep
-  their own richer JSON schema but reuse the Markdown renderer.
+- `Report::write_files(out_dir)`: writes `report.md`, `report.json`, and
+  `report.html`.
+- `write_files(out_dir, markdown, json, html?)`: shared writer for harnesses
+  that keep their own richer JSON schema but reuse the renderers.
 
 ## Example
 
@@ -29,9 +32,13 @@ test "render a tiny report" {
     summary=[Metric(name="passed", value="true")],
     metric_columns=["Mode"],
     rows=[
-      ReportRow(index=1, name="read", success=true, metrics=[
-        Metric(name="Mode", value="filesystem"),
-      ]),
+      ReportRow(
+        index=1,
+        name="read",
+        success=true,
+        metrics=[Metric(name="Mode", value="filesystem")],
+        details=[Metric(name="Log", value="logs/read.log")],
+      ),
     ],
   )
   let markdown = report.markdown()
@@ -40,5 +47,7 @@ test "render a tiny report" {
     markdown.contains("| # | Case | Result | Mode | Reason | Warnings |"),
   )
   assert_true(markdown.contains("| 1 | `read` | pass | filesystem | ok |  |"))
+  assert_true(markdown.contains("## Trial Details"))
+  assert_true(markdown.contains("- Log: `logs/read.log`"))
 }
 ```

--- a/eval/report/README.mbt.md
+++ b/eval/report/README.mbt.md
@@ -48,6 +48,6 @@ test "render a tiny report" {
   )
   assert_true(markdown.contains("| 1 | `read` | pass | filesystem | ok |  |"))
   assert_true(markdown.contains("## Trial Details"))
-  assert_true(markdown.contains("- Log: `logs/read.log`"))
+  assert_true(markdown.contains("- Log:\n\n  ```text\n  logs/read.log\n  ```"))
 }
 ```

--- a/eval/report/pkg.generated.mbti
+++ b/eval/report/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "bobzhang/openseek/eval/report"
 // Values
 pub fn escape_table_cell(String) -> String
 
-pub async fn write_files(String, String, Json) -> Unit
+pub async fn write_files(String, String, Json, html? : String) -> Unit
 
 // Errors
 
@@ -23,6 +23,7 @@ pub struct Report {
 }
 pub fn Report::Report(title~ : String, summary? : Array[Metric], metric_columns? : Array[String], rows? : Array[ReportRow]) -> Self
 pub fn Report::all_passed(Self) -> Bool
+pub fn Report::html(Self) -> String
 pub fn Report::markdown(Self) -> String
 pub fn Report::successes(Self) -> Int
 pub fn Report::to_json(Self) -> Json
@@ -35,9 +36,10 @@ pub struct ReportRow {
   reason : String
   warnings : String
   metrics : Array[Metric]
+  details : Array[Metric]
   log_path : String
 }
-pub fn ReportRow::ReportRow(index~ : Int, name~ : String, success~ : Bool, reason? : String, warnings? : String, metrics? : Array[Metric], log_path? : String) -> Self
+pub fn ReportRow::ReportRow(index~ : Int, name~ : String, success~ : Bool, reason? : String, warnings? : String, metrics? : Array[Metric], details? : Array[Metric], log_path? : String) -> Self
 
 // Type aliases
 

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -25,6 +25,7 @@ pub struct ReportRow {
   reason : String
   warnings : String
   metrics : Array[Metric]
+  details : Array[Metric]
   log_path : String
 }
 
@@ -38,9 +39,10 @@ pub fn ReportRow::ReportRow(
   reason? : String = "ok",
   warnings? : String = "",
   metrics? : Array[Metric] = [],
+  details? : Array[Metric] = [],
   log_path? : String = "",
 ) -> ReportRow {
-  { index, name, success, reason, warnings, metrics, log_path }
+  { index, name, success, reason, warnings, metrics, details, log_path }
 }
 
 ///|
@@ -101,6 +103,15 @@ pub fn Report::markdown(self : Report) -> String {
   for row in self.rows {
     lines.push(row.markdown_row(self.metric_columns))
   }
+  let detail_lines = detail_section_lines(self.rows)
+  if detail_lines.length() > 0 {
+    lines.push("")
+    lines.push("## Trial Details")
+    lines.push("")
+    for line in detail_lines {
+      lines.push(line)
+    }
+  }
   let log_lines = log_section_lines(self.rows)
   if log_lines.length() > 0 {
     lines.push("")
@@ -127,20 +138,135 @@ pub fn Report::to_json(self : Report) -> Json {
 }
 
 ///|
-/// Write both renderings of this report under `out_dir` — the standard
-/// artifact layout eval runners leave behind.
-pub async fn Report::write_files(self : Report, out_dir : String) -> Unit {
-  write_files(out_dir, self.markdown(), self.to_json())
+/// Render the report as a standalone HTML document for browser inspection.
+pub fn Report::html(self : Report) -> String {
+  let out = StringBuilder::new()
+  out.write_string("<!doctype html>\n<html><head><meta charset=\"utf-8\">")
+  out.write_string(
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+  )
+  out.write_string("<title>")
+  out.write_string(escape_html(self.title))
+  out.write_string("</title>")
+  out.write_string(
+    "<style>:root{color-scheme:light;--bg:#f7f9fb;--panel:#fff;--text:#1f2328;--muted:#59636e;--line:#d0d7de;--line-soft:#eaeef2;--good:#116329;--bad:#cf222e;--accent:#0969da;--warn:#9a6700}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,\"Segoe UI\",sans-serif;font-size:14px;line-height:1.45}main{max-width:1440px;margin:0 auto;padding:28px 24px 44px}h1{margin:0 0 16px;font-size:28px;line-height:1.15}h2{margin:28px 0 12px;font-size:18px}.summary{display:flex;flex-wrap:wrap;align-items:flex-start;gap:10px;margin:12px 0 20px}.metric,.trial-card{background:var(--panel);border:1px solid var(--line);border-radius:8px}.metric{padding:9px 10px;min-width:140px;max-width:420px}.summary>.metric{flex:1 1 150px}.summary>.metric:last-child{flex-basis:320px}.metric-name{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}.metric code,.detail-list code,td code,.logs code{background:#f6f8fa;border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px;white-space:pre-wrap;overflow-wrap:anywhere}.table-wrap{overflow-x:auto;background:var(--panel);border:1px solid var(--line);border-radius:8px}table{border-collapse:separate;border-spacing:0;width:100%;font-size:13px}th,td{border-bottom:1px solid var(--line-soft);padding:8px 10px;text-align:left;vertical-align:top}th{background:#f6f8fa;color:#3f4852;font-weight:650;white-space:nowrap}tbody tr:last-child td{border-bottom:0}.pass{color:var(--good);font-weight:700}.fail{color:var(--bad);font-weight:700}.reason-cell,.warning-cell{max-width:360px;overflow-wrap:anywhere}.trial-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:12px}.trial-card{padding:14px}.trial-card header{display:flex;gap:10px;align-items:center;justify-content:space-between;margin-bottom:10px}.trial-card h3{margin:0;font-size:16px}.badge{border-radius:999px;padding:2px 9px;font-size:12px;font-weight:700}.badge.pass{background:#dafbe1}.badge.fail{background:#ffebe9}.detail-list{display:grid;grid-template-columns:minmax(120px,180px) 1fr;gap:6px 12px;margin:0}.detail-list dt{color:var(--muted);font-weight:650}.detail-list dd{margin:0;min-width:0}.detail-list dd.long{white-space:pre-wrap;overflow-wrap:anywhere}.detail-list dd.long code{display:block;max-height:180px;overflow:auto}.logs{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:12px 16px}.logs ul{margin:8px 0 0;padding-left:20px}@media(max-width:720px){main{padding:20px 14px}.summary>.metric{flex-basis:100%;max-width:none}.trial-grid{grid-template-columns:1fr}.detail-list{grid-template-columns:1fr}.detail-list dt{margin-top:6px}}</style>",
+  )
+  out.write_string("</head><body><main>")
+  out.write_string("<h1>")
+  out.write_string(escape_html(self.title))
+  out.write_string("</h1>")
+  if self.summary.length() > 0 {
+    out.write_string("<div class=\"summary\">")
+    for metric in self.summary {
+      out.write_string("<div class=\"metric\"><div class=\"metric-name\">")
+      out.write_string(escape_html(metric.name))
+      out.write_string("</div><code>")
+      out.write_string(escape_html(metric.value))
+      out.write_string("</code></div>")
+    }
+    out.write_string("</div>")
+  }
+  out.write_string("<div class=\"table-wrap\"><table><thead><tr>")
+  let columns : Array[String] = ["#", "Case", "Result"]
+  for column in self.metric_columns {
+    columns.push(column)
+  }
+  columns.push("Reason")
+  columns.push("Warnings")
+  for column in columns {
+    out.write_string("<th>")
+    out.write_string(escape_html(column))
+    out.write_string("</th>")
+  }
+  out.write_string("</tr></thead><tbody>")
+  for row in self.rows {
+    out.write_string("<tr><td>")
+    out.write_string(row.index.to_string())
+    out.write_string("</td><td><code>")
+    out.write_string(escape_html(row.name))
+    out.write_string("</code></td><td class=\"")
+    out.write_string(if row.success { "pass" } else { "fail" })
+    out.write_string("\">")
+    out.write_string(if row.success { "pass" } else { "fail" })
+    out.write_string("</td>")
+    for column in self.metric_columns {
+      out.write_string("<td>")
+      out.write_string(escape_html(row.metric_value(column)))
+      out.write_string("</td>")
+    }
+    out.write_string("<td class=\"reason-cell\">")
+    out.write_string(escape_html(short_cell(row.reason)))
+    out.write_string("</td><td class=\"warning-cell\">")
+    out.write_string(escape_html(short_cell(row.warnings)))
+    out.write_string("</td></tr>")
+  }
+  out.write_string("</tbody></table></div>")
+  if has_detail_section(self.rows) {
+    out.write_string(
+      "<section><h2>Trial Details</h2><div class=\"trial-grid\">",
+    )
+    for row in self.rows {
+      if row.has_details() {
+        out.write_string("<article class=\"trial-card\"><header><h3><code>")
+        out.write_string(escape_html(row.name))
+        out.write_string("</code></h3><span class=\"badge ")
+        out.write_string(if row.success { "pass" } else { "fail" })
+        out.write_string("\">")
+        out.write_string(if row.success { "pass" } else { "fail" })
+        out.write_string("</span></header><dl class=\"detail-list\">")
+        write_html_detail(out, "Reason", row.reason, long=true)
+        if row.warnings != "" {
+          write_html_detail(out, "Warnings", row.warnings, long=true)
+        }
+        for detail in row.details {
+          write_html_detail(
+            out,
+            detail.name,
+            detail.value,
+            long=detail.value.length() > 80,
+          )
+        }
+        out.write_string("</dl></article>")
+      }
+    }
+    out.write_string("</div></section>")
+  }
+  let log_lines = log_section_lines(self.rows)
+  if log_lines.length() > 0 {
+    out.write_string("<section class=\"logs\"><h2>Logs</h2><ul>")
+    for row in self.rows {
+      if row.log_path != "" {
+        out.write_string("<li><code>")
+        out.write_string(escape_html(row.name))
+        out.write_string("</code> trial ")
+        out.write_string(row.index.to_string())
+        out.write_string(": <code>")
+        out.write_string(escape_html(row.log_path))
+        out.write_string("</code></li>")
+      }
+    }
+    out.write_string("</ul></section>")
+  }
+  out.write_string("</main></body></html>\n")
+  out.to_string()
 }
 
 ///|
-/// Write already-rendered report artifacts as `report.md` and `report.json`
-/// under `out_dir`, creating it as needed — for runners that build their
-/// renderings separately.
+/// Write both renderings of this report under `out_dir` — the standard
+/// artifact layout eval runners leave behind.
+pub async fn Report::write_files(self : Report, out_dir : String) -> Unit {
+  write_files(out_dir, self.markdown(), self.to_json(), html=self.html())
+}
+
+///|
+/// Write already-rendered report artifacts under `out_dir`, creating it as
+/// needed. `html` is optional for older runners that only render markdown and
+/// JSON.
 pub async fn write_files(
   out_dir : String,
   markdown : String,
   json : Json,
+  html? : String = "",
 ) -> Unit {
   let _ = @fs.mkdir(out_dir, recursive=true) catch { _ => () }
   @fs.write_file(
@@ -149,6 +275,9 @@ pub async fn write_files(
     create_mode=CreateOrTruncate,
   )
   @fs.write_file(out_dir + "/report.md", markdown, create_mode=CreateOrTruncate)
+  if html != "" {
+    @fs.write_file(out_dir + "/report.html", html, create_mode=CreateOrTruncate)
+  }
 }
 
 ///|
@@ -165,6 +294,7 @@ fn ReportRow::to_json(self : ReportRow) -> Json {
     "reason": self.reason,
     "warnings": self.warnings,
     "metrics": ([ for metric in self.metrics => metric.to_json() ] : Json),
+    "details": ([ for metric in self.details => metric.to_json() ] : Json),
     "log_path": self.log_path,
   }
 }
@@ -208,8 +338,8 @@ fn ReportRow::markdown_row(
   for column in metric_columns {
     cells.push(escape_table_cell(self.metric_value(column)))
   }
-  cells.push(escape_table_cell(self.reason))
-  cells.push(escape_table_cell(self.warnings))
+  cells.push(escape_table_cell(short_cell(self.reason)))
+  cells.push(escape_table_cell(short_cell(self.warnings)))
   "| " + cells.join(" | ") + " |"
 }
 
@@ -235,6 +365,86 @@ fn log_section_lines(rows : Array[ReportRow]) -> Array[String] {
 }
 
 ///|
+fn detail_section_lines(rows : Array[ReportRow]) -> Array[String] {
+  let lines : Array[String] = []
+  for row in rows {
+    if row.has_details() {
+      if lines.length() > 0 {
+        lines.push("")
+      }
+      lines.push("### `\{row.name}`")
+      lines.push("")
+      lines.push("- result: `\{if row.success { "pass" } else { "fail" }}`")
+      lines.push("- reason: \{markdown_text(row.reason)}")
+      if row.warnings != "" {
+        lines.push("- warnings: \{markdown_text(row.warnings)}")
+      }
+      for detail in row.details {
+        lines.push("- \{detail.name}: `\{escape_backticks(detail.value)}`")
+      }
+    }
+  }
+  lines
+}
+
+///|
+fn has_detail_section(rows : Array[ReportRow]) -> Bool {
+  for row in rows {
+    if row.has_details() {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn ReportRow::has_details(self : ReportRow) -> Bool {
+  self.details.length() > 0 || self.reason != "ok" || self.warnings != ""
+}
+
+///|
+fn write_html_detail(
+  out : StringBuilder,
+  name : String,
+  value : String,
+  long~ : Bool,
+) -> Unit {
+  out.write_string("<dt>")
+  out.write_string(escape_html(name))
+  out.write_string("</dt><dd")
+  if long {
+    out.write_string(" class=\"long\"")
+  }
+  out.write_string("><code>")
+  out.write_string(escape_html(value))
+  out.write_string("</code></dd>")
+}
+
+///|
+fn short_cell(text : String) -> String {
+  let squashed = text
+    .replace_all(old="\r\n", new="\n")
+    .replace_all(old="\n", new=" ")
+    .trim()
+    .to_owned()
+  if squashed.length() <= 96 {
+    squashed
+  } else {
+    squashed.sub(start=0, end=96).to_owned() + "..."
+  }
+}
+
+///|
+fn markdown_text(text : String) -> String {
+  "`\{escape_backticks(short_cell(text))}`"
+}
+
+///|
+fn escape_backticks(text : String) -> String {
+  text.replace_all(old="`", new="\\`")
+}
+
+///|
 /// Make free text safe inside a markdown table cell: escape `|` and flatten
 /// newlines to spaces. Failure reasons quote arbitrary model and tool
 /// output, which would otherwise break the table layout.
@@ -242,4 +452,13 @@ pub fn escape_table_cell(text : String) -> String {
   text
   |> String::replace_all(old="|", new="\\|")
   |> String::replace_all(old="\n", new=" ")
+}
+
+///|
+fn escape_html(text : String) -> String {
+  text
+  |> String::replace_all(old="&", new="&amp;")
+  |> String::replace_all(old="<", new="&lt;")
+  |> String::replace_all(old=">", new="&gt;")
+  |> String::replace_all(old="\"", new="&quot;")
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -207,7 +207,9 @@ pub fn Report::html(self : Report) -> String {
     )
     for row in self.rows {
       if row.has_details() {
-        out.write_string("<article class=\"trial-card\"><header><h3><code>")
+        out.write_string("<article class=\"trial-card\"><header><h3>Trial ")
+        out.write_string(row.index.to_string())
+        out.write_string(": <code>")
         out.write_string(escape_html(row.name))
         out.write_string("</code></h3><span class=\"badge ")
         out.write_string(if row.success { "pass" } else { "fail" })
@@ -372,15 +374,18 @@ fn detail_section_lines(rows : Array[ReportRow]) -> Array[String] {
       if lines.length() > 0 {
         lines.push("")
       }
-      lines.push("### `\{row.name}`")
+      lines.push("### Trial \{row.index}: `\{row.name}`")
       lines.push("")
       lines.push("- result: `\{if row.success { "pass" } else { "fail" }}`")
-      lines.push("- reason: \{markdown_text(row.reason)}")
+      lines.push("- reason:")
+      append_markdown_code_block(lines, row.reason)
       if row.warnings != "" {
-        lines.push("- warnings: \{markdown_text(row.warnings)}")
+        lines.push("- warnings:")
+        append_markdown_code_block(lines, row.warnings)
       }
       for detail in row.details {
-        lines.push("- \{detail.name}: `\{escape_backticks(detail.value)}`")
+        lines.push("- \{detail.name}:")
+        append_markdown_code_block(lines, detail.value)
       }
     }
   }
@@ -427,21 +432,57 @@ fn short_cell(text : String) -> String {
     .replace_all(old="\n", new=" ")
     .trim()
     .to_owned()
-  if squashed.length() <= 96 {
-    squashed
-  } else {
-    squashed.sub(start=0, end=96).to_owned() + "..."
+  let out = StringBuilder::new()
+  let mut count = 0
+  for char in squashed {
+    if count >= 96 {
+      return out.to_string() + "..."
+    }
+    out.write_char(char)
+    count += 1
   }
+  out.to_string()
 }
 
 ///|
-fn markdown_text(text : String) -> String {
-  "`\{escape_backticks(short_cell(text))}`"
+fn append_markdown_code_block(lines : Array[String], text : String) -> Unit {
+  let fence = markdown_fence(text)
+  lines.push("")
+  lines.push("  \{fence}text")
+  let normalized = text
+    .replace_all(old="\r\n", new="\n")
+    .replace_all(old="\r", new="\n")
+  for line in normalized.split("\n") {
+    lines.push("  \{line}")
+  }
+  lines.push("  \{fence}")
 }
 
 ///|
-fn escape_backticks(text : String) -> String {
-  text.replace_all(old="`", new="\\`")
+fn markdown_fence(text : String) -> String {
+  let mut current = 0
+  let mut longest = 0
+  for char in text {
+    if char == '`' {
+      current += 1
+      if current > longest {
+        longest = current
+      }
+    } else {
+      current = 0
+    }
+  }
+  let length = if longest >= 3 { longest + 1 } else { 3 }
+  repeat_char('`', length)
+}
+
+///|
+fn repeat_char(char : Char, count : Int) -> String {
+  let out = StringBuilder::new()
+  for _ in 0..<count {
+    out.write_char(char)
+  }
+  out.to_string()
 }
 
 ///|

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -35,17 +35,51 @@ test "markdown renders summary metrics and dynamic columns" {
     text.contains("| # | Case | Result | Mode | Steps | Reason | Warnings |"),
   )
   assert_true(text.contains("## Trial Details"))
-  assert_true(text.contains("- Log: `logs/read.log`"))
+  assert_true(text.contains("### Trial 1: `read`"))
+  assert_true(text.contains("### Trial 2: `shell`"))
+  assert_true(text.contains("- Log:\n\n  ```text\n  logs/read.log\n  ```"))
   assert_true(text.contains("contains \\| pipe and newline"))
   assert_eq(report.successes(), 1)
   assert_false(report.all_passed())
 }
 
 ///|
+fn repeated_text(text : String, count : Int) -> String {
+  let out = StringBuilder::new()
+  for _ in 0..<count {
+    out.write_string(text)
+  }
+  out.to_string()
+}
+
+///|
+test "markdown details keep full arbitrary text" {
+  let long_reason = repeated_text("a", 95) + "😊 full reason tail"
+  let warning = "contains `inline` and ```fenced``` backticks"
+  let report = @report.Report(title="Details", rows=[
+    ReportRow(
+      index=1,
+      name="unicode",
+      success=false,
+      reason=long_reason,
+      warnings=warning,
+      details=[Metric(name="Transcript", value="line 1\nline `2`")],
+    ),
+  ])
+  let text = report.markdown()
+  assert_true(text.contains("## Trial Details"))
+  assert_true(text.contains("😊 full reason tail"))
+  assert_true(text.contains("````text"))
+  assert_true(text.contains("contains `inline` and ```fenced``` backticks"))
+}
+
+///|
 async test "report writes markdown json and html files" {
   let root = @fs.tmpdir(prefix="openseek-eval-report")
   let report = @report.Report(title="Tiny Report", rows=[
-    ReportRow(index=1, name="finish", success=true),
+    ReportRow(index=1, name="finish", success=true, details=[
+      Metric(name="Note", value="ok"),
+    ]),
   ])
   report.write_files(root)
   let markdown = @fs.read_file(root + "/report.md").text()
@@ -54,6 +88,7 @@ async test "report writes markdown json and html files" {
   assert_true(markdown.contains("# Tiny Report"))
   assert_true(json.contains("\"title\":\"Tiny Report\""))
   assert_true(html.contains("<title>Tiny Report</title>"))
+  assert_true(html.contains("<h3>Trial 1: <code>finish</code></h3>"))
   assert_true(html.contains("table-wrap"))
   @fs.rmdir(root, recursive=true)
 }

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -8,10 +8,16 @@ test "markdown renders summary metrics and dynamic columns" {
     ],
     metric_columns=["Mode", "Steps"],
     rows=[
-      ReportRow(index=1, name="read", success=true, metrics=[
-        Metric(name="Mode", value="filesystem"),
-        Metric(name="Steps", value="1"),
-      ]),
+      ReportRow(
+        index=1,
+        name="read",
+        success=true,
+        metrics=[
+          Metric(name="Mode", value="filesystem"),
+          Metric(name="Steps", value="1"),
+        ],
+        details=[Metric(name="Log", value="logs/read.log")],
+      ),
       ReportRow(
         index=2,
         name="shell",
@@ -28,13 +34,15 @@ test "markdown renders summary metrics and dynamic columns" {
   assert_true(
     text.contains("| # | Case | Result | Mode | Steps | Reason | Warnings |"),
   )
+  assert_true(text.contains("## Trial Details"))
+  assert_true(text.contains("- Log: `logs/read.log`"))
   assert_true(text.contains("contains \\| pipe and newline"))
   assert_eq(report.successes(), 1)
   assert_false(report.all_passed())
 }
 
 ///|
-async test "report writes markdown and json files" {
+async test "report writes markdown json and html files" {
   let root = @fs.tmpdir(prefix="openseek-eval-report")
   let report = @report.Report(title="Tiny Report", rows=[
     ReportRow(index=1, name="finish", success=true),
@@ -42,7 +50,10 @@ async test "report writes markdown and json files" {
   report.write_files(root)
   let markdown = @fs.read_file(root + "/report.md").text()
   let json = @fs.read_file(root + "/report.json").text()
+  let html = @fs.read_file(root + "/report.html").text()
   assert_true(markdown.contains("# Tiny Report"))
   assert_true(json.contains("\"title\":\"Tiny Report\""))
+  assert_true(html.contains("<title>Tiny Report</title>"))
+  assert_true(html.contains("table-wrap"))
   @fs.rmdir(root, recursive=true)
 }


### PR DESCRIPTION
## Summary
- Extend the shared eval report model with row details.
- Improve markdown/HTML rendering for richer report inspection.
- Add tests and README coverage for the shared report renderer.

## Validation
- `moon check --target all`
- `moon test eval/report --target native`

## Stack
Base: `codex/session-log-jsonl-viz`.
Merge after the session-log parser PR and before the prompt-task analyzer workflow PR.