### PR TITLE
Split prompt task runner and analyzer workflow

### DIFF
--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -1,12 +1,18 @@
 # Prompt Task Eval
 
 This harness runs a MoonBit prompt task through the real OpenSeek agent with
-isolated workspaces, per-trial logs, independent validation probes, and bounded
-parallelism.
+isolated workspaces, per-trial raw logs, durable session `events.jsonl` logs,
+and bounded parallelism. Reporting is a separate analyzer pass, so reports can
+be regenerated without rerunning model/API trials.
 
 The default task is `eval/prompt_tasks/toml_parser_cli.md`. The runner replaces
-`{{WORKSPACE}}` in the task template with each trial workspace path, starts the
-agent, then independently validates the final TOML project with:
+`{{WORKSPACE}}` in the task template with each trial workspace path and starts
+the agent with `openseek --dir <trial-workspace>` and an explicit per-trial
+session id. Each session log stays under the trial workspace's `.openseek`
+directory. The analyzer loads the run manifest, recursively resolves the
+workspace-local session logs, evaluates each loaded agent session independently,
+then combines those eval results into a run-level report. Workspace validation
+for the TOML task checks:
 
 - `moon check --target native`
 - `moon test --target native`
@@ -28,6 +34,14 @@ moon run eval/prompt_task/cmd/main -- \
   --out .moonagent/eval_runs/toml_flash_current_5x
 ```
 
+Analyze the finished run later:
+
+```bash
+moon run eval/prompt_task/cmd/main -- \
+  --analyze-only \
+  --out .moonagent/eval_runs/toml_flash_current_5x
+```
+
 Run an A/B comparison by using different output directories and prompt labels:
 
 ```bash
@@ -43,5 +57,10 @@ moon run eval/prompt_task/cmd/main -- \
   --out .moonagent/eval_runs/toml_flash_candidate_5x
 ```
 
-The report records success rate, steps, tool errors, validation pass/fail,
-prompt-sensitive log counters, and paths to each raw log.
+The runner writes `run_manifest.json`, `workspaces/`, and `logs/`. Agent
+session logs remain in each workspace at `.openseek/sessions/<session>/`.
+The analyzer writes aggregate `report.md`, `report.json`, and `report.html`
+files under the run output directory. It also writes one independently
+renderable eval result under `eval_results/<trial>/` with its own markdown,
+JSON, and HTML report. The reports record success rate, typed-session metrics,
+validation pass/fail, prompt-sensitive counters, and paths to each raw log.

--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -6,8 +6,10 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
     "--min-successes",
   )
   guard min_successes <= runs else { fail("--min-successes must be <= --runs") }
+  let api_key = value(matches, "api-key")
+  guard api_key != "" else { fail("--api-key is required for running trials") }
   Config(
-    api_key=value(matches, "api-key"),
+    api_key~,
     model=@deepseek.Model::parse(value(matches, "model")),
     runs~,
     concurrency=parse_positive_int(
@@ -24,6 +26,14 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
     system_prompt_file=value(matches, "system-prompt-file"),
     system_prompt_addendum_file=value(matches, "system-prompt-addendum-file"),
   )
+}
+
+///|
+fn flag(matches : @argparse.Matches, name : String) -> Bool {
+  match matches.flags.get(name) {
+    Some(value) => value
+    None => false
+  }
 }
 
 ///|

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -1,11 +1,19 @@
 ///|
 async fn main {
-  let config = @argparse.parse(cli_command()) |> config_from_matches
-  let report = @harness.run_suite(config)
-  println(report.markdown())
-  if !report.passed() {
-    fail(report.failure_message())
+  let matches = @argparse.parse(cli_command())
+  if flag(matches, "analyze-only") {
+    let report = @harness.analyze_run(value(matches, "out"))
+    println(report.markdown())
+    if !report.passed() {
+      fail(report.failure_message())
+    }
+    return
   }
+  let config = config_from_matches(matches)
+  let manifest = @harness.run_experiments(config)
+  println(
+    "prompt task run manifest: \{@harness.manifest_path(manifest.out_dir)}",
+  )
 }
 
 ///|
@@ -17,7 +25,7 @@ fn cli_command() -> @argparse.Command {
       OptionArg(
         "api-key",
         long="api-key",
-        required=true,
+        default_values=[""],
         about="DeepSeek API key.",
       ),
       OptionArg(
@@ -91,6 +99,13 @@ fn cli_command() -> @argparse.Command {
         long="system-prompt-addendum-file",
         default_values=[""],
         about="Pass a system prompt addendum file through to OpenSeek.",
+      ),
+    ],
+    flags=[
+      FlagArg(
+        "analyze-only",
+        long="analyze-only",
+        about="Analyze an existing --out directory without running agent trials.",
       ),
     ],
   )

--- a/eval/prompt_task/cmd/main/main_wbtest.mbt
+++ b/eval/prompt_task/cmd/main/main_wbtest.mbt
@@ -27,6 +27,25 @@ test "cli parses prompt and task options" {
 }
 
 ///|
+test "analyze-only mode does not require an api key" {
+  let matches = cli_command().parse(argv=["--analyze-only", "--out", "existing"])
+  assert_true(flag(matches, "analyze-only"))
+  assert_eq(value(matches, "out"), "existing")
+}
+
+///|
+test "running trials requires an api key" {
+  let matches = cli_command().parse(argv=[])
+  let _ = config_from_matches(matches) catch {
+    error => {
+      assert_true("\{error}".contains("--api-key is required"))
+      return
+    }
+  }
+  fail("missing api key parsed")
+}
+
+///|
 test "cli rejects impossible threshold" {
   let matches = cli_command().parse(argv=[
     "--api-key", "test-key", "--runs", "3", "--min-successes", "4",

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -1,0 +1,605 @@
+///|
+/// Verdict of one behavioral probe run against a trial's workspace, with the
+/// `reason` it failed ("ok" when it passed).
+priv struct ProbeResult {
+  passed : Bool
+  reason : String
+}
+
+///|
+/// Validation verdict for one trial's finished workspace.
+pub struct ValidationResult {
+  ran : Bool
+  passed : Bool
+  reason : String
+  moon_check : Bool
+  moon_test : Bool
+  file_probe : Bool
+  stdin_probe : Bool
+  duplicate_probe : Bool
+}
+
+///|
+/// Everything recorded about one analyzed agent session. Harness metadata and
+/// workspace validation are attached when the session came from a prompt-task
+/// trial.
+pub struct EvalResult {
+  index : Int
+  prompt_label : String
+  success : Bool
+  reason : String
+  workspace : String
+  log_path : String
+  session_id : String
+  events_path : String
+  exit_code : Int
+  steps : Int
+  tool_results : Int
+  tool_errors : Int
+  shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
+  finished : Bool
+  finish_message : String
+  terminal_status : String
+  terminal_message : String
+  validation : ValidationResult
+  parse_errors : Int
+  partial_tail : Bool
+  moon_check_uses : Int
+  moon_test_uses : Int
+  moon_run_e_mentions : Int
+  moon_run_c_mentions : Int
+  bad_run_e_mentions : Int
+  from_str_mentions : Int
+  parse_int_mentions : Int
+  argparse_mentions : Int
+  old_argparse_mentions : Int
+  c_ffi_mentions : Int
+  env_args_mentions : Int
+  result_style_mentions : Int
+  try_mentions : Int
+  warnings : String
+}
+
+///|
+/// One prompt-task eval analysis report.
+pub struct EvalReport {
+  model : String
+  prompt_label : String
+  task_file : String
+  runs : Int
+  concurrency : Int
+  min_successes : Int
+  successes : Int
+  out_dir : String
+  results : Array[EvalResult]
+}
+
+///|
+priv struct EvalContext {
+  index : Int
+  prompt_label : String
+  workspace : String
+  log_path : String
+  events_path : String
+  exit_code : Int
+  validation : ValidationResult
+  parse_errors : Int
+  partial_tail : Bool
+  extra_reasons : Array[String]
+  extra_warnings : Array[String]
+}
+
+///|
+/// Analyze an existing prompt-task run directory.
+pub async fn analyze_run(out_dir : String) -> EvalReport {
+  analyze_manifest(manifest_for_output_dir(read_manifest(out_dir), out_dir))
+}
+
+///|
+/// Analyze a prompt-task run manifest and write report artifacts.
+async fn analyze_manifest(manifest : RunManifest) -> EvalReport {
+  let results : Array[EvalResult] = []
+  for trial in manifest.trials {
+    results.push(analyze_trial(manifest, trial))
+  }
+  let report = combine_results(manifest, results)
+  write_report_files(report)
+  report
+}
+
+///|
+/// Combine independently evaluated sessions into one run-level report.
+fn combine_results(
+  manifest : RunManifest,
+  results : Array[EvalResult],
+) -> EvalReport {
+  {
+    model: manifest.model,
+    prompt_label: manifest.prompt_label,
+    task_file: manifest.task_file,
+    runs: manifest.runs,
+    concurrency: manifest.concurrency,
+    min_successes: manifest.min_successes,
+    successes: count_successes(results),
+    out_dir: manifest.out_dir,
+    results,
+  }
+}
+
+///|
+fn manifest_for_output_dir(
+  manifest : RunManifest,
+  out_dir : String,
+) -> RunManifest {
+  let original_out_dir = manifest.out_dir
+  RunManifest(
+    model=manifest.model,
+    prompt_label=manifest.prompt_label,
+    task_file=manifest.task_file,
+    runs=manifest.runs,
+    concurrency=manifest.concurrency,
+    min_successes=manifest.min_successes,
+    max_steps=manifest.max_steps,
+    out_dir~,
+    trials=[
+      for trial in manifest.trials => {
+        relocate_trial_artifacts(trial, original_out_dir, out_dir)
+      }
+    ],
+  )
+}
+
+///|
+fn relocate_trial_artifacts(
+  trial : TrialArtifact,
+  old_out_dir : String,
+  new_out_dir : String,
+) -> TrialArtifact {
+  TrialArtifact(
+    index=trial.index,
+    workspace=relocate_workspace_path(trial, old_out_dir, new_out_dir),
+    log_path=relocate_output_path(trial.log_path, old_out_dir, new_out_dir),
+    session_id=trial.session_id,
+    events_path=relocate_output_path(
+      trial.events_path,
+      old_out_dir,
+      new_out_dir,
+    ),
+    exit_code=trial.exit_code,
+  )
+}
+
+///|
+fn relocate_workspace_path(
+  trial : TrialArtifact,
+  old_out_dir : String,
+  new_out_dir : String,
+) -> String {
+  let relocated = relocate_output_path(
+    trial.workspace,
+    old_out_dir,
+    new_out_dir,
+  )
+  if relocated != trial.workspace {
+    relocated
+  } else if old_out_dir != new_out_dir {
+    new_out_dir + "/workspaces/" + padded_index(trial.index)
+  } else {
+    trial.workspace
+  }
+}
+
+///|
+fn relocate_output_path(
+  path : String,
+  old_out_dir : String,
+  new_out_dir : String,
+) -> String {
+  if path == "" || old_out_dir == "" || old_out_dir == new_out_dir {
+    return path
+  }
+  let prefix = old_out_dir + "/"
+  if path.has_prefix(prefix) {
+    new_out_dir +
+    "/" +
+    path.sub(start=prefix.length(), end=path.length()).to_owned()
+  } else {
+    path
+  }
+}
+
+///|
+async fn analyze_trial(
+  manifest : RunManifest,
+  trial : TrialArtifact,
+) -> EvalResult {
+  let events_path = resolve_events_path(trial)
+  let events_missing = !@fs.exists(events_path)
+  let events_text = if events_missing {
+    ""
+  } else {
+    @fs.read_file(events_path).text()
+  }
+  let parsed = @session_log.parse_events(events_text)
+  let session = @session_log.session_from_parse(
+    parsed,
+    id=trial.session_id,
+    system_prompt="",
+  )
+  let validation = validate_toml_workspace(trial.workspace)
+  let reasons : Array[String] = []
+  if trial.exit_code != 0 {
+    reasons.push("agent process exited \{trial.exit_code}")
+  }
+  if events_missing {
+    reasons.push("events log missing")
+  }
+  if parsed.errors.length() > 0 {
+    reasons.push("events decode errors \{parsed.errors.length()}")
+  }
+  let warnings : Array[String] = []
+  if parsed.partial_tail {
+    warnings.push("trailing partial event ignored")
+  }
+  eval_session_with_context(session, {
+    index: trial.index,
+    prompt_label: manifest.prompt_label,
+    workspace: trial.workspace,
+    log_path: trial.log_path,
+    events_path,
+    exit_code: trial.exit_code,
+    validation,
+    parse_errors: parsed.errors.length(),
+    partial_tail: parsed.partial_tail,
+    extra_reasons: reasons,
+    extra_warnings: warnings,
+  })
+}
+
+///|
+fn eval_session_with_context(
+  session : @agent_session.Session,
+  context : EvalContext,
+) -> EvalResult {
+  let base = @session_analyzer.analyze_session(session)
+  let reasons : Array[String] = []
+  for reason in context.extra_reasons {
+    reasons.push(reason)
+  }
+  if !base.success {
+    reasons.push(base.reason)
+  }
+  if context.validation.ran && !context.validation.passed {
+    reasons.push(context.validation.reason)
+  }
+  let warnings : Array[String] = []
+  for warning in context.extra_warnings {
+    warnings.push(warning)
+  }
+  if base.warnings != "" {
+    warnings.push(base.warnings)
+  }
+  let success = reasons.length() == 0
+  let text = @session_analyzer.transcript_text(session)
+  {
+    index: context.index,
+    prompt_label: context.prompt_label,
+    success,
+    reason: if success {
+      "ok"
+    } else {
+      reasons.join("; ")
+    },
+    workspace: context.workspace,
+    log_path: context.log_path,
+    session_id: base.session_id,
+    events_path: context.events_path,
+    exit_code: context.exit_code,
+    steps: base.steps,
+    tool_results: base.tool_results,
+    tool_errors: base.tool_errors,
+    shell_uses: base.shell_uses,
+    shell_failures: base.shell_failures,
+    runtime_notices: base.runtime_notices,
+    finished: base.finished,
+    finish_message: base.finish_message,
+    terminal_status: base.terminal_status,
+    terminal_message: base.terminal_message,
+    validation: context.validation,
+    parse_errors: context.parse_errors,
+    partial_tail: context.partial_tail,
+    moon_check_uses: count_occurrences(text, "moon check"),
+    moon_test_uses: count_occurrences(text, "moon test"),
+    moon_run_e_mentions: count_lines_containing_all(text, ["moon run", " -e"]),
+    moon_run_c_mentions: count_lines_containing_all(text, ["moon run", " -c"]),
+    bad_run_e_mentions: count_occurrences(
+      text, "a value is required for `-e <SCRIPT>`",
+    ),
+    from_str_mentions: count_occurrences(text, "@string.from_str"),
+    parse_int_mentions: count_occurrences(text, "@string.parse_int"),
+    argparse_mentions: count_occurrences(text, "@argparse.parse") +
+    count_occurrences(text, ".parse("),
+    old_argparse_mentions: count_occurrences(text, "@argparse.command") +
+    count_occurrences(text, "@argparse.flag") +
+    count_occurrences(text, "@argparse.argument") +
+    count_occurrences(text, ".is_present") +
+    count_occurrences(text, ".value("),
+    c_ffi_mentions: count_occurrences(text, "extern \"c\"") +
+    count_occurrences(text, "native-stub"),
+    env_args_mentions: count_occurrences(text, "@env.args"),
+    result_style_mentions: count_occurrences(text, "Result[") +
+    count_occurrences(text, "Ok(") +
+    count_occurrences(text, "Err("),
+    try_mentions: count_occurrences(text, "try?") +
+    count_occurrences(text, "try!"),
+    warnings: if warnings.length() == 0 {
+      ""
+    } else {
+      warnings.join("; ")
+    },
+  }
+}
+
+///|
+async fn resolve_events_path(trial : TrialArtifact) -> String {
+  if trial.events_path != "" &&
+    path_under_dir(trial.events_path, trial.workspace) &&
+    @fs.exists(trial.events_path) {
+    return trial.events_path
+  }
+  let matches : Array[String] = []
+  collect_session_events(trial.workspace, trial.session_id, matches)
+  if matches.length() > 0 {
+    matches[0]
+  } else if trial.events_path != "" &&
+    path_under_dir(trial.events_path, trial.workspace) {
+    trial.events_path
+  } else {
+    trial.workspace +
+    "/.openseek/sessions/" +
+    trial.session_id +
+    "/events.jsonl"
+  }
+}
+
+///|
+fn path_under_dir(path : String, dir : String) -> Bool {
+  if path == "" || dir == "" {
+    return false
+  }
+  path == dir || path.has_prefix(dir + "/")
+}
+
+///|
+async fn validate_toml_workspace(workspace : String) -> ValidationResult {
+  if !@fs.exists(workspace) || @fs.kind(workspace) != Directory {
+    return {
+      ran: true,
+      passed: false,
+      reason: "workspace missing: \{workspace}",
+      moon_check: false,
+      moon_test: false,
+      file_probe: false,
+      stdin_probe: false,
+      duplicate_probe: false,
+    }
+  }
+  let readiness = toml_workspace_readiness(workspace)
+  if !readiness.passed {
+    return {
+      ran: true,
+      passed: false,
+      reason: readiness.reason,
+      moon_check: false,
+      moon_test: false,
+      file_probe: false,
+      stdin_probe: false,
+      duplicate_probe: false,
+    }
+  }
+  let check = run_command(workspace, ["moon", "check", "--target", "native"])
+  let test_probe = run_command(workspace, ["moon", "test", "--target", "native"])
+  let file_probe = run_file_probe(workspace)
+  let stdin_probe = run_stdin_probe(workspace)
+  let duplicate_probe = run_duplicate_probe(workspace)
+  let failures : Array[String] = []
+  if !check.passed {
+    failures.push("moon check: " + check.reason)
+  }
+  if !test_probe.passed {
+    failures.push("moon test: " + test_probe.reason)
+  }
+  if !file_probe.passed {
+    failures.push("file probe: " + file_probe.reason)
+  }
+  if !stdin_probe.passed {
+    failures.push("stdin probe: " + stdin_probe.reason)
+  }
+  if !duplicate_probe.passed {
+    failures.push("duplicate probe: " + duplicate_probe.reason)
+  }
+  {
+    ran: true,
+    passed: failures.length() == 0,
+    reason: if failures.length() == 0 {
+      "ok"
+    } else {
+      failures.join("; ")
+    },
+    moon_check: check.passed,
+    moon_test: test_probe.passed,
+    file_probe: file_probe.passed,
+    stdin_probe: stdin_probe.passed,
+    duplicate_probe: duplicate_probe.passed,
+  }
+}
+
+///|
+async fn toml_workspace_readiness(workspace : String) -> ProbeResult {
+  if !@fs.exists(workspace + "/moon.mod") {
+    return { passed: false, reason: "moon.mod missing" }
+  }
+  if !@fs.exists(workspace + "/cmd/tomljson/moon.pkg") {
+    return {
+      passed: false,
+      reason: "expected CLI package missing: cmd/tomljson/moon.pkg",
+    }
+  }
+  { passed: true, reason: "ok" }
+}
+
+///|
+async fn run_command(
+  workspace : String,
+  command : Array[String],
+) -> ProbeResult {
+  let args = [ for i in 1..<command.length() => command[i] ]
+  let (code, output) = @process.collect_output_merged(
+    command[0],
+    args,
+    cwd=workspace,
+  )
+  if code == 0 {
+    { passed: true, reason: "ok" }
+  } else {
+    { passed: false, reason: "exit \{code}: " + summarize(output.text()) }
+  }
+}
+
+///|
+async fn run_file_probe(workspace : String) -> ProbeResult {
+  let path = workspace + "/.openseek-file-probe.toml"
+  @fs.write_file(
+    path,
+    (
+      #|[owner]
+      #|name = "Alice"
+      #|age = 30
+      #|[database]
+      #|host = "localhost"
+      #|ports = [8000, 8001]
+      #|
+    ),
+    create_mode=CreateOrTruncate,
+  )
+  let (code, stdout, stderr) = @process.collect_output(
+    "moon",
+    ["run", "--target", "native", "cmd/tomljson", "--", path],
+    cwd=workspace,
+  )
+  json_stdout_probe(code, stdout.text(), stderr.text())
+}
+
+///|
+async fn run_stdin_probe(workspace : String) -> ProbeResult {
+  let path = workspace + "/.openseek-stdin-probe.toml"
+  @fs.write_file(path, "a.b.c = 42\nx.y = true\n", create_mode=CreateOrTruncate)
+  let (code, stdout, stderr) = @process.collect_output(
+    "moon",
+    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
+    stdin=@process.redirect_from_file(path),
+    cwd=workspace,
+  )
+  json_stdout_probe(code, stdout.text(), stderr.text())
+}
+
+///|
+async fn run_duplicate_probe(workspace : String) -> ProbeResult {
+  let path = workspace + "/.openseek-duplicate-probe.toml"
+  @fs.write_file(path, "key = 1\nkey = 2\n", create_mode=CreateOrTruncate)
+  let (code, stdout, stderr) = @process.collect_output(
+    "moon",
+    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
+    stdin=@process.redirect_from_file(path),
+    cwd=workspace,
+  )
+  let combined = stdout.text() + stderr.text()
+  if combined.contains("RUNTIME ERROR") || combined.contains("panic") {
+    return { passed: false, reason: "debug/panic output leaked" }
+  }
+  if !combined.contains("duplicate") && !combined.contains("Duplicate") {
+    return {
+      passed: false,
+      reason: "missing duplicate-key message, exit \{code}: " +
+      summarize(combined),
+    }
+  }
+  { passed: true, reason: "ok" }
+}
+
+///|
+fn json_stdout_probe(
+  code : Int,
+  stdout : String,
+  stderr : String,
+) -> ProbeResult {
+  if code != 0 {
+    return {
+      passed: false,
+      reason: "exit \{code}: " + summarize(stdout + stderr),
+    }
+  }
+  let trimmed = stdout.trim().to_owned()
+  let _ = @json.parse(trimmed) catch {
+    error =>
+      return {
+        passed: false,
+        reason: "stdout is not JSON: \{error}; stdout=" + summarize(stdout),
+      }
+  }
+  { passed: true, reason: "ok" }
+}
+
+///|
+fn count_successes(results : Array[EvalResult]) -> Int {
+  let mut count = 0
+  for result in results {
+    if result.success {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+fn count_occurrences(content : String, needle : String) -> Int {
+  if needle == "" {
+    return 0
+  }
+  let pieces = content.split(needle).collect()
+  pieces.length() - 1
+}
+
+///|
+fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
+  let mut count = 0
+  for piece in content.split("\n") {
+    let line = piece.to_owned()
+    let mut matched = true
+    for needle in needles {
+      if !line.contains(needle) {
+        matched = false
+      }
+    }
+    if matched {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+fn summarize(text : String) -> String {
+  let one_line = text
+    .replace_all(old="\r\n", new="\n")
+    .replace_all(old="\n", new=" ")
+    .trim()
+    .to_owned()
+  if one_line.length() <= 240 {
+    one_line
+  } else {
+    one_line.sub(start=0, end=240).to_owned() + "..."
+  }
+}

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -1,0 +1,356 @@
+///|
+fn session_events(session : @agent_session.Session) -> String {
+  let out = StringBuilder::new()
+  for event in session.events() {
+    out.write_string(event.to_json().stringify())
+    out.write_char('\n')
+  }
+  out.to_string()
+}
+
+///|
+fn sample_events() -> String {
+  let session = @agent_session.Session(SessionId("trial-01"), system_prompt="")
+    .append(User(UserMessage("build a toml cli")))
+    .append(
+      Assistant(
+        AssistantMessage("I will run moon check", tool_calls=[
+          ToolCall(
+            id="call_1",
+            name="moon_cmd",
+            arguments="{\"command\":\"moon check\"}",
+          ),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="call_1",
+          tool_name="moon_cmd",
+          content="moon check passed",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  session_events(session)
+}
+
+///|
+fn assistant_events(session_id : String, content : String) -> String {
+  let session = @agent_session.Session(SessionId(session_id), system_prompt="")
+    .append(User(UserMessage("run moon check and moon test before finishing")))
+    .append(Assistant(AssistantMessage(content)))
+    .append(Terminal(Finished("done")))
+  session_events(session)
+}
+
+///|
+fn eval_session_for_test(session : @agent_session.Session) -> EvalResult {
+  eval_session_with_context(session, {
+    index: 0,
+    prompt_label: "",
+    workspace: "",
+    log_path: "",
+    events_path: "",
+    exit_code: 0,
+    validation: {
+      ran: false,
+      passed: true,
+      reason: "not run",
+      moon_check: false,
+      moon_test: false,
+      file_probe: false,
+      stdin_probe: false,
+      duplicate_probe: false,
+    },
+    parse_errors: 0,
+    partial_tail: false,
+    extra_reasons: [],
+    extra_warnings: [],
+  })
+}
+
+///|
+test "session summary counts typed events" {
+  let parsed = @session_log.parse_events(sample_events())
+  let session = @session_log.session_from_parse(
+    parsed,
+    id="trial-01",
+    system_prompt="",
+  )
+  let result = eval_session_for_test(session)
+  assert_true(result.finished)
+  assert_eq(result.steps, 2)
+  assert_eq(result.tool_results, 1)
+  assert_eq(result.tool_errors, 0)
+  assert_eq(result.shell_uses, 0)
+  assert_eq(result.runtime_notices, 0)
+  assert_eq(result.moon_check_uses, 3)
+}
+
+///|
+test "eval session produces standalone result" {
+  let parsed = @session_log.parse_events(sample_events())
+  let session = @session_log.session_from_parse(
+    parsed,
+    id="trial-01",
+    system_prompt="",
+  )
+  let result = eval_session_for_test(session)
+  assert_true(result.success)
+  assert_eq(result.session_id, "trial-01")
+  assert_eq(result.steps, 2)
+  assert_false(result.validation.ran)
+  assert_true(result.markdown().contains("Prompt Task Eval Result"))
+  assert_true(result.html().contains("<html"))
+}
+
+///|
+test "behavior counters ignore user task prompt" {
+  let session = @agent_session.Session(
+      SessionId("prompt-only"),
+      system_prompt="",
+    )
+    .append(
+      User(
+        UserMessage(
+          "run moon check and moon test with @string.from_str and @argparse.command try?",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let result = eval_session_for_test(session)
+  assert_true(result.success)
+  assert_eq(result.moon_check_uses, 0)
+  assert_eq(result.moon_test_uses, 0)
+  assert_eq(result.from_str_mentions, 0)
+  assert_eq(result.old_argparse_mentions, 0)
+  assert_eq(result.try_mentions, 0)
+}
+
+///|
+test "latest non-finished terminal determines success" {
+  let session = @agent_session.Session(
+      SessionId("multi-turn"),
+      system_prompt="",
+    )
+    .append(User(UserMessage("first")))
+    .append(Terminal(Finished("done")))
+    .append(User(UserMessage("second")))
+    .append(Terminal(Failed("agent failed")))
+  let result = eval_session_for_test(session)
+  assert_false(result.success)
+  assert_false(result.finished)
+  assert_eq(result.terminal_status, "failed")
+  assert_true(result.reason.contains("agent terminal failed"))
+}
+
+///|
+test "finish tool terminal does not double count a model step" {
+  let session = @agent_session.Session(
+      SessionId("trial-finish"),
+      system_prompt="",
+    )
+    .append(User(UserMessage("finish")))
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(
+            id="call_finish",
+            name="finish",
+            arguments="{\"answer\":\"done\"}",
+          ),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="call_finish",
+          tool_name="finish",
+          content="finished: done",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let result = eval_session_for_test(session)
+  assert_eq(result.steps, 1)
+  assert_eq(result.tool_results, 1)
+  assert_true(result.finished)
+}
+
+///|
+test "same output dir preserves absolute workspace paths" {
+  let manifest = RunManifest(
+    model="deepseek-v4-flash",
+    prompt_label="flash",
+    task_file="eval/prompt_tasks/toml_parser_cli.md",
+    runs=1,
+    concurrency=1,
+    min_successes=1,
+    max_steps=160,
+    out_dir=".moonagent/eval_runs/default",
+    trials=[
+      TrialArtifact(
+        index=1,
+        workspace="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01",
+        log_path=".moonagent/eval_runs/default/logs/01.log",
+        session_id="trial-01",
+        events_path="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01/.openseek/sessions/trial-01/events.jsonl",
+        exit_code=0,
+      ),
+    ],
+  )
+  let relocated = manifest_for_output_dir(
+    manifest, ".moonagent/eval_runs/default",
+  )
+  assert_eq(
+    relocated.trials[0].workspace,
+    "/tmp/openseek/.moonagent/eval_runs/default/workspaces/01",
+  )
+}
+
+///|
+async test "analyze run writes reports to caller output directory" {
+  let root = @fs.tmpdir(prefix="openseek-prompt-analyze-out")
+  let out_dir = root + "/actual"
+  let stale_dir = root + "/stale"
+  @fs.mkdir(out_dir, recursive=true)
+  let actual_events_path = out_dir +
+    "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
+  let stale_events_path = stale_dir +
+    "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
+  @fs.mkdir(
+    out_dir + "/workspaces/01/.openseek/sessions/trial-01",
+    recursive=true,
+  )
+  @fs.mkdir(
+    stale_dir + "/workspaces/01/.openseek/sessions/trial-01",
+    recursive=true,
+  )
+  @fs.write_file(
+    actual_events_path,
+    assistant_events("trial-01", "I used @string.parse_int"),
+    create_mode=CreateOrTruncate,
+  )
+  @fs.write_file(
+    stale_events_path,
+    assistant_events("trial-01", "I only used moon test"),
+    create_mode=CreateOrTruncate,
+  )
+  let manifest_json : Json = {
+    "model": "deepseek-v4-flash",
+    "prompt_label": "flash",
+    "task_file": "eval/prompt_tasks/toml_parser_cli.md",
+    "runs": 0,
+    "concurrency": 1,
+    "min_successes": 0,
+    "max_steps": 160,
+    "out_dir": stale_dir,
+    "trials": (
+      [
+        {
+          "index": 1,
+          "workspace": stale_dir + "/workspaces/01",
+          "log_path": stale_dir + "/logs/01.log",
+          "session_id": "trial-01",
+          "events_path": stale_events_path,
+          "exit_code": 0,
+        },
+      ] : Json),
+  }
+  @fs.write_file(
+    manifest_path(out_dir),
+    manifest_json.stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  let report = analyze_run(out_dir)
+  assert_eq(report.out_dir, out_dir)
+  assert_eq(report.results[0].workspace, out_dir + "/workspaces/01")
+  assert_eq(report.results[0].events_path, actual_events_path)
+  assert_false(report.results[0].workspace.contains(stale_dir))
+  assert_eq(report.results[0].parse_int_mentions, 1)
+  assert_eq(report.results[0].moon_test_uses, 0)
+  assert_true(@fs.exists(out_dir + "/report.md"))
+  assert_true(@fs.exists(out_dir + "/report.html"))
+  assert_false(@fs.exists(stale_dir + "/report.md"))
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+test "json stdout probe accepts valid json only" {
+  assert_true(json_stdout_probe(0, "{\"a\":1}\n", "").passed)
+  let invalid = json_stdout_probe(0, "not-json\n", "")
+  assert_false(invalid.passed)
+  assert_true(invalid.reason.contains("stdout is not JSON"))
+}
+
+///|
+test "markdown report includes prompt label and parser metrics" {
+  let report : EvalReport = {
+    model: "deepseek-v4-flash",
+    prompt_label: "flash",
+    task_file: "eval/prompt_tasks/toml_parser_cli.md",
+    runs: 1,
+    concurrency: 1,
+    min_successes: 1,
+    successes: 1,
+    out_dir: "out",
+    results: [
+      {
+        index: 1,
+        prompt_label: "flash",
+        success: true,
+        reason: "ok",
+        workspace: "ws",
+        log_path: "log",
+        session_id: "trial-01",
+        events_path: "events",
+        exit_code: 0,
+        steps: 1,
+        tool_results: 1,
+        tool_errors: 0,
+        shell_uses: 0,
+        shell_failures: 0,
+        runtime_notices: 0,
+        finished: true,
+        finish_message: "done",
+        terminal_status: "finished",
+        terminal_message: "done",
+        validation: {
+          ran: true,
+          passed: true,
+          reason: "ok",
+          moon_check: true,
+          moon_test: true,
+          file_probe: true,
+          stdin_probe: true,
+          duplicate_probe: true,
+        },
+        parse_errors: 0,
+        partial_tail: false,
+        moon_check_uses: 1,
+        moon_test_uses: 1,
+        moon_run_e_mentions: 1,
+        moon_run_c_mentions: 0,
+        bad_run_e_mentions: 0,
+        from_str_mentions: 1,
+        parse_int_mentions: 0,
+        argparse_mentions: 1,
+        old_argparse_mentions: 0,
+        c_ffi_mentions: 0,
+        env_args_mentions: 0,
+        result_style_mentions: 0,
+        try_mentions: 0,
+        warnings: "",
+      },
+    ],
+  }
+  let text = report.markdown()
+  assert_true(text.contains("flash"))
+  assert_true(text.contains("Parse Errors"))
+  assert_true(text.contains("## Trial Details"))
+  assert_true(report.html().contains("<html"))
+  assert_true(report.html().contains("trial-card"))
+}

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -1,109 +1,30 @@
 ///|
-/// Verdict of one behavioral probe run against a trial's workspace, with the
-/// `reason` it failed ("ok" when it passed).
-pub struct ProbeResult {
-  passed : Bool
-  reason : String
-}
-
-///|
-/// Validation verdict for one trial's finished workspace: the overall
-/// `passed`/`reason` plus each individual gate — the project must type-check
-/// (`moon_check`), pass its tests (`moon_test`), and behave correctly on the
-/// file, stdin, and duplicate-handling probes.
-pub struct ValidationResult {
-  passed : Bool
-  reason : String
-  moon_check : Bool
-  moon_test : Bool
-  file_probe : Bool
-  stdin_probe : Bool
-  duplicate_probe : Bool
-}
-
-///|
-/// Everything recorded about one trial: identity (`index`, `prompt_label`),
-/// the verdict (`success`/`reason`), where it ran (`workspace`, `log_path`,
-/// `exit_code`), agent-loop measurements (`steps`, `tool_errors`,
-/// `finished`), the workspace `validation`, and the `*_mentions`/`*_uses`
-/// counters that track how often the transcript touches APIs and idioms the
-/// prompt under test tries to encourage or ban.
-pub struct TrialResult {
-  index : Int
-  prompt_label : String
-  success : Bool
-  reason : String
-  workspace : String
-  log_path : String
-  exit_code : Int
-  steps : Int
-  tool_errors : Int
-  finished : Bool
-  validation : ValidationResult
-  moon_check_uses : Int
-  moon_test_uses : Int
-  moon_run_e_mentions : Int
-  moon_run_c_mentions : Int
-  bad_run_e_mentions : Int
-  from_str_mentions : Int
-  parse_int_mentions : Int
-  argparse_mentions : Int
-  old_argparse_mentions : Int
-  c_ffi_mentions : Int
-  env_args_mentions : Int
-  result_style_mentions : Int
-  try_mentions : Int
-  warnings : String
-}
-
-///|
-/// One prompt-eval run's outcome: the configuration that defined it (model,
-/// prompt label, task file, trial counts), the success tally against
-/// `min_successes`, where artifacts were written, and every trial's result.
-pub struct EvalReport {
-  model : String
-  prompt_label : String
-  task_file : String
-  runs : Int
-  concurrency : Int
-  min_successes : Int
-  successes : Int
-  out_dir : String
-  results : Array[TrialResult]
-}
-
-///|
-priv struct AgentLogSummary {
-  finished : Bool
-  steps : Int
-  tool_errors : Int
-  shell_uses : Int
-}
-
-///|
-/// Run the whole prompt eval: `config.runs` agent trials of the task file,
-/// `config.concurrency` at a time, each in a fresh workspace and validated
-/// end-to-end. Returns the aggregated report; rendering and exit-status
-/// decisions stay with the caller.
-pub async fn run_suite(config : Config) -> EvalReport {
+/// Run the prompt task `config.runs` times, `config.concurrency` at a time,
+/// writing only durable artifacts: workspaces, raw process logs, recorded
+/// session `events.jsonl` files, and a run manifest. No validation or report
+/// analysis is performed in this phase.
+pub async fn run_experiments(config : Config) -> RunManifest {
+  if config.api_key == "" {
+    fail("api_key is required for running trials")
+  }
   prepare_output_dir(config.out_dir)
   let task_template = @fs.read_file(config.task_file).text()
-  let results = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
+  let trials = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
     run_trial(config, task_template, index)
   })
-  let report : EvalReport = {
-    model: config.model.to_string(),
-    prompt_label: config.prompt_label,
-    task_file: config.task_file,
-    runs: config.runs,
-    concurrency: config.concurrency,
-    min_successes: config.min_successes,
-    successes: count_successes(results),
-    out_dir: config.out_dir,
-    results,
-  }
-  write_report_files(report)
-  report
+  let manifest = RunManifest(
+    model=config.model.to_string(),
+    prompt_label=config.prompt_label,
+    task_file=config.task_file,
+    runs=config.runs,
+    concurrency=config.concurrency,
+    min_successes=config.min_successes,
+    max_steps=config.max_steps,
+    out_dir=config.out_dir,
+    trials~,
+  )
+  write_manifest(manifest)
+  manifest
 }
 
 ///|
@@ -140,19 +61,16 @@ async fn run_trial(
   config : Config,
   task_template : String,
   index : Int,
-) -> TrialResult {
-  let workspace = config.out_dir + "/workspaces/" + padded_index(index + 1)
+) -> TrialArtifact {
+  let trial_name = padded_index(index + 1)
+  let workspace = config.out_dir + "/workspaces/" + trial_name
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
+  let session_id = "trial-" + trial_name
   let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
-  // The engine runs *in* the trial workspace, so the prompt's environment
-  // grounding names the workspace rather than the OpenSeek checkout — and
-  // relative paths in the model's tool calls land in the right tree.
-  // Launcher-relative paths (the default --repo-root ".", the engine
-  // binary, prompt files) must be canonicalized before the child cwd
-  // changes their meaning. Prefer a prebuilt --engine binary: `moon run`
-  // resolves the repo's dev_build rule paths against the cwd — the trial
-  // workspace, not the checkout — and fails before the engine starts.
+  // The engine runs from the OpenSeek checkout and receives --dir for the
+  // isolated trial workspace. This keeps launcher-relative paths stable while
+  // ensuring the agent's session store and tool cwd live under the workspace.
   let repo_root = @fs.realpath(config.repo_root)
   let (program, args) = if config.engine != "" {
     (@fs.realpath(config.engine), [])
@@ -164,6 +82,10 @@ async fn run_trial(
     config.max_steps.to_string(),
     "--model",
     config.model.to_string(),
+    "--dir",
+    real_workspace,
+    "--session",
+    session_id,
   ])
   if config.system_prompt_file != "" {
     args.push("--system-prompt-file")
@@ -177,358 +99,93 @@ async fn run_trial(
   let (exit_code, output) = @process.collect_output_merged(
     program,
     args,
-    extra_env={
-      "DEEPSEEK": config.api_key,
-      "DEEPSEEK_MODEL": config.model.to_string(),
-      "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
-      // Trials inherit the developer's env, so point the global skills
-      // lookup at a workspace path that does not exist — the developer's
-      // own ~/.openseek/skills must never reach a trial prompt.
-      "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
-    },
+    extra_env=trial_extra_env(config, real_workspace),
     inherit_env=true,
-    cwd=real_workspace,
+    cwd=repo_root,
   )
-  let log_text = output.text()
-  let log_path = config.out_dir + "/logs/" + padded_index(index + 1) + ".log"
-  @fs.write_file(log_path, log_text, create_mode=CreateOrTruncate)
-  let validation = validate_toml_workspace(real_workspace)
-  evaluate_trial(
-    config.prompt_label,
-    index,
+  let log_path = config.out_dir + "/logs/" + trial_name + ".log"
+  @fs.write_file(log_path, output.text(), create_mode=CreateOrTruncate)
+  let events_path = discover_session_events(
     real_workspace,
-    log_path,
-    exit_code,
-    log_text,
-    validation,
+    session_id,
+    fallback=real_workspace +
+      "/.openseek/sessions/" +
+      session_id +
+      "/events.jsonl",
+  )
+  TrialArtifact(
+    index=index + 1,
+    workspace=real_workspace,
+    log_path~,
+    session_id~,
+    events_path~,
+    exit_code~,
   )
 }
 
 ///|
-fn evaluate_trial(
-  prompt_label : String,
-  index : Int,
-  workspace : String,
-  log_path : String,
-  exit_code : Int,
-  log_text : String,
-  validation : ValidationResult,
-) -> TrialResult {
-  let log_summary = summarize_agent_log(log_text)
-  let finished = log_summary.finished
-  let reasons : Array[String] = []
-  if exit_code != 0 {
-    reasons.push("agent process exited \{exit_code}")
-  }
-  if !finished {
-    reasons.push("finish marker missing")
-  }
-  if !validation.passed {
-    reasons.push(validation.reason)
-  }
-  let warnings : Array[String] = []
-  if log_summary.shell_uses > 0 {
-    warnings.push("shell output observed \{log_summary.shell_uses} time(s)")
-  }
-  let success = reasons.length() == 0
+fn trial_extra_env(
+  config : Config,
+  real_workspace : String,
+) -> Map[String, String] {
   {
-    index: index + 1,
-    prompt_label,
-    success,
-    reason: if success {
-      "ok"
-    } else {
-      reasons.join("; ")
-    },
-    workspace,
-    log_path,
-    exit_code,
-    steps: log_summary.steps,
-    tool_errors: log_summary.tool_errors,
-    finished,
-    validation,
-    moon_check_uses: count_lines_containing_all(log_text, ["command=moon check"]),
-    moon_test_uses: count_lines_containing_all(log_text, ["command=moon test"]),
-    moon_run_e_mentions: count_lines_containing_all(log_text, [
-      "moon run", " -e",
-    ]),
-    moon_run_c_mentions: count_lines_containing_all(log_text, [
-      "moon run", " -c",
-    ]),
-    bad_run_e_mentions: count_occurrences(
-      log_text, "a value is required for `-e <SCRIPT>`",
-    ),
-    from_str_mentions: count_occurrences(log_text, "@string.from_str"),
-    parse_int_mentions: count_occurrences(log_text, "@string.parse_int"),
-    argparse_mentions: count_occurrences(log_text, "@argparse.parse") +
-    count_occurrences(log_text, ".parse("),
-    old_argparse_mentions: count_occurrences(log_text, "@argparse.command") +
-    count_occurrences(log_text, "@argparse.flag") +
-    count_occurrences(log_text, "@argparse.argument") +
-    count_occurrences(log_text, ".is_present") +
-    count_occurrences(log_text, ".value("),
-    c_ffi_mentions: count_occurrences(log_text, "extern \"c\"") +
-    count_occurrences(log_text, "native-stub"),
-    env_args_mentions: count_occurrences(log_text, "@env.args"),
-    result_style_mentions: count_occurrences(log_text, "Result[") +
-    count_occurrences(log_text, "Ok(") +
-    count_occurrences(log_text, "Err("),
-    try_mentions: count_occurrences(log_text, "try?") +
-    count_occurrences(log_text, "try!"),
-    warnings: if warnings.length() == 0 {
-      ""
-    } else {
-      warnings.join("; ")
-    },
+    "DEEPSEEK": config.api_key,
+    "DEEPSEEK_MODEL": config.model.to_string(),
+    "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
+    "OPENSEEK_SESSION_ROOT": ".openseek",
+    "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
   }
 }
 
 ///|
-fn summarize_agent_log(log_text : String) -> AgentLogSummary {
-  let mut has_json_events = false
-  let mut finished = false
-  let mut steps = 0
-  let mut tool_errors = 0
-  let mut shell_uses = 0
-  for line in log_text.split("\n") {
-    let json = @json.parse(line.trim()) catch { _ => continue }
-    match json {
-      { "event": String("agent_step"), .. } => {
-        has_json_events = true
-        steps += 1
-      }
-      { "event": String("agent_finished"), .. } => {
-        has_json_events = true
-        finished = true
-      }
-      {
-        "event": String("tool_result"),
-        "tool_name": String(tool_name),
-        "is_error": is_error,
-        ..
-      } => {
-        has_json_events = true
-        if tool_name == "shell" {
-          shell_uses += 1
-        }
-        match is_error {
-          True => tool_errors += 1
-          _ => ()
-        }
-      }
-      { "event": String(_), .. } => has_json_events = true
-      _ => ()
-    }
-  }
-  if has_json_events {
-    { finished, steps, tool_errors, shell_uses }
-  } else {
-    let leading_shell_use = if log_text.has_prefix("tool: exit=") {
-      1
-    } else {
-      0
-    }
-    let shell_uses = count_occurrences(log_text, "\ntool: exit=") +
-      leading_shell_use
-    {
-      finished: log_text.contains("=== finished ==="),
-      steps: count_occurrences(log_text, "--- step "),
-      tool_errors: count_occurrences(log_text, "tool error:"),
-      shell_uses,
-    }
-  }
-}
-
-///|
-async fn validate_toml_workspace(workspace : String) -> ValidationResult {
-  let check = run_command(workspace, ["moon", "check", "--target", "native"])
-  let test_probe = run_command(workspace, ["moon", "test", "--target", "native"])
-  let file_probe = run_file_probe(workspace)
-  let stdin_probe = run_stdin_probe(workspace)
-  let duplicate_probe = run_duplicate_probe(workspace)
-  let failures : Array[String] = []
-  if !check.passed {
-    failures.push("moon check: " + check.reason)
-  }
-  if !test_probe.passed {
-    failures.push("moon test: " + test_probe.reason)
-  }
-  if !file_probe.passed {
-    failures.push("file probe: " + file_probe.reason)
-  }
-  if !stdin_probe.passed {
-    failures.push("stdin probe: " + stdin_probe.reason)
-  }
-  if !duplicate_probe.passed {
-    failures.push("duplicate probe: " + duplicate_probe.reason)
-  }
-  {
-    passed: failures.length() == 0,
-    reason: if failures.length() == 0 {
-      "ok"
-    } else {
-      failures.join("; ")
-    },
-    moon_check: check.passed,
-    moon_test: test_probe.passed,
-    file_probe: file_probe.passed,
-    stdin_probe: stdin_probe.passed,
-    duplicate_probe: duplicate_probe.passed,
-  }
-}
-
-///|
-async fn run_command(
+async fn discover_session_events(
   workspace : String,
-  command : Array[String],
-) -> ProbeResult {
-  let args = [ for i in 1..<command.length() => command[i] ]
-  let (code, output) = @process.collect_output_merged(
-    command[0],
-    args,
-    cwd=workspace,
-  )
-  if code == 0 {
-    { passed: true, reason: "ok" }
+  session_id : String,
+  fallback~ : String,
+) -> String {
+  let matches : Array[String] = []
+  collect_session_events(workspace, session_id, matches)
+  if matches.length() > 0 {
+    matches[0]
   } else {
-    { passed: false, reason: "exit \{code}: " + summarize(output.text()) }
+    fallback
   }
 }
 
 ///|
-async fn run_file_probe(workspace : String) -> ProbeResult {
-  let path = workspace + "/.openseek-file-probe.toml"
-  @fs.write_file(
-    path,
-    (
-      #|[owner]
-      #|name = "Alice"
-      #|age = 30
-      #|[database]
-      #|host = "localhost"
-      #|ports = [8000, 8001]
-      #|
-    ),
-    create_mode=CreateOrTruncate,
-  )
-  let (code, stdout, stderr) = @process.collect_output(
-    "moon",
-    ["run", "--target", "native", "cmd/tomljson", "--", path],
-    cwd=workspace,
-  )
-  json_stdout_probe(code, stdout.text(), stderr.text())
-}
-
-///|
-async fn run_stdin_probe(workspace : String) -> ProbeResult {
-  let path = workspace + "/.openseek-stdin-probe.toml"
-  @fs.write_file(path, "a.b.c = 42\nx.y = true\n", create_mode=CreateOrTruncate)
-  let (code, stdout, stderr) = @process.collect_output(
-    "moon",
-    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
-    stdin=@process.redirect_from_file(path),
-    cwd=workspace,
-  )
-  json_stdout_probe(code, stdout.text(), stderr.text())
-}
-
-///|
-async fn run_duplicate_probe(workspace : String) -> ProbeResult {
-  let path = workspace + "/.openseek-duplicate-probe.toml"
-  @fs.write_file(path, "key = 1\nkey = 2\n", create_mode=CreateOrTruncate)
-  let (code, stdout, stderr) = @process.collect_output(
-    "moon",
-    ["run", "--target", "native", "cmd/tomljson", "--", "--stdin"],
-    stdin=@process.redirect_from_file(path),
-    cwd=workspace,
-  )
-  let combined = stdout.text() + stderr.text()
-  if combined.contains("RUNTIME ERROR") || combined.contains("panic") {
-    return { passed: false, reason: "debug/panic output leaked" }
-  }
-  if !combined.contains("duplicate") && !combined.contains("Duplicate") {
-    return {
-      passed: false,
-      reason: "missing duplicate-key message, exit \{code}: " +
-      summarize(combined),
+async fn collect_session_events(
+  dir : String,
+  session_id : String,
+  matches : Array[String],
+) -> Unit {
+  guard is_directory(dir) else { return }
+  let names = @fs.readdir(dir, sort=true) catch { _ => return }
+  for name in names {
+    if should_skip_scan_dir(name) {
+      continue
+    }
+    let path = dir + "/" + name
+    if is_directory(path) {
+      collect_session_events(path, session_id, matches)
+    } else if name == "events.jsonl" &&
+      path.contains("/sessions/" + session_id + "/") {
+      matches.push(path)
     }
   }
-  { passed: true, reason: "ok" }
 }
 
 ///|
-fn json_stdout_probe(
-  code : Int,
-  stdout : String,
-  stderr : String,
-) -> ProbeResult {
-  if code != 0 {
-    return {
-      passed: false,
-      reason: "exit \{code}: " + summarize(stdout + stderr),
-    }
-  }
-  let trimmed = stdout.trim().to_owned()
-  let _ = @json.parse(trimmed) catch {
-    error =>
-      return {
-        passed: false,
-        reason: "stdout is not JSON: \{error}; stdout=" + summarize(stdout),
-      }
-  }
-  { passed: true, reason: "ok" }
+async fn is_directory(path : String) -> Bool {
+  (@fs.kind(path, follow_symlink=false) catch { _ => return false }) ==
+  Directory
 }
 
 ///|
-fn count_successes(results : Array[TrialResult]) -> Int {
-  let mut count = 0
-  for result in results {
-    if result.success {
-      count += 1
-    }
-  }
-  count
-}
-
-///|
-fn count_occurrences(content : String, needle : String) -> Int {
-  if needle == "" {
-    return 0
-  }
-  let pieces = content.split(needle).collect()
-  pieces.length() - 1
-}
-
-///|
-fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
-  let mut count = 0
-  for piece in content.split("\n") {
-    let line = piece.to_owned()
-    let mut matched = true
-    for needle in needles {
-      if !line.contains(needle) {
-        matched = false
-      }
-    }
-    if matched {
-      count += 1
-    }
-  }
-  count
-}
-
-///|
-fn summarize(text : String) -> String {
-  let one_line = text
-    .replace_all(old="\r\n", new="\n")
-    .replace_all(old="\n", new=" ")
-    .trim()
-    .to_owned()
-  if one_line.length() <= 240 {
-    one_line
-  } else {
-    one_line.sub(start=0, end=240).to_owned() + "..."
-  }
+fn should_skip_scan_dir(name : String) -> Bool {
+  name == ".git" ||
+  name == "node_modules" ||
+  name == ".mooncakes" ||
+  name == "_build"
 }
 
 ///|

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -1,5 +1,5 @@
 ///|
-async test "prepare output dir creates a missing output directory" {
+async test "prepare output dir creates runner artifact directories" {
   let root = @fs.tmpdir(prefix="openseek-prompt-task-output")
   let out_dir = root + "/out"
   prepare_output_dir(out_dir)
@@ -26,130 +26,28 @@ async test "indexed runner honors concurrency and preserves order" {
 }
 
 ///|
-test "json stdout probe accepts valid json only" {
-  assert_true(json_stdout_probe(0, "{\"a\":1}\n", "").passed)
-  let invalid = json_stdout_probe(0, "not-json\n", "")
-  assert_false(invalid.passed)
-  assert_true(invalid.reason.contains("stdout is not JSON"))
-}
-
-///|
-test "agent log summary reads jsonl events and ignores process noise" {
-  let summary = summarize_agent_log(
-    (
-      #|Blocking waiting for file lock /tmp/.moon-lock ...
-      #|{"event":"agent_step","step":1}
-      #|{"event":"tool_result","tool_name":"write","is_error":true,"content":"failed"}
-      #|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
-      #|{"event":"agent_finished","answer":"ok"}
-    ),
+test "trial environment pins workspace-local session root" {
+  let config = Config(
+    api_key="key",
+    model=V4Flash,
+    runs=1,
+    concurrency=1,
+    min_successes=1,
+    max_steps=12,
+    out_dir="out",
+    repo_root=".",
+    prompt_label="label",
+    task_file="task.md",
+    system_prompt_file="",
+    system_prompt_addendum_file="",
   )
-  assert_true(summary.finished)
-  assert_eq(summary.steps, 1)
-  assert_eq(summary.tool_errors, 1)
-  assert_eq(summary.shell_uses, 1)
-}
-
-///|
-test "agent log summary falls back to legacy text markers" {
-  let summary = summarize_agent_log(
-    (
-      #|tool: exit=0
-      #|--- step 1 ---
-      #|tool error: failed
-      #|=== finished ===
-    ),
-  )
-  assert_true(summary.finished)
-  assert_eq(summary.steps, 1)
-  assert_eq(summary.tool_errors, 1)
-  assert_eq(summary.shell_uses, 1)
-}
-
-///|
-test "trial evaluation uses jsonl finish and counters" {
-  let validation : ValidationResult = {
-    passed: true,
-    reason: "ok",
-    moon_check: true,
-    moon_test: true,
-    file_probe: true,
-    stdin_probe: true,
-    duplicate_probe: true,
+  let env = trial_extra_env(config, "/tmp/workspace")
+  guard env.get("OPENSEEK_SESSION_ROOT") is Some(root) else {
+    fail("expected OPENSEEK_SESSION_ROOT")
   }
-  let result = evaluate_trial(
-    "flash",
-    0,
-    "ws",
-    "log",
-    0,
-    (
-      #|not json
-      #|{"event":"agent_step","step":1}
-      #|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
-      #|{"event":"agent_finished","answer":"ok"}
-    ),
-    validation,
-  )
-  assert_true(result.success)
-  assert_true(result.finished)
-  assert_eq(result.reason, "ok")
-  assert_eq(result.steps, 1)
-  assert_eq(result.tool_errors, 0)
-  assert_eq(result.warnings, "shell output observed 1 time(s)")
-}
-
-///|
-test "markdown report includes concurrency and prompt label" {
-  let report : EvalReport = {
-    model: "deepseek-v4-flash",
-    prompt_label: "flash",
-    task_file: "eval/prompt_tasks/toml_parser_cli.md",
-    runs: 1,
-    concurrency: 1,
-    min_successes: 1,
-    successes: 1,
-    out_dir: "out",
-    results: [
-      {
-        index: 1,
-        prompt_label: "flash",
-        success: true,
-        reason: "ok",
-        workspace: "ws",
-        log_path: "log",
-        exit_code: 0,
-        steps: 10,
-        tool_errors: 0,
-        finished: true,
-        validation: {
-          passed: true,
-          reason: "ok",
-          moon_check: true,
-          moon_test: true,
-          file_probe: true,
-          stdin_probe: true,
-          duplicate_probe: true,
-        },
-        moon_check_uses: 1,
-        moon_test_uses: 1,
-        moon_run_e_mentions: 1,
-        moon_run_c_mentions: 0,
-        bad_run_e_mentions: 0,
-        from_str_mentions: 1,
-        parse_int_mentions: 0,
-        argparse_mentions: 1,
-        old_argparse_mentions: 0,
-        c_ffi_mentions: 0,
-        env_args_mentions: 0,
-        result_style_mentions: 0,
-        try_mentions: 0,
-        warnings: "",
-      },
-    ],
+  assert_eq(root, ".openseek")
+  guard env.get("OPENSEEK_GLOBAL_SKILLS_DIR") is Some(skills_dir) else {
+    fail("expected OPENSEEK_GLOBAL_SKILLS_DIR")
   }
-  let text = report.markdown()
-  assert_true(text.contains("flash"))
-  assert_true(text.contains("concurrency"))
-  assert_true(text.contains("File Probe"))
+  assert_eq(skills_dir, "/tmp/workspace/.no-global-skills")
 }

--- a/eval/prompt_task/harness/manifest.mbt
+++ b/eval/prompt_task/harness/manifest.mbt
@@ -1,0 +1,181 @@
+///|
+let manifest_file_name : String = "run_manifest.json"
+
+///|
+/// Durable artifact record for one prompt-task trial. The runner writes these
+/// fields once; analyzers can replay report generation from them without
+/// rerunning the agent.
+pub struct TrialArtifact {
+  index : Int
+  workspace : String
+  log_path : String
+  session_id : String
+  events_path : String
+  exit_code : Int
+}
+
+///|
+/// Build a trial artifact entry for a completed prompt-task experiment trial.
+pub fn TrialArtifact::TrialArtifact(
+  index~ : Int,
+  workspace~ : String,
+  log_path~ : String,
+  session_id~ : String,
+  events_path~ : String,
+  exit_code~ : Int,
+) -> TrialArtifact {
+  { index, workspace, log_path, session_id, events_path, exit_code }
+}
+
+///|
+/// Manifest for one prompt-task experiment run.
+pub struct RunManifest {
+  model : String
+  prompt_label : String
+  task_file : String
+  runs : Int
+  concurrency : Int
+  min_successes : Int
+  max_steps : Int
+  out_dir : String
+  trials : Array[TrialArtifact]
+}
+
+///|
+/// Build a manifest for a completed prompt-task experiment run.
+pub fn RunManifest::RunManifest(
+  model~ : String,
+  prompt_label~ : String,
+  task_file~ : String,
+  runs~ : Int,
+  concurrency~ : Int,
+  min_successes~ : Int,
+  max_steps~ : Int,
+  out_dir~ : String,
+  trials~ : Array[TrialArtifact],
+) -> RunManifest {
+  {
+    model,
+    prompt_label,
+    task_file,
+    runs,
+    concurrency,
+    min_successes,
+    max_steps,
+    out_dir,
+    trials,
+  }
+}
+
+///|
+/// Path to the run manifest under an eval output directory.
+pub fn manifest_path(out_dir : String) -> String {
+  out_dir + "/" + manifest_file_name
+}
+
+///|
+/// Write the run manifest to `run_manifest.json`.
+async fn write_manifest(manifest : RunManifest) -> Unit {
+  @fs.write_file(
+    manifest_path(manifest.out_dir),
+    manifest.to_json().stringify(),
+    create_mode=CreateOrTruncate,
+  )
+}
+
+///|
+/// Read a run manifest from `run_manifest.json` under `out_dir`.
+async fn read_manifest(out_dir : String) -> RunManifest {
+  let text = @fs.read_file(manifest_path(out_dir)).text()
+  RunManifest::from_json(@json.parse(text))
+}
+
+///|
+fn RunManifest::to_json(self : RunManifest) -> Json {
+  {
+    "model": self.model,
+    "prompt_label": self.prompt_label,
+    "task_file": self.task_file,
+    "runs": self.runs,
+    "concurrency": self.concurrency,
+    "min_successes": self.min_successes,
+    "max_steps": self.max_steps,
+    "out_dir": self.out_dir,
+    "trials": ([ for trial in self.trials => trial.to_json() ] : Json),
+  }
+}
+
+///|
+fn TrialArtifact::to_json(self : TrialArtifact) -> Json {
+  {
+    "index": self.index,
+    "workspace": self.workspace,
+    "log_path": self.log_path,
+    "session_id": self.session_id,
+    "events_path": self.events_path,
+    "exit_code": self.exit_code,
+  }
+}
+
+///|
+fn RunManifest::from_json(json : Json) -> RunManifest raise {
+  let fields = object_fields(json, "manifest")
+  let trials : Array[TrialArtifact] = match fields.get("trials") {
+    Some(Array(items)) =>
+      [
+        for item in items => TrialArtifact::from_json(item)
+      ]
+    Some(_) => fail("manifest.trials must be an array")
+    None => fail("manifest.trials is missing")
+  }
+  {
+    model: string_field(fields, "model"),
+    prompt_label: string_field(fields, "prompt_label"),
+    task_file: string_field(fields, "task_file"),
+    runs: int_field(fields, "runs"),
+    concurrency: int_field(fields, "concurrency"),
+    min_successes: int_field(fields, "min_successes"),
+    max_steps: int_field(fields, "max_steps"),
+    out_dir: string_field(fields, "out_dir"),
+    trials,
+  }
+}
+
+///|
+fn TrialArtifact::from_json(json : Json) -> TrialArtifact raise {
+  let fields = object_fields(json, "trial")
+  {
+    index: int_field(fields, "index"),
+    workspace: string_field(fields, "workspace"),
+    log_path: string_field(fields, "log_path"),
+    session_id: string_field(fields, "session_id"),
+    events_path: string_field(fields, "events_path"),
+    exit_code: int_field(fields, "exit_code"),
+  }
+}
+
+///|
+fn object_fields(json : Json, label : String) -> Map[String, Json] raise {
+  match json {
+    Object(fields) => fields
+    _ => fail("\{label} must be a JSON object")
+  }
+}
+
+///|
+fn string_field(fields : Map[String, Json], key : String) -> String raise {
+  match fields.get(key) {
+    Some(String(value)) => value
+    Some(_) => fail("\{key} must be a string")
+    None => fail("\{key} is missing")
+  }
+}
+
+///|
+fn int_field(fields : Map[String, Json], key : String) -> Int raise {
+  match fields.get(key) {
+    Some(Number(value, ..)) => value.to_int()
+    Some(_) => fail("\{key} must be an int")
+    None => fail("\{key} is missing")
+  }
+}

--- a/eval/prompt_task/harness/manifest_wbtest.mbt
+++ b/eval/prompt_task/harness/manifest_wbtest.mbt
@@ -1,0 +1,32 @@
+///|
+async test "manifest round trips run artifacts" {
+  @async.sleep(0)
+  let root = @fs.tmpdir(prefix="openseek-prompt-task-manifest")
+  let manifest : RunManifest = {
+    model: "deepseek-v4-flash",
+    prompt_label: "flash",
+    task_file: "eval/prompt_tasks/toml_parser_cli.md",
+    runs: 1,
+    concurrency: 1,
+    min_successes: 1,
+    max_steps: 160,
+    out_dir: root,
+    trials: [
+      {
+        index: 1,
+        workspace: root + "/workspaces/01",
+        log_path: root + "/logs/01.log",
+        session_id: "trial-01",
+        events_path: root +
+        "/workspaces/01/.openseek/sessions/trial-01/events.jsonl",
+        exit_code: 0,
+      },
+    ],
+  }
+  write_manifest(manifest)
+  let loaded = read_manifest(root)
+  assert_eq(loaded.model, "deepseek-v4-flash")
+  assert_eq(loaded.trials.length(), 1)
+  assert_eq(loaded.trials[0].session_id, "trial-01")
+  @fs.rmdir(root, recursive=true)
+}

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -1,6 +1,9 @@
 import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/eval/report",
+  "bobzhang/openseek/eval/session_analyzer",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",

--- a/eval/prompt_task/harness/pkg.generated.mbti
+++ b/eval/prompt_task/harness/pkg.generated.mbti
@@ -6,7 +6,11 @@ import {
 }
 
 // Values
-pub async fn run_suite(Config) -> EvalReport
+pub async fn analyze_run(String) -> EvalReport
+
+pub fn manifest_path(String) -> String
+
+pub async fn run_experiments(Config) -> RunManifest
 
 // Errors
 
@@ -37,29 +41,36 @@ pub struct EvalReport {
   min_successes : Int
   successes : Int
   out_dir : String
-  results : Array[TrialResult]
+  results : Array[EvalResult]
 }
 pub fn EvalReport::failure_message(Self) -> String
+pub fn EvalReport::html(Self) -> String
 pub fn EvalReport::markdown(Self) -> String
 pub fn EvalReport::passed(Self) -> Bool
 
-pub struct ProbeResult {
-  passed : Bool
-  reason : String
-}
-
-pub struct TrialResult {
+pub struct EvalResult {
   index : Int
   prompt_label : String
   success : Bool
   reason : String
   workspace : String
   log_path : String
+  session_id : String
+  events_path : String
   exit_code : Int
   steps : Int
+  tool_results : Int
   tool_errors : Int
+  shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
   finished : Bool
+  finish_message : String
+  terminal_status : String
+  terminal_message : String
   validation : ValidationResult
+  parse_errors : Int
+  partial_tail : Bool
   moon_check_uses : Int
   moon_test_uses : Int
   moon_run_e_mentions : Int
@@ -75,8 +86,34 @@ pub struct TrialResult {
   try_mentions : Int
   warnings : String
 }
+pub fn EvalResult::html(Self) -> String
+pub fn EvalResult::markdown(Self) -> String
+
+pub struct RunManifest {
+  model : String
+  prompt_label : String
+  task_file : String
+  runs : Int
+  concurrency : Int
+  min_successes : Int
+  max_steps : Int
+  out_dir : String
+  trials : Array[TrialArtifact]
+}
+pub fn RunManifest::RunManifest(model~ : String, prompt_label~ : String, task_file~ : String, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, trials~ : Array[TrialArtifact]) -> Self
+
+pub struct TrialArtifact {
+  index : Int
+  workspace : String
+  log_path : String
+  session_id : String
+  events_path : String
+  exit_code : Int
+}
+pub fn TrialArtifact::TrialArtifact(index~ : Int, workspace~ : String, log_path~ : String, session_id~ : String, events_path~ : String, exit_code~ : Int) -> Self
 
 pub struct ValidationResult {
+  ran : Bool
   passed : Bool
   reason : String
   moon_check : Bool

--- a/eval/prompt_task/harness/report.mbt
+++ b/eval/prompt_task/harness/report.mbt
@@ -1,6 +1,24 @@
 ///|
 async fn write_report_files(report : EvalReport) -> Unit {
-  @report.write_files(report.out_dir, report.markdown(), report.to_json())
+  @report.write_files(
+    report.out_dir,
+    report.markdown(),
+    report.to_json(),
+    html=report.html(),
+  )
+  for result in report.results {
+    write_eval_result_files(report.out_dir, result)
+  }
+}
+
+///|
+async fn write_eval_result_files(out_dir : String, result : EvalResult) -> Unit {
+  @report.write_files(
+    out_dir + "/eval_results/" + eval_result_artifact_name(result),
+    result.markdown(),
+    result.to_json(),
+    html=result.html(),
+  )
 }
 
 ///|
@@ -20,7 +38,7 @@ fn EvalReport::to_json(self : EvalReport) -> Json {
 }
 
 ///|
-fn TrialResult::to_json(self : TrialResult) -> Json {
+fn EvalResult::to_json(self : EvalResult) -> Json {
   {
     "index": self.index,
     "prompt_label": self.prompt_label,
@@ -28,11 +46,22 @@ fn TrialResult::to_json(self : TrialResult) -> Json {
     "reason": self.reason,
     "workspace": self.workspace,
     "log_path": self.log_path,
+    "session_id": self.session_id,
+    "events_path": self.events_path,
     "exit_code": self.exit_code,
     "steps": self.steps,
+    "tool_results": self.tool_results,
     "tool_errors": self.tool_errors,
+    "shell_uses": self.shell_uses,
+    "shell_failures": self.shell_failures,
+    "runtime_notices": self.runtime_notices,
     "finished": self.finished,
+    "finish_message": self.finish_message,
+    "terminal_status": self.terminal_status,
+    "terminal_message": self.terminal_message,
     "validation": self.validation.to_json(),
+    "parse_errors": self.parse_errors,
+    "partial_tail": self.partial_tail,
     "moon_check_uses": self.moon_check_uses,
     "moon_test_uses": self.moon_test_uses,
     "moon_run_e_mentions": self.moon_run_e_mentions,
@@ -53,6 +82,7 @@ fn TrialResult::to_json(self : TrialResult) -> Json {
 ///|
 fn ValidationResult::to_json(self : ValidationResult) -> Json {
   {
+    "ran": self.ran,
     "passed": self.passed,
     "reason": self.reason,
     "moon_check": self.moon_check,
@@ -64,24 +94,39 @@ fn ValidationResult::to_json(self : ValidationResult) -> Json {
 }
 
 ///|
-/// Whether the run met its success threshold. Thresholded rather than
-/// all-or-nothing because agent trials are stochastic: a prompt is judged on
-/// its success rate, not on a single unlucky trial.
+/// Whether the analysis met its configured success threshold.
 pub fn EvalReport::passed(self : EvalReport) -> Bool {
   self.successes >= self.min_successes
 }
 
 ///|
-/// The one-line failure summary a runner prints (and exits non-zero with)
-/// when the threshold was missed, stating tally and threshold.
+/// One-line failure summary for CLIs that exit non-zero on a missed threshold.
 pub fn EvalReport::failure_message(self : EvalReport) -> String {
   "prompt task eval failed: \{self.successes}/\{self.runs} below threshold \{self.min_successes}/\{self.runs}"
 }
 
 ///|
-/// Render this run as the standard markdown report document.
+/// Render this prompt-task analysis report as Markdown.
 pub fn EvalReport::markdown(self : EvalReport) -> String {
   self.as_report().markdown()
+}
+
+///|
+/// Render this prompt-task analysis report as standalone HTML.
+pub fn EvalReport::html(self : EvalReport) -> String {
+  self.as_report().html()
+}
+
+///|
+/// Render this single-session eval result as Markdown.
+pub fn EvalResult::markdown(self : EvalResult) -> String {
+  self.as_report(out_dir="").markdown()
+}
+
+///|
+/// Render this single-session eval result as standalone HTML.
+pub fn EvalResult::html(self : EvalResult) -> String {
+  self.as_report(out_dir="").html()
 }
 
 ///|
@@ -99,65 +144,206 @@ fn EvalReport::as_report(self : EvalReport) -> @report.Report {
       Metric(name="output", value=self.out_dir),
     ],
     metric_columns=[
-      "Steps", "Tool Errors", "Finished", "Validation", "Check", "Test", "File Probe",
-      "Stdin Probe", "Dup Probe", "Run -e", "Run -c", "Bad -e", "from_str", "parse_int",
-      "argparse", "old argparse", "C FFI", "env args", "containers", "try", "Exit Code",
+      "Steps", "Tool Results", "Tool Errors", "Shell Failures", "Finished", "Validation",
+      "Exit Code",
     ],
     rows=[
       for result in self.results => {
-        ReportRow(
-          index=result.index,
-          name="trial-\{padded_index(result.index)}",
-          success=result.success,
-          reason=result.reason,
-          warnings=result.warnings,
-          metrics=[
-            Metric(name="Steps", value=result.steps.to_string()),
-            Metric(name="Tool Errors", value=result.tool_errors.to_string()),
-            Metric(name="Finished", value=result.finished.to_string()),
-            Metric(
-              name="Validation",
-              value=result.validation.passed.to_string(),
-            ),
-            Metric(name="Check", value=result.validation.moon_check.to_string()),
-            Metric(name="Test", value=result.validation.moon_test.to_string()),
-            Metric(
-              name="File Probe",
-              value=result.validation.file_probe.to_string(),
-            ),
-            Metric(
-              name="Stdin Probe",
-              value=result.validation.stdin_probe.to_string(),
-            ),
-            Metric(
-              name="Dup Probe",
-              value=result.validation.duplicate_probe.to_string(),
-            ),
-            Metric(name="Run -e", value=result.moon_run_e_mentions.to_string()),
-            Metric(name="Run -c", value=result.moon_run_c_mentions.to_string()),
-            Metric(name="Bad -e", value=result.bad_run_e_mentions.to_string()),
-            Metric(name="from_str", value=result.from_str_mentions.to_string()),
-            Metric(
-              name="parse_int",
-              value=result.parse_int_mentions.to_string(),
-            ),
-            Metric(name="argparse", value=result.argparse_mentions.to_string()),
-            Metric(
-              name="old argparse",
-              value=result.old_argparse_mentions.to_string(),
-            ),
-            Metric(name="C FFI", value=result.c_ffi_mentions.to_string()),
-            Metric(name="env args", value=result.env_args_mentions.to_string()),
-            Metric(
-              name="containers",
-              value=result.result_style_mentions.to_string(),
-            ),
-            Metric(name="try", value=result.try_mentions.to_string()),
-            Metric(name="Exit Code", value=result.exit_code.to_string()),
-          ],
-          log_path=result.log_path,
-        )
+        eval_result_row(result, out_dir=self.out_dir, include_eval_link=true)
       }
     ],
   )
+}
+
+///|
+fn EvalResult::as_report(
+  self : EvalResult,
+  out_dir~ : String,
+) -> @report.Report {
+  Report(
+    title="Prompt Task Eval Result: " + eval_result_name(self),
+    summary=[
+      Metric(name="session", value=empty_dash(self.session_id)),
+      Metric(name="prompt", value=empty_dash(self.prompt_label)),
+      Metric(name="result", value=if self.success { "pass" } else { "fail" }),
+      Metric(name="reason", value=self.reason),
+      Metric(name="workspace", value=empty_dash(self.workspace)),
+      Metric(name="events", value=empty_dash(self.events_path)),
+    ],
+    metric_columns=[
+      "Steps", "Tool Results", "Tool Errors", "Shell Failures", "Finished", "Validation",
+      "Exit Code",
+    ],
+    rows=[eval_result_row(self, out_dir~, include_eval_link=false)],
+  )
+}
+
+///|
+fn eval_result_row(
+  result : EvalResult,
+  out_dir~ : String,
+  include_eval_link~ : Bool,
+) -> @report.ReportRow {
+  ReportRow(
+    index=display_index(result),
+    name=eval_result_name(result),
+    success=result.success,
+    reason=result.reason,
+    warnings=result.warnings,
+    metrics=[
+      Metric(name="Steps", value=result.steps.to_string()),
+      Metric(name="Tool Results", value=result.tool_results.to_string()),
+      Metric(name="Tool Errors", value=result.tool_errors.to_string()),
+      Metric(name="Shell Failures", value=result.shell_failures.to_string()),
+      Metric(name="Finished", value=result.finished.to_string()),
+      Metric(name="Validation", value=validation_status(result.validation)),
+      Metric(name="Exit Code", value=result.exit_code.to_string()),
+    ],
+    details=eval_details(result, out_dir~, include_eval_link~),
+    log_path=relative_artifact_path(out_dir, result.log_path),
+  )
+}
+
+///|
+fn eval_details(
+  result : EvalResult,
+  out_dir~ : String,
+  include_eval_link~ : Bool,
+) -> Array[@report.Metric] {
+  let details : Array[@report.Metric] = [
+    Metric(name="Session", value=result.session_id),
+    Metric(
+      name="Workspace",
+      value=relative_artifact_path(out_dir, result.workspace),
+    ),
+    Metric(
+      name="Events",
+      value=relative_artifact_path(out_dir, result.events_path),
+    ),
+    Metric(name="Log", value=relative_artifact_path(out_dir, result.log_path)),
+    Metric(name="Terminal Status", value=empty_dash(result.terminal_status)),
+    Metric(
+      name="Terminal Message",
+      value=empty_dash(summarize(result.terminal_message)),
+    ),
+    Metric(name="Validation Reason", value=result.validation.reason),
+    Metric(name="Validation Ran", value=result.validation.ran.to_string()),
+    Metric(name="Moon Check", value=result.validation.moon_check.to_string()),
+    Metric(name="Moon Test", value=result.validation.moon_test.to_string()),
+    Metric(name="File Probe", value=result.validation.file_probe.to_string()),
+    Metric(name="Stdin Probe", value=result.validation.stdin_probe.to_string()),
+    Metric(
+      name="Duplicate Probe",
+      value=result.validation.duplicate_probe.to_string(),
+    ),
+    Metric(name="Parse Errors", value=result.parse_errors.to_string()),
+    Metric(name="Partial Tail", value=result.partial_tail.to_string()),
+    Metric(name="Shell Uses", value=result.shell_uses.to_string()),
+    Metric(name="Runtime Notices", value=result.runtime_notices.to_string()),
+    Metric(name="moon check mentions", value=result.moon_check_uses.to_string()),
+    Metric(name="moon test mentions", value=result.moon_test_uses.to_string()),
+    Metric(
+      name="moon run -e mentions",
+      value=result.moon_run_e_mentions.to_string(),
+    ),
+    Metric(
+      name="moon run -c mentions",
+      value=result.moon_run_c_mentions.to_string(),
+    ),
+    Metric(name="bad -e mentions", value=result.bad_run_e_mentions.to_string()),
+    Metric(
+      name="@string.from_str mentions",
+      value=result.from_str_mentions.to_string(),
+    ),
+    Metric(
+      name="@string.parse_int mentions",
+      value=result.parse_int_mentions.to_string(),
+    ),
+    Metric(name="argparse mentions", value=result.argparse_mentions.to_string()),
+    Metric(
+      name="old argparse mentions",
+      value=result.old_argparse_mentions.to_string(),
+    ),
+    Metric(name="C FFI mentions", value=result.c_ffi_mentions.to_string()),
+    Metric(
+      name="@env.args mentions",
+      value=result.env_args_mentions.to_string(),
+    ),
+    Metric(
+      name="Result container mentions",
+      value=result.result_style_mentions.to_string(),
+    ),
+    Metric(name="try mentions", value=result.try_mentions.to_string()),
+  ]
+  if include_eval_link {
+    details.push(
+      Metric(
+        name="Eval Result Report",
+        value="eval_results/" +
+          eval_result_artifact_name(result) +
+          "/report.html",
+      ),
+    )
+  }
+  details
+}
+
+///|
+fn relative_artifact_path(out_dir : String, path : String) -> String {
+  if out_dir == "" || path == "" {
+    return path
+  }
+  let prefix = out_dir + "/"
+  if path.has_prefix(prefix) {
+    path.sub(start=prefix.length(), end=path.length()).to_owned()
+  } else {
+    path
+  }
+}
+
+///|
+fn eval_result_name(result : EvalResult) -> String {
+  if result.index > 0 {
+    "trial-\{padded_index(result.index)}"
+  } else if result.session_id != "" {
+    result.session_id
+  } else {
+    "session"
+  }
+}
+
+///|
+fn eval_result_artifact_name(result : EvalResult) -> String {
+  eval_result_name(result)
+  .replace_all(old="/", new="_")
+  .replace_all(old="\\", new="_")
+  .replace_all(old=":", new="_")
+  .replace_all(old=" ", new="_")
+}
+
+///|
+fn display_index(result : EvalResult) -> Int {
+  if result.index > 0 {
+    result.index
+  } else {
+    1
+  }
+}
+
+///|
+fn validation_status(validation : ValidationResult) -> String {
+  if !validation.ran {
+    "not run"
+  } else {
+    validation.passed.to_string()
+  }
+}
+
+///|
+fn empty_dash(value : String) -> String {
+  if value == "" {
+    "-"
+  } else {
+    value
+  }
 }


### PR DESCRIPTION
## Summary
- Keep prompt-task runner, manifest, analyzer, and report code together in `eval/prompt_task/harness`.
- Split the workflow inside the harness: `run_experiments` writes durable workspaces/logs/session events plus `run_manifest.json`, and `analyze_run` regenerates reports later from those artifacts.
- Reuse `eval/session_analyzer` for each loaded agent session, then combine prompt-task-specific validation and counters into an aggregate report.
- Keep trial session artifacts in place under each workspace; the analyzer writes aggregate and per-result markdown/HTML/JSON reports from existing artifacts.

## Validation
- `moon check --target all`
- `moon test eval/session_analyzer eval/prompt_task/harness eval/prompt_task/cmd/main --target native`

## Notes
This PR intentionally does not depend on #155; `cmd/analyze` is for one session, while prompt-task owns multi-session benchmark analysis inside the harness package.