### PR TITLE
refactor: use streaming interpolation (<+) to simplify StringBuilder code

### DIFF
--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -236,9 +236,9 @@ impl FromJson for SessionHeader with fn from_json(
 
 ///|
 fn events_jsonl(events : @vector.Vector[@agent_session.SessionEvent]) -> String {
-  let builder = StringBuilder::new()
+  let builder = StringBuilder()
   for event in events {
-    builder.write_string("\{event.to_json().stringify()}\n")
+    builder <+ "\{event.to_json().stringify()}\n"
   }
   builder.to_string()
 }

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -6,9 +6,9 @@ async fn new_store() -> @store.SessionStore {
 
 ///|
 fn session_events_jsonl(session : @agent_session.Session) -> String {
-  let builder = StringBuilder::new()
+  let builder = StringBuilder()
   for event in session.events() {
-    builder.write_string("\{event.to_json().stringify()}\n")
+    builder <+ "\{event.to_json().stringify()}\n"
   }
   builder.to_string()
 }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -164,7 +164,7 @@ async fn random_salt() -> String {
   let salt = StringBuilder()
   for ch in dir[index + prefix.length():] {
     if ch is ('0'..='9' | 'a'..='z' | 'A'..='Z') {
-      salt.write_char(ch)
+      salt <+ "\{ch}"
     }
   }
   salt.to_string()
@@ -487,17 +487,17 @@ const PromptLabelMaxChars : Int = 60
 /// anything beyond `PromptLabelMaxChars` is elided with `…`. A session
 /// without a recorded prompt shows `-` so the column never vanishes.
 fn compact_prompt_label(prompt : String) -> String {
-  let out = StringBuilder::new()
+  let out = StringBuilder()
   let mut last_was_space = false
   let mut count = 0
   for ch in prompt.trim() {
     if count >= PromptLabelMaxChars {
-      out.write_char('…')
+      out <+ "…"
       break
     }
     if ch is (' ' | '\t' | '\n' | '\r') {
       if !last_was_space {
-        out.write_char(' ')
+        out <+ " "
         count += 1
       }
       last_was_space = true
@@ -508,7 +508,7 @@ fn compact_prompt_label(prompt : String) -> String {
       // commands, not text.
       continue
     } else {
-      out.write_char(ch)
+      out <+ "\{ch}"
       count += 1
       last_was_space = false
     }

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -74,15 +74,13 @@ async fn drain_stderr_capped(reader : @process.ReadFromProcess) -> String {
         }
     }
   }
-  let text = StringBuilder::new()
-  text.write_string(@utf8.decode_lossy(buffer.to_bytes()))
+  let text = StringBuilder()
+  text <+ "\{@utf8.decode_lossy(buffer.to_bytes())}"
   if truncated {
-    text.write_string(
-      "\n… (stderr truncated at \{StderrCaptureLimitBytes} bytes)",
-    )
+    text <+ "\n… (stderr truncated at \{StderrCaptureLimitBytes} bytes)"
   }
   if read_error is Some(message) {
-    text.write_string("\n… (stderr read failed: \{message})")
+    text <+ "\n… (stderr read failed: \{message})"
   }
   text.to_string()
 }
@@ -308,16 +306,16 @@ fn tail_columns(text : String, max_cols : Int) -> String {
 /// code is mostly newlines and indentation, which would otherwise hit the
 /// renderer as control characters.
 fn collapse_preview_whitespace(text : String) -> String {
-  let out = StringBuilder::new()
+  let out = StringBuilder()
   let mut last_was_space = false
   for ch in text {
     if ch is (' ' | '\t' | '\n' | '\r') {
       if !last_was_space {
-        out.write_char(' ')
+        out <+ " "
       }
       last_was_space = true
     } else {
-      out.write_char(ch)
+      out <+ "\{ch}"
       last_was_space = false
     }
   }

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -110,7 +110,7 @@ fn apply_tool_call_delta(
   }
   if json is { "function": { "arguments": String(arguments), .. }, .. } &&
     arguments != "" {
-    call.arguments.write_string(arguments)
+    call.arguments <+ "\{arguments}"
   }
 }
 
@@ -122,11 +122,11 @@ async fn apply_stream_delta(
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> Unit {
   if delta is { "content": String(content), .. } && content != "" {
-    acc.content.write_string(content)
+    acc.content <+ "\{content}"
     on_content_delta(content)
   }
   if delta is { "reasoning_content": String(reasoning), .. } && reasoning != "" {
-    acc.reasoning_content.write_string(reasoning)
+    acc.reasoning_content <+ "\{reasoning}"
     on_reasoning_delta(reasoning)
   }
   if delta is { "tool_calls": Array(calls), .. } {

--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -170,7 +170,7 @@ fn Text::wrap(self : Text, width~ : Int) -> Array[@surface.Line] {
             spans = []
             used = 0
           }
-          run.write_string(" ")
+          run <+ " "
           run_empty = false
           used += 1
         }
@@ -182,7 +182,7 @@ fn Text::wrap(self : Text, width~ : Int) -> Array[@surface.Line] {
           spans = []
           used = 0
         }
-        run.write_stringview(unit)
+        run <+ "\{unit}"
         run_empty = false
         used += next
       }

--- a/tui/internal/composer/composer.mbt
+++ b/tui/internal/composer/composer.mbt
@@ -402,14 +402,8 @@ fn Model::replace_line_range(
   let line = self.logical_lines[line_index]
   let prefix = line.display.view(line.display.start(), start)
   let suffix = line.display.view(end, line.display.end())
-  let cursor_builder = StringBuilder()
-  cursor_builder.write_stringview(prefix)
-  cursor_builder.write_string(replacement)
-  let cursor_text = cursor_builder.to_string()
-  let line_builder = StringBuilder()
-  line_builder.write_string(cursor_text)
-  line_builder.write_stringview(suffix)
-  let new_line = LogicLine::new(DisplayText(line_builder.to_string()))
+  let cursor_text = "\{prefix}\{replacement}"
+  let new_line = LogicLine::new(DisplayText("\{cursor_text}\{suffix}"))
   let replacement_lines = [new_line]
   let logical_lines = splice_logical_lines(
     self.logical_lines,
@@ -438,10 +432,7 @@ fn Model::join_with_next_line(self : Model, line_index~ : Int) -> Unit {
   } else {
     let left = self.logical_lines[line_index].text()
     let right = self.logical_lines[line_index + 1].text()
-    let builder = StringBuilder()
-    builder.write_string(left)
-    builder.write_string(right)
-    let joined = LogicLine::new(DisplayText(builder.to_string()))
+    let joined = LogicLine::new(DisplayText("\{left}\{right}"))
     let replacement_lines = [joined]
     let logical_lines = splice_logical_lines(
       self.logical_lines,
@@ -509,21 +500,11 @@ pub fn Model::insert(self : Model, text : String) -> Unit {
       inserted_line.end(),
     )
     let replacement_line = if inserted.length() == 1 {
-      let builder = StringBuilder()
-      builder.write_stringview(prefix)
-      builder.write_stringview(inserted_text)
-      builder.write_stringview(suffix)
-      LogicLine::new(DisplayText(builder.to_string()))
+      LogicLine::new(DisplayText("\{prefix}\{inserted_text}\{suffix}"))
     } else if index == 0 {
-      let builder = StringBuilder()
-      builder.write_stringview(prefix)
-      builder.write_stringview(inserted_text)
-      LogicLine::new(DisplayText(builder.to_string()))
+      LogicLine::new(DisplayText("\{prefix}\{inserted_text}"))
     } else if index == last {
-      let builder = StringBuilder()
-      builder.write_stringview(inserted_text)
-      builder.write_stringview(suffix)
-      LogicLine::new(DisplayText(builder.to_string()))
+      LogicLine::new(DisplayText("\{inserted_text}\{suffix}"))
     } else {
       LogicLine::new(inserted_line)
     }

--- a/tui/internal/composer/logical_line.mbt
+++ b/tui/internal/composer/logical_line.mbt
@@ -76,9 +76,9 @@ fn join_logical_lines(logical_lines : Array[LogicLine]) -> String {
   let builder = StringBuilder()
   for index in 0..<logical_lines.length() {
     if index > 0 {
-      builder.write_string("\n")
+      builder <+ "\n"
     }
-    builder.write_string(logical_lines[index].text())
+    builder <+ "\{logical_lines[index].text()}"
   }
   builder.to_string()
 }

--- a/tui/internal/render/queued.mbt
+++ b/tui/internal/render/queued.mbt
@@ -11,8 +11,7 @@ fn input_preview_line(input : @core.Input) -> @displaytext.DisplayText {
   let first = lines[0]
   if lines.length() > 1 {
     let builder = StringBuilder()
-    builder.write_string(first.text())
-    builder.write_string(" …")
+    builder <+ "\{first.text()} …"
     DisplayText(builder.to_string())
   } else {
     first

--- a/tui/internal/surface/surface.mbt
+++ b/tui/internal/surface/surface.mbt
@@ -84,7 +84,7 @@ pub fn Line::spans(self : Line) -> Array[Span] {
 pub fn Line::text(self : Line) -> String {
   let builder = StringBuilder()
   for span in self.spans {
-    builder.write_string(span.text.text())
+    builder <+ "\{span.text.text()}"
   }
   builder.to_string()
 }

--- a/tui/internal/text/text.mbt
+++ b/tui/internal/text/text.mbt
@@ -37,9 +37,9 @@ pub fn sanitize(text : String) -> String {
   let builder = StringBuilder()
   for index, line in @displaytext.split_lines(text) {
     if index > 0 {
-      builder.write_string("\n")
+      builder <+ "\n"
     }
-    builder.write_string(sanitize_line(line))
+    builder <+ "\{sanitize_line(line)}"
   }
   builder.to_string()
 }
@@ -66,10 +66,10 @@ fn sanitize_line(line : @displaytext.DisplayText) -> String {
     let unit = line.view(start, end)
     if unit == "\t" {
       let spaces = TabWidth - col % TabWidth
-      builder.write_string(String::make(spaces, ' '))
+      builder <+ "\{String::make(spaces, ' ')}"
       col = col + spaces
     } else if !is_control_unit(unit) {
-      builder.write_stringview(unit)
+      builder <+ "\{unit}"
       col = col + unit_width(line, start~, end~)
     }
     start = end

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -403,13 +403,13 @@ fn truncate(text : String, limit : Int) -> String {
   if text.length() <= limit {
     return text
   }
-  let kept = StringBuilder::new()
+  let kept = StringBuilder()
   let mut count = 0
   for char in text {
     if count >= limit {
       break
     }
-    kept.write_char(char)
+    kept <+ "\{char}"
     count += 1
   }
   kept.to_string() + "…"

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -35,10 +35,9 @@ fn sample_session() -> @agent_session.Session {
 ///|
 /// Serialize a session to the append-only JSONL text the store persists.
 fn events_jsonl(session : @agent_session.Session) -> String {
-  let out = StringBuilder::new()
+  let out = StringBuilder()
   for event in session.events() {
-    out.write_string(event.to_json().stringify())
-    out.write_char('\n')
+    out <+ "\{event.to_json().stringify()}\n"
   }
   out.to_string()
 }


### PR DESCRIPTION
This PR applies the `<+` streaming-interpolation macro across the codebase to reduce boilerplate StringBuilder code.

## What changed

Replaced manual `StringBuilder.write_string`, `write_char`, and `write_stringview` calls with `<+` where it makes the code shorter and clearer.

### High-impact simplifications

- `tui/internal/composer/composer.mbt`: removed temporary StringBuilders in `replace_line_range`, `join_with_next_line`, and `insert_text`; the final `DisplayText` is now built directly with string interpolation.

- `cmd/tui/loop.mbt`: decoded stderr and conditional truncation/read-error trailers are streamed with `<+`.

### Other cleanups

- `agent_session/store/store.mbt` and `store_test.mbt`
- `deepseek/client/stream.mbt`
- `tui/internal/text/text.mbt`
- `tui/internal/composer/logical_line.mbt`
- `tui/internal/surface/surface.mbt`
- `tui/internal/render/queued.mbt`
- `tui/doc/doc.mbt`
- `cmd/openseek/main.mbt`
- `viz/view.mbt` and `viz_test.mbt`

## Verification

- `moon check` ✅
- `moon test` ✅ — **539 tests pass**
- `moon info` ✅ — no `.mbti` changes, public API unchanged
- `moon fmt` ✅

No behavioral changes are intended.