### PR TITLE
[codex] decouple agent from prompt defaults

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -1,73 +1,272 @@
 # OpenSeek Agent
 
-This package contains the native-only agent loop for `bobzhang/openseek`. It
-owns the local tool schemas, native DeepSeek tool-call handling, and dispatch
-for workspace operations. The built-in prompt text and prompt selection live in
-`bobzhang/openseek/prompt`.
+`bobzhang/openseek/agent` is the native-only OpenSeek loop. It connects four
+lower-level packages:
 
-The package depends on:
+- `agent_session`: immutable conversation state and model-message projection;
+- `agent_runtime`: per-loop runtime state, steering, and background events;
+- `agent_tool`: local tool registry and tool dispatch results;
+- `deepseek` and `deepseek/client`: model types and chat-completion requests.
 
-- `bobzhang/openseek/deepseek` for typed models, messages, roles, and tool
-  definitions.
-- `bobzhang/openseek/deepseek/client` for HTTP chat requests.
-- `bobzhang/openseek/logger` for async stdout logging.
-- `bobzhang/openseek/prompt` for built-in prompt text and default prompt
-  selection.
-- `bobzhang/openseek/agent_tool` for tool registries, typed tool output,
-  loop-control actions, and session-scoped background daemon events.
-- `moonbitlang/async/fs` and `moonbitlang/async/process` for local tool
-  execution.
+The package owns the orchestration policy: when to append session events, when
+to call the model, how to execute tool calls, how to fold in runtime updates,
+and how mid-turn steering changes the active turn.
 
-## API Shape
+## Public API
 
-- `default_system_prompt()`: return the default built-in prompt.
-- `default_system_prompt_for_model(model)`: return the default built-in prompt
-  from the prompt package for a DeepSeek model.
-- `run(api_key, model, task, max_steps?, system_prompt_text?)`: run the agent
-  loop for one natural-language task. `system_prompt_text` defaults to the
-  built-in prompt selected by the prompt package, so callers can run prompt
-  experiments without rebuilding the package.
+The exported surface is small:
 
-`run` creates a DeepSeek client, starts a conversation with a system prompt and
-user task, sends native function tool definitions on each turn, executes any
-returned tool calls, and sends `Respond(ToolOutput(...)).content` back with
-`Tool(call.id)` messages. The loop stops when the model answers directly, a
-tool returns `Control(Finish(...))` / `Control(Abort(...))`, or the step limit
-is reached.
+```mbt nocheck
+let prompt = @agent.default_system_prompt_for_model(V4Pro)
 
-The agent client enables DeepSeek V4 thinking mode explicitly with
-`thinking=max`. When DeepSeek returns
-`reasoning_content` with tool calls, the agent preserves it in the assistant
-tool-call message for the next request.
+@agent.run(api_key, V4Pro, "fix the tests")
 
-The base and Flash-specific prompt sources live in the `prompt` package. That
-package uses the module-level `md_to_mbt_string` rule plus `dev_build` to
-generate MoonBit multiline strings from Markdown. The generated files are
-committed so downstream users can build without running local pre-build
-commands.
+let next = @agent.run_turn(
+  api_key,
+  V4Flash,
+  session,
+  "continue",
+  max_steps=100,
+)
 
-## Tools
+let persisted = @agent.run_turn_with_append(
+  api_key,
+  V4Pro,
+  session,
+  "continue",
+  append_item=(session, item) => store.append(session, item),
+)
 
-The agent exposes six local tools to DeepSeek by default:
+@async.with_task_group() <| group => {
+  let runtime = @agent_runtime.AgentRuntime(workspace_root=".")
+  let scope = @agent_runtime.AgentTaskScope(group)
+  let tools = @agent.build_tools(runtime, scope)
+  let next = @agent.run_turn_in_scope(
+    runtime,
+    scope,
+    api_key,
+    V4Pro,
+    session,
+    "continue",
+    append_item=(session, item) => session.append(item),
+    tools~,
+  )
+}
 
-- `shell`: runs `arguments.cmd` through `sh -c`, optionally in `arguments.cwd`,
-  and returns exit code plus merged output.
-- `read`: reads `arguments.path` as text.
-- `edit`: replaces exact text in `arguments.path`.
-- `write`: overwrites `arguments.path` with `arguments.content`.
-- `moon_check`: starts or reuses a session-scoped
-  `moon check --watch --diagnostic-limit 10` watcher, optionally
-  in `arguments.cwd`, and injects later coalesced updates before model turns.
-- `finish`: ends the task with `arguments.answer`.
+@agent.steer(runtime, "also update README")
+```
 
-Tool-call arguments are parsed from DeepSeek's raw JSON argument string and then
-validated by the dispatcher before execution.
+`run` is the highest-level one-shot entry point. It creates a fresh in-memory
+session with id `"one-shot"`, runs one turn, logs progress, discards the final
+session value, and returns `Unit`.
+
+`run_turn` is the in-memory one-turn API. It returns the updated immutable
+session, but it owns a fresh runtime and fresh tool registry for that call. Use
+it when no background tool state needs to survive into a later turn.
+
+`run_turn_with_append` is the durable one-turn API. The `append_item` callback is
+called for every committed item and returns the new authoritative session
+snapshot. Filesystem-backed callers use this to persist progress even if a later
+model call or tool execution fails.
+
+`run_turn_in_scope` is the long-lived engine API. The caller owns the
+`AgentRuntime`, `AgentTaskScope`, and usually a `Tools` registry built once with
+`build_tools`. This is the API used by serve mode so `moon_check` watchers and
+queued steering can span turns.
+
+`steer` queues raw user steering text on an `AgentRuntime`. It does not trim or
+filter. The loop drops blank strings when it drains steering at a step boundary.
+
+## Prompt Defaults
+
+`default_system_prompt()` is a convenience helper for the current V4Pro default.
+Most callers should choose the model first and call
+`default_system_prompt_for_model(model)`.
+
+```mbt check
+///|
+test "prompt helper contracts" {
+  debug_inspect(
+    [
+      @agent.default_system_prompt() ==
+      @agent.default_system_prompt_for_model(V4Pro),
+      @agent.default_system_prompt_for_model(V4Flash).length() > 0,
+    ],
+    content=(
+      #|[true, true]
+    ),
+  )
+}
+```
+
+`run` defaults `system_prompt_text` through
+`default_system_prompt_for_model(model)`. `run_turn`, `run_turn_with_append`,
+and `run_turn_in_scope` do not choose a prompt; they use the prompt already
+stored in the supplied `Session`.
+
+## Standard Tools
+
+`build_tools(runtime, scope)` returns the standard local tool registry:
+
+- `shell`: run a command under the workspace root or an explicit cwd;
+- `read`: read a text file;
+- `edit`: replace exact text in a file;
+- `write`: overwrite a file;
+- `moon_check`: start/reuse a background `moon check --watch` watcher;
+- `finish`: end the task with a final answer.
+
+File-oriented tools capture `runtime.workspace_root()` when the registry is
+built. `moon_check` also captures the runtime and task scope so it can spawn
+bounded watcher tasks and emit runtime updates.
+
+```mbt check
+///|
+async test "standard tools are registered in dispatch order" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime(workspace_root="/repo")
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let tools = @agent.build_tools(runtime, scope)
+    debug_inspect(
+      [
+        for tool in tools.function_tools() => tool.name
+      ],
+      content=(
+        #|["shell", "read", "edit", "write", "moon_check", "finish"]
+      ),
+    )
+  }
+}
+```
+
+Build the registry once for a long-lived engine. Stateful tool records live in
+the registry value, not in `AgentRuntime`; rebuilding it every turn can orphan
+old watcher records and start duplicate watchers.
+
+## Steering
+
+Steering is user input that arrives while a turn is active. `steer(runtime,
+text)` stores the raw string in the runtime's lossless steering queue:
+
+```mbt check
+///|
+test "steer queues raw text" {
+  let runtime = @agent_runtime.AgentRuntime()
+  @agent.steer(runtime, "also run tests")
+  @agent.steer(runtime, "   ")
+  debug_inspect(
+    runtime.drain_steers(),
+    content=(
+      #|["also run tests", "   "]
+    ),
+  )
+}
+```
+
+The agent loop applies non-blank steering at step boundaries. A steer that races
+with a model's final answer or a `finish` tool call keeps the turn alive: the
+would-be final output is recorded as ordinary conversation state, the steer is
+appended as a user message, and the loop continues. Error terminals such as
+abort, cancellation, failure, or exhausted steps still end the turn.
+
+## One-Shot Turns
+
+`run_turn` appends the task as a user event, runs up to `max_steps` model/tool
+iterations, then appends a terminal event. With `max_steps=0`, no model request
+is made; this is useful for documenting the session contract without a network
+dependency:
+
+```mbt check
+///|
+async test "zero step run_turn appends user then failure terminal" {
+  let session = @agent_session.Session(
+    SessionId("readme-turn"),
+    system_prompt="system",
+  )
+  let result = @agent.run_turn(
+    "unused-api-key",
+    V4Flash,
+    session,
+    "hello",
+    max_steps=0,
+  )
+  debug_inspect(
+    [
+      for event in result.events() => {
+        match event.item() {
+          User(message) => "user:\{message.content()}"
+          Terminal(Failed(message)) => "failed:\{message}"
+          _ => "other"
+        }
+      }
+    ],
+    content=(
+      #|["user:hello", "failed:max steps exhausted"]
+    ),
+  )
+}
+```
+
+Use `run_turn_with_append` when the caller needs every item at the moment it is
+committed. The callback is the sequencing authority: return the session snapshot
+that should be used for the rest of the turn.
+
+```mbt check
+///|
+async test "run_turn_with_append calls the persistence hook for each item" {
+  let session = @agent_session.Session(
+    SessionId("readme-persist"),
+    system_prompt="system",
+  )
+  let appended : Array[String] = []
+  let result = @agent.run_turn_with_append(
+    "unused-api-key",
+    V4Flash,
+    session,
+    "persist me",
+    append_item=(session, item) => {
+      appended.push(
+        match item {
+          User(message) => "user:\{message.content()}"
+          Terminal(Failed(message)) => "failed:\{message}"
+          _ => "other"
+        },
+      )
+      session.append(item)
+    },
+    max_steps=0,
+  )
+  debug_inspect(
+    appended,
+    content=(
+      #|["user:persist me", "failed:max steps exhausted"]
+    ),
+  )
+  debug_inspect(result.last_sequence(), content="2")
+}
+```
+
+## Long-Lived Engines
+
+`run_turn_in_scope` is the API for serve mode and other controllers that keep an
+engine alive across prompts. The caller supplies:
+
+- one shared `AgentRuntime` for steering and runtime event queues;
+- one `AgentTaskScope` from an enclosing `@async.with_task_group`;
+- an `append_item` callback for in-memory or durable session updates;
+- usually one shared `Tools` registry from `build_tools(runtime, scope)`.
+
+At each step boundary the loop first applies non-blank steering, then converts
+known runtime events into model-visible notices, then calls DeepSeek with the
+current session projection and tool schemas. Tool calls are executed in order.
+The turn ends on a direct model answer, `finish`, `abort`, cancellation,
+unexpected failure, or exhausted `max_steps`.
 
 ## Operational Notes
 
-This package is intended for trusted local automation. The `shell` tool can run
-arbitrary commands, while `edit` and `write` can modify files visible to the
-process. Use the CLI package when invoking it as an application.
+This package is intended for trusted local automation. The standard `shell`
+tool can run arbitrary commands, while `edit` and `write` can modify files
+visible to the process. Use the CLI package for application-level policy,
+session storage, logging configuration, and serve-mode wire handling.
 
 Run the package tests with:
 
@@ -83,56 +282,21 @@ improving:
 
 - The model needs concrete MoonBit examples, especially for package manifests,
   type aliases, mutable record fields, map construction, and error handling.
-- The model repeatedly imported Rust habits. The prompt now calls out that
-  MoonBit has no postfix `?` unwrapping for `Result`; generated code should
-  match on `Ok`/`Err` or catch raising functions explicitly.
 - Parser examples should include exact receiver annotations, string APIs, and
   unit syntax: `fn Parser::peek(self : Parser)`, `get_char`, `to_owned`, and
   `()` instead of `{}` for no-op branches.
 - Long parser loops should avoid leaving `while` as the final expression of a
-  function returning `Result`; put the final `Ok(...)`/`Err(...)` after the
-  loop or return from explicit branches.
-- The full-guide rerun improved API discovery and cache behavior, but still
-  needed addendum guidance for native CLI imports, blackbox `Debug` tests,
-  unqualified enum constructors under known types, and avoiding panicking
-  `Map::at` when building nested tables.
+  function returning `Result`; put the final `Ok(...)`/`Err(...)` after the loop
+  or return from explicit branches.
 - Long runs should be observable while they are running. The agent writes loop
-  logs through `moonbitlang/async/stdio` instead of `println` so piped runs
-  such as `2>&1 | tee run.log` receive step output promptly.
-- Real workspace commands need a first-class working directory. The `shell`
-  tool now accepts optional `cwd` to avoid repeated ad hoc `cd` command strings.
-- The default step limit is 1000, and the CLI can override it with
-  `--max-steps` or `OPENSEEK_MAX_STEPS`.
-- Current MoonBit projects use `moon.mod`; `moon.mod.json` is legacy. New
-  projects should create `moon.mod`, and manifest or package-import edits
-  should be followed immediately by starting or inspecting `moon_check`.
-- MoonBit validation should call `moon_check` once near the start of an
-  iterative edit loop and then use background `[moon_check update]` messages for
-  fresh compiler feedback. `moon_check` runs
-  `moon check --watch --diagnostic-limit 10`, so broken intermediate states stay
-  compact enough for the model to act on. Repeated `moon_check` calls are
-  allowed and reuse the existing watcher for the same cwd/options tuple. If
-  `moon --watch`
-  crashes, the tool compacts the crash output and automatically starts a
-  replacement watcher under a restart budget.
+  logs through async logging so piped runs such as `2>&1 | tee run.log` receive
+  step output promptly.
+- Current MoonBit projects use `moon.mod`; `moon.mod.json` is legacy. Manifest
+  or package-import edits should be followed quickly by `moon_check` or an
+  explicit shell validation command.
 - Use `shell` for exact end-to-end MoonBit command validation beyond compiler
   feedback, especially `moon test`, `moon run`, `moon info`, `moon fmt`, and
-  README command checks. Use shell for `moon ide doc`, `moon ide outline`,
-  `moon ide peek-def`, `moon ide find-references`, and `moon ide hover`
-  semantic navigation. Pass `cwd` instead of embedding `cd ... &&`.
-- Before finishing user-facing CLI work, derive two or three acceptance probes
-  from the task and run them with shell `moon run` commands. These probes should
-  exercise real file arguments, stdin when promised, stdout shape, stderr
-  cleanliness, and failure-mode output. This prompt guardrail is intentionally
-  lightweight; future cram-style tests can encode the same probes as durable
-  fixtures.
+  README command checks.
 - For snapshot updates, run plain `moon test` first and only run
   `moon test --update` after deciding the failure is a stale snapshot or
   intentional output change, not a behavior bug.
-- Use shell `moon ide doc` before unfamiliar MoonBit APIs and shell
-  `moon ide outline`, `moon ide peek-def`, or `moon ide find-references` before
-  editing existing packages.
-- MoonBit packages are flat like Go packages: files in the same package share a
-  namespace, and file names do not create importable modules. Split generated
-  code into small cohesive files for reviewability, but never refer to those
-  files as modules.

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -4,6 +4,10 @@ let default_max_steps : Int = 1000
 ///|
 /// Queue `text` as steering input for the turn running on `runtime`.
 ///
+/// This is a thin public wrapper over `AgentRuntime::queue_steer`. It does not
+/// inspect, trim, deduplicate, or validate the string. The agent loop filters
+/// blank strings later when it drains pending steers.
+///
 /// Steering lands at the next step boundary — after the in-flight model call
 /// and its tool batch complete, where the loop already folds in runtime
 /// updates — so completed work is never thrown away. User input also wins
@@ -12,11 +16,13 @@ let default_max_steps : Int = 1000
 /// ordinary assistant message, or the finish call's batch is closed out)
 /// and the conversation continues with the steer. Only error terminals
 /// (abort, failure, exhausted steps) still end the turn; a steer queued
-/// then applies to the next one. The text is appended to the session as a
-/// user message and a `steer_applied` event is emitted when it takes
-/// effect. The channel is lossless (unlike the runtime event bus, which
-/// discards under flood), so a steer can never be pushed out by noisy
-/// watcher updates.
+/// then is either applied by the next turn that shares the runtime or drained
+/// and rejected by the caller, as serve mode does after a turn finishes.
+///
+/// When the loop applies a non-blank steer, the text is appended to the session
+/// as a user message, pushed into the model-facing message array, and logged as
+/// a `steer_applied` event. The channel is lossless with respect to runtime
+/// event overflow, so noisy watcher updates cannot push out user steering.
 pub fn steer(runtime : @agent_runtime.AgentRuntime, text : String) -> Unit {
   runtime.queue_steer(text)
 }
@@ -24,12 +30,21 @@ pub fn steer(runtime : @agent_runtime.AgentRuntime, text : String) -> Unit {
 ///|
 /// Build the agent's standard tool registry bound to `runtime` and `scope`.
 ///
-/// Stateful tools live in the registry value itself: `moon_check` keeps its
-/// watcher records in the closure this builds, not in `AgentRuntime`. A
-/// serve-mode caller that wants watchers to survive from one turn to the
-/// next must therefore build the registry once and pass it to every
-/// `run_turn_in_scope` call — rebuilding it each turn would orphan the old
-/// watchers and start duplicates.
+/// The returned registry contains the built-in local tools: `shell`, `read`,
+/// `edit`, `write`, `moon_check`, and `finish`. File-oriented tools capture
+/// `runtime.workspace_root()` when this function is called. The `moon_check`
+/// tool captures both `runtime` and `scope` so it can report asynchronous
+/// watcher updates and spawn bounded background work.
+///
+/// Stateful tools live in the registry value itself: `moon_check` keeps watcher
+/// records in the closure this builds, not in `AgentRuntime`. A serve-mode
+/// caller that wants watchers to survive from one turn to the next must build
+/// the registry once and pass it to every `run_turn_in_scope` call. Rebuilding
+/// it each turn would orphan the old watcher records and may start duplicate
+/// watchers for the same workspace.
+///
+/// Raises if the standard tool definitions contain duplicate names. Under the
+/// checked-in registry that should be a programming error, not user input.
 pub fn[X] build_tools(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[X],
@@ -38,19 +53,44 @@ pub fn[X] build_tools(
 }
 
 ///|
-/// Returns the default built-in system prompt.
+/// Return the model-independent convenience default system prompt.
+///
+/// This currently delegates to `default_system_prompt_for_model(V4Pro)`.
+/// Callers that already know the selected DeepSeek model should prefer
+/// `default_system_prompt_for_model(model)` so model-specific prompt selection
+/// stays explicit.
 pub fn default_system_prompt() -> String {
   @prompt.system_prompt_for_model(V4Pro)
 }
 
 ///|
-/// Returns the default system prompt for a DeepSeek model.
+/// Return the built-in system prompt selected for `model`.
+///
+/// `run` uses this function for its `system_prompt_text` default. Passing an
+/// explicit `system_prompt_text` to `run`, or constructing a `Session` with a
+/// custom `system_prompt`, bypasses this helper for that conversation.
 pub fn default_system_prompt_for_model(model : @deepseek.Model) -> String {
   @prompt.system_prompt_for_model(model)
 }
 
 ///|
-/// Runs the OpenSeek agent loop for a single task.
+/// Run a one-shot OpenSeek task and discard the returned session.
+///
+/// This is the highest-level convenience entry point. It creates a fresh
+/// in-memory session with id `"one-shot"`, appends `task` as the first user
+/// event through `run_turn`, runs the agent loop, logs progress through the
+/// configured process logger, and returns `Unit`. It does not persist the
+/// session and does not expose the final `Session` value to the caller.
+///
+/// `system_prompt_text` defaults to `default_system_prompt_for_model(model)`.
+/// `thinking` defaults to `Max`. `workspace_root` defaults to `"."` and is
+/// passed into the per-turn `AgentRuntime`; local file and shell tools resolve
+/// relative paths against that root. `api_url` is forwarded to the DeepSeek
+/// client and is mainly useful for tests or compatible endpoints.
+///
+/// Prefer `run_turn` when the caller needs the final in-memory session, and
+/// `run_turn_with_append` when every committed event must be persisted as the
+/// turn progresses.
 pub async fn run(
   api_key : String,
   model : @deepseek.Model,
@@ -83,6 +123,21 @@ pub async fn run(
 /// Runs one user turn against an in-memory session and returns the updated
 /// session. Callers that need durable persistence should use
 /// `run_turn_with_append`.
+///
+/// This appends `task` to `session`, owns a fresh `AgentRuntime` and
+/// `AgentTaskScope` for this single turn, builds a fresh standard tool registry,
+/// and returns the session produced by `run_turn_in_scope`. The input session is
+/// immutable; it is not changed in place.
+///
+/// Because the runtime and tools are fresh per call, background stateful tools
+/// such as `moon_check` do not survive across separate `run_turn` calls. That
+/// is usually correct for one-shot callers. Long-lived callers should create
+/// one runtime, one task scope, and one `build_tools` registry, then call
+/// `run_turn_in_scope` repeatedly.
+///
+/// `max_steps` bounds the number of model-request iterations. If it is `0`, the
+/// turn appends the user task and then terminates with
+/// `Terminal(Failed("max steps exhausted"))` without making a model request.
 pub async fn run_turn(
   api_key : String,
   model : @deepseek.Model,
@@ -110,6 +165,22 @@ pub async fn run_turn(
 /// Runs one user turn and calls `append_item` for every session event as soon as
 /// it is committed. This lets a filesystem-backed caller preserve progress even
 /// if the engine process exits later in the turn.
+///
+/// This is the persistence hook for one-shot and CLI session recording. The
+/// callback receives the current session snapshot and the next `SessionItem`;
+/// it must return the new session snapshot after appending that item. The agent
+/// uses the returned value as the current session for all later work, so the
+/// callback is the single source of truth for sequencing.
+///
+/// `append_item` is called for the initial user task, every assistant/tool/
+/// runtime/steer event that is committed, and the terminal event. If the
+/// callback raises, the turn attempts to append a failure terminal describing
+/// that append failure and then re-raises the original error. This means a
+/// durable store can preserve the partial turn up to the failure point.
+///
+/// Like `run_turn`, this owns a fresh runtime, task group, and tool registry for
+/// the duration of one turn. Use `run_turn_in_scope` when the caller needs to
+/// preserve runtime state or tool state across turns.
 pub async fn run_turn_with_append(
   api_key : String,
   model : @deepseek.Model,
@@ -187,6 +258,27 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// spawned some. One-shot callers should prefer
 /// `run_turn`/`run_turn_with_append`, which own everything for the duration
 /// of a single turn.
+///
+/// The loop appends `task` as a user message before the first model request.
+/// At each step boundary it first drains and applies pending non-blank steers,
+/// then drains runtime events and turns known tool updates into model-visible
+/// runtime notices. It sends the current DeepSeek chat projection with the
+/// active tool schemas, records assistant responses, executes tool calls in
+/// order, and records tool results. The turn ends when the model answers with
+/// no tool calls, the `finish` tool returns `Control(Finish)`, a tool returns
+/// `Control(Abort)`, `max_steps` is exhausted, the task is cancelled, or an
+/// unexpected error escapes.
+///
+/// A steer that arrives while the model's apparent final answer or a `finish`
+/// tool call is in flight keeps the turn alive. The would-be final answer is
+/// stored as an ordinary assistant message, or the finish batch is closed with
+/// tool-result messages, then the steer is appended and the loop continues.
+///
+/// `tools` should normally be a registry built once with `build_tools(runtime,
+/// scope)` for a long-lived engine. If `tools` is omitted, this function builds
+/// a fresh registry for this call only. `api_url` is forwarded to the DeepSeek
+/// client. The caller owns the lifetime of `runtime`, `scope`, and any shared
+/// `tools` registry passed here.
 pub async fn[X] run_turn_in_scope(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[X],


### PR DESCRIPTION
## Summary
- Remove the `agent` package dependency on `prompt` and drop `default_system_prompt` / `default_system_prompt_for_model` from the `agent` public API.
- Make `agent.run` require caller-supplied `system_prompt_text`, so prompt selection lives in the application layer while lower-level turn APIs continue to use the prompt stored in `Session`.
- Update `agent/README.mbt.md` and API docs to explain prompt ownership, one-shot APIs, durable append hooks, long-lived scoped turns, tool registry construction, and steering behavior.

## Impact
- Public API change: `@agent.run` now requires `system_prompt_text~ : String`.
- Public API removal: `@agent.default_system_prompt` and `@agent.default_system_prompt_for_model` are removed.
- The CLI already chooses prompt text in the app layer and passes it to `@agent.run`, so the existing CLI flow remains aligned with this split.

## Validation
- `moon check agent --warn-list +73`
- `moon info && moon fmt`
- `moon test agent`
- `moon test`
- `git diff --check`
