### PR TITLE
[codex] decouple agent from prompt defaults

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -12,14 +12,21 @@ The package owns the orchestration policy: when to append session events, when
 to call the model, how to execute tool calls, how to fold in runtime updates,
 and how mid-turn steering changes the active turn.
 
+Prompt text is deliberately outside this package. Applications choose or build
+the system prompt, then pass it to `run` or store it in the `Session` supplied
+to the lower-level turn APIs.
+
 ## Public API
 
 The exported surface is small:
 
 ```mbt nocheck
-let prompt = @agent.default_system_prompt_for_model(V4Pro)
-
-@agent.run(api_key, V4Pro, "fix the tests")
+@agent.run(
+  api_key,
+  V4Pro,
+  "fix the tests",
+  system_prompt_text="You are an OpenSeek agent.",
+)
 
 let next = @agent.run_turn(
   api_key,
@@ -58,7 +65,7 @@ let persisted = @agent.run_turn_with_append(
 
 `run` is the highest-level one-shot entry point. It creates a fresh in-memory
 session with id `"one-shot"`, runs one turn, logs progress, discards the final
-session value, and returns `Unit`.
+session value, and returns `Unit`. The caller must provide `system_prompt_text`.
 
 `run_turn` is the in-memory one-turn API. It returns the updated immutable
 session, but it owns a fresh runtime and fresh tool registry for that call. Use
@@ -77,32 +84,30 @@ queued steering can span turns.
 `steer` queues raw user steering text on an `AgentRuntime`. It does not trim or
 filter. The loop drops blank strings when it drains steering at a step boundary.
 
-## Prompt Defaults
+## Prompt Ownership
 
-`default_system_prompt()` is a convenience helper for the current V4Pro default.
-Most callers should choose the model first and call
-`default_system_prompt_for_model(model)`.
+`agent` does not import `prompt` and does not choose default prompt text. This
+keeps the loop reusable with built-in prompts, test prompts, user-authored
+prompts, or prompts supplied by a different application.
 
 ```mbt check
 ///|
-test "prompt helper contracts" {
+test "turn APIs use the session prompt exactly as supplied" {
+  let session = @agent_session.Session(
+    SessionId("prompt-owner"),
+    system_prompt="custom system",
+  )
   debug_inspect(
-    [
-      @agent.default_system_prompt() ==
-      @agent.default_system_prompt_for_model(V4Pro),
-      @agent.default_system_prompt_for_model(V4Flash).length() > 0,
-    ],
+    session.chat_messages()[0].content,
     content=(
-      #|[true, true]
+      #|"custom system"
     ),
   )
 }
 ```
 
-`run` defaults `system_prompt_text` through
-`default_system_prompt_for_model(model)`. `run_turn`, `run_turn_with_append`,
-and `run_turn_in_scope` do not choose a prompt; they use the prompt already
-stored in the supplied `Session`.
+The CLI remains free to call `@prompt.system_prompt_for_model(model)` before it
+calls `@agent.run`, but that decision lives outside the `agent` package.
 
 ## Standard Tools
 

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -53,27 +53,6 @@ pub fn[X] build_tools(
 }
 
 ///|
-/// Return the model-independent convenience default system prompt.
-///
-/// This currently delegates to `default_system_prompt_for_model(V4Pro)`.
-/// Callers that already know the selected DeepSeek model should prefer
-/// `default_system_prompt_for_model(model)` so model-specific prompt selection
-/// stays explicit.
-pub fn default_system_prompt() -> String {
-  @prompt.system_prompt_for_model(V4Pro)
-}
-
-///|
-/// Return the built-in system prompt selected for `model`.
-///
-/// `run` uses this function for its `system_prompt_text` default. Passing an
-/// explicit `system_prompt_text` to `run`, or constructing a `Session` with a
-/// custom `system_prompt`, bypasses this helper for that conversation.
-pub fn default_system_prompt_for_model(model : @deepseek.Model) -> String {
-  @prompt.system_prompt_for_model(model)
-}
-
-///|
 /// Run a one-shot OpenSeek task and discard the returned session.
 ///
 /// This is the highest-level convenience entry point. It creates a fresh
@@ -82,11 +61,12 @@ pub fn default_system_prompt_for_model(model : @deepseek.Model) -> String {
 /// configured process logger, and returns `Unit`. It does not persist the
 /// session and does not expose the final `Session` value to the caller.
 ///
-/// `system_prompt_text` defaults to `default_system_prompt_for_model(model)`.
-/// `thinking` defaults to `Max`. `workspace_root` defaults to `"."` and is
-/// passed into the per-turn `AgentRuntime`; local file and shell tools resolve
-/// relative paths against that root. `api_url` is forwarded to the DeepSeek
-/// client and is mainly useful for tests or compatible endpoints.
+/// `system_prompt_text` is required. Prompt selection is intentionally owned by
+/// the application layer, not by `agent`; this package does not depend on the
+/// `prompt` package. `thinking` defaults to `Max`. `workspace_root` defaults to
+/// `"."` and is passed into the per-turn `AgentRuntime`; local file and shell
+/// tools resolve relative paths against that root. `api_url` is forwarded to
+/// the DeepSeek client and is mainly useful for tests or compatible endpoints.
 ///
 /// Prefer `run_turn` when the caller needs the final in-memory session, and
 /// `run_turn_with_append` when every committed event must be persisted as the
@@ -95,8 +75,8 @@ pub async fn run(
   api_key : String,
   model : @deepseek.Model,
   task : String,
+  system_prompt_text~ : String,
   max_steps? : Int = default_max_steps,
-  system_prompt_text? : String = default_system_prompt_for_model(model),
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -10,7 +10,6 @@ import {
   "bobzhang/openseek/agent_tool/write",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/deepseek/client",
-  "bobzhang/openseek/prompt",
   "moonbitlang/async",
   "moonbitlang/core/json",
   "tonyfettes/xlog",

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -11,11 +11,7 @@ import {
 // Values
 pub fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X]) -> @agent_tool.Tools raise
 
-pub fn default_system_prompt() -> String
-
-pub fn default_system_prompt_for_model(@deepseek.Model) -> String
-
-pub async fn run(String, @deepseek.Model, String, max_steps? : Int, system_prompt_text? : String, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
+pub async fn run(String, @deepseek.Model, String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
 pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
 


### PR DESCRIPTION
## Summary
- Remove the `agent` package dependency on `prompt` and drop `default_system_prompt` / `default_system_prompt_for_model` from the `agent` public API.
- Make `agent.run` require caller-supplied `system_prompt_text`, so prompt selection lives in the application layer while lower-level turn APIs continue to use the prompt stored in `Session`.
- Update `agent/README.mbt.md` and API docs to explain prompt ownership after the split.

## Impact
- Public API change: `@agent.run` now requires `system_prompt_text~ : String`.
- Public API removal: `@agent.default_system_prompt` and `@agent.default_system_prompt_for_model` are removed.
- The CLI already chooses prompt text in the app layer and passes it to `@agent.run`, so the existing CLI flow remains aligned with this split.

## Validation
- `moon check agent --warn-list +73`
- `moon info && moon fmt`
- `moon test agent`
- `moon test`
- `git diff --check`
