### PR TITLE
Add reusable session analyzer

### DIFF
--- a/eval/session_analyzer/analyzer.mbt
+++ b/eval/session_analyzer/analyzer.mbt
@@ -1,0 +1,222 @@
+///|
+/// Generic evaluation of one recorded OpenSeek session.
+///
+/// This deliberately knows nothing about prompt-task manifests, workspaces, or
+/// task-specific validation. Callers that own a benchmark can attach their own
+/// metadata and probes around this result.
+pub struct EvalResult {
+  session_id : String
+  success : Bool
+  reason : String
+  warnings : String
+  steps : Int
+  tool_results : Int
+  tool_errors : Int
+  shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
+  finished : Bool
+  finish_message : String
+  terminal_status : String
+  terminal_message : String
+}
+
+///|
+priv struct SessionMetrics {
+  finished : Bool
+  finish_message : String
+  steps : Int
+  tool_results : Int
+  tool_errors : Int
+  shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
+  terminal_status : String
+  terminal_message : String
+}
+
+///|
+/// Analyze one already-loaded session.
+pub fn analyze_session(session : @agent_session.Session) -> EvalResult {
+  let metrics = summarize_session(session)
+  let reasons : Array[String] = []
+  if !metrics.finished && metrics.terminal_status != "" {
+    reasons.push(
+      "agent terminal " +
+      metrics.terminal_status +
+      ": " +
+      metrics.terminal_message,
+    )
+  } else if !metrics.finished {
+    reasons.push("finish marker missing")
+  }
+  let warnings : Array[String] = []
+  if metrics.shell_uses > 0 {
+    warnings.push("shell output observed \{metrics.shell_uses} time(s)")
+  }
+  let success = reasons.length() == 0
+  {
+    session_id: session.id().value(),
+    success,
+    reason: if success {
+      "ok"
+    } else {
+      reasons.join("; ")
+    },
+    warnings: if warnings.length() == 0 {
+      ""
+    } else {
+      warnings.join("; ")
+    },
+    steps: metrics.steps,
+    tool_results: metrics.tool_results,
+    tool_errors: metrics.tool_errors,
+    shell_uses: metrics.shell_uses,
+    shell_failures: metrics.shell_failures,
+    runtime_notices: metrics.runtime_notices,
+    finished: metrics.finished,
+    finish_message: metrics.finish_message,
+    terminal_status: metrics.terminal_status,
+    terminal_message: metrics.terminal_message,
+  }
+}
+
+///|
+/// Build the transcript text used by analyzers that count prompt-sensitive
+/// behavior. User prompts and summaries are intentionally excluded so a task
+/// statement cannot inflate model-behavior counters.
+pub fn transcript_text(session : @agent_session.Session) -> String {
+  let out = StringBuilder::new()
+  for event in session.events() {
+    append_item_text(out, event.item())
+  }
+  out.to_string()
+}
+
+///|
+fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
+  let mut finished = false
+  let mut finish_message = ""
+  let mut steps = 0
+  let mut tool_results = 0
+  let mut tool_errors = 0
+  let mut shell_uses = 0
+  let mut shell_failures = 0
+  let mut runtime_notices = 0
+  let mut terminal_status = ""
+  let mut terminal_message = ""
+  let mut previous_finish_tool = false
+  for event in session.events() {
+    match event.item() {
+      Assistant(_) => {
+        steps += 1
+        previous_finish_tool = false
+      }
+      Tool(result) => {
+        tool_results += 1
+        if result.tool_name() == "shell" {
+          shell_uses += 1
+          if shell_result_failed(result.content()) {
+            shell_failures += 1
+          }
+        }
+        if result.is_error() {
+          tool_errors += 1
+        }
+        previous_finish_tool = result.tool_name() == "finish"
+      }
+      Runtime(_) => {
+        runtime_notices += 1
+        previous_finish_tool = false
+      }
+      Terminal(Finished(message)) => {
+        if !previous_finish_tool {
+          steps += 1
+        }
+        finished = true
+        finish_message = message
+        terminal_status = "finished"
+        terminal_message = message
+        previous_finish_tool = false
+      }
+      Terminal(Aborted(message)) => {
+        finished = false
+        terminal_status = "aborted"
+        terminal_message = message
+        previous_finish_tool = false
+      }
+      Terminal(Interrupted(message)) => {
+        finished = false
+        terminal_status = "interrupted"
+        terminal_message = message
+        previous_finish_tool = false
+      }
+      Terminal(Failed(message)) => {
+        finished = false
+        terminal_status = "failed"
+        terminal_message = message
+        previous_finish_tool = false
+      }
+      _ => previous_finish_tool = false
+    }
+  }
+  {
+    finished,
+    finish_message,
+    steps,
+    tool_results,
+    tool_errors,
+    shell_uses,
+    shell_failures,
+    runtime_notices,
+    terminal_status,
+    terminal_message,
+  }
+}
+
+///|
+fn shell_result_failed(content : String) -> Bool {
+  for piece in content.split("\n") {
+    let line = piece.to_owned().trim().to_owned()
+    return line.has_prefix("exit=") && line != "exit=0"
+  }
+  false
+}
+
+///|
+fn append_item_text(
+  out : StringBuilder,
+  item : @agent_session.SessionItem,
+) -> Unit {
+  match item {
+    User(_) | Summary(_) => ()
+    Assistant(message) => {
+      if message.reasoning_content() is Some(reasoning) {
+        write_line(out, reasoning)
+      }
+      write_line(out, message.content())
+      for call in message.tool_calls() {
+        write_line(out, call.name)
+        write_line(out, call.arguments)
+      }
+    }
+    Tool(result) => {
+      write_line(out, result.tool_name())
+      write_line(out, result.content())
+    }
+    Runtime(notice) => write_line(out, notice.content())
+    Terminal(terminal) =>
+      match terminal {
+        Finished(message)
+        | Aborted(message)
+        | Interrupted(message)
+        | Failed(message) => write_line(out, message)
+      }
+  }
+}
+
+///|
+fn write_line(out : StringBuilder, value : String) -> Unit {
+  out.write_string(value)
+  out.write_char('\n')
+}

--- a/eval/session_analyzer/analyzer_wbtest.mbt
+++ b/eval/session_analyzer/analyzer_wbtest.mbt
@@ -1,0 +1,138 @@
+///|
+fn sample_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("trial-01"), system_prompt="")
+  .append(User(UserMessage("build a toml cli")))
+  .append(
+    Assistant(
+      AssistantMessage("I will run moon check", tool_calls=[
+        ToolCall(
+          id="call_1",
+          name="shell",
+          arguments="{\"cmd\":\"moon check\"}",
+        ),
+      ]),
+    ),
+  )
+  .append(
+    Tool(
+      ToolResult(tool_call_id="call_1", tool_name="shell", content="exit=0\nok"),
+    ),
+  )
+  .append(Runtime(RuntimeNotice("[moon_check update]\nFinished.")))
+  .append(Terminal(Finished("done")))
+}
+
+///|
+test "session analyzer counts typed events" {
+  let result = analyze_session(sample_session())
+  assert_true(result.success)
+  assert_true(result.finished)
+  assert_eq(result.reason, "ok")
+  assert_eq(result.steps, 2)
+  assert_eq(result.tool_results, 1)
+  assert_eq(result.tool_errors, 0)
+  assert_eq(result.shell_uses, 1)
+  assert_eq(result.shell_failures, 0)
+  assert_eq(result.runtime_notices, 1)
+}
+
+///|
+test "latest non-finished terminal determines success" {
+  let session = @agent_session.Session(
+      SessionId("multi-turn"),
+      system_prompt="",
+    )
+    .append(User(UserMessage("first")))
+    .append(Terminal(Finished("done")))
+    .append(User(UserMessage("second")))
+    .append(Terminal(Failed("agent failed")))
+  let result = analyze_session(session)
+  assert_false(result.success)
+  assert_false(result.finished)
+  assert_eq(result.terminal_status, "failed")
+  assert_true(result.reason.contains("agent terminal failed"))
+}
+
+///|
+test "finish tool terminal does not double count a model step" {
+  let session = @agent_session.Session(
+      SessionId("trial-finish"),
+      system_prompt="",
+    )
+    .append(User(UserMessage("finish")))
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(
+            id="call_finish",
+            name="finish",
+            arguments="{\"answer\":\"done\"}",
+          ),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="call_finish",
+          tool_name="finish",
+          content="finished: done",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let result = analyze_session(session)
+  assert_eq(result.steps, 1)
+  assert_eq(result.tool_results, 1)
+  assert_true(result.finished)
+}
+
+///|
+test "shell result failure detection reads only the exit header" {
+  assert_false(shell_result_failed("exit=0\nok"))
+  assert_false(shell_result_failed("exit=0\nexit=2"))
+  assert_false(shell_result_failed("not a shell header\nexit=2"))
+  assert_true(shell_result_failed("exit=2\nfailed"))
+  assert_true(shell_result_failed("exit=cancelled\ntruncated"))
+}
+
+///|
+test "transcript text ignores user prompts and summaries" {
+  let session = @agent_session.Session(
+      SessionId("prompt-only"),
+      system_prompt="",
+    )
+    .append(
+      User(
+        UserMessage(
+          "run moon check and moon test with @string.from_str and @argparse.command try?",
+        ),
+      ),
+    )
+    .append(
+      Summary(
+        SessionSummary(content="moon test", from_sequence=1, to_sequence=1),
+      ),
+    )
+    .append(Assistant(AssistantMessage("I used @string.parse_int")))
+    .append(Terminal(Finished("done")))
+  let text = transcript_text(session)
+  assert_false(text.contains("@string.from_str"))
+  assert_false(text.contains("@argparse.command"))
+  assert_false(text.contains("moon test"))
+  assert_true(text.contains("@string.parse_int"))
+}
+
+///|
+async test "eval result renders and writes report files" {
+  let dir = @fs.tmpdir(prefix="openseek-session-analyzer-")
+  let result = analyze_session(sample_session())
+  assert_true(result.markdown().contains("Session Eval Result"))
+  assert_true(result.html().contains("<html"))
+  assert_true(result.to_json().stringify().contains("trial-01"))
+  result.write_files(dir)
+  assert_true(@fs.exists(dir + "/report.md"))
+  assert_true(@fs.exists(dir + "/report.html"))
+  assert_true(@fs.exists(dir + "/report.json"))
+  @fs.rmdir(dir, recursive=true)
+}

--- a/eval/session_analyzer/moon.pkg
+++ b/eval/session_analyzer/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/eval/report",
+  "moonbitlang/core/json",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+} for "wbtest"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/eval/session_analyzer/pkg.generated.mbti
+++ b/eval/session_analyzer/pkg.generated.mbti
@@ -1,0 +1,40 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/eval/session_analyzer"
+
+import {
+  "bobzhang/openseek/agent_session",
+}
+
+// Values
+pub fn analyze_session(@agent_session.Session) -> EvalResult
+
+pub fn transcript_text(@agent_session.Session) -> String
+
+// Errors
+
+// Types and methods
+pub struct EvalResult {
+  session_id : String
+  success : Bool
+  reason : String
+  warnings : String
+  steps : Int
+  tool_results : Int
+  tool_errors : Int
+  shell_uses : Int
+  shell_failures : Int
+  runtime_notices : Int
+  finished : Bool
+  finish_message : String
+  terminal_status : String
+  terminal_message : String
+}
+pub fn EvalResult::html(Self) -> String
+pub fn EvalResult::markdown(Self) -> String
+pub fn EvalResult::to_json(Self) -> Json
+pub async fn EvalResult::write_files(Self, String) -> Unit
+
+// Type aliases
+
+// Traits
+

--- a/eval/session_analyzer/report.mbt
+++ b/eval/session_analyzer/report.mbt
@@ -1,0 +1,94 @@
+///|
+/// Render this single-session result as Markdown.
+pub fn EvalResult::markdown(self : EvalResult) -> String {
+  self.as_report().markdown()
+}
+
+///|
+/// Render this single-session result as standalone HTML.
+pub fn EvalResult::html(self : EvalResult) -> String {
+  self.as_report().html()
+}
+
+///|
+/// Render this single-session result as JSON for tooling.
+pub fn EvalResult::to_json(self : EvalResult) -> Json {
+  {
+    "session_id": self.session_id,
+    "success": self.success,
+    "reason": self.reason,
+    "warnings": self.warnings,
+    "steps": self.steps,
+    "tool_results": self.tool_results,
+    "tool_errors": self.tool_errors,
+    "shell_uses": self.shell_uses,
+    "shell_failures": self.shell_failures,
+    "runtime_notices": self.runtime_notices,
+    "finished": self.finished,
+    "finish_message": self.finish_message,
+    "terminal_status": self.terminal_status,
+    "terminal_message": self.terminal_message,
+  }
+}
+
+///|
+/// Write `report.md`, `report.html`, and `report.json` under `out_dir`.
+pub async fn EvalResult::write_files(
+  self : EvalResult,
+  out_dir : String,
+) -> Unit {
+  @report.write_files(
+    out_dir,
+    self.markdown(),
+    self.to_json(),
+    html=self.html(),
+  )
+}
+
+///|
+fn EvalResult::as_report(self : EvalResult) -> @report.Report {
+  Report(
+    title="Session Eval Result: " + empty_dash(self.session_id),
+    summary=[
+      Metric(name="session", value=empty_dash(self.session_id)),
+      Metric(name="result", value=if self.success { "pass" } else { "fail" }),
+      Metric(name="reason", value=self.reason),
+      Metric(name="terminal", value=empty_dash(self.terminal_status)),
+    ],
+    metric_columns=[
+      "Steps", "Tool Results", "Tool Errors", "Shell Uses", "Shell Failures", "Runtime Notices",
+      "Finished",
+    ],
+    rows=[
+      ReportRow(
+        index=1,
+        name=empty_dash(self.session_id),
+        success=self.success,
+        reason=self.reason,
+        warnings=self.warnings,
+        metrics=[
+          Metric(name="Steps", value=self.steps.to_string()),
+          Metric(name="Tool Results", value=self.tool_results.to_string()),
+          Metric(name="Tool Errors", value=self.tool_errors.to_string()),
+          Metric(name="Shell Uses", value=self.shell_uses.to_string()),
+          Metric(name="Shell Failures", value=self.shell_failures.to_string()),
+          Metric(name="Runtime Notices", value=self.runtime_notices.to_string()),
+          Metric(name="Finished", value=self.finished.to_string()),
+        ],
+        details=[
+          Metric(name="Finish Message", value=self.finish_message),
+          Metric(name="Terminal Message", value=self.terminal_message),
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+fn empty_dash(value : String) -> String {
+  if value == "" {
+    "-"
+  } else {
+    value
+  }
+}


### PR DESCRIPTION
## Summary
- Add `eval/session_analyzer` as a reusable per-session analyzer for `@agent_session.Session`.
- Expose `analyze_session(session) -> EvalResult` and `transcript_text(session)` for benchmark-specific analyzers.
- Add markdown, HTML, and JSON rendering plus report-file writing for a single session eval result.

## Validation
- `moon check --target all`
- `moon test eval/session_analyzer --target native`

## Stack
This is the base PR for the analyzer split. Merge this before the single-session CLI and prompt-task analyzer workflow PRs.