### PR TITLE
Add single-session analyze CLI

### DIFF
--- a/cmd/analyze/main.mbt
+++ b/cmd/analyze/main.mbt
@@ -1,0 +1,116 @@
+///|
+async fn main {
+  run_analyze(@argparse.parse(cli_command()))
+}
+
+///|
+async fn run_analyze(matches : @argparse.Matches) -> Unit {
+  let session = load_session(matches)
+  let result = @session_analyzer.analyze_session(session)
+  let out_dir = value(matches, "out").trim().to_owned()
+  if out_dir != "" {
+    result.write_files(out_dir)
+  } else {
+    match value(matches, "format") {
+      "markdown" => println(result.markdown())
+      "html" => println(result.html())
+      "json" => println(result.to_json().stringify())
+      format => fail("--format must be markdown, html, or json; got: \{format}")
+    }
+  }
+}
+
+///|
+async fn load_session(matches : @argparse.Matches) -> @agent_session.Session {
+  let events_path = value(matches, "events").trim().to_owned()
+  let session_value = value(matches, "session").trim().to_owned()
+  if events_path != "" {
+    return load_events_session(events_path, session_value)
+  }
+  if session_value == "" {
+    fail("--session is required when --events is not provided")
+  }
+  @store.SessionStore(value(matches, "session-root")).load(
+    SessionId(session_value),
+  )
+}
+
+///|
+async fn load_events_session(
+  path : String,
+  session_id : String,
+) -> @agent_session.Session {
+  let text = @fs.read_file(path).text()
+  let parsed = @session_log.parse_events(text)
+  if parsed.errors.length() > 0 {
+    fail("events decode errors \{parsed.errors.length()}")
+  }
+  @session_log.session_from_parse(
+    parsed,
+    id=if session_id == "" {
+      session_id_from_events_path(path)
+    } else {
+      session_id
+    },
+    system_prompt="",
+  )
+}
+
+///|
+fn session_id_from_events_path(path : String) -> String {
+  let without_file = match path.strip_suffix("/events.jsonl") {
+    Some(prefix) => prefix
+    None => path
+  }
+  match without_file.rev_find("/") {
+    Some(index) if index + 1 < without_file.length() =>
+      without_file[index + 1:].to_owned()
+    _ => "session"
+  }
+}
+
+///|
+fn cli_command() -> @argparse.Command {
+  Command("openseek-analyze", about="Analyze one recorded OpenSeek session.", options=[
+    OptionArg(
+      "events",
+      long="events",
+      default_values=[""],
+      about="Path to one session events.jsonl file.",
+    ),
+    OptionArg(
+      "session-root",
+      long="session-root",
+      env="OPENSEEK_SESSION_ROOT",
+      default_values=[".openseek"],
+      about="Directory containing durable OpenSeek sessions.",
+    ),
+    OptionArg(
+      "session",
+      long="session",
+      default_values=[""],
+      about="Session id to load, or override for --events.",
+    ),
+    OptionArg(
+      "format",
+      long="format",
+      default_values=["markdown"],
+      about="Output format when --out is not set: markdown, html, or json.",
+    ),
+    OptionArg(
+      "out",
+      long="out",
+      default_values=[""],
+      about="Directory to write report.md, report.html, and report.json.",
+    ),
+  ])
+}
+
+///|
+fn value(matches : @argparse.Matches, name : String) -> String raise {
+  match matches.values.get(name) {
+    Some([value]) => value
+    Some(values) if values.length() > 0 => values[0]
+    _ => fail("missing parsed argument: \{name}")
+  }
+}

--- a/cmd/analyze/main_wbtest.mbt
+++ b/cmd/analyze/main_wbtest.mbt
@@ -1,0 +1,87 @@
+///|
+fn session_events(session : @agent_session.Session) -> String {
+  let out = StringBuilder::new()
+  for event in session.events() {
+    out.write_string(event.to_json().stringify())
+    out.write_char('\n')
+  }
+  out.to_string()
+}
+
+///|
+fn sample_session(id : String) -> @agent_session.Session {
+  @agent_session.Session(SessionId(id), system_prompt="")
+  .append(Assistant(AssistantMessage("done")))
+  .append(Terminal(Finished("ok")))
+}
+
+///|
+async test "events source can infer session id from path" {
+  let root = @fs.tmpdir(prefix="openseek-analyze-events-")
+  let path = root + "/sessions/trial-01/events.jsonl"
+  @fs.mkdir(root + "/sessions/trial-01", recursive=true)
+  @fs.write_file(
+    path,
+    session_events(sample_session("ignored")),
+    create_mode=CreateOrTruncate,
+  )
+  let matches = cli_command().parse(argv=["--events", path])
+  let session = load_session(matches)
+  assert_eq(session.id().value(), "trial-01")
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "events source can override session id" {
+  let root = @fs.tmpdir(prefix="openseek-analyze-events-id-")
+  let path = root + "/events.jsonl"
+  @fs.write_file(
+    path,
+    session_events(sample_session("ignored")),
+    create_mode=CreateOrTruncate,
+  )
+  let matches = cli_command().parse(argv=[
+    "--events", path, "--session", "chosen",
+  ])
+  let session = load_session(matches)
+  assert_eq(session.id().value(), "chosen")
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "session root source loads store session" {
+  let root = @fs.tmpdir(prefix="openseek-analyze-store-")
+  let store = @store.SessionStore(root)
+  store.create(sample_session("stored"))
+  let matches = cli_command().parse(argv=[
+    "--session-root", root, "--session", "stored",
+  ])
+  let session = load_session(matches)
+  assert_eq(session.id().value(), "stored")
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "run analyze writes all report files" {
+  let root = @fs.tmpdir(prefix="openseek-analyze-run-")
+  let events = root + "/sessions/trial-01/events.jsonl"
+  let out = root + "/report"
+  @fs.mkdir(root + "/sessions/trial-01", recursive=true)
+  @fs.write_file(
+    events,
+    session_events(sample_session("trial-01")),
+    create_mode=CreateOrTruncate,
+  )
+  let matches = cli_command().parse(argv=["--events", events, "--out", out])
+  run_analyze(matches)
+  assert_true(@fs.exists(out + "/report.md"))
+  assert_true(@fs.exists(out + "/report.html"))
+  assert_true(@fs.exists(out + "/report.json"))
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+test "format defaults to markdown" {
+  let matches = cli_command().parse(argv=["--session", "stored"])
+  assert_eq(value(matches, "format"), "markdown")
+}

--- a/cmd/analyze/moon.pkg
+++ b/cmd/analyze/moon.pkg
@@ -1,0 +1,17 @@
+import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/log" @session_log,
+  "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/eval/session_analyzer",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/argparse",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"
+
+options(
+  "is-main": true,
+)

--- a/cmd/analyze/pkg.generated.mbti
+++ b/cmd/analyze/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/analyze"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary
- Add `cmd/analyze` for analyzing exactly one recorded session.
- Support loading from `events.jsonl` directly or from `--session-root` plus `--session`.
- Render one `EvalResult` as markdown, HTML, JSON, or write all report artifacts to `--out`.

## Validation
- `moon check --target all`
- `moon test eval/session_analyzer cmd/analyze --target native`

## Stack
Base: #154 (`codex/session-analyzer-core`).
This PR intentionally exposes only per-session analysis; multi-session benchmark analysis remains inside the harness/analyzer packages.