### PR TITLE
refactor: use string interpolation and <+ to simplify string building

### DIFF
--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -91,11 +91,11 @@ pub async fn discover_skills(dir : String) -> Array[Skill] {
   let skills : Array[Skill] = []
   let entries = @fs.readdir(dir) catch { _ => return skills }
   for entry in entries {
-    let entry_path = dir + "/" + entry
+    let entry_path = "\{dir}/\{entry}"
     if entry.has_suffix(".md") {
       add_skill_file(skills, entry_path)
     } else {
-      let nested = entry_path + "/SKILL.md"
+      let nested = "\{entry_path}/SKILL.md"
       // exists() raises ENOTDIR when entry_path is a plain file; either way
       // there is no nested skill here.
       let has_nested = @fs.exists(nested) catch { _ => false }

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -35,7 +35,7 @@ async test "edit replaces a unique exact match" {
 ///|
 async test "edit resolves relative paths under the workspace root" {
   let dir = @fs.tmpdir(prefix="openseek-edit-workspace-")
-  let path = dir + "/note.txt"
+  let path = "\{dir}/note.txt"
   @fs.write_file(path, "before", create_mode=CreateOrTruncate)
   let result = run_edit_in_workspace(dir, {
     "path": "note.txt",
@@ -131,7 +131,7 @@ async test "edit rejects identical replacement" {
 ///|
 async test "edit rejects suspicious moon.pkg rewrite" {
   let dir = @fs.tmpdir(prefix="openseek-edit-manifest-")
-  let path = dir + "/moon.pkg"
+  let path = "\{dir}/moon.pkg"
   @fs.write_file(
     path,
     "warnings = \"+unnecessary_annotation\"",

--- a/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
@@ -6,7 +6,7 @@ async test "manifest error allows ordinary files" {
 ///|
 async test "manifest error rejects new moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
-  let path = dir + "/moon.mod.json"
+  let path = "\{dir}/moon.mod.json"
   let error = @manifest_error.write_error(path, "{}")
   @fs.rmdir(dir, recursive=true)
   guard error is Some(message) else { fail("expected manifest error") }
@@ -16,7 +16,7 @@ async test "manifest error rejects new moon.mod.json" {
 ///|
 async test "manifest error allows existing moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
-  let path = dir + "/moon.mod.json"
+  let path = "\{dir}/moon.mod.json"
   @fs.write_file(path, "{}", create_mode=CreateOrTruncate)
   let error = @manifest_error.write_error(path, "{}")
   @fs.rmdir(dir, recursive=true)

--- a/agent_tool/moon_check/output.mbt
+++ b/agent_tool/moon_check/output.mbt
@@ -58,7 +58,7 @@ fn ensure_trailing_newline(output : String) -> String {
   if output == "" || output.has_suffix("\n") {
     output
   } else {
-    output + "\n"
+    "\{output}\n"
   }
 }
 
@@ -139,7 +139,7 @@ fn moon_check_response(
   let output = if snapshot.output == "" {
     "\n(no output yet)"
   } else {
-    "\n" + snapshot.output
+    "\n\{snapshot.output}"
   }
   "cwd=\{cwd_text}\ncommand=\{snapshot.command}\nwatcher=\{watcher}\nid=\{snapshot.id}\nstatus=\{moon_check_status_label(snapshot.status)}\nseq=\{snapshot.seq}\{exit}\{truncated}\{restart}\{output}"
 }
@@ -182,7 +182,7 @@ fn MoonCheckSnapshot::update_text(update : MoonCheckSnapshot) -> String {
   let output = if update.output == "" {
     "\n(no output yet)"
   } else {
-    "\n" + update.output
+    "\n\{update.output}"
   }
   "id=\{update.id}\ncwd=\{cwd}\ncommand=\{update.command}\nstatus=\{moon_check_status_label(update.status)}\nseq=\{update.seq}\{exit}\{truncated}\{restart}\{output}"
 }
@@ -216,7 +216,7 @@ pub fn runtime_update_text(
       for update in latest_moon_checks.values() => update.update_text()
     ]
     Some(
-      "[moon_check update]\nevents=\{moon_check_count}\n" + parts.join("\n\n"),
+      "[moon_check update]\nevents=\{moon_check_count}\n\{parts.join("\n\n")}",
     )
   }
 }

--- a/agent_tool/moon_cmd/moon_cmd.mbt
+++ b/agent_tool/moon_cmd/moon_cmd.mbt
@@ -153,7 +153,7 @@ async fn collect_moon_output(
       }
     Some(input) => {
       let dir = @fs.tmpdir(prefix="openseek-moon-cmd-stdin-")
-      let input_path = dir + "/stdin"
+      let input_path = "\{dir}/stdin"
       @fs.write_file(input_path, input, create_mode=CreateOrTruncate)
       let process_input = @process.redirect_from_file(input_path)
       let result = match cwd {
@@ -477,7 +477,7 @@ async test "moon_cmd reports failing fixture tests as tool errors" {
   let project = copy_fixture_project("native_cli_project")
   let canonical = @fs.realpath(project)
   @fs.write_file(
-    project + "/cmd/main/main_wbtest.mbt",
+    "\{project}/cmd/main/main_wbtest.mbt",
     (
       #|///|
       #|test "intentional failure" {
@@ -581,15 +581,15 @@ async test "moon_cmd runs a virtual filesystem native CLI fixture" {
 ///|
 async fn copy_fixture_project(name : String) -> String {
   let target = @fs.tmpdir(prefix="openseek-moon-cmd-")
-  @fs.mkdir(target + "/cmd/main", recursive=true)
-  copy_fixture_file(name, "moon.mod.fixture", target + "/moon.mod")
-  copy_fixture_file(name, "main.mbt.fixture", target + "/cmd/main/main.mbt")
+  @fs.mkdir("\{target}/cmd/main", recursive=true)
+  copy_fixture_file(name, "moon.mod.fixture", "\{target}/moon.mod")
+  copy_fixture_file(name, "main.mbt.fixture", "\{target}/cmd/main/main.mbt")
   copy_fixture_file(
     name,
     "main_wbtest.mbt.fixture",
-    target + "/cmd/main/main_wbtest.mbt",
+    "\{target}/cmd/main/main_wbtest.mbt",
   )
-  copy_fixture_file(name, "moon.pkg.fixture", target + "/cmd/main/moon.pkg")
+  copy_fixture_file(name, "moon.pkg.fixture", "\{target}/cmd/main/moon.pkg")
   target
 }
 

--- a/agent_tool/moon_ide/moon_ide.mbt
+++ b/agent_tool/moon_ide/moon_ide.mbt
@@ -458,9 +458,9 @@ async test "moon_ide outlines a virtual filesystem multi-file package" {
 ///|
 async fn copy_fixture_project(name : String) -> String {
   let target = @fs.tmpdir(prefix="openseek-moon-ide-")
-  copy_fixture_file(name, "moon.mod.fixture", target + "/moon.mod")
-  copy_fixture_file(name, "moon.pkg.fixture", target + "/moon.pkg")
-  copy_fixture_file(name, "lib.mbt.fixture", target + "/lib.mbt")
+  copy_fixture_file(name, "moon.mod.fixture", "\{target}/moon.mod")
+  copy_fixture_file(name, "moon.pkg.fixture", "\{target}/moon.pkg")
+  copy_fixture_file(name, "lib.mbt.fixture", "\{target}/lib.mbt")
   target
 }
 

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -109,7 +109,7 @@ async fn read_file(
     input.max_lines is Some(_) ||
     char_truncated
   let output = if include_header {
-    read_header(path, content, selection, capped, char_truncated) + capped
+    "\{read_header(path, content, selection, capped, char_truncated)}\{capped}"
   } else {
     capped
   }
@@ -159,8 +159,7 @@ async fn read_files(
     if char_truncated {
       truncated_any = true
     }
-    let block = read_header(path, content, selection, capped, char_truncated) +
-      capped
+    let block = "\{read_header(path, content, selection, capped, char_truncated)}\{capped}"
     remaining = remaining - block.length() - 2
     blocks.push(block)
   }
@@ -273,7 +272,7 @@ async test "read returns file contents" {
 async test "read resolves relative paths under the workspace root" {
   let dir = @fs.tmpdir(prefix="openseek-read-workspace-")
   @fs.write_file(
-    dir + "/note.txt",
+    "\{dir}/note.txt",
     "workspace read",
     create_mode=CreateOrTruncate,
   )

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -91,7 +91,7 @@ async test "shell uses the workspace root when cwd is omitted" {
   let result = run_shell_in_workspace(dir, {
     "cmd": "echo root-ok > marker.txt",
   })
-  let marker = @fs.read_file(dir + "/marker.txt").text() catch { _ => "" }
+  let marker = @fs.read_file("\{dir}/marker.txt").text() catch { _ => "" }
   @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -150,7 +150,7 @@ async test "write resolves relative paths under the workspace root" {
     Sync(_) => fail("write tool should be async")
   }
   guard result is Respond(output) else { fail("expected Respond") }
-  let path = dir + "/note.txt"
+  let path = "\{dir}/note.txt"
   assert_false(output.is_error)
   assert_eq(output.content, "ok: wrote 9 chars to \{path}")
   assert_eq(@fs.read_file(path).text(), "workspace")
@@ -204,7 +204,7 @@ async test "write accepts empty content" {
 ///|
 async test "write rejects new legacy moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
-  let path = dir + "/moon.mod.json"
+  let path = "\{dir}/moon.mod.json"
   let result = execute({ "path": path, "content": "{\"name\":\"legacy\"}" })
   @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
@@ -215,7 +215,7 @@ async test "write rejects new legacy moon.mod.json" {
 ///|
 async test "write rejects json style moon.mod" {
   let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
-  let path = dir + "/moon.mod"
+  let path = "\{dir}/moon.mod"
   let result = execute({ "path": path, "content": "{\"name\":\"bad\"}" })
   @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }
@@ -226,7 +226,7 @@ async test "write rejects json style moon.mod" {
 ///|
 async test "write rejects suspiciously tiny moon.pkg" {
   let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
-  let path = dir + "/moon.pkg"
+  let path = "\{dir}/moon.pkg"
   let result = execute({ "path": path, "content": "x" })
   @fs.rmdir(dir, recursive=true)
   guard result is Respond(output) else { fail("expected Respond") }

--- a/cmd/openseek/logging.mbt
+++ b/cmd/openseek/logging.mbt
@@ -51,7 +51,7 @@ async fn FlushedStdout::drain(self : FlushedStdout) -> Unit {
       // `QueueAlreadyClosed` in the report the user sees.
       _ => return
     }
-    @stdio.stdout.write(line + "\n")
+    @stdio.stdout.write("\{line}\n")
   }
 }
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -722,7 +722,7 @@ async fn skills_prompt_section_for_cwd(
     @workspace_path.resolve(workspace_root, global_dir)
   } else {
     match @env.get_env_var("HOME") {
-      Some(home) if home != "" => home + "/.openseek/skills"
+      Some(home) if home != "" => "\{home}/.openseek/skills"
       _ => ""
     }
   }
@@ -886,7 +886,7 @@ test "cli allows session management without api key or task" {
 ///|
 async test "--dir creates a missing final component when its parent exists" {
   let parent = @fs.tmpdir(prefix="openseek-dir-parent-")
-  let child = parent + "/child"
+  let child = "\{parent}/child"
   let parsed = cli_command().parse(argv=["--dir", child, "write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
@@ -899,9 +899,9 @@ async test "--dir creates a missing final component when its parent exists" {
 ///|
 async test "--dir creates a missing final component with trailing separator" {
   let parent = @fs.tmpdir(prefix="openseek-dir-trailing-")
-  let child = parent + "/child"
+  let child = "\{parent}/child"
   let parsed = cli_command().parse(
-    argv=["--dir", child + "/", "write", "MoonBit"],
+    argv=["--dir", "\{child}/", "write", "MoonBit"],
     env={ "DEEPSEEK": "test-key" },
   )
   let root = prepare_workspace_root(parsed)
@@ -923,7 +923,7 @@ test "--dir trailing separator trim preserves roots" {
 ///|
 async test "--dir rejects missing parents instead of creating recursively" {
   let root = @fs.tmpdir(prefix="openseek-dir-missing-parent-")
-  let child = root + "/missing/child"
+  let child = "\{root}/missing/child"
   let parsed = cli_command().parse(argv=["--dir", child, "write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
@@ -945,7 +945,7 @@ async test "--dir rejects missing parents instead of creating recursively" {
 ///|
 async test "--dir rejects existing non-directories" {
   let root = @fs.tmpdir(prefix="openseek-dir-file-")
-  let path = root + "/file"
+  let path = "\{root}/file"
   @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
   let parsed = cli_command().parse(argv=["--dir", path, "write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
@@ -1081,8 +1081,8 @@ test "cli parses max steps option" {
 ///|
 async test "configured system prompt can replace and append files" {
   let dir = @fs.tmpdir(prefix="openseek-prompt-config-")
-  let prompt_path = dir + "/prompt.md"
-  let addendum_path = dir + "/addendum.md"
+  let prompt_path = "\{dir}/prompt.md"
+  let addendum_path = "\{dir}/addendum.md"
   @fs.write_file(prompt_path, "base prompt\n", create_mode=CreateOrTruncate)
   @fs.write_file(addendum_path, "addendum\n", create_mode=CreateOrTruncate)
   let parsed = cli_command().parse(
@@ -1095,7 +1095,7 @@ async test "configured system prompt can replace and append files" {
     // would append a ## Skills section (Codex review).
     env={
       "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": dir + "/no-global-skills",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/no-global-skills",
     },
   )
   // Environment last: base and addendum form the cache-shared prefix; the
@@ -1110,9 +1110,9 @@ async test "configured system prompt can replace and append files" {
 ///|
 async test "configured system prompt advertises global skills" {
   let dir = @fs.tmpdir(prefix="openseek-global-skills-")
-  @fs.mkdir(dir + "/skills", recursive=true)
+  @fs.mkdir("\{dir}/skills", recursive=true)
   @fs.write_file(
-    dir + "/skills/release.md",
+    "\{dir}/skills/release.md",
     (
       #|---
       #|name: release
@@ -1122,13 +1122,13 @@ async test "configured system prompt advertises global skills" {
     ),
     create_mode=CreateOrTruncate,
   )
-  let prompt_path = dir + "/prompt.md"
+  let prompt_path = "\{dir}/prompt.md"
   @fs.write_file(prompt_path, "base\n", create_mode=CreateOrTruncate)
   let parsed = cli_command().parse(
     argv=["--system-prompt-file", prompt_path, "write", "MoonBit"],
     env={
       "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": dir + "/skills",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/skills",
     },
   )
   let prompt = configured_system_prompt(parsed, V4Flash)
@@ -1146,13 +1146,13 @@ async test "configured system prompt uses the selected workspace root" {
   let workspace = @fs.tmpdir(prefix="openseek-prompt-workspace-")
   let real_workspace = @fs.realpath(workspace)
   @fs.write_file(
-    workspace + "/prompt.md",
+    "\{workspace}/prompt.md",
     "workspace prompt\n",
     create_mode=CreateOrTruncate,
   )
-  @fs.mkdir(workspace + "/.openseek/skills", recursive=true)
+  @fs.mkdir("\{workspace}/.openseek/skills", recursive=true)
   @fs.write_file(
-    workspace + "/.openseek/skills/release.md",
+    "\{workspace}/.openseek/skills/release.md",
     (
       #|---
       #|name: release
@@ -1168,7 +1168,7 @@ async test "configured system prompt uses the selected workspace root" {
     ],
     env={
       "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": workspace + "/no-global-skills",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{workspace}/no-global-skills",
     },
   )
   let prompt = configured_system_prompt(
@@ -1204,7 +1204,7 @@ async test "load_or_new_session defers first durable write until append" {
   let root = @fs.tmpdir(prefix="openseek-cli-session-")
   let store = @store.SessionStore(root)
   let id : @agent_session.SessionId = SessionId("cli-test")
-  let prompt_path = root + "/prompt.md"
+  let prompt_path = "\{root}/prompt.md"
   @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
   let parsed = cli_command().parse(
     argv=[
@@ -1214,7 +1214,7 @@ async test "load_or_new_session defers first durable write until append" {
     // Pinned so the exact-prompt assertions stay machine-independent.
     env={
       "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": root + "/no-global-skills",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
     },
   )
   let created = load_or_new_session(store, id, parsed, V4Pro)
@@ -1235,8 +1235,8 @@ async test "load_or_new_session defers first durable write until append" {
 async test "load_or_new_session recovers empty interrupted session directory" {
   let root = @fs.tmpdir(prefix="openseek-cli-session-empty-dir-")
   let id : @agent_session.SessionId = SessionId("cli-test")
-  @fs.mkdir(root + "/sessions/" + id.value(), recursive=true)
-  let prompt_path = root + "/prompt.md"
+  @fs.mkdir("\{root}/sessions/\{id.value()}", recursive=true)
+  let prompt_path = "\{root}/prompt.md"
   @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
   let parsed = cli_command().parse(
     argv=[
@@ -1252,7 +1252,7 @@ async test "load_or_new_session recovers empty interrupted session directory" {
     // Pinned so the exact-prompt assertion stays machine-independent.
     env={
       "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": root + "/no-global-skills",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
     },
   )
   let store = @store.SessionStore(root)
@@ -1292,7 +1292,7 @@ async test "session compact command appends summary without api key" {
     .append(User(UserMessage("hello")))
     .append(Assistant(AssistantMessage("answer")))
   store.create(session)
-  let summary_path = root + "/summary.txt"
+  let summary_path = "\{root}/summary.txt"
   @fs.write_file(summary_path, "summarized turn", create_mode=CreateOrTruncate)
   let parsed = cli_command().parse(
     argv=[
@@ -1314,7 +1314,7 @@ async test "session compact command appends summary without api key" {
 ///|
 async test "session compact file resolves relative to workspace root" {
   let workspace = @fs.tmpdir(prefix="openseek-cli-session-compact-workspace-")
-  let session_root = workspace + "/.openseek"
+  let session_root = "\{workspace}/.openseek"
   let store = @store.SessionStore(session_root)
   let session = @agent_session.Session(
       SessionId("cli-test"),
@@ -1324,7 +1324,7 @@ async test "session compact file resolves relative to workspace root" {
     .append(Assistant(AssistantMessage("answer")))
   store.create(session)
   @fs.write_file(
-    workspace + "/summary.txt",
+    "\{workspace}/summary.txt",
     "workspace summary",
     create_mode=CreateOrTruncate,
   )

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -149,7 +149,7 @@ async fn EngineClient::send(
     )
     return
   }
-  live.writer.write(command.stringify() + "\n") catch {
+  live.writer.write("\{command.stringify()}\n") catch {
     error => {
       self.live = None
       self.messages.put(AgentFailed(run_id~, error))

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -45,11 +45,11 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "agent_aborted" => Some(AgentAborted(@jsonx.string(object, "reason")))
     "max_steps_exhausted" => Some(MaxStepsExhausted)
     "agent_setup_failed" =>
-      Some(AgentError("agent setup failed: " + @jsonx.string(object, "error")))
+      Some(AgentError("agent setup failed: \{@jsonx.string(object, "error")}"))
     // A serve-mode turn that died with a non-cancellation error. Terminal for
     // the run even though the engine process lives on.
     "turn_failed" =>
-      Some(AgentError("turn failed: " + @jsonx.string(object, "error")))
+      Some(AgentError("turn failed: \{@jsonx.string(object, "error")}"))
     _ => None
   }
 }

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -297,7 +297,7 @@ fn tail_columns(text : String, max_cols : Int) -> String {
   let keep_from = display.textual_position_at_or_after(
     @displaytext.DisplayPosition::new(column=display.width() - max_cols + 1),
   )
-  "…" + display.view(keep_from, display.end()).to_owned()
+  "…\{display.view(keep_from, display.end())}"
 }
 
 ///|
@@ -325,7 +325,7 @@ fn collapse_preview_whitespace(text : String) -> String {
 ///|
 fn append_streaming_preview(current : String?, delta : String) -> String {
   let combined = match current {
-    Some(text) => text + delta
+    Some(text) => "\{text}\{delta}"
     None => delta
   }
   // Re-collapsing the bounded buffer keeps a whitespace run that spans two
@@ -429,7 +429,7 @@ fn handle_agent_event(
       state.finish_run()
     }
     AgentAborted(reason) => {
-      cmds.push(AppendItem(Error("aborted: " + reason)))
+      cmds.push(AppendItem(Error("aborted: \{reason}")))
       state.finish_run()
     }
     MaxStepsExhausted => {

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -27,8 +27,8 @@ fn terminal_item(terminal : @agent_session.TurnTerminal) -> @ui.TranscriptItem? 
   match terminal {
     Finished(answer) if !answer.trim().is_empty() => Some(Response(answer))
     Finished(_) => None
-    Aborted(reason) => Some(Error("aborted: " + reason))
-    Interrupted(reason) => Some(Error("interrupted: " + reason))
+    Aborted(reason) => Some(Error("aborted: \{reason}"))
+    Interrupted(reason) => Some(Error("interrupted: \{reason}"))
     Failed(message) => Some(Error(message))
   }
 }

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -56,7 +56,7 @@ fn format_status_bar_text(state : State) -> @doc.Text {
 ///|
 fn format_two_digits(value : Int64) -> String {
   if value < 10L {
-    "0" + value.to_string()
+    "0\{value}"
   } else {
     value.to_string()
   }

--- a/cmd/tui/status_view_wbtest.mbt
+++ b/cmd/tui/status_view_wbtest.mbt
@@ -3,7 +3,7 @@
 /// reserve: label width + chrome columns + preview width never exceeds the
 /// terminal width, and the kept text is the tail (newest characters).
 test "streaming activity line fits the label and preview to the row" {
-  let long = String::make(300, 'x') + " tail-end"
+  let long = "\{String::make(300, 'x')} tail-end"
   for label in ["Streaming ", "Thinking "] {
     let cols = 60
     let line : @doc.Text = Text(

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -50,7 +50,7 @@ fn detail_texts(lines : Array[String]) -> Array[@doc.Text] {
 ///|
 fn tool_title(result : @event.ToolResultEvent) -> @doc.Text {
   let label = if result.is_error { "Tool failed" } else { "Tool" }
-  @doc.Text::plain(label + " " + result.name)
+  @doc.Text::plain("\{label} \{result.name}")
 }
 
 ///|

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -457,9 +457,9 @@ fn trim_trailing_path_separators(path : String) -> String {
 ///|
 fn join_path(parent : String, child : String) -> String {
   if parent.is_empty() || parent.has_suffix("/") || parent.has_suffix("\\") {
-    parent + child
+    "\{parent}\{child}"
   } else {
-    parent + "/" + child
+    "\{parent}/\{child}"
   }
 }
 
@@ -487,9 +487,9 @@ fn module_root_from_exe(exe : String) -> String? {
 /// checkout's own `web/` derived from the executable path, so running from
 /// another project's directory needs no flags.
 fn shell_candidates(web_dir : String, module_root : String?) -> Array[String] {
-  let candidates = [web_dir + "/index.html"]
+  let candidates = ["\{web_dir}/index.html"]
   if module_root is Some(root) {
-    candidates.push(root + "/web/index.html")
+    candidates.push("\{root}/web/index.html")
   }
   candidates
 }
@@ -508,14 +508,14 @@ fn bundle_candidates(
 ) -> Array[String] {
   let candidates = [
     bundle,
-    web_dir + "/viz_app.js",
+    "\{web_dir}/viz_app.js",
     "_build/js/release/build/cmd/viz_app/viz_app.js",
     "_build/js/debug/build/cmd/viz_app/viz_app.js",
   ]
   if module_root is Some(root) {
-    candidates.push(root + "/web/viz_app.js")
-    candidates.push(root + "/_build/js/release/build/cmd/viz_app/viz_app.js")
-    candidates.push(root + "/_build/js/debug/build/cmd/viz_app/viz_app.js")
+    candidates.push("\{root}/web/viz_app.js")
+    candidates.push("\{root}/_build/js/release/build/cmd/viz_app/viz_app.js")
+    candidates.push("\{root}/_build/js/debug/build/cmd/viz_app/viz_app.js")
   }
   candidates
 }

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -119,12 +119,12 @@ test "valid_session_id mirrors the store's id rules" {
 ///|
 async test "discover_session_roots scans recursively and skips heavy dirs" {
   let root = @fs.tmpdir(prefix="openseek-viz-scan-")
-  @fs.mkdir(root + "/app/.openseek/sessions", recursive=true)
-  @fs.mkdir(root + "/packages/lib/.openseek/sessions", recursive=true)
-  @fs.mkdir(root + "/.git/ignored/.openseek/sessions", recursive=true)
-  @fs.mkdir(root + "/node_modules/ignored/.openseek/sessions", recursive=true)
-  @fs.mkdir(root + "/.mooncakes/ignored/.openseek/sessions", recursive=true)
-  @fs.mkdir(root + "/_build/ignored/.openseek/sessions", recursive=true)
+  @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)
+  @fs.mkdir("\{root}/packages/lib/.openseek/sessions", recursive=true)
+  @fs.mkdir("\{root}/.git/ignored/.openseek/sessions", recursive=true)
+  @fs.mkdir("\{root}/node_modules/ignored/.openseek/sessions", recursive=true)
+  @fs.mkdir("\{root}/.mooncakes/ignored/.openseek/sessions", recursive=true)
+  @fs.mkdir("\{root}/_build/ignored/.openseek/sessions", recursive=true)
   let roots = discover_session_roots([root], ".openseek").map(path => {
     path.replace_all(old=root, new="<root>")
   })
@@ -140,8 +140,8 @@ async test "discover_session_roots scans recursively and skips heavy dirs" {
 ///|
 async test "discover_session_roots supports a custom root marker" {
   let root = @fs.tmpdir(prefix="openseek-viz-openroot-")
-  @fs.mkdir(root + "/app/.openroot/sessions", recursive=true)
-  @fs.mkdir(root + "/app/.openseek/sessions", recursive=true)
+  @fs.mkdir("\{root}/app/.openroot/sessions", recursive=true)
+  @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)
   let roots = discover_session_roots([root], ".openroot").map(path => {
     path.replace_all(old=root, new="<root>")
   })
@@ -190,21 +190,21 @@ test "session catalog lookup supports composite and legacy keys" {
 ///|
 async test "session_list_reply includes root metadata and composite keys" {
   let root = @fs.tmpdir(prefix="openseek-viz-list-")
-  let app_store = @store.SessionStore(root + "/app/.openseek")
-  let lib_store = @store.SessionStore(root + "/lib/.openseek")
+  let app_store = @store.SessionStore("\{root}/app/.openseek")
+  let lib_store = @store.SessionStore("\{root}/lib/.openseek")
   app_store.create(@agent_session.Session(SessionId("same"), system_prompt="a"))
   lib_store.create(@agent_session.Session(SessionId("same"), system_prompt="b"))
   let catalog : SessionCatalog = {
     roots: [
       {
         key: "0",
-        path: root + "/app/.openseek",
+        path: "\{root}/app/.openseek",
         label: "app/.openseek",
         store: app_store,
       },
       {
         key: "1",
-        path: root + "/lib/.openseek",
+        path: "\{root}/lib/.openseek",
         label: "lib/.openseek",
         store: lib_store,
       },

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -104,18 +104,14 @@ async fn prepare_output_dir(out_dir : String) -> Unit {
   if @fs.exists(out_dir) {
     @fs.rmdir(out_dir, recursive=true)
   }
-  @fs.mkdir(out_dir + "/workspaces", recursive=true)
-  @fs.mkdir(out_dir + "/logs", recursive=true)
+  @fs.mkdir("\{out_dir}/workspaces", recursive=true)
+  @fs.mkdir("\{out_dir}/logs", recursive=true)
 }
 
 ///|
 async fn run_trial(config : Config, index : Int) -> TrialResult {
   let case = @cases.case_for_trial(index)
-  let workspace = config.out_dir +
-    "/workspaces/" +
-    padded_index(index + 1) +
-    "-" +
-    case.id
+  let workspace = "\{config.out_dir}/workspaces/\{padded_index(index + 1)}-\{case.id}"
   @fs.mkdir(workspace, recursive=true)
   write_fixture(workspace, case)
   let real_workspace = @fs.realpath(workspace)
@@ -129,7 +125,7 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
     "run",
     // cmd/openseek is the engine package (the pre-rename cmd/main no longer
     // exists, so the old invocation could not have launched at all).
-    repo_root + "/cmd/openseek",
+    "\{repo_root}/cmd/openseek",
     "--",
     "--max-steps",
     config.max_steps.to_string(),
@@ -155,18 +151,13 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
       // Trials inherit the developer's env, so point the global skills
       // lookup at a workspace path that does not exist — the developer's
       // own ~/.openseek/skills must never reach a trial prompt.
-      "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
+      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{real_workspace}/.no-global-skills",
     },
     inherit_env=true,
     cwd=real_workspace,
   )
   let log_text = output.text()
-  let log_path = config.out_dir +
-    "/logs/" +
-    padded_index(index + 1) +
-    "-" +
-    case.id +
-    ".log"
+  let log_path = "\{config.out_dir}/logs/\{padded_index(index + 1)}-\{case.id}.log"
   @fs.write_file(log_path, log_text, create_mode=CreateOrTruncate)
   evaluate_trial(
     config.prompt_label,
@@ -325,7 +316,7 @@ async fn check_expected_state(
       Some(content) => content
       None => return "no initial fixture for unchanged file \{unchanged}"
     }
-    let path = workspace + "/" + unchanged
+    let path = "\{workspace}/\{unchanged}"
     let content = @fs.read_file(path).text() catch {
       error => return "unchanged file missing \{unchanged}: \{error}"
     }
@@ -399,7 +390,7 @@ fn count_successes(results : Array[TrialResult]) -> Int {
 ///|
 fn padded_index(value : Int) -> String {
   if value < 10 {
-    "0" + value.to_string()
+    "0\{value}"
   } else {
     value.to_string()
   }

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -32,8 +32,8 @@ async fn prepare_output_dir(out_dir : String) -> Unit {
   if @fs.exists(out_dir) {
     @fs.rmdir(out_dir, recursive=true)
   }
-  @fs.mkdir(out_dir + "/workspaces", recursive=true)
-  @fs.mkdir(out_dir + "/logs", recursive=true)
+  @fs.mkdir("\{out_dir}/workspaces", recursive=true)
+  @fs.mkdir("\{out_dir}/logs", recursive=true)
 }
 
 ///|
@@ -63,10 +63,10 @@ async fn run_trial(
   index : Int,
 ) -> TrialArtifact {
   let trial_name = padded_index(index + 1)
-  let workspace = config.out_dir + "/workspaces/" + trial_name
+  let workspace = "\{config.out_dir}/workspaces/\{trial_name}"
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
-  let session_id = "trial-" + trial_name
+  let session_id = "trial-\{trial_name}"
   let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
   // The engine runs from the OpenSeek checkout and receives --dir for the
   // isolated trial workspace. This keeps launcher-relative paths stable while
@@ -75,7 +75,7 @@ async fn run_trial(
   let (program, args) = if config.engine != "" {
     (@fs.realpath(config.engine), [])
   } else {
-    ("moon", ["run", repo_root + "/cmd/openseek", "--"])
+    ("moon", ["run", "\{repo_root}/cmd/openseek", "--"])
   }
   args.append([
     "--max-steps",
@@ -103,15 +103,12 @@ async fn run_trial(
     inherit_env=true,
     cwd=repo_root,
   )
-  let log_path = config.out_dir + "/logs/" + trial_name + ".log"
+  let log_path = "\{config.out_dir}/logs/\{trial_name}.log"
   @fs.write_file(log_path, output.text(), create_mode=CreateOrTruncate)
   let events_path = discover_session_events(
     real_workspace,
     session_id,
-    fallback=real_workspace +
-      "/.openseek/sessions/" +
-      session_id +
-      "/events.jsonl",
+    fallback="\{real_workspace}/.openseek/sessions/\{session_id}/events.jsonl",
   )
   TrialArtifact(
     index=index + 1,
@@ -133,7 +130,7 @@ fn trial_extra_env(
     "DEEPSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
     "OPENSEEK_SESSION_ROOT": ".openseek",
-    "OPENSEEK_GLOBAL_SKILLS_DIR": real_workspace + "/.no-global-skills",
+    "OPENSEEK_GLOBAL_SKILLS_DIR": "\{real_workspace}/.no-global-skills",
   }
 }
 
@@ -164,11 +161,11 @@ async fn collect_session_events(
     if should_skip_scan_dir(name) {
       continue
     }
-    let path = dir + "/" + name
+    let path = "\{dir}/\{name}"
     if is_directory(path) {
       collect_session_events(path, session_id, matches)
     } else if name == "events.jsonl" &&
-      path.contains("/sessions/" + session_id + "/") {
+      path.contains("/sessions/\{session_id}/") {
       matches.push(path)
     }
   }
@@ -191,7 +188,7 @@ fn should_skip_scan_dir(name : String) -> Bool {
 ///|
 fn padded_index(value : Int) -> String {
   if value < 10 {
-    "0" + value.to_string()
+    "0\{value}"
   } else {
     value.to_string()
   }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -121,7 +121,7 @@ pub fn Report::markdown(self : Report) -> String {
       lines.push(line)
     }
   }
-  lines.join("\n") + "\n"
+  "\{lines.join("\n")}\n"
 }
 
 ///|
@@ -272,13 +272,13 @@ pub async fn write_files(
 ) -> Unit {
   let _ = @fs.mkdir(out_dir, recursive=true) catch { _ => () }
   @fs.write_file(
-    out_dir + "/report.json",
+    "\{out_dir}/report.json",
     json.stringify(),
     create_mode=CreateOrTruncate,
   )
-  @fs.write_file(out_dir + "/report.md", markdown, create_mode=CreateOrTruncate)
+  @fs.write_file("\{out_dir}/report.md", markdown, create_mode=CreateOrTruncate)
   if html != "" {
-    @fs.write_file(out_dir + "/report.html", html, create_mode=CreateOrTruncate)
+    @fs.write_file("\{out_dir}/report.html", html, create_mode=CreateOrTruncate)
   }
 }
 
@@ -309,7 +309,7 @@ fn table_header(metric_columns : Array[String]) -> String {
   }
   cells.push("Reason")
   cells.push("Warnings")
-  "| " + cells.join(" | ") + " |"
+  "| \{cells.join(" | ")} |"
 }
 
 ///|
@@ -320,7 +320,7 @@ fn table_divider(metric_columns : Array[String]) -> String {
   }
   cells.push("---")
   cells.push("---")
-  "| " + cells.join(" | ") + " |"
+  "| \{cells.join(" | ")} |"
 }
 
 ///|
@@ -342,7 +342,7 @@ fn ReportRow::markdown_row(
   }
   cells.push(escape_table_cell(short_cell(self.reason)))
   cells.push(escape_table_cell(short_cell(self.warnings)))
-  "| " + cells.join(" | ") + " |"
+  "| \{cells.join(" | ")} |"
 }
 
 ///|

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -82,9 +82,9 @@ async test "report writes markdown json and html files" {
     ]),
   ])
   report.write_files(root)
-  let markdown = @fs.read_file(root + "/report.md").text()
-  let json = @fs.read_file(root + "/report.json").text()
-  let html = @fs.read_file(root + "/report.html").text()
+  let markdown = @fs.read_file("\{root}/report.md").text()
+  let json = @fs.read_file("\{root}/report.json").text()
+  let html = @fs.read_file("\{root}/report.html").text()
   assert_true(markdown.contains("# Tiny Report"))
   assert_true(json.contains("\"title\":\"Tiny Report\""))
   assert_true(html.contains("<title>Tiny Report</title>"))

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -70,7 +70,7 @@ async fn run_read_case(
     ),
   }).write_to(root)
   let action = dispatch(tools, "read", {
-    "path": root + "/src/read.txt",
+    "path": "\{root}/src/read.txt",
     "start_line": 1,
     "max_lines": 1,
   })
@@ -90,7 +90,7 @@ async fn run_write_case(
     #|second line
     #|
   let action = dispatch(tools, "write", {
-    "path": root + "/created.txt",
+    "path": "\{root}/created.txt",
     "content": content,
   })
   let mut reason = expect_respond(action, contains=["ok: wrote"], error=false)
@@ -122,7 +122,7 @@ async fn run_edit_case(
     ),
   }).write_to(root)
   let action = dispatch(tools, "edit", {
-    "path": root + "/src/note.txt",
+    "path": "\{root}/src/note.txt",
     "old_string": "beta\n",
     "new_string": "delta\n",
   })
@@ -401,6 +401,6 @@ fn short_text(text : String) -> String {
   if squashed.length() <= 160 {
     squashed
   } else {
-    squashed[:160].to_owned() + "..."
+    "\{squashed[:160]}..."
   }
 }

--- a/eval/tool_harness/harness_test.mbt
+++ b/eval/tool_harness/harness_test.mbt
@@ -16,8 +16,8 @@ async test "harness report can be written for inspection" {
   let root = @fs.tmpdir(prefix="openseek-tool-harness-report-")
   let report = @tool_harness.run_harness()
   report.write_files(root)
-  let markdown = @fs.read_file(root + "/report.md").text()
-  let json = @fs.read_file(root + "/report.json").text()
+  let markdown = @fs.read_file("\{root}/report.md").text()
+  let json = @fs.read_file("\{root}/report.json").text()
   assert_true(
     markdown.contains(
       "| # | Case | Result | Mode | Action | Reason | Warnings |",

--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -30,7 +30,7 @@ async fn main {
   if output_matches(output, source) {
     return
   }
-  let tmp = output + ".tmp"
+  let tmp = "\{output}.tmp"
   @fs.write_file(tmp, source, create_mode=CreateOrTruncate)
   @fs.rename(tmp, output, replace=true)
 }

--- a/testkit/filesystem/filesystem.mbt
+++ b/testkit/filesystem/filesystem.mbt
@@ -124,7 +124,7 @@ pub async fn FileSystem::mismatch_on_disk(
     error => return "invalid file system: \{error}"
   }
   for entry in entries {
-    let path = root + "/" + entry.path
+    let path = "\{root}/\{entry.path}"
     let content = @fs.read_file(path).text() catch {
       error => return "missing expected file \{entry.path}: \{error}"
     }
@@ -141,7 +141,7 @@ pub async fn FileSystem::mismatch_on_disk(
 pub async fn write_text(root : String, path : String, content : String) -> Unit {
   validate_relative_path(path)
   ensure_parent_dir(root, path)
-  @fs.write_file(root + "/" + path, content, create_mode=CreateOrTruncate)
+  @fs.write_file("\{root}/\{path}", content, create_mode=CreateOrTruncate)
 }
 
 ///|
@@ -175,7 +175,7 @@ async fn ensure_parent_dir(root : String, path : String) -> Unit {
   for index in 0..<(parts.length() - 1) {
     dirs.push(parts[index])
   }
-  let _ = @fs.mkdir(root + "/" + dirs.join("/"), recursive=true) catch {
+  let _ = @fs.mkdir("\{root}/\{dirs.join("/")}", recursive=true) catch {
     _ => ()
   }
 }

--- a/tui/internal/history/history_test.mbt
+++ b/tui/internal/history/history_test.mbt
@@ -7,7 +7,7 @@ fn prompt_entry(text : String) -> @history.Entry {
 ///|
 fn shell_entry(text : String) -> @history.Entry {
   let composer = @composer.Model::new("")
-  composer.insert_user_text("!" + text)
+  composer.insert_user_text("!\{text}")
   @history.Entry::new(composer.text(), composer.mode())
 }
 

--- a/tui/internal/render/queued.mbt
+++ b/tui/internal/render/queued.mbt
@@ -26,7 +26,7 @@ fn queued_input_line(
   indent~ : Int,
 ) -> @surface.Line {
   let marker = @displaytext.DisplayText(
-    String::make(indent, ' ') + "\{index + 1}. ",
+    "\{String::make(indent, ' ')}\{index + 1}. ",
   )
   let prefix = input.prefix()
   let marker_width = marker.width()
@@ -51,7 +51,7 @@ fn indented_dim_line(
 ) -> @surface.Line {
   @surface.Line::new([
     Span(
-      DisplayText(String::make(indent, ' ') + line.truncate(cols - indent)),
+      DisplayText("\{String::make(indent, ' ')}\{line.truncate(cols - indent)}"),
       style=@style.dim,
     ),
   ])

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -132,7 +132,7 @@ fn offset_label(base : Int64, event : @agent_session.SessionEvent) -> String {
   if base == 0 || event.unix_ms() == 0 {
     return ""
   }
-  "+" + format_span_seconds(event.unix_ms() - base)
+  "+\{format_span_seconds(event.unix_ms() - base)}"
 }
 
 ///|
@@ -412,5 +412,5 @@ fn truncate(text : String, limit : Int) -> String {
     kept <+ "\{char}"
     count += 1
   }
-  kept.to_string() + "…"
+  "\{kept.to_string()}…"
 }


### PR DESCRIPTION
Replace manual StringBuilder.write_string/write_char/write_stringview and many simple  string concatenations with string interpolation and the
 streaming-interpolation macro.

High-impact simplifications:
- tui/internal/composer/composer.mbt: remove temporary StringBuilders in replace_line_range, join_with_next_line, and insert_text.
- cmd/tui/loop.mbt: stream decoded stderr and conditional trailers with <+.
- cmd/openseek/main.mbt, cmd/viz_server/main.mbt, eval/* harnesses, agent_tool/*: build paths and messages with interpolation instead of .

Validation:
- moon check passes
- moon test passes: 539 tests
- moon info produces no .mbti changes; public API unchanged
- moon fmt applied