### PR TITLE
fix(openseek): fall back to USERPROFILE for skills

### DIFF
--- a/agent_skill/README.mbt.md
+++ b/agent_skill/README.mbt.md
@@ -24,8 +24,8 @@ frontmatter falls back to the file stem and an empty description; a missing
 directory is simply an empty library.
 
 Two libraries feed the listing: the user-level (global) one under
-`$HOME/.openseek/skills` (override with `--global-skills-dir` /
-`OPENSEEK_GLOBAL_SKILLS_DIR`) and the workspace one under
-`.openseek/skills`. `merge_skills` combines them with workspace skills
-shadowing same-named global ones, so a project can specialize a shared
-playbook without renaming it.
+`$HOME/.openseek/skills` (`%USERPROFILE%/.openseek/skills` on Windows;
+override with `--global-skills-dir` / `OPENSEEK_GLOBAL_SKILLS_DIR`) and the
+workspace one under `.openseek/skills`. `merge_skills` combines them with
+workspace skills shadowing same-named global ones, so a project can specialize
+a shared playbook without renaming it.

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -269,7 +269,7 @@ fn cli_command() -> @argparse.Command {
         long="global-skills-dir",
         env="OPENSEEK_GLOBAL_SKILLS_DIR",
         default_values=[""],
-        about="User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills.",
+        about="User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows.",
       ),
       OptionArg(
         "session",
@@ -785,8 +785,38 @@ async fn configured_system_prompt(
 }
 
 ///|
+fn global_skills_dir_for_home(value : String?) -> String? {
+  if value is Some(value) {
+    let home = value.trim()
+    if !home.is_empty() {
+      return Some("\{home}/.openseek/skills")
+    }
+  }
+  None
+}
+
+///|
+#cfg(platform="windows")
+fn default_global_skills_dir() -> String? {
+  if global_skills_dir_for_home(@env.get_env_var("USERPROFILE")) is Some(dir) {
+    return Some(dir)
+  }
+  if global_skills_dir_for_home(@env.get_env_var("HOME")) is Some(dir) {
+    return Some(dir)
+  }
+  None
+}
+
+///|
+#cfg(not(platform="windows"))
+fn default_global_skills_dir() -> String? {
+  global_skills_dir_for_home(@env.get_env_var("HOME"))
+}
+
+///|
 /// The skills advertised to the model: the user-level library (`global_dir`,
-/// defaulting to `$HOME/.openseek/skills` when empty) merged with the
+/// defaulting to `$HOME/.openseek/skills` or `%USERPROFILE%/.openseek/skills`
+/// when empty) merged with the
 /// workspace library under `.openseek/skills`, listing `<name>.md` files and
 /// `<name>/SKILL.md` layouts. Workspace skills shadow same-named global ones
 /// so a project can specialize a shared playbook. Empty or absent
@@ -798,17 +828,14 @@ async fn skills_prompt_section_for_cwd(
   workspace_root~ : String,
 ) -> String? {
   let resolved_global_dir = if global_dir != "" {
-    @workspace_path.resolve(workspace_root, global_dir)
+    Some(@workspace_path.resolve(workspace_root, global_dir))
   } else {
-    match @env.get_env_var("HOME") {
-      Some(home) if home != "" => "\{home}/.openseek/skills"
-      _ => ""
-    }
+    default_global_skills_dir()
   }
-  let global_skills = if resolved_global_dir == "" {
-    []
-  } else {
+  let global_skills = if resolved_global_dir is Some(resolved_global_dir) {
     @agent_skill.discover_skills(resolved_global_dir)
+  } else {
+    []
   }
   @agent_skill.skills_prompt_section(
     @agent_skill.merge_skills(

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -37,7 +37,7 @@ Options:
   --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
-  --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
+  --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
   --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION] [default: ]
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
   --session-compact-file <session-compact-file>                Read summary text from this file, append it to --session, and exit. [default: ]


### PR DESCRIPTION
This PR fixes user-level skills directory path discovery on Windows by using `USERPROFILE` on Windows.

## Relationship

This PR is independent and targets `main`. #160 (`--format=json`) and #166 (`md_to_mbt_string` basename fix) also target `main` independently. #167 is stacked only on #166.