### PR TITLE
feat(openseek): add JSON session listing format

### DIFF
--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -47,9 +47,17 @@ The session-management commands are offline and do not require `--api-key`:
 
 ```bash
 moon run cmd/openseek -- --session-list --session-root .openseek
+moon run cmd/openseek -- --session-list --format=json --session-root .openseek
 moon run cmd/openseek -- --session-show --session parser-fix --session-root .openseek
 moon run cmd/openseek -- --session parser-fix --session-compact-file summary.txt --session-compact-from 1 --session-compact-to 120
 ```
+
+`--session-list --format=json` is the machine-readable form of the listing,
+consumed by clients such as the desktop app's sidebar: one JSON array of
+`{id, title, updated_at_ms}` objects, most recently active first. `title` is
+the first line of the session's first user prompt; `updated_at_ms` is `null`
+for a directory whose session files cannot be stat-ed (such husks sort last,
+like the human-readable listing).
 
 `--session-compact-file` appends a typed summary event. It does not delete raw
 events from `events.jsonl`; `agent_session.Session::chat_messages` uses the

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -303,6 +303,12 @@ fn cli_command() -> @argparse.Command {
         default_values=[""],
         about="Last event sequence covered by --session-compact-file.",
       ),
+      OptionArg(
+        "format",
+        long="format",
+        default_values=["text"],
+        about="Output format for --session-list: text or json.",
+      ),
     ],
     flags=[
       FlagArg(
@@ -318,7 +324,7 @@ fn cli_command() -> @argparse.Command {
       FlagArg(
         "session-list",
         long="session-list",
-        about="List durable session ids and exit.",
+        about="List durable sessions (see --format) and exit.",
       ),
       FlagArg(
         "session-show",
@@ -569,8 +575,12 @@ async fn handle_session_command(
   let compact_to = value(matches, "session-compact-to").trim().to_owned()
   let store = @store.SessionStore(session_root(matches, workspace_root~))
   if list_sessions {
-    for listing in store.listings() {
-      println(format_session_listing(listing))
+    match session_list_format(matches) {
+      Text =>
+        for listing in store.listings() {
+          println(format_session_listing(listing))
+        }
+      Json => println(session_list_json(store).stringify())
     }
     return true
   }
@@ -610,6 +620,75 @@ fn session_command_count(matches : @argparse.Matches) -> Int raise {
   (if flag(matches, "session-list") { 1 } else { 0 }) +
   (if flag(matches, "session-show") { 1 } else { 0 }) +
   (if compact_session { 1 } else { 0 })
+}
+
+///|
+priv enum SessionListFormat {
+  Text
+  Json
+}
+
+///|
+fn session_list_format(matches : @argparse.Matches) -> SessionListFormat raise {
+  match value(matches, "format") {
+    "text" => Text
+    "json" => Json
+    other => fail("--format must be text or json, got: \{other}")
+  }
+}
+
+///|
+/// The store's listings as JSON for machine consumers (e.g. the desktop
+/// client's sidebar): an array of `{id, title, updated_at_ms}`, most
+/// recently active first. `title` is the untruncated first line of the first
+/// user prompt; `updated_at_ms` is the session file mtime rounded down to
+/// milliseconds, or `null` for a directory whose session files cannot be
+/// stat-ed (such husks sort last, like the human-readable listing).
+async fn session_list_json(store : @store.SessionStore) -> Json {
+  let entries : Array[Json] = []
+  for listing in store.listings() {
+    let updated_at_ms : Json = match
+      session_listing_updated_at_ms(store, listing) {
+      Some(milliseconds) => Json::number(milliseconds.to_double())
+      None => Json::null()
+    }
+    entries.push({
+      "id": listing.id().value(),
+      "title": session_title(listing.first_prompt()),
+      "updated_at_ms": updated_at_ms,
+    })
+  }
+  Json::array(entries)
+}
+
+///|
+async fn session_listing_updated_at_ms(
+  store : @store.SessionStore,
+  listing : @store.SessionListing,
+) -> Int64? {
+  let id = listing.id()
+  let stamp = @fs.mtime(store.event_log_file(id)) catch {
+    _ => @fs.mtime(store.header_file(id)) catch { _ => return None }
+  }
+  let (seconds, nanoseconds) = stamp
+  Some(mtime_to_unix_millis(seconds, nanoseconds))
+}
+
+///|
+fn mtime_to_unix_millis(seconds : Int64, nanoseconds : Int) -> Int64 {
+  seconds * 1000 + (nanoseconds / 1000000).to_int64()
+}
+
+///|
+/// A machine-facing title for a session: the first line of its first user
+/// prompt, untruncated. Empty when the session has no user prompt.
+fn session_title(first_prompt : String) -> String {
+  let content = first_prompt.trim()
+  let title = match content.split_once("\n") {
+    Some((line, _)) => line.trim()
+    None => content
+  }
+  title.to_owned()
 }
 
 ///|
@@ -1279,6 +1358,81 @@ async test "session list command does not require deepseek setup" {
   )
   assert_true(handle_session_command(parsed))
   @fs.rmdir(root, recursive=true)
+}
+
+///|
+test "session list format defaults to text and rejects unknown values" {
+  let default_format = cli_command().parse(argv=["--session-list"], env={})
+  assert_true(session_list_format(default_format) is Text)
+  let json_format = cli_command().parse(
+    argv=["--session-list", "--format", "json"],
+    env={},
+  )
+  assert_true(session_list_format(json_format) is Json)
+  let bogus = cli_command().parse(argv=["--session-list", "--format", "yaml"], env={})
+  let _ = session_list_format(bogus) catch {
+    error => {
+      assert_true("\{error}".contains("--format must be text or json"))
+      return
+    }
+  }
+  fail("unknown format accepted")
+}
+
+///|
+async test "session list json reports titles newest first with husks last" {
+  let root = @fs.tmpdir(prefix="openseek-cli-session-list-json-")
+  let store = @store.SessionStore(root)
+  let older : @agent_session.Session = Session(
+    SessionId("older"),
+    system_prompt="system",
+  )
+  store.create(
+    older.append(User(UserMessage("  first question\nwith detail  "))),
+  )
+  let newer : @agent_session.Session = Session(
+    SessionId("newer"),
+    system_prompt="system",
+  )
+  store.create(newer)
+  // A directory with no session files at all still appears — last, with no
+  // timestamp — matching the human-readable listing's behavior.
+  @fs.mkdir(root + "/sessions/husk", recursive=true)
+  guard session_list_json(store) is Array(entries) else {
+    fail("expected a JSON array")
+  }
+  assert_eq(entries.length(), 3)
+  guard entries[0] is Object(newest) &&
+    entries[1] is Object(oldest) &&
+    entries[2] is Object(husk) else {
+    fail("expected JSON objects")
+  }
+  assert_true(newest.get("id") is Some(String("newer")))
+  assert_true(newest.get("title") is Some(String("")))
+  assert_true(oldest.get("id") is Some(String("older")))
+  assert_true(oldest.get("title") is Some(String("first question")))
+  guard oldest.get("updated_at_ms") is Some(Number(stamp, ..)) else {
+    fail("expected updated_at_ms")
+  }
+  assert_true(stamp > 0)
+  assert_true(husk.get("id") is Some(String("husk")))
+  assert_true(husk.get("updated_at_ms") is Some(Null))
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+test "session title keeps the untruncated first line" {
+  assert_eq(session_title("  first line\nsecond line  "), "first line")
+  let long_line = "x".repeat(256)
+  let title = session_title(long_line)
+  assert_eq(title.char_length(), 256)
+  assert_eq(title, long_line)
+}
+
+///|
+test "mtime to unix millis preserves subsecond precision" {
+  assert_eq(mtime_to_unix_millis(42L, 987654321), 42987L)
+  assert_eq(mtime_to_unix_millis(42L, 999999), 42000L)
 }
 
 ///|

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -27,7 +27,7 @@ Options:
   -h, --help                                                   Show help information.
   --serve                                                      Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.
   --no-session                                                 Run ephemerally: do not record this run to a durable session.
-  --session-list                                               List durable session ids and exit.
+  --session-list                                               List durable sessions (see --format) and exit.
   --session-show                                               Print the durable session JSON for --session and exit.
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
   --model <model>                                              DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
@@ -43,6 +43,7 @@ Options:
   --session-compact-file <session-compact-file>                Read summary text from this file, append it to --session, and exit. [default: ]
   --session-compact-from <session-compact-from>                First event sequence covered by --session-compact-file. [default: ]
   --session-compact-to <session-compact-to>                    Last event sequence covered by --session-compact-file. [default: ]
+  --format <format>                                            Output format for --session-list: text or json. [default: text]
 ```
 
 ## A DeepSeek API Key Is Required For Agent Runs


### PR DESCRIPTION
## Summary

- add `--format` for `--session-list`, defaulting to existing text output
- add `--format=json` output with `id`, untruncated first-line `title`, and `updated_at_ms`
- preserve session file mtime millisecond precision in `updated_at_ms`
- document the machine-readable listing and update CLI cram output

## Relationship

This PR is independent and targets `main`. It does not depend on #159 or #166, and #167 is not stacked on this PR.

## Validation

- `moon fmt`
- `moon info`
- `moon check --target native`
- `moon test --target native`