### PR TITLE
Split viz app into JS workspace module

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -80,7 +80,7 @@ fn init_model() -> Model {
     parsed: None,
     system_prompt: "",
     header_present: false,
-    view_mode: RawLog,
+    view_mode: ModelView,
     theme: Light,
     sidebar_visible: true,
     collapsed_roots: [],

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -115,3 +115,8 @@ test "theme values map to the data-theme attribute" {
   inspect(Theme::value(Dark), content="dark")
   inspect(Theme::value(System), content="system")
 }
+
+///|
+test "visualizer defaults to model view" {
+  assert_true(init_model().view_mode == ModelView)
+}

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -1,6 +1,7 @@
 ///|
 /// Mount the visualizer onto `#app` and kick off the initial session-list fetch.
 /// The frontend talks only to the read-only viz server's JSON/raw-file API.
+#warnings("-alert_unstable")
 fn main {
   let (emit, app_cell) = @rabbita.cell_with_emit(
     model=init_model(),

--- a/cmd/viz_app/moon.mod
+++ b/cmd/viz_app/moon.mod
@@ -1,0 +1,12 @@
+name = "bobzhang/openseek-viz-app"
+
+version = "0.1.0"
+
+import {
+  "bobzhang/openseek@0.2.0",
+  "moonbit-community/rabbita@0.12.4",
+}
+
+preferred_target = "js"
+
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value"

--- a/cmd/viz_app/pkg.generated.mbti
+++ b/cmd/viz_app/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "bobzhang/openseek/cmd/viz_app"
+package "bobzhang/openseek-viz-app"
 
 // Values
 
@@ -13,6 +13,8 @@ type Model
 type Msg
 
 type SessionRow
+
+type Theme derive(Eq)
 
 // Type aliases
 

--- a/cmd/viz_server/README.md
+++ b/cmd/viz_server/README.md
@@ -6,24 +6,17 @@ bundle, and read-only session JSONL APIs.
 
 ## Build
 
-From the repository root, build all targets before starting the server:
+From the repository root, build before starting the server:
 
 ```sh
-moon build --target all
+moon build
 ```
 
 This builds both the native server and the JavaScript visualizer app. The server
 auto-locates the frontend bundle from Moon's build output, normally:
 
 ```text
-_build/js/debug/build/cmd/viz_app/viz_app.js
-```
-
-If you only need to refresh the frontend bundle, this narrower command is also
-enough:
-
-```sh
-moon build cmd/viz_app --target js
+_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js
 ```
 
 ## Run
@@ -31,7 +24,7 @@ moon build cmd/viz_app --target js
 Start the server from the repository root:
 
 ```sh
-moon run cmd/viz_server
+moon run --target native cmd/viz_server
 ```
 
 By default it listens on `127.0.0.1:8080`, serves `web/index.html`, and scans
@@ -40,13 +33,13 @@ the current directory recursively for `.openseek` session roots.
 Useful options:
 
 ```sh
-moon run cmd/viz_server -- --port 8081
-moon run cmd/viz_server -- --search-dir path/to/project
-moon run cmd/viz_server -- --session-root-name .openroot
+moon run --target native cmd/viz_server -- --port 8081
+moon run --target native cmd/viz_server -- --search-dir path/to/project
+moon run --target native cmd/viz_server -- --session-root-name .openroot
 ```
 
 If the server cannot find the generated JavaScript bundle, pass it explicitly:
 
 ```sh
-moon run cmd/viz_server -- --bundle _build/js/debug/build/cmd/viz_app/viz_app.js
+moon run --target native cmd/viz_server -- --bundle _build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js
 ```

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -106,7 +106,7 @@ async fn build_reply(
       )
     "/viz_app.js" =>
       search_reply(
-        bundle, "text/javascript; charset=utf-8", "viz_app.js not found; build it with: moon build cmd/viz_app --target js",
+        bundle, "text/javascript; charset=utf-8", "viz_app.js not found; build it with: moon build",
       )
     "/api/sessions" => session_list_reply(catalog)
     _ =>
@@ -496,11 +496,11 @@ fn shell_candidates(web_dir : String, module_root : String?) -> Array[String] {
 
 ///|
 /// Where to look for the compiled frontend bundle, in order: an explicit
-/// `--bundle` path, `<web-dir>/viz_app.js`, moon's release and debug build
-/// outputs relative to the working directory, then the same paths under the
-/// executable-derived checkout root. This lets
-/// `moon build cmd/viz_app --target js` followed by
-/// `moon run cmd/viz_server` work with no copy step — from any directory.
+/// `--bundle` path, `<web-dir>/viz_app.js`, moon's release and debug outputs
+/// for the standalone frontend module, legacy in-module frontend build outputs,
+/// then the same paths under the executable-derived checkout root. This lets
+/// `moon build` followed by `moon run --target native cmd/viz_server` work
+/// with no copy step — from any directory.
 fn bundle_candidates(
   bundle : String,
   web_dir : String,
@@ -509,11 +509,19 @@ fn bundle_candidates(
   let candidates = [
     bundle,
     "\{web_dir}/viz_app.js",
+    "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
+    "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
     "_build/js/release/build/cmd/viz_app/viz_app.js",
     "_build/js/debug/build/cmd/viz_app/viz_app.js",
   ]
   if module_root is Some(root) {
     candidates.push("\{root}/web/viz_app.js")
+    candidates.push(
+      "\{root}/_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
+    )
+    candidates.push(
+      "\{root}/_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
+    )
     candidates.push("\{root}/_build/js/release/build/cmd/viz_app/viz_app.js")
     candidates.push("\{root}/_build/js/debug/build/cmd/viz_app/viz_app.js")
   }

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -83,9 +83,13 @@ test "asset candidates search cwd first, then the derived checkout" {
       #|[
       #|  "",
       #|  "web/viz_app.js",
+      #|  "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
+      #|  "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
       #|  "_build/js/release/build/cmd/viz_app/viz_app.js",
       #|  "_build/js/debug/build/cmd/viz_app/viz_app.js",
       #|  "/repo/web/viz_app.js",
+      #|  "/repo/_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
+      #|  "/repo/_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
       #|  "/repo/_build/js/release/build/cmd/viz_app/viz_app.js",
       #|  "/repo/_build/js/debug/build/cmd/viz_app/viz_app.js",
       #|]
@@ -98,6 +102,8 @@ test "asset candidates search cwd first, then the derived checkout" {
       #|[
       #|  "/x/app.js",
       #|  "web/viz_app.js",
+      #|  "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
+      #|  "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
       #|  "_build/js/release/build/cmd/viz_app/viz_app.js",
       #|  "_build/js/debug/build/cmd/viz_app/viz_app.js",
       #|]

--- a/moon.work
+++ b/moon.work
@@ -1,0 +1,4 @@
+members = [
+  ".",
+  "./cmd/viz_app",
+]

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -43,6 +43,7 @@ fn events_jsonl(session : @agent_session.Session) -> String {
 }
 
 ///|
+#warnings("-alert_unstable")
 fn render(html : @html.Html) -> String {
   @rabbita.render_to_string(@rabbita.static_cell(html))
 }


### PR DESCRIPTION
## Summary

- add a `moon.work` workspace with the root module and `cmd/viz_app` as members
- make `cmd/viz_app` its own JS-preferred module so plain `moon build` refreshes the frontend bundle
- teach `cmd/viz_server` to locate the new standalone frontend bundle path while keeping legacy bundle paths as fallbacks
- update viz server docs and generated interface output for the new module boundary

## Validation

- `moon fmt`
- `moon info`
- `moon check --target all`
- `moon test cmd/viz_server`
- `moon build`
- smoke-tested `moon run --target native ~/git/openseek/cmd/viz_server -- --port 9095` from `.repos`; it found 101 session roots, served the rebuilt JS, and a composite session key returned `found: true`