### PR TITLE
[codex] simplify counter loops with accumulators

### DIFF
--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -16,35 +16,35 @@ fn drain_test_state() -> State {
 
 ///|
 fn start_agent_count(cmds : Array[Cmd]) -> Int {
-  let mut count = 0
-  for cmd in cmds {
+  for cmd in cmds; count = 0 {
     if cmd is StartAgent(_, ..) {
-      count = count + 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|
 fn error_item_count(cmds : Array[Cmd]) -> Int {
-  let mut count = 0
-  for cmd in cmds {
+  for cmd in cmds; count = 0 {
     if cmd is AppendItem(Error(_)) {
-      count = count + 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|
 fn run_command_count(cmds : Array[Cmd]) -> Int {
-  let mut count = 0
-  for cmd in cmds {
+  for cmd in cmds; count = 0 {
     if cmd is RunCommand(_, ..) {
-      count = count + 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|
@@ -181,13 +181,13 @@ test "a stale terminal event from a superseded run is ignored" {
 
 ///|
 fn quit_count(cmds : Array[Cmd]) -> Int {
-  let mut count = 0
-  for cmd in cmds {
+  for cmd in cmds; count = 0 {
     if cmd is Quit {
-      count = count + 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -360,31 +360,28 @@ fn count_occurrences(content : String, needle : String) -> Int {
 
 ///|
 fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
-  let mut count = 0
-  for piece in content.split("\n") {
-    let line = piece.to_owned()
-    let mut matched = true
+  for line in content.split("\n"); count = 0 {
     for needle in needles {
       if !line.contains(needle) {
-        matched = false
+        break
       }
+    } nobreak {
+      continue count + 1
     }
-    if matched {
-      count += 1
-    }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|
 fn count_successes(results : Array[TrialResult]) -> Int {
-  let mut count = 0
-  for result in results {
+  for result in results; count = 0 {
     if result.success {
-      count += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|

--- a/eval/file_edit/harness/harness_wbtest.mbt
+++ b/eval/file_edit/harness/harness_wbtest.mbt
@@ -94,6 +94,25 @@ test "count_occurrences counts non-overlapping markers" {
 }
 
 ///|
+test "line counter documents all-match behavior" {
+  let log_text =
+    #|command=moon run -e fn main {}
+    #|command=moon run -c fn main {}
+    #|command=moon test
+    #|note=moon run without command prefix
+  debug_inspect(
+    [
+      count_lines_containing_all(log_text, ["command=moon "]),
+      count_lines_containing_all(log_text, ["moon run", " -e"]),
+      count_lines_containing_all(log_text, ["moon run", " -c"]),
+      count_lines_containing_all(log_text, ["command=moon ", "missing"]),
+      count_lines_containing_all("a\nb\n", []),
+    ],
+    content="[3, 1, 1, 0, 3]",
+  )
+}
+
+///|
 async test "indexed runner honors concurrency and preserves order" {
   let mut active = 0
   let mut max_active = 0

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -635,13 +635,13 @@ fn sanitize_artifact_name(name : String) -> String {
 
 ///|
 fn count_successes(results : Array[EvalResult]) -> Int {
-  let mut count = 0
-  for result in results {
+  for result in results; count = 0 {
     if result.success {
-      count += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|
@@ -655,20 +655,17 @@ fn count_occurrences(content : String, needle : String) -> Int {
 
 ///|
 fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
-  let mut count = 0
-  for piece in content.split("\n") {
-    let line = piece.to_owned()
-    let mut matched = true
+  for line in content.split("\n"); count = 0 {
     for needle in needles {
       if !line.contains(needle) {
-        matched = false
+        break
       }
+    } nobreak {
+      continue count + 1
     }
-    if matched {
-      count += 1
-    }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -131,6 +131,25 @@ test "behavior counters ignore user task prompt" {
 }
 
 ///|
+test "line counter documents all-match behavior" {
+  let text =
+    #|assistant: moon run -e fn main {}
+    #|assistant: moon run -c fn main {}
+    #|assistant: moon test
+    #|user: mention moon run only
+  debug_inspect(
+    [
+      count_lines_containing_all(text, ["assistant:"]),
+      count_lines_containing_all(text, ["moon run", " -e"]),
+      count_lines_containing_all(text, ["moon run", " -c"]),
+      count_lines_containing_all(text, ["assistant:", "missing"]),
+      count_lines_containing_all("a\nb\n", []),
+    ],
+    content="[3, 1, 1, 0, 3]",
+  )
+}
+
+///|
 test "latest non-finished terminal determines success" {
   let session = @agent_session.Session(
       SessionId("multi-turn"),

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -713,11 +713,12 @@ pub fn SuiteReport::passed(self : SuiteReport) -> Bool {
 ///|
 /// One-line failure summary for CLIs that exit non-zero on missed thresholds.
 pub fn SuiteReport::failure_message(self : SuiteReport) -> String {
-  let mut failed = 0
-  for report in self.reports {
+  let failed = for report in self.reports; count = 0 {
     if !report.passed() {
-      failed += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
   "prompt task suite failed: \{failed}/\{self.reports.length()} combos below threshold"
 }
@@ -848,9 +849,10 @@ fn average_result_metric(
   if report.results.length() == 0 {
     return "0.0"
   }
-  let mut total = 0
-  for result in report.results {
-    total += metric(result)
+  let total = for result in report.results; total = 0 {
+    continue total + metric(result)
+  } nobreak {
+    total
   }
   format_average(total, report.results.length())
 }
@@ -866,22 +868,24 @@ fn format_average(total : Int, count : Int) -> String {
 
 ///|
 fn finished_summary(report : EvalReport) -> String {
-  let mut count = 0
-  for result in report.results {
+  let count = for result in report.results; count = 0 {
     if result.finished {
-      count += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
   "\{count}/\{report.results.length()}"
 }
 
 ///|
 fn validation_summary(report : EvalReport) -> String {
-  let mut count = 0
-  for result in report.results {
+  let count = for result in report.results; count = 0 {
     if result.validation.passed {
-      count += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
   "\{count}/\{report.results.length()}"
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -71,13 +71,13 @@ pub fn Report::Report(
 ///|
 /// How many rows passed.
 pub fn Report::successes(self : Report) -> Int {
-  let mut count = 0
-  for row in self.rows {
+  for row in self.rows; count = 0 {
     if row.success {
-      count += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -366,13 +366,13 @@ fn build_report(rows : Array[@report.ReportRow]) -> @report.Report {
 
 ///|
 fn count_successes(rows : Array[@report.ReportRow]) -> Int {
-  let mut count = 0
-  for item in rows {
+  for item in rows; count = 0 {
     if item.success {
-      count += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Replace simple mutable counter loops with MoonBit loop accumulators where the result is a single reducer value.
- Apply the same simplification to sibling eval/report harness helpers and TUI test helper counters.
- Add `debug_inspect` coverage documenting `count_lines_containing_all` all-match behavior, including partial matches and an empty needle list.

## Validation

- `git rebase origin/main`
- `moon info && moon fmt`
- `moon test` (573 passed)
- `git diff --cached --check` before commit
