### PR TITLE
feat(testkit): add @vfs.with_tmpdir

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -92,34 +92,36 @@ test "edit tool advertises the expected schema" {
 ```moonbit check
 ///|
 async test "edit tool applies a focused code change through the registry" {
-  let path = "/tmp/openseek-edit-readme-example.mbt"
-  @fs.write_file(
-    path,
-    "fn greet() -> String {\n  \"hello\"\n}\n",
-    create_mode=CreateOrTruncate,
-  )
+  @vfs.with_tmpdir(tmpdir => {
+    let path = "\{tmpdir}/openseek-edit-readme-example.mbt"
+    @fs.write_file(
+      path,
+      "fn greet() -> String {\n  \"hello\"\n}\n",
+      create_mode=CreateOrTruncate,
+    )
 
-  let tools = @agent_tool.Tools([@edit.definition()])
-  let call = @agent_tool.AgentToolCall(
-    ToolCall(
-      id="call_edit_greeting",
-      name="edit",
-      arguments=(
-        #|{
-        #|  "path": "/tmp/openseek-edit-readme-example.mbt",
-        #|  "old_string": "  \"hello\"",
-        #|  "new_string": "  \"hello, MoonBit\""
-        #|}
+    let tools = @agent_tool.Tools([@edit.definition()])
+    let arguments : Json = {
+      "path": "\{tmpdir}/openseek-edit-readme-example.mbt",
+      "old_string": "  \"hello\"",
+      "new_string": "  \"hello, MoonBit\"",
+    }
+
+    let call = @agent_tool.AgentToolCall(
+      ToolCall(
+        id="call_edit_greeting",
+        name="edit",
+        arguments=arguments.stringify(),
       ),
-    ),
-  )
-  let result = @agent_tool.execute_tool_call(call, tools)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
-  assert_false(output.is_error)
-  assert_eq(
-    @fs.read_file(path).text(),
-    "fn greet() -> String {\n  \"hello, MoonBit\"\n}\n",
-  )
+    )
+    let result = @agent_tool.execute_tool_call(call, tools)
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_false(output.is_error)
+    assert_eq(
+      @fs.read_file(path).text(),
+      "fn greet() -> String {\n  \"hello, MoonBit\"\n}\n",
+    )
+  })
 }
 ```

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -19,17 +19,19 @@ async fn run_edit_in_workspace(
 
 ///|
 async test "edit replaces a unique exact match" {
-  let path = "/tmp/openseek-edit-unique.txt"
-  @fs.write_file(path, "alpha\nbeta\ngamma\n", create_mode=CreateOrTruncate)
-  let result = run_edit({
-    "path": path,
-    "old_string": "beta",
-    "new_string": "delta",
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/unique.txt"
+    @fs.write_file(path, "alpha\nbeta\ngamma\n", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "beta",
+      "new_string": "delta",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "alpha\ndelta\ngamma\n")
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
-  assert_false(output.is_error)
-  assert_eq(@fs.read_file(path).text(), "alpha\ndelta\ngamma\n")
 }
 
 ///|
@@ -51,39 +53,42 @@ async test "edit resolves relative paths under the workspace root" {
 
 ///|
 async test "edit preserves surrounding multiline content" {
-  let path = "/tmp/openseek-edit-multiline.txt"
-  @fs.write_file(
-    path,
-    "fn main {\n  println(\"old\")\n}\n",
-    create_mode=CreateOrTruncate,
-  )
-  let result = run_edit({
-    "path": path,
-    "old_string": "  println(\"old\")",
-    "new_string": "  println(\"new\")",
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/multiline.txt"
+    @fs.write_file(
+      path,
+      "fn main {\n  println(\"old\")\n}\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_edit({
+      "path": path,
+      "old_string": "  println(\"old\")",
+      "new_string": "  println(\"new\")",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "fn main {\n  println(\"new\")\n}\n")
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_eq(@fs.read_file(path).text(), "fn main {\n  println(\"new\")\n}\n")
 }
 
 ///|
 async test "edit rejects missing old_string" {
-  let result = run_edit({ "path": "/tmp/openseek-edit-noop.txt" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "error: edit requires arguments.old_string")
-  assert_true(output.is_error)
+  @vfs.with_tmpdir(dir => {
+    let result = run_edit({ "path": "\{dir}/noop.txt" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "error: edit requires arguments.old_string")
+    assert_true(output.is_error)
+  })
 }
 
 ///|
 async test "edit rejects missing new_string" {
-  let result = run_edit({
-    "path": "/tmp/openseek-edit-noop.txt",
-    "old_string": "x",
+  @vfs.with_tmpdir(dir => {
+    let result = run_edit({ "path": "\{dir}/noop.txt", "old_string": "x" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "error: edit requires arguments.new_string")
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "error: edit requires arguments.new_string")
-  assert_true(output.is_error)
 }
 
 ///|
@@ -96,36 +101,40 @@ async test "edit rejects non-object arguments" {
 
 ///|
 async test "edit rejects empty old_string" {
-  let path = "/tmp/openseek-edit-empty-old.txt"
-  @fs.write_file(path, "content", create_mode=CreateOrTruncate)
-  let result = run_edit({
-    "path": path,
-    "old_string": "",
-    "new_string": "replacement",
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/empty-old.txt"
+    @fs.write_file(path, "content", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "",
+      "new_string": "replacement",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error editing \{path}: old_string must be non-empty",
+    )
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(
-    output.content,
-    "error editing \{path}: old_string must be non-empty",
-  )
-  assert_true(output.is_error)
 }
 
 ///|
 async test "edit rejects identical replacement" {
-  let path = "/tmp/openseek-edit-identical.txt"
-  @fs.write_file(path, "content", create_mode=CreateOrTruncate)
-  let result = run_edit({
-    "path": path,
-    "old_string": "content",
-    "new_string": "content",
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/identical.txt"
+    @fs.write_file(path, "content", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "content",
+      "new_string": "content",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error editing \{path}: old_string and new_string are identical",
+    )
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(
-    output.content,
-    "error editing \{path}: old_string and new_string are identical",
-  )
-  assert_true(output.is_error)
 }
 
 ///|
@@ -152,93 +161,109 @@ async test "edit rejects suspicious moon.pkg rewrite" {
 
 ///|
 async test "edit rejects missing match" {
-  let path = "/tmp/openseek-edit-missing.txt"
-  @fs.write_file(path, "alpha", create_mode=CreateOrTruncate)
-  let result = run_edit({
-    "path": path,
-    "old_string": "beta",
-    "new_string": "gamma",
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/missing.txt"
+    @fs.write_file(path, "alpha", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "beta",
+      "new_string": "gamma",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "error editing \{path}: old_string not found")
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "error editing \{path}: old_string not found")
-  assert_true(output.is_error)
 }
 
 ///|
 async test "edit rejects ambiguous match without replace_all" {
-  let path = "/tmp/openseek-edit-ambiguous.txt"
-  @fs.write_file(path, "alpha beta\nmiddle\nbeta", create_mode=CreateOrTruncate)
-  let result = run_edit({
-    "path": path,
-    "old_string": "beta",
-    "new_string": "delta",
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/ambiguous.txt"
+    @fs.write_file(
+      path,
+      "alpha beta\nmiddle\nbeta",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_edit({
+      "path": path,
+      "old_string": "beta",
+      "new_string": "delta",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error editing \{path}: old_string matched 2 times on lines 1, 3; set replace_all=true to replace all occurrences",
+    )
+    assert_true(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "alpha beta\nmiddle\nbeta")
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(
-    output.content,
-    "error editing \{path}: old_string matched 2 times on lines 1, 3; set replace_all=true to replace all occurrences",
-  )
-  assert_true(output.is_error)
-  assert_eq(@fs.read_file(path).text(), "alpha beta\nmiddle\nbeta")
 }
 
 ///|
 async test "edit reports first ambiguous match lines only" {
-  let path = "/tmp/openseek-edit-many-matches.txt"
-  @fs.write_file(path, "x\nx\nx\nx\nx\nx\n", create_mode=CreateOrTruncate)
-  let result = run_edit({ "path": path, "old_string": "x", "new_string": "y" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(
-    output.content,
-    "error editing \{path}: old_string matched 6 times on lines 1, 2, 3, 4, 5, ...; set replace_all=true to replace all occurrences",
-  )
-  assert_true(output.is_error)
-  assert_eq(@fs.read_file(path).text(), "x\nx\nx\nx\nx\nx\n")
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/many-matches.txt"
+    @fs.write_file(path, "x\nx\nx\nx\nx\nx\n", create_mode=CreateOrTruncate)
+    let result = run_edit({ "path": path, "old_string": "x", "new_string": "y" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error editing \{path}: old_string matched 6 times on lines 1, 2, 3, 4, 5, ...; set replace_all=true to replace all occurrences",
+    )
+    assert_true(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "x\nx\nx\nx\nx\nx\n")
+  })
 }
 
 ///|
 async test "edit replace_all updates every match" {
-  let path = "/tmp/openseek-edit-replace-all.txt"
-  @fs.write_file(path, "alpha beta beta", create_mode=CreateOrTruncate)
-  let result = run_edit({
-    "path": path,
-    "old_string": "beta",
-    "new_string": "delta",
-    "replace_all": true,
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/replace-all.txt"
+    @fs.write_file(path, "alpha beta beta", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "beta",
+      "new_string": "delta",
+      "replace_all": true,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: replaced 2 occurrence(s) in \{path}")
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "alpha delta delta")
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "ok: replaced 2 occurrence(s) in \{path}")
-  assert_false(output.is_error)
-  assert_eq(@fs.read_file(path).text(), "alpha delta delta")
 }
 
 ///|
 async test "edit rejects non-boolean replace_all" {
-  let path = "/tmp/openseek-edit-bad-replace-all.txt"
-  @fs.write_file(path, "alpha", create_mode=CreateOrTruncate)
-  let result = run_edit({
-    "path": path,
-    "old_string": "alpha",
-    "new_string": "beta",
-    "replace_all": "yes",
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/bad-replace-all.txt"
+    @fs.write_file(path, "alpha", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "alpha",
+      "new_string": "beta",
+      "replace_all": "yes",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error: edit requires arguments.replace_all to be a boolean",
+    )
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(
-    output.content,
-    "error: edit requires arguments.replace_all to be a boolean",
-  )
-  assert_true(output.is_error)
 }
 
 ///|
 async test "edit surfaces read errors" {
-  let result = run_edit({
-    "path": "/tmp/openseek-edit-does-not-exist.txt",
-    "old_string": "x",
-    "new_string": "y",
+  @vfs.with_tmpdir(dir => {
+    let result = run_edit({
+      "path": "\{dir}/does-not-exist.txt",
+      "old_string": "x",
+      "new_string": "y",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("error editing"))
+    assert_true(output.content.contains("error reading file"))
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.content.contains("error editing"))
-  assert_true(output.content.contains("error reading file"))
-  assert_true(output.is_error)
 }

--- a/agent_tool/edit/moon.pkg
+++ b/agent_tool/edit/moon.pkg
@@ -9,6 +9,7 @@ import {
 }
 
 import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
 } for "test"
 

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -99,58 +99,56 @@ test "read tool advertises the expected schema" {
 ```moonbit check
 ///|
 async test "read tool reads a workspace note through the registry" {
-  let path = "/tmp/openseek-read-readme-task.txt"
-  let content = "Task: summarize test failures\nStatus: investigating\n"
-  @fs.write_file(path, content, create_mode=CreateOrTruncate)
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/task.txt"
+    let content = "Task: summarize test failures\nStatus: investigating\n"
+    @fs.write_file(path, content, create_mode=CreateOrTruncate)
 
-  let tools = @agent_tool.Tools([@read.definition()])
-  let call = @agent_tool.AgentToolCall(
-    ToolCall(
-      id="call_read_note",
-      name="read",
-      arguments=(
-        #|{
-        #|  "path": "/tmp/openseek-read-readme-task.txt"
-        #|}
+    let tools = @agent_tool.Tools([@read.definition()])
+    // Stringify a JSON object so a Windows temp path (`C:\Users\...`) survives
+    // round-tripping instead of becoming an invalid `\U` escape.
+    let arguments : Json = { "path": path }
+    let call = @agent_tool.AgentToolCall(
+      ToolCall(
+        id="call_read_note",
+        name="read",
+        arguments=arguments.stringify(),
       ),
-    ),
-  )
-  let result = @agent_tool.execute_tool_call(call, tools)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, content)
-  assert_false(output.is_error)
+    )
+    let result = @agent_tool.execute_tool_call(call, tools)
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, content)
+    assert_false(output.is_error)
+  })
 }
 ```
 
 ```moonbit check
 ///|
 async test "read tool supports focused range reads" {
-  let path = "/tmp/openseek-read-readme-range.txt"
-  @fs.write_file(
-    path,
-    "alpha\nbeta\ngamma\ndelta",
-    create_mode=CreateOrTruncate,
-  )
+  @vfs.with_tmpdir(prefix="openseek-read-readme-", dir => {
+    let path = "\{dir}/range.txt"
+    @fs.write_file(
+      path,
+      "alpha\nbeta\ngamma\ndelta",
+      create_mode=CreateOrTruncate,
+    )
 
-  let tools = @agent_tool.Tools([@read.definition()])
-  let call = @agent_tool.AgentToolCall(
-    ToolCall(
-      id="call_read_range",
-      name="read",
-      arguments=(
-        #|{
-        #|  "path": "/tmp/openseek-read-readme-range.txt",
-        #|  "start_line": 2,
-        #|  "max_lines": 2
-        #|}
+    let tools = @agent_tool.Tools([@read.definition()])
+    let arguments : Json = { "path": path, "start_line": 2, "max_lines": 2 }
+    let call = @agent_tool.AgentToolCall(
+      ToolCall(
+        id="call_read_range",
+        name="read",
+        arguments=arguments.stringify(),
       ),
-    ),
-  )
-  let result = @agent_tool.execute_tool_call(call, tools)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.content.contains("start_line=2"))
-  assert_true(output.content.contains("shown_lines=2"))
-  assert_true(output.content.contains("beta\ngamma"))
-  assert_false(output.is_error)
+    )
+    let result = @agent_tool.execute_tool_call(call, tools)
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("start_line=2"))
+    assert_true(output.content.contains("shown_lines=2"))
+    assert_true(output.content.contains("beta\ngamma"))
+    assert_false(output.is_error)
+  })
 }
 ```

--- a/agent_tool/read/moon.pkg
+++ b/agent_tool/read/moon.pkg
@@ -3,6 +3,7 @@ import {
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/read/internal/decode",
   "bobzhang/openseek/internal/workspace_path",
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/json",

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -260,12 +260,14 @@ fn read_header(
 
 ///|
 async test "read returns file contents" {
-  let path = "/tmp/openseek-read-test.txt"
-  @fs.write_file(path, "hello read", create_mode=CreateOrTruncate)
-  let result = execute({ "path": path })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "hello read")
-  assert_false(output.is_error)
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/test.txt"
+    @fs.write_file(path, "hello read", create_mode=CreateOrTruncate)
+    let result = execute({ "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "hello read")
+    assert_false(output.is_error)
+  })
 }
 
 ///|
@@ -289,77 +291,87 @@ async test "read resolves relative paths under the workspace root" {
 
 ///|
 async test "read returns empty string for an empty file" {
-  let path = "/tmp/openseek-read-empty.txt"
-  @fs.write_file(path, "", create_mode=CreateOrTruncate)
-  let result = execute({ "path": path })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "")
-  assert_false(output.is_error)
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/empty.txt"
+    @fs.write_file(path, "", create_mode=CreateOrTruncate)
+    let result = execute({ "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "")
+    assert_false(output.is_error)
+  })
 }
 
 ///|
 async test "read preserves multiline content" {
-  let path = "/tmp/openseek-read-multiline.txt"
-  let content = "line one\nline two\nline three\n"
-  @fs.write_file(path, content, create_mode=CreateOrTruncate)
-  let result = execute({ "path": path })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, content)
-  assert_false(output.is_error)
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/multiline.txt"
+    let content = "line one\nline two\nline three\n"
+    @fs.write_file(path, content, create_mode=CreateOrTruncate)
+    let result = execute({ "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, content)
+    assert_false(output.is_error)
+  })
 }
 
 ///|
 async test "read returns a requested line range with metadata" {
-  let path = "/tmp/openseek-read-range.txt"
-  let content = "line one\nline two\nline three\nline four"
-  @fs.write_file(path, content, create_mode=CreateOrTruncate)
-  let result = execute({ "path": path, "start_line": 2, "max_lines": 2 })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  inspect(
-    output.content,
-    content=(
-      #|path=/tmp/openseek-read-range.txt
-      #|start_line=2
-      #|end_line=3
-      #|total_lines=4
-      #|shown_lines=2
-      #|file_chars=38
-      #|selected_chars=19
-      #|shown_chars=19
-      #|line_limited=true
-      #|truncated=false
-      #|---
-      #|line two
-      #|line three
-    ),
-  )
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/range.txt"
+    let content = "line one\nline two\nline three\nline four"
+    @fs.write_file(path, content, create_mode=CreateOrTruncate)
+    let result = execute({ "path": path, "start_line": 2, "max_lines": 2 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    // The path is a temp dir, so assert the whole block dynamically rather
+    // than snapshotting it with `inspect`.
+    assert_eq(
+      output.content,
+      [
+        "path=\{path}",
+        "start_line=2",
+        "end_line=3",
+        "total_lines=4",
+        "shown_lines=2",
+        "file_chars=38",
+        "selected_chars=19",
+        "shown_chars=19",
+        "line_limited=true",
+        "truncated=false",
+        "---",
+        "line two",
+        "line three",
+      ].join("\n"),
+    )
+  })
 }
 
 ///|
 async test "read caps oversized output and marks it as an error" {
-  let path = "/tmp/openseek-read-capped.txt"
-  @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate)
-  let result = execute({ "path": path, "max_output_chars": 3 })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  inspect(
-    output.content,
-    content=(
-      #|path=/tmp/openseek-read-capped.txt
-      #|start_line=1
-      #|end_line=1
-      #|total_lines=1
-      #|shown_lines=1
-      #|file_chars=6
-      #|selected_chars=6
-      #|shown_chars=3
-      #|line_limited=false
-      #|truncated=true
-      #|---
-      #|abc
-    ),
-  )
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/capped.txt"
+    @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate)
+    let result = execute({ "path": path, "max_output_chars": 3 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_eq(
+      output.content,
+      [
+        "path=\{path}",
+        "start_line=1",
+        "end_line=1",
+        "total_lines=1",
+        "shown_lines=1",
+        "file_chars=6",
+        "selected_chars=6",
+        "shown_chars=3",
+        "line_limited=false",
+        "truncated=true",
+        "---",
+        "abc",
+      ].join("\n"),
+    )
+  })
 }
 
 ///|
@@ -380,58 +392,61 @@ test "read parses and caps optional limits" {
 
 ///|
 async test "read returns several files as headered blocks" {
-  let a = "/tmp/openseek-read-multi-a.txt"
-  let b = "/tmp/openseek-read-multi-b.txt"
-  @fs.write_file(a, "alpha", create_mode=CreateOrTruncate)
-  @fs.write_file(b, "beta", create_mode=CreateOrTruncate)
-  let result = execute({ "paths": [a, b] })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("path=\{a}"))
-  assert_true(output.content.contains("alpha"))
-  assert_true(output.content.contains("path=\{b}"))
-  assert_true(output.content.contains("beta"))
+  @vfs.with_tmpdir(dir => {
+    let a = "\{dir}/multi-a.txt"
+    let b = "\{dir}/multi-b.txt"
+    @fs.write_file(a, "alpha", create_mode=CreateOrTruncate)
+    @fs.write_file(b, "beta", create_mode=CreateOrTruncate)
+    let result = execute({ "paths": [a, b] })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("path=\{a}"))
+    assert_true(output.content.contains("alpha"))
+    assert_true(output.content.contains("path=\{b}"))
+    assert_true(output.content.contains("beta"))
+  })
 }
 
 ///|
 async test "a missing file reports inline while the others return" {
-  let a = "/tmp/openseek-read-multi-ok.txt"
-  @fs.write_file(a, "still here", create_mode=CreateOrTruncate)
-  let result = execute({ "paths": [a, "/tmp/openseek-read-multi-missing.txt"] })
-  guard result is Respond(output) else { fail("expected Respond") }
-  // Partial failure is not a tool error: the good file landed and the bad
-  // path's error block tells the model exactly which read to fix.
-  assert_false(output.is_error)
-  assert_true(output.content.contains("still here"))
-  assert_true(
-    output.content.contains(
-      "error reading /tmp/openseek-read-multi-missing.txt",
-    ),
-  )
+  @vfs.with_tmpdir(dir => {
+    let a = "\{dir}/multi-ok.txt"
+    let missing = "\{dir}/multi-missing.txt"
+    @fs.write_file(a, "still here", create_mode=CreateOrTruncate)
+    let result = execute({ "paths": [a, missing] })
+    guard result is Respond(output) else { fail("expected Respond") }
+    // Partial failure is not a tool error: the good file landed and the bad
+    // path's error block tells the model exactly which read to fix.
+    assert_false(output.is_error)
+    assert_true(output.content.contains("still here"))
+    assert_true(output.content.contains("error reading \{missing}"))
+  })
 }
 
 ///|
 async test "every file missing is a tool error" {
-  let result = execute({
-    "paths": ["/tmp/openseek-read-none-1", "/tmp/openseek-read-none-2"],
+  @vfs.with_tmpdir(dir => {
+    let result = execute({ "paths": ["\{dir}/none-1", "\{dir}/none-2"] })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
 }
 
 ///|
 async test "the output budget is shared and exhaustion is reported" {
-  let a = "/tmp/openseek-read-budget-a.txt"
-  let b = "/tmp/openseek-read-budget-b.txt"
-  @fs.write_file(a, "0123456789", create_mode=CreateOrTruncate)
-  @fs.write_file(b, "abcdefghij", create_mode=CreateOrTruncate)
-  let result = execute({ "paths": [a, b], "max_output_chars": 10 })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("0123456789"))
-  assert_true(output.content.contains("skipped 1 file(s)"))
-  assert_true(output.content.contains(b))
-  assert_false(output.content.contains("abcdefghij"))
+  @vfs.with_tmpdir(dir => {
+    let a = "\{dir}/budget-a.txt"
+    let b = "\{dir}/budget-b.txt"
+    @fs.write_file(a, "0123456789", create_mode=CreateOrTruncate)
+    @fs.write_file(b, "abcdefghij", create_mode=CreateOrTruncate)
+    let result = execute({ "paths": [a, b], "max_output_chars": 10 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("0123456789"))
+    assert_true(output.content.contains("skipped 1 file(s)"))
+    assert_true(output.content.contains(b))
+    assert_false(output.content.contains("abcdefghij"))
+  })
 }
 
 ///|
@@ -439,34 +454,43 @@ async test "headers and error blocks count against the budget" {
   // 40 missing paths with a small budget: error blocks consume the budget,
   // the tail collapses into one bounded marker, and the total output stays
   // near the cap instead of growing per path (Codex review).
-  let paths : Array[Json] = []
-  for i in 0..<40 {
-    paths.push(Json::string("/tmp/openseek-read-flood-\{i}"))
-  }
-  let result = execute({ "paths": Json::array(paths), "max_output_chars": 300 })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("skipped"))
-  assert_true(output.content.contains("and"))
-  // Bounded: the budget plus one overshooting block plus the skip marker,
-  // far below what 40 unbudgeted error blocks (~70 chars each) would emit.
-  assert_true(output.content.length() < 1200)
+  @vfs.with_tmpdir(dir => {
+    let paths : Array[Json] = []
+    for i in 0..<40 {
+      paths.push(Json::string("\{dir}/flood-\{i}"))
+    }
+    let result = execute({
+      "paths": Json::array(paths),
+      "max_output_chars": 300,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("skipped"))
+    assert_true(output.content.contains("and"))
+    // Bounded: the budget plus one overshooting block plus the skip marker,
+    // far below what 40 unbudgeted error blocks (~70 chars each) would emit.
+    assert_true(output.content.length() < 1200)
+  })
 }
 
 ///|
 async test "read rejects path and paths together" {
-  let result = execute({ "path": "/tmp/x", "paths": ["/tmp/y"] })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("not both"))
+  @vfs.with_tmpdir(dir => {
+    let result = execute({ "path": "\{dir}/x", "paths": ["\{dir}/y"] })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("not both"))
+  })
 }
 
 ///|
 async test "read rejects line ranges on multi-file calls" {
-  let result = execute({ "paths": ["/tmp/x", "/tmp/y"], "start_line": 2 })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("single file"))
+  @vfs.with_tmpdir(dir => {
+    let result = execute({ "paths": ["\{dir}/x", "\{dir}/y"], "start_line": 2 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("single file"))
+  })
 }
 
 ///|
@@ -479,10 +503,12 @@ async test "read rejects an empty paths array" {
 
 ///|
 async test "read surfaces filesystem errors" {
-  let result = execute({ "path": "/tmp/openseek-does-not-exist" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.content.contains("error reading"))
-  assert_true(output.is_error)
+  @vfs.with_tmpdir(dir => {
+    let result = execute({ "path": "\{dir}/does-not-exist" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("error reading"))
+    assert_true(output.is_error)
+  })
 }
 
 ///|
@@ -496,13 +522,15 @@ async test "read rejects missing path" {
 
 ///|
 async test "read rejects invalid limits" {
-  let result = execute({ "path": "/tmp/openseek-read-test.txt", "max_lines": 0 })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.content.contains("error: read requires"))
-  assert_true(
-    output.content.contains("arguments.max_lines to be a positive number"),
-  )
-  assert_true(output.is_error)
+  @vfs.with_tmpdir(dir => {
+    let result = execute({ "path": "\{dir}/test.txt", "max_lines": 0 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("error: read requires"))
+    assert_true(
+      output.content.contains("arguments.max_lines to be a positive number"),
+    )
+    assert_true(output.is_error)
+  })
 }
 
 ///|
@@ -515,15 +543,17 @@ async test "read rejects non-object arguments" {
 
 ///|
 async test "a huge max_lines returns the remaining lines without overflow" {
-  let path = "/tmp/openseek-read-huge-max.txt"
-  @fs.write_file(path, "a\nb\nc", create_mode=CreateOrTruncate)
-  let result = execute({
-    "path": path,
-    "start_line": 2,
-    "max_lines": 2147483647,
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/huge-max.txt"
+    @fs.write_file(path, "a\nb\nc", create_mode=CreateOrTruncate)
+    let result = execute({
+      "path": path,
+      "start_line": 2,
+      "max_lines": 2147483647,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("b\nc"))
+    assert_true(output.content.contains("shown_lines=2"))
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("b\nc"))
-  assert_true(output.content.contains("shown_lines=2"))
 }

--- a/agent_tool/write/README.mbt.md
+++ b/agent_tool/write/README.mbt.md
@@ -83,28 +83,25 @@ test "write tool advertises the expected schema" {
 ```moonbit check
 ///|
 async test "write tool updates an implementation note through the registry" {
-  let path = "/tmp/openseek-write-readme-note.txt"
+  let dir = @fs.tmpdir(prefix="openseek-write-readme-")
+  let path = "\{dir}/note.txt"
   @fs.write_file(path, "old note", create_mode=CreateOrTruncate)
 
   let tools = @agent_tool.Tools([@write.definition()])
+  // Build the arguments as JSON and stringify them, rather than embedding the
+  // path in a JSON string literal: a Windows temp path like `C:\Users\...`
+  // would otherwise become an invalid `\U` escape when parsed.
+  let arguments : Json = { "path": path, "content": "tests green" }
   let call = @agent_tool.AgentToolCall(
     ToolCall(
       id="call_write_note",
       name="write",
-      arguments=(
-        #|{
-        #|  "path": "/tmp/openseek-write-readme-note.txt",
-        #|  "content": "tests green"
-        #|}
-      ),
+      arguments=arguments.stringify(),
     ),
   )
   let result = @agent_tool.execute_tool_call(call, tools)
   guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(
-    output.content,
-    "ok: wrote 11 chars to /tmp/openseek-write-readme-note.txt",
-  )
+  assert_eq(output.content, "ok: wrote 11 chars to \{path}")
   assert_false(output.is_error)
   assert_eq(@fs.read_file(path).text(), "tests green")
 }

--- a/agent_tool/write/moon.pkg
+++ b/agent_tool/write/moon.pkg
@@ -3,6 +3,7 @@ import {
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/write/internal/decode",
   "bobzhang/openseek/internal/workspace_path",
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/json",

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -132,13 +132,15 @@ fn is_moon_pkg_path(path : String) -> Bool {
 
 ///|
 async test "write creates a file with the given content" {
-  let path = "/tmp/openseek-write-test.txt"
-  let result = execute({ "path": path, "content": "hello write" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "ok: wrote 11 chars to \{path}")
-  assert_false(output.is_error)
-  let read_back = @fs.read_file(path).text()
-  assert_eq(read_back, "hello write")
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/test.txt"
+    let result = execute({ "path": path, "content": "hello write" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: wrote 11 chars to \{path}")
+    assert_false(output.is_error)
+    let read_back = @fs.read_file(path).text()
+    assert_eq(read_back, "hello write")
+  })
 }
 
 ///|
@@ -179,26 +181,30 @@ async test "write manifest guards accept Windows path separators" {
 
 ///|
 async test "write truncates existing files" {
-  let path = "/tmp/openseek-write-truncate.txt"
-  @fs.write_file(path, "long original content", create_mode=CreateOrTruncate)
-  let result = execute({ "path": path, "content": "short" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "ok: wrote 5 chars to \{path}")
-  assert_false(output.is_error)
-  let read_back = @fs.read_file(path).text()
-  assert_eq(read_back, "short")
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/truncate.txt"
+    @fs.write_file(path, "long original content", create_mode=CreateOrTruncate)
+    let result = execute({ "path": path, "content": "short" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: wrote 5 chars to \{path}")
+    assert_false(output.is_error)
+    let read_back = @fs.read_file(path).text()
+    assert_eq(read_back, "short")
+  })
 }
 
 ///|
 async test "write accepts empty content" {
-  let path = "/tmp/openseek-write-empty.txt"
-  @fs.write_file(path, "previous", create_mode=CreateOrTruncate)
-  let result = execute({ "path": path, "content": "" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "ok: wrote 0 chars to \{path}")
-  assert_false(output.is_error)
-  let read_back = @fs.read_file(path).text()
-  assert_eq(read_back, "")
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/empty.txt"
+    @fs.write_file(path, "previous", create_mode=CreateOrTruncate)
+    let result = execute({ "path": path, "content": "" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: wrote 0 chars to \{path}")
+    assert_false(output.is_error)
+    let read_back = @fs.read_file(path).text()
+    assert_eq(read_back, "")
+  })
 }
 
 ///|
@@ -236,21 +242,26 @@ async test "write rejects suspiciously tiny moon.pkg" {
 
 ///|
 async test "write surfaces filesystem errors" {
-  let result = execute({
-    "path": "/tmp/openseek-missing-dir/does-not-exist.txt",
-    "content": "x",
+  @vfs.with_tmpdir(dir => {
+    // The parent directory does not exist, so the write fails.
+    let result = execute({
+      "path": "\{dir}/missing-dir/does-not-exist.txt",
+      "content": "x",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("error writing"))
+    assert_true(output.is_error)
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.content.contains("error writing"))
-  assert_true(output.is_error)
 }
 
 ///|
 async test "write rejects missing content" {
-  let result = execute({ "path": "/tmp/openseek-noop.txt" })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "error: write requires arguments.content")
-  assert_true(output.is_error)
+  @vfs.with_tmpdir(dir => {
+    let result = execute({ "path": "\{dir}/noop.txt" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "error: write requires arguments.content")
+    assert_true(output.is_error)
+  })
 }
 
 ///|

--- a/scripts/md_to_mbt_string/main_wbtest.mbt
+++ b/scripts/md_to_mbt_string/main_wbtest.mbt
@@ -38,7 +38,8 @@ test "cli rejects unknown option-looking input path" {
 ///|
 test "cli accepts hyphen-leading paths after option delimiter" {
   let parsed = cli_command().parse(argv=["--", "-input.md", "-output.mbt"])
-  guard parsed.values is { "input": ["-input.md", ..], "output": ["-output.mbt", ..], .. } else {
+  guard parsed.values
+    is { "input": ["-input.md", ..], "output": ["-output.mbt", ..], .. } else {
     fail("expected delimiter to allow hyphen-leading paths")
   }
 }
@@ -86,12 +87,40 @@ test "generated source preserves missing final newline" {
 }
 
 ///|
+/// Run `f` in a tmpdir, with best-effort clean up.
+///
+/// We duplicate the `with_tmpdir` implementation here because we need the
+/// dev rules to be ran before type-checking the main openseek repo, and
+/// we cannot import the testkit/filesystem package here.
+async fn[T] with_tmpdir(f : async (String) -> T) -> T {
+  let dir = @fs.tmpdir(prefix="")
+  async fn rmdir() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  try f(dir) catch {
+    error => {
+      rmdir()
+      raise error
+    }
+  } noraise {
+    result => {
+      rmdir()
+      result
+    }
+  }
+}
+
+///|
 async test "output match detects unchanged generated file" {
-  let path = "/tmp/openseek-md-to-mbt-output-match.mbt"
-  let _ = @fs.remove(path) catch { _ => () }
-  assert_false(output_matches(path, "same"))
-  @fs.write_file(path, "same", create_mode=CreateOrTruncate)
-  assert_true(output_matches(path, "same"))
-  assert_false(output_matches(path, "different"))
-  let _ = @fs.remove(path) catch { _ => () }
+  with_tmpdir(dir => {
+    let path = "\{dir}/output-match.mbt"
+    // The fresh directory guarantees the file is absent to start with.
+    assert_false(output_matches(path, "same"))
+    @fs.write_file(path, "same", create_mode=CreateOrTruncate)
+    assert_true(output_matches(path, "same"))
+    assert_false(output_matches(path, "different"))
+  })
 }

--- a/testkit/filesystem/README.mbt.md
+++ b/testkit/filesystem/README.mbt.md
@@ -32,6 +32,9 @@ are implicit and created when the fixture is written to disk.
   otherwise a short failure reason.
 - `write_text(root, path, content)`: validated helper for overwriting one text
   file under a fixture root.
+- `with_tmpdir(body, prefix?)`: run `body` with a fresh temporary directory and
+  remove it afterward — even if `body` raises. Prefer this over a hardcoded
+  `/tmp/...` path so tests stay portable (Windows has no `/tmp`) and self-clean.
 
 ## Examples
 
@@ -66,22 +69,36 @@ test "validate paths at construction time" {
 }
 ```
 
-Use `write_to` and `mismatch_on_disk` for native fixture tests:
+Use `with_tmpdir` to get a self-cleaning scratch directory — no hardcoded
+`/tmp` path and no manual teardown:
+
+```moonbit check
+///|
+async test "write and read back under a temporary directory" {
+  @filesystem.with_tmpdir(dir => {
+    let path = "\{dir}/note.txt"
+    @fs.write_file(path, "hello", create_mode=CreateOrTruncate)
+    assert_eq(@fs.read_file(path).text(), "hello")
+  })
+}
+```
+
+Use `write_to` and `mismatch_on_disk` for native fixture tests; `with_tmpdir`
+hands the fixture a root that is removed once the body returns:
 
 ```moonbit check
 ///|
 async test "materialize and compare a fixture" {
-  let root = @fs.tmpdir(prefix="openseek-testkit-readme")
-  let files = @filesystem.FileSystem({
-    "src/note.txt": "alpha\n",
-    "docs/summary.txt": "ready\n",
+  @filesystem.with_tmpdir(root => {
+    let files = @filesystem.FileSystem({
+      "src/note.txt": "alpha\n",
+      "docs/summary.txt": "ready\n",
+    })
+    files.write_to(root)
+    assert_eq(files.mismatch_on_disk(root), "")
+    @filesystem.write_text(root, "src/note.txt", "changed\n")
+    assert_eq(files.mismatch_on_disk(root), "content mismatch in src/note.txt")
   })
-  files.write_to(root)
-  assert_eq(files.mismatch_on_disk(root), "")
-
-  @filesystem.write_text(root, "src/note.txt", "changed\n")
-  assert_eq(files.mismatch_on_disk(root), "content mismatch in src/note.txt")
-  @fs.rmdir(root, recursive=true)
 }
 ```
 

--- a/testkit/filesystem/filesystem.mbt
+++ b/testkit/filesystem/filesystem.mbt
@@ -145,6 +145,42 @@ pub async fn write_text(root : String, path : String, content : String) -> Unit 
 }
 
 ///|
+/// Run `body` with a freshly created temporary directory, then remove that
+/// directory (and everything under it) once `body` returns or raises.
+///
+/// The path handed to `body` is an existing directory, so callers can write
+/// files directly beneath it without an `@fs.mkdir` first. Prefer this over a
+/// hardcoded `/tmp/...` path: it keeps tests portable (Windows has no `/tmp`),
+/// avoids collisions between concurrent runs, and cleans up after itself even
+/// when `body` fails an assertion.
+pub async fn[T] with_tmpdir(
+  body : async (String) -> T,
+  prefix? : String = "openseek-test-",
+) -> T {
+  let dir = @fs.tmpdir(prefix~)
+  async fn rmdir() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      // We sallow other errors here to perform best-effort clean up.
+      _ => ()
+    }
+  }
+  // `defer` cannot run an async call, so clean up on both paths explicitly and
+  // re-raise the body's error after removing the directory.
+  try body(dir) catch {
+    error => {
+      rmdir()
+      raise error
+    }
+  } noraise {
+    result => {
+      rmdir()
+      result
+    }
+  }
+}
+
+///|
 fn validate_relative_path(path : String) -> Unit raise {
   if path == "" {
     fail("file path must not be empty")

--- a/testkit/filesystem/filesystem_test.mbt
+++ b/testkit/filesystem/filesystem_test.mbt
@@ -60,3 +60,30 @@ async test "fixture writes to disk and reports mismatches" {
   assert_eq(files.mismatch_on_disk(root), "content mismatch in src/note.txt")
   @fs.rmdir(root, recursive=true)
 }
+
+///|
+async test "with_tmpdir hands back a writable dir and removes it afterward" {
+  let captured = @filesystem.with_tmpdir(dir => {
+    let path = "\{dir}/note.txt"
+    @fs.write_file(path, "hello", create_mode=CreateOrTruncate)
+    assert_eq(@fs.read_file(path).text(), "hello")
+    dir
+  })
+  // The directory and its contents are gone once the body returns.
+  assert_false(@fs.exists(captured))
+}
+
+///|
+async test "with_tmpdir cleans up even when the body raises" {
+  let mut leaked = ""
+  @filesystem.with_tmpdir(dir => {
+    leaked = dir
+    @fs.write_file("\{dir}/x", "x", create_mode=CreateOrTruncate)
+    fail("boom")
+  }) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+  assert_true(leaked != "")
+  assert_false(@fs.exists(leaked))
+}

--- a/testkit/filesystem/moon.pkg
+++ b/testkit/filesystem/moon.pkg
@@ -1,11 +1,11 @@
 import {
+  "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/json",
 }
 
 import {
-  "moonbitlang/async",
-  "moonbitlang/async/fs",
+  "moonbitlang/core/test",
 } for "test"
 
 warnings = "+unnecessary_annotation"

--- a/testkit/filesystem/pkg.generated.mbti
+++ b/testkit/filesystem/pkg.generated.mbti
@@ -2,6 +2,8 @@
 package "bobzhang/openseek/testkit/filesystem"
 
 // Values
+pub async fn[T] with_tmpdir(async (String) -> T, prefix? : String) -> T
+
 pub async fn write_text(String, String, String) -> Unit
 
 // Errors


### PR DESCRIPTION
This PR adds a `with_tmpdir` helper to `testkit/filesystem` to help test writers to write proper cross-platform tests that depend on temporary directories. Some test cases hardcoded `/tmp` in paths so they failed and reported corresponding paths did not exist on Windows.

These changes were part of the #8 PR. The old #8 PR was closed because codex on Windows constantly fails to deliver OK quality code.