### PR TITLE
fix(scripts): handle md_to_mbt_string path basenames

### DIFF
--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -42,6 +42,35 @@ async fn output_matches(output : StringView, source : StringView) -> Bool {
 }
 
 ///|
+#warnings("-method_shadowing")
+#cfg(platform="windows")
+fn @path.Path::basename(path : @path.Path) -> StringView {
+  let trimmed = for view = path.0.view() {
+    match view {
+      [] => break view
+      [.. rest, '/' | '\\'] => continue rest
+      _ => break view
+    }
+  }
+  for view = trimmed {
+    match view {
+      [] => break trim_windows_drive_prefix(trimmed)
+      [.., '/' | '\\'] as prefix => break trimmed[prefix.length():]
+      [.. rest, _] => continue rest
+    }
+  }
+}
+
+///|
+#cfg(platform="windows")
+fn trim_windows_drive_prefix(path : StringView) -> StringView {
+  match path {
+    ['a'..='z' | 'A'..='Z', ':', .. rest] => rest
+    _ => path
+  }
+}
+
+///|
 fn function_name_from_base(base : StringView) -> StringView raise {
   match base {
     ([.. stem, .. ".mbt.md"] | [.. stem, .. ".md"]) if stem =~ re"^[a-z_][A-Za-z0-9_]*$" =>

--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -20,7 +20,8 @@ fn cli_command() -> @argparse.Command {
 
 ///|
 async fn main {
-  guard cli_command().parse().values is { "input": [input, ..], "output": [output, ..], .. } else {
+  guard cli_command().parse().values
+    is { "input": [input, ..], "output": [output, ..], .. } else {
     fail("missing parsed arguments")
   }
   let base = @path.Path(input).basename()
@@ -73,7 +74,7 @@ fn trim_windows_drive_prefix(path : StringView) -> StringView {
 ///|
 fn function_name_from_base(base : StringView) -> StringView raise {
   match base {
-    ([.. stem, .. ".mbt.md"] | [.. stem, .. ".md"]) if stem =~ re"^[a-z_][A-Za-z0-9_]*$" =>
+    [.. stem, .. ".mbt.md"] | [.. stem, .. ".md"] if stem =~ re"^[a-z_][A-Za-z0-9_]*$" =>
       stem
     _ =>
       fail(

--- a/scripts/md_to_mbt_string/main_wbtest.mbt
+++ b/scripts/md_to_mbt_string/main_wbtest.mbt
@@ -5,6 +5,28 @@ test "function name from markdown basename" {
 }
 
 ///|
+#cfg(platform="windows")
+test "@path.Path::basename handles Unix and Windows separators" {
+  assert_eq(
+    @path.Path("./prompt/base_prompt.mbt.md").basename(),
+    "base_prompt.mbt.md",
+  )
+  assert_eq(
+    @path.Path(".\\prompt\\flash_prompt.mbt.md").basename(),
+    "flash_prompt.mbt.md",
+  )
+  assert_eq(@path.Path("C:\\a\\b\\c").basename(), "c")
+  assert_eq(@path.Path("C:\\a\\b\\").basename(), "b")
+  assert_eq(@path.Path("C:\\a\\b/c").basename(), "c")
+  assert_eq(@path.Path("").basename(), "")
+  assert_eq(@path.Path("/").basename(), "")
+  assert_eq(@path.Path("\\").basename(), "")
+  assert_eq(@path.Path("a").basename(), "a")
+  assert_eq(@path.Path("a/").basename(), "a")
+  assert_eq(@path.Path("C:\\a").basename(), "a")
+}
+
+///|
 test "function name rejects unsupported extension" {
   try {
     ignore(function_name_from_base("base_prompt.txt"))

--- a/scripts/md_to_mbt_string/pkg.generated.mbti
+++ b/scripts/md_to_mbt_string/pkg.generated.mbti
@@ -6,8 +6,8 @@ package "bobzhang/openseek-scripts/md_to_mbt_string"
 // Errors
 
 // Types and methods
-type ProgramArgs
 
 // Type aliases
 
 // Traits
+


### PR DESCRIPTION
After the cwd fix, it seems that `moon` always passes relative path from module root in forward slash on Windows, and b/c `moonbitlang/x/path` does not support forward slashes on Windows as for now, we have to manually implement the basename function by ourselves here.