### PR TITLE
[codex] Restart crashed moon_check watcher quietly

### DIFF
--- a/agent_tool/moon_check/README.mbt.md
+++ b/agent_tool/moon_check/README.mbt.md
@@ -16,11 +16,10 @@ diagnostic limit keeps early broken-project states from flooding the
 conversation with a large compiler wall. The first call for a given cwd/options
 tuple starts a workspace watcher; later calls with the same tuple reuse the
 existing watcher and return the latest snapshot.
-If the underlying `moon --watch` process exits unexpectedly, `moon_check`
-compacts the crash output and automatically starts a replacement watcher for
-the same tuple, up to a small restart budget. This keeps compiler feedback
-flowing during long agent runs while avoiding repeated crash-banner dumps in
-the model context.
+If the underlying `moon --watch` process exits with a likely crash,
+`moon_check` automatically starts a replacement watcher for the same tuple, up
+to a small restart budget. It carries forward only a short
+`restarted due to crash` notice instead of the crash details.
 
 The schema is intentionally narrow. It accepts MoonBit check options that affect
 diagnostics, but it does not expose unrelated `moon` subcommands. That narrow
@@ -53,7 +52,7 @@ sequenceDiagram
   Agent->>Queue: drain before next model turn
   Queue-->>Agent: moon_check renders coalesced update
   alt watcher exits unexpectedly
-    Tool->>State: compact crash output
+    Tool->>State: record short crash notice
     Tool->>Watcher: restart within budget
     Tool->>State: register replacement
   end
@@ -98,9 +97,8 @@ when the process cannot be launched. The string body has one of these shapes:
 
 - `"cwd=<cwd>\ncommand=moon check --watch --diagnostic-limit 10 ...\nwatcher=<started|reused|restarted>\nid=<id>\nstatus=<running|stopped>\nseq=<n>\n<output>"`.
 - Restarted watchers also include `restart_count`, `restart_limit`, and
-  `restart_reason`. Crash summaries use a compact
-  `[moon_check watcher exited]` block instead of forwarding the full `moon`
-  panic banner.
+  `restart_reason`. Crash restarts carry a short `restarted due to crash`
+  notice instead of forwarding the full `moon` panic banner.
 - `"error running moon_check: <error>"`.
 - `"error: moon_check requires <field description>"`.
 

--- a/agent_tool/moon_check/output.mbt
+++ b/agent_tool/moon_check/output.mbt
@@ -54,6 +54,13 @@ fn moon_check_output_is_crash(output : String) -> Bool {
 }
 
 ///|
+/// Treat Rust panics and signal-style exits as watcher crashes even if moon
+/// exits before printing its normal crash banner.
+fn moon_check_exit_is_crash(output : String, exit_code : Int) -> Bool {
+  moon_check_output_is_crash(output) || exit_code == 101 || exit_code >= 128
+}
+
+///|
 fn ensure_trailing_newline(output : String) -> String {
   if output == "" || output.has_suffix("\n") {
     output
@@ -63,46 +70,17 @@ fn ensure_trailing_newline(output : String) -> String {
 }
 
 ///|
-/// Reduce a `moon` panic banner into a few lines the agent can act on:
-/// exit code, crash flag, the `panicked at ...` line, the underlying detail,
-/// and the restart budget. The full upstream "Please report it at ..." block
-/// is dropped to keep the context window clean across restarts.
-fn compact_moon_check_exit_output(
-  output : String,
-  exit_code : Int,
+/// Short notice carried into the replacement watcher's output after a crash.
+/// The underlying panic text is intentionally not surfaced to the user.
+fn moon_check_crash_notice_output(
   restart_attempt~ : Int,
   restart_limit~ : Int,
 ) -> String {
-  let lines : Array[String] = []
-  lines.push("[moon_check watcher exited]")
-  lines.push("exit=\{exit_code}")
-  if moon_check_output_is_crash(output) {
-    lines.push("moon_crash=true")
-  }
-  match first_line_containing(output, "panicked at") {
-    Some(line) => lines.push("panic=\{line}")
-    None => ()
-  }
-  match first_line_containing(output, "called `") {
-    Some(line) => lines.push("detail=\{line}")
-    None => ()
-  }
   if restart_attempt <= restart_limit {
-    lines.push("restart=attempt \{restart_attempt}/\{restart_limit}")
+    "restarted due to crash"
   } else {
-    lines.push("restart=limit reached \{restart_limit}/\{restart_limit}")
+    "stopped after repeated crashes"
   }
-  lines.join("\n")
-}
-
-///|
-fn first_line_containing(content : String, needle : String) -> String? {
-  for line in content.split("\n") {
-    if line.contains(needle) {
-      return Some(line.trim().to_owned())
-    }
-  }
-  None
 }
 
 ///|
@@ -198,27 +176,22 @@ fn MoonCheckSnapshot::update_text(update : MoonCheckSnapshot) -> String {
 pub fn runtime_update_text(
   events : Array[@agent_runtime.AgentEvent],
 ) -> String? {
+  // Single pass: dedup by key (last writer wins, as the in-order overwrite
+  // did) while counting, with the map as the accumulator and no `mut`.
   let latest_moon_checks : Map[String, MoonCheckSnapshot] = {}
-  let mut moon_check_count = 0
-  for event in events {
-    match event {
-      MoonCheckUpdate(update) => {
-        latest_moon_checks[update.key] = update
-        moon_check_count += 1
-      }
-      _ => ()
+  let count = for event in events; count = 0 {
+    if event is MoonCheckUpdate(update) {
+      latest_moon_checks[update.key] = update
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  if moon_check_count == 0 {
-    None
-  } else {
-    let parts = [
-      for update in latest_moon_checks.values() => update.update_text()
-    ]
-    Some(
-      "[moon_check update]\nevents=\{moon_check_count}\n\{parts.join("\n\n")}",
-    )
-  }
+  guard count > 0 else { return None }
+  let parts = [
+    for update in latest_moon_checks.values() => update.update_text()
+  ]
+  Some("[moon_check update]\nevents=\{count}\n\{parts.join("\n\n")}")
 }
 
 ///|
@@ -392,31 +365,26 @@ test "moon_check update text coalesces by watcher key" {
 }
 
 ///|
-test "moon_check compacts moon watcher crash output" {
-  let summary = compact_moon_check_exit_output(
-    (
-      #|thread 'notify-rs kqueue loop' panicked at /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/kqueue-1.1.1/src/lib.rs:661:86:
-      #|called `Option::unwrap()` on a `None` value
-      #|`moon` has accidentally crashed.
-      #|Please report it at:
-      #|    https://github.com/moonbitlang/moon/issues/new?template=bug_report.md
-      #|
-    ),
-    101,
+test "moon_check crash notice hides crash details" {
+  let summary = moon_check_crash_notice_output(
     restart_attempt=2,
     restart_limit=3,
   )
-  inspect(
-    summary,
-    content=(
-      #|[moon_check watcher exited]
-      #|exit=101
-      #|moon_crash=true
-      #|panic=thread 'notify-rs kqueue loop' panicked at /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/kqueue-1.1.1/src/lib.rs:661:86:
-      #|detail=called `Option::unwrap()` on a `None` value
-      #|restart=attempt 2/3
-    ),
-  )
+  inspect(summary, content="restarted due to crash")
   assert_false(summary.contains("Please report it at"))
   assert_false(summary.contains("github.com/moonbitlang/moon/issues"))
+  assert_false(summary.contains("panicked at"))
+  assert_eq(
+    moon_check_crash_notice_output(restart_attempt=4, restart_limit=3),
+    "stopped after repeated crashes",
+  )
+}
+
+///|
+test "moon_check crash detection handles exits without banner" {
+  assert_true(moon_check_exit_is_crash("", 101))
+  assert_true(moon_check_exit_is_crash("", 134))
+  assert_true(moon_check_exit_is_crash("panicked at watcher", 1))
+  assert_false(moon_check_exit_is_crash("invalid option", 1))
+  assert_false(moon_check_exit_is_crash("", 0))
 }

--- a/agent_tool/moon_check/runtime.mbt
+++ b/agent_tool/moon_check/runtime.mbt
@@ -442,7 +442,7 @@ async test "moon_check runtime ignores stale watcher id updates" {
 }
 
 ///|
-async test "moon_check keeps crash summary in replacement output" {
+async test "moon_check keeps crash notice in replacement output" {
   @async.with_task_group() <| group => {
     let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
     let key = "cwd=/tmp"
@@ -465,14 +465,12 @@ async test "moon_check keeps crash summary in replacement output" {
         max_output_chars=12000,
         restart_count=1,
         restart_limit=3,
-        restart_reason=Some("auto restart after exit 101"),
+        restart_reason=Some("restarted due to crash"),
         exited=Queue(kind=Unbounded),
       ),
     )
     let summary =
-      #|[moon_check watcher exited]
-      #|exit=101
-      #|restart=attempt 1/3
+      #|restarted due to crash
       #|
     ignore(runtime.replace_moon_check_output(key, "moon-check-2", summary))
     let first_replacement_output =
@@ -485,8 +483,8 @@ async test "moon_check keeps crash summary in replacement output" {
       is Some(snapshot) else {
       fail("expected replacement watcher output")
     }
-    assert_true(snapshot.output.contains("[moon_check watcher exited]"))
-    assert_true(snapshot.output.contains("restart=attempt 1/3"))
+    assert_true(snapshot.output.contains("restarted due to crash"))
+    assert_false(snapshot.output.contains("panicked at"))
     assert_true(
       snapshot.output.contains("Success, waiting for filesystem changes..."),
     )

--- a/agent_tool/moon_check/watcher.mbt
+++ b/agent_tool/moon_check/watcher.mbt
@@ -111,7 +111,7 @@ fn moon_check_command_line(input : @decode.MoonCheckInput) -> String {
 /// Spawn `moon check --watch ...` with combined stdout/stderr piped back to
 /// `monitor_moon_check`. Returns the freshly assigned watcher id. The caller
 /// can pre-populate the recorded output via `initial_output` — used when an
-/// auto-restart wants to carry the previous crash summary forward.
+/// auto-restart wants to carry the previous crash notice forward.
 async fn[X] spawn_moon_check_watch(
   runtime : MoonCheckRuntime[X],
   input : @decode.MoonCheckInput,
@@ -222,10 +222,10 @@ async fn[X] monitor_moon_check(
 
 ///|
 /// React to a watcher exit. Three cases:
-/// - **Crash exit** (non-zero exit code AND output matches the moon crash
-///   banner): replace the output with a compact summary (see
-///   `compact_moon_check_exit_output`), mark stopped, and auto-restart if the
-///   restart budget allows (see `should_auto_restart_moon_check`).
+/// - **Crash exit** (non-zero exit code with a moon crash banner, Rust panic
+///   code, or signal-style code): replace the output with a short crash notice,
+///   mark stopped, and auto-restart if the restart budget allows (see
+///   `should_auto_restart_moon_check`).
 /// - **Non-crash non-zero exit**: mark stopped, no output replacement, no
 ///   auto-restart. The next caller of `moon_check` triggers a manual restart.
 /// - **Clean exit** (exit code 0): mark stopped, no auto-restart.
@@ -242,16 +242,14 @@ async fn[X] handle_moon_check_exit(
     snapshot.status is Running else {
     return
   }
-  let moon_crashed = moon_check_output_is_crash(snapshot.output)
+  let moon_crashed = moon_check_exit_is_crash(snapshot.output, exit_code)
   if exit_code != 0 && moon_crashed {
     let restart_attempt = snapshot.restart_count + 1
     ignore(
       runtime.replace_moon_check_output(
         key,
         id,
-        compact_moon_check_exit_output(
-          snapshot.output,
-          exit_code,
+        moon_check_crash_notice_output(
           restart_attempt~,
           restart_limit=snapshot.restart_limit,
         ),
@@ -268,7 +266,7 @@ async fn[X] handle_moon_check_exit(
         cwd,
         key,
         restart_count=stopped_snapshot.restart_count + 1,
-        restart_reason=Some("auto restart after exit \{exit_code}"),
+        restart_reason=Some("restarted due to crash"),
         initial_output=ensure_trailing_newline(stopped_snapshot.output),
       ),
     )
@@ -276,8 +274,8 @@ async fn[X] handle_moon_check_exit(
 }
 
 ///|
-/// Auto-restart only when moon itself crashed (panic / accidental crash
-/// banner) with a non-zero exit, and we still have restart budget left.
+/// Auto-restart only when moon itself crashed with a non-zero exit, and we
+/// still have restart budget left.
 /// Normal compile errors leave the watcher running, so they never reach this
 /// path — only outright watcher exits do.
 fn should_auto_restart_moon_check(
@@ -341,10 +339,9 @@ test "moon_check builds watch command arguments" {
 test "moon_check auto restart respects exit code and budget" {
   let snapshot = test_snapshot(restart_count=2, restart_limit=3)
   assert_true(should_auto_restart_moon_check(snapshot, 101, moon_crashed=true))
+  assert_true(should_auto_restart_moon_check(snapshot, 134, moon_crashed=true))
   assert_false(should_auto_restart_moon_check(snapshot, 0, moon_crashed=true))
-  assert_false(
-    should_auto_restart_moon_check(snapshot, 101, moon_crashed=false),
-  )
+  assert_false(should_auto_restart_moon_check(snapshot, 1, moon_crashed=false))
   assert_false(
     should_auto_restart_moon_check(
       test_snapshot(restart_count=3, restart_limit=3),

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -26,8 +26,8 @@ Blocks that need a top-level `fn main` (forbidden in a non-main package) or that
   - `read`, `edit`, and `write` for files.
   - `moon_check` for `moon check`; it starts or reuses a persistent
     `moon check --watch --diagnostic-limit 10` watcher.
-    If `moon --watch` crashes, `moon_check` compacts the crash output and
-    automatically starts a replacement watcher under a restart budget.
+    If `moon --watch` crashes, `moon_check` automatically starts a replacement
+    watcher under a restart budget and shows only a short restart notice.
   - `shell` for one-shot Moon commands other than `moon check`; pass the
     tool's `cwd` field instead of embedding repeated `cd ... &&` strings.
 - Use `moon_check` once per project directory near the start of an iterative

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -30,8 +30,8 @@ fn flash_prompt() -> String {
     #|  - `read`, `edit`, and `write` for files.
     #|  - `moon_check` for `moon check`; it starts or reuses a persistent
     #|    `moon check --watch --diagnostic-limit 10` watcher.
-    #|    If `moon --watch` crashes, `moon_check` compacts the crash output and
-    #|    automatically starts a replacement watcher under a restart budget.
+    #|    If `moon --watch` crashes, `moon_check` automatically starts a replacement
+    #|    watcher under a restart budget and shows only a short restart notice.
     #|  - `shell` for one-shot Moon commands other than `moon check`; pass the
     #|    tool's `cwd` field instead of embedding repeated `cd ... &&` strings.
     #|- Use `moon_check` once per project directory near the start of an iterative


### PR DESCRIPTION
## Summary

- Restart `moon_check`'s `moon check --watch` process when it exits like a crash, including Rust panic exit code 101 and signal-style exits.
- Replace crash-detail forwarding with a short `restarted due to crash` notice.
- Update moon_check docs and prompt text to describe the quieter restart behavior.

## Why

`moon check --watch` can crash without leaving the standard Moon crash banner in output. The previous restart path only restarted when that banner was present, so bannerless crashes stopped compiler feedback and leaked crash output into the agent/logger path.

## Validation

- `moon check agent_tool/moon_check --warn-list +unnecessary_annotation`
- `moon test agent_tool/moon_check` (20/20)
- `moon test prompt` (19/19)
- `moon info && moon fmt`
- CLI experiment with a fake streaming API and fake `moon`: first `moon check --watch` exited 101, replacement watcher started, logger contained `restarted due to crash`, success update arrived, and crash details were not logged.
- Fresh `codex review --uncommitted`: no actionable correctness issues found.

Note: full `moon test` still fails in the existing live DeepSeek smoke test when API/network credentials are unavailable; unrelated to this change.