### PR TITLE
Migrate read to single-file calls

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -14,9 +14,11 @@ large generated files and dependency sources can flood the transcript and push
 useful context out of the model window.
 
 Ranged or capped reads include a metadata header so the model knows what it saw
-and what it did not see. Automatic character truncation is marked as a tool
-error even when the file was read successfully; that makes lossy context visible
-to the loop instead of silently pretending the returned prefix is complete.
+and what it did not see. The body of those headered blocks is line-numbered
+(`number<TAB>text`) to make follow-up edits and focused reads less error-prone.
+Automatic character truncation is marked as a tool error even when the file was
+read successfully; that makes lossy context visible to the loop instead of
+silently pretending the returned prefix is complete.
 
 Multi-file reads exist because agent traces show models reading related files
 one round trip at a time — each a full model turn. `paths` collapses those
@@ -65,10 +67,11 @@ The action is always `Respond(ToolOutput(...))` — the agent loop forwards
 character truncation. The string body has one of these shapes:
 
 - The file's text contents on uncapped whole-file success.
-- A metadata header followed by `---` and the selected content for ranged reads
-  or capped reads. The header includes line and character counts plus
-  `truncated=true` when `max_output_chars` cut the selected content.
-- Headered blocks separated by blank lines for multi-file reads. A failed
+- A metadata header followed by `---` and line-numbered selected content for
+  ranged reads or capped reads. The header includes line and character counts
+  plus `line_format=number<TAB>text` and `truncated=true` when
+  `max_output_chars` cut the selected content.
+- Headered line-numbered blocks separated by blank lines for multi-file reads. A failed
   file contributes an inline `error reading <path>: <error>` block;
   `is_error` only flips when every file failed or the shared budget
   truncated or skipped content.
@@ -147,7 +150,7 @@ async test "read tool supports focused range reads" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("start_line=2"))
     assert_true(output.content.contains("shown_lines=2"))
-    assert_true(output.content.contains("beta\ngamma"))
+    assert_true(output.content.contains("2\tbeta\n3\tgamma"))
     assert_false(output.is_error)
   })
 }

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -15,7 +15,8 @@ useful context out of the model window.
 
 Ranged or capped reads include a metadata header so the model knows what it saw
 and what it did not see. The body of those headered blocks is line-numbered
-(`number<TAB>text`) to make follow-up edits and focused reads less error-prone.
+(`right-aligned-number| text`) to make follow-up edits and focused reads less
+error-prone.
 Automatic character truncation is marked as a tool error even when the file was
 read successfully; that makes lossy context visible to the loop instead of
 silently pretending the returned prefix is complete.
@@ -69,7 +70,7 @@ character truncation. The string body has one of these shapes:
 - The file's text contents on uncapped whole-file success.
 - A metadata header followed by `---` and line-numbered selected content for
   ranged reads or capped reads. The header includes line and character counts
-  plus `line_format=number<TAB>text` and `truncated=true` when
+  plus `line_format=right-aligned-number| text` and `truncated=true` when
   `max_output_chars` cut the selected content.
 - Headered line-numbered blocks separated by blank lines for multi-file reads. A failed
   file contributes an inline `error reading <path>: <error>` block;
@@ -150,7 +151,7 @@ async test "read tool supports focused range reads" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("start_line=2"))
     assert_true(output.content.contains("shown_lines=2"))
-    assert_true(output.content.contains("2\tbeta\n3\tgamma"))
+    assert_true(output.content.contains("2| beta\n3| gamma"))
     assert_false(output.is_error)
   })
 }

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -92,6 +92,7 @@ test "read tool advertises the expected schema" {
   let text = schema.stringify()
   assert_true(text.contains("\"path\""))
   assert_false(text.contains("\"paths\""))
+  assert_true(text.contains("\"required\""))
   assert_true(text.contains("\"start_line\""))
   assert_true(text.contains("\"max_lines\""))
   assert_true(text.contains("\"max_output_chars\""))

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -6,9 +6,9 @@ only needs a focused region, pass `start_line`, `max_lines`, or
 `max_output_chars`.
 
 When the agent needs several known independent files, prefer batching separate
-single-file `read` tool calls in one assistant response. Use `arguments.paths`
-only when the host cannot batch tool calls or when one shared output budget and
-inline per-file errors are more useful than independent results.
+single-file `read` tool calls in one assistant response. The tool accepts one
+file per call so ranges, errors, and output budgets stay tied to a specific
+file.
 
 Do not use `read` for directories. Inspect directories with `ls` or `tree`, then
 read specific files.
@@ -29,18 +29,9 @@ Automatic character truncation is marked as a tool error even when the file was
 read successfully; that makes lossy context visible to the loop instead of
 silently pretending the returned prefix is complete.
 
-The preferred multi-file pattern is several independent `read` calls in the
-same assistant response. That avoids extra model round trips while preserving
-single-file ranges and independent output budgets. `paths` remains available as
-a fallback for hosts that cannot batch tool calls, or for cases where one shared
-`max_output_chars` budget is desirable: every file returns as its own headered
-block, a file that fails to read reports inline while the others still land
-(mirroring how `moon ide doc` reports per-query misses), and the budget is
-shared across the call in argument order. Headers, separators, and error blocks
-count against it too, and an exhausted budget collapses the unread tail into one
-bounded skipped-files marker, so output stays near the cap no matter how many
-paths the call names. Line-range options stay single-file: a range only means
-something against one file.
+For several known independent files, issue several independent `read` calls in
+the same assistant response. That avoids extra model round trips while
+preserving single-file ranges and independent output budgets.
 
 ## API Style
 
@@ -65,11 +56,10 @@ Prefer a range plus a cap over reading a large file and relying on truncation.
 
 | Name | Type | Required | Notes |
 | ---- | ---- | -------- | ----- |
-| `path` | string | one of `path`/`paths` | Filesystem path. Relative paths resolve against the agent process's current working directory. |
-| `paths` | string array | one of `path`/`paths` | Several files in one call when batching separate read calls is unavailable or a shared budget is desired; per-file errors report inline. |
-| `start_line` | number | no | 1-based first line to return. Defaults to `1`. Single-file calls only. |
-| `max_lines` | number | no | Maximum number of lines to return. Single-file calls only. |
-| `max_output_chars` | number | no | Maximum rendered content chars to return across the call, including line-number gutters when present. Defaults to `12000` and is capped at `50000`. |
+| `path` | string | yes | Filesystem path. Relative paths resolve against the agent process's current working directory. |
+| `start_line` | number | no | 1-based first line to return. Defaults to `1`. |
+| `max_lines` | number | no | Maximum number of lines to return. |
+| `max_output_chars` | number | no | Maximum rendered content chars to return, including line-number gutters when present. Defaults to `12000` and is capped at `50000`. |
 
 ## Action
 
@@ -84,15 +74,11 @@ character truncation. The string body has one of these shapes:
   plus `line_format=right-aligned-number| text`; `shown_chars` counts the
   rendered numbered body, and `truncated=true` when `max_output_chars` cut that
   rendered body.
-- Headered line-numbered blocks separated by blank lines for multi-file reads. A failed
-  file contributes an inline `error reading <path>: <error>` block;
-  `is_error` only flips when every file failed or the shared budget
-  truncated or skipped content.
 - `"error reading <path>: <error>"` — a single-file read failed. Common
   causes: the file is missing, the agent doesn't have read permissions, or
   the bytes aren't valid UTF-8.
-- `"error: read requires arguments.path or arguments.paths"` — payload was an
-  object but named no file.
+- `"error: read requires arguments.path"` — payload was an object but named no
+  file.
 - `"error: read requires object arguments"` — payload was not a JSON object.
 
 ## Example
@@ -105,7 +91,7 @@ test "read tool advertises the expected schema" {
   let JsonSchema(schema) = tool.schema
   let text = schema.stringify()
   assert_true(text.contains("\"path\""))
-  assert_true(text.contains("\"paths\""))
+  assert_false(text.contains("\"paths\""))
   assert_true(text.contains("\"start_line\""))
   assert_true(text.contains("\"max_lines\""))
   assert_true(text.contains("\"max_output_chars\""))

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -1,9 +1,17 @@
 # Read Tool
 
-`read` returns text from a file at `arguments.path`, or from several files in
-one call via `arguments.paths`. By default it returns whole files when they
-fit within the output cap. For larger files, or when the agent only needs a
-focused region, pass `start_line`, `max_lines`, or `max_output_chars`.
+`read` returns text from a file at `arguments.path`. By default it returns whole
+files when they fit within the output cap. For larger files, or when the agent
+only needs a focused region, pass `start_line`, `max_lines`, or
+`max_output_chars`.
+
+When the agent needs several known independent files, prefer batching separate
+single-file `read` tool calls in one assistant response. Use `arguments.paths`
+only when the host cannot batch tool calls or when one shared output budget and
+inline per-file errors are more useful than independent results.
+
+Do not use `read` for directories. Inspect directories with `ls` or `tree`, then
+read specific files.
 
 ## Design Rationale
 
@@ -21,16 +29,18 @@ Automatic character truncation is marked as a tool error even when the file was
 read successfully; that makes lossy context visible to the loop instead of
 silently pretending the returned prefix is complete.
 
-Multi-file reads exist because agent traces show models reading related files
-one round trip at a time — each a full model turn. `paths` collapses those
-into one call: every file returns as its own headered block, a file that
-fails to read reports inline while the others still land (mirroring how
-`moon ide doc` reports per-query misses), and the `max_output_chars` budget
-is shared across the call in argument order — headers, separators, and error
-blocks count against it too, and an exhausted budget collapses the unread
-tail into one bounded skipped-files marker, so output stays near the cap no
-matter how many paths the call names. Line-range options stay single-file: a
-range only means something against one file.
+The preferred multi-file pattern is several independent `read` calls in the
+same assistant response. That avoids extra model round trips while preserving
+single-file ranges and independent output budgets. `paths` remains available as
+a fallback for hosts that cannot batch tool calls, or for cases where one shared
+`max_output_chars` budget is desirable: every file returns as its own headered
+block, a file that fails to read reports inline while the others still land
+(mirroring how `moon ide doc` reports per-query misses), and the budget is
+shared across the call in argument order. Headers, separators, and error blocks
+count against it too, and an exhausted budget collapses the unread tail into one
+bounded skipped-files marker, so output stays near the cap no matter how many
+paths the call names. Line-range options stay single-file: a range only means
+something against one file.
 
 ## API Style
 
@@ -55,7 +65,7 @@ Prefer a range plus a cap over reading a large file and relying on truncation.
 | Name | Type | Required | Notes |
 | ---- | ---- | -------- | ----- |
 | `path` | string | one of `path`/`paths` | Filesystem path. Relative paths resolve against the agent process's current working directory. |
-| `paths` | string array | one of `path`/`paths` | Several files in one call, each returned as a headered block; per-file errors report inline. |
+| `paths` | string array | one of `path`/`paths` | Several files in one call when batching separate read calls is unavailable or a shared budget is desired; per-file errors report inline. |
 | `start_line` | number | no | 1-based first line to return. Defaults to `1`. Single-file calls only. |
 | `max_lines` | number | no | Maximum number of lines to return. Single-file calls only. |
 | `max_output_chars` | number | no | Maximum content chars to return across the call. Defaults to `12000` and is capped at `50000`. |

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -58,6 +58,7 @@ source where the agent has already identified the relevant region:
 ```
 
 Use `max_output_chars` to protect the transcript when file size is uncertain.
+For headered reads, the cap applies after line-number gutters are rendered.
 Prefer a range plus a cap over reading a large file and relying on truncation.
 
 ## Arguments
@@ -68,7 +69,7 @@ Prefer a range plus a cap over reading a large file and relying on truncation.
 | `paths` | string array | one of `path`/`paths` | Several files in one call when batching separate read calls is unavailable or a shared budget is desired; per-file errors report inline. |
 | `start_line` | number | no | 1-based first line to return. Defaults to `1`. Single-file calls only. |
 | `max_lines` | number | no | Maximum number of lines to return. Single-file calls only. |
-| `max_output_chars` | number | no | Maximum content chars to return across the call. Defaults to `12000` and is capped at `50000`. |
+| `max_output_chars` | number | no | Maximum rendered content chars to return across the call, including line-number gutters when present. Defaults to `12000` and is capped at `50000`. |
 
 ## Action
 
@@ -80,8 +81,9 @@ character truncation. The string body has one of these shapes:
 - The file's text contents on uncapped whole-file success.
 - A metadata header followed by `---` and line-numbered selected content for
   ranged reads or capped reads. The header includes line and character counts
-  plus `line_format=right-aligned-number| text` and `truncated=true` when
-  `max_output_chars` cut the selected content.
+  plus `line_format=right-aligned-number| text`; `shown_chars` counts the
+  rendered numbered body, and `truncated=true` when `max_output_chars` cut that
+  rendered body.
 - Headered line-numbered blocks separated by blank lines for multi-file reads. A failed
   file contributes an inline `error reading <path>: <error>` block;
   `is_error` only flips when every file failed or the shared budget

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -1,5 +1,5 @@
 ///|
-/// Characters of file content one `read` call returns when the model does not
+/// Rendered content characters one `read` call returns when the model does not
 /// pick a `max_output_chars` budget itself.
 pub let default_max_output_chars : Int = 12000
 
@@ -12,8 +12,8 @@ pub let hard_max_output_chars : Int = 50000
 /// Decoded arguments of the `read` tool: one or more files (`paths` holds a
 /// single element for a `path` call), starting from the 1-based `start_line`,
 /// at most `max_lines` lines (unbounded when `None`), truncated to
-/// `max_output_chars` characters across the whole call. Line-range options
-/// only combine with a single file.
+/// `max_output_chars` rendered content characters across the whole call.
+/// Line-range options only combine with a single file.
 pub struct ReadInput {
   paths : Array[String]
   start_line : Int

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -9,13 +9,11 @@ pub let default_max_output_chars : Int = 12000
 pub let hard_max_output_chars : Int = 50000
 
 ///|
-/// Decoded arguments of the `read` tool: one or more files (`paths` holds a
-/// single element for a `path` call), starting from the 1-based `start_line`,
-/// at most `max_lines` lines (unbounded when `None`), truncated to
-/// `max_output_chars` rendered content characters across the whole call.
-/// Line-range options only combine with a single file.
+/// Decoded arguments of the `read` tool: one file path, starting from the
+/// 1-based `start_line`, at most `max_lines` lines (unbounded when `None`),
+/// truncated to `max_output_chars` rendered content characters.
 pub struct ReadInput {
-  paths : Array[String]
+  path : String
   start_line : Int
   max_lines : Int?
   max_output_chars : Int
@@ -24,13 +22,13 @@ pub struct ReadInput {
 ///|
 /// Decode `read` tool-call arguments.
 ///
-/// Exactly one of `path` (string) or `paths` (non-empty string array) is
-/// required; the numeric fields must be positive when present and otherwise
-/// default (`start_line` 1, `max_lines` unbounded, `max_output_chars`
-/// `default_max_output_chars` clamped to `hard_max_output_chars`).
-/// `start_line`/`max_lines` are single-file affairs and are rejected for a
-/// multi-file call. Failures name the offending field so the error fed back
-/// to the model says exactly which argument to fix.
+/// `path` is required; `paths` is intentionally not supported. When several
+/// independent files are needed, the model should batch separate `read` calls
+/// in the same assistant response. Numeric fields must be positive when
+/// present and otherwise default (`start_line` 1, `max_lines` unbounded,
+/// `max_output_chars` `default_max_output_chars` clamped to
+/// `hard_max_output_chars`). Failures name the offending field so the error fed
+/// back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> ReadInput raise {
   match arguments {
     Object(fields) => parse_fields(fields)
@@ -40,27 +38,18 @@ pub fn decode(arguments : Json) -> ReadInput raise {
 
 ///|
 fn parse_fields(fields : Map[String, Json]) -> ReadInput raise {
-  let single = optional_string(fields, "path")
-  let multi = optional_path_array(fields, "paths")
-  let paths = match (single, multi) {
-    (Some(path), None) => [path]
-    (None, Some(paths)) => paths
-    (Some(_), Some(_)) =>
-      fail("arguments.path or arguments.paths, not both at once")
-    (None, None) => fail("arguments.path or arguments.paths")
+  reject_paths(fields)
+  let path = match optional_string(fields, "path") {
+    Some(path) => path
+    None => fail("arguments.path")
   }
   let start_line = optional_positive_int(fields, "start_line", 1)
   let max_lines = optional_positive_int_option(fields, "max_lines")
-  if paths.length() > 1 && (start_line != 1 || max_lines is Some(_)) {
-    fail(
-      "arguments.start_line and arguments.max_lines to be combined with a single file only",
-    )
-  }
   let max_output_chars = optional_positive_int(
     fields, "max_output_chars", default_max_output_chars,
   )
   {
-    paths,
+    path,
     start_line,
     max_lines,
     max_output_chars: cap_max_output_chars(max_output_chars),
@@ -78,27 +67,13 @@ fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
 }
 
 ///|
-fn optional_path_array(
-  fields : Map[String, Json],
-  name : String,
-) -> Array[String]? raise {
-  match fields.get(name) {
-    Some(Array(items)) => {
-      guard items.length() > 0 else {
-        fail("arguments.\{name} to be a non-empty array")
-      }
-      let paths : Array[String] = [
-        for item in items => {
-          guard item is String(value) && value != "" else {
-            fail("arguments.\{name} to be an array of non-empty path strings")
-          }
-          value
-        }
-      ]
-      Some(paths)
-    }
-    Some(Null) | None => None
-    _ => fail("arguments.\{name} to be an array of paths")
+fn reject_paths(fields : Map[String, Json]) -> Unit raise {
+  match fields.get("paths") {
+    Some(Null) | None => ()
+    _ =>
+      fail(
+        "arguments.paths is not supported; batch separate read calls in one assistant response",
+      )
   }
 }
 

--- a/agent_tool/read/internal/decode/decode_test.mbt
+++ b/agent_tool/read/internal/decode/decode_test.mbt
@@ -9,7 +9,7 @@ test "decode valid read input" {
     }),
     content=(
       #|{
-      #|  paths: ["file.mbt"],
+      #|  path: "file.mbt",
       #|  start_line: 3,
       #|  max_lines: Some(4),
       #|  max_output_chars: 50000,
@@ -24,7 +24,7 @@ test "decode defaults optional limits" {
     @decode.decode({ "path": "file.mbt" }),
     content=(
       #|{
-      #|  paths: ["file.mbt"],
+      #|  path: "file.mbt",
       #|  start_line: 1,
       #|  max_lines: None,
       #|  max_output_chars: 12000,
@@ -39,6 +39,16 @@ test "decode rejects missing path" {
     error => assert_true("\{error}".contains("arguments.path"))
   } noraise {
     _ => fail("missing path decoded")
+  }
+}
+
+///|
+test "decode rejects paths array" {
+  try @decode.decode({ "paths": ["a.mbt", "b.mbt"] }) catch {
+    error =>
+      assert_true("\{error}".contains("arguments.paths is not supported"))
+  } noraise {
+    _ => fail("paths decoded")
   }
 }
 

--- a/agent_tool/read/internal/decode/pkg.generated.mbti
+++ b/agent_tool/read/internal/decode/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub let hard_max_output_chars : Int
 
 // Types and methods
 pub struct ReadInput {
-  paths : Array[String]
+  path : String
   start_line : Int
   max_lines : Int?
   max_output_chars : Int

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -134,7 +134,7 @@ async fn read_file(
   let selection = select_lines(content, input.start_line, input.max_lines)
   let include_header = input.start_line != 1 ||
     input.max_lines is Some(_) ||
-    selection.content.length() > input.max_output_chars
+    selection.content.char_length() > input.max_output_chars
   if include_header {
     let rendered = render_numbered_content(selection, input.max_output_chars)
     let output = "\{read_header(path, content, selection, rendered)}\{rendered.content}"
@@ -182,9 +182,9 @@ async fn read_files(
     }
     match directory_read_error(path) {
       Some(block) => {
-        if separator_chars + block.length() <= remaining {
+        if separator_chars + block.char_length() <= remaining {
           failures = failures + 1
-          remaining = remaining - separator_chars - block.length()
+          remaining = remaining - separator_chars - block.char_length()
           blocks.push(block)
         } else {
           skipped.push(path)
@@ -197,9 +197,9 @@ async fn read_files(
     let content = @fs.read_file(path).text() catch {
       error => {
         let block = "error reading \{path}: \{error}"
-        if separator_chars + block.length() <= remaining {
+        if separator_chars + block.char_length() <= remaining {
           failures = failures + 1
-          remaining = remaining - separator_chars - block.length()
+          remaining = remaining - separator_chars - block.char_length()
           blocks.push(block)
         } else {
           skipped.push(path)
@@ -215,7 +215,7 @@ async fn read_files(
         if block.truncated {
           truncated_any = true
         }
-        remaining = remaining - separator_chars - block.content.length()
+        remaining = remaining - separator_chars - block.content.char_length()
         blocks.push(block.content)
       }
       None => {
@@ -300,12 +300,23 @@ async fn directory_read_error(path : String) -> String? {
 
 ///|
 fn cap_text(content : String, max_chars : Int) -> String {
-  if content.length() <= max_chars {
+  if content.char_length() <= max_chars {
     content
   } else if max_chars <= 0 {
     ""
   } else {
-    content[:max_chars].to_owned()
+    char_prefix(content, max_chars)
+  }
+}
+
+///|
+fn char_prefix(content : String, max_chars : Int) -> String {
+  if max_chars <= 0 {
+    ""
+  } else if content.char_length() <= max_chars {
+    content
+  } else {
+    StringView::from_iter(content.iter().take(max_chars)).to_owned()
   }
 }
 
@@ -323,10 +334,10 @@ fn render_read_block(
   for _ in 0..<8 {
     let rendered = render_numbered_content(selection, body_budget)
     let header = read_header(path, original, selection, rendered)
-    if header.length() > max_chars {
+    if header.char_length() > max_chars {
       return None
     }
-    let next_body_budget = max_chars - header.length()
+    let next_body_budget = max_chars - header.char_length()
     if next_body_budget == body_budget {
       return Some({
         content: "\{header}\{rendered.content}",
@@ -337,7 +348,7 @@ fn render_read_block(
   }
   let rendered = render_numbered_content(selection, body_budget)
   let header = read_header(path, original, selection, rendered)
-  if header.length() + rendered.content.length() > max_chars {
+  if header.char_length() + rendered.content.char_length() > max_chars {
     None
   } else {
     Some({
@@ -380,18 +391,19 @@ fn render_numbered_content(
     let separator_chars = if numbered.length() == 0 { 0 } else { 1 }
     let line_number = "\{selection.start_line + index}".pad_start(width, ' ')
     let prefix = "\{line_number}| "
-    let prefix_budget = separator_chars + prefix.length()
+    let prefix_budget = separator_chars + prefix.char_length()
     if remaining < prefix_budget {
       truncated = true
       break
     }
     let available = remaining - prefix_budget
     let line = lines[index]
-    if line.length() <= available {
+    let line_chars = line.char_length()
+    if line_chars <= available {
       numbered.push("\{prefix}\{line}")
-      remaining = remaining - prefix_budget - line.length()
+      remaining = remaining - prefix_budget - line_chars
     } else {
-      numbered.push("\{prefix}\{line[:available]}")
+      numbered.push("\{prefix}\{char_prefix(line, available)}")
       remaining = 0
       truncated = true
       break
@@ -407,7 +419,13 @@ fn render_numbered_content(
   } else {
     selection.start_line + shown_lines - 1
   }
-  { content, end_line, shown_lines, shown_chars: content.length(), truncated }
+  {
+    content,
+    end_line,
+    shown_lines,
+    shown_chars: content.char_length(),
+    truncated,
+  }
 }
 
 ///|
@@ -423,8 +441,8 @@ fn read_header(
     "end_line=\{rendered.end_line}",
     "total_lines=\{selection.total_lines}",
     "shown_lines=\{rendered.shown_lines}",
-    "file_chars=\{original.length()}",
-    "selected_chars=\{selection.content.length()}",
+    "file_chars=\{original.char_length()}",
+    "selected_chars=\{selection.content.char_length()}",
     "shown_chars=\{rendered.shown_chars}",
     "line_limited=\{selection.line_limited}",
     "truncated=\{rendered.truncated}",
@@ -565,6 +583,20 @@ async test "read caps after adding line number gutters" {
     assert_true(output.content.contains("truncated=true"))
     assert_true(output.content.contains(" 1| x\n 2| x\n 3| x"))
     assert_false(output.content.contains(" 4| x"))
+  })
+}
+
+///|
+async test "read caps unicode content on character boundaries" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/unicode.txt"
+    @fs.write_file(path, "😀Z", create_mode=CreateOrTruncate)
+    let result = execute({ "path": path, "max_lines": 1, "max_output_chars": 4 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("shown_chars=4"))
+    assert_true(output.content.contains("1| 😀"))
+    assert_false(output.content.contains("Z"))
   })
 }
 

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -1,13 +1,18 @@
 ///|
-/// Tool definition for `read`: returns text from `arguments.path` (or several
-/// files via `arguments.paths`), optionally restricted to a line range and
-/// capped to avoid flooding the agent context.
+/// Tool definition for `read`: returns text from `arguments.path`, optionally
+/// restricted to a line range and capped to avoid flooding the agent context.
+/// When several known independent files are needed, prefer batching several
+/// single-file `read` tool calls in one assistant response. `arguments.paths`
+/// remains available for hosts that cannot batch tool calls or need one shared
+/// output budget.
 ///
 /// ## Arguments
 /// - `path` (string): filesystem path to read. Exactly one of `path`/`paths`
-///   is required.
-/// - `paths` (string array): several files in one call; per-file read errors
-///   report inline while the other files still return.
+///   is required. Directories are not supported; use `ls` or `tree` first, then
+///   read specific files.
+/// - `paths` (string array): several files in one call; useful when the host
+///   cannot batch independent read calls. Per-file read errors report inline
+///   while the other files still return.
 /// - `start_line` (number, optional): 1-based first line to return. Defaults
 ///   to 1. Single-file calls only.
 /// - `max_lines` (number, optional): maximum number of lines to return.
@@ -32,15 +37,18 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text — or several independent files in ONE call via arguments.paths (per-file errors report inline; cheaper than one call per file). Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include right-aligned line numbers.",
+    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible; use arguments.paths only when the host cannot batch calls or one shared output budget is desired. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include right-aligned line numbers.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
-        "path": { "type": "string" },
+        "path": {
+          "type": "string",
+          "description": "Text file path to read. Directories are not supported; use `ls` or `tree` first, then read specific files.",
+        },
         "paths": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Read several files in one call instead of one call per file. Exactly one of path/paths is required.",
+          "description": "Read several files in one call when the host cannot batch separate read calls or when one shared max_output_chars budget is desired. Exactly one of path/paths is required.",
         },
         "start_line": { "type": "number" },
         "max_lines": { "type": "number" },
@@ -444,6 +452,17 @@ async test "line number gutters align to the widest displayed number" {
     assert_true(output.content.contains("100| line 100"))
     assert_true(output.content.contains("111| line 111"))
   })
+}
+
+///|
+test "read description encourages batched reads and directory inspection" {
+  let tool = definition()
+  assert_true(tool.description.contains("batch separate read tool calls"))
+  assert_true(tool.description.contains("Do not use read for directories"))
+  let JsonSchema(schema) = tool.schema
+  let schema_text = schema.stringify()
+  assert_true(schema_text.contains("Directories are not supported"))
+  assert_true(schema_text.contains("host cannot batch separate read calls"))
 }
 
 ///|

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -108,6 +108,12 @@ priv struct RenderedSelection {
 }
 
 ///|
+priv struct RenderedBlock {
+  content : String
+  truncated : Bool
+}
+
+///|
 async fn read_file(
   input : @decode.ReadInput,
   path~ : String,
@@ -169,36 +175,54 @@ async fn read_files(
   let mut truncated_any = false
   let skipped : Array[String] = []
   for path in paths {
-    if remaining <= 0 {
+    let separator_chars = if blocks.length() == 0 { 0 } else { 2 }
+    if remaining <= separator_chars {
       skipped.push(path)
       continue
     }
     match directory_read_error(path) {
       Some(block) => {
-        failures = failures + 1
-        remaining = remaining - block.length() - 2
-        blocks.push(block)
+        if separator_chars + block.length() <= remaining {
+          failures = failures + 1
+          remaining = remaining - separator_chars - block.length()
+          blocks.push(block)
+        } else {
+          skipped.push(path)
+          truncated_any = true
+        }
         continue
       }
       None => ()
     }
     let content = @fs.read_file(path).text() catch {
       error => {
-        failures = failures + 1
         let block = "error reading \{path}: \{error}"
-        remaining = remaining - block.length() - 2
-        blocks.push(block)
+        if separator_chars + block.length() <= remaining {
+          failures = failures + 1
+          remaining = remaining - separator_chars - block.length()
+          blocks.push(block)
+        } else {
+          skipped.push(path)
+          truncated_any = true
+        }
         continue
       }
     }
     let selection = select_lines(content, 1, None)
-    let rendered = render_numbered_content(selection, remaining)
-    if rendered.truncated {
-      truncated_any = true
+    let block_budget = remaining - separator_chars
+    match render_read_block(path, content, selection, block_budget) {
+      Some(block) => {
+        if block.truncated {
+          truncated_any = true
+        }
+        remaining = remaining - separator_chars - block.content.length()
+        blocks.push(block.content)
+      }
+      None => {
+        skipped.push(path)
+        truncated_any = true
+      }
     }
-    let block = "\{read_header(path, content, selection, rendered)}\{rendered.content}"
-    remaining = remaining - block.length() - 2
-    blocks.push(block)
   }
   if skipped.length() > 0 {
     truncated_any = true
@@ -211,9 +235,15 @@ async fn read_files(
     } else {
       ""
     }
-    blocks.push(
-      "skipped \{skipped.length()} file(s), max_output_chars budget exhausted — read them individually: \{preview}\{rest}",
-    )
+    let separator_chars = if blocks.length() == 0 { 0 } else { 2 }
+    if remaining > separator_chars {
+      let marker_budget = remaining - separator_chars
+      let marker = cap_text(
+        "skipped \{skipped.length()} file(s), max_output_chars budget exhausted — read them individually: \{preview}\{rest}",
+        marker_budget,
+      )
+      blocks.push(marker)
+    }
   }
   @agent_tool.ToolAction::respond(
     blocks.join("\n\n"),
@@ -265,6 +295,55 @@ async fn directory_read_error(path : String) -> String? {
         "error reading \{path}: path is a directory; use the shell tool with `ls` or `tree` to inspect directories, then read specific files.",
       )
     _ => None
+  }
+}
+
+///|
+fn cap_text(content : String, max_chars : Int) -> String {
+  if content.length() <= max_chars {
+    content
+  } else if max_chars <= 0 {
+    ""
+  } else {
+    content[:max_chars].to_owned()
+  }
+}
+
+///|
+fn render_read_block(
+  path : String,
+  original : String,
+  selection : ReadSelection,
+  max_chars : Int,
+) -> RenderedBlock? {
+  if max_chars <= 0 {
+    return None
+  }
+  let mut body_budget = max_chars
+  for _ in 0..<8 {
+    let rendered = render_numbered_content(selection, body_budget)
+    let header = read_header(path, original, selection, rendered)
+    if header.length() > max_chars {
+      return None
+    }
+    let next_body_budget = max_chars - header.length()
+    if next_body_budget == body_budget {
+      return Some({
+        content: "\{header}\{rendered.content}",
+        truncated: rendered.truncated,
+      })
+    }
+    body_budget = next_body_budget
+  }
+  let rendered = render_numbered_content(selection, body_budget)
+  let header = read_header(path, original, selection, rendered)
+  if header.length() + rendered.content.length() > max_chars {
+    None
+  } else {
+    Some({
+      content: "\{header}\{rendered.content}",
+      truncated: rendered.truncated,
+    })
   }
 }
 
@@ -584,10 +663,9 @@ async test "the output budget is shared and exhaustion is reported" {
     let result = execute({ "paths": [a, b], "max_output_chars": 10 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
-    assert_true(output.content.contains("1| 0123456"))
+    assert_true(output.content.contains("skipped"))
+    assert_true(output.content.length() <= 10)
     assert_false(output.content.contains("0123456789"))
-    assert_true(output.content.contains("skipped 1 file(s)"))
-    assert_true(output.content.contains(b))
     assert_false(output.content.contains("abcdefghij"))
   })
 }
@@ -609,10 +687,7 @@ async test "headers and error blocks count against the budget" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("skipped"))
-    assert_true(output.content.contains("and"))
-    // Bounded: the budget plus one overshooting block plus the skip marker,
-    // far below what 40 unbudgeted error blocks (~70 chars each) would emit.
-    assert_true(output.content.length() < 1200)
+    assert_true(output.content.length() <= 300)
   })
 }
 

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -17,8 +17,9 @@
 ///   to 1. Single-file calls only.
 /// - `max_lines` (number, optional): maximum number of lines to return.
 ///   Single-file calls only.
-/// - `max_output_chars` (number, optional): maximum returned content chars
-///   for the whole call. Defaults to 12000 and is capped at 50000.
+/// - `max_output_chars` (number, optional): maximum rendered content chars
+///   for the whole call, including line-number gutters when present. Defaults
+///   to 12000 and is capped at 50000.
 ///
 /// ## Result
 /// - `Respond(ToolOutput(<file contents>))` on success for uncapped whole-file
@@ -92,10 +93,18 @@ async fn execute_with_workspace(
 priv struct ReadSelection {
   content : String
   start_line : Int
-  end_line : Int
   total_lines : Int
   shown_lines : Int
   line_limited : Bool
+}
+
+///|
+priv struct RenderedSelection {
+  content : String
+  end_line : Int
+  shown_lines : Int
+  shown_chars : Int
+  truncated : Bool
 }
 
 ///|
@@ -117,21 +126,23 @@ async fn read_file(
       )
   }
   let selection = select_lines(content, input.start_line, input.max_lines)
-  let capped = cap_text(selection.content, input.max_output_chars)
-  let char_truncated = selection.content.length() > input.max_output_chars
   let include_header = input.start_line != 1 ||
     input.max_lines is Some(_) ||
-    char_truncated
-  let output = if include_header {
-    "\{read_header(path, content, selection, capped, char_truncated)}\{numbered_content(selection, capped)}"
+    selection.content.length() > input.max_output_chars
+  if include_header {
+    let rendered = render_numbered_content(selection, input.max_output_chars)
+    let output = "\{read_header(path, content, selection, rendered)}\{rendered.content}"
+    @agent_tool.ToolAction::respond(
+      output,
+      is_error=rendered.truncated,
+      brief="read \{@agent_tool.brief_basename(path)}",
+    )
   } else {
-    capped
+    @agent_tool.ToolAction::respond(
+      selection.content,
+      brief="read \{@agent_tool.brief_basename(path)}",
+    )
   }
-  @agent_tool.ToolAction::respond(
-    output,
-    is_error=char_truncated,
-    brief="read \{@agent_tool.brief_basename(path)}",
-  )
 }
 
 ///|
@@ -181,12 +192,11 @@ async fn read_files(
       }
     }
     let selection = select_lines(content, 1, None)
-    let capped = cap_text(selection.content, remaining)
-    let char_truncated = selection.content.length() > remaining
-    if char_truncated {
+    let rendered = render_numbered_content(selection, remaining)
+    if rendered.truncated {
       truncated_any = true
     }
-    let block = "\{read_header(path, content, selection, capped, char_truncated)}\{numbered_content(selection, capped)}"
+    let block = "\{read_header(path, content, selection, rendered)}\{rendered.content}"
     remaining = remaining - block.length() - 2
     blocks.push(block)
   }
@@ -234,11 +244,6 @@ fn select_lines(
   }
   let selected = lines[start_index:end_exclusive].to_owned()
   let shown_lines = selected.length()
-  let end_line = if shown_lines == 0 {
-    start_line - 1
-  } else {
-    start_line + shown_lines - 1
-  }
   let line_limited = match max_lines {
     Some(_) => end_exclusive < total_lines
     None => false
@@ -246,7 +251,6 @@ fn select_lines(
   {
     content: selected.join("\n"),
     start_line,
-    end_line,
     total_lines,
     shown_lines,
     line_limited,
@@ -265,34 +269,66 @@ async fn directory_read_error(path : String) -> String? {
 }
 
 ///|
-fn cap_text(content : String, max_chars : Int) -> String {
-  if content.length() <= max_chars {
-    content
-  } else {
-    "\{content[:max_chars]}"
-  }
-}
-
-///|
-fn numbered_content(selection : ReadSelection, capped : String) -> String {
+fn render_numbered_content(
+  selection : ReadSelection,
+  max_chars : Int,
+) -> RenderedSelection {
   if selection.shown_lines == 0 {
-    ""
-  } else {
-    add_line_numbers(capped, selection.start_line)
+    return {
+      content: "",
+      end_line: selection.start_line - 1,
+      shown_lines: 0,
+      shown_chars: 0,
+      truncated: false,
+    }
   }
-}
-
-///|
-fn add_line_numbers(content : String, start_line : Int) -> String {
-  let lines = [ for line in content.split("\n") => line.to_owned() ]
-  let last_line = start_line + lines.length() - 1
+  if max_chars <= 0 {
+    return {
+      content: "",
+      end_line: selection.start_line - 1,
+      shown_lines: 0,
+      shown_chars: 0,
+      truncated: true,
+    }
+  }
+  let lines = [ for line in selection.content.split("\n") => line.to_owned() ]
+  let last_line = selection.start_line + lines.length() - 1
   let width = "\{last_line}".length()
   let numbered : Array[String] = []
+  let mut remaining = max_chars
+  let mut truncated = false
   for index in 0..<lines.length() {
-    let line_number = "\{start_line + index}".pad_start(width, ' ')
-    numbered.push("\{line_number}| \{lines[index]}")
+    let separator_chars = if numbered.length() == 0 { 0 } else { 1 }
+    let line_number = "\{selection.start_line + index}".pad_start(width, ' ')
+    let prefix = "\{line_number}| "
+    let prefix_budget = separator_chars + prefix.length()
+    if remaining < prefix_budget {
+      truncated = true
+      break
+    }
+    let available = remaining - prefix_budget
+    let line = lines[index]
+    if line.length() <= available {
+      numbered.push("\{prefix}\{line}")
+      remaining = remaining - prefix_budget - line.length()
+    } else {
+      numbered.push("\{prefix}\{line[:available]}")
+      remaining = 0
+      truncated = true
+      break
+    }
   }
-  numbered.join("\n")
+  if numbered.length() < lines.length() {
+    truncated = true
+  }
+  let content = numbered.join("\n")
+  let shown_lines = numbered.length()
+  let end_line = if shown_lines == 0 {
+    selection.start_line - 1
+  } else {
+    selection.start_line + shown_lines - 1
+  }
+  { content, end_line, shown_lines, shown_chars: content.length(), truncated }
 }
 
 ///|
@@ -300,20 +336,19 @@ fn read_header(
   path : String,
   original : String,
   selection : ReadSelection,
-  capped : String,
-  char_truncated : Bool,
+  rendered : RenderedSelection,
 ) -> String {
   [
     "path=\{path}",
     "start_line=\{selection.start_line}",
-    "end_line=\{selection.end_line}",
+    "end_line=\{rendered.end_line}",
     "total_lines=\{selection.total_lines}",
-    "shown_lines=\{selection.shown_lines}",
+    "shown_lines=\{rendered.shown_lines}",
     "file_chars=\{original.length()}",
     "selected_chars=\{selection.content.length()}",
-    "shown_chars=\{capped.length()}",
+    "shown_chars=\{rendered.shown_chars}",
     "line_limited=\{selection.line_limited}",
-    "truncated=\{char_truncated}",
+    "truncated=\{rendered.truncated}",
     "line_format=right-aligned-number| text",
     "---",
     "",
@@ -397,7 +432,7 @@ async test "read returns a requested line range with metadata" {
         "shown_lines=2",
         "file_chars=38",
         "selected_chars=19",
-        "shown_chars=19",
+        "shown_chars=25",
         "line_limited=true",
         "truncated=false",
         "line_format=right-aligned-number| text",
@@ -432,9 +467,25 @@ async test "read caps oversized output and marks it as an error" {
         "truncated=true",
         "line_format=right-aligned-number| text",
         "---",
-        "1| abc",
+        "1| ",
       ].join("\n"),
     )
+  })
+}
+
+///|
+async test "read caps after adding line number gutters" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/many-lines.txt"
+    let content = [ for _ in 0..<80 => "x" ].join("\n")
+    @fs.write_file(path, content, create_mode=CreateOrTruncate)
+    let result = execute({ "path": path, "max_output_chars": 20 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("shown_chars=17"))
+    assert_true(output.content.contains("truncated=true"))
+    assert_true(output.content.contains(" 1| x\n 2| x\n 3| x"))
+    assert_false(output.content.contains(" 4| x"))
   })
 }
 
@@ -533,7 +584,8 @@ async test "the output budget is shared and exhaustion is reported" {
     let result = execute({ "paths": [a, b], "max_output_chars": 10 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
-    assert_true(output.content.contains("0123456789"))
+    assert_true(output.content.contains("1| 0123456"))
+    assert_false(output.content.contains("0123456789"))
     assert_true(output.content.contains("skipped 1 file(s)"))
     assert_true(output.content.contains(b))
     assert_false(output.content.contains("abcdefghij"))

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -2,17 +2,11 @@
 /// Tool definition for `read`: returns text from `arguments.path`, optionally
 /// restricted to a line range and capped to avoid flooding the agent context.
 /// When several known independent files are needed, prefer batching several
-/// single-file `read` tool calls in one assistant response. `arguments.paths`
-/// remains available for hosts that cannot batch tool calls or need one shared
-/// output budget.
+/// single-file `read` tool calls in one assistant response.
 ///
 /// ## Arguments
-/// - `path` (string): filesystem path to read. Exactly one of `path`/`paths`
-///   is required. Directories are not supported; use `ls` or `tree` first, then
-///   read specific files.
-/// - `paths` (string array): several files in one call; useful when the host
-///   cannot batch independent read calls. Per-file read errors report inline
-///   while the other files still return.
+/// - `path` (string): filesystem path to read. Required. Directories are not
+///   supported; use `ls` or `tree` first, then read specific files.
 /// - `start_line` (number, optional): 1-based first line to return. Defaults
 ///   to 1. Single-file calls only.
 /// - `max_lines` (number, optional): maximum number of lines to return.
@@ -25,9 +19,7 @@
 /// - `Respond(ToolOutput(<file contents>))` on success for uncapped whole-file
 ///   single reads.
 /// - `Respond(ToolOutput(<metadata header + numbered content>))` for ranged
-///   reads or capped reads, and per file for multi-file reads (blocks separated
-///   by a blank line; a failed file contributes an inline `error reading ...`
-///   block and only flips `is_error` when every file failed).
+///   reads or capped reads.
 /// - `Respond(ToolOutput("error reading <path>: <error>", is_error=true))`
 ///   if a single-file read fails (missing file, permission denied, invalid
 ///   UTF-8, directory path, etc.).
@@ -38,18 +30,13 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible; use arguments.paths only when the host cannot batch calls or one shared output budget is desired. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include right-aligned line numbers.",
+    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include right-aligned line numbers.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
         "path": {
           "type": "string",
           "description": "Text file path to read. Directories are not supported; use `ls` or `tree` first, then read specific files.",
-        },
-        "paths": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Read several files in one call when the host cannot batch separate read calls or when one shared max_output_chars budget is desired. Exactly one of path/paths is required.",
         },
         "start_line": { "type": "number" },
         "max_lines": { "type": "number" },
@@ -79,14 +66,7 @@ async fn execute_with_workspace(
       )
     }
   }
-  let paths = [
-    for path in input.paths => @workspace_path.resolve(workspace_root, path)
-  ]
-  if paths.length() == 1 {
-    read_file(input, path=paths[0])
-  } else {
-    read_files(input, paths~)
-  }
+  read_file(input, path=@workspace_path.resolve(workspace_root, input.path))
 }
 
 ///|
@@ -104,12 +84,6 @@ priv struct RenderedSelection {
   end_line : Int
   shown_lines : Int
   shown_chars : Int
-  truncated : Bool
-}
-
-///|
-priv struct RenderedBlock {
-  content : String
   truncated : Bool
 }
 
@@ -149,107 +123,6 @@ async fn read_file(
       brief="read \{@agent_tool.brief_basename(path)}",
     )
   }
-}
-
-///|
-/// Render a multi-file read: one headered block per file, separated by blank
-/// lines, sharing the call's `max_output_chars` budget in argument order. A
-/// file that fails to read contributes an inline error block — the other
-/// files still return, mirroring how `moon ide doc` reports per-query misses
-/// — and `is_error` only flips when every file failed or the budget cut
-/// content (so the model knows to re-read the tail individually).
-///
-/// Every emitted block — header, error text, separators — counts against the
-/// budget, not just file content: otherwise a long paths list of headers or
-/// missing-file errors would outgrow the cap that exists to protect the
-/// context (Codex review). Once the budget is exhausted the unread tail
-/// collapses into a single skipped-files marker, so output stays bounded no
-/// matter how many paths the call names.
-async fn read_files(
-  input : @decode.ReadInput,
-  paths~ : Array[String],
-) -> @agent_tool.ToolAction {
-  let blocks : Array[String] = []
-  let mut remaining = input.max_output_chars
-  let mut failures = 0
-  let mut truncated_any = false
-  let skipped : Array[String] = []
-  for path in paths {
-    let separator_chars = if blocks.length() == 0 { 0 } else { 2 }
-    if remaining <= separator_chars {
-      skipped.push(path)
-      continue
-    }
-    match directory_read_error(path) {
-      Some(block) => {
-        if separator_chars + block.char_length() <= remaining {
-          failures = failures + 1
-          remaining = remaining - separator_chars - block.char_length()
-          blocks.push(block)
-        } else {
-          skipped.push(path)
-          truncated_any = true
-        }
-        continue
-      }
-      None => ()
-    }
-    let content = @fs.read_file(path).text() catch {
-      error => {
-        let block = "error reading \{path}: \{error}"
-        if separator_chars + block.char_length() <= remaining {
-          failures = failures + 1
-          remaining = remaining - separator_chars - block.char_length()
-          blocks.push(block)
-        } else {
-          skipped.push(path)
-          truncated_any = true
-        }
-        continue
-      }
-    }
-    let selection = select_lines(content, 1, None)
-    let block_budget = remaining - separator_chars
-    match render_read_block(path, content, selection, block_budget) {
-      Some(block) => {
-        if block.truncated {
-          truncated_any = true
-        }
-        remaining = remaining - separator_chars - block.content.char_length()
-        blocks.push(block.content)
-      }
-      None => {
-        skipped.push(path)
-        truncated_any = true
-      }
-    }
-  }
-  if skipped.length() > 0 {
-    truncated_any = true
-    // Preview only a handful of names: the marker itself must stay bounded
-    // or a thousand-path call would flood the context through its skip list.
-    let preview_count = if skipped.length() < 5 { skipped.length() } else { 5 }
-    let preview = skipped[0:preview_count].join(", ")
-    let rest = if skipped.length() > 5 {
-      " and \{skipped.length() - 5} more"
-    } else {
-      ""
-    }
-    let separator_chars = if blocks.length() == 0 { 0 } else { 2 }
-    if remaining > separator_chars {
-      let marker_budget = remaining - separator_chars
-      let marker = cap_text(
-        "skipped \{skipped.length()} file(s), max_output_chars budget exhausted — read them individually: \{preview}\{rest}",
-        marker_budget,
-      )
-      blocks.push(marker)
-    }
-  }
-  @agent_tool.ToolAction::respond(
-    blocks.join("\n\n"),
-    is_error=failures == paths.length() || truncated_any,
-    brief="read \{paths.length()} files",
-  )
 }
 
 ///|
@@ -299,17 +172,6 @@ async fn directory_read_error(path : String) -> String? {
 }
 
 ///|
-fn cap_text(content : String, max_chars : Int) -> String {
-  if content.char_length() <= max_chars {
-    content
-  } else if max_chars <= 0 {
-    ""
-  } else {
-    char_prefix(content, max_chars)
-  }
-}
-
-///|
 fn char_prefix(content : String, max_chars : Int) -> String {
   if max_chars <= 0 {
     ""
@@ -317,44 +179,6 @@ fn char_prefix(content : String, max_chars : Int) -> String {
     content
   } else {
     StringView::from_iter(content.iter().take(max_chars)).to_owned()
-  }
-}
-
-///|
-fn render_read_block(
-  path : String,
-  original : String,
-  selection : ReadSelection,
-  max_chars : Int,
-) -> RenderedBlock? {
-  if max_chars <= 0 {
-    return None
-  }
-  let mut body_budget = max_chars
-  for _ in 0..<8 {
-    let rendered = render_numbered_content(selection, body_budget)
-    let header = read_header(path, original, selection, rendered)
-    if header.char_length() > max_chars {
-      return None
-    }
-    let next_body_budget = max_chars - header.char_length()
-    if next_body_budget == body_budget {
-      return Some({
-        content: "\{header}\{rendered.content}",
-        truncated: rendered.truncated,
-      })
-    }
-    body_budget = next_body_budget
-  }
-  let rendered = render_numbered_content(selection, body_budget)
-  let header = read_header(path, original, selection, rendered)
-  if header.char_length() + rendered.content.char_length() > max_chars {
-    None
-  } else {
-    Some({
-      content: "\{header}\{rendered.content}",
-      truncated: rendered.truncated,
-    })
   }
 }
 
@@ -623,8 +447,9 @@ test "read description encourages batched reads and directory inspection" {
   assert_true(tool.description.contains("Do not use read for directories"))
   let JsonSchema(schema) = tool.schema
   let schema_text = schema.stringify()
+  assert_true(schema_text.contains("\"path\""))
+  assert_false(schema_text.contains("\"paths\""))
   assert_true(schema_text.contains("Directories are not supported"))
-  assert_true(schema_text.contains("host cannot batch separate read calls"))
 }
 
 ///|
@@ -635,8 +460,7 @@ test "read parses and caps optional limits" {
     "max_lines": 4,
     "max_output_chars": 999999,
   })
-  assert_eq(input.paths.length(), 1)
-  assert_eq(input.paths[0], "file.mbt")
+  assert_eq(input.path, "file.mbt")
   assert_eq(input.start_line, 3)
   guard input.max_lines is Some(max_lines) else { fail("missing max_lines") }
   assert_eq(max_lines, 4)
@@ -644,111 +468,12 @@ test "read parses and caps optional limits" {
 }
 
 ///|
-async test "read returns several files as headered blocks" {
-  @vfs.with_tmpdir(dir => {
-    let a = "\{dir}/multi-a.txt"
-    let b = "\{dir}/multi-b.txt"
-    @fs.write_file(a, "alpha", create_mode=CreateOrTruncate)
-    @fs.write_file(b, "beta", create_mode=CreateOrTruncate)
-    let result = execute({ "paths": [a, b] })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_false(output.is_error)
-    assert_true(output.content.contains("path=\{a}"))
-    assert_true(output.content.contains("alpha"))
-    assert_true(output.content.contains("path=\{b}"))
-    assert_true(output.content.contains("beta"))
-  })
-}
-
-///|
-async test "a missing file reports inline while the others return" {
-  @vfs.with_tmpdir(dir => {
-    let a = "\{dir}/multi-ok.txt"
-    let missing = "\{dir}/multi-missing.txt"
-    @fs.write_file(a, "still here", create_mode=CreateOrTruncate)
-    let result = execute({ "paths": [a, missing] })
-    guard result is Respond(output) else { fail("expected Respond") }
-    // Partial failure is not a tool error: the good file landed and the bad
-    // path's error block tells the model exactly which read to fix.
-    assert_false(output.is_error)
-    assert_true(output.content.contains("still here"))
-    assert_true(output.content.contains("error reading \{missing}"))
-  })
-}
-
-///|
-async test "every file missing is a tool error" {
-  @vfs.with_tmpdir(dir => {
-    let result = execute({ "paths": ["\{dir}/none-1", "\{dir}/none-2"] })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-  })
-}
-
-///|
-async test "the output budget is shared and exhaustion is reported" {
-  @vfs.with_tmpdir(dir => {
-    let a = "\{dir}/budget-a.txt"
-    let b = "\{dir}/budget-b.txt"
-    @fs.write_file(a, "0123456789", create_mode=CreateOrTruncate)
-    @fs.write_file(b, "abcdefghij", create_mode=CreateOrTruncate)
-    let result = execute({ "paths": [a, b], "max_output_chars": 10 })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("skipped"))
-    assert_true(output.content.length() <= 10)
-    assert_false(output.content.contains("0123456789"))
-    assert_false(output.content.contains("abcdefghij"))
-  })
-}
-
-///|
-async test "headers and error blocks count against the budget" {
-  // 40 missing paths with a small budget: error blocks consume the budget,
-  // the tail collapses into one bounded marker, and the total output stays
-  // near the cap instead of growing per path (Codex review).
-  @vfs.with_tmpdir(dir => {
-    let paths : Array[Json] = []
-    for i in 0..<40 {
-      paths.push(Json::string("\{dir}/flood-\{i}"))
-    }
-    let result = execute({
-      "paths": Json::array(paths),
-      "max_output_chars": 300,
-    })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("skipped"))
-    assert_true(output.content.length() <= 300)
-  })
-}
-
-///|
-async test "read rejects path and paths together" {
-  @vfs.with_tmpdir(dir => {
-    let result = execute({ "path": "\{dir}/x", "paths": ["\{dir}/y"] })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("not both"))
-  })
-}
-
-///|
-async test "read rejects line ranges on multi-file calls" {
-  @vfs.with_tmpdir(dir => {
-    let result = execute({ "paths": ["\{dir}/x", "\{dir}/y"], "start_line": 2 })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("single file"))
-  })
-}
-
-///|
-async test "read rejects an empty paths array" {
-  let result = execute({ "paths": [] })
+async test "read rejects paths array and explains batching" {
+  let result = execute({ "paths": ["a.mbt", "b.mbt"] })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
-  assert_true(output.content.contains("non-empty array"))
+  assert_true(output.content.contains("arguments.paths is not supported"))
+  assert_true(output.content.contains("batch separate read calls"))
 }
 
 ///|

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -32,7 +32,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text — or several independent files in ONE call via arguments.paths (per-file errors report inline; cheaper than one call per file). Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include number<TAB>text line numbers.",
+    description="Read arguments.path as text — or several independent files in ONE call via arguments.paths (per-file errors report inline; cheaper than one call per file). Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include right-aligned line numbers.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -277,9 +277,12 @@ fn numbered_content(selection : ReadSelection, capped : String) -> String {
 ///|
 fn add_line_numbers(content : String, start_line : Int) -> String {
   let lines = [ for line in content.split("\n") => line.to_owned() ]
+  let last_line = start_line + lines.length() - 1
+  let width = "\{last_line}".length()
   let numbered : Array[String] = []
   for index in 0..<lines.length() {
-    numbered.push("\{start_line + index}\t\{lines[index]}")
+    let line_number = "\{start_line + index}".pad_start(width, ' ')
+    numbered.push("\{line_number}| \{lines[index]}")
   }
   numbered.join("\n")
 }
@@ -303,7 +306,7 @@ fn read_header(
     "shown_chars=\{capped.length()}",
     "line_limited=\{selection.line_limited}",
     "truncated=\{char_truncated}",
-    "line_format=number<TAB>text",
+    "line_format=right-aligned-number| text",
     "---",
     "",
   ].join("\n")
@@ -389,10 +392,10 @@ async test "read returns a requested line range with metadata" {
         "shown_chars=19",
         "line_limited=true",
         "truncated=false",
-        "line_format=number<TAB>text",
+        "line_format=right-aligned-number| text",
         "---",
-        "2\tline two",
-        "3\tline three",
+        "2| line two",
+        "3| line three",
       ].join("\n"),
     )
   })
@@ -419,11 +422,27 @@ async test "read caps oversized output and marks it as an error" {
         "shown_chars=3",
         "line_limited=false",
         "truncated=true",
-        "line_format=number<TAB>text",
+        "line_format=right-aligned-number| text",
         "---",
-        "1\tabc",
+        "1| abc",
       ].join("\n"),
     )
+  })
+}
+
+///|
+async test "line number gutters align to the widest displayed number" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/aligned.txt"
+    let content = [ for index in 1..<=111 => "line \{index}" ].join("\n")
+    @fs.write_file(path, content, create_mode=CreateOrTruncate)
+    let result = execute({ "path": path, "start_line": 9, "max_lines": 103 })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("  9| line 9"))
+    assert_true(output.content.contains(" 99| line 99"))
+    assert_true(output.content.contains("100| line 100"))
+    assert_true(output.content.contains("111| line 111"))
   })
 }
 
@@ -617,7 +636,7 @@ async test "a huge max_lines returns the remaining lines without overflow" {
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_true(output.content.contains("2\tb\n3\tc"))
+    assert_true(output.content.contains("2| b\n3| c"))
     assert_true(output.content.contains("shown_lines=2"))
   })
 }

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -33,6 +33,7 @@ pub fn definition(
     description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include right-aligned line numbers.",
     schema=JsonSchema({
       "type": "object",
+      "required": ["path"],
       "properties": {
         "path": {
           "type": "string",
@@ -449,6 +450,7 @@ test "read description encourages batched reads and directory inspection" {
   let schema_text = schema.stringify()
   assert_true(schema_text.contains("\"path\""))
   assert_false(schema_text.contains("\"paths\""))
+  assert_true(schema_text.contains("\"required\""))
   assert_true(schema_text.contains("Directories are not supported"))
 }
 

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -18,13 +18,13 @@
 /// ## Result
 /// - `Respond(ToolOutput(<file contents>))` on success for uncapped whole-file
 ///   single reads.
-/// - `Respond(ToolOutput(<metadata header + content>))` for ranged reads or
-///   capped reads, and per file for multi-file reads (blocks separated by a
-///   blank line; a failed file contributes an inline `error reading ...`
+/// - `Respond(ToolOutput(<metadata header + numbered content>))` for ranged
+///   reads or capped reads, and per file for multi-file reads (blocks separated
+///   by a blank line; a failed file contributes an inline `error reading ...`
 ///   block and only flips `is_error` when every file failed).
 /// - `Respond(ToolOutput("error reading <path>: <error>", is_error=true))`
 ///   if a single-file read fails (missing file, permission denied, invalid
-///   UTF-8, etc.).
+///   UTF-8, directory path, etc.).
 /// - `Respond(ToolOutput("error: read requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition(
@@ -32,7 +32,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text — or several independent files in ONE call via arguments.paths (per-file errors report inline; cheaper than one call per file). Supports optional start_line, max_lines, and max_output_chars for focused single-file reads.",
+    description="Read arguments.path as text — or several independent files in ONE call via arguments.paths (per-file errors report inline; cheaper than one call per file). Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include number<TAB>text line numbers.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -95,6 +95,11 @@ async fn read_file(
   input : @decode.ReadInput,
   path~ : String,
 ) -> @agent_tool.ToolAction {
+  match directory_read_error(path) {
+    Some(message) =>
+      return @agent_tool.ToolAction::respond(message, is_error=true)
+    None => ()
+  }
   let content = @fs.read_file(path).text() catch {
     error =>
       return @agent_tool.ToolAction::respond(
@@ -110,7 +115,7 @@ async fn read_file(
     input.max_lines is Some(_) ||
     char_truncated
   let output = if include_header {
-    "\{read_header(path, content, selection, capped, char_truncated)}\{capped}"
+    "\{read_header(path, content, selection, capped, char_truncated)}\{numbered_content(selection, capped)}"
   } else {
     capped
   }
@@ -149,6 +154,15 @@ async fn read_files(
       skipped.push(path)
       continue
     }
+    match directory_read_error(path) {
+      Some(block) => {
+        failures = failures + 1
+        remaining = remaining - block.length() - 2
+        blocks.push(block)
+        continue
+      }
+      None => ()
+    }
     let content = @fs.read_file(path).text() catch {
       error => {
         failures = failures + 1
@@ -164,7 +178,7 @@ async fn read_files(
     if char_truncated {
       truncated_any = true
     }
-    let block = "\{read_header(path, content, selection, capped, char_truncated)}\{capped}"
+    let block = "\{read_header(path, content, selection, capped, char_truncated)}\{numbered_content(selection, capped)}"
     remaining = remaining - block.length() - 2
     blocks.push(block)
   }
@@ -232,12 +246,42 @@ fn select_lines(
 }
 
 ///|
+async fn directory_read_error(path : String) -> String? {
+  match (@fs.kind(path, follow_symlink=true) catch { _ => return None }) {
+    Directory =>
+      Some(
+        "error reading \{path}: path is a directory; use the shell tool with `ls` or `tree` to inspect directories, then read specific files.",
+      )
+    _ => None
+  }
+}
+
+///|
 fn cap_text(content : String, max_chars : Int) -> String {
   if content.length() <= max_chars {
     content
   } else {
     "\{content[:max_chars]}"
   }
+}
+
+///|
+fn numbered_content(selection : ReadSelection, capped : String) -> String {
+  if selection.shown_lines == 0 {
+    ""
+  } else {
+    add_line_numbers(capped, selection.start_line)
+  }
+}
+
+///|
+fn add_line_numbers(content : String, start_line : Int) -> String {
+  let lines = [ for line in content.split("\n") => line.to_owned() ]
+  let numbered : Array[String] = []
+  for index in 0..<lines.length() {
+    numbered.push("\{start_line + index}\t\{lines[index]}")
+  }
+  numbered.join("\n")
 }
 
 ///|
@@ -259,6 +303,7 @@ fn read_header(
     "shown_chars=\{capped.length()}",
     "line_limited=\{selection.line_limited}",
     "truncated=\{char_truncated}",
+    "line_format=number<TAB>text",
     "---",
     "",
   ].join("\n")
@@ -344,9 +389,10 @@ async test "read returns a requested line range with metadata" {
         "shown_chars=19",
         "line_limited=true",
         "truncated=false",
+        "line_format=number<TAB>text",
         "---",
-        "line two",
-        "line three",
+        "2\tline two",
+        "3\tline three",
       ].join("\n"),
     )
   })
@@ -373,8 +419,9 @@ async test "read caps oversized output and marks it as an error" {
         "shown_chars=3",
         "line_limited=false",
         "truncated=true",
+        "line_format=number<TAB>text",
         "---",
-        "abc",
+        "1\tabc",
       ].join("\n"),
     )
   })
@@ -518,6 +565,17 @@ async test "read surfaces filesystem errors" {
 }
 
 ///|
+async test "read reports directories with an actionable hint" {
+  @vfs.with_tmpdir(dir => {
+    let result = execute({ "path": dir })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("path is a directory"))
+    assert_true(output.content.contains("`ls` or `tree`"))
+  })
+}
+
+///|
 async test "read rejects missing path" {
   let result = execute({})
   guard result is Respond(output) else { fail("expected Respond") }
@@ -559,7 +617,7 @@ async test "a huge max_lines returns the remaining lines without overflow" {
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_true(output.content.contains("b\nc"))
+    assert_true(output.content.contains("2\tb\n3\tc"))
     assert_true(output.content.contains("shown_lines=2"))
   })
 }


### PR DESCRIPTION
## Summary
- Rebases cleanly onto current `main`.
- Keep `read` single-file-only: the schema exposes required `path`, `ReadInput` carries one `path`, and `paths` is rejected with guidance to batch separate read calls in one assistant response.
- Add an explicit directory-path error that points agents to inspect directories with `ls` or `tree` before reading specific files.
- Keep headered read output line-numbered with right-aligned `number| text` gutters, and count those gutters toward `max_output_chars`.
- Preserve Unicode-safe truncation on character boundaries and update docs/tests for the output shape.

## Validation
Latest head (`b6948db`):
- `moon info`
- `moon fmt`
- `git diff --check`
- `moon test agent_tool/read --diagnostic-limit 100` (`21/21`)
- `moon test --diagnostic-limit 100` (`16/16` JS, `612/612` native)

## Fresh Review
- `codex exec review --base upstream/main --dangerously-bypass-approvals-and-sandbox -o /tmp/codex-review-pr170-rebased.md` completed with no actionable findings.
- The review also ran the modified package tests and full `moon test`; it noted the read package is native-only when probing all targets.

## Follow-up Ideas From Kimi Code Read
- Tail reads: support reading from EOF, either with negative `start_line` or a separate `tail_lines`, while keeping absolute line numbers in output.
- Streaming read path: iterate lines and collect only the requested window or tail instead of loading the whole file, while still surfacing total line count when possible.
- Layered caps: add max-line and per-line-length caps next to `max_output_chars`, and report which limit/truncation was hit.
- Text/media guardrails: reject binary, non-UTF-8, NUL-containing, image, and video inputs with direct guidance to media or shell tools.
- Secret guardrails: refuse `.env`, credential stores, and SSH private keys, with explicit exemptions for example/public-key files.
- Status footer: include total line count and truncation reason in a machine-obvious footer so the model can page correctly.