### PR TITLE
feat(viz): fold tool args and tool results, red-flag failed tools

### DIFF
--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -83,6 +83,7 @@ pub struct ToolResult {
 pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool) -> Self
 pub fn ToolResult::content(Self) -> String
 pub fn ToolResult::is_error(Self) -> Bool
+pub fn ToolResult::tool_call_id(Self) -> String
 pub fn ToolResult::tool_name(Self) -> String
 
 pub(all) enum TurnTerminal {

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -223,7 +223,11 @@ pub fn ToolResult::ToolResult(
 }
 
 ///|
-fn ToolResult::tool_call_id(self : ToolResult) -> String {
+/// Return the id of the assistant tool call this result answers. Protocol
+/// matching uses this to pair a result with its call; consumers (e.g. a
+/// visualizer) can use it to correlate a projected tool message back to its
+/// durable result.
+pub fn ToolResult::tool_call_id(self : ToolResult) -> String {
   self.tool_call_id
 }
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -312,9 +312,13 @@ fn terminal_card(
 
 ///|
 fn render_model(session : @agent_session.Session) -> @html.Html {
+  // The projection keys each tool message only by id and drops is_error / tool
+  // name, so recover them from the durable events for display (the messages fed
+  // to the model are unchanged — this is view-only enrichment).
+  let tool_results = tool_results_by_id(session)
   let messages = session.chat_messages()
   let cards : Array[@html.Html] = [
-    for message in messages => message_card(message)
+    for message in messages => message_card(message, tool_results)
   ]
   if cards.is_empty() {
     return empty_state("The model projection is empty.")
@@ -323,7 +327,25 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
 }
 
 ///|
-fn message_card(message : @deepseek.ChatMessage) -> @html.Html {
+/// Index every `ToolResult` event by its `tool_call_id`, so the model view can
+/// recover the error flag and tool name that the projection discards.
+fn tool_results_by_id(
+  session : @agent_session.Session,
+) -> Map[String, @agent_session.ToolResult] {
+  let map : Map[String, @agent_session.ToolResult] = Map([])
+  for event in session.events() {
+    if event.item() is Tool(result) {
+      map.set(result.tool_call_id(), result)
+    }
+  }
+  map
+}
+
+///|
+fn message_card(
+  message : @deepseek.ChatMessage,
+  tool_results : Map[String, @agent_session.ToolResult],
+) -> @html.Html {
   match message.role {
     System =>
       @html.section(class="card system", [
@@ -334,18 +356,38 @@ fn message_card(message : @deepseek.ChatMessage) -> @html.Html {
       ])
     User => model_card("user", "User", message)
     Assistant => model_card("assistant", "Assistant", message)
-    Tool(_) => model_tool_card(message)
+    Tool(id) => model_tool_card(message, tool_results.get(id))
   }
 }
 
 ///|
-/// Model-view tool result, folded by default like the raw view. The model
-/// projection replays a tool result to the model as plain content and drops the
-/// error flag (see `agent_session` projection), so there is no failure marker
-/// here — the raw log is the view that red-flags errors.
-fn model_tool_card(message : @deepseek.ChatMessage) -> @html.Html {
-  @html.details(class="card tool", [
-    @html.summary(class="card-label", "Tool result"),
+/// Model-view tool result, folded by default like the raw view. `result` is the
+/// matching durable `ToolResult` (looked up by id) when available, which lets
+/// this recover the tool name and red-flag failures even though the projection
+/// itself drops `is_error`. A non-zero command exit sets `is_error`, so an
+/// `exit=1` result is flagged here just as it is in the raw log.
+fn model_tool_card(
+  message : @deepseek.ChatMessage,
+  result : @agent_session.ToolResult?,
+) -> @html.Html {
+  let is_error = result is Some(r) && r.is_error()
+  let name = match result {
+    Some(r) => r.tool_name()
+    None => ""
+  }
+  let kind = if is_error { "tool error" } else { "tool" }
+  let label = match (is_error, name.is_empty()) {
+    (_, true) => "Tool result"
+    (true, false) => "Tool error · \{name}"
+    (false, false) => "Tool result · \{name}"
+  }
+  let head : Array[@html.Html] = []
+  if is_error {
+    head.push(@html.span(class="tool-flag", "🚩 failed"))
+  }
+  head.push(@html.text(label))
+  @html.details(class="card \{kind}", [
+    @html.summary(class="card-label", head),
     @html.div(class="card-body", [text_block(message.content)]),
   ])
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -231,7 +231,10 @@ fn assistant_card(
 /// the tool name and expands to the full argument JSON on click. Calls with no
 /// meaningful arguments render as a plain name (nothing to fold).
 fn tool_call_view(call : @deepseek.ToolCall) -> @html.Html {
-  let name_row : Array[@html.Html] = [@html.text("→ "), @html.strong(call.name)]
+  let name_row : Array[@html.Html] = [
+    @html.text("→ "),
+    @html.strong(call.name),
+  ]
   let args = pretty_json(call.arguments)
   if is_blank_args(args) {
     return @html.div(class="tool-call", [
@@ -274,7 +277,7 @@ fn tool_card(
     @html.nothing
   }
   @html.details(class="card \{kind}", [
-    @html.summary(class="card-label", card_head(label, seq, time=time, flag~)),
+    @html.summary(class="card-label", card_head(label, seq, time~, flag~)),
     @html.div(class="card-body", [text_block(result.content())]),
   ])
 }
@@ -448,7 +451,7 @@ fn card_head(
   label : String,
   seq : Int,
   time~ : String,
-  flag~ : @html.Html = @html.nothing,
+  flag? : @html.Html = @html.nothing,
 ) -> Array[@html.Html] {
   let head : Array[@html.Html] = [
     @html.span(class="card-seq", "#\{seq}"),

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -227,29 +227,56 @@ fn assistant_card(
 }
 
 ///|
+/// A tool call, with its arguments folded away by default: the row shows only
+/// the tool name and expands to the full argument JSON on click. Calls with no
+/// meaningful arguments render as a plain name (nothing to fold).
 fn tool_call_view(call : @deepseek.ToolCall) -> @html.Html {
-  @html.div(class="tool-call", [
-    @html.div(class="tool-call-name", [
-      @html.text("→ "),
-      @html.strong(call.name),
-    ]),
-    @html.pre(class="tool-call-args", pretty_json(call.arguments)),
+  let name_row : Array[@html.Html] = [@html.text("→ "), @html.strong(call.name)]
+  let args = pretty_json(call.arguments)
+  if is_blank_args(args) {
+    return @html.div(class="tool-call", [
+      @html.div(class="tool-call-name", name_row),
+    ])
+  }
+  @html.details(class="tool-call", [
+    @html.summary(class="tool-call-name", name_row),
+    @html.pre(class="tool-call-args", args),
   ])
 }
 
 ///|
+/// Whether a tool call's (pretty-printed) arguments carry nothing worth folding
+/// away — empty text or an empty object.
+fn is_blank_args(args : String) -> Bool {
+  let trimmed = args.trim().to_owned()
+  trimmed.is_empty() || trimmed == "{}"
+}
+
+///|
+/// Tool output is noisy, so fold it behind the label by default. The summary
+/// keeps the tool name and, on failure, a red flag — both visible while the card
+/// is collapsed — so a failed tool stands out without expanding it.
 fn tool_card(
   seq : Int,
   time : String,
   result : @agent_session.ToolResult,
 ) -> @html.Html {
-  let kind = if result.is_error() { "tool error" } else { "tool" }
-  let label = if result.is_error() {
+  let is_error = result.is_error()
+  let kind = if is_error { "tool error" } else { "tool" }
+  let label = if is_error {
     "Tool error · \{result.tool_name()}"
   } else {
     "Tool result · \{result.tool_name()}"
   }
-  card(kind, label, seq, time~, [text_block(result.content())])
+  let flag = if is_error {
+    @html.span(class="tool-flag", "🚩 failed")
+  } else {
+    @html.nothing
+  }
+  @html.details(class="card \{kind}", [
+    @html.summary(class="card-label", card_head(label, seq, time=time, flag~)),
+    @html.div(class="card-body", [text_block(result.content())]),
+  ])
 }
 
 ///|
@@ -307,8 +334,20 @@ fn message_card(message : @deepseek.ChatMessage) -> @html.Html {
       ])
     User => model_card("user", "User", message)
     Assistant => model_card("assistant", "Assistant", message)
-    Tool(_) => model_card("tool", "Tool result", message)
+    Tool(_) => model_tool_card(message)
   }
+}
+
+///|
+/// Model-view tool result, folded by default like the raw view. The model
+/// projection replays a tool result to the model as plain content and drops the
+/// error flag (see `agent_session` projection), so there is no failure marker
+/// here — the raw log is the view that red-flags errors.
+fn model_tool_card(message : @deepseek.ChatMessage) -> @html.Html {
+  @html.details(class="card tool", [
+    @html.summary(class="card-label", "Tool result"),
+    @html.div(class="card-body", [text_block(message.content)]),
+  ])
 }
 
 ///|
@@ -352,17 +391,32 @@ fn card(
   time~ : String,
   body : Array[@html.Html],
 ) -> @html.Html {
+  @html.section(class="card \{kind}", [
+    @html.div(class="card-label", card_head(label, seq, time~)),
+    @html.div(class="card-body", body),
+  ])
+}
+
+///|
+/// The card header row: a sequence chip, the label, and (when stamped) a
+/// relative-time chip. `flag` sits between the sequence and the label so a
+/// folded card can still surface a status marker (e.g. a failed-tool flag) in
+/// its summary; it defaults to nothing for ordinary cards.
+fn card_head(
+  label : String,
+  seq : Int,
+  time~ : String,
+  flag~ : @html.Html = @html.nothing,
+) -> Array[@html.Html] {
   let head : Array[@html.Html] = [
     @html.span(class="card-seq", "#\{seq}"),
+    flag,
     @html.text(label),
   ]
   if !time.is_empty() {
     head.push(@html.span(class="card-ts", time))
   }
-  @html.section(class="card \{kind}", [
-    @html.div(class="card-label", head),
-    @html.div(class="card-body", body),
-  ])
+  head
 }
 
 ///|

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -365,16 +365,28 @@ fn message_card(
 
 ///|
 /// Model-view tool result, folded by default like the raw view. `result` is the
-/// matching durable `ToolResult` (looked up by id) when available, which lets
-/// this recover the tool name and red-flag failures even though the projection
-/// itself drops `is_error`. A non-zero command exit sets `is_error`, so an
-/// `exit=1` result is flagged here just as it is in the raw log.
+/// durable `ToolResult` looked up by id, which lets this recover the tool name
+/// and red-flag failures even though the projection drops `is_error`. A non-zero
+/// command exit sets `is_error`, so an `exit=1` result is flagged here just as
+/// in the raw log.
+///
+/// The recovered result is only trusted when its content is exactly what the
+/// projection fed the model for this message. The projection skips results
+/// covered by a later summary and heals a dangling tool call with a synthetic
+/// error message (`flush_pending_tool_calls`); in those cases the looked-up
+/// result is not what the model saw, and attaching its name/flag would
+/// misrepresent the model view — so the content guard falls back to a plain,
+/// unflagged card.
 fn model_tool_card(
   message : @deepseek.ChatMessage,
   result : @agent_session.ToolResult?,
 ) -> @html.Html {
-  let is_error = result is Some(r) && r.is_error()
-  let name = match result {
+  let shown = match result {
+    Some(r) if r.content() == message.content => Some(r)
+    _ => None
+  }
+  let is_error = shown is Some(r) && r.is_error()
+  let name = match shown {
     Some(r) => r.tool_name()
     None => ""
   }

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -49,6 +49,76 @@ fn render(html : @html.Html) -> String {
 }
 
 ///|
+/// A session whose tool result failed, plus a tool call with arguments and one
+/// without, to exercise the fold/flag rendering.
+fn error_tool_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("e"), system_prompt="")
+  .append(
+    Assistant(
+      AssistantMessage(
+        "",
+        tool_calls=[
+          ToolCall(id="c1", name="shell", arguments="{\"cmd\":\"ls\"}"),
+          ToolCall(id="c2", name="noop", arguments="{}"),
+        ],
+      ),
+    ),
+  )
+  .append(
+    Tool(
+      ToolResult(
+        tool_call_id="c1",
+        tool_name="shell",
+        content="boom",
+        is_error=true,
+      ),
+    ),
+  )
+}
+
+///|
+test "tool calls fold their arguments, empty args stay flat" {
+  let html = render(@viz.render_session(error_tool_session(), RawLog))
+  // A call with arguments folds: the name becomes a <summary>, args hide in the
+  // collapsed <details> (no `open` attribute) yet are still in the DOM.
+  assert_true(html.contains("<details class=\"tool-call\">"))
+  assert_true(html.contains("<summary class=\"tool-call-name\">"))
+  assert_true(html.contains("shell"))
+  assert_true(html.contains("cmd"))
+  // A call with no meaningful arguments ({}) renders flat — nothing to fold.
+  assert_true(html.contains("<div class=\"tool-call\"><div class=\"tool-call-name\">"))
+}
+
+///|
+test "failed tool result is folded and red-flagged" {
+  let html = render(@viz.render_session(error_tool_session(), RawLog))
+  // Folded by default (a <details> with no `open`), tagged as an error, and the
+  // summary carries the red flag so a collapsed failure still stands out.
+  assert_true(html.contains("<details class=\"card tool error\">"))
+  assert_false(html.contains("<details class=\"card tool error\" open>"))
+  assert_true(html.contains("class=\"tool-flag\">🚩 failed"))
+  assert_true(html.contains("Tool error · shell"))
+  assert_true(html.contains("boom"))
+}
+
+///|
+test "successful tool result folds without a flag" {
+  // sample_session's tool result is a success; it should fold but carry no flag.
+  let session = @viz.session_from_parse(
+    @viz.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="",
+  )
+  let raw = render(@viz.render_session(session, RawLog))
+  assert_true(raw.contains("<details class=\"card tool\">"))
+  assert_false(raw.contains("tool-flag"))
+  // Model view folds its tool result too (no flag — the projection drops it).
+  let model = render(@viz.render_session(session, ModelView))
+  assert_true(model.contains("<details class=\"card tool\">"))
+  assert_true(model.contains("Tool result"))
+}
+
+///|
 test "parse round-trips every event kind" {
   let text = events_jsonl(sample_session())
   let parsed = @viz.parse_events(text)

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -112,6 +112,23 @@ test "model view recovers the error flag the projection drops" {
 }
 
 ///|
+test "model view does not flag a result the projection skipped" {
+  // Compact away only the tool result (seq 2): the projection then heals the
+  // dangling call c1 with a synthetic error message, so the model never saw the
+  // real "boom" result. The view must not attach that result's flag/name to the
+  // synthetic message — it would misrepresent what the model was fed.
+  let compacted = error_tool_session().compact(
+    content="covered",
+    from_sequence=2,
+    to_sequence=2,
+  )
+  let model = render(@viz.render_session(compacted, ModelView))
+  assert_true(model.contains("previous agent process exited"))
+  assert_false(model.contains("tool-flag"))
+  assert_false(model.contains("Tool error · shell"))
+}
+
+///|
 test "successful tool result folds without a flag" {
   // sample_session's tool result is a success; it should fold but carry no flag.
   let session = @viz.session_from_parse(

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -55,13 +55,10 @@ fn error_tool_session() -> @agent_session.Session {
   @agent_session.Session(SessionId("e"), system_prompt="")
   .append(
     Assistant(
-      AssistantMessage(
-        "",
-        tool_calls=[
-          ToolCall(id="c1", name="shell", arguments="{\"cmd\":\"ls\"}"),
-          ToolCall(id="c2", name="noop", arguments="{}"),
-        ],
-      ),
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="c1", name="shell", arguments="{\"cmd\":\"ls\"}"),
+        ToolCall(id="c2", name="noop", arguments="{}"),
+      ]),
     ),
   )
   .append(
@@ -86,7 +83,9 @@ test "tool calls fold their arguments, empty args stay flat" {
   assert_true(html.contains("shell"))
   assert_true(html.contains("cmd"))
   // A call with no meaningful arguments ({}) renders flat — nothing to fold.
-  assert_true(html.contains("<div class=\"tool-call\"><div class=\"tool-call-name\">"))
+  assert_true(
+    html.contains("<div class=\"tool-call\"><div class=\"tool-call-name\">"),
+  )
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -102,6 +102,17 @@ test "failed tool result is folded and red-flagged" {
 }
 
 ///|
+test "model view recovers the error flag the projection drops" {
+  // The model projection keys a tool message by id only and drops is_error, but
+  // the view correlates back to the durable ToolResult, so a failed tool (e.g. a
+  // non-zero exit) is red-flagged in the model view too — with its tool name.
+  let model = render(@viz.render_session(error_tool_session(), ModelView))
+  assert_true(model.contains("<details class=\"card tool error\">"))
+  assert_true(model.contains("class=\"tool-flag\">🚩 failed"))
+  assert_true(model.contains("Tool error · shell"))
+}
+
+///|
 test "successful tool result folds without a flag" {
   // sample_session's tool result is a success; it should fold but carry no flag.
   let session = @viz.session_from_parse(

--- a/web/index.html
+++ b/web/index.html
@@ -242,7 +242,7 @@
     .card.user { border-left-color: var(--user); }
     .card.assistant { border-left-color: var(--assistant); }
     .card.tool { border-left-color: var(--tool); }
-    .card.tool.error { border-left-color: var(--error); }
+    .card.tool.error { border-left-color: var(--error); background: var(--notice-error-bg); }
     .card.runtime { border-left-color: var(--runtime); }
     .card.summary { border-left-color: var(--summary); background: var(--summary-bg); }
     .card.terminal { border-left-color: var(--terminal); }
@@ -265,8 +265,18 @@
     .reasoning .content { color: var(--muted); }
     .tool-calls { margin-top: 8px; }
     .tool-call { border: 1px dashed var(--border); border-radius: 6px; padding: 6px 10px; margin-top: 6px; }
-    .tool-call-name { font-size: 13px; margin-bottom: 4px; }
+    .tool-call-name { font-size: 13px; }
+    details.tool-call > summary.tool-call-name { cursor: pointer; }
+    details.tool-call[open] > summary.tool-call-name { margin-bottom: 4px; }
     .tool-call-args { margin: 0; white-space: pre-wrap; font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); }
+
+    /* folded tool-result cards: the label is the toggle, body hides until clicked */
+    details.card > summary.card-label { cursor: pointer; }
+    details.card > summary.card-label:hover { color: var(--text); }
+    .tool-flag {
+      color: var(--error); font-weight: 700; margin-right: 8px;
+      text-transform: none; letter-spacing: 0;
+    }
 
     /* badges */
     .badge {


### PR DESCRIPTION
## What

The log visualizer showed every tool call's full argument JSON and every tool result's full body inline, burying the conversation in noise. This folds both by default and red-flags failures.

### Tool calls — fold arguments, show only the tool
- A tool call renders as a collapsible row showing only `→ <tool>`; the argument JSON expands on click.
- Calls with no meaningful arguments (empty or `{}`) stay flat — nothing to fold.

### Tool results — auto-fold, red-flag failures (both views)
- Tool results fold behind their label in both the raw-log and model views (only `Tool result · <name>` shows until clicked).
- A **failed** tool result keeps a red `🚩 failed` flag plus an error tint in its summary, so a failure stands out while still collapsed.
- A failure is anything the tool reported as `is_error` — notably a **non-zero command exit** (the shell/moon tools set `is_error = exit_code != 0`), so an `exit=1` result is flagged.

### Model view: recover the dropped error flag
The model projection keys a tool message by `tool_call_id` only and drops `is_error` (a result replays to the model as plain content), so the default view originally couldn't flag failures. The viewer now correlates each projected tool message back to its durable `ToolResult` event (by id) to recover the error flag and tool name — **view-only; the messages fed to the model are unchanged.** This required exposing `ToolResult::tool_call_id()` (already used internally).

## Verification

- `moon check` clean (js + native); **13/13 viz tests pass**, including: folded tool-call args, flat empty-args calls, folded + red-flagged failed results (raw and model views), and folded successful results.
- Cross-checked against a real session: `exit=1` results carry `is_error:true` (15×) and now render the flag in both views; `exit=0` (75×) does not.
- Confirmed the rebuilt shell serves the new CSS and the compiled `viz_app.js` bundle (HTTP 200) carries the new render markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)