### PR TITLE
feat(viz): find and jump to failed tools

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -583,10 +583,12 @@ fn session_view_class(model : Model) -> String {
 
 ///|
 /// The "find failures" toolbar: a count, an errors-only filter toggle, and
-/// prev/next jumps. Hidden entirely when the current view has no failures, so a
-/// clean session shows no extra chrome.
+/// prev/next jumps. Hidden when the view has no failures AND the filter is off,
+/// so a clean session shows no chrome — but if the filter is on it stays visible
+/// even at zero failures, otherwise "Errors only" could hide the whole log with
+/// no way to switch it back off.
 fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
-  if count == 0 {
+  if count == 0 && !model.errors_only {
     return @html.nothing
   }
   let toggle_class = if model.errors_only {
@@ -594,11 +596,16 @@ fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
   } else {
     "error-toggle"
   }
-  @html.div(class="error-bar", [
-    @html.span(
-      class="error-count",
-      "🚩 \{count} tool error\{plural_s(count)}",
-    ),
+  let children : Array[@html.Html] = []
+  if count > 0 {
+    children.push(
+      @html.span(
+        class="error-count",
+        "🚩 \{count} tool error\{plural_s(count)}",
+      ),
+    )
+  }
+  children.push(
     @html.button(
       class=toggle_class,
       title="Show only failed tool results",
@@ -609,19 +616,27 @@ fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
         "Errors only"
       },
     ),
-    @html.button(
-      class="error-jump",
-      title="Scroll to the previous failure",
-      on_click=emit(JumpToError(-1)),
-      "↑ prev",
-    ),
-    @html.button(
-      class="error-jump",
-      title="Scroll to the next failure",
-      on_click=emit(JumpToError(1)),
-      "↓ next",
-    ),
-  ])
+  )
+  // Jumps only make sense when there is something to jump to.
+  if count > 0 {
+    children.push(
+      @html.button(
+        class="error-jump",
+        title="Scroll to the previous failure",
+        on_click=emit(JumpToError(-1)),
+        "↑ prev",
+      ),
+    )
+    children.push(
+      @html.button(
+        class="error-jump",
+        title="Scroll to the next failure",
+        on_click=emit(JumpToError(1)),
+        "↓ next",
+      ),
+    )
+  }
+  @html.div(class="error-bar", children)
 }
 
 ///|

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -26,6 +26,10 @@ struct Model {
   collapsed_roots : Array[String]
   loading : Bool
   status : String
+  // "Errors only" filter (folds the log down to failed tool results) and the
+  // index of the failure the prev/next jump last scrolled to (-1 = none yet).
+  errors_only : Bool
+  error_focus : Int
 }
 
 ///|
@@ -60,6 +64,8 @@ enum Msg {
   SetTheme(Theme)
   ToggleSidebar
   ToggleRoot(String)
+  ToggleErrorsOnly
+  JumpToError(Int)
 }
 
 ///|
@@ -86,6 +92,8 @@ fn init_model() -> Model {
     collapsed_roots: [],
     loading: false,
     status: "loading sessions…",
+    errors_only: false,
+    error_focus: -1,
   }
 }
 
@@ -129,6 +137,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
           header_present: false,
           loading: true,
           status: "loading \{label}…",
+          error_focus: -1,
         },
       )
     }
@@ -181,7 +190,25 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
             }
         }
       }
-    SetMode(mode) => (@cmd.none, { ..model, view_mode: mode })
+    // A view switch changes which (and how many) failures are on screen, so the
+    // jump cursor restarts from the top.
+    SetMode(mode) => (@cmd.none, { ..model, view_mode: mode, error_focus: -1 })
+    ToggleErrorsOnly =>
+      (@cmd.none, { ..model, errors_only: !model.errors_only })
+    // Scroll to the next/previous failed-tool card, cycling. The count is
+    // recomputed for the active view so the cursor matches what is on screen.
+    JumpToError(direction) => {
+      let count = current_error_count(model)
+      if count <= 0 {
+        (@cmd.none, model)
+      } else {
+        let next = wrap_index(model.error_focus, direction, count)
+        (
+          @cmd.effect(() => scroll_to_nth_error(next)),
+          { ..model, error_focus: next },
+        )
+      }
+    }
     SetTheme(theme) =>
       // Apply the theme as a side effect (set `data-theme` on <html>) so the CSS
       // variable blocks take over; the model tracks it for button highlighting.
@@ -222,6 +249,12 @@ fn fetch_text(
 /// Percent-encode the id so session ids containing URL-reserved characters
 /// (spaces, `?`, `#`) reach the server intact; it percent-decodes the segment.
 extern "js" fn encode_uri_component(value : String) -> String = "encodeURIComponent"
+
+///|
+/// Scroll the nth failed-tool card (`.card.tool.error`, document order) into the
+/// centre of the viewport. The selector matches both views, and the indexing
+/// mirrors `rendered_error_count`, so the cursor stays aligned with the count.
+extern "js" fn scroll_to_nth_error(index : Int) -> Unit = "(n) => { const els = document.querySelectorAll('.card.tool.error'); const el = els[n]; if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }"
 
 ///|
 fn session_url(id : String) -> String {
@@ -481,11 +514,13 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
             id~,
             system_prompt=model.system_prompt,
           )
-          @html.div(class="session-view", [
+          let error_count = @viz.rendered_error_count(session, model.view_mode)
+          @html.div(class=session_view_class(model), [
             header_strip(model, id, row.map(row => row.root_label)),
             mode_toggle(emit, model),
+            error_bar(emit, model, error_count),
             @viz.render_notices(parsed),
-            @viz.render_session(session, model.view_mode),
+            session_log_view(model, session, error_count),
           ])
         }
       }
@@ -533,6 +568,112 @@ fn mode_button(
     "mode-button"
   }
   @html.button(class=classes, on_click=emit(SetMode(mode)), label)
+}
+
+///|
+/// Add the `errors-only` class so the stylesheet folds the log down to failed
+/// tool cards (and the turns containing them).
+fn session_view_class(model : Model) -> String {
+  if model.errors_only {
+    "session-view errors-only"
+  } else {
+    "session-view"
+  }
+}
+
+///|
+/// The "find failures" toolbar: a count, an errors-only filter toggle, and
+/// prev/next jumps. Hidden entirely when the current view has no failures, so a
+/// clean session shows no extra chrome.
+fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
+  if count == 0 {
+    return @html.nothing
+  }
+  let toggle_class = if model.errors_only {
+    "error-toggle active"
+  } else {
+    "error-toggle"
+  }
+  @html.div(class="error-bar", [
+    @html.span(
+      class="error-count",
+      "🚩 \{count} tool error\{plural_s(count)}",
+    ),
+    @html.button(
+      class=toggle_class,
+      title="Show only failed tool results",
+      on_click=emit(ToggleErrorsOnly),
+      if model.errors_only {
+        "Errors only: on"
+      } else {
+        "Errors only"
+      },
+    ),
+    @html.button(
+      class="error-jump",
+      title="Scroll to the previous failure",
+      on_click=emit(JumpToError(-1)),
+      "↑ prev",
+    ),
+    @html.button(
+      class="error-jump",
+      title="Scroll to the next failure",
+      on_click=emit(JumpToError(1)),
+      "↓ next",
+    ),
+  ])
+}
+
+///|
+/// The log, or a hint when the errors-only filter would hide everything (so the
+/// pane never looks empty/broken when a clean view is filtered).
+fn session_log_view(
+  model : Model,
+  session : @agent_session.Session,
+  count : Int,
+) -> @html.Html {
+  if model.errors_only && count == 0 {
+    @html.div(class="errors-only-empty", "No failed tool results in this view.")
+  } else {
+    @viz.render_session(session, model.view_mode)
+  }
+}
+
+///|
+/// Number of failures the active view will draw, recomputed from the loaded log.
+/// Returns 0 when nothing is loaded.
+fn current_error_count(model : Model) -> Int {
+  guard model.selected is Some(key) else { return 0 }
+  guard model.parsed is Some(parsed) else { return 0 }
+  let id = match session_row(model, key) {
+    Some(row) => row.id
+    None => key
+  }
+  let session = @viz.session_from_parse(
+    parsed,
+    id~,
+    system_prompt=model.system_prompt,
+  )
+  @viz.rendered_error_count(session, model.view_mode)
+}
+
+///|
+/// Step `focus` by `direction` and wrap into `0..<n` (n > 0). A fresh cursor
+/// (`focus < 0`) lands on the first failure going forward and the last going
+/// back, so the very first "next"/"prev" behaves intuitively.
+fn wrap_index(focus : Int, direction : Int, n : Int) -> Int {
+  let base = if focus < 0 { if direction > 0 { -1 } else { 0 } } else { focus }
+  let next = base + direction
+  (next % n + n) % n
+}
+
+///|
+fn plural_s(n : Int) -> String {
+  if n == 1 {
+    ""
+  } else {
+    "s"
+  }
 }
 
 // ---- JSON helpers ----------------------------------------------------------

--- a/cmd/viz_app/moon.pkg
+++ b/cmd/viz_app/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/viz",
   "moonbit-community/rabbita",

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub fn render_notices(@log.ParsedLog) -> @html.Html
 
 pub fn render_session(@agent_session.Session, ViewMode) -> @html.Html
 
+pub fn rendered_error_count(@agent_session.Session, ViewMode) -> Int
+
 pub fn session_from_parse(@log.ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
 
 // Errors
@@ -28,3 +30,4 @@ pub(all) enum ViewMode {
 // Type aliases
 
 // Traits
+

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -30,4 +30,3 @@ pub(all) enum ViewMode {
 // Type aliases
 
 // Traits
-

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -109,10 +109,44 @@ fn turn_block(
     Some(duration) => "Turn \{number} · \{turn_preview(turn)} · \{duration}"
     None => "Turn \{number} · \{turn_preview(turn)}"
   }
+  // Surface failed tools in the turn header so a turn carrying errors is
+  // scannable even while its cards are folded or the turn itself is collapsed.
+  let summary : Array[@html.Html] = [@html.text(label)]
+  let errors = count_turn_tool_errors(turn)
+  if errors > 0 {
+    summary.push(
+      @html.span(
+        class="turn-error-badge",
+        " · 🚩 \{errors} error\{plural(errors)}",
+      ),
+    )
+  }
   @html.details(open=true, class="turn", [
-    @html.summary(class="turn-summary", label),
+    @html.summary(class="turn-summary", summary),
     @html.div(class="turn-body", cards),
   ])
+}
+
+///|
+/// Number of failed tool results in a turn, for the turn header's error badge.
+fn count_turn_tool_errors(turn : Array[@agent_session.SessionEvent]) -> Int {
+  let mut count = 0
+  for event in turn {
+    if event.item() is Tool(result) && result.is_error() {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+/// `""` for one, `"s"` otherwise — for pluralizing a count in a label.
+fn plural(n : Int) -> String {
+  if n == 1 {
+    ""
+  } else {
+    "s"
+  }
 }
 
 ///|
@@ -359,8 +393,59 @@ fn message_card(
       ])
     User => model_card("user", "User", message)
     Assistant => model_card("assistant", "Assistant", message)
-    Tool(id) => model_tool_card(message, tool_results.get(id))
+    Tool(_) =>
+      model_tool_card(message, model_shown_result(message, tool_results))
   }
+}
+
+///|
+/// The durable `ToolResult` the model view is allowed to surface for a projected
+/// tool message: the one looked up by id whose content is exactly what the model
+/// was fed. The projection skips results covered by a later summary and heals a
+/// dangling call with a synthetic message; in those cases the looked-up result
+/// is not what the model saw, so the content guard rejects it (returns `None`)
+/// rather than misrepresent the model view. Shared by `model_tool_card` and
+/// `rendered_error_count` so the on-screen flags and the error count never drift.
+fn model_shown_result(
+  message : @deepseek.ChatMessage,
+  tool_results : Map[String, @agent_session.ToolResult],
+) -> @agent_session.ToolResult? {
+  guard message.role is Tool(id) else { return None }
+  match tool_results.get(id) {
+    Some(result) if result.content() == message.content => Some(result)
+    _ => None
+  }
+}
+
+///|
+/// How many tool-error cards `render_session` draws for `mode` — i.e. failed
+/// tool results actually shown, so it equals the number of `.card.tool.error`
+/// elements on screen. `RawLog` shows every errored `ToolResult`; `ModelView`
+/// shows only those the projection emitted and the view trusts (see
+/// `model_shown_result`). Used to drive the "find failures" controls.
+pub fn rendered_error_count(
+  session : @agent_session.Session,
+  mode : ViewMode,
+) -> Int {
+  let mut count = 0
+  match mode {
+    RawLog =>
+      for event in session.events() {
+        if event.item() is Tool(result) && result.is_error() {
+          count += 1
+        }
+      }
+    ModelView => {
+      let tool_results = tool_results_by_id(session)
+      for message in session.chat_messages() {
+        if model_shown_result(message, tool_results) is Some(result) &&
+          result.is_error() {
+          count += 1
+        }
+      }
+    }
+  }
+  count
 }
 
 ///|
@@ -370,21 +455,14 @@ fn message_card(
 /// command exit sets `is_error`, so an `exit=1` result is flagged here just as
 /// in the raw log.
 ///
-/// The recovered result is only trusted when its content is exactly what the
-/// projection fed the model for this message. The projection skips results
-/// covered by a later summary and heals a dangling tool call with a synthetic
-/// error message (`flush_pending_tool_calls`); in those cases the looked-up
-/// result is not what the model saw, and attaching its name/flag would
-/// misrepresent the model view — so the content guard falls back to a plain,
-/// unflagged card.
+/// `shown` is the durable result the view trusts for this message (see
+/// `model_shown_result`) — `None` when the projection healed/compacted it away,
+/// in which case the card is plain and unflagged so it never misrepresents what
+/// the model saw.
 fn model_tool_card(
   message : @deepseek.ChatMessage,
-  result : @agent_session.ToolResult?,
+  shown : @agent_session.ToolResult?,
 ) -> @html.Html {
-  let shown = match result {
-    Some(r) if r.content() == message.content => Some(r)
-    _ => None
-  }
   let is_error = shown is Some(r) && r.is_error()
   let name = match shown {
     Some(r) => r.tool_name()

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -146,6 +146,40 @@ test "successful tool result folds without a flag" {
 }
 
 ///|
+test "turn header badges failed tools" {
+  let html = render(@viz.render_session(error_tool_session(), RawLog))
+  assert_true(html.contains("turn-error-badge"))
+  assert_true(html.contains("🚩 1 error"))
+}
+
+///|
+test "rendered_error_count matches the failures each view draws" {
+  let failing = error_tool_session()
+  inspect(@viz.rendered_error_count(failing, RawLog), content="1")
+  inspect(@viz.rendered_error_count(failing, ModelView), content="1")
+  let clean = @viz.session_from_parse(
+    @viz.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="",
+  )
+  inspect(@viz.rendered_error_count(clean, RawLog), content="0")
+  inspect(@viz.rendered_error_count(clean, ModelView), content="0")
+}
+
+///|
+test "model error count excludes a compacted-away failure raw still shows" {
+  let compacted = error_tool_session().compact(
+    content="covered",
+    from_sequence=2,
+    to_sequence=2,
+  )
+  // Raw still renders the durable errored result; the model view healed the
+  // dangling call, so it has no error card to count.
+  inspect(@viz.rendered_error_count(compacted, RawLog), content="1")
+  inspect(@viz.rendered_error_count(compacted, ModelView), content="0")
+}
+
+///|
 test "parse round-trips every event kind" {
   let text = events_jsonl(sample_session())
   let parsed = @viz.parse_events(text)

--- a/web/index.html
+++ b/web/index.html
@@ -216,6 +216,23 @@
     .mode-button:hover { border-color: var(--accent); }
     .mode-button.active { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
 
+    /* find-failures bar */
+    .error-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: -6px 0 16px; }
+    .error-count { color: var(--error); font-size: 12px; font-weight: 600; margin-right: 2px; }
+    .error-toggle, .error-jump {
+      background: var(--panel); color: var(--text);
+      border: 1px solid var(--border); border-radius: 999px;
+      padding: 4px 12px; cursor: pointer; font-size: 12px;
+    }
+    .error-jump { padding: 4px 11px; font-family: ui-monospace, monospace; }
+    .error-toggle:hover, .error-jump:hover { border-color: var(--error); }
+    .error-toggle.active { background: var(--error); color: #fff; border-color: var(--error); }
+    .turn-error-badge { color: var(--error); }
+    .errors-only-empty { color: var(--muted); margin-top: 24px; }
+    /* errors-only: keep only failed tool cards and the turns that contain them */
+    .session-view.errors-only .card:not(.error) { display: none; }
+    .session-view.errors-only .turn:not(:has(.card.error)) { display: none; }
+
     /* notices */
     .notices { margin-bottom: 16px; }
     .notice { border-radius: 8px; padding: 8px 12px; margin-bottom: 8px; font-size: 13px; }


### PR DESCRIPTION
## What

Folding tool results (shipped earlier) hid failures behind a click, and a long session can carry dozens (the sample session has 35). Flagging alone wasn't enough to *find* them — this adds a find/jump layer.

- **Per-turn error badge** — `🚩 N errors` in the turn header, so a turn carrying failures is scannable even while collapsed.
- **Find-failures toolbar** (shown only when the current view has failures): a failure count, an **Errors only** filter that folds the log down to failed tool cards (and the turns containing them, via a pure-CSS `:has()` rule), and **↑ prev / ↓ next** buttons that scroll through the failures.

## Correctness

The count and jump cursor are driven by `viz.rendered_error_count`, which mirrors exactly what each view draws — raw log shows every errored `ToolResult`; model view shows only those the projection emitted and the content guard trusts (shared `model_shown_result` helper, so flags and count can't drift). The jump selector (`.card.tool.error`) and indexing match that count, so prev/next never targets an off-screen card.

## Verification

- `moon check` (js) clean; `moon fmt` applied; **17/17 viz tests** pass — added tests for the turn badge, `rendered_error_count` across both views, and the compacted-away-failure case (raw counts it, model view doesn't).
- End-to-end: confirmed the shell CSS and rebuilt `viz_app.js` carry the new controls/filter; against a real session (35 failures) the bar renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)