### PR TITLE
[codex] Validate MoonBit manifest edits with moon_config

### DIFF
--- a/agent_tool/edit/internal/manifest_error/README.mbt.md
+++ b/agent_tool/edit/internal/manifest_error/README.mbt.md
@@ -6,6 +6,9 @@ safety checks used before the `edit` tool writes replacement content.
 This package is internal to `agent_tool/edit`. It does not edit files itself;
 it inspects the target path and proposed file content, then returns an optional
 error message for manifest rewrites that look like common agent mistakes.
+`moon.mod`, `moon.pkg`, and `moon.work` writes are also parsed with
+`moonbitlang/moon_config` so malformed current-syntax manifests are rejected at
+the edit boundary.
 
 ## API Shape
 
@@ -17,8 +20,12 @@ error message for manifest rewrites that look like common agent mistakes.
 The guard is intentionally narrow and only handles MoonBit manifest paths:
 
 - New `moon.mod.json` files are rejected because that manifest is legacy.
-- `moon.mod` is rejected when it is empty, JSON-shaped, or missing `name =`.
-- `moon.pkg` is rejected when it is suspiciously tiny or JSON-shaped.
+- `moon.mod` is rejected when it is empty, JSON-shaped, missing `name =`, or
+  rejected by the `moon_config` parser.
+- `moon.pkg` is rejected when it is suspiciously tiny, JSON-shaped, or rejected
+  by the `moon_config` parser.
+- `moon.work` is rejected when it is JSON-shaped or rejected by the
+  `moon_config` parser.
 - Other paths are allowed.
 
 Existing `moon.mod.json` files are allowed so `edit` can still update legacy

--- a/agent_tool/edit/internal/manifest_error/manifest_error.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error.mbt
@@ -10,12 +10,13 @@
 /// manifest fail every later build step.
 pub async fn write_error(path : String, content : String) -> String? {
   let trimmed = content.trim().to_owned()
+  let normalized = normalize_manifest_path(path)
   if is_moon_mod_json_path(path) && !@fs.exists(path) {
     return Some(
       "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
     )
   }
-  if is_moon_mod_path(path) {
+  if is_moon_mod_path(normalized) {
     if trimmed == "" {
       return Some("moon.mod must not be empty")
     }
@@ -25,32 +26,63 @@ pub async fn write_error(path : String, content : String) -> String? {
     if !trimmed.contains("name =") {
       return Some("moon.mod should include a module `name = ...` entry")
     }
+    let (_, reports) = @moon_config.parse_moon_mod(content)
+    if reports.length() > 0 {
+      return Some(manifest_report_error("moon.mod", reports[0].msg))
+    }
   }
-  if is_moon_pkg_path(path) {
+  if is_moon_pkg_path(normalized) {
     if trimmed.length() < 8 {
       return Some("moon.pkg content is suspiciously small")
     }
     if trimmed.has_prefix("{") {
       return Some("moon.pkg uses current text syntax, not JSON")
     }
+    let (_, reports) = @moon_config.parse_moon_pkg(content)
+    if reports.length() > 0 {
+      return Some(manifest_report_error("moon.pkg", reports[0].msg))
+    }
+  }
+  if is_moon_work_path(normalized) {
+    if trimmed.has_prefix("{") {
+      return Some("moon.work uses current text syntax, not JSON")
+    }
+    let (_, reports) = @moon_config.parse_moon_work(content)
+    if reports.length() > 0 {
+      return Some(manifest_report_error("moon.work", reports[0].msg))
+    }
   }
   None
 }
 
 ///|
-fn is_moon_mod_path(path : String) -> Bool {
+fn normalize_manifest_path(path : String) -> String {
   let path = path.replace_all(old="\\", new="/")
+  path
+}
+
+///|
+fn manifest_report_error(manifest : String, message : String) -> String {
+  "\{manifest} is invalid: \{message}"
+}
+
+///|
+fn is_moon_mod_path(path : String) -> Bool {
   path == "moon.mod" || path.has_suffix("/moon.mod")
 }
 
 ///|
 fn is_moon_mod_json_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
+  let path = normalize_manifest_path(path)
   path == "moon.mod.json" || path.has_suffix("/moon.mod.json")
 }
 
 ///|
 fn is_moon_pkg_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
   path == "moon.pkg" || path.has_suffix("/moon.pkg")
+}
+
+///|
+fn is_moon_work_path(path : String) -> Bool {
+  path == "moon.work" || path.has_suffix("/moon.work")
 }

--- a/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
@@ -4,6 +4,29 @@ async test "manifest error allows ordinary files" {
 }
 
 ///|
+async test "manifest error accepts valid current manifests" {
+  let moon_mod =
+    #|name = "user/demo"
+    #|version = "0.1.0"
+    #|
+  assert_true(@manifest_error.write_error("moon.mod", moon_mod) is None)
+  let moon_pkg =
+    #|import {
+    #|  "moonbitlang/core/json",
+    #|}
+    #|
+    #|warnings = "+unnecessary_annotation"
+    #|
+  assert_true(@manifest_error.write_error("moon.pkg", moon_pkg) is None)
+  let moon_work =
+    #|members = [
+    #|  ".",
+    #|]
+    #|
+  assert_true(@manifest_error.write_error("moon.work", moon_work) is None)
+}
+
+///|
 async test "manifest error rejects new moon.mod.json" {
   let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
   let path = "\{dir}/moon.mod.json"
@@ -42,6 +65,24 @@ async test "manifest error rejects invalid moon.mod content" {
 }
 
 ///|
+async test "manifest error rejects parser-reported invalid moon.mod content" {
+  let unexpected_key_content =
+    #|name = "user/demo"
+    #|deps = []
+    #|
+  guard @manifest_error.write_error("moon.mod", unexpected_key_content)
+    is Some(unexpected_key) else {
+    fail("expected unexpected key moon.mod error")
+  }
+  assert_true(unexpected_key.contains("moon.mod is invalid"))
+  assert_true(unexpected_key.contains("unexpected key `deps`"))
+  guard @manifest_error.write_error("moon.mod", "name =") is Some(syntax) else {
+    fail("expected syntax moon.mod error")
+  }
+  assert_true(syntax.contains("moon.mod is invalid"))
+}
+
+///|
 async test "manifest error rejects invalid moon.pkg content" {
   guard @manifest_error.write_error("moon.pkg", "x") is Some(tiny) else {
     fail("expected tiny moon.pkg error")
@@ -51,6 +92,39 @@ async test "manifest error rejects invalid moon.pkg content" {
     fail("expected JSON moon.pkg error")
   }
   assert_eq(json, "moon.pkg uses current text syntax, not JSON")
+}
+
+///|
+async test "manifest error rejects parser-reported invalid moon.pkg content" {
+  guard @manifest_error.write_error("moon.pkg", "name = \"demo\"")
+    is Some(unexpected_key) else {
+    fail("expected unexpected key moon.pkg error")
+  }
+  assert_true(unexpected_key.contains("moon.pkg is invalid"))
+  assert_true(unexpected_key.contains("unexpected key `name`"))
+  guard @manifest_error.write_error("moon.pkg", "import {") is Some(syntax) else {
+    fail("expected syntax moon.pkg error")
+  }
+  assert_true(syntax.contains("moon.pkg is invalid"))
+}
+
+///|
+async test "manifest error rejects invalid moon.work content" {
+  guard @manifest_error.write_error("moon.work", "{\"members\":[]}")
+    is Some(json) else {
+    fail("expected JSON moon.work error")
+  }
+  assert_eq(json, "moon.work uses current text syntax, not JSON")
+  guard @manifest_error.write_error("moon.work", "workspace = []")
+    is Some(unexpected_key) else {
+    fail("expected unexpected key moon.work error")
+  }
+  assert_true(unexpected_key.contains("moon.work is invalid"))
+  assert_true(unexpected_key.contains("unexpected key `workspace`"))
+  guard @manifest_error.write_error("moon.work", "members = [") is Some(syntax) else {
+    fail("expected syntax moon.work error")
+  }
+  assert_true(syntax.contains("moon.work is invalid"))
 }
 
 ///|
@@ -74,4 +148,11 @@ async test "manifest error accepts Windows path separators" {
   assert_eq(
     moon_mod_json, "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
   )
+  guard @manifest_error.write_error(
+      "C:\\workspace\\moon.work", "{\"members\":[]}",
+    )
+    is Some(moon_work) else {
+    fail("expected moon.work error")
+  }
+  assert_eq(moon_work, "moon.work uses current text syntax, not JSON")
 }

--- a/agent_tool/edit/internal/manifest_error/moon.pkg
+++ b/agent_tool/edit/internal/manifest_error/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/async/fs",
+  "moonbitlang/moon_config",
 }
 
 import {

--- a/moon.mod
+++ b/moon.mod
@@ -10,6 +10,7 @@ import {
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",
   "moonbit-community/rabbita@0.12.4",
+  "moonbitlang/moon_config@0.3.4",
 }
 
 readme = "README.mbt.md"


### PR DESCRIPTION
## Summary

- Add `moonbitlang/moon_config` and use it in the edit manifest guard.
- Validate proposed `moon.mod`, `moon.pkg`, and `moon.work` writes with the parser before accepting them.
- Keep the existing clearer guardrails for legacy `moon.mod.json`, JSON-shaped manifests, empty `moon.mod`, and suspiciously tiny `moon.pkg`.
- Extend manifest guard tests and README coverage for the parser-backed behavior.

## Why

The edit tool previously used narrow string heuristics for MoonBit manifest writes. That caught some common mistakes, but malformed current-syntax manifests could still be written and only fail later during build or test commands. `moonbitlang/moon_config` provides the parser-backed validation needed to reject those writes at the edit boundary.

## Validation

- `moon check`
- `moon info`
- `moon fmt`
- `moon test` -> 585 passed, 0 failed
