### PR TITLE
feat: land tool briefs on main (re-merge of #175)

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -523,6 +523,7 @@ pub async fn[X] run_turn_in_scope(
               tool_name=tool_call.name,
               content=output.content,
               is_error=output.is_error,
+              brief?=output.brief,
             ),
           ),
         )

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -80,7 +80,8 @@ pub fn SessionSummary::to_sequence(Self) -> Int
 pub struct ToolResult {
   // private fields
 } derive(ToJson, @debug.Debug, @json.FromJson)
-pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool) -> Self
+pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool, brief? : String) -> Self
+pub fn ToolResult::brief(Self) -> String?
 pub fn ToolResult::content(Self) -> String
 pub fn ToolResult::is_error(Self) -> Bool
 pub fn ToolResult::tool_call_id(Self) -> String

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -52,6 +52,31 @@ test "event timestamps round trip through JSON" {
 }
 
 ///|
+test "ToolResult brief is optional and backwards compatible" {
+  // A record written before briefs existed (no `brief` key) must still decode,
+  // with `brief` defaulting to None — old logs keep parsing.
+  let legacy_json =
+    #|{"tool_call_id":"call_1","tool_name":"read","content":"README","is_error":false}
+  let legacy : @agent_session.ToolResult = @json.from_json(
+    @json.parse(legacy_json),
+  )
+  guard legacy.brief() is None else { fail("legacy brief should be None") }
+  assert_eq(legacy.content(), "README")
+  // A brief round-trips when present.
+  let with_brief = @agent_session.ToolResult(
+    tool_call_id="call_2",
+    tool_name="shell",
+    content="exit=0\na\nb",
+    brief="ran ls → 2 files",
+  )
+  let decoded : @agent_session.ToolResult = @json.from_json(
+    with_brief.to_json(),
+  )
+  guard decoded.brief() is Some(text) else { fail("brief should round-trip") }
+  assert_eq(text, "ran ls → 2 files")
+}
+
+///|
 test "session projects to DeepSeek chat messages" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("inspect")))

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -203,6 +203,7 @@ pub struct ToolResult {
   priv tool_name : String
   priv content : String
   priv is_error : Bool
+  priv brief : String?
 } derive(Debug, ToJson, FromJson)
 
 ///|
@@ -213,13 +214,20 @@ pub struct ToolResult {
 /// `content` is exactly what will be replayed to the model. `is_error`
 /// classifies the content for callers, but the DeepSeek projection currently
 /// sends the same text shape either way.
+///
+/// `brief` is an optional one-line, human-readable summary of what the call did
+/// (e.g. `ran ls → 12 files`), for display only — it is never replayed to the
+/// model. It is optional so logs written before briefs existed (no `brief` key)
+/// still parse, decoding to `None`, exactly like `AssistantMessage`'s
+/// `reasoning_content`.
 pub fn ToolResult::ToolResult(
   tool_call_id~ : String,
   tool_name~ : String,
   content~ : String,
   is_error? : Bool = false,
+  brief? : String,
 ) -> ToolResult {
-  { tool_call_id, tool_name, content, is_error }
+  { tool_call_id, tool_name, content, is_error, brief }
 }
 
 ///|
@@ -246,6 +254,14 @@ pub fn ToolResult::tool_name(self : ToolResult) -> String {
 /// successful result.
 pub fn ToolResult::content(self : ToolResult) -> String {
   self.content
+}
+
+///|
+/// Return the optional one-line human summary of the call, or `None` for results
+/// recorded before briefs existed (or by tools that supply none). Display only —
+/// never part of what the model is replayed.
+pub fn ToolResult::brief(self : ToolResult) -> String? {
+  self.brief
 }
 
 ///|

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -81,16 +81,22 @@ pub struct ToolOutput {
   /// Whether the host should treat this as a tool-level error. The content is
   /// still sent to the model so it can recover or choose another action.
   is_error : Bool
+  /// Optional one-line human summary of what this call did (e.g. `ran ls → 12
+  /// files`). Display-only: persisted on the `ToolResult` for the visualizer and
+  /// never sent to the model. `None` when the tool supplies no brief.
+  brief : String?
 } derive(Debug)
 
 ///|
 /// Constructs typed tool output. `is_error` defaults to `false` for ordinary
-/// successful tool responses.
+/// successful tool responses; `brief` is omitted unless the tool supplies a
+/// one-line summary.
 pub fn ToolOutput::ToolOutput(
   content : String,
   is_error? : Bool = false,
+  brief? : String,
 ) -> ToolOutput {
-  { content, is_error }
+  { content, is_error, brief }
 }
 
 ///|
@@ -113,12 +119,54 @@ pub(all) enum ToolAction {
 } derive(Debug)
 
 ///|
-/// Builds a normal tool response action.
+/// Builds a normal tool response action. `brief` is an optional one-line summary
+/// surfaced in the visualizer (see `ToolOutput::brief`); it never reaches the
+/// model.
 pub fn ToolAction::respond(
   content : String,
   is_error? : Bool = false,
+  brief? : String,
 ) -> ToolAction {
-  Respond(ToolOutput(content, is_error~))
+  Respond(ToolOutput(content, is_error~, brief?))
+}
+
+///|
+/// Build a one-line tool brief: collapse `text` to a single line, trim it, and
+/// cap it to `limit` characters (appending `…` when cut). Iterates by character
+/// so a cap never splits a surrogate pair. Helper for tools assembling a brief.
+pub fn brief_line(text : String, limit? : Int = 72) -> String {
+  let one = text.replace_all(old="\n", new=" ").trim().to_owned()
+  if one.length() <= limit {
+    return one
+  }
+  let kept = StringBuilder()
+  let mut count = 0
+  for ch in one {
+    if count >= limit {
+      break
+    }
+    kept.write_char(ch)
+    count += 1
+  }
+  "\{kept.to_string()}…"
+}
+
+///|
+/// The final path segment of `path` (after the last `/` or `\`), for briefs that
+/// name a file without its directory. Returns `path` unchanged when it has no
+/// separator.
+pub fn brief_basename(path : String) -> String {
+  let cut = match (path.rev_find("/"), path.rev_find("\\")) {
+    (Some(a), Some(b)) => if a > b { a } else { b }
+    (Some(a), None) => a
+    (None, Some(b)) => b
+    (None, None) => -1
+  }
+  if cut < 0 {
+    path
+  } else {
+    path[cut + 1:].to_owned()
+  }
 }
 
 ///|

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -115,6 +115,7 @@ async fn edit_file(
     @fs.write_file(path, new_content, create_mode=CreateOrTruncate)
     @agent_tool.ToolAction::respond(
       "ok: replaced \{replacement_count} occurrence(s) in \{path}",
+      brief="edited \{@agent_tool.brief_basename(path)} (\{replacement_count}×)",
     )
   } catch {
     error =>

--- a/agent_tool/moon_cmd/moon_cmd.mbt
+++ b/agent_tool/moon_cmd/moon_cmd.mbt
@@ -133,9 +133,12 @@ async fn moon_cmd(input : @decode.MoonCommandInput) -> @agent_tool.ToolAction {
   let body = output.text()
   let capped = cap_text(body, input.max_output_chars)
   let truncation = truncation_header(body, input.max_output_chars)
+  let head = @agent_tool.brief_line("moon \{args.join(" ")}", limit=64)
+  let brief = if code != 0 { "\{head} → exit \{code}" } else { head }
   @agent_tool.ToolAction::respond(
     "cwd=\{cwd_text}\ncommand=moon \{args.join(" ")}\{update_review}\{stdin_review}\nexit=\{code}\{truncation}\n\{capped}",
     is_error=code != 0 || is_truncated(body, input.max_output_chars),
+    brief~,
   )
 }
 

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -7,6 +7,10 @@ import {
 }
 
 // Values
+pub fn brief_basename(String) -> String
+
+pub fn brief_line(String, limit? : Int) -> String
+
 pub async fn execute_tool_call(AgentToolCall, Tools) -> ToolAction
 
 // Errors
@@ -39,7 +43,7 @@ pub(all) enum ToolAction {
 } derive(@debug.Debug)
 pub fn ToolAction::abort(String) -> Self
 pub fn ToolAction::finish(String) -> Self
-pub fn ToolAction::respond(String, is_error? : Bool) -> Self
+pub fn ToolAction::respond(String, is_error? : Bool, brief? : String) -> Self
 
 pub(all) enum ToolExecutor {
   Async(async (Json) -> ToolAction)
@@ -49,8 +53,9 @@ pub(all) enum ToolExecutor {
 pub struct ToolOutput {
   content : String
   is_error : Bool
+  brief : String?
 } derive(@debug.Debug)
-pub fn ToolOutput::ToolOutput(String, is_error? : Bool) -> Self
+pub fn ToolOutput::ToolOutput(String, is_error? : Bool, brief? : String) -> Self
 
 pub struct Tools {
   // private fields

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -113,7 +113,11 @@ async fn read_file(
   } else {
     capped
   }
-  @agent_tool.ToolAction::respond(output, is_error=char_truncated)
+  @agent_tool.ToolAction::respond(
+    output,
+    is_error=char_truncated,
+    brief="read \{@agent_tool.brief_basename(path)}",
+  )
 }
 
 ///|
@@ -181,6 +185,7 @@ async fn read_files(
   @agent_tool.ToolAction::respond(
     blocks.join("\n\n"),
     is_error=failures == paths.length() || truncated_any,
+    brief="read \{paths.length()} files",
   )
 }
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -139,7 +139,22 @@ async fn shell(
     }
   }
   let response = shell_response(output, input.max_output_chars)
-  @agent_tool.ToolAction::respond(response.content, is_error=response.is_error)
+  @agent_tool.ToolAction::respond(
+    response.content,
+    is_error=response.is_error,
+    brief=shell_brief(input.cmd, output.exit_code),
+  )
+}
+
+///|
+/// One-line brief for a shell call: the command, plus the exit code when the
+/// command failed.
+fn shell_brief(cmd : String, exit_code : Int?) -> String {
+  let head = @agent_tool.brief_line(cmd, limit=64)
+  match exit_code {
+    Some(code) if code != 0 => "\{head} → exit \{code}"
+    _ => head
+  }
 }
 
 ///|

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -72,6 +72,9 @@ async fn write_file(
     @fs.write_file(path, input.content, create_mode=CreateOrTruncate)
     @agent_tool.ToolAction::respond(
       "ok: wrote \{input.content.length()} chars to \{path}",
+      brief=@agent_tool.brief_line(
+        "wrote \{input.content.length()} chars to \{input.path}",
+      ),
     )
   } catch {
     error =>

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -295,8 +295,11 @@ fn tool_call_view(
 
 ///|
 /// Map each tool call's id to the one-line brief its result recorded, for the
-/// folded call line. Only results that carry a brief appear; older logs and
-/// briefless tools simply produce no entry (the call renders as a plain name).
+/// folded call line. Indexes every durable result, which is correct for the raw
+/// view (it shows every event); the model view instead uses
+/// `model_tool_call_briefs` so it never captions a compacted/healed call. Only
+/// results that carry a brief appear; older logs and briefless tools produce no
+/// entry (the call renders as a plain name).
 fn tool_call_briefs(session : @agent_session.Session) -> Map[String, String] {
   let briefs : Map[String, String] = Map([])
   for event in session.events() {
@@ -379,8 +382,12 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
   // name, so recover them from the durable events for display (the messages fed
   // to the model are unchanged — this is view-only enrichment).
   let tool_results = tool_results_by_id(session)
-  let briefs = tool_call_briefs(session)
   let messages = session.chat_messages()
+  // Model-view briefs must come only from results the projection actually
+  // emitted and the view trusts (see `model_shown_result`); using every durable
+  // brief would caption a healed/compacted call with a result the model never
+  // saw. The raw view, which shows every event, uses all briefs.
+  let briefs = model_tool_call_briefs(messages, tool_results)
   let cards : Array[@html.Html] = [
     for message in messages => message_card(message, tool_results, briefs)
   ]
@@ -388,6 +395,26 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
     return empty_state("The model projection is empty.")
   }
   @html.div(class="log model-log", cards)
+}
+
+///|
+/// Briefs for the model view: keyed by call id, but only from the durable result
+/// the projection emitted for that call and whose content the view trusts. A
+/// compacted-away or healed result contributes no brief, so the call line never
+/// shows a summary the model was not actually fed.
+fn model_tool_call_briefs(
+  messages : Array[@deepseek.ChatMessage],
+  tool_results : Map[String, @agent_session.ToolResult],
+) -> Map[String, String] {
+  let briefs : Map[String, String] = Map([])
+  for message in messages {
+    guard message.role is Tool(id) else { continue }
+    if model_shown_result(message, tool_results) is Some(result) &&
+      result.brief() is Some(brief) {
+      briefs.set(id, brief)
+    }
+  }
+  briefs
 }
 
 ///|

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -58,10 +58,11 @@ pub fn render_notices(parsed : @session_log.ParsedLog) -> @html.Html {
 
 ///|
 fn render_raw(session : @agent_session.Session) -> @html.Html {
+  let briefs = tool_call_briefs(session)
   let turns = group_turns(session.events())
   let blocks : Array[@html.Html] = []
   for index, turn in turns {
-    blocks.push(turn_block(index + 1, turn))
+    blocks.push(turn_block(index + 1, turn, briefs))
   }
   if blocks.is_empty() {
     return empty_state("This session has no events yet.")
@@ -97,13 +98,16 @@ fn group_turns(
 fn turn_block(
   number : Int,
   turn : Array[@agent_session.SessionEvent],
+  briefs : Map[String, String],
 ) -> @html.Html {
   // Offsets are relative to the turn's first stamped event: for reading a
   // log, "how far into the turn" answers latency questions directly, where
   // absolute wall clock would force mental subtraction (and a timezone).
   let base = turn_base_ms(turn)
   let cards : Array[@html.Html] = [
-    for event in turn => event_card(event, time=offset_label(base, event))
+    for event in turn => {
+      event_card(event, time=offset_label(base, event), briefs)
+    }
   ]
   let label = match turn_duration_label(turn) {
     Some(duration) => "Turn \{number} · \{turn_preview(turn)} · \{duration}"
@@ -215,12 +219,13 @@ fn turn_preview(turn : Array[@agent_session.SessionEvent]) -> String {
 fn event_card(
   event : @agent_session.SessionEvent,
   time~ : String,
+  briefs : Map[String, String],
 ) -> @html.Html {
   let seq = event.sequence()
   match event.item() {
     User(message) =>
       card("user", "User", seq, time~, [text_block(message.content())])
-    Assistant(message) => assistant_card(seq, time, message)
+    Assistant(message) => assistant_card(seq, time, message, briefs)
     Tool(result) => tool_card(seq, time, result)
     Runtime(notice) =>
       card("runtime", "Runtime notice", seq, time~, [
@@ -236,6 +241,7 @@ fn assistant_card(
   seq : Int,
   time : String,
   message : @agent_session.AssistantMessage,
+  briefs : Map[String, String],
 ) -> @html.Html {
   let body : Array[@html.Html] = []
   if message.reasoning_content() is Some(reasoning) &&
@@ -253,7 +259,7 @@ fn assistant_card(
   let calls = message.tool_calls()
   if !calls.is_empty() {
     let call_views : Array[@html.Html] = [
-      for call in calls => tool_call_view(call)
+      for call in calls => tool_call_view(call, briefs)
     ]
     body.push(@html.div(class="tool-calls", call_views))
   }
@@ -264,11 +270,17 @@ fn assistant_card(
 /// A tool call, with its arguments folded away by default: the row shows only
 /// the tool name and expands to the full argument JSON on click. Calls with no
 /// meaningful arguments render as a plain name (nothing to fold).
-fn tool_call_view(call : @deepseek.ToolCall) -> @html.Html {
+fn tool_call_view(
+  call : @deepseek.ToolCall,
+  briefs : Map[String, String],
+) -> @html.Html {
   let name_row : Array[@html.Html] = [
     @html.text("→ "),
     @html.strong(call.name),
   ]
+  if briefs.get(call.id) is Some(brief) && !brief.trim().is_empty() {
+    name_row.push(@html.span(class="tool-call-brief", " · \{brief}"))
+  }
   let args = pretty_json(call.arguments)
   if is_blank_args(args) {
     return @html.div(class="tool-call", [
@@ -279,6 +291,20 @@ fn tool_call_view(call : @deepseek.ToolCall) -> @html.Html {
     @html.summary(class="tool-call-name", name_row),
     @html.pre(class="tool-call-args", args),
   ])
+}
+
+///|
+/// Map each tool call's id to the one-line brief its result recorded, for the
+/// folded call line. Only results that carry a brief appear; older logs and
+/// briefless tools simply produce no entry (the call renders as a plain name).
+fn tool_call_briefs(session : @agent_session.Session) -> Map[String, String] {
+  let briefs : Map[String, String] = Map([])
+  for event in session.events() {
+    if event.item() is Tool(result) && result.brief() is Some(brief) {
+      briefs.set(result.tool_call_id(), brief)
+    }
+  }
+  briefs
 }
 
 ///|
@@ -353,9 +379,10 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
   // name, so recover them from the durable events for display (the messages fed
   // to the model are unchanged — this is view-only enrichment).
   let tool_results = tool_results_by_id(session)
+  let briefs = tool_call_briefs(session)
   let messages = session.chat_messages()
   let cards : Array[@html.Html] = [
-    for message in messages => message_card(message, tool_results)
+    for message in messages => message_card(message, tool_results, briefs)
   ]
   if cards.is_empty() {
     return empty_state("The model projection is empty.")
@@ -382,6 +409,7 @@ fn tool_results_by_id(
 fn message_card(
   message : @deepseek.ChatMessage,
   tool_results : Map[String, @agent_session.ToolResult],
+  briefs : Map[String, String],
 ) -> @html.Html {
   match message.role {
     System =>
@@ -391,8 +419,8 @@ fn message_card(
           text_block(message.content),
         ]),
       ])
-    User => model_card("user", "User", message)
-    Assistant => model_card("assistant", "Assistant", message)
+    User => model_card("user", "User", message, briefs)
+    Assistant => model_card("assistant", "Assistant", message, briefs)
     Tool(_) =>
       model_tool_card(message, model_shown_result(message, tool_results))
   }
@@ -490,6 +518,7 @@ fn model_card(
   kind : String,
   label : String,
   message : @deepseek.ChatMessage,
+  briefs : Map[String, String],
 ) -> @html.Html {
   let body : Array[@html.Html] = []
   if message.reasoning_content is Some(reasoning) &&
@@ -506,7 +535,7 @@ fn model_card(
   }
   if !message.tool_calls.is_empty() {
     let call_views : Array[@html.Html] = [
-      for call in message.tool_calls => tool_call_view(call)
+      for call in message.tool_calls => tool_call_view(call, briefs)
     ]
     body.push(@html.div(class="tool-calls", call_views))
   }

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -146,6 +146,36 @@ test "successful tool result folds without a flag" {
 }
 
 ///|
+test "tool call shows the brief its result recorded" {
+  let session = @agent_session.Session(SessionId("b"), system_prompt="")
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(id="c1", name="shell", arguments="{\"cmd\":\"ls\"}"),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="shell",
+          content="exit=0\na",
+          brief="ran ls → 1 file",
+        ),
+      ),
+    )
+  let raw = render(@viz.render_session(session, RawLog))
+  assert_true(raw.contains("tool-call-brief"))
+  assert_true(raw.contains("ran ls → 1 file"))
+  let model = render(@viz.render_session(session, ModelView))
+  assert_true(model.contains("ran ls → 1 file"))
+  // A result with no brief produces no brief span on its call.
+  let plain = render(@viz.render_session(error_tool_session(), RawLog))
+  assert_false(plain.contains("tool-call-brief"))
+}
+
+///|
 test "turn header badges failed tools" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   assert_true(html.contains("turn-error-badge"))

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -176,6 +176,46 @@ test "tool call shows the brief its result recorded" {
 }
 
 ///|
+test "model view omits a brief whose result was compacted away" {
+  let session = @agent_session.Session(SessionId("cb"), system_prompt="")
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(id="c1", name="shell", arguments="{\"cmd\":\"ls\"}"),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="shell",
+          content="files",
+          brief="ran ls → 3 files",
+        ),
+      ),
+    )
+  // Compact away only the result (seq 2): the model projection heals the call
+  // with a synthetic result, so the model never saw this brief.
+  let compacted = session.compact(
+    content="covered",
+    from_sequence=2,
+    to_sequence=2,
+  )
+  // Raw shows the durable brief on the call; the model view must not.
+  assert_true(
+    render(@viz.render_session(compacted, RawLog)).contains(
+      "ran ls → 3 files",
+    ),
+  )
+  assert_false(
+    render(@viz.render_session(compacted, ModelView)).contains(
+      "ran ls → 3 files",
+    ),
+  )
+}
+
+///|
 test "turn header badges failed tools" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   assert_true(html.contains("turn-error-badge"))

--- a/web/index.html
+++ b/web/index.html
@@ -283,6 +283,7 @@
     .tool-calls { margin-top: 8px; }
     .tool-call { border: 1px dashed var(--border); border-radius: 6px; padding: 6px 10px; margin-top: 6px; }
     .tool-call-name { font-size: 13px; }
+    .tool-call-brief { color: var(--muted); font-family: ui-monospace, monospace; font-size: 12px; }
     details.tool-call > summary.tool-call-name { cursor: pointer; }
     details.tool-call[open] > summary.tool-call-name { margin-bottom: 4px; }
     .tool-call-args { margin: 0; white-space: pre-wrap; font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); }


### PR DESCRIPTION
## Why

#175 (tool briefs) was merged into its base branch **`viz-find-failures` (#173)**, not into `main`. But #173 had already been squash-merged into `main` ~2.5 minutes *earlier*, so the brief commits never reached `main`. As a result, `ToolResult` on `main` has no `brief` field, the shell/read/write/edit/moon_cmd tools don't emit one, and the viz renders every tool call as the plain name (e.g. `shell`).

This re-lands the two brief commits from #175 onto `main` (clean cherry-pick — the #173 content is already in main):

- `feat: tools emit a one-line brief, shown on the folded call`
- `fix(viz): derive model-view briefs from the projection, not all events`

## What it restores

`ToolResult.brief : String?` (optional, backwards-compatible), the tool wiring that records a brief, and the viz display on the folded call line (`→ shell · ls -la → exit 0`), correlated by `tool_call_id`. Briefs appear on **new** sessions recorded after this lands; existing logs stay plain.

## Verification

- Clean cherry-pick onto current `main`, no conflicts.
- `moon fmt --check` clean; `moon check --deny-warn` clean (native + js).
- Tests: agent_tool + agent_session **30/30**, viz **19/19** (includes the brief round-trip/backcompat and model-view-projection tests from #175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)