### PR TITLE
feat(viz): flag failed tool calls + error-path briefs (read/write/edit)

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -61,16 +61,21 @@ async fn edit_file(
   input : @decode.EditInput,
   path~ : String,
 ) -> @agent_tool.ToolAction {
+  // Every failure names the file it tried to edit so the viz can show
+  // `→ edit · edit <file> 🚩` on the folded call line.
+  let fail_brief = "edit \{@agent_tool.brief_basename(path)}"
   if input.old_string == "" {
     return @agent_tool.ToolAction::respond(
       "error editing \{path}: old_string must be non-empty",
       is_error=true,
+      brief=fail_brief,
     )
   }
   if input.old_string == input.new_string {
     return @agent_tool.ToolAction::respond(
       "error editing \{path}: old_string and new_string are identical",
       is_error=true,
+      brief=fail_brief,
     )
   }
   let content = @fs.read_file(path).text() catch {
@@ -78,6 +83,7 @@ async fn edit_file(
       return @agent_tool.ToolAction::respond(
         "error editing \{path}: error reading file: \{error}",
         is_error=true,
+        brief=fail_brief,
       )
   }
   let parts = content
@@ -89,12 +95,14 @@ async fn edit_file(
     return @agent_tool.ToolAction::respond(
       "error editing \{path}: old_string not found",
       is_error=true,
+      brief=fail_brief,
     )
   }
   if occurrences > 1 && !input.replace_all {
     return @agent_tool.ToolAction::respond(
       ambiguous_match_message(path, occurrences, parts, input.old_string),
       is_error=true,
+      brief=fail_brief,
     )
   }
   let replacement_count = if input.replace_all { occurrences } else { 1 }
@@ -108,6 +116,7 @@ async fn edit_file(
       return @agent_tool.ToolAction::respond(
         "error editing \{path}: \{message}",
         is_error=true,
+        brief=fail_brief,
       )
     None => ()
   }
@@ -122,6 +131,7 @@ async fn edit_file(
       @agent_tool.ToolAction::respond(
         "error editing \{path}: error writing file: \{error}",
         is_error=true,
+        brief=fail_brief,
       )
   }
 }

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -18,6 +18,23 @@ async fn run_edit_in_workspace(
 }
 
 ///|
+async test "a failed edit names the file in its brief" {
+  @vfs.with_tmpdir(dir => {
+    // Editing a missing file fails; the error still briefs the target file so
+    // the viz shows `→ edit · edit ghost.mbt 🚩`.
+    let result = run_edit({
+      "path": "\{dir}/ghost.mbt",
+      "old_string": "a",
+      "new_string": "b",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    guard output.brief is Some(brief) else { fail("expected a brief") }
+    assert_eq(brief, "edit ghost.mbt")
+  })
+}
+
+///|
 async test "edit replaces a unique exact match" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/unique.txt"

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -100,6 +100,7 @@ async fn read_file(
       return @agent_tool.ToolAction::respond(
         "error reading \{path}: \{error}",
         is_error=true,
+        brief="read \{@agent_tool.brief_basename(path)}",
       )
   }
   let selection = select_lines(content, input.start_line, input.max_lines)

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -66,6 +66,7 @@ async fn write_file(
         return @agent_tool.ToolAction::respond(
           "error writing \{path}: \{message}",
           is_error=true,
+          brief="write \{@agent_tool.brief_basename(path)}",
         )
       None => ()
     }
@@ -81,6 +82,7 @@ async fn write_file(
       @agent_tool.ToolAction::respond(
         "error writing \{path}: \{error}",
         is_error=true,
+        brief="write \{@agent_tool.brief_basename(path)}",
       )
   }
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -304,8 +304,7 @@ fn tool_call_briefs(session : @agent_session.Session) -> Map[String, String] {
   let briefs : Map[String, String] = Map([])
   for event in session.events() {
     if event.item() is Tool(result) {
-      let display = call_brief_display(result.brief(), result.is_error())
-      if display != "" {
+      if call_brief_display(result.brief(), result.is_error()) is Some(display) {
         briefs.set(result.tool_call_id(), display)
       }
     }
@@ -316,18 +315,14 @@ fn tool_call_briefs(session : @agent_session.Session) -> Map[String, String] {
 ///|
 /// The folded-call brief text: the tool's one-line brief (if any) plus a red
 /// flag when its result errored, so a failed call (e.g. a missing-file `read`)
-/// stands out in the assistant's action list without expanding it. Returns `""`
-/// when there is nothing to show (a successful call with no brief).
-fn call_brief_display(brief : String?, is_error : Bool) -> String {
-  let base = match brief {
-    Some(text) => text
-    None => ""
-  }
-  match (base, is_error) {
-    ("", false) => ""
-    ("", true) => "🚩"
-    (text, false) => text
-    (text, true) => "\{text} 🚩"
+/// stands out in the assistant's action list without expanding it. `None` when
+/// there is nothing to show (a successful call with no brief).
+fn call_brief_display(brief : String?, is_error : Bool) -> String? {
+  match (brief, is_error) {
+    (None, false) => None
+    (None, true) => Some("🚩")
+    (Some(text), false) => Some(text)
+    (Some(text), true) => Some("\{text} 🚩")
   }
 }
 
@@ -430,11 +425,9 @@ fn model_tool_call_briefs(
   let briefs : Map[String, String] = Map([])
   for message in messages {
     guard message.role is Tool(id) else { continue }
-    if model_shown_result(message, tool_results) is Some(result) {
-      let display = call_brief_display(result.brief(), result.is_error())
-      if display != "" {
-        briefs.set(id, display)
-      }
+    if model_shown_result(message, tool_results) is Some(result) &&
+      call_brief_display(result.brief(), result.is_error()) is Some(display) {
+      briefs.set(id, display)
     }
   }
   briefs

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -303,11 +303,32 @@ fn tool_call_view(
 fn tool_call_briefs(session : @agent_session.Session) -> Map[String, String] {
   let briefs : Map[String, String] = Map([])
   for event in session.events() {
-    if event.item() is Tool(result) && result.brief() is Some(brief) {
-      briefs.set(result.tool_call_id(), brief)
+    if event.item() is Tool(result) {
+      let display = call_brief_display(result.brief(), result.is_error())
+      if display != "" {
+        briefs.set(result.tool_call_id(), display)
+      }
     }
   }
   briefs
+}
+
+///|
+/// The folded-call brief text: the tool's one-line brief (if any) plus a red
+/// flag when its result errored, so a failed call (e.g. a missing-file `read`)
+/// stands out in the assistant's action list without expanding it. Returns `""`
+/// when there is nothing to show (a successful call with no brief).
+fn call_brief_display(brief : String?, is_error : Bool) -> String {
+  let base = match brief {
+    Some(text) => text
+    None => ""
+  }
+  match (base, is_error) {
+    ("", false) => ""
+    ("", true) => "🚩"
+    (text, false) => text
+    (text, true) => "\{text} 🚩"
+  }
 }
 
 ///|
@@ -409,9 +430,11 @@ fn model_tool_call_briefs(
   let briefs : Map[String, String] = Map([])
   for message in messages {
     guard message.role is Tool(id) else { continue }
-    if model_shown_result(message, tool_results) is Some(result) &&
-      result.brief() is Some(brief) {
-      briefs.set(id, brief)
+    if model_shown_result(message, tool_results) is Some(result) {
+      let display = call_brief_display(result.brief(), result.is_error())
+      if display != "" {
+        briefs.set(id, display)
+      }
     }
   }
   briefs

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -170,9 +170,52 @@ test "tool call shows the brief its result recorded" {
   assert_true(raw.contains("ran ls → 1 file"))
   let model = render(@viz.render_session(session, ModelView))
   assert_true(model.contains("ran ls → 1 file"))
-  // A result with no brief produces no brief span on its call.
-  let plain = render(@viz.render_session(error_tool_session(), RawLog))
-  assert_false(plain.contains("tool-call-brief"))
+  // A *successful* result with no brief produces no brief span on its call.
+  let clean = @viz.session_from_parse(
+    @viz.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="",
+  )
+  assert_false(
+    render(@viz.render_session(clean, RawLog)).contains("tool-call-brief"),
+  )
+}
+
+///|
+test "a failed tool call is flagged on the folded call line" {
+  // error_tool_session: c1 (shell) failed with no brief -> flagged with 🚩.
+  let raw = render(@viz.render_session(error_tool_session(), RawLog))
+  assert_true(raw.contains("tool-call-brief"))
+  assert_true(raw.contains("🚩"))
+  // A failed result that carries a brief shows the brief and the flag, in both
+  // views.
+  let with_brief = @agent_session.Session(SessionId("fb"), system_prompt="")
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(id="r1", name="read", arguments="{\"path\":\"x.txt\"}"),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="r1",
+          tool_name="read",
+          content="error reading x.txt: missing",
+          is_error=true,
+          brief="read x.txt",
+        ),
+      ),
+    )
+  assert_true(
+    render(@viz.render_session(with_brief, RawLog)).contains("read x.txt 🚩"),
+  )
+  assert_true(
+    render(@viz.render_session(with_brief, ModelView)).contains(
+      "read x.txt 🚩",
+    ),
+  )
 }
 
 ///|


### PR DESCRIPTION
## What

The folded tool-call line only showed a brief on **success**, so a failed `read`/`write`/`edit` rendered as a plain `→ read` with no indication it failed. This makes failures visible at a glance in the assistant's action list.

- **Viz** — appends a 🚩 to a call's brief whenever its result errored (`call_brief_display`), in both raw and model views. Even a failed call with no brief renders `→ read 🚩`.
- **read / write / edit** — now emit a brief on their **error** paths too (the target's basename), so a failure shows what it touched: `→ read · read x.txt 🚩`, `→ write · write foo.mbt 🚩`, `→ edit · edit bar.mbt 🚩`. (shell/moon_cmd already brief failures via their exit code, so they pick up the flag automatically.)

(This re-lands a commit that was stranded when #177 merged — `call_brief_display` never reached `main` — plus the new `edit` error briefs.)

## Verification

- `moon check --deny-warn` clean; `moon fmt` applied.
- Tests: viz **20/20** (failed-call flag, with/without brief, both views), edit **18/18** (added a failed-edit-briefs-the-file test), read/write pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)