### PR TITLE
[codex] simplify brief text helpers

### DIFF
--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -135,20 +135,21 @@ pub fn ToolAction::respond(
 /// cap it to `limit` characters (appending `…` when cut). Iterates by character
 /// so a cap never splits a surrogate pair. Helper for tools assembling a brief.
 pub fn brief_line(text : String, limit? : Int = 72) -> String {
-  let one = text.replace_all(old="\n", new=" ").trim().to_owned()
+  let one = text.replace_all(old="\n", new=" ").trim()
   if one.length() <= limit {
-    return one
-  }
-  let kept = StringBuilder()
-  let mut count = 0
-  for ch in one {
-    if count >= limit {
-      break
+    "\{one}"
+  } else {
+    let kept = StringBuilder()
+    for ch in one; count = 0 {
+      if count >= limit {
+        break
+      }
+      kept.write_char(ch)
+      continue count + 1
     }
-    kept.write_char(ch)
-    count += 1
+    kept.write_char('…')
+    kept.to_string()
   }
-  "\{kept.to_string()}…"
 }
 
 ///|

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -394,18 +394,19 @@ async fn print_fleet_summary(
 /// Collapse to a single trimmed line capped at `max` characters (ellipsis when
 /// cut), iterating by character so a cap never splits a surrogate pair.
 fn one_line_brief(text : String, max : Int) -> String {
-  let one = text.replace_all(old="\n", new=" ").trim().to_owned()
+  let one = text.replace_all(old="\n", new=" ").trim()
   if one.length() <= max {
-    return one
-  }
-  let kept = StringBuilder()
-  let mut count = 0
-  for ch in one {
-    if count >= max {
-      break
+    "\{one}"
+  } else {
+    let kept = StringBuilder()
+    for ch in one; count = 0 {
+      if count >= max {
+        break
+      }
+      kept.write_char(ch)
+      continue count + 1
     }
-    kept.write_char(ch)
-    count += 1
+    kept.write_char('…')
+    kept.to_string()
   }
-  "\{kept.to_string()}…"
 }

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -674,10 +674,9 @@ fn summarize(text : String) -> String {
     .replace_all(old="\r\n", new="\n")
     .replace_all(old="\n", new=" ")
     .trim()
-    .to_owned()
   if one_line.length() <= 240 {
-    one_line
+    "\{one_line}"
   } else {
-    one_line.sub(start=0, end=240).to_owned() + "..."
+    "\{one_line.sub(start=0, end=240)}..."
   }
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -431,15 +431,14 @@ fn short_cell(text : String) -> String {
     .replace_all(old="\r\n", new="\n")
     .replace_all(old="\n", new=" ")
     .trim()
-    .to_owned()
   let out = StringBuilder::new()
-  let mut count = 0
-  for char in squashed {
+  for char in squashed; count = 0 {
     if count >= 96 {
-      return out.to_string() + "..."
+      out.write_string("...")
+      break
     }
     out.write_char(char)
-    count += 1
+    continue count + 1
   }
   out.to_string()
 }

--- a/viz/text_helpers_wbtest.mbt
+++ b/viz/text_helpers_wbtest.mbt
@@ -1,0 +1,10 @@
+///|
+test "one_line collapses newlines and trims whitespace" {
+  assert_eq(one_line("  alpha\nbeta  "), "alpha beta")
+}
+
+///|
+test "truncate caps by character without splitting surrogate pairs" {
+  assert_eq(truncate("hello world", 5), "hello…")
+  assert_eq(truncate("a🤣b", 2), "a🤣…")
+}

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -654,7 +654,8 @@ fn pretty_json(raw : String) -> String {
 
 ///|
 fn one_line(text : String) -> String {
-  text.replace_all(old="\n", new=" ").trim().to_owned()
+  let one = text.replace_all(old="\n", new=" ").trim()
+  "\{one}"
 }
 
 ///|
@@ -662,16 +663,17 @@ fn one_line(text : String) -> String {
 /// Iterates by character so it never splits a surrogate pair.
 fn truncate(text : String, limit : Int) -> String {
   if text.length() <= limit {
-    return text
-  }
-  let kept = StringBuilder()
-  let mut count = 0
-  for char in text {
-    if count >= limit {
-      break
+    text
+  } else {
+    let kept = StringBuilder()
+    for char in text; count = 0 {
+      if count >= limit {
+        break
+      }
+      kept.write_char(char)
+      continue count + 1
     }
-    kept <+ "\{char}"
-    count += 1
+    kept.write_char('…')
+    kept.to_string()
   }
-  "\{kept.to_string()}…"
 }


### PR DESCRIPTION
## Summary

- Simplify brief/summary text helpers to avoid unnecessary `mut` counters and `to_owned()` conversions.
- Generalize the same view-first cleanup across skill metadata parsing, moon-check formatting, shell/read/moon command caps, TUI/CLI trim handling, stream parsing, and report/viz counters.
- Keep public signatures and generated interfaces unchanged.
- Add focused viz white-box coverage for one-line trimming and character-safe truncation.

## Validation

- `moon check --warn-list +73` (passes with existing unnecessary-annotation warnings in `cmd/viz_server`)
- `moon test agent_skill agent_tool/edit agent_tool/moon_check agent_tool/moon_cmd agent_tool/moon_ide agent_tool/read agent_tool/shell agent_tool/write cmd/openseek cmd/tui deepseek/client eval/report tui`
- `moon test --target js viz`
- `moon info && moon fmt`
- `moon test`