### PR TITLE
[codex] generalize string view simplifications

### DIFF
--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -52,11 +52,11 @@ fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) 
     }
     match line.find(":") {
       Some(index) => {
-        let key = line[0:index].to_owned().trim().to_owned()
-        let value = line[index + 1:].to_owned().trim().to_owned()
+        let key = line[0:index].trim()
+        let value = line[index + 1:].trim()
         match key {
-          "name" => if value != "" { name = value }
-          "description" => description = value
+          "name" => if value != "" { name = "\{value}" }
+          "description" => description = "\{value}"
           _ => ()
         }
       }
@@ -71,11 +71,11 @@ fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) 
 /// skill name.
 fn file_stem(path : String) -> String {
   let base = match path.rev_find("/") {
-    Some(index) => path[index + 1:].to_owned()
+    Some(index) => "\{path[index + 1:]}"
     None => path
   }
   match base.rev_find(".") {
-    Some(index) => base[0:index].to_owned()
+    Some(index) => "\{base[0:index]}"
     None => base
   }
 }
@@ -116,11 +116,11 @@ async fn add_skill_file(skills : Array[Skill], path : String) -> Unit {
       // For <name>/SKILL.md layouts the directory carries the name — its
       // full basename, dots included ("node.js" stays "node.js").
       let parent = match path.rev_find("/") {
-        Some(index) => path[0:index].to_owned()
+        Some(index) => "\{path[0:index]}"
         None => path
       }
       match parent.rev_find("/") {
-        Some(index) => parent[index + 1:].to_owned()
+        Some(index) => "\{parent[index + 1:]}"
         None => parent
       }
     }

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -50,10 +50,10 @@ fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) 
     if line.trim() == "---" {
       break
     }
-    match line.find(":") {
-      Some(index) => {
-        let key = line[0:index].trim()
-        let value = line[index + 1:].trim()
+    match line.split_once(":") {
+      Some((key, value)) => {
+        let key = key.trim()
+        let value = value.trim()
         match key {
           "name" => if value != "" { name = "\{value}" }
           "description" => description = "\{value}"

--- a/agent_tool/edit/internal/manifest_error/manifest_error.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error.mbt
@@ -9,7 +9,7 @@
 /// boundary fixes the mistake in one round trip, instead of letting a broken
 /// manifest fail every later build step.
 pub async fn write_error(path : String, content : String) -> String? {
-  let trimmed = content.trim().to_owned()
+  let trimmed = content.trim()
   if is_moon_mod_json_path(path) && !@fs.exists(path) {
     return Some(
       "moon.mod.json is legacy; create moon.mod for new MoonBit projects",

--- a/agent_tool/internal/error/error.mbt
+++ b/agent_tool/internal/error/error.mbt
@@ -12,11 +12,11 @@ pub fn failure_message(error_text : String) -> String {
     return error_text
   }
   let message = pieces[pieces.length() - 1]
-  if message.has_suffix(")") {
-    message[:message.length() - 1].to_owned()
-  } else {
-    message
+  let message = match message.strip_suffix(")") {
+    Some(trimmed) => trimmed
+    None => message
   }
+  "\{message}"
 }
 
 ///|

--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -500,5 +500,5 @@ fn stable_moon_check_output(
       stable_lines.push(line.to_owned())
     }
   }
-  stable_lines.join("\n").trim().to_owned()
+  "\{stable_lines.join("\n").trim()}"
 }

--- a/agent_tool/moon_check/output.mbt
+++ b/agent_tool/moon_check/output.mbt
@@ -7,7 +7,7 @@ fn retain_output_tail(content : String, max_chars : Int) -> String {
   } else {
     let keep_from = content.char_length() - max_chars
     match content.offset_of_nth_char(keep_from) {
-      Some(offset) => content[offset:].to_owned()
+      Some(offset) => "\{content[offset:]}"
       None => content
     }
   }
@@ -35,7 +35,7 @@ fn latest_run_segment(content : String) -> String {
   if segment == "" {
     content
   } else {
-    segment.to_owned()
+    "\{segment}"
   }
 }
 
@@ -99,7 +99,7 @@ fn compact_moon_check_exit_output(
 fn first_line_containing(content : String, needle : String) -> String? {
   for line in content.split("\n") {
     if line.contains(needle) {
-      return Some(line.trim().to_owned())
+      return Some("\{line.trim()}")
     }
   }
   None
@@ -199,15 +199,16 @@ pub fn runtime_update_text(
   events : Array[@agent_runtime.AgentEvent],
 ) -> String? {
   let latest_moon_checks : Map[String, MoonCheckSnapshot] = {}
-  let mut moon_check_count = 0
-  for event in events {
+  let moon_check_count = for event in events; count = 0 {
     match event {
       MoonCheckUpdate(update) => {
         latest_moon_checks[update.key] = update
-        moon_check_count += 1
+        continue count + 1
       }
       _ => ()
     }
+  } nobreak {
+    count
   }
   if moon_check_count == 0 {
     None

--- a/agent_tool/moon_cmd/moon_cmd.mbt
+++ b/agent_tool/moon_cmd/moon_cmd.mbt
@@ -181,7 +181,7 @@ fn cap_text(content : String, max_chars : Int) -> String {
   if content.length() <= max_chars {
     content
   } else {
-    content[:max_chars].to_owned()
+    "\{content[:max_chars]}"
   }
 }
 

--- a/agent_tool/moon_ide/moon_ide.mbt
+++ b/agent_tool/moon_ide/moon_ide.mbt
@@ -143,7 +143,7 @@ fn cap_text(content : String, max_chars : Int) -> String {
   if content.length() <= max_chars {
     content
   } else {
-    content[:max_chars].to_owned()
+    "\{content[:max_chars]}"
   }
 }
 

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -236,7 +236,7 @@ fn cap_text(content : String, max_chars : Int) -> String {
   if content.length() <= max_chars {
     content
   } else {
-    content[:max_chars].to_owned()
+    "\{content[:max_chars]}"
   }
 }
 

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -58,7 +58,7 @@ fn shell_words(cmd : String) -> Array[String] {
 
 ///|
 fn clean_shell_word(word : String) -> String {
-  word.trim(chars="\t\r\n ").to_owned().trim(chars=";&|()").to_owned()
+  "\{word.trim(chars="\t\r\n ").trim(chars=";&|()")}"
 }
 
 ///|
@@ -76,7 +76,7 @@ fn looks_like_env_assignment(word : String) -> Bool {
   if word.contains("/") || word.contains("-") {
     return false
   }
-  let parts = word.split("=").map(part => part.to_owned()).collect()
+  let parts = word.split("=").collect()
   parts.length() == 2 && parts[0] != "" && parts[1] != ""
 }
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -282,7 +282,7 @@ async fn read_output_prefix(
 ///|
 fn text_prefix_by_chars(text : String, max_chars : Int) -> String {
   match text.offset_of_nth_char(max_chars) {
-    Some(end) => text[:end].to_owned()
+    Some(end) => "\{text[:end]}"
     None => text
   }
 }

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -120,7 +120,7 @@ fn parent_dir(path : String) -> String {
 
 ///|
 async fn manifest_write_error(path : String, content : String) -> String? {
-  let trimmed = content.trim().to_owned()
+  let trimmed = content.trim()
   if is_moon_mod_json_path(path) && !@fs.exists(path) {
     return Some(
       "moon.mod.json is legacy; create moon.mod for new MoonBit projects",

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -28,11 +28,9 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
   let model = @deepseek.Model::parse(value(matches, "model"))
   let max_steps = max_steps(matches)
   let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
-  let dir = trim_trailing_path_separators(
-    value(matches, "dir").trim().to_owned(),
-  )
+  let dir = trim_trailing_path_separators("\{value(matches, "dir").trim()}")
   let (run_dirs, source) = resolve_run_dirs(dir, concurrency)
-  let session_root_value = value(matches, "session-root").trim().to_owned()
+  let session_root_value = "\{value(matches, "session-root").trim()}"
   // Skip the configured session store (not just the default) so a custom
   // --session-root does not copy stale source sessions into every trial.
   let sessions_rel = workspace_sessions_rel(session_root_value)
@@ -323,7 +321,7 @@ fn copy_skip(rel : String, sessions_rel~ : String) -> Bool {
 /// the configured `--session-root`. `""` when the store is configured outside the
 /// workspace (an absolute root), so nothing inside the copy needs skipping.
 fn workspace_sessions_rel(session_root_value : String) -> String {
-  let root = trim_trailing_path_separators(session_root_value.trim().to_owned())
+  let root = trim_trailing_path_separators("\{session_root_value.trim()}")
   if root == "" || @path.Path(root).is_absolute() {
     ""
   } else if root == "." {
@@ -345,7 +343,7 @@ fn has_shebang(data : Bytes) -> Bool {
 /// is non-default, since each run records its session under that root inside its
 /// run directory, and `--session-show` resolves the root relative to `--dir`.
 fn inspect_hint(session_root_value : String) -> String {
-  let root = session_root_value.trim().to_owned()
+  let root = session_root_value.trim()
   let extra = if root == "" || root == ".openseek" {
     ""
   } else {

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -184,22 +184,19 @@ async fn random_salt() -> String {
 ///|
 fn failure_message(error_text : String) -> String {
   match error_text.strip_prefix("error: ") {
-    Some(message) => return message.to_owned()
+    Some(message) => return "\{message}"
     None => ()
   }
   let marker = " FAILED: "
-  let pieces : Array[String] = error_text
-    .split(marker)
-    .map(piece => piece.to_owned())
-    .collect()
+  let pieces = error_text.split(marker).collect()
   if pieces.length() < 2 {
     return error_text
   }
   let message = pieces[pieces.length() - 1]
   if message.has_suffix(")") {
-    message[:message.length() - 1].to_owned()
+    "\{message[:message.length() - 1]}"
   } else {
-    message
+    "\{message}"
   }
 }
 
@@ -387,20 +384,20 @@ fn flag(matches : @argparse.Matches, name : String) -> Bool {
 
 ///|
 fn api_key(matches : @argparse.Matches) -> String raise {
-  let key = value(matches, "api-key").trim().to_owned()
+  let key = value(matches, "api-key").trim()
   if key.is_empty() {
     fail("--api-key or DEEPSEEK is required for agent runs")
   }
-  key
+  "\{key}"
 }
 
 ///|
 fn api_url(matches : @argparse.Matches) -> String? raise {
-  let url = value(matches, "api-url").trim().to_owned()
+  let url = value(matches, "api-url").trim()
   if url.is_empty() {
     None
   } else {
-    Some(url)
+    Some("\{url}")
   }
 }
 
@@ -411,20 +408,20 @@ fn max_steps(matches : @argparse.Matches) -> Int raise {
 
 ///|
 fn task_text(matches : @argparse.Matches) -> String raise {
-  let task = values(matches, "task").join(" ").trim().to_owned()
+  let task = values(matches, "task").join(" ").trim()
   if task.is_empty() {
     fail("task description is required for agent runs")
   }
-  task
+  "\{task}"
 }
 
 ///|
 fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? raise {
-  let id = value(matches, "session").trim().to_owned()
+  let id = value(matches, "session").trim()
   if id.is_empty() {
     None
   } else {
-    Some(SessionId(id))
+    Some(SessionId("\{id}"))
   }
 }
 
@@ -433,9 +430,7 @@ async fn prepare_workspace_root(
   matches : @argparse.Matches,
   log_created? : Bool = true,
 ) -> String {
-  let dir = trim_trailing_path_separators(
-    value(matches, "dir").trim().to_owned(),
-  )
+  let dir = trim_trailing_path_separators("\{value(matches, "dir").trim()}")
   if dir.is_empty() {
     fail("--dir or OPENSEEK_DIR must not be empty")
   }
@@ -492,11 +487,11 @@ fn session_root(
   matches : @argparse.Matches,
   workspace_root? : String = ".",
 ) -> String raise {
-  let root = value(matches, "session-root").trim().to_owned()
+  let root = value(matches, "session-root").trim()
   if root.is_empty() {
     fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
   }
-  @workspace_path.resolve(workspace_root, root)
+  @workspace_path.resolve(workspace_root, "\{root}")
 }
 
 ///|
@@ -512,29 +507,26 @@ const PromptLabelMaxChars : Int = 60
 /// without a recorded prompt shows `-` so the column never vanishes.
 fn compact_prompt_label(prompt : String) -> String {
   let out = StringBuilder()
-  let mut last_was_space = false
-  let mut count = 0
-  for ch in prompt.trim() {
+  for ch in prompt.trim(); last_was_space = false, count = 0 {
     if count >= PromptLabelMaxChars {
-      out <+ "…"
+      out.write_char('…')
       break
     }
     if ch is (' ' | '\t' | '\n' | '\r') {
       if !last_was_space {
-        out <+ " "
-        count += 1
+        out.write_char(' ')
+        continue true, count + 1
       }
-      last_was_space = true
+      continue true, count
     } else if ch.to_int() < 0x20 ||
       ch.to_int() == 0x7F ||
       (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
       // C0/C1 controls and DEL: ESC, CSI, OSC and friends render as terminal
       // commands, not text.
-      continue
+      continue last_was_space, count
     } else {
-      out <+ "\{ch}"
-      count += 1
-      last_was_space = false
+      out.write_char(ch)
+      continue false, count + 1
     }
   }
   let label = out.to_string()
@@ -588,9 +580,9 @@ async fn handle_session_command(
   }
   let list_sessions = flag(matches, "session-list")
   let show_session = flag(matches, "session-show")
-  let compact_file = value(matches, "session-compact-file").trim().to_owned()
-  let compact_from = value(matches, "session-compact-from").trim().to_owned()
-  let compact_to = value(matches, "session-compact-to").trim().to_owned()
+  let compact_file = value(matches, "session-compact-file").trim()
+  let compact_from = value(matches, "session-compact-from").trim()
+  let compact_to = value(matches, "session-compact-to").trim()
   let store = @store.SessionStore(session_root(matches, workspace_root~))
   if list_sessions {
     match session_list_format(matches) {
@@ -611,10 +603,14 @@ async fn handle_session_command(
     fail("--session-compact-file is required for session compaction")
   }
   let from_sequence = required_positive_int(
-    compact_from, "--session-compact-from",
+    "\{compact_from}",
+    "--session-compact-from",
   )
-  let to_sequence = required_positive_int(compact_to, "--session-compact-to")
-  let summary_path = @workspace_path.resolve(workspace_root, compact_file)
+  let to_sequence = required_positive_int(
+    "\{compact_to}",
+    "--session-compact-to",
+  )
+  let summary_path = @workspace_path.resolve(workspace_root, "\{compact_file}")
   let summary = @fs.read_file(summary_path).text()
   let compacted = store.compact(
     store.load(id),
@@ -706,7 +702,7 @@ fn session_title(first_prompt : String) -> String {
     Some((line, _)) => line.trim()
     None => content
   }
-  title.to_owned()
+  "\{title}"
 }
 
 ///|
@@ -914,11 +910,11 @@ fn parse_positive_int(input : String, label : String) -> Int raise {
 
 ///|
 fn required_positive_int(input : String, label : String) -> Int raise {
-  let trimmed = input.trim().to_owned()
+  let trimmed = input.trim()
   if trimmed.is_empty() {
     fail("\{label} is required")
   }
-  parse_positive_int(trimmed, label)
+  parse_positive_int("\{trimmed}", label)
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -193,11 +193,11 @@ fn failure_message(error_text : String) -> String {
     return error_text
   }
   let message = pieces[pieces.length() - 1]
-  if message.has_suffix(")") {
-    "\{message[:message.length() - 1]}"
-  } else {
-    "\{message}"
+  let message = match message.strip_suffix(")") {
+    Some(trimmed) => trimmed
+    None => message
   }
+  "\{message}"
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -307,16 +307,15 @@ fn tail_columns(text : String, max_cols : Int) -> String {
 /// renderer as control characters.
 fn collapse_preview_whitespace(text : String) -> String {
   let out = StringBuilder()
-  let mut last_was_space = false
-  for ch in text {
+  for ch in text; last_was_space = false {
     if ch is (' ' | '\t' | '\n' | '\r') {
       if !last_was_space {
-        out <+ " "
+        out.write_char(' ')
       }
-      last_was_space = true
+      continue true
     } else {
-      out <+ "\{ch}"
-      last_was_space = false
+      out.write_char(ch)
+      continue false
     }
   }
   out.to_string()

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -159,7 +159,7 @@ fn api_url(matches : @argparse.Matches) -> String? raise {
 ///|
 fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? {
   let session = match values(matches, "session") {
-    [session, ..] => session.trim().to_owned()
+    [session, ..] => "\{session.trim()}"
     [] => ""
   }
   if session.is_empty() {

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -171,27 +171,24 @@ async fn build_reply(
       )
     "/api/sessions" => session_list_reply(catalog)
     _ =>
-      if path.has_prefix("/api/sessions/") {
-        session_path_reply(catalog, path)
-      } else {
-        text_reply(404, "Not Found", "no route for \{path}")
+      match path.strip_prefix("/api/sessions/") {
+        Some(rest) => session_path_reply(catalog, "\{rest}")
+        None => text_reply(404, "Not Found", "no route for \{path}")
       }
   }
 }
 
 ///|
-/// Resolve `/api/sessions/<key>` (envelope) or `/api/sessions/<key>/<file>`
-/// (raw). A key is either legacy `<id>` for the first root, or `<root>|<id>`
-/// for a discovered root. The segment is percent-decoded, so ids containing
+/// Resolve `<key>` (envelope) or `<key>/<file>` (raw) after the
+/// `/api/sessions/` route prefix. A key is either legacy `<id>` for the first
+/// root, or `<root>|<id>` for a discovered root. The segment is percent-decoded, so ids containing
 /// URL-reserved characters (spaces, `?`, `#`) still resolve to the right
 /// session. The store's own id validation rejects path separators and `..`, so
 /// a crafted id cannot escape the session directory.
-async fn session_path_reply(catalog : SessionCatalog, path : String) -> Reply {
-  let rest = slice_from(path, "/api/sessions/".length())
-  let (key, file) = match rest.find("/") {
+async fn session_path_reply(catalog : SessionCatalog, rest : String) -> Reply {
+  let (key, file) = match rest.split_once("/") {
     None => (percent_decode(rest), None)
-    Some(index) =>
-      (percent_decode(slice(rest, 0, index)), Some(slice_from(rest, index + 1)))
+    Some((key, file)) => (percent_decode("\{key}"), Some("\{file}"))
   }
   let (root, id_value) = match catalog.lookup(key) {
     Some(found) => found
@@ -457,13 +454,12 @@ fn SessionCatalog::lookup(
   self : SessionCatalog,
   key : String,
 ) -> (SessionRoot, String)? {
-  match key.find("|") {
-    Some(index) => {
-      let root_key = slice(key, 0, index)
-      let id = slice_from(key, index + 1)
+  match key.split_once("|") {
+    Some((root_key, id)) => {
+      let root_key = "\{root_key}"
       for root in self.roots {
         if root.key == root_key {
-          return Some((root, id))
+          return Some((root, "\{id}"))
         }
       }
       None
@@ -536,9 +532,14 @@ fn join_path(parent : String, child : String) -> String {
 /// before the `_build` component locates the checkout and its assets,
 /// wherever the server was started from.
 fn module_root_from_exe(exe : String) -> String? {
-  match exe.find("/_build/") {
-    Some(index) => Some(slice(exe, 0, index))
-    None => if exe.has_prefix("_build/") { Some(".") } else { None }
+  match exe.split_once("/_build/") {
+    Some((root, _)) => Some("\{root}")
+    None =>
+      if exe.strip_prefix("_build/") is Some(_) {
+        Some(".")
+      } else {
+        None
+      }
   }
 }
 
@@ -642,17 +643,10 @@ fn text_reply(code : Int, reason : String, message : String) -> Reply {
 ///|
 /// The path without any `?query` suffix.
 fn strip_query(path : String) -> String {
-  match path.find("?") {
-    Some(index) => slice(path, 0, index)
+  match path.split_once("?") {
+    Some((path, _)) => "\{path}"
     None => path
   }
-}
-
-///|
-/// Code-unit slice `s[start:end]` as an owned `String`. Indices here always come
-/// from `find`/`length`, so they are in range.
-fn slice(s : String, start : Int, end : Int) -> String {
-  s[start:end].to_owned()
 }
 
 ///|

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -164,7 +164,7 @@ fn sse_data_fragment(raw : String) -> String? {
     raw
   }
   if line.has_prefix("data:") {
-    Some(line[5:].trim().to_owned())
+    Some("\{line[5:].trim()}")
   } else {
     None
   }
@@ -181,7 +181,7 @@ async fn flush_sse_event(
   if data_lines.length() == 0 {
     return false
   }
-  let data = data_lines.join("\n").trim().to_owned()
+  let data = "\{data_lines.join("\n").trim()}"
   data_lines.clear()
   // A flushed data payload means the completion is producing output
   // server-side — text, tool-call deltas, usage, or the terminal marker —

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -158,15 +158,13 @@ async fn apply_stream_json(
 
 ///|
 fn sse_data_fragment(raw : String) -> String? {
-  let line = if raw.has_suffix("\r") {
-    raw[:raw.length() - 1].to_owned()
-  } else {
-    raw
+  let line = match raw.strip_suffix("\r") {
+    Some(line) => line
+    None => raw
   }
-  if line.has_prefix("data:") {
-    Some("\{line[5:].trim()}")
-  } else {
-    None
+  match line.strip_prefix("data:") {
+    Some(data) => Some("\{data.trim()}")
+    None => None
   }
 }
 

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -262,12 +262,9 @@ fn relocate_output_path(
     return path
   }
   let prefix = old_out_dir + "/"
-  if path.has_prefix(prefix) {
-    new_out_dir +
-    "/" +
-    path.sub(start=prefix.length(), end=path.length()).to_owned()
-  } else {
-    path
+  match path.strip_prefix(prefix) {
+    Some(rest) => "\{new_out_dir}/\{rest}"
+    None => path
   }
 }
 

--- a/eval/prompt_task/harness/report.mbt
+++ b/eval/prompt_task/harness/report.mbt
@@ -304,10 +304,9 @@ fn relative_artifact_path(out_dir : String, path : String) -> String {
     return path
   }
   let prefix = out_dir + "/"
-  if path.has_prefix(prefix) {
-    path.sub(start=prefix.length(), end=path.length()).to_owned()
-  } else {
-    path
+  match path.strip_prefix(prefix) {
+    Some(rest) => "\{rest}"
+    None => path
   }
 }
 

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -459,17 +459,15 @@ fn append_markdown_code_block(lines : Array[String], text : String) -> Unit {
 
 ///|
 fn markdown_fence(text : String) -> String {
-  let mut current = 0
-  let mut longest = 0
-  for char in text {
+  let longest = for char in text; current = 0, longest = 0 {
     if char == '`' {
-      current += 1
-      if current > longest {
-        longest = current
-      }
+      let next = current + 1
+      continue next, if next > longest { next } else { longest }
     } else {
-      current = 0
+      continue 0, longest
     }
+  } nobreak {
+    longest
   }
   let length = if longest >= 3 { longest + 1 } else { 3 }
   repeat_char('`', length)

--- a/tui/input.mbt
+++ b/tui/input.mbt
@@ -1,7 +1,7 @@
 ///|
 fn submitted_input(text : String, mode : @composer.Mode) -> Input {
   if mode.is_shell() {
-    Command(text.trim().to_owned())
+    Command("\{text.trim()}")
   } else {
     Prompt(text)
   }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -134,13 +134,13 @@ fn turn_block(
 ///|
 /// Number of failed tool results in a turn, for the turn header's error badge.
 fn count_turn_tool_errors(turn : Array[@agent_session.SessionEvent]) -> Int {
-  let mut count = 0
-  for event in turn {
+  for event in turn; count = 0 {
     if event.item() is Tool(result) && result.is_error() {
-      count += 1
+      continue count + 1
     }
+  } nobreak {
+    count
   }
-  count
 }
 
 ///|
@@ -498,25 +498,27 @@ pub fn rendered_error_count(
   session : @agent_session.Session,
   mode : ViewMode,
 ) -> Int {
-  let mut count = 0
   match mode {
     RawLog =>
-      for event in session.events() {
+      for event in session.events(); count = 0 {
         if event.item() is Tool(result) && result.is_error() {
-          count += 1
+          continue count + 1
         }
+      } nobreak {
+        count
       }
     ModelView => {
       let tool_results = tool_results_by_id(session)
-      for message in session.chat_messages() {
+      for message in session.chat_messages(); count = 0 {
         if model_shown_result(message, tool_results) is Some(result) &&
           result.is_error() {
-          count += 1
+          continue count + 1
         }
+      } nobreak {
+        count
       }
     }
   }
-  count
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Generalize the view-first cleanup from brief helpers across nearby string utilities.
- Remove avoidable `to_owned()` conversions at StringView return boundaries in skill metadata parsing, moon-check formatting, stream parsing, manifest guards, command caps, and CLI/TUI trim handling.
- Convert simple `mut` count/whitespace loops to functional loop state where the state is local and linear.
- Prefer `split_once`, `strip_prefix`, and `strip_suffix` for first-delimiter and boundary-slice cases instead of manual `find` plus slicing.
- Keep generated `.mbti` interfaces unchanged.

## Validation

- `moon check --warn-list +73` (passes with existing unnecessary-annotation warnings in `cmd/viz_server`)
- `moon test agent_skill agent_tool/edit agent_tool/moon_check agent_tool/moon_cmd agent_tool/moon_ide agent_tool/read agent_tool/shell agent_tool/write cmd/openseek cmd/tui deepseek/client eval/report tui`
- `moon test agent_skill cmd/viz_server cmd/openseek agent_tool/internal/error eval/prompt_task/harness deepseek/client`
- `moon test --target js viz`
- `moon info && moon fmt`
- `moon test`