### PR TITLE
[codex] use rev_split_once for trailing delimiters

### DIFF
--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -70,13 +70,13 @@ fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) 
 /// The markdown file's stem (`foo` for `dir/foo.md`), used as the fallback
 /// skill name.
 fn file_stem(path : String) -> String {
-  let base = match path.rev_find("/") {
-    Some(index) => "\{path[index + 1:]}"
+  let base = match path.rev_split_once("/") {
+    Some((_, base)) => base
     None => path
   }
-  match base.rev_find(".") {
-    Some(index) => "\{base[0:index]}"
-    None => base
+  match base.rev_split_once(".") {
+    Some((stem, _)) => "\{stem}"
+    None => "\{base}"
   }
 }
 
@@ -115,13 +115,13 @@ async fn add_skill_file(skills : Array[Skill], path : String) -> Unit {
     "SKILL" => {
       // For <name>/SKILL.md layouts the directory carries the name — its
       // full basename, dots included ("node.js" stays "node.js").
-      let parent = match path.rev_find("/") {
-        Some(index) => "\{path[0:index]}"
+      let parent = match path.rev_split_once("/") {
+        Some((parent, _)) => parent
         None => path
       }
-      match parent.rev_find("/") {
-        Some(index) => "\{parent[index + 1:]}"
-        None => parent
+      match parent.rev_split_once("/") {
+        Some((_, name)) => "\{name}"
+        None => "\{parent}"
       }
     }
     stem => stem

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -305,8 +305,8 @@ fn within_root(path : String, root : String) -> Bool {
 /// `.openseek/skills` are deliberately kept so a trial behaves like a normal run.
 /// `sessions_rel` is `""` when the session store lives outside the workspace.
 fn copy_skip(rel : String, sessions_rel~ : String) -> Bool {
-  let base = match rel.rev_find("/") {
-    Some(index) => rel[index + 1:].to_owned()
+  let base = match rel.rev_split_once("/") {
+    Some((_, base)) => base
     None => rel
   }
   if base == "_build" || base == "node_modules" {

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -171,9 +171,9 @@ async fn random_salt() -> String {
   // Locate the prefix instead of splitting on a path separator: Windows
   // paths use backslashes, and a `/`-only basename split would drop the
   // salt there entirely (Codex review).
-  guard dir.rev_find(prefix) is Some(index) else { return "" }
+  guard dir.rev_split_once(prefix) is Some((_, suffix)) else { return "" }
   let salt = StringBuilder()
-  for ch in dir[index + prefix.length():] {
+  for ch in suffix {
     if ch is ('0'..='9' | 'a'..='z' | 'A'..='Z') {
       salt <+ "\{ch}"
     }


### PR DESCRIPTION
## Summary

- Follow up on #184 by replacing the simple `rev_find` plus slicing cases with `rev_split_once`.
- Keep this limited to last-delimiter splits where both sides map directly to views: skill file stems, nested skill parent names, random salt suffix extraction, and copy-skip basename checks.
- Leave mixed `/` and `\\` path separator helpers unchanged because they intentionally compare two delimiter positions.

## Validation

- `moon fmt`
- `moon check --warn-list +73` (passes with existing unnecessary-annotation warnings in `cmd/viz_server`)
- `moon test agent_skill cmd/openseek`
- `moon info && moon fmt` (exposed unrelated generated-interface drift in `testkit/filesystem/pkg.generated.mbti`; not included)
- `moon test`
- `git diff --check HEAD~1`