### PR TITLE
fix(viz_server): scan --session-root for nested stores; drop empty container roots

### DIFF
--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -359,8 +359,20 @@ async fn session_catalog(
   session_root_name : String,
 ) -> SessionCatalog {
   let paths : Array[String] = []
-  paths.push(session_root)
-  for root in discover_session_roots(search_dirs, session_root_name) {
+  // Serve the explicit --session-root directly only when it is actually a store
+  // (named like the root marker, or holding a `sessions/` directory). Otherwise
+  // it is a container — e.g. a directory of best-of-N run workspaces, each with
+  // its own nested store — and announcing it as a root would list zero sessions.
+  if is_session_store(session_root, session_root_name) {
+    paths.push(session_root)
+  }
+  // Scan the --session-root as well as the --search-dirs, so nested stores under
+  // a container root are surfaced the same way search-dir trees are.
+  let scan_dirs = [session_root]
+  for dir in search_dirs {
+    scan_dirs.push(dir)
+  }
+  for root in discover_session_roots(scan_dirs, session_root_name) {
     paths.push(root)
   }
   let unique = unique_paths(paths)
@@ -419,6 +431,15 @@ async fn scan_session_roots(
 async fn is_directory(path : String) -> Bool {
   (@fs.kind(path, follow_symlink=false) catch { _ => return false }) ==
   Directory
+}
+
+///|
+/// Whether `path` is itself a session store (servable directly) rather than a
+/// container to scan: it is named like the root marker (e.g. `.openseek`), or it
+/// already holds a `sessions/` directory.
+async fn is_session_store(path : String, session_root_name : String) -> Bool {
+  path_tail(path) == session_root_name ||
+  is_directory(join_path(path, "sessions"))
 }
 
 ///|

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -177,6 +177,40 @@ async test "discover_session_roots supports a custom root marker" {
 }
 
 ///|
+async test "session_catalog scans a container session root for nested stores" {
+  let root = @fs.tmpdir(prefix="openseek-viz-nested-")
+  // A directory of best-of-N run workspaces, each with its own nested store.
+  @fs.mkdir("\{root}/A-1/.openseek/sessions/run", recursive=true)
+  @fs.mkdir("\{root}/B-1/.openseek/sessions/run", recursive=true)
+  let catalog = session_catalog(root, [], ".openseek")
+  let paths = catalog.roots.map(r => r.path.replace_all(old=root, new="<root>"))
+  paths.sort()
+  // The empty container itself is not announced; its nested stores are.
+  @debug.debug_inspect(
+    paths,
+    content=(
+      #|["<root>/A-1/.openseek", "<root>/B-1/.openseek"]
+    ),
+  )
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
+async test "session_catalog serves a direct store named like the root marker" {
+  let root = @fs.tmpdir(prefix="openseek-viz-direct-")
+  @fs.mkdir("\{root}/.openseek/sessions/run", recursive=true)
+  let catalog = session_catalog("\{root}/.openseek", [], ".openseek")
+  let paths = catalog.roots.map(r => r.path.replace_all(old=root, new="<root>"))
+  @debug.debug_inspect(
+    paths,
+    content=(
+      #|["<root>/.openseek"]
+    ),
+  )
+  @fs.rmdir(root, recursive=true)
+}
+
+///|
 test "session catalog lookup supports composite and legacy keys" {
   let catalog : SessionCatalog = {
     roots: [


### PR DESCRIPTION
## Problem

Running `viz_server --session-root /tmp/ab-runs` (a directory of best-of-N / fleet run workspaces, each with its own nested `.openseek`) printed:

```
openseek viz: serving 8 session root(s)
openseek viz: sessions under '/tmp/ab-runs'
openseek viz: sessions under './.repos/toml_run_1/.openseek'
... (6 more)
```

…but the served listing had only **7** roots — `/tmp/ab-runs` and its A/B sessions were missing. Cause: `--search-dir` trees are scanned recursively (default `["."]`, which found `./.repos/*`), but `--session-root` is pushed *literally* and never scanned. So `/tmp/ab-runs` was announced as a root yet `SessionStore("/tmp/ab-runs").listings()` found nothing (the sessions live at `/tmp/ab-runs/<run>/.openseek/sessions/...`).

## Fix

- **Scan `--session-root`** for nested stores, the same way `--search-dir` trees are scanned, so nested sessions are surfaced.
- **Only announce `--session-root` directly when it is actually a store** (named like the root marker, or holding a `sessions/` directory). A bare container is no longer listed as an empty root, so the banner matches what is served.

## Verification

- `moon check --deny-warn` clean; viz_server **14/14** (added: a container root surfaces its nested stores and is not itself announced; a direct `.openseek` store is still served).
- End-to-end against the real `/tmp/ab-runs`: `GET /api/sessions` now returns **17** sessions — the 7 `./.repos/*` plus all 10 `/tmp/ab-runs/{A,B}-{1..5}/.openseek` — with no empty container root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)