### PR TITLE
[codex] migrate tests to vfs tempdirs

### DIFF
--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -82,33 +82,33 @@ must choose the id before loading.
 ```mbt check
 ///|
 async test "create and load a complete session" {
-  let root = @fs.tmpdir(prefix="openseek-store-readme-create-")
-  let store = @store.SessionStore(root)
-  let session = @agent_session.Session(
-      SessionId("demo"),
-      system_prompt="system",
-    )
-    .append(User(UserMessage("hello")))
-    .append(Terminal(Finished("done")))
+  @vfs.with_tmpdir(prefix="openseek-store-readme-create-", root => {
+    let store = @store.SessionStore(root)
+    let session = @agent_session.Session(
+        SessionId("demo"),
+        system_prompt="system",
+      )
+      .append(User(UserMessage("hello")))
+      .append(Terminal(Finished("done")))
 
-  store.create(session)
-  let loaded = store.load(SessionId("demo"))
-  debug_inspect(
-    loaded,
-    content=(
-      #|{
-      #|  id: { value: "demo" },
-      #|  system_prompt: "system",
-      #|  events: <Vector:
-      #|    [
-      #|      { sequence: 1, ts: 0, item: User({ content: "hello" }) },
-      #|      { sequence: 2, ts: 0, item: Terminal(Finished("done")) },
-      #|    ]>,
-      #|  last_sequence: 2,
-      #|}
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
+    store.create(session)
+    let loaded = store.load(SessionId("demo"))
+    debug_inspect(
+      loaded,
+      content=(
+        #|{
+        #|  id: { value: "demo" },
+        #|  system_prompt: "system",
+        #|  events: <Vector:
+        #|    [
+        #|      { sequence: 1, ts: 0, item: User({ content: "hello" }) },
+        #|      { sequence: 2, ts: 0, item: Terminal(Finished("done")) },
+        #|    ]>,
+        #|  last_sequence: 2,
+        #|}
+      ),
+    )
+  })
 }
 ```
 
@@ -125,44 +125,44 @@ example stable while still showing the resumed conversation shape.
 ```mbt check
 ///|
 async test "append saves progress and load resumes it" {
-  let root = @fs.tmpdir(prefix="openseek-store-readme-append-")
-  let store = @store.SessionStore(root)
-  let session = @agent_session.Session(
-    SessionId("demo"),
-    system_prompt="system",
-  )
+  @vfs.with_tmpdir(prefix="openseek-store-readme-append-", root => {
+    let store = @store.SessionStore(root)
+    let session = @agent_session.Session(
+      SessionId("demo"),
+      system_prompt="system",
+    )
 
-  store.create(session)
-  let session = store.append(session, User(UserMessage("inspect README")))
-  ignore(store.append(session, Terminal(Finished("done"))))
+    store.create(session)
+    let session = store.append(session, User(UserMessage("inspect README")))
+    ignore(store.append(session, Terminal(Finished("done"))))
 
-  let loaded = store.load(SessionId("demo"))
-  debug_inspect(
-    loaded.chat_messages(),
-    content=(
-      #|[
-      #|  {
-      #|    role: System,
-      #|    content: "system",
-      #|    tool_calls: [],
-      #|    reasoning_content: None,
-      #|  },
-      #|  {
-      #|    role: User,
-      #|    content: "inspect README",
-      #|    tool_calls: [],
-      #|    reasoning_content: None,
-      #|  },
-      #|  {
-      #|    role: Assistant,
-      #|    content: "done",
-      #|    tool_calls: [],
-      #|    reasoning_content: None,
-      #|  },
-      #|]
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
+    let loaded = store.load(SessionId("demo"))
+    debug_inspect(
+      loaded.chat_messages(),
+      content=(
+        #|[
+        #|  {
+        #|    role: System,
+        #|    content: "system",
+        #|    tool_calls: [],
+        #|    reasoning_content: None,
+        #|  },
+        #|  {
+        #|    role: User,
+        #|    content: "inspect README",
+        #|    tool_calls: [],
+        #|    reasoning_content: None,
+        #|  },
+        #|  {
+        #|    role: Assistant,
+        #|    content: "done",
+        #|    tool_calls: [],
+        #|    reasoning_content: None,
+        #|  },
+        #|]
+      ),
+    )
+  })
 }
 ```
 
@@ -173,27 +173,27 @@ forking the log:
 ```mbt check
 ///|
 async test "append rejects a stale in-memory session" {
-  let root = @fs.tmpdir(prefix="openseek-store-readme-stale-")
-  let store = @store.SessionStore(root)
-  let session = @agent_session.Session(
-    SessionId("demo"),
-    system_prompt="system",
-  )
+  @vfs.with_tmpdir(prefix="openseek-store-readme-stale-", root => {
+    let store = @store.SessionStore(root)
+    let session = @agent_session.Session(
+      SessionId("demo"),
+      system_prompt="system",
+    )
 
-  store.create(session)
-  ignore(store.append(session, User(UserMessage("first"))))
-  let result = try store.append(session, User(UserMessage("stale"))) catch {
-    error => "error: \{error}".contains("stale session snapshot")
-  } noraise {
-    _ => false
-  }
-  debug_inspect(
-    result,
-    content=(
-      #|true
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
+    store.create(session)
+    ignore(store.append(session, User(UserMessage("first"))))
+    let result = try store.append(session, User(UserMessage("stale"))) catch {
+      error => "error: \{error}".contains("stale session snapshot")
+    } noraise {
+      _ => false
+    }
+    debug_inspect(
+      result,
+      content=(
+        #|true
+      ),
+    )
+  })
 }
 ```
 
@@ -207,46 +207,46 @@ events are skipped and the later summary message is used instead.
 ```mbt check
 ///|
 async test "compact appends a durable summary" {
-  let root = @fs.tmpdir(prefix="openseek-store-readme-compact-")
-  let store = @store.SessionStore(root)
-  let session = @agent_session.Session(
-      SessionId("demo"),
-      system_prompt="system",
+  @vfs.with_tmpdir(prefix="openseek-store-readme-compact-", root => {
+    let store = @store.SessionStore(root)
+    let session = @agent_session.Session(
+        SessionId("demo"),
+        system_prompt="system",
+      )
+      .append(User(UserMessage("old user")))
+      .append(Assistant(AssistantMessage("old assistant")))
+
+    store.create(session)
+    ignore(
+      store.compact(
+        session,
+        content="old user and assistant discussed README",
+        from_sequence=1,
+        to_sequence=2,
+      ),
     )
-    .append(User(UserMessage("old user")))
-    .append(Assistant(AssistantMessage("old assistant")))
 
-  store.create(session)
-  ignore(
-    store.compact(
-      session,
-      content="old user and assistant discussed README",
-      from_sequence=1,
-      to_sequence=2,
-    ),
-  )
-
-  let loaded = store.load(SessionId("demo"))
-  debug_inspect(
-    loaded.chat_messages(),
-    content=(
-      #|[
-      #|  {
-      #|    role: System,
-      #|    content: "system",
-      #|    tool_calls: [],
-      #|    reasoning_content: None,
-      #|  },
-      #|  {
-      #|    role: User,
-      #|    content: "[conversation summary]\nsource_events=1..2\nold user and assistant discussed README",
-      #|    tool_calls: [],
-      #|    reasoning_content: None,
-      #|  },
-      #|]
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
+    let loaded = store.load(SessionId("demo"))
+    debug_inspect(
+      loaded.chat_messages(),
+      content=(
+        #|[
+        #|  {
+        #|    role: System,
+        #|    content: "system",
+        #|    tool_calls: [],
+        #|    reasoning_content: None,
+        #|  },
+        #|  {
+        #|    role: User,
+        #|    content: "[conversation summary]\nsource_events=1..2\nold user and assistant discussed README",
+        #|    tool_calls: [],
+        #|    reasoning_content: None,
+        #|  },
+        #|]
+      ),
+    )
+  })
 }
 ```
 
@@ -260,20 +260,20 @@ returns the newest loadable session id, skipping torn sessions.
 ```mbt check
 ///|
 async test "list sessions by id" {
-  let root = @fs.tmpdir(prefix="openseek-store-readme-list-")
-  let store = @store.SessionStore(root)
+  @vfs.with_tmpdir(prefix="openseek-store-readme-list-", root => {
+    let store = @store.SessionStore(root)
 
-  store.create(Session(SessionId("b"), system_prompt="system"))
-  store.create(Session(SessionId("a"), system_prompt="system"))
-  debug_inspect(
-    [
-      for id in store.list() => id.value()
-    ],
-    content=(
-      #|["a", "b"]
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
+    store.create(Session(SessionId("b"), system_prompt="system"))
+    store.create(Session(SessionId("a"), system_prompt="system"))
+    debug_inspect(
+      [
+        for id in store.list() => id.value()
+      ],
+      content=(
+        #|["a", "b"]
+      ),
+    )
+  })
 }
 ```
 

--- a/agent_session/store/moon.pkg
+++ b/agent_session/store/moon.pkg
@@ -8,6 +8,7 @@ import {
 }
 
 import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
   "moonbitlang/async/fs",
 } for "test"

--- a/agent_skill/moon.pkg
+++ b/agent_skill/moon.pkg
@@ -3,6 +3,7 @@ import {
 }
 
 import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
 } for "test"
 

--- a/agent_skill/skill_test.mbt
+++ b/agent_skill/skill_test.mbt
@@ -5,105 +5,105 @@ async fn write_skill(path : String, text : String) -> Unit {
 
 ///|
 async test "discovery reads flat files and SKILL.md directories, sorted" {
-  let dir = @fs.tmpdir(prefix="openseek-skills-")
-  write_skill(
-    dir + "/zeta.md",
-    (
-      #|---
-      #|name: zeta-protocol
-      #|description: How to zeta.
-      #|---
-      #|Body text.
-    ),
-  )
-  @fs.mkdir(dir + "/alpha", recursive=true)
-  write_skill(
-    dir + "/alpha/SKILL.md",
-    (
-      #|---
-      #|description: Alpha steps.
-      #|---
-      #|Steps.
-    ),
-  )
-  // No frontmatter at all: still listed under its file stem.
-  write_skill(dir + "/bare.md", "Just instructions, no header.")
-  // A dotted directory name survives intact ("node.js", not "node").
-  @fs.mkdir(dir + "/node.js", recursive=true)
-  write_skill(dir + "/node.js/SKILL.md", "Node skill body.")
-  // A non-skill directory and a stray file are ignored.
-  @fs.mkdir(dir + "/not-a-skill", recursive=true)
-  write_skill(dir + "/notes.txt", "not markdown")
-  let skills = @agent_skill.discover_skills(dir)
-  assert_eq(skills.length(), 4)
-  // Sorted by name (String order is length-first, so "bare" precedes
-  // "alpha"); the SKILL.md layout names itself after its directory.
-  assert_eq(skills[0].name(), "bare")
-  assert_eq(skills[0].description(), "")
-  assert_eq(skills[1].name(), "alpha")
-  assert_eq(skills[1].description(), "Alpha steps.")
-  assert_eq(skills[1].path(), dir + "/alpha/SKILL.md")
-  assert_eq(skills[2].name(), "node.js")
-  assert_eq(skills[3].name(), "zeta-protocol")
-  assert_eq(skills[3].description(), "How to zeta.")
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-skills-", dir => {
+    write_skill(
+      dir + "/zeta.md",
+      (
+        #|---
+        #|name: zeta-protocol
+        #|description: How to zeta.
+        #|---
+        #|Body text.
+      ),
+    )
+    @fs.mkdir(dir + "/alpha", recursive=true)
+    write_skill(
+      dir + "/alpha/SKILL.md",
+      (
+        #|---
+        #|description: Alpha steps.
+        #|---
+        #|Steps.
+      ),
+    )
+    // No frontmatter at all: still listed under its file stem.
+    write_skill(dir + "/bare.md", "Just instructions, no header.")
+    // A dotted directory name survives intact ("node.js", not "node").
+    @fs.mkdir(dir + "/node.js", recursive=true)
+    write_skill(dir + "/node.js/SKILL.md", "Node skill body.")
+    // A non-skill directory and a stray file are ignored.
+    @fs.mkdir(dir + "/not-a-skill", recursive=true)
+    write_skill(dir + "/notes.txt", "not markdown")
+    let skills = @agent_skill.discover_skills(dir)
+    assert_eq(skills.length(), 4)
+    // Sorted by name (String order is length-first, so "bare" precedes
+    // "alpha"); the SKILL.md layout names itself after its directory.
+    assert_eq(skills[0].name(), "bare")
+    assert_eq(skills[0].description(), "")
+    assert_eq(skills[1].name(), "alpha")
+    assert_eq(skills[1].description(), "Alpha steps.")
+    assert_eq(skills[1].path(), dir + "/alpha/SKILL.md")
+    assert_eq(skills[2].name(), "node.js")
+    assert_eq(skills[3].name(), "zeta-protocol")
+    assert_eq(skills[3].description(), "How to zeta.")
+  })
 }
 
 ///|
 async test "a malformed frontmatter never hides the skill" {
-  let dir = @fs.tmpdir(prefix="openseek-skills-malformed-")
-  // Opening --- with no closing fence: keys still parse until EOF.
-  write_skill(
-    dir + "/open.md",
-    (
-      #|---
-      #|name: still-found
-      #|no colon line
-    ),
-  )
-  let skills = @agent_skill.discover_skills(dir)
-  assert_eq(skills.length(), 1)
-  assert_eq(skills[0].name(), "still-found")
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-skills-malformed-", dir => {
+    // Opening --- with no closing fence: keys still parse until EOF.
+    write_skill(
+      dir + "/open.md",
+      (
+        #|---
+        #|name: still-found
+        #|no colon line
+      ),
+    )
+    let skills = @agent_skill.discover_skills(dir)
+    assert_eq(skills.length(), 1)
+    assert_eq(skills[0].name(), "still-found")
+  })
 }
 
 ///|
 async test "workspace skills shadow same-named global skills on merge" {
-  let global_dir = @fs.tmpdir(prefix="openseek-skills-global-")
-  let workspace_dir = @fs.tmpdir(prefix="openseek-skills-workspace-")
-  write_skill(
-    global_dir + "/deploy.md",
-    (
-      #|---
-      #|description: Generic deploy steps.
-      #|---
-    ),
-  )
-  write_skill(global_dir + "/lint.md", "Global lint steps.")
-  write_skill(
-    workspace_dir + "/deploy.md",
-    (
-      #|---
-      #|description: This project's deploy steps.
-      #|---
-    ),
-  )
-  write_skill(workspace_dir + "/triage.md", "Workspace triage steps.")
-  let merged = @agent_skill.merge_skills(
-    @agent_skill.discover_skills(global_dir),
-    overrides=@agent_skill.discover_skills(workspace_dir),
-  )
-  // "deploy" appears once — the workspace copy; "lint" survives from the
-  // global library; everything stays name-sorted across both sources.
-  assert_eq(merged.length(), 3)
-  assert_eq(merged[0].name(), "lint")
-  assert_eq(merged[0].path(), global_dir + "/lint.md")
-  assert_eq(merged[1].name(), "deploy")
-  assert_eq(merged[1].description(), "This project's deploy steps.")
-  assert_eq(merged[1].path(), workspace_dir + "/deploy.md")
-  assert_eq(merged[2].name(), "triage")
-  @fs.rmdir(global_dir, recursive=true)
-  @fs.rmdir(workspace_dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-skills-global-", global_dir => {
+    @vfs.with_tmpdir(prefix="openseek-skills-workspace-", workspace_dir => {
+      write_skill(
+        global_dir + "/deploy.md",
+        (
+          #|---
+          #|description: Generic deploy steps.
+          #|---
+        ),
+      )
+      write_skill(global_dir + "/lint.md", "Global lint steps.")
+      write_skill(
+        workspace_dir + "/deploy.md",
+        (
+          #|---
+          #|description: This project's deploy steps.
+          #|---
+        ),
+      )
+      write_skill(workspace_dir + "/triage.md", "Workspace triage steps.")
+      let merged = @agent_skill.merge_skills(
+        @agent_skill.discover_skills(global_dir),
+        overrides=@agent_skill.discover_skills(workspace_dir),
+      )
+      // "deploy" appears once — the workspace copy; "lint" survives from the
+      // global library; everything stays name-sorted across both sources.
+      assert_eq(merged.length(), 3)
+      assert_eq(merged[0].name(), "lint")
+      assert_eq(merged[0].path(), global_dir + "/lint.md")
+      assert_eq(merged[1].name(), "deploy")
+      assert_eq(merged[1].description(), "This project's deploy steps.")
+      assert_eq(merged[1].path(), workspace_dir + "/deploy.md")
+      assert_eq(merged[2].name(), "triage")
+    })
+  })
 }
 
 ///|
@@ -115,27 +115,27 @@ async test "a missing skills directory is an empty library" {
 
 ///|
 async test "the prompt section lists usage, names, and paths" {
-  let dir = @fs.tmpdir(prefix="openseek-skills-prompt-")
-  write_skill(
-    dir + "/release.md",
-    (
-      #|---
-      #|name: release
-      #|description: Cut a release of this project.
-      #|---
-      #|1. bump version
-    ),
-  )
-  let skills = @agent_skill.discover_skills(dir)
-  guard @agent_skill.skills_prompt_section(skills) is Some(section) else {
-    fail("expected a section")
-  }
-  assert_true(section.contains("## Skills"))
-  assert_true(section.contains("read its file with the read tool"))
-  assert_true(
-    section.contains(
-      "- release — Cut a release of this project. (file: \{dir}/release.md)",
-    ),
-  )
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-skills-prompt-", dir => {
+    write_skill(
+      dir + "/release.md",
+      (
+        #|---
+        #|name: release
+        #|description: Cut a release of this project.
+        #|---
+        #|1. bump version
+      ),
+    )
+    let skills = @agent_skill.discover_skills(dir)
+    guard @agent_skill.skills_prompt_section(skills) is Some(section) else {
+      fail("expected a section")
+    }
+    assert_true(section.contains("## Skills"))
+    assert_true(section.contains("read its file with the read tool"))
+    assert_true(
+      section.contains(
+        "- release — Cut a release of this project. (file: \{dir}/release.md)",
+      ),
+    )
+  })
 }

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -53,19 +53,19 @@ async test "edit replaces a unique exact match" {
 
 ///|
 async test "edit resolves relative paths under the workspace root" {
-  let dir = @fs.tmpdir(prefix="openseek-edit-workspace-")
-  let path = "\{dir}/note.txt"
-  @fs.write_file(path, "before", create_mode=CreateOrTruncate)
-  let result = run_edit_in_workspace(dir, {
-    "path": "note.txt",
-    "old_string": "before",
-    "new_string": "after",
+  @vfs.with_tmpdir(prefix="openseek-edit-workspace-", dir => {
+    let path = "\{dir}/note.txt"
+    @fs.write_file(path, "before", create_mode=CreateOrTruncate)
+    let result = run_edit_in_workspace(dir, {
+      "path": "note.txt",
+      "old_string": "before",
+      "new_string": "after",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_eq(@fs.read_file(path).text(), "after")
   })
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
-  assert_eq(@fs.read_file(path).text(), "after")
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -156,24 +156,26 @@ async test "edit rejects identical replacement" {
 
 ///|
 async test "edit rejects suspicious moon.pkg rewrite" {
-  let dir = @fs.tmpdir(prefix="openseek-edit-manifest-")
-  let path = "\{dir}/moon.pkg"
-  @fs.write_file(
-    path,
-    "warnings = \"+unnecessary_annotation\"",
-    create_mode=CreateOrTruncate,
-  )
-  let result = run_edit({
-    "path": path,
-    "old_string": "warnings = \"+unnecessary_annotation\"",
-    "new_string": "x",
+  @vfs.with_tmpdir(prefix="openseek-edit-manifest-", dir => {
+    let path = "\{dir}/moon.pkg"
+    @fs.write_file(
+      path,
+      "warnings = \"+unnecessary_annotation\"",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_edit({
+      "path": path,
+      "old_string": "warnings = \"+unnecessary_annotation\"",
+      "new_string": "x",
+    })
+    let read_back = @fs.read_file(path).text()
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("moon.pkg content is suspiciously small"),
+    )
+    assert_eq(read_back, "warnings = \"+unnecessary_annotation\"")
   })
-  let read_back = @fs.read_file(path).text()
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("moon.pkg content is suspiciously small"))
-  assert_eq(read_back, "warnings = \"+unnecessary_annotation\"")
 }
 
 ///|

--- a/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error_test.mbt
@@ -5,22 +5,22 @@ async test "manifest error allows ordinary files" {
 
 ///|
 async test "manifest error rejects new moon.mod.json" {
-  let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
-  let path = "\{dir}/moon.mod.json"
-  let error = @manifest_error.write_error(path, "{}")
-  @fs.rmdir(dir, recursive=true)
-  guard error is Some(message) else { fail("expected manifest error") }
-  assert_true(message.contains("moon.mod.json is legacy"))
+  @vfs.with_tmpdir(prefix="openseek-edit-manifest-error-", dir => {
+    let path = "\{dir}/moon.mod.json"
+    let error = @manifest_error.write_error(path, "{}")
+    guard error is Some(message) else { fail("expected manifest error") }
+    assert_true(message.contains("moon.mod.json is legacy"))
+  })
 }
 
 ///|
 async test "manifest error allows existing moon.mod.json" {
-  let dir = @fs.tmpdir(prefix="openseek-edit-manifest-error-")
-  let path = "\{dir}/moon.mod.json"
-  @fs.write_file(path, "{}", create_mode=CreateOrTruncate)
-  let error = @manifest_error.write_error(path, "{}")
-  @fs.rmdir(dir, recursive=true)
-  assert_true(error is None)
+  @vfs.with_tmpdir(prefix="openseek-edit-manifest-error-", dir => {
+    let path = "\{dir}/moon.mod.json"
+    @fs.write_file(path, "{}", create_mode=CreateOrTruncate)
+    let error = @manifest_error.write_error(path, "{}")
+    assert_true(error is None)
+  })
 }
 
 ///|

--- a/agent_tool/edit/internal/manifest_error/moon.pkg
+++ b/agent_tool/edit/internal/manifest_error/moon.pkg
@@ -3,6 +3,7 @@ import {
 }
 
 import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
 } for "test"
 

--- a/agent_tool/moon_check/moon_check.mbt
+++ b/agent_tool/moon_check/moon_check.mbt
@@ -378,50 +378,50 @@ async test "moon_check reports diagnostics from a broken fixture project" {
 
 ///|
 async test "moon_check validates a virtual filesystem workspace" {
-  let project = @fs.tmpdir(prefix="openseek-moon-check-vfs-")
-  @vfs.FileSystem({
-    "moon.mod": (
-      #|name = "openseek/moon_check_vfs_fixture"
-      #|
-      #|version = "0.1.0"
-      #|
-      #|preferred_target = "native"
-      #|
-    ),
-    "math/moon.pkg": (
-      #|warnings = "+unnecessary_annotation"
-      #|
-    ),
-    "math/math.mbt": (
-      #|///|
-      #|pub fn add(left : Int, right : Int) -> Int {
-      #|  left + right
-      #|}
-      #|
-    ),
-  }).write_to(project)
-  let canonical = @fs.realpath(project)
-  @async.with_task_group() <| group => {
-    let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
-    let args : Json = { "cwd": project, "target": "native" }
-    let result = execute(runtime, args)
-    ignore(runtime.stop_moon_check(moon_check_key(@decode.decode(args))))
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_false(output.is_error)
-    inspect(
-      stable_moon_check_output(output.content, project, canonical),
-      content=(
-        #|cwd=<fixture>
-        #|command=moon check --watch --diagnostic-limit 10 --target native
-        #|watcher=started
-        #|id=moon-check-1
-        #|status=running
-        #|seq=<seq>
-        #|Finished. moon: ran 2 tasks, now up to date
+  @vfs.with_tmpdir(prefix="openseek-moon-check-vfs-", project => {
+    @vfs.FileSystem({
+      "moon.mod": (
+        #|name = "openseek/moon_check_vfs_fixture"
+        #|
+        #|version = "0.1.0"
+        #|
+        #|preferred_target = "native"
+        #|
       ),
-    )
-  }
-  @fs.rmdir(project, recursive=true)
+      "math/moon.pkg": (
+        #|warnings = "+unnecessary_annotation"
+        #|
+      ),
+      "math/math.mbt": (
+        #|///|
+        #|pub fn add(left : Int, right : Int) -> Int {
+        #|  left + right
+        #|}
+        #|
+      ),
+    }).write_to(project)
+    let canonical = @fs.realpath(project)
+    @async.with_task_group() <| group => {
+      let runtime = MoonCheckRuntime(AgentRuntime(), AgentTaskScope(group))
+      let args : Json = { "cwd": project, "target": "native" }
+      let result = execute(runtime, args)
+      ignore(runtime.stop_moon_check(moon_check_key(@decode.decode(args))))
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_false(output.is_error)
+      inspect(
+        stable_moon_check_output(output.content, project, canonical),
+        content=(
+          #|cwd=<fixture>
+          #|command=moon check --watch --diagnostic-limit 10 --target native
+          #|watcher=started
+          #|id=moon-check-1
+          #|status=running
+          #|seq=<seq>
+          #|Finished. moon: ran 2 tasks, now up to date
+        ),
+      )
+    }
+  })
 }
 
 ///|

--- a/agent_tool/moon_cmd/moon_cmd.mbt
+++ b/agent_tool/moon_cmd/moon_cmd.mbt
@@ -508,77 +508,77 @@ async test "moon_cmd reports failing fixture tests as tool errors" {
 
 ///|
 async test "moon_cmd runs a virtual filesystem native CLI fixture" {
-  let project = @fs.tmpdir(prefix="openseek-moon-cmd-vfs-")
-  @vfs.FileSystem({
-    "moon.mod": (
-      #|name = "openseek/moon_cmd_vfs_fixture"
-      #|
-      #|version = "0.1.0"
-      #|
-      #|preferred_target = "native"
-      #|
-    ),
-    "cmd/main/moon.pkg": (
-      #|import {
-      #|  "moonbitlang/core/env"
-      #|}
-      #|
-      #|supported_targets = "+native"
-      #|
-      #|options(
-      #|  "is-main": true,
-      #|)
-      #|
-    ),
-    "cmd/main/main.mbt": (
-      #|///|
-      #|fn main {
-      #|  if has_probe_arg() {
-      #|    println("moon-cmd-vfs-probe")
-      #|  } else {
-      #|    println("moon-cmd-vfs-missing")
-      #|  }
-      #|}
-      #|
-      #|///|
-      #|fn has_probe_arg() -> Bool {
-      #|  for arg in @env.args() {
-      #|    if arg == "--probe" {
-      #|      return true
-      #|    }
-      #|  }
-      #|  false
-      #|}
-      #|
-    ),
-    "cmd/main/main_wbtest.mbt": (
-      #|///|
-      #|test "probe helper default" {
-      #|  assert_false(has_probe_arg())
-      #|}
-      #|
-    ),
-  }).write_to(project)
-  let canonical = @fs.realpath(project)
-  let result = execute({
-    "cwd": project,
-    "command": "run",
-    "target": "native",
-    "path": "cmd/main",
-    "program_args": ["--probe"],
+  @vfs.with_tmpdir(prefix="openseek-moon-cmd-vfs-", project => {
+    @vfs.FileSystem({
+      "moon.mod": (
+        #|name = "openseek/moon_cmd_vfs_fixture"
+        #|
+        #|version = "0.1.0"
+        #|
+        #|preferred_target = "native"
+        #|
+      ),
+      "cmd/main/moon.pkg": (
+        #|import {
+        #|  "moonbitlang/core/env"
+        #|}
+        #|
+        #|supported_targets = "+native"
+        #|
+        #|options(
+        #|  "is-main": true,
+        #|)
+        #|
+      ),
+      "cmd/main/main.mbt": (
+        #|///|
+        #|fn main {
+        #|  if has_probe_arg() {
+        #|    println("moon-cmd-vfs-probe")
+        #|  } else {
+        #|    println("moon-cmd-vfs-missing")
+        #|  }
+        #|}
+        #|
+        #|///|
+        #|fn has_probe_arg() -> Bool {
+        #|  for arg in @env.args() {
+        #|    if arg == "--probe" {
+        #|      return true
+        #|    }
+        #|  }
+        #|  false
+        #|}
+        #|
+      ),
+      "cmd/main/main_wbtest.mbt": (
+        #|///|
+        #|test "probe helper default" {
+        #|  assert_false(has_probe_arg())
+        #|}
+        #|
+      ),
+    }).write_to(project)
+    let canonical = @fs.realpath(project)
+    let result = execute({
+      "cwd": project,
+      "command": "run",
+      "target": "native",
+      "path": "cmd/main",
+      "program_args": ["--probe"],
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    inspect(
+      stable_moon_cmd_output(output.content, project, canonical).trim(),
+      content=(
+        #|cwd=<fixture>
+        #|command=moon run --target native cmd/main -- --probe
+        #|exit=0
+        #|moon-cmd-vfs-probe
+      ),
+    )
   })
-  @fs.rmdir(project, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  inspect(
-    stable_moon_cmd_output(output.content, project, canonical).trim(),
-    content=(
-      #|cwd=<fixture>
-      #|command=moon run --target native cmd/main -- --probe
-      #|exit=0
-      #|moon-cmd-vfs-probe
-    ),
-  )
 }
 
 ///|

--- a/agent_tool/moon_ide/moon_ide.mbt
+++ b/agent_tool/moon_ide/moon_ide.mbt
@@ -377,82 +377,82 @@ async test "moon_ide finds references in a real fixture package" {
 
 ///|
 async test "moon_ide outlines a virtual filesystem multi-file package" {
-  let project = @fs.tmpdir(prefix="openseek-moon-ide-vfs-")
-  @vfs.FileSystem({
-    "moon.mod": (
-      #|name = "openseek/moon_ide_vfs_fixture"
-      #|
-      #|version = "0.1.0"
-      #|
-      #|preferred_target = "native"
-      #|
-    ),
-    "moon.pkg": (
-      #|warnings = "+unnecessary_annotation"
-      #|
-    ),
-    "model.mbt": (
-      #|///|
-      #|pub struct User {
-      #|  name : String
-      #|} derive(Debug, Eq)
-      #|
-      #|///|
-      #|pub fn User::new(name : String) -> User {
-      #|  { name }
-      #|}
-      #|
-      #|///|
-      #|pub fn User::label(self : User) -> String {
-      #|  "user:" + self.name
-      #|}
-      #|
-    ),
-    "render.mbt": (
-      #|///|
-      #|pub fn render_user(user : User) -> String {
-      #|  user.label()
-      #|}
-      #|
-      #|///|
-      #|pub fn sample() -> String {
-      #|  render_user(User::new("ada"))
-      #|}
-      #|
-    ),
-  }).write_to(project)
-  let canonical = @fs.realpath(project)
-  let result = execute({
-    "cwd": project,
-    "action": "outline",
-    "path": ".",
-    "target": "native",
-    "max_output_chars": 4000,
+  @vfs.with_tmpdir(prefix="openseek-moon-ide-vfs-", project => {
+    @vfs.FileSystem({
+      "moon.mod": (
+        #|name = "openseek/moon_ide_vfs_fixture"
+        #|
+        #|version = "0.1.0"
+        #|
+        #|preferred_target = "native"
+        #|
+      ),
+      "moon.pkg": (
+        #|warnings = "+unnecessary_annotation"
+        #|
+      ),
+      "model.mbt": (
+        #|///|
+        #|pub struct User {
+        #|  name : String
+        #|} derive(Debug, Eq)
+        #|
+        #|///|
+        #|pub fn User::new(name : String) -> User {
+        #|  { name }
+        #|}
+        #|
+        #|///|
+        #|pub fn User::label(self : User) -> String {
+        #|  "user:" + self.name
+        #|}
+        #|
+      ),
+      "render.mbt": (
+        #|///|
+        #|pub fn render_user(user : User) -> String {
+        #|  user.label()
+        #|}
+        #|
+        #|///|
+        #|pub fn sample() -> String {
+        #|  render_user(User::new("ada"))
+        #|}
+        #|
+      ),
+    }).write_to(project)
+    let canonical = @fs.realpath(project)
+    let result = execute({
+      "cwd": project,
+      "action": "outline",
+      "path": ".",
+      "target": "native",
+      "max_output_chars": 4000,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    inspect(
+      stable_moon_ide_output(output.content, project, canonical).trim(),
+      content=(
+        #|cwd=<fixture>
+        #|command=moon ide outline --target native .
+        #|exit=0
+        #|render.mbt:
+        #| L2 | pub fn render_user(user : User) -> String {
+        #|      ...
+        #| L7 | pub fn sample() -> String {
+        #|      ...
+        #|
+        #|model.mbt:
+        #| L02 | pub struct User {
+        #|       ...
+        #| L07 | pub fn User::new(name : String) -> User {
+        #|       ...
+        #| L12 | pub fn User::label(self : User) -> String {
+        #|       ...
+      ),
+    )
   })
-  @fs.rmdir(project, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  inspect(
-    stable_moon_ide_output(output.content, project, canonical).trim(),
-    content=(
-      #|cwd=<fixture>
-      #|command=moon ide outline --target native .
-      #|exit=0
-      #|render.mbt:
-      #| L2 | pub fn render_user(user : User) -> String {
-      #|      ...
-      #| L7 | pub fn sample() -> String {
-      #|      ...
-      #|
-      #|model.mbt:
-      #| L02 | pub struct User {
-      #|       ...
-      #| L07 | pub fn User::new(name : String) -> User {
-      #|       ...
-      #| L12 | pub fn User::label(self : User) -> String {
-      #|       ...
-    ),
-  )
 }
 
 ///|

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -278,21 +278,21 @@ async test "read returns file contents" {
 
 ///|
 async test "read resolves relative paths under the workspace root" {
-  let dir = @fs.tmpdir(prefix="openseek-read-workspace-")
-  @fs.write_file(
-    "\{dir}/note.txt",
-    "workspace read",
-    create_mode=CreateOrTruncate,
-  )
-  let tool = definition(workspace_root=dir)
-  let result = match tool.execute {
-    Async(execute) => execute({ "path": "note.txt" })
-    Sync(_) => fail("read tool should be async")
-  }
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "workspace read")
-  assert_false(output.is_error)
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-read-workspace-", dir => {
+    @fs.write_file(
+      "\{dir}/note.txt",
+      "workspace read",
+      create_mode=CreateOrTruncate,
+    )
+    let tool = definition(workspace_root=dir)
+    let result = match tool.execute {
+      Async(execute) => execute({ "path": "note.txt" })
+      Sync(_) => fail("read tool should be async")
+    }
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "workspace read")
+    assert_false(output.is_error)
+  })
 }
 
 ///|

--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -97,25 +97,25 @@ test "shell tool advertises the expected schema" {
 ```moonbit check
 ///|
 async test "shell tool runs a project-style command through the registry" {
-  let dir = @fs.tmpdir(prefix="openseek-shell-readme-")
-  let tools = @agent_tool.Tools([@shell.definition()])
-  let arguments : Json = {
-    "cmd": "echo 'alpha beta'",
-    "cwd": dir,
-    "timeout_ms": 5000,
-  }
-  let call = @agent_tool.AgentToolCall(
-    ToolCall(
-      id="call_shell_count",
-      name="shell",
-      arguments=arguments.stringify(),
-    ),
-  )
-  let result = @agent_tool.execute_tool_call(call, tools)
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("exit=0"))
-  assert_true(output.content.contains("alpha beta"))
+  @vfs.with_tmpdir(prefix="openseek-shell-readme-", dir => {
+    let tools = @agent_tool.Tools([@shell.definition()])
+    let arguments : Json = {
+      "cmd": "echo 'alpha beta'",
+      "cwd": dir,
+      "timeout_ms": 5000,
+    }
+    let call = @agent_tool.AgentToolCall(
+      ToolCall(
+        id="call_shell_count",
+        name="shell",
+        arguments=arguments.stringify(),
+      ),
+    )
+    let result = @agent_tool.execute_tool_call(call, tools)
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("exit=0"))
+    assert_true(output.content.contains("alpha beta"))
+  })
 }
 ```

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -73,52 +73,52 @@ async test "shell follows final successful PowerShell command on Windows" {
 
 ///|
 async test "shell honors cwd when non-empty" {
-  let dir = @fs.tmpdir(prefix="openseek-shell-cwd-")
-  let result = run_shell({ "cmd": "echo cwd-ok > marker.txt", "cwd": dir })
-  let dir_path : @path.Path = dir
-  let marker_path = dir_path.join("marker.txt").normalize().to_string()
-  let marker = @fs.read_file(marker_path).text() catch { _ => "" }
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("exit=0"))
-  assert_eq(marker.trim(), "cwd-ok")
+  @vfs.with_tmpdir(prefix="openseek-shell-cwd-", dir => {
+    let result = run_shell({ "cmd": "echo cwd-ok > marker.txt", "cwd": dir })
+    let dir_path : @path.Path = dir
+    let marker_path = dir_path.join("marker.txt").normalize().to_string()
+    let marker = @fs.read_file(marker_path).text() catch { _ => "" }
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("exit=0"))
+    assert_eq(marker.trim(), "cwd-ok")
+  })
 }
 
 ///|
 async test "shell uses the workspace root when cwd is omitted" {
-  let dir = @fs.tmpdir(prefix="openseek-shell-workspace-")
-  let result = run_shell_in_workspace(dir, {
-    "cmd": "echo root-ok > marker.txt",
+  @vfs.with_tmpdir(prefix="openseek-shell-workspace-", dir => {
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "echo root-ok > marker.txt",
+    })
+    let marker = @fs.read_file("\{dir}/marker.txt").text() catch { _ => "" }
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("exit=0"))
+    assert_eq(marker.trim(), "root-ok")
   })
-  let marker = @fs.read_file("\{dir}/marker.txt").text() catch { _ => "" }
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("exit=0"))
-  assert_eq(marker.trim(), "root-ok")
 }
 
 ///|
 async test "shell reads a virtual filesystem fixture from cwd" {
-  let project = @fs.tmpdir(prefix="openseek-shell-vfs-")
-  @vfs.FileSystem({
-    "data/input.txt": (
-      #|shell-vfs
-      #|
-    ),
-  }).write_to(project)
-  let result = run_shell({ "cmd": "cat data/input.txt", "cwd": project })
-  @fs.rmdir(project, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  inspect(
-    output.content.trim(),
-    content=(
-      #|exit=0
-      #|shell-vfs
-    ),
-  )
+  @vfs.with_tmpdir(prefix="openseek-shell-vfs-", project => {
+    @vfs.FileSystem({
+      "data/input.txt": (
+        #|shell-vfs
+        #|
+      ),
+    }).write_to(project)
+    let result = run_shell({ "cmd": "cat data/input.txt", "cwd": project })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    inspect(
+      output.content.trim(),
+      content=(
+        #|exit=0
+        #|shell-vfs
+      ),
+    )
+  })
 }
 
 ///|
@@ -421,25 +421,25 @@ async test "shell rejects non-object arguments" {
 
 ///|
 async test "shell rejects non-existent cwd" {
-  let dir = @fs.tmpdir(prefix="openseek-shell-cwd-")
-  let dir_path : @path.Path = dir
-  let path = dir_path.join("does-not-exist").normalize().to_string()
-  let result = run_shell({ "cmd": "echo hello", "cwd": path })
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("cwd does not exist"))
+  @vfs.with_tmpdir(prefix="openseek-shell-cwd-", dir => {
+    let dir_path : @path.Path = dir
+    let path = dir_path.join("does-not-exist").normalize().to_string()
+    let result = run_shell({ "cmd": "echo hello", "cwd": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("cwd does not exist"))
+  })
 }
 
 ///|
 async test "shell rejects cwd that is a file not a directory" {
-  let dir = @fs.tmpdir(prefix="openseek-shell-cwd-")
-  let dir_path : @path.Path = dir
-  let path = dir_path.join("file.txt").normalize().to_string()
-  @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
-  let result = run_shell({ "cmd": "echo hello", "cwd": path })
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("cwd is not a directory"))
+  @vfs.with_tmpdir(prefix="openseek-shell-cwd-", dir => {
+    let dir_path : @path.Path = dir
+    let path = dir_path.join("file.txt").normalize().to_string()
+    @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
+    let result = run_shell({ "cmd": "echo hello", "cwd": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("cwd is not a directory"))
+  })
 }

--- a/agent_tool/write/README.mbt.md
+++ b/agent_tool/write/README.mbt.md
@@ -83,26 +83,27 @@ test "write tool advertises the expected schema" {
 ```moonbit check
 ///|
 async test "write tool updates an implementation note through the registry" {
-  let dir = @fs.tmpdir(prefix="openseek-write-readme-")
-  let path = "\{dir}/note.txt"
-  @fs.write_file(path, "old note", create_mode=CreateOrTruncate)
+  @vfs.with_tmpdir(prefix="openseek-write-readme-", dir => {
+    let path = "\{dir}/note.txt"
+    @fs.write_file(path, "old note", create_mode=CreateOrTruncate)
 
-  let tools = @agent_tool.Tools([@write.definition()])
-  // Build the arguments as JSON and stringify them, rather than embedding the
-  // path in a JSON string literal: a Windows temp path like `C:\Users\...`
-  // would otherwise become an invalid `\U` escape when parsed.
-  let arguments : Json = { "path": path, "content": "tests green" }
-  let call = @agent_tool.AgentToolCall(
-    ToolCall(
-      id="call_write_note",
-      name="write",
-      arguments=arguments.stringify(),
-    ),
-  )
-  let result = @agent_tool.execute_tool_call(call, tools)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_eq(output.content, "ok: wrote 11 chars to \{path}")
-  assert_false(output.is_error)
-  assert_eq(@fs.read_file(path).text(), "tests green")
+    let tools = @agent_tool.Tools([@write.definition()])
+    // Build the arguments as JSON and stringify them, rather than embedding the
+    // path in a JSON string literal: a Windows temp path like `C:\Users\...`
+    // would otherwise become an invalid `\U` escape when parsed.
+    let arguments : Json = { "path": path, "content": "tests green" }
+    let call = @agent_tool.AgentToolCall(
+      ToolCall(
+        id="call_write_note",
+        name="write",
+        arguments=arguments.stringify(),
+      ),
+    )
+    let result = @agent_tool.execute_tool_call(call, tools)
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: wrote 11 chars to \{path}")
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "tests green")
+  })
 }
 ```

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -207,18 +207,18 @@ async test "write creates a file with the given content" {
 
 ///|
 async test "write resolves relative paths under the workspace root" {
-  let dir = @fs.tmpdir(prefix="openseek-write-workspace-")
-  let tool = definition(workspace_root=dir)
-  let result = match tool.execute {
-    Async(execute) => execute({ "path": "note.txt", "content": "workspace" })
-    Sync(_) => fail("write tool should be async")
-  }
-  guard result is Respond(output) else { fail("expected Respond") }
-  let path = "\{dir}/note.txt"
-  assert_false(output.is_error)
-  assert_eq(output.content, "ok: wrote 9 chars to \{path}")
-  assert_eq(@fs.read_file(path).text(), "workspace")
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-write-workspace-", dir => {
+    let tool = definition(workspace_root=dir)
+    let result = match tool.execute {
+      Async(execute) => execute({ "path": "note.txt", "content": "workspace" })
+      Sync(_) => fail("write tool should be async")
+    }
+    guard result is Respond(output) else { fail("expected Respond") }
+    let path = "\{dir}/note.txt"
+    assert_false(output.is_error)
+    assert_eq(output.content, "ok: wrote 9 chars to \{path}")
+    assert_eq(@fs.read_file(path).text(), "workspace")
+  })
 }
 
 ///|
@@ -271,39 +271,39 @@ async test "write accepts empty content" {
 
 ///|
 async test "write rejects new legacy moon.mod.json" {
-  let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
-  let path = "\{dir}/moon.mod.json"
-  let result = execute({ "path": path, "content": "{\"name\":\"legacy\"}" })
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("moon.mod.json is legacy"))
+  @vfs.with_tmpdir(prefix="openseek-write-manifest-", dir => {
+    let path = "\{dir}/moon.mod.json"
+    let result = execute({ "path": path, "content": "{\"name\":\"legacy\"}" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("moon.mod.json is legacy"))
+  })
 }
 
 ///|
 async test "write rejects json style moon.mod" {
-  let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
-  let path = "\{dir}/moon.mod"
-  let result = execute({ "path": path, "content": "{\"name\":\"bad\"}" })
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  assert_true(output.is_error)
-  assert_true(output.content.contains("moon.mod uses current text syntax"))
+  @vfs.with_tmpdir(prefix="openseek-write-manifest-", dir => {
+    let path = "\{dir}/moon.mod"
+    let result = execute({ "path": path, "content": "{\"name\":\"bad\"}" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("moon.mod uses current text syntax"))
+  })
 }
 
 ///|
 async test "write rejects suspiciously tiny moon.pkg" {
-  let dir = @fs.tmpdir(prefix="openseek-write-manifest-")
-  let path = "\{dir}/moon.pkg"
-  let result = execute({ "path": path, "content": "x" })
-  @fs.rmdir(dir, recursive=true)
-  guard result is Respond(output) else { fail("expected Respond") }
-  debug_inspect(
-    output.is_error,
-    content=(
-      #|false
-    ),
-  )
+  @vfs.with_tmpdir(prefix="openseek-write-manifest-", dir => {
+    let path = "\{dir}/moon.pkg"
+    let result = execute({ "path": path, "content": "x" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    debug_inspect(
+      output.is_error,
+      content=(
+        #|false
+      ),
+    )
+  })
 }
 
 ///|

--- a/cmd/openseek/concurrent_wbtest.mbt
+++ b/cmd/openseek/concurrent_wbtest.mbt
@@ -63,18 +63,23 @@ test "inspect_hint adds --session-root only when non-default" {
 
 ///|
 async test "copy_tree dereferences an in-workspace file symlink" {
-  let root = @fs.tmpdir(prefix="openseek-fleet-symlink-")
-  let src = "\{root}/s"
-  @fs.mkdir(src, recursive=true)
-  @fs.write_file("\{src}/real.txt", "content", create_mode=CreateOrTruncate)
-  // A relative, in-workspace symlink (like README.md -> README.mbt.md).
-  @fs.symlink(target="real.txt", "\{src}/link.txt")
-  let dst = "\{root}/d"
-  copy_tree(src, dst, sessions_rel=".openseek/sessions", root=@fs.realpath(src))
-  assert_eq(@fs.read_file("\{dst}/real.txt").text(), "content")
-  // The link is materialized as a regular file with the target's content.
-  assert_eq(@fs.read_file("\{dst}/link.txt").text(), "content")
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-fleet-symlink-", root => {
+    let src = "\{root}/s"
+    @fs.mkdir(src, recursive=true)
+    @fs.write_file("\{src}/real.txt", "content", create_mode=CreateOrTruncate)
+    // A relative, in-workspace symlink (like README.md -> README.mbt.md).
+    @fs.symlink(target="real.txt", "\{src}/link.txt")
+    let dst = "\{root}/d"
+    copy_tree(
+      src,
+      dst,
+      sessions_rel=".openseek/sessions",
+      root=@fs.realpath(src),
+    )
+    assert_eq(@fs.read_file("\{dst}/real.txt").text(), "content")
+    // The link is materialized as a regular file with the target's content.
+    assert_eq(@fs.read_file("\{dst}/link.txt").text(), "content")
+  })
 }
 
 ///|
@@ -92,90 +97,100 @@ test "terminal_summary reads the last terminal" {
 
 ///|
 async test "resolve_run_dirs names siblings and reports a copy source" {
-  let root = @fs.tmpdir(prefix="openseek-fleet-resolve-")
-  @fs.mkdir("\{root}/proj", recursive=true)
-  // Existing dir → a source to copy, with sibling _run_N names.
-  let (dirs, source) = resolve_run_dirs("\{root}/proj", 2)
-  assert_eq(dirs.length(), 2)
-  assert_true(dirs[0].has_suffix("proj_run_1"))
-  assert_true(dirs[1].has_suffix("proj_run_2"))
-  guard source is Some(_) else {
-    fail("expected a copy source for an existing dir")
-  }
-  // Absent dir (parent exists) → no source (build-from-scratch).
-  let (ghost_dirs, ghost_source) = resolve_run_dirs("\{root}/ghost", 1)
-  assert_true(ghost_dirs[0].has_suffix("ghost_run_1"))
-  guard ghost_source is None else {
-    fail("expected no source for an absent dir")
-  }
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-fleet-resolve-", root => {
+    @fs.mkdir("\{root}/proj", recursive=true)
+    // Existing dir → a source to copy, with sibling _run_N names.
+    let (dirs, source) = resolve_run_dirs("\{root}/proj", 2)
+    assert_eq(dirs.length(), 2)
+    assert_true(dirs[0].has_suffix("proj_run_1"))
+    assert_true(dirs[1].has_suffix("proj_run_2"))
+    guard source is Some(_) else {
+      fail("expected a copy source for an existing dir")
+    }
+    // Absent dir (parent exists) → no source (build-from-scratch).
+    let (ghost_dirs, ghost_source) = resolve_run_dirs("\{root}/ghost", 1)
+    assert_true(ghost_dirs[0].has_suffix("ghost_run_1"))
+    guard ghost_source is None else {
+      fail("expected no source for an absent dir")
+    }
+  })
 }
 
 ///|
 async test "resolve_run_dirs rejects an existing run directory" {
-  let root = @fs.tmpdir(prefix="openseek-fleet-collide-")
-  @fs.mkdir("\{root}/proj", recursive=true)
-  @fs.mkdir("\{root}/proj_run_1", recursive=true)
-  let mut raised = false
-  let _ = resolve_run_dirs("\{root}/proj", 2) catch {
-    _ => {
-      raised = true
-      ([], None)
+  @vfs.with_tmpdir(prefix="openseek-fleet-collide-", root => {
+    @fs.mkdir("\{root}/proj", recursive=true)
+    @fs.mkdir("\{root}/proj_run_1", recursive=true)
+    let mut raised = false
+    let _ = resolve_run_dirs("\{root}/proj", 2) catch {
+      _ => {
+        raised = true
+        ([], None)
+      }
     }
-  }
-  assert_true(raised)
-  @fs.rmdir(root, recursive=true)
+    assert_true(raised)
+  })
 }
 
 ///|
 async test "copy_tree keeps files, .git dir, skills; skips build and sessions" {
-  let root = @fs.tmpdir(prefix="openseek-fleet-copy-")
-  let src = "\{root}/s"
-  @fs.mkdir("\{src}/sub", recursive=true)
-  @fs.mkdir("\{src}/_build", recursive=true)
-  @fs.mkdir("\{src}/.git", recursive=true)
-  @fs.mkdir("\{src}/.openseek/skills", recursive=true)
-  @fs.mkdir("\{src}/.openseek/sessions/old", recursive=true)
-  @fs.write_file("\{src}/a.txt", "hi", create_mode=CreateOrTruncate)
-  @fs.write_file("\{src}/sub/b.txt", "yo", create_mode=CreateOrTruncate)
-  @fs.write_file("\{src}/_build/junk", "x", create_mode=CreateOrTruncate)
-  @fs.write_file("\{src}/.git/config", "g", create_mode=CreateOrTruncate)
-  @fs.write_file(
-    "\{src}/.openseek/skills/s.md",
-    "skill",
-    create_mode=CreateOrTruncate,
-  )
-  @fs.write_file(
-    "\{src}/.openseek/sessions/old/events.jsonl",
-    "{}",
-    create_mode=CreateOrTruncate,
-  )
-  let dst = "\{root}/d"
-  copy_tree(src, dst, sessions_rel=".openseek/sessions", root=@fs.realpath(src))
-  assert_eq(@fs.read_file("\{dst}/a.txt").text(), "hi")
-  assert_true(@fs.exists("\{dst}/sub/b.txt"))
-  assert_true(@fs.exists("\{dst}/.git/config")) // normal .git dir kept
-  assert_true(@fs.exists("\{dst}/.openseek/skills/s.md")) // skills kept
-  assert_false(@fs.exists("\{dst}/_build")) // build skipped
-  assert_false(@fs.exists("\{dst}/.openseek/sessions")) // session logs skipped
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-fleet-copy-", root => {
+    let src = "\{root}/s"
+    @fs.mkdir("\{src}/sub", recursive=true)
+    @fs.mkdir("\{src}/_build", recursive=true)
+    @fs.mkdir("\{src}/.git", recursive=true)
+    @fs.mkdir("\{src}/.openseek/skills", recursive=true)
+    @fs.mkdir("\{src}/.openseek/sessions/old", recursive=true)
+    @fs.write_file("\{src}/a.txt", "hi", create_mode=CreateOrTruncate)
+    @fs.write_file("\{src}/sub/b.txt", "yo", create_mode=CreateOrTruncate)
+    @fs.write_file("\{src}/_build/junk", "x", create_mode=CreateOrTruncate)
+    @fs.write_file("\{src}/.git/config", "g", create_mode=CreateOrTruncate)
+    @fs.write_file(
+      "\{src}/.openseek/skills/s.md",
+      "skill",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{src}/.openseek/sessions/old/events.jsonl",
+      "{}",
+      create_mode=CreateOrTruncate,
+    )
+    let dst = "\{root}/d"
+    copy_tree(
+      src,
+      dst,
+      sessions_rel=".openseek/sessions",
+      root=@fs.realpath(src),
+    )
+    assert_eq(@fs.read_file("\{dst}/a.txt").text(), "hi")
+    assert_true(@fs.exists("\{dst}/sub/b.txt"))
+    assert_true(@fs.exists("\{dst}/.git/config")) // normal .git dir kept
+    assert_true(@fs.exists("\{dst}/.openseek/skills/s.md")) // skills kept
+    assert_false(@fs.exists("\{dst}/_build")) // build skipped
+    assert_false(@fs.exists("\{dst}/.openseek/sessions")) // session logs skipped
+  })
 }
 
 ///|
 async test "copy_tree skips a worktree .git file (never points at the original)" {
-  let root = @fs.tmpdir(prefix="openseek-fleet-worktree-")
-  let src = "\{root}/wt"
-  @fs.mkdir(src, recursive=true)
-  // A linked worktree/submodule stores .git as a *file* pointing elsewhere.
-  @fs.write_file(
-    "\{src}/.git",
-    "gitdir: \{root}/main/.git/worktrees/wt",
-    create_mode=CreateOrTruncate,
-  )
-  @fs.write_file("\{src}/code.mbt", "x", create_mode=CreateOrTruncate)
-  let dst = "\{root}/d"
-  copy_tree(src, dst, sessions_rel=".openseek/sessions", root=@fs.realpath(src))
-  assert_true(@fs.exists("\{dst}/code.mbt"))
-  assert_false(@fs.exists("\{dst}/.git")) // worktree pointer not copied
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-fleet-worktree-", root => {
+    let src = "\{root}/wt"
+    @fs.mkdir(src, recursive=true)
+    // A linked worktree/submodule stores .git as a *file* pointing elsewhere.
+    @fs.write_file(
+      "\{src}/.git",
+      "gitdir: \{root}/main/.git/worktrees/wt",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file("\{src}/code.mbt", "x", create_mode=CreateOrTruncate)
+    let dst = "\{root}/d"
+    copy_tree(
+      src,
+      dst,
+      sessions_rel=".openseek/sessions",
+      root=@fs.realpath(src),
+    )
+    assert_true(@fs.exists("\{dst}/code.mbt"))
+    assert_false(@fs.exists("\{dst}/.git")) // worktree pointer not copied
+  })
 }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1014,29 +1014,30 @@ test "cli allows session management without api key or task" {
 
 ///|
 async test "--dir creates a missing final component when its parent exists" {
-  let parent = @fs.tmpdir(prefix="openseek-dir-parent-")
-  let child = "\{parent}/child"
-  let parsed = cli_command().parse(argv=["--dir", child, "write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+  @vfs.with_tmpdir(prefix="openseek-dir-parent-", parent => {
+    let child = "\{parent}/child"
+    let parsed = cli_command().parse(
+      argv=["--dir", child, "write", "MoonBit"],
+      env={ "DEEPSEEK": "test-key" },
+    )
+    let root = prepare_workspace_root(parsed)
+    assert_true(@fs.exists(child))
+    assert_eq(root, @fs.realpath(child))
   })
-  let root = prepare_workspace_root(parsed)
-  assert_true(@fs.exists(child))
-  assert_eq(root, @fs.realpath(child))
-  @fs.rmdir(parent, recursive=true)
 }
 
 ///|
 async test "--dir creates a missing final component with trailing separator" {
-  let parent = @fs.tmpdir(prefix="openseek-dir-trailing-")
-  let child = "\{parent}/child"
-  let parsed = cli_command().parse(
-    argv=["--dir", "\{child}/", "write", "MoonBit"],
-    env={ "DEEPSEEK": "test-key" },
-  )
-  let root = prepare_workspace_root(parsed)
-  assert_true(@fs.exists(child))
-  assert_eq(root, @fs.realpath(child))
-  @fs.rmdir(parent, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-dir-trailing-", parent => {
+    let child = "\{parent}/child"
+    let parsed = cli_command().parse(
+      argv=["--dir", "\{child}/", "write", "MoonBit"],
+      env={ "DEEPSEEK": "test-key" },
+    )
+    let root = prepare_workspace_root(parsed)
+    assert_true(@fs.exists(child))
+    assert_eq(root, @fs.realpath(child))
+  })
 }
 
 ///|
@@ -1051,43 +1052,42 @@ test "--dir trailing separator trim preserves roots" {
 
 ///|
 async test "--dir rejects missing parents instead of creating recursively" {
-  let root = @fs.tmpdir(prefix="openseek-dir-missing-parent-")
-  let child = "\{root}/missing/child"
-  let parsed = cli_command().parse(argv=["--dir", child, "write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
-  })
-  let _ = prepare_workspace_root(parsed) catch {
-    error => {
-      assert_true(
-        "\{error}".contains(
-          "parent directory for --dir does not exist: \{root}/missing",
-        ),
-      )
-      @fs.rmdir(root, recursive=true)
-      return
+  @vfs.with_tmpdir(prefix="openseek-dir-missing-parent-", root => {
+    let child = "\{root}/missing/child"
+    let parsed = cli_command().parse(
+      argv=["--dir", child, "write", "MoonBit"],
+      env={ "DEEPSEEK": "test-key" },
+    )
+    let _ = prepare_workspace_root(parsed) catch {
+      error => {
+        assert_true(
+          "\{error}".contains(
+            "parent directory for --dir does not exist: \{root}/missing",
+          ),
+        )
+        return
+      }
     }
-  }
-  @fs.rmdir(root, recursive=true)
-  fail("missing parent accepted")
+    fail("missing parent accepted")
+  })
 }
 
 ///|
 async test "--dir rejects existing non-directories" {
-  let root = @fs.tmpdir(prefix="openseek-dir-file-")
-  let path = "\{root}/file"
-  @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
-  let parsed = cli_command().parse(argv=["--dir", path, "write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
-  })
-  let _ = prepare_workspace_root(parsed) catch {
-    error => {
-      assert_true("\{error}".contains("--dir is not a directory: \{path}"))
-      @fs.rmdir(root, recursive=true)
-      return
+  @vfs.with_tmpdir(prefix="openseek-dir-file-", root => {
+    let path = "\{root}/file"
+    @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
+    let parsed = cli_command().parse(argv=["--dir", path, "write", "MoonBit"], env={
+      "DEEPSEEK": "test-key",
+    })
+    let _ = prepare_workspace_root(parsed) catch {
+      error => {
+        assert_true("\{error}".contains("--dir is not a directory: \{path}"))
+        return
+      }
     }
-  }
-  @fs.rmdir(root, recursive=true)
-  fail("file path accepted as --dir")
+    fail("file path accepted as --dir")
+  })
 }
 
 ///|
@@ -1209,110 +1209,110 @@ test "cli parses max steps option" {
 
 ///|
 async test "configured system prompt can replace and append files" {
-  let dir = @fs.tmpdir(prefix="openseek-prompt-config-")
-  let prompt_path = "\{dir}/prompt.md"
-  let addendum_path = "\{dir}/addendum.md"
-  @fs.write_file(prompt_path, "base prompt\n", create_mode=CreateOrTruncate)
-  @fs.write_file(addendum_path, "addendum\n", create_mode=CreateOrTruncate)
-  let parsed = cli_command().parse(
-    argv=[
-      "--system-prompt-file", prompt_path, "--system-prompt-addendum-file", addendum_path,
-      "write", "MoonBit",
-    ],
-    // The pinned global-skills dir keeps the exact-text assertion below
-    // machine-independent: without it, a developer's ~/.openseek/skills
-    // would append a ## Skills section (Codex review).
-    env={
-      "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/no-global-skills",
-    },
-  )
-  // Environment last: base and addendum form the cache-shared prefix; the
-  // per-project cwd is the only divergence point.
-  assert_eq(
-    configured_system_prompt(parsed, V4Flash),
-    "base prompt\n\n\naddendum\n\n\n\{environment_prompt_section()}",
-  )
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-prompt-config-", dir => {
+    let prompt_path = "\{dir}/prompt.md"
+    let addendum_path = "\{dir}/addendum.md"
+    @fs.write_file(prompt_path, "base prompt\n", create_mode=CreateOrTruncate)
+    @fs.write_file(addendum_path, "addendum\n", create_mode=CreateOrTruncate)
+    let parsed = cli_command().parse(
+      argv=[
+        "--system-prompt-file", prompt_path, "--system-prompt-addendum-file", addendum_path,
+        "write", "MoonBit",
+      ],
+      // The pinned global-skills dir keeps the exact-text assertion below
+      // machine-independent: without it, a developer's ~/.openseek/skills
+      // would append a ## Skills section (Codex review).
+      env={
+        "DEEPSEEK": "test-key",
+        "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/no-global-skills",
+      },
+    )
+    // Environment last: base and addendum form the cache-shared prefix; the
+    // per-project cwd is the only divergence point.
+    assert_eq(
+      configured_system_prompt(parsed, V4Flash),
+      "base prompt\n\n\naddendum\n\n\n\{environment_prompt_section()}",
+    )
+  })
 }
 
 ///|
 async test "configured system prompt advertises global skills" {
-  let dir = @fs.tmpdir(prefix="openseek-global-skills-")
-  @fs.mkdir("\{dir}/skills", recursive=true)
-  @fs.write_file(
-    "\{dir}/skills/release.md",
-    (
-      #|---
-      #|name: release
-      #|description: Cut a release.
-      #|---
-      #|steps
-    ),
-    create_mode=CreateOrTruncate,
-  )
-  let prompt_path = "\{dir}/prompt.md"
-  @fs.write_file(prompt_path, "base\n", create_mode=CreateOrTruncate)
-  let parsed = cli_command().parse(
-    argv=["--system-prompt-file", prompt_path, "write", "MoonBit"],
-    env={
-      "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/skills",
-    },
-  )
-  let prompt = configured_system_prompt(parsed, V4Flash)
-  assert_true(prompt.contains("## Skills"))
-  assert_true(
-    prompt.contains(
-      "release — Cut a release. (file: \{dir}/skills/release.md)",
-    ),
-  )
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-global-skills-", dir => {
+    @fs.mkdir("\{dir}/skills", recursive=true)
+    @fs.write_file(
+      "\{dir}/skills/release.md",
+      (
+        #|---
+        #|name: release
+        #|description: Cut a release.
+        #|---
+        #|steps
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    let prompt_path = "\{dir}/prompt.md"
+    @fs.write_file(prompt_path, "base\n", create_mode=CreateOrTruncate)
+    let parsed = cli_command().parse(
+      argv=["--system-prompt-file", prompt_path, "write", "MoonBit"],
+      env={
+        "DEEPSEEK": "test-key",
+        "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/skills",
+      },
+    )
+    let prompt = configured_system_prompt(parsed, V4Flash)
+    assert_true(prompt.contains("## Skills"))
+    assert_true(
+      prompt.contains(
+        "release — Cut a release. (file: \{dir}/skills/release.md)",
+      ),
+    )
+  })
 }
 
 ///|
 async test "configured system prompt uses the selected workspace root" {
-  let workspace = @fs.tmpdir(prefix="openseek-prompt-workspace-")
-  let real_workspace = @fs.realpath(workspace)
-  @fs.write_file(
-    "\{workspace}/prompt.md",
-    "workspace prompt\n",
-    create_mode=CreateOrTruncate,
-  )
-  @fs.mkdir("\{workspace}/.openseek/skills", recursive=true)
-  @fs.write_file(
-    "\{workspace}/.openseek/skills/release.md",
-    (
-      #|---
-      #|name: release
-      #|description: Cut a workspace release.
-      #|---
-      #|steps
-    ),
-    create_mode=CreateOrTruncate,
-  )
-  let parsed = cli_command().parse(
-    argv=[
-      "--dir", workspace, "--system-prompt-file", "prompt.md", "write", "MoonBit",
-    ],
-    env={
-      "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{workspace}/no-global-skills",
-    },
-  )
-  let prompt = configured_system_prompt(
-    parsed,
-    V4Flash,
-    workspace_root=real_workspace,
-  )
-  assert_true(prompt.has_prefix("workspace prompt"))
-  assert_true(prompt.contains("Working directory: \{real_workspace}"))
-  assert_true(
-    prompt.contains(
-      "release — Cut a workspace release. (file: \{real_workspace}/.openseek/skills/release.md)",
-    ),
-  )
-  @fs.rmdir(workspace, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-prompt-workspace-", workspace => {
+    let real_workspace = @fs.realpath(workspace)
+    @fs.write_file(
+      "\{workspace}/prompt.md",
+      "workspace prompt\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.mkdir("\{workspace}/.openseek/skills", recursive=true)
+    @fs.write_file(
+      "\{workspace}/.openseek/skills/release.md",
+      (
+        #|---
+        #|name: release
+        #|description: Cut a workspace release.
+        #|---
+        #|steps
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    let parsed = cli_command().parse(
+      argv=[
+        "--dir", workspace, "--system-prompt-file", "prompt.md", "write", "MoonBit",
+      ],
+      env={
+        "DEEPSEEK": "test-key",
+        "OPENSEEK_GLOBAL_SKILLS_DIR": "\{workspace}/no-global-skills",
+      },
+    )
+    let prompt = configured_system_prompt(
+      parsed,
+      V4Flash,
+      workspace_root=real_workspace,
+    )
+    assert_true(prompt.has_prefix("workspace prompt"))
+    assert_true(prompt.contains("Working directory: \{real_workspace}"))
+    assert_true(
+      prompt.contains(
+        "release — Cut a workspace release. (file: \{real_workspace}/.openseek/skills/release.md)",
+      ),
+    )
+  })
 }
 
 ///|
@@ -1330,84 +1330,84 @@ async test "configured system prompt defaults to the flash prompt" {
 
 ///|
 async test "load_or_new_session defers first durable write until append" {
-  let root = @fs.tmpdir(prefix="openseek-cli-session-")
-  let store = @store.SessionStore(root)
-  let id : @agent_session.SessionId = SessionId("cli-test")
-  let prompt_path = "\{root}/prompt.md"
-  @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
-  let parsed = cli_command().parse(
-    argv=[
-      "--session-root", root, "--session", "cli-test", "--system-prompt-file", prompt_path,
-      "write", "MoonBit",
-    ],
-    // Pinned so the exact-prompt assertions stay machine-independent.
-    env={
-      "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
-    },
-  )
-  let created = load_or_new_session(store, id, parsed, V4Pro)
-  let grounded_prompt = "system\n\n\{environment_prompt_section()}"
-  assert_eq(created.system_prompt(), grounded_prompt)
-  assert_eq(created.events().length(), 0)
-  assert_false(store.exists(id))
-  let with_event = store.append(created, User(UserMessage("hello")))
-  assert_eq(with_event.events().length(), 1)
-  @fs.remove(prompt_path)
-  let loaded = load_or_new_session(store, id, parsed, V4Pro)
-  assert_eq(loaded.system_prompt(), grounded_prompt)
-  assert_eq(loaded.events().length(), 1)
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-cli-session-", root => {
+    let store = @store.SessionStore(root)
+    let id : @agent_session.SessionId = SessionId("cli-test")
+    let prompt_path = "\{root}/prompt.md"
+    @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
+    let parsed = cli_command().parse(
+      argv=[
+        "--session-root", root, "--session", "cli-test", "--system-prompt-file",
+        prompt_path, "write", "MoonBit",
+      ],
+      // Pinned so the exact-prompt assertions stay machine-independent.
+      env={
+        "DEEPSEEK": "test-key",
+        "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
+      },
+    )
+    let created = load_or_new_session(store, id, parsed, V4Pro)
+    let grounded_prompt = "system\n\n\{environment_prompt_section()}"
+    assert_eq(created.system_prompt(), grounded_prompt)
+    assert_eq(created.events().length(), 0)
+    assert_false(store.exists(id))
+    let with_event = store.append(created, User(UserMessage("hello")))
+    assert_eq(with_event.events().length(), 1)
+    @fs.remove(prompt_path)
+    let loaded = load_or_new_session(store, id, parsed, V4Pro)
+    assert_eq(loaded.system_prompt(), grounded_prompt)
+    assert_eq(loaded.events().length(), 1)
+  })
 }
 
 ///|
 async test "load_or_new_session recovers empty interrupted session directory" {
-  let root = @fs.tmpdir(prefix="openseek-cli-session-empty-dir-")
-  let id : @agent_session.SessionId = SessionId("cli-test")
-  @fs.mkdir("\{root}/sessions/\{id.value()}", recursive=true)
-  let prompt_path = "\{root}/prompt.md"
-  @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
-  let parsed = cli_command().parse(
-    argv=[
-      "--session-root",
-      root,
-      "--session",
-      id.value(),
-      "--system-prompt-file",
-      prompt_path,
-      "write",
-      "MoonBit",
-    ],
-    // Pinned so the exact-prompt assertion stays machine-independent.
-    env={
-      "DEEPSEEK": "test-key",
-      "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
-    },
-  )
-  let store = @store.SessionStore(root)
-  let session = load_or_new_session(store, id, parsed, V4Pro)
-  assert_eq(
-    session.system_prompt(),
-    "system\n\n\{environment_prompt_section()}",
-  )
-  assert_eq(session.events().length(), 0)
-  let with_event = store.append(session, User(UserMessage("hello")))
-  assert_eq(with_event.events().length(), 1)
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-cli-session-empty-dir-", root => {
+    let id : @agent_session.SessionId = SessionId("cli-test")
+    @fs.mkdir("\{root}/sessions/\{id.value()}", recursive=true)
+    let prompt_path = "\{root}/prompt.md"
+    @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
+    let parsed = cli_command().parse(
+      argv=[
+        "--session-root",
+        root,
+        "--session",
+        id.value(),
+        "--system-prompt-file",
+        prompt_path,
+        "write",
+        "MoonBit",
+      ],
+      // Pinned so the exact-prompt assertion stays machine-independent.
+      env={
+        "DEEPSEEK": "test-key",
+        "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
+      },
+    )
+    let store = @store.SessionStore(root)
+    let session = load_or_new_session(store, id, parsed, V4Pro)
+    assert_eq(
+      session.system_prompt(),
+      "system\n\n\{environment_prompt_section()}",
+    )
+    assert_eq(session.events().length(), 0)
+    let with_event = store.append(session, User(UserMessage("hello")))
+    assert_eq(with_event.events().length(), 1)
+  })
 }
 
 ///|
 async test "session list command does not require deepseek setup" {
-  let root = @fs.tmpdir(prefix="openseek-cli-session-list-")
-  let store = @store.SessionStore(root)
-  store.create(Session(SessionId("b"), system_prompt="system"))
-  store.create(Session(SessionId("a"), system_prompt="system"))
-  let parsed = cli_command().parse(
-    argv=["--session-root", root, "--session-list"],
-    env={},
-  )
-  assert_true(handle_session_command(parsed))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-cli-session-list-", root => {
+    let store = @store.SessionStore(root)
+    store.create(Session(SessionId("b"), system_prompt="system"))
+    store.create(Session(SessionId("a"), system_prompt="system"))
+    let parsed = cli_command().parse(
+      argv=["--session-root", root, "--session-list"],
+      env={},
+    )
+    assert_true(handle_session_command(parsed))
+  })
 }
 
 ///|
@@ -1431,43 +1431,43 @@ test "session list format defaults to text and rejects unknown values" {
 
 ///|
 async test "session list json reports titles newest first with husks last" {
-  let root = @fs.tmpdir(prefix="openseek-cli-session-list-json-")
-  let store = @store.SessionStore(root)
-  let older : @agent_session.Session = Session(
-    SessionId("older"),
-    system_prompt="system",
-  )
-  store.create(
-    older.append(User(UserMessage("  first question\nwith detail  "))),
-  )
-  let newer : @agent_session.Session = Session(
-    SessionId("newer"),
-    system_prompt="system",
-  )
-  store.create(newer)
-  // A directory with no session files at all still appears — last, with no
-  // timestamp — matching the human-readable listing's behavior.
-  @fs.mkdir(root + "/sessions/husk", recursive=true)
-  guard session_list_json(store) is Array(entries) else {
-    fail("expected a JSON array")
-  }
-  assert_eq(entries.length(), 3)
-  guard entries[0] is Object(newest) &&
-    entries[1] is Object(oldest) &&
-    entries[2] is Object(husk) else {
-    fail("expected JSON objects")
-  }
-  assert_true(newest.get("id") is Some(String("newer")))
-  assert_true(newest.get("title") is Some(String("")))
-  assert_true(oldest.get("id") is Some(String("older")))
-  assert_true(oldest.get("title") is Some(String("first question")))
-  guard oldest.get("updated_at_ms") is Some(Number(stamp, ..)) else {
-    fail("expected updated_at_ms")
-  }
-  assert_true(stamp > 0)
-  assert_true(husk.get("id") is Some(String("husk")))
-  assert_true(husk.get("updated_at_ms") is Some(Null))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-cli-session-list-json-", root => {
+    let store = @store.SessionStore(root)
+    let older : @agent_session.Session = Session(
+      SessionId("older"),
+      system_prompt="system",
+    )
+    store.create(
+      older.append(User(UserMessage("  first question\nwith detail  "))),
+    )
+    let newer : @agent_session.Session = Session(
+      SessionId("newer"),
+      system_prompt="system",
+    )
+    store.create(newer)
+    // A directory with no session files at all still appears — last, with no
+    // timestamp — matching the human-readable listing's behavior.
+    @fs.mkdir(root + "/sessions/husk", recursive=true)
+    guard session_list_json(store) is Array(entries) else {
+      fail("expected a JSON array")
+    }
+    assert_eq(entries.length(), 3)
+    guard entries[0] is Object(newest) &&
+      entries[1] is Object(oldest) &&
+      entries[2] is Object(husk) else {
+      fail("expected JSON objects")
+    }
+    assert_true(newest.get("id") is Some(String("newer")))
+    assert_true(newest.get("title") is Some(String("")))
+    assert_true(oldest.get("id") is Some(String("older")))
+    assert_true(oldest.get("title") is Some(String("first question")))
+    guard oldest.get("updated_at_ms") is Some(Number(stamp, ..)) else {
+      fail("expected updated_at_ms")
+    }
+    assert_true(stamp > 0)
+    assert_true(husk.get("id") is Some(String("husk")))
+    assert_true(husk.get("updated_at_ms") is Some(Null))
+  })
 }
 
 ///|
@@ -1487,65 +1487,69 @@ test "mtime to unix millis preserves subsecond precision" {
 
 ///|
 async test "session compact command appends summary without api key" {
-  let root = @fs.tmpdir(prefix="openseek-cli-session-compact-")
-  let store = @store.SessionStore(root)
-  let session = @agent_session.Session(
-      SessionId("cli-test"),
-      system_prompt="system",
+  @vfs.with_tmpdir(prefix="openseek-cli-session-compact-", root => {
+    let store = @store.SessionStore(root)
+    let session = @agent_session.Session(
+        SessionId("cli-test"),
+        system_prompt="system",
+      )
+      .append(User(UserMessage("hello")))
+      .append(Assistant(AssistantMessage("answer")))
+    store.create(session)
+    let summary_path = "\{root}/summary.txt"
+    @fs.write_file(
+      summary_path,
+      "summarized turn",
+      create_mode=CreateOrTruncate,
     )
-    .append(User(UserMessage("hello")))
-    .append(Assistant(AssistantMessage("answer")))
-  store.create(session)
-  let summary_path = "\{root}/summary.txt"
-  @fs.write_file(summary_path, "summarized turn", create_mode=CreateOrTruncate)
-  let parsed = cli_command().parse(
-    argv=[
-      "--session-root", root, "--session", "cli-test", "--session-compact-file",
-      summary_path, "--session-compact-from", "1", "--session-compact-to", "2",
-    ],
-    env={},
-  )
-  assert_true(handle_session_command(parsed))
-  let loaded = store.load(SessionId("cli-test"))
-  assert_eq(loaded.events().length(), 3)
-  guard loaded.events()[2].item() is Summary(summary) else {
-    fail("expected summary")
-  }
-  assert_eq(summary.content(), "summarized turn")
-  @fs.rmdir(root, recursive=true)
+    let parsed = cli_command().parse(
+      argv=[
+        "--session-root", root, "--session", "cli-test", "--session-compact-file",
+        summary_path, "--session-compact-from", "1", "--session-compact-to", "2",
+      ],
+      env={},
+    )
+    assert_true(handle_session_command(parsed))
+    let loaded = store.load(SessionId("cli-test"))
+    assert_eq(loaded.events().length(), 3)
+    guard loaded.events()[2].item() is Summary(summary) else {
+      fail("expected summary")
+    }
+    assert_eq(summary.content(), "summarized turn")
+  })
 }
 
 ///|
 async test "session compact file resolves relative to workspace root" {
-  let workspace = @fs.tmpdir(prefix="openseek-cli-session-compact-workspace-")
-  let session_root = "\{workspace}/.openseek"
-  let store = @store.SessionStore(session_root)
-  let session = @agent_session.Session(
-      SessionId("cli-test"),
-      system_prompt="system",
+  @vfs.with_tmpdir(prefix="openseek-cli-session-compact-workspace-", workspace => {
+    let session_root = "\{workspace}/.openseek"
+    let store = @store.SessionStore(session_root)
+    let session = @agent_session.Session(
+        SessionId("cli-test"),
+        system_prompt="system",
+      )
+      .append(User(UserMessage("hello")))
+      .append(Assistant(AssistantMessage("answer")))
+    store.create(session)
+    @fs.write_file(
+      "\{workspace}/summary.txt",
+      "workspace summary",
+      create_mode=CreateOrTruncate,
     )
-    .append(User(UserMessage("hello")))
-    .append(Assistant(AssistantMessage("answer")))
-  store.create(session)
-  @fs.write_file(
-    "\{workspace}/summary.txt",
-    "workspace summary",
-    create_mode=CreateOrTruncate,
-  )
-  let parsed = cli_command().parse(
-    argv=[
-      "--session", "cli-test", "--session-compact-file", "summary.txt", "--session-compact-from",
-      "1", "--session-compact-to", "2",
-    ],
-    env={},
-  )
-  assert_true(handle_session_command(parsed, workspace_root=workspace))
-  let loaded = store.load(SessionId("cli-test"))
-  guard loaded.events()[2].item() is Summary(summary) else {
-    fail("expected summary")
-  }
-  assert_eq(summary.content(), "workspace summary")
-  @fs.rmdir(workspace, recursive=true)
+    let parsed = cli_command().parse(
+      argv=[
+        "--session", "cli-test", "--session-compact-file", "summary.txt", "--session-compact-from",
+        "1", "--session-compact-to", "2",
+      ],
+      env={},
+    )
+    assert_true(handle_session_command(parsed, workspace_root=workspace))
+    let loaded = store.load(SessionId("cli-test"))
+    guard loaded.events()[2].item() is Summary(summary) else {
+      fail("expected summary")
+    }
+    assert_eq(summary.content(), "workspace summary")
+  })
 }
 
 ///|

--- a/cmd/tui/continue_wbtest.mbt
+++ b/cmd/tui/continue_wbtest.mbt
@@ -1,26 +1,26 @@
 ///|
 async test "--continue resolves the most recently active session" {
-  let root = @fs.tmpdir(prefix="openseek-tui-continue-")
-  let store = @store.SessionStore(root)
-  store.create(Session(SessionId("older"), system_prompt="system"))
-  // Filesystem mtimes need a beat between writes to order reliably.
-  @async.sleep(50)
-  store.create(Session(SessionId("newer"), system_prompt="system"))
-  let parsed = cli_command().parse(
-    argv=["--continue", "--session-root", root],
-    env={ "DEEPSEEK": "test-key" },
-  )
-  let config = with_latest_session(parse_config(parsed))
-  assert_eq(config.session_id.value(), "newer")
-  // An empty store keeps the generated fresh session: nothing to continue,
-  // so the TUI starts a new conversation instead of refusing to launch.
-  let empty_root = @fs.tmpdir(prefix="openseek-tui-continue-empty-")
-  let parsed = cli_command().parse(
-    argv=["--continue", "--session-root", empty_root],
-    env={ "DEEPSEEK": "test-key" },
-  )
-  let fresh = with_latest_session(parse_config(parsed))
-  assert_true(fresh.session_id.value().has_prefix("tui-"))
-  @fs.rmdir(root, recursive=true)
-  @fs.rmdir(empty_root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-tui-continue-", root => {
+    @vfs.with_tmpdir(prefix="openseek-tui-continue-empty-", empty_root => {
+      let store = @store.SessionStore(root)
+      store.create(Session(SessionId("older"), system_prompt="system"))
+      // Filesystem mtimes need a beat between writes to order reliably.
+      @async.sleep(50)
+      store.create(Session(SessionId("newer"), system_prompt="system"))
+      let parsed = cli_command().parse(
+        argv=["--continue", "--session-root", root],
+        env={ "DEEPSEEK": "test-key" },
+      )
+      let config = with_latest_session(parse_config(parsed))
+      assert_eq(config.session_id.value(), "newer")
+      // An empty store keeps the generated fresh session: nothing to continue,
+      // so the TUI starts a new conversation instead of refusing to launch.
+      let parsed = cli_command().parse(
+        argv=["--continue", "--session-root", empty_root],
+        env={ "DEEPSEEK": "test-key" },
+      )
+      let fresh = with_latest_session(parse_config(parsed))
+      assert_true(fresh.session_id.value().has_prefix("tui-"))
+    })
+  })
 }

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -20,7 +20,7 @@ import {
 }
 
 import {
-  "moonbitlang/async/fs",
+  "bobzhang/openseek/testkit/filesystem" @vfs,
 } for "wbtest"
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -140,74 +140,78 @@ test "valid_session_id mirrors the store's id rules" {
 
 ///|
 async test "discover_session_roots scans recursively and skips heavy dirs" {
-  let root = @fs.tmpdir(prefix="openseek-viz-scan-")
-  @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)
-  @fs.mkdir("\{root}/packages/lib/.openseek/sessions", recursive=true)
-  @fs.mkdir("\{root}/.git/ignored/.openseek/sessions", recursive=true)
-  @fs.mkdir("\{root}/node_modules/ignored/.openseek/sessions", recursive=true)
-  @fs.mkdir("\{root}/.mooncakes/ignored/.openseek/sessions", recursive=true)
-  @fs.mkdir("\{root}/_build/ignored/.openseek/sessions", recursive=true)
-  let roots = discover_session_roots([root], ".openseek").map(path => {
-    path.replace_all(old=root, new="<root>")
+  @vfs.with_tmpdir(prefix="openseek-viz-scan-", root => {
+    @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)
+    @fs.mkdir("\{root}/packages/lib/.openseek/sessions", recursive=true)
+    @fs.mkdir("\{root}/.git/ignored/.openseek/sessions", recursive=true)
+    @fs.mkdir("\{root}/node_modules/ignored/.openseek/sessions", recursive=true)
+    @fs.mkdir("\{root}/.mooncakes/ignored/.openseek/sessions", recursive=true)
+    @fs.mkdir("\{root}/_build/ignored/.openseek/sessions", recursive=true)
+    let roots = discover_session_roots([root], ".openseek").map(path => {
+      path.replace_all(old=root, new="<root>")
+    })
+    @debug.debug_inspect(
+      roots,
+      content=(
+        #|["<root>/app/.openseek", "<root>/packages/lib/.openseek"]
+      ),
+    )
   })
-  @debug.debug_inspect(
-    roots,
-    content=(
-      #|["<root>/app/.openseek", "<root>/packages/lib/.openseek"]
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
 }
 
 ///|
 async test "discover_session_roots supports a custom root marker" {
-  let root = @fs.tmpdir(prefix="openseek-viz-openroot-")
-  @fs.mkdir("\{root}/app/.openroot/sessions", recursive=true)
-  @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)
-  let roots = discover_session_roots([root], ".openroot").map(path => {
-    path.replace_all(old=root, new="<root>")
+  @vfs.with_tmpdir(prefix="openseek-viz-openroot-", root => {
+    @fs.mkdir("\{root}/app/.openroot/sessions", recursive=true)
+    @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)
+    let roots = discover_session_roots([root], ".openroot").map(path => {
+      path.replace_all(old=root, new="<root>")
+    })
+    @debug.debug_inspect(
+      roots,
+      content=(
+        #|["<root>/app/.openroot"]
+      ),
+    )
   })
-  @debug.debug_inspect(
-    roots,
-    content=(
-      #|["<root>/app/.openroot"]
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
 }
 
 ///|
 async test "session_catalog scans a container session root for nested stores" {
-  let root = @fs.tmpdir(prefix="openseek-viz-nested-")
-  // A directory of best-of-N run workspaces, each with its own nested store.
-  @fs.mkdir("\{root}/A-1/.openseek/sessions/run", recursive=true)
-  @fs.mkdir("\{root}/B-1/.openseek/sessions/run", recursive=true)
-  let catalog = session_catalog(root, [], ".openseek")
-  let paths = catalog.roots.map(r => r.path.replace_all(old=root, new="<root>"))
-  paths.sort()
-  // The empty container itself is not announced; its nested stores are.
-  @debug.debug_inspect(
-    paths,
-    content=(
-      #|["<root>/A-1/.openseek", "<root>/B-1/.openseek"]
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-viz-nested-", root => {
+    // A directory of best-of-N run workspaces, each with its own nested store.
+    @fs.mkdir("\{root}/A-1/.openseek/sessions/run", recursive=true)
+    @fs.mkdir("\{root}/B-1/.openseek/sessions/run", recursive=true)
+    let catalog = session_catalog(root, [], ".openseek")
+    let paths = catalog.roots.map(r => {
+      r.path.replace_all(old=root, new="<root>")
+    })
+    paths.sort()
+    // The empty container itself is not announced; its nested stores are.
+    @debug.debug_inspect(
+      paths,
+      content=(
+        #|["<root>/A-1/.openseek", "<root>/B-1/.openseek"]
+      ),
+    )
+  })
 }
 
 ///|
 async test "session_catalog serves a direct store named like the root marker" {
-  let root = @fs.tmpdir(prefix="openseek-viz-direct-")
-  @fs.mkdir("\{root}/.openseek/sessions/run", recursive=true)
-  let catalog = session_catalog("\{root}/.openseek", [], ".openseek")
-  let paths = catalog.roots.map(r => r.path.replace_all(old=root, new="<root>"))
-  @debug.debug_inspect(
-    paths,
-    content=(
-      #|["<root>/.openseek"]
-    ),
-  )
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-viz-direct-", root => {
+    @fs.mkdir("\{root}/.openseek/sessions/run", recursive=true)
+    let catalog = session_catalog("\{root}/.openseek", [], ".openseek")
+    let paths = catalog.roots.map(r => {
+      r.path.replace_all(old=root, new="<root>")
+    })
+    @debug.debug_inspect(
+      paths,
+      content=(
+        #|["<root>/.openseek"]
+      ),
+    )
+  })
 }
 
 ///|
@@ -245,32 +249,36 @@ test "session catalog lookup supports composite and legacy keys" {
 
 ///|
 async test "session_list_reply includes root metadata and composite keys" {
-  let root = @fs.tmpdir(prefix="openseek-viz-list-")
-  let app_store = @store.SessionStore("\{root}/app/.openseek")
-  let lib_store = @store.SessionStore("\{root}/lib/.openseek")
-  app_store.create(@agent_session.Session(SessionId("same"), system_prompt="a"))
-  lib_store.create(@agent_session.Session(SessionId("same"), system_prompt="b"))
-  let catalog : SessionCatalog = {
-    roots: [
-      {
-        key: "0",
-        path: "\{root}/app/.openseek",
-        label: "app/.openseek",
-        store: app_store,
-      },
-      {
-        key: "1",
-        path: "\{root}/lib/.openseek",
-        label: "lib/.openseek",
-        store: lib_store,
-      },
-    ],
-  }
-  let reply = session_list_reply(catalog)
-  let text = reply.body
-  assert_true(text.contains("\"key\":\"0|same\""))
-  assert_true(text.contains("\"key\":\"1|same\""))
-  assert_true(text.contains("\"root_label\":\"app/.openseek\""))
-  assert_true(text.contains("\"root_label\":\"lib/.openseek\""))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-viz-list-", root => {
+    let app_store = @store.SessionStore("\{root}/app/.openseek")
+    let lib_store = @store.SessionStore("\{root}/lib/.openseek")
+    app_store.create(
+      @agent_session.Session(SessionId("same"), system_prompt="a"),
+    )
+    lib_store.create(
+      @agent_session.Session(SessionId("same"), system_prompt="b"),
+    )
+    let catalog : SessionCatalog = {
+      roots: [
+        {
+          key: "0",
+          path: "\{root}/app/.openseek",
+          label: "app/.openseek",
+          store: app_store,
+        },
+        {
+          key: "1",
+          path: "\{root}/lib/.openseek",
+          label: "lib/.openseek",
+          store: lib_store,
+        },
+      ],
+    }
+    let reply = session_list_reply(catalog)
+    let text = reply.body
+    assert_true(text.contains("\"key\":\"0|same\""))
+    assert_true(text.contains("\"key\":\"1|same\""))
+    assert_true(text.contains("\"root_label\":\"app/.openseek\""))
+    assert_true(text.contains("\"root_label\":\"lib/.openseek\""))
+  })
 }

--- a/cmd/viz_server/moon.pkg
+++ b/cmd/viz_server/moon.pkg
@@ -1,4 +1,8 @@
 import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "wbtest"
+
+import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
   "moonbitlang/async",

--- a/eval/file_edit/harness/harness_wbtest.mbt
+++ b/eval/file_edit/harness/harness_wbtest.mbt
@@ -1,90 +1,90 @@
 ///|
 async test "prepare output dir creates a missing output directory" {
-  let root = @fs.tmpdir(prefix="openseek-file-edit-output")
-  let out_dir = root + "/out"
-  prepare_output_dir(out_dir)
-  assert_true(@fs.exists(out_dir + "/workspaces"))
-  assert_true(@fs.exists(out_dir + "/logs"))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-file-edit-output", root => {
+    let out_dir = root + "/out"
+    prepare_output_dir(out_dir)
+    assert_true(@fs.exists(out_dir + "/workspaces"))
+    assert_true(@fs.exists(out_dir + "/logs"))
+  })
 }
 
 ///|
 async test "dry run exact replacement oracle" {
-  let case = @cases.case_for_trial(0)
-  let root = @fs.tmpdir(prefix="openseek-file-edit-harness")
-  let workspace = root + "/workspace"
-  let log_path = root + "/trial.log"
-  @fs.mkdir(workspace, recursive=true)
-  write_fixture(workspace, case)
-  @vfs.FileSystem({ "src/note.txt": "alpha\ndelta\ngamma\n" }).write_to(
-    workspace,
-  )
-  @fs.write_file(
-    log_path,
-    (
-      $|--- step 1 ---
-      $|tool: ok: replaced 1 occurrence
-      $|=== finished ===
-      $|file-edit-eval:\{case.id}
-    ),
-    create_mode=CreateOrTruncate,
-  )
-  let result = evaluate_trial(
-    "builtin",
-    0,
-    case,
-    workspace,
-    log_path,
-    0,
-    @fs.read_file(log_path).text(),
-  )
-  assert_true(result.success)
-  assert_eq(result.reason, "ok")
-  assert_eq(result.prompt_label, "builtin")
-  assert_eq(result.edit_successes, 1)
-  assert_true(result.marker_present)
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-file-edit-harness", root => {
+    let case = @cases.case_for_trial(0)
+    let workspace = root + "/workspace"
+    let log_path = root + "/trial.log"
+    @fs.mkdir(workspace, recursive=true)
+    write_fixture(workspace, case)
+    @vfs.FileSystem({ "src/note.txt": "alpha\ndelta\ngamma\n" }).write_to(
+      workspace,
+    )
+    @fs.write_file(
+      log_path,
+      (
+        $|--- step 1 ---
+        $|tool: ok: replaced 1 occurrence
+        $|=== finished ===
+        $|file-edit-eval:\{case.id}
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    let result = evaluate_trial(
+      "builtin",
+      0,
+      case,
+      workspace,
+      log_path,
+      0,
+      @fs.read_file(log_path).text(),
+    )
+    assert_true(result.success)
+    assert_eq(result.reason, "ok")
+    assert_eq(result.prompt_label, "builtin")
+    assert_eq(result.edit_successes, 1)
+    assert_true(result.marker_present)
+  })
 }
 
 ///|
 async test "dry run exact replacement oracle with jsonl agent log" {
-  let case = @cases.case_for_trial(0)
-  let root = @fs.tmpdir(prefix="openseek-file-edit-harness-jsonl")
-  let workspace = root + "/workspace"
-  let log_path = root + "/trial.log"
-  @fs.mkdir(workspace, recursive=true)
-  write_fixture(workspace, case)
-  @vfs.FileSystem({ "src/note.txt": "alpha\ndelta\ngamma\n" }).write_to(
-    workspace,
-  )
-  @fs.write_file(
-    log_path,
-    (
-      $|not json
-      $|{"event":"agent_step","step":1}
-      $|{"event":"tool_result","tool_name":"edit","is_error":false,"content":"ok: replaced 1 occurrence"}
-      $|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
-      $|{"event":"agent_finished","answer":"file-edit-eval:\{case.id}"}
-    ),
-    create_mode=CreateOrTruncate,
-  )
-  let result = evaluate_trial(
-    "builtin",
-    0,
-    case,
-    workspace,
-    log_path,
-    0,
-    @fs.read_file(log_path).text(),
-  )
-  assert_true(result.success)
-  assert_eq(result.steps, 1)
-  assert_eq(result.tool_errors, 0)
-  assert_eq(result.shell_uses, 1)
-  assert_eq(result.edit_successes, 1)
-  assert_true(result.marker_present)
-  assert_eq(result.warnings, "shell tool used 1 time(s)")
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-file-edit-harness-jsonl", root => {
+    let case = @cases.case_for_trial(0)
+    let workspace = root + "/workspace"
+    let log_path = root + "/trial.log"
+    @fs.mkdir(workspace, recursive=true)
+    write_fixture(workspace, case)
+    @vfs.FileSystem({ "src/note.txt": "alpha\ndelta\ngamma\n" }).write_to(
+      workspace,
+    )
+    @fs.write_file(
+      log_path,
+      (
+        $|not json
+        $|{"event":"agent_step","step":1}
+        $|{"event":"tool_result","tool_name":"edit","is_error":false,"content":"ok: replaced 1 occurrence"}
+        $|{"event":"tool_result","tool_name":"shell","is_error":false,"content":"exit=0"}
+        $|{"event":"agent_finished","answer":"file-edit-eval:\{case.id}"}
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    let result = evaluate_trial(
+      "builtin",
+      0,
+      case,
+      workspace,
+      log_path,
+      0,
+      @fs.read_file(log_path).text(),
+    )
+    assert_true(result.success)
+    assert_eq(result.steps, 1)
+    assert_eq(result.tool_errors, 0)
+    assert_eq(result.shell_uses, 1)
+    assert_eq(result.edit_successes, 1)
+    assert_true(result.marker_present)
+    assert_eq(result.warnings, "shell tool used 1 time(s)")
+  })
 }
 
 ///|

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -235,78 +235,78 @@ test "same output dir preserves absolute workspace paths" {
 
 ///|
 async test "analyze run writes reports to caller output directory" {
-  let root = @fs.tmpdir(prefix="openseek-prompt-analyze-out")
-  let out_dir = root + "/actual"
-  let stale_dir = root + "/stale"
-  @fs.mkdir(out_dir, recursive=true)
-  let actual_events_path = out_dir +
-    "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
-  let stale_events_path = stale_dir +
-    "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
-  @fs.mkdir(
-    out_dir + "/workspaces/01/.openseek/sessions/trial-01",
-    recursive=true,
-  )
-  @fs.mkdir(
-    stale_dir + "/workspaces/01/.openseek/sessions/trial-01",
-    recursive=true,
-  )
-  @fs.write_file(
-    actual_events_path,
-    assistant_events("trial-01", "I used @string.parse_int"),
-    create_mode=CreateOrTruncate,
-  )
-  @fs.write_file(
-    stale_events_path,
-    assistant_events("trial-01", "I only used moon test"),
-    create_mode=CreateOrTruncate,
-  )
-  let manifest_json : Json = {
-    "model": "deepseek-v4-flash",
-    "problem_id": "toml_parser_cli",
-    "prompt_label": "flash",
-    "task_file": "eval/prompt_tasks/toml_parser_cli.md",
-    "runs": 0,
-    "concurrency": 1,
-    "min_successes": 0,
-    "max_steps": 160,
-    "out_dir": stale_dir,
-    "validation_probes": (
-      [
-        {
-          "name": "moon check",
-          "command": ["moon", "--version"],
-          "expect_exit": 0,
-        },
-      ] : Json),
-    "trials": (
-      [
-        {
-          "index": 1,
-          "workspace": stale_dir + "/workspaces/01",
-          "log_path": stale_dir + "/logs/01.log",
-          "session_id": "trial-01",
-          "events_path": stale_events_path,
-          "exit_code": 0,
-        },
-      ] : Json),
-  }
-  @fs.write_file(
-    manifest_path(out_dir),
-    manifest_json.stringify(),
-    create_mode=CreateOrTruncate,
-  )
-  let report = analyze_run(out_dir)
-  assert_eq(report.out_dir, out_dir)
-  assert_eq(report.results[0].workspace, out_dir + "/workspaces/01")
-  assert_eq(report.results[0].events_path, actual_events_path)
-  assert_false(report.results[0].workspace.contains(stale_dir))
-  assert_eq(report.results[0].parse_int_mentions, 1)
-  assert_eq(report.results[0].moon_test_uses, 0)
-  assert_true(@fs.exists(out_dir + "/report.md"))
-  assert_true(@fs.exists(out_dir + "/report.html"))
-  assert_false(@fs.exists(stale_dir + "/report.md"))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-prompt-analyze-out", root => {
+    let out_dir = root + "/actual"
+    let stale_dir = root + "/stale"
+    @fs.mkdir(out_dir, recursive=true)
+    let actual_events_path = out_dir +
+      "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
+    let stale_events_path = stale_dir +
+      "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
+    @fs.mkdir(
+      out_dir + "/workspaces/01/.openseek/sessions/trial-01",
+      recursive=true,
+    )
+    @fs.mkdir(
+      stale_dir + "/workspaces/01/.openseek/sessions/trial-01",
+      recursive=true,
+    )
+    @fs.write_file(
+      actual_events_path,
+      assistant_events("trial-01", "I used @string.parse_int"),
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      stale_events_path,
+      assistant_events("trial-01", "I only used moon test"),
+      create_mode=CreateOrTruncate,
+    )
+    let manifest_json : Json = {
+      "model": "deepseek-v4-flash",
+      "problem_id": "toml_parser_cli",
+      "prompt_label": "flash",
+      "task_file": "eval/prompt_tasks/toml_parser_cli.md",
+      "runs": 0,
+      "concurrency": 1,
+      "min_successes": 0,
+      "max_steps": 160,
+      "out_dir": stale_dir,
+      "validation_probes": (
+        [
+          {
+            "name": "moon check",
+            "command": ["moon", "--version"],
+            "expect_exit": 0,
+          },
+        ] : Json),
+      "trials": (
+        [
+          {
+            "index": 1,
+            "workspace": stale_dir + "/workspaces/01",
+            "log_path": stale_dir + "/logs/01.log",
+            "session_id": "trial-01",
+            "events_path": stale_events_path,
+            "exit_code": 0,
+          },
+        ] : Json),
+    }
+    @fs.write_file(
+      manifest_path(out_dir),
+      manifest_json.stringify(),
+      create_mode=CreateOrTruncate,
+    )
+    let report = analyze_run(out_dir)
+    assert_eq(report.out_dir, out_dir)
+    assert_eq(report.results[0].workspace, out_dir + "/workspaces/01")
+    assert_eq(report.results[0].events_path, actual_events_path)
+    assert_false(report.results[0].workspace.contains(stale_dir))
+    assert_eq(report.results[0].parse_int_mentions, 1)
+    assert_eq(report.results[0].moon_test_uses, 0)
+    assert_true(@fs.exists(out_dir + "/report.md"))
+    assert_true(@fs.exists(out_dir + "/report.html"))
+    assert_false(@fs.exists(stale_dir + "/report.md"))
+  })
 }
 
 ///|

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -1,11 +1,11 @@
 ///|
 async test "prepare output dir creates runner artifact directories" {
-  let root = @fs.tmpdir(prefix="openseek-prompt-task-output")
-  let out_dir = root + "/out"
-  prepare_output_dir(out_dir)
-  assert_true(@fs.exists(out_dir + "/workspaces"))
-  assert_true(@fs.exists(out_dir + "/logs"))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-prompt-task-output", root => {
+    let out_dir = root + "/out"
+    prepare_output_dir(out_dir)
+    assert_true(@fs.exists(out_dir + "/workspaces"))
+    assert_true(@fs.exists(out_dir + "/logs"))
+  })
 }
 
 ///|

--- a/eval/prompt_task/harness/manifest_wbtest.mbt
+++ b/eval/prompt_task/harness/manifest_wbtest.mbt
@@ -1,41 +1,41 @@
 ///|
 async test "manifest round trips run artifacts" {
   @async.sleep(0)
-  let root = @fs.tmpdir(prefix="openseek-prompt-task-manifest")
-  let manifest : RunManifest = {
-    model: "deepseek-v4-flash",
-    problem_id: "toml_parser_cli",
-    prompt_label: "flash",
-    task_file: "eval/prompt_tasks/toml_parser_cli.md",
-    runs: 1,
-    concurrency: 1,
-    min_successes: 1,
-    max_steps: 160,
-    out_dir: root,
-    validation_probes: [
-      ValidationProbeSpec(name="moon check", command=[
-        "moon", "check", "--target", "native",
-      ]),
-    ],
-    trials: [
-      {
-        index: 1,
-        workspace: root + "/workspaces/01",
-        log_path: root + "/logs/01.log",
-        session_id: "trial-01",
-        events_path: root +
-        "/workspaces/01/.openseek/sessions/trial-01/events.jsonl",
-        exit_code: 0,
-      },
-    ],
-  }
-  write_manifest(manifest)
-  let loaded = read_manifest(root)
-  assert_eq(loaded.model, "deepseek-v4-flash")
-  assert_eq(loaded.problem_id, "toml_parser_cli")
-  assert_eq(loaded.validation_probes.length(), 1)
-  assert_eq(loaded.validation_probes[0].name, "moon check")
-  assert_eq(loaded.trials.length(), 1)
-  assert_eq(loaded.trials[0].session_id, "trial-01")
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-prompt-task-manifest", root => {
+    let manifest : RunManifest = {
+      model: "deepseek-v4-flash",
+      problem_id: "toml_parser_cli",
+      prompt_label: "flash",
+      task_file: "eval/prompt_tasks/toml_parser_cli.md",
+      runs: 1,
+      concurrency: 1,
+      min_successes: 1,
+      max_steps: 160,
+      out_dir: root,
+      validation_probes: [
+        ValidationProbeSpec(name="moon check", command=[
+          "moon", "check", "--target", "native",
+        ]),
+      ],
+      trials: [
+        {
+          index: 1,
+          workspace: root + "/workspaces/01",
+          log_path: root + "/logs/01.log",
+          session_id: "trial-01",
+          events_path: root +
+          "/workspaces/01/.openseek/sessions/trial-01/events.jsonl",
+          exit_code: 0,
+        },
+      ],
+    }
+    write_manifest(manifest)
+    let loaded = read_manifest(root)
+    assert_eq(loaded.model, "deepseek-v4-flash")
+    assert_eq(loaded.problem_id, "toml_parser_cli")
+    assert_eq(loaded.validation_probes.length(), 1)
+    assert_eq(loaded.validation_probes[0].name, "moon check")
+    assert_eq(loaded.trials.length(), 1)
+    assert_eq(loaded.trials[0].session_id, "trial-01")
+  })
 }

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -10,6 +10,10 @@ import {
   "moonbitlang/core/json",
 }
 
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "wbtest"
+
 warnings = "+unnecessary_annotation"
 
 supported_targets = "+native"

--- a/eval/prompt_task/harness/suite_wbtest.mbt
+++ b/eval/prompt_task/harness/suite_wbtest.mbt
@@ -34,72 +34,73 @@ fn suite_config_json() -> Json {
 
 ///|
 async test "suite config parses relative task paths and flattens jobs" {
-  let root = @fs.tmpdir(prefix="openseek-prompt-suite-config")
-  @fs.mkdir(root + "/suite", recursive=true)
-  let suite_file = root + "/suite/suite.json"
-  @fs.write_file(
-    suite_file,
-    suite_config_json().stringify(),
-    create_mode=CreateOrTruncate,
-  )
-  let config = suite_config_from_file(
-    suite_file,
-    api_key="key",
-    out_dir=root + "/runs",
-    repo_root=".",
-    engine="",
-    system_prompt_file="",
-    system_prompt_addendum_file="",
-  )
-  assert_eq(config.name, "mini-suite")
-  assert_eq(config.models.length(), 2)
-  assert_eq(config.problems.length(), 2)
-  assert_eq(config.problems[0].task_file, root + "/suite/tasks/alpha.md")
-  assert_eq(config.problems[1].prompt_label, "Beta Problem")
-  let jobs = suite_jobs(config)
-  assert_eq(jobs.length(), 12)
-  assert_eq(jobs[0].model.to_string(), "deepseek-v4-flash")
-  assert_eq(jobs[0].problem.id, "alpha")
-  assert_eq(jobs[0].repeat_index, 0)
-  assert_eq(jobs[3].problem.id, "beta")
-  assert_eq(jobs[6].model.to_string(), "deepseek-v4-pro")
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-prompt-suite-config", root => {
+    @fs.mkdir(root + "/suite", recursive=true)
+    let suite_file = root + "/suite/suite.json"
+    @fs.write_file(
+      suite_file,
+      suite_config_json().stringify(),
+      create_mode=CreateOrTruncate,
+    )
+    let config = suite_config_from_file(
+      suite_file,
+      api_key="key",
+      out_dir=root + "/runs",
+      repo_root=".",
+      engine="",
+      system_prompt_file="",
+      system_prompt_addendum_file="",
+    )
+    assert_eq(config.name, "mini-suite")
+    assert_eq(config.models.length(), 2)
+    assert_eq(config.problems.length(), 2)
+    assert_eq(config.problems[0].task_file, root + "/suite/tasks/alpha.md")
+    assert_eq(config.problems[1].prompt_label, "Beta Problem")
+    let jobs = suite_jobs(config)
+    assert_eq(jobs.length(), 12)
+    assert_eq(jobs[0].model.to_string(), "deepseek-v4-flash")
+    assert_eq(jobs[0].problem.id, "alpha")
+    assert_eq(jobs[0].repeat_index, 0)
+    assert_eq(jobs[3].problem.id, "beta")
+    assert_eq(jobs[6].model.to_string(), "deepseek-v4-pro")
+  })
 }
 
 ///|
 async test "suite manifest round trips combos" {
-  let root = @fs.tmpdir(prefix="openseek-prompt-suite-manifest")
-  let manifest = SuiteManifest(
-    name="mini-suite",
-    out_dir=root,
-    runs_per_combo=1,
-    concurrency=1,
-    min_successes=0,
-    max_steps=20,
-    models=["deepseek-v4-flash"],
-    problems=[
-      ProblemSpec(id="alpha", task_file="tasks/alpha.md", validation_probes=[
-        simple_probe("moon check"),
-      ]),
-    ],
-    combos=[
-      ComboRun(
-        model="deepseek-v4-flash",
-        problem_id="alpha",
-        prompt_label="alpha:deepseek-v4-flash",
-        task_file="tasks/alpha.md",
-        out_dir=root + "/combos/deepseek-v4-flash/alpha",
-        manifest_path=root + "/combos/deepseek-v4-flash/alpha/run_manifest.json",
-      ),
-    ],
-  )
-  write_suite_manifest(manifest)
-  let loaded = read_suite_manifest(root)
-  assert_eq(loaded.name, "mini-suite")
-  assert_eq(loaded.combos.length(), 1)
-  assert_eq(loaded.combos[0].problem_id, "alpha")
-  assert_eq(loaded.problems[0].validation_probes[0].name, "moon check")
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-prompt-suite-manifest", root => {
+    let manifest = SuiteManifest(
+      name="mini-suite",
+      out_dir=root,
+      runs_per_combo=1,
+      concurrency=1,
+      min_successes=0,
+      max_steps=20,
+      models=["deepseek-v4-flash"],
+      problems=[
+        ProblemSpec(id="alpha", task_file="tasks/alpha.md", validation_probes=[
+          simple_probe("moon check"),
+        ]),
+      ],
+      combos=[
+        ComboRun(
+          model="deepseek-v4-flash",
+          problem_id="alpha",
+          prompt_label="alpha:deepseek-v4-flash",
+          task_file="tasks/alpha.md",
+          out_dir=root + "/combos/deepseek-v4-flash/alpha",
+          manifest_path=root +
+            "/combos/deepseek-v4-flash/alpha/run_manifest.json",
+        ),
+      ],
+    )
+    write_suite_manifest(manifest)
+    let loaded = read_suite_manifest(root)
+    assert_eq(loaded.name, "mini-suite")
+    assert_eq(loaded.combos.length(), 1)
+    assert_eq(loaded.combos[0].problem_id, "alpha")
+    assert_eq(loaded.problems[0].validation_probes[0].name, "moon check")
+  })
 }
 
 ///|

--- a/eval/report/moon.pkg
+++ b/eval/report/moon.pkg
@@ -4,6 +4,7 @@ import {
 }
 
 import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
   "moonbitlang/async/fs",
 } for "test"

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -75,20 +75,20 @@ test "markdown details keep full arbitrary text" {
 
 ///|
 async test "report writes markdown json and html files" {
-  let root = @fs.tmpdir(prefix="openseek-eval-report")
-  let report = @report.Report(title="Tiny Report", rows=[
-    ReportRow(index=1, name="finish", success=true, details=[
-      Metric(name="Note", value="ok"),
-    ]),
-  ])
-  report.write_files(root)
-  let markdown = @fs.read_file("\{root}/report.md").text()
-  let json = @fs.read_file("\{root}/report.json").text()
-  let html = @fs.read_file("\{root}/report.html").text()
-  assert_true(markdown.contains("# Tiny Report"))
-  assert_true(json.contains("\"title\":\"Tiny Report\""))
-  assert_true(html.contains("<title>Tiny Report</title>"))
-  assert_true(html.contains("<h3>Trial 1: <code>finish</code></h3>"))
-  assert_true(html.contains("table-wrap"))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-eval-report", root => {
+    let report = @report.Report(title="Tiny Report", rows=[
+      ReportRow(index=1, name="finish", success=true, details=[
+        Metric(name="Note", value="ok"),
+      ]),
+    ])
+    report.write_files(root)
+    let markdown = @fs.read_file("\{root}/report.md").text()
+    let json = @fs.read_file("\{root}/report.json").text()
+    let html = @fs.read_file("\{root}/report.html").text()
+    assert_true(markdown.contains("# Tiny Report"))
+    assert_true(json.contains("\"title\":\"Tiny Report\""))
+    assert_true(html.contains("<title>Tiny Report</title>"))
+    assert_true(html.contains("<h3>Trial 1: <code>finish</code></h3>"))
+    assert_true(html.contains("table-wrap"))
+  })
 }

--- a/eval/session_analyzer/analyzer_wbtest.mbt
+++ b/eval/session_analyzer/analyzer_wbtest.mbt
@@ -125,14 +125,14 @@ test "transcript text ignores user prompts and summaries" {
 
 ///|
 async test "eval result renders and writes report files" {
-  let dir = @fs.tmpdir(prefix="openseek-session-analyzer-")
-  let result = analyze_session(sample_session())
-  assert_true(result.markdown().contains("Session Eval Result"))
-  assert_true(result.html().contains("<html"))
-  assert_true(result.to_json().stringify().contains("trial-01"))
-  result.write_files(dir)
-  assert_true(@fs.exists(dir + "/report.md"))
-  assert_true(@fs.exists(dir + "/report.html"))
-  assert_true(@fs.exists(dir + "/report.json"))
-  @fs.rmdir(dir, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-session-analyzer-", dir => {
+    let result = analyze_session(sample_session())
+    assert_true(result.markdown().contains("Session Eval Result"))
+    assert_true(result.html().contains("<html"))
+    assert_true(result.to_json().stringify().contains("trial-01"))
+    result.write_files(dir)
+    assert_true(@fs.exists(dir + "/report.md"))
+    assert_true(@fs.exists(dir + "/report.html"))
+    assert_true(@fs.exists(dir + "/report.json"))
+  })
 }

--- a/eval/session_analyzer/moon.pkg
+++ b/eval/session_analyzer/moon.pkg
@@ -5,6 +5,7 @@ import {
 }
 
 import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",
   "moonbitlang/async/fs",
 } for "wbtest"

--- a/eval/tool_harness/harness_test.mbt
+++ b/eval/tool_harness/harness_test.mbt
@@ -13,16 +13,16 @@ async test "deterministic harness exercises every tool" {
 
 ///|
 async test "harness report can be written for inspection" {
-  let root = @fs.tmpdir(prefix="openseek-tool-harness-report-")
-  let report = @tool_harness.run_harness()
-  report.write_files(root)
-  let markdown = @fs.read_file("\{root}/report.md").text()
-  let json = @fs.read_file("\{root}/report.json").text()
-  assert_true(
-    markdown.contains(
-      "| # | Case | Result | Mode | Action | Reason | Warnings |",
-    ),
-  )
-  assert_true(json.contains("\"title\":\"Tool Harness\""))
-  @fs.rmdir(root, recursive=true)
+  @vfs.with_tmpdir(prefix="openseek-tool-harness-report-", root => {
+    let report = @tool_harness.run_harness()
+    report.write_files(root)
+    let markdown = @fs.read_file("\{root}/report.md").text()
+    let json = @fs.read_file("\{root}/report.json").text()
+    assert_true(
+      markdown.contains(
+        "| # | Case | Result | Mode | Action | Reason | Warnings |",
+      ),
+    )
+    assert_true(json.contains("\"title\":\"Tool Harness\""))
+  })
 }

--- a/testkit/filesystem/filesystem_test.mbt
+++ b/testkit/filesystem/filesystem_test.mbt
@@ -49,16 +49,16 @@ test "json fixture rejects non-string contents" {
 
 ///|
 async test "fixture writes to disk and reports mismatches" {
-  let root = @fs.tmpdir(prefix="openseek-testkit-fs")
-  let files = @filesystem.FileSystem({
-    "src/note.txt": "alpha\n",
-    "docs/summary.txt": "ready\n",
+  @filesystem.with_tmpdir(prefix="openseek-testkit-fs", root => {
+    let files = @filesystem.FileSystem({
+      "src/note.txt": "alpha\n",
+      "docs/summary.txt": "ready\n",
+    })
+    files.write_to(root)
+    assert_eq(files.mismatch_on_disk(root), "")
+    @filesystem.write_text(root, "src/note.txt", "changed\n")
+    assert_eq(files.mismatch_on_disk(root), "content mismatch in src/note.txt")
   })
-  files.write_to(root)
-  assert_eq(files.mismatch_on_disk(root), "")
-  @filesystem.write_text(root, "src/note.txt", "changed\n")
-  assert_eq(files.mismatch_on_disk(root), "content mismatch in src/note.txt")
-  @fs.rmdir(root, recursive=true)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Replace most one-off test `@fs.tmpdir` + `@fs.rmdir` pairs with `@vfs.with_tmpdir` / `@filesystem.with_tmpdir` so temporary directories are cleaned up on assertion failures too.
- Cover tool tests, command white-box tests, eval harness tests, checked README examples, and filesystem fixture tests.
- Add test-only `@vfs` imports where needed and remove a now-unused `async/fs` white-box import.
- Leave production/shared tempdir helpers in place, including `random_salt`, fixture-copy helpers, the filesystem helper implementation itself, and the session-store test helper file.

## Validation

- `moon fmt`
- `moon check --warn-list +73` (passes with existing unnecessary-annotation warnings in `cmd/viz_server`)
- `moon test agent_skill agent_tool/edit agent_tool/moon_check agent_tool/moon_cmd agent_tool/moon_ide agent_tool/read agent_tool/shell agent_tool/write cmd/openseek cmd/tui cmd/viz_server eval/file_edit/harness eval/prompt_task/harness eval/report eval/session_analyzer eval/tool_harness testkit/filesystem agent_session/store`
- `moon info && moon fmt` (exposed pre-existing `testkit/filesystem/pkg.generated.mbti` drift for `dir_outline`; not included in this scoped PR)
- `moon test`
- `git diff --check`