### PR TITLE
[codex] filter markdown comments in prompt generation

### DIFF
--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
+You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.<!-- md_to_mbt_string smoke: stripped from generated base prompt. -->
 Use finish when the task is complete.
 
 About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek, a MoonBit coding agent optimized for DeepSeek.
+You are OpenSeek, a MoonBit coding agent optimized for DeepSeek.<!-- md_to_mbt_string smoke: stripped from generated flash prompt. -->
 
 Use the native tools to inspect, create, edit, validate, and finish work. If
 work is needed, call a tool. When the task is complete, call `finish`.

--- a/scripts/internal/markdown_comments/markdown_comments.mbt
+++ b/scripts/internal/markdown_comments/markdown_comments.mbt
@@ -1,0 +1,247 @@
+///|
+priv struct SourceRange {
+  first : Int
+  last_exclusive : Int
+}
+
+///|
+pub fn without_comments(markdown : String) -> String {
+  let ranges = comment_ranges(markdown)
+  guard !ranges.is_empty() else { markdown }
+  ranges.sort_by(fn(left, right) { left.first.compare(right.first) })
+  remove_source_ranges(markdown, ranges)
+}
+
+///|
+fn comment_ranges(markdown : String) -> Array[SourceRange] {
+  let ranges = []
+  let doc = @cmark.Doc::from_string(locs=true, markdown)
+  collect_block_comment_ranges(markdown, doc.block, ranges)
+  ranges
+}
+
+///|
+fn collect_block_comment_ranges(
+  markdown : String,
+  block : @cmark.Block,
+  ranges : Array[SourceRange],
+) -> Unit {
+  match block {
+    HtmlBlock(node) => push_html_block_ranges(markdown, ranges, node.v)
+    Heading(node) => collect_inline_comment_ranges(node.v.inline, ranges)
+    Paragraph(node) => collect_inline_comment_ranges(node.v.inline, ranges)
+    BlockQuote(node) =>
+      collect_block_comment_ranges(markdown, node.v.block, ranges)
+    Blocks(node) =>
+      for child in node.v.iter() {
+        collect_block_comment_ranges(markdown, child, ranges)
+      }
+    List(node) =>
+      for item in node.v.items.iter() {
+        collect_block_comment_ranges(markdown, item.v.block, ranges)
+      }
+    ExtFootnoteDefinition(node) =>
+      collect_block_comment_ranges(markdown, node.v.block, ranges)
+    ExtTable(node) =>
+      for row_entry in node.v.rows.iter() {
+        let (row, _) = row_entry
+        collect_table_row_comment_ranges(row.v, ranges)
+      }
+    BlankLine(_)
+    | CodeBlock(_)
+    | LinkRefDefinition(_)
+    | ThematicBreak(_)
+    | ExtMathBlock(_) => ()
+  }
+}
+
+///|
+fn collect_table_row_comment_ranges(
+  row : @cmark.TableRow,
+  ranges : Array[SourceRange],
+) -> Unit {
+  match row {
+    Header(cells) | Data(cells) =>
+      for cell in cells.iter() {
+        let (inline, _) = cell
+        collect_inline_comment_ranges(inline, ranges)
+      }
+    Sep(_) => ()
+  }
+}
+
+///|
+fn collect_inline_comment_ranges(
+  inline : @cmark.Inline,
+  ranges : Array[SourceRange],
+) -> Unit {
+  match inline {
+    RawHtml(node) =>
+      if inline_raw_html_is_comment(node.v) {
+        push_loc_range(ranges, node.meta)
+      }
+    Inlines(node) =>
+      for child in node.v.iter() {
+        collect_inline_comment_ranges(child, ranges)
+      }
+    Image(node) | Link(node) =>
+      collect_inline_comment_ranges(node.v.text, ranges)
+    Emphasis(node) | StrongEmphasis(node) =>
+      collect_inline_comment_ranges(node.v.inline, ranges)
+    ExtStrikethrough(node) => collect_inline_comment_ranges(node.v.0, ranges)
+    Autolink(_) | Break(_) | CodeSpan(_) | ExtMathSpan(_) | Text(_) => ()
+  }
+}
+
+///|
+fn push_html_block_ranges(
+  markdown : String,
+  ranges : Array[SourceRange],
+  block : @cmark.HtmlBlock,
+) -> Unit {
+  guard block.0.get(0) is Some(first_line) else { return }
+  guard block.0.get(block.0.length() - 1) is Some(last_line) else { return }
+  let first_loc = first_line.meta.loc
+  let last_loc = last_line.meta.loc
+  if first_loc.is_none() ||
+    first_loc.is_empty() ||
+    last_loc.is_none() ||
+    last_loc.is_empty() {
+    return
+  }
+  let len = markdown.length()
+  let start = line_start(markdown, clamp(first_loc.first_ccode, min=0, max=len))
+  let stop = clamp(last_loc.last_ccode + 1, min=start, max=len)
+  push_html_comment_ranges(markdown, ranges, start~, stop~)
+}
+
+///|
+fn inline_raw_html_is_comment(raw : @cmark.InlineRawHtml) -> Bool {
+  let text = StringBuilder()
+  for tight in raw.0.iter() {
+    text.write_string(tight.to_string())
+  }
+  is_html_comment(text.to_string())
+}
+
+///|
+fn is_html_comment(text : StringView) -> Bool {
+  text.trim_start().has_prefix("<!--")
+}
+
+///|
+fn push_loc_range(ranges : Array[SourceRange], meta : @cmark_base.Meta) -> Unit {
+  let loc = meta.loc
+  if loc.is_none() || loc.is_empty() {
+    return
+  }
+  ranges.push({ first: loc.first_ccode, last_exclusive: loc.last_ccode + 1 })
+}
+
+///|
+fn push_html_comment_ranges(
+  markdown : String,
+  ranges : Array[SourceRange],
+  start~ : Int,
+  stop~ : Int,
+) -> Unit {
+  let len = markdown.length()
+  let stop = clamp(stop, min=0, max=len)
+  let mut cursor = clamp(start, min=0, max=stop)
+  while cursor < stop {
+    match find_html_comment_open(markdown, start=cursor, stop~) {
+      Some(first) =>
+        match find_html_comment_close(markdown, start=first + 4, stop~) {
+          Some(last_exclusive) => {
+            ranges.push({ first, last_exclusive })
+            cursor = last_exclusive
+          }
+          None => break
+        }
+      None => break
+    }
+  }
+}
+
+///|
+fn find_html_comment_open(markdown : String, start~ : Int, stop~ : Int) -> Int? {
+  let stop = clamp(stop, min=0, max=markdown.length())
+  let start = clamp(start, min=0, max=stop)
+  for cursor = start; cursor + 3 < stop; cursor = cursor + 1 {
+    if markdown[cursor] == '<' &&
+      markdown[cursor + 1] == '!' &&
+      markdown[cursor + 2] == '-' &&
+      markdown[cursor + 3] == '-' {
+      break Some(cursor)
+    }
+  } nobreak {
+    None
+  }
+}
+
+///|
+fn find_html_comment_close(
+  markdown : String,
+  start~ : Int,
+  stop~ : Int,
+) -> Int? {
+  let stop = clamp(stop, min=0, max=markdown.length())
+  let start = clamp(start, min=0, max=stop)
+  for cursor = start; cursor + 2 < stop; cursor = cursor + 1 {
+    if markdown[cursor] == '-' &&
+      markdown[cursor + 1] == '-' &&
+      markdown[cursor + 2] == '>' {
+      break Some(cursor + 3)
+    }
+  } nobreak {
+    None
+  }
+}
+
+///|
+fn line_start(markdown : String, offset : Int) -> Int {
+  for cursor = offset; cursor > 0; {
+    if markdown[cursor - 1] == '\n' || markdown[cursor - 1] == '\r' {
+      break cursor
+    }
+    continue cursor - 1
+  } nobreak {
+    cursor
+  }
+}
+
+///|
+fn remove_source_ranges(
+  markdown : String,
+  ranges : Array[SourceRange],
+) -> String {
+  let len = markdown.length()
+  let out = StringBuilder(size_hint=len)
+  let mut cursor = 0
+  for range in ranges {
+    let first = clamp(range.first, min=0, max=len)
+    let last_exclusive = clamp(range.last_exclusive, min=0, max=len)
+    if last_exclusive <= cursor {
+      continue
+    }
+    if first > cursor {
+      out.write_string(markdown.unsafe_substring(start=cursor, end=first))
+    }
+    cursor = last_exclusive
+  }
+  if cursor < len {
+    out.write_string(markdown.unsafe_substring(start=cursor, end=len))
+  }
+  out.to_string()
+}
+
+///|
+fn clamp(value : Int, min~ : Int, max~ : Int) -> Int {
+  if value < min {
+    min
+  } else if value > max {
+    max
+  } else {
+    value
+  }
+}

--- a/scripts/internal/markdown_comments/markdown_comments_test.mbt
+++ b/scripts/internal/markdown_comments/markdown_comments_test.mbt
@@ -1,0 +1,222 @@
+///|
+fn strip(markdown : String) -> String {
+  @markdown_comments.without_comments(markdown)
+}
+
+///|
+fn visible_cr(markdown : String) -> String {
+  markdown.split("\r").collect().join("|")
+}
+
+///|
+test "without comments keeps ordinary markdown unchanged" {
+  inspect(
+    strip("# Title\n\nBody with <span>html</span>.\n"),
+    content="# Title\n\nBody with <span>html</span>.\n",
+  )
+}
+
+///|
+test "top-level block comments are removed" {
+  inspect(
+    strip(
+      (
+        #|# Title
+        #|
+        #|<!-- hidden block
+        #|still hidden -->
+        #|
+        #|Visible.
+        #|
+      ),
+    ),
+    content=(
+      #|# Title
+      #|
+      #|
+      #|
+      #|Visible.
+      #|
+    ),
+  )
+}
+
+///|
+test "single-line block comments can share a line with visible text" {
+  inspect(
+    strip("<!-- hidden --> Visible after block comment.\n"),
+    content=" Visible after block comment.\n",
+  )
+}
+
+///|
+test "adjacent comment ranges are all removed" {
+  inspect(
+    strip("<!-- first --> Visible <!-- second --> after.\n"),
+    content=" Visible  after.\n",
+  )
+}
+
+///|
+test "inline comments are removed from paragraphs" {
+  inspect(
+    strip("Visible <!-- hidden inline --> text.\n"),
+    content="Visible  text.\n",
+  )
+}
+
+///|
+test "multiline inline comments are removed from paragraphs" {
+  inspect(strip("foo <!-- hidden\ncomment --> bar\n"), content="foo  bar\n")
+}
+
+///|
+test "comments in headings and emphasis are removed" {
+  inspect(
+    strip("# Title <!-- hidden --> now\n\nA **bold <!-- hidden --> word**.\n"),
+    content="# Title  now\n\nA **bold  word**.\n",
+  )
+}
+
+///|
+test "comments in blockquotes and lists are removed" {
+  inspect(
+    strip(
+      (
+        #|> Quoted <!-- hidden --> text.
+        #|
+        #|- First <!-- hidden --> item
+        #|- <!-- hidden --> second
+        #|
+      ),
+    ),
+    content=(
+      #|> Quoted  text.
+      #|
+      #|- First  item
+      #|-  second
+      #|
+    ),
+  )
+}
+
+///|
+test "comments in table cells are removed" {
+  inspect(
+    strip(
+      (
+        #|| Left | Right |
+        #|| --- | --- |
+        #|| a <!-- hidden --> cell | <!-- hidden --> b |
+        #|
+      ),
+    ),
+    content=(
+      #|| Left | Right |
+      #|| --- | --- |
+      #|| a  cell |  b |
+      #|
+    ),
+  )
+}
+
+///|
+test "fenced and indented code keep comment text" {
+  inspect(
+    strip(
+      (
+        #|```markdown
+        #|<!-- kept in fenced code -->
+        #|```
+        #|
+        #|    <!-- kept in indented code -->
+        #|
+      ),
+    ),
+    content=(
+      #|```markdown
+      #|<!-- kept in fenced code -->
+      #|```
+      #|
+      #|    <!-- kept in indented code -->
+      #|
+    ),
+  )
+}
+
+///|
+test "plain html blocks are preserved" {
+  inspect(strip("<div>kept html</div>\n"), content="<div>kept html</div>\n")
+}
+
+///|
+test "comments inside multiline html blocks are removed" {
+  inspect(
+    strip(
+      (
+        #|<div>
+        #|<!-- hidden inside html block -->
+        #|kept html block
+        #|</div>
+        #|
+      ),
+    ),
+    content=(
+      #|<div>
+      #|
+      #|kept html block
+      #|</div>
+      #|
+    ),
+  )
+}
+
+///|
+test "same-line html block comments are removed" {
+  inspect(
+    strip("<div><!-- hidden same-line html block -->kept html inline</div>\n"),
+    content="<div>kept html inline</div>\n",
+  )
+}
+
+///|
+test "multiple html block comments are removed independently" {
+  inspect(
+    strip("<section><!-- one -->kept<!-- two --></section>\n"),
+    content="<section>kept</section>\n",
+  )
+}
+
+///|
+test "unicode before comments keeps byte ranges aligned" {
+  inspect(
+    strip("Hello 月 <!-- hidden --> world\n"),
+    content="Hello 月  world\n",
+  )
+}
+
+///|
+test "cr-only line endings preserve preceding text" {
+  inspect(
+    visible_cr(
+      strip("Before\r<!-- hidden --> Visible <!-- second --> after\rAfter\r"),
+    ),
+    content="Before| Visible  after|After|",
+  )
+}
+
+///|
+test "crlf line endings preserve visible text" {
+  inspect(
+    visible_cr(strip("Before\r\n<!-- hidden --> Visible\r\nAfter\r\n")),
+    content="Before|\n Visible|\nAfter|\n",
+  )
+}
+
+///|
+test "incomplete comments are preserved" {
+  inspect(
+    strip("Before <!-- hidden\nAfter\n"),
+    content="Before <!-- hidden\nAfter\n",
+  )
+}

--- a/scripts/internal/markdown_comments/moon.pkg
+++ b/scripts/internal/markdown_comments/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "moonbit-community/cmark/cmark",
+  "moonbit-community/cmark/cmark_base",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/scripts/internal/markdown_comments/pkg.generated.mbti
+++ b/scripts/internal/markdown_comments/pkg.generated.mbti
@@ -1,0 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek-scripts/internal/markdown_comments"
+
+// Values
+pub fn without_comments(String) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -89,6 +89,7 @@ fn generated_source(
   function_name~ : StringView,
   markdown~ : StringView,
 ) -> String {
+  let markdown = @markdown_comments.without_comments(markdown.to_owned())
   let lines = markdown.split("\n")
   (
     $|// Generated from \{base} by moon dev_build. DO NOT EDIT.

--- a/scripts/md_to_mbt_string/main_wbtest.mbt
+++ b/scripts/md_to_mbt_string/main_wbtest.mbt
@@ -73,19 +73,22 @@ test "generated source matches dev_build output shape" {
     function_name="base_prompt",
     markdown="# Title\n\nbody\n",
   )
-  let expected =
-    #|// Generated from base_prompt.md by moon dev_build. DO NOT EDIT.
-    #|///|
-    #|fn base_prompt() -> String {
-    #|  (
-    #|    #|# Title
-    #|    #|
-    #|    #|body
-    #|    #|
-    #|  )
-    #|}
-    #|
-  assert_eq(source, expected)
+  inspect(
+    source,
+    content=(
+      #|// Generated from base_prompt.md by moon dev_build. DO NOT EDIT.
+      #|///|
+      #|fn base_prompt() -> String {
+      #|  (
+      #|    #|# Title
+      #|    #|
+      #|    #|body
+      #|    #|
+      #|  )
+      #|}
+      #|
+    ),
+  )
 }
 
 ///|
@@ -95,17 +98,112 @@ test "generated source preserves missing final newline" {
     function_name="flash_prompt",
     markdown="one\ntwo",
   )
-  let expected =
-    #|// Generated from flash_prompt.md by moon dev_build. DO NOT EDIT.
-    #|///|
-    #|fn flash_prompt() -> String {
-    #|  (
-    #|    #|one
-    #|    #|two
-    #|  )
-    #|}
+  inspect(
+    source,
+    content=(
+      #|// Generated from flash_prompt.md by moon dev_build. DO NOT EDIT.
+      #|///|
+      #|fn flash_prompt() -> String {
+      #|  (
+      #|    #|one
+      #|    #|two
+      #|  )
+      #|}
+      #|
+    ),
+  )
+}
+
+///|
+test "generated source filters markdown comments" {
+  let markdown =
+    #|# Title
     #|
-  assert_eq(source, expected)
+    #|<!-- hidden block
+    #|still hidden -->
+    #|
+    #|<!-- hidden --> Visible after block comment.
+    #|
+    #|<!-- first --> Visible <!-- second --> after.
+    #|
+    #|Visible <!-- hidden inline --> text.
+    #|
+    #|```markdown
+    #|<!-- kept in code -->
+    #|```
+    #|
+    #|<div>kept html</div>
+    #|
+    #|<div>
+    #|<!-- hidden inside html block -->
+    #|kept html block
+    #|</div>
+    #|
+    #|<div><!-- hidden same-line html block -->kept html inline</div>
+    #|
+  let source = generated_source(
+    base="flash_prompt.md",
+    function_name="flash_prompt",
+    markdown~,
+  )
+  inspect(
+    source,
+    content=(
+      #|// Generated from flash_prompt.md by moon dev_build. DO NOT EDIT.
+      #|///|
+      #|fn flash_prompt() -> String {
+      #|  (
+      #|    #|# Title
+      #|    #|
+      #|    #|
+      #|    #|
+      #|    #| Visible after block comment.
+      #|    #|
+      #|    #| Visible  after.
+      #|    #|
+      #|    #|Visible  text.
+      #|    #|
+      #|    #|```markdown
+      #|    #|<!-- kept in code -->
+      #|    #|```
+      #|    #|
+      #|    #|<div>kept html</div>
+      #|    #|
+      #|    #|<div>
+      #|    #|
+      #|    #|kept html block
+      #|    #|</div>
+      #|    #|
+      #|    #|<div>kept html inline</div>
+      #|    #|
+      #|  )
+      #|}
+      #|
+    ),
+  )
+}
+
+///|
+test "generated source filters multiline inline comments" {
+  let source = generated_source(
+    base="flash_prompt.md",
+    function_name="flash_prompt",
+    markdown="foo <!-- hidden\ncomment --> bar\n",
+  )
+  inspect(
+    source,
+    content=(
+      #|// Generated from flash_prompt.md by moon dev_build. DO NOT EDIT.
+      #|///|
+      #|fn flash_prompt() -> String {
+      #|  (
+      #|    #|foo  bar
+      #|    #|
+      #|  )
+      #|}
+      #|
+    ),
+  )
 }
 
 ///|

--- a/scripts/md_to_mbt_string/moon.pkg
+++ b/scripts/md_to_mbt_string/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/core/argparse",
   "moonbitlang/x/path",
+  "bobzhang/openseek-scripts/internal/markdown_comments",
 }
 
 warnings = "+unnecessary_annotation"

--- a/scripts/moon.mod
+++ b/scripts/moon.mod
@@ -5,6 +5,7 @@ version = "0.1.0"
 import {
   "moonbitlang/async@0.19.1",
   "moonbitlang/x@0.4.45",
+  "moonbit-community/cmark@0.4.4",
 }
 
 preferred_target = "native"


### PR DESCRIPTION
## Summary

- Add `moonbit-community/cmark` to the prompt generator scripts module.
- Parse prompt Markdown before code generation and remove HTML comment nodes from generated prompt text.
- Switch generated-source prompt tests to snapshots and add coverage for block comments, inline comments, fenced code, and ordinary HTML.

## Validation

- `moon -C scripts/md_to_mbt_string test --target native --update`
- `moon -C scripts/md_to_mbt_string test --target native`
- `moon -C scripts info && moon -C scripts fmt`
- `moon info && moon fmt`
- `moon -C scripts test --target native`
- `moon test`