### PR TITLE
Show model timestamps as total seconds

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -174,6 +174,17 @@ fn offset_label(base : Int64, event : @agent_session.SessionEvent) -> String {
 }
 
 ///|
+fn model_offset_label(
+  base : Int64,
+  event : @agent_session.SessionEvent,
+) -> String {
+  if base == 0 || event.unix_ms() == 0 {
+    return ""
+  }
+  "+\{format_span_total_seconds(event.unix_ms() - base)}"
+}
+
+///|
 fn turn_duration_label(turn : Array[@agent_session.SessionEvent]) -> String? {
   let base = turn_base_ms(turn)
   guard base > 0 else { return None }
@@ -203,6 +214,14 @@ fn format_span_seconds(span_ms : Int64) -> String {
     let pad = if seconds < 10 { "0" } else { "" }
     "\{minutes}m \{pad}\{seconds}.\{rest % 10}s"
   }
+}
+
+///|
+/// A millisecond span as total elapsed seconds. Model-view timestamp chips use
+/// this instead of minute-splitting so `70.3s` cannot read like just `10.3s`.
+fn format_span_total_seconds(span_ms : Int64) -> String {
+  let tenths = span_ms / 100
+  "\{tenths / 10}.\{tenths % 10}s"
 }
 
 ///|
@@ -423,14 +442,14 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
 
 ///|
 /// Relative event-time labels, keyed by durable event sequence. This uses the
-/// same per-turn base as the raw log so model view answers the same latency
-/// question while showing the compacted model-facing messages.
+/// same per-turn base as the raw log, but keeps labels in total seconds so
+/// minute-boundary chips stay unambiguous in the compact model projection.
 fn event_time_labels(session : @agent_session.Session) -> Map[Int, String] {
   let labels : Map[Int, String] = Map([])
   for turn in group_turns(session.events()) {
     let base = turn_base_ms(turn)
     for event in turn {
-      labels.set(event.sequence(), offset_label(base, event))
+      labels.set(event.sequence(), model_offset_label(base, event))
     }
   }
   labels

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -130,12 +130,13 @@ test "model view shows relative event timestamps" {
       Tool(ToolResult(tool_call_id="c1", tool_name="shell", content="ok")),
       unix_ms=103200L,
     )
-    .append(Terminal(Finished("done")), unix_ms=108900L)
+    .append(Terminal(Finished("done")), unix_ms=170300L)
   let html = render(@viz.render_session(session, ModelView))
   assert_true(html.contains("class=\"card-ts\">+0.0s"))
   assert_true(html.contains("class=\"card-ts\">+1.5s"))
   assert_true(html.contains("class=\"card-ts\">+3.2s"))
-  assert_true(html.contains("class=\"card-ts\">+8.9s"))
+  assert_true(html.contains("class=\"card-ts\">+70.3s"))
+  assert_false(html.contains("class=\"card-ts\">+1m 10.3s"))
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Keep model-view timestamp chips in total elapsed seconds instead of minute-split formatting.
- Preserve raw log compact duration formatting.
- Add a regression assertion for the `70.3s` minute-boundary case.

## Testing
- `moon check viz --target js --diagnostic-limit 50`
- `moon test viz --target js --diagnostic-limit 50`
- `moon info && moon fmt`
- `moon check --diagnostic-limit 50`
- `moon test --target js --diagnostic-limit 50`
- `git diff --check`
- Fresh Codex CLI review: `codex review --commit 35c301c` reported no actionable correctness issues; targeted viz check/tests passed. The review's full `moon test` also hit the existing network-dependent DeepSeek smoke test failure, unrelated to this change.