### PR TITLE
Cover new sessions persisting project layout

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1361,6 +1361,60 @@ async test "load_or_new_session defers first durable write until append" {
 }
 
 ///|
+async test "new durable session header persists project layout" {
+  @vfs.with_tmpdir(prefix="openseek-cli-session-layout-", root => {
+    let workspace = "\{root}/workspace"
+    @vfs.FileSystem::from_pairs([
+      ("cmd/tool/main.mbt", "x"),
+      ("toml/parser.mbt", "x"),
+      (".openseek/ignored", "x"),
+      ("_build/out/x", "x"),
+    ]).write_to(workspace)
+    @fs.write_file(
+      "\{workspace}/prompt.md",
+      "system",
+      create_mode=CreateOrTruncate,
+    )
+    let real_workspace = @fs.realpath(workspace)
+    let store = @store.SessionStore("\{real_workspace}/.openseek")
+    let id : @agent_session.SessionId = SessionId("cli-test")
+    let parsed = cli_command().parse(
+      argv=[
+        "--dir",
+        workspace,
+        "--session-root",
+        ".openseek",
+        "--session",
+        id.value(),
+        "--system-prompt-file",
+        "prompt.md",
+        "write",
+        "MoonBit",
+      ],
+      env={
+        "DEEPSEEK": "test-key",
+        "OPENSEEK_GLOBAL_SKILLS_DIR": "\{workspace}/no-global-skills",
+      },
+    )
+    let created = load_or_new_session(
+      store,
+      id,
+      parsed,
+      V4Pro,
+      workspace_root=real_workspace,
+    )
+    let _ = store.append(created, User(UserMessage("hello")))
+    let loaded = store.load(id)
+    let prompt = loaded.system_prompt()
+    assert_true(prompt.contains("Working directory: \{real_workspace}"))
+    assert_true(prompt.contains("Project layout"))
+    assert_true(prompt.contains("cmd/\n  tool/\ntoml/"))
+    assert_false(prompt.contains(".openseek/ignored"))
+    assert_false(prompt.contains("_build/"))
+  })
+}
+
+///|
 async test "load_or_new_session recovers empty interrupted session directory" {
   @vfs.with_tmpdir(prefix="openseek-cli-session-empty-dir-", root => {
     let id : @agent_session.SessionId = SessionId("cli-test")

--- a/testkit/filesystem/pkg.generated.mbti
+++ b/testkit/filesystem/pkg.generated.mbti
@@ -2,6 +2,8 @@
 package "bobzhang/openseek/testkit/filesystem"
 
 // Values
+pub async fn dir_outline(String, max_depth? : Int, max_dirs? : Int) -> String
+
 pub async fn[T] with_tmpdir(async (String) -> T, prefix? : String) -> T
 
 pub async fn write_text(String, String, String) -> Unit


### PR DESCRIPTION
## Summary
- Add regression coverage that a newly persisted durable session header includes the current project layout in its stored system prompt.
- Keep the generated `testkit/filesystem` interface in sync with the existing public `dir_outline` helper after `moon info`.

## Rationale
We do not need viz-side backfill for old session headers. The important path is that new demo/session runs write the prompt that already includes `environment_prompt_section(...)`, including the project layout outline.

## Validation
- `moon check cmd/openseek --target native --diagnostic-limit 50`
- `moon test cmd/openseek --target native --diagnostic-limit 50`
- `moon info && moon fmt`
- `git diff --check`