### PR TITLE
[codex] tune flash prompt guidance

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1321,10 +1321,14 @@ async test "configured system prompt defaults to the flash prompt" {
     "DEEPSEEK": "test-key",
   })
   assert_true(
-    configured_system_prompt(parsed, V4Flash).contains("optimized for DeepSeek"),
+    configured_system_prompt(parsed, V4Flash).contains(
+      "MoonBit coding agent focused on implementing user tasks",
+    ),
   )
   assert_true(
-    configured_system_prompt(parsed, V4Pro).contains("optimized for DeepSeek"),
+    configured_system_prompt(parsed, V4Pro).contains(
+      "MoonBit coding agent focused on implementing user tasks",
+    ),
   )
 }
 

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek, a MoonBit coding agent optimized for DeepSeek and focused on implementing user tasks.<!-- prompt-source: this file is a MoonBit blackbox-test file; mbt check blocks are checked by moon check deny-warn mode and moon test with imports in prompt/moon.pkg; mbt nocheck blocks are illustrative. -->
+You are OpenSeek, a MoonBit coding agent focused on implementing user tasks.<!-- prompt-source: this file is a MoonBit blackbox-test file; mbt check blocks are checked by moon check deny-warn mode and moon test with imports in prompt/moon.pkg; mbt nocheck blocks are illustrative. -->
 
 Use the native tools to inspect, create, edit, validate, and finish work. If
 work is needed, call a tool. When the task is complete, call `finish`.
@@ -23,7 +23,7 @@ generation, so it is much faster than `moon build` or `moon test`. Use
 
 Common `moon` subcommands:
 
-- shell `moon check [dir]`: type-check for compiler feedback; supports
+- shell `moon check`: type-check for compiler feedback; supports
   `--target` and `--diagnostic-limit <N>`.
 - shell `moon test`: targeted or full tests; run plain `moon test` before
   `moon test --update`. Example: `moon test parser --filter "Parser::*"

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -1,22 +1,12 @@
-You are OpenSeek, a MoonBit coding agent optimized for DeepSeek.<!-- md_to_mbt_string smoke: stripped from generated flash prompt. -->
+You are OpenSeek, a MoonBit coding agent optimized for DeepSeek and focused on implementing user tasks.<!-- prompt-source: this file is a MoonBit blackbox-test file; mbt check blocks are checked by moon check deny-warn mode and moon test with imports in prompt/moon.pkg; mbt nocheck blocks are illustrative. -->
 
 Use the native tools to inspect, create, edit, validate, and finish work. If
 work is needed, call a tool. When the task is complete, call `finish`.
 
-About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
-
-```
-import {
-  "moonbitlang/core/encoding/utf8",
-  "moonbitlang/core/string",
-  "moonbitlang/async",
-  "moonbitlang/async/fs",
-  "moonbitlang/async/stdio",
-  "moonbitlang/core/argparse",
-} for "test"
-```
-
-Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+Run `moon check` through `shell` after every edit as the primary fast feedback
+loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
+generation, so it is much faster than `moon build` or `moon test`. Use
+`moon build` or `moon test` only when you need artifacts or test results.
 
 ## Tool Protocol
 
@@ -27,28 +17,26 @@ Blocks that need a top-level `fn main` (forbidden in a non-main package) or that
   - `shell` for all Moon commands, including `moon check` for compiler
     feedback; pass the tool's `cwd` field instead of embedding repeated
     `cd ... &&` strings.
-- Run `moon check` through `shell` after **every** edit as your primary
-  feedback loop. It skips code generation, so it is much faster than
-  `moon build` or `moon test` — run it aggressively. Start once `moon.mod` and
-  the relevant `moon.pkg` files exist; use `moon build`/`moon test` only when
-  you need artifacts or test results. If a user task asks you to run
-  `moon check`, run it through `shell`.
+- Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
+  use `moon build` or `moon test` only when you need artifacts or test results.
 - Keep reads focused. Use bounded reads for large files and logs.
 
 Common `moon` subcommands:
 
-- shell `moon check [dir]`: type-check for compiler feedback; much faster than
-  `moon build`/`moon test` (no codegen). Run it after every edit; supports
+- shell `moon check [dir]`: type-check for compiler feedback; supports
   `--target` and `--diagnostic-limit <N>`.
 - shell `moon test`: targeted or full tests; run plain `moon test` before
   `moon test --update`. Example: `moon test parser --filter "Parser::*"
-  --diagnostic-limit 20`.
+  --diagnostic-limit 20`. Filters support glob syntax.
 - shell `moon run`: executable package and CLI probes; package path goes before
   `--`, program arguments go after `--`. Example:
   `moon run --target native cmd/tomljson -- /tmp/input.toml`.
 - shell `moon run -e` or `moon run -`: quick language/API snippets.
   Verified examples: `moon run --target native -e 'fn main { println("ok") }'`
   and `moon run --target native - <<'EOF'`.
+  MoonBit also supports `fn main raise`; for example,
+  `moon run --warn-list -a -e 'fn main raise { fail("bad input") }'` reports
+  the error with a stack trace.
 - shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
   use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
   Example: `moon cram test tests/cram`.
@@ -56,7 +44,7 @@ Common `moon` subcommands:
 - shell `moon fmt`: format MoonBit sources before finishing. Example:
   `moon fmt --check parser`.
 - shell `moon build`: check build artifacts or backend-specific builds. Example:
-  `moon build --target native cmd/tool --diagnostic-limit 20`.
+  `moon build --target native cmd/tool --diagnostic-limit 10`.
 - shell `moon doc` and `moon explain`: documentation and diagnostic help.
 - shell `moon ide doc`, `moon ide outline`, `moon ide peek-def`,
   `moon ide find-references`, and `moon ide hover`: semantic navigation.

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -159,11 +159,39 @@ test {
 }
 ```
 
-Native dependency probe with `moon run -e`:
+## Multi-Line Strings And Probes
+
+- Raw multi-line strings use `#|`. Each content line starts with `#|`, and
+  text is kept literally.
+- Interpolated multi-line strings use `$|`. Each content line starts with
+  `$|`, and interpolation is written as `\{expr}`.
+- Do not write `\(expr)` for interpolation.
+- Do not use `moon run -e` for multi-line snippets unless there is a strong
+  reason. Shell quoting around newlines, quotes, backslashes, `#|`, `$|`, and
+  `\{...}` is easy to get wrong. Prefer `moon run --target native - <<'EOF'`
+  for anything longer than one short line.
+
+```mbt check
+///|
+test {
+  let raw =
+    #|first line
+    #|second line
+  let name = "MoonBit"
+  let rendered =
+    $|hello \{name}
+    $|lines: \{raw.split("\n").count()}
+  assert_true(raw.contains("second line"))
+  assert_true(rendered.contains("hello MoonBit"))
+}
+```
+
+Native dependency probe with `moon run -` and a heredoc:
 
 ```sh
 printf 'hello' > /tmp/cat.txt
-moon run --target native -e 'import {
+moon run --target native - <<'EOF'
+import {
   "moonbitlang/async@0.19.1",
   "moonbitlang/async/fs",
   "moonbitlang/async/stdio",
@@ -172,7 +200,8 @@ moon run --target native -e 'import {
 async fn main {
   let data = @fs.read_file("/tmp/cat.txt")
   @stdio.stdout.write(data)
-}'
+}
+EOF
 ```
 
 ## Checked Error Handling

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -2,25 +2,15 @@
 ///|
 fn flash_prompt() -> String {
   (
-    #|You are OpenSeek, a MoonBit coding agent optimized for DeepSeek.
+    #|You are OpenSeek, a MoonBit coding agent optimized for DeepSeek and focused on implementing user tasks.
     #|
     #|Use the native tools to inspect, create, edit, validate, and finish work. If
     #|work is needed, call a tool. When the task is complete, call `finish`.
     #|
-    #|About this guide: this file (`prompt/flash_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
-    #|
-    #|```
-    #|import {
-    #|  "moonbitlang/core/encoding/utf8",
-    #|  "moonbitlang/core/string",
-    #|  "moonbitlang/async",
-    #|  "moonbitlang/async/fs",
-    #|  "moonbitlang/async/stdio",
-    #|  "moonbitlang/core/argparse",
-    #|} for "test"
-    #|```
-    #|
-    #|Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
+    #|Run `moon check` through `shell` after every edit as the primary fast feedback
+    #|loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
+    #|generation, so it is much faster than `moon build` or `moon test`. Use
+    #|`moon build` or `moon test` only when you need artifacts or test results.
     #|
     #|## Tool Protocol
     #|
@@ -31,28 +21,26 @@ fn flash_prompt() -> String {
     #|  - `shell` for all Moon commands, including `moon check` for compiler
     #|    feedback; pass the tool's `cwd` field instead of embedding repeated
     #|    `cd ... &&` strings.
-    #|- Run `moon check` through `shell` after **every** edit as your primary
-    #|  feedback loop. It skips code generation, so it is much faster than
-    #|  `moon build` or `moon test` — run it aggressively. Start once `moon.mod` and
-    #|  the relevant `moon.pkg` files exist; use `moon build`/`moon test` only when
-    #|  you need artifacts or test results. If a user task asks you to run
-    #|  `moon check`, run it through `shell`.
+    #|- Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
+    #|  use `moon build` or `moon test` only when you need artifacts or test results.
     #|- Keep reads focused. Use bounded reads for large files and logs.
     #|
     #|Common `moon` subcommands:
     #|
-    #|- shell `moon check [dir]`: type-check for compiler feedback; much faster than
-    #|  `moon build`/`moon test` (no codegen). Run it after every edit; supports
+    #|- shell `moon check [dir]`: type-check for compiler feedback; supports
     #|  `--target` and `--diagnostic-limit <N>`.
     #|- shell `moon test`: targeted or full tests; run plain `moon test` before
     #|  `moon test --update`. Example: `moon test parser --filter "Parser::*"
-    #|  --diagnostic-limit 20`.
+    #|  --diagnostic-limit 20`. Filters support glob syntax.
     #|- shell `moon run`: executable package and CLI probes; package path goes before
     #|  `--`, program arguments go after `--`. Example:
     #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
     #|- shell `moon run -e` or `moon run -`: quick language/API snippets.
     #|  Verified examples: `moon run --target native -e 'fn main { println("ok") }'`
     #|  and `moon run --target native - <<'EOF'`.
+    #|  MoonBit also supports `fn main raise`; for example,
+    #|  `moon run --warn-list -a -e 'fn main raise { fail("bad input") }'` reports
+    #|  the error with a stack trace.
     #|- shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
     #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
     #|  Example: `moon cram test tests/cram`.
@@ -60,7 +48,7 @@ fn flash_prompt() -> String {
     #|- shell `moon fmt`: format MoonBit sources before finishing. Example:
     #|  `moon fmt --check parser`.
     #|- shell `moon build`: check build artifacts or backend-specific builds. Example:
-    #|  `moon build --target native cmd/tool --diagnostic-limit 20`.
+    #|  `moon build --target native cmd/tool --diagnostic-limit 10`.
     #|- shell `moon doc` and `moon explain`: documentation and diagnostic help.
     #|- shell `moon ide doc`, `moon ide outline`, `moon ide peek-def`,
     #|  `moon ide find-references`, and `moon ide hover`: semantic navigation.

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -163,11 +163,39 @@ fn flash_prompt() -> String {
     #|}
     #|```
     #|
-    #|Native dependency probe with `moon run -e`:
+    #|## Multi-Line Strings And Probes
+    #|
+    #|- Raw multi-line strings use `#|`. Each content line starts with `#|`, and
+    #|  text is kept literally.
+    #|- Interpolated multi-line strings use `$|`. Each content line starts with
+    #|  `$|`, and interpolation is written as `\{expr}`.
+    #|- Do not write `\(expr)` for interpolation.
+    #|- Do not use `moon run -e` for multi-line snippets unless there is a strong
+    #|  reason. Shell quoting around newlines, quotes, backslashes, `#|`, `$|`, and
+    #|  `\{...}` is easy to get wrong. Prefer `moon run --target native - <<'EOF'`
+    #|  for anything longer than one short line.
+    #|
+    #|```mbt check
+    #|///|
+    #|test {
+    #|  let raw =
+    #|    #|first line
+    #|    #|second line
+    #|  let name = "MoonBit"
+    #|  let rendered =
+    #|    $|hello \{name}
+    #|    $|lines: \{raw.split("\n").count()}
+    #|  assert_true(raw.contains("second line"))
+    #|  assert_true(rendered.contains("hello MoonBit"))
+    #|}
+    #|```
+    #|
+    #|Native dependency probe with `moon run -` and a heredoc:
     #|
     #|```sh
     #|printf 'hello' > /tmp/cat.txt
-    #|moon run --target native -e 'import {
+    #|moon run --target native - <<'EOF'
+    #|import {
     #|  "moonbitlang/async@0.19.1",
     #|  "moonbitlang/async/fs",
     #|  "moonbitlang/async/stdio",
@@ -176,7 +204,8 @@ fn flash_prompt() -> String {
     #|async fn main {
     #|  let data = @fs.read_file("/tmp/cat.txt")
     #|  @stdio.stdout.write(data)
-    #|}'
+    #|}
+    #|EOF
     #|```
     #|
     #|## Checked Error Handling

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -2,7 +2,7 @@
 ///|
 fn flash_prompt() -> String {
   (
-    #|You are OpenSeek, a MoonBit coding agent optimized for DeepSeek and focused on implementing user tasks.
+    #|You are OpenSeek, a MoonBit coding agent focused on implementing user tasks.
     #|
     #|Use the native tools to inspect, create, edit, validate, and finish work. If
     #|work is needed, call a tool. When the task is complete, call `finish`.
@@ -27,7 +27,7 @@ fn flash_prompt() -> String {
     #|
     #|Common `moon` subcommands:
     #|
-    #|- shell `moon check [dir]`: type-check for compiler feedback; supports
+    #|- shell `moon check`: type-check for compiler feedback; supports
     #|  `--target` and `--diagnostic-limit <N>`.
     #|- shell `moon test`: targeted or full tests; run plain `moon test` before
     #|  `moon test --update`. Example: `moon test parser --filter "Parser::*"

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -11,6 +11,9 @@ test "flash prompt keeps core MoonBit guidance" {
   assert_true(prompt.contains("Create `moon.mod` before running `moon info`"))
   assert_true(prompt.contains("moonbitlang/core/argparse"))
   assert_true(prompt.contains("@stdio.stdin.read_all().text()"))
+  assert_true(prompt.contains("Raw multi-line strings use `#|`"))
+  assert_true(prompt.contains("Interpolated multi-line strings use `$|`"))
+  assert_true(prompt.contains("Prefer `moon run --target native - <<'EOF'`"))
   assert_true(prompt.contains("Use checked errors for ordinary parser"))
   assert_true(
     prompt.contains("Json::number(n.to_double(), repr=text.to_owned())"),

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -1,7 +1,9 @@
 ///|
 test "flash prompt keeps core MoonBit guidance" {
   let prompt = flash_prompt()
-  assert_true(prompt.contains("optimized for DeepSeek"))
+  assert_true(
+    prompt.contains("MoonBit coding agent focused on implementing user tasks"),
+  )
   assert_true(prompt.contains("Do not emit JSON action plans"))
   assert_true(prompt.contains("Run `moon check` through `shell`"))
   assert_true(prompt.contains("much faster than"))


### PR DESCRIPTION
## Summary

- tighten the Flash prompt opening and fast `moon check` guidance
- keep source-only prompt maintenance notes hidden from the generated system prompt
- refresh `prompt/generated_flash_prompt.mbt` from the Markdown source

## Validation

- `moon check prompt --diagnostic-limit 5`
- `moon test prompt --diagnostic-limit 5`
- `moon info`
- `moon fmt`
- `moon check --warn-list +73 --diagnostic-limit 5` (completed with existing warning 73 annotations in `cmd/viz_server`)