### PR TITLE
Show viz run metadata

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -24,6 +24,7 @@ struct Model {
   parsed : @session_log.ParsedLog?
   system_prompt : String
   header_present : Bool
+  log_bytes : Int64
   view_mode : @viz.ViewMode
   theme : Theme
   sidebar_visible : Bool
@@ -76,7 +77,7 @@ enum Msg {
 /// any completed response as `Ok`, so absence and malformed payloads are
 /// distinguished here from the body, not the HTTP status.
 enum LoadOutcome {
-  Loaded(@session_log.ParsedLog, String, Bool)
+  Loaded(@session_log.ParsedLog, String, Bool, Int64)
   NotFound
   Malformed
 }
@@ -89,6 +90,7 @@ fn init_model() -> Model {
     parsed: None,
     system_prompt: "",
     header_present: false,
+    log_bytes: 0L,
     view_mode: ModelView,
     theme: Light,
     sidebar_visible: true,
@@ -137,6 +139,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
           parsed: None,
           system_prompt: "",
           header_present: false,
+          log_bytes: 0L,
           loading: true,
           status: "loading \{label}…",
         },
@@ -156,7 +159,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
             )
           Ok(text) =>
             match parse_load(text) {
-              Loaded(parsed, system_prompt, header_present) =>
+              Loaded(parsed, system_prompt, header_present, log_bytes) =>
                 (
                   @cmd.none,
                   {
@@ -164,6 +167,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
                     parsed: Some(parsed),
                     system_prompt,
                     header_present,
+                    log_bytes,
                     loading: false,
                     status: events_status(parsed),
                   },
@@ -716,7 +720,7 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
           let error_count = @viz.rendered_error_count(session, model.view_mode)
           @html.div(class=session_view_class(model), [
             header_strip(model, id, row.map(row => row.root_label)),
-            mode_toggle(emit, model),
+            mode_row(emit, model, parsed),
             error_bar(emit, model, error_count),
             @viz.render_notices(parsed),
             session_log_view(model, session, error_count),
@@ -755,6 +759,18 @@ fn mode_toggle(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
 }
 
 ///|
+fn mode_row(
+  emit : @cmd.Emit[Msg],
+  model : Model,
+  parsed : @session_log.ParsedLog,
+) -> @html.Html {
+  @html.div(class="mode-row", [
+    mode_toggle(emit, model),
+    session_metadata(model, parsed),
+  ])
+}
+
+///|
 fn mode_button(
   emit : @cmd.Emit[Msg],
   model : Model,
@@ -767,6 +783,81 @@ fn mode_button(
     "mode-button"
   }
   @html.button(class=classes, on_click=emit(SetMode(mode)), label)
+}
+
+///|
+fn session_metadata(
+  model : Model,
+  parsed : @session_log.ParsedLog,
+) -> @html.Html {
+  let steps = assistant_step_count(parsed)
+  @html.div(class="session-metadata", [
+    @html.span("log \{format_log_size(model.log_bytes)}"),
+    @html.span("\{steps} step\{plural_s(steps)}"),
+    @html.span("runtime \{runtime_label(parsed)}"),
+  ])
+}
+
+///|
+fn assistant_step_count(parsed : @session_log.ParsedLog) -> Int {
+  for event in parsed.events; count = 0 {
+    if event.item() is Assistant(_) {
+      continue count + 1
+    }
+  } nobreak {
+    count
+  }
+}
+
+///|
+fn runtime_label(parsed : @session_log.ParsedLog) -> String {
+  match running_ms(parsed) {
+    Some(milliseconds) => format_span_total_seconds(milliseconds)
+    None => "n/a"
+  }
+}
+
+///|
+fn running_ms(parsed : @session_log.ParsedLog) -> Int64? {
+  let mut first = 0L
+  let mut last = 0L
+  for event in parsed.events {
+    let stamp = event.unix_ms()
+    if stamp > 0 {
+      if first == 0L {
+        first = stamp
+      }
+      last = stamp
+    }
+  }
+  if first > 0L && last >= first {
+    Some(last - first)
+  } else {
+    None
+  }
+}
+
+///|
+fn format_span_total_seconds(span_ms : Int64) -> String {
+  let tenths = span_ms / 100L
+  "\{tenths / 10L}.\{tenths % 10L}s"
+}
+
+///|
+fn format_log_size(bytes : Int64) -> String {
+  if bytes < 1024L {
+    "\{bytes} B"
+  } else if bytes < 1048576L {
+    format_scaled_size(bytes, 1024L, "KiB")
+  } else {
+    format_scaled_size(bytes, 1048576L, "MiB")
+  }
+}
+
+///|
+fn format_scaled_size(bytes : Int64, unit : Int64, suffix : String) -> String {
+  let tenths = bytes * 10L / unit
+  "\{tenths / 10L}.\{tenths % 10L} \{suffix}"
 }
 
 ///|
@@ -954,5 +1045,9 @@ fn parse_load(text : String) -> LoadOutcome {
       )
     _ => ("", false)
   }
-  Loaded(parsed, system_prompt, header_present)
+  let log_bytes = match fields.get("events_bytes") {
+    Some(Number(value, ..)) => value.to_int64()
+    _ => events_text.length().to_int64()
+  }
+  Loaded(parsed, system_prompt, header_present, log_bytes)
 }

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -1,12 +1,13 @@
 ///|
 test "parse_load reads a found envelope with header" {
   let text =
-    #|{"found":true,"events":"{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","header":{"version":1,"system_prompt":"SYS"}}
+    #|{"found":true,"events":"{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","events_bytes":77,"header":{"version":1,"system_prompt":"SYS"}}
   match parse_load(text) {
-    Loaded(parsed, system_prompt, header_present) => {
+    Loaded(parsed, system_prompt, header_present, log_bytes) => {
       inspect(parsed.events.length(), content="1")
       inspect(system_prompt, content="SYS")
       inspect(header_present, content="true")
+      inspect(log_bytes, content="77")
     }
     _ => fail("expected Loaded")
   }
@@ -17,12 +18,33 @@ test "parse_load treats a null header as events-only" {
   let text =
     #|{"found":true,"events":"","header":null}
   match parse_load(text) {
-    Loaded(_, system_prompt, header_present) => {
+    Loaded(_, system_prompt, header_present, log_bytes) => {
       inspect(system_prompt, content="")
       inspect(header_present, content="false")
+      inspect(log_bytes, content="0")
     }
     _ => fail("expected Loaded")
   }
+}
+
+///|
+test "session metadata counts steps and total runtime" {
+  let text =
+    #|{"found":true,"events":"{\"sequence\":1,\"ts\":100000,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":101500,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"\",\"tool_calls\":[]}}}\n{\"sequence\":3,\"ts\":170300,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n","events_bytes":307,"header":null}
+  match parse_load(text) {
+    Loaded(parsed, _, _, log_bytes) => {
+      inspect(format_log_size(log_bytes), content="307 B")
+      inspect(assistant_step_count(parsed), content="1")
+      inspect(runtime_label(parsed), content="70.3s")
+    }
+    _ => fail("expected Loaded")
+  }
+}
+
+///|
+test "log size formats larger byte counts" {
+  inspect(format_log_size(554702L), content="541.7 KiB")
+  inspect(format_log_size(2097152L), content="2.0 MiB")
 }
 
 ///|

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -227,7 +227,7 @@ fn valid_session_id(value : String) -> Bool {
 
 ///|
 /// Serve one session as a single JSON envelope:
-/// `{ "found": Bool, "events": String, "header": Json|null }`.
+/// `{ "found": Bool, "events": String, "events_bytes": Number, "header": Json|null }`.
 ///
 /// The frontend's HTTP client (`rabbita/http`) resolves any completed response
 /// as success regardless of status code, so absence and content must be encoded
@@ -253,6 +253,7 @@ async fn session_envelope_reply(
   } else {
     ""
   }
+  let events_bytes = if events_exists { file_size(events_path) } else { 0L }
   let header : Json = if header_exists {
     @json.parse(read_text_lossy(header_path)) catch {
       _ => Json::null()
@@ -260,7 +261,12 @@ async fn session_envelope_reply(
   } else {
     Json::null()
   }
-  json_reply({ "found": true, "events": events_text, "header": header })
+  json_reply({
+    "found": true,
+    "events": events_text,
+    "events_bytes": Json::number(events_bytes.to_double()),
+    "header": header,
+  })
 }
 
 ///|
@@ -653,6 +659,15 @@ async fn asset_reply(path : String, content_type : String) -> Reply {
 /// and is reported as a benign truncated tail.
 async fn read_text_lossy(path : String) -> String {
   @utf8.decode_lossy(@fs.read_file(path).binary())
+}
+
+///|
+async fn file_size(path : String) -> Int64 {
+  let file = @fs.open(path, mode=ReadOnly) catch { _ => return 0L }
+  defer file.close()
+  file.size() catch {
+    _ => 0L
+  }
 }
 
 ///|

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -288,3 +288,26 @@ async test "session_list_reply includes root metadata and composite keys" {
     assert_true(text.contains("\"is_marker\":true"))
   })
 }
+
+///|
+async test "session_envelope_reply includes event log byte size" {
+  @vfs.with_tmpdir(prefix="openseek-viz-envelope-", root => {
+    let store = @store.SessionStore("\{root}/.openseek")
+    let session = @agent_session.Session(SessionId("demo"), system_prompt="").append(
+      User(UserMessage("hi")),
+    )
+    store.create(session)
+    let reply = session_envelope_reply(store, SessionId("demo"))
+    guard @json.parse(reply.body) is Object(fields) else {
+      fail("expected JSON object")
+    }
+    guard fields.get("events") is Some(String(events_text)) else {
+      fail("expected events")
+    }
+    guard fields.get("events_bytes") is Some(Number(size, ..)) else {
+      fail("expected events_bytes")
+    }
+    inspect(size.to_int(), content="\{events_text.length()}")
+    assert_true(size.to_int() > 0)
+  })
+}

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -30,6 +30,7 @@ no browser needed in CI.
 - `GET /` → the viewer shell (`web/index.html`)
 - `GET /viz_app.js` → the compiled frontend bundle (auto-located from the moon build output)
 - `GET /api/sessions` → `[{key, id, root, root_label, last_active, first_prompt}, …]`, most recent first across all roots
+- `GET /api/sessions/<key>` → `{found, events, events_bytes, header}` envelope for the frontend
 - `GET /api/sessions/<key>/events.jsonl` → raw append-only log
 - `GET /api/sessions/<key>/session.json` → raw header (404 when absent; the frontend degrades to events-only)
 

--- a/web/index.html
+++ b/web/index.html
@@ -207,7 +207,15 @@
     .header-meta { color: var(--muted); font-size: 12px; }
 
     /* mode toggle */
-    .mode-toggle { display: flex; gap: 8px; margin-bottom: 16px; }
+    .mode-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 8px 14px;
+      margin-bottom: 16px;
+    }
+    .mode-toggle { display: flex; gap: 8px; }
     .mode-button {
       background: var(--panel); color: var(--text);
       border: 1px solid var(--border); border-radius: 999px;
@@ -215,6 +223,22 @@
     }
     .mode-button:hover { border-color: var(--accent); }
     .mode-button.active { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
+    .session-metadata {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 6px 10px;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+    }
+    .session-metadata span {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 3px 8px;
+      background: var(--panel);
+      white-space: nowrap;
+    }
 
     /* find-failures bar */
     .error-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: -6px 0 16px; }


### PR DESCRIPTION
## Summary
- Show log size, assistant-step count, and runtime next to the Raw log / Model view controls.
- Add exact `events_bytes` to the visualizer session API, with a frontend fallback for older envelopes.
- Add focused app/server tests and document the session envelope field.

## Validation
- `moon check cmd/viz_app --target js --diagnostic-limit 50`
- `moon test cmd/viz_app --target js --diagnostic-limit 50`
- `moon check cmd/viz_server --target native --diagnostic-limit 50`
- `moon test cmd/viz_server --target native --diagnostic-limit 50`
- `moon build cmd/viz_app --target js --diagnostic-limit 50`
- `moon info`
- `moon fmt`
- `git diff --check`

## Fresh Codex CLI Review
- Reviewed commit `028756df9140051eedc3202bb6e7f478d3e10dfa` with `codex review --commit`.
- Result: no actionable correctness issues found.
- Focused app/server tests passed in an archive copy of the reviewed commit.
- Full `moon test --target all` passed for wasm, wasm-gc, and js; native only failed on the existing external-network DeepSeek smoke test DNS lookup.

## Split From
- Supersedes the metadata portion of #196.