### PR TITLE
Show raw log spans as total seconds

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -170,7 +170,7 @@ fn offset_label(base : Int64, event : @agent_session.SessionEvent) -> String {
   if base == 0 || event.unix_ms() == 0 {
     return ""
   }
-  "+\{format_span_seconds(event.unix_ms() - base)}"
+  "+\{format_span_total_seconds(event.unix_ms() - base)}"
 }
 
 ///|
@@ -195,29 +195,14 @@ fn turn_duration_label(turn : Array[@agent_session.SessionEvent]) -> String? {
     }
   }
   if last > base {
-    Some(format_span_seconds(last - base))
+    Some(format_span_total_seconds(last - base))
   } else {
     None
   }
 }
 
 ///|
-/// A millisecond span as a compact human duration: `3.4s`, `2m 05.1s`.
-fn format_span_seconds(span_ms : Int64) -> String {
-  let tenths = span_ms / 100
-  if tenths < 600 {
-    "\{tenths / 10}.\{tenths % 10}s"
-  } else {
-    let minutes = tenths / 600
-    let rest = tenths % 600
-    let seconds = rest / 10
-    let pad = if seconds < 10 { "0" } else { "" }
-    "\{minutes}m \{pad}\{seconds}.\{rest % 10}s"
-  }
-}
-
-///|
-/// A millisecond span as total elapsed seconds. Model-view timestamp chips use
+/// A millisecond span as total elapsed seconds. Session-view timestamp chips use
 /// this instead of minute-splitting so `70.3s` cannot read like just `10.3s`.
 fn format_span_total_seconds(span_ms : Int64) -> String {
   let tenths = span_ms / 100

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -406,7 +406,7 @@ test "notices surface partial tails and bad lines" {
 ///|
 /// Stamped events render relative offsets and a turn duration; unstamped
 /// events (the 0 sentinel) render no time chips at all.
-test "raw view shows per-event offsets and turn duration from ts" {
+test "raw view shows total-second offsets and turn duration from ts" {
   let stamped = @agent_session.Session(SessionId("t"), system_prompt="")
     .append(User(UserMessage("go")), unix_ms=1781151318110L)
     .append(Runtime(RuntimeNotice("working")), unix_ms=1781151319242L)
@@ -414,8 +414,9 @@ test "raw view shows per-event offsets and turn duration from ts" {
   let html = render(@viz.render_session(stamped, RawLog))
   assert_true(html.contains("+0.0s"))
   assert_true(html.contains("+1.1s"))
-  assert_true(html.contains("+2m 05.5s"))
-  assert_true(html.contains("· 2m 05.5s"))
+  assert_true(html.contains("+125.5s"))
+  assert_true(html.contains("· 125.5s"))
+  assert_false(html.contains("+2m 05.5s"))
   let unstamped = @agent_session.Session(SessionId("u"), system_prompt="")
     .append(User(UserMessage("go")))
     .append(Terminal(Finished("done")))


### PR DESCRIPTION
## Summary
- Render raw-log timestamp offsets and turn durations with total seconds.
- Remove the minute-split raw-log formatter so long spans display like `70.3s`, avoiding labels that can be read as `10.3s`.
- Update the raw-log regression test expectations.

## Validation
- `moon check viz --target js --diagnostic-limit 50`
- `moon test viz --target js --diagnostic-limit 50`
- `moon info`
- `moon fmt`
- `git diff --check`

## Fresh Codex CLI Review
- Reviewed commit `09149041f7d418dc65ae8eb892411370dddba2b7` with `codex review --commit`.
- Result: no actionable regression found.
- Full `moon test` only failed on the existing external-network DeepSeek smoke test DNS lookup.

## Split From
- Supersedes the raw-log timing portion of #196.