### PR TITLE
Show absolute viz session times

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1,11 +1,12 @@
 ///|
 /// One row of the `/api/sessions` listing shown in the sidebar. The server
-/// already returns rows most-recently-active first, so the row only needs an id
-/// and a human label.
+/// already returns rows most-recently-active first; the row keeps `last_active`
+/// so the sidebar can show when an experiment last wrote to disk.
 struct SessionRow {
   key : String
   id : String
   root_label : String
+  last_active : Int64?
   // Whether the server discovered this root as a marker store (a `.openseek`-like
   // directory) rather than a direct `--session-root` store. Drives whether the
   // sidebar strips the last path segment when grouping. Absent → `false`.
@@ -250,6 +251,14 @@ fn fetch_text(
 /// Percent-encode the id so session ids containing URL-reserved characters
 /// (spaces, `?`, `#`) reach the server intact; it percent-decodes the segment.
 extern "js" fn encode_uri_component(value : String) -> String = "encodeURIComponent"
+
+///|
+extern "js" fn format_unix_ms_utc(milliseconds : Double) -> String =
+  #|(milliseconds) => {
+  #|  const date = new Date(milliseconds);
+  #|  if (!Number.isFinite(date.getTime())) return "";
+  #|  return date.toISOString().slice(0, 16).replace("T", " ") + " UTC";
+  #|}
 
 ///|
 /// Scroll to the next/previous failed-tool card relative to the viewport's
@@ -676,10 +685,13 @@ fn sidebar_row(
   let classes = if selected { "session-item selected" } else { "session-item" }
   @html.li(class=classes, on_click=emit(Select(row.key)), [
     @html.div(class="session-item-label", label),
-    @html.div(
-      class="session-item-id",
-      session_row_label(row.root_label, row.id, row.is_marker),
-    ),
+    @html.div(class="session-item-meta", [
+      @html.span(
+        class="session-item-id",
+        session_row_label(row.root_label, row.id, row.is_marker),
+      ),
+      last_active_view(row.last_active),
+    ]),
   ])
 }
 
@@ -795,6 +807,7 @@ fn session_metadata(
     @html.span("log \{format_log_size(model.log_bytes)}"),
     @html.span("\{steps} step\{plural_s(steps)}"),
     @html.span("runtime \{runtime_label(parsed)}"),
+    @html.span("ended \{end_time_label(parsed)}"),
   ])
 }
 
@@ -838,9 +851,56 @@ fn running_ms(parsed : @session_log.ParsedLog) -> Int64? {
 }
 
 ///|
+fn end_time_label(parsed : @session_log.ParsedLog) -> String {
+  match last_event_ms(parsed) {
+    Some(milliseconds) => absolute_time_label(milliseconds)
+    None => "n/a"
+  }
+}
+
+///|
+fn last_event_ms(parsed : @session_log.ParsedLog) -> Int64? {
+  let mut last = 0L
+  for event in parsed.events {
+    let stamp = event.unix_ms()
+    if stamp > 0 {
+      last = stamp
+    }
+  }
+  if last > 0L {
+    Some(last)
+  } else {
+    None
+  }
+}
+
+///|
 fn format_span_total_seconds(span_ms : Int64) -> String {
   let tenths = span_ms / 100L
   "\{tenths / 10L}.\{tenths % 10L}s"
+}
+
+///|
+fn last_active_label(last_active : Int64?) -> String {
+  match last_active {
+    Some(seconds) => absolute_time_label(seconds * 1000L)
+    None => ""
+  }
+}
+
+///|
+fn absolute_time_label(milliseconds : Int64) -> String {
+  format_unix_ms_utc(milliseconds.to_double())
+}
+
+///|
+fn last_active_view(last_active : Int64?) -> @html.Html {
+  let label = last_active_label(last_active)
+  if label.is_empty() {
+    @html.nothing
+  } else {
+    @html.span(class="session-item-time", label)
+  }
 }
 
 ///|
@@ -1010,8 +1070,12 @@ fn session_row_of(json : Json) -> SessionRow? {
     Some(String(value)) => value
     _ => ""
   }
+  let last_active = match fields.get("last_active") {
+    Some(Number(value, ..)) => Some(value.to_int64())
+    _ => None
+  }
   let is_marker = fields.get("is_marker") is Some(True)
-  Some({ key, id, root_label, is_marker, first_prompt })
+  Some({ key, id, root_label, last_active, is_marker, first_prompt })
 }
 
 ///|

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -36,9 +36,17 @@ test "session metadata counts steps and total runtime" {
       inspect(format_log_size(log_bytes), content="307 B")
       inspect(assistant_step_count(parsed), content="1")
       inspect(runtime_label(parsed), content="70.3s")
+      inspect(end_time_label(parsed), content="1970-01-01 00:02 UTC")
     }
     _ => fail("expected Loaded")
   }
+}
+
+///|
+test "absolute time labels format UTC timestamps" {
+  inspect(absolute_time_label(0L), content="1970-01-01 00:00 UTC")
+  inspect(last_active_label(Some(0L)), content="1970-01-01 00:00 UTC")
+  inspect(last_active_label(None), content="")
 }
 
 ///|
@@ -68,9 +76,11 @@ test "parse_session_rows reads the listing, skipping malformed rows" {
   inspect(rows[0].id, content="a")
   inspect(rows[0].root_label, content="app/.openseek")
   inspect(rows[0].first_prompt, content="hello")
+  debug_inspect(rows[0].last_active, content="Some(1)")
   inspect(rows[1].key, content="b")
   inspect(rows[1].id, content="b")
   inspect(rows[1].root_label, content="lib/.openseek")
+  debug_inspect(rows[1].last_active, content="None")
 }
 
 ///|
@@ -113,7 +123,7 @@ test "sidebar_groups clusters by container, in listing order, no duplicates" {
 
 ///|
 fn marker_row(key : String, id : String, root_label : String) -> SessionRow {
-  { key, id, root_label, is_marker: true, first_prompt: "" }
+  { key, id, root_label, last_active: None, is_marker: true, first_prompt: "" }
 }
 
 ///|
@@ -172,6 +182,7 @@ test "sidebar_groups keeps unrelated direct stores separate" {
       key: "0|a",
       id: "a",
       root_label: "/srv/store-a",
+      last_active: None,
       is_marker: false,
       first_prompt: "",
     },
@@ -179,6 +190,7 @@ test "sidebar_groups keeps unrelated direct stores separate" {
       key: "1|b",
       id: "b",
       root_label: "/srv/store-b",
+      last_active: None,
       is_marker: false,
       first_prompt: "",
     },

--- a/web/index.html
+++ b/web/index.html
@@ -175,7 +175,17 @@
     .session-item:hover { background: var(--panel-2); }
     .session-item.selected { background: var(--panel-2); border-color: var(--accent); }
     .session-item-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .session-item-id { color: var(--muted); font-size: 11px; font-family: ui-monospace, monospace; }
+    .session-item-meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 11px;
+      font-family: ui-monospace, monospace;
+    }
+    .session-item-id { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .session-item-time { flex: 0 0 auto; }
 
     /* theme switcher */
     .theme-toggle { display: flex; gap: 6px; padding: 10px 14px; border-top: 1px solid var(--border); }


### PR DESCRIPTION
## Summary
- Keep normalized per-event/runtime timing, but add absolute UTC end time to the main session metadata row.
- Parse `last_active` from the session listing and show it in each sidebar row so the experiment date is visible before opening a run.
- Add focused tests for UTC formatting and parsed `last_active` values.

## Validation
- `moon check cmd/viz_app --target js --diagnostic-limit 50`
- `moon test cmd/viz_app --target js --diagnostic-limit 50`
- `moon build cmd/viz_app --target js --diagnostic-limit 50`
- `moon info && moon fmt`
- `git diff --check`