### PR TITLE
[codex] Mention auto-triggered moon check in prompts

### DIFF
--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -35,7 +35,7 @@ For fast, reliable task execution, follow this order:
    - Keep changes inside the correct package, use `///|` top-level delimiters, and split code into cohesive files.
 
 6. **Validate in a tight loop**
-   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
+   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. The host may auto-trigger `moon check` when necessary and may summarize it compactly; treat that summary as feedback, and run an explicit check when you need full diagnostics. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
    - Run targeted tests with `moon test [dirname|filename] --filter 'glob'` and use `moon test --update` for snapshot changes.
 
 7. **Finalize before handoff**

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -7,6 +7,9 @@ Run `moon check` through `shell` after every edit as the primary fast feedback
 loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
 generation, so it is much faster than `moon build` or `moon test`. Use
 `moon build` or `moon test` only when you need artifacts or test results.
+The host may auto-trigger `moon check` when necessary and may summarize it
+compactly; treat that summary as feedback, and run an explicit check when you
+need full diagnostics.
 
 ## Tool Protocol
 

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -39,7 +39,7 @@ fn base_prompt() -> String {
     #|   - Keep changes inside the correct package, use `///|` top-level delimiters, and split code into cohesive files.
     #|
     #|6. **Validate in a tight loop**
-    #|   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
+    #|   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. The host may auto-trigger `moon check` when necessary and may summarize it compactly; treat that summary as feedback, and run an explicit check when you need full diagnostics. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
     #|   - Run targeted tests with `moon test [dirname|filename] --filter 'glob'` and use `moon test --update` for snapshot changes.
     #|
     #|7. **Finalize before handoff**

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -11,6 +11,9 @@ fn flash_prompt() -> String {
     #|loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
     #|generation, so it is much faster than `moon build` or `moon test`. Use
     #|`moon build` or `moon test` only when you need artifacts or test results.
+    #|The host may auto-trigger `moon check` when necessary and may summarize it
+    #|compactly; treat that summary as feedback, and run an explicit check when you
+    #|need full diagnostics.
     #|
     #|## Tool Protocol
     #|

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -6,6 +6,7 @@ test "flash prompt keeps core MoonBit guidance" {
   )
   assert_true(prompt.contains("Do not emit JSON action plans"))
   assert_true(prompt.contains("Run `moon check` through `shell`"))
+  assert_true(prompt.contains("may auto-trigger `moon check`"))
   assert_true(prompt.contains("much faster than"))
   assert_true(prompt.contains("primary"))
   assert_true(prompt.contains("Create `moon.mod` before running `moon info`"))


### PR DESCRIPTION
## Summary

Add prompt guidance that the host may auto-trigger `moon check` when necessary and summarize that feedback compactly. The prompt still tells the agent to run explicit checks when full diagnostics are needed.

## Why

This prepares the system prompt for compact automatic check feedback without implying the model should ignore diagnostics or stop validating explicitly.

## Validation

- `moon check prompt --target native --diagnostic-limit 5`
- `moon test prompt --target native --diagnostic-limit 10`
- `moon info && moon fmt`
- `git diff --check`

## 5x A/B

Result: **not an improvement** on the TOML parser CLI eval.

| Branch | Prompt label | Successes | Finished | Validation passed | Steps |
| --- | --- | --- | --- | --- | --- |
| `origin/main` (`d11f976`) | `origin-main-5x` | `4/5` | `4/5` | `4/5` | `157, 129, 160, 81, 120` |
| this PR | `auto-check-notice-5x` | `1/5` | `2/5` | `4/5` | `160, 160, 160, 90, 131` |

Conclusion: this prompt wording regressed the eval, so I do not recommend merging this PR as-is.