### PR TITLE
dir_outline returns String?; improve environment prompt; add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode/
 _build/
 .mooncakes/
 .moonagent/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "moonbit.inlayHints.forBinderTypes": false,
+  "moonbit.inlayHints.forAnonymousFunctionReturnTypes": false,
+  "moonbit.inlayHints.forFunctionParameterNames": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "moonbit.inlayHints.forBinderTypes": false,
-  "moonbit.inlayHints.forAnonymousFunctionReturnTypes": false,
-  "moonbit.inlayHints.forFunctionParameterNames": false
-}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -908,99 +908,17 @@ async test "environment section names the cwd and appends the layout outline" {
   let section = environment_prompt_section()
   let cwd = @fs.realpath(".")
   // Normalise the machine-specific CWD so the snapshot is portable across
-  // local dev and CI, while still asserting the full rendered structure.
+  // local dev and CI, while still asserting a stable contiguous layout block.
   let portable = section.replace_all(old=cwd, new="{cwd}")
-  inspect(
-    portable,
-    content=(
-      #|## Environment
-      #|
-      #|Working directory: {cwd}
-      #|Relative paths resolve against it; treat it as the workspace root and stay inside it.
-      #|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
-      #|Project layout (directories; hidden, build, and vendored dirs omitted):
-      #|cmd/
-      #|  tui/
-      #|    internal/
-      #|  viz_app/
-      #|  openseek/
-      #|  viz_server/
-      #|tui/
-      #|  doc/
-      #|  core/
-      #|  style/
-      #|  internal/
-      #|    task/
-      #|    text/
-      #|    render/
-      #|    history/
-      #|    surface/
-      #|    composer/
-      #|    geometry/
-      #|    viewport/
-      #|    terminal_size/
-      #|viz/
-      #|web/
-      #|docs/
-      #|  plans/
-      #|eval/
-      #|  report/
-      #|  prompts/
-      #|  file_edit/
-      #|    cmd/
-      #|    cases/
-      #|    harness/
-      #|  prompt_task/
-      #|    cmd/
-      #|    harness/
-      #|  prompt_tasks/
-      #|  tool_harness/
-      #|  prompt_reports/
-      #|  session_analyzer/
-      #|agent/
-      #|shell/
-      #|tests/
-      #|  cram/
-      #|  live/
-      #|prompt/
-      #|harness/
-      #|  toml/
-      #|scripts/
-      #|  internal/
-      #|    markdown_comments/
-      #|  md_to_mbt_string/
-      #|testkit/
-      #|  filesystem/
-      #|deepseek/
-      #|  client/
-      #|internal/
-      #|  workspace_path/
-      #|agent_tool/
-      #|  edit/
-      #|    internal/
-      #|  read/
-      #|    internal/
-      #|  shell/
-      #|    internal/
-      #|  write/
-      #|    internal/
-      #|  finish/
-      #|    internal/
-      #|  internal/
-      #|    error/
-      #|  moon_cmd/
-      #|    fixtures/
-      #|    internal/
-      #|  moon_ide/
-      #|    fixtures/
-      #|    internal/
-      #|  moon_check/
-      #|    internal/
-      #|agent_skill/
-      #|agent_runtime/
-      #|agent_session/
-      #|  log/
-      #|  store/
+  assert_true(
+    portable.contains(
+      (
+        #|Project layout (directories; hidden, build, and vendored dirs omitted):
+        #|cmd/
+        #|  tui/
+        #|    internal/
+        #|  viz_app/
+      ),
     ),
   )
 }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -881,29 +881,174 @@ async fn environment_prompt_section(workspace_root? : String = ".") -> String {
       _ => workspace_root
     }
   }
-  let section =
+  // FIXME(upstream)
+  // " \{sb => f(sb)}"
+  // `f` is not allowed to be async, either fix it or better error message (macro expansion should work)
+  let outline = @vfs.dir_outline(cwd)
+  fn layout(sb : StringBuilder) {
+    match outline {
+      Some(body) => sb <+ "\{body}"
+      None => sb <+ "(empty directory)"
+    }
+  }
+  (
     $|## Environment
     $|
     $|Working directory: \{cwd}
-    $|Relative paths resolve against it; treat it as the workspace root and stay inside it. Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
-  let body = @vfs.dir_outline(cwd)
-  let layout = if body == "" {
-    ""
-  } else {
-    "\n\nProject layout (directories; hidden, build, and vendored dirs omitted):\n\{body}"
-  }
-  "\{section}\{layout}"
+    $|Relative paths resolve against it; treat it as the workspace root and stay inside it.
+    $|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
+    $|Project layout (directories; hidden, build, and vendored dirs omitted):
+    $|\{sb=>layout(sb)}
+  )
 }
 
 ///|
 async test "environment section names the cwd and appends the layout outline" {
   let section = environment_prompt_section()
   let cwd = @fs.realpath(".")
-  assert_true(section.contains("Working directory: \{cwd}"))
-  assert_true(section.contains("stay inside it"))
-  // The repo root has subdirectories, so the layout outline is appended (its
-  // content is covered by @layout's own snapshot test).
-  assert_true(section.contains("Project layout"))
+  inspect(
+    section,
+    content=(
+      #|## Environment
+      #|
+      #|Working directory: /Users/hongbozhang/git/openseek
+      #|Relative paths resolve against it; treat it as the workspace root and stay inside it.
+      #|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
+      #|Project layout (directories; hidden, build, and vendored dirs omitted):
+      #|cmd/
+      #|  tui/
+      #|    internal/
+      #|  viz_app/
+      #|  openseek/
+      #|  viz_server/
+      #|tui/
+      #|  doc/
+      #|  core/
+      #|  style/
+      #|  internal/
+      #|    task/
+      #|    text/
+      #|    render/
+      #|    history/
+      #|    surface/
+      #|    composer/
+      #|    geometry/
+      #|    viewport/
+      #|    terminal_size/
+      #|viz/
+      #|web/
+      #|docs/
+      #|  plans/
+      #|eval/
+      #|  report/
+      #|  prompts/
+      #|  file_edit/
+      #|    cmd/
+      #|    cases/
+      #|    harness/
+      #|  prompt_task/
+      #|    cmd/
+      #|    harness/
+      #|  prompt_tasks/
+      #|  tool_harness/
+      #|  prompt_reports/
+      #|  session_analyzer/
+      #|agent/
+      #|shell/
+      #|tests/
+      #|  cram/
+      #|  live/
+      #|prompt/
+      #|harness/
+      #|  toml/
+      #|scripts/
+      #|  internal/
+      #|    markdown_comments/
+      #|  md_to_mbt_string/
+      #|testkit/
+      #|  filesystem/
+      #|deepseek/
+      #|  client/
+      #|internal/
+      #|  workspace_path/
+      #|agent_tool/
+      #|  edit/
+      #|    internal/
+      #|  read/
+      #|    internal/
+      #|  shell/
+      #|    internal/
+      #|  write/
+      #|    internal/
+      #|  finish/
+      #|    internal/
+      #|  internal/
+      #|    error/
+      #|  moon_cmd/
+      #|    fixtures/
+      #|    internal/
+      #|  moon_ide/
+      #|    fixtures/
+      #|    internal/
+      #|  moon_check/
+      #|    internal/
+      #|agent_skill/
+      #|agent_runtime/
+      #|agent_session/
+      #|  log/
+      #|  store/
+    ),
+  )
+
+}
+
+///|
+async test "environment section reports empty directory layout" {
+  @vfs.with_tmpdir(root => {
+    let section = environment_prompt_section(workspace_root=root)
+    let resolved_root = @fs.realpath(root)
+    let replaced = section.replace_all(old=resolved_root, new="{resolved_root}")
+    inspect(
+      replaced,
+      content=(
+        #|## Environment
+        #|
+        #|Working directory: {resolved_root}
+        #|Relative paths resolve against it; treat it as the workspace root and stay inside it.
+        #|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
+        #|Project layout (directories; hidden, build, and vendored dirs omitted):
+        #|(empty directory)
+      ),
+    )    
+  })
+}
+
+///|
+async test "environment section inline snapshot for deterministic layout" {
+  @vfs.with_tmpdir(root => {
+    @vfs.FileSystem({
+      "a/one.txt": "x",
+      "b/two.txt": "x",
+      ".git/objects/o": "x",
+      "node_modules/pkg/index.js": "x",
+      "_build/out.log": "x",
+    }).write_to(root)
+    let resolved_root = @fs.realpath(root)
+    let section = environment_prompt_section(workspace_root=root)
+    inspect(
+      section,
+      content=(
+        $|## Environment
+        $|
+        $|Working directory: \{resolved_root}
+        $|Relative paths resolve against it; treat it as the workspace root and stay inside it.
+        $|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
+        $|Project layout (directories; hidden, build, and vendored dirs omitted):
+        $|a/
+        $|b/
+      ),
+    )
+  })
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -999,7 +999,6 @@ async test "environment section names the cwd and appends the layout outline" {
       #|  store/
     ),
   )
-
 }
 
 ///|
@@ -1019,7 +1018,7 @@ async test "environment section reports empty directory layout" {
         #|Project layout (directories; hidden, build, and vendored dirs omitted):
         #|(empty directory)
       ),
-    )    
+    )
   })
 }
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -906,99 +906,16 @@ async fn environment_prompt_section(workspace_root? : String = ".") -> String {
 async test "environment section names the cwd and appends the layout outline" {
   let section = environment_prompt_section()
   let cwd = @fs.realpath(".")
-  inspect(
-    section,
-    content=(
-      #|## Environment
-      #|
-      #|Working directory: /Users/hongbozhang/git/openseek
-      #|Relative paths resolve against it; treat it as the workspace root and stay inside it.
-      #|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
-      #|Project layout (directories; hidden, build, and vendored dirs omitted):
-      #|cmd/
-      #|  tui/
-      #|    internal/
-      #|  viz_app/
-      #|  openseek/
-      #|  viz_server/
-      #|tui/
-      #|  doc/
-      #|  core/
-      #|  style/
-      #|  internal/
-      #|    task/
-      #|    text/
-      #|    render/
-      #|    history/
-      #|    surface/
-      #|    composer/
-      #|    geometry/
-      #|    viewport/
-      #|    terminal_size/
-      #|viz/
-      #|web/
-      #|docs/
-      #|  plans/
-      #|eval/
-      #|  report/
-      #|  prompts/
-      #|  file_edit/
-      #|    cmd/
-      #|    cases/
-      #|    harness/
-      #|  prompt_task/
-      #|    cmd/
-      #|    harness/
-      #|  prompt_tasks/
-      #|  tool_harness/
-      #|  prompt_reports/
-      #|  session_analyzer/
-      #|agent/
-      #|shell/
-      #|tests/
-      #|  cram/
-      #|  live/
-      #|prompt/
-      #|harness/
-      #|  toml/
-      #|scripts/
-      #|  internal/
-      #|    markdown_comments/
-      #|  md_to_mbt_string/
-      #|testkit/
-      #|  filesystem/
-      #|deepseek/
-      #|  client/
-      #|internal/
-      #|  workspace_path/
-      #|agent_tool/
-      #|  edit/
-      #|    internal/
-      #|  read/
-      #|    internal/
-      #|  shell/
-      #|    internal/
-      #|  write/
-      #|    internal/
-      #|  finish/
-      #|    internal/
-      #|  internal/
-      #|    error/
-      #|  moon_cmd/
-      #|    fixtures/
-      #|    internal/
-      #|  moon_ide/
-      #|    fixtures/
-      #|    internal/
-      #|  moon_check/
-      #|    internal/
-      #|agent_skill/
-      #|agent_runtime/
-      #|agent_session/
-      #|  log/
-      #|  store/
-    ),
-  )
+  // Normalise the machine-specific CWD so the snapshot is portable across
+  // local dev and CI, while still asserting the full rendered structure.
+  let portable = section.replace_all(old=cwd, new="{cwd}")
+  assert_true(portable.contains("Working directory: {cwd}"))
+  assert_true(portable.contains("stay inside it"))
+  assert_true(portable.contains("Project layout"))
+  // The repo root has committed directories; spot-check a stable subset.
+  assert_true(portable.contains("cmd/"))
+  assert_true(portable.contains("testkit/"))
+  assert_true(portable.contains("agent_tool/"))
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -888,7 +888,8 @@ async fn environment_prompt_section(workspace_root? : String = ".") -> String {
   fn layout(sb : StringBuilder) {
     match outline {
       Some(body) => sb <+ "\{body}"
-      None => sb <+ "(empty directory)"
+      None =>
+        sb <+ "(empty directory): use `moon new` to create a new project here"
     }
   }
   (
@@ -909,13 +910,99 @@ async test "environment section names the cwd and appends the layout outline" {
   // Normalise the machine-specific CWD so the snapshot is portable across
   // local dev and CI, while still asserting the full rendered structure.
   let portable = section.replace_all(old=cwd, new="{cwd}")
-  assert_true(portable.contains("Working directory: {cwd}"))
-  assert_true(portable.contains("stay inside it"))
-  assert_true(portable.contains("Project layout"))
-  // The repo root has committed directories; spot-check a stable subset.
-  assert_true(portable.contains("cmd/"))
-  assert_true(portable.contains("testkit/"))
-  assert_true(portable.contains("agent_tool/"))
+  inspect(
+    portable,
+    content=(
+      #|## Environment
+      #|
+      #|Working directory: {cwd}
+      #|Relative paths resolve against it; treat it as the workspace root and stay inside it.
+      #|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
+      #|Project layout (directories; hidden, build, and vendored dirs omitted):
+      #|cmd/
+      #|  tui/
+      #|    internal/
+      #|  viz_app/
+      #|  openseek/
+      #|  viz_server/
+      #|tui/
+      #|  doc/
+      #|  core/
+      #|  style/
+      #|  internal/
+      #|    task/
+      #|    text/
+      #|    render/
+      #|    history/
+      #|    surface/
+      #|    composer/
+      #|    geometry/
+      #|    viewport/
+      #|    terminal_size/
+      #|viz/
+      #|web/
+      #|docs/
+      #|  plans/
+      #|eval/
+      #|  report/
+      #|  prompts/
+      #|  file_edit/
+      #|    cmd/
+      #|    cases/
+      #|    harness/
+      #|  prompt_task/
+      #|    cmd/
+      #|    harness/
+      #|  prompt_tasks/
+      #|  tool_harness/
+      #|  prompt_reports/
+      #|  session_analyzer/
+      #|agent/
+      #|shell/
+      #|tests/
+      #|  cram/
+      #|  live/
+      #|prompt/
+      #|harness/
+      #|  toml/
+      #|scripts/
+      #|  internal/
+      #|    markdown_comments/
+      #|  md_to_mbt_string/
+      #|testkit/
+      #|  filesystem/
+      #|deepseek/
+      #|  client/
+      #|internal/
+      #|  workspace_path/
+      #|agent_tool/
+      #|  edit/
+      #|    internal/
+      #|  read/
+      #|    internal/
+      #|  shell/
+      #|    internal/
+      #|  write/
+      #|    internal/
+      #|  finish/
+      #|    internal/
+      #|  internal/
+      #|    error/
+      #|  moon_cmd/
+      #|    fixtures/
+      #|    internal/
+      #|  moon_ide/
+      #|    fixtures/
+      #|    internal/
+      #|  moon_check/
+      #|    internal/
+      #|agent_skill/
+      #|agent_runtime/
+      #|agent_session/
+      #|  log/
+      #|  store/
+    ),
+  )
 }
 
 ///|
@@ -933,7 +1020,7 @@ async test "environment section reports empty directory layout" {
         #|Relative paths resolve against it; treat it as the workspace root and stay inside it.
         #|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
         #|Project layout (directories; hidden, build, and vendored dirs omitted):
-        #|(empty directory)
+        #|(empty directory): use `moon new` to create a new project here
       ),
     )
   })

--- a/testkit/filesystem/outline.mbt
+++ b/testkit/filesystem/outline.mbt
@@ -106,9 +106,7 @@ async test "dir_outline lists directories, omitting files and noise" {
       ".git/objects/o": "x",
       "README.md": "x",
     }).write_to(root)
-    guard dir_outline(root) is Some(outline) else {
-      fail("expected outline")
-    }
+    guard dir_outline(root) is Some(outline) else { fail("expected outline") }
     inspect(
       outline,
       content=(
@@ -146,11 +144,9 @@ async test "dir_outline respects max_depth" {
 ///|
 async test "dir_outline truncates at max_dirs" {
   with_tmpdir(root => {
-    FileSystem({
-      "a/x.txt": "x",
-      "b/x.txt": "x",
-      "c/x.txt": "x",
-    }).write_to(root)
+    FileSystem({ "a/x.txt": "x", "b/x.txt": "x", "c/x.txt": "x" }).write_to(
+      root,
+    )
     guard dir_outline(root, max_dirs=2) is Some(outline) else {
       fail("expected outline")
     }
@@ -174,9 +170,7 @@ async test "dir_outline skips hidden and build dirs at nested levels" {
       "src/_build/out.txt": "x",
       "src/visible/note.txt": "x",
     }).write_to(root)
-    guard dir_outline(root) is Some(outline) else {
-      fail("expected outline")
-    }
+    guard dir_outline(root) is Some(outline) else { fail("expected outline") }
     inspect(
       outline,
       content=(

--- a/testkit/filesystem/outline.mbt
+++ b/testkit/filesystem/outline.mbt
@@ -5,21 +5,21 @@
 /// (`_build`, `target`), and vendored deps (`node_modules`) are omitted.
 ///
 /// Bounded to `max_depth` levels and `max_dirs` entries so it stays small on
-/// large repositories; a trailing `…` line marks truncation. Returns `""` for an
-/// empty or unreadable directory. Symlinks are not followed, so the walk cannot
-/// cycle.
+/// large repositories; a trailing `…` line marks truncation. Returns `None` for
+/// an empty or unreadable directory. Symlinks are not followed, so the walk
+/// cannot cycle.
 pub async fn dir_outline(
   root : String,
   max_depth? : Int = 3,
   max_dirs? : Int = 100,
-) -> String {
+) -> String? {
   let out : Array[String] = []
   collect_dirs(root, 0, max_depth, max_dirs, out)
   if out.is_empty() {
-    return ""
+    return None
   }
   let truncated = if out.length() >= max_dirs { "\n  …" } else { "" }
-  out.join("\n") + truncated
+  Some(out.join("\n") + truncated)
 }
 
 ///|
@@ -98,16 +98,19 @@ fn outline_indent(depth : Int) -> String {
 /// omitted.
 async test "dir_outline lists directories, omitting files and noise" {
   with_tmpdir(root => {
-    FileSystem::from_pairs([
-      ("src/lib.mbt", "x"),
-      ("lib/internal/x.mbt", "x"),
-      ("node_modules/pkg/index.js", "x"),
-      ("_build/out/x", "x"),
-      (".git/objects/o", "x"),
-      ("README.md", "x"),
-    ]).write_to(root)
+    FileSystem({
+      "src/lib.mbt": "x",
+      "lib/internal/x.mbt": "x",
+      "node_modules/pkg/index.js": "x",
+      "_build/out/x": "x",
+      ".git/objects/o": "x",
+      "README.md": "x",
+    }).write_to(root)
+    guard dir_outline(root) is Some(outline) else {
+      fail("expected outline")
+    }
     inspect(
-      dir_outline(root),
+      outline,
       content=(
         #|lib/
         #|  internal/
@@ -119,7 +122,69 @@ async test "dir_outline lists directories, omitting files and noise" {
 
 ///|
 async test "dir_outline is empty for an empty directory" {
-  with_tmpdir(root => inspect(dir_outline(root), content=""))
+  with_tmpdir(root => assert_true(dir_outline(root) is None))
+}
+
+///|
+async test "dir_outline respects max_depth" {
+  with_tmpdir(root => {
+    FileSystem({ "a/b/c/file.txt": "x", "z/file.txt": "x" }).write_to(root)
+    guard dir_outline(root, max_depth=2) is Some(outline) else {
+      fail("expected outline")
+    }
+    inspect(
+      outline,
+      content=(
+        #|a/
+        #|  b/
+        #|z/
+      ),
+    )
+  })
+}
+
+///|
+async test "dir_outline truncates at max_dirs" {
+  with_tmpdir(root => {
+    FileSystem({
+      "a/x.txt": "x",
+      "b/x.txt": "x",
+      "c/x.txt": "x",
+    }).write_to(root)
+    guard dir_outline(root, max_dirs=2) is Some(outline) else {
+      fail("expected outline")
+    }
+    inspect(
+      outline,
+      content=(
+        #|a/
+        #|b/
+        #|  …
+      ),
+    )
+  })
+}
+
+///|
+async test "dir_outline skips hidden and build dirs at nested levels" {
+  with_tmpdir(root => {
+    FileSystem({
+      "src/.cache/tmp.txt": "x",
+      "src/target/out.txt": "x",
+      "src/_build/out.txt": "x",
+      "src/visible/note.txt": "x",
+    }).write_to(root)
+    guard dir_outline(root) is Some(outline) else {
+      fail("expected outline")
+    }
+    inspect(
+      outline,
+      content=(
+        #|src/
+        #|  visible/
+      ),
+    )
+  })
 }
 
 ///|

--- a/testkit/filesystem/pkg.generated.mbti
+++ b/testkit/filesystem/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "bobzhang/openseek/testkit/filesystem"
 
 // Values
-pub async fn dir_outline(String, max_depth? : Int, max_dirs? : Int) -> String
+pub async fn dir_outline(String, max_depth? : Int, max_dirs? : Int) -> String?
 
 pub async fn[T] with_tmpdir(async (String) -> T, prefix? : String) -> T
 


### PR DESCRIPTION
## Summary

### `testkit/filesystem` — `dir_outline` returns `String?`
- Changed `dir_outline` return type from `String` to `String?`; empty/unreadable directories now return `None` instead of `""`.
- Converted the existing outline fixture from `FileSystem::from_pairs` to the JSON-style `FileSystem({})` constructor.
- Added four new tests covering `max_depth`, `max_dirs` truncation, nested skip rules (hidden/build dirs), and a full inline snapshot.

### `cmd/openseek` — environment prompt improvements
- Environment prompt now explicitly says `(empty directory)` instead of silently omitting the layout section when the workspace has no directories.
- Refactored the layout suffix into a local `fn layout(sb)` callback so the entire prompt is built with `$|` string-interpolation rather than separate string concatenation.
- Added an inline snapshot test that asserts the full rendered environment block for a deterministic temp-dir fixture (hidden/build dirs filtered, two visible dirs shown).

### `.vscode/settings.json`
- Disable MoonBit extension inlay hints at workspace level (`forBinderTypes`, `forAnonymousFunctionReturnTypes`, `forFunctionParameterNames`).