### PR TITLE
[codex] Auto-check MoonBit edits

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -63,6 +63,9 @@ The action is always `Respond(ToolOutput(...))` — the agent loop forwards
 has one of these shapes:
 
 - `"ok: replaced <n> occurrence(s) in <path>"` on success.
+  If the target is `moon.mod`, `moon.pkg`, or a `.mbt` file inside a MoonBit
+  package, the response may append bounded raw compiler feedback starting with
+  `"moon check:\nexit=<code>"` after the success line.
 - `"error editing <path>: old_string not found"` — no exact match was found.
 - `"error editing <path>: old_string matched <n> times on lines <line>, ...; set replace_all=true to replace all occurrences"` — the edit was ambiguous.
 - `"error editing <path>: moon.pkg content is suspiciously small"` or similar

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -122,8 +122,12 @@ async fn edit_file(
   }
   try {
     @fs.write_file(path, new_content, create_mode=CreateOrTruncate)
-    @agent_tool.ToolAction::respond(
+    let content = @auto_check.append_summary(
+      path,
       "ok: replaced \{replacement_count} occurrence(s) in \{path}",
+    )
+    @agent_tool.ToolAction::respond(
+      content,
       brief="edited \{@agent_tool.brief_basename(path)} (\{replacement_count}×)",
     )
   } catch {

--- a/agent_tool/edit/moon.pkg
+++ b/agent_tool/edit/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/edit/internal/decode",
   "bobzhang/openseek/agent_tool/edit/internal/manifest_error",
+  "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/internal/workspace_path",
   "moonbitlang/async/fs",

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -1,0 +1,200 @@
+///|
+const MoonCheckTimeoutMs : Int = 30000
+
+///|
+const MoonCheckMaxOutputChars : Int = 12000
+
+///|
+const MoonCheckCommand : String = "moon check --diagnostic-limit 1"
+
+///|
+/// Append bounded raw `moon check` feedback after successful writes to MoonBit
+/// source or manifest files. Non-MoonBit paths and paths outside a MoonBit
+/// module are returned unchanged.
+pub async fn append_summary(path : String, content : String) -> String {
+  let summary = auto_check_summary(path) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+  match summary {
+    Some(summary) => "\{content}\n\{summary}"
+    None => content
+  }
+}
+
+///|
+async fn auto_check_summary(path : String) -> String? {
+  if !is_relevant_moonbit_path(path) {
+    return None
+  }
+  let cwd = containing_dir(path)
+  match nearest_moon_module_dir(cwd) {
+    Some(_) => ()
+    None => return None
+  }
+  if is_moonbit_source_path(path) && !@fs.exists(join_path(cwd, "moon.pkg")) {
+    return Some("moon check: skipped (no moon.pkg in file directory)")
+  }
+  let result = @async.with_timeout_opt(MoonCheckTimeoutMs, () => {
+    @shell.collect_shell_output(
+      MoonCheckCommand,
+      cwd~,
+      max_output_chars=MoonCheckMaxOutputChars,
+    )
+  }) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return Some("moon check: failed to run")
+  }
+  match result {
+    Some(output) => Some(format_moon_check_output(output))
+    None => Some("moon check: timed out")
+  }
+}
+
+///|
+fn format_moon_check_output(output : @shell.ShellOutput) -> String {
+  format_moon_check_output_parts(
+    output.exit_code,
+    output.text,
+    output.output_limit_reached,
+  )
+}
+
+///|
+fn format_moon_check_output_parts(
+  exit_code : Int?,
+  output : String,
+  output_limit_reached : Bool,
+) -> String {
+  let header = match exit_code {
+    Some(code) => "moon check:\nexit=\{code}"
+    None => "moon check:\nexit=cancelled"
+  }
+  let header = if output_limit_reached {
+    "\{header}\noutput_limit_reached=true"
+  } else {
+    header
+  }
+  if output == "" {
+    header
+  } else {
+    "\{header}\n\{output}"
+  }
+}
+
+///|
+fn is_relevant_moonbit_path(path : String) -> Bool {
+  let path = path.replace_all(old="\\", new="/")
+  path == "moon.mod" ||
+  path.has_suffix("/moon.mod") ||
+  path == "moon.pkg" ||
+  path.has_suffix("/moon.pkg") ||
+  is_moonbit_source_path(path)
+}
+
+///|
+fn is_moonbit_source_path(path : String) -> Bool {
+  path.replace_all(old="\\", new="/").has_suffix(".mbt")
+}
+
+///|
+fn containing_dir(path : String) -> String {
+  let path = path.replace_all(old="\\", new="/")
+  match path.rev_find("/") {
+    Some(0) => "/"
+    Some(cut) => path[:cut].to_owned()
+    None => "."
+  }
+}
+
+///|
+async fn nearest_moon_module_dir(start : String) -> String? {
+  for dir = start {
+    if @fs.exists(join_path(dir, "moon.mod")) {
+      return Some(dir)
+    }
+    match parent_dir(dir) {
+      Some(parent) => continue parent
+      None => return None
+    }
+  }
+}
+
+///|
+fn parent_dir(dir : String) -> String? {
+  let normalized = strip_trailing_slash(dir.replace_all(old="\\", new="/"))
+  if normalized == "" || normalized == "." || normalized == "/" {
+    return None
+  }
+  match normalized.rev_find("/") {
+    Some(0) => Some("/")
+    Some(cut) => Some(normalized[:cut].to_owned())
+    None => Some(".")
+  }
+}
+
+///|
+fn strip_trailing_slash(path : String) -> String {
+  if path.length() > 1 && path.has_suffix("/") {
+    strip_trailing_slash(path[:path.length() - 1].to_owned())
+  } else {
+    path
+  }
+}
+
+///|
+fn join_path(dir : String, base : String) -> String {
+  if dir == "" || dir == "." {
+    base
+  } else if dir.has_suffix("/") {
+    "\{dir}\{base}"
+  } else {
+    "\{dir}/\{base}"
+  }
+}
+
+///|
+test "relevant path detection covers MoonBit source and manifests" {
+  assert_true(is_relevant_moonbit_path("moon.mod"))
+  assert_true(is_relevant_moonbit_path("lib/moon.pkg"))
+  assert_true(is_relevant_moonbit_path("lib/parser.mbt"))
+  assert_false(is_relevant_moonbit_path("lib/parser.mbti"))
+  assert_false(is_relevant_moonbit_path("README.mbt.md"))
+}
+
+///|
+test "formats raw moon check output with exit code" {
+  assert_eq(
+    format_moon_check_output_parts(
+      Some(255),
+      (
+        #|Error: Failed to calculate build plan
+        #|
+        #|Caused by:
+        #|    0: Failed to resolve the module dependency graph
+      ),
+      false,
+    ),
+    (
+      #|moon check:
+      #|exit=255
+      #|Error: Failed to calculate build plan
+      #|
+      #|Caused by:
+      #|    0: Failed to resolve the module dependency graph
+    ),
+  )
+}
+
+///|
+test "formats truncated moon check output with metadata" {
+  assert_eq(
+    format_moon_check_output_parts(None, "long output", true),
+    (
+      #|moon check:
+      #|exit=cancelled
+      #|output_limit_reached=true
+      #|long output
+    ),
+  )
+}

--- a/agent_tool/internal/auto_check/auto_check_test.mbt
+++ b/agent_tool/internal/auto_check/auto_check_test.mbt
@@ -1,0 +1,137 @@
+///|
+async test "append_summary runs compact check for MoonBit source" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/auto_check\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/moon.pkg",
+      "warnings = \"+unnecessary_annotation\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    let path = "\{dir}/main.mbt"
+    @fs.write_file(
+      path,
+      "fn main {\n  let x = missing\n}\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = @auto_check.append_summary(
+      path,
+      "ok: wrote 28 chars to \{path}",
+    )
+    assert_true(
+      result.has_prefix("ok: wrote 28 chars to \{path}\nmoon check:\nexit="),
+    )
+    assert_true(result.contains("Error:"))
+    assert_false(result.contains("first error:"))
+    assert_false(result.contains("moon check: 0 errors, 0 warnings"))
+  })
+}
+
+///|
+async test "append_summary surfaces raw moon check failure" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-manifest-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/auto_check_manifest\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    let path = "\{dir}/moon.pkg"
+    @fs.write_file(
+      path,
+      "warnings = \"+unnecessary_annotation\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = @auto_check.append_summary(path, "ok: wrote manifest")
+    assert_true(result.has_prefix("ok: wrote manifest\nmoon check:\nexit="))
+    assert_true(result.contains("Error:"))
+    assert_false(result.contains("first error:"))
+    assert_false(result.contains("moon check: 0 errors, 0 warnings"))
+  })
+}
+
+///|
+async test "append_summary preserves module dependency graph failure text" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-deps-", dir => {
+    let path = "\{dir}/moon.mod"
+    @fs.write_file(
+      path,
+      "name = \"tmp/auto_check_deps\"\nimport { \"moonbitlang/async\" }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = @auto_check.append_summary(path, "ok: wrote manifest")
+    assert_true(result.has_prefix("ok: wrote manifest\nmoon check:\nexit=255"))
+    assert_true(result.contains("Error: Failed to calculate build plan"))
+    assert_true(
+      result.contains("Failed to resolve the module dependency graph"),
+    )
+    assert_true(
+      result.contains(
+        "moon.mod only supports versioned registry dependencies in `import`",
+      ),
+    )
+    assert_false(result.contains("failed to run check for target Wasm"))
+    assert_false(result.contains("first error:"))
+  })
+}
+
+///|
+async test "append_summary surfaces failed pre-build despite zero diagnostics" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-prebuild-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/auto_check_prebuild\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    let path = "\{dir}/moon.pkg"
+    @fs.write_file(
+      path,
+      (
+        #|options(
+        #|  "pre-build": [
+        #|    {
+        #|      "command": "false",
+        #|      "input": [ "in.txt" ],
+        #|      "output": "generated.mbt",
+        #|    },
+        #|  ],
+        #|)
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file("\{dir}/in.txt", "", create_mode=CreateOrTruncate)
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn hi() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = @auto_check.append_summary(path, "ok: wrote manifest")
+    assert_true(result.has_prefix("ok: wrote manifest\nmoon check:\nexit="))
+    assert_true(result.contains("Error:"))
+    assert_false(result.contains("first error:"))
+    assert_false(result.contains("moon check: 0 errors, 0 warnings"))
+  })
+}
+
+///|
+async test "append_summary skips unpackaged MoonBit source" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-unpackaged-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/auto_check_unpacked\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    let path = "\{dir}/main.mbt"
+    @fs.write_file(
+      path,
+      "pub fn bad() -> Int { missing }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = @auto_check.append_summary(path, "ok: wrote unpackaged source")
+    assert_eq(
+      result, "ok: wrote unpackaged source\nmoon check: skipped (no moon.pkg in file directory)",
+    )
+  })
+}

--- a/agent_tool/internal/auto_check/moon.pkg
+++ b/agent_tool/internal/auto_check/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "bobzhang/openseek/agent_tool/shell",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+}
+
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/auto_check"
+
+// Values
+pub async fn append_summary(String, String) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/agent_tool/write/README.mbt.md
+++ b/agent_tool/write/README.mbt.md
@@ -54,6 +54,9 @@ has one of these shapes:
 
 - `"ok: wrote <n> chars to <path>"` on success — `n` is the character count
   of the written content.
+  If the target is `moon.mod`, `moon.pkg`, or a `.mbt` file inside a MoonBit
+  package, the response may append bounded raw compiler feedback starting with
+  `"moon check:\nexit=<code>"` after the success line.
 - `"error writing <path>: <error>"` — the write failed. Common causes:
   permission denied, missing parent directory, read-only filesystem.
 - `"error writing <path>: moon.mod.json is legacy; create moon.mod ..."` or

--- a/agent_tool/write/moon.pkg
+++ b/agent_tool/write/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/write/internal/decode",
   "bobzhang/openseek/internal/workspace_path",

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -72,8 +72,12 @@ async fn write_file(
     }
     create_parent_dirs(path)
     @fs.write_file(path, input.content, create_mode=CreateOrTruncate)
-    @agent_tool.ToolAction::respond(
+    let content = @auto_check.append_summary(
+      path,
       "ok: wrote \{input.content.length()} chars to \{path}",
+    )
+    @agent_tool.ToolAction::respond(
+      content,
       brief=@agent_tool.brief_line(
         "wrote \{input.content.length()} chars to \{input.path}",
       ),

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -35,7 +35,7 @@ For fast, reliable task execution, follow this order:
    - Keep changes inside the correct package, use `///|` top-level delimiters, and split code into cohesive files.
 
 6. **Validate in a tight loop**
-   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
+   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. After `edit` or `write` changes `moon.mod`, `moon.pkg`, or package `.mbt` files, the tool result may append bounded raw feedback starting with `moon check:` and `exit=<code>`; treat it as immediate compiler feedback, and run an explicit `moon check` when you need full diagnostics. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
    - Run targeted tests with `moon test [dirname|filename] --filter 'glob'` and use `moon test --update` for snapshot changes.
 
 7. **Finalize before handoff**

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -7,6 +7,10 @@ Run `moon check` through `shell` after every edit as the primary fast feedback
 loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
 generation, so it is much faster than `moon build` or `moon test`. Use
 `moon build` or `moon test` only when you need artifacts or test results.
+After `edit` or `write` changes `moon.mod`, `moon.pkg`, or package `.mbt`
+files, the tool result may append bounded raw feedback starting with
+`moon check:` and `exit=<code>`. Treat it as immediate compiler feedback, and
+run an explicit `moon check` when you need full diagnostics.
 
 ## Tool Protocol
 

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -39,7 +39,7 @@ fn base_prompt() -> String {
     #|   - Keep changes inside the correct package, use `///|` top-level delimiters, and split code into cohesive files.
     #|
     #|6. **Validate in a tight loop**
-    #|   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
+    #|   - Run `moon check` after **every** edit. It type-checks without code generation, so it is much faster than `moon build` or `moon test` — make it your primary, high-frequency feedback signal and run it aggressively. After `edit` or `write` changes `moon.mod`, `moon.pkg`, or package `.mbt` files, the tool result may append bounded raw feedback starting with `moon check:` and `exit=<code>`; treat it as immediate compiler feedback, and run an explicit `moon check` when you need full diagnostics. Reach for `moon build`/`moon test` only when you actually need build artifacts or test results. Add `--warn-list +unnecessary_annotation` to enable warning 73 for redundant annotations and over-qualified constructors (`--warn-list +73` is equivalent).
     #|   - Run targeted tests with `moon test [dirname|filename] --filter 'glob'` and use `moon test --update` for snapshot changes.
     #|
     #|7. **Finalize before handoff**

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -11,6 +11,10 @@ fn flash_prompt() -> String {
     #|loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
     #|generation, so it is much faster than `moon build` or `moon test`. Use
     #|`moon build` or `moon test` only when you need artifacts or test results.
+    #|After `edit` or `write` changes `moon.mod`, `moon.pkg`, or package `.mbt`
+    #|files, the tool result may append bounded raw feedback starting with
+    #|`moon check:` and `exit=<code>`. Treat it as immediate compiler feedback, and
+    #|run an explicit `moon check` when you need full diagnostics.
     #|
     #|## Tool Protocol
     #|

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -6,6 +6,8 @@ test "flash prompt keeps core MoonBit guidance" {
   )
   assert_true(prompt.contains("Do not emit JSON action plans"))
   assert_true(prompt.contains("Run `moon check` through `shell`"))
+  assert_true(prompt.contains("moon check:"))
+  assert_true(prompt.contains("exit=<code>"))
   assert_true(prompt.contains("much faster than"))
   assert_true(prompt.contains("primary"))
   assert_true(prompt.contains("Create `moon.mod` before running `moon info`"))


### PR DESCRIPTION
## Summary

Adds automatic bounded raw `moon check` feedback after successful `write`/`edit` calls that touch MoonBit manifests or package source files.

- Runs `moon check --diagnostic-limit 1` from the edited file's containing directory.
- Appends raw output with an `exit=<code>` header, for example:

```text
moon check:
exit=255
Error: Failed to calculate build plan
...
```

- Preserves build-plan and dependency-graph failures instead of collapsing them into a lossy `first error` summary.
- Keeps timeout, output cap, relevance filtering, cancellation handling, and unpackaged `.mbt` skip behavior.
- Updates the base and flash prompts so agents expect auto-triggered raw compiler feedback.

## Validation

- `moon test agent_tool/internal/auto_check agent_tool/edit agent_tool/write prompt --target native --diagnostic-limit 20`
- `moon check --target all --diagnostic-limit 20`
- `moon fmt && moon info`
- `git diff --check`

## Notes

This intentionally drops JSON/count post-processing and `--target all` for the auto-trigger path. The output stays close to Moon's own message so failures such as invalid `moon.mod` dependency syntax remain visible to the agent.