### PR TITLE
Use Claude-style read line prefixes

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -22,9 +22,9 @@ large generated files and dependency sources can flood the transcript and push
 useful context out of the model window.
 
 Ranged or capped reads include a metadata header so the model knows what it saw
-and what it did not see. The body of those headered blocks is line-numbered
-(`right-aligned-number| text`) to make follow-up edits and focused reads less
-error-prone.
+and what it did not see. The body of those headered blocks is line-numbered as
+`<line-number>\t<content>`, matching the common `cat -n` style used by other
+coding agents.
 Automatic character truncation is marked as a tool error even when the file was
 read successfully; that makes lossy context visible to the loop instead of
 silently pretending the returned prefix is complete.
@@ -71,7 +71,7 @@ character truncation. The string body has one of these shapes:
 - The file's text contents on uncapped whole-file success.
 - A metadata header followed by `---` and line-numbered selected content for
   ranged reads or capped reads. The header includes line and character counts
-  plus `line_format=right-aligned-number| text`; `shown_chars` counts the
+  plus `line_format=<line-number>\t<content>`; `shown_chars` counts the
   rendered numbered body, and `truncated=true` when `max_output_chars` cut that
   rendered body.
 - `"error reading <path>: <error>"` — a single-file read failed. Common
@@ -150,7 +150,7 @@ async test "read tool supports focused range reads" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("start_line=2"))
     assert_true(output.content.contains("shown_lines=2"))
-    assert_true(output.content.contains("2| beta\n3| gamma"))
+    assert_true(output.content.contains("2\tbeta\n3\tgamma"))
     assert_false(output.is_error)
   })
 }

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -30,7 +30,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs include right-aligned line numbers.",
+    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs use `<line-number>\\t<content>` numbered lines.",
     schema=JsonSchema({
       "type": "object",
       "required": ["path"],
@@ -207,15 +207,12 @@ fn render_numbered_content(
     }
   }
   let lines = [ for line in selection.content.split("\n") => line.to_owned() ]
-  let last_line = selection.start_line + lines.length() - 1
-  let width = "\{last_line}".length()
   let numbered : Array[String] = []
   let mut remaining = max_chars
   let mut truncated = false
   for index in 0..<lines.length() {
     let separator_chars = if numbered.length() == 0 { 0 } else { 1 }
-    let line_number = "\{selection.start_line + index}".pad_start(width, ' ')
-    let prefix = "\{line_number}| "
+    let prefix = "\{selection.start_line + index}\t"
     let prefix_budget = separator_chars + prefix.char_length()
     if remaining < prefix_budget {
       truncated = true
@@ -271,7 +268,7 @@ fn read_header(
     "shown_chars=\{rendered.shown_chars}",
     "line_limited=\{selection.line_limited}",
     "truncated=\{rendered.truncated}",
-    "line_format=right-aligned-number| text",
+    "line_format=<line-number>\\t<content>",
     "---",
     "",
   ].join("\n")
@@ -354,13 +351,13 @@ async test "read returns a requested line range with metadata" {
         "shown_lines=2",
         "file_chars=38",
         "selected_chars=19",
-        "shown_chars=25",
+        "shown_chars=23",
         "line_limited=true",
         "truncated=false",
-        "line_format=right-aligned-number| text",
+        "line_format=<line-number>\\t<content>",
         "---",
-        "2| line two",
-        "3| line three",
+        "2\tline two",
+        "3\tline three",
       ].join("\n"),
     )
   })
@@ -387,9 +384,9 @@ async test "read caps oversized output and marks it as an error" {
         "shown_chars=3",
         "line_limited=false",
         "truncated=true",
-        "line_format=right-aligned-number| text",
+        "line_format=<line-number>\\t<content>",
         "---",
-        "1| ",
+        "1\ta",
       ].join("\n"),
     )
   })
@@ -404,10 +401,10 @@ async test "read caps after adding line number gutters" {
     let result = execute({ "path": path, "max_output_chars": 20 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
-    assert_true(output.content.contains("shown_chars=17"))
+    assert_true(output.content.contains("shown_chars=19"))
     assert_true(output.content.contains("truncated=true"))
-    assert_true(output.content.contains(" 1| x\n 2| x\n 3| x"))
-    assert_false(output.content.contains(" 4| x"))
+    assert_true(output.content.contains("1\tx\n2\tx\n3\tx\n4\tx\n5\tx"))
+    assert_false(output.content.contains("6\tx"))
   })
 }
 
@@ -416,17 +413,17 @@ async test "read caps unicode content on character boundaries" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/unicode.txt"
     @fs.write_file(path, "😀Z", create_mode=CreateOrTruncate)
-    let result = execute({ "path": path, "max_lines": 1, "max_output_chars": 4 })
+    let result = execute({ "path": path, "max_lines": 1, "max_output_chars": 3 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
-    assert_true(output.content.contains("shown_chars=4"))
-    assert_true(output.content.contains("1| 😀"))
+    assert_true(output.content.contains("shown_chars=3"))
+    assert_true(output.content.contains("1\t😀"))
     assert_false(output.content.contains("Z"))
   })
 }
 
 ///|
-async test "line number gutters align to the widest displayed number" {
+async test "line number gutters use tab-separated cat-n style" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/aligned.txt"
     let content = [ for index in 1..<=111 => "line \{index}" ].join("\n")
@@ -434,10 +431,14 @@ async test "line number gutters align to the widest displayed number" {
     let result = execute({ "path": path, "start_line": 9, "max_lines": 103 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_true(output.content.contains("  9| line 9"))
-    assert_true(output.content.contains(" 99| line 99"))
-    assert_true(output.content.contains("100| line 100"))
-    assert_true(output.content.contains("111| line 111"))
+    assert_true(
+      output.content.contains("line_format=<line-number>\\t<content>"),
+    )
+    assert_true(output.content.contains("9\tline 9"))
+    assert_true(output.content.contains("99\tline 99"))
+    assert_true(output.content.contains("100\tline 100"))
+    assert_true(output.content.contains("111\tline 111"))
+    assert_false(output.content.contains("| line"))
   })
 }
 
@@ -541,7 +542,7 @@ async test "a huge max_lines returns the remaining lines without overflow" {
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_true(output.content.contains("2| b\n3| c"))
+    assert_true(output.content.contains("2\tb\n3\tc"))
     assert_true(output.content.contains("shown_lines=2"))
   })
 }


### PR DESCRIPTION
## Summary
- Direct PR to `main`; rebased onto current `origin/main` / `upstream/main`.
- Switch headered `read` body lines from right-aligned `number| text` gutters to Claude/Kimi-style `<line>\t<content>` prefixes.
- Update read metadata, README examples, and focused tests to describe and verify the tab-prefixed line format.
- Keep line-prefix characters counted toward `max_output_chars` so truncation remains honest.

## Validation
Latest head (`26e3833`):
- `moon info`
- `moon fmt`
- `git diff --check`
- `moon test agent_tool/read --diagnostic-limit 100` (`21/21`)
- `moon test --diagnostic-limit 100` (`16/16` JS, `612/612` native)

## Fresh Review
- Previous #212 layer review: `codex exec review --base upstream/codex/improve-read-tool-quality --dangerously-bypass-approvals-and-sandbox -o /tmp/codex-review-pr212-rebased.md` completed with no actionable findings before this pure rebase.
- That review also ran `moon test agent_tool/read`, `moon check --target all`, full `moon test`, and `git diff --check`.