### PR TITLE
[codex] Suppress streaming reasoning delta logs

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -332,18 +332,11 @@ pub async fn[X] run_turn_in_scope(
       let response = client.chat(
         messages,
         tools=tools.function_tools(),
-        stream=StreamHandler(
-          on_content_delta=delta => {
-            if delta != "" {
-              @xlog.info() <? { "event": "assistant_delta", "content": delta }
-            }
-          },
-          on_reasoning_delta=delta => {
-            if delta != "" {
-              @xlog.info() <? { "event": "reasoning_delta", "content": delta }
-            }
-          },
-        ),
+        stream=StreamHandler(on_content_delta=delta => {
+          if delta != "" {
+            @xlog.info() <? { "event": "assistant_delta", "content": delta }
+          }
+        }),
       )
       // Reasoning first, so a consumer appending events in order shows the
       // thinking above the answer it led to.

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -21,6 +21,8 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/async/socket",
+  "moonbitlang/core/json",
+  "tonyfettes/xlog",
 } for "test"
 
 warnings = "+unnecessary_annotation"

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -195,3 +195,102 @@ async test "blank steering input is dropped at the boundary" {
     assert_eq(result.events().length(), 3)
   }
 }
+
+///|
+struct MemoryLogHandler {
+  entries : Array[Json]
+}
+
+///|
+impl @xlog.Handler for MemoryLogHandler with fn handle(
+  self : MemoryLogHandler,
+  entry : @xlog.Entry,
+) -> Unit {
+  self.entries.push(entry.to_json())
+}
+
+///|
+fn log_event(entry : Json) -> String {
+  match entry {
+    Object(object) =>
+      match object.get("event") {
+        Some(String(event)) => event
+        _ => ""
+      }
+    _ => ""
+  }
+}
+
+///|
+async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping reasoning log test")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        let _ = body.read_all()
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"I\"}}]}\n\n",
+        )
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\" think\"}}]}\n\n",
+        )
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+        )
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=1,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "streaming reasoning deltas are skipped in logs" {
+  @async.with_task_group() <| group => {
+    guard reasoning_log_test_server(group) is Some(url) else { return }
+    let entries : Array[Json] = []
+    let logger = @xlog.global()
+    defer {
+      logger.set_handler(@xlog.Stdout())
+      logger.set_config(Config())
+    }
+    logger.set_handler(MemoryLogHandler::{ entries, })
+    logger.set_level(Info)
+    let session = @agent_session.Session(
+      SessionId("reasoning-log-test"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn(
+      "test-key",
+      V4Flash,
+      session,
+      "do the task",
+      max_steps=1,
+      api_url=url,
+    )
+    let events = result.events()
+    assert_eq(events.length(), 2)
+    assert_true(events[0].item() is User(_))
+    guard events[1].item() is Terminal(Finished("done")) else {
+      fail("expected a completed one-step turn")
+    }
+    let event_names = entries.map(log_event)
+    assert_false(event_names.contains("reasoning_delta"))
+    assert_true(event_names.contains("reasoning_message"))
+    assert_true(event_names.contains("assistant_delta"))
+    assert_true(event_names.contains("assistant_message"))
+  }
+}


### PR DESCRIPTION
## Summary

Suppress per-token `reasoning_delta` xlog events from the agent loop. The DeepSeek client still aggregates streaming reasoning internally, and the agent still emits the final `reasoning_message`, so consumers keep the completed reasoning entry without flooding stdout/session logs with one record per reasoning token.

## Why

Thinking-mode streams can produce many tiny reasoning fragments such as `{"event":"reasoning_delta","content":" I"}`. Those events make CLI/test output and log files noisy while duplicating the final accumulated `reasoning_message`.

## Validation

- `moon check`
- `moon test agent`
- `moon test` (`18/18` js, `627/627` native)
- `moon info && moon fmt`
- `git diff --check`
- Fresh `codex review --uncommitted`: no actionable correctness issues found

## Notes

The TUI decoder still understands `reasoning_delta` for compatibility with recorded or external engine streams, but the built-in agent no longer emits those per-token reasoning events.