### PR TITLE
[codex] Add simple summary compaction

### DIFF
--- a/agent_session/compact/compact.mbt
+++ b/agent_session/compact/compact.mbt
@@ -1,0 +1,95 @@
+///|
+const CompactionUserPrompt : String =
+  #|You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff
+  #|summary for another model that will resume this task.
+  #|
+  #|Summarize the entire conversation context above. Include:
+  #|- Current goal and user intent
+  #|- Key decisions and constraints
+  #|- Important files, commands, tool results, and implementation details
+  #|- What remains to be done, with concrete next steps
+  #|
+  #|Be concise, structured, and focused on helping the next model continue
+  #|without losing context. Return only the summary text.
+
+///|
+fn compaction_messages(
+  session : @agent_session.Session,
+) -> Array[@deepseek.ChatMessage] {
+  session.chat_messages()..push(ChatMessage(User, content=CompactionUserPrompt))
+}
+
+///|
+async fn generate_compaction_summary(
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  session : @agent_session.Session,
+  api_url? : String,
+) -> String {
+  let client = @client.Client(api_key~, model~, api_url?, thinking=No)
+  let response = client.chat(compaction_messages(session))
+  let summary = response.content.trim().to_owned()
+  if summary.is_empty() {
+    fail("compaction summary was empty")
+  }
+  summary
+}
+
+///|
+async fn append_compaction_summary(
+  store? : @store.SessionStore,
+  session : @agent_session.Session,
+  summary~ : String,
+  from_sequence~ : Int,
+  to_sequence~ : Int,
+) -> @agent_session.Session {
+  if store is Some(store) {
+    store.compact(session, content=summary, from_sequence~, to_sequence~)
+  } else {
+    session.compact(
+      content=summary,
+      from_sequence~,
+      to_sequence~,
+      unix_ms=@env.now().reinterpret_as_int64(),
+    )
+  }
+}
+
+///|
+/// Summarize the current session through the model endpoint and append the
+/// resulting checkpoint summary to the session history.
+pub async fn compact_session(
+  store? : @store.SessionStore,
+  session : @agent_session.Session,
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  api_url? : String,
+) -> @agent_session.Session {
+  let from_sequence = 1
+  let to_sequence = session.last_sequence()
+  if to_sequence <= 0 {
+    fail("session compaction requires at least one event")
+  }
+  @xlog.info() <?
+    {
+      "event": "compaction_started",
+      "from_sequence": from_sequence,
+      "to_sequence": to_sequence,
+    }
+  let summary = generate_compaction_summary(api_key~, model~, session, api_url?)
+  let next = append_compaction_summary(
+    store?,
+    session,
+    summary~,
+    from_sequence~,
+    to_sequence~,
+  )
+  @xlog.info() <?
+    {
+      "event": "compaction_finished",
+      "from_sequence": from_sequence,
+      "to_sequence": to_sequence,
+      "summary": summary,
+    }
+  next
+}

--- a/agent_session/compact/compact_test.mbt
+++ b/agent_session/compact/compact_test.mbt
@@ -1,0 +1,14 @@
+///|
+async test "compaction rejects empty sessions before summary generation" {
+  try
+    @compact.compact_session(
+      Session(SessionId("empty"), system_prompt="system"),
+      api_key="",
+      model=V4Flash,
+    )
+  catch {
+    error => assert_true("\{error}".contains("at least one event"))
+  } noraise {
+    _ => fail("accepted empty session")
+  }
+}

--- a/agent_session/compact/compact_wbtest.mbt
+++ b/agent_session/compact/compact_wbtest.mbt
@@ -1,0 +1,44 @@
+///|
+test "compaction messages use projected history plus checkpoint prompt" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(Assistant(AssistantMessage("answer")))
+    .append(User(UserMessage("next")))
+  let messages = compaction_messages(session)
+  assert_eq(messages.length(), 5)
+  assert_true(messages[0].role is System)
+  assert_eq(messages[0].content, "system")
+  assert_true(messages[1].role is User)
+  assert_eq(messages[1].content, "first")
+  assert_true(messages[2].role is Assistant)
+  assert_eq(messages[2].content, "answer")
+  assert_true(messages[3].role is User)
+  assert_eq(messages[3].content, "next")
+  assert_true(messages[4].role is User)
+  assert_true(messages[4].content.contains("CONTEXT CHECKPOINT COMPACTION"))
+  assert_false(messages[4].content.contains("sequence"))
+  assert_false(messages[4].content.contains("JSONL"))
+}
+
+///|
+async test "compaction summary can update an ephemeral session" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("first")),
+  )
+  let next = append_compaction_summary(
+    session,
+    summary="summary",
+    from_sequence=1,
+    to_sequence=1,
+  )
+  assert_eq(next.last_sequence(), 2)
+  guard next.events()[1].item() is Summary(summary) else {
+    fail("expected summary event")
+  }
+  assert_eq(summary.content(), "summary")
+  assert_eq(summary.from_sequence(), 1)
+  assert_eq(summary.to_sequence(), 1)
+  let messages = next.chat_messages()
+  assert_eq(messages.length(), 2)
+  assert_true(messages[1].content.contains("summary"))
+}

--- a/agent_session/compact/moon.pkg
+++ b/agent_session/compact/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "moonbitlang/core/env",
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/deepseek/client",
+  "tonyfettes/xlog",
+}
+
+import {
+  "moonbitlang/async",
+} for "test"
+
+import {
+  "moonbitlang/async",
+} for "wbtest"
+
+supported_targets = "+native"

--- a/agent_session/compact/pkg.generated.mbti
+++ b/agent_session/compact/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_session/compact"
+
+import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/deepseek",
+}
+
+// Values
+pub async fn compact_session(store? : @store.SessionStore, @agent_session.Session, api_key~ : String, model~ : @deepseek.Model, api_url? : String) -> @agent_session.Session
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -63,6 +63,20 @@ like the human-readable listing).
 events from `events.jsonl`; `agent_session.Session::chat_messages` uses the
 summary to compact model context on replay.
 
+In `--serve` mode, controllers can ask the engine to generate and append a
+summary without using a temporary file:
+
+```jsonl
+{"command":"compact"}
+```
+
+The engine handles this in command order, waits for any active turn to finish,
+generates the summary with the configured model endpoint, appends a `Summary`
+event covering the current session, and emits `compaction_started`,
+`compaction_finished`, or `compaction_failed` JSONL events. With `--session`,
+the summary is persisted to the durable session log. With `--no-session`, it
+only updates the live in-memory session for the current serve process.
+
 ## Examples
 
 ```bash

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -5,6 +5,7 @@ import {
   "bobzhang/openseek/agent_skill",
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/agent_session/compact",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/prompt",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -4,17 +4,34 @@
 priv enum ServeCommand {
   Prompt(String)
   Steer(String)
+  Compact
   Cancel
 }
 
 ///|
+/// A queued serve-mode operation that must wait for active work to finish.
+priv enum PendingWork {
+  PendingPrompt(String)
+  PendingCompact
+}
+
+///|
+/// The one operation currently occupying the serve loop. Compaction is a
+/// non-steerable active operation, but it is still cancellable like a turn.
+priv enum ActiveWork {
+  ActiveTurn(@async.Task[Unit])
+  ActiveCompact(@async.Task[Unit])
+}
+
+///|
 /// One unit of work for the serve loop's single consumer: a wire command in
-/// arrival order, the completion of the active turn, or the stdin-EOF
-/// shutdown marker. Funneling all three through one queue is what makes
+/// arrival order, the completion of active work, or the stdin-EOF shutdown
+/// marker. Funneling all three through one queue is what makes
 /// command handling race-free against turn lifecycle.
 priv enum ServeStep {
   Wire(ServeCommand)
   TurnDone
+  CompactDone(@agent_session.Session)
   Shutdown
 }
 
@@ -22,15 +39,18 @@ priv enum ServeStep {
 /// Decode one JSONL command line from the controller.
 ///
 /// `prompt` starts a turn, `steer` injects input into the running one,
-/// `cancel` interrupts it. Anything else is an `Err` whose text is emitted
-/// as a `command_error` event — a controller bug must be visible on the
-/// wire, not silently swallowed, but it must not kill the session either.
+/// `compact` summarizes the current conversation once no work is active, and
+/// `cancel` interrupts the active or next queued prompt. Anything else is an
+/// `Err` whose text is emitted as a `command_error` event — a controller bug
+/// must be visible on the wire, not silently swallowed, but it must not kill
+/// the session either.
 fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
   match json {
     { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text))
     { "command": "steer", "text": String(text), .. } => Ok(Steer(text))
     { "command": "prompt", .. } | { "command": "steer", .. } =>
       Err("expected a string \"text\" field")
+    { "command": "compact", .. } => Ok(Compact)
     { "command": "cancel", .. } => Ok(Cancel)
     { "command": String(other), .. } => Err("unknown command: \{other}")
     _ => Err("expected a {\"command\": ...} object")
@@ -47,6 +67,7 @@ test "serve commands decode and reject with actionable errors" {
     decode_serve_command({ "command": "steer", "text": "left" })
     is Ok(Steer("left")),
   )
+  assert_true(decode_serve_command({ "command": "compact" }) is Ok(Compact))
   assert_true(decode_serve_command({ "command": "cancel" }) is Ok(Cancel))
   guard decode_serve_command({ "command": "prompt" }) is Err(message) else {
     fail("textless prompt accepted")
@@ -63,6 +84,40 @@ test "serve commands decode and reject with actionable errors" {
 }
 
 ///|
+fn remove_next_pending_prompt(pending : Array[PendingWork]) -> Unit {
+  for index, work in pending {
+    if work is PendingPrompt(_) {
+      ignore(pending.remove(index))
+      return
+    }
+  }
+}
+
+///|
+fn has_pending_prompt(pending : Array[PendingWork]) -> Bool {
+  for work in pending {
+    if work is PendingPrompt(_) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+test "pending prompt helpers ignore queued compactions" {
+  let pending : Array[PendingWork] = []
+  assert_false(has_pending_prompt(pending))
+  pending.push(PendingCompact)
+  assert_false(has_pending_prompt(pending))
+  pending.push(PendingPrompt("next"))
+  assert_true(has_pending_prompt(pending))
+  remove_next_pending_prompt(pending)
+  assert_false(has_pending_prompt(pending))
+  assert_eq(pending.length(), 1)
+  assert_true(pending[0] is PendingCompact)
+}
+
+///|
 /// Run the engine as a long-lived session server: read JSONL commands from
 /// stdin, run turns sequentially against one shared session, and write the
 /// usual JSONL event stream to stdout. This is the engine half of the
@@ -76,8 +131,8 @@ test "serve commands decode and reject with actionable errors" {
 /// submitted) turn; with no turn to land in it is rejected with a
 /// `steer_dropped` event — that only happens by racing the terminal event
 /// through the pipes, and an engine must never start a turn the controller
-/// did not ask for. `cancel` interrupts the current turn but never the
-/// process. stdin EOF is the shutdown signal: the running turn finishes
+/// did not ask for. `cancel` interrupts the current active work but never the
+/// process. stdin EOF is the shutdown signal: the running work finishes
 /// first, then the loop drains and exits.
 async fn run_serve(
   matches : @argparse.Matches,
@@ -113,7 +168,7 @@ async fn run_serve(
   }
   // The live conversation value. `append_item` updates it on every appended
   // event, so even a turn that raises leaves `session` reflecting all the
-  // events it durably recorded before failing.
+  // events it recorded before failing.
   let mut session = initial_session
   @async.with_task_group(group => {
     let runtime = @agent_runtime.AgentRuntime(workspace_root~)
@@ -147,9 +202,21 @@ async fn run_serve(
       }
       steps.try_put(Shutdown) |> ignore
     }
-    let pending : Array[String] = []
-    let mut active_turn : @async.Task[Unit]? = None
+    let pending : Array[PendingWork] = []
+    let mut active_work : ActiveWork? = None
     let mut shutting_down = false
+    async fn compact_and_report(
+      current : @agent_session.Session,
+    ) -> @agent_session.Session {
+      @compact.compact_session(store?, current, api_key~, model~, api_url?) catch {
+        error if @async.is_being_cancelled() ||
+          @async.is_cancellation_error(error) => raise error
+        error => {
+          @xlog.error() <? { "event": "compaction_failed", "error": "\{error}" }
+          current
+        }
+      }
+    }
     fn start_turn(task_text : String) -> @async.Task[Unit] {
       group.spawn() <| () => {
         let _ = @agent.run_turn_in_scope(
@@ -192,6 +259,43 @@ async fn run_serve(
       }
     }
 
+    fn start_compaction(current : @agent_session.Session) -> @async.Task[Unit] {
+      group.spawn() <| () => {
+        let next = compact_and_report(current) catch {
+          error if @async.is_being_cancelled() ||
+            @async.is_cancellation_error(error) => {
+            @xlog.warn() <?
+              { "event": "compaction_failed", "error": "cancelled" }
+            current
+          }
+          error => {
+            @xlog.error() <?
+              { "event": "compaction_failed", "error": "\{error}" }
+            current
+          }
+        }
+        ignore(steps.try_put(CompactDone(next)) catch { _ => false })
+      }
+    }
+
+    fn start_next_pending() -> Unit {
+      pending_loop~: for ;; {
+        if active_work is Some(_) || pending.length() == 0 {
+          break pending_loop~
+        }
+        match pending.remove(0) {
+          PendingPrompt(text) => {
+            active_work = Some(ActiveTurn(start_turn(text)))
+            break pending_loop~
+          }
+          PendingCompact => {
+            active_work = Some(ActiveCompact(start_compaction(session)))
+            break pending_loop~
+          }
+        }
+      }
+    }
+
     serve~: for ;; {
       let step = steps.get() catch {
         error if @async.is_being_cancelled() ||
@@ -200,34 +304,37 @@ async fn run_serve(
       }
       match step {
         Wire(Prompt(text)) =>
-          match active_turn {
+          match active_work {
             // One turn at a time: extra prompts wait their wire-order turn.
-            Some(_) => pending.push(text)
-            None => active_turn = Some(start_turn(text))
+            Some(_) => pending.push(PendingPrompt(text))
+            None => active_work = Some(ActiveTurn(start_turn(text)))
           }
         Wire(Steer(text)) =>
-          if active_turn is Some(_) || pending.length() > 0 {
-            // A turn is running or already submitted ahead of this steer:
-            // the lossless steering queue delivers it at that turn's next
-            // step boundary (or its first, if it has not started yet).
-            @agent.steer(runtime, text)
-          } else {
-            // An idle engine never converts a steer into a prompt: the only
-            // way a steer arrives idle is racing the turn's terminal event
-            // through the pipes, and silently starting a turn the controller
-            // never asked for would mutate the session behind its back.
-            // Reject it on the wire so the controller can ask for a resubmit.
-            @xlog.warn() <? { "event": "steer_dropped", "content": text }
+          match active_work {
+            Some(ActiveTurn(_)) => @agent.steer(runtime, text)
+            Some(ActiveCompact(_)) | None =>
+              if has_pending_prompt(pending) {
+                @agent.steer(runtime, text)
+              } else {
+                @xlog.warn() <? { "event": "steer_dropped", "content": text }
+              }
           }
         Wire(Cancel) =>
-          match active_turn {
-            Some(task) => task.cancel()
+          match active_work {
+            Some(ActiveTurn(task)) => task.cancel()
+            Some(ActiveCompact(task)) => task.cancel()
             None =>
-              // No active turn: in wire order the cancel targets the next
+              // No active work: in wire order the cancel targets the next
               // submitted prompt, so withdraw it before it starts.
               if pending.length() > 0 {
-                let _ = pending.remove(0)
+                remove_next_pending_prompt(pending)
               }
+          }
+        Wire(Compact) =>
+          if active_work is Some(_) {
+            pending.push(PendingCompact)
+          } else {
+            active_work = Some(ActiveCompact(start_compaction(session)))
           }
         TurnDone => {
           // A steer that raced the turn's end (or was queued while it was
@@ -237,16 +344,23 @@ async fn run_serve(
           for text in runtime.drain_steers() {
             @xlog.warn() <? { "event": "steer_dropped", "content": text }
           }
-          active_turn = None
-          if pending.length() > 0 {
-            active_turn = Some(start_turn(pending.remove(0)))
-          } else if shutting_down {
+          active_work = None
+          start_next_pending()
+          if active_work is None && pending.length() == 0 && shutting_down {
+            break serve~
+          }
+        }
+        CompactDone(next) => {
+          session = next
+          active_work = None
+          start_next_pending()
+          if active_work is None && pending.length() == 0 && shutting_down {
             break serve~
           }
         }
         Shutdown => {
           shutting_down = true
-          if active_turn is None && pending.length() == 0 {
+          if active_work is None && pending.length() == 0 {
             break serve~
           }
         }


### PR DESCRIPTION
Compaction support in the server mode of `cmd/openseek`.

In server mode, `cmd/openseek` now accepts command like this:

```
{"command":"compact"}
```

When it receives such command, it will perform compaction.

Note that compaction is **non-steerable**, which means user cannot steer input to it. However, compaction can be cancelled.

**NOTE**: This PR does not include slash command support.

### Implementation

This PR extends the `pending` local array from accepting `String` to `PendingWork`, where can be either a plain text prompt, or a compaction task. Also, this PR also extends the `active_turn` concept from a purely agent task, to can be either an agent task or a compaction task.