### PR TITLE
[codex] Tighten MoonBit flash prompt guidance

### DIFF
--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -103,7 +103,11 @@ Common `moon` subcommands:
   inspect private helpers.
 - Top-level MoonBit items are separated by `///|`.
 
-Example module:
+When adding registry dependencies, prefer `moon add moonbitlang/async` or
+`moon add moonbitlang/x` from the module root so MoonBit writes a valid current
+version. Do not guess dependency versions by hand.
+
+Example module skeleton:
 
 ```moon.mod
 name = "username/project"

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -75,8 +75,14 @@ Common `moon` subcommands:
 - Current MoonBit modules use `moon.mod`.
 - Create `moon.mod` before running `moon info`; otherwise `moon` may walk up to
   an unrelated parent module.
+- `moon.mod` is the module manifest: keep module `name`, `version`,
+  module-level dependency versions, `warnings`, and module options there.
 - Packages are directories with `moon.pkg`. Files inside one package share a
   flat namespace; file names do not create modules.
+- `moon.pkg` is the package manifest: keep package imports, import aliases,
+  test/wbtest imports, `supported_targets`, and package options such as
+  `"is-main"` there. Do not put package imports or aliases in `moon.mod`; do
+  not put module dependency versions in `moon.pkg`.
 - Treat files like Go package files: splitting a package into small focused
   `.mbt` files does not affect visibility, and is preferred when it avoids
   large fragile edits.
@@ -92,6 +98,9 @@ Common `moon` subcommands:
   `moonbitlang/core/string` for typed `@string.from_str` parsing,
   `moonbitlang/core/argparse` for CLI parsing, or `moonbitlang/core/json` for
   `@json.parse`.
+- Use `pub fn` for APIs called from another package. Plain `fn` is private.
+- `_test.mbt` files are black-box tests. Use `_wbtest.mbt` only when tests must
+  inspect private helpers.
 - Top-level MoonBit items are separated by `///|`.
 
 Example module:
@@ -160,8 +169,12 @@ options(
   native-only APIs.
 - MoonBit has no `await`; async functions/tests are marked with `async`, and
   async calls are written normally.
-- Use `let mut` only when rebinding a variable. Mutable maps/arrays can be
-  updated without rebinding.
+- Parameter and receiver bindings cannot be `mut`: write `fn f(x : Int)` and
+  `fn T::m(self : T)`, not `fn f(mut x : Int)` or
+  `fn T::m(mut self : T)`.
+- Use `let mut x = ...` only for local rebinding. Mutable maps/arrays can be
+  updated without rebinding. Use `mut field : T` only on struct fields that you
+  assign, e.g. `self.field = value`.
 - Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
 - Match arms are separated by newlines or semicolons, not `|`:
 
@@ -266,6 +279,11 @@ EOF
   helpers in user-facing CLI code because they can print panic/debug stacks.
 - For one-off internal failures use `fail("message")`; for clean user-facing
   parser errors, use a small `suberror`.
+- Use `suberror` for custom errors. Pattern matching error constructors is
+  valid. When matching errors from another package, qualify constructors, for
+  example `catch { @pkga.A => ...; @pkga.B => ... }`. If another package needs
+  stable classification or display, decide whether constructor patterns are
+  part of the public API or expose helper functions.
 
 Checked-error pattern:
 
@@ -313,8 +331,12 @@ fn message(name : String, line : Int) -> String {
   )
 }
 ```
-- `s[i]` returns a UTF-16 code unit, not a `Char`. Prefer `s.get_char(i)` for
-  `Char?` and `for c in s` for Unicode-safe iteration.
+- `s[i]` returns a UTF-16 code unit, not a `Char`. Integer and char literals
+  overload by expected type, so `let x : UInt16 = 0` and `s[i] == '='` are
+  valid. Do not write constructor-style casts such as `UInt16(92)`. For a
+  variable `ch : Char`, compare without allocating `Some(ch)`:
+  `s.get_char(i) is Some(c) && c == ch`. Do not write `is Some(ch)` to compare
+  an existing variable; lowercase names in patterns bind a new variable.
 - `s[start:end]`, `s[:end]`, and `s[start:]` create zero-copy `StringView`s.
   Pass views directly to string APIs and parsers; use `.to_owned()` only when a
   callee stores or requires an owned `String`.
@@ -339,14 +361,12 @@ test {
 - Prefer typed parsing with `@string.from_str` and an explicit annotation, for
   example `let n : Int = @string.from_str(text)` in normal code or tests. Do
   not write `@string.from_str[:Int](text)` or `@string.from_str[Int](text)`.
-- Map lookup `map[key]` can panic if missing. Check `map.contains(key)` first
-  when input is user-controlled.
-- JSON constructors are `Json::Null`, `Json::True`, `Json::False`,
-  `Json::Number(n, ..)`, `Json::String(s)`, `Json::Array(a)`, and
-  `Json::Object(m)`.
-- Prefer JSON builder helpers for creating values: `Json::object(map)`,
-  `Json::array(arr)`, `Json::string(s)`, `Json::number(n)`, and
-  `Json::boolean(b)`.
+- Map lookup `map[key]` can panic if missing. Use `map.get(key)` for `T?`;
+  direct indexing is only for keys you already know exist.
+- Build JSON values with helpers: `Json::object(map)`, `Json::array(arr)`,
+  `Json::string(s)`, `Json::number(n)`, `Json::boolean(b)`, and `Json::null()`.
+  Do not create JSON with `Json::Object(...)`, `Json::String(...)`, or
+  `Json::True`; use variants mainly for pattern matching.
 - For integer JSON numbers, use `Json::number(n.to_double(), repr=text.to_owned())`
   when you need output to preserve integer spelling.
 - For JSON CLI stdout and tests, use `json.stringify()` or inspect
@@ -366,6 +386,9 @@ test {
 - Do not implement ordinary file/stdin IO with C FFI. Use `moonbitlang/async/fs`
   and `moonbitlang/async/stdio`.
 - A native CLI that reads either a path or stdin usually needs `async fn main`.
+- For custom CLI diagnostics, write to stderr with `@stdio.stderr.write(...)`.
+  For a nonzero exit, add the `moonbitlang/x` module, import
+  `"moonbitlang/x/sys"` in `moon.pkg`, and call `@sys.exit(1)`.
 
 Pattern:
 

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -107,7 +107,11 @@ fn flash_prompt() -> String {
     #|  inspect private helpers.
     #|- Top-level MoonBit items are separated by `///|`.
     #|
-    #|Example module:
+    #|When adding registry dependencies, prefer `moon add moonbitlang/async` or
+    #|`moon add moonbitlang/x` from the module root so MoonBit writes a valid current
+    #|version. Do not guess dependency versions by hand.
+    #|
+    #|Example module skeleton:
     #|
     #|```moon.mod
     #|name = "username/project"

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -79,8 +79,14 @@ fn flash_prompt() -> String {
     #|- Current MoonBit modules use `moon.mod`.
     #|- Create `moon.mod` before running `moon info`; otherwise `moon` may walk up to
     #|  an unrelated parent module.
+    #|- `moon.mod` is the module manifest: keep module `name`, `version`,
+    #|  module-level dependency versions, `warnings`, and module options there.
     #|- Packages are directories with `moon.pkg`. Files inside one package share a
     #|  flat namespace; file names do not create modules.
+    #|- `moon.pkg` is the package manifest: keep package imports, import aliases,
+    #|  test/wbtest imports, `supported_targets`, and package options such as
+    #|  `"is-main"` there. Do not put package imports or aliases in `moon.mod`; do
+    #|  not put module dependency versions in `moon.pkg`.
     #|- Treat files like Go package files: splitting a package into small focused
     #|  `.mbt` files does not affect visibility, and is preferred when it avoids
     #|  large fragile edits.
@@ -96,6 +102,9 @@ fn flash_prompt() -> String {
     #|  `moonbitlang/core/string` for typed `@string.from_str` parsing,
     #|  `moonbitlang/core/argparse` for CLI parsing, or `moonbitlang/core/json` for
     #|  `@json.parse`.
+    #|- Use `pub fn` for APIs called from another package. Plain `fn` is private.
+    #|- `_test.mbt` files are black-box tests. Use `_wbtest.mbt` only when tests must
+    #|  inspect private helpers.
     #|- Top-level MoonBit items are separated by `///|`.
     #|
     #|Example module:
@@ -164,8 +173,12 @@ fn flash_prompt() -> String {
     #|  native-only APIs.
     #|- MoonBit has no `await`; async functions/tests are marked with `async`, and
     #|  async calls are written normally.
-    #|- Use `let mut` only when rebinding a variable. Mutable maps/arrays can be
-    #|  updated without rebinding.
+    #|- Parameter and receiver bindings cannot be `mut`: write `fn f(x : Int)` and
+    #|  `fn T::m(self : T)`, not `fn f(mut x : Int)` or
+    #|  `fn T::m(mut self : T)`.
+    #|- Use `let mut x = ...` only for local rebinding. Mutable maps/arrays can be
+    #|  updated without rebinding. Use `mut field : T` only on struct fields that you
+    #|  assign, e.g. `self.field = value`.
     #|- Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
     #|- Match arms are separated by newlines or semicolons, not `|`:
     #|
@@ -270,6 +283,11 @@ fn flash_prompt() -> String {
     #|  helpers in user-facing CLI code because they can print panic/debug stacks.
     #|- For one-off internal failures use `fail("message")`; for clean user-facing
     #|  parser errors, use a small `suberror`.
+    #|- Use `suberror` for custom errors. Pattern matching error constructors is
+    #|  valid. When matching errors from another package, qualify constructors, for
+    #|  example `catch { @pkga.A => ...; @pkga.B => ... }`. If another package needs
+    #|  stable classification or display, decide whether constructor patterns are
+    #|  part of the public API or expose helper functions.
     #|
     #|Checked-error pattern:
     #|
@@ -317,8 +335,12 @@ fn flash_prompt() -> String {
     #|  )
     #|}
     #|```
-    #|- `s[i]` returns a UTF-16 code unit, not a `Char`. Prefer `s.get_char(i)` for
-    #|  `Char?` and `for c in s` for Unicode-safe iteration.
+    #|- `s[i]` returns a UTF-16 code unit, not a `Char`. Integer and char literals
+    #|  overload by expected type, so `let x : UInt16 = 0` and `s[i] == '='` are
+    #|  valid. Do not write constructor-style casts such as `UInt16(92)`. For a
+    #|  variable `ch : Char`, compare without allocating `Some(ch)`:
+    #|  `s.get_char(i) is Some(c) && c == ch`. Do not write `is Some(ch)` to compare
+    #|  an existing variable; lowercase names in patterns bind a new variable.
     #|- `s[start:end]`, `s[:end]`, and `s[start:]` create zero-copy `StringView`s.
     #|  Pass views directly to string APIs and parsers; use `.to_owned()` only when a
     #|  callee stores or requires an owned `String`.
@@ -343,14 +365,12 @@ fn flash_prompt() -> String {
     #|- Prefer typed parsing with `@string.from_str` and an explicit annotation, for
     #|  example `let n : Int = @string.from_str(text)` in normal code or tests. Do
     #|  not write `@string.from_str[:Int](text)` or `@string.from_str[Int](text)`.
-    #|- Map lookup `map[key]` can panic if missing. Check `map.contains(key)` first
-    #|  when input is user-controlled.
-    #|- JSON constructors are `Json::Null`, `Json::True`, `Json::False`,
-    #|  `Json::Number(n, ..)`, `Json::String(s)`, `Json::Array(a)`, and
-    #|  `Json::Object(m)`.
-    #|- Prefer JSON builder helpers for creating values: `Json::object(map)`,
-    #|  `Json::array(arr)`, `Json::string(s)`, `Json::number(n)`, and
-    #|  `Json::boolean(b)`.
+    #|- Map lookup `map[key]` can panic if missing. Use `map.get(key)` for `T?`;
+    #|  direct indexing is only for keys you already know exist.
+    #|- Build JSON values with helpers: `Json::object(map)`, `Json::array(arr)`,
+    #|  `Json::string(s)`, `Json::number(n)`, `Json::boolean(b)`, and `Json::null()`.
+    #|  Do not create JSON with `Json::Object(...)`, `Json::String(...)`, or
+    #|  `Json::True`; use variants mainly for pattern matching.
     #|- For integer JSON numbers, use `Json::number(n.to_double(), repr=text.to_owned())`
     #|  when you need output to preserve integer spelling.
     #|- For JSON CLI stdout and tests, use `json.stringify()` or inspect
@@ -370,6 +390,9 @@ fn flash_prompt() -> String {
     #|- Do not implement ordinary file/stdin IO with C FFI. Use `moonbitlang/async/fs`
     #|  and `moonbitlang/async/stdio`.
     #|- A native CLI that reads either a path or stdin usually needs `async fn main`.
+    #|- For custom CLI diagnostics, write to stderr with `@stdio.stderr.write(...)`.
+    #|  For a nonzero exit, add the `moonbitlang/x` module, import
+    #|  `"moonbitlang/x/sys"` in `moon.pkg`, and call `@sys.exit(1)`.
     #|
     #|Pattern:
     #|

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -14,9 +14,48 @@ test "flash prompt keeps core MoonBit guidance" {
   assert_true(prompt.contains("much faster than"))
   assert_true(prompt.contains("primary"))
   assert_true(prompt.contains("Create `moon.mod` before running `moon info`"))
+  assert_true(prompt.contains("`moon.mod` is the module manifest"))
+  assert_true(prompt.contains("module-level dependency versions"))
+  assert_true(prompt.contains("`moon.pkg` is the package manifest"))
+  assert_true(prompt.contains("package imports, import aliases"))
+  assert_true(
+    prompt.contains("Do not put package imports or aliases in `moon.mod`"),
+  )
+  assert_true(
+    prompt.contains("do\n  not put module dependency versions in `moon.pkg`"),
+  )
+  assert_true(prompt.contains("Plain `fn` is private"))
+  assert_true(prompt.contains("_test.mbt` files are black-box tests"))
+  assert_true(prompt.contains("Use `suberror` for custom errors"))
+  assert_true(prompt.contains("Pattern matching error constructors is"))
+  assert_true(
+    prompt.contains("valid. When matching errors from another package"),
+  )
+  assert_true(prompt.contains("catch { @pkga.A => ...; @pkga.B => ... }"))
+  assert_true(
+    prompt.contains("Parameter and receiver bindings cannot be `mut`"),
+  )
+  assert_true(
+    prompt.contains("not `fn f(mut x : Int)` or\n  `fn T::m(mut self : T)`"),
+  )
+  assert_true(prompt.contains("fn f(mut x : Int)"))
+  assert_true(prompt.contains("fn T::m(mut self : T)"))
+  assert_true(prompt.contains("Use `let mut x = ...` only for local rebinding"))
+  assert_true(prompt.contains("Use `mut field : T` only on struct fields"))
   assert_true(prompt.contains("small focused"))
   assert_true(prompt.contains("moonbitlang/core/argparse"))
   assert_true(prompt.contains("@stdio.stdin.read_all().text()"))
+  assert_true(prompt.contains("@stdio.stderr.write(...)"))
+  assert_true(prompt.contains("@sys.exit(1)"))
+  assert_true(prompt.contains("let x : UInt16 = 0"))
+  assert_true(prompt.contains("s[i] == '='"))
+  assert_true(prompt.contains("without allocating `Some(ch)`"))
+  assert_true(prompt.contains("s.get_char(i) is Some(c) && c == ch"))
+  assert_true(
+    prompt.contains("lowercase names in patterns bind a new variable"),
+  )
+  assert_true(prompt.contains("Do not write constructor-style casts"))
+  assert_true(prompt.contains("UInt16(92)"))
   assert_true(prompt.contains("s[:4]"))
   assert_true(prompt.contains("Raw multi-line strings use `#|`"))
   assert_true(prompt.contains("Interpolated multi-line strings use `$|`"))
@@ -26,6 +65,8 @@ test "flash prompt keeps core MoonBit guidance" {
   assert_true(
     prompt.contains("Json::number(n.to_double(), repr=text.to_owned())"),
   )
+  assert_true(prompt.contains("Do not create JSON with `Json::Object(...)`"))
+  assert_true(prompt.contains("Use `map.get(key)` for `T?`"))
   assert_true(
     prompt.contains("Do not implement ordinary file/stdin IO with C FFI"),
   )

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -27,9 +27,7 @@ pub(all) enum Input {
 pub fn Input::prefix(Self) -> @displaytext.DisplayText
 pub fn Input::text(Self) -> String
 
-pub struct ToolCall {
-  // private fields
-} derive(@debug.Debug)
+type ToolCall derive(@debug.Debug)
 pub fn ToolCall::ToolCall(@doc.Text, status? : ToolStatus, details? : Array[@doc.Text]) -> Self
 
 pub(all) enum ToolStatus {

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -14,21 +14,15 @@ pub fn dim_text(String) -> Text
 // Errors
 
 // Types and methods
-pub struct Doc {
-  // private fields
-}
+type Doc
 pub fn Doc::Doc(Array[Text]) -> Self
 pub fn Doc::layout(Self, width~ : Int) -> Array[@surface.Line]
 
-pub struct Span {
-  // private fields
-} derive(@debug.Debug)
+type Span derive(@debug.Debug)
 pub fn Span::Span(@displaytext.DisplayText, style? : @style.Style) -> Self
 pub fn Span::plain(String) -> Self
 
-pub struct Text {
-  // private fields
-} derive(@debug.Debug)
+type Text derive(@debug.Debug)
 pub fn Text::Text(Array[Span]) -> Self
 pub fn Text::first_line(Self, width~ : Int) -> @surface.Line
 pub fn Text::plain(String) -> Self

--- a/tui/internal/surface/pkg.generated.mbti
+++ b/tui/internal/surface/pkg.generated.mbti
@@ -21,9 +21,7 @@ pub fn Line::new(Array[Span]) -> Self
 pub fn Line::spans(Self) -> Array[Span]
 pub fn Line::text(Self) -> String
 
-pub struct Span {
-  // private fields
-} derive(Eq)
+type Span derive(Eq)
 pub fn Span::Span(@displaytext.DisplayText, style? : @style.Style) -> Self
 pub fn Span::style(Self) -> @style.Style
 pub fn Span::text(Self) -> String

--- a/tui/internal/task/pkg.generated.mbti
+++ b/tui/internal/task/pkg.generated.mbti
@@ -10,9 +10,7 @@ import {
 // Errors
 
 // Types and methods
-pub struct Queue {
-  // private fields
-}
+type Queue
 pub fn Queue::Queue(kind~ : @aqueue.Kind) -> Self
 pub async fn Queue::run(Self) -> Unit
 pub async fn[T] Queue::wait(Self, async () -> T) -> T

--- a/tui/internal/terminal_size/pkg.generated.mbti
+++ b/tui/internal/terminal_size/pkg.generated.mbti
@@ -7,9 +7,7 @@ pub let default : TerminalSize
 // Errors
 
 // Types and methods
-pub struct TerminalSize {
-  // private fields
-}
+type TerminalSize
 pub fn TerminalSize::TerminalSize(rows~ : Int, cols~ : Int) -> Self
 pub fn TerminalSize::cols(Self) -> Int
 pub fn TerminalSize::rows(Self) -> Int


### PR DESCRIPTION
## Summary

- tighten the MoonBit flash prompt around module/package boundaries, checked errors, CLI IO, string/Char handling, and validation loops
- add concise dependency guidance for using `moon add` rather than guessing registry versions
- regenerate the generated flash prompt source

## Validation

- `moon check prompt --diagnostic-limit 20`
- `moon test prompt --filter 'flash prompt*' --diagnostic-limit 20`\n- `moon test prompt --diagnostic-limit 20`