### PR TITLE
[codex] Add compaction prompt task eval harness

### DIFF
--- a/agent_session/compact/compact.mbt
+++ b/agent_session/compact/compact.mbt
@@ -1,0 +1,96 @@
+///|
+const CompactionUserPrompt : String =
+  #|You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff
+  #|summary for another model that will resume this task.
+  #|
+  #|Summarize the entire conversation context above. Include:
+  #|- Current goal and user intent
+  #|- Key decisions and constraints
+  #|- Important files, commands, tool results, and implementation details
+  #|- What remains to be done, with concrete next steps
+  #|
+  #|Be concise, structured, and focused on helping the next model continue
+  #|without losing context. Return only the summary text.
+
+///|
+fn compaction_messages(
+  session : @agent_session.Session,
+) -> Array[@deepseek.ChatMessage] {
+  session.chat_messages()..push(ChatMessage(User, content=CompactionUserPrompt))
+}
+
+///|
+async fn generate_compaction_summary(
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  session : @agent_session.Session,
+  api_url? : String,
+) -> String {
+  let client = @client.Client(api_key~, model~, api_url?, thinking=No)
+  let response = client.chat(compaction_messages(session))
+  let summary = response.content.trim().to_owned()
+  if summary.is_empty() {
+    fail("compaction summary was empty")
+  }
+  summary
+}
+
+///|
+async fn append_compaction_summary(
+  store? : @store.SessionStore,
+  session : @agent_session.Session,
+  summary~ : String,
+  from_sequence~ : Int,
+  to_sequence~ : Int,
+) -> @agent_session.Session {
+  match store {
+    Some(store) =>
+      store.compact(session, content=summary, from_sequence~, to_sequence~)
+    None =>
+      session.compact(
+        content=summary,
+        from_sequence~,
+        to_sequence~,
+        unix_ms=@env.now().reinterpret_as_int64(),
+      )
+  }
+}
+
+///|
+/// Summarize the current session through the model endpoint and append the
+/// resulting checkpoint summary to the session history.
+pub async fn compact_session(
+  store? : @store.SessionStore,
+  session : @agent_session.Session,
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  api_url? : String,
+) -> @agent_session.Session {
+  let from_sequence = 1
+  let to_sequence = session.last_sequence()
+  if to_sequence <= 0 {
+    fail("session compaction requires at least one event")
+  }
+  @xlog.info() <?
+    {
+      "event": "compaction_started",
+      "from_sequence": from_sequence,
+      "to_sequence": to_sequence,
+    }
+  let summary = generate_compaction_summary(api_key~, model~, session, api_url?)
+  let next = append_compaction_summary(
+    store?,
+    session,
+    summary~,
+    from_sequence~,
+    to_sequence~,
+  )
+  @xlog.info() <?
+    {
+      "event": "compaction_finished",
+      "from_sequence": from_sequence,
+      "to_sequence": to_sequence,
+      "summary": summary,
+    }
+  next
+}

--- a/agent_session/compact/compact_test.mbt
+++ b/agent_session/compact/compact_test.mbt
@@ -1,0 +1,14 @@
+///|
+async test "compaction rejects empty sessions before summary generation" {
+  try
+    @compact.compact_session(
+      Session(SessionId("empty"), system_prompt="system"),
+      api_key="",
+      model=V4Flash,
+    )
+  catch {
+    error => assert_true("\{error}".contains("at least one event"))
+  } noraise {
+    _ => fail("accepted empty session")
+  }
+}

--- a/agent_session/compact/compact_wbtest.mbt
+++ b/agent_session/compact/compact_wbtest.mbt
@@ -1,0 +1,44 @@
+///|
+test "compaction messages use projected history plus checkpoint prompt" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(Assistant(AssistantMessage("answer")))
+    .append(User(UserMessage("next")))
+  let messages = compaction_messages(session)
+  assert_eq(messages.length(), 5)
+  assert_true(messages[0].role is System)
+  assert_eq(messages[0].content, "system")
+  assert_true(messages[1].role is User)
+  assert_eq(messages[1].content, "first")
+  assert_true(messages[2].role is Assistant)
+  assert_eq(messages[2].content, "answer")
+  assert_true(messages[3].role is User)
+  assert_eq(messages[3].content, "next")
+  assert_true(messages[4].role is User)
+  assert_true(messages[4].content.contains("CONTEXT CHECKPOINT COMPACTION"))
+  assert_false(messages[4].content.contains("sequence"))
+  assert_false(messages[4].content.contains("JSONL"))
+}
+
+///|
+async test "compaction summary can update an ephemeral session" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("first")),
+  )
+  let next = append_compaction_summary(
+    session,
+    summary="summary",
+    from_sequence=1,
+    to_sequence=1,
+  )
+  assert_eq(next.last_sequence(), 2)
+  guard next.events()[1].item() is Summary(summary) else {
+    fail("expected summary event")
+  }
+  assert_eq(summary.content(), "summary")
+  assert_eq(summary.from_sequence(), 1)
+  assert_eq(summary.to_sequence(), 1)
+  let messages = next.chat_messages()
+  assert_eq(messages.length(), 2)
+  assert_true(messages[1].content.contains("summary"))
+}

--- a/agent_session/compact/moon.pkg
+++ b/agent_session/compact/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "moonbitlang/core/env",
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/deepseek/client",
+  "tonyfettes/xlog",
+}
+
+import {
+  "moonbitlang/async",
+} for "test"
+
+import {
+  "moonbitlang/async",
+} for "wbtest"
+
+supported_targets = "+native"

--- a/agent_session/compact/pkg.generated.mbti
+++ b/agent_session/compact/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_session/compact"
+
+import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/deepseek",
+}
+
+// Values
+pub async fn compact_session(store? : @store.SessionStore, @agent_session.Session, api_key~ : String, model~ : @deepseek.Model, api_url? : String) -> @agent_session.Session
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -63,6 +63,20 @@ like the human-readable listing).
 events from `events.jsonl`; `agent_session.Session::chat_messages` uses the
 summary to compact model context on replay.
 
+In `--serve` mode, controllers can ask the engine to generate and append a
+summary without using a temporary file:
+
+```jsonl
+{"command":"compact"}
+```
+
+The engine handles this in command order, waits for any active turn to finish,
+generates the summary with the configured model endpoint, appends a `Summary`
+event covering the current session, and emits `compaction_started`,
+`compaction_finished`, or `compaction_failed` JSONL events. With `--session`,
+the summary is persisted to the durable session log. With `--no-session`, it
+only updates the live in-memory session for the current serve process.
+
 ## Examples
 
 ```bash

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -5,6 +5,7 @@ import {
   "bobzhang/openseek/agent_skill",
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
+  "bobzhang/openseek/agent_session/compact",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/prompt",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -4,17 +4,34 @@
 priv enum ServeCommand {
   Prompt(String)
   Steer(String)
+  Compact
   Cancel
 }
 
 ///|
+/// A queued serve-mode operation that must wait for active work to finish.
+priv enum PendingWork {
+  PendingPrompt(String)
+  PendingCompact
+}
+
+///|
+/// The one operation currently occupying the serve loop. Compaction is a
+/// non-steerable active operation, but it is still cancellable like a turn.
+priv enum ActiveWork {
+  ActiveTurn(@async.Task[Unit])
+  ActiveCompact(@async.Task[Unit])
+}
+
+///|
 /// One unit of work for the serve loop's single consumer: a wire command in
-/// arrival order, the completion of the active turn, or the stdin-EOF
-/// shutdown marker. Funneling all three through one queue is what makes
+/// arrival order, the completion of active work, or the stdin-EOF shutdown
+/// marker. Funneling all three through one queue is what makes
 /// command handling race-free against turn lifecycle.
 priv enum ServeStep {
   Wire(ServeCommand)
   TurnDone
+  CompactDone(@agent_session.Session)
   Shutdown
 }
 
@@ -22,15 +39,18 @@ priv enum ServeStep {
 /// Decode one JSONL command line from the controller.
 ///
 /// `prompt` starts a turn, `steer` injects input into the running one,
-/// `cancel` interrupts it. Anything else is an `Err` whose text is emitted
-/// as a `command_error` event — a controller bug must be visible on the
-/// wire, not silently swallowed, but it must not kill the session either.
+/// `compact` summarizes the current conversation once no work is active, and
+/// `cancel` interrupts the active or next queued prompt. Anything else is an
+/// `Err` whose text is emitted as a `command_error` event — a controller bug
+/// must be visible on the wire, not silently swallowed, but it must not kill
+/// the session either.
 fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
   match json {
     { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text))
     { "command": "steer", "text": String(text), .. } => Ok(Steer(text))
     { "command": "prompt", .. } | { "command": "steer", .. } =>
       Err("expected a string \"text\" field")
+    { "command": "compact", .. } => Ok(Compact)
     { "command": "cancel", .. } => Ok(Cancel)
     { "command": String(other), .. } => Err("unknown command: \{other}")
     _ => Err("expected a {\"command\": ...} object")
@@ -47,6 +67,7 @@ test "serve commands decode and reject with actionable errors" {
     decode_serve_command({ "command": "steer", "text": "left" })
     is Ok(Steer("left")),
   )
+  assert_true(decode_serve_command({ "command": "compact" }) is Ok(Compact))
   assert_true(decode_serve_command({ "command": "cancel" }) is Ok(Cancel))
   guard decode_serve_command({ "command": "prompt" }) is Err(message) else {
     fail("textless prompt accepted")
@@ -63,6 +84,40 @@ test "serve commands decode and reject with actionable errors" {
 }
 
 ///|
+fn remove_next_pending_prompt(pending : Array[PendingWork]) -> Unit {
+  for index, work in pending {
+    if work is PendingPrompt(_) {
+      ignore(pending.remove(index))
+      return
+    }
+  }
+}
+
+///|
+fn has_pending_prompt(pending : Array[PendingWork]) -> Bool {
+  for work in pending {
+    if work is PendingPrompt(_) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+test "pending prompt helpers ignore queued compactions" {
+  let pending : Array[PendingWork] = []
+  assert_false(has_pending_prompt(pending))
+  pending.push(PendingCompact)
+  assert_false(has_pending_prompt(pending))
+  pending.push(PendingPrompt("next"))
+  assert_true(has_pending_prompt(pending))
+  remove_next_pending_prompt(pending)
+  assert_false(has_pending_prompt(pending))
+  assert_eq(pending.length(), 1)
+  assert_true(pending[0] is PendingCompact)
+}
+
+///|
 /// Run the engine as a long-lived session server: read JSONL commands from
 /// stdin, run turns sequentially against one shared session, and write the
 /// usual JSONL event stream to stdout. This is the engine half of the
@@ -76,8 +131,8 @@ test "serve commands decode and reject with actionable errors" {
 /// submitted) turn; with no turn to land in it is rejected with a
 /// `steer_dropped` event — that only happens by racing the terminal event
 /// through the pipes, and an engine must never start a turn the controller
-/// did not ask for. `cancel` interrupts the current turn but never the
-/// process. stdin EOF is the shutdown signal: the running turn finishes
+/// did not ask for. `cancel` interrupts the current active work but never the
+/// process. stdin EOF is the shutdown signal: the running work finishes
 /// first, then the loop drains and exits.
 async fn run_serve(
   matches : @argparse.Matches,
@@ -113,7 +168,7 @@ async fn run_serve(
   }
   // The live conversation value. `append_item` updates it on every appended
   // event, so even a turn that raises leaves `session` reflecting all the
-  // events it durably recorded before failing.
+  // events it recorded before failing.
   let mut session = initial_session
   @async.with_task_group(group => {
     let runtime = @agent_runtime.AgentRuntime(workspace_root~)
@@ -147,9 +202,21 @@ async fn run_serve(
       }
       steps.try_put(Shutdown) |> ignore
     }
-    let pending : Array[String] = []
-    let mut active_turn : @async.Task[Unit]? = None
+    let pending : Array[PendingWork] = []
+    let mut active_work : ActiveWork? = None
     let mut shutting_down = false
+    async fn compact_and_report(
+      current : @agent_session.Session,
+    ) -> @agent_session.Session {
+      @compact.compact_session(store?, current, api_key~, model~, api_url?) catch {
+        error if @async.is_being_cancelled() ||
+          @async.is_cancellation_error(error) => raise error
+        error => {
+          @xlog.error() <? { "event": "compaction_failed", "error": "\{error}" }
+          current
+        }
+      }
+    }
     fn start_turn(task_text : String) -> @async.Task[Unit] {
       group.spawn() <| () => {
         let _ = @agent.run_turn_in_scope(
@@ -192,6 +259,43 @@ async fn run_serve(
       }
     }
 
+    fn start_compaction(current : @agent_session.Session) -> @async.Task[Unit] {
+      group.spawn() <| () => {
+        let next = compact_and_report(current) catch {
+          error if @async.is_being_cancelled() ||
+            @async.is_cancellation_error(error) => {
+            @xlog.warn() <?
+              { "event": "compaction_failed", "error": "cancelled" }
+            current
+          }
+          error => {
+            @xlog.error() <?
+              { "event": "compaction_failed", "error": "\{error}" }
+            current
+          }
+        }
+        ignore(steps.try_put(CompactDone(next)) catch { _ => false })
+      }
+    }
+
+    fn start_next_pending() -> Unit {
+      pending_loop~: for ;; {
+        if active_work is Some(_) || pending.length() == 0 {
+          break pending_loop~
+        }
+        match pending.remove(0) {
+          PendingPrompt(text) => {
+            active_work = Some(ActiveTurn(start_turn(text)))
+            break pending_loop~
+          }
+          PendingCompact => {
+            active_work = Some(ActiveCompact(start_compaction(session)))
+            break pending_loop~
+          }
+        }
+      }
+    }
+
     serve~: for ;; {
       let step = steps.get() catch {
         error if @async.is_being_cancelled() ||
@@ -200,34 +304,51 @@ async fn run_serve(
       }
       match step {
         Wire(Prompt(text)) =>
-          match active_turn {
+          match active_work {
             // One turn at a time: extra prompts wait their wire-order turn.
-            Some(_) => pending.push(text)
-            None => active_turn = Some(start_turn(text))
+            Some(_) => pending.push(PendingPrompt(text))
+            None => active_work = Some(ActiveTurn(start_turn(text)))
           }
         Wire(Steer(text)) =>
-          if active_turn is Some(_) || pending.length() > 0 {
-            // A turn is running or already submitted ahead of this steer:
-            // the lossless steering queue delivers it at that turn's next
-            // step boundary (or its first, if it has not started yet).
-            @agent.steer(runtime, text)
-          } else {
-            // An idle engine never converts a steer into a prompt: the only
-            // way a steer arrives idle is racing the turn's terminal event
-            // through the pipes, and silently starting a turn the controller
-            // never asked for would mutate the session behind its back.
-            // Reject it on the wire so the controller can ask for a resubmit.
-            @xlog.warn() <? { "event": "steer_dropped", "content": text }
+          match active_work {
+            Some(ActiveTurn(_)) => @agent.steer(runtime, text)
+            Some(ActiveCompact(_)) =>
+              if has_pending_prompt(pending) {
+                @agent.steer(runtime, text)
+              } else {
+                @xlog.warn() <? { "event": "steer_dropped", "content": text }
+              }
+            None =>
+              if has_pending_prompt(pending) {
+                // A turn is already submitted ahead of this steer: the
+                // lossless steering queue delivers it at that turn's first
+                // step boundary.
+                @agent.steer(runtime, text)
+              } else {
+                // An idle engine never converts a steer into a prompt: the
+                // only way a steer arrives idle is racing the terminal event
+                // through the pipes, and silently starting a turn the
+                // controller never asked for would mutate the session behind
+                // its back. Reject it on the wire so the controller can ask
+                // for a resubmit.
+                @xlog.warn() <? { "event": "steer_dropped", "content": text }
+              }
           }
         Wire(Cancel) =>
-          match active_turn {
-            Some(task) => task.cancel()
+          match active_work {
+            Some(ActiveTurn(task)) => task.cancel()
+            Some(ActiveCompact(task)) => task.cancel()
             None =>
-              // No active turn: in wire order the cancel targets the next
+              // No active work: in wire order the cancel targets the next
               // submitted prompt, so withdraw it before it starts.
               if pending.length() > 0 {
-                let _ = pending.remove(0)
+                remove_next_pending_prompt(pending)
               }
+          }
+        Wire(Compact) =>
+          match active_work {
+            Some(_) => pending.push(PendingCompact)
+            None => active_work = Some(ActiveCompact(start_compaction(session)))
           }
         TurnDone => {
           // A steer that raced the turn's end (or was queued while it was
@@ -237,16 +358,23 @@ async fn run_serve(
           for text in runtime.drain_steers() {
             @xlog.warn() <? { "event": "steer_dropped", "content": text }
           }
-          active_turn = None
-          if pending.length() > 0 {
-            active_turn = Some(start_turn(pending.remove(0)))
-          } else if shutting_down {
+          active_work = None
+          start_next_pending()
+          if active_work is None && pending.length() == 0 && shutting_down {
+            break serve~
+          }
+        }
+        CompactDone(next) => {
+          session = next
+          active_work = None
+          start_next_pending()
+          if active_work is None && pending.length() == 0 && shutting_down {
             break serve~
           }
         }
         Shutdown => {
           shutting_down = true
-          if active_turn is None && pending.length() == 0 {
+          if active_work is None && pending.length() == 0 {
             break serve~
           }
         }

--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -42,6 +42,25 @@ moon run --target native eval/prompt_task/cmd/main -- \
   --out .moonagent/eval_runs/toml_flash_current_5x
 ```
 
+Run the compaction resume benchmark:
+
+```bash
+moon run --target native eval/prompt_task/cmd/main -- \
+  --api-key "$DEEPSEEK" \
+  --suite-file eval/prompt_task/suites/compaction_resume_recall.json \
+  --out .moonagent/eval_runs/compaction_resume_recall \
+  --repo-root .
+```
+
+If a task file contains one or more `--COMPACT--` delimiter lines, the runner
+splits it into phases, executes each phase in the same durable session, and
+sends `{"command":"compact"}` through `openseek --serve` between adjacent
+phases. Empty phases are rejected. Task files without that delimiter keep the
+regular single-prompt behavior. Completed runs can be reanalyzed with the
+existing `--analyze-only` command. The suite above supplies the recall-specific
+validation probe; direct `--task-file` runs keep the runner's existing default
+TOML validation.
+
 Run a multi-problem suite:
 
 ```bash

--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -61,6 +61,42 @@ existing `--analyze-only` command. The suite above supplies the recall-specific
 validation probe; direct `--task-file` runs keep the runner's existing default
 TOML validation.
 
+For a more realistic compaction stress case, a suite problem can seed the trial
+session from an external Claude JSONL transcript before the first phase runs.
+This is meant for local benchmarks against private `~/.claude` exports or copied
+fixtures; do not commit the transcript itself. The harness converts assistant
+text, `tool_use`, and `tool_result` blocks into normal OpenSeek session events,
+injects a deterministic recall needle around the configured byte budget, then
+runs the usual phase/compact/resume flow.
+
+Example suite problem:
+
+```json
+{
+  "id": "compaction_claude_tool_recall",
+  "task_file": "tasks/compaction_fixture_recall.md",
+  "session_fixture": {
+    "format": "claude-jsonl",
+    "path": "/absolute/path/to/claude-session.jsonl",
+    "target_bytes": 200000,
+    "needle_id": "COMPACT-ACTIVE-WORK-742",
+    "needle_text": "cancelled compaction must emit compaction_failed",
+    "answer_file": "{{WORKSPACE}}/.openseek-compaction-answer.json"
+  },
+  "validation_probes": [
+    {
+      "name": "needle answer",
+      "command": ["cat", "{{WORKSPACE}}/.openseek-compaction-answer.json"],
+      "stdout_contains": "COMPACT-ACTIVE-WORK-742"
+    }
+  ]
+}
+```
+
+The task file should still use `--COMPACT--`; the post-compact phase should ask
+the agent to recover the injected decision and write the exact answer to the
+configured `answer_file`.
+
 Run a multi-problem suite:
 
 ```bash

--- a/eval/prompt_task/harness/claude_fixture.mbt
+++ b/eval/prompt_task/harness/claude_fixture.mbt
@@ -1,0 +1,322 @@
+///|
+priv enum ClaudeFixturePart {
+  FixtureUser(String)
+  FixtureAssistant(String, Array[@deepseek.ToolCall])
+  FixtureTool(String, String, String, Bool)
+}
+
+///|
+async fn seed_session_fixture(
+  fixture : SessionFixtureSpec,
+  session_id~ : String,
+  workspace~ : String,
+  system_prompt~ : String,
+) -> Unit {
+  guard fixture.format == "claude-jsonl" else {
+    fail("unsupported session fixture format: \{fixture.format}")
+  }
+  let session = claude_jsonl_fixture_session(
+    fixture,
+    session_id~,
+    workspace~,
+    system_prompt~,
+  )
+  let store = @store.SessionStore(workspace + "/.openseek")
+  store.create(session)
+}
+
+///|
+async fn claude_jsonl_fixture_session(
+  fixture : SessionFixtureSpec,
+  session_id~ : String,
+  workspace~ : String,
+  system_prompt~ : String,
+) -> @agent_session.Session {
+  let text = @fs.read_file(fixture.path).text()
+  let tool_names : Map[String, String] = {}
+  let mut session = @agent_session.Session(
+    SessionId(session_id),
+    system_prompt~,
+  )
+  let needle = fixture_needle_text(fixture, workspace)
+  let mut inserted_needle = false
+  let mut approx_bytes = 0
+  let threshold = fixture.target_bytes / 2
+  let mut done = false
+  for line in text.split("\n") {
+    if done {
+      continue
+    }
+    let trimmed = line.trim()
+    if trimmed.is_empty() {
+      continue
+    }
+    let parts = claude_fixture_parts(@json.parse(trimmed), tool_names)
+    for part in parts {
+      if done {
+        continue
+      }
+      match part {
+        FixtureTool(id, name, content, is_error) => {
+          let content = if !inserted_needle && approx_bytes >= threshold {
+            inserted_needle = true
+            content + "\n\n" + needle
+          } else {
+            content
+          }
+          session = session.append(
+            Tool(
+              ToolResult(tool_call_id=id, tool_name=name, content~, is_error~),
+            ),
+          )
+          approx_bytes += content.length()
+        }
+        _ => {
+          session = append_fixture_part(session, part)
+          approx_bytes += fixture_part_bytes(part)
+        }
+      }
+      if approx_bytes >= fixture.target_bytes {
+        done = true
+      }
+    }
+  }
+  if !inserted_needle {
+    session = append_synthetic_needle(session, needle)
+  }
+  session
+}
+
+///|
+fn append_fixture_part(
+  session : @agent_session.Session,
+  part : ClaudeFixturePart,
+) -> @agent_session.Session {
+  match part {
+    FixtureUser(content) => session.append(User(UserMessage(content)))
+    FixtureAssistant(content, calls) =>
+      session.append(Assistant(AssistantMessage(content, tool_calls=calls)))
+    FixtureTool(id, name, content, is_error) =>
+      session.append(
+        Tool(ToolResult(tool_call_id=id, tool_name=name, content~, is_error~)),
+      )
+  }
+}
+
+///|
+fn fixture_part_bytes(part : ClaudeFixturePart) -> Int {
+  match part {
+    FixtureUser(content) => content.length()
+    FixtureAssistant(content, calls) => {
+      let mut size = content.length()
+      for call in calls {
+        size += call.name.length() + call.arguments.length()
+      }
+      size
+    }
+    FixtureTool(_, _, content, _) => content.length()
+  }
+}
+
+///|
+fn fixture_needle_text(
+  fixture : SessionFixtureSpec,
+  workspace : String,
+) -> String {
+  let answer_file = replace_workspace(fixture.answer_file, workspace)
+  if answer_file == "" {
+    (
+      $|BENCHMARK_DECISION_ID: \{fixture.needle_id}
+      $|BENCHMARK_REQUIRED_FIX: \{fixture.needle_text}
+    )
+  } else {
+    (
+      $|BENCHMARK_DECISION_ID: \{fixture.needle_id}
+      $|BENCHMARK_REQUIRED_FIX: \{fixture.needle_text}
+      $|BENCHMARK_ANSWER_FILE: \{answer_file}
+    )
+  }
+}
+
+///|
+fn append_synthetic_needle(
+  session : @agent_session.Session,
+  needle : String,
+) -> @agent_session.Session {
+  let call_id = "fixture-needle-read"
+  let call : @deepseek.ToolCall = ToolCall(
+    id=call_id,
+    name="Read",
+    arguments=({ "file_path": "fixture/needle.md" } : Json).stringify(),
+  )
+  session
+  .append(Assistant(AssistantMessage("", tool_calls=[call])))
+  .append(
+    Tool(
+      ToolResult(
+        tool_call_id=call_id,
+        tool_name="Read",
+        content=needle,
+        brief="fixture needle",
+      ),
+    ),
+  )
+}
+
+///|
+fn claude_fixture_parts(
+  json : Json,
+  tool_names : Map[String, String],
+) -> Array[ClaudeFixturePart] raise {
+  let fields = object_fields(json, "claude jsonl line")
+  let message_fields = match fields.get("message") {
+    Some(Object(fields)) => fields
+    _ => return []
+  }
+  let role = string_field_default(
+    message_fields,
+    "role",
+    string_field_default(fields, "type", ""),
+  )
+  let content = match message_fields.get("content") {
+    Some(content) => content
+    None => return []
+  }
+  match role {
+    "assistant" => claude_assistant_parts(content, tool_names)
+    "user" => claude_user_parts(content, tool_names)
+    _ => []
+  }
+}
+
+///|
+fn claude_assistant_parts(
+  content : Json,
+  tool_names : Map[String, String],
+) -> Array[ClaudeFixturePart] raise {
+  match content {
+    String(text) =>
+      if text.trim().is_empty() {
+        []
+      } else {
+        [FixtureAssistant(text, [])]
+      }
+    Array(blocks) => {
+      let texts : Array[String] = []
+      let calls : Array[@deepseek.ToolCall] = []
+      for block in blocks {
+        match block {
+          Object(fields) =>
+            match string_field_default(fields, "type", "") {
+              "text" =>
+                push_non_empty(texts, string_field_default(fields, "text", ""))
+              "tool_use" => {
+                let id = string_field(fields, "id")
+                let name = string_field(fields, "name")
+                let arguments = match fields.get("input") {
+                  Some(input) => input.stringify()
+                  None => "{}"
+                }
+                tool_names[id] = name
+                calls.push(ToolCall(id~, name~, arguments~))
+              }
+              _ => ()
+            }
+          String(text) => push_non_empty(texts, text)
+          _ => ()
+        }
+      }
+      let text = texts.join("\n\n")
+      if text == "" && calls.length() == 0 {
+        []
+      } else {
+        [FixtureAssistant(text, calls)]
+      }
+    }
+    _ => []
+  }
+}
+
+///|
+fn claude_user_parts(
+  content : Json,
+  tool_names : Map[String, String],
+) -> Array[ClaudeFixturePart] raise {
+  match content {
+    String(text) =>
+      if text.trim().is_empty() {
+        []
+      } else {
+        [FixtureUser(text)]
+      }
+    Array(blocks) => {
+      let texts : Array[String] = []
+      let tools : Array[ClaudeFixturePart] = []
+      for block in blocks {
+        match block {
+          Object(fields) =>
+            match string_field_default(fields, "type", "") {
+              "text" =>
+                push_non_empty(texts, string_field_default(fields, "text", ""))
+              "tool_result" => {
+                let id = string_field(fields, "tool_use_id")
+                let name = match tool_names.get(id) {
+                  Some(name) => name
+                  None => "unknown"
+                }
+                let result_content = match fields.get("content") {
+                  Some(value) => claude_content_text(value)
+                  None => ""
+                }
+                tools.push(
+                  FixtureTool(
+                    id,
+                    name,
+                    result_content,
+                    bool_field_default(fields, "is_error", false),
+                  ),
+                )
+              }
+              _ => ()
+            }
+          String(text) => push_non_empty(texts, text)
+          _ => ()
+        }
+      }
+      let parts = tools
+      let text = texts.join("\n\n")
+      if text != "" {
+        parts.push(FixtureUser(text))
+      }
+      parts
+    }
+    _ => []
+  }
+}
+
+///|
+fn claude_content_text(content : Json) -> String {
+  match content {
+    String(text) => text
+    Array(items) => {
+      let texts : Array[String] = []
+      for item in items {
+        push_non_empty(texts, claude_content_text(item))
+      }
+      texts.join("\n\n")
+    }
+    Object(fields) =>
+      match fields.get("text") {
+        Some(String(text)) => text
+        _ => content.stringify()
+      }
+    _ => content.stringify()
+  }
+}
+
+///|
+fn push_non_empty(items : Array[String], value : String) -> Unit {
+  if !value.trim().is_empty() {
+    items.push(value)
+  }
+}

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -84,7 +84,7 @@ pub async fn run_experiments(config : Config) -> RunManifest {
   let task = parse_trial_task(@fs.read_file(config.task_file).text())
   prepare_output_dir(config.out_dir)
   let trials = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
-    run_trial(config, task, index)
+    run_trial(config, task, index, None)
   })
   let manifest = RunManifest(
     model=config.model.to_string(),
@@ -137,6 +137,7 @@ async fn run_trial(
   config : Config,
   task : TrialTask,
   index : Int,
+  session_fixture : SessionFixtureSpec?,
 ) -> TrialArtifact {
   let trial_name = padded_index(index + 1)
   let workspace = "\{config.out_dir}/workspaces/\{trial_name}"
@@ -148,6 +149,16 @@ async fn run_trial(
   // ensuring the agent's session store and tool cwd live under the workspace.
   let repo_root = @fs.realpath(config.repo_root)
   let log_path = "\{config.out_dir}/logs/\{trial_name}.log"
+  match session_fixture {
+    Some(fixture) =>
+      seed_session_fixture(
+        fixture,
+        session_id~,
+        workspace=real_workspace,
+        system_prompt=fixture_system_prompt(config),
+      )
+    None => ()
+  }
   let exit_code = run_trial_task(
     config,
     task,
@@ -169,6 +180,24 @@ async fn run_trial(
     events_path~,
     exit_code~,
   )
+}
+
+///|
+async fn fixture_system_prompt(config : Config) -> String {
+  let base = if config.system_prompt_file == "" {
+    @prompt.system_prompt_for_model(config.model)
+  } else {
+    @fs.read_file(@fs.realpath(config.system_prompt_file)).text()
+  }
+  if config.system_prompt_addendum_file == "" {
+    base
+  } else {
+    (
+      $|\{base}
+      $|
+      $|\{@fs.read_file(@fs.realpath(config.system_prompt_addendum_file)).text()}
+    )
+  }
 }
 
 ///|

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -1,4 +1,78 @@
 ///|
+const CompactDelimiter : String = "\n--COMPACT--\n"
+
+///|
+priv enum TrialTask {
+  Single(String)
+  Compact(Array[String])
+}
+
+///|
+fn parse_trial_task(task_template : String) -> TrialTask raise {
+  let bounded = "\n\{task_template}\n"
+  if !bounded.contains(CompactDelimiter) {
+    return Single(task_template)
+  }
+  let phases = [
+    for part in bounded.split(CompactDelimiter) => {
+      let phase = part.trim().to_owned()
+      if phase.is_empty() {
+        fail("task file contains an empty phase around --COMPACT--")
+      }
+      phase
+    }
+  ]
+  Compact(phases)
+}
+
+///|
+async fn run_compact_task(
+  config : Config,
+  phases : Array[String],
+  session_id~ : String,
+  workspace~ : String,
+  repo_root~ : String,
+  log_path~ : String,
+) -> Int {
+  let log = StringBuilder::new()
+  let mut exit_code = 0
+  let phase_count = phases.length()
+  for index, phase in phases {
+    let phase_prompt = replace_workspace(phase, workspace)
+    let phase_result = run_openseek_turn(
+      config,
+      phase_prompt,
+      session_id~,
+      workspace~,
+      repo_root~,
+    )
+    append_log_section(log, "phase\{index + 1}", phase_result)
+    if exit_code == 0 && phase_result.0 != 0 {
+      exit_code = phase_result.0
+    }
+    if index + 1 < phase_count {
+      let compact_result = run_compaction(
+        config,
+        session_id~,
+        workspace~,
+        repo_root~,
+      )
+      let label = if phase_count == 2 {
+        "compact"
+      } else {
+        "compact\{index + 1}"
+      }
+      append_log_section(log, label, compact_result)
+      if exit_code == 0 && compact_result.0 != 0 {
+        exit_code = compact_result.0
+      }
+    }
+  }
+  @fs.write_file(log_path, log.to_string(), create_mode=CreateOrTruncate)
+  exit_code
+}
+
+///|
 /// Run the prompt task `config.runs` times, `config.concurrency` at a time,
 /// writing only durable artifacts: workspaces, raw process logs, recorded
 /// session `events.jsonl` files, and a run manifest. No validation or report
@@ -7,10 +81,10 @@ pub async fn run_experiments(config : Config) -> RunManifest {
   if config.api_key == "" {
     fail("api_key is required for running trials")
   }
+  let task = parse_trial_task(@fs.read_file(config.task_file).text())
   prepare_output_dir(config.out_dir)
-  let task_template = @fs.read_file(config.task_file).text()
   let trials = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
-    run_trial(config, task_template, index)
+    run_trial(config, task, index)
   })
   let manifest = RunManifest(
     model=config.model.to_string(),
@@ -61,7 +135,7 @@ async fn[X] run_indexed_with_concurrency(
 ///|
 async fn run_trial(
   config : Config,
-  task_template : String,
+  task : TrialTask,
   index : Int,
 ) -> TrialArtifact {
   let trial_name = padded_index(index + 1)
@@ -69,44 +143,19 @@ async fn run_trial(
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
   let session_id = "trial-\{trial_name}"
-  let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
   // The engine runs from the OpenSeek checkout and receives --dir for the
   // isolated trial workspace. This keeps launcher-relative paths stable while
   // ensuring the agent's session store and tool cwd live under the workspace.
   let repo_root = @fs.realpath(config.repo_root)
-  let (program, args) = if config.engine != "" {
-    (@fs.realpath(config.engine), [])
-  } else {
-    ("moon", ["run", "--target", "native", "\{repo_root}/cmd/openseek", "--"])
-  }
-  args.append([
-    "--max-steps",
-    config.max_steps.to_string(),
-    "--model",
-    config.model.to_string(),
-    "--dir",
-    real_workspace,
-    "--session",
-    session_id,
-  ])
-  if config.system_prompt_file != "" {
-    args.push("--system-prompt-file")
-    args.push(@fs.realpath(config.system_prompt_file))
-  }
-  if config.system_prompt_addendum_file != "" {
-    args.push("--system-prompt-addendum-file")
-    args.push(@fs.realpath(config.system_prompt_addendum_file))
-  }
-  args.push(task)
-  let (exit_code, output) = @process.collect_output_merged(
-    program,
-    args,
-    extra_env=trial_extra_env(config, real_workspace),
-    inherit_env=true,
-    cwd=repo_root,
-  )
   let log_path = "\{config.out_dir}/logs/\{trial_name}.log"
-  @fs.write_file(log_path, output.text(), create_mode=CreateOrTruncate)
+  let exit_code = run_trial_task(
+    config,
+    task,
+    session_id~,
+    workspace=real_workspace,
+    repo_root~,
+    log_path~,
+  )
   let events_path = discover_session_events(
     real_workspace,
     session_id,
@@ -120,6 +169,145 @@ async fn run_trial(
     events_path~,
     exit_code~,
   )
+}
+
+///|
+async fn run_trial_task(
+  config : Config,
+  task : TrialTask,
+  session_id~ : String,
+  workspace~ : String,
+  repo_root~ : String,
+  log_path~ : String,
+) -> Int {
+  match task {
+    Single(task_template) => {
+      let prompt = replace_workspace(task_template, workspace)
+      let (exit_code, output) = run_openseek_turn(
+        config,
+        prompt,
+        session_id~,
+        workspace~,
+        repo_root~,
+      )
+      @fs.write_file(log_path, output, create_mode=CreateOrTruncate)
+      exit_code
+    }
+    Compact(phases) =>
+      run_compact_task(
+        config,
+        phases,
+        session_id~,
+        workspace~,
+        repo_root~,
+        log_path~,
+      )
+  }
+}
+
+///|
+async fn run_openseek_turn(
+  config : Config,
+  prompt : String,
+  session_id~ : String,
+  workspace~ : String,
+  repo_root~ : String,
+) -> (Int, String) {
+  let (program, args) = openseek_command(config, repo_root~)
+  append_common_openseek_args(args, config, session_id~, workspace~)
+  args.push(prompt)
+  let (exit_code, output) = @process.collect_output_merged(
+    program,
+    args,
+    extra_env=trial_extra_env(config, workspace),
+    inherit_env=true,
+    cwd=repo_root,
+  )
+  (exit_code, output.text())
+}
+
+///|
+async fn run_compaction(
+  config : Config,
+  session_id~ : String,
+  workspace~ : String,
+  repo_root~ : String,
+) -> (Int, String) {
+  let command_path = workspace + "/.openseek-compact-command.jsonl"
+  @fs.write_file(
+    command_path,
+    "{\"command\":\"compact\"}\n",
+    create_mode=CreateOrTruncate,
+  )
+  let stdin = @process.redirect_from_file(command_path)
+  let (program, args) = openseek_command(config, repo_root~)
+  append_common_openseek_args(args, config, session_id~, workspace~)
+  args.push("--serve")
+  let (exit_code, output) = @process.collect_output_merged(
+    program,
+    args,
+    stdin~,
+    extra_env=trial_extra_env(config, workspace),
+    inherit_env=true,
+    cwd=repo_root,
+  )
+  (exit_code, output.text())
+}
+
+///|
+async fn openseek_command(
+  config : Config,
+  repo_root~ : String,
+) -> (String, Array[String]) {
+  if config.engine != "" {
+    (@fs.realpath(config.engine), [])
+  } else {
+    ("moon", ["run", "--target", "native", "\{repo_root}/cmd/openseek", "--"])
+  }
+}
+
+///|
+async fn append_common_openseek_args(
+  args : Array[String],
+  config : Config,
+  session_id~ : String,
+  workspace~ : String,
+) -> Unit {
+  args.append([
+    "--max-steps",
+    config.max_steps.to_string(),
+    "--model",
+    config.model.to_string(),
+    "--dir",
+    workspace,
+    "--session",
+    session_id,
+  ])
+  if config.system_prompt_file != "" {
+    args.push("--system-prompt-file")
+    args.push(@fs.realpath(config.system_prompt_file))
+  }
+  if config.system_prompt_addendum_file != "" {
+    args.push("--system-prompt-addendum-file")
+    args.push(@fs.realpath(config.system_prompt_addendum_file))
+  }
+}
+
+///|
+fn append_log_section(
+  log : StringBuilder,
+  label : String,
+  result : (Int, String),
+) -> Unit {
+  log.write_string("===== ")
+  log.write_string(label)
+  log.write_string(" exit=")
+  log.write_string(result.0.to_string())
+  log.write_string(" =====\n")
+  log.write_string(result.1)
+  if !result.1.has_suffix("\n") {
+    log.write_char('\n')
+  }
 }
 
 ///|

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -100,3 +100,92 @@ test "trial environment pins workspace-local session root" {
   }
   assert_eq(skills_dir, "/tmp/workspace/.no-global-skills")
 }
+
+///|
+fn claude_jsonl_fixture_for_test() -> String {
+  let user_prompt : Json = {
+    "type": "user",
+    "message": { "role": "user", "content": "inspect parser behavior" },
+  }
+  let assistant_call : Json = {
+    "type": "assistant",
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_read_1",
+          "name": "Read",
+          "input": { "file_path": "parser.mbt" },
+        },
+      ],
+    },
+  }
+  let tool_result : Json = {
+    "type": "user",
+    "message": {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_read_1",
+          "content": "parse_expr currently accepts trailing commas",
+        },
+      ],
+    },
+  }
+  user_prompt.stringify() +
+  "\n" +
+  assistant_call.stringify() +
+  "\n" +
+  tool_result.stringify() +
+  "\n"
+}
+
+///|
+async test "claude jsonl fixture seeds session and injects recall needle" {
+  @vfs.with_tmpdir(prefix="openseek-prompt-task-fixture", root => {
+    let transcript = root + "/claude.jsonl"
+    let workspace = root + "/workspace"
+    @fs.mkdir(workspace, recursive=true)
+    @fs.write_file(
+      transcript,
+      claude_jsonl_fixture_for_test(),
+      create_mode=CreateOrTruncate,
+    )
+    seed_session_fixture(
+      SessionFixtureSpec(
+        format="claude-jsonl",
+        path=transcript,
+        target_bytes=80,
+        needle_id="COMPACT-ACTIVE-WORK-742",
+        needle_text="cancelled compaction must emit compaction_failed",
+        answer_file="{{WORKSPACE}}/answer.json",
+      ),
+      session_id="trial-01",
+      workspace~,
+      system_prompt="system",
+    )
+    let loaded = @store.SessionStore(workspace + "/.openseek").load(
+      SessionId("trial-01"),
+    )
+    assert_eq(loaded.events().length(), 3)
+    guard loaded.events()[1].item() is Assistant(message) else {
+      fail("expected assistant tool call")
+    }
+    assert_eq(message.tool_calls().length(), 1)
+    assert_eq(message.tool_calls()[0].name, "Read")
+    let mut found_needle = false
+    let mut found_answer_file = false
+    for chat in loaded.chat_messages() {
+      if chat.content.contains("BENCHMARK_DECISION_ID: COMPACT-ACTIVE-WORK-742") {
+        found_needle = true
+      }
+      if chat.content.contains(workspace + "/answer.json") {
+        found_answer_file = true
+      }
+    }
+    assert_true(found_needle)
+    assert_true(found_answer_file)
+  })
+}

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -26,6 +26,53 @@ async test "indexed runner honors concurrency and preserves order" {
 }
 
 ///|
+test "trial task parser keeps single-stage tasks unchanged" {
+  match parse_trial_task("hello\nworld\n") {
+    Single(task) => assert_eq(task, "hello\nworld\n")
+    Compact(_) => fail("unexpected compact task")
+  }
+}
+
+///|
+test "trial task parser splits one compact delimiter" {
+  match parse_trial_task(" phase 1 \n--COMPACT--\n phase 2 ") {
+    Compact(phases) => json_inspect(phases, content=["phase 1", "phase 2"])
+    Single(_) => fail("expected compact task")
+  }
+}
+
+///|
+test "trial task parser accepts multiple compact delimiters" {
+  match
+    parse_trial_task(
+      " phase 1 \n--COMPACT--\n phase 2 \n--COMPACT--\n phase 3 ",
+    ) {
+    Compact(phases) =>
+      json_inspect(phases, content=["phase 1", "phase 2", "phase 3"])
+    Single(_) => fail("expected compact task")
+  }
+}
+
+///|
+fn assert_empty_compact_phase_rejected(input : String) -> Unit raise {
+  let _ = parse_trial_task(input) catch {
+    Failure::Failure(message) => {
+      assert_true(message.contains("empty phase"))
+      return
+    }
+    _ => fail("unexpected error")
+  }
+  fail("accepted empty compact phase")
+}
+
+///|
+test "trial task parser rejects empty compact phases" {
+  assert_empty_compact_phase_rejected("--COMPACT--\nphase")
+  assert_empty_compact_phase_rejected("phase\n--COMPACT--")
+  assert_empty_compact_phase_rejected("a\n--COMPACT--\n\n--COMPACT--\nb")
+}
+
+///|
 test "trial environment pins workspace-local session root" {
   let config = Config(
     api_key="key",

--- a/eval/prompt_task/harness/manifest.mbt
+++ b/eval/prompt_task/harness/manifest.mbt
@@ -48,6 +48,34 @@ pub fn ValidationProbeSpec::ValidationProbeSpec(
 }
 
 ///|
+/// External transcript used to seed a durable trial session before running a
+/// compact-mode prompt task. The fixture file stays outside the repository; the
+/// runner records only this configuration and writes converted session events
+/// into each isolated trial workspace.
+pub struct SessionFixtureSpec {
+  format : String
+  path : String
+  target_bytes : Int
+  needle_id : String
+  needle_text : String
+  answer_file : String
+}
+
+///|
+/// Build a transcript fixture spec. `format` currently supports
+/// `claude-jsonl`.
+pub fn SessionFixtureSpec::SessionFixtureSpec(
+  format~ : String,
+  path~ : String,
+  target_bytes~ : Int,
+  needle_id~ : String,
+  needle_text~ : String,
+  answer_file? : String = "",
+) -> SessionFixtureSpec {
+  { format, path, target_bytes, needle_id, needle_text, answer_file }
+}
+
+///|
 /// Durable artifact record for one prompt-task trial. The runner writes these
 /// fields once; analyzers can replay report generation from them without
 /// rerunning the agent.
@@ -179,6 +207,18 @@ fn ValidationProbeSpec::to_json(self : ValidationProbeSpec) -> Json {
 }
 
 ///|
+fn SessionFixtureSpec::to_json(self : SessionFixtureSpec) -> Json {
+  {
+    "format": self.format,
+    "path": self.path,
+    "target_bytes": self.target_bytes,
+    "needle_id": self.needle_id,
+    "needle_text": self.needle_text,
+    "answer_file": self.answer_file,
+  }
+}
+
+///|
 fn TrialArtifact::to_json(self : TrialArtifact) -> Json {
   {
     "index": self.index,
@@ -255,6 +295,23 @@ fn ValidationProbeSpec::from_json(json : Json) -> ValidationProbeSpec raise {
     stdout_contains=string_field_default(fields, "stdout_contains", ""),
     stderr_contains=string_field_default(fields, "stderr_contains", ""),
     stdout_json=bool_field_default(fields, "stdout_json", false),
+  )
+}
+
+///|
+fn SessionFixtureSpec::from_json(json : Json) -> SessionFixtureSpec raise {
+  let fields = object_fields(json, "session fixture")
+  let target_bytes = int_field(fields, "target_bytes")
+  guard target_bytes > 0 else {
+    fail("session fixture target_bytes must be positive")
+  }
+  SessionFixtureSpec(
+    format=string_field(fields, "format"),
+    path=string_field(fields, "path"),
+    target_bytes~,
+    needle_id=string_field(fields, "needle_id"),
+    needle_text=string_field(fields, "needle_text"),
+    answer_file=string_field_default(fields, "answer_file", ""),
   )
 }
 

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -1,9 +1,11 @@
 import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/log" @session_log,
+  "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/eval/report",
   "bobzhang/openseek/eval/session_analyzer",
+  "bobzhang/openseek/prompt",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",

--- a/eval/prompt_task/harness/pkg.generated.mbti
+++ b/eval/prompt_task/harness/pkg.generated.mbti
@@ -124,9 +124,10 @@ pub struct ProblemSpec {
   id : String
   prompt_label : String
   task_file : String
+  session_fixture : SessionFixtureSpec?
   validation_probes : Array[ValidationProbeSpec]
 }
-pub fn ProblemSpec::ProblemSpec(id~ : String, prompt_label? : String, task_file~ : String, validation_probes~ : Array[ValidationProbeSpec]) -> Self
+pub fn ProblemSpec::ProblemSpec(id~ : String, prompt_label? : String, task_file~ : String, session_fixture? : SessionFixtureSpec, validation_probes~ : Array[ValidationProbeSpec]) -> Self
 
 pub struct RunManifest {
   model : String
@@ -142,6 +143,16 @@ pub struct RunManifest {
   trials : Array[TrialArtifact]
 }
 pub fn RunManifest::RunManifest(model~ : String, problem_id~ : String, prompt_label~ : String, task_file~ : String, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, validation_probes~ : Array[ValidationProbeSpec], trials~ : Array[TrialArtifact]) -> Self
+
+pub struct SessionFixtureSpec {
+  format : String
+  path : String
+  target_bytes : Int
+  needle_id : String
+  needle_text : String
+  answer_file : String
+}
+pub fn SessionFixtureSpec::SessionFixtureSpec(format~ : String, path~ : String, target_bytes~ : Int, needle_id~ : String, needle_text~ : String, answer_file? : String) -> Self
 
 pub struct SuiteConfig {
   api_key : String

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -380,7 +380,7 @@ async fn run_suite_job(
   suite : SuiteConfig,
   job : SuiteJob,
 ) -> SuiteTrialArtifact {
-  let task_template = @fs.read_file(job.problem.task_file).text()
+  let task = parse_trial_task(@fs.read_file(job.problem.task_file).text())
   let config = Config(
     api_key=suite.api_key,
     model=job.model,
@@ -401,7 +401,7 @@ async fn run_suite_job(
   {
     model: job.model.to_string(),
     problem_id: job.problem.id,
-    artifact: run_trial(config, task_template, job.repeat_index),
+    artifact: run_trial(config, task, job.repeat_index),
   }
 }
 

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -7,6 +7,7 @@ pub struct ProblemSpec {
   id : String
   prompt_label : String
   task_file : String
+  session_fixture : SessionFixtureSpec?
   validation_probes : Array[ValidationProbeSpec]
 }
 
@@ -16,6 +17,7 @@ pub fn ProblemSpec::ProblemSpec(
   id~ : String,
   prompt_label? : String = "",
   task_file~ : String,
+  session_fixture? : SessionFixtureSpec,
   validation_probes~ : Array[ValidationProbeSpec],
 ) -> ProblemSpec {
   {
@@ -26,6 +28,7 @@ pub fn ProblemSpec::ProblemSpec(
       prompt_label
     },
     task_file,
+    session_fixture,
     validation_probes,
   }
 }
@@ -318,8 +321,32 @@ fn ProblemSpec::from_json(json : Json, base_dir : String) -> ProblemSpec raise {
     id~,
     prompt_label=string_field_default(fields, "prompt_label", id),
     task_file=resolve_relative_path(base_dir, string_field(fields, "task_file")),
+    session_fixture?=parse_session_fixture(fields, base_dir),
     validation_probes=probes,
   )
+}
+
+///|
+fn parse_session_fixture(
+  fields : Map[String, Json],
+  base_dir : String,
+) -> SessionFixtureSpec? raise {
+  match fields.get("session_fixture") {
+    Some(Null) | None => None
+    Some(json) => {
+      let fixture = SessionFixtureSpec::from_json(json)
+      Some(
+        SessionFixtureSpec(
+          format=fixture.format,
+          path=resolve_relative_path(base_dir, fixture.path),
+          target_bytes=fixture.target_bytes,
+          needle_id=fixture.needle_id,
+          needle_text=fixture.needle_text,
+          answer_file=fixture.answer_file,
+        ),
+      )
+    }
+  }
 }
 
 ///|
@@ -401,7 +428,12 @@ async fn run_suite_job(
   {
     model: job.model.to_string(),
     problem_id: job.problem.id,
-    artifact: run_trial(config, task, job.repeat_index),
+    artifact: run_trial(
+      config,
+      task,
+      job.repeat_index,
+      job.problem.session_fixture,
+    ),
   }
 }
 
@@ -605,6 +637,10 @@ fn ProblemSpec::to_json(self : ProblemSpec) -> Json {
     "id": self.id,
     "prompt_label": self.prompt_label,
     "task_file": self.task_file,
+    "session_fixture": match self.session_fixture {
+      Some(fixture) => fixture.to_json()
+      None => Json::null()
+    },
     "validation_probes": (
       [
         for probe in self.validation_probes => probe.to_json()
@@ -628,6 +664,7 @@ fn ProblemSpec::from_manifest_json(json : Json) -> ProblemSpec raise {
     id=string_field(fields, "id"),
     prompt_label=string_field(fields, "prompt_label"),
     task_file=string_field(fields, "task_file"),
+    session_fixture?=parse_session_fixture(fields, "."),
     validation_probes=probes,
   )
 }

--- a/eval/prompt_task/harness/suite_wbtest.mbt
+++ b/eval/prompt_task/harness/suite_wbtest.mbt
@@ -16,6 +16,14 @@ fn suite_config_json() -> Json {
       {
         "id": "alpha",
         "task_file": "tasks/alpha.md",
+        "session_fixture": {
+          "format": "claude-jsonl",
+          "path": "fixtures/alpha.jsonl",
+          "target_bytes": 200000,
+          "needle_id": "COMPACT-ACTIVE-WORK-742",
+          "needle_text": "cancelled compaction must emit compaction_failed",
+          "answer_file": "{{WORKSPACE}}/answer.json",
+        },
         "validation_probes": [
           { "name": "moon check", "command": ["moon", "--version"] },
         ],
@@ -55,6 +63,12 @@ async test "suite config parses relative task paths and flattens jobs" {
     assert_eq(config.models.length(), 2)
     assert_eq(config.problems.length(), 2)
     assert_eq(config.problems[0].task_file, root + "/suite/tasks/alpha.md")
+    guard config.problems[0].session_fixture is Some(fixture) else {
+      fail("expected alpha session fixture")
+    }
+    assert_eq(fixture.path, root + "/suite/fixtures/alpha.jsonl")
+    assert_eq(fixture.target_bytes, 200000)
+    assert_eq(fixture.needle_id, "COMPACT-ACTIVE-WORK-742")
     assert_eq(config.problems[1].prompt_label, "Beta Problem")
     let jobs = suite_jobs(config)
     assert_eq(jobs.length(), 12)

--- a/eval/prompt_task/suites/compaction_resume_recall.json
+++ b/eval/prompt_task/suites/compaction_resume_recall.json
@@ -1,0 +1,28 @@
+{
+  "name": "compaction_resume_recall",
+  "models": [
+    "deepseek-v4-flash"
+  ],
+  "runs_per_combo": 5,
+  "concurrency": 5,
+  "min_successes": 5,
+  "max_steps": 160,
+  "problems": [
+    {
+      "id": "compaction_resume_recall",
+      "prompt_label": "compaction-resume",
+      "task_file": "../../prompt_tasks/compaction_resume_recall.md",
+      "validation_probes": [
+        {
+          "name": "compaction recall answer",
+          "command": [
+            "cat",
+            ".openseek-compaction-answer.txt"
+          ],
+          "expect_exit": 0,
+          "stdout_contains": "ORCHID-742"
+        }
+      ]
+    }
+  ]
+}

--- a/eval/prompt_task/tasks/compaction_fixture_recall.md
+++ b/eval/prompt_task/tasks/compaction_fixture_recall.md
@@ -1,0 +1,23 @@
+You are evaluating context retention. A previous transcript has already been
+seeded into this session. Do not inspect files yet.
+
+Reply only: ready for compaction.
+
+--COMPACT--
+
+Recover the benchmark decision from the earlier conversation context. Look for
+these exact labels:
+
+- `BENCHMARK_DECISION_ID`
+- `BENCHMARK_REQUIRED_FIX`
+- `BENCHMARK_ANSWER_FILE`
+
+Write a JSON object to the path named by `BENCHMARK_ANSWER_FILE`. If that label
+is absent, write to `{{WORKSPACE}}/.openseek-compaction-answer.json`.
+
+The JSON object must include:
+
+- `decision_id`: the exact `BENCHMARK_DECISION_ID` value
+- `required_fix`: the exact `BENCHMARK_REQUIRED_FIX` value
+
+After writing the file, finish with a short confirmation.

--- a/eval/prompt_tasks/compaction_resume_recall.md
+++ b/eval/prompt_tasks/compaction_resume_recall.md
@@ -1,0 +1,15 @@
+You are running phase 1 of an OpenSeek compaction resume benchmark.
+
+Remember these benchmark facts for the next phase:
+
+- benchmark_code: ORCHID-742
+- answer_file: {{WORKSPACE}}/.openseek-compaction-answer.txt
+- phase 2 must write exactly the benchmark_code value to answer_file, with no extra text.
+
+Do not create the answer file in this phase. Finish with a short acknowledgement that phase 1 is recorded.
+
+--COMPACT--
+
+You are running phase 2 of the same benchmark.
+
+Use the previous conversation context to recover the benchmark_code value from phase 1. Write exactly that value, and nothing else, to the answer_file path from phase 1. Then finish with a short message that includes `compaction-resume-eval`.


### PR DESCRIPTION
## Summary

- Add prompt-task support for phased tasks split by one or more `--COMPACT--` delimiters.
- Run compaction between adjacent phases in the same durable session.
- Add a compaction resume recall suite and validation probe.

This PR is stacked on #216 because it exercises the serve-mode `compact` command added there.

## Validation

- `moon fmt`
- `moon info`
- `moon check`
- `moon test eval/prompt_task/harness`
- `moon test eval/prompt_task/cmd/main`
