### PR TITLE
[codex] Stream responses through item writer

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -332,11 +332,18 @@ pub async fn[X] run_turn_in_scope(
       let response = client.chat(
         messages,
         tools=tools.function_tools(),
-        stream=StreamHandler(on_content_delta=delta => {
-          if delta != "" {
-            @xlog.info() <? { "event": "assistant_delta", "content": delta }
-          }
-        }),
+        stream=StreamHandler(
+          on_content_delta=delta => {
+            if delta != "" {
+              @xlog.info() <? { "event": "assistant_delta", "content": delta }
+            }
+          },
+          on_reasoning_delta=delta => {
+            if delta != "" {
+              @xlog.info() <? { "event": "reasoning_delta", "content": delta }
+            }
+          },
+        ),
       )
       // Reasoning first, so a consumer appending events in order shows the
       // thinking above the answer it led to.

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -258,7 +258,7 @@ async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
 }
 
 ///|
-async test "streaming reasoning deltas are skipped in logs" {
+async test "streaming reasoning deltas are logged" {
   @async.with_task_group() <| group => {
     guard reasoning_log_test_server(group) is Some(url) else { return }
     let entries : Array[Json] = []
@@ -288,7 +288,7 @@ async test "streaming reasoning deltas are skipped in logs" {
       fail("expected a completed one-step turn")
     }
     let event_names = entries.map(log_event)
-    assert_false(event_names.contains("reasoning_delta"))
+    assert_true(event_names.contains("reasoning_delta"))
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -1,4 +1,17 @@
 ///|
+fn update_event(state : State, event : @event.AgentEvent) -> Array[Cmd] {
+  update(state, AgentProgress(run_id=state.run_id, event))
+}
+
+///|
+fn update_json(state : State, value : Json) -> Array[Cmd] {
+  match @event.decode_event(value) {
+    Some(event) => update_event(state, event)
+    None => []
+  }
+}
+
+///|
 /// Decode one engine event and run it through `update`, appending any resulting
 /// transcript items to `items`. Accumulating into a caller-owned array lets a
 /// test replay a whole session and snapshot the rendered transcript at the end.
@@ -7,15 +20,16 @@ fn append_items(
   value : Json,
   items : Array[@ui.TranscriptItem],
 ) -> Unit {
-  match @event.decode_event(value) {
-    Some(event) =>
-      for cmd in update(state, AgentProgress(run_id=state.run_id, event)) {
-        if cmd is AppendItem(item) {
-          items.push(item)
-        }
-      }
-    None => ()
+  for cmd in update_json(state, value) {
+    if cmd is AppendItem(item) {
+      items.push(item)
+    }
   }
+}
+
+///|
+fn spans_text(spans : Array[@doc.Span]) -> String {
+  @doc.Text::Text(spans).split_lines().map(text => text.text()).join("|")
 }
 
 ///|
@@ -258,179 +272,218 @@ test "parse_runtime_update aggregates status across watcher sections" {
 }
 
 ///|
-test "assistant_delta accumulates live text and commits only the final message" {
+test "assistant_delta opens a live response item and final message finishes it" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
   let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "Hel" }),
-    items,
-  )
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "lo" }),
-    items,
-  )
+  let first = update_event(state, AssistantDelta("Hel"))
+  guard first is [BeginStreamingItem(Response), WriteStreamingItem(spans)] else {
+    fail("expected stream begin and write")
+  }
+  inspect(spans_text(spans), content="Hel")
+  assert_true(state.stream_phase is ResponseStreaming)
+  let second = update_event(state, AssistantDelta("lo"))
+  guard second is [WriteStreamingItem(spans)] else {
+    fail("expected another stream write")
+  }
+  inspect(spans_text(spans), content="lo")
   assert_eq(items.length(), 0)
-  assert_true(state.streaming_response is Some("Hello"))
   assert_true(state.step_response is None)
-  append_items(
-    state,
-    Json::object({ "event": "assistant_message", "content": "Hello" }),
-    items,
-  )
-  assert_true(state.streaming_response is None)
+  let final_message = update_event(state, AssistantMessage("Hello"))
+  guard final_message is [FinishStreamingItem] else {
+    fail("expected stream finish")
+  }
+  assert_true(state.stream_phase is ResponseDone)
   assert_true(state.step_response is Some("Hello"))
-  append_items(
-    state,
-    Json::object({ "event": "agent_finished", "answer": "Hello" }),
-    items,
-  )
-  debug_inspect(items, content="[Response(\"Hello\")]")
+  for cmd in update_event(state, AgentFinished("Hello")) {
+    if cmd is AppendItem(item) {
+      items.push(item)
+    }
+  }
+  assert_eq(items.length(), 0)
 }
 
 ///|
-test "assistant_message clears live streaming text while tools continue" {
+test "assistant_message finishes live stream while tools continue" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
   let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "Need tool" }),
-    items,
-  )
-  assert_true(state.streaming_response is Some("Need tool"))
-  append_items(
-    state,
-    Json::object({ "event": "assistant_message", "content": "Need tool" }),
-    items,
-  )
+  let _ = update_event(state, AssistantDelta("Need tool"))
+  assert_true(state.stream_phase is ResponseStreaming)
+  let cmds = update_event(state, AssistantMessage("Need tool"))
+  guard cmds is [FinishStreamingItem] else { fail("expected stream finish") }
   assert_true(state.run is Running(_))
-  assert_true(state.streaming_response is None)
+  assert_true(state.stream_phase is ResponseDone)
   assert_true(state.step_response is Some("Need tool"))
-  assert_eq(items.length(), 1)
-}
-
-///|
-test "assistant_delta live preview keeps the newest tail within the cap" {
-  let state = drain_test_state()
-  let _ = update(state, UiInput(Steer(Prompt("do it"))))
-  let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    Json::object({
-      "event": "assistant_delta",
-      "content": String::make(StreamingPreviewMaxColumns * 4, 'x'),
-    }),
-    items,
-  )
-  guard state.streaming_response is Some(first) else {
-    fail("expected streaming preview")
-  }
-  assert_true(
-    @displaytext.DisplayText(first).width() <= StreamingPreviewMaxColumns,
-  )
-  assert_true(first.has_prefix("…"))
-  // The preview is a tail window: new deltas keep showing up at its end
-  // (instead of freezing once the cap is reached, as a head truncation would).
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "more" }),
-    items,
-  )
-  guard state.streaming_response is Some(second) else {
-    fail("expected streaming preview")
-  }
-  assert_true(second.has_suffix("more"))
-  assert_true(
-    @displaytext.DisplayText(second).width() <= StreamingPreviewMaxColumns,
-  )
   assert_eq(items.length(), 0)
 }
 
 ///|
-test "streamed newlines collapse so the preview stays one line" {
+test "agent_finished closes live response stream without duplicating answer" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
-  let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "fn main {\n" }),
-    items,
-  )
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "  println(1)\n}" }),
-    items,
-  )
-  // The run of newline + indentation spanning the two deltas collapses to a
-  // single space; the preview holds no control characters.
-  assert_true(state.streaming_response is Some("fn main { println(1) }"))
+  let _ = update_event(state, AssistantDelta("done"))
+  assert_true(state.stream_phase is ResponseStreaming)
+  let cmds = update_event(state, AgentFinished("done"))
+  guard cmds is [FinishStreamingItem] else {
+    fail("expected only stream finish")
+  }
+  assert_true(state.run is Idle)
+  assert_true(state.stream_phase is StreamNotStarted)
 }
 
 ///|
-test "reasoning_message commits a thought item and clears the preview" {
+test "assistant_delta writes raw spans without activity-line truncation" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
-  let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    Json::object({ "event": "reasoning_delta", "content": "Let me think" }),
-    items,
-  )
-  assert_true(state.streaming_reasoning is Some("Let me think"))
-  // The full reasoning lands as one `✻` thought item, and the live preview
-  // is finished with.
-  append_items(
-    state,
-    Json::object({
-      "event": "reasoning_message",
-      "content": "Let me think about names.\nThe user said Hongbo.",
-    }),
-    items,
-  )
-  assert_true(state.streaming_reasoning is None)
-  guard items is [Thought(_)] else { fail("expected a single Thought item") }
-  // Blank reasoning never appends an empty aside.
-  append_items(
-    state,
-    Json::object({ "event": "reasoning_message", "content": "  " }),
-    items,
-  )
-  assert_eq(items.length(), 1)
+  let long = String::make(300, 'x')
+  let cmds = update_event(state, AssistantDelta(long))
+  guard cmds is [BeginStreamingItem(Response), WriteStreamingItem(spans)] else {
+    fail("expected stream write")
+  }
+  assert_eq(spans_text(spans).length(), long.length())
 }
 
 ///|
-test "reasoning_delta drives the thinking preview until content arrives" {
+test "assistant_delta preserves hard newlines for the item writer" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let first = update_event(state, AssistantDelta("fn main {\n"))
+  guard first is [BeginStreamingItem(Response), WriteStreamingItem(spans)] else {
+    fail("expected stream write")
+  }
+  inspect(spans_text(spans), content="fn main {|")
+  let second = update_event(state, AssistantDelta("  println(1)\n}"))
+  guard second is [WriteStreamingItem(spans)] else {
+    fail("expected stream write")
+  }
+  inspect(spans_text(spans), content="  println(1)|}")
+}
+
+///|
+test "reasoning_delta streams a thought item and final reasoning closes it" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
   let items : Array[@ui.TranscriptItem] = []
-  append_items(
+  let start = update_event(state, ReasoningDelta("Let me think"))
+  guard start is [BeginStreamingItem(Thought), WriteStreamingItem(spans)] else {
+    fail("expected thought stream start")
+  }
+  inspect(spans_text(spans), content="Let me think")
+  assert_true(state.stream_phase is ReasoningStreaming)
+  // The full reasoning only closes the streamed thought item. It must not append
+  // the old compact `✻ thought` block.
+  let finish = update_event(
     state,
-    Json::object({ "event": "reasoning_delta", "content": "Let me think" }),
-    items,
+    ReasoningMessage("Let me think about names.\nThe user said Hongbo."),
   )
-  assert_true(state.streaming_reasoning is Some("Let me think"))
-  assert_true(state.streaming_response is None)
+  guard finish is [FinishStreamingItem] else {
+    fail("expected thought stream finish")
+  }
+  assert_true(state.stream_phase is ReasoningDone)
   assert_eq(items.length(), 0)
-  // The first content delta ends the thinking phase: the content preview
-  // replaces the reasoning one.
-  append_items(
+  // A later blank reasoning message does not append an empty aside.
+  for cmd in update_event(state, ReasoningMessage("  ")) {
+    if cmd is AppendItem(item) {
+      items.push(item)
+    }
+  }
+  assert_eq(items.length(), 0)
+}
+
+///|
+test "reasoning_message falls back to a thought stream when no deltas arrived" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let cmds = update_event(state, ReasoningMessage("final thought"))
+  guard cmds
+    is [
+      BeginStreamingItem(Thought),
+      WriteStreamingItem(spans),
+      FinishStreamingItem,
+    ] else {
+    fail("expected fallback thought stream")
+  }
+  inspect(spans_text(spans), content="final thought")
+  assert_true(state.stream_phase is ReasoningDone)
+}
+
+///|
+test "late reasoning_message does not open a thought stream over response" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let first = update_event(state, AssistantDelta("answer"))
+  guard first is [BeginStreamingItem(Response), WriteStreamingItem(_)] else {
+    fail("expected response stream start")
+  }
+  assert_true(state.stream_phase is ResponseStreaming)
+  // Some engines only expose final reasoning after content has already
+  // streamed. That final reasoning is too late to preserve thought-before-answer
+  // order, so it must not try to open a nested thought writer.
+  assert_eq(update_event(state, ReasoningMessage("late thought")).length(), 0)
+  assert_true(state.stream_phase is ResponseStreaming)
+  let finish = update_event(state, AssistantMessage("answer"))
+  guard finish is [FinishStreamingItem] else {
+    fail("expected response stream finish")
+  }
+  assert_true(state.stream_phase is ResponseDone)
+}
+
+///|
+test "late reasoning_message stays ignored after response is closed" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let _ = update_event(state, AssistantMessage("answer"))
+  assert_true(state.stream_phase is ResponseDone)
+  assert_eq(update_event(state, ReasoningMessage("late thought")).length(), 0)
+  assert_true(state.stream_phase is ResponseDone)
+}
+
+///|
+test "reasoning stream finishes before response stream starts" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let cmds = update_event(state, ReasoningDelta("Let me think"))
+  guard cmds is [BeginStreamingItem(Thought), WriteStreamingItem(_)] else {
+    fail("expected thought stream start")
+  }
+  assert_true(state.stream_phase is ReasoningStreaming)
+  // The first content delta finishes the thought stream before opening the
+  // response stream, so no compact thought item is inserted in the middle.
+  let response = update_event(state, AssistantDelta("Answer"))
+  guard response
+    is [
+      FinishStreamingItem,
+      BeginStreamingItem(Response),
+      WriteStreamingItem(_),
+    ] else {
+    fail("expected thought finish then response stream start")
+  }
+  assert_true(state.stream_phase is ResponseStreaming)
+  // The final full reasoning message is ignored because deltas already produced
+  // the thought item.
+  assert_eq(update_event(state, ReasoningMessage("Let me think")).length(), 0)
+  // The committed message closes the response stream.
+  let finish = update_event(state, AssistantMessage("Answer"))
+  guard finish is [FinishStreamingItem] else { fail("expected stream finish") }
+  assert_true(state.stream_phase is ResponseDone)
+}
+
+///|
+test "run failure closes a live response stream before appending error" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let _ = update_event(state, AssistantDelta("partial"))
+  assert_true(state.stream_phase is ResponseStreaming)
+  let cmds = update(
     state,
-    Json::object({ "event": "assistant_delta", "content": "Answer" }),
-    items,
+    AgentFailed(run_id=state.run_id, Failure::Failure("boom")),
   )
-  assert_true(state.streaming_reasoning is None)
-  assert_true(state.streaming_response is Some("Answer"))
-  // The committed message clears both previews.
-  append_items(
-    state,
-    Json::object({ "event": "assistant_message", "content": "Answer" }),
-    items,
-  )
-  assert_true(state.streaming_response is None)
-  assert_true(state.streaming_reasoning is None)
+  guard cmds is [FinishStreamingItem, AppendItem(Error(_))] else {
+    fail("expected stream finish before error")
+  }
+  assert_true(state.stream_phase is StreamNotStarted)
+  assert_true(state.run is Idle)
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -275,15 +275,6 @@ async fn run_shell_command(
 }
 
 ///|
-// The live streaming line is only a transient status preview: it keeps the
-// *tail* of the stream (the newest text) so the line visibly moves while the
-// model types. The final assistant text is committed later by
-// `assistant_message`, so the buffer only needs to cover the widest plausible
-// terminal row; the bound keeps per-delta work constant during long
-// code-generation streams.
-const StreamingPreviewMaxColumns : Int = 240
-
-///|
 /// Keep the last `max_cols` display columns of `text`, marking an elided front
 /// with a leading `…`. The inverse of `DisplayText::truncate`, which keeps the
 /// front — a streaming preview must keep the end, where the new text arrives.
@@ -322,18 +313,30 @@ fn collapse_preview_whitespace(text : String) -> String {
 }
 
 ///|
-fn append_streaming_preview(current : String?, delta : String) -> String {
-  let combined = match current {
-    Some(text) => "\{text}\{delta}"
-    None => delta
+fn finish_response_stream(state : State, cmds : Array[Cmd]) -> Unit {
+  if state.stream_phase is ResponseStreaming {
+    cmds.push(FinishStreamingItem)
+    state.stream_phase = ResponseDone
   }
-  // Re-collapsing the bounded buffer keeps a whitespace run that spans two
-  // deltas collapsed too; the buffer is at most a few hundred chars, so the
-  // rescan is constant work per delta.
-  tail_columns(
-    collapse_preview_whitespace(combined),
-    StreamingPreviewMaxColumns,
-  )
+}
+
+///|
+fn finish_reasoning_stream(state : State, cmds : Array[Cmd]) -> Unit {
+  if state.stream_phase is ReasoningStreaming {
+    cmds.push(FinishStreamingItem)
+    state.stream_phase = ReasoningDone
+  }
+}
+
+///|
+fn finish_open_streams(state : State, cmds : Array[Cmd]) -> Unit {
+  finish_reasoning_stream(state, cmds)
+  finish_response_stream(state, cmds)
+}
+
+///|
+fn reasoning_span(text : String) -> @doc.Span {
+  Span(DisplayText(text), style=@style.dim)
 }
 
 ///|
@@ -347,33 +350,61 @@ fn handle_agent_event(
 ) -> Unit {
   match event {
     AgentStep => {
+      finish_open_streams(state, cmds)
       state.step_response = None
-      state.streaming_response = None
-      state.streaming_reasoning = None
+      state.stream_phase = StreamNotStarted
     }
     AssistantDelta(text) =>
       if text != "" {
-        state.streaming_response = Some(
-          append_streaming_preview(state.streaming_response, text),
-        )
+        match state.stream_phase {
+          StreamNotStarted | ReasoningDone => {
+            cmds.push(BeginStreamingItem(Response))
+            state.stream_phase = ResponseStreaming
+          }
+          ReasoningStreaming => {
+            finish_reasoning_stream(state, cmds)
+            cmds.push(BeginStreamingItem(Response))
+            state.stream_phase = ResponseStreaming
+          }
+          ResponseStreaming => ()
+          ResponseDone => ()
+        }
+        if state.stream_phase is ResponseStreaming {
+          cmds.push(WriteStreamingItem([@doc.Span::plain(text)]))
+        }
         // Content starting means the thinking phase is over; the content
-        // preview replaces the reasoning one.
-        state.streaming_reasoning = None
+        // stream replaces the generic reasoning label.
       }
     ReasoningDelta(text) =>
       if text != "" {
-        state.streaming_reasoning = Some(
-          append_streaming_preview(state.streaming_reasoning, text),
-        )
+        match state.stream_phase {
+          StreamNotStarted => {
+            cmds.push(BeginStreamingItem(Thought))
+            state.stream_phase = ReasoningStreaming
+            cmds.push(WriteStreamingItem([reasoning_span(text)]))
+          }
+          ReasoningStreaming =>
+            cmds.push(WriteStreamingItem([reasoning_span(text)]))
+          ReasoningDone | ResponseStreaming | ResponseDone => ()
+        }
       }
-    // The turn's full reasoning, emitted once streaming ends and before the
-    // assistant message commits — so the transcript reads thought → answer.
-    ReasoningMessage(text) => {
-      state.streaming_reasoning = None
-      if !text.trim().is_empty() {
-        cmds.push(AppendItem(reasoning_item(text)))
+    // The final full reasoning arrives after the model call completes. If
+    // deltas already built the thought item, only close it; otherwise use the
+    // final message as a fallback thought item only while no response writer is
+    // open. Once content has streamed, opening a late thought writer would nest
+    // live transcript items and reorder the transcript.
+    ReasoningMessage(text) =>
+      match state.stream_phase {
+        ReasoningStreaming => finish_reasoning_stream(state, cmds)
+        StreamNotStarted =>
+          if !text.trim().is_empty() {
+            cmds.push(BeginStreamingItem(Thought))
+            cmds.push(WriteStreamingItem([reasoning_span(text)]))
+            cmds.push(FinishStreamingItem)
+            state.stream_phase = ReasoningDone
+          }
+        ReasoningDone | ResponseStreaming | ResponseDone => ()
       }
-    }
     // A steer took effect at the engine's step boundary: echo the input into
     // the transcript at its true conversational position, the way the model
     // actually saw it.
@@ -391,10 +422,22 @@ fn handle_agent_event(
     }
     AssistantMessage(text) => {
       state.step_response = Some(text)
-      state.streaming_response = None
-      state.streaming_reasoning = None
-      if !text.trim().is_empty() {
-        cmds.push(AppendItem(Response(text)))
+      match state.stream_phase {
+        ResponseStreaming => finish_response_stream(state, cmds)
+        StreamNotStarted | ReasoningDone => {
+          if !text.trim().is_empty() {
+            cmds.push(AppendItem(Response(text)))
+          }
+          state.stream_phase = ResponseDone
+        }
+        ReasoningStreaming => {
+          finish_reasoning_stream(state, cmds)
+          if !text.trim().is_empty() {
+            cmds.push(AppendItem(Response(text)))
+          }
+          state.stream_phase = ResponseDone
+        }
+        ResponseDone => ()
       }
     }
     // Out-of-band runtime diagnostics (e.g. `moon check --watch`) the engine fed
@@ -415,6 +458,7 @@ fn handle_agent_event(
     Usage(usage) => state.usage = Some(usage)
     ToolResult(result) => cmds.push(AppendItem(tool_item(result)))
     AgentFinished(answer) => {
+      let had_response_stream = state.stream_phase is ResponseStreaming
       let already_appended = if state.step_response is Some(response) {
         response == answer
       } else {
@@ -422,20 +466,24 @@ fn handle_agent_event(
       }
       // `AgentFinished` follows `AssistantMessage` for normal chat responses,
       // but tool-controlled finish results may arrive without one.
-      if !already_appended && !answer.trim().is_empty() {
+      finish_open_streams(state, cmds)
+      if !had_response_stream && !already_appended && !answer.trim().is_empty() {
         cmds.push(AppendItem(Response(answer)))
       }
       state.finish_run()
     }
     AgentAborted(reason) => {
+      finish_open_streams(state, cmds)
       cmds.push(AppendItem(Error("aborted: \{reason}")))
       state.finish_run()
     }
     MaxStepsExhausted => {
+      finish_open_streams(state, cmds)
       cmds.push(AppendItem(Error("max steps exhausted")))
       state.finish_run()
     }
     AgentError(message) => {
+      finish_open_streams(state, cmds)
       cmds.push(AppendItem(Error(message)))
       state.finish_run()
     }
@@ -543,14 +591,17 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
       }
     AgentProgress(event, ..) => handle_agent_event(state, event, cmds)
     AgentCancelled(..) => {
+      finish_open_streams(state, cmds)
       cmds.push(AppendItem(Error("interrupted")))
       state.finish_run()
     }
     AgentFailed(error, ..) => {
+      finish_open_streams(state, cmds)
       cmds.push(AppendItem(Error("agent failed: \{error}")))
       state.finish_run()
     }
     CommandResult(item, ..) => {
+      finish_open_streams(state, cmds)
       cmds.push(AppendItem(item))
       state.finish_run()
     }
@@ -605,11 +656,24 @@ async fn[G] run_message_loop(
   // `running_task` so an interrupt can cancel it directly.
   let engine = EngineClient(state.config, messages)
   let mut running_task : @async.Task[Unit]? = None
+  let mut item_writer : @ui.ItemWriter? = None
   outer~: for ;; {
     let message = messages.get()
     for cmd in update(state, message) {
       match cmd {
         AppendItem(item) => ui.append_item(item)
+        BeginStreamingItem(kind) =>
+          item_writer = Some(ui.append_streaming_item(kind))
+        WriteStreamingItem(spans) =>
+          if item_writer is Some(writer) {
+            writer.write(spans)
+          }
+        FinishStreamingItem => {
+          if item_writer is Some(writer) {
+            writer.finish()
+          }
+          item_writer = None
+        }
         StartAgent(run_id~, task) =>
           match state.config.engine_mode {
             Serve => {

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -48,6 +48,15 @@ priv enum RunState {
 }
 
 ///|
+priv enum StepStreamPhase {
+  StreamNotStarted
+  ReasoningStreaming
+  ReasoningDone
+  ResponseStreaming
+  ResponseDone
+}
+
+///|
 priv struct State {
   config : AppConfig
   queued : Array[@ui.Input]
@@ -64,14 +73,11 @@ priv struct State {
   // Final assistant text for the current step, used to avoid appending the same
   // answer again when `AgentFinished` follows `AssistantMessage`.
   mut step_response : String?
-  // Incremental assistant text currently arriving from `assistant_delta`
-  // events. Cleared once the final assistant message is committed.
-  mut streaming_response : String?
-  // Incremental thinking-mode text arriving from `reasoning_delta` events.
-  // Shown only until the first content delta arrives, so the activity line
-  // moves during the (often long) reasoning phase instead of sitting on
-  // "Working (Ns)".
-  mut streaming_reasoning : String?
+  // Transcript writer/content phase for the current agent step. Reasoning and
+  // response share one phase so the state cannot represent two simultaneous
+  // live item writers, and so "response not started" remains distinct from
+  // "response already closed".
+  mut stream_phase : StepStreamPhase
   // Steering input sent to the engine but not yet confirmed (no
   // steer_applied/steer_dropped back). Shown on the activity line so the
   // moment of pressing Enter is acknowledged immediately — the transcript
@@ -96,8 +102,7 @@ fn State::new(config : AppConfig) -> State {
     run_is_command: false,
     pending_steers: [],
     step_response: None,
-    streaming_response: None,
-    streaming_reasoning: None,
+    stream_phase: StreamNotStarted,
     usage: None,
     watcher_status: "",
   }
@@ -111,8 +116,7 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run_id = self.run_id + 1
   self.run = Running(started_ms)
   self.step_response = None
-  self.streaming_response = None
-  self.streaming_reasoning = None
+  self.stream_phase = StreamNotStarted
   self.run_id
 }
 
@@ -140,8 +144,7 @@ fn State::finish_run(self : State) -> Unit {
   // arrives untagged and renders its own resubmit notice.
   self.pending_steers.clear()
   self.step_response = None
-  self.streaming_response = None
-  self.streaming_reasoning = None
+  self.stream_phase = StreamNotStarted
   if self.config.engine_mode is OneShot {
     self.watcher_status = ""
   }
@@ -197,6 +200,9 @@ fn Msg::run_id(self : Msg) -> Int? {
 ///|
 priv enum Cmd {
   AppendItem(@ui.TranscriptItem)
+  BeginStreamingItem(@ui.StreamingItemKind)
+  WriteStreamingItem(Array[@doc.Span])
+  FinishStreamingItem
   // Start the agent / a local command for a run; carries the run id to tag that
   // task's messages with.
   StartAgent(run_id~ : Int, String)

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -85,15 +85,8 @@ fn elapsed_seconds(started_ms : Int64, now_ms : Int64) -> Int64 {
 }
 
 ///|
-/// Columns of the activity row not available to the label or preview: the
-/// composer indent the renderer prepends (2) and one column of slack so the
-/// preview's newest characters are never cut by the renderer's own width
-/// clip, which keeps the line's *front* — the oldest text — on overflow.
-const ActivityChromeColumns : Int = 3
-
-///|
 /// Most columns the pending-steer acknowledgment may take on the activity
-/// row, so it never starves the streaming preview it shares the line with.
+/// row, so it never starves the main task label it shares the line with.
 const SteerSegmentMaxColumns : Int = 44
 
 ///|
@@ -121,78 +114,23 @@ fn pending_steer_segment(steers : Array[String]) -> Array[@doc.Span] {
 }
 
 ///|
-/// A streaming activity line: the dim `label` followed by the tail of `text`
-/// clipped to the columns the label (and any pending-steer acknowledgment)
-/// leaves free, so the newest characters always fit the row. The preview
-/// dims with `dim_preview` (reasoning reads as an aside; content reads at
-/// full strength).
-fn streaming_activity_spans(
-  label : String,
-  text : String,
-  cols~ : Int,
-  dim_preview~ : Bool,
-  reserved~ : Int,
-) -> Array[@doc.Span] {
-  let budget = cols -
-    ActivityChromeColumns -
-    reserved -
-    @displaytext.DisplayText(label).width()
-  let preview = tail_columns(text, if budget < 16 { 16 } else { budget })
-  [
-    Span(DisplayText(label), style=@style.dim),
-    if dim_preview {
-      Span(DisplayText(preview), style=@style.dim)
-    } else {
-      @doc.Span::plain(preview)
-    },
-  ]
-}
-
-///|
-fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
+fn format_activity_text(state : State) -> @doc.Text? {
   let started_ms = match state.run {
     Idle => return None
     Running(started_ms) => started_ms
     Interrupting(started_ms) => started_ms
   }
   let steer_segment = pending_steer_segment(state.pending_steers)
-  // The acknowledgment sits at the row's end, where the renderer clips on
-  // overflow — so the preview must cede exactly its width to keep it
-  // visible.
-  let reserved = if steer_segment.length() > 0 {
-    SteerSegmentMaxColumns
-  } else {
-    0
-  }
-  if state.streaming_response is Some(response) && !response.trim().is_empty() {
-    let spans = streaming_activity_spans(
-      "Streaming ",
-      response,
-      cols~,
-      dim_preview=false,
-      reserved~,
-    )
-    return Some(Text(spans + steer_segment))
-  }
-  // Thinking-mode runs spend their first (often long) stretch emitting only
-  // reasoning deltas; show their tail dimmed so the line moves from the first
-  // token rather than sitting on "Working (Ns)" until content starts.
-  if state.streaming_reasoning is Some(reasoning) &&
-    !reasoning.trim().is_empty() {
-    let spans = streaming_activity_spans(
-      "Thinking ",
-      reasoning,
-      cols~,
-      dim_preview=true,
-      reserved~,
-    )
-    return Some(Text(spans + steer_segment))
-  }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @async.now()),
   )
+  let label = match state.stream_phase {
+    ResponseStreaming => "Streaming"
+    ReasoningStreaming => "Thinking"
+    StreamNotStarted | ReasoningDone | ResponseDone => "Working"
+  }
   let spans : Array[@doc.Span] = [
-    @doc.Span::plain("Working"),
+    @doc.Span::plain(label),
     Span(DisplayText(" (\{elapsed})"), style=@style.dim),
   ]
   Some(Text(spans + steer_segment))
@@ -202,7 +140,7 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
 async fn refresh_ui(ui : @ui.Ui, state : State) -> Unit {
   ui.set_live_view(
     status=format_status_bar_text(state),
-    activity=format_activity_text(state, cols=ui.columns()),
+    activity=format_activity_text(state),
     queued_inputs=state.queued,
   )
 }

--- a/cmd/tui/status_view_wbtest.mbt
+++ b/cmd/tui/status_view_wbtest.mbt
@@ -1,37 +1,30 @@
 ///|
-/// The preview budget is measured from the actual label, not a fixed
-/// reserve: label width + chrome columns + preview width never exceeds the
-/// terminal width, and the kept text is the tail (newest characters).
-test "streaming activity line fits the label and preview to the row" {
-  let long = "\{String::make(300, 'x')} tail-end"
-  for label in ["Streaming ", "Thinking "] {
-    let cols = 60
-    let line : @doc.Text = Text(
-      streaming_activity_spans(
-        label,
-        long,
-        cols~,
-        dim_preview=false,
-        reserved=0,
-      ),
-    )
-    let rendered = line.split_lines()
-    assert_eq(rendered.length(), 1)
-    // Reconstruct the row's display width from its spans: label + preview.
-    let label_width = @displaytext.DisplayText(label).width()
-    let budget = cols - ActivityChromeColumns - label_width
-    let preview = tail_columns(long, budget)
-    assert_true(@displaytext.DisplayText(preview).width() <= budget)
-    assert_true(preview.has_prefix("…"))
-    assert_true(preview.has_suffix("tail-end"))
+fn activity_line_text(state : State) -> String raise {
+  guard format_activity_text(state) is Some(text) else {
+    fail("expected activity text")
   }
+  text.text()
 }
 
 ///|
-test "streaming activity preview keeps a floor on absurdly narrow rows" {
-  // Below the floor the preview clamps to 16 columns rather than vanishing,
-  // matching the renderer's own too-small handling.
-  let preview = tail_columns(String::make(100, 'y'), 16)
+test "activity labels streaming and thinking without model text" {
+  let state = drain_test_state()
+  state.run = Running(@async.now())
+
+  inspect(activity_line_text(state), content="Working (0s)")
+
+  state.stream_phase = ReasoningStreaming
+  inspect(activity_line_text(state), content="Thinking (0s)")
+
+  state.stream_phase = ResponseStreaming
+  inspect(activity_line_text(state), content="Streaming (0s)")
+}
+
+///|
+test "pending steer activity segment keeps newest tail" {
+  let long = "\{String::make(100, 'y')} tail-end"
+  let preview = tail_columns(long, 16)
   assert_true(@displaytext.DisplayText(preview).width() <= 16)
   assert_true(preview.has_prefix("…"))
+  assert_true(preview.has_suffix("tail-end"))
 }

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -65,21 +65,6 @@ fn tool_item(result : @event.ToolResultEvent) -> @ui.TranscriptItem {
 }
 
 ///|
-/// Render a turn's completed thinking as a `✻` transcript aside: a dim
-/// "thought" title over the reasoning's first and last lines. The full text
-/// already streamed through the activity line; the transcript keeps a
-/// compact trace the user can scroll back to, so the *why* of an answer
-/// survives the moment it was streamed.
-fn reasoning_item(text : String) -> @ui.TranscriptItem {
-  Thought(
-    ToolCall(
-      @doc.dim_text("thought"),
-      details=detail_texts(compact_lines(text, ToolOutputLineLimit)),
-    ),
-  )
-}
-
-///|
 /// Render the result of a `!` shell command the TUI ran locally: the command
 /// line as the title (with a non-zero/cancelled marker), and its full captured
 /// output as dimmed detail lines. The output is already character-capped by

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -27,6 +27,11 @@ pub(all) enum Input {
 pub fn Input::prefix(Self) -> @displaytext.DisplayText
 pub fn Input::text(Self) -> String
 
+pub(all) enum StreamingItemKind {
+  Response
+  Thought
+} derive(Eq, @debug.Debug)
+
 type ToolCall derive(@debug.Debug)
 pub fn ToolCall::ToolCall(@doc.Text, status? : ToolStatus, details? : Array[@doc.Text]) -> Self
 

--- a/tui/core/transcript.mbt
+++ b/tui/core/transcript.mbt
@@ -54,6 +54,16 @@ pub(all) enum TranscriptItem {
 } derive(Debug)
 
 ///|
+/// A transcript item shape that can be built incrementally by an `ItemWriter`.
+///
+/// The item writer owns the content and line lifecycle, while this kind chooses
+/// the transcript marker.
+pub(all) enum StreamingItemKind {
+  Response
+  Thought
+} derive(Eq, Debug)
+
+///|
 /// Prefix each split line of `text` with a bullet/continuation marker in
 /// `style`, producing one `@doc.Text` block per line.
 fn bulleted_lines(

--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -38,6 +38,37 @@ pub fn Text::Text(spans : Array[Span]) -> Text {
 }
 
 ///|
+/// A copy of this block with `spans` appended after its existing spans.
+///
+/// This is used by streaming transcript writers: each write supplies inline
+/// styled fragments, while `Text` remains the logical block that can later be
+/// split on hard line breaks or wrapped for the current terminal width.
+pub fn Text::append_spans(self : Text, spans : Array[Span]) -> Text {
+  Text(self.spans + spans)
+}
+
+///|
+/// Whether this block contains no text in any span.
+pub fn Text::is_empty(self : Text) -> Bool {
+  for span in self.spans {
+    if span.display.text() != "" {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Plain text content of this block with styling stripped.
+pub fn Text::text(self : Text) -> String {
+  let builder = StringBuilder()
+  for span in self.spans {
+    builder <+ "\{span.display.text()}"
+  }
+  builder.to_string()
+}
+
+///|
 /// Build a text block containing one unstyled span.
 pub fn Text::plain(text : String) -> Text {
   Text([Span::plain(text)])

--- a/tui/doc/doc_test.mbt
+++ b/tui/doc/doc_test.mbt
@@ -90,3 +90,17 @@ test "doc constructors copy mutable arrays" {
   texts.push(@doc.Text::plain("b"))
   inspect(doc.layout(width=20).map(line => line.text()).join("|"), content="a")
 }
+
+///|
+test "text appends inline spans and exposes plain text" {
+  let text = @doc.Text::Text([@doc.Span::plain("hello")]).append_spans([
+    @doc.Span::plain("\nworld"),
+  ])
+  inspect(text.text(), content="hello\nworld")
+  inspect(
+    text.split_lines().map(block => block.text()).join("|"),
+    content="hello|world",
+  )
+  assert_true(@doc.Text::Text([]).is_empty())
+  assert_false(text.is_empty())
+}

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -24,10 +24,13 @@ pub fn Span::plain(String) -> Self
 
 type Text derive(@debug.Debug)
 pub fn Text::Text(Array[Span]) -> Self
+pub fn Text::append_spans(Self, Array[Span]) -> Self
 pub fn Text::first_line(Self, width~ : Int) -> @surface.Line
+pub fn Text::is_empty(Self) -> Bool
 pub fn Text::plain(String) -> Self
 pub fn Text::prepend_span(Self, Span) -> Self
 pub fn Text::split_lines(Self) -> Array[Self]
+pub fn Text::text(Self) -> String
 
 // Type aliases
 

--- a/tui/exports.mbt
+++ b/tui/exports.mbt
@@ -3,4 +3,10 @@
 // inputs and transcript items.
 
 ///|
-pub using @core {type Input, type Event, type ToolStatus, type TranscriptItem}
+pub using @core {
+  type Input,
+  type Event,
+  type StreamingItemKind,
+  type ToolStatus,
+  type TranscriptItem,
+}

--- a/tui/internal/render/pkg.generated.mbti
+++ b/tui/internal/render/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 }
 
 // Values
-pub fn composer_surface(@composer.Model, activity~ : @doc.Text?, queued_inputs~ : Array[@core.Input], status~ : @doc.Text, notice~ : @doc.Text?, cols~ : Int, max_rows~ : Int) -> @surface.Surface
+pub fn composer_surface(@composer.Model, live_transcript_rows? : Array[@surface.Line], activity~ : @doc.Text?, queued_inputs~ : Array[@core.Input], status~ : @doc.Text, notice~ : @doc.Text?, cols~ : Int, max_rows~ : Int) -> @surface.Surface
 
 // Errors
 

--- a/tui/internal/render/render.mbt
+++ b/tui/internal/render/render.mbt
@@ -1,10 +1,10 @@
 // Lay the live composer area out into a render-data `@surface.Surface`.
 //
 // Given the editing `@composer.Model` plus styled status/activity text and any
-// pre-rendered queued-input rows, `composer_surface` stacks the queued rows, an
-// optional activity block, the bordered composer body, and the status line into
-// one surface, and places the cursor on the active input row. It is the view
-// layer for the composer: pure, terminal-agnostic, and performs no IO.
+// pre-rendered live transcript / queued-input rows, `composer_surface` stacks
+// the optional rows above the bordered composer body and status line into one
+// surface, and places the cursor on the active input row. It is the view layer
+// for the composer: pure, terminal-agnostic, and performs no IO.
 //
 // Queued follow-up inputs are rendered into their preview block here (see
 // queued.mbt); the editing model and the doc vocabulary cover the rest.
@@ -59,6 +59,20 @@ fn indent_line(line : @surface.Line, indent~ : Int) -> @surface.Line {
 }
 
 ///|
+fn tail_rows(
+  rows : Array[@surface.Line],
+  max_rows~ : Int,
+) -> Array[@surface.Line] {
+  let out : Array[@surface.Line] = []
+  guard max_rows > 0 else { return out }
+  let start = (rows.length() - max_rows).max(0)
+  for index in start..<rows.length() {
+    out.push(rows[index])
+  }
+  out
+}
+
+///|
 /// The shortest terminal the live area fits in without clipping: a spacer, two
 /// separators, one composer row, and the status line.
 const MinLiveRows : Int = 5
@@ -88,11 +102,11 @@ fn too_small_surface(cols~ : Int) -> @surface.Surface {
 ///|
 /// Lay the composer area out for `cols` columns.
 ///
-/// `activity` is an optional in-progress block ("Working …") for the current
-/// task; `queued_inputs` are the follow-ups that run after it. They render as one
-/// group above the composer — activity first (present), then the queue (next) —
-/// in temporal order. `status`/`notice` form the bottom status line, with
-/// `notice` taking precedence when present.
+/// `live_transcript_rows` is the unfinished transcript item currently being
+/// redrawn in place; `activity` is an optional in-progress block ("Working …")
+/// for the current task; `queued_inputs` are the follow-ups that run after it.
+/// They render above the composer in temporal order. `status`/`notice` form the
+/// bottom status line, with `notice` taking precedence when present.
 ///
 /// `max_rows` is the live area's row budget (the terminal height). The queued
 /// preview is bounded to whatever rows remain after the composer and its chrome,
@@ -100,6 +114,7 @@ fn too_small_surface(cols~ : Int) -> @surface.Surface {
 /// into; the overflow collapses into a `… N more` line.
 pub fn composer_surface(
   composer : @composer.Model,
+  live_transcript_rows? : Array[@surface.Line] = [],
   activity~ : @doc.Text?,
   queued_inputs~ : Array[@core.Input],
   status~ : @doc.Text,
@@ -126,9 +141,12 @@ pub fn composer_surface(
   // two separators, the composer itself, and the status line. The composer wins
   // the row budget; the activity line and queue get whatever is left over.
   let fixed = 1 + composer_rows + 2 + 1
+  let optional_budget = max_rows - fixed
+  let live_rows = tail_rows(live_transcript_rows, max_rows=optional_budget)
+  let live_extra = live_rows.length()
   // Show the activity line only if it plus its trailing blank still fit, so a
   // very short terminal drops "Working …" rather than clipping the prompt.
-  let show_activity = activity is Some(_) && max_rows >= fixed + 2
+  let show_activity = activity is Some(_) && max_rows >= fixed + live_extra + 2
   // Reserve the activity line + its bracketing blanks (between + trailing) when
   // shown, otherwise just the queue's trailing blank.
   let chrome = if show_activity { 3 } else { 1 }
@@ -136,14 +154,21 @@ pub fn composer_surface(
     queued_inputs,
     cols~,
     indent~,
-    max_rows=max_rows - fixed - chrome,
+    max_rows=max_rows - fixed - live_extra - chrome,
   )
   let has_queue = queued.length() > 0
+  let has_live_rows = live_rows.length() > 0
   let rows : Array[@surface.Line] = []
   // A blank spacer above the live area so the committed transcript does not butt
   // directly against the composer's top border — matching the blank that
   // precedes each transcript item.
-  rows.push(@surface.Line::new([]))
+  if has_live_rows {
+    for row in live_rows {
+      rows.push(row)
+    }
+  } else {
+    rows.push(@surface.Line::new([]))
+  }
   if show_activity && activity is Some(activity) {
     rows.push(indent_line(activity.first_line(width=cols - indent), indent~))
   }
@@ -155,7 +180,7 @@ pub fn composer_surface(
     rows.push(row)
   }
   // Set the live-status group off from the composer border with a blank.
-  if show_activity || has_queue {
+  if show_activity || has_queue || has_live_rows {
     rows.push(@surface.Line::new([]))
   }
   let composer_top = rows.length()

--- a/tui/internal/render/render_test.mbt
+++ b/tui/internal/render/render_test.mbt
@@ -240,6 +240,33 @@ test "composer surface renders the input viewport" {
 }
 
 ///|
+test "composer surface renders live transcript rows above composer" {
+  let surface = @render.composer_surface(
+    @composer.Model::new(""),
+    live_transcript_rows=[
+      @surface.Line::new([]),
+      @surface.Line::new([Span(DisplayText("⏺ hello"))]),
+    ],
+    activity=None,
+    queued_inputs=[],
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=24,
+  )
+  inspect(surface.height(), content="7")
+  inspect(surface.line_at(0).text(), content="")
+  inspect(surface.line_at(1).text(), content="⏺ hello")
+  inspect(surface.line_at(2).text(), content="")
+  inspect(
+    surface.line_at(3).text(),
+    content="────────────────────────────────────────",
+  )
+  inspect(display_prefix(surface.line_at(4).text(), 1), content="❯")
+  inspect(surface.cursor().row(), content="4")
+}
+
+///|
 test "composer surface renders activity above separator" {
   let surface = @render.composer_surface(
     @composer.Model::new(""),

--- a/tui/item_writer.mbt
+++ b/tui/item_writer.mbt
@@ -1,0 +1,195 @@
+///|
+/// A handle for incrementally writing one transcript item.
+///
+/// The writer is owned by `Ui`: completed hard lines are committed into
+/// scrollback, while the current unfinished line stays in the live surface until
+/// `finish` commits it.
+struct ItemWriter {
+  ui : Ui
+  item : LiveTranscriptItem
+}
+
+///|
+priv struct LiveTranscriptItem {
+  kind : @core.StreamingItemKind
+  completed : Array[@doc.Text]
+  mut current : @doc.Text
+  mut finished : Bool
+}
+
+///|
+fn LiveTranscriptItem::new(
+  kind : @core.StreamingItemKind,
+) -> LiveTranscriptItem {
+  { kind, completed: [], current: Text([]), finished: false }
+}
+
+///|
+fn streaming_prefix(
+  kind : @core.StreamingItemKind,
+  line_index : Int,
+) -> @doc.Span {
+  let marker = match kind {
+    Response => if line_index == 0 { "⏺ " } else { "  " }
+    Thought => if line_index == 0 { "✻ " } else { "  " }
+  }
+  Span(DisplayText(marker), style=@style.dim)
+}
+
+///|
+fn streaming_line_text(
+  kind : @core.StreamingItemKind,
+  line : @doc.Text,
+  line_index~ : Int,
+) -> @doc.Text {
+  line.prepend_span(streaming_prefix(kind, line_index))
+}
+
+///|
+fn LiveTranscriptItem::line_rows(
+  self : LiveTranscriptItem,
+  line : @doc.Text,
+  line_index~ : Int,
+  cols~ : Int,
+) -> Array[@surface.Line] {
+  let rows : Array[@surface.Line] = []
+  if line_index == 0 {
+    rows.push(@surface.Line::new([]))
+  }
+  let doc = @doc.Doc::Doc([streaming_line_text(self.kind, line, line_index~)])
+  for row in doc.layout(width=cols) {
+    rows.push(row)
+  }
+  rows
+}
+
+///|
+fn LiveTranscriptItem::completed_doc(self : LiveTranscriptItem) -> @doc.Doc? {
+  guard self.completed.length() > 0 else { return None }
+  let texts : Array[@doc.Text] = []
+  for index, line in self.completed {
+    texts.push(streaming_line_text(self.kind, line, line_index=index))
+  }
+  Some(Doc(texts))
+}
+
+///|
+fn LiveTranscriptItem::current_rows(
+  self : LiveTranscriptItem,
+  cols~ : Int,
+) -> Array[@surface.Line] {
+  if self.current.is_empty() {
+    return []
+  }
+  self.line_rows(self.current, line_index=self.completed.length(), cols~)
+}
+
+///|
+fn LiveTranscriptItem::append_spans(
+  self : LiveTranscriptItem,
+  spans : Array[@doc.Span],
+) -> Array[@doc.Text] {
+  let split = self.current.append_spans(spans).split_lines()
+  let completed : Array[@doc.Text] = []
+  guard split.length() > 0 else {
+    self.current = Text([])
+    return completed
+  }
+  for index in 0..<(split.length() - 1) {
+    completed.push(split[index])
+  }
+  self.current = split[split.length() - 1]
+  completed
+}
+
+///|
+fn Ui::live_transcript_rows(self : Ui, cols~ : Int) -> Array[@surface.Line] {
+  match self.live_item {
+    Some(item) => item.current_rows(cols~)
+    None => []
+  }
+}
+
+///|
+fn ItemWriter::is_active(self : ItemWriter) -> Bool {
+  !self.item.finished &&
+  self.ui.live_item is Some(active) &&
+  physical_equal(active, self.item)
+}
+
+///|
+async fn ItemWriter::commit_completed_line(
+  self : ItemWriter,
+  viewport : @viewport.Viewport,
+  line : @doc.Text,
+) -> Unit {
+  let line_index = self.item.completed.length()
+  viewport.insert_before(
+    self.ui.tty,
+    self.item.line_rows(line, line_index~, cols=viewport.cols()),
+  )
+  self.item.completed.push(line)
+}
+
+///|
+/// Start a streaming transcript item and return its writer.
+///
+/// Only one item may be open at a time. This matches the TUI's single active
+/// agent turn and keeps line ownership unambiguous.
+pub async fn Ui::append_streaming_item(
+  self : Ui,
+  kind : @core.StreamingItemKind,
+) -> ItemWriter {
+  let item = LiveTranscriptItem::new(kind)
+  self.commands.wait(() => {
+    guard self.live_item is None else { abort("streaming item already open") }
+    self.live_item = Some(item)
+  })
+  { ui: self, item }
+}
+
+///|
+/// Append styled inline fragments to this item.
+///
+/// Hard line breaks inside the spans complete transcript lines. Completed lines
+/// are pushed to scrollback immediately; the final unfinished line remains live
+/// and is redrawn in place until another hard break or `finish`.
+pub async fn ItemWriter::write(
+  self : ItemWriter,
+  spans : Array[@doc.Span],
+) -> Unit {
+  self.ui.commands.wait(() => {
+    guard self.is_active() else { return }
+    let completed = self.item.append_spans(spans)
+    guard self.ui.viewport is Some(viewport) else {
+      abort("stream write without an entered UI")
+    }
+    viewport.refresh_size(self.ui.tty)
+    for line in completed {
+      self.commit_completed_line(viewport, line)
+    }
+    self.ui.redraw_frame(viewport)
+  })
+}
+
+///|
+/// Finish this item, committing any unfinished line and closing the writer.
+pub async fn ItemWriter::finish(self : ItemWriter) -> Unit {
+  self.ui.commands.wait(() => {
+    guard self.is_active() else { return }
+    guard self.ui.viewport is Some(viewport) else {
+      abort("stream finish without an entered UI")
+    }
+    viewport.refresh_size(self.ui.tty)
+    if !self.item.current.is_empty() {
+      self.commit_completed_line(viewport, self.item.current)
+      self.item.current = Text([])
+    }
+    if self.item.completed_doc() is Some(doc) {
+      self.ui.transcript.push(doc)
+    }
+    self.item.finished = true
+    self.ui.live_item = None
+    self.ui.redraw_frame(viewport)
+  })
+}

--- a/tui/moon.pkg
+++ b/tui/moon.pkg
@@ -10,6 +10,8 @@ import {
   "bobzhang/openseek/tui/internal/surface",
   "bobzhang/openseek/tui/internal/task",
   "bobzhang/openseek/tui/internal/viewport",
+  "bobzhang/openseek/tui/style",
+  "moonbit-community/displaytext",
   "moonbit-community/tty",
   "moonbit-community/tty/input" @tty/input,
 }

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -15,8 +15,13 @@ pub async fn[T] with_ui(config? : Config, async (Ui) -> T) -> T
 type Config
 pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int) -> Self
 
+type ItemWriter
+pub async fn ItemWriter::finish(Self) -> Unit
+pub async fn ItemWriter::write(Self, Array[@doc.Span]) -> Unit
+
 type Ui
 pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
+pub async fn Ui::append_streaming_item(Self, @core.StreamingItemKind) -> ItemWriter
 pub fn Ui::columns(Self) -> Int
 pub async fn Ui::read_event(Self) -> @core.Event
 #deprecated
@@ -31,6 +36,8 @@ pub async fn Ui::set_status(Self, @doc.Text) -> Unit
 pub using @core {type Event}
 
 pub using @core {type Input}
+
+pub using @core {type StreamingItemKind}
 
 pub using @core {type ToolStatus}
 

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -6,6 +6,7 @@ fn Ui::composer_surface(
 ) -> @surface.Surface {
   @render.composer_surface(
     self.composer,
+    live_transcript_rows=self.live_transcript_rows(cols~),
     activity=self.activity,
     queued_inputs=self.queued_inputs,
     status=self.status,
@@ -52,6 +53,13 @@ fn Ui::transcript_rows(self : Self, cols~ : Int) -> Array[@surface.Line] {
   for doc in self.transcript {
     for row in item_rows(doc, cols~) {
       rows.push(row)
+    }
+  }
+  if self.live_item is Some(item) {
+    if item.completed_doc() is Some(doc) {
+      for row in item_rows(doc, cols~) {
+        rows.push(row)
+      }
     }
   }
   rows

--- a/tui/ui.mbt
+++ b/tui/ui.mbt
@@ -8,6 +8,7 @@ struct Ui {
   composer : @composer.Model
   history : @history.History
   transcript : Array[@doc.Doc]
+  mut live_item : LiveTranscriptItem?
   mut activity : @doc.Text?
   mut queued_inputs : Array[Input]
   mut status : @doc.Text
@@ -29,6 +30,7 @@ fn Ui::new(tty : @tty.Tty, config : Config) -> Ui {
     composer,
     history: @history.History::new(),
     transcript: [],
+    live_item: None,
     activity: None,
     queued_inputs: [],
     status: @doc.Text::plain(""),


### PR DESCRIPTION
## Summary

- Route assistant and reasoning streaming through a live transcript `ItemWriter` instead of the activity line.
- Add a step-level stream phase so reasoning and response writers cannot overlap, and so response-not-started is distinct from response-closed.
- Keep completed hard lines in scrollback while the current line redraws live, with focused tests for writer behavior and state transitions.

## Why

The previous activity-line streaming model could not preserve completed rows in scrollback or cleanly handle reasoning/response transitions. During the first pass, late `reasoning_message` events could also try to open a second live writer over an active response stream. The explicit stream phase makes those transitions representable and prevents nested writers.

## Validation

- `moon info`
- `moon fmt`
- `moon check`
- `moon test`
- tmux smoke: late reasoning after response stream does not crash or insert a thought item
- tmux smoke: reasoning deltas before response render as `✻` above the `⏺` response