### PR TITLE
viz: human-friendly tool-call args with a Rendered/Original toggle

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -34,6 +34,9 @@ struct Model {
   status : String
   // "Errors only" filter folds the log down to failed tool results.
   errors_only : Bool
+  // Tool-call arguments rendering: the human-friendly form (values shown verbatim,
+  // no JSON quoting) by default, or the original pretty-printed JSON for debugging.
+  show_original_args : Bool
 }
 
 ///|
@@ -65,6 +68,7 @@ enum Msg {
   Select(String)
   SessionFetched(String, Result[String, Error])
   SetMode(@viz.ViewMode)
+  SetArgsView(Bool)
   SetTheme(Theme)
   ToggleSidebar
   ToggleRoot(String)
@@ -99,6 +103,7 @@ fn init_model() -> Model {
     loading: false,
     status: "loading sessions…",
     errors_only: false,
+    show_original_args: false,
   }
 }
 
@@ -197,6 +202,8 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
         }
       }
     SetMode(mode) => (@cmd.none, { ..model, view_mode: mode })
+    SetArgsView(show_original) =>
+      (@cmd.none, { ..model, show_original_args: show_original })
     ToggleErrorsOnly =>
       (@cmd.none, { ..model, errors_only: !model.errors_only })
     // Scroll to the next/previous failed-tool card, cycling. The count is
@@ -732,8 +739,12 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
           let error_count = @viz.rendered_error_count(session, model.view_mode)
           @html.div(class=session_view_class(model), [
             header_strip(model, id, row.map(row => row.root_label)),
-            mode_row(emit, model, parsed),
-            error_bar(emit, model, error_count),
+            // Pin the view/args toggles and the error bar to the top of the
+            // scroll area so they stay reachable while reading a long log.
+            @html.div(class="sticky-toolbar", [
+              mode_row(emit, model, parsed),
+              error_bar(emit, model, error_count),
+            ]),
             @viz.render_notices(parsed),
             session_log_view(model, session, error_count),
           ])
@@ -777,9 +788,39 @@ fn mode_row(
   parsed : @session_log.ParsedLog,
 ) -> @html.Html {
   @html.div(class="mode-row", [
-    mode_toggle(emit, model),
+    @html.div(class="mode-cluster", [
+      mode_toggle(emit, model),
+      args_toggle(emit, model),
+    ]),
     session_metadata(model, parsed),
   ])
+}
+
+///|
+/// Toggle between the human-friendly tool-argument rendering (values verbatim, no
+/// JSON quoting) and the original pretty-printed JSON kept for debugging. Both are
+/// always in the DOM; this only flips which one the stylesheet shows.
+fn args_toggle(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  @html.div(class="mode-toggle args-toggle", [
+    @html.span(class="args-toggle-label", "Tool args"),
+    args_button(emit, model, false, "Rendered"),
+    args_button(emit, model, true, "Original"),
+  ])
+}
+
+///|
+fn args_button(
+  emit : @cmd.Emit[Msg],
+  model : Model,
+  show_original : Bool,
+  label : String,
+) -> @html.Html {
+  let classes = if model.show_original_args == show_original {
+    "mode-button active"
+  } else {
+    "mode-button"
+  }
+  @html.button(class=classes, on_click=emit(SetArgsView(show_original)), label)
 }
 
 ///|
@@ -951,12 +992,14 @@ fn format_scaled_size(bytes : Int64, unit : Int64, suffix : String) -> String {
 
 ///|
 /// Add the `errors-only` class so the stylesheet folds the log down to failed
-/// tool cards (and the turns containing them).
+/// tool cards (and the turns containing them), and `show-original` so it swaps the
+/// friendly tool-argument rendering for the raw JSON.
 fn session_view_class(model : Model) -> String {
-  if model.errors_only {
-    "session-view errors-only"
-  } else {
-    "session-view"
+  match (model.errors_only, model.show_original_args) {
+    (false, false) => "session-view"
+    (true, false) => "session-view errors-only"
+    (false, true) => "session-view show-original"
+    (true, true) => "session-view errors-only show-original"
   }
 }
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -342,8 +342,15 @@ fn assistant_card(
 
 ///|
 /// A tool call, with its arguments folded away by default: the row shows only
-/// the tool name and expands to the full argument JSON on click. Calls with no
-/// meaningful arguments render as a plain name (nothing to fold).
+/// the tool name and expands on click. Calls with no meaningful arguments render
+/// as a plain name (nothing to fold).
+///
+/// Expanded, the call carries *two* renderings of its arguments: a human-friendly
+/// one where each field's value is shown verbatim (a `write_file` body is real
+/// text, not a quoted-and-escaped JSON string) and the original pretty-printed
+/// JSON. Only one is visible at a time — the stylesheet shows the friendly form by
+/// default and swaps to the original under `.show-original`, so the raw arguments
+/// stay one toggle away for debugging without re-rendering.
 fn tool_call_view(
   call : @deepseek.ToolCall,
   briefs : Map[String, String],
@@ -355,16 +362,83 @@ fn tool_call_view(
   if briefs.get(call.id) is Some(brief) && !brief.trim().is_empty() {
     name_row.push(@html.span(class="tool-call-brief", " · \{brief}"))
   }
-  let args = pretty_json(call.arguments)
-  if is_blank_args(args) {
+  let original = pretty_json(call.arguments)
+  if is_blank_args(original) {
     return @html.div(class="tool-call", [
       @html.div(class="tool-call-name", name_row),
     ])
   }
   @html.details(class="tool-call", [
     @html.summary(class="tool-call-name", name_row),
-    @html.pre(class="tool-call-args", args),
+    render_args_friendly(call.arguments),
+    @html.pre(class="tool-call-args tool-call-args-original", original),
   ])
+}
+
+///|
+/// The human-friendly rendering of a tool call's arguments: one row per field,
+/// with the value shown verbatim rather than as a quoted-and-escaped JSON string,
+/// so a `write_file` body or a `bash` command reads as plain text. Falls back to
+/// the pretty-printed JSON (in the same hidden-on-toggle block) when the arguments
+/// are not a JSON object — a bare value, an array, or text the model emitted that
+/// does not parse.
+fn render_args_friendly(raw : String) -> @html.Html {
+  let json = @json.parse(raw) catch {
+    _ => return @html.pre(class="tool-call-args tool-call-args-rendered", raw)
+  }
+  match json {
+    Object(fields) if !fields.is_empty() => {
+      let rows : Array[@html.Html] = [
+        for key, value in fields => arg_field(key, value)
+      ]
+      @html.div(class="tool-call-args-rendered", rows)
+    }
+    _ =>
+      @html.pre(
+        class="tool-call-args tool-call-args-rendered",
+        pretty_json(raw),
+      )
+  }
+}
+
+///|
+/// One `key: value` row of the friendly arguments view. String values render
+/// verbatim — a multi-line value (e.g. a file body) as a preformatted block, a
+/// single-line value inline. Non-string scalars render inline; nested arrays and
+/// objects keep their JSON form, which is rare for tool arguments.
+fn arg_field(key : String, value : Json) -> @html.Html {
+  let row : Array[@html.Html] = [@html.span(class="arg-key", key)]
+  match value {
+    String(text) =>
+      if text.contains("\n") {
+        row.push(@html.pre(class="arg-value", text))
+      } else {
+        row.push(@html.span(class="arg-value-inline", text))
+      }
+    Array(_) | Object(_) =>
+      row.push(@html.pre(class="arg-value", value.stringify(indent=2)))
+    scalar =>
+      row.push(@html.span(class="arg-value-inline", scalar_text(scalar)))
+  }
+  @html.div(class="arg-field", row)
+}
+
+///|
+/// A JSON scalar as the plain text to show inline. Numbers keep their original
+/// source spelling when the parser preserved it.
+fn scalar_text(value : Json) -> String {
+  match value {
+    True => "true"
+    False => "false"
+    Null => "null"
+    Number(n, repr~) =>
+      match repr {
+        Some(text) => text
+        None => n.to_string()
+      }
+    String(text) => text
+    other => other.stringify()
+  }
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -138,6 +138,54 @@ test "tool calls fold their arguments, empty args stay flat" {
 }
 
 ///|
+test "tool args render verbatim, keeping the raw JSON for debugging" {
+  // A write_file-style call: the body is a multi-line string. The friendly view
+  // must show it as real text (no JSON quoting/escaping), while the original
+  // pretty-printed JSON stays in the DOM, hidden behind the `.show-original`
+  // toggle, so the raw escaped form is still available for debugging.
+  let session = @agent_session.Session(SessionId("w"), system_prompt="").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="w1",
+          name="write_file",
+          arguments="{\"path\":\"notes.txt\",\"content\":\"alpha\\nbeta\"}",
+        ),
+      ]),
+    ),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  // Friendly form: a key/value row per field, the body shown verbatim with a real
+  // newline — not the JSON-escaped `alpha\nbeta`.
+  assert_true(html.contains("class=\"tool-call-args-rendered\""))
+  assert_true(html.contains("class=\"arg-key\">path"))
+  assert_true(html.contains("class=\"arg-key\">content"))
+  assert_true(html.contains("notes.txt"))
+  assert_true(html.contains("class=\"arg-value\">alpha\nbeta</pre>"))
+  // Original form preserved for debugging: the escaped JSON string.
+  assert_true(html.contains("tool-call-args-original"))
+  assert_true(html.contains("alpha\\nbeta"))
+}
+
+///|
+test "non-object tool args fall back to JSON in both forms" {
+  // Arguments that are not a JSON object (here a bare array) have no key/value
+  // fields, so the friendly view falls back to pretty JSON rather than inventing
+  // a structure.
+  let session = @agent_session.Session(SessionId("arr"), system_prompt="").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="a1", name="batch", arguments="[1,2,3]"),
+      ]),
+    ),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("class=\"tool-call-args tool-call-args-rendered\""))
+  assert_true(html.contains("tool-call-args-original"))
+  assert_false(html.contains("arg-key"))
+}
+
+///|
 test "failed tool result is folded and red-flagged" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   // Folded by default (a <details> with no `open`), tagged as an error, and the

--- a/web/index.html
+++ b/web/index.html
@@ -198,10 +198,14 @@
     .theme-button:hover { border-color: var(--accent); }
     .theme-button.active { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
 
-    /* main */
-    .main { overflow-y: auto; padding: 20px 28px; }
+    /* main: no top padding on the scroll container itself, so the sticky toolbar
+       can pin flush to the very top. The 20px top breathing room moves onto the
+       content (.session-view / .main-toolbar) where it scrolls away normally. */
+    .main { overflow-y: auto; padding: 0 28px; }
+    .session-view { padding-top: 20px; }
     .main-toolbar {
       min-height: 34px;
+      padding-top: 20px;
       display: flex;
       align-items: center;
       justify-content: flex-start;
@@ -217,6 +221,20 @@
     .header-meta { color: var(--muted); font-size: 12px; }
 
     /* mode toggle */
+    /* sticky toolbar: keeps the view/args toggles + error bar pinned to the top
+       of the scrolling .main while reading a long log. Negative side margins let
+       its background span the .main padding gutter so content can't peek beside it. */
+    .sticky-toolbar {
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      background: var(--bg);
+      margin: 0 -28px 16px;
+      padding: 12px 28px;
+      border-bottom: 1px solid var(--border);
+    }
+    .sticky-toolbar .mode-row { margin-bottom: 0; }
+    .sticky-toolbar .error-bar { margin: 10px 0 0; }
     .mode-row {
       display: flex;
       align-items: center;
@@ -225,7 +243,9 @@
       gap: 8px 14px;
       margin-bottom: 16px;
     }
-    .mode-toggle { display: flex; gap: 8px; }
+    .mode-cluster { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 16px; }
+    .mode-toggle { display: flex; align-items: center; gap: 8px; }
+    .args-toggle-label { color: var(--muted); font-size: 12px; margin-right: 2px; }
     .mode-button {
       background: var(--panel); color: var(--text);
       border: 1px solid var(--border); border-radius: 999px;
@@ -328,6 +348,23 @@
     details.tool-call > summary.tool-call-name { cursor: pointer; }
     details.tool-call[open] > summary.tool-call-name { margin-bottom: 4px; }
     .tool-call-args { margin: 0; white-space: pre-wrap; font-family: ui-monospace, monospace; font-size: 12px; color: var(--muted); }
+
+    /* friendly tool-args: one key: value row per field, values shown verbatim */
+    .tool-call-args-rendered { margin: 0; font-size: 12px; }
+    .arg-field { margin: 3px 0; }
+    .arg-key { color: var(--accent); font-family: ui-monospace, monospace; font-size: 12px; font-weight: 600; }
+    .arg-key::after { content: ": "; color: var(--muted); font-weight: 400; }
+    .arg-value-inline { font-family: ui-monospace, monospace; font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+    .arg-value {
+      margin: 3px 0 0; padding: 6px 8px;
+      background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px;
+      white-space: pre-wrap; word-break: break-word;
+      font-family: ui-monospace, monospace; font-size: 12px;
+    }
+    /* tool-args toggle: friendly form by default, raw JSON under .show-original */
+    .tool-call-args-original { display: none; }
+    .session-view.show-original .tool-call-args-original { display: block; }
+    .session-view.show-original .tool-call-args-rendered { display: none; }
 
     /* folded tool-result cards: the label is the toggle, body hides until clicked */
     details.card > summary.card-label { cursor: pointer; }


### PR DESCRIPTION
## What & why

Tool-call arguments in the session viewer were shown as pretty-printed JSON, so a `write_file` body or a `bash` command appeared as a quoted-and-escaped string (`"line one\nline two"`). This makes them human-readable while keeping the raw form for debugging.

## Changes

- **Generic friendly rendering** (`viz/view.mbt`): render args like a JSON object but with string values shown **verbatim** — one `key: value` row per field, multi-line values as a `<pre>` block with real newlines, scalars inline. Not special-cased per tool. Non-object/malformed args fall back to pretty JSON so nothing is misrepresented.
- **Rendered / Original toggle** (`cmd/viz_app/app.mbt`): a "Tool args: Rendered / Original" switch next to the Raw log / Model view toggle. Both forms always live in the DOM; the toggle is CSS-driven (`.show-original` on `.session-view`), so switching is instant with no re-render and the raw JSON is always one click away.
- **Sticky toolbar** (`cmd/viz_app/app.mbt`, `web/index.html`): the view/args toggles + error bar are pinned to the top of the scroll area (`position: sticky`) so they stay reachable while reading a long log. The scroll container's top padding moved onto the content so the bar pins **flush** to the top with no gap.

## Safety

Verbatim values are HTML-escaped by the renderer (SSR `write_escaped_text` / live `textContent`), so untrusted file contents cannot inject markup.

## Testing

- `moon check` clean; full suite passes (added two `viz` tests: verbatim rendering + non-object fallback).
- Verified the running app in a headless Chrome screenshot pass: Rendered shows file bodies as plain text; the toggle swaps to raw JSON; the toolbar pins flush at the top while scrolling (gap fixed), with correct at-rest spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)