### PR TITLE
[codex] add shell parser policy analysis

### DIFF
--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -44,6 +44,18 @@ Prefer dedicated tools when they encode useful policy. Run Moon commands such as
 `shell` with the `cwd` field. Use shell features such as pipes and heredocs for
 CLI probes.
 
+After a successful mutating Moon command, `shell` appends bounded
+`moon check --diagnostic-limit 1` feedback from the nearest MoonBit module root,
+respecting `moon -C <dir>` and explicit cwd changes such as
+`cd ./dir && moon ...`. Bare relative `cd dir` is skipped because `CDPATH` can
+change which directory the shell enters. This covers commands such as
+`moon add`, `moon remove`, `moon update`, `moon fmt`, `moon info`,
+`moon test --update`, and `moon ide rename ... --apply`. Read-only variants
+such as dry-run commands and `moon fmt --check` are left alone, as are Moon
+invocations with per-command environment overrides such as `FOO=bar moon` or
+`env FOO=bar moon`. Follow-up checks are skipped when `timeout_ms` is set and
+share the remaining `max_output_chars` budget.
+
 ## Arguments
 
 | Name | Type   | Required | Notes |
@@ -62,6 +74,8 @@ arguments, non-zero shell exit codes, and output truncation. The string body
 has one of these shapes:
 
 - `"exit=<code>\n<stdout/stderr merged>"` — normal completion.
+- For successful mutating `moon` commands, the normal completion output may be
+  followed by a `moon check:` section with bounded compiler diagnostics.
 - `"exit=<code-or-cancelled>\ntruncated=true\noutput_limit_reached=true\nshown_chars=<n>\nmax_output_chars=<n>\n<output-prefix>"` —
   output exceeded `max_output_chars` while the process pipe was being read. The
   command is cancelled if it has not already exited; no full output length is

--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -34,14 +34,17 @@ The policy allows:
 
 ## Detection Strategy
 
-The implementation is deliberately small and conservative:
+The implementation is deliberately conservative:
 
-- Split the shell command into rough words.
-- Skip simple leading environment assignments such as `DEEPSEEK_MODEL=x`.
-- Reject a leading `moon_cmd`.
+- Parse the command with the internal shell policy parser.
+- Reject `moon_cmd` when it is a statically visible simple command name,
+  including in flat compounds such as `cd demo && moon_cmd check`.
+- If parsing is too complex, keep a small fallback for the old leading
+  `moon_cmd` typo case.
 
-This is a heuristic parser, not a full POSIX shell parser. Known hardening work
-is tracked in `agent_tool/shell/TODO.md`.
+This is still not a security sandbox and not a full POSIX shell interpreter.
+Commands whose runtime argv cannot be known statically are allowed unless they
+match the narrow fallback typo check.
 
 ## Examples
 

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -8,6 +8,18 @@
 /// the model what to do instead, because the model is the caller who reads it.
 pub fn moonbit_command_policy_error(cmd : String) -> String? {
   let parsed = @shell_parse.parse_for_policy(cmd)
+  moonbit_command_policy_error_for_parse(cmd, parsed)
+}
+
+///|
+/// Apply shell command policy using an already-computed shell parse result.
+///
+/// This is used by `shell` so policy and follow-up Moon checks share one parse
+/// of the same command string.
+pub fn moonbit_command_policy_error_for_parse(
+  cmd : String,
+  parsed : @shell_parse.ParseResult,
+) -> String? {
   if @shell_parse.contains_command(parsed, "moon_cmd") {
     Some(moon_cmd_error_message())
   } else if parsed is Simple(_) {

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -7,18 +7,26 @@
 /// which is pointed back at running `moon ...` directly. The error wording tells
 /// the model what to do instead, because the model is the caller who reads it.
 pub fn moonbit_command_policy_error(cmd : String) -> String? {
-  let words = shell_words(cmd)
-  match first_command_word_index(words) {
-    None => None
-    Some(index) =>
-      if words[index] == "moon_cmd" {
-        Some(
-          "error: moon_cmd is not a shell command; run moon subcommands like `moon check` or `moon test` through shell directly",
-        )
-      } else {
-        None
-      }
+  let parsed = @shell_parse.parse_for_policy(cmd)
+  if @shell_parse.contains_command(parsed, "moon_cmd") {
+    Some(moon_cmd_error_message())
+  } else if parsed is Simple(_) {
+    None
+  } else if rough_first_command_name(cmd) == Some("moon_cmd") {
+    Some(moon_cmd_error_message())
+  } else {
+    None
   }
+}
+
+///|
+fn moon_cmd_error_message() -> String {
+  "error: moon_cmd is not a shell command; run moon subcommands like `moon check` or `moon test` through shell directly"
+}
+
+///|
+fn rough_first_command_name(cmd : String) -> String? {
+  first_command_word(shell_words(cmd))
 }
 
 ///|
@@ -39,10 +47,10 @@ fn clean_shell_word(word : String) -> String {
 }
 
 ///|
-fn first_command_word_index(words : Array[String]) -> Int? {
-  for index, word in words {
+fn first_command_word(words : Array[String]) -> String? {
+  for word in words {
     if !looks_like_env_assignment(word) {
-      return Some(index)
+      return Some(word)
     }
   }
   None

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -44,7 +44,7 @@ test "command policy detects moon_cmd in simple shell compounds" {
       "cd demo && moon_cmd check", "DEEPSEEK_MODEL=x moon_cmd run cmd/main", "env DEEPSEEK_MODEL=x moon_cmd check",
       "env -- DEEPSEEK_MODEL=x moon_cmd check", "command moon_cmd check", "command -- moon_cmd check",
       "command -p moon_cmd check", "true || moon_cmd test", "moon_cmd check > out.log",
-      "cd demo && moon_cmd check # trailing note",
+      "cd demo && moon_cmd check # trailing note", "true;\nmoon_cmd check",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected moon_cmd to be redirected for \{cmd}")

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -36,3 +36,34 @@ test "command policy still redirects the moon_cmd tool name" {
   }
   assert_true(message.contains("moon_cmd is not a shell command"))
 }
+
+///|
+test "command policy detects moon_cmd in simple shell compounds" {
+  for
+    cmd in [
+      "cd demo && moon_cmd check", "DEEPSEEK_MODEL=x moon_cmd run cmd/main", "env DEEPSEEK_MODEL=x moon_cmd check",
+      "command moon_cmd check", "true || moon_cmd test", "moon_cmd check > out.log",
+    ] {
+    guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
+      fail("expected moon_cmd to be redirected for \{cmd}")
+    }
+    assert_true(message.contains("moon_cmd is not a shell command"))
+  }
+}
+
+///|
+test "command policy does not match moon_cmd as data" {
+  assert_true(
+    @command_policy.moonbit_command_policy_error("printf '%s\\n' moon_cmd")
+    is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error("echo moon_cmd | cat") is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error(
+      "MOON_TOOL=moon_cmd moon check",
+    )
+    is None,
+  )
+}

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -42,7 +42,9 @@ test "command policy detects moon_cmd in simple shell compounds" {
   for
     cmd in [
       "cd demo && moon_cmd check", "DEEPSEEK_MODEL=x moon_cmd run cmd/main", "env DEEPSEEK_MODEL=x moon_cmd check",
-      "command moon_cmd check", "true || moon_cmd test", "moon_cmd check > out.log",
+      "env -- DEEPSEEK_MODEL=x moon_cmd check", "command moon_cmd check", "command -- moon_cmd check",
+      "command -p moon_cmd check", "true || moon_cmd test", "moon_cmd check > out.log",
+      "cd demo && moon_cmd check # trailing note",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected moon_cmd to be redirected for \{cmd}")
@@ -63,6 +65,12 @@ test "command policy does not match moon_cmd as data" {
   assert_true(
     @command_policy.moonbit_command_policy_error(
       "MOON_TOOL=moon_cmd moon check",
+    )
+    is None,
+  )
+  assert_true(
+    @command_policy.moonbit_command_policy_error(
+      "env DEEPSEEK_MODEL=x -i moon_cmd check",
     )
     is None,
   )

--- a/agent_tool/shell/internal/command_policy/moon.pkg
+++ b/agent_tool/shell/internal/command_policy/moon.pkg
@@ -1,1 +1,5 @@
+import {
+  "bobzhang/openseek/agent_tool/shell/internal/shell_parse",
+}
+
 warnings = "+unnecessary_annotation"

--- a/agent_tool/shell/internal/command_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/command_policy/pkg.generated.mbti
@@ -1,8 +1,14 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/openseek/agent_tool/shell/internal/command_policy"
 
+import {
+  "bobzhang/openseek/agent_tool/shell/internal/shell_parse",
+}
+
 // Values
 pub fn moonbit_command_policy_error(String) -> String?
+
+pub fn moonbit_command_policy_error_for_parse(String, @shell_parse.ParseResult) -> String?
 
 // Errors
 

--- a/agent_tool/shell/internal/shell_parse/README.mbt.md
+++ b/agent_tool/shell/internal/shell_parse/README.mbt.md
@@ -1,0 +1,35 @@
+# Shell Parse
+
+`shell_parse` is a conservative parser for shell policy decisions. It accepts
+flat command lines whose argv can be known statically, and classifies runtime
+shell behavior such as expansions, command substitution, subshells, heredocs,
+and globbing as `TooComplex`.
+
+The package is not a shell interpreter and is not a security sandbox. Its job is
+to give higher-level policy code a trustworthy list of simple commands when the
+input is statically knowable, and to decline analysis otherwise.
+
+```moonbit check
+///|
+test "shell parser exposes effective command names" {
+  guard @shell_parse.parse_for_policy("cd ./pkg && command -p moon fmt")
+    is Simple(commands) else {
+    fail("expected flat command line")
+  }
+  assert_eq(commands.length(), 2)
+  assert_true(commands[0].command_name() == Some("cd"))
+  assert_true(commands[1].command_name() == Some("moon"))
+  assert_true(commands[1].command_index() == Some(2))
+  assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+}
+```
+
+```moonbit check
+///|
+test "shell parser declines runtime shell expansion" {
+  assert_true(
+    @shell_parse.parse_for_policy("moon $SUBCOMMAND") is TooComplex(_),
+  )
+  assert_true(@shell_parse.parse_for_policy("moon test *.mbt") is TooComplex(_))
+}
+```

--- a/agent_tool/shell/internal/shell_parse/README.mbt.md
+++ b/agent_tool/shell/internal/shell_parse/README.mbt.md
@@ -9,27 +9,69 @@ The package is not a shell interpreter and is not a security sandbox. Its job is
 to give higher-level policy code a trustworthy list of simple commands when the
 input is statically knowable, and to decline analysis otherwise.
 
+The full `SimpleCommand` snapshot is intentionally part of the example. Policy
+callers often need both the literal argv and the effective command name: wrappers
+such as `command -p moon fmt` keep `"command"` in `argv[0]`, but
+`command_name()` reports `"moon"` because that is the program the wrapper will
+execute.
+
 ```moonbit check
 ///|
-test "shell parser exposes effective command names" {
-  guard @shell_parse.parse_for_policy("cd ./pkg && command -p moon fmt")
-    is Simple(commands) else {
-    fail("expected flat command line")
-  }
-  assert_eq(commands.length(), 2)
-  assert_true(commands[0].command_name() == Some("cd"))
-  assert_true(commands[1].command_name() == Some("moon"))
-  assert_true(commands[1].command_index() == Some(2))
-  assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+test "shell parser exposes static command structure" {
+  let parsed = @shell_parse.parse_for_policy(
+    "cd ./pkg && FOO=bar command -p moon fmt > out.log",
+  )
+  debug_inspect(
+    parsed,
+    content=(
+      #|Simple(
+      #|  [
+      #|    {
+      #|      argv: ["cd", "./pkg"],
+      #|      env: [],
+      #|      redirects: [],
+      #|      separator_before: None,
+      #|      source: "cd ./pkg",
+      #|    },
+      #|    {
+      #|      argv: ["command", "-p", "moon", "fmt"],
+      #|      env: [{ name: "FOO", value: "bar" }],
+      #|      redirects: [{ op: ">", target: "out.log" }],
+      #|      separator_before: Some("&&"),
+      #|      source: "FOO=bar command -p moon fmt > out.log",
+      #|    },
+      #|  ],
+      #|)
+    ),
+  )
+  guard parsed is Simple(commands) else { fail("expected flat command line") }
+  debug_inspect(
+    commands.map(command => (command.command_name(), command.command_index())),
+    content=(
+      #|[(Some("cd"), Some(0)), (Some("moon"), Some(2))]
+    ),
+  )
 }
 ```
+
+When static argv is unknowable, callers should branch on `TooComplex` instead
+of guessing. This includes ordinary shell expansion features whose result
+depends on runtime state.
 
 ```moonbit check
 ///|
 test "shell parser declines runtime shell expansion" {
-  assert_true(
-    @shell_parse.parse_for_policy("moon $SUBCOMMAND") is TooComplex(_),
+  debug_inspect(
+    @shell_parse.parse_for_policy("moon $SUBCOMMAND"),
+    content=(
+      #|TooComplex("shell expansion is not supported")
+    ),
   )
-  assert_true(@shell_parse.parse_for_policy("moon test *.mbt") is TooComplex(_))
+  debug_inspect(
+    @shell_parse.parse_for_policy("moon test *.mbt"),
+    content=(
+      #|TooComplex("unquoted glob expansion is not supported")
+    ),
+  )
 }
 ```

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -1,0 +1,200 @@
+///|
+fn lex(command : String) -> LexResult {
+  let chars : Array[Char] = []
+  for ch in command {
+    chars.push(ch)
+  }
+  let tokens : Array[Token] = []
+  let mut word = StringBuilder()
+  let mut word_empty = true
+  let mut state = Plain
+  let mut index = 0
+  while index < chars.length() {
+    let ch = chars[index]
+    match state {
+      Plain => {
+        if is_shell_space(ch) {
+          push_word(tokens, word, word_empty)
+          word = StringBuilder()
+          word_empty = true
+          index += 1
+          continue
+        }
+        match ch {
+          '\'' => {
+            state = SingleQuoted
+            index += 1
+          }
+          '"' => {
+            state = DoubleQuoted
+            index += 1
+          }
+          '\\' => {
+            if index + 1 >= chars.length() {
+              return LexSyntaxError("trailing backslash")
+            }
+            if chars[index + 1] == '\n' || chars[index + 1] == '\r' {
+              return LexTooComplex("line continuation is not supported")
+            }
+            word.write_char(chars[index + 1])
+            word_empty = false
+            index += 2
+          }
+          '$' | '`' => return LexTooComplex("shell expansion is not supported")
+          '(' | ')' =>
+            return LexTooComplex(
+              "subshells and command groups are not supported",
+            )
+          '{' | '}' => return LexTooComplex("brace expansion is not supported")
+          '#' => return LexTooComplex("shell comments are not supported")
+          '*' | '?' | '[' =>
+            return LexTooComplex("unquoted glob expansion is not supported")
+          '~' if word_empty =>
+            return LexTooComplex("tilde expansion is not supported")
+          '&' => {
+            push_word(tokens, word, word_empty)
+            word = StringBuilder()
+            word_empty = true
+            if peek_char(chars, index + 1) == Some('&') {
+              tokens.push(Op("&&"))
+              index += 2
+            } else if peek_char(chars, index + 1) == Some('>') {
+              tokens.push(Op("&>"))
+              index += 2
+            } else {
+              return LexTooComplex("background operator is not supported")
+            }
+          }
+          '|' => {
+            push_word(tokens, word, word_empty)
+            word = StringBuilder()
+            word_empty = true
+            if peek_char(chars, index + 1) == Some('|') {
+              tokens.push(Op("||"))
+              index += 2
+            } else {
+              tokens.push(Op("|"))
+              index += 1
+            }
+          }
+          ';' => {
+            push_word(tokens, word, word_empty)
+            word = StringBuilder()
+            word_empty = true
+            tokens.push(Op(";"))
+            index += 1
+          }
+          '>' => {
+            push_word(tokens, word, word_empty)
+            word = StringBuilder()
+            word_empty = true
+            if peek_char(chars, index + 1) == Some('&') {
+              tokens.push(Op(">&"))
+              index += 2
+            } else if peek_char(chars, index + 1) == Some('>') {
+              tokens.push(Op(">>"))
+              index += 2
+            } else {
+              tokens.push(Op(">"))
+              index += 1
+            }
+          }
+          '<' => {
+            push_word(tokens, word, word_empty)
+            word = StringBuilder()
+            word_empty = true
+            if peek_char(chars, index + 1) == Some('<') {
+              return LexTooComplex("here documents are not supported")
+            }
+            tokens.push(Op("<"))
+            index += 1
+          }
+          '\n' | '\r' => {
+            push_word(tokens, word, word_empty)
+            word = StringBuilder()
+            word_empty = true
+            tokens.push(Op(";"))
+            index += 1
+          }
+          _ => {
+            word.write_char(ch)
+            word_empty = false
+            index += 1
+          }
+        }
+      }
+      SingleQuoted => {
+        if ch == '\'' {
+          state = Plain
+        } else {
+          word.write_char(ch)
+          word_empty = false
+        }
+        index += 1
+      }
+      DoubleQuoted =>
+        match ch {
+          '"' => {
+            state = Plain
+            index += 1
+          }
+          '$' | '`' =>
+            return LexTooComplex(
+              "expansion inside double quotes is not supported",
+            )
+          '\\' => {
+            if index + 1 >= chars.length() {
+              return LexSyntaxError("trailing backslash in double quotes")
+            }
+            let next = chars[index + 1]
+            if next == '\n' || next == '\r' {
+              return LexTooComplex("line continuation is not supported")
+            }
+            if next == '"' || next == '\\' || next == '$' || next == '`' {
+              word.write_char(next)
+              word_empty = false
+              index += 2
+            } else {
+              word.write_char(ch)
+              word_empty = false
+              index += 1
+            }
+          }
+          _ => {
+            word.write_char(ch)
+            word_empty = false
+            index += 1
+          }
+        }
+    }
+  }
+  match state {
+    SingleQuoted => LexSyntaxError("unterminated single quote")
+    DoubleQuoted => LexSyntaxError("unterminated double quote")
+    Plain => {
+      push_word(tokens, word, word_empty)
+      LexOk(tokens)
+    }
+  }
+}
+
+///|
+fn push_word(tokens : Array[Token], word : StringBuilder, empty : Bool) -> Unit {
+  if !empty {
+    tokens.push(Word(word.to_string()))
+  }
+}
+
+///|
+fn peek_char(chars : Array[Char], index : Int) -> Char? {
+  if index < chars.length() {
+    Some(chars[index])
+  } else {
+    None
+  }
+}
+
+///|
+fn is_shell_space(ch : Char) -> Bool {
+  ch == ' ' || ch == '\t'
+}

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -1,17 +1,60 @@
 ///|
+priv struct LexerWord {
+  mut text : StringBuilder
+  mut empty : Bool
+  mut has_quote_or_escape : Bool
+  mut quote_or_escape_before_equals : Bool
+  mut seen_unquoted_equals : Bool
+  mut assignment_tilde_candidate : Bool
+  mut has_assignment_tilde_expansion : Bool
+}
+
+///|
+fn LexerWord::new() -> LexerWord {
+  {
+    text: StringBuilder(),
+    empty: true,
+    has_quote_or_escape: false,
+    quote_or_escape_before_equals: false,
+    seen_unquoted_equals: false,
+    assignment_tilde_candidate: false,
+    has_assignment_tilde_expansion: false,
+  }
+}
+
+///|
+fn LexerWord::flush(self : LexerWord, tokens : Array[Token]) -> Unit {
+  if !self.empty {
+    tokens.push(
+      Word(self.text.to_string(), {
+        has_quote_or_escape: self.has_quote_or_escape,
+        quote_or_escape_before_equals: self.quote_or_escape_before_equals,
+        has_assignment_tilde_expansion: self.has_assignment_tilde_expansion,
+      }),
+    )
+  }
+}
+
+///|
+fn LexerWord::flush_and_reset(self : LexerWord, tokens : Array[Token]) -> Unit {
+  self.flush(tokens)
+  self.text = StringBuilder()
+  self.empty = true
+  self.has_quote_or_escape = false
+  self.quote_or_escape_before_equals = false
+  self.seen_unquoted_equals = false
+  self.assignment_tilde_candidate = false
+  self.has_assignment_tilde_expansion = false
+}
+
+///|
 fn lex(command : String) -> LexResult {
   let chars : Array[Char] = []
   for ch in command {
     chars.push(ch)
   }
   let tokens : Array[Token] = []
-  let mut word = StringBuilder()
-  let mut word_empty = true
-  let mut word_has_quote_or_escape = false
-  let mut word_quote_or_escape_before_equals = false
-  let mut word_seen_unquoted_equals = false
-  let mut word_assignment_tilde_candidate = false
-  let mut word_has_assignment_tilde_expansion = false
+  let word = LexerWord::new()
   let mut state = Plain
   let mut index = 0
   while index < chars.length() {
@@ -19,104 +62,94 @@ fn lex(command : String) -> LexResult {
     match state {
       Plain => {
         if is_shell_space(ch) {
-          push_word(
-            tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-            word_has_assignment_tilde_expansion,
-          )
-          word = StringBuilder()
-          word_empty = true
-          word_has_quote_or_escape = false
-          word_quote_or_escape_before_equals = false
-          word_seen_unquoted_equals = false
-          word_assignment_tilde_candidate = false
-          word_has_assignment_tilde_expansion = false
+          word.flush_and_reset(tokens)
           index += 1
           continue
         }
         match ch {
           '\'' => {
             state = SingleQuoted
-            word_empty = false
-            word_has_quote_or_escape = true
-            if !word_seen_unquoted_equals {
-              word_quote_or_escape_before_equals = true
+            word.empty = false
+            word.has_quote_or_escape = true
+            if !word.seen_unquoted_equals {
+              word.quote_or_escape_before_equals = true
             }
-            word_assignment_tilde_candidate = false
+            word.assignment_tilde_candidate = false
             index += 1
           }
           '"' => {
             state = DoubleQuoted
-            word_empty = false
-            word_has_quote_or_escape = true
-            if !word_seen_unquoted_equals {
-              word_quote_or_escape_before_equals = true
+            word.empty = false
+            word.has_quote_or_escape = true
+            if !word.seen_unquoted_equals {
+              word.quote_or_escape_before_equals = true
             }
-            word_assignment_tilde_candidate = false
+            word.assignment_tilde_candidate = false
             index += 1
           }
-          '\\' => {
-            if index + 1 >= chars.length() {
-              return LexSyntaxError("trailing backslash")
+          '\\' =>
+            if shell_backslash_escapes() {
+              if index + 1 >= chars.length() {
+                return LexSyntaxError("trailing backslash")
+              }
+              if chars[index + 1] == '\n' || chars[index + 1] == '\r' {
+                return LexTooComplex("line continuation is not supported")
+              }
+              word.text.write_char(chars[index + 1])
+              word.empty = false
+              word.has_quote_or_escape = true
+              if !word.seen_unquoted_equals {
+                word.quote_or_escape_before_equals = true
+              }
+              word.assignment_tilde_candidate = false
+              index += 2
+            } else {
+              word.text.write_char(ch)
+              word.empty = false
+              word.assignment_tilde_candidate = false
+              index += 1
             }
-            if chars[index + 1] == '\n' || chars[index + 1] == '\r' {
-              return LexTooComplex("line continuation is not supported")
-            }
-            word.write_char(chars[index + 1])
-            word_empty = false
-            word_has_quote_or_escape = true
-            if !word_seen_unquoted_equals {
-              word_quote_or_escape_before_equals = true
-            }
-            word_assignment_tilde_candidate = false
-            index += 2
-          }
           '$' | '`' => return LexTooComplex("shell expansion is not supported")
           '(' | ')' =>
             return LexTooComplex(
               "subshells and command groups are not supported",
             )
           '{' | '}' => return LexTooComplex("brace expansion is not supported")
-          '#' => return LexTooComplex("shell comments are not supported")
+          '#' =>
+            if word.empty {
+              state = Comment
+              index += 1
+            } else {
+              word.text.write_char(ch)
+              word.empty = false
+              word.assignment_tilde_candidate = false
+              index += 1
+            }
           '*' | '?' | '[' =>
             return LexTooComplex("unquoted glob expansion is not supported")
-          '~' if word_empty =>
+          '~' if word.empty =>
             return LexTooComplex("tilde expansion is not supported")
           '&' => {
-            let attached = !word_empty
-            push_word(
-              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-              word_has_assignment_tilde_expansion,
-            )
-            word = StringBuilder()
-            word_empty = true
-            word_has_quote_or_escape = false
-            word_quote_or_escape_before_equals = false
-            word_seen_unquoted_equals = false
-            word_assignment_tilde_candidate = false
-            word_has_assignment_tilde_expansion = false
+            let attached = !word.empty
+            word.flush_and_reset(tokens)
             if peek_char(chars, index + 1) == Some('&') {
               tokens.push(Op("&&", attached))
               index += 2
             } else if peek_char(chars, index + 1) == Some('>') {
-              tokens.push(Op("&>", attached))
-              index += 2
+              if peek_char(chars, index + 2) == Some('>') {
+                tokens.push(Op("&>>", attached))
+                index += 3
+              } else {
+                tokens.push(Op("&>", attached))
+                index += 2
+              }
             } else {
               return LexTooComplex("background operator is not supported")
             }
           }
           '|' => {
-            let attached = !word_empty
-            push_word(
-              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-              word_has_assignment_tilde_expansion,
-            )
-            word = StringBuilder()
-            word_empty = true
-            word_has_quote_or_escape = false
-            word_quote_or_escape_before_equals = false
-            word_seen_unquoted_equals = false
-            word_assignment_tilde_candidate = false
-            word_has_assignment_tilde_expansion = false
+            let attached = !word.empty
+            word.flush_and_reset(tokens)
             if peek_char(chars, index + 1) == Some('|') {
               tokens.push(Op("||", attached))
               index += 2
@@ -126,34 +159,14 @@ fn lex(command : String) -> LexResult {
             }
           }
           ';' => {
-            let attached = !word_empty
-            push_word(
-              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-              word_has_assignment_tilde_expansion,
-            )
-            word = StringBuilder()
-            word_empty = true
-            word_has_quote_or_escape = false
-            word_quote_or_escape_before_equals = false
-            word_seen_unquoted_equals = false
-            word_assignment_tilde_candidate = false
-            word_has_assignment_tilde_expansion = false
+            let attached = !word.empty
+            word.flush_and_reset(tokens)
             tokens.push(Op(";", attached))
             index += 1
           }
           '>' => {
-            let attached = !word_empty
-            push_word(
-              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-              word_has_assignment_tilde_expansion,
-            )
-            word = StringBuilder()
-            word_empty = true
-            word_has_quote_or_escape = false
-            word_quote_or_escape_before_equals = false
-            word_seen_unquoted_equals = false
-            word_assignment_tilde_candidate = false
-            word_has_assignment_tilde_expansion = false
+            let attached = !word.empty
+            word.flush_and_reset(tokens)
             if peek_char(chars, index + 1) == Some('&') {
               tokens.push(Op(">&", attached))
               index += 2
@@ -166,53 +179,37 @@ fn lex(command : String) -> LexResult {
             }
           }
           '<' => {
-            let attached = !word_empty
-            push_word(
-              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-              word_has_assignment_tilde_expansion,
-            )
-            word = StringBuilder()
-            word_empty = true
-            word_has_quote_or_escape = false
-            word_quote_or_escape_before_equals = false
-            word_seen_unquoted_equals = false
-            word_assignment_tilde_candidate = false
-            word_has_assignment_tilde_expansion = false
+            let attached = !word.empty
+            word.flush_and_reset(tokens)
             if peek_char(chars, index + 1) == Some('<') {
               return LexTooComplex("here documents are not supported")
+            } else if peek_char(chars, index + 1) == Some('&') {
+              tokens.push(Op("<&", attached))
+              index += 2
+            } else {
+              tokens.push(Op("<", attached))
+              index += 1
             }
-            tokens.push(Op("<", attached))
-            index += 1
           }
           '\n' | '\r' => {
-            let attached = !word_empty
-            push_word(
-              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-              word_has_assignment_tilde_expansion,
-            )
-            word = StringBuilder()
-            word_empty = true
-            word_has_quote_or_escape = false
-            word_quote_or_escape_before_equals = false
-            word_seen_unquoted_equals = false
-            word_assignment_tilde_candidate = false
-            word_has_assignment_tilde_expansion = false
+            let attached = !word.empty
+            word.flush_and_reset(tokens)
             tokens.push(Op(";", attached))
             index += 1
           }
           _ => {
-            if word_assignment_tilde_candidate && ch == '~' {
-              word_has_assignment_tilde_expansion = true
+            if word.assignment_tilde_candidate && ch == '~' {
+              word.has_assignment_tilde_expansion = true
             }
-            word.write_char(ch)
-            word_empty = false
-            if ch == '=' && !word_seen_unquoted_equals {
-              word_seen_unquoted_equals = true
-              word_assignment_tilde_candidate = true
-            } else if word_seen_unquoted_equals && ch == ':' {
-              word_assignment_tilde_candidate = true
+            word.text.write_char(ch)
+            word.empty = false
+            if ch == '=' && !word.seen_unquoted_equals {
+              word.seen_unquoted_equals = true
+              word.assignment_tilde_candidate = true
+            } else if word.seen_unquoted_equals && ch == ':' {
+              word.assignment_tilde_candidate = true
             } else {
-              word_assignment_tilde_candidate = false
+              word.assignment_tilde_candidate = false
             }
             index += 1
           }
@@ -222,8 +219,8 @@ fn lex(command : String) -> LexResult {
         if ch == '\'' {
           state = Plain
         } else {
-          word.write_char(ch)
-          word_empty = false
+          word.text.write_char(ch)
+          word.empty = false
         }
         index += 1
       }
@@ -237,67 +234,68 @@ fn lex(command : String) -> LexResult {
             return LexTooComplex(
               "expansion inside double quotes is not supported",
             )
-          '\\' => {
-            if index + 1 >= chars.length() {
-              return LexSyntaxError("trailing backslash in double quotes")
-            }
-            let next = chars[index + 1]
-            if next == '\n' || next == '\r' {
-              return LexTooComplex("line continuation is not supported")
-            }
-            if next == '"' || next == '\\' || next == '$' || next == '`' {
-              word.write_char(next)
-              word_empty = false
-              word_has_quote_or_escape = true
-              if !word_seen_unquoted_equals {
-                word_quote_or_escape_before_equals = true
+          '\\' =>
+            if shell_backslash_escapes() {
+              if index + 1 >= chars.length() {
+                return LexSyntaxError("trailing backslash in double quotes")
               }
-              word_assignment_tilde_candidate = false
-              index += 2
+              let next = chars[index + 1]
+              if next == '\n' || next == '\r' {
+                return LexTooComplex("line continuation is not supported")
+              }
+              if next == '"' || next == '\\' || next == '$' || next == '`' {
+                word.text.write_char(next)
+                word.empty = false
+                word.has_quote_or_escape = true
+                if !word.seen_unquoted_equals {
+                  word.quote_or_escape_before_equals = true
+                }
+                word.assignment_tilde_candidate = false
+                index += 2
+              } else {
+                word.text.write_char(ch)
+                word.empty = false
+                index += 1
+              }
             } else {
-              word.write_char(ch)
-              word_empty = false
+              word.text.write_char(ch)
+              word.empty = false
               index += 1
             }
-          }
           _ => {
-            word.write_char(ch)
-            word_empty = false
+            word.text.write_char(ch)
+            word.empty = false
             index += 1
           }
         }
+      Comment => {
+        if ch == '\n' || ch == '\r' {
+          push_comment_newline_separator(tokens)
+          state = Plain
+        }
+        index += 1
+      }
     }
   }
   match state {
     SingleQuoted => LexSyntaxError("unterminated single quote")
     DoubleQuoted => LexSyntaxError("unterminated double quote")
+    Comment => LexOk(tokens)
     Plain => {
-      push_word(
-        tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
-        word_has_assignment_tilde_expansion,
-      )
+      word.flush(tokens)
       LexOk(tokens)
     }
   }
 }
 
 ///|
-fn push_word(
-  tokens : Array[Token],
-  word : StringBuilder,
-  empty : Bool,
-  has_quote_or_escape : Bool,
-  quote_or_escape_before_equals : Bool,
-  has_assignment_tilde_expansion : Bool,
-) -> Unit {
-  if !empty {
-    tokens.push(
-      Word(word.to_string(), {
-        has_quote_or_escape,
-        quote_or_escape_before_equals,
-        has_assignment_tilde_expansion,
-      }),
-    )
+fn push_comment_newline_separator(tokens : Array[Token]) -> Unit {
+  if tokens.length() == 0 {
+    return
+  }
+  match tokens[tokens.length() - 1] {
+    Op("&&" | "||" | ";" | "|", _) => ()
+    _ => tokens.push(Op(";", false))
   }
 }
 
@@ -313,4 +311,16 @@ fn peek_char(chars : Array[Char], index : Int) -> Char? {
 ///|
 fn is_shell_space(ch : Char) -> Bool {
   ch == ' ' || ch == '\t'
+}
+
+///|
+#cfg(platform="windows")
+fn shell_backslash_escapes() -> Bool {
+  false
+}
+
+///|
+#cfg(not(platform="windows"))
+fn shell_backslash_escapes() -> Bool {
+  true
 }

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -23,10 +23,12 @@ fn lex(command : String) -> LexResult {
         match ch {
           '\'' => {
             state = SingleQuoted
+            word_empty = false
             index += 1
           }
           '"' => {
             state = DoubleQuoted
+            word_empty = false
             index += 1
           }
           '\\' => {

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -8,6 +8,10 @@ fn lex(command : String) -> LexResult {
   let mut word = StringBuilder()
   let mut word_empty = true
   let mut word_has_quote_or_escape = false
+  let mut word_quote_or_escape_before_equals = false
+  let mut word_seen_unquoted_equals = false
+  let mut word_assignment_tilde_candidate = false
+  let mut word_has_assignment_tilde_expansion = false
   let mut state = Plain
   let mut index = 0
   while index < chars.length() {
@@ -15,10 +19,17 @@ fn lex(command : String) -> LexResult {
     match state {
       Plain => {
         if is_shell_space(ch) {
-          push_word(tokens, word, word_empty, word_has_quote_or_escape)
+          push_word(
+            tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+            word_has_assignment_tilde_expansion,
+          )
           word = StringBuilder()
           word_empty = true
           word_has_quote_or_escape = false
+          word_quote_or_escape_before_equals = false
+          word_seen_unquoted_equals = false
+          word_assignment_tilde_candidate = false
+          word_has_assignment_tilde_expansion = false
           index += 1
           continue
         }
@@ -27,12 +38,20 @@ fn lex(command : String) -> LexResult {
             state = SingleQuoted
             word_empty = false
             word_has_quote_or_escape = true
+            if !word_seen_unquoted_equals {
+              word_quote_or_escape_before_equals = true
+            }
+            word_assignment_tilde_candidate = false
             index += 1
           }
           '"' => {
             state = DoubleQuoted
             word_empty = false
             word_has_quote_or_escape = true
+            if !word_seen_unquoted_equals {
+              word_quote_or_escape_before_equals = true
+            }
+            word_assignment_tilde_candidate = false
             index += 1
           }
           '\\' => {
@@ -45,6 +64,10 @@ fn lex(command : String) -> LexResult {
             word.write_char(chars[index + 1])
             word_empty = false
             word_has_quote_or_escape = true
+            if !word_seen_unquoted_equals {
+              word_quote_or_escape_before_equals = true
+            }
+            word_assignment_tilde_candidate = false
             index += 2
           }
           '$' | '`' => return LexTooComplex("shell expansion is not supported")
@@ -60,10 +83,17 @@ fn lex(command : String) -> LexResult {
             return LexTooComplex("tilde expansion is not supported")
           '&' => {
             let attached = !word_empty
-            push_word(tokens, word, word_empty, word_has_quote_or_escape)
+            push_word(
+              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+              word_has_assignment_tilde_expansion,
+            )
             word = StringBuilder()
             word_empty = true
             word_has_quote_or_escape = false
+            word_quote_or_escape_before_equals = false
+            word_seen_unquoted_equals = false
+            word_assignment_tilde_candidate = false
+            word_has_assignment_tilde_expansion = false
             if peek_char(chars, index + 1) == Some('&') {
               tokens.push(Op("&&", attached))
               index += 2
@@ -76,10 +106,17 @@ fn lex(command : String) -> LexResult {
           }
           '|' => {
             let attached = !word_empty
-            push_word(tokens, word, word_empty, word_has_quote_or_escape)
+            push_word(
+              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+              word_has_assignment_tilde_expansion,
+            )
             word = StringBuilder()
             word_empty = true
             word_has_quote_or_escape = false
+            word_quote_or_escape_before_equals = false
+            word_seen_unquoted_equals = false
+            word_assignment_tilde_candidate = false
+            word_has_assignment_tilde_expansion = false
             if peek_char(chars, index + 1) == Some('|') {
               tokens.push(Op("||", attached))
               index += 2
@@ -90,19 +127,33 @@ fn lex(command : String) -> LexResult {
           }
           ';' => {
             let attached = !word_empty
-            push_word(tokens, word, word_empty, word_has_quote_or_escape)
+            push_word(
+              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+              word_has_assignment_tilde_expansion,
+            )
             word = StringBuilder()
             word_empty = true
             word_has_quote_or_escape = false
+            word_quote_or_escape_before_equals = false
+            word_seen_unquoted_equals = false
+            word_assignment_tilde_candidate = false
+            word_has_assignment_tilde_expansion = false
             tokens.push(Op(";", attached))
             index += 1
           }
           '>' => {
             let attached = !word_empty
-            push_word(tokens, word, word_empty, word_has_quote_or_escape)
+            push_word(
+              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+              word_has_assignment_tilde_expansion,
+            )
             word = StringBuilder()
             word_empty = true
             word_has_quote_or_escape = false
+            word_quote_or_escape_before_equals = false
+            word_seen_unquoted_equals = false
+            word_assignment_tilde_candidate = false
+            word_has_assignment_tilde_expansion = false
             if peek_char(chars, index + 1) == Some('&') {
               tokens.push(Op(">&", attached))
               index += 2
@@ -116,10 +167,17 @@ fn lex(command : String) -> LexResult {
           }
           '<' => {
             let attached = !word_empty
-            push_word(tokens, word, word_empty, word_has_quote_or_escape)
+            push_word(
+              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+              word_has_assignment_tilde_expansion,
+            )
             word = StringBuilder()
             word_empty = true
             word_has_quote_or_escape = false
+            word_quote_or_escape_before_equals = false
+            word_seen_unquoted_equals = false
+            word_assignment_tilde_candidate = false
+            word_has_assignment_tilde_expansion = false
             if peek_char(chars, index + 1) == Some('<') {
               return LexTooComplex("here documents are not supported")
             }
@@ -128,16 +186,34 @@ fn lex(command : String) -> LexResult {
           }
           '\n' | '\r' => {
             let attached = !word_empty
-            push_word(tokens, word, word_empty, word_has_quote_or_escape)
+            push_word(
+              tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+              word_has_assignment_tilde_expansion,
+            )
             word = StringBuilder()
             word_empty = true
             word_has_quote_or_escape = false
+            word_quote_or_escape_before_equals = false
+            word_seen_unquoted_equals = false
+            word_assignment_tilde_candidate = false
+            word_has_assignment_tilde_expansion = false
             tokens.push(Op(";", attached))
             index += 1
           }
           _ => {
+            if word_assignment_tilde_candidate && ch == '~' {
+              word_has_assignment_tilde_expansion = true
+            }
             word.write_char(ch)
             word_empty = false
+            if ch == '=' && !word_seen_unquoted_equals {
+              word_seen_unquoted_equals = true
+              word_assignment_tilde_candidate = true
+            } else if word_seen_unquoted_equals && ch == ':' {
+              word_assignment_tilde_candidate = true
+            } else {
+              word_assignment_tilde_candidate = false
+            }
             index += 1
           }
         }
@@ -173,6 +249,10 @@ fn lex(command : String) -> LexResult {
               word.write_char(next)
               word_empty = false
               word_has_quote_or_escape = true
+              if !word_seen_unquoted_equals {
+                word_quote_or_escape_before_equals = true
+              }
+              word_assignment_tilde_candidate = false
               index += 2
             } else {
               word.write_char(ch)
@@ -192,7 +272,10 @@ fn lex(command : String) -> LexResult {
     SingleQuoted => LexSyntaxError("unterminated single quote")
     DoubleQuoted => LexSyntaxError("unterminated double quote")
     Plain => {
-      push_word(tokens, word, word_empty, word_has_quote_or_escape)
+      push_word(
+        tokens, word, word_empty, word_has_quote_or_escape, word_quote_or_escape_before_equals,
+        word_has_assignment_tilde_expansion,
+      )
       LexOk(tokens)
     }
   }
@@ -204,9 +287,17 @@ fn push_word(
   word : StringBuilder,
   empty : Bool,
   has_quote_or_escape : Bool,
+  quote_or_escape_before_equals : Bool,
+  has_assignment_tilde_expansion : Bool,
 ) -> Unit {
   if !empty {
-    tokens.push(Word(word.to_string(), has_quote_or_escape))
+    tokens.push(
+      Word(word.to_string(), {
+        has_quote_or_escape,
+        quote_or_escape_before_equals,
+        has_assignment_tilde_expansion,
+      }),
+    )
   }
 }
 

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -7,6 +7,7 @@ fn lex(command : String) -> LexResult {
   let tokens : Array[Token] = []
   let mut word = StringBuilder()
   let mut word_empty = true
+  let mut word_has_quote_or_escape = false
   let mut state = Plain
   let mut index = 0
   while index < chars.length() {
@@ -14,9 +15,10 @@ fn lex(command : String) -> LexResult {
     match state {
       Plain => {
         if is_shell_space(ch) {
-          push_word(tokens, word, word_empty)
+          push_word(tokens, word, word_empty, word_has_quote_or_escape)
           word = StringBuilder()
           word_empty = true
+          word_has_quote_or_escape = false
           index += 1
           continue
         }
@@ -24,11 +26,13 @@ fn lex(command : String) -> LexResult {
           '\'' => {
             state = SingleQuoted
             word_empty = false
+            word_has_quote_or_escape = true
             index += 1
           }
           '"' => {
             state = DoubleQuoted
             word_empty = false
+            word_has_quote_or_escape = true
             index += 1
           }
           '\\' => {
@@ -40,6 +44,7 @@ fn lex(command : String) -> LexResult {
             }
             word.write_char(chars[index + 1])
             word_empty = false
+            word_has_quote_or_escape = true
             index += 2
           }
           '$' | '`' => return LexTooComplex("shell expansion is not supported")
@@ -54,68 +59,80 @@ fn lex(command : String) -> LexResult {
           '~' if word_empty =>
             return LexTooComplex("tilde expansion is not supported")
           '&' => {
-            push_word(tokens, word, word_empty)
+            let attached = !word_empty
+            push_word(tokens, word, word_empty, word_has_quote_or_escape)
             word = StringBuilder()
             word_empty = true
+            word_has_quote_or_escape = false
             if peek_char(chars, index + 1) == Some('&') {
-              tokens.push(Op("&&"))
+              tokens.push(Op("&&", attached))
               index += 2
             } else if peek_char(chars, index + 1) == Some('>') {
-              tokens.push(Op("&>"))
+              tokens.push(Op("&>", attached))
               index += 2
             } else {
               return LexTooComplex("background operator is not supported")
             }
           }
           '|' => {
-            push_word(tokens, word, word_empty)
+            let attached = !word_empty
+            push_word(tokens, word, word_empty, word_has_quote_or_escape)
             word = StringBuilder()
             word_empty = true
+            word_has_quote_or_escape = false
             if peek_char(chars, index + 1) == Some('|') {
-              tokens.push(Op("||"))
+              tokens.push(Op("||", attached))
               index += 2
             } else {
-              tokens.push(Op("|"))
+              tokens.push(Op("|", attached))
               index += 1
             }
           }
           ';' => {
-            push_word(tokens, word, word_empty)
+            let attached = !word_empty
+            push_word(tokens, word, word_empty, word_has_quote_or_escape)
             word = StringBuilder()
             word_empty = true
-            tokens.push(Op(";"))
+            word_has_quote_or_escape = false
+            tokens.push(Op(";", attached))
             index += 1
           }
           '>' => {
-            push_word(tokens, word, word_empty)
+            let attached = !word_empty
+            push_word(tokens, word, word_empty, word_has_quote_or_escape)
             word = StringBuilder()
             word_empty = true
+            word_has_quote_or_escape = false
             if peek_char(chars, index + 1) == Some('&') {
-              tokens.push(Op(">&"))
+              tokens.push(Op(">&", attached))
               index += 2
             } else if peek_char(chars, index + 1) == Some('>') {
-              tokens.push(Op(">>"))
+              tokens.push(Op(">>", attached))
               index += 2
             } else {
-              tokens.push(Op(">"))
+              tokens.push(Op(">", attached))
               index += 1
             }
           }
           '<' => {
-            push_word(tokens, word, word_empty)
+            let attached = !word_empty
+            push_word(tokens, word, word_empty, word_has_quote_or_escape)
             word = StringBuilder()
             word_empty = true
+            word_has_quote_or_escape = false
             if peek_char(chars, index + 1) == Some('<') {
               return LexTooComplex("here documents are not supported")
             }
-            tokens.push(Op("<"))
+            tokens.push(Op("<", attached))
             index += 1
           }
           '\n' | '\r' => {
-            push_word(tokens, word, word_empty)
+            let attached = !word_empty
+            push_word(tokens, word, word_empty, word_has_quote_or_escape)
             word = StringBuilder()
             word_empty = true
-            tokens.push(Op(";"))
+            word_has_quote_or_escape = false
+            tokens.push(Op(";", attached))
             index += 1
           }
           _ => {
@@ -155,6 +172,7 @@ fn lex(command : String) -> LexResult {
             if next == '"' || next == '\\' || next == '$' || next == '`' {
               word.write_char(next)
               word_empty = false
+              word_has_quote_or_escape = true
               index += 2
             } else {
               word.write_char(ch)
@@ -174,16 +192,21 @@ fn lex(command : String) -> LexResult {
     SingleQuoted => LexSyntaxError("unterminated single quote")
     DoubleQuoted => LexSyntaxError("unterminated double quote")
     Plain => {
-      push_word(tokens, word, word_empty)
+      push_word(tokens, word, word_empty, word_has_quote_or_escape)
       LexOk(tokens)
     }
   }
 }
 
 ///|
-fn push_word(tokens : Array[Token], word : StringBuilder, empty : Bool) -> Unit {
+fn push_word(
+  tokens : Array[Token],
+  word : StringBuilder,
+  empty : Bool,
+  has_quote_or_escape : Bool,
+) -> Unit {
   if !empty {
-    tokens.push(Word(word.to_string()))
+    tokens.push(Word(word.to_string(), has_quote_or_escape))
   }
 }
 

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -192,9 +192,8 @@ fn lex(command : String) -> LexResult {
             }
           }
           '\n' | '\r' => {
-            let attached = !word.empty
             word.flush_and_reset(tokens)
-            tokens.push(Op(";", attached))
+            push_newline_separator(tokens)
             index += 1
           }
           _ => {
@@ -270,7 +269,7 @@ fn lex(command : String) -> LexResult {
         }
       Comment => {
         if ch == '\n' || ch == '\r' {
-          push_comment_newline_separator(tokens)
+          push_newline_separator(tokens)
           state = Plain
         }
         index += 1
@@ -289,7 +288,7 @@ fn lex(command : String) -> LexResult {
 }
 
 ///|
-fn push_comment_newline_separator(tokens : Array[Token]) -> Unit {
+fn push_newline_separator(tokens : Array[Token]) -> Unit {
   if tokens.length() == 0 {
     return
   }

--- a/agent_tool/shell/internal/shell_parse/moon.pkg
+++ b/agent_tool/shell/internal/shell_parse/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -21,6 +21,7 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
   let mut redirects : Array[Redirect] = []
   let mut saw_part = false
   let mut pending_separator : String? = None
+  let mut separator_before : String? = None
   let mut index = 0
   while index < tokens.length() {
     match tokens[index] {
@@ -76,12 +77,18 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
         if !saw_part {
           return SyntaxError("operator \{op} has no preceding command")
         }
-        push_command(commands, env, argv, redirects)
+        match too_complex_shell_control_word(argv) {
+          Some(word) =>
+            return TooComplex("shell control command is not supported: \{word}")
+          None => ()
+        }
+        push_command(commands, env, argv, redirects, separator_before)
         env = []
         argv = []
         redirects = []
         saw_part = false
         pending_separator = Some(op)
+        separator_before = Some(op)
         index += 1
       }
       Op(op, _) if is_redirect_op(op) => {
@@ -104,7 +111,12 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
       Some(op) => return SyntaxError("operator \{op} has no following command")
     }
   } else {
-    push_command(commands, env, argv, redirects)
+    match too_complex_shell_control_word(argv) {
+      Some(word) =>
+        return TooComplex("shell control command is not supported: \{word}")
+      None => ()
+    }
+    push_command(commands, env, argv, redirects, separator_before)
   }
   Simple(commands)
 }
@@ -127,11 +139,13 @@ fn push_command(
   env : Array[EnvAssignment],
   argv : Array[String],
   redirects : Array[Redirect],
+  separator_before : String?,
 ) -> Unit {
   commands.push({
     argv,
     env,
     redirects,
+    separator_before,
     source: render_source(env, argv, redirects),
   })
 }
@@ -162,12 +176,18 @@ fn is_separator(op : String) -> Bool {
 
 ///|
 fn is_redirect_op(op : String) -> Bool {
-  op == ">" || op == ">>" || op == "<" || op == "&>" || op == ">&"
+  op == ">" ||
+  op == ">>" ||
+  op == "<" ||
+  op == "&>" ||
+  op == "&>>" ||
+  op == ">&" ||
+  op == "<&"
 }
 
 ///|
 fn is_fd_redirect_op(op : String) -> Bool {
-  op == ">" || op == ">>" || op == ">&" || op == "<"
+  op == ">" || op == ">>" || op == ">&" || op == "<" || op == "<&"
 }
 
 ///|
@@ -242,6 +262,7 @@ fn is_too_complex_command_word(word : String) -> Bool {
     | "else"
     | "esac"
     | "eval"
+    | "exit"
     | "exec"
     | "fi"
     | "for"
@@ -257,4 +278,57 @@ fn is_too_complex_command_word(word : String) -> Bool {
     | "while" => true
     _ => false
   }
+}
+
+///|
+fn too_complex_shell_control_word(argv : Array[String]) -> String? {
+  match effective_shell_control_word_index(argv) {
+    Some(index) if is_too_complex_command_word(argv[index]) => Some(argv[index])
+    _ => None
+  }
+}
+
+///|
+fn effective_shell_control_word_index(argv : Array[String]) -> Int? {
+  if argv.length() == 0 {
+    return None
+  }
+  match argv[0] {
+    "command" => command_payload_index(argv)
+    "builtin" =>
+      if argv.length() > 1 {
+        if argv[1] == "--" {
+          if argv.length() > 2 {
+            Some(2)
+          } else {
+            None
+          }
+        } else {
+          Some(1)
+        }
+      } else {
+        None
+      }
+    _ => Some(0)
+  }
+}
+
+///|
+fn command_payload_index(argv : Array[String]) -> Int? {
+  let mut index = 1
+  while index < argv.length() {
+    match argv[index] {
+      "--" =>
+        if index + 1 < argv.length() {
+          return Some(index + 1)
+        } else {
+          return None
+        }
+      "-p" => index += 1
+      "-v" | "-V" => return None
+      arg if arg.has_prefix("-") => return None
+      _ => return Some(index)
+    }
+  }
+  None
 }

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -28,7 +28,7 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
         pending_separator = None
         if is_fd_word(word) && index + 1 < tokens.length() {
           match tokens[index + 1] {
-            Op(next_op) if next_op == ">" || next_op == ">>" || next_op == ">&" => {
+            Op(next_op) if is_fd_redirect_op(next_op) => {
               let op = "\{word}\{next_op}"
               match parse_redirect_target(tokens, index + 2) {
                 Some((target, next_index)) => {
@@ -46,7 +46,14 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
         }
         if argv.length() == 0 && is_env_assignment_word(word) {
           match split_env_assignment(word) {
-            Some(assignment) => env.push(assignment)
+            Some(assignment) => {
+              if assignment_value_may_expand_tilde(assignment.value) {
+                return TooComplex(
+                  "tilde expansion in environment assignment is not supported",
+                )
+              }
+              env.push(assignment)
+            }
             None => argv.push(word)
           }
         } else {
@@ -152,6 +159,11 @@ fn is_redirect_op(op : String) -> Bool {
 }
 
 ///|
+fn is_fd_redirect_op(op : String) -> Bool {
+  op == ">" || op == ">>" || op == ">&" || op == "<"
+}
+
+///|
 fn is_fd_word(word : String) -> Bool {
   if word == "" {
     return false
@@ -181,6 +193,11 @@ fn split_env_assignment(word : String) -> EnvAssignment? {
     }
   }
   Some({ name, value: values.join("=") })
+}
+
+///|
+fn assignment_value_may_expand_tilde(value : String) -> Bool {
+  value.has_prefix("~") || value.contains(":~")
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -24,11 +24,13 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
   let mut index = 0
   while index < tokens.length() {
     match tokens[index] {
-      Word(word) => {
+      Word(word, has_quote_or_escape) => {
         pending_separator = None
-        if is_fd_word(word) && index + 1 < tokens.length() {
+        if !has_quote_or_escape &&
+          is_fd_word(word) &&
+          index + 1 < tokens.length() {
           match tokens[index + 1] {
-            Op(next_op) if is_fd_redirect_op(next_op) => {
+            Op(next_op, true) if is_fd_redirect_op(next_op) => {
               let op = "\{word}\{next_op}"
               match parse_redirect_target(tokens, index + 2) {
                 Some((target, next_index)) => {
@@ -45,6 +47,9 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
           }
         }
         if argv.length() == 0 && is_env_assignment_word(word) {
+          if has_quote_or_escape {
+            return TooComplex("quoted environment assignment is not supported")
+          }
           match split_env_assignment(word) {
             Some(assignment) => {
               if assignment_value_may_expand_tilde(assignment.value) {
@@ -65,7 +70,7 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
         saw_part = true
         index += 1
       }
-      Op(op) if is_separator(op) => {
+      Op(op, _) if is_separator(op) => {
         if !saw_part {
           return SyntaxError("operator \{op} has no preceding command")
         }
@@ -77,7 +82,7 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
         pending_separator = Some(op)
         index += 1
       }
-      Op(op) if is_redirect_op(op) => {
+      Op(op, _) if is_redirect_op(op) => {
         pending_separator = None
         match parse_redirect_target(tokens, index + 1) {
           Some((target, next_index)) => {
@@ -88,7 +93,7 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
           None => return SyntaxError("redirection \{op} requires a target")
         }
       }
-      Op(op) => return TooComplex("unsupported shell operator: \{op}")
+      Op(op, _) => return TooComplex("unsupported shell operator: \{op}")
     }
   }
   if !saw_part {
@@ -108,8 +113,8 @@ fn parse_redirect_target(tokens : Array[Token], index : Int) -> (String, Int)? {
     None
   } else {
     match tokens[index] {
-      Word(target) => Some((target, index + 1))
-      Op(_) => None
+      Word(target, _) => Some((target, index + 1))
+      Op(_, _) => None
     }
   }
 }

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -24,9 +24,9 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
   let mut index = 0
   while index < tokens.length() {
     match tokens[index] {
-      Word(word, has_quote_or_escape) => {
+      Word(word, meta) => {
         pending_separator = None
-        if !has_quote_or_escape &&
+        if !meta.has_quote_or_escape &&
           is_fd_word(word) &&
           index + 1 < tokens.length() {
           match tokens[index + 1] {
@@ -47,12 +47,14 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
           }
         }
         if argv.length() == 0 && is_env_assignment_word(word) {
-          if has_quote_or_escape {
-            return TooComplex("quoted environment assignment is not supported")
+          if meta.quote_or_escape_before_equals {
+            return TooComplex(
+              "quoted environment assignment name is not supported",
+            )
           }
           match split_env_assignment(word) {
             Some(assignment) => {
-              if assignment_value_may_expand_tilde(assignment.value) {
+              if meta.has_assignment_tilde_expansion {
                 return TooComplex(
                   "tilde expansion in environment assignment is not supported",
                 )
@@ -198,11 +200,6 @@ fn split_env_assignment(word : String) -> EnvAssignment? {
     }
   }
   Some({ name, value: values.join("=") })
-}
-
-///|
-fn assignment_value_may_expand_tilde(value : String) -> Bool {
-  value.has_prefix("~") || value.contains(":~")
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -1,0 +1,241 @@
+///|
+/// Conservatively parse a shell command for policy decisions.
+///
+/// The parser only accepts a subset where argv can be known statically. It is a
+/// parser for agent policy, not a shell interpreter. Commands using expansion,
+/// command substitution, subshells, command groups, heredocs, or glob expansion
+/// return `TooComplex`.
+pub fn parse_for_policy(command : String) -> ParseResult {
+  match lex(command) {
+    LexOk(tokens) => parse_tokens(tokens)
+    LexTooComplex(reason) => TooComplex(reason)
+    LexSyntaxError(message) => SyntaxError(message)
+  }
+}
+
+///|
+fn parse_tokens(tokens : Array[Token]) -> ParseResult {
+  let commands : Array[SimpleCommand] = []
+  let mut env : Array[EnvAssignment] = []
+  let mut argv : Array[String] = []
+  let mut redirects : Array[Redirect] = []
+  let mut saw_part = false
+  let mut pending_separator : String? = None
+  let mut index = 0
+  while index < tokens.length() {
+    match tokens[index] {
+      Word(word) => {
+        pending_separator = None
+        if is_fd_word(word) && index + 1 < tokens.length() {
+          match tokens[index + 1] {
+            Op(next_op) if next_op == ">" || next_op == ">>" || next_op == ">&" => {
+              let op = "\{word}\{next_op}"
+              match parse_redirect_target(tokens, index + 2) {
+                Some((target, next_index)) => {
+                  redirects.push({ op, target })
+                  saw_part = true
+                  index = next_index
+                  continue
+                }
+                None =>
+                  return SyntaxError("redirection \{op} requires a target")
+              }
+            }
+            _ => ()
+          }
+        }
+        if argv.length() == 0 && is_env_assignment_word(word) {
+          match split_env_assignment(word) {
+            Some(assignment) => env.push(assignment)
+            None => argv.push(word)
+          }
+        } else {
+          if argv.length() == 0 && is_too_complex_command_word(word) {
+            return TooComplex("shell control command is not supported: \{word}")
+          }
+          argv.push(word)
+        }
+        saw_part = true
+        index += 1
+      }
+      Op(op) if is_separator(op) => {
+        if !saw_part {
+          return SyntaxError("operator \{op} has no preceding command")
+        }
+        push_command(commands, env, argv, redirects)
+        env = []
+        argv = []
+        redirects = []
+        saw_part = false
+        pending_separator = Some(op)
+        index += 1
+      }
+      Op(op) if is_redirect_op(op) => {
+        pending_separator = None
+        match parse_redirect_target(tokens, index + 1) {
+          Some((target, next_index)) => {
+            redirects.push({ op, target })
+            saw_part = true
+            index = next_index
+          }
+          None => return SyntaxError("redirection \{op} requires a target")
+        }
+      }
+      Op(op) => return TooComplex("unsupported shell operator: \{op}")
+    }
+  }
+  if !saw_part {
+    match pending_separator {
+      Some(";") | None => ()
+      Some(op) => return SyntaxError("operator \{op} has no following command")
+    }
+  } else {
+    push_command(commands, env, argv, redirects)
+  }
+  Simple(commands)
+}
+
+///|
+fn parse_redirect_target(tokens : Array[Token], index : Int) -> (String, Int)? {
+  if index >= tokens.length() {
+    None
+  } else {
+    match tokens[index] {
+      Word(target) => Some((target, index + 1))
+      Op(_) => None
+    }
+  }
+}
+
+///|
+fn push_command(
+  commands : Array[SimpleCommand],
+  env : Array[EnvAssignment],
+  argv : Array[String],
+  redirects : Array[Redirect],
+) -> Unit {
+  commands.push({
+    argv,
+    env,
+    redirects,
+    source: render_source(env, argv, redirects),
+  })
+}
+
+///|
+fn render_source(
+  env : Array[EnvAssignment],
+  argv : Array[String],
+  redirects : Array[Redirect],
+) -> String {
+  let parts : Array[String] = []
+  for assignment in env {
+    parts.push("\{assignment.name}=\{assignment.value}")
+  }
+  for arg in argv {
+    parts.push(arg)
+  }
+  for redirect in redirects {
+    parts.push("\{redirect.op} \{redirect.target}")
+  }
+  parts.join(" ")
+}
+
+///|
+fn is_separator(op : String) -> Bool {
+  op == "&&" || op == "||" || op == ";" || op == "|"
+}
+
+///|
+fn is_redirect_op(op : String) -> Bool {
+  op == ">" || op == ">>" || op == "<" || op == "&>" || op == ">&"
+}
+
+///|
+fn is_fd_word(word : String) -> Bool {
+  if word == "" {
+    return false
+  }
+  for ch in word {
+    if !(ch is ('0'..='9')) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn split_env_assignment(word : String) -> EnvAssignment? {
+  let parts = word.split("=").collect()
+  if parts.length() < 2 {
+    return None
+  }
+  let name = parts[0].to_owned()
+  if !is_valid_env_name(name) {
+    return None
+  }
+  let values : Array[String] = []
+  for index, part in parts {
+    if index > 0 {
+      values.push(part.to_owned())
+    }
+  }
+  Some({ name, value: values.join("=") })
+}
+
+///|
+fn is_env_assignment_word(word : String) -> Bool {
+  split_env_assignment(word) is Some(_)
+}
+
+///|
+fn is_valid_env_name(name : String) -> Bool {
+  if name == "" {
+    return false
+  }
+  let mut index = 0
+  for ch in name {
+    let valid = if index == 0 {
+      ch is ('a'..='z') || ch is ('A'..='Z') || ch == '_'
+    } else {
+      ch is ('a'..='z') || ch is ('A'..='Z') || ch is ('0'..='9') || ch == '_'
+    }
+    if !valid {
+      return false
+    }
+    index += 1
+  }
+  true
+}
+
+///|
+fn is_too_complex_command_word(word : String) -> Bool {
+  match word {
+    "!"
+    | "{"
+    | "}"
+    | "."
+    | "case"
+    | "coproc"
+    | "do"
+    | "done"
+    | "elif"
+    | "else"
+    | "esac"
+    | "eval"
+    | "exec"
+    | "fi"
+    | "for"
+    | "function"
+    | "if"
+    | "in"
+    | "select"
+    | "source"
+    | "then"
+    | "time"
+    | "trap"
+    | "until"
+    | "while" => true
+    _ => false
+  }
+}

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -42,3 +42,4 @@ pub fn SimpleCommand::command_name(Self) -> String?
 // Type aliases
 
 // Traits
+

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -1,0 +1,47 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell/internal/shell_parse"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn contains_command(ParseResult, String) -> Bool
+
+pub fn has_cd(ParseResult) -> Bool
+
+pub fn has_cd_and_command(ParseResult, String) -> Bool
+
+pub fn parse_for_policy(String) -> ParseResult
+
+// Errors
+
+// Types and methods
+pub(all) struct EnvAssignment {
+  name : String
+  value : String
+} derive(Eq, @debug.Debug)
+
+pub(all) enum ParseResult {
+  Simple(Array[SimpleCommand])
+  TooComplex(String)
+  SyntaxError(String)
+} derive(Eq, @debug.Debug)
+
+pub(all) struct Redirect {
+  op : String
+  target : String
+} derive(Eq, @debug.Debug)
+
+pub(all) struct SimpleCommand {
+  argv : Array[String]
+  env : Array[EnvAssignment]
+  redirects : Array[Redirect]
+  source : String
+} derive(Eq, @debug.Debug)
+pub fn SimpleCommand::command_name(Self) -> String?
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -42,4 +42,3 @@ pub fn SimpleCommand::command_name(Self) -> String?
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -8,10 +8,6 @@ import {
 // Values
 pub fn contains_command(ParseResult, String) -> Bool
 
-pub fn has_cd(ParseResult) -> Bool
-
-pub fn has_cd_and_command(ParseResult, String) -> Bool
-
 pub fn parse_for_policy(String) -> ParseResult
 
 // Errors
@@ -37,8 +33,10 @@ pub(all) struct SimpleCommand {
   argv : Array[String]
   env : Array[EnvAssignment]
   redirects : Array[Redirect]
+  separator_before : String?
   source : String
 } derive(Eq, @debug.Debug)
+pub fn SimpleCommand::command_index(Self) -> Int?
 pub fn SimpleCommand::command_name(Self) -> String?
 
 // Type aliases

--- a/agent_tool/shell/internal/shell_parse/query.mbt
+++ b/agent_tool/shell/internal/shell_parse/query.mbt
@@ -1,0 +1,89 @@
+///|
+/// Return the effective command name for this simple command.
+///
+/// This strips leading environment assignments represented in `env`, and also
+/// recognizes the common `env NAME=value command ...` wrapper. It deliberately
+/// avoids interpreting complex `env` option forms; those remain `env`.
+pub fn SimpleCommand::command_name(self : SimpleCommand) -> String? {
+  effective_command_name(self.argv)
+}
+
+///|
+/// True when the parsed result contains a simple command with the requested
+/// effective command name.
+pub fn contains_command(result : ParseResult, name : String) -> Bool {
+  match result {
+    Simple(commands) =>
+      commands.any(command => command.command_name() == Some(name))
+    _ => false
+  }
+}
+
+///|
+/// True when the parsed result contains a statically visible directory-changing
+/// command (`cd`, `pushd`, or `popd`).
+pub fn has_cd(result : ParseResult) -> Bool {
+  match result {
+    Simple(commands) =>
+      commands.any(command => {
+        match command.command_name() {
+          Some("cd" | "pushd" | "popd") => true
+          _ => false
+        }
+      })
+    _ => false
+  }
+}
+
+///|
+/// True when the parsed result contains both a directory-changing command and a
+/// command with the requested effective name.
+pub fn has_cd_and_command(result : ParseResult, name : String) -> Bool {
+  has_cd(result) && contains_command(result, name)
+}
+
+///|
+fn effective_command_name(argv : Array[String]) -> String? {
+  if argv.length() == 0 {
+    return None
+  }
+  match argv[0] {
+    "env" => env_wrapped_command_name(argv)
+    "command" | "builtin" =>
+      if argv.length() > 1 {
+        Some(argv[1])
+      } else {
+        Some(argv[0])
+      }
+    command => Some(command)
+  }
+}
+
+///|
+fn env_wrapped_command_name(argv : Array[String]) -> String? {
+  let mut index = 1
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "--" {
+      index += 1
+      break
+    }
+    if is_env_assignment_word(arg) {
+      index += 1
+      continue
+    }
+    if arg == "-i" || arg == "-" {
+      index += 1
+      continue
+    }
+    if arg.has_prefix("-") {
+      return Some("env")
+    }
+    return Some(arg)
+  }
+  if index < argv.length() {
+    Some(argv[index])
+  } else {
+    Some("env")
+  }
+}

--- a/agent_tool/shell/internal/shell_parse/query.mbt
+++ b/agent_tool/shell/internal/shell_parse/query.mbt
@@ -5,7 +5,20 @@
 /// recognizes the common `env NAME=value command ...` wrapper. It deliberately
 /// avoids interpreting complex `env` option forms; those remain `env`.
 pub fn SimpleCommand::command_name(self : SimpleCommand) -> String? {
-  effective_command_name(self.argv)
+  match self.command_index() {
+    Some(index) if index < self.argv.length() => Some(self.argv[index])
+    _ => None
+  }
+}
+
+///|
+/// Return the index in `argv` of this command's effective command word.
+///
+/// This is the index-aware counterpart of `command_name()`, so consumers that
+/// need to continue scanning command flags do not have to duplicate wrapper
+/// grammar.
+pub fn SimpleCommand::command_index(self : SimpleCommand) -> Int? {
+  effective_command_index(self.argv)
 }
 
 ///|
@@ -20,47 +33,30 @@ pub fn contains_command(result : ParseResult, name : String) -> Bool {
 }
 
 ///|
-/// True when the parsed result contains a statically visible directory-changing
-/// command (`cd`, `pushd`, or `popd`).
-pub fn has_cd(result : ParseResult) -> Bool {
-  match result {
-    Simple(commands) =>
-      commands.any(command => {
-        match command.command_name() {
-          Some("cd" | "pushd" | "popd") => true
-          _ => false
-        }
-      })
-    _ => false
-  }
-}
-
-///|
-/// True when the parsed result contains both a directory-changing command and a
-/// command with the requested effective name.
-pub fn has_cd_and_command(result : ParseResult, name : String) -> Bool {
-  has_cd(result) && contains_command(result, name)
-}
-
-///|
-fn effective_command_name(argv : Array[String]) -> String? {
+fn effective_command_index(argv : Array[String]) -> Int? {
   if argv.length() == 0 {
     return None
   }
   match argv[0] {
-    "env" => env_wrapped_command_name(argv)
-    "command" | "builtin" =>
+    "env" => env_wrapped_command_index(argv)
+    "command" => command_wrapped_command_index(argv)
+    "builtin" =>
       if argv.length() > 1 {
-        Some(argv[1])
+        let index = if argv[1] == "--" { 2 } else { 1 }
+        if index < argv.length() {
+          Some(index)
+        } else {
+          Some(0)
+        }
       } else {
-        Some(argv[0])
+        Some(0)
       }
-    command => Some(command)
+    _ => Some(0)
   }
 }
 
 ///|
-fn env_wrapped_command_name(argv : Array[String]) -> String? {
+fn command_wrapped_command_index(argv : Array[String]) -> Int? {
   let mut index = 1
   while index < argv.length() {
     let arg = argv[index]
@@ -68,22 +64,50 @@ fn env_wrapped_command_name(argv : Array[String]) -> String? {
       index += 1
       break
     }
-    if is_env_assignment_word(arg) {
+    if arg == "-p" {
       index += 1
       continue
     }
-    if arg == "-i" || arg == "-" {
-      index += 1
-      continue
+    if arg == "-v" || arg == "-V" || arg.has_prefix("-") {
+      return Some(0)
     }
-    if arg.has_prefix("-") {
-      return Some("env")
-    }
-    return Some(arg)
+    return Some(index)
   }
   if index < argv.length() {
-    Some(argv[index])
+    Some(index)
   } else {
-    Some("env")
+    Some(0)
+  }
+}
+
+///|
+fn env_wrapped_command_index(argv : Array[String]) -> Int? {
+  let mut index = 1
+  let mut scanning_options = true
+  while index < argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    if scanning_options && (arg == "-i" || arg == "-") {
+      index += 1
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") {
+      return Some(0)
+    }
+    if is_env_assignment_word(arg) {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    return Some(index)
+  }
+  if index < argv.length() {
+    Some(index)
+  } else {
+    Some(0)
   }
 }

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -78,6 +78,32 @@ test "parse environment assignments and redirects" {
 }
 
 ///|
+test "parse quoted and escaped environment assignment values" {
+  guard @shell_parse.parse_for_policy("FOO=\"bar baz\" PATH=\\~/bin moon check")
+    is Simple(commands) else {
+    fail("expected quoted assignment values")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(
+    commands[0].env ==
+    [{ name: "FOO", value: "bar baz" }, { name: "PATH", value: "~/bin" }],
+  )
+  assert_true(commands[0].argv == ["moon", "check"])
+  guard @shell_parse.parse_for_policy("FOO=bar\\ baz moon check")
+    is Simple(escaped) else {
+    fail("expected escaped assignment value")
+  }
+  assert_true(escaped[0].env == [{ name: "FOO", value: "bar baz" }])
+  assert_true(escaped[0].argv == ["moon", "check"])
+  guard @shell_parse.parse_for_policy("HOME=\"~\" moon check")
+    is Simple(quoted_tilde) else {
+    fail("expected quoted tilde assignment value")
+  }
+  assert_true(quoted_tilde[0].env == [{ name: "HOME", value: "~" }])
+  assert_true(quoted_tilde[0].argv == ["moon", "check"])
+}
+
+///|
 test "parse fd qualified input redirects" {
   guard @shell_parse.parse_for_policy("cmd 0<input 2<err.log")
     is Simple(commands) else {
@@ -122,6 +148,7 @@ test "keep quoted words out of special shell grammar" {
   assert_true(commands[0].redirects == [{ op: "<", target: "input" }])
   assert_true(@shell_parse.parse_for_policy("A\"\"=x env") is TooComplex(_))
   assert_true(@shell_parse.parse_for_policy("A\\=x env") is TooComplex(_))
+  assert_true(@shell_parse.parse_for_policy("\"A\"=x env") is TooComplex(_))
 }
 
 ///|
@@ -219,6 +246,9 @@ test "return too complex for runtime expansion and shell structures" {
   assert_true(@shell_parse.parse_for_policy("HOME=~ cmd") is TooComplex(_))
   assert_true(
     @shell_parse.parse_for_policy("PATH=/bin:~/bin cmd") is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("HOME=~/\"quoted\" cmd") is TooComplex(_),
   )
 }
 

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -308,6 +308,31 @@ test "parse shell comments without losing visible commands" {
 }
 
 ///|
+test "parse newlines without duplicate separators" {
+  guard @shell_parse.parse_for_policy("moon fmt;\n") is Simple(trailing) else {
+    fail("expected trailing separator before newline")
+  }
+  assert_eq(trailing.length(), 1)
+  assert_true(trailing[0].argv == ["moon", "fmt"])
+  guard @shell_parse.parse_for_policy("moon fmt\n\nmoon test")
+    is Simple(blank_line) else {
+    fail("expected blank line between commands")
+  }
+  assert_eq(blank_line.length(), 2)
+  assert_true(blank_line[0].argv == ["moon", "fmt"])
+  assert_true(blank_line[1].argv == ["moon", "test"])
+  assert_true(blank_line[1].separator_before is Some(";"))
+  guard @shell_parse.parse_for_policy("cd ./pkg &&\nmoon fmt")
+    is Simple(and_newline) else {
+    fail("expected newline after && to continue compound command")
+  }
+  assert_eq(and_newline.length(), 2)
+  assert_true(and_newline[0].argv == ["cd", "./pkg"])
+  assert_true(and_newline[1].argv == ["moon", "fmt"])
+  assert_true(and_newline[1].separator_before is Some("&&"))
+}
+
+///|
 test "parse pipes and conditionals as visible top level commands" {
   guard @shell_parse.parse_for_policy("moon check 2>&1 | tee out.log || true")
     is Simple(commands) else {

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -40,6 +40,20 @@ test "parse quotes and backslash escapes without expansion" {
 }
 
 ///|
+test "preserve empty quoted words" {
+  guard @shell_parse.parse_for_policy("cmd \"\" '' arg") is Simple(commands) else {
+    fail("expected empty quoted words")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].argv == ["cmd", "", "", "arg"])
+  guard @shell_parse.parse_for_policy("\"\" moon") is Simple(empty_name) else {
+    fail("expected empty command word")
+  }
+  assert_true(empty_name[0].argv == ["", "moon"])
+  assert_true(!@shell_parse.contains_command(Simple(empty_name), "moon"))
+}
+
+///|
 test "parse environment assignments and redirects" {
   guard @shell_parse.parse_for_policy(
       "FOO=bar JSON=a=b moon run cmd/main > out.json 2>> err.log 2>&1",
@@ -60,6 +74,20 @@ test "parse environment assignments and redirects" {
       { op: "2>>", target: "err.log" },
       { op: "2>&", target: "1" },
     ],
+  )
+}
+
+///|
+test "parse fd qualified input redirects" {
+  guard @shell_parse.parse_for_policy("cmd 0<input 2< err.log")
+    is Simple(commands) else {
+    fail("expected fd qualified input redirects")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].argv == ["cmd"])
+  assert_true(
+    commands[0].redirects ==
+    [{ op: "0<", target: "input" }, { op: "2<", target: "err.log" }],
   )
 }
 
@@ -154,6 +182,10 @@ test "return too complex for runtime expansion and shell structures" {
   assert_true(@shell_parse.parse_for_policy("moon \\\ncheck") is TooComplex(_))
   assert_true(
     @shell_parse.parse_for_policy("eval 'moon check'") is TooComplex(_),
+  )
+  assert_true(@shell_parse.parse_for_policy("HOME=~ cmd") is TooComplex(_))
+  assert_true(
+    @shell_parse.parse_for_policy("PATH=/bin:~/bin cmd") is TooComplex(_),
   )
 }
 

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -1,0 +1,170 @@
+///|
+test "parse simple moon command" {
+  guard @shell_parse.parse_for_policy("moon check --target native")
+    is Simple(commands) else {
+    fail("expected simple command")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].argv == ["moon", "check", "--target", "native"])
+  assert_eq(commands[0].env.length(), 0)
+  assert_eq(commands[0].redirects.length(), 0)
+  assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+}
+
+///|
+test "parse cd then moon as separate top level commands" {
+  guard @shell_parse.parse_for_policy("cd pkg/foo && moon test --target native")
+    is Simple(commands) else {
+    fail("expected simple compound command")
+  }
+  assert_eq(commands.length(), 2)
+  assert_true(commands[0].argv == ["cd", "pkg/foo"])
+  assert_true(commands[1].argv == ["moon", "test", "--target", "native"])
+  assert_true(@shell_parse.has_cd(Simple(commands)))
+  assert_true(@shell_parse.has_cd_and_command(Simple(commands), "moon"))
+}
+
+///|
+test "parse quotes and backslash escapes without expansion" {
+  guard @shell_parse.parse_for_policy(
+      "moon run cmd/main -- \"a b\" 'c$d' escaped\\ space",
+    )
+    is Simple(commands) else {
+    fail("expected quoted command")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(
+    commands[0].argv ==
+    ["moon", "run", "cmd/main", "--", "a b", "c$d", "escaped space"],
+  )
+}
+
+///|
+test "parse environment assignments and redirects" {
+  guard @shell_parse.parse_for_policy(
+      "FOO=bar JSON=a=b moon run cmd/main > out.json 2>> err.log 2>&1",
+    )
+    is Simple(commands) else {
+    fail("expected command with env and redirects")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(
+    commands[0].env ==
+    [{ name: "FOO", value: "bar" }, { name: "JSON", value: "a=b" }],
+  )
+  assert_true(commands[0].argv == ["moon", "run", "cmd/main"])
+  assert_true(
+    commands[0].redirects ==
+    [
+      { op: ">", target: "out.json" },
+      { op: "2>>", target: "err.log" },
+      { op: "2>&", target: "1" },
+    ],
+  )
+}
+
+///|
+test "detect env wrapper command name" {
+  guard @shell_parse.parse_for_policy("env FOO=bar moon check")
+    is Simple(commands) else {
+    fail("expected env wrapper")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].command_name() == Some("moon"))
+  assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+}
+
+///|
+test "detect command wrapper but keep complex env options conservative" {
+  guard @shell_parse.parse_for_policy("command moon check") is Simple(commands) else {
+    fail("expected command wrapper")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].command_name() == Some("moon"))
+  assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+  guard @shell_parse.parse_for_policy("env -u FOO moon check")
+    is Simple(env_commands) else {
+    fail("expected env option wrapper to parse")
+  }
+  assert_true(env_commands[0].command_name() == Some("env"))
+  assert_true(!@shell_parse.contains_command(Simple(env_commands), "moon"))
+}
+
+///|
+test "parse safe quoted glob and escaped dollar as literals" {
+  guard @shell_parse.parse_for_policy(
+      "moon test \"*.mbt\" '${NOT_EXPANDED}' \"\\$literal\"",
+    )
+    is Simple(commands) else {
+    fail("expected quoted literals")
+  }
+  assert_true(
+    commands[0].argv == ["moon", "test", "*.mbt", "${NOT_EXPANDED}", "$literal"],
+  )
+}
+
+///|
+test "parse pipes and conditionals as visible top level commands" {
+  guard @shell_parse.parse_for_policy("moon check 2>&1 | tee out.log || true")
+    is Simple(commands) else {
+    fail("expected pipeline and conditional commands")
+  }
+  assert_eq(commands.length(), 3)
+  assert_true(commands[0].argv == ["moon", "check"])
+  assert_true(commands[0].redirects == [{ op: "2>&", target: "1" }])
+  assert_true(commands[1].argv == ["tee", "out.log"])
+  assert_true(commands[2].argv == ["true"])
+  assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+}
+
+///|
+test "return syntax errors for dangling operators and redirects" {
+  assert_true(@shell_parse.parse_for_policy("moon check &&") is SyntaxError(_))
+  assert_true(@shell_parse.parse_for_policy("moon check >") is SyntaxError(_))
+  assert_true(@shell_parse.parse_for_policy("&& moon check") is SyntaxError(_))
+  assert_true(
+    @shell_parse.parse_for_policy("moon 'unterminated") is SyntaxError(_),
+  )
+}
+
+///|
+test "return too complex for runtime expansion and shell structures" {
+  assert_true(
+    @shell_parse.parse_for_policy("cd \"$(pwd)\" && moon check")
+    is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("TOOL=moon; $TOOL check") is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("(cd pkg && moon check)") is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("for f in file; do moon check; done")
+    is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("for f in *.mbt; do moon check; done")
+    is TooComplex(_),
+  )
+  assert_true(@shell_parse.parse_for_policy("moon test *.mbt") is TooComplex(_))
+  assert_true(
+    @shell_parse.parse_for_policy("moon check <<EOF") is TooComplex(_),
+  )
+  assert_true(@shell_parse.parse_for_policy("moon \\\ncheck") is TooComplex(_))
+  assert_true(
+    @shell_parse.parse_for_policy("eval 'moon check'") is TooComplex(_),
+  )
+}
+
+///|
+test "allow trailing semicolon and blank input" {
+  guard @shell_parse.parse_for_policy("moon check;") is Simple(commands) else {
+    fail("expected trailing semicolon to be accepted")
+  }
+  assert_eq(commands.length(), 1)
+  guard @shell_parse.parse_for_policy("   \t ") is Simple(blank) else {
+    fail("expected blank command to parse")
+  }
+  assert_eq(blank.length(), 0)
+}

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -79,7 +79,7 @@ test "parse environment assignments and redirects" {
 
 ///|
 test "parse fd qualified input redirects" {
-  guard @shell_parse.parse_for_policy("cmd 0<input 2< err.log")
+  guard @shell_parse.parse_for_policy("cmd 0<input 2<err.log")
     is Simple(commands) else {
     fail("expected fd qualified input redirects")
   }
@@ -89,6 +89,39 @@ test "parse fd qualified input redirects" {
     commands[0].redirects ==
     [{ op: "0<", target: "input" }, { op: "2<", target: "err.log" }],
   )
+}
+
+///|
+test "preserve spaced numeric arguments before redirects" {
+  guard @shell_parse.parse_for_policy("cmd 2 < input 3 > out")
+    is Simple(commands) else {
+    fail("expected spaced numeric arguments and redirects")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].argv == ["cmd", "2", "3"])
+  assert_true(
+    commands[0].redirects ==
+    [{ op: "<", target: "input" }, { op: ">", target: "out" }],
+  )
+  guard @shell_parse.parse_for_policy("cmd 2>out 3>>err") is Simple(attached) else {
+    fail("expected attached fd redirects")
+  }
+  assert_true(attached[0].argv == ["cmd"])
+  assert_true(
+    attached[0].redirects ==
+    [{ op: "2>", target: "out" }, { op: "3>>", target: "err" }],
+  )
+}
+
+///|
+test "keep quoted words out of special shell grammar" {
+  guard @shell_parse.parse_for_policy("cmd \"2\"<input") is Simple(commands) else {
+    fail("expected quoted numeric argument")
+  }
+  assert_true(commands[0].argv == ["cmd", "2"])
+  assert_true(commands[0].redirects == [{ op: "<", target: "input" }])
+  assert_true(@shell_parse.parse_for_policy("A\"\"=x env") is TooComplex(_))
+  assert_true(@shell_parse.parse_for_policy("A\\=x env") is TooComplex(_))
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -20,11 +20,14 @@ test "parse cd then moon as separate top level commands" {
   assert_eq(commands.length(), 2)
   assert_true(commands[0].argv == ["cd", "pkg/foo"])
   assert_true(commands[1].argv == ["moon", "test", "--target", "native"])
-  assert_true(@shell_parse.has_cd(Simple(commands)))
-  assert_true(@shell_parse.has_cd_and_command(Simple(commands), "moon"))
+  assert_true(commands[0].separator_before is None)
+  assert_true(commands[1].separator_before is Some("&&"))
+  assert_true(commands[0].command_index() == Some(0))
+  assert_true(commands[1].command_index() == Some(0))
 }
 
 ///|
+#cfg(not(platform="windows"))
 test "parse quotes and backslash escapes without expansion" {
   guard @shell_parse.parse_for_policy(
       "moon run cmd/main -- \"a b\" 'c$d' escaped\\ space",
@@ -37,6 +40,16 @@ test "parse quotes and backslash escapes without expansion" {
     commands[0].argv ==
     ["moon", "run", "cmd/main", "--", "a b", "c$d", "escaped space"],
   )
+}
+
+///|
+#cfg(platform="windows")
+test "parse Windows path backslashes as literal characters" {
+  guard @shell_parse.parse_for_policy("moon -C .\\pkg fmt") is Simple(commands) else {
+    fail("expected Windows path command")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].argv == ["moon", "-C", ".\\pkg", "fmt"])
 }
 
 ///|
@@ -78,6 +91,7 @@ test "parse environment assignments and redirects" {
 }
 
 ///|
+#cfg(not(platform="windows"))
 test "parse quoted and escaped environment assignment values" {
   guard @shell_parse.parse_for_policy("FOO=\"bar baz\" PATH=\\~/bin moon check")
     is Simple(commands) else {
@@ -140,6 +154,20 @@ test "preserve spaced numeric arguments before redirects" {
 }
 
 ///|
+test "parse append both and fd duplicate redirects" {
+  guard @shell_parse.parse_for_policy("cmd &>>out <&3") is Simple(commands) else {
+    fail("expected append-both and fd duplicate redirects")
+  }
+  assert_eq(commands.length(), 1)
+  assert_true(commands[0].argv == ["cmd"])
+  assert_true(
+    commands[0].redirects ==
+    [{ op: "&>>", target: "out" }, { op: "<&", target: "3" }],
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
 test "keep quoted words out of special shell grammar" {
   guard @shell_parse.parse_for_policy("cmd \"2\"<input") is Simple(commands) else {
     fail("expected quoted numeric argument")
@@ -159,7 +187,40 @@ test "detect env wrapper command name" {
   }
   assert_eq(commands.length(), 1)
   assert_true(commands[0].command_name() == Some("moon"))
+  assert_true(commands[0].command_index() == Some(2))
   assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+  guard @shell_parse.parse_for_policy("env -- FOO=bar moon check")
+    is Simple(dash_dash_commands) else {
+    fail("expected env -- wrapper")
+  }
+  assert_true(dash_dash_commands[0].command_name() == Some("moon"))
+  assert_true(dash_dash_commands[0].command_index() == Some(3))
+  assert_true(@shell_parse.contains_command(Simple(dash_dash_commands), "moon"))
+}
+
+///|
+test "env options are only recognized before assignments" {
+  guard @shell_parse.parse_for_policy("env FOO=bar -i moon check")
+    is Simple(after_assignment) else {
+    fail("expected env command after assignment")
+  }
+  assert_true(after_assignment[0].command_name() == Some("-i"))
+  assert_true(after_assignment[0].command_index() == Some(2))
+  assert_true(!@shell_parse.contains_command(Simple(after_assignment), "moon"))
+  guard @shell_parse.parse_for_policy("env FOO=bar -- moon check")
+    is Simple(after_dash_dash) else {
+    fail("expected env command after assignment before dash dash")
+  }
+  assert_true(after_dash_dash[0].command_name() == Some("--"))
+  assert_true(after_dash_dash[0].command_index() == Some(2))
+  assert_true(!@shell_parse.contains_command(Simple(after_dash_dash), "moon"))
+  guard @shell_parse.parse_for_policy("env -i FOO=bar moon check")
+    is Simple(before_assignment) else {
+    fail("expected env option before assignment")
+  }
+  assert_true(before_assignment[0].command_name() == Some("moon"))
+  assert_true(before_assignment[0].command_index() == Some(3))
+  assert_true(@shell_parse.contains_command(Simple(before_assignment), "moon"))
 }
 
 ///|
@@ -169,16 +230,40 @@ test "detect command wrapper but keep complex env options conservative" {
   }
   assert_eq(commands.length(), 1)
   assert_true(commands[0].command_name() == Some("moon"))
+  assert_true(commands[0].command_index() == Some(1))
   assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
+  guard @shell_parse.parse_for_policy("command -- moon check")
+    is Simple(dash_dash_commands) else {
+    fail("expected command -- wrapper")
+  }
+  assert_true(dash_dash_commands[0].command_name() == Some("moon"))
+  assert_true(dash_dash_commands[0].command_index() == Some(2))
+  assert_true(@shell_parse.contains_command(Simple(dash_dash_commands), "moon"))
+  guard @shell_parse.parse_for_policy("command -p moon check")
+    is Simple(path_commands) else {
+    fail("expected command -p wrapper")
+  }
+  assert_true(path_commands[0].command_name() == Some("moon"))
+  assert_true(path_commands[0].command_index() == Some(2))
+  assert_true(@shell_parse.contains_command(Simple(path_commands), "moon"))
+  guard @shell_parse.parse_for_policy("command -v moon")
+    is Simple(lookup_commands) else {
+    fail("expected command -v lookup")
+  }
+  assert_true(lookup_commands[0].command_name() == Some("command"))
+  assert_true(lookup_commands[0].command_index() == Some(0))
+  assert_true(!@shell_parse.contains_command(Simple(lookup_commands), "moon"))
   guard @shell_parse.parse_for_policy("env -u FOO moon check")
     is Simple(env_commands) else {
     fail("expected env option wrapper to parse")
   }
   assert_true(env_commands[0].command_name() == Some("env"))
+  assert_true(env_commands[0].command_index() == Some(0))
   assert_true(!@shell_parse.contains_command(Simple(env_commands), "moon"))
 }
 
 ///|
+#cfg(not(platform="windows"))
 test "parse safe quoted glob and escaped dollar as literals" {
   guard @shell_parse.parse_for_policy(
       "moon test \"*.mbt\" '${NOT_EXPANDED}' \"\\$literal\"",
@@ -188,6 +273,37 @@ test "parse safe quoted glob and escaped dollar as literals" {
   }
   assert_true(
     commands[0].argv == ["moon", "test", "*.mbt", "${NOT_EXPANDED}", "$literal"],
+  )
+}
+
+///|
+test "parse shell comments without losing visible commands" {
+  guard @shell_parse.parse_for_policy("moon check # trailing note")
+    is Simple(one_line) else {
+    fail("expected trailing comment to be ignored")
+  }
+  assert_eq(one_line.length(), 1)
+  assert_true(one_line[0].argv == ["moon", "check"])
+  guard @shell_parse.parse_for_policy(
+      "moon check # first command\n# blank comment\nmoon test",
+    )
+    is Simple(multi_line) else {
+    fail("expected comments to preserve newline command separation")
+  }
+  assert_eq(multi_line.length(), 2)
+  assert_true(multi_line[0].argv == ["moon", "check"])
+  assert_true(multi_line[1].argv == ["moon", "test"])
+  assert_true(multi_line[1].separator_before is Some(";"))
+  guard @shell_parse.parse_for_policy("echo a#b # trailing note")
+    is Simple(literal_hash) else {
+    fail("expected hash inside word to remain literal")
+  }
+  assert_true(literal_hash[0].argv == ["echo", "a#b"])
+  assert_true(
+    @shell_parse.parse_for_policy("moon check && # note") is SyntaxError(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("printf x > # note") is SyntaxError(_),
   )
 }
 
@@ -202,6 +318,9 @@ test "parse pipes and conditionals as visible top level commands" {
   assert_true(commands[0].redirects == [{ op: "2>&", target: "1" }])
   assert_true(commands[1].argv == ["tee", "out.log"])
   assert_true(commands[2].argv == ["true"])
+  assert_true(commands[0].separator_before is None)
+  assert_true(commands[1].separator_before is Some("|"))
+  assert_true(commands[2].separator_before is Some("||"))
   assert_true(@shell_parse.contains_command(Simple(commands), "moon"))
 }
 
@@ -216,6 +335,7 @@ test "return syntax errors for dangling operators and redirects" {
 }
 
 ///|
+#cfg(not(platform="windows"))
 test "return too complex for runtime expansion and shell structures" {
   assert_true(
     @shell_parse.parse_for_policy("cd \"$(pwd)\" && moon check")
@@ -242,6 +362,19 @@ test "return too complex for runtime expansion and shell structures" {
   assert_true(@shell_parse.parse_for_policy("moon \\\ncheck") is TooComplex(_))
   assert_true(
     @shell_parse.parse_for_policy("eval 'moon check'") is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("exit 0; moon fmt") is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("command exit 0; moon fmt") is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("command -p exit 0; moon fmt")
+    is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("command -v exit; moon fmt") is Simple(_),
   )
   assert_true(@shell_parse.parse_for_policy("HOME=~ cmd") is TooComplex(_))
   assert_true(

--- a/agent_tool/shell/internal/shell_parse/types.mbt
+++ b/agent_tool/shell/internal/shell_parse/types.mbt
@@ -17,12 +17,15 @@ pub(all) enum ParseResult {
 /// `argv` contains the command name and arguments after shell quoting and
 /// backslash escaping are resolved. `env` contains leading `NAME=value`
 /// assignments that apply to this command. `redirects` contains basic
-/// redirections attached to the command. `source` is a compact normalized
-/// rendering for diagnostics; it is not guaranteed to byte-match the input.
+/// redirections attached to the command. `separator_before` records the
+/// top-level operator before this command (`&&`, `||`, `;`, or `|`), if any.
+/// `source` is a compact normalized rendering for diagnostics; it is not
+/// guaranteed to byte-match the input.
 pub(all) struct SimpleCommand {
   argv : Array[String]
   env : Array[EnvAssignment]
   redirects : Array[Redirect]
+  separator_before : String?
   source : String
 } derive(Debug, Eq)
 
@@ -69,4 +72,5 @@ priv enum LexState {
   Plain
   SingleQuoted
   DoubleQuoted
+  Comment
 }

--- a/agent_tool/shell/internal/shell_parse/types.mbt
+++ b/agent_tool/shell/internal/shell_parse/types.mbt
@@ -46,8 +46,15 @@ pub(all) struct Redirect {
 ///|
 /// Internal lexer token used by the shell policy parser.
 priv enum Token {
-  Word(String, Bool)
+  Word(String, WordMeta)
   Op(String, Bool)
+}
+
+///|
+priv struct WordMeta {
+  has_quote_or_escape : Bool
+  quote_or_escape_before_equals : Bool
+  has_assignment_tilde_expansion : Bool
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/types.mbt
+++ b/agent_tool/shell/internal/shell_parse/types.mbt
@@ -46,8 +46,8 @@ pub(all) struct Redirect {
 ///|
 /// Internal lexer token used by the shell policy parser.
 priv enum Token {
-  Word(String)
-  Op(String)
+  Word(String, Bool)
+  Op(String, Bool)
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/types.mbt
+++ b/agent_tool/shell/internal/shell_parse/types.mbt
@@ -1,0 +1,65 @@
+///|
+/// Result of conservatively analyzing one shell command string.
+///
+/// `Simple` means the parser produced a trustworthy flat list of top-level
+/// simple commands. `TooComplex` means the command uses shell behavior whose
+/// runtime argv cannot be known statically. `SyntaxError` means the command is
+/// malformed even within the supported subset.
+pub(all) enum ParseResult {
+  Simple(Array[SimpleCommand])
+  TooComplex(String)
+  SyntaxError(String)
+} derive(Debug, Eq)
+
+///|
+/// One statically analyzable shell simple command.
+///
+/// `argv` contains the command name and arguments after shell quoting and
+/// backslash escaping are resolved. `env` contains leading `NAME=value`
+/// assignments that apply to this command. `redirects` contains basic
+/// redirections attached to the command. `source` is a compact normalized
+/// rendering for diagnostics; it is not guaranteed to byte-match the input.
+pub(all) struct SimpleCommand {
+  argv : Array[String]
+  env : Array[EnvAssignment]
+  redirects : Array[Redirect]
+  source : String
+} derive(Debug, Eq)
+
+///|
+/// Leading environment assignment such as `FOO=bar` before a command word.
+pub(all) struct EnvAssignment {
+  name : String
+  value : String
+} derive(Debug, Eq)
+
+///|
+/// Basic shell redirection parsed from a simple command.
+///
+/// The parser only returns `Simple` for redirections whose target is a static
+/// word. Unsupported redirection forms are classified as `TooComplex`.
+pub(all) struct Redirect {
+  op : String
+  target : String
+} derive(Debug, Eq)
+
+///|
+/// Internal lexer token used by the shell policy parser.
+priv enum Token {
+  Word(String)
+  Op(String)
+}
+
+///|
+priv enum LexResult {
+  LexOk(Array[Token])
+  LexTooComplex(String)
+  LexSyntaxError(String)
+}
+
+///|
+priv enum LexState {
+  Plain
+  SingleQuoted
+  DoubleQuoted
+}

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -3,17 +3,18 @@ import {
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/shell/internal/command_policy",
   "bobzhang/openseek/agent_tool/shell/internal/decode",
+  "bobzhang/openseek/agent_tool/shell/internal/shell_parse",
   "bobzhang/openseek/internal/workspace_path",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
+  "moonbitlang/x/path",
 }
 
 import {
   "bobzhang/openseek/testkit/filesystem" @vfs,
-  "moonbitlang/x/path",
 } for "test"
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -221,6 +221,9 @@ fn cwd_command_effect(
   base_cwd : String,
 ) -> CwdCommandEffect {
   let argv = command.argv
+  if argv.length() > 0 && argv[0] == "env" {
+    return NotCwdCommand
+  }
   match command.command_index() {
     Some(command_index) if command_index < argv.length() =>
       match argv[command_index] {
@@ -329,12 +332,19 @@ fn parse_moon_invocation(
         cwd = resolve_command_cwd(cwd, argv[index + 1])
         index += 2
       }
+      option if moon_attached_cwd_option(option) is Some(target) => {
+        cwd = resolve_command_cwd(cwd, target)
+        index += 1
+      }
       "--target-dir" | "-Z" | "--unstable-feature" => {
         if index + 1 >= argv.length() {
           return None
         }
         index += 2
       }
+      option if moon_attached_value_option(option, "--target-dir") ||
+        moon_attached_value_option(option, "-Z") ||
+        moon_attached_value_option(option, "--unstable-feature") => index += 1
       "--dry-run" => {
         dry_run = true
         index += 1
@@ -346,6 +356,41 @@ fn parse_moon_invocation(
     }
   }
   None
+}
+
+///|
+fn moon_attached_cwd_option(option : String) -> String? {
+  if option.has_prefix("-C=") {
+    option_value_after_prefix(option, "-C=")
+  } else {
+    option_value_after_prefix(option, "-C")
+  }
+}
+
+///|
+fn moon_attached_value_option(option : String, name : String) -> Bool {
+  if name.has_prefix("--") {
+    option_value_after_prefix(option, name + "=") is Some(_)
+  } else if option.has_prefix(name + "=") {
+    option_value_after_prefix(option, name + "=") is Some(_)
+  } else {
+    option_value_after_prefix(option, name) is Some(_)
+  }
+}
+
+///|
+fn option_value_after_prefix(option : String, prefix : String) -> String? {
+  match option.strip_prefix(prefix) {
+    Some(value) => {
+      let value = value.to_owned()
+      if value == "" {
+        None
+      } else {
+        Some(value)
+      }
+    }
+    None => None
+  }
 }
 
 ///|
@@ -478,7 +523,12 @@ test "detect moon commands that should trigger follow-up check" {
   assert_true(should_auto_check_moon_command("moon fmt # trailing note"))
   assert_true(should_auto_check_moon_command("moon info"))
   assert_true(should_auto_check_moon_command("moon -C pkg fmt"))
+  assert_true(should_auto_check_moon_command("moon -Cpkg fmt"))
+  assert_true(should_auto_check_moon_command("moon -C=pkg fmt"))
   assert_true(should_auto_check_moon_command("moon -q -C pkg info"))
+  assert_true(
+    should_auto_check_moon_command("moon --target-dir=/tmp/build fmt"),
+  )
   assert_true(
     should_auto_check_moon_command(
       "moon ide rename old_name new_name --loc main.mbt:1:8 --apply",
@@ -585,12 +635,27 @@ test "detect moon command check cwd from -C option" {
     is Some("/repo/pkg"),
   )
   assert_true(
+    moon_auto_check_start_cwd("moon -Cpkg fmt", Some("/repo"))
+    is Some("/repo/pkg"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("moon -C=pkg fmt", Some("/repo"))
+    is Some("/repo/pkg"),
+  )
+  assert_true(
     moon_auto_check_start_cwd("moon -C ../other info", Some("/repo/pkg"))
     is Some("/repo/other"),
   )
   assert_true(
     moon_auto_check_start_cwd("moon -C /tmp/mod fmt", Some("/repo"))
     is Some("/tmp/mod"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "moon --target-dir=/tmp/moonbuild fmt",
+      Some("/repo"),
+    )
+    is Some("/repo"),
   )
   assert_true(
     moon_auto_check_start_cwd("cd project && moon fmt", Some("/repo")) is None,
@@ -602,6 +667,14 @@ test "detect moon command check cwd from -C option" {
   assert_true(
     moon_auto_check_start_cwd("cd ./project &&\nmoon fmt", Some("/repo"))
     is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("env cd ./project && moon fmt", Some("/repo"))
+    is Some("/repo"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("env -i cd ./project && moon fmt", Some("/repo"))
+    is Some("/repo"),
   )
   assert_true(
     moon_auto_check_start_cwd("cd -- project && moon fmt", Some("/repo"))

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -575,6 +575,7 @@ test "do not trigger follow-up check for read-only moon commands or data" {
 }
 
 ///|
+#cfg(not(platform="windows"))
 test "detect moon command check cwd from -C option" {
   assert_true(
     moon_auto_check_start_cwd("moon fmt", Some("/repo")) is Some("/repo"),

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -1,0 +1,700 @@
+///|
+const MoonCheckTimeoutMs : Int = 30000
+
+///|
+const MoonCheckMaxOutputChars : Int = 12000
+
+///|
+const MoonCheckCommand : String = "moon check --diagnostic-limit 1"
+
+///|
+async fn append_moon_command_check_summary(
+  parsed : @shell_parse.ParseResult,
+  cwd : String?,
+  content : String,
+  output : ShellOutput,
+  timeout_ms : Int?,
+  max_output_chars : Int,
+) -> String {
+  if output.exit_code != Some(0) || output.output_limit_reached {
+    return content
+  }
+  if timeout_ms is Some(_) {
+    return content
+  }
+  let check_max_output_chars = moon_check_output_budget(
+    content, max_output_chars,
+  )
+  if check_max_output_chars <= 0 {
+    return content
+  }
+  let check_start = match moon_auto_check_start_cwd_for_parse(parsed, cwd) {
+    Some(check_start) => check_start
+    None => return content
+  }
+  let summary = moon_check_summary_for_cwd(check_start, check_max_output_chars) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+  match summary {
+    Some(summary) => "\{content}\n\{summary}"
+    None => content
+  }
+}
+
+///|
+fn moon_check_output_budget(content : String, max_output_chars : Int) -> Int {
+  let remaining = max_output_chars - content.char_length() - 1
+  if remaining <= 0 {
+    0
+  } else if remaining < MoonCheckMaxOutputChars {
+    remaining
+  } else {
+    MoonCheckMaxOutputChars
+  }
+}
+
+///|
+async fn moon_check_summary_for_cwd(
+  cwd : String,
+  max_output_chars : Int,
+) -> String? {
+  let check_cwd = match nearest_moon_module_dir(cwd) {
+    Some(check_cwd) => check_cwd
+    None => return None
+  }
+  let result = @async.with_timeout_opt(MoonCheckTimeoutMs, () => {
+    collect_shell_output(MoonCheckCommand, cwd=check_cwd, max_output_chars~)
+  }) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return Some("moon check: failed to run")
+  }
+  match result {
+    Some(output) => Some(format_moon_check_output(output))
+    None => Some("moon check: timed out")
+  }
+}
+
+///|
+fn format_moon_check_output(output : ShellOutput) -> String {
+  let header = match output.exit_code {
+    Some(0) => "moon check:"
+    Some(code) => "moon check:\nexit=\{code}"
+    None => "moon check:\nexit=cancelled"
+  }
+  let header = if output.output_limit_reached {
+    "\{header}\noutput_limit_reached=true"
+  } else {
+    header
+  }
+  if output.text == "" {
+    header
+  } else {
+    "\{header}\n\{output.text}"
+  }
+}
+
+///|
+fn should_auto_check_moon_command(cmd : String) -> Bool {
+  moon_auto_check_start_cwd(cmd, None) is Some(_)
+}
+
+///|
+fn moon_auto_check_start_cwd(cmd : String, cwd : String?) -> String? {
+  moon_auto_check_start_cwd_for_parse(@shell_parse.parse_for_policy(cmd), cwd)
+}
+
+///|
+fn moon_auto_check_start_cwd_for_parse(
+  parsed : @shell_parse.ParseResult,
+  cwd : String?,
+) -> String? {
+  let base_cwd = cwd.unwrap_or(".")
+  match parsed {
+    Simple(commands) => {
+      if has_unsafe_command_separator(commands) {
+        return None
+      }
+      let mut current_cwd : String? = Some(base_cwd)
+      let mut cwd_depends_on_cd = false
+      for index, command in commands {
+        match command.separator_before {
+          None | Some(";") =>
+            if cwd_depends_on_cd {
+              current_cwd = None
+              cwd_depends_on_cd = false
+            }
+          Some("&&") => ()
+          _ => return None
+        }
+        match current_cwd {
+          Some(cwd) => {
+            if command_may_mutate_shell_environment(command) {
+              current_cwd = None
+              cwd_depends_on_cd = false
+              continue
+            }
+            match cwd_command_effect(command, cwd) {
+              KnownCwd(next_cwd) => {
+                if next_command_is_guarded_by_and(commands, index) {
+                  current_cwd = Some(next_cwd)
+                  cwd_depends_on_cd = true
+                } else {
+                  current_cwd = None
+                  cwd_depends_on_cd = false
+                }
+                continue
+              }
+              UnknownCwd => {
+                current_cwd = None
+                cwd_depends_on_cd = false
+                continue
+              }
+              NotCwdCommand => ()
+            }
+            if index + 1 == commands.length() {
+              match auto_check_cwd_for_moon_command(command, cwd) {
+                Some(cwd) => return Some(cwd)
+                None => ()
+              }
+            }
+          }
+          None => ()
+        }
+      }
+      None
+    }
+    _ => None
+  }
+}
+
+///|
+fn command_may_mutate_shell_environment(
+  command : @shell_parse.SimpleCommand,
+) -> Bool {
+  if command.argv.length() == 0 {
+    return command.env.length() > 0
+  }
+  match command.command_index() {
+    Some(command_index) if command_index < command.argv.length() =>
+      shell_environment_builtin(command.argv[command_index])
+    _ => false
+  }
+}
+
+///|
+fn shell_environment_builtin(command_name : String) -> Bool {
+  match command_name {
+    "export" | "readonly" | "set" | "unset" | "typeset" | "declare" | "local" =>
+      true
+    _ => false
+  }
+}
+
+///|
+fn has_unsafe_command_separator(
+  commands : Array[@shell_parse.SimpleCommand],
+) -> Bool {
+  commands.any(command => command.separator_before is Some("|" | "||"))
+}
+
+///|
+fn next_command_is_guarded_by_and(
+  commands : Array[@shell_parse.SimpleCommand],
+  index : Int,
+) -> Bool {
+  index + 1 < commands.length() &&
+  commands[index + 1].separator_before == Some("&&")
+}
+
+///|
+priv enum CwdCommandEffect {
+  NotCwdCommand
+  KnownCwd(String)
+  UnknownCwd
+}
+
+///|
+fn cwd_command_effect(
+  command : @shell_parse.SimpleCommand,
+  base_cwd : String,
+) -> CwdCommandEffect {
+  let argv = command.argv
+  match command.command_index() {
+    Some(command_index) if command_index < argv.length() =>
+      match argv[command_index] {
+        "cd" =>
+          if command.env.length() > 0 {
+            UnknownCwd
+          } else {
+            cd_command_effect(argv, command_index + 1, base_cwd)
+          }
+        "pushd" | "popd" => UnknownCwd
+        _ => NotCwdCommand
+      }
+    _ => NotCwdCommand
+  }
+}
+
+///|
+fn cd_command_effect(
+  argv : Array[String],
+  arg_start : Int,
+  base_cwd : String,
+) -> CwdCommandEffect {
+  let remaining = argv.length() - arg_start
+  if remaining == 1 {
+    let target = argv[arg_start]
+    if target == "--" || target.has_prefix("-") {
+      UnknownCwd
+    } else if cd_target_resolves_from_base(target) {
+      KnownCwd(resolve_command_cwd(base_cwd, target))
+    } else {
+      UnknownCwd
+    }
+  } else if remaining == 2 && argv[arg_start] == "--" {
+    let target = argv[arg_start + 1]
+    if cd_target_resolves_from_base(target) {
+      KnownCwd(resolve_command_cwd(base_cwd, target))
+    } else {
+      UnknownCwd
+    }
+  } else {
+    UnknownCwd
+  }
+}
+
+///|
+fn cd_target_resolves_from_base(target : String) -> Bool {
+  let target_path : @path.Path = target
+  let normalized = target.replace_all(old="\\", new="/")
+  target_path.is_absolute() ||
+  normalized == "." ||
+  normalized == ".." ||
+  normalized.has_prefix("./") ||
+  normalized.has_prefix("../")
+}
+
+///|
+fn auto_check_cwd_for_moon_command(
+  command : @shell_parse.SimpleCommand,
+  base_cwd : String,
+) -> String? {
+  if command_has_custom_environment(command) {
+    return None
+  }
+  match moon_command_start(command) {
+    Some(index) =>
+      match parse_moon_invocation(command.argv, index, base_cwd) {
+        Some(invocation) if !invocation.dry_run &&
+          is_auto_check_moon_subcommand(
+            command.argv,
+            invocation.subcommand_index,
+          ) => Some(invocation.cwd)
+        _ => None
+      }
+    _ => None
+  }
+}
+
+///|
+fn command_has_custom_environment(command : @shell_parse.SimpleCommand) -> Bool {
+  command.env.length() > 0 ||
+  (command.argv.length() > 0 && command.argv[0] == "env")
+}
+
+///|
+priv struct MoonInvocation {
+  subcommand_index : Int
+  cwd : String
+  dry_run : Bool
+}
+
+///|
+fn parse_moon_invocation(
+  argv : Array[String],
+  moon_index : Int,
+  base_cwd : String,
+) -> MoonInvocation? {
+  let mut index = moon_index + 1
+  let mut cwd = base_cwd
+  let mut dry_run = false
+  while index < argv.length() {
+    match argv[index] {
+      "-C" => {
+        if index + 1 >= argv.length() {
+          return None
+        }
+        cwd = resolve_command_cwd(cwd, argv[index + 1])
+        index += 2
+      }
+      "--target-dir" | "-Z" | "--unstable-feature" => {
+        if index + 1 >= argv.length() {
+          return None
+        }
+        index += 2
+      }
+      "--dry-run" => {
+        dry_run = true
+        index += 1
+      }
+      "-q" | "--quiet" | "-v" | "--verbose" | "--trace" => index += 1
+      "-V" | "--version" | "-h" | "--help" => return None
+      option if option.has_prefix("-") => return None
+      _ => return Some({ subcommand_index: index, cwd, dry_run })
+    }
+  }
+  None
+}
+
+///|
+fn is_auto_check_moon_subcommand(
+  argv : Array[String],
+  subcommand_index : Int,
+) -> Bool {
+  if argv_contains_flag(argv, subcommand_index + 1, "--dry-run") {
+    return false
+  }
+  if argv_contains_help_flag(argv, subcommand_index + 1) {
+    return false
+  }
+  match argv[subcommand_index] {
+    "add" | "remove" | "update" | "info" => true
+    "fmt" =>
+      !argv_contains_flag(argv, subcommand_index + 1, "--check") &&
+      !argv_contains_flag(argv, subcommand_index + 1, "--warn")
+    "ide" =>
+      subcommand_index + 1 < argv.length() &&
+      argv[subcommand_index + 1] == "rename" &&
+      argv_contains_flag(argv, subcommand_index + 2, "--apply")
+    "test" => argv_contains_update_flag(argv, subcommand_index + 1)
+    _ => false
+  }
+}
+
+///|
+fn argv_contains_update_flag(argv : Array[String], start : Int) -> Bool {
+  argv_contains_flag(argv, start, "--update") ||
+  argv_contains_flag(argv, start, "-u")
+}
+
+///|
+fn argv_contains_help_flag(argv : Array[String], start : Int) -> Bool {
+  argv_contains_flag(argv, start, "--help") ||
+  argv_contains_flag(argv, start, "-h")
+}
+
+///|
+fn argv_contains_flag(argv : Array[String], start : Int, flag : String) -> Bool {
+  for index in start..<argv.length() {
+    if argv[index] == flag {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn moon_command_start(command : @shell_parse.SimpleCommand) -> Int? {
+  match command.command_index() {
+    Some(index) if index < command.argv.length() &&
+      command.argv[index] == "moon" => Some(index)
+    _ => None
+  }
+}
+
+///|
+fn resolve_command_cwd(base : String, target : String) -> String {
+  let target_path : @path.Path = target
+  if target_path.is_absolute() {
+    target_path.normalize().to_string()
+  } else {
+    let base_path : @path.Path = base
+    base_path.join(target_path).normalize().to_string()
+  }
+}
+
+///|
+async fn nearest_moon_module_dir(start : String) -> String? {
+  for dir = start {
+    if @fs.exists(join_path(dir, "moon.mod")) {
+      return Some(dir)
+    }
+    match parent_dir(dir) {
+      Some(parent) => continue parent
+      None => return None
+    }
+  }
+}
+
+///|
+fn parent_dir(dir : String) -> String? {
+  let normalized = strip_trailing_slash(dir.replace_all(old="\\", new="/"))
+  if normalized == "" ||
+    normalized == "." ||
+    normalized == "/" ||
+    is_windows_drive_root(normalized) {
+    return None
+  }
+  match normalized.rev_find("/") {
+    Some(0) => Some("/")
+    Some(cut) => Some(normalized[:cut].to_owned())
+    None => Some(".")
+  }
+}
+
+///|
+fn is_windows_drive_root(path : String) -> Bool {
+  path.length() == 2 && path[1] == ':'
+}
+
+///|
+fn strip_trailing_slash(path : String) -> String {
+  if path.length() > 1 && path.has_suffix("/") {
+    strip_trailing_slash(path[:path.length() - 1].to_owned())
+  } else {
+    path
+  }
+}
+
+///|
+fn join_path(dir : String, base : String) -> String {
+  if dir == "" || dir == "." {
+    base
+  } else if dir.has_suffix("/") {
+    "\{dir}\{base}"
+  } else {
+    "\{dir}/\{base}"
+  }
+}
+
+///|
+test "detect moon commands that should trigger follow-up check" {
+  assert_true(should_auto_check_moon_command("moon add moonbitlang/async"))
+  assert_true(should_auto_check_moon_command("moon remove moonbitlang/async"))
+  assert_true(should_auto_check_moon_command("moon update"))
+  assert_true(should_auto_check_moon_command("moon fmt"))
+  assert_true(should_auto_check_moon_command("moon fmt # trailing note"))
+  assert_true(should_auto_check_moon_command("moon info"))
+  assert_true(should_auto_check_moon_command("moon -C pkg fmt"))
+  assert_true(should_auto_check_moon_command("moon -q -C pkg info"))
+  assert_true(
+    should_auto_check_moon_command(
+      "moon ide rename old_name new_name --loc main.mbt:1:8 --apply",
+    ),
+  )
+  assert_true(should_auto_check_moon_command("moon test --update"))
+  assert_true(should_auto_check_moon_command("command moon fmt"))
+  assert_true(should_auto_check_moon_command("command -- moon fmt"))
+  assert_true(should_auto_check_moon_command("command -p moon fmt"))
+  assert_true(should_auto_check_moon_command("cd ./pkg && moon fmt"))
+  assert_true(
+    should_auto_check_moon_command("cd ./pkg && moon fmt # trailing note"),
+  )
+}
+
+///|
+test "bound follow-up check output by remaining shell output budget" {
+  assert_eq(moon_check_output_budget("exit=0\nabc", 10), 0)
+  assert_eq(
+    moon_check_output_budget("exit=0\n", 20000),
+    MoonCheckMaxOutputChars,
+  )
+  assert_eq(moon_check_output_budget("exit=0\nabcdef", 20), 6)
+}
+
+///|
+test "do not trigger follow-up check for read-only moon commands or data" {
+  assert_false(should_auto_check_moon_command("moon check"))
+  assert_false(should_auto_check_moon_command("moon test"))
+  assert_false(should_auto_check_moon_command("moon --dry-run fmt"))
+  assert_false(should_auto_check_moon_command("moon fmt --check"))
+  assert_false(should_auto_check_moon_command("moon fmt --dry-run"))
+  assert_false(should_auto_check_moon_command("moon fmt --help"))
+  assert_false(should_auto_check_moon_command("moon add pkg -h"))
+  assert_false(should_auto_check_moon_command("moon add pkg --dry-run"))
+  assert_false(should_auto_check_moon_command("moon test --update --dry-run"))
+  assert_false(should_auto_check_moon_command("moon test --update --help"))
+  assert_false(should_auto_check_moon_command("moon ide doc String"))
+  assert_false(
+    should_auto_check_moon_command(
+      "moon ide rename old_name new_name --loc main.mbt:1:8",
+    ),
+  )
+  assert_false(
+    should_auto_check_moon_command(
+      "moon ide rename old_name new_name --loc main.mbt:1:8 --apply --help",
+    ),
+  )
+  assert_false(should_auto_check_moon_command("FOO=bar moon fmt"))
+  assert_false(should_auto_check_moon_command("env FOO=bar moon add pkg"))
+  assert_false(should_auto_check_moon_command("env -i moon fmt"))
+  assert_false(should_auto_check_moon_command("command -v moon"))
+  assert_false(should_auto_check_moon_command("echo moon add"))
+  assert_false(should_auto_check_moon_command("MOON=moon add pkg"))
+  assert_false(should_auto_check_moon_command("env -u FOO moon add pkg"))
+  assert_false(should_auto_check_moon_command("moon $SUBCOMMAND"))
+  assert_false(should_auto_check_moon_command("true || moon fmt"))
+  assert_false(should_auto_check_moon_command("false && cd other; moon fmt"))
+  assert_false(should_auto_check_moon_command("cd pkg && moon fmt"))
+  assert_false(should_auto_check_moon_command("cd pkg | moon fmt"))
+  assert_false(should_auto_check_moon_command("cd pkg; moon fmt"))
+  assert_false(
+    should_auto_check_moon_command("cd missing; cd project && moon fmt"),
+  )
+  assert_false(should_auto_check_moon_command("false && moon fmt; true"))
+  assert_false(should_auto_check_moon_command("moon fmt --badflag; true"))
+  assert_false(should_auto_check_moon_command("moon fmt && true"))
+  assert_false(should_auto_check_moon_command("exit 0; moon fmt"))
+  assert_false(should_auto_check_moon_command("exit 0 && moon fmt"))
+  assert_false(should_auto_check_moon_command("command exit 0; moon fmt"))
+  assert_false(should_auto_check_moon_command("command -p exit 0; moon fmt"))
+  assert_false(
+    should_auto_check_moon_command("export MOON_HOME=/tmp/custom; moon fmt"),
+  )
+  assert_false(should_auto_check_moon_command("set -a; FOO=bar; moon fmt"))
+  assert_false(should_auto_check_moon_command("PATH=/tmp; moon fmt"))
+  assert_false(
+    should_auto_check_moon_command("command export FOO=bar; moon fmt"),
+  )
+  assert_false(
+    should_auto_check_moon_command("builtin export FOO=bar; moon fmt"),
+  )
+  assert_false(
+    should_auto_check_moon_command("CDPATH=/tmp cd ./project && moon fmt"),
+  )
+  assert_false(
+    should_auto_check_moon_command("FOO=bar cd ./project && moon fmt"),
+  )
+}
+
+///|
+test "detect moon command check cwd from -C option" {
+  assert_true(
+    moon_auto_check_start_cwd("moon fmt", Some("/repo")) is Some("/repo"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("moon -C pkg fmt", Some("/repo"))
+    is Some("/repo/pkg"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("moon -C ../other info", Some("/repo/pkg"))
+    is Some("/repo/other"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("moon -C /tmp/mod fmt", Some("/repo"))
+    is Some("/tmp/mod"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd project && moon fmt", Some("/repo")) is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd ./project && moon fmt", Some("/repo"))
+    is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd -- project && moon fmt", Some("/repo"))
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd -- ./project && moon fmt", Some("/repo"))
+    is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("command cd project && moon fmt", Some("/repo"))
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("command cd ./project && moon fmt", Some("/repo"))
+    is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "command -- cd project && moon fmt",
+      Some("/repo"),
+    )
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "command -- cd ./project && moon fmt",
+      Some("/repo"),
+    )
+    is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("builtin cd project && moon fmt", Some("/repo"))
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("builtin cd ./project && moon fmt", Some("/repo"))
+    is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd && moon fmt", Some("/repo")) is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd - && moon fmt", Some("/repo")) is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd -P project && moon fmt", Some("/repo"))
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("pushd project && moon fmt", Some("/repo"))
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "cd project && moon -C nested info",
+      Some("/repo"),
+    )
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "cd ./project && moon -C nested info",
+      Some("/repo"),
+    )
+    is Some("/repo/project/nested"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "moon check && cd project && moon fmt",
+      Some("/repo"),
+    )
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "moon check && cd ./project && moon fmt",
+      Some("/repo"),
+    )
+    is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "moon check && cd project; moon fmt",
+      Some("/repo"),
+    )
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd(
+      "cd missing; cd project && moon fmt",
+      Some("/repo"),
+    )
+    is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("moon check; moon fmt", Some("/repo"))
+    is Some("/repo"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("moon fmt; true", Some("/repo")) is None,
+  )
+  assert_true(
+    moon_auto_check_start_cwd("echo ok; moon fmt", Some("/repo"))
+    is Some("/repo"),
+  )
+}

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -187,6 +187,7 @@ fn shell_environment_builtin(command_name : String) -> Bool {
   match command_name {
     "export" | "readonly" | "set" | "unset" | "typeset" | "declare" | "local" =>
       true
+    "alias" | "unalias" | "hash" => true
     _ => false
   }
 }
@@ -488,6 +489,7 @@ test "detect moon commands that should trigger follow-up check" {
   assert_true(should_auto_check_moon_command("command -- moon fmt"))
   assert_true(should_auto_check_moon_command("command -p moon fmt"))
   assert_true(should_auto_check_moon_command("cd ./pkg && moon fmt"))
+  assert_true(should_auto_check_moon_command("cd ./pkg &&\nmoon fmt"))
   assert_true(
     should_auto_check_moon_command("cd ./pkg && moon fmt # trailing note"),
   )
@@ -555,6 +557,10 @@ test "do not trigger follow-up check for read-only moon commands or data" {
   assert_false(should_auto_check_moon_command("set -a; FOO=bar; moon fmt"))
   assert_false(should_auto_check_moon_command("PATH=/tmp; moon fmt"))
   assert_false(
+    should_auto_check_moon_command("alias moon='echo fake'\nmoon fmt"),
+  )
+  assert_false(should_auto_check_moon_command("hash -r\nmoon fmt"))
+  assert_false(
     should_auto_check_moon_command("command export FOO=bar; moon fmt"),
   )
   assert_false(
@@ -590,6 +596,10 @@ test "detect moon command check cwd from -C option" {
   )
   assert_true(
     moon_auto_check_start_cwd("cd ./project && moon fmt", Some("/repo"))
+    is Some("/repo/project"),
+  )
+  assert_true(
+    moon_auto_check_start_cwd("cd ./project &&\nmoon fmt", Some("/repo"))
     is Some("/repo/project"),
   )
   assert_true(

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -71,13 +71,18 @@ async fn execute_with_workspace(
       )
     }
   }
-  match @command_policy.moonbit_command_policy_error(input.cmd) {
+  let parsed_command = @shell_parse.parse_for_policy(input.cmd)
+  match
+    @command_policy.moonbit_command_policy_error_for_parse(
+      input.cmd,
+      parsed_command,
+    ) {
     Some(message) =>
       return @agent_tool.ToolAction::respond(message, is_error=true)
     None => ()
   }
   let cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
-  shell(input, cwd) catch {
+  shell(input, parsed_command, cwd) catch {
     error =>
       @agent_tool.ToolAction::respond(
         "error running shell: \{error}",
@@ -89,6 +94,7 @@ async fn execute_with_workspace(
 ///|
 async fn shell(
   input : @decode.ShellInput,
+  parsed_command : @shell_parse.ParseResult,
   cwd : String?,
 ) -> @agent_tool.ToolAction {
   if cwd is Some(cwd) {
@@ -139,8 +145,16 @@ async fn shell(
     }
   }
   let response = shell_response(output, input.max_output_chars)
-  @agent_tool.ToolAction::respond(
+  let content = append_moon_command_check_summary(
+    parsed_command,
+    cwd,
     response.content,
+    output,
+    input.timeout_ms,
+    input.max_output_chars,
+  )
+  @agent_tool.ToolAction::respond(
+    content,
     is_error=response.is_error,
     brief=shell_brief(input.cmd, output.exit_code),
   )

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -494,7 +494,10 @@ async test "shell appends moon check from moon command target cwd" {
       ),
       create_mode=CreateOrTruncate,
     )
-    for cmd in ["moon -C project fmt", "cd ./project && moon fmt"] {
+    for
+      cmd in [
+        "moon -C project fmt", "moon -Cproject fmt", "moon -C=project fmt", "cd ./project && moon fmt",
+      ] {
       let result = run_shell({ "cmd": cmd, "cwd": dir })
       guard result is Respond(output) else { fail("expected Respond") }
       assert_false(output.is_error)

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -398,6 +398,114 @@ async test "shell rejects moon_cmd as a shell command" {
 }
 
 ///|
+#cfg(not(platform="windows"))
+async test "shell appends moon check after applied moon ide rename" {
+  @vfs.with_tmpdir(prefix="openseek-shell-auto-check-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/shell_auto_check\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/moon.pkg",
+      "warnings = \"+unnecessary_annotation\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      (
+        #|pub fn old_name() -> Int { missing_symbol }
+        #|
+        #|pub fn call() -> Int { old_name() }
+        #|
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell({
+      "cmd": "moon ide rename old_name new_name --loc main.mbt:1:8 --apply",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.has_prefix("exit=0\n"))
+    assert_true(output.content.contains("Applied 2 edit(s)"))
+    assert_true(output.content.contains("\nmoon check:\nexit="))
+    assert_true(output.content.contains("missing_symbol"))
+    let renamed = @fs.read_file("\{dir}/main.mbt").text()
+    assert_true(renamed.contains("new_name"))
+    assert_false(renamed.contains("old_name"))
+  })
+}
+
+///|
+async test "shell does not append moon check for non-mutating moon shapes" {
+  @vfs.with_tmpdir(prefix="openseek-shell-no-auto-check-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/shell_no_auto_check\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/moon.pkg",
+      "warnings = \"+unnecessary_annotation\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      (
+        #|pub fn broken() -> Int { missing_symbol }
+        #|
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    for cmd in ["echo moon add", "true || moon fmt", "moon fmt --check"] {
+      let result = run_shell({ "cmd": cmd, "cwd": dir })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_false(output.content.contains("moon check:"))
+    }
+    let timed = run_shell({ "cmd": "moon fmt", "cwd": dir, "timeout_ms": 30000 })
+    guard timed is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_false(output.content.contains("moon check:"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell appends moon check from moon command target cwd" {
+  @vfs.with_tmpdir(prefix="openseek-shell-auto-check-c-option-", dir => {
+    let project = "\{dir}/project"
+    @fs.mkdir(project)
+    @fs.write_file(
+      "\{project}/moon.mod",
+      "name = \"tmp/shell_auto_check_c_option\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{project}/moon.pkg",
+      "warnings = \"+unnecessary_annotation\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{project}/main.mbt",
+      (
+        #|pub fn broken() -> Int { missing_symbol }
+        #|
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    for cmd in ["moon -C project fmt", "cd ./project && moon fmt"] {
+      let result = run_shell({ "cmd": cmd, "cwd": dir })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_false(output.is_error)
+      assert_true(output.content.has_prefix("exit=0\n"))
+      assert_true(output.content.contains("\nmoon check:\nexit="))
+      assert_true(output.content.contains("missing_symbol"))
+    }
+  })
+}
+
+///|
 async test "shell rejects missing cmd" {
   let result = run_shell({ "cwd": "unused" })
   guard result is Respond(output) else { fail("expected Respond") }


### PR DESCRIPTION
## Summary

- Add an internal conservative shell parser for static policy analysis of simple POSIX shell commands.
- Use that parser in shell command policy so accidental `moon_cmd` invocations are detected in flat compounds such as `cd demo && moon_cmd check`.
- Preserve the narrow existing policy: ordinary `moon ...` commands still run through shell, and complex commands are only blocked by the legacy leading `moon_cmd` fallback.

## Validation

- `moon fmt agent_tool/shell/internal/shell_parse`
- `moon check agent_tool/shell/internal/shell_parse`
- `moon test agent_tool/shell/internal/shell_parse`
- `moon info agent_tool/shell/internal/shell_parse`
- `moon fmt agent_tool/shell/internal/command_policy`
- `moon check agent_tool/shell/internal/command_policy`
- `moon test agent_tool/shell/internal/command_policy`
- `moon info agent_tool/shell/internal/command_policy`
- `moon check --target all`
- `moon test agent_tool/shell`
- `moon test`
- `git diff --check`

## Independent Reviews

- Fresh Codex CLI reviewed `05cf9f4`; findings fixed in `5b42d69`.
- Fresh Codex CLI reviewed `5b42d69`; findings fixed in `33f1105`.
- Fresh Codex CLI reviewed `33f1105`; findings fixed in `d60a02c`.
- Fresh Codex CLI reviewed `d60a02c`; no actionable issues.
- Fresh Codex CLI reviewed `2aa2f8d`; no actionable issues.
