### PR TITLE
viz: keep the failing call's card in "errors only"

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -59,11 +59,12 @@ pub fn render_notices(parsed : @session_log.ParsedLog) -> @html.Html {
 ///|
 fn render_raw(session : @agent_session.Session) -> @html.Html {
   let briefs = tool_call_briefs(session)
+  let failed = raw_failed_call_ids(session)
   let step_labels = agent_step_labels(session)
   let turns = group_turns(session.events())
   let blocks : Array[@html.Html] = []
   for index, turn in turns {
-    blocks.push(turn_block(index + 1, turn, briefs, step_labels))
+    blocks.push(turn_block(index + 1, turn, briefs, failed, step_labels))
   }
   if blocks.is_empty() {
     return empty_state("This session has no events yet.")
@@ -160,6 +161,7 @@ fn turn_block(
   number : Int,
   turn : Array[@agent_session.SessionEvent],
   briefs : Map[String, String],
+  failed : Map[String, Unit],
   step_labels : Map[Int, String],
 ) -> @html.Html {
   // Offsets are relative to the turn's first stamped event: for reading a
@@ -172,6 +174,7 @@ fn turn_block(
         event,
         time=offset_label(base, event),
         briefs,
+        failed,
         step_label=step_labels.get(event.sequence()).unwrap_or(""),
       )
     }
@@ -291,6 +294,7 @@ fn event_card(
   event : @agent_session.SessionEvent,
   time~ : String,
   briefs : Map[String, String],
+  failed : Map[String, Unit],
   step_label~ : String,
 ) -> @html.Html {
   let seq = event.sequence()
@@ -298,7 +302,7 @@ fn event_card(
     User(message) =>
       card("user", "User", seq, time~, [text_block(message.content())])
     Assistant(message) =>
-      assistant_card(seq, time, message, briefs, step_label~)
+      assistant_card(seq, time, message, briefs, failed, step_label~)
     Tool(result) => tool_card(seq, time, result)
     Runtime(notice) =>
       card("runtime", "Runtime notice", seq, time~, [
@@ -315,6 +319,7 @@ fn assistant_card(
   time : String,
   message : @agent_session.AssistantMessage,
   briefs : Map[String, String],
+  failed : Map[String, Unit],
   step_label~ : String,
 ) -> @html.Html {
   let body : Array[@html.Html] = []
@@ -333,7 +338,7 @@ fn assistant_card(
   let calls = message.tool_calls()
   if !calls.is_empty() {
     let call_views : Array[@html.Html] = [
-      for call in calls => tool_call_view(call, briefs)
+      for call in calls => tool_call_view(call, briefs, failed)
     ]
     body.push(@html.div(class="tool-calls", call_views))
   }
@@ -351,9 +356,14 @@ fn assistant_card(
 /// JSON. Only one is visible at a time — the stylesheet shows the friendly form by
 /// default and swaps to the original under `.show-original`, so the raw arguments
 /// stay one toggle away for debugging without re-rendering.
+///
+/// A call whose result failed is tagged `tool-call-failed`, which flags it in the
+/// full view and lets the "errors only" stylesheet keep its assistant card — so a
+/// failure shows the originating call cell alongside the error result cell.
 fn tool_call_view(
   call : @deepseek.ToolCall,
   briefs : Map[String, String],
+  failed : Map[String, Unit],
 ) -> @html.Html {
   let name_row : Array[@html.Html] = [
     @html.text("→ "),
@@ -362,13 +372,16 @@ fn tool_call_view(
   if briefs.get(call.id) is Some(brief) && !brief.trim().is_empty() {
     name_row.push(@html.span(class="tool-call-brief", " · \{brief}"))
   }
+  let cls = if failed.contains(call.id) {
+    "tool-call tool-call-failed"
+  } else {
+    "tool-call"
+  }
   let original = pretty_json(call.arguments)
   if is_blank_args(original) {
-    return @html.div(class="tool-call", [
-      @html.div(class="tool-call-name", name_row),
-    ])
+    return @html.div(class=cls, [@html.div(class="tool-call-name", name_row)])
   }
-  @html.details(class="tool-call", [
+  @html.details(class=cls, [
     @html.summary(class="tool-call-name", name_row),
     render_args_friendly(call.arguments),
     @html.pre(class="tool-call-args tool-call-args-original", original),
@@ -548,6 +561,7 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
   // to the model are unchanged — this is view-only enrichment).
   let tool_results = tool_results_by_id(session)
   let messages = session.chat_messages()
+  let failed = model_failed_call_ids(messages, tool_results)
   let time_labels = model_message_time_labels(session)
   let step_labels = model_message_step_labels(session)
   // Model-view briefs must come only from results the projection actually
@@ -567,7 +581,7 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
       } else {
         ""
       }
-      message_card(message, tool_results, briefs, time~, step_label~)
+      message_card(message, tool_results, failed, briefs, time~, step_label~)
     }
   ]
   if cards.is_empty() {
@@ -789,9 +803,43 @@ fn tool_results_by_id(
 }
 
 ///|
+/// Ids of tool calls whose durable result errored — used to tag the call in the
+/// raw view so "errors only" keeps its assistant card next to the error result.
+fn raw_failed_call_ids(session : @agent_session.Session) -> Map[String, Unit] {
+  let ids : Map[String, Unit] = Map([])
+  for event in session.events() {
+    if event.item() is Tool(result) && result.is_error() {
+      ids.set(result.tool_call_id(), ())
+    }
+  }
+  ids
+}
+
+///|
+/// Ids of tool calls whose result the model view both showed and saw fail (see
+/// `model_shown_result`). Mirrors the model view's error cards so a tagged call
+/// always has a matching error result on screen — a compacted-away failure tags
+/// nothing, just as it draws no error card.
+fn model_failed_call_ids(
+  messages : Array[@deepseek.ChatMessage],
+  tool_results : Map[String, @agent_session.ToolResult],
+) -> Map[String, Unit] {
+  let ids : Map[String, Unit] = Map([])
+  for message in messages {
+    guard message.role is Tool(id) else { continue }
+    if model_shown_result(message, tool_results) is Some(result) &&
+      result.is_error() {
+      ids.set(id, ())
+    }
+  }
+  ids
+}
+
+///|
 fn message_card(
   message : @deepseek.ChatMessage,
   tool_results : Map[String, @agent_session.ToolResult],
+  failed : Map[String, Unit],
   briefs : Map[String, String],
   time~ : String,
   step_label~ : String,
@@ -807,9 +855,18 @@ fn message_card(
           text_block(message.content),
         ]),
       ])
-    User => model_card("user", "User", message, briefs, time~, step_label~)
+    User =>
+      model_card("user", "User", message, briefs, failed, time~, step_label~)
     Assistant =>
-      model_card("assistant", "Assistant", message, briefs, time~, step_label~)
+      model_card(
+        "assistant",
+        "Assistant",
+        message,
+        briefs,
+        failed,
+        time~,
+        step_label~,
+      )
     Tool(_) =>
       model_tool_card(message, model_shown_result(message, tool_results), time~)
   }
@@ -917,6 +974,7 @@ fn model_card(
   label : String,
   message : @deepseek.ChatMessage,
   briefs : Map[String, String],
+  failed : Map[String, Unit],
   time~ : String,
   step_label~ : String,
 ) -> @html.Html {
@@ -935,7 +993,7 @@ fn model_card(
   }
   if !message.tool_calls.is_empty() {
     let call_views : Array[@html.Html] = [
-      for call in message.tool_calls => tool_call_view(call, briefs)
+      for call in message.tool_calls => tool_call_view(call, briefs, failed)
     ]
     body.push(@html.div(class="tool-calls", call_views))
   }

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -127,7 +127,8 @@ test "tool calls fold their arguments, empty args stay flat" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   // A call with arguments folds: the name becomes a <summary>, args hide in the
   // collapsed <details> (no `open` attribute) yet are still in the DOM.
-  assert_true(html.contains("<details class=\"tool-call\">"))
+  // c1 (shell) has args and its result failed, so its fold carries the failed tag.
+  assert_true(html.contains("<details class=\"tool-call tool-call-failed\">"))
   assert_true(html.contains("<summary class=\"tool-call-name\">"))
   assert_true(html.contains("shell"))
   assert_true(html.contains("cmd"))
@@ -183,6 +184,26 @@ test "non-object tool args fall back to JSON in both forms" {
   assert_true(html.contains("class=\"tool-call-args tool-call-args-rendered\""))
   assert_true(html.contains("tool-call-args-original"))
   assert_false(html.contains("arg-key"))
+}
+
+///|
+test "a failed tool call is tagged so errors-only keeps its call card" {
+  // error_tool_session: c1 (shell) failed. Its call gets `tool-call-failed`, the
+  // hook the errors-only stylesheet uses to keep the assistant card holding the
+  // call — so the call cell and the error result cell both stay (not merged).
+  let raw = render(@viz.render_session(error_tool_session(), RawLog))
+  assert_true(raw.contains("tool-call-failed"))
+  let model = render(@viz.render_session(error_tool_session(), ModelView))
+  assert_true(model.contains("tool-call-failed"))
+  // A clean session tags no call as failed.
+  let clean = @viz.session_from_parse(
+    @viz.parse_events(events_jsonl(sample_session())),
+    id="demo",
+    system_prompt="",
+  )
+  assert_false(
+    render(@viz.render_session(clean, RawLog)).contains("tool-call-failed"),
+  )
 }
 
 ///|

--- a/web/index.html
+++ b/web/index.html
@@ -283,8 +283,11 @@
     .error-toggle.active { background: var(--error); color: #fff; border-color: var(--error); }
     .turn-error-badge { color: var(--error); }
     .errors-only-empty { color: var(--muted); margin-top: 24px; }
-    /* errors-only: keep only failed tool cards and the turns that contain them */
-    .session-view.errors-only .card:not(.error) { display: none; }
+    /* errors-only: keep failed tool-result cards AND the assistant card holding the
+       failing call (so the call and its result stay as two cells), plus the turns
+       containing an error; hide everything else. */
+    .session-view.errors-only .card:not(.error):not(.assistant) { display: none; }
+    .session-view.errors-only .card.assistant:not(:has(.tool-call-failed)) { display: none; }
     .session-view.errors-only .turn:not(:has(.card.error)) { display: none; }
 
     /* notices */
@@ -365,6 +368,10 @@
     .tool-call-args-original { display: none; }
     .session-view.show-original .tool-call-args-original { display: block; }
     .session-view.show-original .tool-call-args-rendered { display: none; }
+
+    /* a tool call whose result failed: tint its border so it stands out, and let
+       errors-only keep the assistant card that holds it. */
+    .tool-call-failed { border-color: var(--error); }
 
     /* folded tool-result cards: the label is the toggle, body hides until clicked */
     details.card > summary.card-label { cursor: pointer; }


### PR DESCRIPTION
## What & why

Follow-up to #221. In the session viewer, **Errors only** filtered the log down to failed tool-result cards and hid the assistant card holding the originating tool call — so you could see a failure's *output* but not *what was called*.

## Change

- Tag a tool call whose result errored with `tool-call-failed` (this also tints the call's border in the full view, so failures stand out there too).
- The errors-only stylesheet now keeps the assistant card that holds such a call, in addition to the error result card.

So a failure keeps **two cells side by side** — the originating call and its error result — rather than merging them into one cell or dropping the call. Determined per-view: the raw view tags calls whose durable result errored; the model view tags only calls whose result it actually showed and saw fail (mirrors its error cards).

## Testing

- `moon check` clean; `viz` suite passes (added a test asserting failed calls get the `tool-call-failed` tag in both views, and clean sessions get none).
- Verified in headless-Chrome screenshots: errors-only keeps the call card + result card as two cells (failed call border tinted), unrelated turns/cards hidden; the full view is unchanged apart from the subtle failed-call border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)