### PR TITLE
Simplify md_to_mbt_string build rule

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -28,5 +28,5 @@ warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_def
 
 rule(
   name: "md_to_mbt_string",
-  command: "moon run --quiet --target native scripts/md_to_mbt_string -- \"$input\" \"$output\"",
+  command: "moon run scripts/md_to_mbt_string -- \"$input\" \"$output\"",
 )


### PR DESCRIPTION
Drop `--quiet --target native` from the `md_to_mbt_string` rule command in `moon.mod`, running it as a plain `moon run scripts/md_to_mbt_string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)