### PR TITLE
[codex] strip prompt-only markdown comments

### DIFF
--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -1,7 +1,7 @@
 You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.<!-- md_to_mbt_string smoke: stripped from generated base prompt. -->
 Use finish when the task is complete.
 
-About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
+<!-- About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
 
 ```
 import {
@@ -9,7 +9,7 @@ import {
   "moonbitlang/core/string",
   "moonbitlang/async",
 } for "test"
-```
+``` -->
 
 Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
 

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -21,8 +21,8 @@ diagnostics.
 - Use the right tool for the job:
   - `read`, `edit`, and `write` for files.
   - `shell` for all Moon commands, including `moon check` for compiler
-    feedback; pass the tool's `cwd` field instead of embedding repeated
-    `cd ... &&` strings.
+    feedback; pass the tool's `cwd` field, or use `moon -C dir check` instead
+    of embedding repeated `cd ... &&` strings.
 - Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
   use `moon build` or `moon test` only when you need artifacts or test results.
 - Keep reads focused. Use bounded reads for large files and logs.

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -1,19 +1,12 @@
 // Generated from base_prompt.mbt.md by moon dev_build. DO NOT EDIT.
+
 ///|
 fn base_prompt() -> String {
   (
     #|You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
     #|Use finish when the task is complete.
     #|
-    #|About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
     #|
-    #|```
-    #|import {
-    #|  "moonbitlang/core/encoding/utf8",
-    #|  "moonbitlang/core/string",
-    #|  "moonbitlang/async",
-    #|} for "test"
-    #|```
     #|
     #|Blocks that need a top-level `fn main` (forbidden in a non-main package) or that depend on identifiers defined elsewhere stay marked ```` ```mbt nocheck ```` and are illustrative only.
     #|

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -1,4 +1,5 @@
 // Generated from flash_prompt.mbt.md by moon dev_build. DO NOT EDIT.
+
 ///|
 fn flash_prompt() -> String {
   (
@@ -25,8 +26,8 @@ fn flash_prompt() -> String {
     #|- Use the right tool for the job:
     #|  - `read`, `edit`, and `write` for files.
     #|  - `shell` for all Moon commands, including `moon check` for compiler
-    #|    feedback; pass the tool's `cwd` field instead of embedding repeated
-    #|    `cd ... &&` strings.
+    #|    feedback; pass the tool's `cwd` field, or use `moon -C dir check` instead
+    #|    of embedding repeated `cd ... &&` strings.
     #|- Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
     #|  use `moon build` or `moon test` only when you need artifacts or test results.
     #|- Keep reads focused. Use bounded reads for large files and logs.

--- a/prompt/moon.pkg
+++ b/prompt/moon.pkg
@@ -22,7 +22,6 @@ dev_build(
   input: "flash_prompt.mbt.md",
   output: "generated_flash_prompt.mbt",
 )
-
 // -unused_default_value: the Label and Optional Parameters section
 // demonstrates the f_misuse anti-pattern on purpose; "fixing" the example
 // would change the prompt text the model sees.
@@ -33,3 +32,9 @@ dev_build(
 warnings = "+unnecessary_annotation-unused_value-unused_type_declaration-unused_constructor-unused_field-todo-declaration_unimplemented-missing_doc-unused_default_value"
 
 supported_targets = "+native"
+
+options(
+  formatter: {
+    "ignore": [ "generated_base_prompt.mbt", "generated_flash_prompt.mbt" ],
+  },
+)

--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -93,6 +93,7 @@ fn generated_source(
   let lines = markdown.split("\n")
   (
     $|// Generated from \{base} by moon dev_build. DO NOT EDIT.
+    $|
     $|///|
     $|fn \{function_name}() -> String {
     $|  (


### PR DESCRIPTION
## What changed

- Wrap the prompt-guide testing note in an HTML comment so it remains in `base_prompt.mbt.md` for maintainers but is stripped from the generated base prompt.
- Regenerate prompt sources with the markdown-comment stripping behavior.
- Tell the formatter to ignore generated prompt files so generated string formatting remains stable.
- Fix the flash prompt wording around using `cwd` or `moon -C dir check`.

## Impact

This keeps prompt-only maintenance notes out of the runtime prompt while preserving checked documentation in the source file.

## Validation

- `moon check --diagnostic-limit 5`
- `moon test`
- `moon info && moon fmt`

Note: local `moon info` regenerated unrelated TUI `.mbti` formatting churn with this Moon toolchain; that generated churn was intentionally excluded from this PR.