### PR TITLE
[codex] inline read output header

### DIFF
--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -31,7 +31,7 @@ pub fn AgentToolCall::AgentToolCall(
 ///|
 /// A JSON Schema describing the arguments a tool accepts. Wraps a raw `Json`
 /// value so registry entries advertise schemas explicitly.
-pub(all) struct JsonSchema(Json)
+pub(all) struct JsonSchema(Json) derive(Debug)
 
 ///|
 /// A locally registered tool: the name and JSON Schema sent to DeepSeek, plus a
@@ -42,7 +42,7 @@ pub struct AgentToolDefinition {
   description : String
   schema : JsonSchema
   execute : ToolExecutor
-}
+} derive(Debug(ignore=ToolExecutor))
 
 ///|
 /// Builds a tool definition with a name, JSON Schema for the arguments, and

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -32,10 +32,10 @@ pub struct AgentToolDefinition {
   description : String
   schema : JsonSchema
   execute : ToolExecutor
-}
+} derive(@debug.Debug)
 pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor) -> Self
 
-pub(all) struct JsonSchema(Json)
+pub(all) struct JsonSchema(Json) derive(@debug.Debug)
 
 pub(all) enum ToolAction {
   Respond(ToolOutput)

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -87,15 +87,37 @@ character truncation. The string body has one of these shapes:
 ///|
 test "read tool advertises the expected schema" {
   let tool = @read.definition()
-  assert_eq(tool.name, "read")
-  let JsonSchema(schema) = tool.schema
-  let text = schema.stringify()
-  assert_true(text.contains("\"path\""))
-  assert_false(text.contains("\"paths\""))
-  assert_true(text.contains("\"required\""))
-  assert_true(text.contains("\"start_line\""))
-  assert_true(text.contains("\"max_lines\""))
-  assert_true(text.contains("\"max_output_chars\""))
+  debug_inspect(
+    tool,
+    content=(
+      #|{
+      #|  name: "read",
+      #|  description: "Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Headered outputs use `<line-number>\\t<content>` numbered lines.",
+      #|  schema: JsonSchema(
+      #|    Object(
+      #|      {
+      #|        "type": String("object"),
+      #|        "required": Array([String("path")]),
+      #|        "properties": Object(
+      #|          {
+      #|            "path": Object(
+      #|              {
+      #|                "type": String("string"),
+      #|                "description": String("Text file path to read. Directories are not supported; use `ls` or `tree` first, then read specific files."),
+      #|              },
+      #|            ),
+      #|            "start_line": Object({ "type": String("number") }),
+      #|            "max_lines": Object({ "type": String("number") }),
+      #|            "max_output_chars": Object({ "type": String("number") }),
+      #|          },
+      #|        ),
+      #|      },
+      #|    ),
+      #|  ),
+      #|  execute: ...,
+      #|}
+    ),
+  )
 }
 ```
 
@@ -119,9 +141,18 @@ async test "read tool reads a workspace note through the registry" {
       ),
     )
     let result = @agent_tool.execute_tool_call(call, tools)
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, content)
-    assert_false(output.is_error)
+    debug_inspect(
+      result,
+      content=(
+        #|Respond(
+        #|  {
+        #|    content: "Task: summarize test failures\nStatus: investigating\n",
+        #|    is_error: false,
+        #|    brief: Some("read task.txt"),
+        #|  },
+        #|)
+      ),
+    )
   })
 }
 ```

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -107,22 +107,29 @@ async fn read_file(
       )
   }
   let selection = select_lines(content, input.start_line, input.max_lines)
+  let brief = "read \{@agent_tool.brief_basename(path)}"
   let include_header = input.start_line != 1 ||
     input.max_lines is Some(_) ||
     selection.content.char_length() > input.max_output_chars
   if include_header {
     let rendered = render_numbered_content(selection, input.max_output_chars)
-    let output = "\{read_header(path, content, selection, rendered)}\{rendered.content}"
-    @agent_tool.ToolAction::respond(
-      output,
-      is_error=rendered.truncated,
-      brief="read \{@agent_tool.brief_basename(path)}",
-    )
+    let output =
+      $|path=\{path}
+      $|start_line=\{selection.start_line}
+      $|end_line=\{rendered.end_line}
+      $|total_lines=\{selection.total_lines}
+      $|shown_lines=\{rendered.shown_lines}
+      $|file_chars=\{content.char_length()}
+      $|selected_chars=\{selection.content.char_length()}
+      $|shown_chars=\{rendered.shown_chars}
+      $|line_limited=\{selection.line_limited}
+      $|truncated=\{rendered.truncated}
+      $|line_format=<line-number>\{"\\t"}<content>
+      $|---
+      $|\{rendered.content}
+    @agent_tool.ToolAction::respond(output, is_error=rendered.truncated, brief~)
   } else {
-    @agent_tool.ToolAction::respond(
-      selection.content,
-      brief="read \{@agent_tool.brief_basename(path)}",
-    )
+    @agent_tool.ToolAction::respond(selection.content, brief~)
   }
 }
 
@@ -132,7 +139,7 @@ fn select_lines(
   start_line : Int,
   max_lines : Int?,
 ) -> ReadSelection {
-  let lines = [ for line in content.split("\n") => line.to_owned() ]
+  let lines = [ for line in content.split("\n") => line ]
   let total_lines = lines.length()
   // Clamp both bounds into [0, total_lines] so the slice below is always
   // ascending and in range — a start past the last line selects nothing.
@@ -146,7 +153,7 @@ fn select_lines(
       start_index + count.clamp(min=0, max=total_lines - start_index)
     None => total_lines
   }
-  let selected = lines[start_index:end_exclusive].to_owned()
+  let selected = lines[start_index:end_exclusive]
   let shown_lines = selected.length()
   let line_limited = match max_lines {
     Some(_) => end_exclusive < total_lines
@@ -248,30 +255,6 @@ fn render_numbered_content(
     shown_chars: content.char_length(),
     truncated,
   }
-}
-
-///|
-fn read_header(
-  path : String,
-  original : String,
-  selection : ReadSelection,
-  rendered : RenderedSelection,
-) -> String {
-  [
-    "path=\{path}",
-    "start_line=\{selection.start_line}",
-    "end_line=\{rendered.end_line}",
-    "total_lines=\{selection.total_lines}",
-    "shown_lines=\{rendered.shown_lines}",
-    "file_chars=\{original.char_length()}",
-    "selected_chars=\{selection.content.char_length()}",
-    "shown_chars=\{rendered.shown_chars}",
-    "line_limited=\{selection.line_limited}",
-    "truncated=\{rendered.truncated}",
-    "line_format=<line-number>\\t<content>",
-    "---",
-    "",
-  ].join("\n")
 }
 
 ///|


### PR DESCRIPTION
## What changed

- Inline the read tool's header rendering into `read_file` and remove the separate `read_header` helper.
- Render the header and body as a single `$|` multiline string with `rendered.content` interpolated directly.
- Reuse the computed read brief for both headered and plain responses.
- Update read tool documentation/examples and generated interface metadata for the public `Debug` derives used by the docs.

## Impact

This is a small refactor and documentation update for the read tool output path. The existing header/body output shape is preserved.

## Validation

- `moon check --diagnostic-limit 5`
- `moon test agent_tool/read`
- `moon info && moon fmt`

Note: local `moon info` produced unrelated TUI `.mbti` format churn with this toolchain; that churn was intentionally excluded from this PR.