### PR TITLE
dedupe + harden agent_tool truncation helpers, with a documented README

### DIFF
--- a/agent_tool/internal/output/README.mbt.md
+++ b/agent_tool/internal/output/README.mbt.md
@@ -1,0 +1,106 @@
+# `@output` — bounded tool output
+
+Internal helpers shared by the agent's `moon`-running tools (`moon_ide`,
+`moon_cmd`, …) to keep a tool result within a caller-supplied size budget and to
+tell the model, in-band, when output was clipped.
+
+A tool renders its result as an optional **truncation header** followed by the
+**capped body**:
+
+```
+<truncation_header(body, max)>
+<cap_text(body, max)>
+```
+
+so the model sees a banner describing what was dropped before reading the
+(possibly shortened) text. All three functions measure length in UTF-16 code
+units, matching MoonBit's `String::length`.
+
+## `cap_text` — keep at most `max_chars`
+
+Returns the content unchanged when it already fits, otherwise keeps the leading
+`max_chars` code units:
+
+```mbt check
+///|
+test "cap_text keeps short text and clips long text" {
+  inspect(@output.cap_text("ok", 8), content="ok")
+  inspect(@output.cap_text("hello, world", 5), content="hello")
+}
+```
+
+A character that needs two code units (a surrogate pair, such as an emoji) is
+never split: if the budget lands inside the pair the whole character is dropped,
+so the kept prefix is always valid text:
+
+```mbt check
+///|
+test "cap_text does not split a surrogate pair" {
+  // "😀" is two UTF-16 code units; a budget of 1 keeps nothing, 2 keeps it whole.
+  inspect(@output.cap_text("😀x", 1), content="")
+  inspect(@output.cap_text("😀x", 2), content="😀")
+}
+```
+
+## `is_truncated` — would `cap_text` drop anything?
+
+The predicate behind the header. It is `true` exactly when the content is longer
+than the budget:
+
+```mbt check
+///|
+test "is_truncated compares length against the budget" {
+  inspect(@output.is_truncated("hello, world", 5), content="true")
+  inspect(@output.is_truncated("ok", 8), content="false")
+  // The boundary fits: length == budget is not truncation.
+  inspect(@output.is_truncated("hello", 5), content="false")
+}
+```
+
+## `truncation_header` — describe what was dropped
+
+When (and only when) the content is truncated, this renders a metadata block —
+a leading newline plus `truncated`/`output_chars`/`shown_chars` lines reporting
+the original and shown sizes. It is the empty string when nothing was dropped,
+so a tool can always concatenate it unconditionally:
+
+```mbt check
+///|
+test "truncation_header reports sizes, or is empty when it fits" {
+  inspect(
+    @output.truncation_header("hello, world", 5),
+    content=(
+      #|
+      #|truncated=true
+      #|output_chars=12
+      #|shown_chars=5
+    ),
+  )
+  inspect(@output.truncation_header("ok", 8), content="")
+}
+```
+
+## Putting it together
+
+How a tool composes a bounded result — header first, then the capped body:
+
+```mbt check
+///|
+test "compose a bounded tool result" {
+  let body = "abcdefghij"
+  let max = 4
+  let rendered = @output.truncation_header(body, max) +
+    "\n" +
+    @output.cap_text(body, max)
+  inspect(
+    rendered,
+    content=(
+      #|
+      #|truncated=true
+      #|output_chars=10
+      #|shown_chars=4
+      #|abcd
+    ),
+  )
+}
+```

--- a/agent_tool/internal/output/README.md
+++ b/agent_tool/internal/output/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/output/moon.pkg
+++ b/agent_tool/internal/output/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/output/output.mbt
+++ b/agent_tool/internal/output/output.mbt
@@ -1,0 +1,28 @@
+///|
+/// Truncate `content` to at most `max_chars` UTF-16 code units, returning it
+/// unchanged when it already fits.
+pub fn cap_text(content : String, max_chars : Int) -> String {
+  if content.length() <= max_chars {
+    content
+  } else {
+    "\{content[:max_chars]}"
+  }
+}
+
+///|
+/// Whether `content` is longer than `max_chars`, i.e. whether `cap_text` would
+/// drop characters from it.
+pub fn is_truncated(content : String, max_chars : Int) -> Bool {
+  content.length() > max_chars
+}
+
+///|
+/// A trailing metadata block describing the truncation of `content` at
+/// `max_chars`, or the empty string when nothing was dropped.
+pub fn truncation_header(content : String, max_chars : Int) -> String {
+  if is_truncated(content, max_chars) {
+    "\ntruncated=true\noutput_chars=\{content.length()}\nshown_chars=\{max_chars}"
+  } else {
+    ""
+  }
+}

--- a/agent_tool/internal/output/output.mbt
+++ b/agent_tool/internal/output/output.mbt
@@ -1,12 +1,33 @@
 ///|
 /// Truncate `content` to at most `max_chars` UTF-16 code units, returning it
-/// unchanged when it already fits.
+/// unchanged when it already fits. A budget landing in the middle of a
+/// surrogate pair steps back one unit so the kept prefix is always valid text.
 pub fn cap_text(content : String, max_chars : Int) -> String {
   if content.length() <= max_chars {
     content
   } else {
-    "\{content[:max_chars]}"
+    "\{content[:char_boundary_at_or_below(content, max_chars)]}"
   }
+}
+
+///|
+/// Largest code-unit offset `<= max_units` that is a valid character boundary.
+/// A surrogate pair spans two code units; if `max_units` lands on the trailing
+/// surrogate, step back one so the leading surrogate is dropped too. Only
+/// reached with `0 <= max_units < content.length()`.
+fn char_boundary_at_or_below(content : String, max_units : Int) -> Int {
+  if max_units > 0 && is_low_surrogate(content[max_units]) {
+    max_units - 1
+  } else {
+    max_units
+  }
+}
+
+///|
+/// Whether `unit` is a UTF-16 low (trailing) surrogate — the second half of a
+/// surrogate pair.
+fn is_low_surrogate(unit : UInt16) -> Bool {
+  unit >= 0xDC00 && unit <= 0xDFFF
 }
 
 ///|
@@ -18,10 +39,13 @@ pub fn is_truncated(content : String, max_chars : Int) -> Bool {
 
 ///|
 /// A trailing metadata block describing the truncation of `content` at
-/// `max_chars`, or the empty string when nothing was dropped.
+/// `max_chars`, or the empty string when nothing was dropped. `shown_chars`
+/// is the length actually kept by `cap_text`, which can be one less than
+/// `max_chars` when the budget would have split a surrogate pair.
 pub fn truncation_header(content : String, max_chars : Int) -> String {
   if is_truncated(content, max_chars) {
-    "\ntruncated=true\noutput_chars=\{content.length()}\nshown_chars=\{max_chars}"
+    let shown_chars = char_boundary_at_or_below(content, max_chars)
+    "\ntruncated=true\noutput_chars=\{content.length()}\nshown_chars=\{shown_chars}"
   } else {
     ""
   }

--- a/agent_tool/internal/output/output_test.mbt
+++ b/agent_tool/internal/output/output_test.mbt
@@ -1,0 +1,17 @@
+///|
+test "cap_text truncates to max_chars and leaves shorter text alone" {
+  assert_eq(@output.cap_text("abcdef", 3), "abc")
+  assert_eq(@output.cap_text("abc", 3), "abc")
+  assert_eq(@output.cap_text("ab", 3), "ab")
+}
+
+///|
+test "truncation reporting" {
+  assert_true(@output.is_truncated("abcdef", 3))
+  assert_false(@output.is_truncated("abc", 3))
+  assert_eq(
+    @output.truncation_header("abcdef", 3),
+    "\ntruncated=true\noutput_chars=6\nshown_chars=3",
+  )
+  assert_eq(@output.truncation_header("abc", 3), "")
+}

--- a/agent_tool/internal/output/output_test.mbt
+++ b/agent_tool/internal/output/output_test.mbt
@@ -6,6 +6,27 @@ test "cap_text truncates to max_chars and leaves shorter text alone" {
 }
 
 ///|
+test "cap_text never splits a surrogate pair" {
+  // "😀" is one code point but two UTF-16 code units, so a budget of 1 lands
+  // inside it; cap_text drops the whole pair rather than slicing it (which would
+  // abort). "x😀" with a budget of 2 likewise keeps only the leading "x".
+  assert_eq(@output.cap_text("😀x", 1), "")
+  assert_eq(@output.cap_text("😀x", 2), "😀")
+  assert_eq(@output.cap_text("x😀y", 2), "x")
+}
+
+///|
+test "truncation_header shown_chars matches what cap_text keeps" {
+  // At a surrogate boundary cap_text keeps fewer than the budget, and the header
+  // reports that smaller, accurate count rather than the requested max.
+  assert_eq(@output.cap_text("😀x", 1), "")
+  assert_eq(
+    @output.truncation_header("😀x", 1),
+    "\ntruncated=true\noutput_chars=3\nshown_chars=0",
+  )
+}
+
+///|
 test "truncation reporting" {
   assert_true(@output.is_truncated("abcdef", 3))
   assert_false(@output.is_truncated("abc", 3))

--- a/agent_tool/internal/output/pkg.generated.mbti
+++ b/agent_tool/internal/output/pkg.generated.mbti
@@ -1,0 +1,18 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/output"
+
+// Values
+pub fn cap_text(String, Int) -> String
+
+pub fn is_truncated(String, Int) -> Bool
+
+pub fn truncation_header(String, Int) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/moon_cmd/moon.pkg
+++ b/agent_tool/moon_cmd/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/output",
   "bobzhang/openseek/agent_tool/moon_cmd/internal/decode",
   "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",

--- a/agent_tool/moon_cmd/moon_cmd.mbt
+++ b/agent_tool/moon_cmd/moon_cmd.mbt
@@ -131,13 +131,13 @@ async fn moon_cmd(input : @decode.MoonCommandInput) -> @agent_tool.ToolAction {
     None => ""
   }
   let body = output.text()
-  let capped = cap_text(body, input.max_output_chars)
-  let truncation = truncation_header(body, input.max_output_chars)
+  let capped = @output.cap_text(body, input.max_output_chars)
+  let truncation = @output.truncation_header(body, input.max_output_chars)
   let head = @agent_tool.brief_line("moon \{args.join(" ")}", limit=64)
   let brief = if code != 0 { "\{head} → exit \{code}" } else { head }
   @agent_tool.ToolAction::respond(
     "cwd=\{cwd_text}\ncommand=moon \{args.join(" ")}\{update_review}\{stdin_review}\nexit=\{code}\{truncation}\n\{capped}",
-    is_error=code != 0 || is_truncated(body, input.max_output_chars),
+    is_error=code != 0 || @output.is_truncated(body, input.max_output_chars),
     brief~,
   )
 }
@@ -173,29 +173,6 @@ async fn collect_moon_output(
       @fs.rmdir(dir, recursive=true)
       result
     }
-  }
-}
-
-///|
-fn cap_text(content : String, max_chars : Int) -> String {
-  if content.length() <= max_chars {
-    content
-  } else {
-    "\{content[:max_chars]}"
-  }
-}
-
-///|
-fn is_truncated(content : String, max_chars : Int) -> Bool {
-  content.length() > max_chars
-}
-
-///|
-fn truncation_header(content : String, max_chars : Int) -> String {
-  if is_truncated(content, max_chars) {
-    "\ntruncated=true\noutput_chars=\{content.length()}\nshown_chars=\{max_chars}"
-  } else {
-    ""
   }
 }
 
@@ -330,16 +307,6 @@ test "moon_cmd accepts classified moon test update" {
 test "moon_cmd parses and caps output limit" {
   let input = @decode.decode({ "command": "check", "max_output_chars": 999999 })
   assert_eq(input.max_output_chars, @decode.hard_max_output_chars)
-}
-
-///|
-test "moon_cmd records truncation metadata" {
-  assert_eq(cap_text("abcdef", 3), "abc")
-  assert_true(is_truncated("abcdef", 3))
-  assert_eq(
-    truncation_header("abcdef", 3),
-    "\ntruncated=true\noutput_chars=6\nshown_chars=3",
-  )
 }
 
 ///|

--- a/agent_tool/moon_ide/moon.pkg
+++ b/agent_tool/moon_ide/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/output",
   "bobzhang/openseek/agent_tool/moon_ide/internal/decode",
   "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",

--- a/agent_tool/moon_ide/moon_ide.mbt
+++ b/agent_tool/moon_ide/moon_ide.mbt
@@ -130,30 +130,12 @@ async fn moon_ide(input : @decode.MoonIdeInput) -> @agent_tool.ToolAction {
     None => "."
   }
   let body = output.text()
-  let capped = cap_text(body, input.max_output_chars)
-  let truncation = truncation_header(body, input.max_output_chars)
+  let capped = @output.cap_text(body, input.max_output_chars)
+  let truncation = @output.truncation_header(body, input.max_output_chars)
   @agent_tool.ToolAction::respond(
     "cwd=\{cwd_text}\ncommand=moon \{args.join(" ")}\nexit=\{code}\{truncation}\n\{capped}",
     is_error=code != 0,
   )
-}
-
-///|
-fn cap_text(content : String, max_chars : Int) -> String {
-  if content.length() <= max_chars {
-    content
-  } else {
-    "\{content[:max_chars]}"
-  }
-}
-
-///|
-fn truncation_header(content : String, max_chars : Int) -> String {
-  if content.length() <= max_chars {
-    ""
-  } else {
-    "\ntruncated=true\noutput_chars=\{content.length()}\nshown_chars=\{max_chars}"
-  }
 }
 
 ///|
@@ -239,15 +221,6 @@ test "moon_ide rejects missing required fields" {
     }
   }
   fail("hover without loc parsed")
-}
-
-///|
-test "moon_ide records truncation metadata" {
-  assert_eq(cap_text("abcdef", 3), "abc")
-  assert_eq(
-    truncation_header("abcdef", 3),
-    "\ntruncated=true\noutput_chars=6\nshown_chars=3",
-  )
 }
 
 ///|


### PR DESCRIPTION
## What

Three related changes to the agent tools' output-truncation helpers.

### 1. Dedupe (`dedupe:`)
`cap_text` / `is_truncated` / `truncation_header` were copy-pasted across the `moon_ide` and `moon_cmd` tool packages. Move them to a single shared internal package, `agent_tool/internal/output` (matching the existing `internal/error` / `internal/auto_check` layout); their micro-tests move with them. No public API change.

### 2. Harden `cap_text` against surrogate splits (`fix:`)
`cap_text` sliced at exactly `max_chars` code units, which **aborts** when the budget lands inside a surrogate pair (e.g. an emoji in tool output at the cap boundary — surfaced by codex's review probe). It now steps the boundary back one unit in that case (mirroring `read.mbt`'s `char_boundary_at_or_below`), so the kept prefix is always valid text. `truncation_header` reports that same actual boundary as `shown_chars`, so the header never overstates what was kept. The crash predated this package — deduping into one place is exactly what makes it a single-point fix covering both tools.

### 3. README (`docs:`)
A high-quality `README.mbt.md` documenting the helpers, the header-then-capped-body layout tools render, and the surrogate-pair safety. Every example is an `mbt check` test, so the README is verified by `moon test` and can't drift from the code. `README.md` symlinks to it for GitHub.

## Validation

- `moon check` + `moon fmt` clean; 45 tests pass across the affected agent_tool packages (9 in the new package, including surrogate-pair cases).
- Reviewed by **codex** across three rounds: it flagged the surrogate crash and a follow-up `shown_chars` inconsistency (both now fixed), and the final review found *"no detectable correctness regression."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
