### PR TITLE
dedupe: extract shared text-metric helpers into eval/internal/metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ eval/*
 !eval/report/**
 !eval/tool_harness/
 !eval/tool_harness/**
+!eval/internal/
+!eval/internal/**

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -228,19 +228,29 @@ async fn evaluate_trial(
     steps: log_summary.steps,
     tool_errors: log_summary.tool_errors,
     shell_uses,
-    moon_cmd_uses: count_lines_containing_all(log_text, ["command=moon "]),
-    moon_run_e_mentions: count_lines_containing_all(log_text, [
+    moon_cmd_uses: @metrics.count_lines_containing_all(log_text, [
+      "command=moon ",
+    ]),
+    moon_run_e_mentions: @metrics.count_lines_containing_all(log_text, [
       "moon run", " -e",
     ]),
-    moon_run_c_mentions: count_lines_containing_all(log_text, [
+    moon_run_c_mentions: @metrics.count_lines_containing_all(log_text, [
       "moon run", " -c",
     ]),
-    moon_check_uses: count_lines_containing_all(log_text, ["command=moon check"]),
-    moon_test_uses: count_lines_containing_all(log_text, ["command=moon test"]),
-    moon_info_uses: count_lines_containing_all(log_text, ["command=moon info"]),
-    moon_fmt_uses: count_lines_containing_all(log_text, ["command=moon fmt"]),
-    edit_successes: count_occurrences(log_text, "ok: replaced "),
-    write_successes: count_occurrences(log_text, "ok: wrote "),
+    moon_check_uses: @metrics.count_lines_containing_all(log_text, [
+      "command=moon check",
+    ]),
+    moon_test_uses: @metrics.count_lines_containing_all(log_text, [
+      "command=moon test",
+    ]),
+    moon_info_uses: @metrics.count_lines_containing_all(log_text, [
+      "command=moon info",
+    ]),
+    moon_fmt_uses: @metrics.count_lines_containing_all(log_text, [
+      "command=moon fmt",
+    ]),
+    edit_successes: @metrics.count_occurrences(log_text, "ok: replaced "),
+    write_successes: @metrics.count_occurrences(log_text, "ok: wrote "),
     validation_passed,
     marker_present: marker_ok,
     warnings: if warnings.length() == 0 {
@@ -291,11 +301,11 @@ fn summarize_agent_log(log_text : String) -> AgentLogSummary {
     } else {
       0
     }
-    let shell_uses = count_occurrences(log_text, "\ntool: exit=") +
+    let shell_uses = @metrics.count_occurrences(log_text, "\ntool: exit=") +
       leading_shell_use
     {
-      steps: count_occurrences(log_text, "--- step "),
-      tool_errors: count_occurrences(log_text, "tool error:"),
+      steps: @metrics.count_occurrences(log_text, "--- step "),
+      tool_errors: @metrics.count_occurrences(log_text, "tool error:"),
       shell_uses,
     }
   }
@@ -348,30 +358,6 @@ async fn run_validation(
     ""
   } else {
     "validation failed: \{validation.join(" ")} exited \{code}: \{output.text()}"
-  }
-}
-
-///|
-fn count_occurrences(content : String, needle : String) -> Int {
-  if needle == "" {
-    return 0
-  }
-  let pieces = content.split(needle).collect()
-  pieces.length() - 1
-}
-
-///|
-fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
-  for line in content.split("\n"); count = 0 {
-    for needle in needles {
-      if !line.contains(needle) {
-        break
-      }
-    } nobreak {
-      continue count + 1
-    }
-  } nobreak {
-    count
   }
 }
 

--- a/eval/file_edit/harness/harness_wbtest.mbt
+++ b/eval/file_edit/harness/harness_wbtest.mbt
@@ -88,31 +88,6 @@ async test "dry run exact replacement oracle with jsonl agent log" {
 }
 
 ///|
-test "count_occurrences counts non-overlapping markers" {
-  assert_eq(count_occurrences("tool error: a\ntool error: b", "tool error:"), 2)
-  assert_eq(count_occurrences("abc", "z"), 0)
-}
-
-///|
-test "line counter documents all-match behavior" {
-  let log_text =
-    #|command=moon run -e fn main {}
-    #|command=moon run -c fn main {}
-    #|command=moon test
-    #|note=moon run without command prefix
-  debug_inspect(
-    [
-      count_lines_containing_all(log_text, ["command=moon "]),
-      count_lines_containing_all(log_text, ["moon run", " -e"]),
-      count_lines_containing_all(log_text, ["moon run", " -c"]),
-      count_lines_containing_all(log_text, ["command=moon ", "missing"]),
-      count_lines_containing_all("a\nb\n", []),
-    ],
-    content="[3, 1, 1, 0, 3]",
-  )
-}
-
-///|
 async test "indexed runner honors concurrency and preserves order" {
   let mut active = 0
   let mut max_active = 0
@@ -150,13 +125,31 @@ test "log monitor counts prompt-sensitive moon commands" {
     #|tool: cwd=.
     #|command=moon fmt
     #|exit=0
-  assert_eq(count_lines_containing_all(log_text, ["command=moon "]), 6)
-  assert_eq(count_lines_containing_all(log_text, ["moon run", " -e"]), 1)
-  assert_eq(count_lines_containing_all(log_text, ["moon run", " -c"]), 1)
-  assert_eq(count_lines_containing_all(log_text, ["command=moon check"]), 1)
-  assert_eq(count_lines_containing_all(log_text, ["command=moon test"]), 1)
-  assert_eq(count_lines_containing_all(log_text, ["command=moon info"]), 1)
-  assert_eq(count_lines_containing_all(log_text, ["command=moon fmt"]), 1)
+  assert_eq(@metrics.count_lines_containing_all(log_text, ["command=moon "]), 6)
+  assert_eq(
+    @metrics.count_lines_containing_all(log_text, ["moon run", " -e"]),
+    1,
+  )
+  assert_eq(
+    @metrics.count_lines_containing_all(log_text, ["moon run", " -c"]),
+    1,
+  )
+  assert_eq(
+    @metrics.count_lines_containing_all(log_text, ["command=moon check"]),
+    1,
+  )
+  assert_eq(
+    @metrics.count_lines_containing_all(log_text, ["command=moon test"]),
+    1,
+  )
+  assert_eq(
+    @metrics.count_lines_containing_all(log_text, ["command=moon info"]),
+    1,
+  )
+  assert_eq(
+    @metrics.count_lines_containing_all(log_text, ["command=moon fmt"]),
+    1,
+  )
 }
 
 ///|

--- a/eval/file_edit/harness/moon.pkg
+++ b/eval/file_edit/harness/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/eval/file_edit/cases",
+  "bobzhang/openseek/eval/internal/metrics",
   "bobzhang/openseek/eval/report",
   "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",

--- a/eval/internal/metrics/metrics.mbt
+++ b/eval/internal/metrics/metrics.mbt
@@ -1,0 +1,30 @@
+///|
+/// Count the non-overlapping occurrences of `needle` in `content`. An empty
+/// `needle` counts as zero rather than matching every position.
+pub fn count_occurrences(content : String, needle : String) -> Int {
+  if needle == "" {
+    return 0
+  }
+  let pieces = content.split(needle).collect()
+  pieces.length() - 1
+}
+
+///|
+/// Count the lines of `content` (split on `\n`) that contain every string in
+/// `needles`. With an empty `needles` every line qualifies.
+pub fn count_lines_containing_all(
+  content : String,
+  needles : Array[String],
+) -> Int {
+  for line in content.split("\n"); count = 0 {
+    for needle in needles {
+      if !line.contains(needle) {
+        break
+      }
+    } nobreak {
+      continue count + 1
+    }
+  } nobreak {
+    count
+  }
+}

--- a/eval/internal/metrics/metrics_test.mbt
+++ b/eval/internal/metrics/metrics_test.mbt
@@ -1,0 +1,28 @@
+///|
+test "count_occurrences counts non-overlapping markers" {
+  assert_eq(
+    @metrics.count_occurrences("tool error: a\ntool error: b", "tool error:"),
+    2,
+  )
+  assert_eq(@metrics.count_occurrences("abc", "z"), 0)
+  assert_eq(@metrics.count_occurrences("abc", ""), 0)
+}
+
+///|
+test "count_lines_containing_all documents all-match behavior" {
+  let log_text =
+    #|command=moon run -e fn main {}
+    #|command=moon run -c fn main {}
+    #|command=moon test
+    #|note=moon run without command prefix
+  debug_inspect(
+    [
+      @metrics.count_lines_containing_all(log_text, ["command=moon "]),
+      @metrics.count_lines_containing_all(log_text, ["moon run", " -e"]),
+      @metrics.count_lines_containing_all(log_text, ["moon run", " -c"]),
+      @metrics.count_lines_containing_all(log_text, ["command=moon ", "missing"]),
+      @metrics.count_lines_containing_all("a\nb\n", []),
+    ],
+    content="[3, 1, 1, 0, 3]",
+  )
+}

--- a/eval/internal/metrics/moon.pkg
+++ b/eval/internal/metrics/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/eval/internal/metrics/pkg.generated.mbti
+++ b/eval/internal/metrics/pkg.generated.mbti
@@ -1,0 +1,16 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/eval/internal/metrics"
+
+// Values
+pub fn count_lines_containing_all(String, Array[String]) -> Int
+
+pub fn count_occurrences(String, String) -> Int
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -371,30 +371,34 @@ fn eval_session_with_context(
     validation: context.validation,
     parse_errors: context.parse_errors,
     partial_tail: context.partial_tail,
-    moon_check_uses: count_occurrences(text, "moon check"),
-    moon_test_uses: count_occurrences(text, "moon test"),
-    moon_run_e_mentions: count_lines_containing_all(text, ["moon run", " -e"]),
-    moon_run_c_mentions: count_lines_containing_all(text, ["moon run", " -c"]),
-    bad_run_e_mentions: count_occurrences(
+    moon_check_uses: @metrics.count_occurrences(text, "moon check"),
+    moon_test_uses: @metrics.count_occurrences(text, "moon test"),
+    moon_run_e_mentions: @metrics.count_lines_containing_all(text, [
+      "moon run", " -e",
+    ]),
+    moon_run_c_mentions: @metrics.count_lines_containing_all(text, [
+      "moon run", " -c",
+    ]),
+    bad_run_e_mentions: @metrics.count_occurrences(
       text, "a value is required for `-e <SCRIPT>`",
     ),
-    from_str_mentions: count_occurrences(text, "@string.from_str"),
-    parse_int_mentions: count_occurrences(text, "@string.parse_int"),
-    argparse_mentions: count_occurrences(text, "@argparse.parse") +
-    count_occurrences(text, ".parse("),
-    old_argparse_mentions: count_occurrences(text, "@argparse.command") +
-    count_occurrences(text, "@argparse.flag") +
-    count_occurrences(text, "@argparse.argument") +
-    count_occurrences(text, ".is_present") +
-    count_occurrences(text, ".value("),
-    c_ffi_mentions: count_occurrences(text, "extern \"c\"") +
-    count_occurrences(text, "native-stub"),
-    env_args_mentions: count_occurrences(text, "@env.args"),
-    result_style_mentions: count_occurrences(text, "Result[") +
-    count_occurrences(text, "Ok(") +
-    count_occurrences(text, "Err("),
-    try_mentions: count_occurrences(text, "try?") +
-    count_occurrences(text, "try!"),
+    from_str_mentions: @metrics.count_occurrences(text, "@string.from_str"),
+    parse_int_mentions: @metrics.count_occurrences(text, "@string.parse_int"),
+    argparse_mentions: @metrics.count_occurrences(text, "@argparse.parse") +
+    @metrics.count_occurrences(text, ".parse("),
+    old_argparse_mentions: @metrics.count_occurrences(text, "@argparse.command") +
+    @metrics.count_occurrences(text, "@argparse.flag") +
+    @metrics.count_occurrences(text, "@argparse.argument") +
+    @metrics.count_occurrences(text, ".is_present") +
+    @metrics.count_occurrences(text, ".value("),
+    c_ffi_mentions: @metrics.count_occurrences(text, "extern \"c\"") +
+    @metrics.count_occurrences(text, "native-stub"),
+    env_args_mentions: @metrics.count_occurrences(text, "@env.args"),
+    result_style_mentions: @metrics.count_occurrences(text, "Result[") +
+    @metrics.count_occurrences(text, "Ok(") +
+    @metrics.count_occurrences(text, "Err("),
+    try_mentions: @metrics.count_occurrences(text, "try?") +
+    @metrics.count_occurrences(text, "try!"),
     warnings: if warnings.length() == 0 {
       ""
     } else {
@@ -634,30 +638,6 @@ fn sanitize_artifact_name(name : String) -> String {
 fn count_successes(results : Array[EvalResult]) -> Int {
   for result in results; count = 0 {
     if result.success {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
-}
-
-///|
-fn count_occurrences(content : String, needle : String) -> Int {
-  if needle == "" {
-    return 0
-  }
-  let pieces = content.split(needle).collect()
-  pieces.length() - 1
-}
-
-///|
-fn count_lines_containing_all(content : String, needles : Array[String]) -> Int {
-  for line in content.split("\n"); count = 0 {
-    for needle in needles {
-      if !line.contains(needle) {
-        break
-      }
-    } nobreak {
       continue count + 1
     }
   } nobreak {

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -139,11 +139,11 @@ test "line counter documents all-match behavior" {
     #|user: mention moon run only
   debug_inspect(
     [
-      count_lines_containing_all(text, ["assistant:"]),
-      count_lines_containing_all(text, ["moon run", " -e"]),
-      count_lines_containing_all(text, ["moon run", " -c"]),
-      count_lines_containing_all(text, ["assistant:", "missing"]),
-      count_lines_containing_all("a\nb\n", []),
+      @metrics.count_lines_containing_all(text, ["assistant:"]),
+      @metrics.count_lines_containing_all(text, ["moon run", " -e"]),
+      @metrics.count_lines_containing_all(text, ["moon run", " -c"]),
+      @metrics.count_lines_containing_all(text, ["assistant:", "missing"]),
+      @metrics.count_lines_containing_all("a\nb\n", []),
     ],
     content="[3, 1, 1, 0, 3]",
   )

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/eval/internal/metrics",
   "bobzhang/openseek/eval/report",
   "bobzhang/openseek/eval/session_analyzer",
   "moonbitlang/async",


### PR DESCRIPTION
## What

Dedupe verbatim-duplicated text-metric helpers into a shared internal package, `eval/internal/metrics`.

- `count_occurrences` and `count_lines_containing_all` were duplicated byte-for-byte in the `prompt_task` and `file_edit` eval harnesses. They now live in one package; call sites use the qualified `@metrics.*` form and the dedicated tests move with the functions.
- `.gitignore` gains the `eval/internal` allow-list entry that every tracked eval source dir already has (the eval tree is `eval/*`-ignored with per-dir `!` exceptions).

## Validation

- `moon check` clean; `moon fmt` clean; no public API change.
- Targeted tests pass (26 across the affected eval packages).
- Reviewed by **codex** (`codex review --base main`): *"behavior-preserving extraction of duplicated metric helpers into an internal package… no introduced correctness issues were identified."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
