### PR TITLE
reuse core: String::pad_start and String::repeat instead of hand-rolled helpers

### DIFF
--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -56,21 +56,11 @@ pub fn SessionId::generated(
   salt? : String = "",
 ) -> SessionId {
   fn pad2(value : Int) -> String {
-    if value < 10 {
-      "0\{value}"
-    } else {
-      "\{value}"
-    }
+    value.to_string().pad_start(2, '0')
   }
 
   fn pad3(value : Int) -> String {
-    if value < 10 {
-      "00\{value}"
-    } else if value < 100 {
-      "0\{value}"
-    } else {
-      "\{value}"
-    }
+    value.to_string().pad_start(3, '0')
   }
 
   let tail = if salt == "" { "" } else { "-\{salt}" }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -540,11 +540,7 @@ fn compact_prompt_label(prompt : String) -> String {
 ///|
 fn format_utc_minute(seconds : Int64) -> String {
   fn pad2(value : Int) -> String {
-    if value < 10 {
-      "0\{value}"
-    } else {
-      "\{value}"
-    }
+    value.to_string().pad_start(2, '0')
   }
 
   let time = @time.unix(seconds) catch { _ => return "-" }

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -374,9 +374,5 @@ fn count_successes(results : Array[TrialResult]) -> Int {
 
 ///|
 fn padded_index(value : Int) -> String {
-  if value < 10 {
-    "0\{value}"
-  } else {
-    value.to_string()
-  }
+  value.to_string().pad_start(2, '0')
 }

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -189,9 +189,5 @@ fn should_skip_scan_dir(name : String) -> Bool {
 
 ///|
 fn padded_index(value : Int) -> String {
-  if value < 10 {
-    "0\{value}"
-  } else {
-    value.to_string()
-  }
+  value.to_string().pad_start(2, '0')
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -468,16 +468,7 @@ fn markdown_fence(text : String) -> String {
     longest
   }
   let length = if longest >= 3 { longest + 1 } else { 3 }
-  repeat_char('`', length)
-}
-
-///|
-fn repeat_char(char : Char, count : Int) -> String {
-  let out = StringBuilder::new()
-  for _ in 0..<count {
-    out.write_char(char)
-  }
-  out.to_string()
+  "`".repeat(length)
 }
 
 ///|

--- a/eval/report/report_test.mbt
+++ b/eval/report/report_test.mbt
@@ -44,17 +44,8 @@ test "markdown renders summary metrics and dynamic columns" {
 }
 
 ///|
-fn repeated_text(text : String, count : Int) -> String {
-  let out = StringBuilder::new()
-  for _ in 0..<count {
-    out.write_string(text)
-  }
-  out.to_string()
-}
-
-///|
 test "markdown details keep full arbitrary text" {
-  let long_reason = repeated_text("a", 95) + "😊 full reason tail"
+  let long_reason = "a".repeat(95) + "😊 full reason tail"
   let warning = "contains `inline` and ```fenced``` backticks"
   let report = @report.Report(title="Details", rows=[
     ReportRow(


### PR DESCRIPTION
## What

Stop reimplementing standard-library string helpers — use `moonbitlang/core` directly. No public API change.

- **`String::pad_start`** replaces the hand-rolled `if value < 10 { "0\{value}" } …` logic in:
  - `pad2`/`pad3` — session-id and UTC-minute timestamps (`agent_session`, `cmd/openseek`).
  - `padded_index` — eval trial directory names (`eval/prompt_task`, `eval/file_edit`).
  All inputs are non-negative date components / 1-based indices, so output is identical.
- **`String::repeat`** replaces the `StringBuilder` write-loops in `repeat_char` and `repeated_text` (`eval/report`); both had a single caller, so they're inlined.

## Validation

- `moon check` + `moon fmt` clean; targeted tests pass (98 across the affected packages).
- Reviewed by **codex** (`codex review --base main`): *"behavior-preserving replacements of local padding/repetition helpers with standard String methods… No actionable regressions were identified."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
