### PR TITLE
test: drop brittle prompt substring walls; snapshot deepseek request bodies

### DIFF
--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -1,24 +1,38 @@
+// `encode_chat_request` builds the JSON request body sent to DeepSeek's
+// chat-completions endpoint. Each test snapshots the exact body a given set of
+// options produces, so the file doubles as documentation of the wire format.
+// Regenerate the snapshots with `moon test --update` after changing the encoder.
+
 ///|
-test "encode_chat_request omits response format by default" {
+test "minimal request: flash model, no response_format, non-stream" {
   let body = @deepseek.encode_chat_request(model=V4Flash) <| [
     ChatMessage(System, content="plain text is fine"),
     ChatMessage(User, content="ping"),
   ]
-  let text = body.stringify()
-  assert_true(text.contains("\"stream\":false"))
-  assert_false(text.contains("\"response_format\""))
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [
+      { "role": "system", "content": "plain text is fine" },
+      { "role": "user", "content": "ping" },
+    ],
+    "stream": false,
+  })
 }
 
 ///|
-test "encode_chat_request defaults to V4Pro" {
+test "model defaults to V4Pro" {
   let body = @deepseek.encode_chat_request() <| [
     ChatMessage(User, content="ping"),
   ]
-  assert_true(body.stringify().contains("\"model\":\"deepseek-v4-pro\""))
+  json_inspect(body, content={
+    "model": "deepseek-v4-pro",
+    "messages": [{ "role": "user", "content": "ping" }],
+    "stream": false,
+  })
 }
 
 ///|
-test "encode_chat_request can ask for json output explicitly" {
+test "response_format=JsonObject asks for a JSON object reply" {
   let body = @deepseek.encode_chat_request(
     model=V4Flash,
     response_format=JsonObject,
@@ -26,13 +40,19 @@ test "encode_chat_request can ask for json output explicitly" {
     ChatMessage(System, content="json only"),
     ChatMessage(User, content="ping"),
   ]
-  guard body is { "response_format": { "type": String("json_object"), .. }, .. } else {
-    fail("wrong response_format")
-  }
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [
+      { "role": "system", "content": "json only" },
+      { "role": "user", "content": "ping" },
+    ],
+    "stream": false,
+    "response_format": { "type": "json_object" },
+  })
 }
 
 ///|
-test "encode_chat_request includes tools when present" {
+test "tools are advertised as function definitions" {
   let tool = @deepseek.ToolDefinition("shell", "Run a shell command.", {
     "type": "object",
     "properties": { "cmd": { "type": "string" } },
@@ -41,64 +61,95 @@ test "encode_chat_request includes tools when present" {
   let body = @deepseek.encode_chat_request(model=V4Flash, tools=[tool]) <| [
     ChatMessage(User, content="run tests"),
   ]
-  let text = body.stringify()
-  assert_true(text.contains("\"model\":\"deepseek-v4-flash\""))
-  assert_true(text.contains("\"messages\""))
-  assert_true(text.contains("\"tools\""))
-  assert_true(text.contains("\"type\":\"function\""))
-  assert_true(text.contains("\"name\":\"shell\""))
-  assert_true(text.contains("\"required\""))
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [{ "role": "user", "content": "run tests" }],
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "shell",
+          "description": "Run a shell command.",
+          "parameters": {
+            "type": "object",
+            "properties": { "cmd": { "type": "string" } },
+            "required": ["cmd"],
+          },
+        },
+      },
+    ],
+  })
 }
 
 ///|
-test "encode_chat_request enables usage-bearing stream mode" {
+test "stream=true requests usage-bearing streaming" {
   let body = @deepseek.encode_chat_request(model=V4Flash, stream=true) <| [
     ChatMessage(User, content="stream this"),
   ]
-  let text = body.stringify()
-  assert_true(text.contains("\"stream\":true"))
-  guard body
-    is { "stream": True, "stream_options": { "include_usage": True, .. }, .. } else {
-    fail("wrong stream options")
-  }
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [{ "role": "user", "content": "stream this" }],
+    "stream": true,
+    "stream_options": { "include_usage": true },
+  })
 }
 
 ///|
-test "encode_chat_request encodes thinking controls" {
-  let high = @deepseek.encode_chat_request(model=V4Pro, thinking=High) <| [
+test "thinking=High enables reasoning at high effort" {
+  let body = @deepseek.encode_chat_request(model=V4Pro, thinking=High) <| [
     ChatMessage(User, content="solve"),
   ]
-  let high_text = high.stringify()
-  assert_true(high_text.contains("\"thinking\""))
-  assert_true(high_text.contains("\"type\":\"enabled\""))
-  assert_true(high_text.contains("\"reasoning_effort\":\"high\""))
-
-  let max = @deepseek.encode_chat_request(model=V4Pro, thinking=Max) <| [
-    ChatMessage(User, content="solve"),
-  ]
-  assert_true(max.stringify().contains("\"reasoning_effort\":\"max\""))
-
-  let no = @deepseek.encode_chat_request(model=V4Pro, thinking=No) <| [
-    ChatMessage(User, content="solve"),
-  ]
-  let no_text = no.stringify()
-  assert_true(no_text.contains("\"type\":\"disabled\""))
-  assert_false(no_text.contains("\"reasoning_effort\""))
+  json_inspect(body, content={
+    "model": "deepseek-v4-pro",
+    "messages": [{ "role": "user", "content": "solve" }],
+    "stream": false,
+    "thinking": { "type": "enabled" },
+    "reasoning_effort": "high",
+  })
 }
 
 ///|
-test "encode_chat_request omits tools and thinking when absent" {
+test "thinking=Max enables reasoning at max effort" {
+  let body = @deepseek.encode_chat_request(model=V4Pro, thinking=Max) <| [
+    ChatMessage(User, content="solve"),
+  ]
+  json_inspect(body, content={
+    "model": "deepseek-v4-pro",
+    "messages": [{ "role": "user", "content": "solve" }],
+    "stream": false,
+    "thinking": { "type": "enabled" },
+    "reasoning_effort": "max",
+  })
+}
+
+///|
+test "thinking=No disables reasoning and omits reasoning_effort" {
+  let body = @deepseek.encode_chat_request(model=V4Pro, thinking=No) <| [
+    ChatMessage(User, content="solve"),
+  ]
+  json_inspect(body, content={
+    "model": "deepseek-v4-pro",
+    "messages": [{ "role": "user", "content": "solve" }],
+    "stream": false,
+    "thinking": { "type": "disabled" },
+  })
+}
+
+///|
+test "tools and thinking are omitted when absent" {
   let body = @deepseek.encode_chat_request(model=V4Flash) <| [
     ChatMessage(User, content="hi"),
   ]
-  let text = body.stringify()
-  assert_false(text.contains("\"tools\""))
-  assert_false(text.contains("\"thinking\""))
-  assert_false(text.contains("\"reasoning_effort\""))
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [{ "role": "user", "content": "hi" }],
+    "stream": false,
+  })
 }
 
 ///|
-test "encode_chat_request rounds-trips assistant tool call echo and tool result" {
+test "assistant tool-call echo and tool result round-trip" {
   let call = @deepseek.ToolCall(
     id="call_42",
     name="shell",
@@ -110,20 +161,33 @@ test "encode_chat_request rounds-trips assistant tool call echo and tool result"
     ChatMessage(Assistant, content="", tool_calls=[call]),
     ChatMessage(Tool("call_42"), content="exit=0\nok"),
   ]
-  let text = body.stringify()
-  assert_true(text.contains("\"role\":\"system\""))
-  assert_true(text.contains("\"role\":\"user\""))
-  assert_true(text.contains("\"role\":\"assistant\""))
-  assert_true(text.contains("\"role\":\"tool\""))
-  assert_true(text.contains("\"content\":null"))
-  assert_true(text.contains("\"tool_call_id\":\"call_42\""))
-  assert_true(
-    text.contains("\"arguments\":\"{\\\"cmd\\\":\\\"moon test\\\"}\""),
-  )
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [
+      { "role": "system", "content": "be terse" },
+      { "role": "user", "content": "run the tests" },
+      {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_42",
+            "type": "function",
+            "function": {
+              "name": "shell",
+              "arguments": "{\"cmd\":\"moon test\"}",
+            },
+          },
+        ],
+      },
+      { "role": "tool", "content": "exit=0\nok", "tool_call_id": "call_42" },
+    ],
+    "stream": false,
+  })
 }
 
 ///|
-test "encode_chat_request encodes multiple tool definitions" {
+test "multiple tool definitions are all encoded" {
   let shell = @deepseek.ToolDefinition("shell", "Run a shell command.", {
     "type": "object",
     "properties": { "cmd": { "type": "string" } },
@@ -140,7 +204,35 @@ test "encode_chat_request encodes multiple tool definitions" {
   ) <| [
     ChatMessage(User, content="look around"),
   ]
-  let text = body.stringify()
-  assert_true(text.contains("\"name\":\"shell\""))
-  assert_true(text.contains("\"name\":\"read\""))
+  json_inspect(body, content={
+    "model": "deepseek-v4-flash",
+    "messages": [{ "role": "user", "content": "look around" }],
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "shell",
+          "description": "Run a shell command.",
+          "parameters": {
+            "type": "object",
+            "properties": { "cmd": { "type": "string" } },
+            "required": ["cmd"],
+          },
+        },
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "read",
+          "description": "Read a file.",
+          "parameters": {
+            "type": "object",
+            "properties": { "path": { "type": "string" } },
+            "required": ["path"],
+          },
+        },
+      },
+    ],
+  })
 }

--- a/prompt/prompt_wbtest.mbt
+++ b/prompt/prompt_wbtest.mbt
@@ -1,96 +1,14 @@
 ///|
-test "flash prompt keeps core MoonBit guidance" {
-  let prompt = flash_prompt()
-  assert_true(
-    prompt.contains("MoonBit coding agent focused on implementing user tasks"),
-  )
-  assert_true(prompt.contains("Do not emit JSON action plans"))
-  assert_true(prompt.contains("Run `moon check` through `shell`"))
-  assert_true(prompt.contains("moon check:"))
-  assert_true(prompt.contains("failures include `exit=<code>`"))
-  assert_true(prompt.contains("exit=cancelled"))
-  assert_true(prompt.contains(".mbt.md"))
-  assert_true(prompt.contains("module-root `moon check --diagnostic-limit 1`"))
-  assert_true(prompt.contains("much faster than"))
-  assert_true(prompt.contains("primary"))
-  assert_true(prompt.contains("Create `moon.mod` before running `moon info`"))
-  assert_true(prompt.contains("`moon.mod` is the module manifest"))
-  assert_true(prompt.contains("module-level dependency versions"))
-  assert_true(prompt.contains("`moon.pkg` is the package manifest"))
-  assert_true(prompt.contains("package imports, import aliases"))
-  assert_true(
-    prompt.contains("Do not put package imports or aliases in `moon.mod`"),
-  )
-  assert_true(
-    prompt.contains("do\n  not put module dependency versions in `moon.pkg`"),
-  )
-  assert_true(prompt.contains("Plain `fn` is private"))
-  assert_true(prompt.contains("_test.mbt` files are black-box tests"))
-  assert_true(prompt.contains("Use `suberror` for custom errors"))
-  assert_true(prompt.contains("Pattern matching error constructors is"))
-  assert_true(
-    prompt.contains("valid. When matching errors from another package"),
-  )
-  assert_true(prompt.contains("catch { @pkga.A => ...; @pkga.B => ... }"))
-  assert_true(
-    prompt.contains("Parameter and receiver bindings cannot be `mut`"),
-  )
-  assert_true(
-    prompt.contains("not `fn f(mut x : Int)` or\n  `fn T::m(mut self : T)`"),
-  )
-  assert_true(prompt.contains("fn f(mut x : Int)"))
-  assert_true(prompt.contains("fn T::m(mut self : T)"))
-  assert_true(prompt.contains("Use `let mut x = ...` only for local rebinding"))
-  assert_true(prompt.contains("Use `mut field : T` only on struct fields"))
-  assert_true(prompt.contains("small focused"))
-  assert_true(prompt.contains("moonbitlang/core/argparse"))
-  assert_true(prompt.contains("@stdio.stdin.read_all().text()"))
-  assert_true(prompt.contains("@stdio.stderr.write(...)"))
-  assert_true(prompt.contains("@sys.exit(1)"))
-  assert_true(prompt.contains("let x : UInt16 = 0"))
-  assert_true(prompt.contains("s[i] == '='"))
-  assert_true(prompt.contains("without allocating `Some(ch)`"))
-  assert_true(prompt.contains("s.get_char(i) is Some(c) && c == ch"))
-  assert_true(
-    prompt.contains("lowercase names in patterns bind a new variable"),
-  )
-  assert_true(prompt.contains("Do not write constructor-style casts"))
-  assert_true(prompt.contains("UInt16(92)"))
-  assert_true(prompt.contains("s[:4]"))
-  assert_true(prompt.contains("Raw multi-line strings use `#|`"))
-  assert_true(prompt.contains("Interpolated multi-line strings use `$|`"))
-  assert_true(prompt.contains("Prefer `moon run - <<'EOF'`"))
-  assert_true(prompt.contains("moon run --target native - <<'EOF'"))
-  assert_true(prompt.contains("Use checked errors for ordinary parser"))
-  assert_true(
-    prompt.contains("Json::number(n.to_double(), repr=text.to_owned())"),
-  )
-  assert_true(prompt.contains("Do not create JSON with `Json::Object(...)`"))
-  assert_true(prompt.contains("Use `map.get(key)` for `T?`"))
-  assert_true(
-    prompt.contains("Do not implement ordinary file/stdin IO with C FFI"),
-  )
-  assert_true(
-    prompt.contains("moon run --target native cmd/tomljson -- /tmp/input.toml"),
-  )
-}
-
-///|
-test "flash prompt omits obsolete guidance" {
-  let prompt = flash_prompt()
-  assert_false(prompt.contains("check_daemon"))
-  assert_false(prompt.contains("moon_ide"))
-  assert_false(prompt.contains("moon_cmd"))
-  assert_false(prompt.contains("try?"))
-  assert_false(prompt.contains("try!"))
-  assert_false(prompt.contains("@string.parse_int"))
-  assert_false(prompt.contains("Spec-driven Development"))
-  assert_false(prompt.contains("proof_invariant"))
-  assert_false(prompt.contains("Loop Invariants"))
-}
-
-///|
-test "default prompt uses the flash prompt for all DeepSeek V4 models" {
+/// The built-in system prompt is currently model-independent: every DeepSeek
+/// model receives the flash prompt. (The base prompt stays in the package for
+/// prompt experiments but is not selected by default.)
+///
+/// Prompt *wording* is authored in `flash_prompt.mbt.md` and its quality is
+/// exercised end-to-end by the `eval/prompt_task` suite. Asserting on
+/// individual phrases of the generated prompt here only mirrors that document
+/// and breaks on every rewording, so this package pins just the selection
+/// contract.
+test "system_prompt_for_model returns the flash prompt for every model" {
   assert_eq(system_prompt_for_model(V4Flash), flash_prompt())
   assert_eq(system_prompt_for_model(V4Pro), flash_prompt())
 }


### PR DESCRIPTION
## What

Two test-quality cleanups: drop a brittle test that mirrored a static document, and make a structured-output test read like documentation via snapshots.

### `test(prompt)` — remove the substring walls
`prompt_wbtest.mbt` asserted ~70 `prompt.contains("…")` fragments that simply mirrored `flash_prompt.mbt.md`. They tested no behavior and broke on every rewording. Prompt wording is authored in the `.mbt.md` and its quality is exercised end-to-end by `eval/prompt_task`, so the package now pins only the real contract — `system_prompt_for_model` returns the flash prompt for every model — with a doc comment explaining why content isn't asserted here. (96 → 15 lines.)

### `test(deepseek)` — snapshot the request bodies
`encode_chat_request_test.mbt` replaced ~27 `text.contains("…")` checks with one `json_inspect` snapshot per case. `moon fmt` pretty-prints them into indented JSON, so each test documents the exact wire format (key order, `content:null` for tool-call echoes, omitted optional fields) — and verifies more than the old fragment checks. Regenerate with `moon test --update`.

## Scope note
I intentionally left the other `contains`-based tests alone: the tool tests (`shell`, `moon_check`, `moon_ide`, `read`, `auto_check`) assert markers in output that carries absolute paths / variable text, where snapshots would be flaky and substring checks are correct; `viz_test` renders large deterministic HTML where a single snapshot reads worse than the current commented, targeted checks.

## Validation

- `moon check` + `moon fmt` clean; 56 prompt+deepseek tests pass.
- Reviewed by **codex** (`codex review --base main`): *"No actionable regressions were found in the changed tests. The targeted modified tests pass."* Codex also confirmed the removed prompt assertions weren't protecting anything (the obsolete terms live only in the unused base prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
