### PR TITLE
test(agent_session): snapshot structured values as documentation

### DIFF
--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -41,29 +41,103 @@ fn events_jsonl(session : @agent_session.Session) -> String {
 
 ///|
 test "parse round-trips every event kind" {
-  let parsed = @log.parse_events(events_jsonl(sample_session()))
-  inspect(parsed.events.length(), content="5")
-  inspect(parsed.errors.length(), content="0")
-  inspect(parsed.partial_tail, content="false")
+  // Serializing the sample session and parsing it back recovers all five event
+  // kinds (user, assistant-with-tool-call, tool, runtime, terminal) with no
+  // errors and no partial tail.
+  debug_inspect(
+    @log.parse_events(events_jsonl(sample_session())),
+    content=(
+      #|{
+      #|  events: [
+      #|    { sequence: 1, ts: 0, item: User({ content: "list the files" }) },
+      #|    {
+      #|      sequence: 2,
+      #|      ts: 0,
+      #|      item: Assistant(
+      #|        {
+      #|          content: "I'll run ls.",
+      #|          tool_calls: [{ id: "call_1", name: "shell", arguments: "{\"cmd\":\"ls\"}" }],
+      #|          reasoning_content: Some("The user wants a directory listing."),
+      #|        },
+      #|      ),
+      #|    },
+      #|    {
+      #|      sequence: 3,
+      #|      ts: 0,
+      #|      item: Tool(
+      #|        {
+      #|          tool_call_id: "call_1",
+      #|          tool_name: "shell",
+      #|          content: "README.md\nsrc",
+      #|          is_error: false,
+      #|          brief: None,
+      #|        },
+      #|      ),
+      #|    },
+      #|    {
+      #|      sequence: 4,
+      #|      ts: 0,
+      #|      item: Runtime({ content: "moon check: 0 errors" }),
+      #|    },
+      #|    {
+      #|      sequence: 5,
+      #|      ts: 0,
+      #|      item: Terminal(Finished("Here are your files: README.md, src.")),
+      #|    },
+      #|  ],
+      #|  errors: [],
+      #|  partial_tail: false,
+      #|}
+    ),
+  )
 }
 
 ///|
 test "parse tolerates a truncated final line" {
+  // A half-written last line (a crash mid-append) is dropped, the preceding
+  // events survive, and partial_tail flags the truncation.
   let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi"
-  let parsed = @log.parse_events(text)
-  inspect(parsed.events.length(), content="1")
-  inspect(parsed.errors.length(), content="0")
-  inspect(parsed.partial_tail, content="true")
+  debug_inspect(
+    @log.parse_events(text),
+    content=(
+      #|{
+      #|  events: [{ sequence: 1, ts: 0, item: User({ content: "hi" }) }],
+      #|  errors: [],
+      #|  partial_tail: true,
+      #|}
+    ),
+  )
 }
 
 ///|
 test "parse records a bad interior line without aborting" {
+  // A corrupt interior line is recorded while the valid events on either side
+  // still parse. We snapshot the surviving events and the error's line number
+  // and original text, but not the parser's `message` — that wording belongs to
+  // moonbitlang/core and should not be pinned here.
   let text = "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\nnot json at all\n{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n"
   let parsed = @log.parse_events(text)
-  inspect(parsed.events.length(), content="2")
-  inspect(parsed.errors.length(), content="1")
-  inspect(parsed.errors[0].line_number, content="2")
-  inspect(parsed.partial_tail, content="false")
+  debug_inspect(
+    parsed.events,
+    content=(
+      #|[
+      #|  { sequence: 1, ts: 0, item: User({ content: "hi" }) },
+      #|  { sequence: 2, ts: 0, item: Terminal(Finished("done")) },
+      #|]
+    ),
+  )
+  debug_inspect(
+    parsed.errors.map(e => (e.line_number, e.content)),
+    content=(
+      #|[(2, "not json at all")]
+    ),
+  )
+  inspect(
+    parsed.partial_tail,
+    content=(
+      #|false
+    ),
+  )
 }
 
 ///|

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -95,23 +95,46 @@ test "session projects to DeepSeek chat messages" {
       ),
     )
     .append(Terminal(Finished("done")))
-  let messages = session.chat_messages()
-  assert_eq(messages.length(), 5)
-  assert_true(messages[0].role is System)
-  assert_eq(messages[0].content, "system")
-  assert_true(messages[1].role is User)
-  assert_eq(messages[1].content, "inspect")
-  assert_true(messages[2].role is Assistant)
-  assert_eq(messages[2].content, "")
-  assert_true(messages[2].reasoning_content is Some("need file"))
-  assert_eq(messages[2].tool_calls.length(), 1)
-  assert_eq(messages[2].tool_calls[0].id, "call_1")
-  assert_eq(messages[2].tool_calls[0].name, "read")
-  assert_eq(messages[2].tool_calls[0].arguments, "{\"path\":\"README.md\"}")
-  assert_true(messages[3].role is Tool("call_1"))
-  assert_eq(messages[3].content, "README")
-  assert_true(messages[4].role is Assistant)
-  assert_eq(messages[4].content, "done")
+  // The projection is the documented contract: a leading System message, the
+  // user/assistant/tool turns, and a trailing Assistant message carrying the
+  // finish text. The snapshot pins every field of every message.
+  debug_inspect(
+    session.chat_messages(),
+    content=(
+      #|[
+      #|  {
+      #|    role: System,
+      #|    content: "system",
+      #|    tool_calls: [],
+      #|    reasoning_content: None,
+      #|  },
+      #|  {
+      #|    role: User,
+      #|    content: "inspect",
+      #|    tool_calls: [],
+      #|    reasoning_content: None,
+      #|  },
+      #|  {
+      #|    role: Assistant,
+      #|    content: "",
+      #|    tool_calls: [{ id: "call_1", name: "read", arguments: "{\"path\":\"README.md\"}" }],
+      #|    reasoning_content: Some("need file"),
+      #|  },
+      #|  {
+      #|    role: Tool("call_1"),
+      #|    content: "README",
+      #|    tool_calls: [],
+      #|    reasoning_content: None,
+      #|  },
+      #|  {
+      #|    role: Assistant,
+      #|    content: "done",
+      #|    tool_calls: [],
+      #|    reasoning_content: None,
+      #|  },
+      #|]
+    ),
+  )
 }
 
 ///|


### PR DESCRIPTION
## What

Continue the "tests as documentation" effort (after #235) by turning field-by-field assertions on deterministic structured values into single snapshots in `agent_session`.

- **`session_test`** — "session projects to DeepSeek chat messages" replaced 15 separate `assert_eq`/`assert_true` checks with one `debug_inspect` of the projected `ChatMessage` array. The snapshot documents the whole projection: the leading `System` message, the user/assistant/tool turns (with tool-call fields and `reasoning_content`), and the trailing finish message.
- **`log_test`** — the three `parse_events` tests replaced per-field count `inspect`s with `debug_inspect` snapshots of the parsed result, documenting the actual recovered structure: every event kind round-tripping, a dropped truncated tail, and a recorded bad interior line.

## Deliberate restraint
The "bad interior line" test snapshots only the surviving events and the error's `(line_number, content)` — **not** the parser's `message` field, which is `moonbitlang/core` wording. Pinning that would reintroduce exactly the external-dependency brittleness this effort is removing.

I stopped here: a scan of the rest of the suite found it already uses snapshots well, or correctly uses substring/scalar checks where output carries paths/timestamps (store, shell, edit) or large fragile HTML (viz) — converting those would make tests *worse*.

## Validation
- `moon check` (0 warnings) + `moon fmt` clean; 21 agent_session tests pass.
- Reviewed by **codex** (`codex review --base main`): *"only strengthen/reshape existing tests into fuller snapshots… I did not find any actionable regression introduced by the diff."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
