### PR TITLE
read: suggest a same-stem sibling on file-not-found

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -82,7 +82,9 @@ output truncation. The string body has one of these shapes:
   `is_error` to `true`.
 - `"error reading <path>: <error>"` — a single-file read failed. Common
   causes: the file is missing, the agent doesn't have read permissions, or
-  the bytes aren't valid UTF-8.
+  the bytes aren't valid UTF-8. When the path is missing and a sibling shares
+  its stem (e.g. `foo.ts` requested while `foo.mbt` exists), the message ends
+  with ` Did you mean <name>?` so the agent can retry without an extra `ls`.
 - `"error: read requires arguments.path"` — payload was an object but named no
   file.
 - `"error: read requires object arguments"` — payload was not a JSON object.

--- a/agent_tool/read/moon.pkg
+++ b/agent_tool/read/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/json",
+  "moonbitlang/x/path",
 }
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -154,7 +154,10 @@ async fn similar_file_hint(path : String) -> String {
   if stem == "" {
     return ""
   }
-  let names = @fs.readdir(requested.dirname().to_string(), sort=true) catch {
+  // `dirname` is "" for a bare relative name (`README`); read its siblings from
+  // the current directory so those paths get the same hint as nested ones.
+  let dir = requested.dirname().to_string()
+  let names = @fs.readdir(if dir == "" { "." } else { dir }, sort=true) catch {
     _ => return ""
   }
   for candidate in names {
@@ -573,6 +576,14 @@ async test "read suggests a same-stem sibling when the path is missing" {
     guard bare is Respond(out2) else { fail("expected Respond") }
     assert_true(out2.content.has_suffix("Did you mean README.md?"))
   })
+}
+
+///|
+test "file_stem strips only the final extension" {
+  assert_eq(file_stem("foo.ts"), "foo")
+  assert_eq(file_stem("foo.test.ts"), "foo.test")
+  assert_eq(file_stem("Makefile"), "Makefile")
+  assert_eq(file_stem(".gitignore"), ".gitignore")
 }
 
 ///|

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -162,14 +162,23 @@ async fn similar_file_hint(path : String) -> String {
   }
   // `dirname` is "" for a bare relative name (`README`); read its siblings from
   // the current directory so those paths get the same hint as nested ones.
-  let dir = requested.dirname().to_string()
-  let names = @fs.readdir(if dir == "" { "." } else { dir }, sort=true) catch {
-    _ => return ""
-  }
+  let dirname = requested.dirname().to_string()
+  let parent = if dirname == "" { "." } else { dirname }
+  let names = @fs.readdir(parent, sort=true) catch { _ => return "" }
   for candidate in names {
-    if candidate != name && file_stem(candidate) == stem {
-      return " Did you mean \{candidate}?"
+    if candidate == name || file_stem(candidate) != stem {
+      continue
     }
+    // `read` rejects directories, so a same-stem dir (`foo/` next to `foo.mbt`,
+    // a common package layout) would just point the agent at another failure —
+    // skip it and keep scanning for a same-stem file.
+    let kind = @fs.kind("\{parent}/\{candidate}", follow_symlink=true) catch {
+      _ => continue
+    }
+    if kind is Directory {
+      continue
+    }
+    return " Did you mean \{candidate}?"
   }
   ""
 }
@@ -603,6 +612,20 @@ async test "read hint probe does not mask errors for a non-directory parent" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("error reading"))
+  })
+}
+
+///|
+async test "read suggestion skips a same-stem directory for a sibling file" {
+  @vfs.with_tmpdir(dir => {
+    // `parser/` sorts before `parser.mbt`; the hint must skip the directory
+    // (read rejects directories) and point at the file instead.
+    @fs.mkdir("\{dir}/parser")
+    @fs.write_file("\{dir}/parser.mbt", "x", create_mode=CreateOrTruncate)
+    let result = execute({ "path": "\{dir}/parser.ts" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.has_suffix("Did you mean parser.mbt?"))
   })
 }
 

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -25,7 +25,9 @@
 ///   the `max_output_chars` budget cut the body (`truncated=true`).
 /// - `Respond(ToolOutput("error reading <path>: <error>", is_error=true))`
 ///   if a single-file read fails (missing file, permission denied, invalid
-///   UTF-8, directory path, etc.).
+///   UTF-8, directory path, etc.). When the path is missing and a sibling shares
+///   its stem (e.g. `foo.ts` requested, `foo.mbt` present), the message ends
+///   with ` Did you mean <name>?`.
 /// - `Respond(ToolOutput("error: read requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition(
@@ -102,7 +104,7 @@ async fn read_file(
   let content = @fs.read_file(path).text() catch {
     error =>
       return @agent_tool.ToolAction::respond(
-        "error reading \{path}: \{error}",
+        "error reading \{path}: \{error}\{similar_file_hint(path)}",
         is_error=true,
         brief~,
       )
@@ -132,6 +134,49 @@ fn read_footer(
   rendered : RenderedSelection,
 ) -> String {
   "<system>start_line=\{selection.start_line} shown_lines=\{rendered.shown_lines} total_lines=\{selection.total_lines} truncated=\{rendered.truncated}</system>"
+}
+
+///|
+/// When a read fails because the path does not exist, suggest a sibling file
+/// with the same stem but a different extension (e.g. `foo.ts` requested while
+/// `foo.mbt` is present) so the model can recover without an extra `ls`. Mirrors
+/// Claude Code's `findSimilarFile`: same-stem only, no fuzzy matching, so the
+/// suggestion is almost never misleading. Returns `""` (no hint) when the path
+/// exists — i.e. the read failed for some other reason such as a permission
+/// error or invalid UTF-8 — or when nothing similar is found.
+async fn similar_file_hint(path : String) -> String {
+  if @fs.exists(path) {
+    return ""
+  }
+  let requested : @path.Path = path
+  let name = requested.basename().to_owned()
+  let stem = file_stem(name)
+  if stem == "" {
+    return ""
+  }
+  let names = @fs.readdir(requested.dirname().to_string(), sort=true) catch {
+    _ => return ""
+  }
+  for candidate in names {
+    if candidate != name && file_stem(candidate) == stem {
+      return " Did you mean \{candidate}?"
+    }
+  }
+  ""
+}
+
+///|
+/// A filename without its final extension, matching `basename(name, extname)`.
+/// `"foo.ts"` -> `"foo"`, `"foo.test.ts"` -> `"foo.test"`, and an extensionless
+/// or dotfile name (`"Makefile"`, `".gitignore"`) is returned unchanged.
+fn file_stem(name : String) -> String {
+  let as_path : @path.Path = name
+  let ext = as_path.extname().to_owned()
+  if ext == "" || ext.length() >= name.length() {
+    name
+  } else {
+    name[:name.length() - ext.length()].to_owned()
+  }
 }
 
 ///|
@@ -509,6 +554,36 @@ async test "read surfaces filesystem errors" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("error reading"))
     assert_true(output.is_error)
+  })
+}
+
+///|
+async test "read suggests a same-stem sibling when the path is missing" {
+  @vfs.with_tmpdir(dir => {
+    // A different extension on the same stem is the common typo this recovers.
+    @fs.write_file("\{dir}/parser.mbt", "x", create_mode=CreateOrTruncate)
+    let result = execute({ "path": "\{dir}/parser.ts" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("error reading"))
+    assert_true(output.content.has_suffix("Did you mean parser.mbt?"))
+    // The same recovery works for an extensionless request (`README`).
+    @fs.write_file("\{dir}/README.md", "x", create_mode=CreateOrTruncate)
+    let bare = execute({ "path": "\{dir}/README" })
+    guard bare is Respond(out2) else { fail("expected Respond") }
+    assert_true(out2.content.has_suffix("Did you mean README.md?"))
+  })
+}
+
+///|
+async test "read omits a suggestion when no sibling shares the stem" {
+  @vfs.with_tmpdir(dir => {
+    @fs.write_file("\{dir}/unrelated.mbt", "x", create_mode=CreateOrTruncate)
+    let result = execute({ "path": "\{dir}/parser.ts" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("error reading"))
+    assert_false(output.content.contains("Did you mean"))
   })
 }
 

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -145,7 +145,13 @@ fn read_footer(
 /// exists — i.e. the read failed for some other reason such as a permission
 /// error or invalid UTF-8 — or when nothing similar is found.
 async fn similar_file_hint(path : String) -> String {
-  if @fs.exists(path) {
+  // `@fs.exists` only maps ENOENT to `false`; it re-raises other access errors
+  // (EACCES on an unsearchable parent, ENOTDIR for `<file>/child`). This probe
+  // runs while formatting an existing read failure, so any raise here would
+  // escape the clean "error reading ..." response — treat a failed probe as "no
+  // hint", exactly like the `readdir` path below.
+  let exists = @fs.exists(path) catch { _ => return "" }
+  if exists {
     return ""
   }
   let requested : @path.Path = path
@@ -584,6 +590,20 @@ test "file_stem strips only the final extension" {
   assert_eq(file_stem("foo.test.ts"), "foo.test")
   assert_eq(file_stem("Makefile"), "Makefile")
   assert_eq(file_stem(".gitignore"), ".gitignore")
+}
+
+///|
+async test "read hint probe does not mask errors for a non-directory parent" {
+  @vfs.with_tmpdir(dir => {
+    @fs.write_file("\{dir}/notdir", "x", create_mode=CreateOrTruncate)
+    // Reading `<file>/child` fails with ENOTDIR, which the sibling probe's
+    // `@fs.exists` re-raises; the read must still return a clean tool error
+    // rather than letting that raise escape.
+    let result = execute({ "path": "\{dir}/notdir/child" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("error reading"))
+  })
 }
 
 ///|


### PR DESCRIPTION
## Summary

Adopts Claude Code's `findSimilarFile` recovery hint for the `read` tool. When a read fails because the path **does not exist**, `read` looks for a sibling in the same directory with the **same stem but a different extension** (e.g. you asked for `foo.ts` but `foo.mbt` is there) and appends ` Did you mean <name>?` to the error — so the agent can retry without an extra `ls`.

Mirrors Claude's heuristic exactly: **same-stem only, no fuzzy/edit-distance matching**, so a suggestion is almost never misleading. It's also gated to fire only on genuine not-found:

- If the path **exists** (the read failed for another reason — permission, invalid UTF-8), no hint.
- If the parent dir is unreadable or nothing shares the stem, no hint.

## Examples

- `read foo.ts` with `foo.mbt` present → `error reading …/foo.ts: … Did you mean foo.mbt?`
- `read README` with `README.md` present → `… Did you mean README.md?`
- `read foo.ts` with only `unrelated.mbt` present → plain error, no suggestion.

## Validation

- `moon fmt` / `moon check` (project-wide) clean, **0 warnings** (deny-warnings gate)
- `moon test agent_tool/read` → **24 passed** (adds same-stem suggestion, extensionless-stem, and no-false-positive cases)
- `moon test eval/tool_harness` → 3 passed (real read dispatch)
- No public API change (`similar_file_hint`/`file_stem` are private), so `pkg.generated.mbti` is unchanged
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)