### PR TITLE
read: report a zero-byte file explicitly

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -77,9 +77,10 @@ output truncation. The string body has one of these shapes:
 - On success: `<line-number>\t<content>` lines, then a newline, then the footer
   `<system>start_line=<n> shown_lines=<k> total_lines=<t> truncated=<bool></system>`.
   When the selected body is empty (the range starts past EOF, or the budget is
-  zero) only the footer is returned. `truncated=true` — set when
-  `max_output_chars` cut the numbered body — is the one case that flips
-  `is_error` to `true`.
+  zero) only the footer is returned. A zero-byte file returns just the footer
+  with `total_lines=0 note=empty file`, rather than a phantom blank `1\t` line.
+  `truncated=true` — set when `max_output_chars` cut the numbered body — is the
+  one case that flips `is_error` to `true`.
 - `"error reading <path>: <error>"` — a single-file read failed. Common
   causes: the file is missing, the agent doesn't have read permissions, or
   the bytes aren't valid UTF-8.

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -21,8 +21,10 @@
 ///   Every read has the same shape regardless of range or cap: `<line-number>\t
 ///   <content>` lines followed by a single
 ///   `<system>start_line=.. shown_lines=.. total_lines=.. truncated=..</system>`
-///   footer (footer only when the body is empty). `is_error` is `true` only when
-///   the `max_output_chars` budget cut the body (`truncated=true`).
+///   footer (footer only when the body is empty, e.g. a range past EOF). A
+///   zero-byte file returns just that footer with `total_lines=0 note=empty
+///   file`. `is_error` is `true` only when the `max_output_chars` budget cut the
+///   body (`truncated=true`).
 /// - `Respond(ToolOutput("error reading <path>: <error>", is_error=true))`
 ///   if a single-file read fails (missing file, permission denied, invalid
 ///   UTF-8, directory path, etc.).
@@ -106,6 +108,17 @@ async fn read_file(
         is_error=true,
         brief~,
       )
+  }
+  // A zero-byte file would otherwise render as a phantom blank line `1\t`;
+  // report it explicitly so the model doesn't read that as real content. A file
+  // containing only a newline is not empty (it has blank lines) and renders
+  // normally.
+  if content == "" {
+    return @agent_tool.ToolAction::respond(
+      "<system>start_line=\{input.start_line} shown_lines=0 total_lines=0 truncated=false note=empty file</system>",
+      is_error=false,
+      brief~,
+    )
   }
   let selection = select_lines(content, input.start_line, input.max_lines)
   let rendered = render_numbered_content(selection, input.max_output_chars)
@@ -292,7 +305,7 @@ async test "read resolves relative paths under the workspace root" {
 }
 
 ///|
-async test "read renders an empty file as a single empty numbered line" {
+async test "read reports a zero-byte file explicitly" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/empty.txt"
     @fs.write_file(path, "", create_mode=CreateOrTruncate)
@@ -301,8 +314,24 @@ async test "read renders an empty file as a single empty numbered line" {
     assert_false(output.is_error)
     assert_eq(
       output.content,
+      "<system>start_line=1 shown_lines=0 total_lines=0 truncated=false note=empty file</system>",
+    )
+  })
+}
+
+///|
+async test "read treats a single-newline file as one blank line, not empty" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/newline.txt"
+    @fs.write_file(path, "\n", create_mode=CreateOrTruncate)
+    let result = execute({ "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    // "\n" splits into two empty lines, so this is not the empty-file case.
+    assert_eq(
+      output.content,
       [
-        "1\t", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
+        "1\t", "2\t", "<system>start_line=1 shown_lines=2 total_lines=2 truncated=false</system>",
       ].join("\n"),
     )
   })


### PR DESCRIPTION
## Summary

Adopts Claude Code's explicit empty-file notice. A zero-byte file currently renders as a phantom blank line:
```
1\t
<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>
```
— which reads like the file has one (blank) line of real content. Now an empty file returns just a clear footer:
```
<system>start_line=1 shown_lines=0 total_lines=0 truncated=false note=empty file</system>
```
(`is_error=false`). Claude returns `<system-reminder>the file exists but the contents are empty</system-reminder>`; this keeps openseek's parseable footer style and adds `total_lines=0 note=empty file`.

A file containing only a newline is **not** empty (`"\n"` splits into two blank lines) and still renders normally — covered by a test.

## Validation

- `moon fmt` / `moon check` clean, 0 warnings
- `moon test agent_tool/read` → **23 passed** (exact-output empty-file case + single-newline guard)
- `moon test eval/tool_harness` → 3 passed (real read dispatch)
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)