### PR TITLE
viz: lift element children out of call parens with `<|`

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -399,13 +399,13 @@ fn events_status(parsed : @session_log.ParsedLog) -> String {
 
 ///|
 fn view(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
-  @html.div(class=app_class(model), [
+  @html.div(class=app_class(model)) <| [
     sidebar_pane(emit, model),
-    @html.section(class="main", [
+    @html.section(class="main") <| [
       main_toolbar(emit, model),
       main_pane(emit, model),
-    ]),
-  ])
+    ],
+  ]
 }
 
 ///|
@@ -422,22 +422,21 @@ fn sidebar_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
   if !model.sidebar_visible {
     return @html.nothing
   }
-  @html.aside(class="sidebar", [
-    @html.div(class="sidebar-head", [
-      @html.div(class="sidebar-title-row", [
+  @html.aside(class="sidebar") <| [
+    @html.div(class="sidebar-head") <| [
+      @html.div(class="sidebar-title-row") <| [
         @html.h1(class="brand", "OpenSeek sessions"),
         @html.button(
           class="sidebar-hide-button",
           title="Hide sessions",
           on_click=emit(ToggleSidebar),
-          "Hide",
-        ),
-      ]),
-      @html.div(class="status", model.status),
-    ]),
+        ) <| "Hide",
+      ],
+      @html.div(class="status") <| model.status,
+    ],
     sidebar_list(emit, model),
     theme_toggle(emit, model),
-  ])
+  ]
 }
 
 ///|
@@ -445,23 +444,22 @@ fn main_toolbar(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
   if model.sidebar_visible {
     return @html.nothing
   }
-  @html.div(class="main-toolbar", [
+  @html.div(class="main-toolbar") <| [
     @html.button(
       class="sidebar-show-button",
       title="Show sessions",
       on_click=emit(ToggleSidebar),
-      "Show sessions",
-    ),
-  ])
+    ) <| "Show sessions",
+  ]
 }
 
 ///|
 fn theme_toggle(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
-  @html.div(class="theme-toggle", [
+  @html.div(class="theme-toggle") <| [
     theme_button(emit, model, Light, "Light"),
     theme_button(emit, model, Dark, "Dark"),
     theme_button(emit, model, System, "System"),
-  ])
+  ]
 }
 
 ///|
@@ -476,13 +474,13 @@ fn theme_button(
   } else {
     "theme-button"
   }
-  @html.button(class=classes, on_click=emit(SetTheme(theme)), label)
+  @html.button(class=classes, on_click=emit(SetTheme(theme))) <| label
 }
 
 ///|
 fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
   if model.sessions.is_empty() {
-    return @html.div(class="sidebar-empty", "no sessions found")
+    return @html.div(class="sidebar-empty") <| "no sessions found"
   }
   let sections : Array[@html.Html] = []
   for group in sidebar_groups(model.sessions) {
@@ -492,7 +490,7 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
     let collapsed = root_collapsed(model, group)
     let display = group_display(group)
     sections.push(
-      @html.div(class=session_root_class(collapsed), [
+      @html.div(class=session_root_class(collapsed)) <| [
         @html.button(
           class="session-root-toggle",
           title=if collapsed {
@@ -501,28 +499,24 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
             "Collapse \{display}"
           },
           on_click=emit(ToggleRoot(group)),
-          [
-            @html.span(
-              class="session-root-caret",
-              if collapsed {
-                "▸"
-              } else {
-                "▾"
-              },
-            ),
-            @html.span(class="session-root-name", display),
-            @html.span(class="session-root-count", rows.length().to_string()),
-          ],
-        ),
+        ) <| [
+          @html.span(class="session-root-caret") <| (if collapsed {
+            "▸"
+          } else {
+            "▾"
+          }),
+          @html.span(class="session-root-name") <| display,
+          @html.span(class="session-root-count") <| rows.length().to_string(),
+        ],
         if collapsed {
           @html.nothing
         } else {
-          @html.ul(class="session-root-sessions", rows)
+          @html.ul(class="session-root-sessions") <| rows
         },
-      ]),
+      ],
     )
   }
-  @html.div(class="session-list", sections)
+  @html.div(class="session-list") <| sections
 }
 
 ///|
@@ -690,40 +684,35 @@ fn sidebar_row(
     row.first_prompt
   }
   let classes = if selected { "session-item selected" } else { "session-item" }
-  @html.li(class=classes, on_click=emit(Select(row.key)), [
-    @html.div(class="session-item-label", label),
-    @html.div(class="session-item-meta", [
-      @html.span(
-        class="session-item-id",
-        session_row_label(row.root_label, row.id, row.is_marker),
+  @html.li(class=classes, on_click=emit(Select(row.key))) <| [
+    @html.div(class="session-item-label") <| label,
+    @html.div(class="session-item-meta") <| [
+      @html.span(class="session-item-id") <| session_row_label(
+        row.root_label,
+        row.id,
+        row.is_marker,
       ),
       last_active_view(row.last_active),
-    ]),
-  ])
+    ],
+  ]
 }
 
 ///|
 fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
   match model.selected {
     None =>
-      @html.div(
-        class="placeholder",
-        if model.sidebar_visible {
-          "Select a session from the left to view it."
-        } else {
-          "Show sessions to select a session."
-        },
-      )
+      @html.div(class="placeholder") <| (if model.sidebar_visible {
+        "Select a session from the left to view it."
+      } else {
+        "Show sessions to select a session."
+      })
     Some(key) =>
       match model.parsed {
         None =>
           if model.loading {
-            @html.div(
-              class="placeholder",
-              "Loading \{session_label(model, key)}…",
-            )
+            @html.div(class="placeholder") <| "Loading \{session_label(model, key)}…"
           } else {
-            @html.div(class="placeholder", model.status)
+            @html.div(class="placeholder") <| model.status
           }
         Some(parsed) => {
           let row = session_row(model, key)
@@ -737,17 +726,17 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
             system_prompt=model.system_prompt,
           )
           let error_count = @viz.rendered_error_count(session, model.view_mode)
-          @html.div(class=session_view_class(model), [
+          @html.div(class=session_view_class(model)) <| [
             header_strip(model, id, row.map(row => row.root_label)),
             // Pin the view/args toggles and the error bar to the top of the
             // scroll area so they stay reachable while reading a long log.
-            @html.div(class="sticky-toolbar", [
+            @html.div(class="sticky-toolbar") <| [
               mode_row(emit, model, parsed),
               error_bar(emit, model, error_count),
-            ]),
+            ],
             @viz.render_notices(parsed),
             session_log_view(model, session, error_count),
-          ])
+          ]
         }
       }
   }
@@ -764,21 +753,18 @@ fn header_strip(model : Model, id : String, root_label : String?) -> @html.Html 
     Some(root) => " · \{root}"
     None => ""
   }
-  @html.header(class="header-strip", [
-    @html.div(class="header-id", id),
-    @html.div(
-      class="header-meta",
-      "\{model.status} · \{prompt_note}\{root_note}",
-    ),
-  ])
+  @html.header(class="header-strip") <| [
+    @html.div(class="header-id") <| id,
+    @html.div(class="header-meta") <| "\{model.status} · \{prompt_note}\{root_note}",
+  ]
 }
 
 ///|
 fn mode_toggle(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
-  @html.div(class="mode-toggle", [
+  @html.div(class="mode-toggle") <| [
     mode_button(emit, model, RawLog, "Raw log"),
     mode_button(emit, model, ModelView, "Model view"),
-  ])
+  ]
 }
 
 ///|
@@ -787,13 +773,13 @@ fn mode_row(
   model : Model,
   parsed : @session_log.ParsedLog,
 ) -> @html.Html {
-  @html.div(class="mode-row", [
-    @html.div(class="mode-cluster", [
+  @html.div(class="mode-row") <| [
+    @html.div(class="mode-cluster") <| [
       mode_toggle(emit, model),
       args_toggle(emit, model),
-    ]),
+    ],
     session_metadata(model, parsed),
-  ])
+  ]
 }
 
 ///|
@@ -801,11 +787,11 @@ fn mode_row(
 /// JSON quoting) and the original pretty-printed JSON kept for debugging. Both are
 /// always in the DOM; this only flips which one the stylesheet shows.
 fn args_toggle(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
-  @html.div(class="mode-toggle args-toggle", [
-    @html.span(class="args-toggle-label", "Tool args"),
+  @html.div(class="mode-toggle args-toggle") <| [
+    @html.span(class="args-toggle-label") <| "Tool args",
     args_button(emit, model, false, "Rendered"),
     args_button(emit, model, true, "Original"),
-  ])
+  ]
 }
 
 ///|
@@ -820,7 +806,7 @@ fn args_button(
   } else {
     "mode-button"
   }
-  @html.button(class=classes, on_click=emit(SetArgsView(show_original)), label)
+  @html.button(class=classes, on_click=emit(SetArgsView(show_original))) <| label
 }
 
 ///|
@@ -835,7 +821,7 @@ fn mode_button(
   } else {
     "mode-button"
   }
-  @html.button(class=classes, on_click=emit(SetMode(mode)), label)
+  @html.button(class=classes, on_click=emit(SetMode(mode))) <| label
 }
 
 ///|
@@ -844,12 +830,12 @@ fn session_metadata(
   parsed : @session_log.ParsedLog,
 ) -> @html.Html {
   let steps = agent_step_count(parsed)
-  @html.div(class="session-metadata", [
+  @html.div(class="session-metadata") <| [
     @html.span("log \{format_log_size(model.log_bytes)}"),
     @html.span("\{steps} step\{plural_s(steps)}"),
     @html.span("runtime \{runtime_label(parsed)}"),
     @html.span("ended \{end_time_label(parsed)}"),
-  ])
+  ]
 }
 
 ///|
@@ -969,7 +955,7 @@ fn last_active_view(last_active : Int64?) -> @html.Html {
   if label.is_empty() {
     @html.nothing
   } else {
-    @html.span(class="session-item-time", label)
+    @html.span(class="session-item-time") <| label
   }
 }
 
@@ -1021,10 +1007,7 @@ fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
   let children : Array[@html.Html] = []
   if count > 0 {
     children.push(
-      @html.span(
-        class="error-count",
-        "🚩 \{count} tool error\{plural_s(count)}",
-      ),
+      @html.span(class="error-count") <| "🚩 \{count} tool error\{plural_s(count)}",
     )
   }
   children.push(
@@ -1032,12 +1015,7 @@ fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
       class=toggle_class,
       title="Show only failed tool results",
       on_click=emit(ToggleErrorsOnly),
-      if model.errors_only {
-        "Errors only: on"
-      } else {
-        "Errors only"
-      },
-    ),
+    ) <| (if model.errors_only { "Errors only: on" } else { "Errors only" }),
   )
   // Jumps only make sense when there is something to jump to.
   if count > 0 {
@@ -1046,19 +1024,17 @@ fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
         class="error-jump",
         title="Scroll to the previous failure",
         on_click=emit(JumpToError(-1)),
-        "↑ prev",
-      ),
+      ) <| "↑ prev",
     )
     children.push(
       @html.button(
         class="error-jump",
         title="Scroll to the next failure",
         on_click=emit(JumpToError(1)),
-        "↓ next",
-      ),
+      ) <| "↓ next",
     )
   }
-  @html.div(class="error-bar", children)
+  @html.div(class="error-bar") <| children
 }
 
 ///|
@@ -1070,7 +1046,7 @@ fn session_log_view(
   count : Int,
 ) -> @html.Html {
   if model.errors_only && count == 0 {
-    @html.div(class="errors-only-empty", "No failed tool results in this view.")
+    @html.div(class="errors-only-empty") <| "No failed tool results in this view."
   } else {
     @viz.render_session(session, model.view_mode)
   }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -28,29 +28,29 @@ pub fn render_notices(parsed : @session_log.ParsedLog) -> @html.Html {
   let notices : Array[@html.Html] = []
   if parsed.partial_tail {
     notices.push(
-      @html.div(class="notice notice-warn", [
+      @html.div(class="notice notice-warn") <| [
         @html.text(
           "⚠ trailing partial line ignored (process likely exited mid-append)",
         ),
-      ]),
+      ],
     )
   }
   for error in parsed.errors {
     notices.push(
-      @html.div(class="notice notice-error", [
-        @html.div(class="notice-head", [
+      @html.div(class="notice notice-error") <| [
+        @html.div(class="notice-head") <| [
           @html.text(
             "⚠ line \{error.line_number} could not be decoded: \{error.message}",
           ),
-        ]),
-        @html.pre(class="notice-body", error.content),
-      ]),
+        ],
+        @html.pre(class="notice-body") <| error.content,
+      ],
     )
   }
   if notices.is_empty() {
     @html.nothing
   } else {
-    @html.div(class="notices", notices)
+    @html.div(class="notices") <| notices
   }
 }
 
@@ -69,7 +69,7 @@ fn render_raw(session : @agent_session.Session) -> @html.Html {
   if blocks.is_empty() {
     return empty_state("This session has no events yet.")
   }
-  @html.div(class="log raw-log", blocks)
+  @html.div(class="log raw-log") <| blocks
 }
 
 ///|
@@ -189,16 +189,13 @@ fn turn_block(
   let errors = count_turn_tool_errors(turn)
   if errors > 0 {
     summary.push(
-      @html.span(
-        class="turn-error-badge",
-        " · 🚩 \{errors} error\{plural(errors)}",
-      ),
+      @html.span(class="turn-error-badge") <| " · 🚩 \{errors} error\{plural(errors)}",
     )
   }
-  @html.details(open=true, class="turn", [
-    @html.summary(class="turn-summary", summary),
-    @html.div(class="turn-body", cards),
-  ])
+  @html.details(open=true, class="turn") <| [
+    @html.summary(class="turn-summary") <| summary,
+    @html.div(class="turn-body") <| cards,
+  ]
 }
 
 ///|
@@ -326,10 +323,10 @@ fn assistant_card(
   if message.reasoning_content() is Some(reasoning) &&
     !reasoning.trim().is_empty() {
     body.push(
-      @html.details(class="reasoning", [
+      @html.details(class="reasoning") <| [
         @html.summary("reasoning"),
         text_block(reasoning),
-      ]),
+      ],
     )
   }
   if !message.content().trim().is_empty() {
@@ -340,7 +337,7 @@ fn assistant_card(
     let call_views : Array[@html.Html] = [
       for call in calls => tool_call_view(call, briefs, failed)
     ]
-    body.push(@html.div(class="tool-calls", call_views))
+    body.push(@html.div(class="tool-calls") <| call_views)
   }
   card("assistant", "Assistant", seq, time~, body, step_label~)
 }
@@ -370,7 +367,7 @@ fn tool_call_view(
     @html.strong(call.name),
   ]
   if briefs.get(call.id) is Some(brief) && !brief.trim().is_empty() {
-    name_row.push(@html.span(class="tool-call-brief", " · \{brief}"))
+    name_row.push(@html.span(class="tool-call-brief") <| " · \{brief}")
   }
   let cls = if failed.contains(call.id) {
     "tool-call tool-call-failed"
@@ -379,13 +376,15 @@ fn tool_call_view(
   }
   let original = pretty_json(call.arguments)
   if is_blank_args(original) {
-    return @html.div(class=cls, [@html.div(class="tool-call-name", name_row)])
+    return @html.div(class=cls) <| [
+      @html.div(class="tool-call-name") <| name_row,
+    ]
   }
-  @html.details(class=cls, [
-    @html.summary(class="tool-call-name", name_row),
+  @html.details(class=cls) <| [
+    @html.summary(class="tool-call-name") <| name_row,
     render_args_friendly(call.arguments),
-    @html.pre(class="tool-call-args tool-call-args-original", original),
-  ])
+    @html.pre(class="tool-call-args tool-call-args-original") <| original,
+  ]
 }
 
 ///|
@@ -397,19 +396,18 @@ fn tool_call_view(
 /// does not parse.
 fn render_args_friendly(raw : String) -> @html.Html {
   let json = @json.parse(raw) catch {
-    _ => return @html.pre(class="tool-call-args tool-call-args-rendered", raw)
+    _ => return @html.pre(class="tool-call-args tool-call-args-rendered") <| raw
   }
   match json {
     Object(fields) if !fields.is_empty() => {
       let rows : Array[@html.Html] = [
         for key, value in fields => arg_field(key, value)
       ]
-      @html.div(class="tool-call-args-rendered", rows)
+      @html.div(class="tool-call-args-rendered") <| rows
     }
     _ =>
-      @html.pre(
-        class="tool-call-args tool-call-args-rendered",
-        pretty_json(raw),
+      @html.pre(class="tool-call-args tool-call-args-rendered") <| pretty_json(
+        raw,
       )
   }
 }
@@ -420,20 +418,20 @@ fn render_args_friendly(raw : String) -> @html.Html {
 /// single-line value inline. Non-string scalars render inline; nested arrays and
 /// objects keep their JSON form, which is rare for tool arguments.
 fn arg_field(key : String, value : Json) -> @html.Html {
-  let row : Array[@html.Html] = [@html.span(class="arg-key", key)]
+  let row : Array[@html.Html] = [@html.span(class="arg-key") <| key]
   match value {
     String(text) =>
       if text.contains("\n") {
-        row.push(@html.pre(class="arg-value", text))
+        row.push(@html.pre(class="arg-value") <| text)
       } else {
-        row.push(@html.span(class="arg-value-inline", text))
+        row.push(@html.span(class="arg-value-inline") <| text)
       }
     Array(_) | Object(_) =>
-      row.push(@html.pre(class="arg-value", value.stringify(indent=2)))
+      row.push(@html.pre(class="arg-value") <| value.stringify(indent=2))
     scalar =>
-      row.push(@html.span(class="arg-value-inline", scalar_text(scalar)))
+      row.push(@html.span(class="arg-value-inline") <| scalar_text(scalar))
   }
-  @html.div(class="arg-field", row)
+  @html.div(class="arg-field") <| row
 }
 
 ///|
@@ -512,14 +510,16 @@ fn tool_card(
     "Tool result · \{result.tool_name()}"
   }
   let flag = if is_error {
-    @html.span(class="tool-flag", "🚩 failed")
+    @html.span(class="tool-flag") <| "🚩 failed"
   } else {
     @html.nothing
   }
-  @html.details(class="card \{kind}", [
-    @html.summary(class="card-label", card_head(label, seq, time~, flag~)),
-    @html.div(class="card-body", [text_block(result.content())]),
-  ])
+  @html.details(class="card \{kind}") <| [
+    @html.summary(class="card-label") <| card_head(label, seq, time~, flag~),
+    @html.div(class="card-body") <| [
+      text_block(result.content()),
+    ],
+  ]
 }
 
 ///|
@@ -545,7 +545,9 @@ fn terminal_card(
     Interrupted(reason) => ("interrupted", reason)
     Failed(message) => ("failed", message)
   }
-  let body : Array[@html.Html] = [@html.span(class="badge badge-\{kind}", kind)]
+  let body : Array[@html.Html] = [
+    @html.span(class="badge badge-\{kind}") <| kind,
+  ]
   if !message.trim().is_empty() {
     body.push(text_block(message))
   }
@@ -587,7 +589,7 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
   if cards.is_empty() {
     return empty_state("The model projection is empty.")
   }
-  @html.div(class="log model-log", cards)
+  @html.div(class="log model-log") <| cards
 }
 
 ///|
@@ -846,15 +848,15 @@ fn message_card(
 ) -> @html.Html {
   match message.role {
     System =>
-      @html.section(class="card system", [
-        @html.details(open=false, [
-          @html.summary(
-            class="card-label",
-            model_card_head("System prompt", time~),
+      @html.section(class="card system") <| [
+        @html.details(open=false) <| [
+          @html.summary(class="card-label") <| model_card_head(
+            "System prompt",
+            time~,
           ),
           text_block(message.content),
-        ]),
-      ])
+        ],
+      ]
     User =>
       model_card("user", "User", message, briefs, failed, time~, step_label~)
     Assistant =>
@@ -951,21 +953,20 @@ fn model_tool_card(
     (true, false) => "Tool error · \{name}"
     (false, false) => "Tool result · \{name}"
   }
-  @html.details(class="card \{kind}", [
-    @html.summary(
-      class="card-label",
-      model_card_head(
-        label,
-        time~,
-        flag=if is_error {
-          @html.span(class="tool-flag", "🚩 failed")
-        } else {
-          @html.nothing
-        },
-      ),
+  @html.details(class="card \{kind}") <| [
+    @html.summary(class="card-label") <| model_card_head(
+      label,
+      time~,
+      flag=if is_error {
+        @html.span(class="tool-flag") <| "🚩 failed"
+      } else {
+        @html.nothing
+      },
     ),
-    @html.div(class="card-body", [text_block(message.content)]),
-  ])
+    @html.div(class="card-body") <| [
+      text_block(message.content),
+    ],
+  ]
 }
 
 ///|
@@ -982,10 +983,10 @@ fn model_card(
   if message.reasoning_content is Some(reasoning) &&
     !reasoning.trim().is_empty() {
     body.push(
-      @html.details(class="reasoning", [
+      @html.details(class="reasoning") <| [
         @html.summary("reasoning"),
         text_block(reasoning),
-      ]),
+      ],
     )
   }
   if !message.content.trim().is_empty() {
@@ -995,12 +996,12 @@ fn model_card(
     let call_views : Array[@html.Html] = [
       for call in message.tool_calls => tool_call_view(call, briefs, failed)
     ]
-    body.push(@html.div(class="tool-calls", call_views))
+    body.push(@html.div(class="tool-calls") <| call_views)
   }
-  @html.section(class="card \{kind}", [
-    @html.div(class="card-label", model_card_head(label, time~, step_label~)),
-    @html.div(class="card-body", body),
-  ])
+  @html.section(class="card \{kind}") <| [
+    @html.div(class="card-label") <| model_card_head(label, time~, step_label~),
+    @html.div(class="card-body") <| body,
+  ]
 }
 
 // ---- shared helpers --------------------------------------------------------
@@ -1014,10 +1015,10 @@ fn model_card_head(
 ) -> Array[@html.Html] {
   let head : Array[@html.Html] = [flag, @html.text(label)]
   if !step_label.is_empty() {
-    head.push(@html.span(class="card-step", step_label))
+    head.push(@html.span(class="card-step") <| step_label)
   }
   if !time.is_empty() {
-    head.push(@html.span(class="card-ts", time))
+    head.push(@html.span(class="card-ts") <| time)
   }
   head
 }
@@ -1031,10 +1032,10 @@ fn card(
   body : Array[@html.Html],
   step_label? : String = "",
 ) -> @html.Html {
-  @html.section(class="card \{kind}", [
-    @html.div(class="card-label", card_head(label, seq, time~, step_label~)),
-    @html.div(class="card-body", body),
-  ])
+  @html.section(class="card \{kind}") <| [
+    @html.div(class="card-label") <| card_head(label, seq, time~, step_label~),
+    @html.div(class="card-body") <| body,
+  ]
 }
 
 ///|
@@ -1050,15 +1051,15 @@ fn card_head(
   step_label? : String = "",
 ) -> Array[@html.Html] {
   let head : Array[@html.Html] = [
-    @html.span(class="card-seq", "#\{seq}"),
+    @html.span(class="card-seq") <| "#\{seq}",
     flag,
     @html.text(label),
   ]
   if !step_label.is_empty() {
-    head.push(@html.span(class="card-step", step_label))
+    head.push(@html.span(class="card-step") <| step_label)
   }
   if !time.is_empty() {
-    head.push(@html.span(class="card-ts", time))
+    head.push(@html.span(class="card-ts") <| time)
   }
   head
 }
@@ -1068,15 +1069,17 @@ fn card_head(
 /// placeholder so a card never collapses to nothing.
 fn text_block(content : String) -> @html.Html {
   if content.trim().is_empty() {
-    @html.span(class="empty", "(empty)")
+    @html.span(class="empty") <| "(empty)"
   } else {
-    @html.pre(class="content", content)
+    @html.pre(class="content") <| content
   }
 }
 
 ///|
 fn empty_state(message : String) -> @html.Html {
-  @html.div(class="empty-state", [@html.text(message)])
+  @html.div(class="empty-state") <| [
+    @html.text(message),
+  ]
 }
 
 ///|


### PR DESCRIPTION
## What

Wholesale formatting refactor of the viz HTML layer: every rabbita element constructor call site is rewritten from

```moonbit
@html.div(class="turn", [ ... ])
```

to

```moonbit
@html.div(class="turn") <| [ ... ]
```

lifting the trailing `children` positional out of the parens via the `<|` apply operator, so the markup tree reads with one consistent shape and the outermost element drops its `])` pileup.

- `viz/view.mbt` — 55 call sites
- `cmd/viz_app/app.mbt` — 46 call sites

## How it was applied

A brace/string/comment-aware transformer lifted the **last positional argument** (always `children` in rabbita's API). Two rules fell out of the compiler:

- **Attribute-less calls are left as-is** — `@html.text(...)`, `@html.strong(name)`, `@html.div([...])` have no attrs to separate, so a `() <|` form would be pure noise.
- **Control-flow children are parenthesised** — `<|` takes a *simple expression* on the right, so the sites with `if` children became `@html.span(class="...") <| (if ... { } else { })`.

## Verification

- `moon check --target js` — clean on `viz` and `cmd/viz_app`
- `moon test --target js` — **194/194 pass** (pure formatting change, no behavior change)
- `moon fmt` — applied and idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)