### PR TITLE
write: signal create vs. overwrite, nudge read-before-overwrite

### DIFF
--- a/agent_tool/write/README.mbt.md
+++ b/agent_tool/write/README.mbt.md
@@ -1,8 +1,11 @@
 # Write Tool
 
-`write` overwrites `arguments.path` with `arguments.content`. Existing files
-are truncated; missing parent directories are **not** created — the agent
-should `shell` a `mkdir -p` first when it needs nested directories.
+`write` creates or overwrites `arguments.path` with `arguments.content`.
+Existing files are truncated and missing parent directories are created, so a
+`write` to `dir/sub/moon.pkg` works without a separate `mkdir`. When the path
+already exists the success message flags the overwrite, so the model can tell it
+replaced content it may not have read — prefer `edit` for targeted changes, and
+read an existing file before overwriting it.
 
 ## Design Rationale
 
@@ -12,10 +15,9 @@ contents are known. That makes the operation easy to explain in the transcript:
 the model supplied the whole desired file body, and the host wrote exactly that
 body.
 
-Parent directories are not created implicitly because directory creation is a
-separate workspace mutation. Keeping it explicit makes broad filesystem changes
-visible in the log and lets the agent choose whether to create a directory,
-reuse an existing package, or fix an incorrect path.
+Missing parent directories are created so a single `write` can lay down a file
+in a fresh package directory without a separate `mkdir` step; the created path
+stays inside the resolved workspace root.
 
 ## API Style
 
@@ -54,8 +56,10 @@ The action is always `Respond(ToolOutput(...))` — the agent loop forwards
 `false` on success and `true` for write or argument failures. The string body
 has one of these shapes:
 
-- `"ok: wrote <n> chars to <path>"` on success — `n` is the character count
-  of the written content.
+- `"ok: wrote <n> chars to <path>"` when a new file is created — `n` is the
+  character count of the written content. When the path already existed the
+  line ends with ` (overwrote existing file)` so the model can tell it clobbered
+  prior content.
   If the target is `moon.mod`, `moon.pkg`, `.mbt`, or `.mbt.md` inside a
   MoonBit module, the response may append bounded raw compiler feedback from
   module-root `moon check --diagnostic-limit 1`, starting with
@@ -108,7 +112,11 @@ async test "write tool updates an implementation note through the registry" {
     )
     let result = @agent_tool.execute_tool_call(call, tools)
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: wrote 11 chars to \{path}")
+    // The note already existed, so the result flags the overwrite.
+    assert_eq(
+      output.content,
+      "ok: wrote 11 chars to \{path} (overwrote existing file)",
+    )
     assert_false(output.is_error)
     assert_eq(@fs.read_file(path).text(), "tests green")
   })

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -9,7 +9,9 @@
 ///   before writing.
 ///
 /// ## Result
-/// - `Respond(ToolOutput("ok: wrote <n> chars to <path>"))` on success.
+/// - `Respond(ToolOutput("ok: wrote <n> chars to <path>"))` when a new file is
+///   created; the message gains ` (overwrote existing file)` when the path
+///   already existed, so the model can tell it clobbered prior content.
 /// - `Respond(ToolOutput("error writing <path>: <error>", is_error=true))`
 ///   if the write fails.
 /// - `Respond(ToolOutput("error: write requires ...", is_error=true))` for
@@ -19,7 +21,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="write",
-    description="Overwrite arguments.path with arguments.content.",
+    description="Create or overwrite arguments.path with arguments.content (missing parent directories are created). If the file already exists, read it first so you do not discard content you have not seen, and prefer the edit tool for targeted changes. Do not create Markdown or README files unless the user explicitly asks for them.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -71,15 +73,27 @@ async fn write_file(
       None => ()
     }
     create_parent_dirs(path)
+    // Probe before writing so the result can tell the model whether it created a
+    // new file or clobbered an existing one — a wholesale `write` over content it
+    // never read is a common way to lose work. A non-ENOENT `exists` error (e.g.
+    // ENOTDIR) falls through to the write below and the `catch` reports it.
+    let existed = @fs.exists(path)
     @fs.write_file(path, input.content, create_mode=CreateOrTruncate)
-    let content = @auto_check.append_summary(
-      path,
-      "ok: wrote \{input.content.length()} chars to \{path}",
-    )
+    let chars = input.content.length()
+    let summary = if existed {
+      "ok: wrote \{chars} chars to \{path} (overwrote existing file)"
+    } else {
+      "ok: wrote \{chars} chars to \{path}"
+    }
+    let content = @auto_check.append_summary(path, summary)
     @agent_tool.ToolAction::respond(
       content,
       brief=@agent_tool.brief_line(
-        "wrote \{input.content.length()} chars to \{input.path}",
+        if existed {
+          "overwrote \{input.path}"
+        } else {
+          "wrote \{chars} chars to \{input.path}"
+        },
       ),
     )
   } catch {
@@ -269,10 +283,32 @@ async test "write truncates existing files" {
     @fs.write_file(path, "long original content", create_mode=CreateOrTruncate)
     let result = execute({ "path": path, "content": "short" })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: wrote 5 chars to \{path}")
+    // The path already existed, so the result flags the overwrite.
+    assert_eq(
+      output.content,
+      "ok: wrote 5 chars to \{path} (overwrote existing file)",
+    )
     assert_false(output.is_error)
     let read_back = @fs.read_file(path).text()
     assert_eq(read_back, "short")
+  })
+}
+
+///|
+async test "write reports whether it created or overwrote a file" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/note.txt"
+    // First write to a fresh path: a plain "created" result, no overwrite note.
+    let created = execute({ "path": path, "content": "v1" })
+    guard created is Respond(first) else { fail("expected Respond") }
+    assert_eq(first.content, "ok: wrote 2 chars to \{path}")
+    // Writing again clobbers the existing file, which the result now calls out.
+    let overwritten = execute({ "path": path, "content": "v2!" })
+    guard overwritten is Respond(second) else { fail("expected Respond") }
+    assert_eq(
+      second.content,
+      "ok: wrote 3 chars to \{path} (overwrote existing file)",
+    )
   })
 }
 
@@ -283,7 +319,10 @@ async test "write accepts empty content" {
     @fs.write_file(path, "previous", create_mode=CreateOrTruncate)
     let result = execute({ "path": path, "content": "" })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: wrote 0 chars to \{path}")
+    assert_eq(
+      output.content,
+      "ok: wrote 0 chars to \{path} (overwrote existing file)",
+    )
     assert_false(output.is_error)
     let read_back = @fs.read_file(path).text()
     assert_eq(read_back, "")


### PR DESCRIPTION
## What

Two small, **stateless** adoptions of Claude Code's `FileWriteTool` behavior for the `write` tool (the cheap wins from the write-vs-Claude comparison).

### 1. Signal create vs. overwrite
`write` previously returned `ok: wrote <n> chars to <path>` whether it created a new file or clobbered an existing one. It now probes with `@fs.exists` just before writing and appends ` (overwrote existing file)` in the overwrite case, so the model can tell a wholesale `write` replaced content it may never have read.

New-file wording is unchanged, so the `"ok: wrote "` marker that `eval/file_edit` (write-success metric) and `eval/tool_harness` rely on is preserved.

### 2. Nudge read-before-overwrite (prompt)
The tool description now tells the model to read an existing file before overwriting it, prefer `edit` for targeted changes, and not create Markdown/README files unless explicitly asked.

### Also
Fixes the package README, which wrongly claimed parent directories are **not** created — the code creates them (`create_parent_dirs`, with a passing test). The README example test (which overwrites a file) and the result-shape docs are updated to match the new message.

## Scope note
This intentionally stops short of Claude's **hard** read-before-write staleness guard ("File has not been read yet… / has been modified since read"), which would need session read-state plumbing (read records reads → shared state → write checks) that openseek doesn't have today. The `edit` tool already covers safe modification via exact `old_string` matching, so the remaining exposure is a blind full-overwrite of an unread file — which this change now at least surfaces in the result.

## Validation
- `moon check` + `moon fmt` clean.
- `moon test agent_tool/write` → 18 passed (adds a create-vs-overwrite test; README doc tests updated).
- `moon test eval/tool_harness` → 3 passed (depends on `ok: wrote`).
- No public API change.
- Reviewed by **codex** (`codex review --base main`): *"No actionable correctness issues… preserves existing write behavior while updating the success message."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
