### PR TITLE
simplify: inline single-use forwarding wrappers

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -302,7 +302,7 @@ pub async fn[X] run_turn_in_scope(
         append_item~,
       )
       let runtime_events = runtime.drain_events()
-      if runtime_update_message(runtime_events) is Some(update) {
+      if @moon_check.runtime_update_text(runtime_events) is Some(update) {
         // A batch in which every watcher reproduces its previous notice
         // (volatile counters aside) is collapsed to a one-line marker: the
         // model still learns its edit was processed with an unchanged
@@ -543,11 +543,6 @@ pub async fn[X] run_turn_in_scope(
       raise error
     }
   }
-}
-
-///|
-fn runtime_update_message(events : Array[@agent_runtime.AgentEvent]) -> String? {
-  @moon_check.runtime_update_text(events)
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -24,7 +24,7 @@ pub fn moonbit_command_policy_error_for_parse(
     Some(moon_cmd_error_message())
   } else if parsed is Simple(_) {
     None
-  } else if rough_first_command_name(cmd) == Some("moon_cmd") {
+  } else if first_command_word(shell_words(cmd)) == Some("moon_cmd") {
     Some(moon_cmd_error_message())
   } else {
     None
@@ -34,11 +34,6 @@ pub fn moonbit_command_policy_error_for_parse(
 ///|
 fn moon_cmd_error_message() -> String {
   "error: moon_cmd is not a shell command; run moon subcommands like `moon check` or `moon test` through shell directly"
-}
-
-///|
-fn rough_first_command_name(cmd : String) -> String? {
-  first_command_word(shell_words(cmd))
 }
 
 ///|

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -522,7 +522,7 @@ fn root_label(path : String) -> String {
 fn path_tail(path : String) -> String {
   let trimmed = trim_trailing_path_separators(path)
   match last_path_separator(trimmed) {
-    Some(index) => slice_from(trimmed, index + 1)
+    Some(index) => trimmed[index + 1:].to_owned()
     None => trimmed
   }
 }
@@ -692,12 +692,6 @@ fn strip_query(path : String) -> String {
     Some((path, _)) => "\{path}"
     None => path
   }
-}
-
-///|
-/// Code-unit slice `s[start:]` as an owned `String`.
-fn slice_from(s : String, start : Int) -> String {
-  s[start:].to_owned()
 }
 
 ///|

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -75,7 +75,7 @@ pub async fn run_suite(config : Config) -> EvalReport {
     out_dir: config.out_dir,
     results,
   }
-  write_report_files(report)
+  @report.write_files(report.out_dir, report.markdown(), report.to_json())
   report
 }
 

--- a/eval/file_edit/harness/report.mbt
+++ b/eval/file_edit/harness/report.mbt
@@ -1,9 +1,4 @@
 ///|
-async fn write_report_files(report : EvalReport) -> Unit {
-  @report.write_files(report.out_dir, report.markdown(), report.to_json())
-}
-
-///|
 fn EvalReport::to_json(self : EvalReport) -> Json {
   {
     "model": self.model,


### PR DESCRIPTION
## Summary

A small, conservative pass that inlines private single-use functions whose body is a single **forwarding/aliasing** expression — the wrapper name adds nothing the inlined call doesn't already show:

| Package | Wrapper | Inlined to |
| --- | --- | --- |
| `agent` | `runtime_update_message(e)` | `@moon_check.runtime_update_text(e)` (pure cross-package rename) |
| `agent_tool/shell/internal/command_policy` | `rough_first_command_name(cmd)` | `first_command_word(shell_words(cmd))` |
| `cmd/viz_server` | `slice_from(s, i)` | `s[i:].to_owned()` |
| `eval/file_edit/harness` | `write_report_files(report)` | `@report.write_files(report.out_dir, report.markdown(), report.to_json())` |

## Judgement / what was deliberately kept

I scanned the whole repo for single-use private functions (~82 with ≤6-line bodies). The vast majority are **well-named predicates and formatters** — `is_separator(op)`, `is_low_surrogate(u)`, `strip_query(path)`, `validate_target(t)`, `exit_header(code)`, `format_span_total_seconds(ms)`, `is_session_store(...)`, … — whose names document intent at the call site. Those *do* improve readability, so they stay. Only pure forwarding/aliasing wrappers (the four above) are removed. The codebase is already clean here, so the harvest is intentionally small rather than padded with churn.

## Validation

- `moon fmt` / `moon check` (project-wide) clean, **0 warnings** (deny-warnings gate)
- `moon test` on the four affected packages → **38 passed**
- All four functions were private, so `pkg.generated.mbti` is unchanged
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)