### PR TITLE
edit: point at the closest actual line when old_string is not found

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -68,7 +68,11 @@ has one of these shapes:
   module-root `moon check --diagnostic-limit 1`, starting with
   `"moon check:"` after the success line. Failed checks include `exit=<code>`
   or `exit=cancelled`.
-- `"error editing <path>: old_string not found"` — no exact match was found.
+- `"error editing <path>: old_string not found. <hint>"` — no exact match was
+  found. The hint points at the closest actual line in the file (`The closest
+  text in the file is line N: …`) when a distinctive line of `old_string` still
+  occurs there, or otherwise nudges a re-read — so the model can recover the
+  exact current text instead of guessing again.
 - `"error editing <path>: old_string matched <n> times on lines <line>, ...; set replace_all=true to replace all occurrences"` — the edit was ambiguous.
 - `"error editing <path>: moon.pkg use // for comment syntax, not #"` or similar
   manifest-guard messages — the replacement would likely break MoonBit package

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -15,7 +15,9 @@
 ///   success.
 /// - `Respond(ToolOutput("error editing <path>: ...", is_error=true))` for
 ///   filesystem failures, empty/no-op edits, missing matches, or ambiguous
-///   matches. Ambiguous-match errors include the first matching line numbers.
+///   matches. Ambiguous-match errors include the first matching line numbers; a
+///   not-found error points at the closest actual line in the file (or nudges a
+///   re-read) so the model can correct `old_string`.
 /// - `Respond(ToolOutput("error: edit requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition(
@@ -23,7 +25,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
-    description="Replace exact text in arguments.path with arguments.new_string.",
+    description="Replace exact text in arguments.path with arguments.new_string. old_string must match the file's current text exactly — read the file first if you are unsure — and must be unique unless replace_all is set.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -94,7 +96,7 @@ async fn edit_file(
   let occurrences = parts.length() - 1
   if occurrences == 0 {
     return @agent_tool.ToolAction::respond(
-      "error editing \{path}: old_string not found",
+      "error editing \{path}: old_string not found.\{not_found_hint(content, input.old_string)}",
       is_error=true,
       brief=fail_brief,
     )
@@ -140,6 +142,81 @@ async fn edit_file(
         brief=fail_brief,
       )
   }
+}
+
+///|
+/// Diagnostic appended when `old_string` is not found, so the model has more to
+/// recover from than a bare "not found" — its top failure mode is an
+/// `old_string` that no longer matches the file (misremembered text or a stale
+/// view). Anchors on the most distinctive line of `old_string` — longest, and
+/// containing a letter or digit — that also appears in the file (exact once
+/// trimmed, else a substring overlap) and reports it with its 1-based line
+/// number. Falls back to a read-first nudge when nothing distinctive matches.
+fn not_found_hint(content : String, old_string : String) -> String {
+  let file_lines = [ for line in content.split("\n") => line.to_owned() ]
+  // Longest lines first: they are the most distinctive and least likely to
+  // anchor on the wrong place.
+  let anchors = [ for line in old_string.split("\n") => line.to_owned() ]
+  anchors.sort_by((a, b) => b.trim().length() - a.trim().length())
+  for anchor in anchors {
+    let needle = anchor.trim()
+    if needle.length() < 4 || !has_alnum(needle) {
+      continue
+    }
+    // A line equal once trimmed: same text, most likely different indentation.
+    for index, line in file_lines {
+      if line.trim() == needle {
+        return closest_text_hint(index + 1, line)
+      }
+    }
+    // A line that overlaps the anchor as a substring either way.
+    for index, line in file_lines {
+      let trimmed = line.trim()
+      if line.contains(needle) ||
+        (
+          trimmed.length() >= 4 &&
+          has_alnum(trimmed) &&
+          needle.contains(trimmed)
+        ) {
+        return closest_text_hint(index + 1, line)
+      }
+    }
+  }
+  " Read the file first, then copy old_string exactly from its current contents."
+}
+
+///|
+fn closest_text_hint(line_number : Int, line : String) -> String {
+  " The closest text in the file is line \{line_number}: \{cap_chars(line.trim(), 120)} — re-read the file and copy old_string exactly from its current contents."
+}
+
+///|
+/// First `max` characters of `s`, Unicode-safe (never splitting a code point),
+/// with a trailing ellipsis when it was longer.
+fn cap_chars(s : StringView, max : Int) -> String {
+  let buf = StringBuilder::new()
+  let mut count = 0
+  for c in s {
+    if count >= max {
+      buf.write_string("…")
+      break
+    }
+    buf.write_char(c)
+    count = count + 1
+  }
+  buf.to_string()
+}
+
+///|
+/// Whether `s` contains an ASCII letter or digit. Used to skip structural lines
+/// (`///|`, `{`, `}`) that make poor, ambiguous match anchors.
+fn has_alnum(s : StringView) -> Bool {
+  for c in s {
+    if c is ('0'..='9' | 'a'..='z' | 'A'..='Z') {
+      return true
+    }
+  }
+  false
 }
 
 ///|

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -207,8 +207,38 @@ async test "edit rejects missing match" {
       "new_string": "gamma",
     })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "error editing \{path}: old_string not found")
+    // "beta" shares nothing with the file, so the hint falls back to a read nudge.
+    assert_true(
+      output.content.has_prefix("error editing \{path}: old_string not found"),
+    )
+    assert_true(output.content.contains("Read the file first"))
     assert_true(output.is_error)
+  })
+}
+
+///|
+async test "edit points at the closest line when old_string is slightly off" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/parser.mbt"
+    @fs.write_file(
+      path,
+      "fn parse(input : String) -> Int {\n  let value = 1\n  value\n}\n",
+      create_mode=CreateOrTruncate,
+    )
+    // The signature line is right but an inner line is wrong, so old_string is
+    // not found verbatim; the hint anchors on the matching signature line so the
+    // model can see the file's actual text and fix its old_string.
+    let result = run_edit({
+      "path": path,
+      "old_string": "fn parse(input : String) -> Int {\n  let value = 99\n}",
+      "new_string": "fn parse(input : String) -> Int {\n  let value = 2\n}",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("old_string not found"))
+    assert_true(output.content.contains("line 1"))
+    assert_true(output.content.contains("fn parse(input : String) -> Int {"))
+    assert_true(output.content.contains("re-read the file"))
   })
 }
 


### PR DESCRIPTION
## What

When an `edit` fails because `old_string` isn't found, the error now points the model at the **closest actual text** instead of a bare `old_string not found`:

> `error editing <path>: old_string not found. The closest text in the file is line 42: fn parse(input : String) -> Int { — re-read the file and copy old_string exactly from its current contents.`

It anchors on the most distinctive line of `old_string` (longest, containing a letter/digit) that still appears in the file — exact once trimmed, else a substring overlap — and reports its 1-based line number. When nothing distinctive matches, it nudges a re-read. The tool description also now tells the model `old_string` must match the current text exactly (read first if unsure).

## Why this, not Claude's normalization (data-driven)

Across **19 recorded toml-parser runs**, `edit` succeeds **93%** of the time. The dominant failure is **`old_string not found` (32/649, 5%)** (ambiguous 8, identical 7). I sampled all 32: they are almost never whitespace/quote mismatches — so porting Claude's `normalizeQuotes`/`stripTrailingWhitespace` would recover ~none of them. The real cause is an `old_string` that no longer matches the file — **misremembered text or a stale view** (298 of 649 edits were to files never read this session).

So the high-value fix isn't fuzzy-matching the input; it's showing the model the file's actual text so it can self-correct — the `edit` analog of the read tool's "Did you mean?" (#237).

**Validated against the 32 recorded cases** (using each target file's final content as a proxy): **26 anchor to a real code line, 5 fall back to the read nudge.**

## Safety / scope
Pure error-message change — matching semantics are untouched, so there's **no risk of editing the wrong place**. No public API change (`definition` signature unchanged; the new helpers are private). Out of scope (and lower-value here): quote/whitespace-normalized fallback matching, and a hard read-before-edit guard.

## Validation
- `moon check` (0 warnings) + `moon fmt` clean; 20 `agent_tool/edit` tests pass (added closest-line and read-nudge cases; updated the existing not-found assertion).
- Reviewed by **codex** (`codex review --base main`): *"enriching edit-tool not-found diagnostics… did not identify a discrete correctness issue introduced by the patch."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
