### PR TITLE
reuse core: UInt16::is_trailing_surrogate for char-boundary checks

### DIFF
--- a/agent_tool/internal/output/output.mbt
+++ b/agent_tool/internal/output/output.mbt
@@ -16,18 +16,11 @@ pub fn cap_text(content : String, max_chars : Int) -> String {
 /// surrogate, step back one so the leading surrogate is dropped too. Only
 /// reached with `0 <= max_units < content.length()`.
 fn char_boundary_at_or_below(content : String, max_units : Int) -> Int {
-  if max_units > 0 && is_low_surrogate(content[max_units]) {
+  if max_units > 0 && content[max_units].is_trailing_surrogate() {
     max_units - 1
   } else {
     max_units
   }
-}
-
-///|
-/// Whether `unit` is a UTF-16 low (trailing) surrogate — the second half of a
-/// surrogate pair.
-fn is_low_surrogate(unit : UInt16) -> Bool {
-  unit >= 0xDC00 && unit <= 0xDFFF
 }
 
 ///|

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -208,7 +208,7 @@ fn code_unit_prefix(content : String, max_units : Int) -> String {
 /// (the unit at `max_units` is a trailing surrogate) step back one so the
 /// leading surrogate is dropped too. Callers pass `max_units < content.length()`.
 fn char_boundary_at_or_below(content : String, max_units : Int) -> Int {
-  if content.at(max_units).is_trailing_surrogate() {
+  if content[max_units].is_trailing_surrogate() {
     max_units - 1
   } else {
     max_units

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -208,17 +208,11 @@ fn code_unit_prefix(content : String, max_units : Int) -> String {
 /// (the unit at `max_units` is a trailing surrogate) step back one so the
 /// leading surrogate is dropped too. Callers pass `max_units < content.length()`.
 fn char_boundary_at_or_below(content : String, max_units : Int) -> Int {
-  if is_low_surrogate(content.at(max_units)) {
+  if content.at(max_units).is_trailing_surrogate() {
     max_units - 1
   } else {
     max_units
   }
-}
-
-///|
-fn is_low_surrogate(unit : UInt16) -> Bool {
-  let code = unit.to_int()
-  code >= 0xDC00 && code <= 0xDFFF
 }
 
 ///|


### PR DESCRIPTION
## Summary

The read tool (`agent_tool/read`) and `agent_tool/internal/output` each hand-rolled the same predicate to avoid splitting a surrogate pair at a truncation boundary:

```moonbit
fn is_low_surrogate(unit : UInt16) -> Bool { unit >= 0xDC00 && unit <= 0xDFFF }
```

MoonBit core already ships this as `UInt16::is_trailing_surrogate` (a "low surrogate" *is* the trailing half of a pair, U+DC00–U+DFFF). Call the core method at both sites and delete both local copies.

`moon ide doc 'UInt16::*surrogate*'` confirms core also exposes `is_leading_surrogate` / `is_surrogate` if those are needed later.

## Validation

- `moon fmt` / `moon check` clean, 0 warnings
- `moon test agent_tool/read agent_tool/internal/output` → **32 passed**
- Both predicates were private, so `pkg.generated.mbti` is unchanged
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)