### PR TITLE
dedupe: share moon --target validation across decode packages

### DIFF
--- a/agent_tool/internal/moon_target/moon.pkg
+++ b/agent_tool/internal/moon_target/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/moon_target/moon_target.mbt
+++ b/agent_tool/internal/moon_target/moon_target.mbt
@@ -1,0 +1,16 @@
+///|
+/// The MoonBit compilation backends accepted by `moon`'s `--target` flag. The
+/// list is shared by every tool that decodes a `target` argument so a new
+/// backend is added in exactly one place.
+let supported_targets : Array[String] = [
+  "wasm", "wasm-gc", "js", "native", "llvm", "all",
+]
+
+///|
+/// Validate a `--target` value, raising the decode error tools feed back to the
+/// model when it is not one of `supported_targets`.
+pub fn validate_target(target : String) -> Unit raise {
+  if !supported_targets.contains(target) {
+    fail("arguments.target to be one of wasm, wasm-gc, js, native, llvm, all")
+  }
+}

--- a/agent_tool/internal/moon_target/pkg.generated.mbti
+++ b/agent_tool/internal/moon_target/pkg.generated.mbti
@@ -1,0 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/moon_target"
+
+// Values
+pub fn validate_target(String) -> Unit raise
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/moon_check/internal/decode/decode.mbt
+++ b/agent_tool/moon_check/internal/decode/decode.mbt
@@ -31,7 +31,7 @@ fn parse_fields(fields : Map[String, Json]) -> MoonCheckInput raise {
   let cwd = optional_string(fields, "cwd")
   let target = optional_string(fields, "target")
   match target {
-    Some(value) => validate_target(value)
+    Some(value) => @moon_target.validate_target(value)
     None => ()
   }
   let warn_list = optional_string(fields, "warn_list")
@@ -60,13 +60,5 @@ fn optional_bool(fields : Map[String, Json], name : String) -> Bool raise {
     Some(True) => true
     Some(False) | Some(Null) | None => false
     _ => fail("arguments.\{name} to be a boolean")
-  }
-}
-
-///|
-fn validate_target(target : String) -> Unit raise {
-  let allowed = ["wasm", "wasm-gc", "js", "native", "llvm", "all"]
-  if !allowed.contains(target) {
-    fail("arguments.target to be one of wasm, wasm-gc, js, native, llvm, all")
   }
 }

--- a/agent_tool/moon_check/internal/decode/moon.pkg
+++ b/agent_tool/moon_check/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/moon_target",
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/moon_cmd/internal/decode/decode.mbt
+++ b/agent_tool/moon_cmd/internal/decode/decode.mbt
@@ -50,7 +50,7 @@ fn parse_fields(fields : Map[String, Json]) -> MoonCommandInput raise {
   let target = optional_string(fields, "target")
   match target {
     Some(value) => {
-      validate_target(value)
+      @moon_target.validate_target(value)
       validate_target_supported(command)
     }
     None => ()
@@ -187,14 +187,6 @@ fn validate_command(command : String) -> Unit raise {
   let allowed = ["check", "test", "run", "info", "fmt", "build"]
   if !allowed.contains(command) {
     fail("arguments.command to be one of check, test, run, info, fmt, build")
-  }
-}
-
-///|
-fn validate_target(target : String) -> Unit raise {
-  let allowed = ["wasm", "wasm-gc", "js", "native", "llvm", "all"]
-  if !allowed.contains(target) {
-    fail("arguments.target to be one of wasm, wasm-gc, js, native, llvm, all")
   }
 }
 

--- a/agent_tool/moon_cmd/internal/decode/moon.pkg
+++ b/agent_tool/moon_cmd/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/moon_target",
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/moon_ide/internal/decode/decode.mbt
+++ b/agent_tool/moon_ide/internal/decode/decode.mbt
@@ -51,7 +51,7 @@ fn parse_fields(fields : Map[String, Json]) -> MoonIdeInput raise {
   let loc = optional_string(fields, "loc")
   let target = optional_string(fields, "target")
   match target {
-    Some(value) => validate_target(value)
+    Some(value) => @moon_target.validate_target(value)
     None => ()
   }
   let no_check = optional_bool(fields, "no_check", default=false)
@@ -138,14 +138,6 @@ fn validate_action(action : String) -> Unit raise {
     fail(
       "arguments.action to be one of doc, outline, peek_def, hover, find_references",
     )
-  }
-}
-
-///|
-fn validate_target(target : String) -> Unit raise {
-  let allowed = ["wasm", "wasm-gc", "js", "native", "llvm", "all"]
-  if !allowed.contains(target) {
-    fail("arguments.target to be one of wasm, wasm-gc, js, native, llvm, all")
   }
 }
 

--- a/agent_tool/moon_ide/internal/decode/moon.pkg
+++ b/agent_tool/moon_ide/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/moon_target",
   "moonbitlang/core/json",
 }
 


### PR DESCRIPTION
## Summary

`validate_target` was copy-pasted **identically** in three decode packages — `agent_tool/moon_cmd`, `agent_tool/moon_ide`, `agent_tool/moon_check` — each with the same backend allow-list and the same error message:

```moonbit
fn validate_target(target : String) -> Unit raise {
  let allowed = ["wasm", "wasm-gc", "js", "native", "llvm", "all"]
  if !allowed.contains(target) {
    fail("arguments.target to be one of wasm, wasm-gc, js, native, llvm, all")
  }
}
```

Adding or renaming a backend meant editing three files in lockstep — a drift hazard. Extracted to a small shared `agent_tool/internal/moon_target` package; each decode package now calls `@moon_target.validate_target`. moon_cmd's `validate_command` and `validate_target_supported` stay local (not shared).

Checked the library first per the dedupe guidance — core has no moon-target validator (the allow-list is moon-specific), so this is a plain extract-to-shared.

## Validation

- `moon fmt` / `moon check` clean, 0 warnings; `moon info` regenerated interfaces
- `moon test` on the four packages → **55 passed**
- The decode packages' public `.mbti` is unchanged (the shared call isn't in any public signature); the new package exposes just `pub fn validate_target(String) -> Unit raise`
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)