### PR TITLE
dedupe: share moon-manifest path classification (write + edit)

### DIFF
--- a/agent_tool/edit/internal/manifest_error/manifest_error.mbt
+++ b/agent_tool/edit/internal/manifest_error/manifest_error.mbt
@@ -10,17 +10,17 @@
 /// manifest fail every later build step.
 pub async fn write_error(path : String, content : String) -> String? {
   let trimmed = content.trim()
-  if is_generated_mbti_path(path) {
+  if @manifest_path.is_generated_mbti_path(path) {
     return Some(
       "*.generated.mbti files are generated; run moon info instead of editing them",
     )
   }
-  if is_moon_mod_json_path(path) && !@fs.exists(path) {
+  if @manifest_path.is_moon_mod_json_path(path) && !@fs.exists(path) {
     return Some(
       "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
     )
   }
-  if is_moon_mod_path(path) {
+  if @manifest_path.is_moon_mod_path(path) {
     if trimmed == "" {
       return Some("moon.mod must not be empty")
     }
@@ -31,7 +31,7 @@ pub async fn write_error(path : String, content : String) -> String? {
       return Some("moon.mod should include a module `name = ...` entry")
     }
   }
-  if is_moon_pkg_path(path) {
+  if @manifest_path.is_moon_pkg_path(path) {
     // Tiny moon.pkg files are normal for dummy packages; keep guarding syntax
     // shapes that are known agent mistakes.
     if trimmed.has_prefix("#") {
@@ -42,33 +42,4 @@ pub async fn write_error(path : String, content : String) -> String? {
     }
   }
   None
-}
-
-///|
-fn is_moon_mod_path(path : String) -> Bool {
-  let path = normalized_path(path)
-  path == "moon.mod" || path.has_suffix("/moon.mod")
-}
-
-///|
-fn is_moon_mod_json_path(path : String) -> Bool {
-  let path = normalized_path(path)
-  path == "moon.mod.json" || path.has_suffix("/moon.mod.json")
-}
-
-///|
-fn is_moon_pkg_path(path : String) -> Bool {
-  let path = normalized_path(path)
-  path == "moon.pkg" || path.has_suffix("/moon.pkg")
-}
-
-///|
-fn is_generated_mbti_path(path : String) -> Bool {
-  let path = normalized_path(path)
-  path.has_suffix(".generated.mbti")
-}
-
-///|
-fn normalized_path(path : String) -> String {
-  path.replace_all(old="\\", new="/")
 }

--- a/agent_tool/edit/internal/manifest_error/moon.pkg
+++ b/agent_tool/edit/internal/manifest_error/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/manifest_path",
   "moonbitlang/async/fs",
 }
 

--- a/agent_tool/internal/manifest_path/manifest_path.mbt
+++ b/agent_tool/internal/manifest_path/manifest_path.mbt
@@ -1,0 +1,35 @@
+///|
+/// Path classification for MoonBit manifests and generated interfaces, shared
+/// by the write and edit tools so both agree on what counts as a `moon.mod` /
+/// `moon.pkg` / `*.generated.mbti` path. Backslashes are normalized to `/` so a
+/// Windows path classifies the same as its POSIX form.
+fn normalized(path : String) -> String {
+  path.replace_all(old="\\", new="/")
+}
+
+///|
+/// Whether `path` is a `moon.mod` module manifest (the non-JSON form).
+pub fn is_moon_mod_path(path : String) -> Bool {
+  let path = normalized(path)
+  path == "moon.mod" || path.has_suffix("/moon.mod")
+}
+
+///|
+/// Whether `path` is a `moon.mod.json` module manifest.
+pub fn is_moon_mod_json_path(path : String) -> Bool {
+  let path = normalized(path)
+  path == "moon.mod.json" || path.has_suffix("/moon.mod.json")
+}
+
+///|
+/// Whether `path` is a `moon.pkg` package manifest (the non-JSON form).
+pub fn is_moon_pkg_path(path : String) -> Bool {
+  let path = normalized(path)
+  path == "moon.pkg" || path.has_suffix("/moon.pkg")
+}
+
+///|
+/// Whether `path` is a generated interface file (`*.generated.mbti`).
+pub fn is_generated_mbti_path(path : String) -> Bool {
+  normalized(path).has_suffix(".generated.mbti")
+}

--- a/agent_tool/internal/manifest_path/moon.pkg
+++ b/agent_tool/internal/manifest_path/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/manifest_path/pkg.generated.mbti
+++ b/agent_tool/internal/manifest_path/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/manifest_path"
+
+// Values
+pub fn is_generated_mbti_path(String) -> Bool
+
+pub fn is_moon_mod_json_path(String) -> Bool
+
+pub fn is_moon_mod_path(String) -> Bool
+
+pub fn is_moon_pkg_path(String) -> Bool
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/write/moon.pkg
+++ b/agent_tool/write/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/manifest_path",
   "bobzhang/openseek/agent_tool/write/internal/decode",
   "bobzhang/openseek/internal/workspace_path",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -140,17 +140,17 @@ fn parent_dir(path : String) -> String {
 ///|
 async fn manifest_write_error(path : String, content : String) -> String? {
   let trimmed = content.trim()
-  if is_generated_mbti_path(path) {
+  if @manifest_path.is_generated_mbti_path(path) {
     return Some(
       "*.generated.mbti files are generated; run moon info instead of editing them",
     )
   }
-  if is_moon_mod_json_path(path) && !@fs.exists(path) {
+  if @manifest_path.is_moon_mod_json_path(path) && !@fs.exists(path) {
     return Some(
       "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
     )
   }
-  if is_moon_mod_path(path) {
+  if @manifest_path.is_moon_mod_path(path) {
     if trimmed == "" {
       return Some("moon.mod must not be empty")
     }
@@ -161,7 +161,7 @@ async fn manifest_write_error(path : String, content : String) -> String? {
       return Some("moon.mod should include a module `name = ...` entry")
     }
   }
-  if is_moon_pkg_path(path) {
+  if @manifest_path.is_moon_pkg_path(path) {
     // This is normal when we create a moon.pkg dummy file
     // another mistake is AI is trying to write 
     // # as a comment
@@ -176,30 +176,6 @@ async fn manifest_write_error(path : String, content : String) -> String? {
     }
   }
   None
-}
-
-///|
-fn is_moon_mod_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
-  path == "moon.mod" || path.has_suffix("/moon.mod")
-}
-
-///|
-fn is_moon_mod_json_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
-  path == "moon.mod.json" || path.has_suffix("/moon.mod.json")
-}
-
-///|
-fn is_moon_pkg_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
-  path == "moon.pkg" || path.has_suffix("/moon.pkg")
-}
-
-///|
-fn is_generated_mbti_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
-  path.has_suffix(".generated.mbti")
 }
 
 ///|


### PR DESCRIPTION
## Summary

The four manifest-path predicates were duplicated between `agent_tool/write` and `agent_tool/edit/internal/manifest_error`:

- `is_moon_mod_path`, `is_moon_mod_json_path`, `is_moon_pkg_path`, `is_generated_mbti_path`

Same backslash normalization, same suffix checks — just written slightly differently (`write` inlined `replace_all`; `manifest_error` factored a `normalized_path` helper). Extracted to a shared `agent_tool/internal/manifest_path` package; both tools now call `@manifest_path.is_*` so they classify manifests identically from one source.

No library equivalent (these are moon-project-specific), so it's a plain extract-to-shared dedupe — same shape as #245.

### Noted, not done here
`manifest_error.write_error` and `write.manifest_write_error` are themselves nearly identical (same checks + messages). That's a larger overlap between the edit and write tools and is left for a separate, deliberate change rather than folded into this predicate dedupe.

## Validation

- `moon fmt` / `moon check` clean, 0 warnings; `moon info` regenerated interfaces
- `moon test` on write/edit/manifest_error/manifest_path → **46 passed**
- Consumers' public `.mbti` unchanged (calls aren't in public signatures); new package exposes the four `pub fn is_*`
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)