### PR TITLE
dedupe: share char_boundary_at_or_below in agent_tool/internal/utils

### DIFF
--- a/agent_tool/internal/output/moon.pkg
+++ b/agent_tool/internal/output/moon.pkg
@@ -1,1 +1,5 @@
+import {
+  "bobzhang/openseek/agent_tool/internal/utils",
+}
+
 warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/output/output.mbt
+++ b/agent_tool/internal/output/output.mbt
@@ -6,20 +6,7 @@ pub fn cap_text(content : String, max_chars : Int) -> String {
   if content.length() <= max_chars {
     content
   } else {
-    "\{content[:char_boundary_at_or_below(content, max_chars)]}"
-  }
-}
-
-///|
-/// Largest code-unit offset `<= max_units` that is a valid character boundary.
-/// A surrogate pair spans two code units; if `max_units` lands on the trailing
-/// surrogate, step back one so the leading surrogate is dropped too. Only
-/// reached with `0 <= max_units < content.length()`.
-fn char_boundary_at_or_below(content : String, max_units : Int) -> Int {
-  if max_units > 0 && content[max_units].is_trailing_surrogate() {
-    max_units - 1
-  } else {
-    max_units
+    "\{content[:@utils.char_boundary_at_or_below(content, max_chars)]}"
   }
 }
 
@@ -37,7 +24,7 @@ pub fn is_truncated(content : String, max_chars : Int) -> Bool {
 /// `max_chars` when the budget would have split a surrogate pair.
 pub fn truncation_header(content : String, max_chars : Int) -> String {
   if is_truncated(content, max_chars) {
-    let shown_chars = char_boundary_at_or_below(content, max_chars)
+    let shown_chars = @utils.char_boundary_at_or_below(content, max_chars)
     "\ntruncated=true\noutput_chars=\{content.length()}\nshown_chars=\{shown_chars}"
   } else {
     ""

--- a/agent_tool/internal/utils/moon.pkg
+++ b/agent_tool/internal/utils/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/utils/pkg.generated.mbti
+++ b/agent_tool/internal/utils/pkg.generated.mbti
@@ -1,0 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/utils"
+
+// Values
+pub fn char_boundary_at_or_below(String, Int) -> Int
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/internal/utils/utils.mbt
+++ b/agent_tool/internal/utils/utils.mbt
@@ -1,0 +1,17 @@
+///|
+/// Largest code-unit offset `<= max_units` that is a valid UTF-16 character
+/// boundary. A surrogate pair spans two code units; if `max_units` lands on a
+/// trailing surrogate, step back one so a cut there never splits the pair.
+/// `max_units <= 0` is returned unchanged. Callers pass `max_units <
+/// content.length()` so the index access stays in bounds.
+///
+/// Shared by every tool that caps output to a UTF-16 code-unit budget (`read`
+/// renders numbered lines, `agent_tool/internal/output` caps tool output) so
+/// the surrogate-safety rule lives in exactly one place.
+pub fn char_boundary_at_or_below(content : String, max_units : Int) -> Int {
+  if max_units > 0 && content[max_units].is_trailing_surrogate() {
+    max_units - 1
+  } else {
+    max_units
+  }
+}

--- a/agent_tool/read/moon.pkg
+++ b/agent_tool/read/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/utils",
   "bobzhang/openseek/agent_tool/read/internal/decode",
   "bobzhang/openseek/internal/workspace_path",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -198,20 +198,7 @@ fn code_unit_prefix(content : String, max_units : Int) -> String {
   } else if content.length() <= max_units {
     content
   } else {
-    "\{content[:char_boundary_at_or_below(content, max_units)]}"
-  }
-}
-
-///|
-/// Largest code-unit offset `<= max_units` that is a valid character boundary.
-/// A surrogate pair spans two code units; if `max_units` would land between them
-/// (the unit at `max_units` is a trailing surrogate) step back one so the
-/// leading surrogate is dropped too. Callers pass `max_units < content.length()`.
-fn char_boundary_at_or_below(content : String, max_units : Int) -> Int {
-  if content[max_units].is_trailing_surrogate() {
-    max_units - 1
-  } else {
-    max_units
+    "\{content[:@utils.char_boundary_at_or_below(content, max_units)]}"
   }
 }
 


### PR DESCRIPTION
## Summary

`char_boundary_at_or_below` — snap a UTF-16 code-unit offset down to a character boundary so a truncation cut never splits a surrogate pair — was **duplicated** in two places:

- `agent_tool/read/read.mbt` (used by `code_unit_prefix` when capping a numbered line)
- `agent_tool/internal/output/output.mbt` (used by `cap_text` and `truncation_header`)

Moved it to a shared `agent_tool/internal/utils` package; both call sites now use `@utils.char_boundary_at_or_below`, so the surrogate-safety rule lives in exactly one place (and already uses core `UInt16::is_trailing_surrogate` after #244).

### Scope kept minimal
The thin per-tool slices around it — read's `code_unit_prefix` and output's `cap_text` — stay where they are: they're one-line `content[:boundary(...)]` calls that differ only in their empty/over-budget guards, and read better next to their call sites. Only the substantive shared logic (the boundary computation) moves. moon_cmd / moon_ide are untouched (`@output.cap_text` API unchanged).

## Validation

- `moon fmt` / `moon check` clean, 0 warnings; `moon info` regenerated interfaces
- `moon test` on read / output / utils / moon_cmd / moon_ide → **68 passed**
- New package exposes just `pub fn char_boundary_at_or_below(String, Int) -> Int`; consumers' public `.mbti` unchanged
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)