### PR TITLE
shell policy: block `sed -i` in-place editing, redirect to the edit tool

### DIFF
--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -3,14 +3,20 @@
 This internal package contains the command-routing policy used by the `shell`
 tool before it runs `sh -c`.
 
-The policy exists for one narrow reason: the bare tool name `moon_cmd`, typed as
-a shell command, is not an executable — it should be the real `moon ...`
-subcommand run through shell. Everything else, including `moon check`, runs
-normally.
+The policy redirects two command shapes that an agent should not run through
+shell:
+
+- the bare tool name `moon_cmd`, typed as a shell command — it is not an
+  executable and should be the real `moon ...` subcommand run through shell;
+- `sed -i` (in-place file editing) — it silently misapplies edits often enough
+  to be untrustworthy, so the agent is sent to the `edit`/`write` tools.
+
+Everything else, including `moon check` and read-only `sed` (`sed -n '1,5p'`,
+`... | sed s/a/b/`), runs normally.
 
 This package is not a security sandbox. It is a local automation guardrail for a
 trusted agent. The shell tool can run arbitrary commands; this package only
-rejects the `moon_cmd` tool-name typo before execution.
+redirects the `moon_cmd` typo and `sed -i` editing before execution.
 
 ## Enforced Policy
 
@@ -22,6 +28,7 @@ The current policy blocks:
 | Command shape | Reason |
 | --- | --- |
 | `moon_cmd ...` | `moon_cmd` is a tool name, not an executable shell command; run `moon ...` directly. |
+| `sed -i ...` (incl. `--in-place`, `-i.bak`, `-Ei`) | In-place file editing is unreliable; use the `edit` tool to change contents or `write` to replace a file. |
 
 The policy allows:
 
@@ -29,6 +36,7 @@ The policy allows:
 | --- | --- |
 | `moon check` | Type-check for compiler feedback; runs through shell like any other `moon` subcommand. |
 | `moon test`, `moon run`, `moon info`, `moon fmt`, `moon build` | One-shot Moon commands run through shell. |
+| `sed -n '1,5p' f`, `... \| sed s/a/b/` | Read-only `sed` (no in-place flag) remains in shell. |
 | `git status --short` | Non-MoonBit commands remain in shell. |
 | `printf hi \| wc -c` | Shell-specific pipelines remain in shell. |
 
@@ -39,12 +47,18 @@ The implementation is deliberately conservative:
 - Parse the command with the internal shell policy parser.
 - Reject `moon_cmd` when it is a statically visible simple command name,
   including in flat compounds such as `cd demo && moon_cmd check`.
+- Reject `sed` carrying an in-place flag when it is a statically visible simple
+  command (after any `env`/`command`/`builtin` wrapper). The in-place flag is
+  read off `sed`'s own arguments, so an unrelated `-i` such as `grep -i sed` or
+  `env -i sed ...` does not trip it.
 - If parsing is too complex, keep a small fallback for the old leading
   `moon_cmd` typo case.
 
 This is still not a security sandbox and not a full POSIX shell interpreter.
 Commands whose runtime argv cannot be known statically are allowed unless they
-match the narrow fallback typo check.
+match the narrow fallback typo check — so `find ... -exec sed -i` and
+`xargs sed -i`, where `sed` is not the statically visible command, are not
+caught.
 
 ## Examples
 

--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -51,14 +51,27 @@ The implementation is deliberately conservative:
   command (after any `env`/`command`/`builtin` wrapper). The in-place flag is
   read off `sed`'s own arguments, so an unrelated `-i` such as `grep -i sed` or
   `env -i sed ...` does not trip it.
-- If parsing is too complex, keep a small fallback for the old leading
-  `moon_cmd` typo case.
+- If the structured parse fails (globs, expansions — e.g.
+  `sed -i 's/a/b/' *.mbt`), fall back to a **rough, quote-unaware** text scan:
+  split on `&&`/`||`/`;`/`|` and flag a segment whose leading command word is
+  `moon_cmd`, or `sed` carrying an in-place flag.
 
-This is still not a security sandbox and not a full POSIX shell interpreter.
-Commands whose runtime argv cannot be known statically are allowed unless they
-match the narrow fallback typo check — so `find ... -exec sed -i` and
-`xargs sed -i`, where `sed` is not the statically visible command, are not
-caught.
+This is still not a security sandbox and not a full POSIX shell interpreter. The
+rough fallback is best-effort, not exhaustive — by design it does not catch:
+
+- `sed` that is not the segment's leading command — `find ... -exec sed -i`,
+  `xargs sed -i`;
+- `sed -i` reached only through a wrapper in a too-complex parse —
+  `command sed -i ... *.glob` (wrappers are handled in the precise path, not the
+  fallback);
+- operators or env values hidden inside quotes, which the quote-unaware split
+  can mis-segment.
+
+The structural reason these escape is that an unquoted glob makes the whole
+command `TooComplex`; the deeper fix is to teach the lexer to treat an unquoted
+glob as an opaque word (so the command name and flags stay statically visible)
+rather than failing the parse. That is a shared-parser change left for a separate
+PR.
 
 ## Examples
 

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -112,7 +112,7 @@ fn rough_command_segments(cmd : String) -> Array[String] {
 /// `command`/`env`/`builtin`, matching the moon_cmd fallback's conservatism.
 fn segment_leads_with_sed_in_place(words : Array[String]) -> Bool {
   let mut index = 0
-  while index < words.length() && looks_like_env_assignment(words[index]) {
+  while index < words.length() && is_env_assignment_prefix(words[index]) {
     index += 1
   }
   guard index < words.length() && words[index] == "sed" else { return false }
@@ -179,6 +179,38 @@ fn first_command_word(words : Array[String]) -> String? {
     }
   }
   None
+}
+
+///|
+/// A leading `NAME=value` environment prefix (any value), used to skip command
+/// env assignments when locating a segment's command word. More permissive than
+/// `looks_like_env_assignment`, which rejects values containing `/`, `-`, or
+/// empty — so a real prefix like `PATH=/usr/bin` before `sed -i` is skipped.
+fn is_env_assignment_prefix(word : String) -> Bool {
+  match word.find("=") {
+    Some(0) | None => false
+    Some(equals) => is_valid_env_name(word[:equals])
+  }
+}
+
+///|
+fn is_valid_env_name(name : StringView) -> Bool {
+  if name.length() == 0 {
+    return false
+  }
+  let mut first = true
+  for ch in name {
+    let valid = if first {
+      first = false
+      ch is ('a'..='z' | 'A'..='Z' | '_')
+    } else {
+      ch is ('a'..='z' | 'A'..='Z' | '0'..='9' | '_')
+    }
+    if !valid {
+      return false
+    }
+  }
+  true
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -61,15 +61,62 @@ fn sed_in_place_error_message() -> String {
 fn sed_edits_files(command : @shell_parse.SimpleCommand) -> Bool {
   guard command.command_name() is Some("sed") else { return false }
   guard command.command_index() is Some(start) else { return false }
-  // `command_index` skips the wrapper, so scan only `sed`'s own arguments.
-  for index in (start + 1)..<command.argv.length() {
-    let arg = command.argv[index]
+  // `command_index` skips the wrapper, so scan only `sed`'s own arguments. The
+  // argv is already unquoted by the real parser.
+  scan_sed_args_for_in_place(command.argv, start + 1, quoted=false)
+}
+
+///|
+/// Scan `sed` arguments starting at `start` for an in-place flag. `-e`/`-f` (and
+/// `--expression`/`--file`) consume the next word as their script/file value, so
+/// that operand is skipped — `sed -f -i file` reads a script file named `-i`, it
+/// is not an in-place edit. Stops at `--` (the rest are file operands). With
+/// `quoted~`, a fully-quoted token is unquoted first (the rough fallback path,
+/// where `shell_words` keeps quotes).
+fn scan_sed_args_for_in_place(
+  args : Array[String],
+  start : Int,
+  quoted~ : Bool,
+) -> Bool {
+  let mut index = start
+  while index < args.length() {
+    let arg = if quoted {
+      strip_surrounding_quotes(args[index])
+    } else {
+      args[index]
+    }
     if arg == "--" {
-      // Everything after `--` is a file operand, not a flag.
       break
     }
     if is_sed_in_place_flag(arg) {
       return true
+    }
+    index += if sed_option_consumes_next(arg) { 2 } else { 1 }
+  }
+  false
+}
+
+///|
+/// Whether a `sed` short/long option takes the *next* word as its value (so the
+/// scanner must skip that operand): a `-e`/`-f` cluster whose `e`/`f` is the last
+/// character, or `--expression`/`--file` without an attached `=value`.
+fn sed_option_consumes_next(arg : String) -> Bool {
+  if arg == "--expression" || arg == "--file" {
+    return true
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  let chars = [ for ch in arg => ch ]
+  let mut idx = 1
+  while idx < chars.length() {
+    match chars[idx] {
+      // `e`/`f` consume the remainder of the token; if they are the last char,
+      // the value is the next word.
+      'e' | 'f' => return idx == chars.length() - 1
+      // `i` consumes the remainder as its in-place suffix, not the next word.
+      'i' => return false
+      _ => idx += 1
     }
   }
   false
@@ -121,16 +168,7 @@ fn segment_leads_with_sed_in_place(words : Array[String]) -> Bool {
     strip_surrounding_quotes(words[index]) == "sed" else {
     return false
   }
-  for cursor in (index + 1)..<words.length() {
-    let word = strip_surrounding_quotes(words[cursor])
-    if word == "--" {
-      break
-    }
-    if is_sed_in_place_flag(word) {
-      return true
-    }
-  }
-  false
+  scan_sed_args_for_in_place(words, index + 1, quoted=true)
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -4,8 +4,11 @@
 ///
 /// `moon check` (and every other `moon` subcommand) runs through shell; the
 /// only redirection left is the tool name `moon_cmd` typed as a shell command,
-/// which is pointed back at running `moon ...` directly. The error wording tells
-/// the model what to do instead, because the model is the caller who reads it.
+/// which is pointed back at running `moon ...` directly. `sed -i` (in-place file
+/// editing) is also blocked: it silently misapplies edits often enough to be
+/// untrustworthy, so the model is sent to the `edit`/`write` tools instead. The
+/// error wording tells the model what to do, because the model is the caller who
+/// reads it.
 pub fn moonbit_command_policy_error(cmd : String) -> String? {
   let parsed = @shell_parse.parse_for_policy(cmd)
   moonbit_command_policy_error_for_parse(cmd, parsed)
@@ -22,8 +25,12 @@ pub fn moonbit_command_policy_error_for_parse(
 ) -> String? {
   if @shell_parse.contains_command(parsed, "moon_cmd") {
     Some(moon_cmd_error_message())
-  } else if parsed is Simple(_) {
-    None
+  } else if parsed is Simple(commands) {
+    if commands.any(sed_edits_files) {
+      Some(sed_in_place_error_message())
+    } else {
+      None
+    }
   } else if first_command_word(shell_words(cmd)) == Some("moon_cmd") {
     Some(moon_cmd_error_message())
   } else {
@@ -34,6 +41,60 @@ pub fn moonbit_command_policy_error_for_parse(
 ///|
 fn moon_cmd_error_message() -> String {
   "error: moon_cmd is not a shell command; run moon subcommands like `moon check` or `moon test` through shell directly"
+}
+
+///|
+fn sed_in_place_error_message() -> String {
+  "error: `sed -i` edits files in place and is unreliable for code changes; use the `edit` tool to modify file contents, or `write` to replace a whole file"
+}
+
+///|
+/// True when `command` is `sed` (after any `env`/`command`/`builtin` wrapper)
+/// invoked with an in-place edit flag. Read-only `sed` — `sed -n '1,5p' file`,
+/// `... | sed s/a/b/`, or a non-`sed` `-i` such as `grep -i` / `env -i sed ...`
+/// — is left alone.
+fn sed_edits_files(command : @shell_parse.SimpleCommand) -> Bool {
+  guard command.command_name() is Some("sed") else { return false }
+  guard command.command_index() is Some(start) else { return false }
+  // `command_index` skips the wrapper, so scan only `sed`'s own arguments.
+  for index in (start + 1)..<command.argv.length() {
+    let arg = command.argv[index]
+    if arg == "--" {
+      // Everything after `--` is a file operand, not a flag.
+      break
+    }
+    if is_sed_in_place_flag(arg) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Whether a single `sed` argument requests in-place editing: the long
+/// `--in-place[=suffix]` form, or a short cluster containing `i` (`-i`, `-i.bak`,
+/// `-Ei`). `-e`/`-f` consume the rest of the token as their value, so an `i`
+/// inside a script like `-e's/i/x/'` is not mistaken for `-i`.
+fn is_sed_in_place_flag(arg : String) -> Bool {
+  if arg == "--in-place" || arg.has_prefix("--in-place=") {
+    return true
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  let mut first = true
+  for ch in arg {
+    if first {
+      first = false
+      continue
+    }
+    match ch {
+      'i' => return true
+      'e' | 'f' => return false
+      _ => ()
+    }
+  }
+  false
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -31,10 +31,18 @@ pub fn moonbit_command_policy_error_for_parse(
     } else {
       None
     }
-  } else if first_command_word(shell_words(cmd)) == Some("moon_cmd") {
-    Some(moon_cmd_error_message())
   } else {
-    None
+    // Parse too complex to analyze structurally (globs, expansions, …): fall
+    // back to a rough leading-word check for the `moon_cmd` typo or a `sed -i`
+    // edit, e.g. `sed -i 's/a/b/' *.mbt`.
+    let words = shell_words(cmd)
+    if first_command_word(words) == Some("moon_cmd") {
+      Some(moon_cmd_error_message())
+    } else if rough_leading_sed_in_place(words) {
+      Some(sed_in_place_error_message())
+    } else {
+      None
+    }
   }
 }
 
@@ -64,6 +72,29 @@ fn sed_edits_files(command : @shell_parse.SimpleCommand) -> Bool {
       break
     }
     if is_sed_in_place_flag(arg) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Rough fallback for parses too complex to analyze structurally: true when the
+/// leading command word (after env assignments) is `sed` and a following word is
+/// an in-place flag. Used only when `parse_for_policy` returns `TooComplex` /
+/// `SyntaxError`, e.g. `sed -i 's/a/b/' *.mbt`. It does not unwrap
+/// `command`/`env`/`builtin`, matching the moon_cmd fallback's conservatism.
+fn rough_leading_sed_in_place(words : Array[String]) -> Bool {
+  let mut index = 0
+  while index < words.length() && looks_like_env_assignment(words[index]) {
+    index += 1
+  }
+  guard index < words.length() && words[index] == "sed" else { return false }
+  for cursor in (index + 1)..<words.length() {
+    if words[cursor] == "--" {
+      break
+    }
+    if is_sed_in_place_flag(words[cursor]) {
       return true
     }
   }

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -59,7 +59,8 @@ fn sed_in_place_error_message() -> String {
 /// `... | sed s/a/b/`, or a non-`sed` `-i` such as `grep -i` / `env -i sed ...`
 /// — is left alone.
 fn sed_edits_files(command : @shell_parse.SimpleCommand) -> Bool {
-  guard command.command_name() is Some("sed") else { return false }
+  guard command.command_name() is Some(name) else { return false }
+  guard command_basename(name) == "sed" else { return false }
   guard command.command_index() is Some(start) else { return false }
   // `command_index` skips the wrapper, so scan only `sed`'s own arguments. The
   // argv is already unquoted by the real parser.
@@ -165,12 +166,24 @@ fn segment_leads_with_sed_in_place(words : Array[String]) -> Bool {
     index += 1
   }
   // `shell_words` keeps quotes, so strip a fully-quoted token before matching —
-  // the shell still passes `'sed'` / `'-i'` through as `sed` / `-i`.
+  // the shell still passes `'sed'` / `'-i'` through as `sed` / `-i`. Compare the
+  // basename so `/usr/bin/sed` / `./sed` match too.
   guard index < words.length() &&
-    strip_surrounding_quotes(words[index]) == "sed" else {
+    command_basename(strip_surrounding_quotes(words[index])) == "sed" else {
     return false
   }
   scan_sed_args_for_in_place(words, index + 1, quoted=true)
+}
+
+///|
+/// The final path component of a command word, so a path-qualified `sed`
+/// (`/usr/bin/sed`, `./sed`) compares equal to `sed`. Handles both separators.
+fn command_basename(name : String) -> String {
+  let normalized = name.replace_all(old="\\", new="/")
+  match normalized.rev_find("/") {
+    Some(slash) => normalized[slash + 1:].to_owned()
+    None => name
+  }
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -115,16 +115,38 @@ fn segment_leads_with_sed_in_place(words : Array[String]) -> Bool {
   while index < words.length() && is_env_assignment_prefix(words[index]) {
     index += 1
   }
-  guard index < words.length() && words[index] == "sed" else { return false }
+  // `shell_words` keeps quotes, so strip a fully-quoted token before matching —
+  // the shell still passes `'sed'` / `'-i'` through as `sed` / `-i`.
+  guard index < words.length() &&
+    strip_surrounding_quotes(words[index]) == "sed" else {
+    return false
+  }
   for cursor in (index + 1)..<words.length() {
-    if words[cursor] == "--" {
+    let word = strip_surrounding_quotes(words[cursor])
+    if word == "--" {
       break
     }
-    if is_sed_in_place_flag(words[cursor]) {
+    if is_sed_in_place_flag(word) {
       return true
     }
   }
   false
+}
+
+///|
+/// Strip one layer of matching single or double quotes wrapping the whole token
+/// (`'-i'` -> `-i`). Only used in the rough fallback, where `shell_words` leaves
+/// quotes in place; the precise path receives already-unquoted argv.
+fn strip_surrounding_quotes(word : String) -> String {
+  if word.length() >= 2 &&
+    (
+      (word.has_prefix("'") && word.has_suffix("'")) ||
+      (word.has_prefix("\"") && word.has_suffix("\""))
+    ) {
+    word[1:word.length() - 1].to_owned()
+  } else {
+    word
+  }
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -139,13 +139,15 @@ fn rough_sed_in_place(cmd : String) -> Bool {
 }
 
 ///|
-/// Split `cmd` into rough command segments on the `&&`, `||`, `;`, `|`, and
-/// newline separators. Quote-unaware — adequate for the complex-parse fallback,
-/// which only needs approximate command boundaries.
+/// Split `cmd` into rough command segments on the `&&`, `||`, `;`, `|`, `&`
+/// (background), and newline separators. Quote-unaware — adequate for the
+/// complex-parse fallback, which only needs approximate command boundaries.
+/// `&&` is replaced before bare `&` so it is not split into two empty segments.
 fn rough_command_segments(cmd : String) -> Array[String] {
   let normalized = cmd
     .replace_all(old="&&", new="\n")
     .replace_all(old="||", new="\n")
+    .replace_all(old="&", new="\n")
     .replace_all(old=";", new="\n")
     .replace_all(old="|", new="\n")
   [

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -31,18 +31,15 @@ pub fn moonbit_command_policy_error_for_parse(
     } else {
       None
     }
-  } else {
+  } else if first_command_word(shell_words(cmd)) == Some("moon_cmd") {
     // Parse too complex to analyze structurally (globs, expansions, …): fall
-    // back to a rough leading-word check for the `moon_cmd` typo or a `sed -i`
-    // edit, e.g. `sed -i 's/a/b/' *.mbt`.
-    let words = shell_words(cmd)
-    if first_command_word(words) == Some("moon_cmd") {
-      Some(moon_cmd_error_message())
-    } else if rough_leading_sed_in_place(words) {
-      Some(sed_in_place_error_message())
-    } else {
-      None
-    }
+    // back to rough checks for the `moon_cmd` typo or a `sed -i` edit such as
+    // `cd src && sed -i 's/a/b/' *.mbt`.
+    Some(moon_cmd_error_message())
+  } else if rough_sed_in_place(cmd) {
+    Some(sed_in_place_error_message())
+  } else {
+    None
   }
 }
 
@@ -79,12 +76,41 @@ fn sed_edits_files(command : @shell_parse.SimpleCommand) -> Bool {
 }
 
 ///|
-/// Rough fallback for parses too complex to analyze structurally: true when the
-/// leading command word (after env assignments) is `sed` and a following word is
-/// an in-place flag. Used only when `parse_for_policy` returns `TooComplex` /
-/// `SyntaxError`, e.g. `sed -i 's/a/b/' *.mbt`. It does not unwrap
+/// Rough fallback for parses too complex to analyze structurally (globs,
+/// expansions) — used only when `parse_for_policy` returns `TooComplex` /
+/// `SyntaxError`. Split on shell separators and flag any segment that leads with
+/// `sed` carrying an in-place flag, so `cd src && sed -i 's/a/b/' *.mbt` is
+/// caught and `echo sed -i *.txt` (sed as data) is not. Quote-unaware, like the
+/// moon_cmd fallback: an operator inside quotes can still split a segment.
+fn rough_sed_in_place(cmd : String) -> Bool {
+  for segment in rough_command_segments(cmd) {
+    if segment_leads_with_sed_in_place(shell_words(segment)) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Split `cmd` into rough command segments on the `&&`, `||`, `;`, `|`, and
+/// newline separators. Quote-unaware — adequate for the complex-parse fallback,
+/// which only needs approximate command boundaries.
+fn rough_command_segments(cmd : String) -> Array[String] {
+  let normalized = cmd
+    .replace_all(old="&&", new="\n")
+    .replace_all(old="||", new="\n")
+    .replace_all(old=";", new="\n")
+    .replace_all(old="|", new="\n")
+  [
+    for segment in normalized.split("\n") => segment.to_owned()
+  ]
+}
+
+///|
+/// True when a segment's leading command word (after env assignments) is `sed`
+/// and a following word is an in-place flag. Does not unwrap
 /// `command`/`env`/`builtin`, matching the moon_cmd fallback's conservatism.
-fn rough_leading_sed_in_place(words : Array[String]) -> Bool {
+fn segment_leads_with_sed_in_place(words : Array[String]) -> Bool {
   let mut index = 0
   while index < words.length() && looks_like_env_assignment(words[index]) {
     index += 1

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -84,6 +84,9 @@ test "command policy redirects sed in-place editing to the edit tool" {
       "sed --in-place 's/a/b/' f", "sed --in-place=.bak 's/a/b/' f", "sed -Ei 's/a/b/' f",
       "sed -ni 's/a/b/' f", "command sed -i 's/a/b/' f", "env FOO=bar sed -i 's/a/b/' f",
       "cat f | sed -i 's/a/b/' f", "cd src && sed -i 's/a/b/' f",
+      // Globs/expansions parse as TooComplex; caught by the rough fallback.
+       "sed -i 's/a/b/' *.mbt", "sed -i.bak 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
+      "VAR=x sed -i 's/a/b/' *.mbt",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected sed -i to be redirected for \{cmd}")
@@ -98,6 +101,8 @@ test "command policy allows read-only and non-sed uses of -i" {
     cmd in [
       "sed -n '1,5p' file.mbt", "sed 's/a/b/' file.mbt", "cat file | sed 's/a/b/'",
       "grep -i sed file.mbt", "env -i sed 's/a/b/' file", "echo sed -i", "sed -e 's/i/x/' file",
+      // TooComplex (glob) but not editing: a read-only sed and a non-sed leader.
+       "sed 's/a/b/' *.mbt", "echo sed -i *.txt", "grep -i sed *.mbt",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is None else {
       fail("expected \{cmd} to be allowed")

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -75,3 +75,32 @@ test "command policy does not match moon_cmd as data" {
     is None,
   )
 }
+
+///|
+test "command policy redirects sed in-place editing to the edit tool" {
+  for
+    cmd in [
+      "sed -i 's/a/b/' file.mbt", "sed -i.bak 's/a/b/' file.mbt", "sed -i '' 's/a/b/' file.mbt",
+      "sed --in-place 's/a/b/' f", "sed --in-place=.bak 's/a/b/' f", "sed -Ei 's/a/b/' f",
+      "sed -ni 's/a/b/' f", "command sed -i 's/a/b/' f", "env FOO=bar sed -i 's/a/b/' f",
+      "cat f | sed -i 's/a/b/' f", "cd src && sed -i 's/a/b/' f",
+    ] {
+    guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
+      fail("expected sed -i to be redirected for \{cmd}")
+    }
+    assert_true(message.contains("sed -i") && message.contains("edit"))
+  }
+}
+
+///|
+test "command policy allows read-only and non-sed uses of -i" {
+  for
+    cmd in [
+      "sed -n '1,5p' file.mbt", "sed 's/a/b/' file.mbt", "cat file | sed 's/a/b/'",
+      "grep -i sed file.mbt", "env -i sed 's/a/b/' file", "echo sed -i", "sed -e 's/i/x/' file",
+    ] {
+    guard @command_policy.moonbit_command_policy_error(cmd) is None else {
+      fail("expected \{cmd} to be allowed")
+    }
+  }
+}

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -88,7 +88,7 @@ test "command policy redirects sed in-place editing to the edit tool" {
       // including after a separator.
        "sed -i 's/a/b/' *.mbt", "sed -i.bak 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
       "VAR=x sed -i 's/a/b/' *.mbt", "cd src && sed -i 's/a/b/' *.mbt", "ls *.mbt; sed -i 's/a/b/' f",
-      "cat *.mbt | sed -i 's/a/b/' f",
+      "cat *.mbt | sed -i 's/a/b/' f", "PATH=/usr/bin sed -i 's/a/b/' *.mbt",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected sed -i to be redirected for \{cmd}")

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -88,7 +88,7 @@ test "command policy redirects sed in-place editing to the edit tool" {
       // including after a separator.
        "sed -i 's/a/b/' *.mbt", "sed -i.bak 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
       "VAR=x sed -i 's/a/b/' *.mbt", "cd src && sed -i 's/a/b/' *.mbt", "ls *.mbt; sed -i 's/a/b/' f",
-      "cat *.mbt | sed -i 's/a/b/' f", "PATH=/usr/bin sed -i 's/a/b/' *.mbt",
+      "cat *.mbt | sed -i 's/a/b/' f", "PATH=/usr/bin sed -i 's/a/b/' *.mbt", "sed '-i' 's/a/b/' *.mbt",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected sed -i to be redirected for \{cmd}")

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -84,9 +84,11 @@ test "command policy redirects sed in-place editing to the edit tool" {
       "sed --in-place 's/a/b/' f", "sed --in-place=.bak 's/a/b/' f", "sed -Ei 's/a/b/' f",
       "sed -ni 's/a/b/' f", "command sed -i 's/a/b/' f", "env FOO=bar sed -i 's/a/b/' f",
       "cat f | sed -i 's/a/b/' f", "cd src && sed -i 's/a/b/' f",
-      // Globs/expansions parse as TooComplex; caught by the rough fallback.
+      // Globs/expansions parse as TooComplex; caught by the rough fallback,
+      // including after a separator.
        "sed -i 's/a/b/' *.mbt", "sed -i.bak 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
-      "VAR=x sed -i 's/a/b/' *.mbt",
+      "VAR=x sed -i 's/a/b/' *.mbt", "cd src && sed -i 's/a/b/' *.mbt", "ls *.mbt; sed -i 's/a/b/' f",
+      "cat *.mbt | sed -i 's/a/b/' f",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected sed -i to be redirected for \{cmd}")
@@ -101,8 +103,10 @@ test "command policy allows read-only and non-sed uses of -i" {
     cmd in [
       "sed -n '1,5p' file.mbt", "sed 's/a/b/' file.mbt", "cat file | sed 's/a/b/'",
       "grep -i sed file.mbt", "env -i sed 's/a/b/' file", "echo sed -i", "sed -e 's/i/x/' file",
-      // TooComplex (glob) but not editing: a read-only sed and a non-sed leader.
-       "sed 's/a/b/' *.mbt", "echo sed -i *.txt", "grep -i sed *.mbt",
+      // TooComplex (glob) but not editing: read-only sed (even after a
+      // separator) and non-sed leaders.
+       "sed 's/a/b/' *.mbt", "echo sed -i *.txt", "grep -i sed *.mbt", "cat *.mbt | sed 's/a/b/'",
+      "cd src && grep -i sed *.mbt",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is None else {
       fail("expected \{cmd} to be allowed")

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -89,6 +89,7 @@ test "command policy redirects sed in-place editing to the edit tool" {
        "sed -i 's/a/b/' *.mbt", "sed -i.bak 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
       "VAR=x sed -i 's/a/b/' *.mbt", "cd src && sed -i 's/a/b/' *.mbt", "ls *.mbt; sed -i 's/a/b/' f",
       "cat *.mbt | sed -i 's/a/b/' f", "PATH=/usr/bin sed -i 's/a/b/' *.mbt", "sed '-i' 's/a/b/' *.mbt",
+      "sleep 1 & sed -i 's/a/b/' *.mbt",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected sed -i to be redirected for \{cmd}")

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -89,7 +89,7 @@ test "command policy redirects sed in-place editing to the edit tool" {
        "sed -i 's/a/b/' *.mbt", "sed -i.bak 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
       "VAR=x sed -i 's/a/b/' *.mbt", "cd src && sed -i 's/a/b/' *.mbt", "ls *.mbt; sed -i 's/a/b/' f",
       "cat *.mbt | sed -i 's/a/b/' f", "PATH=/usr/bin sed -i 's/a/b/' *.mbt", "sed '-i' 's/a/b/' *.mbt",
-      "sleep 1 & sed -i 's/a/b/' *.mbt",
+      "sleep 1 & sed -i 's/a/b/' *.mbt", "/usr/bin/sed -i 's/a/b/' file.mbt", "./sed -i 's/a/b/' *.mbt",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected sed -i to be redirected for \{cmd}")

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -103,6 +103,9 @@ test "command policy allows read-only and non-sed uses of -i" {
     cmd in [
       "sed -n '1,5p' file.mbt", "sed 's/a/b/' file.mbt", "cat file | sed 's/a/b/'",
       "grep -i sed file.mbt", "env -i sed 's/a/b/' file", "echo sed -i", "sed -e 's/i/x/' file",
+      // `-f`/`-e` consume the next word as the script/file, so a script file
+      // named `-i` is not an in-place flag.
+       "sed -f -i file.mbt", "sed -e 's/a/b/' -e p file.mbt",
       // TooComplex (glob) but not editing: read-only sed (even after a
       // separator) and non-sed leaders.
        "sed 's/a/b/' *.mbt", "echo sed -i *.txt", "grep -i sed *.mbt", "cat *.mbt | sed 's/a/b/'",

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -398,6 +398,17 @@ async test "shell rejects moon_cmd as a shell command" {
 }
 
 ///|
+async test "shell rejects sed -i in-place editing" {
+  // Blocked by policy before execution, so no file is touched; the model is
+  // redirected to the edit tool.
+  let result = run_shell({ "cmd": "sed -i 's/old/new/' main.mbt" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("sed -i"))
+  assert_true(output.content.contains("edit"))
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "shell appends moon check after applied moon ide rename" {
   @vfs.with_tmpdir(prefix="openseek-shell-auto-check-", dir => {


### PR DESCRIPTION
## Summary

`sed -i` editing exits 0 but silently misapplies edits often enough to be untrustworthy — the agent should use the dedicated `edit`/`write` tools. This extends the shell command policy (which already redirects the `moon_cmd` tool-name typo) to reject `sed` carrying an in-place flag, with a message pointing at the `edit` tool.

## What's blocked / allowed

**Blocked** (→ "use the `edit` tool …"):
`sed -i …`, `sed -i.bak`, `sed -i '' …` (BSD), `sed --in-place[=suffix]`, `sed -Ei`/`-ni`, and the same under wrappers / compounds (`command sed -i`, `env FOO=bar sed -i`, `… | sed -i`, `cd src && sed -i`).

**Allowed** (unchanged): read-only `sed` (`sed -n '1,5p' f`, `… | sed s/a/b/`, `sed -e 's/i/x/' f`), unrelated `-i` (`grep -i sed`, `env -i sed …`), and `sed` as data (`echo sed -i`).

## Detection

Follows the existing `moon_cmd` policy's **precision** philosophy: fire only when `sed` is a statically visible simple command. The in-place flag is read off `sed`'s *own* arguments via `SimpleCommand::command_index` (which skips any `env`/`command`/`builtin` wrapper), so `env -i sed …` isn't fooled by env's `-i`. The short-cluster scan stops at `-e`/`-f` (which consume their value), so an `i` inside a script like `-e's/i/x/'` isn't mistaken for `-i`.

**Known gap (documented):** `find … -exec sed -i` and `xargs sed -i` — where `sed` is an argument of another command, not the visible command — are not caught. Catching those reliably needs runtime knowledge the static parser doesn't have, and broadening the match would risk false positives (e.g. `echo sed -i`). Can revisit if it matters.

## Validation

- `moon fmt` / `moon check` (project-wide) clean, 0 warnings
- `moon test agent_tool/shell agent_tool/shell/internal/command_policy` → **42 passed** (new unit tests for blocked/allowed shapes + a shell-level integration test)
- Helpers are private, so `pkg.generated.mbti` is unchanged
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)