### PR TITLE
Add line-range bounds to edit tool

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -14,6 +14,12 @@ single-match edit is ambiguous, the error reports the first matching line
 numbers so the caller can add enough surrounding context to make `old_string`
 unique.
 
+Optional `start_line` and `end_line` bounds turn the edit into a bounded exact
+replacement. The match is still by `old_string`, but counting and replacement
+happen only inside the inclusive 1-based line range. This keeps repeated text
+outside the intended area from making a focused edit ambiguous or being changed
+by `replace_all=true`.
+
 Rejecting empty `old_string` and identical replacements protects against
 no-op or explosive edits. The tool is designed for small surgical changes; if a
 file needs a complete rewrite, `write` is the clearer API.
@@ -46,6 +52,19 @@ part of the same change:
 }
 ```
 
+Use a line range when the same text appears elsewhere and the intended edit is
+localized:
+
+```json
+{
+  "path": "agent/prompt.mbt",
+  "old_string": "moon check",
+  "new_string": "moon check --diagnostic-limit 1",
+  "start_line": 120,
+  "end_line": 140
+}
+```
+
 ## Arguments
 
 | Name          | Type    | Required | Notes |
@@ -53,7 +72,9 @@ part of the same change:
 | `path`        | string  | yes | Filesystem path. Relative paths resolve against the agent process's current working directory. |
 | `old_string`  | string  | yes | Exact text to replace. Empty strings are rejected. |
 | `new_string`  | string  | yes | Replacement text. It must differ from `old_string`. |
-| `replace_all` | boolean | no  | Defaults to `false`. When false, `old_string` must occur exactly once. |
+| `replace_all` | boolean | no  | Defaults to `false`. When false, `old_string` must occur exactly once in the selected range. |
+| `start_line`  | integer | no  | 1-based first line of the search/replace range. Defaults to the file start. |
+| `end_line`    | integer | no  | 1-based last line of the search/replace range. Defaults to the file end. |
 
 ## Action
 
@@ -68,8 +89,8 @@ has one of these shapes:
   module-root `moon check --diagnostic-limit 1`, starting with
   `"moon check:"` after the success line. Failed checks include `exit=<code>`
   or `exit=cancelled`.
-- `"error editing <path>: old_string not found"` — no exact match was found.
-- `"error editing <path>: old_string matched <n> times on lines <line>, ...; set replace_all=true to replace all occurrences"` — the edit was ambiguous.
+- `"error editing <path>: old_string not found"` — no exact match was found in the selected range.
+- `"error editing <path>: old_string matched <n> times on lines <line>, ...; set replace_all=true to replace all occurrences"` — the edit was ambiguous in the selected range.
 - `"error editing <path>: moon.pkg use // for comment syntax, not #"` or similar
   manifest-guard messages — the replacement would likely break MoonBit package
   discovery.
@@ -90,6 +111,8 @@ test "edit tool advertises the expected schema" {
   assert_true(text.contains("\"old_string\""))
   assert_true(text.contains("\"new_string\""))
   assert_true(text.contains("\"replace_all\""))
+  assert_true(text.contains("\"start_line\""))
+  assert_true(text.contains("\"end_line\""))
   assert_true(text.contains("\"required\""))
 }
 ```

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -9,6 +9,9 @@
 ///   `old_string`.
 /// - `replace_all` (bool, optional): replace every occurrence. Defaults to
 ///   `false`; when false, `old_string` must occur exactly once.
+/// - `start_line` / `end_line` (integer, optional): 1-based inclusive line
+///   bounds. When present, `old_string` is searched and replaced only inside
+///   that range.
 ///
 /// ## Result
 /// - `Respond(ToolOutput("ok: replaced <n> occurrence(s) in <path>"))` on
@@ -23,7 +26,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
-    description="Replace exact text in arguments.path with arguments.new_string.",
+    description="Replace exact text in arguments.path with arguments.new_string. Optional start_line/end_line restrict the search and replacement to a 1-based inclusive line range.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -31,6 +34,8 @@ pub fn definition(
         "old_string": { "type": "string" },
         "new_string": { "type": "string" },
         "replace_all": { "type": "boolean" },
+        "start_line": { "type": "integer" },
+        "end_line": { "type": "integer" },
       },
       "required": ["path", "old_string", "new_string"],
     }),
@@ -87,31 +92,40 @@ async fn edit_file(
         brief=fail_brief,
       )
   }
-  let parts = content
+  let region = select_edit_region(content, input)
+  let parts = region.body
     .split(input.old_string)
     .map(part => part.to_owned())
     .collect()
   let occurrences = parts.length() - 1
   if occurrences == 0 {
     return @agent_tool.ToolAction::respond(
-      "error editing \{path}: old_string not found",
+      "error editing \{path}: old_string not found\{range_detail(input)}",
       is_error=true,
       brief=fail_brief,
     )
   }
   if occurrences > 1 && !input.replace_all {
     return @agent_tool.ToolAction::respond(
-      ambiguous_match_message(path, occurrences, parts, input.old_string),
+      ambiguous_match_message(
+        path,
+        occurrences,
+        parts,
+        input.old_string,
+        range_detail(input),
+        start_line=region.start_line,
+      ),
       is_error=true,
       brief=fail_brief,
     )
   }
   let replacement_count = if input.replace_all { occurrences } else { 1 }
-  let new_content = if input.replace_all {
+  let new_body = if input.replace_all {
     parts.join(input.new_string)
   } else {
-    content.replace(old=input.old_string, new=input.new_string)
+    region.body.replace(old=input.old_string, new=input.new_string)
   }
+  let new_content = "\{region.prefix}\{new_body}\{region.suffix}"
   match @manifest_error.write_error(path, new_content) {
     Some(message) =>
       return @agent_tool.ToolAction::respond(
@@ -148,8 +162,10 @@ fn ambiguous_match_message(
   occurrences : Int,
   parts : Array[String],
   old_string : String,
+  range_detail : String,
+  start_line~ : Int,
 ) -> String {
-  let lines = occurrence_line_labels(parts, old_string, 5)
+  let lines = occurrence_line_labels(parts, old_string, 5, start_line~)
   let line_detail = if lines.length() == 0 {
     ""
   } else if occurrences > lines.length() {
@@ -157,7 +173,7 @@ fn ambiguous_match_message(
   } else {
     " on lines \{lines.join(", ")}"
   }
-  "error editing \{path}: old_string matched \{occurrences} times\{line_detail}; set replace_all=true to replace all occurrences"
+  "error editing \{path}: old_string matched \{occurrences} times\{line_detail}\{range_detail}; set replace_all=true to replace all occurrences\{replace_all_scope_suffix(range_detail)}"
 }
 
 ///|
@@ -165,9 +181,10 @@ fn occurrence_line_labels(
   parts : Array[String],
   old_string : String,
   max : Int,
+  start_line~ : Int,
 ) -> Array[String] {
   let labels : Array[String] = []
-  let mut current_line = 1
+  let mut current_line = start_line
   let occurrence_count = parts.length() - 1
   for index in 0..<occurrence_count {
     current_line = current_line + newline_count(parts[index])
@@ -182,4 +199,93 @@ fn occurrence_line_labels(
 ///|
 fn newline_count(text : String) -> Int {
   text.split("\n").count() - 1
+}
+
+///|
+priv struct EditRegion {
+  prefix : String
+  body : String
+  suffix : String
+  start_line : Int
+}
+
+///|
+fn select_edit_region(
+  content : String,
+  input : @decode.EditInput,
+) -> EditRegion {
+  let start_line = match input.start_line {
+    Some(line) => line
+    None => 1
+  }
+  let start = line_start_offset(content, start_line)
+  let end = match input.end_line {
+    Some(line) => line_end_offset(content, line)
+    None => content.length()
+  }
+  // `decode` guarantees end_line >= start_line when both are present. These
+  // clamps make ranges beyond EOF select an empty suffix without panicking.
+  let start = start.clamp(min=0, max=content.length())
+  let end = end.clamp(min=start, max=content.length())
+  {
+    prefix: content.unsafe_substring(start=0, end=start),
+    body: content.unsafe_substring(start~, end~),
+    suffix: content.unsafe_substring(start=end, end=content.length()),
+    start_line,
+  }
+}
+
+///|
+fn line_start_offset(content : String, line : Int) -> Int {
+  if line <= 1 {
+    0
+  } else {
+    let len = content.length()
+    let mut current_line = 1
+    for cursor = 0; cursor < len; cursor = cursor + 1 {
+      if content[cursor] == '\n' {
+        current_line = current_line + 1
+        if current_line == line {
+          break cursor + 1
+        }
+      }
+    } nobreak {
+      len
+    }
+  }
+}
+
+///|
+fn line_end_offset(content : String, line : Int) -> Int {
+  let len = content.length()
+  let mut current_line = 1
+  for cursor = 0; cursor < len; cursor = cursor + 1 {
+    if content[cursor] == '\n' {
+      if current_line == line {
+        break cursor + 1
+      }
+      current_line = current_line + 1
+    }
+  } nobreak {
+    len
+  }
+}
+
+///|
+fn range_detail(input : @decode.EditInput) -> String {
+  match (input.start_line, input.end_line) {
+    (Some(start), Some(end)) => " in line range \{start}-\{end}"
+    (Some(start), None) => " from line \{start}"
+    (None, Some(end)) => " through line \{end}"
+    (None, None) => ""
+  }
+}
+
+///|
+fn replace_all_scope_suffix(range_detail : String) -> String {
+  if range_detail == "" {
+    ""
+  } else {
+    " in that range"
+  }
 }

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -52,6 +52,52 @@ async test "edit replaces a unique exact match" {
 }
 
 ///|
+async test "edit range limits a unique replacement" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/range.txt"
+    @fs.write_file(path, "target\nkeep\ntarget\n", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "target",
+      "new_string": "changed",
+      "start_line": 3,
+      "end_line": 3,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "target\nkeep\nchanged\n")
+  })
+}
+
+///|
+async test "edit range replace_all stays inside range" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/range-replace-all.txt"
+    @fs.write_file(
+      path,
+      "token\ninside token\ninside token\noutside token\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_edit({
+      "path": path,
+      "old_string": "token",
+      "new_string": "value",
+      "replace_all": true,
+      "start_line": 2,
+      "end_line": 3,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "ok: replaced 2 occurrence(s) in \{path}")
+    assert_false(output.is_error)
+    assert_eq(
+      @fs.read_file(path).text(),
+      "token\ninside value\ninside value\noutside token\n",
+    )
+  })
+}
+
+///|
 async test "edit resolves relative paths under the workspace root" {
   @vfs.with_tmpdir(prefix="openseek-edit-workspace-", dir => {
     let path = "\{dir}/note.txt"
@@ -213,6 +259,28 @@ async test "edit rejects missing match" {
 }
 
 ///|
+async test "edit reports range for missing match" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/range-missing.txt"
+    @fs.write_file(path, "alpha\nbeta\nalpha\n", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "alpha",
+      "new_string": "gamma",
+      "start_line": 2,
+      "end_line": 2,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error editing \{path}: old_string not found in line range 2-2",
+    )
+    assert_true(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "alpha\nbeta\nalpha\n")
+  })
+}
+
+///|
 async test "edit rejects ambiguous match without replace_all" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/ambiguous.txt"
@@ -233,6 +301,32 @@ async test "edit rejects ambiguous match without replace_all" {
     )
     assert_true(output.is_error)
     assert_eq(@fs.read_file(path).text(), "alpha beta\nmiddle\nbeta")
+  })
+}
+
+///|
+async test "edit reports ambiguous matches inside range" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/range-ambiguous.txt"
+    @fs.write_file(
+      path,
+      "beta\nbeta\nmiddle\nbeta\nbeta\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_edit({
+      "path": path,
+      "old_string": "beta",
+      "new_string": "delta",
+      "start_line": 2,
+      "end_line": 4,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error editing \{path}: old_string matched 2 times on lines 2, 4 in line range 2-4; set replace_all=true to replace all occurrences in that range",
+    )
+    assert_true(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "beta\nbeta\nmiddle\nbeta\nbeta\n")
   })
 }
 

--- a/agent_tool/edit/internal/decode/README.mbt.md
+++ b/agent_tool/edit/internal/decode/README.mbt.md
@@ -11,8 +11,8 @@ the parent `edit` package.
 
 ## API Shape
 
-- `EditInput(path, old_string, new_string, replace_all)`: the normalized edit
-  request.
+- `EditInput(path, old_string, new_string, replace_all, start_line, end_line)`:
+  the normalized edit request.
 - `decode(arguments)`: accepts a JSON object and returns `EditInput`, or raises
   when required fields are missing or have invalid types.
 
@@ -24,6 +24,8 @@ the parent `edit` package.
 | `old_string` | string | yes | Missing or non-string values raise `arguments.old_string`. |
 | `new_string` | string | yes | Missing or non-string values raise `arguments.new_string`. |
 | `replace_all` | boolean | no | Defaults to `false`; non-boolean values raise `arguments.replace_all to be a boolean`. |
+| `start_line` | integer | no | Optional positive 1-based inclusive range start. |
+| `end_line` | integer | no | Optional positive 1-based inclusive range end; if both bounds are present, it must be greater than or equal to `start_line`. |
 
 Extra fields are ignored. Non-object JSON values raise `object arguments`.
 
@@ -45,13 +47,19 @@ test "decode edit input from tool arguments" {
   assert_eq(focused.old_string, "Replace exact text")
   assert_eq(focused.new_string, "Replace one exact text span")
   assert_false(focused.replace_all)
+  assert_true(focused.start_line is None)
+  assert_true(focused.end_line is None)
 
   let broad = @decode.decode({
     "path": "agent_tool/edit/README.mbt.md",
     "old_string": "moon.mod.json",
     "new_string": "moon.mod",
     "replace_all": true,
+    "start_line": 1,
+    "end_line": 20,
   })
   assert_true(broad.replace_all)
+  assert_true(broad.start_line is Some(1))
+  assert_true(broad.end_line is Some(20))
 }
 ```

--- a/agent_tool/edit/internal/decode/decode.mbt
+++ b/agent_tool/edit/internal/decode/decode.mbt
@@ -1,54 +1,89 @@
 ///|
 /// Decoded arguments of the `edit` tool: replace `old_string` with
 /// `new_string` in the file at `path` — every occurrence when `replace_all`,
-/// otherwise exactly one.
+/// otherwise exactly one. Optional line bounds restrict the search/replace
+/// region to an inclusive 1-based line range.
 pub struct EditInput {
   path : String
   old_string : String
   new_string : String
   replace_all : Bool
+  start_line : Int?
+  end_line : Int?
 } derive(Debug)
 
 ///|
 /// Decode `edit` tool-call arguments.
 ///
 /// `path`, `old_string`, and `new_string` are required strings;
-/// `replace_all` is an optional boolean defaulting to `false`. Failures name
-/// the first offending field (e.g. `arguments.old_string`) so the error fed
-/// back to the model says exactly which argument to fix.
+/// `replace_all` is an optional boolean defaulting to `false`, and
+/// `start_line`/`end_line` are optional positive 1-based inclusive bounds.
+/// Failures name the first offending field (e.g. `arguments.old_string`) so the
+/// error fed back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> EditInput raise {
   match arguments {
-    {
-      "path": String(path),
-      "old_string": String(old_string),
-      "new_string": String(new_string),
-      "replace_all": True,
-      ..
-    } => { path, old_string, new_string, replace_all: true }
-    {
-      "path": String(path),
-      "old_string": String(old_string),
-      "new_string": String(new_string),
-      "replace_all": False,
-      ..
-    } => { path, old_string, new_string, replace_all: false }
-    {
-      "path": String(_),
-      "old_string": String(_),
-      "new_string": String(_),
-      "replace_all": _,
-      ..
-    } => fail("arguments.replace_all to be a boolean")
-    {
-      "path": String(path),
-      "old_string": String(old_string),
-      "new_string": String(new_string),
-      ..
-    } => { path, old_string, new_string, replace_all: false }
-    { "path": String(_), "old_string": String(_), .. } =>
-      fail("arguments.new_string")
-    { "path": String(_), .. } => fail("arguments.old_string")
-    Object(_) => fail("arguments.path")
+    Object(fields) => parse_fields(fields)
     _ => fail("object arguments")
+  }
+}
+
+///|
+fn parse_fields(fields : Map[String, Json]) -> EditInput raise {
+  let path = required_string(fields, "path")
+  let old_string = required_string(fields, "old_string")
+  let new_string = required_string(fields, "new_string")
+  let replace_all = optional_bool(fields, "replace_all", false)
+  let start_line = optional_positive_int_option(fields, "start_line")
+  let end_line = optional_positive_int_option(fields, "end_line")
+  match (start_line, end_line) {
+    (Some(start), Some(end)) if end < start =>
+      fail(
+        "arguments.end_line to be greater than or equal to arguments.start_line",
+      )
+    _ => ()
+  }
+  { path, old_string, new_string, replace_all, start_line, end_line }
+}
+
+///|
+fn required_string(fields : Map[String, Json], name : String) -> String raise {
+  match fields.get(name) {
+    Some(String(value)) => value
+    _ => fail("arguments.\{name}")
+  }
+}
+
+///|
+fn optional_bool(
+  fields : Map[String, Json],
+  name : String,
+  default : Bool,
+) -> Bool raise {
+  match fields.get(name) {
+    Some(True) => true
+    Some(False) => false
+    Some(Null) | None => default
+    _ => fail("arguments.\{name} to be a boolean")
+  }
+}
+
+///|
+fn optional_positive_int_option(
+  fields : Map[String, Json],
+  name : String,
+) -> Int? raise {
+  match fields.get(name) {
+    Some(Number(value, ..)) => {
+      let int_value = value.to_int()
+      if int_value.to_double() != value {
+        fail("arguments.\{name} to be an integer")
+      }
+      if int_value <= 0 {
+        fail("arguments.\{name} to be a positive integer")
+      }
+      Some(int_value)
+    }
+    Some(Null) | None => None
+    _ => fail("arguments.\{name} to be an integer")
   }
 }

--- a/agent_tool/edit/internal/decode/decode_test.mbt
+++ b/agent_tool/edit/internal/decode/decode_test.mbt
@@ -12,6 +12,8 @@ test "decode valid edit input" {
       #|  old_string: "old",
       #|  new_string: "new",
       #|  replace_all: false,
+      #|  start_line: None,
+      #|  end_line: None,
       #|}
     ),
   )
@@ -32,6 +34,31 @@ test "decode replace_all flag" {
       #|  old_string: "old",
       #|  new_string: "new",
       #|  replace_all: true,
+      #|  start_line: None,
+      #|  end_line: None,
+      #|}
+    ),
+  )
+}
+
+///|
+test "decode line range" {
+  debug_inspect(
+    @decode.decode({
+      "path": "file.mbt",
+      "old_string": "old",
+      "new_string": "new",
+      "start_line": 2,
+      "end_line": 4,
+    }),
+    content=(
+      #|{
+      #|  path: "file.mbt",
+      #|  old_string: "old",
+      #|  new_string: "new",
+      #|  replace_all: false,
+      #|  start_line: Some(2),
+      #|  end_line: Some(4),
       #|}
     ),
   )
@@ -50,6 +77,69 @@ test "decode rejects invalid replace_all" {
     error => assert_true("\{error}".contains("arguments.replace_all"))
   } noraise {
     _ => fail("invalid replace_all decoded")
+  }
+}
+
+///|
+test "decode rejects invalid line range" {
+  try
+    @decode.decode({
+      "path": "file.mbt",
+      "old_string": "old",
+      "new_string": "new",
+      "start_line": 0,
+    })
+  catch {
+    error =>
+      assert_true(
+        "\{error}".contains("arguments.start_line to be a positive integer"),
+      )
+  } noraise {
+    _ => fail("invalid start_line decoded")
+  }
+  try
+    @decode.decode({
+      "path": "file.mbt",
+      "old_string": "old",
+      "new_string": "new",
+      "end_line": "4",
+    })
+  catch {
+    error =>
+      assert_true("\{error}".contains("arguments.end_line to be an integer"))
+  } noraise {
+    _ => fail("invalid end_line decoded")
+  }
+  try
+    @decode.decode({
+      "path": "file.mbt",
+      "old_string": "old",
+      "new_string": "new",
+      "start_line": 1.9,
+    })
+  catch {
+    error =>
+      assert_true("\{error}".contains("arguments.start_line to be an integer"))
+  } noraise {
+    _ => fail("fractional start_line decoded")
+  }
+  try
+    @decode.decode({
+      "path": "file.mbt",
+      "old_string": "old",
+      "new_string": "new",
+      "start_line": 4,
+      "end_line": 2,
+    })
+  catch {
+    error =>
+      assert_true(
+        "\{error}".contains(
+          "arguments.end_line to be greater than or equal to arguments.start_line",
+        ),
+      )
+  } noraise {
+    _ => fail("inverted line range decoded")
   }
 }
 

--- a/agent_tool/edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/edit/internal/decode/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub struct EditInput {
   old_string : String
   new_string : String
   replace_all : Bool
+  start_line : Int?
+  end_line : Int?
 } derive(@debug.Debug)
 
 // Type aliases


### PR DESCRIPTION
## Summary

- add optional `start_line` / `end_line` integer bounds to the `edit` tool schema and tool description
- restrict exact-match counting and replacement to the selected inclusive line range
- add focused edit/decode tests and README docs for bounded replacements

## Validation

- `moon check agent_tool/edit agent_tool/edit/internal/decode --warn-list +73`
- `moon test agent_tool/edit agent_tool/edit/internal/decode --target native --warn-list +73` (31 passed)
- `moon check --warn-list +73` (passes with existing warning-73 diagnostics in `cmd/viz_server`)
- `moon test --target native --warn-list +73` (678 passed)
- `moon info`
- `git diff --check`
- fresh `codex exec review --uncommitted --ephemeral` after fixes: no correctness issues found

Note: the fresh reviewer's default `moon test` run hit the known network-dependent DeepSeek realworld DNS smoke test in its sandbox; the full native test suite passed locally with the command above.