### PR TITLE
shell policy: drop the rough sed fallback (false positives)

### DIFF
--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -42,36 +42,44 @@ The policy allows:
 
 ## Detection Strategy
 
-The implementation is deliberately conservative:
+Detection is **precise, not heuristic**, and prefers **no false positives**
+(never block a command that is not actually an in-place edit) over exhaustive
+recall:
 
 - Parse the command with the internal shell policy parser.
 - Reject `moon_cmd` when it is a statically visible simple command name,
   including in flat compounds such as `cd demo && moon_cmd check`.
 - Reject `sed` carrying an in-place flag when it is a statically visible simple
-  command (after any `env`/`command`/`builtin` wrapper). The in-place flag is
-  read off `sed`'s own arguments, so an unrelated `-i` such as `grep -i sed` or
-  `env -i sed ...` does not trip it.
-- If the structured parse fails (globs, expansions — e.g.
-  `sed -i 's/a/b/' *.mbt`), fall back to a **rough, quote-unaware** text scan:
-  split on `&&`/`||`/`;`/`|` and flag a segment whose leading command word is
-  `moon_cmd`, or `sed` carrying an in-place flag.
+  command. Because this runs on the structured parse, it correctly handles
+  `env`/`command`/`builtin` wrappers (via `command_index`), a path-qualified
+  `/usr/bin/sed` (via basename), quotes and separators (the parser unquotes argv
+  and splits commands), and `sed`'s own option grammar — `grep -i sed`,
+  `env -i sed ...`, and a script file named `-i` (`sed -f -i file`) are left
+  alone, and `-i` is read off `sed`'s own arguments only.
+- When the structured parse **fails** (globs, expansions, here-documents — e.g.
+  `sed -i 's/a/b/' *.mbt`), only the narrow leading-word `moon_cmd` typo check
+  runs. `sed -i` is **not** matched there.
 
-This is still not a security sandbox and not a full POSIX shell interpreter. The
-rough fallback is best-effort, not exhaustive — by design it does not catch:
+This is not a security sandbox and not a full POSIX shell interpreter. The
+sed guard is intentionally limited to commands the parser can analyze, because a
+rough text scan of an unparseable command produces false positives — a quoted
+`|sed -i` inside `grep 'a|sed -i' *.x`, or a here-document body that writes
+`sed -i` to a script — and a false block is worse than missing a globbed edit.
 
-- `sed` that is not the segment's leading command — `find ... -exec sed -i`,
+Known gaps that are therefore *allowed* to run (false negatives, by design):
+
+- any `sed -i` whose command parses as `TooComplex` — i.e. with an unquoted glob
+  (`sed -i 's/a/b/' *.mbt`), command/process substitution (`$(...)`), or a
+  here-document;
+- `sed` that is not a command's leading word — `find ... -exec sed -i`,
   `xargs sed -i`;
-- `sed -i` reached only through a wrapper in a too-complex parse —
-  `command sed -i ... *.glob` (wrappers are handled in the precise path, not the
-  fallback);
-- operators or env values hidden inside quotes, which the quote-unaware split
-  can mis-segment.
+- `sed -i` behind an `env` option the parser does not unwrap, e.g.
+  `env -u FOO sed -i ...` (`command_name()` stays `env`).
 
-The structural reason these escape is that an unquoted glob makes the whole
-command `TooComplex`; the deeper fix is to teach the lexer to treat an unquoted
-glob as an opaque word (so the command name and flags stay statically visible)
-rather than failing the parse. That is a shared-parser change left for a separate
-PR.
+The clean way to recover the common globbed case is to teach the lexer to treat
+an unquoted glob as an opaque word, so the command stays `Simple` and the precise
+path handles it; that shared-parser change (which also helps the `moon_cmd`
+policy and the `env`-option gap) is left for a separate PR.
 
 ## Examples
 

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -32,12 +32,15 @@ pub fn moonbit_command_policy_error_for_parse(
       None
     }
   } else if first_command_word(shell_words(cmd)) == Some("moon_cmd") {
-    // Parse too complex to analyze structurally (globs, expansions, …): fall
-    // back to rough checks for the `moon_cmd` typo or a `sed -i` edit such as
-    // `cd src && sed -i 's/a/b/' *.mbt`.
+    // Too-complex parse (globs, expansions, heredocs): keep only the narrow
+    // leading-word `moon_cmd` typo fallback. `sed -i` is blocked solely on the
+    // precise `Simple` path above — a rough text scan of an unparseable command
+    // risks blocking read-only ones (a quoted `|` in `grep 'a|sed -i' *.x`, a
+    // heredoc body that writes `sed -i`), and a false block is worse than
+    // missing a globbed edit. Recovering globbed `sed -i` cleanly means teaching
+    // the lexer to treat an unquoted glob as an opaque word so the command stays
+    // `Simple`; that shared-parser change is left for a follow-up.
     Some(moon_cmd_error_message())
-  } else if rough_sed_in_place(cmd) {
-    Some(sed_in_place_error_message())
   } else {
     None
   }
@@ -54,38 +57,28 @@ fn sed_in_place_error_message() -> String {
 }
 
 ///|
-/// True when `command` is `sed` (after any `env`/`command`/`builtin` wrapper)
-/// invoked with an in-place edit flag. Read-only `sed` — `sed -n '1,5p' file`,
-/// `... | sed s/a/b/`, or a non-`sed` `-i` such as `grep -i` / `env -i sed ...`
-/// — is left alone.
+/// True when `command` is `sed` (after any `env`/`command`/`builtin` wrapper,
+/// and ignoring a `/usr/bin/` style path) invoked with an in-place edit flag.
+/// Read-only `sed` — `sed -n '1,5p' file`, `... | sed s/a/b/`, or a non-`sed`
+/// `-i` such as `grep -i` / `env -i sed ...` — is left alone.
 fn sed_edits_files(command : @shell_parse.SimpleCommand) -> Bool {
   guard command.command_name() is Some(name) else { return false }
   guard command_basename(name) == "sed" else { return false }
   guard command.command_index() is Some(start) else { return false }
-  // `command_index` skips the wrapper, so scan only `sed`'s own arguments. The
-  // argv is already unquoted by the real parser.
-  scan_sed_args_for_in_place(command.argv, start + 1, quoted=false)
+  // `command_index` skips the wrapper, so scan only `sed`'s own arguments; the
+  // argv is already unquoted by the parser.
+  scan_sed_args_for_in_place(command.argv, start + 1)
 }
 
 ///|
 /// Scan `sed` arguments starting at `start` for an in-place flag. `-e`/`-f` (and
 /// `--expression`/`--file`) consume the next word as their script/file value, so
 /// that operand is skipped — `sed -f -i file` reads a script file named `-i`, it
-/// is not an in-place edit. Stops at `--` (the rest are file operands). With
-/// `quoted~`, a fully-quoted token is unquoted first (the rough fallback path,
-/// where `shell_words` keeps quotes).
-fn scan_sed_args_for_in_place(
-  args : Array[String],
-  start : Int,
-  quoted~ : Bool,
-) -> Bool {
+/// is not an in-place edit. Stops at `--` (the rest are file operands).
+fn scan_sed_args_for_in_place(args : Array[String], start : Int) -> Bool {
   let mut index = start
   while index < args.length() {
-    let arg = if quoted {
-      strip_surrounding_quotes(args[index])
-    } else {
-      args[index]
-    }
+    let arg = args[index]
     if arg == "--" {
       break
     }
@@ -124,58 +117,6 @@ fn sed_option_consumes_next(arg : String) -> Bool {
 }
 
 ///|
-/// Rough fallback for parses too complex to analyze structurally (globs,
-/// expansions) — used only when `parse_for_policy` returns `TooComplex` /
-/// `SyntaxError`. Split on shell separators and flag any segment that leads with
-/// `sed` carrying an in-place flag, so `cd src && sed -i 's/a/b/' *.mbt` is
-/// caught and `echo sed -i *.txt` (sed as data) is not. Quote-unaware, like the
-/// moon_cmd fallback: an operator inside quotes can still split a segment.
-fn rough_sed_in_place(cmd : String) -> Bool {
-  for segment in rough_command_segments(cmd) {
-    if segment_leads_with_sed_in_place(shell_words(segment)) {
-      return true
-    }
-  }
-  false
-}
-
-///|
-/// Split `cmd` into rough command segments on the `&&`, `||`, `;`, `|`, `&`
-/// (background), and newline separators. Quote-unaware — adequate for the
-/// complex-parse fallback, which only needs approximate command boundaries.
-/// `&&` is replaced before bare `&` so it is not split into two empty segments.
-fn rough_command_segments(cmd : String) -> Array[String] {
-  let normalized = cmd
-    .replace_all(old="&&", new="\n")
-    .replace_all(old="||", new="\n")
-    .replace_all(old="&", new="\n")
-    .replace_all(old=";", new="\n")
-    .replace_all(old="|", new="\n")
-  [
-    for segment in normalized.split("\n") => segment.to_owned()
-  ]
-}
-
-///|
-/// True when a segment's leading command word (after env assignments) is `sed`
-/// and a following word is an in-place flag. Does not unwrap
-/// `command`/`env`/`builtin`, matching the moon_cmd fallback's conservatism.
-fn segment_leads_with_sed_in_place(words : Array[String]) -> Bool {
-  let mut index = 0
-  while index < words.length() && is_env_assignment_prefix(words[index]) {
-    index += 1
-  }
-  // `shell_words` keeps quotes, so strip a fully-quoted token before matching —
-  // the shell still passes `'sed'` / `'-i'` through as `sed` / `-i`. Compare the
-  // basename so `/usr/bin/sed` / `./sed` match too.
-  guard index < words.length() &&
-    command_basename(strip_surrounding_quotes(words[index])) == "sed" else {
-    return false
-  }
-  scan_sed_args_for_in_place(words, index + 1, quoted=true)
-}
-
-///|
 /// The final path component of a command word, so a path-qualified `sed`
 /// (`/usr/bin/sed`, `./sed`) compares equal to `sed`. Handles both separators.
 fn command_basename(name : String) -> String {
@@ -183,22 +124,6 @@ fn command_basename(name : String) -> String {
   match normalized.rev_find("/") {
     Some(slash) => normalized[slash + 1:].to_owned()
     None => name
-  }
-}
-
-///|
-/// Strip one layer of matching single or double quotes wrapping the whole token
-/// (`'-i'` -> `-i`). Only used in the rough fallback, where `shell_words` leaves
-/// quotes in place; the precise path receives already-unquoted argv.
-fn strip_surrounding_quotes(word : String) -> String {
-  if word.length() >= 2 &&
-    (
-      (word.has_prefix("'") && word.has_suffix("'")) ||
-      (word.has_prefix("\"") && word.has_suffix("\""))
-    ) {
-    word[1:word.length() - 1].to_owned()
-  } else {
-    word
   }
 }
 
@@ -254,38 +179,6 @@ fn first_command_word(words : Array[String]) -> String? {
     }
   }
   None
-}
-
-///|
-/// A leading `NAME=value` environment prefix (any value), used to skip command
-/// env assignments when locating a segment's command word. More permissive than
-/// `looks_like_env_assignment`, which rejects values containing `/`, `-`, or
-/// empty — so a real prefix like `PATH=/usr/bin` before `sed -i` is skipped.
-fn is_env_assignment_prefix(word : String) -> Bool {
-  match word.find("=") {
-    Some(0) | None => false
-    Some(equals) => is_valid_env_name(word[:equals])
-  }
-}
-
-///|
-fn is_valid_env_name(name : StringView) -> Bool {
-  if name.length() == 0 {
-    return false
-  }
-  let mut first = true
-  for ch in name {
-    let valid = if first {
-      first = false
-      ch is ('a'..='z' | 'A'..='Z' | '_')
-    } else {
-      ch is ('a'..='z' | 'A'..='Z' | '0'..='9' | '_')
-    }
-    if !valid {
-      return false
-    }
-  }
-  true
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -83,18 +83,31 @@ test "command policy redirects sed in-place editing to the edit tool" {
       "sed -i 's/a/b/' file.mbt", "sed -i.bak 's/a/b/' file.mbt", "sed -i '' 's/a/b/' file.mbt",
       "sed --in-place 's/a/b/' f", "sed --in-place=.bak 's/a/b/' f", "sed -Ei 's/a/b/' f",
       "sed -ni 's/a/b/' f", "command sed -i 's/a/b/' f", "env FOO=bar sed -i 's/a/b/' f",
-      "cat f | sed -i 's/a/b/' f", "cd src && sed -i 's/a/b/' f",
-      // Globs/expansions parse as TooComplex; caught by the rough fallback,
-      // including after a separator.
-       "sed -i 's/a/b/' *.mbt", "sed -i.bak 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
-      "VAR=x sed -i 's/a/b/' *.mbt", "cd src && sed -i 's/a/b/' *.mbt", "ls *.mbt; sed -i 's/a/b/' f",
-      "cat *.mbt | sed -i 's/a/b/' f", "PATH=/usr/bin sed -i 's/a/b/' *.mbt", "sed '-i' 's/a/b/' *.mbt",
-      "sleep 1 & sed -i 's/a/b/' *.mbt", "/usr/bin/sed -i 's/a/b/' file.mbt", "./sed -i 's/a/b/' *.mbt",
+      "cat f | sed -i 's/a/b/' f", "cd src && sed -i 's/a/b/' f", "'sed' -i 's/a/b/' f",
+      // Path-qualified sed (Simple parse) is matched by basename.
+       "/usr/bin/sed -i 's/a/b/' file.mbt", "./sed -i 's/a/b/' f",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is Some(message) else {
       fail("expected sed -i to be redirected for \{cmd}")
     }
     assert_true(message.contains("sed -i") && message.contains("edit"))
+  }
+}
+
+///|
+test "command policy does not block sed -i in too-complex (glob/heredoc) parses" {
+  // Documented tradeoff: a globbed / heredoc / expansion `sed -i` parses as
+  // TooComplex and is allowed to run. Blocking it would need a rough text scan
+  // of an unparseable command, which causes false positives (a quoted `|` in
+  // `grep 'a|sed -i' *.x`, a heredoc body), and a false block is worse than a
+  // missed glob. The precise path still catches every `Simple` form above.
+  for
+    cmd in [
+      "sed -i 's/a/b/' *.mbt", "cd src && sed -i 's/a/b/' *.mbt", "sed -i 's/a/b/' $(ls)",
+    ] {
+    guard @command_policy.moonbit_command_policy_error(cmd) is None else {
+      fail("expected \{cmd} to be allowed (too-complex parse)")
+    }
   }
 }
 
@@ -107,10 +120,11 @@ test "command policy allows read-only and non-sed uses of -i" {
       // `-f`/`-e` consume the next word as the script/file, so a script file
       // named `-i` is not an in-place flag.
        "sed -f -i file.mbt", "sed -e 's/a/b/' -e p file.mbt",
-      // TooComplex (glob) but not editing: read-only sed (even after a
-      // separator) and non-sed leaders.
+      // TooComplex parses that are NOT in-place edits must never be blocked:
+      // read-only sed, non-sed leaders, a quoted `|sed -i` inside a grep
+      // pattern, and a heredoc body that writes `sed -i`.
        "sed 's/a/b/' *.mbt", "echo sed -i *.txt", "grep -i sed *.mbt", "cat *.mbt | sed 's/a/b/'",
-      "cd src && grep -i sed *.mbt",
+      "cd src && grep -i sed *.mbt", "grep 'foo|sed -i' *.mbt", "cat > script.sh <<EOF\nsed -i 's/a/b/' f\nEOF",
     ] {
     guard @command_policy.moonbit_command_policy_error(cmd) is None else {
       fail("expected \{cmd} to be allowed")


### PR DESCRIPTION
## Summary

**Follow-up to #248.** That PR merged at an earlier commit (`main` is at rev "match path-qualified sed") that still carried the rough, quote-unaware complex-parse fallback for `sed -i`. My later fixes (heredoc exclusion, then removing the fallback) were pushed after the merge and never landed — this PR brings the final state in.

### Why
The rough fallback **false-positives** — the worst failure mode for a command guardrail:
- `grep 'foo|sed -i' *.mbt` — a read-only grep — gets blocked, because the quote-unaware split breaks at the quoted `|` and sees a `sed -i'` segment;
- `cat > script.sh <<EOF\nsed -i 's/a/b/' f\nEOF` — writing a script via heredoc — gets blocked, because the scan reads the heredoc body as commands.

A false block (rejecting a legitimate read-only command) is worse than missing a globbed edit.

### What changes
`sed -i` is now blocked **solely on the precise, quote-aware `Simple` parse**, which already handles `env`/`command`/`builtin` wrappers, separators, pipes, path-qualified `/usr/bin/sed` (basename), and sed's own option grammar (`-e`/`-f` operands, a script file named `-i`) — with **no false positives**. Globbed / expansion / heredoc `sed -i` parses as `TooComplex` and is allowed: a documented, tested false negative. The clean way to recover the common globbed case is lexer-level glob tolerance in `shell_parse` (also helps the `moon_cmd` policy), left for a separate PR.

Removes ~90 lines of fragile heuristics (segment splitting, quote stripping, env prefixes, heredoc exclusion).

## Validation

- `moon fmt` / `moon check` clean, 0 warnings
- `moon test agent_tool/shell agent_tool/shell/internal/command_policy` → **43 passed** (incl. explicit tests that the former false-positive cases are now allowed, and that globbed `sed -i` is a documented allow)
- Independent `codex review` (see comments) — clean after this simplification

🤖 Generated with [Claude Code](https://claude.com/claude-code)