### PR TITLE
shell: move exit/truncation metadata into a `<system>` footer (read convention)

### DIFF
--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -70,13 +70,17 @@ share the remaining `max_output_chars` budget.
 The action is always `Respond(ToolOutput(...))` — the agent loop forwards
 `ToolOutput.content` to the model as a tool-call response and never finishes
 from a `shell` invocation. `is_error` is `true` for launch failures, invalid
-arguments, non-zero shell exit codes, and output truncation. The string body
-has one of these shapes:
+arguments, non-zero shell exit codes, and output truncation.
 
-- `"exit=<code>\n<stdout/stderr merged>"` — normal completion.
-- For successful mutating `moon` commands, the normal completion output may be
-  followed by a `moon check:` section with bounded compiler diagnostics.
-- `"exit=<code-or-cancelled>\ntruncated=true\noutput_limit_reached=true\nshown_chars=<n>\nmax_output_chars=<n>\n<output-prefix>"` —
+Metadata is a trailing `<system>...</system>` footer (the `read` tool
+convention): the merged stdout/stderr output comes first, then a single footer
+line. An output-less command returns just the footer. The string body has one of
+these shapes:
+
+- `"<stdout/stderr merged>\n<system>exit=<code></system>"` — normal completion.
+- For successful mutating `moon` commands, the output may be followed by a
+  `moon check:` section with bounded compiler diagnostics (after the footer).
+- `"<output-prefix>\n<system>exit=<code-or-cancelled> truncated=true output_limit_reached=true shown_chars=<n> max_output_chars=<n></system>"` —
   output exceeded `max_output_chars` while the process pipe was being read. The
   command is cancelled if it has not already exited; no full output length is
   reported because the full output was intentionally not collected.

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -37,8 +37,20 @@ async fn append_moon_command_check_summary(
     _ => None
   }
   match summary {
-    Some(summary) => "\{content}\n\{summary}"
+    Some(summary) => insert_before_system_footer(content, summary)
     None => content
+  }
+}
+
+///|
+/// Insert `block` just before the trailing `<system>...</system>` footer of a
+/// shell response, so the footer stays the last line (the read-tool convention).
+/// `content` from `shell_response` always ends with that footer line.
+fn insert_before_system_footer(content : String, block : String) -> String {
+  match content.rev_split_once("\n") {
+    Some((head, footer)) => "\{head}\n\{block}\n\{footer}"
+    // Output-less command: content is the footer line alone.
+    None => "\{block}\n\{content}"
   }
 }
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -15,10 +15,13 @@
 ///   reported as a tool error.
 ///
 /// ## Result
-/// - `Respond(ToolOutput("exit=<code>\n<output>", is_error=<code != 0>))`
+/// Metadata is a trailing `<system>...</system>` footer (the `read` tool
+/// convention): output first, one footer line last. Output-less commands return
+/// just the footer.
+/// - `Respond(ToolOutput("<output>\n<system>exit=<code></system>", is_error=<code != 0>))`
 ///   when the platform shell runs. Non-zero exit codes are typed as tool errors
 ///   while preserving the full output for the model.
-/// - `Respond(ToolOutput("exit=<code-or-cancelled>\ntruncated=true\noutput_limit_reached=true\nshown_chars=<n>\nmax_output_chars=<n>\n<output-prefix>", is_error=true))`
+/// - `Respond(ToolOutput("<output-prefix>\n<system>exit=<code-or-cancelled> truncated=true output_limit_reached=true shown_chars=<n> max_output_chars=<n></system>", is_error=true))`
 ///   when output exceeds `max_output_chars`. The command may be cancelled before
 ///   its natural exit code is available.
 /// - `Respond(ToolOutput("error running shell: ...", is_error=true))` when
@@ -322,16 +325,17 @@ fn shell_response(
   max_output_chars : Int,
 ) -> ShellResponse {
   if output.output_limit_reached {
-    {
-      content: "\{exit_header(output.exit_code)}\ntruncated=true\noutput_limit_reached=true\nshown_chars=\{output.text.char_length()}\nmax_output_chars=\{max_output_chars}\n\{output.text}",
-      is_error: true,
-    }
+    let footer = "<system>\{exit_header(output.exit_code)} truncated=true output_limit_reached=true shown_chars=\{output.text.char_length()} max_output_chars=\{max_output_chars}</system>"
+    { content: with_system_footer(output.text, footer), is_error: true }
   } else {
     let code = match output.exit_code {
       Some(code) => code
       None => 0
     }
-    { content: "exit=\{code}\n\{output.text}", is_error: code != 0 }
+    {
+      content: with_system_footer(output.text, "<system>exit=\{code}</system>"),
+      is_error: code != 0,
+    }
   }
 }
 
@@ -340,6 +344,21 @@ fn exit_header(exit_code : Int?) -> String {
   match exit_code {
     Some(code) => "exit=\{code}"
     None => "exit=cancelled"
+  }
+}
+
+///|
+/// Append a trailing `<system>...</system>` metadata footer to command output,
+/// matching the `read` tool convention (output first, one footer line last).
+/// Output-less commands return just the footer, and a single newline separates
+/// output from the footer even when the output already ends in one.
+fn with_system_footer(text : String, footer : String) -> String {
+  if text == "" {
+    footer
+  } else if text.has_suffix("\n") {
+    "\{text}\{footer}"
+  } else {
+    "\{text}\n\{footer}"
   }
 }
 
@@ -364,6 +383,6 @@ test "shell formats output limit metadata" {
       { exit_code: Some(0), text: "abc", output_limit_reached: true },
       3,
     ).content,
-    "exit=0\ntruncated=true\noutput_limit_reached=true\nshown_chars=3\nmax_output_chars=3\nabc",
+    "abc\n<system>exit=0 truncated=true output_limit_reached=true shown_chars=3 max_output_chars=3</system>",
   )
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -114,8 +114,8 @@ async test "shell reads a virtual filesystem fixture from cwd" {
     inspect(
       output.content.trim(),
       content=(
-        #|exit=0
         #|shell-vfs
+        #|<system>exit=0</system>
       ),
     )
   })
@@ -139,7 +139,7 @@ async test "shell leaves output at exact limit as a normal result on Windows" {
   })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_eq(output.content, "exit=0\nabc")
+  assert_eq(output.content, "abc\n<system>exit=0</system>")
 }
 
 ///|
@@ -148,7 +148,7 @@ async test "shell leaves output at exact limit as a normal result on Unix" {
   let result = run_shell({ "cmd": "printf %s 'abc'", "max_output_chars": 3 })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_eq(output.content, "exit=0\nabc")
+  assert_eq(output.content, "abc\n<system>exit=0</system>")
 }
 
 ///|
@@ -160,7 +160,7 @@ async test "shell counts output limits in characters for non-ascii text on Windo
   })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_eq(output.content, "exit=0\n中中")
+  assert_eq(output.content, "中中\n<system>exit=0</system>")
 }
 
 ///|
@@ -169,7 +169,7 @@ async test "shell counts output limits in characters for non-ascii text on Unix"
   let result = run_shell({ "cmd": "printf %s '中中'", "max_output_chars": 2 })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_eq(output.content, "exit=0\n中中")
+  assert_eq(output.content, "中中\n<system>exit=0</system>")
 }
 
 ///|
@@ -181,7 +181,7 @@ async test "shell leaves four-byte utf8 output at exact character limit on Windo
   })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_eq(output.content, "exit=0\n😀")
+  assert_eq(output.content, "😀\n<system>exit=0</system>")
 }
 
 ///|
@@ -190,7 +190,7 @@ async test "shell leaves four-byte utf8 output at exact character limit on Unix"
   let result = run_shell({ "cmd": "printf %s '😀'", "max_output_chars": 1 })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
-  assert_eq(output.content, "exit=0\n😀")
+  assert_eq(output.content, "😀\n<system>exit=0</system>")
 }
 
 ///|
@@ -204,7 +204,7 @@ async test "shell stops oversized output while the command is still running on W
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=3\nmax_output_chars=3\nabc$",
+    output.content =~ re"^abc\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=3 max_output_chars=3</system>$",
   )
   assert_false(output.content.contains("timed out"))
   assert_false(output.content.contains("abcdef"))
@@ -221,7 +221,7 @@ async test "shell stops oversized output while the command is still running on U
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=3\nmax_output_chars=3\nabc$",
+    output.content =~ re"^abc\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=3 max_output_chars=3</system>$",
   )
   assert_false(output.content.contains("timed out"))
   assert_false(output.content.contains("abcdef"))
@@ -238,7 +238,7 @@ async test "shell does not cut multi-byte utf8 output mid-character on Windows" 
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=2\nmax_output_chars=2\n中中$",
+    output.content =~ re"^中中\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=2 max_output_chars=2</system>$",
   )
   assert_false(output.content.contains("�"))
   assert_false(output.content.contains("中中中"))
@@ -255,7 +255,7 @@ async test "shell does not cut multi-byte utf8 output mid-character on Unix" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=2\nmax_output_chars=2\n中中$",
+    output.content =~ re"^中中\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=2 max_output_chars=2</system>$",
   )
   assert_false(output.content.contains("�"))
   assert_false(output.content.contains("中中中"))
@@ -272,7 +272,7 @@ async test "shell does not split four-byte utf8 characters on Windows" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=1\nmax_output_chars=1\n😀$",
+    output.content =~ re"^😀\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=1 max_output_chars=1</system>$",
   )
   assert_false(output.content.contains("�"))
   assert_false(output.content.contains("😀😀"))
@@ -289,7 +289,7 @@ async test "shell does not split four-byte utf8 characters on Unix" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=1\nmax_output_chars=1\n😀$",
+    output.content =~ re"^😀\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=1 max_output_chars=1</system>$",
   )
   assert_false(output.content.contains("�"))
   assert_false(output.content.contains("😀😀"))
@@ -328,7 +328,7 @@ async test "shell output limit wins over an unbounded producer on Windows" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=5\nmax_output_chars=5\nyyyyy$",
+    output.content =~ re"^yyyyy\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=5 max_output_chars=5</system>$",
   )
   assert_false(output.content.contains("timed out"))
 }
@@ -344,7 +344,7 @@ async test "shell output limit wins over an unbounded producer on Unix" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
-    output.content =~ re"^exit=cancelled\ntruncated=true\noutput_limit_reached=true\nshown_chars=5\nmax_output_chars=5\nyyyyy$",
+    output.content =~ re"^yyyyy\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=5 max_output_chars=5</system>$",
   )
   assert_false(output.content.contains("timed out"))
 }
@@ -438,10 +438,13 @@ async test "shell appends moon check after applied moon ide rename" {
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_true(output.content.has_prefix("exit=0\n"))
+    assert_true(output.content.contains("<system>exit=0</system>"))
     assert_true(output.content.contains("Applied 2 edit(s)"))
     assert_true(output.content.contains("\nmoon check:\nexit="))
     assert_true(output.content.contains("missing_symbol"))
+    // The `<system>` footer stays the last line even with the moon check block
+    // inserted before it.
+    assert_true(output.content.has_suffix("<system>exit=0</system>"))
     let renamed = @fs.read_file("\{dir}/main.mbt").text()
     assert_true(renamed.contains("new_name"))
     assert_false(renamed.contains("old_name"))
@@ -512,7 +515,7 @@ async test "shell appends moon check from moon command target cwd" {
       let result = run_shell({ "cmd": cmd, "cwd": dir })
       guard result is Respond(output) else { fail("expected Respond") }
       assert_false(output.is_error)
-      assert_true(output.content.has_prefix("exit=0\n"))
+      assert_true(output.content.contains("<system>exit=0</system>"))
       assert_true(output.content.contains("\nmoon check:\nexit="))
       assert_true(output.content.contains("missing_symbol"))
     }


### PR DESCRIPTION
## Summary

The `shell` tool put its metadata as a **header before** the output:
```
exit=<code>
<stdout/stderr merged>
```
and a multi-line truncation block. This switches it to the **`read` tool convention** — output first, then a single trailing `<system>…</system>` footer:
```
<stdout/stderr merged>
<system>exit=<code></system>
```
Truncated:
```
<output-prefix>
<system>exit=<code-or-cancelled> truncated=true output_limit_reached=true shown_chars=<n> max_output_chars=<n></system>
```
An output-less command returns just the footer, and exactly one newline separates output from the footer even when the output already ends in one.

## Consumer updated (important)

The eval **session analyzer** detected shell failures by reading a *leading* `exit=` line (`shell_result_failed`). With the metadata now in the footer, that would silently stop detecting failures — so it's updated to read the `<system>…exit=<code>…</system>` footer. A nice side effect: it no longer mistakes a bare `exit=N` inside an appended `moon check:` block for the shell's own exit. (`eval/prompt_task/harness` gets `shell_failures` via this analyzer, so it's covered too.)

The `moon check:` follow-up sub-block (appended after a successful mutating `moon` command) keeps its own `moon check:` label for now; unifying it into `<system>` is a possible follow-up.

## Validation

- `moon fmt` / `moon check` (project-wide) clean, 0 warnings
- `moon test agent_tool/shell eval/session_analyzer` → 40 passed (all format snapshots updated: normal, non-ascii/emoji exact-limit, truncation regexes, vfs inspect, moon-auto-check)
- Broader sweep `agent_session deepseek/client eval/{file_edit,prompt_task,tool_harness}/… agent agent_tool/internal/auto_check cmd/tui viz` → green
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)