### PR TITLE
session analyzer: count shell failures from is_error, not output text

### DIFF
--- a/eval/session_analyzer/analyzer.mbt
+++ b/eval/session_analyzer/analyzer.mbt
@@ -116,7 +116,10 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
         tool_results += 1
         if result.tool_name() == "shell" {
           shell_uses += 1
-          if shell_result_failed(result.content()) {
+          // Use the recorded `is_error` flag rather than re-parsing the shell
+          // output: the tool already decided success/failure, so this stays
+          // correct regardless of the output format.
+          if result.is_error() {
             shell_failures += 1
           }
         }
@@ -172,15 +175,6 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
     terminal_status,
     terminal_message,
   }
-}
-
-///|
-fn shell_result_failed(content : String) -> Bool {
-  for piece in content.split("\n") {
-    let line = piece.to_owned().trim().to_owned()
-    return line.has_prefix("exit=") && line != "exit=0"
-  }
-  false
 }
 
 ///|

--- a/eval/session_analyzer/analyzer_wbtest.mbt
+++ b/eval/session_analyzer/analyzer_wbtest.mbt
@@ -88,12 +88,37 @@ test "finish tool terminal does not double count a model step" {
 }
 
 ///|
-test "shell result failure detection reads only the exit header" {
-  assert_false(shell_result_failed("exit=0\nok"))
-  assert_false(shell_result_failed("exit=0\nexit=2"))
-  assert_false(shell_result_failed("not a shell header\nexit=2"))
-  assert_true(shell_result_failed("exit=2\nfailed"))
-  assert_true(shell_result_failed("exit=cancelled\ntruncated"))
+test "shell failures count is_error shell results, not output text" {
+  let session = @agent_session.Session(SessionId("t"), system_prompt="")
+    .append(
+      Tool(ToolResult(tool_call_id="ok", tool_name="shell", content="ok")),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="bad",
+          tool_name="shell",
+          // The failure is the recorded flag, not anything in the output text.
+          content="boom",
+          is_error=true,
+        ),
+      ),
+    )
+    .append(
+      // A non-shell error counts toward tool_errors but not shell_failures.
+      Tool(
+        ToolResult(
+          tool_call_id="edit",
+          tool_name="edit",
+          content="nope",
+          is_error=true,
+        ),
+      ),
+    )
+  let result = analyze_session(session)
+  assert_eq(result.shell_uses, 2)
+  assert_eq(result.shell_failures, 1)
+  assert_eq(result.tool_errors, 2)
 }
 
 ///|


### PR DESCRIPTION
## Summary

The eval session analyzer decided shell failures by **re-parsing the shell tool's output string** for an `exit=` line (`shell_result_failed`). That coupled the analyzer to the shell output format — it's the only reason a recent shell output-format change had to touch the analyzer at all.

`ToolResult` already records an `is_error : Bool` (the tool decided success/failure when it produced the result), and the analyzer **already** uses `result.is_error()` for `tool_errors`. This switches `shell_failures` to the same field and deletes the string parser, decoupling the analyzer from the output format for good.

Inspired by Claude Code, whose tools carry structured results (`{ exitCode, stdout, stderr }` + an `isError` flag) and whose consumers read those fields rather than re-parsing the rendered text.

## Semantics note

`is_error` is slightly broader than the old parse: a timeout, bad arguments, a launch failure, or a policy block (`sed -i`, `moon_cmd`) now counts as a shell failure — consistent with `tool_errors`, and arguably more correct ("the shell call failed"). The old parse only counted non-zero exit / cancellation.

## Deferred follow-up

Command-aware exit semantics — e.g. `moon ide doc` with no result, or `grep` with no match (exit 1), should **not** be a failure — is a separate, larger change (the shell tool would need to interpret exit codes per command, the way Claude's `commandSemantics` does). Left for later.

## Validation

- `moon fmt` / `moon check` clean, 0 warnings
- `moon test eval/session_analyzer eval/prompt_task/harness` → 24 passed (new test asserts shell_failures counts only `is_error` shell results, ignores the output text, and a non-shell error counts toward `tool_errors` but not `shell_failures`)
- Independent `codex review` (see comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)