### PR TITLE
ci: run the check job on stable in addition to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
         run: moon check --deny-warn
 
       - name: Check generated interfaces
+        # `moon info` formats abstract types differently across toolchain
+        # versions (`type X` on nightly vs `pub struct X { // private fields }`
+        # on stable), and the committed `.mbti` are nightly-generated — so this
+        # consistency check is only meaningful on nightly.
+        if: matrix.moonbit-channel == 'nightly'
         run: |
           moon info
           if [ -n "$(git status --porcelain -- '*.mbti')" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,16 @@ jobs:
     permissions:
       contents: read
     strategy:
+      # Run both channels independently (fail-fast: false): a stable/nightly
+      # green-red split tells us at a glance whether a failure is a
+      # nightly-toolchain regression or our own bug.
       fail-fast: false
       matrix:
         include:
-          # Temporarily disabled until `<?` is available on stable/latest.
-          # - moonbit-channel: stable
-          #   moonbit-version: latest
           - moonbit-channel: nightly
             moonbit-version: nightly
+          - moonbit-channel: stable
+            moonbit-version: latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

CI only ran the `check` job against the **nightly** toolchain, so when nightly regresses (today: `moon check --deny-warn` exiting 255 with the contradictory *"Failed with 0 warnings, 0 errors"*) there's no way to tell a toolchain regression from our own bug.

This re-enables the **stable** channel as a second matrix entry. With `fail-fast: false` the two run independently, producing two distinct checks — `check (nightly)` and `check (stable)` — so:

- nightly ❌ + stable ✅ → **nightly-toolchain regression** (not us)
- both ❌ → **our bug**

The old reason for disabling stable (`<?` not available on stable/latest) no longer applies — `<?` is supported on stable now.

## Notes

- `check (stable)` is a **new** matrix job, so it is not a required status check unless branch protection is explicitly configured to require it — i.e. it won't block PRs by default; it's there for the signal. Make it required once it's reliably green.
- Pure workflow change; no MoonBit code touched. The real validation is this PR's own CI run: if `check (stable)` is green here, the comparison works and confirms today's nightly failures are a toolchain regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)