### PR TITLE
[backup] TUI slash commands with /model and /resume pickers

### DIFF
--- a/cmd/tui/continue_wbtest.mbt
+++ b/cmd/tui/continue_wbtest.mbt
@@ -24,3 +24,19 @@ async test "--continue resolves the most recently active session" {
     })
   })
 }
+
+///|
+async test "resume completion items list durable sessions" {
+  @vfs.with_tmpdir(prefix="openseek-tui-resume-completion-", root => {
+    let store = @store.SessionStore(root)
+    store.create(Session(SessionId("demo"), system_prompt="system"))
+    let parsed = cli_command().parse(argv=["--session-root", root], env={
+      "DEEPSEEK": "test-key",
+    })
+    let items = resume_completion_items(parse_config(parsed))
+    guard items is [item] else { fail("expected one resume completion") }
+    assert_eq(item.label(), "demo")
+    assert_eq(item.insert_text(), "demo")
+    assert_eq(item.description(), "session")
+  })
+}

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -48,6 +48,50 @@ fn run_command_count(cmds : Array[Cmd]) -> Int {
 }
 
 ///|
+fn restart_engine_count(cmds : Array[Cmd]) -> Int {
+  for cmd in cmds; count = 0 {
+    if cmd is RestartEngine(_) {
+      continue count + 1
+    }
+  } nobreak {
+    count
+  }
+}
+
+///|
+fn resume_session_count(cmds : Array[Cmd]) -> Int {
+  for cmd in cmds; count = 0 {
+    if cmd is ResumeSession(_) {
+      continue count + 1
+    }
+  } nobreak {
+    count
+  }
+}
+
+///|
+fn compact_session_count(cmds : Array[Cmd]) -> Int {
+  for cmd in cmds; count = 0 {
+    if cmd is CompactSession(_) {
+      continue count + 1
+    }
+  } nobreak {
+    count
+  }
+}
+
+///|
+fn open_picker_count(cmds : Array[Cmd]) -> Int {
+  for cmd in cmds; count = 0 {
+    if cmd is (OpenPicker(_) | OpenResumePicker) {
+      continue count + 1
+    }
+  } nobreak {
+    count
+  }
+}
+
+///|
 test "engine configuration travels through the environment" {
   let config = drain_test_state().config
   let env = engine_extra_env(config)
@@ -98,6 +142,210 @@ test "agent engine env clears inherited api url without override" {
     "OPENSEEK_API_URL": "https://parent.example/chat/completions",
   })
   assert_true(env.get("OPENSEEK_API_URL") == Some(""))
+}
+
+///|
+test "model slash command opens a picker without a name and updates with one" {
+  let state = drain_test_state()
+  // Bare /model opens the model picker (the handler's job) rather than erroring
+  // or changing anything.
+  let bare = update(state, UiInput(SlashCommand(name="model", arguments="")))
+  guard bare is [OpenPicker(name~, items~)] else {
+    fail("expected bare /model to open the model picker")
+  }
+  assert_eq(name, "model")
+  assert_true(items.length() > 0)
+  assert_eq(error_item_count(bare), 0)
+  assert_eq(restart_engine_count(bare), 0)
+  assert_eq(state.config.model.to_string(), "deepseek-v4-pro")
+
+  let changed = update(
+    state,
+    UiInput(SlashCommand(name="model", arguments="deepseek-v4-flash")),
+  )
+  assert_eq(restart_engine_count(changed), 1)
+  assert_eq(error_item_count(changed), 0)
+  assert_eq(state.config.model.to_string(), "deepseek-v4-flash")
+}
+
+///|
+test "model slash command rejects invalid or running changes" {
+  let state = drain_test_state()
+  let invalid = update(
+    state,
+    UiInput(SlashCommand(name="model", arguments="deepseek-v4-unknown")),
+  )
+  assert_eq(error_item_count(invalid), 1)
+  assert_eq(restart_engine_count(invalid), 0)
+  assert_eq(state.config.model.to_string(), "deepseek-v4-pro")
+
+  let _ = update(state, UiInput(Steer(Prompt("work"))))
+  let running = update(
+    state,
+    UiInput(SlashCommand(name="model", arguments="deepseek-v4-flash")),
+  )
+  assert_eq(error_item_count(running), 1)
+  assert_eq(restart_engine_count(running), 0)
+  assert_eq(state.config.model.to_string(), "deepseek-v4-pro")
+}
+
+///|
+test "exit slash command quits" {
+  let state = drain_test_state()
+  let cmds = update(state, UiInput(SlashCommand(name="exit", arguments="")))
+  assert_eq(quit_count(cmds), 1)
+
+  let rejected = update(
+    state,
+    UiInput(SlashCommand(name="exit", arguments="now")),
+  )
+  assert_eq(quit_count(rejected), 0)
+  assert_eq(error_item_count(rejected), 1)
+}
+
+///|
+test "resume slash command opens a picker without an id and resumes with one" {
+  let state = drain_test_state()
+  // Bare /resume opens the session picker (fetched fresh by the loop) rather
+  // than erroring; only an explicit id resumes directly.
+  let bare = update(state, UiInput(SlashCommand(name="resume", arguments="")))
+  guard bare is [OpenResumePicker] else {
+    fail("expected bare /resume to open the session picker")
+  }
+  assert_eq(error_item_count(bare), 0)
+  assert_eq(resume_session_count(bare), 0)
+
+  let explicit = update(
+    state,
+    UiInput(SlashCommand(name="resume", arguments=" demo ")),
+  )
+  guard explicit is [ResumeSession(id)] else {
+    fail("expected explicit-session resume command")
+  }
+  assert_eq(id.value(), "demo")
+}
+
+///|
+test "resume slash command rejects running or queued work" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("work"))))
+  let running = update(
+    state,
+    UiInput(SlashCommand(name="resume", arguments="")),
+  )
+  assert_eq(error_item_count(running), 1)
+  assert_eq(resume_session_count(running), 0)
+  // A busy session refuses even the bare (picker) form rather than opening it.
+  assert_eq(open_picker_count(running), 0)
+
+  let queued_state = drain_test_state()
+  queued_state.queued.push(Prompt("later"))
+  let queued_cmds : Array[Cmd] = []
+  handle_resume_command(queued_state, "", queued_cmds)
+  assert_eq(error_item_count(queued_cmds), 1)
+  assert_eq(open_picker_count(queued_cmds), 0)
+  assert_eq(resume_session_count(queued_cmds), 0)
+}
+
+///|
+test "compact slash command starts a compaction run when idle" {
+  let state = drain_test_state()
+  let cmds = update(state, UiInput(SlashCommand(name="compact", arguments="")))
+  assert_eq(compact_session_count(cmds), 1)
+  assert_eq(error_item_count(cmds), 0)
+  // The run is held busy so a concurrent prompt cannot interleave with the
+  // engine's compaction, and so the activity line shows work in progress.
+  assert_false(state.run is Idle)
+  // The start notice precedes the command, so the compaction is the tail.
+  guard cmds is [_, CompactSession(run_id~)] else {
+    fail("expected a compaction command")
+  }
+  assert_true(state.owns_run(run_id))
+
+  // A second compact while the first is still running is refused, not queued.
+  let busy = update(state, UiInput(SlashCommand(name="compact", arguments="")))
+  assert_eq(compact_session_count(busy), 0)
+  assert_eq(error_item_count(busy), 1)
+
+  // The engine's terminal event closes the run and previews the new context.
+  let done = update(
+    state,
+    AgentProgress(run_id~, CompactionFinished("- goal: ship /compact")),
+  )
+  assert_eq(compact_session_count(done), 0)
+  guard done is [AppendItem(Notice(_))] else {
+    fail("expected a compaction preview notice")
+  }
+  assert_true(state.run is Idle)
+}
+
+///|
+test "a prompt during compaction is rejected locally, not steered" {
+  let state = drain_test_state()
+  let started = update(
+    state,
+    UiInput(SlashCommand(name="compact", arguments="")),
+  )
+  guard started is [_, CompactSession(_)] else {
+    fail("expected compaction to start")
+  }
+  assert_true(state.run_is_compaction)
+
+  // Enter with a prompt must not steer (the engine drops steers during
+  // compaction); it is rejected locally so the text is not lost.
+  let steered = update(state, UiInput(Steer(Prompt("hello"))))
+  assert_eq(error_item_count(steered), 1)
+  assert_true(steered.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_eq(state.pending_steers.length(), 0)
+
+  // Tab queues it instead, to run once compaction lands.
+  let _ = update(state, UiInput(Queue(Prompt("hello"))))
+  assert_eq(state.queued.length(), 1)
+
+  // When compaction finishes the queued prompt drains and starts.
+  let done = update(
+    state,
+    AgentProgress(run_id=state.run_id, CompactionFinished("summary")),
+  )
+  assert_false(state.run_is_compaction)
+  assert_eq(start_agent_count(done), 1)
+}
+
+///|
+test "compact slash command rejects arguments and pending work" {
+  let with_args = drain_test_state()
+  let rejected = update(
+    with_args,
+    UiInput(SlashCommand(name="compact", arguments="now")),
+  )
+  assert_eq(error_item_count(rejected), 1)
+  assert_eq(compact_session_count(rejected), 0)
+  assert_true(with_args.run is Idle)
+
+  let queued_state = drain_test_state()
+  queued_state.queued.push(Prompt("later"))
+  let queued_cmds : Array[Cmd] = []
+  handle_compact_command(queued_state, "", queued_cmds)
+  assert_eq(error_item_count(queued_cmds), 1)
+  assert_eq(compact_session_count(queued_cmds), 0)
+}
+
+///|
+test "compact slash command is unavailable on a oneshot engine" {
+  let state = drain_test_state()
+  state.config = { ..state.config, engine_mode: OneShot }
+  let cmds = update(state, UiInput(SlashCommand(name="compact", arguments="")))
+  assert_eq(error_item_count(cmds), 1)
+  assert_eq(compact_session_count(cmds), 0)
+  assert_true(state.run is Idle)
+}
+
+///|
+test "unknown slash command reports an error" {
+  let state = drain_test_state()
+  let cmds = update(state, UiInput(SlashCommand(name="unknown", arguments="")))
+  assert_eq(error_item_count(cmds), 1)
+  assert_true(state.run is Idle)
 }
 
 ///|

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -4,6 +4,11 @@
 priv struct EngineProcess {
   writer : @process.WriteToProcess
   proc : @process.Process
+  // The client's spawn counter at the time this engine was created. A reader at
+  // EOF resets engine-scoped status (the watcher segment) only when it is still
+  // the latest engine — once a successor has spawned, the successor owns that
+  // status and a stale exit must not blank it.
+  generation : Int
   // Run bookkeeping is owned by the process whose stream produced it: a
   // reader at EOF must report the run that was open on *its* engine, never
   // one a respawned successor has since started.
@@ -29,9 +34,13 @@ priv struct EngineProcess {
 /// reported into the message loop as that run's failure, with the captured
 /// stderr prefix as the diagnostic.
 priv struct EngineClient {
-  config : AppConfig
+  mut config : AppConfig
   messages : @async.Queue[Msg]
   mut live : EngineProcess?
+  // Bumped on every spawn; the latest engine's generation. A dying engine
+  // compares its own generation against this to know whether a successor has
+  // taken over (so its EngineExited must be suppressed).
+  mut generation : Int
 }
 
 ///|
@@ -39,7 +48,7 @@ fn EngineClient::EngineClient(
   config : AppConfig,
   messages : @async.Queue[Msg],
 ) -> EngineClient {
-  { config, messages, live: None }
+  { config, messages, live: None, generation: 0 }
 }
 
 ///|
@@ -69,7 +78,14 @@ async fn[G] EngineClient::start(
     stderr=child_stderr,
     no_wait=true,
   )
-  let engine : EngineProcess = { writer, proc, latest_run: 0, run_open: false }
+  self.generation = self.generation + 1
+  let engine : EngineProcess = {
+    writer,
+    proc,
+    generation: self.generation,
+    latest_run: 0,
+    run_open: false,
+  }
   self.live = Some(engine)
   group.spawn_bg(no_wait=true) <| () => {
     let stderr_task = group.spawn(no_wait=true) <| () => {
@@ -127,8 +143,13 @@ async fn[G] EngineClient::start(
       )
     }
     // The watchers this engine owned died with it: let the loop reset
-    // engine-scoped status, whatever the exit reason.
-    self.messages.put(EngineExited)
+    // engine-scoped status. But only the latest engine owns that status — if a
+    // restart (or respawn) has since spawned a successor, this exit is stale and
+    // resetting would blank the new engine's live watcher segment, so suppress
+    // it. A clean restart with no successor yet still resets, correctly.
+    if engine.generation == self.generation {
+      self.messages.put(EngineExited)
+    }
   }
 }
 
@@ -184,6 +205,35 @@ async fn[G] EngineClient::prompt(
 }
 
 ///|
+/// Ask the engine to compact the conversation. Like `prompt`, this is an
+/// explicit user operation on the durable session, so it may spawn the engine
+/// (a fresh process resumes the same session and compacts it) and it opens a
+/// run whose terminal event — `compaction_finished` or a failure — closes it.
+async fn[G] EngineClient::compact(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+  run_id : Int,
+) -> Unit {
+  if self.live is None {
+    self.start(group) catch {
+      error => {
+        self.messages.put(AgentFailed(run_id~, error))
+        return
+      }
+    }
+  }
+  guard self.live is Some(live) else {
+    self.messages.put(
+      AgentFailed(run_id~, Failure::Failure("engine is not running")),
+    )
+    return
+  }
+  live.latest_run = run_id
+  live.run_open = true
+  self.send(run_id, { "command": "compact" })
+}
+
+///|
 /// Steer the running turn, or report the input as undeliverable when there
 /// is no live engine with an open run (e.g. the engine died an instant
 /// before the user pressed Enter). Steering must never spawn an engine: an
@@ -224,4 +274,14 @@ fn EngineClient::shutdown(self : EngineClient) -> Unit {
   if self.live is Some(live) {
     live.writer.close()
   }
+}
+
+///|
+/// Replace the engine configuration used for future prompts. If a serve process
+/// is already idle, close its command stream so the next prompt respawns with
+/// the new environment.
+fn EngineClient::restart(self : EngineClient, config : AppConfig) -> Unit {
+  self.shutdown()
+  self.live = None
+  self.config = config
 }

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -50,6 +50,24 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     // the run even though the engine process lives on.
     "turn_failed" =>
       Some(AgentError("turn failed: \{@jsonx.string(object, "error")}"))
+    // The engine rejected a command (e.g. an older or custom engine that does
+    // not understand `compact`) and keeps serving. It emits no terminal event,
+    // so without this the run that sent the command would stay open forever and
+    // the TUI would hang busy. Fail the run instead.
+    "command_error" =>
+      Some(
+        AgentError("engine rejected command: \{@jsonx.string(object, "error")}"),
+      )
+    // Compaction lifecycle on a serve engine. `compaction_started` carries no
+    // controller-visible state — the run is already shown busy — so it is left
+    // to drop as an unknown event. The two outcomes are terminal for the
+    // compaction run: success carries the summary (the new context) for a
+    // preview, failure folds into the general agent-error category like a
+    // failed turn.
+    "compaction_finished" =>
+      Some(CompactionFinished(@jsonx.string(object, "summary")))
+    "compaction_failed" =>
+      Some(AgentError("compaction failed: \{@jsonx.string(object, "error")}"))
     _ => None
   }
 }

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -84,6 +84,49 @@ test "a failed serve turn decodes to a terminal agent error" {
 }
 
 ///|
+test "a rejected command decodes to a terminal agent error" {
+  // An engine that does not understand a command keeps serving and emits no
+  // terminal event; decoding the rejection as a terminal error is what closes
+  // the run that sent it (e.g. /compact against an older engine).
+  assert_true(
+    @event.decode_event(
+      Json::object({
+        "event": "command_error",
+        "error": "unknown command: compact",
+      }),
+    )
+    is Some(AgentError("engine rejected command: unknown command: compact")),
+  )
+}
+
+///|
+test "compaction wire events decode to their terminal forms" {
+  // Success carries the summary so the controller can preview the new context.
+  assert_true(
+    @event.decode_event(
+      Json::object({
+        "event": "compaction_finished",
+        "from_sequence": 1,
+        "to_sequence": 42,
+        "summary": "handoff",
+      }),
+    )
+    is Some(CompactionFinished("handoff")),
+  )
+  // Failure folds into the general agent-error category like a failed turn.
+  assert_true(
+    @event.decode_event(
+      Json::object({ "event": "compaction_failed", "error": "cancelled" }),
+    )
+    is Some(AgentError("compaction failed: cancelled")),
+  )
+  // The start marker carries no controller state, so it drops like any unknown.
+  assert_true(
+    @event.decode_event(Json::object({ "event": "compaction_started" })) is None,
+  )
+}
+
+///|
 test "decode returns None for a non-object value or unknown event" {
   // `@jsonl` handles blank and malformed lines before decoding; the mapping only
   // has to tolerate a non-object value and a newer engine's unknown event kind.

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -47,4 +47,9 @@ pub(all) enum AgentEvent {
   AgentAborted(String)
   MaxStepsExhausted
   AgentError(String)
+  // The serve engine finished compacting the conversation: a terminal event for
+  // the controller's compaction run. Carries the summary the engine appended to
+  // the durable session — now the conversation's context — so the controller can
+  // preview it.
+  CompactionFinished(String)
 }

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub(all) enum AgentEvent {
   AgentAborted(String)
   MaxStepsExhausted
   AgentError(String)
+  CompactionFinished(String)
 }
 
 pub(all) struct ToolResultEvent {

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -115,8 +115,11 @@ fn confirm_pending_steer(state : State, text : String) -> Unit {
 ///|
 fn is_terminal_event(event : @event.AgentEvent) -> Bool {
   match event {
-    AgentFinished(_) | AgentAborted(_) | MaxStepsExhausted | AgentError(_) =>
-      true
+    AgentFinished(_)
+    | AgentAborted(_)
+    | MaxStepsExhausted
+    | AgentError(_)
+    | CompactionFinished(_) => true
     _ => false
   }
 }
@@ -436,7 +439,208 @@ fn handle_agent_event(
       cmds.push(AppendItem(Error(message)))
       state.finish_run()
     }
+    // Compaction landed: the engine summarized the conversation into the durable
+    // session. The transcript on screen is unchanged — it is the display, not
+    // the model's context — so confirm with a notice that previews the summary
+    // now standing in for the prior turns, and close the run.
+    CompactionFinished(summary) => {
+      cmds.push(AppendItem(compaction_item(summary)))
+      state.finish_run()
+    }
   }
+}
+
+///|
+fn command_notice(title : String) -> @ui.TranscriptItem {
+  Notice(ToolCall(@doc.Text::plain(title)))
+}
+
+///|
+fn handle_model_command(
+  state : State,
+  arguments : String,
+  cmds : Array[Cmd],
+) -> Unit {
+  let model_name = arguments.trim()
+  if model_name.is_empty() {
+    // No model named: open the picker so the user can choose one.
+    cmds.push(OpenPicker(name="model", items=model_completion_items()))
+    return
+  }
+  if !(state.run is Idle) {
+    cmds.push(
+      AppendItem(Error("Model can only be changed when no task is running.")),
+    )
+    return
+  }
+  let model = @deepseek.Model::parse(model_name.to_owned()) catch {
+    error => {
+      cmds.push(AppendItem(Error("\{error}")))
+      return
+    }
+  }
+  state.config = { ..state.config, model, }
+  state.watcher_status = ""
+  cmds.push(RestartEngine(state.config))
+  cmds.push(
+    AppendItem(command_notice("model set to \{state.config.model.to_string()}")),
+  )
+}
+
+///|
+fn handle_resume_command(
+  state : State,
+  arguments : String,
+  cmds : Array[Cmd],
+) -> Unit {
+  if !(state.run is Idle) {
+    cmds.push(
+      AppendItem(Error("Session can only be resumed when no task is running.")),
+    )
+    return
+  }
+  if state.queued.length() > 0 {
+    cmds.push(
+      AppendItem(Error("Session cannot be resumed with queued input pending.")),
+    )
+    return
+  }
+  let session_id = arguments.trim().to_owned()
+  if session_id.is_empty() {
+    // No id given: open the session picker. The list is fetched by the loop
+    // when this runs, so it always reflects the sessions that exist now.
+    cmds.push(OpenResumePicker)
+  } else {
+    cmds.push(ResumeSession(SessionId(session_id)))
+  }
+}
+
+///|
+fn handle_compact_command(
+  state : State,
+  arguments : String,
+  cmds : Array[Cmd],
+) -> Unit {
+  if !arguments.trim().is_empty() {
+    cmds.push(AppendItem(Error("/compact does not accept arguments")))
+    return
+  }
+  // Compaction is a command on the persistent serve engine; a oneshot engine is
+  // spawned per prompt and has no session to summarize between turns.
+  if state.config.engine_mode is OneShot {
+    cmds.push(
+      AppendItem(Error("Compaction is not supported by a oneshot engine.")),
+    )
+    return
+  }
+  if !(state.run is Idle) {
+    cmds.push(
+      AppendItem(
+        Error("Context can only be compacted when no task is running."),
+      ),
+    )
+    return
+  }
+  if state.queued.length() > 0 {
+    cmds.push(
+      AppendItem(
+        Error("Context cannot be compacted with queued input pending."),
+      ),
+    )
+    return
+  }
+  // Hold the loop busy for the duration: compaction is a model call that can run
+  // for many seconds, and a slash command never echoes itself into the
+  // transcript, so the notice is the only sign work has begun until it lands.
+  cmds.push(AppendItem(command_notice("compacting context…")))
+  let run_id = state.start_run(@async.now())
+  // Mark the run non-steerable: a prompt typed while this is in flight must be
+  // queued, not steered into a compaction the engine will refuse it from.
+  state.run_is_compaction = true
+  cmds.push(CompactSession(run_id~))
+}
+
+///|
+
+///|
+fn handle_slash_command(
+  state : State,
+  name : String,
+  arguments : String,
+  cmds : Array[Cmd],
+) -> Unit {
+  match name.to_lower() {
+    "model" => handle_model_command(state, arguments, cmds)
+    "exit" =>
+      if arguments.trim().is_empty() {
+        cmds.push(Quit)
+      } else {
+        cmds.push(AppendItem(Error("/exit does not accept arguments")))
+      }
+    "resume" => handle_resume_command(state, arguments, cmds)
+    "compact" => handle_compact_command(state, arguments, cmds)
+    other => cmds.push(AppendItem(Error("Unknown slash command: /\{other}")))
+  }
+}
+
+///|
+/// Open the /resume session picker. The candidates are read from the store here
+/// (so the list reflects the sessions that exist at open time rather than a
+/// startup snapshot), and the three outcomes are kept distinct: a listing
+/// failure surfaces the real error, an empty store says so, and a non-empty one
+/// opens the picker — so a broken session root is never mistaken for an empty
+/// store, and an empty store never silently reopens an empty picker.
+async fn open_resume_picker(state : State, ui : @ui.Ui) -> Unit {
+  let items = resume_completion_items(state.config) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      ui.append_item(Error("failed to list sessions: \{error}"))
+      return
+    }
+  }
+  if items.is_empty() {
+    ui.append_item(Error("No saved sessions to resume."))
+  } else {
+    ui.open_picker(name="resume", items~)
+  }
+}
+
+///|
+async fn resume_tui_session(
+  state : State,
+  ui : @ui.Ui,
+  engine : EngineClient,
+  session_id : @agent_session.SessionId,
+) -> Unit {
+  let store = @store.SessionStore(state.config.session_root)
+  let session = store.load(session_id) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      // Pick the message from whether the session actually exists: a missing id
+      // (the common typo case) and an invalid id (path separators or `.`/`..`,
+      // which make the store raise on the very path it would probe) both read
+      // plainly instead of leaking the raw open() error and path. The probe is
+      // guarded so it can never unwind the resume and exit the TUI.
+      let present = store.exists(session_id) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => false
+      }
+      if present {
+        ui.append_item(
+          Error("failed to resume session \{session_id.value()}: \{error}"),
+        )
+      } else {
+        ui.append_item(Error("No session \"\{session_id.value()}\" to resume."))
+      }
+      return
+    }
+  }
+  state.switch_session(session.id())
+  engine.restart(state.config)
+  ui.replace_transcript(session_transcript_items(session))
+  ui.append_item(
+    command_notice("resumed session \{state.config.session_id.value()}"),
+  )
 }
 
 ///|
@@ -456,6 +660,8 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
         // Enter while idle submits; Enter while a task runs steers it — the
         // text is folded into the running turn at its next step boundary.
         // Shell commands cannot steer a model turn, so they still queue.
+        SlashCommand(name~, arguments~) =>
+          handle_slash_command(state, name, arguments, cmds)
         Steer(input) =>
           if state.run is Idle {
             state.queued.push(input)
@@ -478,6 +684,17 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
               AppendItem(
                 Error(
                   "A local shell command is running and cannot be steered. Press Tab to queue this input.",
+                ),
+              ),
+            )
+          } else if state.run_is_compaction {
+            // Compaction is a non-steerable model call; the serve engine drops
+            // steers during it. Reject locally so the prompt is not lost — the
+            // user can queue it to run once compaction lands.
+            cmds.push(
+              AppendItem(
+                Error(
+                  "Context is being compacted and cannot be steered. Press Tab to queue this input.",
                 ),
               ),
             )
@@ -634,6 +851,17 @@ async fn[G] run_message_loop(
             },
           )
         SteerAgent(text) => engine.steer(text)
+        // Compaction is an engine operation with no local task. Clear any stale
+        // command handle (as a queued prompt would) so a Ctrl-C cancels this
+        // compaction turn rather than a finished command task.
+        CompactSession(run_id~) => {
+          running_task = None
+          engine.compact(group, run_id)
+        }
+        OpenPicker(name~, items~) => ui.open_picker(name~, items~)
+        OpenResumePicker => open_resume_picker(state, ui)
+        RestartEngine(config) => engine.restart(config)
+        ResumeSession(target) => resume_tui_session(state, ui, engine, target)
         CancelAgent =>
           match running_task {
             // A local shell command (or a one-shot engine run) in flight:

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -234,10 +234,68 @@ fn initial_task(matches : @argparse.Matches) -> String? {
 }
 
 ///|
+fn model_completion_items() -> Array[@ui.CompletionItem] {
+  [
+    @ui.CompletionItem::new(
+      label=@deepseek.V4Flash.to_string(),
+      description="model",
+    ),
+    @ui.CompletionItem::new(
+      label=@deepseek.V4Pro.to_string(),
+      description="model",
+    ),
+  ]
+}
+
+///|
+fn resume_completion_description(listing : @store.SessionListing) -> String {
+  let prompt = listing.first_prompt().trim().to_owned()
+  if prompt.is_empty() {
+    "session"
+  } else {
+    prompt
+  }
+}
+
+///|
+/// The session candidates for the /resume picker. Raises if the store cannot be
+/// listed (e.g. an unreadable session root) so the caller can surface the real
+/// error, rather than swallowing it into an empty list that looks like a store
+/// with no sessions.
+async fn resume_completion_items(
+  config : AppConfig,
+) -> Array[@ui.CompletionItem] {
+  let listings = @store.SessionStore(config.session_root).listings()
+  [
+    for listing in listings => {
+      @ui.CompletionItem::new(
+        label=listing.id().value(),
+        description=resume_completion_description(listing),
+      )
+    }
+  ]
+}
+
+///|
 async fn run_tui(config : AppConfig, initial : String?) -> Unit {
-  @ui.with_ui(config=@ui.Config::new(composer_max_rows=4), ui => {
-    run_app(config, initial, ui)
-  })
+  // Commands only name and describe themselves; argument pickers (model list,
+  // session list) are opened by the handler with freshly-fetched candidates, so
+  // there is no startup snapshot to go stale.
+  @ui.with_ui(
+    config=@ui.Config::new(composer_max_rows=4, slash_commands=[
+      @ui.SlashCommandSpec::new(name="model", description="switch the model"),
+      @ui.SlashCommandSpec::new(name="exit", description="exit the TUI"),
+      @ui.SlashCommandSpec::new(
+        name="resume",
+        description="resume a durable session",
+      ),
+      @ui.SlashCommandSpec::new(
+        name="compact",
+        description="summarize and compact the conversation",
+      ),
+    ]),
+    ui => run_app(config, initial, ui),
+  )
 }
 
 ///|

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -52,6 +52,19 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
 }
 
 ///|
+fn session_transcript_items(
+  session : @agent_session.Session,
+) -> Array[@ui.TranscriptItem] {
+  let items : Array[@ui.TranscriptItem] = []
+  for event in session.events() {
+    if session_item(event.item()) is Some(item) {
+      items.push(item)
+    }
+  }
+  items
+}
+
+///|
 async fn append_session_history(config : AppConfig, ui : @ui.Ui) -> Unit {
   let session_id = config.session_id
   let store = @store.SessionStore(config.session_root)
@@ -68,9 +81,7 @@ async fn append_session_history(config : AppConfig, ui : @ui.Ui) -> Unit {
       return
     }
   }
-  for event in session.events() {
-    if session_item(event.item()) is Some(item) {
-      ui.append_item(item)
-    }
+  for item in session_transcript_items(session) {
+    ui.append_item(item)
   }
 }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -49,7 +49,7 @@ priv enum RunState {
 
 ///|
 priv struct State {
-  config : AppConfig
+  mut config : AppConfig
   queued : Array[@ui.Input]
   mut run : RunState
   // Monotonic id of the most recently started run, bumped each time an input is
@@ -61,6 +61,11 @@ priv struct State {
   // engine turn. Steering and interrupt escalation must not touch the
   // persistent engine while the work in flight is a local task.
   mut run_is_command : Bool
+  // Whether the active run is a conversation compaction rather than an engine
+  // turn. Compaction is a non-steerable model call (the serve engine drops
+  // steers during it), so a prompt typed mid-compaction is rejected locally with
+  // a queue hint rather than steered into the void.
+  mut run_is_compaction : Bool
   // Final assistant text for the current step, used to avoid appending the same
   // answer again when `AgentFinished` follows `AssistantMessage`.
   mut step_response : String?
@@ -94,6 +99,7 @@ fn State::new(config : AppConfig) -> State {
     run: Idle,
     run_id: 0,
     run_is_command: false,
+    run_is_compaction: false,
     pending_steers: [],
     step_response: None,
     streaming_response: None,
@@ -135,6 +141,7 @@ fn State::owns_run(self : State, id : Int) -> Bool {
 fn State::finish_run(self : State) -> Unit {
   self.run = Idle
   self.run_is_command = false
+  self.run_is_compaction = false
   // Anything still unconfirmed died with the turn; the engine sweeps its
   // queue at turn end and reports each leftover as steer_dropped, which
   // arrives untagged and renders its own resubmit notice.
@@ -145,6 +152,23 @@ fn State::finish_run(self : State) -> Unit {
   if self.config.engine_mode is OneShot {
     self.watcher_status = ""
   }
+}
+
+///|
+fn State::switch_session(
+  self : State,
+  session_id : @agent_session.SessionId,
+) -> Unit {
+  self.config = { ..self.config, session_id, }
+  self.run = Idle
+  self.run_is_command = false
+  self.run_is_compaction = false
+  self.pending_steers.clear()
+  self.step_response = None
+  self.streaming_response = None
+  self.streaming_reasoning = None
+  self.usage = None
+  self.watcher_status = ""
 }
 
 ///|
@@ -204,6 +228,18 @@ priv enum Cmd {
   // Redirect the running turn: the text rides the engine's steer command and
   // lands at the turn's next step boundary.
   SteerAgent(String)
+  // Ask the serve engine to summarize and compact the conversation; carries the
+  // run id so the compaction's wire events are tagged to the run that requested
+  // it, exactly like a prompt.
+  CompactSession(run_id~ : Int)
+  // Open an argument picker for a slash command, populated with candidates the
+  // handler supplies. `OpenResumePicker` is separate because its candidates (the
+  // session list) require an async store read the synchronous `update` cannot
+  // do, so the message loop fetches them before opening.
+  OpenPicker(name~ : String, items~ : Array[@ui.CompletionItem])
+  OpenResumePicker
+  RestartEngine(AppConfig)
+  ResumeSession(@agent_session.SessionId)
   CancelAgent
   // Second Ctrl-C while already interrupting: the cancel command was not
   // enough, so kill the engine process outright.

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -78,6 +78,25 @@ fn reasoning_item(text : String) -> @ui.TranscriptItem {
 }
 
 ///|
+/// Lines of the post-compaction context preview shown in the transcript. The
+/// summary becomes the conversation's entire context, so a fuller preview than a
+/// tool's clipped output earns its space.
+const CompactionPreviewLineLimit : Int = 12
+
+///|
+/// Render a completed compaction as a `↻` notice whose detail lines preview the
+/// summary that is now the conversation's context — its head and tail, with the
+/// middle elided when it runs long, the same way tool output is compacted.
+fn compaction_item(summary : String) -> @ui.TranscriptItem {
+  Notice(
+    ToolCall(
+      @doc.Text::plain("context compacted"),
+      details=detail_texts(compact_lines(summary, CompactionPreviewLineLimit)),
+    ),
+  )
+}
+
+///|
 /// Render the result of a `!` shell command the TUI ran locally: the command
 /// line as the title (with a non-zero/cancelled marker), and its full captured
 /// output as dimmed detail lines. The output is already character-capped by

--- a/tui/completion.mbt
+++ b/tui/completion.mbt
@@ -1,0 +1,412 @@
+///|
+priv struct CompletionMenu {
+  key : String
+  items : Array[@completion.CompletionItem]
+  action : CompletionAction
+}
+
+///|
+/// The items backing an open argument picker and the command they belong to.
+/// Supplied by the command handler through `Ui::open_picker`, so candidates are
+/// fetched fresh each time (e.g. the current session list for `/resume`) rather
+/// than baked into the command spec at startup.
+priv struct PickerSource {
+  command : String
+  items : Array[@completion.CompletionItem]
+}
+
+///|
+/// Mutable state backing the input-completion menu: `key` identifies the
+/// current menu context (so the selection resets when it changes), `selected`
+/// is the highlighted item index, and `dismissed` records an Esc dismissal.
+priv struct CompletionState {
+  mut key : String
+  mut selected : Int
+  mut dismissed : Bool
+}
+
+///|
+fn CompletionState::new() -> CompletionState {
+  { key: "", selected: 0, dismissed: false }
+}
+
+///|
+/// Forget the current menu context, clearing the selection and any dismissal.
+fn CompletionState::reset(self : CompletionState) -> Unit {
+  self.key = ""
+  self.selected = 0
+  self.dismissed = false
+}
+
+///|
+fn completion_menu_for_composer(
+  commands : @slash.SlashCommands,
+  composer : @composer.Model,
+  picker? : PickerSource,
+) -> CompletionMenu? {
+  if !composer.mode().is_input() {
+    return None
+  }
+  let text = composer.text()
+  if text.contains("\n") {
+    return None
+  }
+  guard text.strip_prefix("/") is Some(rest) else { return None }
+  let rest = rest.to_owned()
+  // No separator yet: complete the command name from the configured set.
+  if !@slash.has_arguments(rest) {
+    if commands.is_empty() {
+      return None
+    }
+    return Some({
+      key: "command:\{rest.to_lower()}",
+      items: @completion.completion_item_matches(
+        commands.completion_items(),
+        rest,
+      ),
+      action: SlashCommandName,
+    })
+  }
+  // Past the command name: an argument menu only exists while a handler-opened
+  // picker is active for this command. Without one, the typed text is a
+  // free-form argument the handler will dispatch — there is nothing to complete.
+  guard @slash.SlashCommandInvocation::parse(text) is Some(invocation) else {
+    return None
+  }
+  guard picker is Some(picker) &&
+    picker.command.equal_ignore_ascii_case(invocation.name()) else {
+    return None
+  }
+  let arguments = invocation.arguments()
+  Some({
+    key: "argument:\{picker.command.to_lower()}:\{arguments.to_lower()}",
+    items: @completion.completion_item_matches(picker.items, arguments),
+    action: SlashCommandArgument(name=invocation.name()),
+  })
+}
+
+///|
+/// The slash command syntactically present in the composer, if any.
+///
+/// Returns None when no slash commands are configured, so a consumer that has
+/// not opted into the feature keeps submitting `/`-prefixed lines as ordinary
+/// input. When the feature is enabled, parsing is independent of whether the
+/// specific name is registered — an unknown command still dispatches so the
+/// handler reports it rather than the agent receiving it as a prompt or it
+/// being swallowed as a no-completion notice.
+fn slash_command_invocation_for_composer(
+  commands : @slash.SlashCommands,
+  composer : @composer.Model,
+) -> @slash.SlashCommandInvocation? {
+  if commands.is_empty() {
+    return None
+  }
+  if !composer.mode().is_input() {
+    return None
+  }
+  let text = composer.text()
+  if text.contains("\n") {
+    return None
+  }
+  @slash.SlashCommandInvocation::parse(text)
+}
+
+///|
+fn Ui::completion_menu(self : Self) -> CompletionMenu? {
+  completion_menu_for_composer(
+    self.config.slash_commands,
+    self.composer,
+    picker?=self.picker,
+  )
+}
+
+///|
+fn Ui::sync_completion_menu(self : Self) -> Unit {
+  match self.completion_menu() {
+    Some(menu) => {
+      if menu.key != self.completion.key {
+        self.completion.key = menu.key
+        self.completion.selected = 0
+      }
+      if menu.items.length() == 0 {
+        self.completion.selected = 0
+      } else if self.completion.selected >= menu.items.length() {
+        self.completion.selected = menu.items.length() - 1
+      }
+    }
+    None => self.completion.reset()
+  }
+}
+
+///|
+/// Whether the terminal is tall enough to draw the completion menu. A menu that
+/// cannot be rendered must not capture keys, so this gates `completion_menu_open`
+/// (and the Enter decision) on the same row budget the renderer uses.
+fn Ui::completion_menu_visible(self : Self) -> Bool {
+  guard self.viewport is Some(viewport) else { return true }
+  @render.completion_menu_fits(max_rows=viewport.rows())
+}
+
+///|
+fn Ui::completion_menu_open(self : Self) -> Bool {
+  !self.completion.dismissed &&
+  self.completion_menu_visible() &&
+  self.completion_menu() is Some(_)
+}
+
+///|
+async fn Ui::redraw_after_completion_selection(self : Self) -> Unit {
+  self.notice = None
+  self.redraw()
+}
+
+///|
+async fn Ui::move_completion_selection(self : Self, delta : Int) -> Unit {
+  let len = match self.completion_menu() {
+    Some(menu) => menu.items.length()
+    None => 0
+  }
+  if len > 0 {
+    if delta < 0 {
+      self.completion.selected = if self.completion.selected <= 0 {
+        len - 1
+      } else {
+        self.completion.selected - 1
+      }
+    } else {
+      self.completion.selected = if self.completion.selected + 1 >= len {
+        0
+      } else {
+        self.completion.selected + 1
+      }
+    }
+  }
+  self.redraw_after_completion_selection()
+}
+
+///|
+/// The canonical `/name arguments` text for a dispatched slash command, used
+/// for history so recall repeats what actually ran rather than the half-typed
+/// prefix in the composer.
+fn slash_command_text(name~ : String, arguments~ : String) -> String {
+  if arguments.is_empty() {
+    "/\{name}"
+  } else {
+    "/\{name} \{arguments}"
+  }
+}
+
+///|
+async fn Ui::submit_slash_command(
+  self : Self,
+  name~ : String,
+  arguments~ : String,
+) -> Event? {
+  // Record what ran, not `composer.text()`: accepting a completion can dispatch
+  // arguments that differ from the typed prefix, and recalling the prefix would
+  // re-select the first match and run a different command.
+  let text = slash_command_text(name~, arguments~)
+  self.history.push(@history.Entry::new(text, self.composer.mode()))
+  self.composer.reset()
+  self.history.reset_navigation()
+  self.notice = None
+  self.completion.reset()
+  self.picker = None
+  self.redraw()
+  Some(SlashCommand(name~, arguments~))
+}
+
+///|
+/// The composer text that accepting the highlighted menu item produces: a
+/// completed command name (`/mod` → `/model`) or, from an open picker, the
+/// highlighted argument (`/resume ` → `/resume session-3`). None when the menu is
+/// empty (e.g. an unknown command), so there is nothing to accept.
+fn completion_acceptance_text(menu : CompletionMenu, selected : Int) -> String? {
+  guard menu.items.get(selected) is Some(item) else { return None }
+  let text = match menu.action {
+    SlashCommandName => "/\{item.insert_text()}"
+    SlashCommandArgument(name~) => "/\{name} \{item.insert_text()}"
+  }
+  // A completion item can carry untrusted external text — a `/resume` id is a
+  // session directory name read verbatim, and ids are not control-character
+  // validated. The accepted text reaches the composer via `replace`, which skips
+  // the input-sanitization path, so sanitize here: collapse to one line and drop
+  // control bytes, so a crafted id cannot write terminal escapes on redraw or
+  // turn the slash command into multiline prompt text.
+  Some(@text.sanitize_oneline(text).text())
+}
+
+///|
+/// Accept the highlighted completion into the composer without submitting; Tab
+/// completes the text where Enter would submit it.
+async fn Ui::accept_completion(self : Self) -> Event? {
+  guard self.completion_menu() is Some(menu) else { return None }
+  guard completion_acceptance_text(menu, self.completion.selected) is Some(text) else {
+    return None
+  }
+  self.composer.replace(text, mode=self.composer.mode())
+  self.redraw_after_text_change()
+  None
+}
+
+///|
+/// Whether the composer holds a slash-command entry: the feature is enabled and
+/// the single-line input begins with `/`. Such a line is completed or dispatched
+/// on Enter, never queued as a prompt — not even a lone `/`, which is not yet a
+/// valid invocation but must not be queued as literal text.
+fn composer_is_slash_entry(
+  commands : @slash.SlashCommands,
+  composer : @composer.Model,
+) -> Bool {
+  if commands.is_empty() {
+    return false
+  }
+  if !composer.mode().is_input() {
+    return false
+  }
+  let text = composer.text()
+  if text.contains("\n") {
+    return false
+  }
+  text.has_prefix("/")
+}
+
+///|
+/// Open an argument picker for slash command `name`, drawing from `items`.
+///
+/// The command handler calls this (e.g. `/model` lists the models, `/resume`
+/// lists the current sessions) rather than the completion layer inferring a
+/// picker from static spec data. It points the menu at `items` and rewrites the
+/// composer to `/name ` so the argument-completion menu renders them; typing
+/// filters the list and Enter accepts the highlighted item. Runs on the command
+/// queue so the buffer edit and redraw serialize with other UI updates.
+///
+/// A picker is only opened by submitting a bare slash command (Enter on
+/// `/model` or `/resume`); typing the `/name ` separator no longer requests one.
+/// The picker opens after that submission — and, for `/resume`, after async work
+/// to list the store. In the meantime the tty reader is still live, so only
+/// apply it over the expected entry state: an empty composer (the bare command
+/// just cleared it on submit), which is filled with `/name `; or a composer the
+/// user has since typed as this command's entry (`/name ...`), which is left
+/// as-is so a typed filter is preserved. Any other text means the user moved on
+/// — do not clobber it.
+pub async fn Ui::open_picker(
+  self : Self,
+  name~ : String,
+  items~ : Array[@completion.CompletionItem],
+) -> Unit {
+  self.commands.wait(() => {
+    let text = self.composer.text()
+    let entering_this_command = @slash.SlashCommandInvocation::parse(text)
+      is Some(inv) &&
+      inv.name().equal_ignore_ascii_case(name)
+    if text.is_empty() || entering_this_command {
+      // Fill an empty composer; an already-typed `/name ...` keeps its text (and
+      // any in-progress argument the menu filters on).
+      if text.is_empty() {
+        self.composer.replace("/\{name} ", mode=self.composer.mode())
+      }
+      self.picker = Some({ command: name, items: items.copy() })
+      // A picker opened over a recalled entry must not keep History in recall
+      // mode, and the menu must reflect the current buffer.
+      self.history.reset_navigation()
+      self.completion.dismissed = false
+      self.sync_completion_menu()
+      self.notice = None
+      self.redraw()
+    }
+  })
+}
+
+///|
+/// What pressing Enter in the composer should do, decided purely from the
+/// command set, the composer text, and the menu state.
+priv enum EnterDecision {
+  /// Dispatch a slash command with these arguments.
+  RunSlashCommand(name~ : String, arguments~ : String)
+  /// Submit the composer text as ordinary input (prompt or shell command).
+  SubmitInput
+  /// The menu is open but nothing matches; show a notice and do nothing.
+  NoCompletionMatch
+}
+
+///|
+/// Decide what Enter does. Accepting a highlighted command name dispatches it
+/// with no arguments — the handler decides whether to run it or open an argument
+/// picker (see `Ui::open_picker`). With a picker open, the highlighted argument
+/// is accepted; an argument with no matching item runs as typed so free-form
+/// values still dispatch. An unknown command still dispatches so the handler can
+/// reject it, and anything else is submitted as ordinary input.
+///
+/// `menu_visible` is false when the terminal is too short to draw the menu, in
+/// which case it must not influence the decision even though it is logically
+/// open.
+fn ui_enter_decision(
+  commands : @slash.SlashCommands,
+  composer : @composer.Model,
+  completion : CompletionState,
+  menu_visible~ : Bool,
+  picker? : PickerSource,
+) -> EnterDecision {
+  let menu = if completion.dismissed || !menu_visible {
+    None
+  } else {
+    completion_menu_for_composer(commands, composer, picker?)
+  }
+  let invocation = slash_command_invocation_for_composer(commands, composer)
+  guard menu is Some(menu) else {
+    return match invocation {
+      Some(inv) => RunSlashCommand(name=inv.name(), arguments=inv.arguments())
+      // No menu and nothing to dispatch. A slash entry that does not parse into
+      // a command (a lone `/`, `/ `, after the menu was dismissed or is too
+      // short to draw) must not be submitted as a prompt — that would leak
+      // malformed slash input into the agent conversation. Leave it as a
+      // no-match instead; only genuine non-slash input is submitted.
+      None =>
+        if composer_is_slash_entry(commands, composer) {
+          NoCompletionMatch
+        } else {
+          SubmitInput
+        }
+    }
+  }
+  match menu.action {
+    // Command-name menu: accept the highlighted command and dispatch it with no
+    // arguments. The handler runs it or opens an argument picker; either way the
+    // completion layer does not decide.
+    SlashCommandName =>
+      match menu.items.get(completion.selected) {
+        Some(item) => RunSlashCommand(name=item.insert_text(), arguments="")
+        // Nothing matches the typed name: dispatch it (an unknown command) so
+        // the handler can reject it instead of swallowing it as a notice.
+        None =>
+          match invocation {
+            Some(inv) =>
+              RunSlashCommand(name=inv.name(), arguments=inv.arguments())
+            None => NoCompletionMatch
+          }
+      }
+    // Argument menu: accept the highlighted argument; with no match, run the
+    // command as typed so free-form arguments still dispatch.
+    SlashCommandArgument(name~) =>
+      match menu.items.get(completion.selected) {
+        // Sanitize the picked argument exactly as the Tab path does
+        // (`completion_acceptance_text`): a picker item can carry untrusted
+        // external text (a `/resume` id is an unvalidated session directory
+        // name), and the dispatched value is stored verbatim in history, so a
+        // crafted id with newlines or escapes must not survive into a later
+        // recall.
+        Some(item) =>
+          RunSlashCommand(
+            name~,
+            arguments=@text.sanitize_oneline(item.insert_text()).text(),
+          )
+        None =>
+          match invocation {
+            Some(inv) =>
+              RunSlashCommand(name=inv.name(), arguments=inv.arguments())
+            None => NoCompletionMatch
+          }
+      }
+  }
+}

--- a/tui/completion/completion.mbt
+++ b/tui/completion/completion.mbt
@@ -1,0 +1,111 @@
+///|
+/// One item the UI can offer in the input-completion menu.
+struct CompletionItem {
+  label : String
+  insert_text : String
+  description : String
+} derive(Eq, Debug)
+
+///|
+/// Build a completion item. `label` is shown in the menu, `insert_text` is the
+/// semantic value submitted when the item is accepted.
+pub fn CompletionItem::new(
+  label~ : String,
+  insert_text? : String,
+  description? : String = "",
+) -> CompletionItem {
+  { label, insert_text: insert_text.unwrap_or(label), description }
+}
+
+///|
+/// User-visible label shown in the completion menu.
+pub fn CompletionItem::label(self : CompletionItem) -> String {
+  self.label
+}
+
+///|
+/// Text submitted or inserted when this item is accepted.
+pub fn CompletionItem::insert_text(self : CompletionItem) -> String {
+  self.insert_text
+}
+
+///|
+/// User-visible description shown to the right of the label.
+pub fn CompletionItem::description(self : CompletionItem) -> String {
+  self.description
+}
+
+///|
+/// Completion items whose label or inserted text starts with `filter`,
+/// case-insensitively, with exact matches ranked ahead of broader prefix
+/// matches (original order preserved within each group).
+///
+/// The exact-first ordering matters because Enter accepts the first item: when
+/// candidates can be prefixes of one another and are not sorted by relevance —
+/// `/resume`, whose session ids are arbitrary and listed by recency — typing a
+/// complete id like `abc` must resume `abc`, not a longer, more recent `abcd`
+/// that also prefix-matches and happens to sort first.
+pub fn completion_item_matches(
+  items : Array[CompletionItem],
+  filter : String,
+) -> Array[CompletionItem] {
+  let lowered = filter.to_lower()
+  let exact : Array[CompletionItem] = []
+  let prefix : Array[CompletionItem] = []
+  for item in items {
+    let label = item.label.to_lower()
+    let insert = item.insert_text.to_lower()
+    if label == lowered || insert == lowered {
+      exact.push(item)
+    } else if label.has_prefix(lowered) || insert.has_prefix(lowered) {
+      prefix.push(item)
+    }
+  }
+  exact + prefix
+}
+
+///|
+/// Open or closed state for the input-completion menu.
+struct Model {
+  open : Bool
+  items : Array[CompletionItem]
+  selected : Int
+} derive(Eq, Debug)
+
+///|
+/// A closed completion menu.
+pub fn Model::closed() -> Model {
+  { open: false, items: [], selected: 0 }
+}
+
+///|
+/// An open completion menu. `selected` is clamped to the available item range.
+pub fn Model::open(
+  items~ : Array[CompletionItem],
+  selected? : Int = 0,
+) -> Model {
+  let selected = if items.length() == 0 {
+    0
+  } else {
+    selected.clamp(min=0, max=items.length() - 1)
+  }
+  { open: true, items: items.copy(), selected }
+}
+
+///|
+/// Whether the completion menu is open.
+pub fn Model::is_open(self : Model) -> Bool {
+  self.open
+}
+
+///|
+/// Completion items currently shown in the menu.
+pub fn Model::items(self : Model) -> Array[CompletionItem] {
+  self.items.copy()
+}
+
+///|
+/// Selected item index, clamped when the model is built.
+pub fn Model::selected(self : Model) -> Int {
+  self.selected
+}

--- a/tui/completion/completion_test.mbt
+++ b/tui/completion/completion_test.mbt
@@ -1,0 +1,65 @@
+///|
+test "completion item matches label or inserted text case-insensitively" {
+  let items = [
+    @completion.CompletionItem::new(
+      label="/model",
+      insert_text="model",
+      description="show model",
+    ),
+    @completion.CompletionItem::new(label="/help", insert_text="help"),
+  ]
+  let by_inserted = @completion.completion_item_matches(items, "mo")
+  assert_eq(by_inserted.length(), 1)
+  assert_eq(by_inserted[0].label(), "/model")
+  assert_eq(by_inserted[0].insert_text(), "model")
+
+  let by_label = @completion.completion_item_matches(items, "/H")
+  assert_eq(by_label.length(), 1)
+  assert_eq(by_label[0].insert_text(), "help")
+  assert_eq(@completion.completion_item_matches(items, "x").length(), 0)
+}
+
+///|
+test "exact completion matches rank ahead of longer prefix matches" {
+  // Recency-ordered ids where a longer, newer id sorts before the exact one the
+  // user typed (the /resume hazard): `abc` must win index 0 over `abcd`, since
+  // Enter accepts the first item.
+  let items = [
+    @completion.CompletionItem::new(label="abcd"),
+    @completion.CompletionItem::new(label="abc"),
+  ]
+  let matches = @completion.completion_item_matches(items, "abc")
+  assert_eq(matches.length(), 2)
+  assert_eq(matches[0].insert_text(), "abc")
+  assert_eq(matches[1].insert_text(), "abcd")
+
+  // A non-exact prefix still matches both, keeping the original recency order.
+  let prefix_only = @completion.completion_item_matches(items, "ab")
+  assert_eq(prefix_only.length(), 2)
+  assert_eq(prefix_only[0].insert_text(), "abcd")
+  assert_eq(prefix_only[1].insert_text(), "abc")
+}
+
+///|
+test "completion model carries open state defensively" {
+  let items = [
+    @completion.CompletionItem::new(label="deepseek-v4-flash"),
+    @completion.CompletionItem::new(label="deepseek-v4-pro"),
+  ]
+  let model = @completion.Model::open(items~, selected=99)
+  items.push(@completion.CompletionItem::new(label="other"))
+  assert_true(model.is_open())
+  assert_eq(model.selected(), 1)
+  let model_items = model.items()
+  assert_eq(model_items.length(), 2)
+  assert_eq(model_items[0].insert_text(), "deepseek-v4-flash")
+  assert_eq(model_items[1].insert_text(), "deepseek-v4-pro")
+}
+
+///|
+test "closed completion model has no items" {
+  let model = @completion.Model::closed()
+  assert_true(!model.is_open())
+  assert_eq(model.selected(), 0)
+  assert_eq(model.items().length(), 0)
+}

--- a/tui/completion/moon.pkg
+++ b/tui/completion/moon.pkg
@@ -1,0 +1,3 @@
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/completion/pkg.generated.mbti
+++ b/tui/completion/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/completion"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn completion_item_matches(Array[CompletionItem], String) -> Array[CompletionItem]
+
+// Errors
+
+// Types and methods
+type CompletionItem derive(Eq, @debug.Debug)
+pub fn CompletionItem::description(Self) -> String
+pub fn CompletionItem::insert_text(Self) -> String
+pub fn CompletionItem::label(Self) -> String
+pub fn CompletionItem::new(label~ : String, insert_text? : String, description? : String) -> Self
+
+type Model derive(Eq, @debug.Debug)
+pub fn Model::closed() -> Self
+pub fn Model::is_open(Self) -> Bool
+pub fn Model::items(Self) -> Array[CompletionItem]
+pub fn Model::open(items~ : Array[CompletionItem], selected? : Int) -> Self
+pub fn Model::selected(Self) -> Int
+
+// Type aliases
+
+// Traits
+

--- a/tui/config.mbt
+++ b/tui/config.mbt
@@ -8,16 +8,19 @@ const DefaultComposerMaxRows : Int = @composer.DefaultMaxTextRows
 struct Config {
   esc_timeout_ms : Int
   composer_max_rows : Int
+  slash_commands : @slash.SlashCommands
 }
 
 ///|
 /// Build a UI `Config`. `esc_timeout_ms` bounds how long the reader waits to
 /// disambiguate a lone `Esc` from a CSI escape sequence, and `composer_max_rows`
-/// caps how tall the editable input area grows. Non-positive values fall back to
-/// the defaults (`50` ms and `@composer.DefaultMaxTextRows`).
+/// caps how tall the editable input area grows. `slash_commands` configures the
+/// optional slash-command completion menu. Non-positive numeric values fall back
+/// to the defaults (`50` ms and `@composer.DefaultMaxTextRows`).
 pub fn Config::new(
   esc_timeout_ms? : Int = DefaultEscTimeoutMs,
   composer_max_rows? : Int = DefaultComposerMaxRows,
+  slash_commands? : Array[@slash.SlashCommandSpec] = [],
 ) -> Config {
   let esc_timeout_ms = if esc_timeout_ms < 1 {
     DefaultEscTimeoutMs
@@ -29,5 +32,5 @@ pub fn Config::new(
   } else {
     composer_max_rows
   }
-  { esc_timeout_ms, composer_max_rows }
+  { esc_timeout_ms, composer_max_rows, slash_commands: slash_commands.copy() }
 }

--- a/tui/core/event.mbt
+++ b/tui/core/event.mbt
@@ -3,6 +3,7 @@
 pub(all) enum Event {
   Queue(Input)
   Steer(Input)
+  SlashCommand(name~ : String, arguments~ : String)
   Interrupt
   Quit
 } derive(Eq, Debug)

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub let prompt_prefix : @displaytext.DisplayText
 pub(all) enum Event {
   Queue(Input)
   Steer(Input)
+  SlashCommand(name~ : String, arguments~ : String)
   Interrupt
   Quit
 } derive(Eq, @debug.Debug)

--- a/tui/exports.mbt
+++ b/tui/exports.mbt
@@ -4,3 +4,9 @@
 
 ///|
 pub using @core {type Input, type Event, type ToolStatus, type TranscriptItem}
+
+///|
+pub using @completion {type CompletionItem}
+
+///|
+pub using @slash {type SlashCommandSpec}

--- a/tui/input.mbt
+++ b/tui/input.mbt
@@ -13,6 +13,12 @@ fn Ui::current_history_entry(self : Self) -> @history.Entry {
 }
 
 ///|
+priv enum CompletionAction {
+  SlashCommandName
+  SlashCommandArgument(name~ : String)
+}
+
+///|
 async fn Ui::submit_current_input(self : Self) -> Input? {
   if self.composer.text().length() == 0 && self.composer.mode().is_input() {
     self.notice = Some(@doc.dim_text("empty input"))
@@ -24,6 +30,8 @@ async fn Ui::submit_current_input(self : Self) -> Input? {
     self.history.push(@history.Entry::new(text, mode))
     self.composer.reset()
     self.notice = None
+    self.completion.reset()
+    self.picker = None
     self.redraw()
     Some(submitted_input(text, mode))
   }
@@ -40,12 +48,16 @@ async fn Ui::redraw_after_cursor_move(self : Self) -> Unit {
 ///|
 async fn Ui::redraw_after_text_change(self : Self) -> Unit {
   self.history.reset_navigation()
+  self.completion.dismissed = false
+  self.sync_completion_menu()
   self.notice = None
   self.redraw()
 }
 
 ///|
 async fn Ui::redraw_after_history_recall(self : Self) -> Unit {
+  self.completion.dismissed = false
+  self.sync_completion_menu()
   self.notice = None
   self.redraw()
 }
@@ -88,6 +100,7 @@ async fn Ui::move_down_or_recall_history(self : Self) -> Unit {
 
 ///|
 async fn Ui::handle_key(self : Self, key : @tty/input.KeyEvent) -> Event? {
+  self.sync_completion_menu()
   match key.code {
     Char('a') if key.modifiers.ctrl() => {
       self.composer.move_home()
@@ -141,8 +154,39 @@ async fn Ui::handle_key(self : Self, key : @tty/input.KeyEvent) -> Event? {
       self.redraw_after_text_change()
       None
     }
-    Enter => self.submit_current_input().map(input => Steer(input))
-    Tab => self.submit_current_input().map(input => Queue(input))
+    Enter =>
+      match
+        ui_enter_decision(
+          self.config.slash_commands,
+          self.composer,
+          self.completion,
+          menu_visible=self.completion_menu_visible(),
+          picker?=self.picker,
+        ) {
+        RunSlashCommand(name~, arguments~) =>
+          self.submit_slash_command(name~, arguments~)
+        SubmitInput => self.submit_current_input().map(input => Steer(input))
+        NoCompletionMatch => {
+          self.notice = Some(@doc.dim_text("no matching completion"))
+          self.redraw()
+          None
+        }
+      }
+    Tab =>
+      // In a completion menu, Tab accepts the highlighted item (completes the
+      // text) rather than submitting. A slash-command line is never queued as a
+      // prompt — even a bare `/` — so it falls through to a no-op when there is
+      // nothing to complete. Only ordinary input is queued.
+      if self.completion_menu_open() {
+        self.accept_completion()
+      } else if composer_is_slash_entry(
+          self.config.slash_commands,
+          self.composer,
+        ) {
+        None
+      } else {
+        self.submit_current_input().map(input => Queue(input))
+      }
     Escape => {
       // Esc only resets history navigation; it deliberately does NOT interrupt.
       // Under the kitty keyboard protocol every key is an ESC-prefixed sequence,
@@ -151,6 +195,10 @@ async fn Ui::handle_key(self : Self, key : @tty/input.KeyEvent) -> Event? {
       // Interrupt would spuriously cancel a running task or, when idle, quit.
       // Ctrl+C is the deliberate interrupt/quit key.
       self.history.reset_navigation()
+      if self.completion_menu_open() {
+        self.completion.dismissed = true
+        self.redraw()
+      }
       None
     }
     Char('k') if key.modifiers.ctrl() => {
@@ -159,11 +207,19 @@ async fn Ui::handle_key(self : Self, key : @tty/input.KeyEvent) -> Event? {
       None
     }
     Char('n') if key.modifiers.ctrl() => {
-      self.move_down_or_recall_history()
+      if self.completion_menu_open() {
+        self.move_completion_selection(1)
+      } else {
+        self.move_down_or_recall_history()
+      }
       None
     }
     Char('p') if key.modifiers.ctrl() => {
-      self.move_up_or_recall_history()
+      if self.completion_menu_open() {
+        self.move_completion_selection(-1)
+      } else {
+        self.move_up_or_recall_history()
+      }
       None
     }
     Char('u') if key.modifiers.ctrl() => {
@@ -172,11 +228,19 @@ async fn Ui::handle_key(self : Self, key : @tty/input.KeyEvent) -> Event? {
       None
     }
     Up => {
-      self.move_up_or_recall_history()
+      if self.completion_menu_open() {
+        self.move_completion_selection(-1)
+      } else {
+        self.move_up_or_recall_history()
+      }
       None
     }
     Down => {
-      self.move_down_or_recall_history()
+      if self.completion_menu_open() {
+        self.move_completion_selection(1)
+      } else {
+        self.move_down_or_recall_history()
+      }
       None
     }
     Left => {

--- a/tui/internal/render/moon.pkg
+++ b/tui/internal/render/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/tui/completion",
   "bobzhang/openseek/tui/core",
   "bobzhang/openseek/tui/doc",
   "bobzhang/openseek/tui/internal/composer",

--- a/tui/internal/render/pkg.generated.mbti
+++ b/tui/internal/render/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/tui/internal/render"
 
 import {
+  "bobzhang/openseek/tui/completion",
   "bobzhang/openseek/tui/core",
   "bobzhang/openseek/tui/doc",
   "bobzhang/openseek/tui/internal/composer",
@@ -9,7 +10,9 @@ import {
 }
 
 // Values
-pub fn composer_surface(@composer.Model, activity~ : @doc.Text?, queued_inputs~ : Array[@core.Input], status~ : @doc.Text, notice~ : @doc.Text?, cols~ : Int, max_rows~ : Int) -> @surface.Surface
+pub fn completion_menu_fits(max_rows~ : Int) -> Bool
+
+pub fn composer_surface(@composer.Model, activity~ : @doc.Text?, queued_inputs~ : Array[@core.Input], completion? : @completion.Model, status~ : @doc.Text, notice~ : @doc.Text?, cols~ : Int, max_rows~ : Int) -> @surface.Surface
 
 // Errors
 

--- a/tui/internal/render/queued.mbt
+++ b/tui/internal/render/queued.mbt
@@ -3,22 +3,6 @@
 // so it lives here rather than as a `@core` projection.
 
 ///|
-fn input_preview_line(input : @core.Input) -> @displaytext.DisplayText {
-  // Defense-in-depth: queued previews are written straight to the terminal, so
-  // strip any control bytes the input may carry (composer input is already
-  // sanitized, but other sources — e.g. an initial CLI task — are not).
-  let lines = @text.sanitize_lines(input.text())
-  let first = lines[0]
-  if lines.length() > 1 {
-    let builder = StringBuilder()
-    builder <+ "\{first.text()} …"
-    DisplayText(builder.to_string())
-  } else {
-    first
-  }
-}
-
-///|
 fn queued_input_line(
   input : @core.Input,
   index~ : Int,
@@ -31,12 +15,17 @@ fn queued_input_line(
   let prefix = input.prefix()
   let marker_width = marker.width()
   let prefix_width = prefix.width()
+  // Defense-in-depth: queued previews are written straight to the terminal, so
+  // collapse the input to one sanitized line (composer input is already
+  // sanitized, but other sources — e.g. an initial CLI task — are not).
   @surface.Line::new([
     Span(marker, style=@style.dim),
     Span(prefix, style=@style.dim),
     Span(
       DisplayText(
-        input_preview_line(input).truncate(cols - marker_width - prefix_width),
+        @text.sanitize_oneline(input.text()).truncate(
+          cols - marker_width - prefix_width,
+        ),
       ),
       style=@style.dim,
     ),

--- a/tui/internal/render/render.mbt
+++ b/tui/internal/render/render.mbt
@@ -44,6 +44,87 @@ fn status_line(
 }
 
 ///|
+const MaxCompletionMenuRows : Int = 6
+
+///|
+fn padded_line(spans : Array[@surface.Span], cols~ : Int) -> @surface.Line {
+  let used = for span in spans; width = 0 {
+    continue width + @displaytext.DisplayText(span.text()).width()
+  } nobreak {
+    width
+  }
+  if used < cols {
+    spans.push(
+      Span(DisplayText(String::make(cols - used, ' ')), style=@style.default),
+    )
+  }
+  @surface.Line::new(spans)
+}
+
+///|
+fn completion_menu_rows(
+  items : Array[@completion.CompletionItem],
+  selected : Int,
+  cols~ : Int,
+  indent~ : Int,
+  max_rows~ : Int,
+) -> Array[@surface.Line] {
+  if max_rows <= 0 {
+    return []
+  }
+  if items.length() == 0 {
+    return [
+      indent_line(
+        padded_line(
+          [Span(DisplayText("no completions match"), style=@style.dim)],
+          cols=cols - indent,
+        ),
+        indent~,
+      ),
+    ]
+  }
+  let selected = selected.clamp(min=0, max=items.length() - 1)
+  let visible_count = MaxCompletionMenuRows.min(max_rows).min(items.length())
+  let start = if selected >= visible_count {
+    selected - visible_count + 1
+  } else {
+    0
+  }
+  let end = (start + visible_count).min(items.length())
+  [
+    for index in start..<end => {
+      let item = items[index]
+      let active = index == selected
+      let style = if active { @style.ok } else { @style.dim }
+      let width = cols - indent
+      // App-provided label/description are echoed straight to the terminal, so
+      // collapse each to one sanitized line and truncate it to the row width —
+      // a newline would desync the surface row count from what is drawn.
+      let marker = @displaytext.DisplayText(if active { "› " } else { "  " })
+      let label = @displaytext.DisplayText(
+        @text.sanitize_oneline(item.label()).truncate(width - marker.width()),
+      )
+      let spans : Array[@surface.Span] = [
+        Span(marker, style~),
+        Span(label, style~),
+      ]
+      let used = marker.width() + label.width()
+      if !item.description().is_empty() && used + 2 < width {
+        let gap = @displaytext.DisplayText("  ")
+        let description = @displaytext.DisplayText(
+          @text.sanitize_oneline(item.description()).truncate(
+            width - used - gap.width(),
+          ),
+        )
+        spans.push(Span(gap, style=@style.dim))
+        spans.push(Span(description, style=@style.dim))
+      }
+      indent_line(padded_line(spans, cols=width), indent~)
+    }
+  ]
+}
+
+///|
 /// Prepend `indent` blank columns to a line so it lines up with the composer's
 /// editable text (which starts after the prompt prefix), not the left edge.
 fn indent_line(line : @surface.Line, indent~ : Int) -> @surface.Line {
@@ -62,6 +143,16 @@ fn indent_line(line : @surface.Line, indent~ : Int) -> @surface.Line {
 /// The shortest terminal the live area fits in without clipping: a spacer, two
 /// separators, one composer row, and the status line.
 const MinLiveRows : Int = 5
+
+///|
+/// Whether a terminal `max_rows` tall has room to draw at least one completion
+/// row below the composer — the live area reserves `MinLiveRows` for the
+/// composer and its chrome. The input layer gates completion key handling on
+/// this so a menu that is logically open but too short to render does not
+/// silently capture Enter/Up/Down.
+pub fn completion_menu_fits(max_rows~ : Int) -> Bool {
+  max_rows - MinLiveRows >= 1
+}
 
 ///|
 /// A one-line notice shown in place of the composer when the terminal is too
@@ -102,6 +193,7 @@ pub fn composer_surface(
   composer : @composer.Model,
   activity~ : @doc.Text?,
   queued_inputs~ : Array[@core.Input],
+  completion? : @completion.Model = @completion.Model::closed(),
   status~ : @doc.Text,
   notice~ : @doc.Text?,
   cols~ : Int,
@@ -116,16 +208,33 @@ pub fn composer_surface(
   // Status and activity rows have no prompt prefix, so indent them to the
   // composer's text column (after `❯ `) instead of the screen's left edge.
   let indent = composer.input_prefix(0).width()
+  let completion_rows = if completion.is_open() {
+    completion_menu_rows(
+      completion.items(),
+      completion.selected(),
+      cols~,
+      indent~,
+      max_rows=max_rows - MinLiveRows,
+    )
+  } else {
+    []
+  }
   // Lay the composer out first, capped to the rows left after its mandatory
   // chrome (spacer + two separators + status), so a tall multiline draft scrolls
   // to the cursor instead of overflowing the budget. Its height then bounds the
   // queued preview below.
-  composer.resize(cols~, max_rows=max_rows - (MinLiveRows - 1))
+  composer.resize(
+    cols~,
+    max_rows=max_rows - (MinLiveRows - 1) - completion_rows.length(),
+  )
   let composer_rows = composer.visible_text_rows()
   // Rows that must always stay visible — the composer and its chrome: a spacer,
-  // two separators, the composer itself, and the status line. The composer wins
-  // the row budget; the activity line and queue get whatever is left over.
-  let fixed = 1 + composer_rows + 2 + 1
+  // two separators, the composer itself, the open completion menu (drawn just
+  // above the status line), and the status line. The composer and menu win the
+  // row budget; the activity line and queue get whatever is left over. Counting
+  // the completion rows here keeps the queue from claiming their space and
+  // pushing the menu and status past the bottom of the terminal.
+  let fixed = 1 + composer_rows + 2 + completion_rows.length() + 1
   // Show the activity line only if it plus its trailing blank still fit, so a
   // very short terminal drops "Working …" rather than clipping the prompt.
   let show_activity = activity is Some(_) && max_rows >= fixed + 2
@@ -166,6 +275,9 @@ pub fn composer_surface(
     }
   }
   rows.push(separator_line(cols~))
+  for row in completion_rows {
+    rows.push(row)
+  }
   rows.push(
     indent_line(status_line(status, notice, cols=cols - indent), indent~),
   )

--- a/tui/internal/render/render_test.mbt
+++ b/tui/internal/render/render_test.mbt
@@ -240,6 +240,185 @@ test "composer surface renders the input viewport" {
 }
 
 ///|
+test "composer surface renders slash command completions below composer" {
+  let surface = @render.composer_surface(
+    @composer.Model::new("/"),
+    activity=None,
+    queued_inputs=[],
+    completion=@completion.Model::open(items=[
+      @completion.CompletionItem::new(
+        label="/model",
+        insert_text="model",
+        description="show or change the model",
+      ),
+    ]),
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=60,
+    max_rows=24,
+  )
+  inspect(surface.height(), content="6")
+  inspect(
+    surface.line_at(4).text().trim(),
+    content=(
+      #|› /model  show or change the model
+    ),
+  )
+  inspect(surface.cursor().row(), content="2")
+  inspect(surface.cursor().col(), content="3")
+}
+
+///|
+test "composer surface renders model argument completions below composer" {
+  let surface = @render.composer_surface(
+    @composer.Model::new("/model deepseek-v4-f"),
+    activity=None,
+    queued_inputs=[],
+    completion=@completion.Model::open(items=[
+      @completion.CompletionItem::new(
+        label="deepseek-v4-flash",
+        description="model",
+      ),
+    ]),
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=50,
+    max_rows=24,
+  )
+  inspect(surface.height(), content="6")
+  inspect(
+    surface.line_at(4).text().trim(),
+    content=(
+      #|› deepseek-v4-flash  model
+    ),
+  )
+}
+
+///|
+test "composer surface renders prefiltered completion items" {
+  let surface = @render.composer_surface(
+    @composer.Model::new("/mo"),
+    activity=None,
+    queued_inputs=[],
+    completion=@completion.Model::open(items=[
+      @completion.CompletionItem::new(
+        label="/model",
+        insert_text="model",
+        description="show model",
+      ),
+    ]),
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=24,
+  )
+  inspect(surface.height(), content="6")
+  inspect(
+    surface.line_at(4).text().trim(),
+    content=(
+      #|› /model  show model
+    ),
+  )
+}
+
+///|
+test "composer surface reserves completion rows from the queue budget" {
+  // With the menu open and a queue competing for rows on a short terminal, the
+  // total live area (menu and status included) must stay within the budget, or
+  // the viewport keeps only the leading rows and clips the menu off the bottom.
+  let surface = @render.composer_surface(
+    @composer.Model::new("/"),
+    activity=None,
+    queued_inputs=[
+      Prompt("a"),
+      Prompt("b"),
+      Prompt("c"),
+      Prompt("d"),
+      Prompt("e"),
+    ],
+    completion=@completion.Model::open(items=[
+      @completion.CompletionItem::new(label="/model", description="m1"),
+      @completion.CompletionItem::new(label="/exit", description="m2"),
+      @completion.CompletionItem::new(label="/resume", description="m3"),
+    ]),
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=12,
+  )
+  assert_true(surface.height() <= 12)
+  // The status line and the menu it sits below both survive within budget.
+  inspect(surface.line_at(surface.height() - 1).text().trim(), content="ready")
+  inspect(
+    surface.line_at(surface.height() - 2).text().trim(),
+    content=(
+      #|/resume  m3
+    ),
+  )
+}
+
+///|
+test "composer surface keeps a multi-line completion description on one row" {
+  let surface = @render.composer_surface(
+    @composer.Model::new("/"),
+    activity=None,
+    queued_inputs=[],
+    completion=@completion.Model::open(items=[
+      @completion.CompletionItem::new(
+        label="session-1",
+        description="first line\nsecond line",
+      ),
+    ]),
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=50,
+    max_rows=24,
+  )
+  let menu_row = surface.line_at(surface.height() - 2).text()
+  // A raw newline would move the terminal cursor while the surface still counts
+  // the item as a single row, corrupting the live frame.
+  assert_true(!menu_row.contains("\n"))
+  inspect(
+    menu_row.trim(),
+    content=(
+      #|› session-1  first line …
+    ),
+  )
+}
+
+///|
+test "completion menu fits only above the minimum live height" {
+  // At or below MinLiveRows the menu gets a zero budget and is not drawn, so it
+  // must not be treated as active by the input layer.
+  assert_true(!@render.completion_menu_fits(max_rows=4))
+  assert_true(!@render.completion_menu_fits(max_rows=5))
+  assert_true(@render.completion_menu_fits(max_rows=6))
+}
+
+///|
+test "composer surface drops completion menu when terminal is only minimum height" {
+  let surface = @render.composer_surface(
+    @composer.Model::new("/"),
+    activity=None,
+    queued_inputs=[],
+    completion=@completion.Model::open(items=[
+      @completion.CompletionItem::new(
+        label="/model",
+        insert_text="model",
+        description="show model",
+      ),
+    ]),
+    status=@doc.Text::plain("ready"),
+    notice=None,
+    cols=40,
+    max_rows=5,
+  )
+  inspect(surface.height(), content="5")
+  inspect(surface.line_at(4).text().trim(), content="ready")
+  inspect(surface.cursor().row(), content="2")
+}
+
+///|
 test "composer surface renders activity above separator" {
   let surface = @render.composer_surface(
     @composer.Model::new(""),

--- a/tui/internal/text/pkg.generated.mbti
+++ b/tui/internal/text/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub fn sanitize(String) -> String
 
 pub fn sanitize_lines(String) -> Array[@displaytext.DisplayText]
 
+pub fn sanitize_oneline(String) -> @displaytext.DisplayText
+
 pub fn unit_width(@displaytext.DisplayText, start~ : @displaytext.TextualPosition, end~ : @displaytext.TextualPosition) -> Int
 
 // Errors

--- a/tui/internal/text/text.mbt
+++ b/tui/internal/text/text.mbt
@@ -54,6 +54,22 @@ pub fn sanitize_lines(text : String) -> Array[@displaytext.DisplayText] {
 }
 
 ///|
+/// Sanitize `text` and collapse it to a single display line: the first hard
+/// line, with a trailing ` …` when later lines were dropped. Live previews that
+/// echo app-provided text on one row (queued inputs, completion-menu items)
+/// use this so a multi-line value never writes a newline to the terminal while
+/// the surface still counts it as one row.
+pub fn sanitize_oneline(text : String) -> @displaytext.DisplayText {
+  let lines = sanitize_lines(text)
+  guard lines is [first, ..] else { return DisplayText("") }
+  if lines.length() > 1 {
+    DisplayText("\{first.text()} …")
+  } else {
+    first
+  }
+}
+
+///|
 /// Sanitize one already-segmented hard line into a plain string: expand tabs to
 /// the next `TabWidth` stop and drop C0 controls and `DEL`. Shared by `sanitize`
 /// (which joins the results) and `sanitize_lines` (which re-wraps each in a

--- a/tui/moon.pkg
+++ b/tui/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/io" @async/io,
   "moonbitlang/async/aqueue",
+  "bobzhang/openseek/tui/completion",
   "bobzhang/openseek/tui/core",
   "bobzhang/openseek/tui/doc",
   "bobzhang/openseek/tui/internal/composer",
@@ -9,7 +10,10 @@ import {
   "bobzhang/openseek/tui/internal/render",
   "bobzhang/openseek/tui/internal/surface",
   "bobzhang/openseek/tui/internal/task",
+  "bobzhang/openseek/tui/internal/text",
   "bobzhang/openseek/tui/internal/viewport",
+  "bobzhang/openseek/tui/slash",
+  "moonbit-community/displaytext",
   "moonbit-community/tty",
   "moonbit-community/tty/input" @tty/input,
 }

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -2,8 +2,10 @@
 package "bobzhang/openseek/tui"
 
 import {
+  "bobzhang/openseek/tui/completion",
   "bobzhang/openseek/tui/core",
   "bobzhang/openseek/tui/doc",
+  "bobzhang/openseek/tui/slash",
 }
 
 // Values
@@ -13,12 +15,14 @@ pub async fn[T] with_ui(config? : Config, async (Ui) -> T) -> T
 
 // Types and methods
 type Config
-pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int) -> Self
+pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int, slash_commands? : Array[@slash.SlashCommandSpec]) -> Self
 
 type Ui
 pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
 pub fn Ui::columns(Self) -> Int
+pub async fn Ui::open_picker(Self, name~ : String, items~ : Array[@completion.CompletionItem]) -> Unit
 pub async fn Ui::read_event(Self) -> @core.Event
+pub async fn Ui::replace_transcript(Self, Array[@core.TranscriptItem]) -> Unit
 #deprecated
 pub async fn Ui::set_activity(Self, @doc.Text?) -> Unit
 pub async fn Ui::set_live_view(Self, status~ : @doc.Text, activity~ : @doc.Text?, queued_inputs~ : Array[@core.Input]) -> Unit
@@ -28,9 +32,13 @@ pub async fn Ui::set_queued_inputs(Self, Array[@core.Input]) -> Unit
 pub async fn Ui::set_status(Self, @doc.Text) -> Unit
 
 // Type aliases
+pub using @completion {type CompletionItem}
+
 pub using @core {type Event}
 
 pub using @core {type Input}
+
+pub using @slash {type SlashCommandSpec}
 
 pub using @core {type ToolStatus}
 

--- a/tui/slash/moon.pkg
+++ b/tui/slash/moon.pkg
@@ -1,0 +1,7 @@
+import {
+  "bobzhang/openseek/tui/completion",
+}
+
+supported_targets = "native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/tui/slash/pkg.generated.mbti
+++ b/tui/slash/pkg.generated.mbti
@@ -1,0 +1,33 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/tui/slash"
+
+import {
+  "bobzhang/openseek/tui/completion",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn has_arguments(String) -> Bool
+
+// Errors
+
+// Types and methods
+type SlashCommandInvocation derive(Eq, @debug.Debug)
+pub fn SlashCommandInvocation::arguments(Self) -> String
+pub fn SlashCommandInvocation::name(Self) -> String
+pub fn SlashCommandInvocation::parse(String) -> Self?
+
+type SlashCommandSpec derive(Eq, @debug.Debug)
+pub fn SlashCommandSpec::description(Self) -> String
+pub fn SlashCommandSpec::name(Self) -> String
+pub fn SlashCommandSpec::new(name~ : String, description~ : String) -> Self
+
+pub(all) struct SlashCommands(Array[SlashCommandSpec])
+pub fn SlashCommands::completion_items(Self) -> Array[@completion.CompletionItem]
+pub fn SlashCommands::get(Self, String) -> SlashCommandSpec?
+pub fn SlashCommands::is_empty(Self) -> Bool
+
+// Type aliases
+
+// Traits
+

--- a/tui/slash/slash_command.mbt
+++ b/tui/slash/slash_command.mbt
@@ -1,0 +1,124 @@
+///|
+/// One slash command the UI can offer in the input-completion menu.
+///
+/// A command takes no static argument candidates: argument pickers are opened by
+/// the command handler with freshly-fetched items (see `Ui::open_picker`), so the
+/// spec only names the command and describes it for the name-completion menu.
+struct SlashCommandSpec {
+  name : String
+  description : String
+} derive(Eq, Debug)
+
+///|
+/// Build a slash command spec. `name` does not include the leading slash.
+pub fn SlashCommandSpec::new(
+  name~ : String,
+  description~ : String,
+) -> SlashCommandSpec {
+  { name, description }
+}
+
+///|
+/// Command name without the leading slash.
+pub fn SlashCommandSpec::name(self : SlashCommandSpec) -> String {
+  self.name
+}
+
+///|
+/// User-visible command description shown in the completion menu.
+pub fn SlashCommandSpec::description(self : SlashCommandSpec) -> String {
+  self.description
+}
+
+///|
+/// An ordered set of slash commands the UI can offer and dispatch.
+pub(all) struct SlashCommands(Array[SlashCommandSpec])
+
+///|
+/// Whether there are no commands.
+pub fn SlashCommands::is_empty(self : SlashCommands) -> Bool {
+  self.0.is_empty()
+}
+
+///|
+/// Command whose name equals `name`, case-insensitively, if any.
+pub fn SlashCommands::get(
+  self : SlashCommands,
+  name : String,
+) -> SlashCommandSpec? {
+  for command in self.0 {
+    if command.name().equal_ignore_ascii_case(name) {
+      return Some(command)
+    }
+  }
+  None
+}
+
+///|
+/// Completion items, one per command, for the leading-slash menu.
+pub fn SlashCommands::completion_items(
+  self : SlashCommands,
+) -> Array[@completion.CompletionItem] {
+  let items : Array[@completion.CompletionItem] = []
+  for command in self.0 {
+    items.push(
+      @completion.CompletionItem::new(
+        label="/\{command.name()}",
+        insert_text=command.name(),
+        description=command.description(),
+      ),
+    )
+  }
+  items
+}
+
+///|
+/// A slash command reference parsed from input text: the command name (without
+/// the leading slash) and its trimmed argument string. Parsing is syntactic
+/// only; resolve the name against a `SlashCommands` set to know if it is known.
+struct SlashCommandInvocation {
+  name : String
+  arguments : String
+} derive(Eq, Debug)
+
+///|
+/// Parse `text` as a single `/name arguments` entry. Returns None unless `text`
+/// is `/`-prefixed with a non-empty name; the name is not checked against any
+/// command set.
+pub fn SlashCommandInvocation::parse(text : String) -> SlashCommandInvocation? {
+  guard text.strip_prefix("/") is Some(rest) else { return None }
+  // The name runs up to the first whitespace; the remainder, trimmed, is the
+  // argument string.
+  let name = StringBuilder()
+  for ch in rest {
+    if ch.is_whitespace() {
+      break
+    }
+    name.write_char(ch)
+  }
+  let name = name.to_string()
+  guard !name.is_empty() else { return None }
+  let arguments = rest.view(start_offset=name.length()).trim().to_owned()
+  Some({ name, arguments })
+}
+
+///|
+/// Command name without the leading slash.
+pub fn SlashCommandInvocation::name(self : SlashCommandInvocation) -> String {
+  self.name
+}
+
+///|
+/// Trimmed argument string following the command name.
+pub fn SlashCommandInvocation::arguments(
+  self : SlashCommandInvocation,
+) -> String {
+  self.arguments
+}
+
+///|
+/// Whether the text following a leading slash already contains an argument
+/// separator (whitespace), i.e. the user has moved past the command name.
+pub fn has_arguments(rest : String) -> Bool {
+  rest.any(c => c.is_whitespace())
+}

--- a/tui/slash/slash_command_test.mbt
+++ b/tui/slash/slash_command_test.mbt
@@ -1,0 +1,29 @@
+///|
+test "has_arguments detects the separator after the command name" {
+  assert_true(!@slash.has_arguments("model"))
+  assert_true(@slash.has_arguments("model "))
+  assert_true(@slash.has_arguments("model deepseek-v4-flash"))
+}
+
+///|
+test "SlashCommandInvocation::parse reads /name arguments syntactically" {
+  guard @slash.SlashCommandInvocation::parse("/model deepseek-v4-flash")
+    is Some(invocation) else {
+    fail("expected model invocation")
+  }
+  assert_eq(invocation.name(), "model")
+  assert_eq(invocation.arguments(), "deepseek-v4-flash")
+  // Trailing whitespace yields an empty, trimmed argument string.
+  guard @slash.SlashCommandInvocation::parse("/model   ") is Some(trimmed) else {
+    fail("expected model invocation with empty arguments")
+  }
+  assert_eq(trimmed.name(), "model")
+  assert_eq(trimmed.arguments(), "")
+  // Parsing is syntactic; unknown names still parse.
+  guard @slash.SlashCommandInvocation::parse("/unknown x") is Some(unknown) else {
+    fail("expected unknown invocation to parse")
+  }
+  assert_eq(unknown.name(), "unknown")
+  assert_true(@slash.SlashCommandInvocation::parse("model") is None)
+  assert_true(@slash.SlashCommandInvocation::parse("/") is None)
+}

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -4,10 +4,19 @@ fn Ui::composer_surface(
   cols~ : Int,
   rows~ : Int,
 ) -> @surface.Surface {
+  let completion = match self.completion_menu() {
+    Some(menu) if !self.completion.dismissed =>
+      @completion.Model::open(
+        items=menu.items,
+        selected=self.completion.selected,
+      )
+    _ => @completion.Model::closed()
+  }
   @render.composer_surface(
     self.composer,
     activity=self.activity,
     queued_inputs=self.queued_inputs,
+    completion~,
     status=self.status,
     notice=self.notice,
     cols~,
@@ -110,6 +119,32 @@ async fn Ui::append_transcript(self : Self, doc : @doc.Doc) -> Unit {
 /// transcript via `append_transcript`.
 pub async fn Ui::append_item(self : Self, item : TranscriptItem) -> Unit {
   self.append_transcript(@doc.ToDoc::to_doc(item))
+}
+
+///|
+/// Replace the permanent transcript with `items` and redraw the terminal from
+/// semantic state. This is used when an application switches conversations
+/// without restarting the UI.
+pub async fn Ui::replace_transcript(
+  self : Self,
+  items : Array[TranscriptItem],
+) -> Unit {
+  self.commands.wait(() => {
+    let docs : Array[@doc.Doc] = []
+    for item in items {
+      docs.push(@doc.ToDoc::to_doc(item))
+    }
+    self.transcript = docs
+    guard self.viewport is Some(viewport) else {
+      abort("replace transcript without an entered UI")
+    }
+    viewport.refresh_size(self.tty)
+    viewport.replay_scrollback(
+      self.tty,
+      scrollback=self.transcript_rows(cols=viewport.cols()),
+      surface=self.composer_surface(cols=viewport.cols(), rows=viewport.rows()),
+    )
+  })
 }
 
 ///|

--- a/tui/ui.mbt
+++ b/tui/ui.mbt
@@ -7,7 +7,13 @@ struct Ui {
   mut viewport : @viewport.Viewport?
   composer : @composer.Model
   history : @history.History
-  transcript : Array[@doc.Doc]
+  completion : CompletionState
+  // Items backing the open argument picker, set by the command handler via
+  // `open_picker`. The argument-completion menu draws from this rather than from
+  // static spec data, so a command (e.g. /resume) supplies fresh candidates each
+  // time its picker opens. `None` when no picker is open.
+  mut picker : PickerSource?
+  mut transcript : Array[@doc.Doc]
   mut activity : @doc.Text?
   mut queued_inputs : Array[Input]
   mut status : @doc.Text
@@ -28,6 +34,8 @@ fn Ui::new(tty : @tty.Tty, config : Config) -> Ui {
     viewport: None,
     composer,
     history: @history.History::new(),
+    completion: CompletionState::new(),
+    picker: None,
     transcript: [],
     activity: None,
     queued_inputs: [],

--- a/tui/ui_wbtest.mbt
+++ b/tui/ui_wbtest.mbt
@@ -7,3 +7,452 @@ test "submitted input marks prompt and shell command" {
   assert_true(submitted_input("pwd ", shell.mode()) == Command("pwd"))
   assert_true(submitted_input("", shell.mode()) == Command(""))
 }
+
+///|
+test "completion menu only opens for single-line slash input contexts" {
+  let slash = @composer.Model::new("")
+  slash.insert_user_text("/mo")
+  guard completion_menu_for_composer(model_command_specs(), slash)
+    is Some(command_menu) else {
+    fail("expected command completion menu")
+  }
+  assert_eq(command_menu.key, "command:mo")
+  assert_eq(command_menu.items.length(), 1)
+  assert_eq(command_menu.items[0].label(), "/model")
+  assert_true(command_menu.action is SlashCommandName)
+
+  let plain = @composer.Model::new("")
+  plain.insert_user_text("co")
+  assert_true(
+    completion_menu_for_composer(model_command_specs(), plain) is None,
+  )
+
+  // Past the command name, an argument menu exists only while a picker is open.
+  let spaced = @composer.Model::new("")
+  spaced.insert_user_text("/model deepseek-v4-f")
+  assert_true(
+    completion_menu_for_composer(model_command_specs(), spaced) is None,
+  )
+  guard completion_menu_for_composer(
+      model_command_specs(),
+      spaced,
+      picker=model_picker(),
+    )
+    is Some(argument_menu) else {
+    fail("expected model argument completion menu")
+  }
+  assert_eq(argument_menu.key, "argument:model:deepseek-v4-f")
+  assert_eq(argument_menu.items.length(), 1)
+  assert_eq(argument_menu.items[0].insert_text(), "deepseek-v4-flash")
+  guard argument_menu.action is SlashCommandArgument(name=command_name) else {
+    fail("expected model argument completion action")
+  }
+  assert_eq(command_name, "model")
+
+  let multiline = @composer.Model::new("")
+  multiline.insert_user_text("/model\n")
+  assert_true(
+    completion_menu_for_composer(
+      model_command_specs(),
+      multiline,
+      picker=model_picker(),
+    )
+    is None,
+  )
+}
+
+///|
+fn model_command_specs() -> Array[@slash.SlashCommandSpec] {
+  [@slash.SlashCommandSpec::new(name="model", description="show or change")]
+}
+
+///|
+fn resume_command_specs() -> Array[@slash.SlashCommandSpec] {
+  [@slash.SlashCommandSpec::new(name="resume", description="resume a session")]
+}
+
+///|
+/// A handler-opened picker for /model, standing in for the items a command
+/// handler supplies at open time (now the only source of argument candidates).
+fn model_picker() -> PickerSource {
+  {
+    command: "model",
+    items: [
+      @completion.CompletionItem::new(label="deepseek-v4-flash"),
+      @completion.CompletionItem::new(label="deepseek-v4-pro"),
+    ],
+  }
+}
+
+///|
+fn composer_with(text : String) -> @composer.Model {
+  let composer = @composer.Model::new("")
+  composer.insert_user_text(text)
+  composer
+}
+
+///|
+test "enter dispatches the accepted command name with no arguments" {
+  // Typing `/model` (exact) or `/mod` (partial) and pressing Enter dispatches
+  // `model` with empty args; the handler decides to open a picker. The
+  // completion layer no longer drafts anything itself.
+  for typed in ["/model", "/mod"] {
+    guard ui_enter_decision(
+        model_command_specs(),
+        composer_with(typed),
+        CompletionState::new(),
+        menu_visible=true,
+      )
+      is RunSlashCommand(name~, arguments~) else {
+      fail("expected \{typed} to dispatch the model command")
+    }
+    assert_eq(name, "model")
+    assert_eq(arguments, "")
+  }
+}
+
+///|
+test "enter accepts the highlighted argument from an open picker" {
+  guard ui_enter_decision(
+      model_command_specs(),
+      composer_with("/model deepseek-v4-f"),
+      CompletionState::new(),
+      menu_visible=true,
+      picker=model_picker(),
+    )
+    is RunSlashCommand(name~, arguments~) else {
+    fail("expected the highlighted model completion to run")
+  }
+  assert_eq(name, "model")
+  assert_eq(arguments, "deepseek-v4-flash")
+}
+
+///|
+test "enter sanitizes a picked argument before dispatching it" {
+  // A picker item can carry untrusted text — a `/resume` id is an unvalidated
+  // session directory name. Pressing Enter on it must apply the same one-line,
+  // control-stripping sanitization Tab does, so a crafted id with a newline or
+  // escape cannot be stored in history and later recalled as multiline/control
+  // text.
+  let picker : PickerSource = {
+    command: "resume",
+    items: [@completion.CompletionItem::new(label="bad\nid\u{1b}[0m")],
+  }
+  guard ui_enter_decision(
+      resume_command_specs(),
+      composer_with("/resume "),
+      CompletionState::new(),
+      menu_visible=true,
+      picker~,
+    )
+    is RunSlashCommand(name~, arguments~) else {
+    fail("expected the highlighted session id to run")
+  }
+  assert_eq(name, "resume")
+  assert_false(arguments.contains("\n"))
+  assert_false(arguments.contains("\u{1b}"))
+}
+
+///|
+test "enter runs a free-form argument with no completion match" {
+  // `/resume <id>` must dispatch even when the id is absent from the static
+  // completion list, so the explicit-resume handler still sees the id.
+  guard ui_enter_decision(
+      resume_command_specs(),
+      composer_with("/resume unknown-session"),
+      CompletionState::new(),
+      menu_visible=true,
+    )
+    is RunSlashCommand(name~, arguments~) else {
+    fail("expected /resume to run with the typed id")
+  }
+  assert_eq(name, "resume")
+  assert_eq(arguments, "unknown-session")
+}
+
+///|
+test "accepted slash completion is recorded so recall re-runs it" {
+  // Accepting `deepseek-v4-pro` from `/model deepseek` dispatches the pro model,
+  // so history must store the canonical command — not the typed prefix, which
+  // would re-select the first match (flash) on recall.
+  let recorded = slash_command_text(name="model", arguments="deepseek-v4-pro")
+  assert_eq(recorded, "/model deepseek-v4-pro")
+  assert_eq(slash_command_text(name="model", arguments=""), "/model")
+  guard ui_enter_decision(
+      model_command_specs(),
+      composer_with(recorded),
+      CompletionState::new(),
+      menu_visible=true,
+      picker=model_picker(),
+    )
+    is RunSlashCommand(name~, arguments~) else {
+    fail("expected the recalled command to run")
+  }
+  assert_eq(name, "model")
+  assert_eq(arguments, "deepseek-v4-pro")
+  // Recalling the typed prefix instead would re-select the first match (flash).
+  guard ui_enter_decision(
+      model_command_specs(),
+      composer_with("/model deepseek"),
+      CompletionState::new(),
+      menu_visible=true,
+      picker=model_picker(),
+    )
+    is RunSlashCommand(arguments=first_match, ..) else {
+    fail("expected the prefix to run the first match")
+  }
+  assert_eq(first_match, "deepseek-v4-flash")
+}
+
+///|
+test "enter ignores the completion menu when it cannot be rendered" {
+  // On a terminal too short to draw the menu (menu_visible=false), keys must not
+  // be captured by an invisible picker: `/model ` runs as typed rather than
+  // silently accepting the first model.
+  guard ui_enter_decision(
+      model_command_specs(),
+      composer_with("/model "),
+      CompletionState::new(),
+      menu_visible=false,
+      picker=model_picker(),
+    )
+    is RunSlashCommand(name~, arguments~) else {
+    fail("expected /model to dispatch when the menu is hidden")
+  }
+  assert_eq(name, "model")
+  assert_eq(arguments, "")
+  // Visible, the same input would accept the highlighted model instead.
+  guard ui_enter_decision(
+      model_command_specs(),
+      composer_with("/model "),
+      CompletionState::new(),
+      menu_visible=true,
+      picker=model_picker(),
+    )
+    is RunSlashCommand(arguments=picked, ..) else {
+    fail("expected the visible picker to accept a model")
+  }
+  assert_eq(picked, "deepseek-v4-flash")
+}
+
+///|
+test "a malformed slash entry is not submitted as a prompt" {
+  let specs = model_command_specs()
+  // Menu dismissed (Esc): a lone `/` or `/ ` parses to no command, but must not
+  // be submitted — that would leak the raw slash text into the agent.
+  let dismissed = CompletionState::new()
+  dismissed.dismissed = true
+  for typed in ["/", "/ "] {
+    assert_true(
+      ui_enter_decision(
+        specs,
+        composer_with(typed),
+        dismissed,
+        menu_visible=true,
+      )
+      is NoCompletionMatch,
+    )
+  }
+  // Same protection when the terminal is too short to draw the menu.
+  assert_true(
+    ui_enter_decision(
+      specs,
+      composer_with("/"),
+      CompletionState::new(),
+      menu_visible=false,
+    )
+    is NoCompletionMatch,
+  )
+  // Ordinary (non-slash) input is still submitted normally.
+  assert_true(
+    ui_enter_decision(
+      specs,
+      composer_with("hello"),
+      dismissed,
+      menu_visible=true,
+    )
+    is SubmitInput,
+  )
+}
+
+///|
+test "enter submits ordinary input outside a slash context" {
+  assert_true(
+    ui_enter_decision(
+      model_command_specs(),
+      composer_with("hello world"),
+      CompletionState::new(),
+      menu_visible=true,
+    )
+    is SubmitInput,
+  )
+}
+
+///|
+test "tab completes a command name and a picker argument" {
+  // `/mod` completes to the highlighted command name.
+  guard completion_menu_for_composer(
+      model_command_specs(),
+      composer_with("/mod"),
+    )
+    is Some(name_menu) else {
+    fail("expected command menu")
+  }
+  assert_true(completion_acceptance_text(name_menu, 0) is Some("/model"))
+
+  // A bare `/` completes to the first command, never queuing the slash.
+  guard completion_menu_for_composer(model_command_specs(), composer_with("/"))
+    is Some(all_menu) else {
+    fail("expected command menu for bare slash")
+  }
+  assert_true(completion_acceptance_text(all_menu, 0) is Some("/model"))
+
+  // With a picker open, Tab completes the highlighted argument.
+  guard completion_menu_for_composer(
+      model_command_specs(),
+      composer_with("/model deepseek-v4-p"),
+      picker=model_picker(),
+    )
+    is Some(arg_menu) else {
+    fail("expected argument menu")
+  }
+  assert_true(
+    completion_acceptance_text(arg_menu, 0) is Some("/model deepseek-v4-pro"),
+  )
+
+  // An unknown command has no item to accept.
+  guard completion_menu_for_composer(
+      model_command_specs(),
+      composer_with("/nope"),
+    )
+    is Some(empty_menu) else {
+    fail("expected an (empty) command menu")
+  }
+  assert_true(completion_acceptance_text(empty_menu, 0) is None)
+}
+
+///|
+test "accepting a completion sanitizes untrusted item text" {
+  // A /resume id is a session directory name taken verbatim; a crafted one with
+  // a newline or ESC must not reach the composer as multiline text or terminal
+  // control bytes (composer.replace bypasses input sanitization).
+  let menu : CompletionMenu = {
+    key: "argument:resume:",
+    items: [
+      @completion.CompletionItem::new(
+        label="evil",
+        insert_text="ev\nil\u{1b}[2J",
+      ),
+    ],
+    action: SlashCommandArgument(name="resume"),
+  }
+  guard completion_acceptance_text(menu, 0) is Some(text) else {
+    fail("expected acceptance text")
+  }
+  assert_false(text.contains("\n"))
+  assert_false(text.contains("\u{1b}"))
+  // A clean id passes through unchanged (sanitization is a no-op for safe text).
+  let clean : CompletionMenu = {
+    key: "argument:resume:",
+    items: [@completion.CompletionItem::new(label="session-1")],
+    action: SlashCommandArgument(name="resume"),
+  }
+  assert_true(completion_acceptance_text(clean, 0) is Some("/resume session-1"))
+}
+
+///|
+test "a slash-command line is never queued as a prompt" {
+  let specs = model_command_specs()
+  // Both a partial command and a lone `/` are slash entries (not queued).
+  assert_true(composer_is_slash_entry(specs, composer_with("/mod")))
+  assert_true(composer_is_slash_entry(specs, composer_with("/")))
+  // Ordinary text is not.
+  assert_false(composer_is_slash_entry(specs, composer_with("hello")))
+  // Multi-line input is never a slash entry.
+  assert_false(composer_is_slash_entry(specs, composer_with("/model\nx")))
+  // With the feature disabled, a slash line is ordinary input (queueable).
+  let no_commands : @slash.SlashCommands = []
+  assert_false(composer_is_slash_entry(no_commands, composer_with("/path")))
+}
+
+///|
+test "slash command invocation parses any single-line slash entry" {
+  let specs = model_command_specs()
+  let with_args = @composer.Model::new("")
+  with_args.insert_user_text("/model deepseek-v4-flash")
+  guard slash_command_invocation_for_composer(specs, with_args)
+    is Some(invocation) else {
+    fail("expected model slash invocation")
+  }
+  assert_eq(invocation.name(), "model")
+  assert_eq(invocation.arguments(), "deepseek-v4-flash")
+
+  let trailing_space = @composer.Model::new("")
+  trailing_space.insert_user_text("/model   ")
+  guard slash_command_invocation_for_composer(specs, trailing_space)
+    is Some(invocation) else {
+    fail("expected model slash invocation")
+  }
+  assert_eq(invocation.arguments(), "")
+
+  // Unknown commands still parse — dispatch is independent of registration.
+  let unknown = @composer.Model::new("")
+  unknown.insert_user_text("/unknown focus")
+  guard slash_command_invocation_for_composer(specs, unknown)
+    is Some(unknown_inv) else {
+    fail("expected unknown command to parse syntactically")
+  }
+  assert_eq(unknown_inv.name(), "unknown")
+  assert_eq(unknown_inv.arguments(), "focus")
+
+  // With no commands configured the feature is off: a slash line is not an
+  // invocation, so it stays ordinary input.
+  let no_commands : @slash.SlashCommands = []
+  let disabled = @composer.Model::new("")
+  disabled.insert_user_text("/path/to/file")
+  assert_true(
+    slash_command_invocation_for_composer(no_commands, disabled) is None,
+  )
+}
+
+///|
+test "enter submits slash-prefixed input when no commands are configured" {
+  let no_commands : @slash.SlashCommands = []
+  assert_true(
+    ui_enter_decision(
+      no_commands,
+      composer_with("/path"),
+      CompletionState::new(),
+      menu_visible=true,
+    )
+    is SubmitInput,
+  )
+}
+
+///|
+test "enter dispatches unknown slash commands to the handler" {
+  // An unknown command must reach the handler (which reports the error) rather
+  // than being sent to the agent as a prompt or swallowed as a notice.
+  guard ui_enter_decision(
+      model_command_specs(),
+      composer_with("/doesnotexist test"),
+      CompletionState::new(),
+      menu_visible=true,
+    )
+    is RunSlashCommand(name~, arguments~) else {
+    fail("expected unknown command with arguments to dispatch")
+  }
+  assert_eq(name, "doesnotexist")
+  assert_eq(arguments, "test")
+  guard ui_enter_decision(
+      model_command_specs(),
+      composer_with("/doesnotexist"),
+      CompletionState::new(),
+      menu_visible=true,
+    )
+    is RunSlashCommand(name=bare_name, arguments=bare_args) else {
+    fail("expected bare unknown command to dispatch")
+  }
+  assert_eq(bare_name, "doesnotexist")
+  assert_eq(bare_args, "")
+}


### PR DESCRIPTION
Backup of the full TUI slash-command implementation **before** stripping it down to only \`/exit\` and \`/compact\`.

Preserves the handler-driven argument pickers and supporting machinery:
- \`/model\` — picker over the model list, restarts the engine on change.
- \`/resume\` — picker over the live session store (async listing), with explicit-id resume.
- The argument-completion menu, \`Ui::open_picker\`, \`PickerSource\`, and the \`SlashCommandArgument\` completion path.
- Picker-argument sanitization on Tab and Enter.

This branch is the reference point for the picker work; the slimmed-down version continues on \`haoxiang/tui-slash-commands\` (#217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)