### PR TITLE
Make edit calls line anchored

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -6,19 +6,10 @@ code changes where overwriting the whole file would be unnecessarily broad.
 ## Design Rationale
 
 `edit` uses exact `old_string` replacement instead of a patch language because
-the host can validate the change with simple, deterministic rules. The default
-single-match requirement prevents ambiguous edits in files that contain repeated
-snippets. `replace_all=true` is explicit so broad changes show up in the tool
-call rather than being an accidental consequence of a loose match. When a
-single-match edit is ambiguous, the error reports the first matching line
-numbers so the caller can add enough surrounding context to make `old_string`
-unique.
-
-Optional `start_line` and `end_line` bounds turn the edit into a bounded exact
-replacement. The match is still by `old_string`, but counting and replacement
-happen only inside the inclusive 1-based line range. This keeps repeated text
-outside the intended area from making a focused edit ambiguous or being changed
-by `replace_all=true`.
+the host can validate the change with simple, deterministic rules. `start_line`
+anchors the edit near the caller's intended location, then the first matching
+`old_string` at or after that line is replaced. Optional `end_line` narrows the
+search when the caller wants a tighter inclusive 1-based line range.
 
 Rejecting empty `old_string` and identical replacements protects against
 no-op or explosive edits. The tool is designed for small surgical changes; if a
@@ -30,30 +21,19 @@ legacy `moon.mod.json`, JSON-style `moon.mod` or `moon.pkg`, or `moon.pkg` with
 
 ## API Style
 
-Use a context-rich exact string that should occur once:
+Use a context-rich exact string near the starting line:
 
 ```json
 {
   "path": "agent/prompt.mbt",
   "old_string": "Use moon check before moon test.",
-  "new_string": "Use moon check before moon test, and inspect failures before editing."
+  "new_string": "Use moon check before moon test, and inspect failures before editing.",
+  "start_line": 42
 }
 ```
 
-Set `replace_all=true` only after deciding every occurrence is intentionally
-part of the same change:
-
-```json
-{
-  "path": "agent/prompt.mbt",
-  "old_string": "moon.mod.json",
-  "new_string": "moon.mod",
-  "replace_all": true
-}
-```
-
-Use a line range when the same text appears elsewhere and the intended edit is
-localized:
+Use `end_line` when the same text appears shortly after the intended location
+and the edit should stay inside a tighter range:
 
 ```json
 {
@@ -72,9 +52,12 @@ localized:
 | `path`        | string  | yes | Filesystem path. Relative paths resolve against the agent process's current working directory. |
 | `old_string`  | string  | yes | Exact text to replace. Empty strings are rejected. |
 | `new_string`  | string  | yes | Replacement text. It must differ from `old_string`. |
-| `replace_all` | boolean | no  | Defaults to `false`. When false, `old_string` must occur exactly once in the selected range. |
-| `start_line`  | integer | no  | 1-based first line of the search/replace range. Defaults to the file start. |
+| `start_line`  | integer | yes | 1-based first line of the search/replace range. The first match at or after this line is replaced. |
 | `end_line`    | integer | no  | 1-based last line of the search/replace range. Defaults to the file end. |
+
+Legacy calls with `replace_all=false` are tolerated, but `replace_all=true` is
+rejected. Use separate line-anchored edit calls when several known locations in
+one file should be fixed.
 
 ## Action
 
@@ -83,14 +66,14 @@ The action is always `Respond(ToolOutput(...))` — the agent loop forwards
 `false` on success and `true` for edit or argument failures. The string body
 has one of these shapes:
 
-- `"ok: replaced <n> occurrence(s) in <path>"` on success.
+- `"ok: replaced <n> occurrence(s) at line <line> in <path>"` on success.
   If the target is `moon.mod`, `moon.pkg`, `.mbt`, or `.mbt.md` inside a
   MoonBit module, the response may append bounded raw compiler feedback from
   module-root `moon check --diagnostic-limit 1`, starting with
   `"moon check:"` after the success line. Failed checks include `exit=<code>`
   or `exit=cancelled`.
 - `"error editing <path>: old_string not found"` — no exact match was found in the selected range.
-- `"error editing <path>: old_string matched <n> times on lines <line>, ...; set replace_all=true to replace all occurrences"` — the edit was ambiguous in the selected range.
+- `"error editing <path>: replace_all=true is no longer supported; use separate line-anchored edit calls for multiple replacements"` — the call requested a global replacement.
 - `"error editing <path>: moon.pkg use // for comment syntax, not #"` or similar
   manifest-guard messages — the replacement would likely break MoonBit package
   discovery.
@@ -110,7 +93,7 @@ test "edit tool advertises the expected schema" {
   assert_true(text.contains("\"path\""))
   assert_true(text.contains("\"old_string\""))
   assert_true(text.contains("\"new_string\""))
-  assert_true(text.contains("\"replace_all\""))
+  assert_false(text.contains("\"replace_all\""))
   assert_true(text.contains("\"start_line\""))
   assert_true(text.contains("\"end_line\""))
   assert_true(text.contains("\"required\""))
@@ -133,6 +116,7 @@ async test "edit tool applies a focused code change through the registry" {
       "path": "\{tmpdir}/openseek-edit-readme-example.mbt",
       "old_string": "  \"hello\"",
       "new_string": "  \"hello, MoonBit\"",
+      "start_line": 2,
     }
 
     let call = @agent_tool.AgentToolCall(
@@ -144,7 +128,10 @@ async test "edit tool applies a focused code change through the registry" {
     )
     let result = @agent_tool.execute_tool_call(call, tools)
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_eq(
+      output.content,
+      "ok: replaced 1 occurrence(s) at line 2 in \{path}",
+    )
     assert_false(output.is_error)
     assert_eq(
       @fs.read_file(path).text(),

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -7,18 +7,16 @@
 ///   non-empty.
 /// - `new_string` (string, required): replacement text. It must differ from
 ///   `old_string`.
-/// - `replace_all` (bool, optional): replace every occurrence. Defaults to
-///   `false`; when false, `old_string` must occur exactly once.
-/// - `start_line` / `end_line` (integer, optional): 1-based inclusive line
-///   bounds. When present, `old_string` is searched and replaced only inside
-///   that range.
+/// - `start_line` (integer, required): 1-based inclusive first line to search.
+/// - `end_line` (integer, optional): 1-based inclusive last line to search.
+/// - `replace_all=true` is rejected. Use separate line-anchored edit calls for
+///   multiple replacements.
 ///
 /// ## Result
-/// - `Respond(ToolOutput("ok: replaced <n> occurrence(s) in <path>"))` on
-///   success.
+/// - `Respond(ToolOutput("ok: replaced <n> occurrence(s) at line <line> in <path>"))`
+///   on success.
 /// - `Respond(ToolOutput("error editing <path>: ...", is_error=true))` for
-///   filesystem failures, empty/no-op edits, missing matches, or ambiguous
-///   matches. Ambiguous-match errors include the first matching line numbers.
+///   filesystem failures, empty/no-op edits, or missing matches.
 /// - `Respond(ToolOutput("error: edit requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition(
@@ -26,18 +24,17 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
-    description="Replace exact text in arguments.path with arguments.new_string. Optional start_line/end_line restrict the search and replacement to a 1-based inclusive line range.",
+    description="Replace the first exact text span at or after arguments.start_line in arguments.path with arguments.new_string. Optional end_line restricts the search to a 1-based inclusive line range. For multiple fixes in one file, use separate edit calls with explicit line anchors.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
         "path": { "type": "string" },
         "old_string": { "type": "string" },
         "new_string": { "type": "string" },
-        "replace_all": { "type": "boolean" },
         "start_line": { "type": "integer" },
         "end_line": { "type": "integer" },
       },
-      "required": ["path", "old_string", "new_string"],
+      "required": ["path", "old_string", "new_string", "start_line"],
     }),
     execute=Async(arguments => execute_with_workspace(workspace_root, arguments)),
   )
@@ -69,6 +66,13 @@ async fn edit_file(
   // Every failure names the file it tried to edit so the viz can show
   // `→ edit · edit <file> 🚩` on the folded call line.
   let fail_brief = "edit \{@agent_tool.brief_basename(path)}"
+  if input.replace_all {
+    return @agent_tool.ToolAction::respond(
+      "error editing \{path}: replace_all=true is no longer supported; use separate line-anchored edit calls for multiple replacements",
+      is_error=true,
+      brief=fail_brief,
+    )
+  }
   if input.old_string == "" {
     return @agent_tool.ToolAction::respond(
       "error editing \{path}: old_string must be non-empty",
@@ -97,34 +101,21 @@ async fn edit_file(
     .split(input.old_string)
     .map(part => part.to_owned())
     .collect()
-  let occurrences = parts.length() - 1
-  if occurrences == 0 {
+  if parts.length() <= 1 {
     return @agent_tool.ToolAction::respond(
       "error editing \{path}: old_string not found\{range_detail(input)}",
       is_error=true,
       brief=fail_brief,
     )
   }
-  if occurrences > 1 && !input.replace_all {
-    return @agent_tool.ToolAction::respond(
-      ambiguous_match_message(
-        path,
-        occurrences,
-        parts,
-        input.old_string,
-        range_detail(input),
-        start_line=region.start_line,
-      ),
-      is_error=true,
-      brief=fail_brief,
-    )
-  }
-  let replacement_count = if input.replace_all { occurrences } else { 1 }
-  let new_body = if input.replace_all {
-    parts.join(input.new_string)
-  } else {
-    region.body.replace(old=input.old_string, new=input.new_string)
-  }
+  let replacement_count = 1
+  let match_start = parts[0].length()
+  let match_end = match_start + input.old_string.length()
+  let match_line = line_number_at_offset(
+    content,
+    region.prefix.length() + match_start,
+  )
+  let new_body = "\{parts[0]}\{input.new_string}\{region.body.unsafe_substring(start=match_end, end=region.body.length())}"
   let new_content = "\{region.prefix}\{new_body}\{region.suffix}"
   match @manifest_error.write_error(path, new_content) {
     Some(message) =>
@@ -137,13 +128,11 @@ async fn edit_file(
   }
   try {
     @fs.write_file(path, new_content, create_mode=CreateOrTruncate)
-    let content = @auto_check.append_summary(
-      path,
-      "ok: replaced \{replacement_count} occurrence(s) in \{path}",
-    )
+    let summary = "ok: replaced \{replacement_count} occurrence(s) at line \{match_line} in \{path}"
+    let content = @auto_check.append_summary(path, summary)
     @agent_tool.ToolAction::respond(
       content,
-      brief="edited \{@agent_tool.brief_basename(path)} (\{replacement_count}×)",
+      brief="edited \{@agent_tool.brief_basename(path)}:\{match_line} (\{replacement_count}×)",
     )
   } catch {
     error if @async.is_being_cancelled() => raise error
@@ -157,56 +146,10 @@ async fn edit_file(
 }
 
 ///|
-fn ambiguous_match_message(
-  path : String,
-  occurrences : Int,
-  parts : Array[String],
-  old_string : String,
-  range_detail : String,
-  start_line~ : Int,
-) -> String {
-  let lines = occurrence_line_labels(parts, old_string, 5, start_line~)
-  let line_detail = if lines.length() == 0 {
-    ""
-  } else if occurrences > lines.length() {
-    " on lines \{lines.join(", ")}, ..."
-  } else {
-    " on lines \{lines.join(", ")}"
-  }
-  "error editing \{path}: old_string matched \{occurrences} times\{line_detail}\{range_detail}; set replace_all=true to replace all occurrences\{replace_all_scope_suffix(range_detail)}"
-}
-
-///|
-fn occurrence_line_labels(
-  parts : Array[String],
-  old_string : String,
-  max : Int,
-  start_line~ : Int,
-) -> Array[String] {
-  let labels : Array[String] = []
-  let mut current_line = start_line
-  let occurrence_count = parts.length() - 1
-  for index in 0..<occurrence_count {
-    current_line = current_line + newline_count(parts[index])
-    if labels.length() < max {
-      labels.push("\{current_line}")
-    }
-    current_line = current_line + newline_count(old_string)
-  }
-  labels
-}
-
-///|
-fn newline_count(text : String) -> Int {
-  text.split("\n").count() - 1
-}
-
-///|
 priv struct EditRegion {
   prefix : String
   body : String
   suffix : String
-  start_line : Int
 }
 
 ///|
@@ -214,10 +157,7 @@ fn select_edit_region(
   content : String,
   input : @decode.EditInput,
 ) -> EditRegion {
-  let start_line = match input.start_line {
-    Some(line) => line
-    None => 1
-  }
+  let start_line = input.start_line
   let start = line_start_offset(content, start_line)
   let end = match input.end_line {
     Some(line) => line_end_offset(content, line)
@@ -231,7 +171,6 @@ fn select_edit_region(
     prefix: content.unsafe_substring(start=0, end=start),
     body: content.unsafe_substring(start~, end~),
     suffix: content.unsafe_substring(start=end, end=content.length()),
-    start_line,
   }
 }
 
@@ -272,20 +211,21 @@ fn line_end_offset(content : String, line : Int) -> Int {
 }
 
 ///|
-fn range_detail(input : @decode.EditInput) -> String {
-  match (input.start_line, input.end_line) {
-    (Some(start), Some(end)) => " in line range \{start}-\{end}"
-    (Some(start), None) => " from line \{start}"
-    (None, Some(end)) => " through line \{end}"
-    (None, None) => ""
+fn line_number_at_offset(content : String, offset : Int) -> Int {
+  let bounded_offset = offset.clamp(min=0, max=content.length())
+  let mut line = 1
+  for cursor = 0; cursor < bounded_offset; cursor = cursor + 1 {
+    if content[cursor] == '\n' {
+      line = line + 1
+    }
   }
+  line
 }
 
 ///|
-fn replace_all_scope_suffix(range_detail : String) -> String {
-  if range_detail == "" {
-    ""
-  } else {
-    " in that range"
+fn range_detail(input : @decode.EditInput) -> String {
+  match input.end_line {
+    Some(end) => " in line range \{input.start_line}-\{end}"
+    None => " from line \{input.start_line}"
   }
 }

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -26,6 +26,7 @@ async test "a failed edit names the file in its brief" {
       "path": "\{dir}/ghost.mbt",
       "old_string": "a",
       "new_string": "b",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
@@ -43,10 +44,16 @@ async test "edit replaces a unique exact match" {
       "path": path,
       "old_string": "beta",
       "new_string": "delta",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_eq(
+      output.content,
+      "ok: replaced 1 occurrence(s) at line 2 in \{path}",
+    )
     assert_false(output.is_error)
+    guard output.brief is Some(brief) else { fail("expected a brief") }
+    assert_eq(brief, "edited unique.txt:2 (1×)")
     assert_eq(@fs.read_file(path).text(), "alpha\ndelta\ngamma\n")
   })
 }
@@ -64,14 +71,17 @@ async test "edit range limits a unique replacement" {
       "end_line": 3,
     })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_eq(
+      output.content,
+      "ok: replaced 1 occurrence(s) at line 3 in \{path}",
+    )
     assert_false(output.is_error)
     assert_eq(@fs.read_file(path).text(), "target\nkeep\nchanged\n")
   })
 }
 
 ///|
-async test "edit range replace_all stays inside range" {
+async test "edit rejects replace_all even with a range" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/range-replace-all.txt"
     @fs.write_file(
@@ -88,11 +98,14 @@ async test "edit range replace_all stays inside range" {
       "end_line": 3,
     })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: replaced 2 occurrence(s) in \{path}")
-    assert_false(output.is_error)
+    assert_eq(
+      output.content,
+      "error editing \{path}: replace_all=true is no longer supported; use separate line-anchored edit calls for multiple replacements",
+    )
+    assert_true(output.is_error)
     assert_eq(
       @fs.read_file(path).text(),
-      "token\ninside value\ninside value\noutside token\n",
+      "token\ninside token\ninside token\noutside token\n",
     )
   })
 }
@@ -106,10 +119,14 @@ async test "edit resolves relative paths under the workspace root" {
       "path": "note.txt",
       "old_string": "before",
       "new_string": "after",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_eq(output.content, "ok: replaced 1 occurrence(s) in \{path}")
+    assert_eq(
+      output.content,
+      "ok: replaced 1 occurrence(s) at line 1 in \{path}",
+    )
     assert_eq(@fs.read_file(path).text(), "after")
   })
 }
@@ -127,6 +144,7 @@ async test "edit preserves surrounding multiline content" {
       "path": path,
       "old_string": "  println(\"old\")",
       "new_string": "  println(\"new\")",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
@@ -171,6 +189,7 @@ async test "edit rejects empty old_string" {
       "path": path,
       "old_string": "",
       "new_string": "replacement",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
@@ -190,6 +209,7 @@ async test "edit rejects identical replacement" {
       "path": path,
       "old_string": "content",
       "new_string": "content",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
@@ -213,6 +233,7 @@ async test "edit rejects invalid moon.pkg comment rewrite" {
       "path": path,
       "old_string": "warnings = \"+unnecessary_annotation\"",
       "new_string": "# comment",
+      "start_line": 1,
     })
     let read_back = @fs.read_file(path).text()
     guard result is Respond(output) else { fail("expected Respond") }
@@ -233,6 +254,7 @@ async test "edit rejects generated mbti files" {
       "path": path,
       "old_string": "old",
       "new_string": "new",
+      "start_line": 1,
     })
     let read_back = @fs.read_file(path).text()
     guard result is Respond(output) else { fail("expected Respond") }
@@ -251,9 +273,13 @@ async test "edit rejects missing match" {
       "path": path,
       "old_string": "beta",
       "new_string": "gamma",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "error editing \{path}: old_string not found")
+    assert_eq(
+      output.content,
+      "error editing \{path}: old_string not found from line 1",
+    )
     assert_true(output.is_error)
   })
 }
@@ -281,9 +307,9 @@ async test "edit reports range for missing match" {
 }
 
 ///|
-async test "edit rejects ambiguous match without replace_all" {
+async test "edit replaces first match from start line" {
   @vfs.with_tmpdir(dir => {
-    let path = "\{dir}/ambiguous.txt"
+    let path = "\{dir}/first-match.txt"
     @fs.write_file(
       path,
       "alpha beta\nmiddle\nbeta",
@@ -293,21 +319,22 @@ async test "edit rejects ambiguous match without replace_all" {
       "path": path,
       "old_string": "beta",
       "new_string": "delta",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
-      "error editing \{path}: old_string matched 2 times on lines 1, 3; set replace_all=true to replace all occurrences",
+      "ok: replaced 1 occurrence(s) at line 1 in \{path}",
     )
-    assert_true(output.is_error)
-    assert_eq(@fs.read_file(path).text(), "alpha beta\nmiddle\nbeta")
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "alpha delta\nmiddle\nbeta")
   })
 }
 
 ///|
-async test "edit reports ambiguous matches inside range" {
+async test "edit replaces first match inside range" {
   @vfs.with_tmpdir(dir => {
-    let path = "\{dir}/range-ambiguous.txt"
+    let path = "\{dir}/range-first-match.txt"
     @fs.write_file(
       path,
       "beta\nbeta\nmiddle\nbeta\nbeta\n",
@@ -323,31 +350,36 @@ async test "edit reports ambiguous matches inside range" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
-      "error editing \{path}: old_string matched 2 times on lines 2, 4 in line range 2-4; set replace_all=true to replace all occurrences in that range",
+      "ok: replaced 1 occurrence(s) at line 2 in \{path}",
     )
-    assert_true(output.is_error)
-    assert_eq(@fs.read_file(path).text(), "beta\nbeta\nmiddle\nbeta\nbeta\n")
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "beta\ndelta\nmiddle\nbeta\nbeta\n")
   })
 }
 
 ///|
-async test "edit reports first ambiguous match lines only" {
+async test "edit replaces first repeated match only" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/many-matches.txt"
     @fs.write_file(path, "x\nx\nx\nx\nx\nx\n", create_mode=CreateOrTruncate)
-    let result = run_edit({ "path": path, "old_string": "x", "new_string": "y" })
+    let result = run_edit({
+      "path": path,
+      "old_string": "x",
+      "new_string": "y",
+      "start_line": 1,
+    })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
-      "error editing \{path}: old_string matched 6 times on lines 1, 2, 3, 4, 5, ...; set replace_all=true to replace all occurrences",
+      "ok: replaced 1 occurrence(s) at line 1 in \{path}",
     )
-    assert_true(output.is_error)
-    assert_eq(@fs.read_file(path).text(), "x\nx\nx\nx\nx\nx\n")
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "y\nx\nx\nx\nx\nx\n")
   })
 }
 
 ///|
-async test "edit replace_all updates every match" {
+async test "edit rejects unbounded replace_all" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/replace-all.txt"
     @fs.write_file(path, "alpha beta beta", create_mode=CreateOrTruncate)
@@ -356,11 +388,15 @@ async test "edit replace_all updates every match" {
       "old_string": "beta",
       "new_string": "delta",
       "replace_all": true,
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(output.content, "ok: replaced 2 occurrence(s) in \{path}")
-    assert_false(output.is_error)
-    assert_eq(@fs.read_file(path).text(), "alpha delta delta")
+    assert_eq(
+      output.content,
+      "error editing \{path}: replace_all=true is no longer supported; use separate line-anchored edit calls for multiple replacements",
+    )
+    assert_true(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "alpha beta beta")
   })
 }
 
@@ -374,6 +410,7 @@ async test "edit rejects non-boolean replace_all" {
       "old_string": "alpha",
       "new_string": "beta",
       "replace_all": "yes",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
@@ -391,6 +428,7 @@ async test "edit surfaces read errors" {
       "path": "\{dir}/does-not-exist.txt",
       "old_string": "x",
       "new_string": "y",
+      "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("error editing"))

--- a/agent_tool/edit/internal/decode/README.mbt.md
+++ b/agent_tool/edit/internal/decode/README.mbt.md
@@ -5,9 +5,10 @@ arguments into the typed `EditInput` record consumed by the `edit` tool.
 
 This package is internal to `agent_tool/edit`. It owns only argument-shape
 decoding: it checks that required fields are present with the expected JSON
-types, supplies the default `replace_all=false`, and raises focused error
-messages for malformed payloads. Filesystem access and edit semantics stay in
-the parent `edit` package.
+types, preserves the legacy `replace_all` flag so the parent tool can return a
+targeted migration error, and raises focused error messages for malformed
+payloads. Filesystem access and edit semantics stay in the parent `edit`
+package.
 
 ## API Shape
 
@@ -23,15 +24,15 @@ the parent `edit` package.
 | `path` | string | yes | Missing or non-string values raise `arguments.path`. |
 | `old_string` | string | yes | Missing or non-string values raise `arguments.old_string`. |
 | `new_string` | string | yes | Missing or non-string values raise `arguments.new_string`. |
-| `replace_all` | boolean | no | Defaults to `false`; non-boolean values raise `arguments.replace_all to be a boolean`. |
-| `start_line` | integer | no | Optional positive 1-based inclusive range start. |
-| `end_line` | integer | no | Optional positive 1-based inclusive range end; if both bounds are present, it must be greater than or equal to `start_line`. |
+| `replace_all` | boolean | no | Legacy field. Defaults to `false`; `true` is rejected by `agent_tool/edit` with guidance to use explicit line-anchored edits. |
+| `start_line` | integer | yes | Required positive 1-based inclusive search start. |
+| `end_line` | integer | no | Optional positive 1-based inclusive range end; when present, it must be greater than or equal to `start_line`. |
 
 Extra fields are ignored. Non-object JSON values raise `object arguments`.
 
-The decoder does not reject empty `old_string`, identical replacements, missing
-files, ambiguous matches, or manifest edits. Those checks require file contents
-or tool policy and are handled by `agent_tool/edit`.
+The decoder does not reject empty `old_string`, identical replacements,
+`replace_all=true`, missing files, missing matches, or manifest edits. Those
+checks require file contents or tool policy and are handled by `agent_tool/edit`.
 
 ## Example
 
@@ -42,12 +43,13 @@ test "decode edit input from tool arguments" {
     "path": "agent_tool/edit/edit.mbt",
     "old_string": "Replace exact text",
     "new_string": "Replace one exact text span",
+    "start_line": 1,
   })
   assert_eq(focused.path, "agent_tool/edit/edit.mbt")
   assert_eq(focused.old_string, "Replace exact text")
   assert_eq(focused.new_string, "Replace one exact text span")
   assert_false(focused.replace_all)
-  assert_true(focused.start_line is None)
+  assert_eq(focused.start_line, 1)
   assert_true(focused.end_line is None)
 
   let broad = @decode.decode({
@@ -59,7 +61,7 @@ test "decode edit input from tool arguments" {
     "end_line": 20,
   })
   assert_true(broad.replace_all)
-  assert_true(broad.start_line is Some(1))
+  assert_eq(broad.start_line, 1)
   assert_true(broad.end_line is Some(20))
 }
 ```

--- a/agent_tool/edit/internal/decode/decode.mbt
+++ b/agent_tool/edit/internal/decode/decode.mbt
@@ -1,14 +1,15 @@
 ///|
 /// Decoded arguments of the `edit` tool: replace `old_string` with
-/// `new_string` in the file at `path` — every occurrence when `replace_all`,
-/// otherwise exactly one. Optional line bounds restrict the search/replace
-/// region to an inclusive 1-based line range.
+/// `new_string` in the file at `path`. `start_line` anchors the search, and
+/// optional `end_line` bounds it to an inclusive 1-based line range. The legacy
+/// `replace_all` flag is still decoded so `agent_tool/edit` can return a
+/// targeted migration error for `replace_all=true`.
 pub struct EditInput {
   path : String
   old_string : String
   new_string : String
   replace_all : Bool
-  start_line : Int?
+  start_line : Int
   end_line : Int?
 } derive(Debug)
 
@@ -16,8 +17,9 @@ pub struct EditInput {
 /// Decode `edit` tool-call arguments.
 ///
 /// `path`, `old_string`, and `new_string` are required strings;
-/// `replace_all` is an optional boolean defaulting to `false`, and
-/// `start_line`/`end_line` are optional positive 1-based inclusive bounds.
+/// `start_line` is a required positive 1-based inclusive search start;
+/// `replace_all` is a legacy optional boolean defaulting to `false`, and
+/// `end_line` is an optional positive 1-based inclusive search end.
 /// Failures name the first offending field (e.g. `arguments.old_string`) so the
 /// error fed back to the model says exactly which argument to fix.
 pub fn decode(arguments : Json) -> EditInput raise {
@@ -33,10 +35,10 @@ fn parse_fields(fields : Map[String, Json]) -> EditInput raise {
   let old_string = required_string(fields, "old_string")
   let new_string = required_string(fields, "new_string")
   let replace_all = optional_bool(fields, "replace_all", false)
-  let start_line = optional_positive_int_option(fields, "start_line")
+  let start_line = required_positive_int(fields, "start_line", "arguments")
   let end_line = optional_positive_int_option(fields, "end_line")
-  match (start_line, end_line) {
-    (Some(start), Some(end)) if end < start =>
+  match end_line {
+    Some(end) if end < start_line =>
       fail(
         "arguments.end_line to be greater than or equal to arguments.start_line",
       )
@@ -85,5 +87,26 @@ fn optional_positive_int_option(
     }
     Some(Null) | None => None
     _ => fail("arguments.\{name} to be an integer")
+  }
+}
+
+///|
+fn required_positive_int(
+  fields : Map[String, Json],
+  name : String,
+  prefix : String,
+) -> Int raise {
+  match fields.get(name) {
+    Some(Number(value, ..)) => {
+      let int_value = value.to_int()
+      if int_value.to_double() != value {
+        fail("\{prefix}.\{name} to be an integer")
+      }
+      if int_value <= 0 {
+        fail("\{prefix}.\{name} to be a positive integer")
+      }
+      int_value
+    }
+    _ => fail("\{prefix}.\{name} to be an integer")
   }
 }

--- a/agent_tool/edit/internal/decode/decode_test.mbt
+++ b/agent_tool/edit/internal/decode/decode_test.mbt
@@ -5,6 +5,7 @@ test "decode valid edit input" {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
+      "start_line": 1,
     }),
     content=(
       #|{
@@ -12,7 +13,7 @@ test "decode valid edit input" {
       #|  old_string: "old",
       #|  new_string: "new",
       #|  replace_all: false,
-      #|  start_line: None,
+      #|  start_line: 1,
       #|  end_line: None,
       #|}
     ),
@@ -27,6 +28,7 @@ test "decode replace_all flag" {
       "old_string": "old",
       "new_string": "new",
       "replace_all": true,
+      "start_line": 1,
     }),
     content=(
       #|{
@@ -34,7 +36,7 @@ test "decode replace_all flag" {
       #|  old_string: "old",
       #|  new_string: "new",
       #|  replace_all: true,
-      #|  start_line: None,
+      #|  start_line: 1,
       #|  end_line: None,
       #|}
     ),
@@ -57,7 +59,7 @@ test "decode line range" {
       #|  old_string: "old",
       #|  new_string: "new",
       #|  replace_all: false,
-      #|  start_line: Some(2),
+      #|  start_line: 2,
       #|  end_line: Some(4),
       #|}
     ),
@@ -72,6 +74,7 @@ test "decode rejects invalid replace_all" {
       "old_string": "old",
       "new_string": "new",
       "replace_all": "yes",
+      "start_line": 1,
     })
   catch {
     error => assert_true("\{error}".contains("arguments.replace_all"))
@@ -102,6 +105,7 @@ test "decode rejects invalid line range" {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
+      "start_line": 1,
       "end_line": "4",
     })
   catch {
@@ -154,6 +158,17 @@ test "decode rejects missing required fields" {
     error => assert_true("\{error}".contains("arguments.new_string"))
   } noraise {
     _ => fail("missing new_string decoded")
+  }
+  try
+    @decode.decode({
+      "path": "file.mbt",
+      "old_string": "old",
+      "new_string": "new",
+    })
+  catch {
+    error => assert_true("\{error}".contains("arguments.start_line"))
+  } noraise {
+    _ => fail("missing start_line decoded")
   }
 }
 

--- a/agent_tool/edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/edit/internal/decode/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub struct EditInput {
   old_string : String
   new_string : String
   replace_all : Bool
-  start_line : Int?
+  start_line : Int
   end_line : Int?
 } derive(@debug.Debug)
 

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -124,6 +124,7 @@ async fn run_edit_case(
     "path": "\{root}/src/note.txt",
     "old_string": "beta\n",
     "new_string": "delta\n",
+    "start_line": 2,
   })
   let mut reason = expect_respond(
     action,


### PR DESCRIPTION
## Summary

- Require `start_line` for `edit` calls and keep `end_line` optional.
- Restrict matching to the selected line window and replace only the first matching occurrence.
- Report the actual matched line in successful edit output and folded brief, e.g. `ok: replaced 1 occurrence(s) at line 42 in <path>`.
- Reject `replace_all=true` so broad multi-replacement edits do not go through the single-edit tool.
- Update edit/decode docs, tests, generated interface, and the tool harness fixture.

## Validation

- `moon fmt`
- `moon info`
- `moon check --deny-warn`
- `moon test agent_tool/edit --target native --no-render` (23/23; generated test-driver missing-doc warnings printed, exit 0)
- `moon test agent_tool/edit eval/tool_harness --target native --no-render` (26/26; generated test-driver missing-doc warnings printed, exit 0)
- `git diff --check`

## TOML parser e2e smoke

Ran the existing prompt-task TOML parser CLI eval once on `origin/main` and once on this branch with the same model/settings before the matched-line-output follow-up:

- model: `deepseek-v4-flash`
- runs/concurrency: `1/1`
- max steps: `160`
- task: `eval/prompt_tasks/toml_parser_cli.md`

Results:

- `origin/main` (`b0d1f53`): `0/1` terminal successes. The generated project passed all validation probes (`moon check`, `moon test`, file probe, stdin probe, duplicate probe), but the agent exhausted max steps before final response.
- this branch: `1/1` success. The generated project passed all validation probes and the agent finished normally.

The candidate run exercised the new edit API with `start_line`, so this did not show an edit-tool regression. This is a smoke test, not a statistically strong model benchmark.