### PR TITLE
Block shell source writes from agent shell

### DIFF
--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -10,8 +10,8 @@ const MoonCheckCommand : String = "moon check --diagnostic-limit 1"
 ///|
 /// Append bounded raw `moon check` feedback after successful writes to MoonBit
 /// source or manifest files. The check runs from the containing MoonBit module
-/// root. Non-MoonBit paths and paths outside a MoonBit module are returned
-/// unchanged.
+/// or workspace root. Non-MoonBit paths and paths outside a MoonBit project are
+/// returned unchanged.
 pub async fn append_summary(path : String, content : String) -> String {
   let summary = auto_check_summary(path) catch {
     error if @async.is_being_cancelled() => raise error
@@ -50,7 +50,7 @@ async fn moon_check_cwd(path : String) -> String? {
   if !is_relevant_moonbit_path(path) {
     return None
   }
-  nearest_moon_module_dir(containing_dir(path))
+  nearest_moon_project_dir(containing_dir(path))
 }
 
 ///|
@@ -92,6 +92,8 @@ fn is_relevant_moonbit_path(path : String) -> Bool {
   path.has_suffix("/moon.mod") ||
   path == "moon.pkg" ||
   path.has_suffix("/moon.pkg") ||
+  path == "moon.work" ||
+  path.has_suffix("/moon.work") ||
   is_moonbit_source_path(path)
 }
 
@@ -112,9 +114,10 @@ fn containing_dir(path : String) -> String {
 }
 
 ///|
-async fn nearest_moon_module_dir(start : String) -> String? {
+async fn nearest_moon_project_dir(start : String) -> String? {
   for dir = start {
-    if @fs.exists(join_path(dir, "moon.mod")) {
+    if @fs.exists(join_path(dir, "moon.mod")) ||
+      @fs.exists(join_path(dir, "moon.work")) {
       return Some(dir)
     }
     match parent_dir(dir) {
@@ -169,6 +172,7 @@ fn join_path(dir : String, base : String) -> String {
 test "relevant path detection covers MoonBit source and manifests" {
   assert_true(is_relevant_moonbit_path("moon.mod"))
   assert_true(is_relevant_moonbit_path("lib/moon.pkg"))
+  assert_true(is_relevant_moonbit_path("moon.work"))
   assert_true(is_relevant_moonbit_path("lib/parser.mbt"))
   assert_true(is_relevant_moonbit_path("lib/README.mbt.md"))
   assert_false(is_relevant_moonbit_path("lib/parser.mbti"))

--- a/agent_tool/internal/auto_check/auto_check_test.mbt
+++ b/agent_tool/internal/auto_check/auto_check_test.mbt
@@ -145,6 +145,17 @@ async test "append_summary preserves module dependency graph failure text" {
 }
 
 ///|
+async test "append_summary checks from moon.work workspace root" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-workspace-", dir => {
+    let path = "\{dir}/moon.work"
+    @fs.write_file(path, "members = [\"pkg\"\n", create_mode=CreateOrTruncate)
+    let result = @auto_check.append_summary(path, "ok: wrote workspace")
+    assert_true(result.has_prefix("ok: wrote workspace\nmoon check:\nexit=255"))
+    assert_true(result.contains("failed to parse workspace file"))
+  })
+}
+
+///|
 async test "append_summary surfaces failed pre-build despite zero diagnostics" {
   @vfs.with_tmpdir(prefix="openseek-auto-check-prebuild-", dir => {
     @fs.write_file(

--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -45,8 +45,8 @@ Prefer dedicated tools when they encode useful policy. Run Moon commands such as
 CLI probes.
 
 After a successful mutating Moon command, `shell` appends bounded
-`moon check --diagnostic-limit 1` feedback from the nearest MoonBit module root,
-respecting `moon -C <dir>` and explicit cwd changes such as
+`moon check --diagnostic-limit 1` feedback from the nearest MoonBit module or
+workspace root, respecting `moon -C <dir>` and explicit cwd changes such as
 `cd ./dir && moon ...`. Bare relative `cd dir` is skipped because `CDPATH` can
 change which directory the shell enters. This covers commands such as
 `moon add`, `moon remove`, `moon update`, `moon fmt`, `moon info`,
@@ -55,6 +55,39 @@ such as dry-run commands and `moon fmt --check` are left alone, as are Moon
 invocations with per-command environment overrides such as `FOO=bar moon` or
 `env FOO=bar moon`. Follow-up checks are skipped when `timeout_ms` is set and
 share the remaining `max_output_chars` budget.
+
+When `/usr/bin/sandbox-exec` is available, agent shell commands run with
+MoonBit source files and manifests read-only by default. The profile blocks
+shell writes to `.mbt`, `.mbt.md`, `.mbti`, `moon.mod`, `moon.pkg`, `moon.work`,
+and the legacy JSON manifest names under the workspace root, while still
+allowing Moon-managed build/cache paths such as `_build` and `.mooncakes`. The
+profile is cached per normalized workspace root so ordinary read-only shell use
+does not rescan the repository every time. `sandbox-exec` is treated as usable
+only after a probe proves that a deny rule is actually enforced. If a command
+hits that sandbox, the tool keeps the original command output and adds guidance
+to retry compiler-feedback or mechanical code fixes with line-anchored `edit`,
+not shell-generated rewrites routed through another tool.
+
+Direct output redirects to protected source paths are blocked before the command
+runs. This catches masked forms such as `cmd 2>/dev/null > main.mbt || true`
+where the shell would otherwise hide the sandbox denial from the tool output.
+Direct `mv`/`rm` source-tree operations and obvious source-writing script
+snippets are also blocked before execution, including scripts that create
+MoonBit source under `_build` and then rename it into a package directory.
+Source-mutating Git operations such as `git checkout -- .`, `git restore`,
+`git reset --hard`, non-dry-run `git clean`, and non-checking `git apply` are
+blocked for the same reason.
+Too-complex command strings with in-place `sed` edits are rejected even when the
+source paths are indirect, as in `while read f; do sed -i ... "$f"; done`.
+Too-complex commands with visible MoonBit source creation or tree transfer
+markers are also rejected before execution.
+
+Narrowly recognized Moon commands that are expected to write source or package
+metadata run outside the source-write sandbox: `moon fmt`, `moon info`,
+`moon add`, `moon remove`, `moon update`, `moon test --update`, and
+`moon ide rename ... --apply`. Compounds are conservative; `moon fmt &&
+moon check` is trusted, while a broad script or source rewrite through shell is
+not.
 
 ## Arguments
 
@@ -79,7 +112,7 @@ these shapes:
 
 - `"<stdout/stderr merged>\n<system>exit=<code></system>"` — normal completion.
 - For successful mutating `moon` commands, the output may be followed by a
-  `moon check:` section with bounded compiler diagnostics (after the footer).
+  `moon check:` section with bounded compiler diagnostics before the footer.
 - `"<output-prefix>\n<system>exit=<code-or-cancelled> truncated=true output_limit_reached=true shown_chars=<n> max_output_chars=<n></system>"` —
   output exceeded `max_output_chars` while the process pipe was being read. The
   command is cancelled if it has not already exited; no full output length is

--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -9,7 +9,7 @@ shell:
 - the bare tool name `moon_cmd`, typed as a shell command — it is not an
   executable and should be the real `moon ...` subcommand run through shell;
 - `sed -i` (in-place file editing) — it silently misapplies edits often enough
-  to be untrustworthy, so the agent is sent to the `edit`/`write` tools.
+  to be untrustworthy, so the agent is sent to line-anchored `edit`.
 
 Everything else, including `moon check` and read-only `sed` (`sed -n '1,5p'`,
 `... | sed s/a/b/`), runs normally.
@@ -28,7 +28,7 @@ The current policy blocks:
 | Command shape | Reason |
 | --- | --- |
 | `moon_cmd ...` | `moon_cmd` is a tool name, not an executable shell command; run `moon ...` directly. |
-| `sed -i ...` (incl. `--in-place`, `-i.bak`, `-Ei`) | In-place file editing is unreliable; use the `edit` tool to change contents or `write` to replace a file. |
+| `sed -i ...` (incl. `--in-place`, `-i.bak`, `-Ei`) | In-place file editing is unreliable; use line-anchored `edit` calls for source changes. |
 
 The policy allows:
 
@@ -65,21 +65,27 @@ sed guard is intentionally limited to commands the parser can analyze, because a
 rough text scan of an unparseable command produces false positives — a quoted
 `|sed -i` inside `grep 'a|sed -i' *.x`, or a here-document body that writes
 `sed -i` to a script — and a false block is worse than missing a globbed edit.
+The outer `shell` tool still stops TooComplex in-place `sed` commands before
+execution, including shell loops where source paths are read indirectly from a
+file. Other source-specific TooComplex shapes may also be stopped before
+execution or at runtime with the source-write sandbox.
 
-Known gaps that are therefore *allowed* to run (false negatives, by design):
+Known parser-policy gaps that are therefore *allowed* past this package (false
+negatives, by design):
 
-- any `sed -i` whose command parses as `TooComplex` — i.e. with an unquoted glob
-  (`sed -i 's/a/b/' *.mbt`), command/process substitution (`$(...)`), or a
-  here-document;
+- any `sed -i` whose command parses as `TooComplex` and is not in a recognizable
+  command position, such as after `do`, `then`, `if`, `-exec`, or `-execdir`;
 - `sed` that is not a command's leading word — `find ... -exec sed -i`,
   `xargs sed -i`;
-- `sed -i` behind an `env` option the parser does not unwrap, e.g.
-  `env -u FOO sed -i ...` (`command_name()` stays `env`).
+- `sed -i` behind an `env` option that changes command interpretation or cwd,
+  e.g. `env -S 'sed -i ...'` or `env -C pkg sed -i ...`
+  (`command_name()` stays `env`).
 
-The clean way to recover the common globbed case is to teach the lexer to treat
-an unquoted glob as an opaque word, so the command stays `Simple` and the precise
-path handles it; that shared-parser change (which also helps the `moon_cmd`
-policy and the `env`-option gap) is left for a separate PR.
+The outer `shell` tool recovers the common globbed, `find -exec`, and shell-loop
+cases with a conservative text fallback. A cleaner lower-level recovery would be
+to teach the lexer to treat an unquoted glob as an opaque word, so the command
+stays `Simple` and this parser-policy package can own the precise path; that
+shared-parser change is left for a separate PR.
 
 ## Examples
 

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -6,7 +6,7 @@
 /// only redirection left is the tool name `moon_cmd` typed as a shell command,
 /// which is pointed back at running `moon ...` directly. `sed -i` (in-place file
 /// editing) is also blocked: it silently misapplies edits often enough to be
-/// untrustworthy, so the model is sent to the `edit`/`write` tools instead. The
+/// untrustworthy, so the model is sent to targeted edit tools instead. The
 /// error wording tells the model what to do, because the model is the caller who
 /// reads it.
 pub fn moonbit_command_policy_error(cmd : String) -> String? {
@@ -53,7 +53,7 @@ fn moon_cmd_error_message() -> String {
 
 ///|
 fn sed_in_place_error_message() -> String {
-  "error: `sed -i` edits files in place and is unreliable for code changes; use the `edit` tool to modify file contents, or `write` to replace a whole file"
+  "error: `sed -i` edits files in place and is unreliable for code changes; use line-anchored `edit` calls for source changes"
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -83,7 +83,8 @@ test "command policy redirects sed in-place editing to the edit tool" {
       "sed -i 's/a/b/' file.mbt", "sed -i.bak 's/a/b/' file.mbt", "sed -i '' 's/a/b/' file.mbt",
       "sed --in-place 's/a/b/' f", "sed --in-place=.bak 's/a/b/' f", "sed -Ei 's/a/b/' f",
       "sed -ni 's/a/b/' f", "command sed -i 's/a/b/' f", "env FOO=bar sed -i 's/a/b/' f",
-      "cat f | sed -i 's/a/b/' f", "cd src && sed -i 's/a/b/' f", "'sed' -i 's/a/b/' f",
+      "env -u FOO sed -i 's/a/b/' f", "env --unset FOO sed -i 's/a/b/' f", "cat f | sed -i 's/a/b/' f",
+      "cd src && sed -i 's/a/b/' f", "'sed' -i 's/a/b/' f",
       // Path-qualified sed (Simple parse) is matched by basename.
        "/usr/bin/sed -i 's/a/b/' file.mbt", "./sed -i 's/a/b/' f",
     ] {
@@ -91,6 +92,8 @@ test "command policy redirects sed in-place editing to the edit tool" {
       fail("expected sed -i to be redirected for \{cmd}")
     }
     assert_true(message.contains("sed -i") && message.contains("edit"))
+    assert_true(message.contains("line-anchored"))
+    assert_false(message.contains("`write`"))
   }
 }
 

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -173,6 +173,9 @@ fn lex(command : String) -> LexResult {
             } else if peek_char(chars, index + 1) == Some('>') {
               tokens.push(Op(">>", attached))
               index += 2
+            } else if peek_char(chars, index + 1) == Some('|') {
+              tokens.push(Op(">|", attached))
+              index += 2
             } else {
               tokens.push(Op(">", attached))
               index += 1
@@ -185,6 +188,9 @@ fn lex(command : String) -> LexResult {
               return LexTooComplex("here documents are not supported")
             } else if peek_char(chars, index + 1) == Some('&') {
               tokens.push(Op("<&", attached))
+              index += 2
+            } else if peek_char(chars, index + 1) == Some('>') {
+              tokens.push(Op("<>", attached))
               index += 2
             } else {
               tokens.push(Op("<", attached))

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -177,7 +177,9 @@ fn is_separator(op : String) -> Bool {
 ///|
 fn is_redirect_op(op : String) -> Bool {
   op == ">" ||
+  op == ">|" ||
   op == ">>" ||
+  op == "<>" ||
   op == "<" ||
   op == "&>" ||
   op == "&>>" ||
@@ -187,7 +189,13 @@ fn is_redirect_op(op : String) -> Bool {
 
 ///|
 fn is_fd_redirect_op(op : String) -> Bool {
-  op == ">" || op == ">>" || op == ">&" || op == "<" || op == "<&"
+  op == ">" ||
+  op == ">|" ||
+  op == ">>" ||
+  op == ">&" ||
+  op == "<>" ||
+  op == "<" ||
+  op == "<&"
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/query.mbt
+++ b/agent_tool/shell/internal/shell_parse/query.mbt
@@ -2,8 +2,8 @@
 /// Return the effective command name for this simple command.
 ///
 /// This strips leading environment assignments represented in `env`, and also
-/// recognizes the common `env NAME=value command ...` wrapper. It deliberately
-/// avoids interpreting complex `env` option forms; those remain `env`.
+/// recognizes common `env` wrappers such as `env NAME=value command ...` and
+/// `env -u NAME command ...`. More complex option forms remain `env`.
 pub fn SimpleCommand::command_name(self : SimpleCommand) -> String? {
   match self.command_index() {
     Some(index) if index < self.argv.length() => Some(self.argv[index])
@@ -95,6 +95,15 @@ fn env_wrapped_command_index(argv : Array[String]) -> Int? {
       index += 1
       continue
     }
+    if scanning_options && env_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    if scanning_options &&
+      (env_option_with_attached_value(arg) || env_no_arg_option(arg)) {
+      index += 1
+      continue
+    }
     if scanning_options && arg.has_prefix("-") {
       return Some(0)
     }
@@ -109,5 +118,23 @@ fn env_wrapped_command_index(argv : Array[String]) -> Int? {
     Some(index)
   } else {
     Some(0)
+  }
+}
+
+///|
+fn env_option_consumes_next(arg : String) -> Bool {
+  arg == "-u" || arg == "--unset"
+}
+
+///|
+fn env_option_with_attached_value(arg : String) -> Bool {
+  (arg.has_prefix("-u") && arg != "-u") || arg.has_prefix("--unset=")
+}
+
+///|
+fn env_no_arg_option(arg : String) -> Bool {
+  match arg {
+    "--ignore-environment" | "-0" | "--null" | "--debug" => true
+    _ => false
   }
 }

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -155,14 +155,20 @@ test "preserve spaced numeric arguments before redirects" {
 
 ///|
 test "parse append both and fd duplicate redirects" {
-  guard @shell_parse.parse_for_policy("cmd &>>out <&3") is Simple(commands) else {
-    fail("expected append-both and fd duplicate redirects")
+  guard @shell_parse.parse_for_policy("cmd &>>out <&3 >| forced 4<>rw")
+    is Simple(commands) else {
+    fail("expected append-both, fd duplicate, and read-write redirects")
   }
   assert_eq(commands.length(), 1)
   assert_true(commands[0].argv == ["cmd"])
   assert_true(
     commands[0].redirects ==
-    [{ op: "&>>", target: "out" }, { op: "<&", target: "3" }],
+    [
+      { op: "&>>", target: "out" },
+      { op: "<&", target: "3" },
+      { op: ">|", target: "forced" },
+      { op: "4<>", target: "rw" },
+    ],
   )
 }
 
@@ -224,7 +230,7 @@ test "env options are only recognized before assignments" {
 }
 
 ///|
-test "detect command wrapper but keep complex env options conservative" {
+test "detect command wrapper and keep unknown env options conservative" {
   guard @shell_parse.parse_for_policy("command moon check") is Simple(commands) else {
     fail("expected command wrapper")
   }
@@ -257,9 +263,27 @@ test "detect command wrapper but keep complex env options conservative" {
     is Simple(env_commands) else {
     fail("expected env option wrapper to parse")
   }
-  assert_true(env_commands[0].command_name() == Some("env"))
-  assert_true(env_commands[0].command_index() == Some(0))
-  assert_true(!@shell_parse.contains_command(Simple(env_commands), "moon"))
+  assert_true(env_commands[0].command_name() == Some("moon"))
+  assert_true(env_commands[0].command_index() == Some(3))
+  assert_true(@shell_parse.contains_command(Simple(env_commands), "moon"))
+  guard @shell_parse.parse_for_policy("env -S 'moon check'")
+    is Simple(complex_env_commands) else {
+    fail("expected complex env option wrapper to parse")
+  }
+  assert_true(complex_env_commands[0].command_name() == Some("env"))
+  assert_true(complex_env_commands[0].command_index() == Some(0))
+  assert_true(
+    !@shell_parse.contains_command(Simple(complex_env_commands), "moon"),
+  )
+  guard @shell_parse.parse_for_policy("env -C /tmp moon check")
+    is Simple(env_chdir_commands) else {
+    fail("expected env chdir wrapper to parse")
+  }
+  assert_true(env_chdir_commands[0].command_name() == Some("env"))
+  assert_true(env_chdir_commands[0].command_index() == Some(0))
+  assert_true(
+    !@shell_parse.contains_command(Simple(env_chdir_commands), "moon"),
+  )
 }
 
 ///|

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -17,6 +17,10 @@ import {
   "bobzhang/openseek/testkit/filesystem" @vfs,
 } for "test"
 
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "wbtest"
+
 warnings = "+unnecessary_annotation"
 
 supported_targets = "+native"

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -71,7 +71,7 @@ async fn moon_check_summary_for_cwd(
   cwd : String,
   max_output_chars : Int,
 ) -> String? {
-  let check_cwd = match nearest_moon_module_dir(cwd) {
+  let check_cwd = match nearest_moon_project_dir(cwd) {
     Some(check_cwd) => check_cwd
     None => return None
   }
@@ -437,14 +437,49 @@ fn argv_contains_update_flag(argv : Array[String], start : Int) -> Bool {
 }
 
 ///|
+fn argv_contains_update_flag_before_double_dash(
+  argv : Array[String],
+  start : Int,
+) -> Bool {
+  argv_contains_flag_before_double_dash(argv, start, "--update") ||
+  argv_contains_flag_before_double_dash(argv, start, "-u")
+}
+
+///|
 fn argv_contains_help_flag(argv : Array[String], start : Int) -> Bool {
   argv_contains_flag(argv, start, "--help") ||
   argv_contains_flag(argv, start, "-h")
 }
 
 ///|
+fn argv_contains_help_flag_before_double_dash(
+  argv : Array[String],
+  start : Int,
+) -> Bool {
+  argv_contains_flag_before_double_dash(argv, start, "--help") ||
+  argv_contains_flag_before_double_dash(argv, start, "-h")
+}
+
+///|
 fn argv_contains_flag(argv : Array[String], start : Int, flag : String) -> Bool {
   for index in start..<argv.length() {
+    if argv[index] == flag {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn argv_contains_flag_before_double_dash(
+  argv : Array[String],
+  start : Int,
+  flag : String,
+) -> Bool {
+  for index in start..<argv.length() {
+    if argv[index] == "--" {
+      return false
+    }
     if argv[index] == flag {
       return true
     }
@@ -473,9 +508,10 @@ fn resolve_command_cwd(base : String, target : String) -> String {
 }
 
 ///|
-async fn nearest_moon_module_dir(start : String) -> String? {
+async fn nearest_moon_project_dir(start : String) -> String? {
   for dir = start {
-    if @fs.exists(join_path(dir, "moon.mod")) {
+    if @fs.exists(join_path(dir, "moon.mod")) ||
+      @fs.exists(join_path(dir, "moon.work")) {
       return Some(dir)
     }
     match parent_dir(dir) {

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1,0 +1,6382 @@
+///|
+const SandboxExecPath : String = "/usr/bin/sandbox-exec"
+
+///|
+const SandboxSourceWriteFeedback : String = "shell sandbox: source file writes from shell are blocked. For compiler-feedback or mechanical code fixes, use line-anchored `edit` calls instead of shell-generated rewrites. Do not generate rewritten files in shell and then overwrite source files with another tool; keep `shell` for read-only analysis and validation commands."
+
+///|
+let source_write_profile_cache : Map[String, CachedSourceWriteProfile] = {}
+
+///|
+let sandbox_exec_available_cache : Ref[Bool?] = { val: None }
+
+///|
+priv struct WatchedSourceProfileDir {
+  path : String
+  mtime_s : Int64
+  mtime_ns : Int
+}
+
+///|
+priv struct SourceWriteProfileScan {
+  literal_paths : Array[String]
+  watched_dirs : Array[WatchedSourceProfileDir]
+  cacheable : Bool
+}
+
+///|
+priv struct SourceWriteProfileScanBuilder {
+  literal_paths : Array[String]
+  watched_dirs : Array[WatchedSourceProfileDir]
+  mut cacheable : Bool
+}
+
+///|
+priv struct CachedSourceWriteProfile {
+  profile : String
+  watched_dirs : Array[WatchedSourceProfileDir]
+  denial_subjects : Array[String]
+}
+
+///|
+priv struct SourceWriteProfileData {
+  profile : String
+  denial_subjects : Array[String]
+}
+
+///|
+priv enum SourceWriteMode {
+  SourceReadOnly
+  TrustedSourceWrite
+}
+
+///|
+priv struct AgentShellLaunch {
+  program : String
+  args : Array[String]
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
+}
+
+///|
+priv struct AgentShellOutput {
+  output : ShellOutput
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
+}
+
+///|
+async fn collect_agent_shell_output(
+  workspace_root : String,
+  cmd : String,
+  parsed : @shell_parse.ParseResult,
+  cwd? : String,
+  max_output_chars~ : Int,
+) -> AgentShellOutput {
+  let launch = agent_shell_launch(workspace_root, cmd, parsed, cwd?)
+  let output = collect_process_output(
+    launch.program,
+    launch.args,
+    cwd?,
+    max_output_chars~,
+  )
+  {
+    output,
+    source_write_sandboxed: launch.source_write_sandboxed,
+    sandbox_denial_subjects: launch.sandbox_denial_subjects,
+  }
+}
+
+///|
+async fn agent_shell_launch(
+  workspace_root : String,
+  cmd : String,
+  parsed : @shell_parse.ParseResult,
+  cwd? : String,
+) -> AgentShellLaunch {
+  let real_workspace_root = @fs.realpath(workspace_root)
+  let real_cwd = match cwd {
+    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
+    None => None
+  }
+  let mode = source_write_mode_for_parse(parsed, real_workspace_root, real_cwd)
+  if mode is TrustedSourceWrite || !sandbox_exec_available() {
+    return {
+      program: PlatformShellProgram,
+      args: platform_shell_args(cmd),
+      source_write_sandboxed: false,
+      sandbox_denial_subjects: [],
+    }
+  }
+  let profile_data = source_write_readonly_profile_data(real_workspace_root)
+  let args = ["-p", profile_data.profile, PlatformShellProgram]
+  for arg in platform_shell_args(cmd) {
+    args.push(arg)
+  }
+  {
+    program: SandboxExecPath,
+    args,
+    source_write_sandboxed: true,
+    sandbox_denial_subjects: profile_data.denial_subjects,
+  }
+}
+
+///|
+async fn sandbox_exec_available() -> Bool {
+  match sandbox_exec_available_cache.val {
+    Some(value) => value
+    None => {
+      let value = probe_sandbox_exec_available()
+      sandbox_exec_available_cache.val = Some(value)
+      value
+    }
+  }
+}
+
+///|
+async fn probe_sandbox_exec_available() -> Bool {
+  if !@fs.exists(SandboxExecPath) {
+    return false
+  }
+  let probe_dir = @fs.tmpdir(prefix="openseek-sandbox-probe-") catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  let blocked_path = @path.Path(probe_dir)
+    .join(Path("blocked"))
+    .normalize()
+    .to_string()
+  let probe_profile = sandbox_denial_probe_profile(blocked_path)
+  let args = ["-p", probe_profile, PlatformShellProgram]
+  for arg in platform_shell_args(PlatformNoopCommand) {
+    args.push(arg)
+  }
+  let output = collect_process_output(
+    SandboxExecPath,
+    args,
+    max_output_chars=200,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => {
+      cleanup_sandbox_probe(probe_dir, blocked_path)
+      return false
+    }
+  }
+  if output.exit_code != Some(0) {
+    cleanup_sandbox_probe(probe_dir, blocked_path)
+    return false
+  }
+  let write_args = ["-p", probe_profile, PlatformShellProgram]
+  for arg in platform_shell_args("printf probe > \{shell_quote(blocked_path)}") {
+    write_args.push(arg)
+  }
+  let write_output = collect_process_output(
+    SandboxExecPath,
+    write_args,
+    max_output_chars=400,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => {
+      cleanup_sandbox_probe(probe_dir, blocked_path)
+      return false
+    }
+  }
+  let denied = write_output.exit_code != Some(0) && !@fs.exists(blocked_path)
+  cleanup_sandbox_probe(probe_dir, blocked_path)
+  denied
+}
+
+///|
+#cfg(platform="windows")
+const PlatformNoopCommand : String = "exit 0"
+
+///|
+#cfg(not(platform="windows"))
+const PlatformNoopCommand : String = ":"
+
+///|
+fn sandbox_denial_probe_profile(blocked_path : String) -> String {
+  (
+    $|(version 1)
+    $|(allow default)
+    $|(deny file-write* (literal "\{sbpl_string_escape(blocked_path)}"))
+  )
+}
+
+///|
+fn shell_quote(text : String) -> String {
+  "'\{text.replace_all(old="'", new="'\\''")}'"
+}
+
+///|
+async fn cleanup_sandbox_probe(
+  probe_dir : String,
+  blocked_path : String,
+) -> Unit {
+  ignore(@fs.remove(blocked_path) catch { _ => () })
+  ignore(@fs.rmdir(probe_dir) catch { _ => () })
+}
+
+///|
+async fn source_write_readonly_profile_data(
+  real_workspace_root : String,
+) -> SourceWriteProfileData {
+  let real_workspace_root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  match source_write_profile_cache.get(real_workspace_root) {
+    Some(cached) if cached_source_write_profile_valid(cached) =>
+      return {
+        profile: cached.profile,
+        denial_subjects: cached.denial_subjects,
+      }
+    Some(_) => ()
+    None => ()
+  }
+  let scan = protected_source_tree_profile_scan(real_workspace_root)
+  let denial_subjects = source_write_denial_subjects(scan.literal_paths)
+  let source_regex = source_write_regex(real_workspace_root)
+  let source_create_regex = source_write_create_regex(real_workspace_root)
+  let profile = StringBuilder()
+  profile.write_string("(version 1)\n")
+  profile.write_string("(allow default)\n")
+  profile.write_string(
+    "(deny file-write-create (regex \"\{sbpl_string_escape(source_create_regex)}\"))\n",
+  )
+  profile.write_string(
+    "(deny file-write* (regex \"\{sbpl_string_escape(source_regex)}\"))\n",
+  )
+  for dir in scan.literal_paths {
+    profile.write_string(
+      "(deny file-write* (literal \"\{sbpl_string_escape(dir)}\"))\n",
+    )
+  }
+  let profile = profile.to_string()
+  if scan.cacheable {
+    source_write_profile_cache[real_workspace_root] = {
+      profile,
+      watched_dirs: scan.watched_dirs,
+      denial_subjects,
+    }
+  }
+  { profile, denial_subjects }
+}
+
+///|
+fn source_write_denial_subjects(literal_paths : Array[String]) -> Array[String] {
+  let subjects : Array[String] = []
+  for path in literal_paths {
+    subjects.push(path)
+    let base = path_basename(path)
+    if base != path {
+      subjects.push(base)
+    }
+  }
+  subjects
+}
+
+///|
+async fn cached_source_write_profile_valid(
+  cached : CachedSourceWriteProfile,
+) -> Bool {
+  for watched in cached.watched_dirs {
+    let (mtime_s, mtime_ns) = @fs.mtime(watched.path, follow_symlink=false) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => return false
+    }
+    if mtime_s != watched.mtime_s || mtime_ns != watched.mtime_ns {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn source_write_regex(real_workspace_root : String) -> String {
+  let root = regex_escape(strip_trailing_slash(real_workspace_root))
+  let source_dir = protected_source_directory_component_regex()
+  let source_file = "([^/]*(\\.mbt\\.md|\\.mbt|\\.mbti)|(moon\\.mod\\.json|moon\\.pkg\\.json|moon\\.mod|moon\\.pkg|moon\\.work))"
+  "^" + root + "(/|$)(\{source_dir}/)*\{source_file}$"
+}
+
+///|
+fn source_write_create_regex(real_workspace_root : String) -> String {
+  source_write_regex(real_workspace_root)
+}
+
+///|
+fn protected_source_directory_component_regex() -> String {
+  let normal = "[^/_.][^/]*"
+  let not_build = "(_|_b|_bu|_bui|_buil|_build[^/]+|_[^b/][^/]*|_b[^u/][^/]*|_bu[^i/][^/]*|_bui[^l/][^/]*|_buil[^d/][^/]*)"
+  let not_mooncakes = "(\\.|\\.m|\\.mo|\\.moo|\\.moon|\\.moonc|\\.moonca|\\.mooncak|\\.mooncake|\\.mooncakes[^/]+|\\.[^m/][^/]*|\\.m[^o/][^/]*|\\.mo[^o/][^/]*|\\.moo[^n/][^/]*|\\.moon[^c/][^/]*|\\.moonc[^a/][^/]*|\\.moonca[^k/][^/]*|\\.mooncak[^e/][^/]*|\\.mooncake[^s/][^/]*)"
+  "(\{normal}|\{not_build}|\{not_mooncakes})"
+}
+
+///|
+async fn protected_source_tree_profile_scan(
+  real_workspace_root : String,
+) -> SourceWriteProfileScan {
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let state : SourceWriteProfileScanBuilder = {
+    literal_paths: [],
+    watched_dirs: [],
+    cacheable: true,
+  }
+  ignore(collect_protected_source_tree_profile_scan(root, root, state))
+  {
+    literal_paths: state.literal_paths,
+    watched_dirs: state.watched_dirs,
+    cacheable: state.cacheable,
+  }
+}
+
+///|
+async fn collect_protected_source_tree_profile_scan(
+  root : String,
+  dir : String,
+  state : SourceWriteProfileScanBuilder,
+) -> Bool {
+  if dir != root && is_moon_managed_workspace_path(root, dir) {
+    return false
+  }
+  if dir != root && should_prune_profile_scan_path(root, dir) {
+    return false
+  }
+  let (mtime_s, mtime_ns) = @fs.mtime(dir, follow_symlink=false) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => {
+      state.cacheable = false
+      return false
+    }
+  }
+  state.watched_dirs.push({ path: dir, mtime_s, mtime_ns })
+  let entries = @fs.readdir(dir, include_hidden=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => {
+      state.cacheable = false
+      return false
+    }
+  }
+  let mut contains_protected = false
+  for entry in entries {
+    let child = @path.Path(dir).join(Path(entry)).normalize().to_string()
+    if is_moon_managed_workspace_path(root, child) {
+      continue
+    }
+    if is_protected_workspace_source_path(root, child) {
+      contains_protected = true
+      continue
+    }
+    let kind = @fs.kind(child, follow_symlink=false) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => {
+        state.cacheable = false
+        continue
+      }
+    }
+    match kind {
+      Directory =>
+        if collect_protected_source_tree_profile_scan(root, child, state) {
+          contains_protected = true
+        }
+      _ => ()
+    }
+  }
+  if contains_protected && dir != root {
+    state.literal_paths.push(dir)
+  }
+  contains_protected
+}
+
+///|
+fn should_prune_profile_scan_path(root : String, path : String) -> Bool {
+  guard is_under_workspace_root(root, path) && path != root else {
+    return false
+  }
+  let relative = path[root.length() + 1:].to_owned()
+  relative
+  .replace_all(old="\\", new="/")
+  .split("/")
+  .any(part => {
+    part == ".git" ||
+    part == ".hg" ||
+    part == ".svn" ||
+    part == ".jj" ||
+    part == "node_modules"
+  })
+}
+
+///|
+fn source_write_mode_for_parse(
+  parsed : @shell_parse.ParseResult,
+  real_workspace_root : String,
+  cwd : String?,
+) -> SourceWriteMode {
+  match parsed {
+    Simple(commands) if direct_source_write_redirect_target_for_root(
+        parsed, real_workspace_root, cwd,
+      )
+      is None &&
+      commands_are_trusted_source_writes(commands) => TrustedSourceWrite
+    _ => SourceReadOnly
+  }
+}
+
+///|
+fn commands_are_trusted_source_writes(
+  commands : Array[@shell_parse.SimpleCommand],
+) -> Bool {
+  let mut has_trusted_write = false
+  for index, command in commands {
+    if command.separator_before is Some("|" | "||") {
+      return false
+    }
+    match trusted_command_class(command, commands, index) {
+      TrustedCommandWrite => has_trusted_write = true
+      TrustedCommandNeutral | TrustedCommandRead => ()
+      UntrustedCommand => return false
+    }
+  }
+  has_trusted_write
+}
+
+///|
+priv enum TrustedCommandClass {
+  TrustedCommandWrite
+  TrustedCommandRead
+  TrustedCommandNeutral
+  UntrustedCommand
+}
+
+///|
+fn trusted_command_class(
+  command : @shell_parse.SimpleCommand,
+  commands : Array[@shell_parse.SimpleCommand],
+  index : Int,
+) -> TrustedCommandClass {
+  match command.command_index() {
+    Some(command_index) if command_index < command.argv.length() =>
+      match command.argv[command_index] {
+        "cd" =>
+          if command.env.length() == 0 &&
+            static_relative_cd_command_effect(command, ".") is KnownCwd(_) &&
+            next_command_is_guarded_by_and(commands, index) {
+            TrustedCommandNeutral
+          } else {
+            UntrustedCommand
+          }
+        "moon" => trusted_moon_command_class(command, command_index)
+        _ => UntrustedCommand
+      }
+    _ => UntrustedCommand
+  }
+}
+
+///|
+fn trusted_moon_command_class(
+  command : @shell_parse.SimpleCommand,
+  moon_index : Int,
+) -> TrustedCommandClass {
+  if command_has_custom_environment(command) {
+    return UntrustedCommand
+  }
+  match parse_moon_invocation(command.argv, moon_index, ".") {
+    Some(invocation) if invocation.dry_run => TrustedCommandRead
+    Some(invocation) if is_auto_check_moon_subcommand(
+        command.argv,
+        invocation.subcommand_index,
+      ) => TrustedCommandWrite
+    Some(invocation) if is_moon_subcommand_that_may_run_prebuild(
+        command.argv,
+        invocation.subcommand_index,
+      ) => TrustedCommandWrite
+    Some(invocation) if is_source_readonly_moon_subcommand(
+        command.argv,
+        invocation.subcommand_index,
+      ) => TrustedCommandRead
+    _ => UntrustedCommand
+  }
+}
+
+///|
+fn is_moon_subcommand_that_may_run_prebuild(
+  argv : Array[String],
+  subcommand_index : Int,
+) -> Bool {
+  match argv[subcommand_index] {
+    "run" =>
+      !argv_contains_update_flag_before_double_dash(argv, subcommand_index + 1) &&
+      !argv_contains_help_flag_before_double_dash(argv, subcommand_index + 1) &&
+      !moon_run_uses_inline_or_stdin_source(argv, subcommand_index + 1)
+    "check" | "build" | "test" =>
+      !argv_contains_update_flag(argv, subcommand_index + 1) &&
+      !argv_contains_help_flag(argv, subcommand_index + 1)
+    _ => false
+  }
+}
+
+///|
+fn moon_run_uses_inline_or_stdin_source(
+  argv : Array[String],
+  start : Int,
+) -> Bool {
+  let mut index = start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "--" {
+      index += 1
+      continue
+    }
+    if arg == "-e" || moon_run_attached_inline_script_option(arg) {
+      return true
+    }
+    if moon_run_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return false
+      }
+      index += 2
+      continue
+    }
+    if moon_run_attached_value_option(arg) {
+      index += 1
+      continue
+    }
+    if arg.has_prefix("-") && arg != "-" {
+      index += 1
+      continue
+    }
+    return arg == "-"
+  }
+  false
+}
+
+///|
+fn moon_run_option_consumes_next(arg : String) -> Bool {
+  match arg {
+    "-e"
+    | "--target"
+    | "--target-dir"
+    | "--warn-list"
+    | "-j"
+    | "--jobs"
+    | "--render-no-loc"
+    | "--diagnostic-limit" => true
+    _ => false
+  }
+}
+
+///|
+fn moon_run_attached_inline_script_option(arg : String) -> Bool {
+  arg.has_prefix("-e") && arg.length() > 2
+}
+
+///|
+fn moon_run_attached_value_option(arg : String) -> Bool {
+  moon_attached_value_option(arg, "--target") ||
+  moon_attached_value_option(arg, "--target-dir") ||
+  moon_attached_value_option(arg, "--warn-list") ||
+  moon_attached_value_option(arg, "-j") ||
+  moon_attached_value_option(arg, "--jobs") ||
+  moon_attached_value_option(arg, "--render-no-loc") ||
+  moon_attached_value_option(arg, "--diagnostic-limit")
+}
+
+///|
+fn is_source_readonly_moon_subcommand(
+  argv : Array[String],
+  subcommand_index : Int,
+) -> Bool {
+  if argv_contains_update_flag(argv, subcommand_index + 1) {
+    return false
+  }
+  if argv_contains_help_flag(argv, subcommand_index + 1) {
+    return true
+  }
+  match argv[subcommand_index] {
+    "check" => true
+    "fmt" =>
+      argv_contains_flag(argv, subcommand_index + 1, "--check") ||
+      argv_contains_flag(argv, subcommand_index + 1, "--warn")
+    _ => false
+  }
+}
+
+///|
+fn redirect_writes_file(redirect : @shell_parse.Redirect) -> Bool {
+  match strip_fd_prefix(redirect.op) {
+    ">" | ">|" | ">>" | "<>" | "&>" | "&>>" => true
+    ">&" => !is_fd_redirect_target(redirect.target)
+    _ => false
+  }
+}
+
+///|
+fn strip_fd_prefix(op : String) -> String {
+  let mut index = 0
+  for ch in op {
+    if ch is ('0'..='9') {
+      index += 1
+    } else {
+      break
+    }
+  }
+  op[index:].to_owned()
+}
+
+///|
+fn is_fd_redirect_target(target : String) -> Bool {
+  if target == "-" || target == "" {
+    return true
+  }
+  for ch in target {
+    if !(ch is ('0'..='9')) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+async fn direct_source_write_redirect_target(
+  parsed : @shell_parse.ParseResult,
+  workspace_root : String,
+  cwd : String?,
+) -> String? {
+  let real_workspace_root = @fs.realpath(workspace_root)
+  let real_cwd = match cwd {
+    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
+    None => None
+  }
+  direct_source_write_redirect_target_for_root_following_existing_links(
+    parsed, real_workspace_root, real_cwd,
+  )
+}
+
+///|
+async fn direct_source_write_redirect_target_for_root_following_existing_links(
+  parsed : @shell_parse.ParseResult,
+  real_workspace_root : String,
+  cwd : String?,
+) -> String? {
+  match parsed {
+    Simple(commands) =>
+      direct_source_write_redirect_target_in_commands_following_existing_links(
+        commands,
+        real_workspace_root,
+        source_write_detection_cwd(real_workspace_root, cwd),
+      )
+    _ => None
+  }
+}
+
+///|
+fn direct_source_write_redirect_target_for_root(
+  parsed : @shell_parse.ParseResult,
+  real_workspace_root : String,
+  cwd : String?,
+) -> String? {
+  match parsed {
+    Simple(commands) =>
+      direct_source_write_redirect_target_in_commands(
+        commands,
+        real_workspace_root,
+        source_write_detection_cwd(real_workspace_root, cwd),
+      )
+    _ => None
+  }
+}
+
+///|
+fn direct_source_write_redirect_target_in_commands(
+  commands : Array[@shell_parse.SimpleCommand],
+  real_workspace_root : String,
+  initial_cwd : String,
+) -> String? {
+  let mut cwd_state = source_write_initial_cwd_state(initial_cwd)
+  for index, command in commands {
+    for redirect in command.redirects {
+      if redirect_writes_file(redirect) {
+        for
+          cwd in source_write_detection_cwds(
+            cwd_state.active,
+            real_workspace_root,
+          ) {
+          let target = resolve_source_write_redirect_target(
+            cwd,
+            redirect.target,
+          )
+          if is_protected_workspace_source_path(real_workspace_root, target) {
+            return Some(target)
+          }
+        }
+      }
+    }
+    cwd_state = source_write_next_cwd_state(
+      command,
+      cwd_state,
+      next_command_separator(commands, index),
+    )
+  }
+  None
+}
+
+///|
+async fn direct_source_write_redirect_target_in_commands_following_existing_links(
+  commands : Array[@shell_parse.SimpleCommand],
+  real_workspace_root : String,
+  initial_cwd : String,
+) -> String? {
+  let mut cwd_state = source_write_initial_cwd_state(initial_cwd)
+  for index, command in commands {
+    for redirect in command.redirects {
+      if redirect_writes_file(redirect) {
+        for
+          cwd in source_write_detection_cwds_following_existing_links(
+            cwd_state.active,
+            real_workspace_root,
+          ) {
+          let target = resolve_source_write_redirect_target(
+            cwd,
+            redirect.target,
+          )
+          if is_protected_workspace_source_path(real_workspace_root, target) {
+            return Some(target)
+          }
+          match
+            existing_path_resolves_to_protected_workspace_source(
+              real_workspace_root, target,
+            ) {
+            Some(resolved) => return Some(resolved)
+            None => ()
+          }
+        }
+      }
+    }
+    cwd_state = source_write_next_cwd_state(
+      command,
+      cwd_state,
+      next_command_separator(commands, index),
+    )
+  }
+  None
+}
+
+///|
+priv struct SourceWriteCwdState {
+  active : Array[String?]
+  deferred : Array[String?]
+}
+
+///|
+fn source_write_initial_cwd_state(initial_cwd : String) -> SourceWriteCwdState {
+  { active: [Some(initial_cwd)], deferred: [] }
+}
+
+///|
+fn source_write_detection_cwds(
+  candidates : Array[String?],
+  real_workspace_root : String,
+) -> Array[String] {
+  let cwds : Array[String] = []
+  for candidate in candidates {
+    let cwd = candidate.unwrap_or(real_workspace_root)
+    push_unique_normalized_path(cwds, cwd)
+  }
+  cwds
+}
+
+///|
+async fn source_write_detection_cwds_following_existing_links(
+  candidates : Array[String?],
+  real_workspace_root : String,
+) -> Array[String] {
+  let cwds : Array[String] = []
+  for candidate in candidates {
+    let cwd = candidate.unwrap_or(real_workspace_root)
+    push_unique_normalized_path(cwds, cwd)
+    let real_cwd = @fs.realpath(cwd) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => cwd
+    }
+    push_unique_normalized_path(cwds, real_cwd)
+  }
+  cwds
+}
+
+///|
+fn source_write_next_cwd_state(
+  command : @shell_parse.SimpleCommand,
+  state : SourceWriteCwdState,
+  next_separator : String?,
+) -> SourceWriteCwdState {
+  let success : Array[String?] = []
+  let failure : Array[String?] = []
+  for cwd in state.active {
+    match cwd_command_effect_for_detection(command, cwd) {
+      KnownCwd(next) => {
+        push_unique_cwd_candidate(success, Some(next))
+        push_unique_cwd_candidate(failure, cwd)
+      }
+      UnknownCwd => {
+        push_unique_cwd_candidate(success, None)
+        push_unique_cwd_candidate(failure, cwd)
+      }
+      NotCwdCommand => {
+        push_unique_cwd_candidate(success, cwd)
+        push_unique_cwd_candidate(failure, cwd)
+      }
+    }
+  }
+  match next_separator {
+    Some("&&") => {
+      append_unique_cwd_candidates(state.deferred, failure)
+      { active: success, deferred: state.deferred }
+    }
+    Some("||") => {
+      append_unique_cwd_candidates(failure, state.deferred)
+      { active: failure, deferred: success }
+    }
+    Some("|") => {
+      append_unique_cwd_candidates(failure, state.deferred)
+      { active: failure, deferred: [] }
+    }
+    _ => {
+      append_unique_cwd_candidates(success, failure)
+      append_unique_cwd_candidates(success, state.deferred)
+      { active: success, deferred: [] }
+    }
+  }
+}
+
+///|
+fn next_command_separator(
+  commands : Array[@shell_parse.SimpleCommand],
+  index : Int,
+) -> String? {
+  if index + 1 < commands.length() {
+    commands[index + 1].separator_before
+  } else {
+    None
+  }
+}
+
+///|
+fn append_unique_cwd_candidates(
+  target : Array[String?],
+  source : Array[String?],
+) -> Unit {
+  for candidate in source {
+    push_unique_cwd_candidate(target, candidate)
+  }
+}
+
+///|
+fn push_unique_cwd_candidate(
+  candidates : Array[String?],
+  candidate : String?,
+) -> Unit {
+  if !candidates.any(existing => cwd_candidate_equal(existing, candidate)) {
+    candidates.push(candidate)
+  }
+}
+
+///|
+fn cwd_candidate_equal(left : String?, right : String?) -> Bool {
+  match (left, right) {
+    (Some(left), Some(right)) => left == right
+    (None, None) => true
+    _ => false
+  }
+}
+
+///|
+async fn existing_path_resolves_to_protected_workspace_source(
+  real_workspace_root : String,
+  target : String,
+) -> String? {
+  let resolved = @fs.realpath(target) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return None
+  }
+  if is_protected_workspace_source_path(real_workspace_root, resolved) {
+    Some(resolved)
+  } else {
+    None
+  }
+}
+
+///|
+async fn direct_source_tree_operation_target(
+  parsed : @shell_parse.ParseResult,
+  workspace_root : String,
+  cwd : String?,
+) -> String? {
+  let real_workspace_root = @fs.realpath(workspace_root)
+  let real_cwd = match cwd {
+    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
+    None => None
+  }
+  direct_source_tree_operation_target_for_root(
+    parsed, real_workspace_root, real_cwd,
+  )
+}
+
+///|
+async fn direct_source_tree_operation_target_for_root(
+  parsed : @shell_parse.ParseResult,
+  real_workspace_root : String,
+  cwd : String?,
+) -> String? {
+  match parsed {
+    Simple(commands) =>
+      direct_source_tree_operation_target_in_commands(
+        commands,
+        real_workspace_root,
+        source_write_detection_cwd(real_workspace_root, cwd),
+      )
+    _ => None
+  }
+}
+
+///|
+async fn dynamic_source_tree_operation_target(
+  parsed : @shell_parse.ParseResult,
+  cmd : String,
+  workspace_root : String,
+  cwd : String?,
+) -> String? {
+  guard parsed is TooComplex(_) else { return None }
+  if !command_text_mentions_dynamic_source_tree_write(cmd) {
+    return None
+  }
+  let real_workspace_root = @fs.realpath(workspace_root)
+  let real_cwd = match cwd {
+    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
+    None => None
+  }
+  dynamic_source_tree_operation_target_for_text(
+    cmd,
+    real_workspace_root,
+    source_write_detection_cwd(real_workspace_root, real_cwd),
+  )
+}
+
+///|
+fn command_text_mentions_dynamic_source_tree_write(text : String) -> Bool {
+  let executable_text = command_text_without_heredoc_bodies(text)
+  if command_text_mentions_unsafe_git_source_operation(executable_text) {
+    return true
+  }
+  if command_text_mentions_unsafe_in_place_sed(executable_text) ||
+    command_text_mentions_powershell_source_operation(executable_text) ||
+    command_text_redirects_to_source_path(executable_text) {
+    return true
+  }
+  let mentions_source_path = script_text_mentions_source_path(executable_text)
+  let mentions_generated_path = script_text_mentions_generated_tree_path(
+    executable_text,
+  )
+  if !mentions_source_path && !mentions_generated_path {
+    return false
+  }
+  let mut source_tree_command = false
+  let mut tree_transfer_command = false
+  let words = command_text_words(executable_text)
+  for index, word in words {
+    if !command_text_is_command_position(words, index) {
+      continue
+    }
+    match command_basename(word) {
+      "mv" | "cp" | "install" => {
+        source_tree_command = true
+        tree_transfer_command = true
+      }
+      "rm" | "touch" | "tee" => source_tree_command = true
+      _ => ()
+    }
+  }
+  if mentions_source_path &&
+    (source_tree_command || script_text_mentions_write_or_move(executable_text)) {
+    return true
+  }
+  mentions_generated_path &&
+  (tree_transfer_command || script_text_mentions_tree_transfer(executable_text))
+}
+
+///|
+fn dynamic_source_tree_operation_target_for_text(
+  text : String,
+  real_workspace_root : String,
+  initial_cwd : String,
+) -> String? {
+  if !command_text_mentions_dynamic_source_tree_write(text) {
+    return None
+  }
+  let cwd = command_text_static_cwd_before_dynamic_source_write(
+    text, initial_cwd,
+  )
+  if command_text_source_literals_are_only_absolute_outside_workspace(
+      text, real_workspace_root,
+    ) {
+    return None
+  }
+  match script_source_literal_preblock_target(text, real_workspace_root, cwd) {
+    Some(target) =>
+      if target.contains("*") || target.contains("?") || target.contains("[") {
+        return git_workspace_scope_target(real_workspace_root, cwd)
+      } else {
+        return Some(target)
+      }
+    None => ()
+  }
+  git_workspace_scope_target(real_workspace_root, cwd)
+}
+
+///|
+fn command_text_static_cwd_before_dynamic_source_write(
+  text : String,
+  initial_cwd : String,
+) -> String {
+  let words = command_text_words(command_text_without_heredoc_bodies(text))
+  let mut cwd = initial_cwd
+  for index, word in words {
+    if !command_text_is_command_position(words, index) {
+      continue
+    }
+    let end = command_text_segment_end(words, index)
+    if command_basename(word) == "cd" {
+      let target_index = if index + 3 == end && words[index + 1] == "--" {
+        Some(index + 2)
+      } else if index + 2 == end {
+        Some(index + 1)
+      } else {
+        None
+      }
+      match target_index {
+        Some(target_index) => {
+          let target = words[target_index]
+          if target != "" && target != "--" && !target.has_prefix("-") {
+            cwd = resolve_source_write_redirect_target(cwd, target)
+          }
+        }
+        None => ()
+      }
+    } else {
+      let segment : Array[String] = []
+      for segment_index in index..<end {
+        segment.push(words[segment_index])
+      }
+      if command_text_mentions_dynamic_source_tree_write(segment.join(" ")) {
+        return cwd
+      }
+    }
+  }
+  cwd
+}
+
+///|
+fn command_text_source_literals_are_only_absolute_outside_workspace(
+  text : String,
+  real_workspace_root : String,
+) -> Bool {
+  let mut saw_source_literal = false
+  for literal in script_quoted_literals(text) {
+    if script_text_mentions_source_path(literal) {
+      saw_source_literal = true
+      let nested_literals = script_quoted_literals(literal)
+      let nested_source_literals : Array[String] = []
+      for nested in nested_literals {
+        if script_text_mentions_source_path(nested) {
+          nested_source_literals.push(nested)
+        }
+      }
+      let source_literals = if nested_source_literals.length() > 0 {
+        nested_source_literals
+      } else {
+        [literal]
+      }
+      if source_literals.any(source_literal => {
+          let path : @path.Path = source_literal
+          !path.is_absolute() ||
+          is_protected_workspace_source_path(
+            real_workspace_root, source_literal,
+          )
+        }) {
+        return false
+      }
+    }
+  }
+  saw_source_literal
+}
+
+///|
+fn command_text_redirects_to_source_path(text : String) -> Bool {
+  for line in text.split("\n") {
+    for target in heredoc_output_targets_in_line(line.to_owned()) {
+      if script_text_mentions_source_path(target) {
+        return true
+      }
+    }
+  }
+  false
+}
+
+///|
+fn command_text_mentions_unsafe_in_place_sed(text : String) -> Bool {
+  let words = command_text_words(text)
+  for index in 0..<words.length() {
+    if command_token_basename_is(words[index], "sed") &&
+      command_text_is_command_position(words, index) {
+      if command_text_sed_segment_has_in_place(words, index) {
+        if !command_text_sed_is_safe_non_source_find_exec(words, index) {
+          return true
+        }
+      }
+    }
+  }
+  false
+}
+
+///|
+fn command_text_mentions_unsafe_git_source_operation(text : String) -> Bool {
+  let words = command_text_words(text)
+  for index in 0..<words.length() {
+    if command_token_basename_is(words[index], "git") &&
+      command_text_is_command_position(words, index) {
+      let segment_end = command_text_segment_end(words, index)
+      match command_text_git_subcommand_index(words, index + 1, segment_end) {
+        Some(subcommand_index) =>
+          if command_text_git_subcommand_updates_source_tree(
+              words, subcommand_index, segment_end,
+            ) {
+            return true
+          }
+        None => ()
+      }
+    }
+  }
+  false
+}
+
+///|
+fn command_text_mentions_powershell_source_operation(text : String) -> Bool {
+  let words = command_text_words(text)
+  for index, word in words {
+    if !command_text_is_command_position(words, index) {
+      continue
+    }
+    let name = command_basename(word).to_lower()
+    if powershell_source_writing_command_name(name) {
+      let end = command_text_segment_end(words, index)
+      for arg_index in (index + 1)..<end {
+        if script_text_mentions_source_path(words[arg_index]) {
+          return true
+        }
+      }
+    }
+  }
+  false
+}
+
+///|
+fn powershell_source_writing_command_name(name : String) -> Bool {
+  match name {
+    "set-content"
+    | "sc"
+    | "add-content"
+    | "ac"
+    | "clear-content"
+    | "clc"
+    | "out-file"
+    | "tee-object"
+    | "copy-item"
+    | "cpi"
+    | "move-item"
+    | "mi"
+    | "remove-item"
+    | "ri"
+    | "del"
+    | "erase"
+    | "rename-item"
+    | "rni"
+    | "ren"
+    | "new-item"
+    | "ni" => true
+    _ => false
+  }
+}
+
+///|
+fn command_text_git_subcommand_index(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Int? {
+  let mut index = start
+  while index < end {
+    let arg = words[index]
+    if arg == "--help" || arg == "-h" {
+      return None
+    }
+    if arg == "-C" ||
+      arg == "--work-tree" ||
+      git_global_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    if git_attached_cwd_option(arg) is Some(_) ||
+      git_attached_work_tree_option(arg) is Some(_) ||
+      git_global_option_with_attached_value(arg) ||
+      git_global_no_arg_option(arg) {
+      index += 1
+      continue
+    }
+    if arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    return Some(index)
+  }
+  None
+}
+
+///|
+fn command_text_git_subcommand_updates_source_tree(
+  words : Array[String],
+  subcommand_index : Int,
+  segment_end : Int,
+) -> Bool {
+  if command_text_git_subcommand_args_request_help(
+      words,
+      subcommand_index + 1,
+      segment_end,
+    ) {
+    return false
+  }
+  match words[subcommand_index] {
+    "checkout" | "switch" => true
+    "restore" =>
+      command_text_git_restore_updates_worktree(
+        words,
+        subcommand_index + 1,
+        segment_end,
+      )
+    "reset" =>
+      command_text_git_reset_updates_worktree(
+        words,
+        subcommand_index + 1,
+        segment_end,
+      )
+    "clean" =>
+      command_text_git_clean_updates_worktree(
+        words,
+        subcommand_index + 1,
+        segment_end,
+      )
+    "apply" =>
+      command_text_git_apply_updates_worktree(
+        words,
+        subcommand_index + 1,
+        segment_end,
+      )
+    "rm" =>
+      command_text_git_rm_updates_worktree(
+        words,
+        subcommand_index + 1,
+        segment_end,
+      )
+    "mv" =>
+      command_text_git_mv_updates_worktree(
+        words,
+        subcommand_index + 1,
+        segment_end,
+      )
+    _ => false
+  }
+}
+
+///|
+fn command_text_git_subcommand_args_request_help(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  start < end && (words[start] == "--help" || words[start] == "-h")
+}
+
+///|
+fn command_text_git_restore_updates_worktree(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut staged = false
+  let mut worktree = false
+  let mut index = start
+  while index < end {
+    let arg = words[index]
+    if arg == "--" {
+      break
+    }
+    if arg == "--staged" || git_restore_short_option_cluster_has(arg, "S") {
+      staged = true
+    }
+    if arg == "--worktree" || git_restore_short_option_cluster_has(arg, "W") {
+      worktree = true
+    }
+    if git_restore_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    index += 1
+  }
+  worktree || !staged
+}
+
+///|
+fn command_text_git_reset_updates_worktree(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut index = start
+  while index < end {
+    match words[index] {
+      "--hard" | "--merge" | "--keep" => return true
+      _ => index += 1
+    }
+  }
+  false
+}
+
+///|
+fn command_text_git_clean_updates_worktree(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut dry_run = false
+  let mut index = start
+  while index < end {
+    let arg = words[index]
+    if git_clean_short_option_has_dry_run(arg) ||
+      git_clean_long_option_is_dry_run(arg) {
+      dry_run = true
+    }
+    if git_clean_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    index += 1
+  }
+  !dry_run
+}
+
+///|
+fn command_text_git_apply_updates_worktree(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut applies = true
+  let mut cached_only = false
+  let mut index = start
+  while index < end {
+    match words[index] {
+      "--check" | "--stat" | "--numstat" | "--summary" => applies = false
+      "--cached" => cached_only = true
+      "--index" => cached_only = false
+      "--apply" => applies = true
+      _ => ()
+    }
+    index += 1
+  }
+  applies && !cached_only
+}
+
+///|
+fn command_text_git_rm_updates_worktree(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut cached_only = false
+  let mut dry_run = false
+  for index in start..<end {
+    let arg = words[index]
+    match arg {
+      "--cached" => cached_only = true
+      "-n" | "--dry-run" => dry_run = true
+      _ => if git_restore_short_option_cluster_has(arg, "n") { dry_run = true }
+    }
+  }
+  !cached_only && !dry_run
+}
+
+///|
+fn command_text_git_mv_updates_worktree(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  for index in start..<end {
+    let arg = words[index]
+    if arg == "-n" ||
+      arg == "--dry-run" ||
+      git_restore_short_option_cluster_has(arg, "n") {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn command_text_sed_segment_has_in_place(
+  words : Array[String],
+  sed_index : Int,
+) -> Bool {
+  scan_sed_args_for_in_place(
+    words,
+    sed_index + 1,
+    command_text_segment_end(words, sed_index),
+  )
+}
+
+///|
+fn command_text_sed_is_safe_non_source_find_exec(
+  words : Array[String],
+  sed_index : Int,
+) -> Bool {
+  let payload_start = command_text_segment_start(words, sed_index)
+  if payload_start == 0 {
+    return false
+  }
+  let exec_index = payload_start - 1
+  let exec = words[exec_index]
+  guard exec == "-exec" || exec == "-execdir" else { return false }
+  let command_start = command_text_segment_start(words, exec_index)
+  guard command_start < words.length() else { return false }
+  guard command_token_basename_is(words[command_start], "find") else {
+    return false
+  }
+  find_non_source_name_or_path_filter_proves_safe_before(
+    words,
+    command_start + 1,
+    exec_index,
+  ) &&
+  sed_targets_only_find_results(
+    words,
+    sed_index + 1,
+    command_text_segment_end(words, sed_index),
+  )
+}
+
+///|
+fn command_text_word_is_command_separator(word : String) -> Bool {
+  word == ";" || word == "&" || word == "&&" || word == "||" || word == "|"
+}
+
+///|
+fn command_text_segment_end(words : Array[String], command_index : Int) -> Int {
+  let mut index = command_index + 1
+  while index < words.length() {
+    if command_text_word_is_command_separator(words[index]) {
+      return index
+    }
+    index += 1
+  }
+  words.length()
+}
+
+///|
+fn command_text_is_command_position(words : Array[String], index : Int) -> Bool {
+  if index == 0 {
+    return true
+  }
+  let prev = words[index - 1]
+  if prev == ";" ||
+    prev == "&&" ||
+    prev == "||" ||
+    prev == "|" ||
+    prev == "(" ||
+    prev == "{" ||
+    prev == "-exec" ||
+    prev == "-execdir" ||
+    prev == "elif" ||
+    prev == "do" ||
+    prev == "then" ||
+    prev == "else" ||
+    prev == "if" ||
+    prev == "while" ||
+    prev == "until" ||
+    prev == "time" {
+    return true
+  }
+  command_text_effective_command_index(
+    words,
+    command_text_segment_start(words, index),
+    index + 1,
+  ) ==
+  Some(index)
+}
+
+///|
+fn command_text_segment_start(words : Array[String], before : Int) -> Int {
+  let mut index = before
+  while index > 0 {
+    if command_text_word_starts_next_command_segment(words[index - 1]) {
+      return index
+    }
+    index -= 1
+  }
+  0
+}
+
+///|
+fn command_text_word_starts_next_command_segment(word : String) -> Bool {
+  command_text_word_is_command_separator(word) ||
+  word == "(" ||
+  word == "{" ||
+  word == "!" ||
+  word == "if" ||
+  word == "while" ||
+  word == "until" ||
+  word == "elif" ||
+  word == "then" ||
+  word == "else" ||
+  word == "do" ||
+  word == "-exec" ||
+  word == "-execdir" ||
+  word == "time"
+}
+
+///|
+fn command_text_effective_command_index(
+  words : Array[String],
+  start : Int,
+  limit : Int,
+) -> Int? {
+  let mut start = start
+  while start < limit && command_text_env_assignment_word(words[start]) {
+    start += 1
+  }
+  if start >= limit {
+    return None
+  }
+  match words[start] {
+    "env" => command_text_env_wrapped_command_index(words, start, limit)
+    "command" => command_text_command_wrapped_command_index(words, start, limit)
+    "builtin" =>
+      if start + 1 < limit {
+        let index = if words[start + 1] == "--" { start + 2 } else { start + 1 }
+        if index < limit {
+          Some(index)
+        } else {
+          Some(start)
+        }
+      } else {
+        Some(start)
+      }
+    _ => Some(start)
+  }
+}
+
+///|
+fn command_text_env_wrapped_command_index(
+  words : Array[String],
+  start : Int,
+  limit : Int,
+) -> Int? {
+  let mut index = start + 1
+  let mut scanning_options = true
+  while index < limit {
+    let arg = words[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    if scanning_options && (arg == "-i" || arg == "-") {
+      index += 1
+      continue
+    }
+    if scanning_options && command_text_env_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    if scanning_options &&
+      (
+        command_text_env_option_with_attached_value(arg) ||
+        command_text_env_no_arg_option(arg)
+      ) {
+      index += 1
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") {
+      return Some(start)
+    }
+    if command_text_env_assignment_word(arg) {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    return Some(index)
+  }
+  Some(start)
+}
+
+///|
+fn command_text_command_wrapped_command_index(
+  words : Array[String],
+  start : Int,
+  limit : Int,
+) -> Int? {
+  let mut index = start + 1
+  while index < limit {
+    let arg = words[index]
+    if arg == "--" {
+      index += 1
+      break
+    }
+    if arg == "-p" {
+      index += 1
+      continue
+    }
+    if arg == "-v" || arg == "-V" || arg.has_prefix("-") {
+      return Some(start)
+    }
+    return Some(index)
+  }
+  if index < limit {
+    Some(index)
+  } else {
+    Some(start)
+  }
+}
+
+///|
+fn command_text_env_option_consumes_next(arg : String) -> Bool {
+  arg == "-u" || arg == "--unset"
+}
+
+///|
+fn command_text_env_option_with_attached_value(arg : String) -> Bool {
+  (arg.has_prefix("-u") && arg != "-u") || arg.has_prefix("--unset=")
+}
+
+///|
+fn command_text_env_no_arg_option(arg : String) -> Bool {
+  match arg {
+    "--ignore-environment" | "-0" | "--null" | "--debug" => true
+    _ => false
+  }
+}
+
+///|
+fn command_text_env_assignment_word(word : String) -> Bool {
+  let parts = word.split("=").collect()
+  if parts.length() < 2 {
+    return false
+  }
+  command_text_valid_env_name(parts[0].to_owned())
+}
+
+///|
+fn command_text_valid_env_name(name : String) -> Bool {
+  if name == "" {
+    return false
+  }
+  let mut index = 0
+  for ch in name {
+    let valid = if index == 0 {
+      ch is ('a'..='z') || ch is ('A'..='Z') || ch == '_'
+    } else {
+      ch is ('a'..='z') || ch is ('A'..='Z') || ch is ('0'..='9') || ch == '_'
+    }
+    if !valid {
+      return false
+    }
+    index += 1
+  }
+  true
+}
+
+///|
+priv struct HeredocDelimiter {
+  marker : String
+  strip_tabs : Bool
+}
+
+///|
+priv struct HeredocReadResult {
+  marker : String
+  next : Int
+}
+
+///|
+priv struct CommandWordReadResult {
+  word : String
+  next : Int
+}
+
+///|
+fn command_text_without_heredoc_bodies(text : String) -> String {
+  let lines : Array[String] = [
+    for line in text.split("\n") => line.to_owned()
+  ]
+  if command_lines_execute_generated_heredoc_script(lines) {
+    return text
+  }
+  command_lines_without_nonexecuted_heredoc_bodies(lines)
+}
+
+///|
+fn command_lines_without_nonexecuted_heredoc_bodies(
+  lines : Array[String],
+) -> String {
+  let output = StringBuilder()
+  let mut index = 0
+  while index < lines.length() {
+    let line = lines[index]
+    output.write_string(line)
+    if index + 1 < lines.length() {
+      output.write_char('\n')
+    }
+    let delimiters = heredoc_delimiters_in_line(line)
+    if delimiters.length() > 0 && !command_line_executes_heredoc_body(line) {
+      index += 1
+      for delimiter in delimiters {
+        while index < lines.length() {
+          if heredoc_line_matches_delimiter(lines[index], delimiter) {
+            index += 1
+            break
+          }
+          index += 1
+        }
+      }
+    } else {
+      index += 1
+    }
+  }
+  output.to_string()
+}
+
+///|
+fn command_lines_execute_generated_heredoc_script(
+  lines : Array[String],
+) -> Bool {
+  let targets : Array[String] = []
+  for line in lines {
+    let delimiters = heredoc_delimiters_in_line(line)
+    if delimiters.length() > 0 && !command_line_executes_heredoc_body(line) {
+      for target in heredoc_output_targets_in_line(line) {
+        if target != "" {
+          targets.push(target)
+        }
+      }
+    }
+  }
+  if targets.length() == 0 {
+    return false
+  }
+  let executable_text = command_lines_without_nonexecuted_heredoc_bodies(lines)
+  command_text_executes_generated_heredoc_target(executable_text, targets)
+}
+
+///|
+fn heredoc_output_targets_in_line(line : String) -> Array[String] {
+  let targets : Array[String] = []
+  let chars = [ for ch in line => ch ]
+  let mut index = 0
+  let mut quote : Char? = None
+  let mut escaped = false
+  while index < chars.length() {
+    let ch = chars[index]
+    match quote {
+      Some(end_quote) =>
+        if escaped {
+          escaped = false
+        } else if end_quote == '"' && ch == '\\' {
+          escaped = true
+        } else if ch == end_quote {
+          quote = None
+        }
+      None =>
+        if escaped {
+          escaped = false
+        } else if ch == '\\' {
+          escaped = true
+        } else if ch == '\'' || ch == '"' {
+          quote = Some(ch)
+        } else if ch == '>' {
+          index += 1
+          if index < chars.length() &&
+            (chars[index] == '>' || chars[index] == '|' || chars[index] == '&') {
+            index += 1
+          }
+          while index < chars.length() && command_text_line_space(chars[index]) {
+            index += 1
+          }
+          match read_command_word(chars, index) {
+            Some(result) => {
+              if !command_redirect_target_is_fd(result.word) {
+                targets.push(result.word)
+              }
+              index = result.next
+              continue
+            }
+            None => ()
+          }
+        } else if ch == '&' &&
+          index + 1 < chars.length() &&
+          chars[index + 1] == '>' {
+          index += 2
+          if index < chars.length() && chars[index] == '>' {
+            index += 1
+          }
+          while index < chars.length() && command_text_line_space(chars[index]) {
+            index += 1
+          }
+          match read_command_word(chars, index) {
+            Some(result) => {
+              if !command_redirect_target_is_fd(result.word) {
+                targets.push(result.word)
+              }
+              index = result.next
+              continue
+            }
+            None => ()
+          }
+        }
+    }
+    index += 1
+  }
+  for target in heredoc_tee_output_targets_in_line(line) {
+    targets.push(target)
+  }
+  targets
+}
+
+///|
+fn heredoc_tee_output_targets_in_line(line : String) -> Array[String] {
+  guard command_line_before_first_heredoc(line) is Some(prefix) else {
+    return []
+  }
+  let targets : Array[String] = []
+  for target in heredoc_tee_output_targets_in_command_text(prefix) {
+    targets.push(target)
+  }
+  match command_line_after_first_post_heredoc_pipe(line) {
+    Some(suffix) =>
+      for target in heredoc_tee_output_targets_in_command_text(suffix) {
+        targets.push(target)
+      }
+    None => ()
+  }
+  targets
+}
+
+///|
+fn heredoc_tee_output_targets_in_command_text(text : String) -> Array[String] {
+  let targets : Array[String] = []
+  let words = command_text_words(text)
+  for index, word in words {
+    if command_token_basename_is(word, "tee") &&
+      command_text_is_command_position(words, index) {
+      for
+        target in command_text_tee_targets(
+          words,
+          index + 1,
+          command_text_segment_end(words, index),
+        ) {
+        targets.push(target)
+      }
+    }
+  }
+  targets
+}
+
+///|
+fn command_line_before_first_heredoc(line : String) -> String? {
+  let prefix = StringBuilder()
+  let chars = [ for ch in line => ch ]
+  let mut index = 0
+  let mut quote : Char? = None
+  let mut escaped = false
+  while index < chars.length() {
+    let ch = chars[index]
+    match quote {
+      Some(end_quote) => {
+        prefix.write_char(ch)
+        if escaped {
+          escaped = false
+        } else if end_quote == '"' && ch == '\\' {
+          escaped = true
+        } else if ch == end_quote {
+          quote = None
+        }
+      }
+      None =>
+        if escaped {
+          prefix.write_char(ch)
+          escaped = false
+        } else if ch == '\\' {
+          prefix.write_char(ch)
+          escaped = true
+        } else if ch == '\'' || ch == '"' {
+          prefix.write_char(ch)
+          quote = Some(ch)
+        } else if ch == '<' &&
+          index + 1 < chars.length() &&
+          chars[index + 1] == '<' {
+          return Some(prefix.to_string())
+        } else {
+          prefix.write_char(ch)
+        }
+    }
+    index += 1
+  }
+  None
+}
+
+///|
+fn command_line_after_first_post_heredoc_pipe(line : String) -> String? {
+  let chars = [ for ch in line => ch ]
+  let mut index = 0
+  let mut quote : Char? = None
+  let mut escaped = false
+  let mut saw_heredoc = false
+  while index < chars.length() {
+    let ch = chars[index]
+    match quote {
+      Some(end_quote) =>
+        if escaped {
+          escaped = false
+        } else if end_quote == '"' && ch == '\\' {
+          escaped = true
+        } else if ch == end_quote {
+          quote = None
+        }
+      None =>
+        if escaped {
+          escaped = false
+        } else if ch == '\\' {
+          escaped = true
+        } else if ch == '\'' || ch == '"' {
+          quote = Some(ch)
+        } else if !saw_heredoc &&
+          ch == '<' &&
+          index + 1 < chars.length() &&
+          chars[index + 1] == '<' {
+          saw_heredoc = true
+          index += 1
+        } else if saw_heredoc &&
+          ch == '|' &&
+          !(index > 0 && chars[index - 1] == '|') &&
+          !(index + 1 < chars.length() && chars[index + 1] == '|') {
+          return Some(chars_to_string(chars, index + 1))
+        }
+    }
+    index += 1
+  }
+  None
+}
+
+///|
+fn chars_to_string(chars : Array[Char], start : Int) -> String {
+  let output = StringBuilder()
+  for index in start..<chars.length() {
+    output.write_char(chars[index])
+  }
+  output.to_string()
+}
+
+///|
+fn command_text_tee_targets(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Array[String] {
+  let targets : Array[String] = []
+  let mut scanning_options = true
+  for index in start..<end {
+    let arg = words[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      continue
+    }
+    if scanning_options && tee_supported_no_arg_option(arg) {
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      continue
+    }
+    targets.push(arg)
+  }
+  targets
+}
+
+///|
+fn read_command_word(
+  chars : Array[Char],
+  start : Int,
+) -> CommandWordReadResult? {
+  if start >= chars.length() {
+    return None
+  }
+  let word = StringBuilder()
+  let mut index = start
+  let mut quote : Char? = None
+  let mut escaped = false
+  while index < chars.length() {
+    let ch = chars[index]
+    match quote {
+      Some(end_quote) =>
+        if escaped {
+          word.write_char(ch)
+          escaped = false
+        } else if end_quote == '"' && ch == '\\' {
+          escaped = true
+        } else if ch == end_quote {
+          quote = None
+        } else {
+          word.write_char(ch)
+        }
+      None =>
+        if escaped {
+          word.write_char(ch)
+          escaped = false
+        } else if ch == '\\' {
+          escaped = true
+        } else if ch == '\'' || ch == '"' {
+          quote = Some(ch)
+        } else if command_text_line_space(ch) || command_word_stop_char(ch) {
+          break
+        } else {
+          word.write_char(ch)
+        }
+    }
+    index += 1
+  }
+  let word = word.to_string()
+  if word == "" {
+    None
+  } else {
+    Some({ word, next: index })
+  }
+}
+
+///|
+fn command_word_stop_char(ch : Char) -> Bool {
+  ch == ';' ||
+  ch == '&' ||
+  ch == '|' ||
+  ch == '<' ||
+  ch == '>' ||
+  ch == '(' ||
+  ch == ')'
+}
+
+///|
+fn command_redirect_target_is_fd(target : String) -> Bool {
+  if target == "-" || target == "" {
+    return true
+  }
+  for ch in target {
+    if !(ch is ('0'..='9')) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn command_text_executes_generated_heredoc_target(
+  text : String,
+  targets : Array[String],
+) -> Bool {
+  let words = command_text_words(text)
+  for index, word in words {
+    if !command_text_is_command_position(words, index) {
+      continue
+    }
+    if command_text_token_executes_stdin_script(word) {
+      if script_runtime_invocation_mentions_heredoc_target(
+          words,
+          word,
+          index + 1,
+          command_text_segment_end(words, index),
+          targets,
+        ) {
+        return true
+      }
+    }
+    if command_text_token_sources_script(word) {
+      if script_runtime_invocation_mentions_heredoc_target(
+          words,
+          word,
+          index + 1,
+          command_text_segment_end(words, index),
+          targets,
+        ) {
+        return true
+      }
+    }
+    if command_word_matches_heredoc_target(word, targets) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn command_text_token_sources_script(word : String) -> Bool {
+  word == "." || word == "source"
+}
+
+///|
+fn script_runtime_invocation_mentions_heredoc_target(
+  words : Array[String],
+  runtime : String,
+  start : Int,
+  end : Int,
+  targets : Array[String],
+) -> Bool {
+  let mut index = start
+  while index < end {
+    let word = words[index]
+    if word == "--" {
+      index += 1
+      if index < end {
+        return command_word_matches_heredoc_target(words[index], targets)
+      }
+      return false
+    }
+    if shell_runtime_c_payload_mentions_heredoc_target(
+        runtime, words, index, end, targets,
+      ) {
+      return true
+    }
+    if script_runtime_option_consumes_next(runtime, word) {
+      index += 2
+      continue
+    }
+    if word.has_prefix("-") && word != "-" {
+      index += 1
+      continue
+    }
+    return command_word_matches_heredoc_target(word, targets)
+  }
+  false
+}
+
+///|
+fn shell_runtime_c_payload_mentions_heredoc_target(
+  runtime : String,
+  words : Array[String],
+  index : Int,
+  end : Int,
+  targets : Array[String],
+) -> Bool {
+  if !source_writing_shell_runtime(command_basename(runtime)) {
+    return false
+  }
+  let word = words[index]
+  if word == "-c" || shell_short_option_cluster_has_c(word) {
+    index + 1 < end &&
+    command_text_executes_generated_heredoc_target(words[index + 1], targets)
+  } else {
+    false
+  }
+}
+
+///|
+fn script_runtime_option_consumes_next(runtime : String, arg : String) -> Bool {
+  let base = source_writing_runtime_name(command_basename(runtime))
+  if source_writing_shell_runtime(base) {
+    return shell_option_consumes_next(arg)
+  }
+  if base == "python" || base == "python3" || base.has_prefix("python3.") {
+    arg == "-e" || arg == "-m" || arg == "-r" || arg == "-I"
+  } else {
+    match base {
+      "node" | "ruby" | "perl" | "php" =>
+        arg == "-e" || arg == "-m" || arg == "-r" || arg == "-I"
+      _ => false
+    }
+  }
+}
+
+///|
+fn command_word_matches_heredoc_target(
+  word : String,
+  targets : Array[String],
+) -> Bool {
+  for target in targets {
+    if command_word_matches_one_heredoc_target(word, target) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn command_word_matches_one_heredoc_target(
+  word : String,
+  target : String,
+) -> Bool {
+  let word = strip_leading_dot_slash(word)
+  let target = strip_leading_dot_slash(target)
+  word == target || path_basename(word) == path_basename(target)
+}
+
+///|
+fn strip_leading_dot_slash(path : String) -> String {
+  let mut result = path
+  while result.has_prefix("./") {
+    result = result[2:].to_owned()
+  }
+  result
+}
+
+///|
+fn heredoc_delimiters_in_line(line : String) -> Array[HeredocDelimiter] {
+  let delimiters : Array[HeredocDelimiter] = []
+  let chars = [ for ch in line => ch ]
+  let mut index = 0
+  let mut quote : Char? = None
+  let mut escaped = false
+  while index < chars.length() {
+    let ch = chars[index]
+    match quote {
+      Some(end_quote) =>
+        if escaped {
+          escaped = false
+        } else if end_quote == '"' && ch == '\\' {
+          escaped = true
+        } else if ch == end_quote {
+          quote = None
+        }
+      None =>
+        if escaped {
+          escaped = false
+        } else if ch == '\\' {
+          escaped = true
+        } else if ch == '\'' || ch == '"' {
+          quote = Some(ch)
+        } else if ch == '<' &&
+          index + 1 < chars.length() &&
+          chars[index + 1] == '<' {
+          index += 2
+          let strip_tabs = if index < chars.length() && chars[index] == '-' {
+            index += 1
+            true
+          } else {
+            false
+          }
+          while index < chars.length() && command_text_line_space(chars[index]) {
+            index += 1
+          }
+          match read_heredoc_delimiter(chars, index) {
+            Some(result) => {
+              if result.marker != "" {
+                delimiters.push({ marker: result.marker, strip_tabs })
+              }
+              index = result.next
+              continue
+            }
+            None => ()
+          }
+        }
+    }
+    index += 1
+  }
+  delimiters
+}
+
+///|
+fn read_heredoc_delimiter(
+  chars : Array[Char],
+  start : Int,
+) -> HeredocReadResult? {
+  if start >= chars.length() {
+    return None
+  }
+  let marker = StringBuilder()
+  let first = chars[start]
+  if first == '\'' || first == '"' {
+    let quote = first
+    let mut index = start + 1
+    let mut escaped = false
+    while index < chars.length() {
+      let ch = chars[index]
+      if escaped {
+        marker.write_char(ch)
+        escaped = false
+      } else if quote == '"' && ch == '\\' {
+        escaped = true
+      } else if ch == quote {
+        return Some({ marker: marker.to_string(), next: index + 1 })
+      } else {
+        marker.write_char(ch)
+      }
+      index += 1
+    }
+    None
+  } else {
+    let mut index = start
+    while index < chars.length() && heredoc_delimiter_char(chars[index]) {
+      if chars[index] == '\\' &&
+        index + 1 < chars.length() &&
+        heredoc_delimiter_char(chars[index + 1]) {
+        marker.write_char(chars[index + 1])
+        index += 2
+        continue
+      }
+      marker.write_char(chars[index])
+      index += 1
+    }
+    Some({ marker: marker.to_string(), next: index })
+  }
+}
+
+///|
+fn heredoc_delimiter_char(ch : Char) -> Bool {
+  !command_text_line_space(ch) &&
+  ch != ';' &&
+  ch != '&' &&
+  ch != '|' &&
+  ch != '<' &&
+  ch != '>' &&
+  ch != '(' &&
+  ch != ')'
+}
+
+///|
+fn heredoc_line_matches_delimiter(
+  line : String,
+  delimiter : HeredocDelimiter,
+) -> Bool {
+  let line = strip_trailing_cr(line)
+  let line = if delimiter.strip_tabs { strip_leading_tabs(line) } else { line }
+  line == delimiter.marker
+}
+
+///|
+fn strip_trailing_cr(line : String) -> String {
+  if line.has_suffix("\r") {
+    line[:line.length() - 1].to_owned()
+  } else {
+    line
+  }
+}
+
+///|
+fn strip_leading_tabs(line : String) -> String {
+  let mut index = 0
+  for ch in line {
+    if ch == '\t' {
+      index += 1
+    } else {
+      break
+    }
+  }
+  line[index:].to_owned()
+}
+
+///|
+fn command_text_line_space(ch : Char) -> Bool {
+  ch == ' ' || ch == '\t'
+}
+
+///|
+fn command_line_executes_heredoc_body(line : String) -> Bool {
+  let words = command_text_words(line)
+  for index, word in words {
+    if command_text_token_executes_stdin_script(word) &&
+      command_text_is_command_position(words, index) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn command_text_token_executes_stdin_script(word : String) -> Bool {
+  let base = source_writing_runtime_name(command_basename(word))
+  base == "sh" ||
+  base == "bash" ||
+  base == "zsh" ||
+  base == "dash" ||
+  base == "ksh" ||
+  base == "python" ||
+  base == "python3" ||
+  base.has_prefix("python3.") ||
+  base == "node" ||
+  base == "ruby" ||
+  base == "perl" ||
+  base == "php"
+}
+
+///|
+fn command_text_words(text : String) -> Array[String] {
+  let words : Array[String] = []
+  let mut token = StringBuilder()
+  let chars = [ for ch in text => ch ]
+  let mut index = 0
+  let mut quote : Char? = None
+  let mut escaped = false
+  while index < chars.length() {
+    let ch = chars[index]
+    match quote {
+      Some(end_quote) =>
+        if escaped {
+          token.write_char(ch)
+          escaped = false
+        } else if end_quote == '"' && ch == '\\' {
+          escaped = true
+        } else if ch == end_quote {
+          quote = None
+        } else {
+          token.write_char(ch)
+        }
+      None =>
+        if escaped {
+          token.write_char(ch)
+          escaped = false
+        } else if ch == '\\' {
+          escaped = true
+        } else if ch == '\'' || ch == '"' {
+          quote = Some(ch)
+        } else if shell_token_char(ch) {
+          token.write_char(ch)
+        } else {
+          token = push_command_text_word(words, token)
+          match ch {
+            '&' =>
+              if index + 1 < chars.length() && chars[index + 1] == '&' {
+                words.push("&&")
+                index += 1
+              } else {
+                words.push("&")
+              }
+            '|' =>
+              if index + 1 < chars.length() && chars[index + 1] == '|' {
+                words.push("||")
+                index += 1
+              } else {
+                words.push("|")
+              }
+            ';' => words.push(";")
+            '\n' | '\r' => words.push(";")
+            '(' => words.push("(")
+            _ => ()
+          }
+        }
+    }
+    index += 1
+  }
+  ignore(push_command_text_word(words, token))
+  words
+}
+
+///|
+fn push_command_text_word(
+  words : Array[String],
+  token : StringBuilder,
+) -> StringBuilder {
+  let word = token.to_string()
+  if word != "" {
+    words.push(word)
+  }
+  StringBuilder()
+}
+
+///|
+fn shell_token_char(ch : Char) -> Bool {
+  ch is ('a'..='z') ||
+  ch is ('A'..='Z') ||
+  ch is ('0'..='9') ||
+  ch == '_' ||
+  ch == '-' ||
+  ch == '.' ||
+  ch == '/' ||
+  ch == '=' ||
+  ch == '*' ||
+  ch == '?' ||
+  ch == '[' ||
+  ch == ']' ||
+  ch == '!' ||
+  ch == '^' ||
+  ch == ':' ||
+  ch == ',' ||
+  ch == '{' ||
+  ch == '}' ||
+  ch == '+'
+}
+
+///|
+fn command_token_basename_is(token : String, word : String) -> Bool {
+  token == word || token.has_suffix("/\{word}")
+}
+
+///|
+async fn direct_source_tree_operation_target_in_commands(
+  commands : Array[@shell_parse.SimpleCommand],
+  real_workspace_root : String,
+  initial_cwd : String,
+) -> String? {
+  let mut cwd_state = source_write_initial_cwd_state(initial_cwd)
+  let predicted_dirs : Array[String] = []
+  for index, command in commands {
+    match command.separator_before {
+      Some("|") => predicted_dirs.clear()
+      _ => ()
+    }
+    for
+      detection_cwd in source_write_detection_cwds_following_existing_links(
+        cwd_state.active,
+        real_workspace_root,
+      ) {
+      match
+        source_tree_operation_target_for_command(
+          command, real_workspace_root, detection_cwd, predicted_dirs,
+        ) {
+        Some(target) => return Some(target)
+        None => ()
+      }
+      record_created_dirs_for_command(command, detection_cwd, predicted_dirs)
+    }
+    cwd_state = source_write_next_cwd_state(
+      command,
+      cwd_state,
+      next_command_separator(commands, index),
+    )
+  }
+  None
+}
+
+///|
+async fn source_tree_operation_target_for_command(
+  command : @shell_parse.SimpleCommand,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  guard command.command_index() is Some(command_index) else { return None }
+  guard command_index < command.argv.length() else { return None }
+  match command_basename(command.argv[command_index]) {
+    name if source_writing_shell_runtime(name) =>
+      source_writing_shell_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    name if source_writing_script_runtime(name) =>
+      source_writing_script_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    name if source_writing_awk_runtime(name) =>
+      source_writing_awk_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    "mv" =>
+      source_tree_mv_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+        predicted_dirs,
+      )
+    "rm" =>
+      source_tree_rm_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    "cp" =>
+      source_tree_cp_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+        predicted_dirs,
+      )
+    "install" =>
+      source_tree_install_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+        predicted_dirs,
+      )
+    "git" =>
+      source_tree_git_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    "find" =>
+      source_tree_find_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    "touch" =>
+      source_tree_touch_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    "tee" =>
+      source_tree_tee_target(
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+      )
+    name =>
+      source_tree_powershell_target(
+        name,
+        command.argv,
+        command_index + 1,
+        real_workspace_root,
+        cwd,
+        predicted_dirs,
+      )
+  }
+}
+
+///|
+async fn source_tree_powershell_target(
+  command_name : String,
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  match command_basename(command_name).to_lower() {
+    "set-content"
+    | "sc"
+    | "add-content"
+    | "ac"
+    | "clear-content"
+    | "clc"
+    | "out-file"
+    | "tee-object" =>
+      powershell_write_target(argv, arg_start, real_workspace_root, cwd)
+    "copy-item" | "cpi" =>
+      powershell_copy_target(
+        argv, arg_start, real_workspace_root, cwd, predicted_dirs,
+      )
+    "move-item" | "mi" =>
+      powershell_move_target(
+        argv, arg_start, real_workspace_root, cwd, predicted_dirs,
+      )
+    "remove-item" | "ri" | "del" | "erase" =>
+      powershell_remove_target(argv, arg_start, real_workspace_root, cwd)
+    "rename-item" | "rni" | "ren" =>
+      powershell_rename_target(
+        argv, arg_start, real_workspace_root, cwd, predicted_dirs,
+      )
+    "new-item" | "ni" =>
+      powershell_write_target(argv, arg_start, real_workspace_root, cwd)
+    _ => None
+  }
+}
+
+///|
+priv struct PowershellPathOperands {
+  paths : Array[String]
+  dest : String?
+  new_name : String?
+}
+
+///|
+async fn powershell_write_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  guard parse_powershell_path_operands(argv, arg_start) is Some(operands) else {
+    return git_workspace_scope_target(real_workspace_root, cwd)
+  }
+  for path in operands.paths {
+    let target = resolve_source_write_redirect_target(cwd, path)
+    if is_protected_workspace_source_path(real_workspace_root, target) {
+      return Some(target)
+    }
+    match
+      existing_path_resolves_to_protected_workspace_source(
+        real_workspace_root, target,
+      ) {
+      Some(resolved) => return Some(resolved)
+      None => ()
+    }
+  }
+  None
+}
+
+///|
+async fn powershell_copy_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  guard parse_powershell_path_operands(argv, arg_start) is Some(parsed) else {
+    return git_workspace_scope_target(real_workspace_root, cwd)
+  }
+  guard operands_with_optional_dest(parsed.paths, parsed.dest) is Some(operands) else {
+    return None
+  }
+  source_tree_copy_destination_target(
+    operands, real_workspace_root, cwd, predicted_dirs,
+  )
+}
+
+///|
+async fn powershell_move_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  guard parse_powershell_path_operands(argv, arg_start) is Some(parsed) else {
+    return git_workspace_scope_target(real_workspace_root, cwd)
+  }
+  guard operands_with_optional_dest(parsed.paths, parsed.dest) is Some(operands) else {
+    return None
+  }
+  source_tree_move_target(operands, real_workspace_root, cwd, predicted_dirs)
+}
+
+///|
+async fn powershell_remove_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  guard parse_powershell_path_operands(argv, arg_start) is Some(operands) else {
+    return git_workspace_scope_target(real_workspace_root, cwd)
+  }
+  for path in operands.paths {
+    let target = resolve_source_write_redirect_target(cwd, path)
+    if protected_workspace_source_or_tree_path(real_workspace_root, target) {
+      return Some(target)
+    }
+  }
+  None
+}
+
+///|
+async fn powershell_rename_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  guard parse_powershell_path_operands(argv, arg_start) is Some(parsed) else {
+    return git_workspace_scope_target(real_workspace_root, cwd)
+  }
+  let new_name = match parsed.new_name {
+    Some(new_name) => new_name
+    None if parsed.paths.length() >= 2 =>
+      parsed.paths[parsed.paths.length() - 1]
+    None =>
+      return powershell_remove_target(argv, arg_start, real_workspace_root, cwd)
+  }
+  let sources : Array[String] = []
+  let source_count = if parsed.new_name is Some(_) {
+    parsed.paths.length()
+  } else {
+    parsed.paths.length() - 1
+  }
+  for index in 0..<source_count {
+    sources.push(parsed.paths[index])
+  }
+  let dest = match sources.get(0) {
+    Some(source) =>
+      match parent_dir(resolve_source_write_redirect_target(cwd, source)) {
+        Some(dir) => resolve_source_write_redirect_target(dir, new_name)
+        None => resolve_source_write_redirect_target(cwd, new_name)
+      }
+    None => resolve_source_write_redirect_target(cwd, new_name)
+  }
+  source_tree_move_target(
+    { sources, dest: Some(dest) },
+    real_workspace_root,
+    cwd,
+    predicted_dirs,
+  )
+}
+
+///|
+fn parse_powershell_path_operands(
+  argv : Array[String],
+  arg_start : Int,
+) -> PowershellPathOperands? {
+  let paths : Array[String] = []
+  let mut dest : String? = None
+  let mut new_name : String? = None
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "--%" {
+      return None
+    }
+    match powershell_attached_parameter(arg) {
+      Some((name, value)) => {
+        if powershell_path_parameter(name) {
+          paths.push(value)
+        } else if powershell_destination_parameter(name) {
+          dest = Some(value)
+        } else if name == "newname" || name == "name" {
+          new_name = Some(value)
+        } else if powershell_known_value_parameter(name) {
+          ()
+        } else if !powershell_no_value_parameter(name) {
+          return None
+        }
+        index += 1
+        continue
+      }
+      None => ()
+    }
+    match powershell_parameter_name(arg) {
+      Some(name) => {
+        if powershell_path_parameter(name) ||
+          powershell_destination_parameter(name) ||
+          name == "newname" ||
+          name == "name" ||
+          powershell_known_value_parameter(name) {
+          if index + 1 >= argv.length() {
+            return None
+          }
+          let value = argv[index + 1]
+          if powershell_path_parameter(name) {
+            paths.push(value)
+          } else if powershell_destination_parameter(name) {
+            dest = Some(value)
+          } else if name == "newname" || name == "name" {
+            new_name = Some(value)
+          }
+          index += 2
+          continue
+        }
+        if powershell_no_value_parameter(name) {
+          index += 1
+          continue
+        }
+        return None
+      }
+      None => ()
+    }
+    paths.push(arg)
+    index += 1
+  }
+  Some({ paths, dest, new_name })
+}
+
+///|
+fn powershell_attached_parameter(arg : String) -> (String, String)? {
+  guard arg.has_prefix("-") && arg != "-" else { return None }
+  match arg.find(":") {
+    Some(colon) if colon > 1 =>
+      Some((arg[1:colon].to_owned().to_lower(), arg[colon + 1:].to_owned()))
+    _ => None
+  }
+}
+
+///|
+fn powershell_parameter_name(arg : String) -> String? {
+  if !arg.has_prefix("-") || arg == "-" {
+    None
+  } else {
+    Some(arg[1:].to_owned().to_lower())
+  }
+}
+
+///|
+fn powershell_path_parameter(name : String) -> Bool {
+  name == "path" || name == "literalpath" || name == "filepath"
+}
+
+///|
+fn powershell_destination_parameter(name : String) -> Bool {
+  name == "destination"
+}
+
+///|
+fn powershell_known_value_parameter(name : String) -> Bool {
+  match name {
+    "value"
+    | "encoding"
+    | "stream"
+    | "filter"
+    | "include"
+    | "exclude"
+    | "credential"
+    | "itemtype"
+    | "type"
+    | "erroraction"
+    | "warningaction"
+    | "informationaction" => true
+    _ => false
+  }
+}
+
+///|
+fn powershell_no_value_parameter(name : String) -> Bool {
+  match name {
+    "force"
+    | "recurse"
+    | "whatif"
+    | "confirm"
+    | "verbose"
+    | "debug"
+    | "append"
+    | "noclobber"
+    | "nonewline"
+    | "passthru" => true
+    _ => false
+  }
+}
+
+///|
+fn record_created_dirs_for_command(
+  command : @shell_parse.SimpleCommand,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> Unit {
+  guard command.command_index() is Some(command_index) else { return }
+  guard command_index < command.argv.length() else { return }
+  if command_basename(command.argv[command_index]) != "mkdir" {
+    return
+  }
+  guard parse_mkdir_dirs(command.argv, command_index + 1, cwd) is Some(dirs) else {
+    return
+  }
+  for dir in dirs {
+    push_unique_normalized_path(predicted_dirs, dir)
+  }
+}
+
+///|
+fn source_writing_shell_runtime(name : String) -> Bool {
+  let name = source_writing_runtime_name(name)
+  name == "sh" ||
+  name == "bash" ||
+  name == "zsh" ||
+  name == "dash" ||
+  name == "ksh"
+}
+
+///|
+fn source_writing_script_runtime(name : String) -> Bool {
+  let name = source_writing_runtime_name(name)
+  name == "python" ||
+  name == "python3" ||
+  name.has_prefix("python3.") ||
+  name == "perl" ||
+  name == "ruby" ||
+  name == "node"
+}
+
+///|
+fn source_writing_awk_runtime(name : String) -> Bool {
+  let name = source_writing_runtime_name(name)
+  name == "awk" || name == "gawk" || name == "mawk" || name == "nawk"
+}
+
+///|
+fn source_writing_runtime_name(name : String) -> String {
+  let name = name.to_lower()
+  match name.strip_suffix(".exe") {
+    Some(base) => base.to_owned()
+    None => name
+  }
+}
+
+///|
+async fn source_writing_shell_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  guard shell_c_command_text(argv, arg_start) is Some(body) else { return None }
+  let parsed = @shell_parse.parse_for_policy(body)
+  match
+    direct_source_write_redirect_target_for_root_following_existing_links(
+      parsed,
+      real_workspace_root,
+      Some(cwd),
+    ) {
+    Some(target) => return Some(target)
+    None => ()
+  }
+  match
+    direct_source_tree_operation_target_for_root(
+      parsed,
+      real_workspace_root,
+      Some(cwd),
+    ) {
+    Some(target) => return Some(target)
+    None => ()
+  }
+  if command_text_mentions_dynamic_source_tree_write(body) {
+    return dynamic_source_tree_operation_target_for_text(
+      body,
+      real_workspace_root,
+      source_write_detection_cwd(real_workspace_root, Some(cwd)),
+    )
+  }
+  None
+}
+
+///|
+fn shell_c_command_text(argv : Array[String], arg_start : Int) -> String? {
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "-c" || shell_short_option_cluster_has_c(arg) {
+      if index + 1 < argv.length() {
+        return Some(argv[index + 1])
+      } else {
+        return None
+      }
+    }
+    if shell_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      index += 2
+      continue
+    }
+    if shell_long_option_without_next(arg) || shell_attached_value_option(arg) {
+      index += 1
+      continue
+    }
+    if arg == "--" {
+      return None
+    }
+    if arg.has_prefix("-") && arg != "-" && !arg.has_prefix("--") {
+      index += 1
+      continue
+    }
+    return None
+  }
+  None
+}
+
+///|
+fn shell_option_consumes_next(arg : String) -> Bool {
+  arg == "-o" ||
+  arg == "+o" ||
+  arg == "-O" ||
+  arg == "+O" ||
+  arg == "--init-file" ||
+  arg == "--rcfile" ||
+  arg == "--emulate"
+}
+
+///|
+fn shell_long_option_without_next(arg : String) -> Bool {
+  match arg {
+    "--noprofile"
+    | "--norc"
+    | "--posix"
+    | "--login"
+    | "--noediting"
+    | "--restricted"
+    | "--no-rcs"
+    | "--no-globalrcs" => true
+    _ => false
+  }
+}
+
+///|
+fn shell_attached_value_option(arg : String) -> Bool {
+  arg.has_prefix("--init-file=") ||
+  arg.has_prefix("--rcfile=") ||
+  arg.has_prefix("--emulate=")
+}
+
+///|
+fn shell_short_option_cluster_has_c(arg : String) -> Bool {
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg.length() <= 2 {
+    return false
+  }
+  arg[1:].contains("c")
+}
+
+///|
+async fn source_writing_script_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  let text = command_tail_text(argv, arg_start)
+  if !script_text_mentions_write_or_move(text) {
+    return None
+  }
+  match script_generated_tree_transfer_target(text, real_workspace_root, cwd) {
+    Some(target) => return Some(target)
+    None => ()
+  }
+  if !script_text_mentions_source_path(text) {
+    return None
+  }
+  script_source_literal_preblock_target(text, real_workspace_root, cwd)
+}
+
+///|
+fn source_writing_awk_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  guard awk_program_text(argv, arg_start) is Some(program) else { return None }
+  awk_output_redirect_target(program, real_workspace_root, cwd)
+}
+
+///|
+priv struct GitInvocation {
+  subcommand : String
+  subcommand_index : Int
+  cwd : String
+}
+
+///|
+async fn source_tree_git_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  guard git_invocation(argv, arg_start, real_workspace_root, cwd)
+    is Some(invocation) else {
+    return None
+  }
+  let subcommand_index = invocation.subcommand_index
+  let git_cwd = invocation.cwd
+  if git_subcommand_args_request_help(argv, subcommand_index + 1) {
+    return None
+  }
+  match invocation.subcommand {
+    "checkout" =>
+      git_checkout_target(
+        argv,
+        subcommand_index + 1,
+        real_workspace_root,
+        git_cwd,
+      )
+    "switch" => git_workspace_scope_target(real_workspace_root, git_cwd)
+    "restore" =>
+      git_restore_target(
+        argv,
+        subcommand_index + 1,
+        real_workspace_root,
+        git_cwd,
+      )
+    "reset" =>
+      if git_reset_updates_worktree(argv, subcommand_index + 1) {
+        git_workspace_scope_target(real_workspace_root, git_cwd)
+      } else {
+        None
+      }
+    "clean" =>
+      if git_clean_updates_worktree(argv, subcommand_index + 1) {
+        git_workspace_scope_target(real_workspace_root, git_cwd)
+      } else {
+        None
+      }
+    "apply" =>
+      if git_apply_updates_worktree(argv, subcommand_index + 1) {
+        git_workspace_scope_target(real_workspace_root, git_cwd)
+      } else {
+        None
+      }
+    "rm" =>
+      git_rm_target(argv, subcommand_index + 1, real_workspace_root, git_cwd)
+    "mv" =>
+      git_mv_target(argv, subcommand_index + 1, real_workspace_root, git_cwd)
+    _ => None
+  }
+}
+
+///|
+fn git_invocation(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> GitInvocation? {
+  let mut index = arg_start
+  let mut effective_cwd = source_write_detection_cwd(
+    real_workspace_root,
+    Some(cwd),
+  )
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "--" {
+      return None
+    }
+    if arg == "--help" || arg == "-h" {
+      return None
+    }
+    if arg == "-C" {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      effective_cwd = resolve_source_write_redirect_target(
+        effective_cwd,
+        argv[index + 1],
+      )
+      index += 2
+      continue
+    }
+    match git_attached_cwd_option(arg) {
+      Some(next_cwd) => {
+        effective_cwd = resolve_source_write_redirect_target(
+          effective_cwd, next_cwd,
+        )
+        index += 1
+        continue
+      }
+      None => ()
+    }
+    if arg == "--work-tree" {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      effective_cwd = resolve_source_write_redirect_target(
+        effective_cwd,
+        argv[index + 1],
+      )
+      index += 2
+      continue
+    }
+    match git_attached_work_tree_option(arg) {
+      Some(work_tree) => {
+        effective_cwd = resolve_source_write_redirect_target(
+          effective_cwd, work_tree,
+        )
+        index += 1
+        continue
+      }
+      None => ()
+    }
+    if git_global_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    if git_global_option_with_attached_value(arg) ||
+      git_global_no_arg_option(arg) {
+      index += 1
+      continue
+    }
+    if arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    return Some({ subcommand: arg, subcommand_index: index, cwd: effective_cwd })
+  }
+  None
+}
+
+///|
+fn git_attached_cwd_option(arg : String) -> String? {
+  if arg.has_prefix("-C") && arg != "-C" {
+    Some(arg[2:].to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+fn git_attached_work_tree_option(arg : String) -> String? {
+  if arg.has_prefix("--work-tree=") {
+    Some(arg["--work-tree=".length():].to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+fn git_global_option_consumes_next(arg : String) -> Bool {
+  arg == "-c" ||
+  arg == "--config-env" ||
+  arg == "--exec-path" ||
+  arg == "--git-dir" ||
+  arg == "--namespace"
+}
+
+///|
+fn git_global_option_with_attached_value(arg : String) -> Bool {
+  (arg.has_prefix("-c") && arg != "-c") ||
+  arg.has_prefix("--config-env=") ||
+  arg.has_prefix("--exec-path=") ||
+  arg.has_prefix("--git-dir=") ||
+  arg.has_prefix("--namespace=")
+}
+
+///|
+fn git_global_no_arg_option(arg : String) -> Bool {
+  match arg {
+    "--version"
+    | "--help"
+    | "-p"
+    | "--paginate"
+    | "-P"
+    | "--no-pager"
+    | "--no-replace-objects"
+    | "--no-optional-locks"
+    | "--no-lazy-fetch"
+    | "--literal-pathspecs"
+    | "--glob-pathspecs"
+    | "--noglob-pathspecs"
+    | "--icase-pathspecs"
+    | "--bare" => true
+    _ => false
+  }
+}
+
+///|
+fn git_subcommand_args_request_help(
+  argv : Array[String],
+  arg_start : Int,
+) -> Bool {
+  arg_start < argv.length() &&
+  (argv[arg_start] == "--help" || argv[arg_start] == "-h")
+}
+
+///|
+async fn git_checkout_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  if git_command_has_dash_dash(argv, arg_start) {
+    return git_restore_pathspec_target(
+      git_pathspecs_after_dash_dash(argv, arg_start),
+      real_workspace_root,
+      cwd,
+    )
+  }
+  git_workspace_scope_target(real_workspace_root, cwd)
+}
+
+///|
+fn git_workspace_scope_target(
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let target = source_write_detection_cwd(real_workspace_root, Some(cwd))
+  if is_under_workspace_root(root, target) {
+    Some(target)
+  } else {
+    None
+  }
+}
+
+///|
+fn git_command_has_dash_dash(argv : Array[String], arg_start : Int) -> Bool {
+  let mut index = arg_start
+  while index < argv.length() {
+    if argv[index] == "--" {
+      return true
+    }
+    index += 1
+  }
+  false
+}
+
+///|
+async fn git_restore_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  if !git_restore_updates_worktree(argv, arg_start) {
+    return None
+  }
+  let paths = git_restore_paths(argv, arg_start)
+  git_restore_pathspec_target(paths, real_workspace_root, cwd)
+}
+
+///|
+fn git_restore_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
+  let mut staged = false
+  let mut worktree = false
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "--" {
+      break
+    }
+    if arg == "--staged" || git_restore_short_option_cluster_has(arg, "S") {
+      staged = true
+    }
+    if arg == "--worktree" || git_restore_short_option_cluster_has(arg, "W") {
+      worktree = true
+    }
+    if git_restore_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    index += 1
+  }
+  worktree || !staged
+}
+
+///|
+fn git_restore_short_option_cluster_has(arg : String, flag : String) -> Bool {
+  arg.has_prefix("-") &&
+  !arg.has_prefix("--") &&
+  arg != "-" &&
+  arg.contains(flag)
+}
+
+///|
+async fn git_restore_pathspec_target(
+  paths : Array[String],
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  if paths.length() == 0 {
+    return git_workspace_scope_target(real_workspace_root, cwd)
+  }
+  let mut has_positive_pathspec = false
+  for path in paths {
+    if !git_pathspec_is_exclude(path) {
+      has_positive_pathspec = true
+      break
+    }
+  }
+  if !has_positive_pathspec {
+    return git_workspace_scope_target(real_workspace_root, cwd)
+  }
+  for path in paths {
+    if git_pathspec_is_exclude(path) {
+      continue
+    }
+    guard git_positive_pathspec(path, real_workspace_root, cwd) is Some(spec) else {
+      continue
+    }
+    if spec.path == "" || spec.path == "." {
+      return git_workspace_scope_target(real_workspace_root, spec.base)
+    }
+    let target = resolve_source_write_redirect_target(spec.base, spec.path)
+    if protected_workspace_source_or_tree_path(real_workspace_root, target) {
+      return Some(target)
+    }
+    if git_pathspec_may_restore_workspace_source(real_workspace_root, target) {
+      return Some(target)
+    }
+  }
+  None
+}
+
+///|
+priv struct GitPositivePathspec {
+  base : String
+  path : String
+}
+
+///|
+fn git_positive_pathspec(
+  pathspec : String,
+  real_workspace_root : String,
+  cwd : String,
+) -> GitPositivePathspec? {
+  if pathspec.has_prefix(":/") {
+    return Some({ base: real_workspace_root, path: pathspec[2:].to_owned() })
+  }
+  if pathspec.has_prefix(":(") {
+    match pathspec.find(")") {
+      Some(close) => {
+        let magic = pathspec[2:close]
+        if git_long_pathspec_magic_is_exclude(magic) {
+          return None
+        }
+        let base = if git_long_pathspec_magic_is_top(magic) {
+          real_workspace_root
+        } else {
+          cwd
+        }
+        return Some({ base, path: pathspec[close + 1:].to_owned() })
+      }
+      None => ()
+    }
+  }
+  Some({ base: cwd, path: pathspec })
+}
+
+///|
+fn git_pathspec_is_exclude(pathspec : String) -> Bool {
+  if pathspec.has_prefix(":!") || pathspec.has_prefix(":^") {
+    return true
+  }
+  if pathspec.has_prefix(":/!") || pathspec.has_prefix(":/^") {
+    return true
+  }
+  if pathspec.has_prefix(":(") {
+    match pathspec.find(")") {
+      Some(close) =>
+        return git_long_pathspec_magic_is_exclude(pathspec[2:close])
+      None => return false
+    }
+  }
+  false
+}
+
+///|
+fn git_long_pathspec_magic_is_top(magic : StringView) -> Bool {
+  for part in magic.split(",") {
+    if part == "top" || part == "/" {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn git_long_pathspec_magic_is_exclude(magic : StringView) -> Bool {
+  for part in magic.split(",") {
+    if part == "exclude" || part == "!" || part == "^" {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn git_pathspecs_after_dash_dash(
+  argv : Array[String],
+  arg_start : Int,
+) -> Array[String] {
+  let paths : Array[String] = []
+  let mut index = arg_start
+  let mut after_dash_dash = false
+  while index < argv.length() {
+    let arg = argv[index]
+    if !after_dash_dash && arg == "--" {
+      after_dash_dash = true
+      index += 1
+      continue
+    }
+    if after_dash_dash {
+      paths.push(arg)
+    }
+    index += 1
+  }
+  paths
+}
+
+///|
+fn git_pathspec_may_restore_workspace_source(
+  real_workspace_root : String,
+  target : String,
+) -> Bool {
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let target = @path.Path(target).normalize().to_string()
+  is_under_workspace_root(root, target) &&
+  !is_moon_managed_workspace_path(root, target) &&
+  !looks_like_non_source_file_path(target)
+}
+
+///|
+fn git_restore_paths(argv : Array[String], arg_start : Int) -> Array[String] {
+  let paths : Array[String] = []
+  let mut index = arg_start
+  let mut after_dash_dash = false
+  while index < argv.length() {
+    let arg = argv[index]
+    if !after_dash_dash && arg == "--" {
+      after_dash_dash = true
+      index += 1
+      continue
+    }
+    if !after_dash_dash && git_restore_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    if !after_dash_dash && git_restore_option_with_attached_value(arg) {
+      index += 1
+      continue
+    }
+    if !after_dash_dash && arg.has_prefix("-") && arg != "-" {
+      index += 1
+      continue
+    }
+    if after_dash_dash || !arg.has_prefix("-") || arg == "-" {
+      paths.push(arg)
+    }
+    index += 1
+  }
+  paths
+}
+
+///|
+fn git_restore_option_consumes_next(arg : String) -> Bool {
+  arg == "--source" || arg == "-s" || arg == "--pathspec-from-file"
+}
+
+///|
+fn git_restore_option_with_attached_value(arg : String) -> Bool {
+  arg.has_prefix("--source=") || arg.has_prefix("--pathspec-from-file=")
+}
+
+///|
+fn git_reset_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
+  let mut index = arg_start
+  while index < argv.length() {
+    match argv[index] {
+      "--hard" | "--merge" | "--keep" => return true
+      _ => index += 1
+    }
+  }
+  false
+}
+
+///|
+fn git_clean_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
+  let mut dry_run = false
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if git_clean_short_option_has_dry_run(arg) ||
+      git_clean_long_option_is_dry_run(arg) {
+      dry_run = true
+    }
+    if git_clean_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    index += 1
+  }
+  !dry_run
+}
+
+///|
+fn git_clean_long_option_is_dry_run(arg : String) -> Bool {
+  arg == "--dry-run"
+}
+
+///|
+fn git_clean_option_consumes_next(arg : String) -> Bool {
+  arg == "--exclude" || git_clean_short_option_cluster_consumes_next(arg)
+}
+
+///|
+fn git_clean_short_option_cluster_consumes_next(arg : String) -> Bool {
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  let chars = [ for ch in arg => ch ]
+  chars.length() >= 2 && chars[chars.length() - 1] == 'e'
+}
+
+///|
+fn git_clean_short_option_has_dry_run(arg : String) -> Bool {
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  let chars = [ for ch in arg => ch ]
+  for index in 1..<chars.length() {
+    match chars[index] {
+      'n' => return true
+      'e' => return false
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+fn git_apply_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
+  let mut applies = true
+  let mut cached_only = false
+  let mut index = arg_start
+  while index < argv.length() {
+    match argv[index] {
+      "--check" | "--stat" | "--numstat" | "--summary" => applies = false
+      "--cached" => cached_only = true
+      "--index" => cached_only = false
+      "--apply" => applies = true
+      _ => ()
+    }
+    index += 1
+  }
+  applies && !cached_only
+}
+
+///|
+async fn git_rm_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  let mut cached_only = false
+  let mut dry_run = false
+  let mut pathspec_from_file = false
+  let paths : Array[String] = []
+  let mut index = arg_start
+  let mut after_dash_dash = false
+  while index < argv.length() {
+    let arg = argv[index]
+    if !after_dash_dash && arg == "--" {
+      after_dash_dash = true
+      index += 1
+      continue
+    }
+    if !after_dash_dash {
+      match arg {
+        "--cached" => {
+          cached_only = true
+          index += 1
+          continue
+        }
+        "-n" | "--dry-run" => {
+          dry_run = true
+          index += 1
+          continue
+        }
+        "--pathspec-from-file" => {
+          if index + 1 >= argv.length() {
+            return None
+          }
+          pathspec_from_file = true
+          index += 2
+          continue
+        }
+        "--pathspec-file-nul" => {
+          index += 1
+          continue
+        }
+        _ =>
+          if git_restore_short_option_cluster_has(arg, "n") {
+            dry_run = true
+            index += 1
+            continue
+          } else if arg.has_prefix("--pathspec-from-file=") {
+            pathspec_from_file = true
+            index += 1
+            continue
+          } else if arg.has_prefix("-") && arg != "-" {
+            index += 1
+            continue
+          }
+      }
+    }
+    paths.push(arg)
+    index += 1
+  }
+  if cached_only || dry_run {
+    None
+  } else if pathspec_from_file {
+    git_workspace_scope_target(real_workspace_root, cwd)
+  } else {
+    git_restore_pathspec_target(paths, real_workspace_root, cwd)
+  }
+}
+
+///|
+async fn git_mv_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  let paths : Array[String] = []
+  let mut index = arg_start
+  let mut after_dash_dash = false
+  while index < argv.length() {
+    let arg = argv[index]
+    if !after_dash_dash && arg == "--" {
+      after_dash_dash = true
+      index += 1
+      continue
+    }
+    if !after_dash_dash {
+      if arg == "-n" ||
+        arg == "--dry-run" ||
+        git_restore_short_option_cluster_has(arg, "n") {
+        return None
+      }
+      if arg.has_prefix("-") && arg != "-" {
+        index += 1
+        continue
+      }
+    }
+    paths.push(arg)
+    index += 1
+  }
+  if paths.length() < 2 {
+    None
+  } else {
+    git_restore_pathspec_target(paths, real_workspace_root, cwd)
+  }
+}
+
+///|
+async fn source_tree_find_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  if !find_executes_sed_in_place(argv, arg_start) {
+    return None
+  }
+  if find_in_place_sed_targets_are_proven_non_source(argv, arg_start) {
+    return None
+  }
+  let has_filter = find_has_name_or_path_filter(argv, arg_start)
+  let starts = find_start_paths(argv, arg_start)
+  let starts = if starts.length() == 0 { ["."] } else { starts }
+  for start in starts {
+    let target = resolve_source_write_redirect_target(cwd, start)
+    if is_under_workspace_root(real_workspace_root, target) &&
+      (
+        !has_filter ||
+        is_protected_workspace_source_path(real_workspace_root, target) ||
+        protected_workspace_source_or_tree_path(real_workspace_root, target)
+      ) {
+      return Some(target)
+    }
+  }
+  None
+}
+
+///|
+fn find_executes_sed_in_place(argv : Array[String], arg_start : Int) -> Bool {
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "-exec" || arg == "-execdir" {
+      let exec_start = index + 1
+      let exec_end = find_exec_end(argv, exec_start)
+      if command_text_effective_command_index(argv, exec_start, exec_end)
+        is Some(sed_index) &&
+        command_basename(argv[sed_index]) == "sed" &&
+        scan_sed_args_for_in_place(argv, sed_index + 1, exec_end) {
+        return true
+      }
+      index = exec_end + 1
+    } else {
+      index += 1
+    }
+  }
+  false
+}
+
+///|
+fn find_in_place_sed_targets_are_proven_non_source(
+  argv : Array[String],
+  arg_start : Int,
+) -> Bool {
+  let mut saw_in_place_sed = false
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "-exec" || arg == "-execdir" {
+      let exec_start = index + 1
+      let exec_end = find_exec_end(argv, exec_start)
+      if command_text_effective_command_index(argv, exec_start, exec_end)
+        is Some(sed_index) &&
+        command_basename(argv[sed_index]) == "sed" &&
+        scan_sed_args_for_in_place(argv, sed_index + 1, exec_end) {
+        saw_in_place_sed = true
+        if !find_non_source_name_or_path_filter_proves_safe_before(
+            argv, arg_start, index,
+          ) {
+          return false
+        }
+        if !sed_targets_only_find_results(argv, sed_index + 1, exec_end) {
+          return false
+        }
+      }
+      index = exec_end + 1
+    } else {
+      index += 1
+    }
+  }
+  saw_in_place_sed
+}
+
+///|
+fn find_exec_end(argv : Array[String], start : Int) -> Int {
+  let mut index = start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == ";" || arg == "+" {
+      return index
+    }
+    index += 1
+  }
+  argv.length()
+}
+
+///|
+fn find_start_paths(argv : Array[String], arg_start : Int) -> Array[String] {
+  let starts : Array[String] = []
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if find_arg_starts_expression(arg) {
+      break
+    }
+    starts.push(arg)
+    index += 1
+  }
+  starts
+}
+
+///|
+fn find_arg_starts_expression(arg : String) -> Bool {
+  arg == "!" || arg == "(" || arg == ")" || arg == "," || arg.has_prefix("-")
+}
+
+///|
+fn find_non_source_name_or_path_filter_proves_safe_before(
+  argv : Array[String],
+  arg_start : Int,
+  end : Int,
+) -> Bool {
+  find_has_excluding_name_or_path_filter_before(argv, arg_start, end) &&
+  !find_has_source_name_or_path_filter_before(argv, arg_start, end) &&
+  !find_has_branching_or_negated_expression_before(argv, arg_start, end)
+}
+
+///|
+fn find_has_branching_or_negated_expression_before(
+  argv : Array[String],
+  arg_start : Int,
+  end : Int,
+) -> Bool {
+  let mut index = find_expression_start(argv, arg_start)
+  while index < end {
+    match argv[index] {
+      "-o" | "-or" | "!" | "-not" | "(" | ")" | "," => return true
+      _ => index += 1
+    }
+  }
+  false
+}
+
+///|
+fn find_expression_start(argv : Array[String], arg_start : Int) -> Int {
+  let mut index = arg_start
+  while index < argv.length() && !find_arg_starts_expression(argv[index]) {
+    index += 1
+  }
+  index
+}
+
+///|
+fn find_has_name_or_path_filter(argv : Array[String], arg_start : Int) -> Bool {
+  find_source_filter_before(argv, arg_start, argv.length(), accept_any=true)
+}
+
+///|
+fn find_has_excluding_name_or_path_filter_before(
+  argv : Array[String],
+  arg_start : Int,
+  end : Int,
+) -> Bool {
+  let mut index = arg_start
+  while index < end {
+    let arg = argv[index]
+    if find_filter_option_takes_pattern(arg) {
+      if index + 1 < end &&
+        find_pattern_excludes_protected_source(
+          argv[index + 1],
+          case_insensitive=find_filter_option_case_insensitive(arg),
+        ) {
+        return true
+      }
+      index += 2
+      continue
+    }
+    index += 1
+  }
+  false
+}
+
+///|
+fn find_has_source_name_or_path_filter_before(
+  argv : Array[String],
+  arg_start : Int,
+  end : Int,
+) -> Bool {
+  find_source_filter_before(argv, arg_start, end, accept_any=false)
+}
+
+///|
+fn find_source_filter_before(
+  argv : Array[String],
+  arg_start : Int,
+  end : Int,
+  accept_any~ : Bool,
+) -> Bool {
+  let mut index = arg_start
+  while index < end {
+    let arg = argv[index]
+    if find_filter_option_takes_pattern(arg) {
+      if accept_any {
+        return true
+      }
+      if index + 1 < end &&
+        find_pattern_mentions_protected_source(
+          argv[index + 1],
+          case_insensitive=find_filter_option_case_insensitive(arg),
+        ) {
+        return true
+      }
+      index += 2
+      continue
+    }
+    index += 1
+  }
+  false
+}
+
+///|
+fn find_filter_option_takes_pattern(arg : String) -> Bool {
+  arg == "-name" ||
+  arg == "-iname" ||
+  arg == "-path" ||
+  arg == "-ipath" ||
+  arg == "-wholename" ||
+  arg == "-iwholename"
+}
+
+///|
+fn find_filter_option_case_insensitive(arg : String) -> Bool {
+  arg == "-iname" || arg == "-ipath" || arg == "-iwholename"
+}
+
+///|
+fn find_pattern_mentions_protected_source(
+  pattern : String,
+  case_insensitive~ : Bool,
+) -> Bool {
+  let pattern = if case_insensitive { pattern.to_lower() } else { pattern }
+  pattern.contains(".mbt") ||
+  pattern.contains(".mbti") ||
+  pattern.contains("moon.mod") ||
+  pattern.contains("moon.pkg") ||
+  pattern.contains("moon.work")
+}
+
+///|
+fn find_pattern_excludes_protected_source(
+  pattern : String,
+  case_insensitive~ : Bool,
+) -> Bool {
+  let pattern = if case_insensitive { pattern.to_lower() } else { pattern }
+  let base = path_basename(pattern)
+  match find_glob_literal_suffix(base) {
+    Some(suffix) if suffix != "" => !protected_source_suffix_can_match(suffix)
+    _ => false
+  }
+}
+
+///|
+fn find_glob_literal_suffix(pattern : String) -> String? {
+  let mut suffix_start = 0
+  let mut in_bracket = false
+  for index, ch in pattern {
+    if in_bracket {
+      if ch == ']' {
+        in_bracket = false
+        suffix_start = index + 1
+      }
+    } else {
+      match ch {
+        '*' | '?' => suffix_start = index + 1
+        '[' => {
+          in_bracket = true
+          suffix_start = index + 1
+        }
+        _ => ()
+      }
+    }
+  }
+  if in_bracket {
+    None
+  } else {
+    Some(pattern[suffix_start:].to_owned())
+  }
+}
+
+///|
+fn protected_source_suffix_can_match(suffix : String) -> Bool {
+  [
+    "main.mbt", "main.mbti", "README.mbt.md", "moon.mod", "moon.pkg", "moon.mod.json",
+    "moon.pkg.json", "moon.work",
+  ].any(source => source.has_suffix(suffix))
+}
+
+///|
+fn scan_sed_args_for_in_place(
+  argv : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut index = start
+  while index < end {
+    let arg = argv[index]
+    if arg == "--" {
+      return false
+    }
+    if is_sed_in_place_flag(arg) {
+      return true
+    }
+    index += if sed_option_consumes_next(arg) { 2 } else { 1 }
+  }
+  false
+}
+
+///|
+fn sed_targets_only_find_results(
+  argv : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut index = start
+  let mut script_seen = false
+  let mut placeholder_seen = false
+  while index < end {
+    let arg = argv[index]
+    if arg == "--" {
+      index += 1
+      continue
+    }
+    if arg == "+" {
+      break
+    }
+    if sed_in_place_flag_consumes_empty_suffix(argv, index, end) {
+      index += 2
+      continue
+    }
+    if sed_option_consumes_next(arg) {
+      if sed_option_supplies_script(arg) {
+        script_seen = true
+      }
+      index += 2
+      continue
+    }
+    if sed_option_supplies_script(arg) {
+      script_seen = true
+      index += 1
+      continue
+    }
+    if is_sed_in_place_flag(arg) || sed_readonly_option(arg) {
+      index += 1
+      continue
+    }
+    if !script_seen {
+      script_seen = true
+      index += 1
+      continue
+    }
+    if arg == "{}" {
+      placeholder_seen = true
+    } else if find_pattern_mentions_protected_source(
+        arg,
+        case_insensitive=false,
+      ) ||
+      is_protected_source_path(arg) {
+      return false
+    } else {
+      return false
+    }
+    index += 1
+  }
+  placeholder_seen
+}
+
+///|
+fn sed_in_place_flag_consumes_empty_suffix(
+  argv : Array[String],
+  index : Int,
+  end : Int,
+) -> Bool {
+  index + 1 < end && argv[index] == "-i" && argv[index + 1] == ""
+}
+
+///|
+fn sed_option_supplies_script(arg : String) -> Bool {
+  if arg == "--expression" ||
+    arg == "--file" ||
+    arg.has_prefix("--expression=") ||
+    arg.has_prefix("--file=") {
+    return true
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'e' | 'f' => return true
+      'i' => return false
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+fn sed_readonly_option(arg : String) -> Bool {
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'n' | 'E' | 'r' | 's' | 'u' | 'l' => ()
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+fn sed_option_consumes_next(arg : String) -> Bool {
+  if arg == "--expression" || arg == "--file" {
+    return true
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  let chars = [ for ch in arg => ch ]
+  let mut idx = 1
+  while idx < chars.length() {
+    match chars[idx] {
+      'e' | 'f' => return idx == chars.length() - 1
+      'i' => return false
+      _ => idx += 1
+    }
+  }
+  false
+}
+
+///|
+fn is_sed_in_place_flag(arg : String) -> Bool {
+  if arg == "--in-place" || arg.has_prefix("--in-place=") {
+    return true
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  let mut first = true
+  for ch in arg {
+    if first {
+      first = false
+      continue
+    }
+    match ch {
+      'i' => return true
+      'e' | 'f' => return false
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+fn awk_program_text(argv : Array[String], arg_start : Int) -> String? {
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "--" {
+      if index + 1 < argv.length() {
+        return Some(argv[index + 1])
+      }
+      return None
+    }
+    if awk_option_is_inline_program(arg) {
+      if index + 1 < argv.length() {
+        return Some(argv[index + 1])
+      }
+      return None
+    }
+    match awk_attached_inline_program(arg) {
+      Some(program) => return Some(program)
+      None => ()
+    }
+    if awk_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      index += 2
+      continue
+    }
+    if awk_attached_value_option(arg) {
+      index += 1
+      continue
+    }
+    if arg.has_prefix("-") && arg != "-" {
+      index += 1
+      continue
+    }
+    return Some(arg)
+  }
+  None
+}
+
+///|
+fn awk_option_is_inline_program(arg : String) -> Bool {
+  arg == "-e" || arg == "--source"
+}
+
+///|
+fn awk_attached_inline_program(arg : String) -> String? {
+  if arg.has_prefix("--source=") {
+    Some(arg["--source=".length():].to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+fn awk_option_consumes_next(arg : String) -> Bool {
+  arg == "-F" ||
+  arg == "-v" ||
+  arg == "-f" ||
+  arg == "-i" ||
+  arg == "-l" ||
+  arg == "--field-separator" ||
+  arg == "--assign" ||
+  arg == "--file" ||
+  arg == "--include" ||
+  arg == "--load"
+}
+
+///|
+fn awk_attached_value_option(arg : String) -> Bool {
+  (
+    arg.length() > 2 &&
+    (
+      arg.has_prefix("-F") ||
+      arg.has_prefix("-v") ||
+      arg.has_prefix("-f") ||
+      arg.has_prefix("-i") ||
+      arg.has_prefix("-l")
+    )
+  ) ||
+  arg.has_prefix("--field-separator=") ||
+  arg.has_prefix("--assign=") ||
+  arg.has_prefix("--file=") ||
+  arg.has_prefix("--include=") ||
+  arg.has_prefix("--load=")
+}
+
+///|
+fn awk_output_redirect_target(
+  program : String,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let cwd = @path.Path(cwd).normalize().to_string()
+  let mut quote : Char? = None
+  let mut escaped = false
+  let mut index = 0
+  while index < program.length() {
+    match program.get_char(index) {
+      Some(ch) =>
+        match quote {
+          None =>
+            if ch == '"' || ch == '\'' {
+              quote = Some(ch)
+              escaped = false
+            } else if ch == '>' {
+              match awk_redirect_literal_target(program, index, root, cwd) {
+                Some(target) => return Some(target)
+                None => ()
+              }
+            }
+          Some(end_quote) =>
+            if escaped {
+              escaped = false
+            } else if ch == '\\' {
+              escaped = true
+            } else if ch == end_quote {
+              quote = None
+            }
+        }
+      None => ()
+    }
+    index += 1
+  }
+  None
+}
+
+///|
+fn awk_redirect_literal_target(
+  program : String,
+  operator_index : Int,
+  root : String,
+  cwd : String,
+) -> String? {
+  let mut index = operator_index + 1
+  if index < program.length() && program.get_char(index) is Some('>') {
+    index += 1
+  }
+  while index < program.length() {
+    match program.get_char(index) {
+      Some(ch) if ch == ' ' || ch == '\t' => index += 1
+      _ => break
+    }
+  }
+  if index >= program.length() {
+    return None
+  }
+  let quote = match program.get_char(index) {
+    Some(ch) => ch
+    None => return None
+  }
+  if quote != '"' && quote != '\'' {
+    return None
+  }
+  match collect_quoted_literal_from(program, index, quote) {
+    Some(literal) => {
+      let target = resolve_source_write_redirect_target(cwd, literal)
+      if is_protected_workspace_source_path(root, target) {
+        Some(target)
+      } else {
+        None
+      }
+    }
+    None => None
+  }
+}
+
+///|
+fn collect_quoted_literal_from(
+  text : String,
+  start : Int,
+  quote : Char,
+) -> String? {
+  let literal = StringBuilder()
+  let mut escaped = false
+  let mut index = start + 1
+  while index < text.length() {
+    match text.get_char(index) {
+      Some(ch) =>
+        if escaped {
+          literal.write_char(ch)
+          escaped = false
+        } else if ch == '\\' {
+          escaped = true
+        } else if ch == quote {
+          return Some(literal.to_string())
+        } else {
+          literal.write_char(ch)
+        }
+      None => ()
+    }
+    index += 1
+  }
+  None
+}
+
+///|
+async fn script_generated_tree_transfer_target(
+  text : String,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  if !script_text_mentions_tree_transfer(text) {
+    return None
+  }
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let cwd = @path.Path(cwd).normalize().to_string()
+  for marker in script_tree_transfer_markers() {
+    let mut offset = 0
+    while offset < text.length() {
+      match text[offset:].find(marker) {
+        Some(found) => {
+          let start = offset + found
+          match
+            script_generated_tree_transfer_call_target(
+              text[start:].to_owned(),
+              root,
+              cwd,
+            ) {
+            Some(target) => return Some(target)
+            None => ()
+          }
+          match
+            script_generated_tree_transfer_literal_pair_target(text, root, cwd) {
+            Some(target) => return Some(target)
+            None => ()
+          }
+          offset = start + marker.length()
+        }
+        None => break
+      }
+    }
+  }
+  None
+}
+
+///|
+async fn script_generated_tree_transfer_literal_pair_target(
+  text : String,
+  root : String,
+  cwd : String,
+) -> String? {
+  let literals = script_quoted_literals(text)
+  for source_index in 0..<literals.length() {
+    for dest_index in 0..<literals.length() {
+      if source_index != dest_index {
+        let source = resolve_source_write_redirect_target(
+          cwd,
+          literals[source_index],
+        )
+        let dest = resolve_source_write_redirect_target(
+          cwd,
+          literals[dest_index],
+        )
+        if script_generated_tree_transfer_literal_pair_can_create_workspace_source(
+            root, source, dest,
+          ) {
+          return Some(dest)
+        }
+      }
+    }
+  }
+  None
+}
+
+///|
+async fn script_generated_tree_transfer_literal_pair_can_create_workspace_source(
+  root : String,
+  source : String,
+  dest : String,
+) -> Bool {
+  if !script_generated_tree_transfer_can_create_workspace_source(
+      root, source, dest,
+    ) {
+    return false
+  }
+  is_protected_source_path(source) ||
+  is_protected_source_path(dest) ||
+  (
+    !looks_like_non_source_file_path(source) &&
+    !looks_like_non_source_file_path(dest)
+  )
+}
+
+///|
+async fn script_generated_tree_transfer_call_target(
+  text : String,
+  root : String,
+  cwd : String,
+) -> String? {
+  let literals = script_quoted_literals(text)
+  if literals.length() < 2 {
+    return None
+  }
+  let source = resolve_source_write_redirect_target(cwd, literals[0])
+  let dest = resolve_source_write_redirect_target(cwd, literals[1])
+  if script_generated_tree_transfer_can_create_workspace_source(
+      root, source, dest,
+    ) {
+    Some(dest)
+  } else {
+    None
+  }
+}
+
+///|
+async fn script_generated_tree_transfer_can_create_workspace_source(
+  root : String,
+  source : String,
+  dest : String,
+) -> Bool {
+  let source = @path.Path(source).normalize().to_string()
+  let dest = @path.Path(dest).normalize().to_string()
+  if !is_under_workspace_root(root, dest) ||
+    is_moon_managed_workspace_path(root, dest) {
+    return false
+  }
+  if !is_under_workspace_root(root, source) {
+    return source_path_or_tree_contains_protected_source(source)
+  }
+  if !is_moon_managed_workspace_path(root, source) {
+    return source_path_or_tree_contains_protected_source(source)
+  }
+  !(looks_like_non_source_file_path(source) &&
+  looks_like_non_source_file_path(dest))
+}
+
+///|
+fn script_source_literal_preblock_target(
+  text : String,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let cwd = @path.Path(cwd).normalize().to_string()
+  let mut saw_source_literal = false
+  let mut saw_workspace_source_literal = false
+  let mut saw_absolute_outside_source_literal = false
+  for literal in script_quoted_literals(text) {
+    if script_text_mentions_source_path(literal) {
+      saw_source_literal = true
+      let target = resolve_source_write_redirect_target(cwd, literal)
+      if is_protected_workspace_source_path(root, target) {
+        return Some(target)
+      }
+      if is_under_workspace_root(root, target) {
+        saw_workspace_source_literal = true
+      } else if @path.Path(literal).is_absolute() {
+        saw_absolute_outside_source_literal = true
+      }
+    }
+  }
+  if saw_workspace_source_literal {
+    Some(cwd)
+  } else if saw_source_literal && saw_absolute_outside_source_literal {
+    None
+  } else if is_under_workspace_root(root, cwd) {
+    Some(cwd)
+  } else {
+    None
+  }
+}
+
+///|
+fn script_quoted_literals(text : String) -> Array[String] {
+  let literals : Array[String] = []
+  let mut quote : Char? = None
+  let mut escaped = false
+  let mut literal = StringBuilder()
+  for ch in text {
+    match quote {
+      None =>
+        if ch == '"' || ch == '\'' {
+          quote = Some(ch)
+          escaped = false
+          literal = StringBuilder()
+        }
+      Some(end_quote) =>
+        if escaped {
+          literal.write_char(ch)
+          escaped = false
+        } else if ch == '\\' {
+          escaped = true
+        } else if ch == end_quote {
+          literals.push(literal.to_string())
+          quote = None
+        } else {
+          literal.write_char(ch)
+        }
+    }
+  }
+  literals
+}
+
+///|
+fn command_tail_text(argv : Array[String], start : Int) -> String {
+  let text = StringBuilder()
+  for index in start..<argv.length() {
+    if index > start {
+      text.write_char(' ')
+    }
+    text.write_string(argv[index])
+  }
+  text.to_string()
+}
+
+///|
+fn script_text_mentions_source_path(text : String) -> Bool {
+  text.contains(".mbt") ||
+  text.contains(".mbti") ||
+  text.contains("moon.mod") ||
+  text.contains("moon.pkg") ||
+  text.contains("moon.work")
+}
+
+///|
+fn script_text_mentions_generated_tree_path(text : String) -> Bool {
+  text.contains("_build") || text.contains(".mooncakes")
+}
+
+///|
+fn script_text_mentions_write_or_move(text : String) -> Bool {
+  script_text_mentions_non_stdio_write_method(text) ||
+  text.contains("write_text") ||
+  text.contains("write_bytes") ||
+  text.contains("writeFile") ||
+  text.contains("appendFile") ||
+  text.contains("createWriteStream") ||
+  text.contains("copyFile") ||
+  text.contains("cpSync") ||
+  text.contains("renameSync") ||
+  text.contains("fs.rename") ||
+  text.contains("fs.promises.rename") ||
+  text.contains("rmSync") ||
+  script_text_mentions_open_write_mode(text) ||
+  text.contains("os.remove(") ||
+  text.contains("os.unlink(") ||
+  text.contains(".unlink(") ||
+  text.contains("fs.unlink") ||
+  text.contains("fs.rm") ||
+  text.contains("os.rename(") ||
+  text.contains("os.replace(") ||
+  text.contains("rename(") ||
+  text.contains("shutil.copy") ||
+  text.contains("shutil.move") ||
+  text.contains("shutil.copytree") ||
+  text.contains("copytree(")
+}
+
+///|
+fn script_text_mentions_open_write_mode(text : String) -> Bool {
+  let marker = "open("
+  let mut offset = 0
+  while offset < text.length() {
+    match text[offset:].find(marker) {
+      Some(relative_index) => {
+        let args_start = offset + relative_index + marker.length()
+        let tail = text[args_start:]
+        let args_end = match tail.find(")") {
+          Some(relative_end) => args_start + relative_end
+          None => text.length()
+        }
+        let args = text[args_start:args_end]
+        if [
+            "\"w\"", "'w'", "\"wb\"", "'wb'", "\"w+\"", "'w+'", "\"wb+\"", "'wb+'",
+            "\"w+b\"", "'w+b'", "\"a\"", "'a'", "\"ab\"", "'ab'", "\"a+\"", "'a+'",
+            "\"ab+\"", "'ab+'", "\"a+b\"", "'a+b'", "\"x\"", "'x'", "\"xb\"", "'xb'",
+            "\"x+\"", "'x+'", "\"xb+\"", "'xb+'", "\"x+b\"", "'x+b'", "\"r+\"", "'r+'",
+            "\"rb+\"", "'rb+'", "\"r+b\"", "'r+b'",
+          ].any(mode => args.contains(mode)) {
+          return true
+        }
+        offset = args_start
+      }
+      None => return false
+    }
+  }
+  false
+}
+
+///|
+fn script_text_mentions_non_stdio_write_method(text : String) -> Bool {
+  let marker = ".write("
+  let mut offset = 0
+  while offset < text.length() {
+    match text[offset:].find(marker) {
+      Some(relative_index) => {
+        let index = offset + relative_index
+        if !write_method_receiver_is_stdio(text, index) {
+          return true
+        }
+        offset = index + marker.length()
+      }
+      None => return false
+    }
+  }
+  false
+}
+
+///|
+fn write_method_receiver_is_stdio(text : String, write_dot_index : Int) -> Bool {
+  let start = if write_dot_index > 64 { write_dot_index - 64 } else { 0 }
+  let receiver = text[start:write_dot_index]
+    .replace_all(old=" ", new="")
+    .replace_all(old="\t", new="")
+  receiver.has_suffix("stdout") ||
+  receiver.has_suffix("stderr") ||
+  receiver.has_suffix("sys.stdout") ||
+  receiver.has_suffix("sys.stderr") ||
+  receiver.has_suffix("sys.stdout.buffer") ||
+  receiver.has_suffix("sys.stderr.buffer") ||
+  receiver.has_suffix("process.stdout") ||
+  receiver.has_suffix("process.stderr") ||
+  receiver.has_suffix("STDOUT") ||
+  receiver.has_suffix("STDERR")
+}
+
+///|
+fn script_text_mentions_tree_transfer(text : String) -> Bool {
+  script_tree_transfer_markers().any(marker => text.contains(marker))
+}
+
+///|
+fn script_tree_transfer_markers() -> Array[String] {
+  [
+    "fs.promises.rename", "fs.rename", "renameSync", "cpSync", "fs.cp", "os.rename(",
+    "os.replace(", "shutil.move", "shutil.copy(", "shutil.copytree", "copytree(",
+    "rename(",
+  ]
+}
+
+///|
+fn command_basename(name : String) -> String {
+  let normalized = name.replace_all(old="\\", new="/")
+  match normalized.rev_find("/") {
+    Some(slash) => normalized[slash + 1:].to_owned()
+    None => name
+  }
+}
+
+///|
+priv struct MvOperands {
+  sources : Array[String]
+  dest : String?
+}
+
+///|
+async fn source_tree_mv_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  guard parse_mv_operands(argv, arg_start) is Some(operands) else {
+    return None
+  }
+  source_tree_move_target(operands, real_workspace_root, cwd, predicted_dirs)
+}
+
+///|
+async fn source_tree_move_target(
+  operands : MvOperands,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  let dest_target = operands.dest.map(dest => {
+    resolve_source_write_redirect_target(cwd, dest)
+  })
+  for source in operands.sources {
+    let target = resolve_source_write_redirect_target(cwd, source)
+    if protected_workspace_source_or_tree_path(real_workspace_root, target) {
+      return Some(target)
+    }
+    match dest_target {
+      Some(dest) => {
+        let source_contains_protected = source_path_or_tree_contains_protected_source(
+          target,
+        )
+        if move_destination_can_create_workspace_source(
+            real_workspace_root,
+            dest,
+            target,
+            source_contains_protected~,
+            predicted_dirs~,
+          ) {
+          return Some(dest)
+        }
+      }
+      None => ()
+    }
+  }
+  match dest_target {
+    Some(target) =>
+      if is_protected_workspace_source_path(real_workspace_root, target) {
+        Some(target)
+      } else {
+        None
+      }
+    None => None
+  }
+}
+
+///|
+async fn source_path_or_tree_contains_protected_source(target : String) -> Bool {
+  let target = @path.Path(target).normalize().to_string()
+  if is_protected_source_path(target) {
+    return true
+  }
+  let kind = @fs.kind(target, follow_symlink=false) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  match kind {
+    Directory => directory_contains_protected_source_path(target)
+    SymLink => {
+      let resolved = @fs.realpath(target) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => return false
+      }
+      source_path_or_tree_contains_protected_source(resolved)
+    }
+    _ => false
+  }
+}
+
+///|
+async fn directory_contains_protected_source_path(dir : String) -> Bool {
+  let entries = @fs.readdir(dir, include_hidden=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  for entry in entries {
+    let child = @path.Path(dir).join(Path(entry)).normalize().to_string()
+    if is_protected_source_path(child) {
+      return true
+    }
+    let kind = @fs.kind(child, follow_symlink=false) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => continue
+    }
+    match kind {
+      Directory =>
+        if directory_contains_protected_source_path(child) {
+          return true
+        }
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+async fn move_destination_can_create_workspace_source(
+  real_workspace_root : String,
+  dest : String,
+  source : String,
+  source_contains_protected~ : Bool,
+  predicted_dirs~ : Array[String],
+) -> Bool {
+  if is_protected_workspace_source_path(real_workspace_root, dest) {
+    return true
+  }
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let dest = @path.Path(dest).normalize().to_string()
+  if !is_under_workspace_root(root, dest) ||
+    is_moon_managed_workspace_path(root, dest) {
+    return false
+  }
+  let source_kind = @fs.kind(source, follow_symlink=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ =>
+      return missing_move_source_can_create_workspace_source(
+        root,
+        dest,
+        source,
+        predicted_dirs~,
+      )
+  }
+  let dest_is_directory = path_is_directory(dest) ||
+    path_is_predicted_directory(dest, predicted_dirs)
+  match source_kind {
+    Directory => source_contains_protected
+    _ => source_contains_protected && dest_is_directory
+  }
+}
+
+///|
+async fn missing_move_source_can_create_workspace_source(
+  root : String,
+  dest : String,
+  source : String,
+  predicted_dirs~ : Array[String],
+) -> Bool {
+  let dest_is_directory = path_is_directory(dest) ||
+    path_is_predicted_directory(dest, predicted_dirs)
+  let source = @path.Path(source).normalize().to_string()
+  let final_dest = if dest_is_directory {
+    @path.Path(dest).join(Path(path_basename(source))).normalize().to_string()
+  } else {
+    dest
+  }
+  if is_protected_workspace_source_path(root, final_dest) {
+    return true
+  }
+  if dest_is_directory &&
+    is_under_workspace_root(root, source) &&
+    is_moon_managed_workspace_path(root, source) {
+    return true
+  }
+  if path_is_predicted_directory(source, predicted_dirs) {
+    return true
+  }
+  !(looks_like_non_source_file_path(source) &&
+  looks_like_non_source_file_path(final_dest))
+}
+
+///|
+fn looks_like_non_source_file_path(path : String) -> Bool {
+  let base = path_basename(path)
+  match base.rev_find(".") {
+    Some(dot) if dot + 1 < base.length() =>
+      !is_protected_source_path(base) &&
+      looks_like_file_extension(base[dot + 1:].to_owned())
+    _ => false
+  }
+}
+
+///|
+fn looks_like_file_extension(ext : String) -> Bool {
+  for ch in ext {
+    if !(ch is ('a'..='z') || ch is ('A'..='Z')) {
+      return false
+    }
+  }
+  ext.length() > 0
+}
+
+///|
+fn path_basename(path : String) -> String {
+  let normalized = strip_trailing_slash(path.replace_all(old="\\", new="/"))
+  match normalized.rev_find("/") {
+    Some(slash) => normalized[slash + 1:].to_owned()
+    None => normalized
+  }
+}
+
+///|
+async fn path_is_directory(path : String) -> Bool {
+  let kind = @fs.kind(path, follow_symlink=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  kind == Directory
+}
+
+///|
+fn path_is_predicted_directory(
+  path : String,
+  predicted_dirs : Array[String],
+) -> Bool {
+  let normalized = normalized_directory_path(path)
+  predicted_dirs.any(dir => dir == normalized)
+}
+
+///|
+fn push_unique_normalized_path(paths : Array[String], path : String) -> Unit {
+  let normalized = normalized_directory_path(path)
+  if !paths.any(existing => existing == normalized) {
+    paths.push(normalized)
+  }
+}
+
+///|
+fn normalized_directory_path(path : String) -> String {
+  strip_trailing_slash(@path.Path(path).normalize().to_string())
+}
+
+///|
+fn parse_mkdir_dirs(
+  argv : Array[String],
+  arg_start : Int,
+  cwd : String,
+) -> Array[String]? {
+  let dirs : Array[String] = []
+  let mut index = arg_start
+  let mut scanning_options = true
+  while index < argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    if scanning_options && mkdir_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      index += 2
+      continue
+    }
+    if scanning_options &&
+      (mkdir_attached_value_option(arg) || mkdir_supported_no_arg_option(arg)) {
+      index += 1
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    dirs.push(resolve_source_write_redirect_target(cwd, arg))
+    index += 1
+  }
+  Some(dirs)
+}
+
+///|
+fn mkdir_option_consumes_next(arg : String) -> Bool {
+  arg == "-m" || arg == "--mode" || arg == "-Z" || arg == "--context"
+}
+
+///|
+fn mkdir_attached_value_option(arg : String) -> Bool {
+  if arg.has_prefix("--mode=") || arg.has_prefix("--context=") {
+    return true
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg.length() <= 2 {
+    return false
+  }
+  for index, ch in arg[1:] {
+    if ch == 'm' || ch == 'Z' {
+      return index + 2 < arg.length()
+    }
+  }
+  false
+}
+
+///|
+fn mkdir_supported_no_arg_option(arg : String) -> Bool {
+  if arg == "-" {
+    return false
+  }
+  match arg {
+    "--parents" | "--verbose" => return true
+    _ => ()
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'p' | 'v' => ()
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+fn parse_mv_operands(argv : Array[String], arg_start : Int) -> MvOperands? {
+  let operands : Array[String] = []
+  let mut index = arg_start
+  let mut target_directory : String? = None
+  let mut scanning_options = true
+  while index < argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    if scanning_options && mv_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      if arg == "-t" || arg == "--target-directory" {
+        target_directory = Some(argv[index + 1])
+      }
+      index += 2
+      continue
+    }
+    if scanning_options {
+      match mv_attached_target_directory_option(arg) {
+        Some(dest) => {
+          target_directory = Some(dest)
+          index += 1
+          continue
+        }
+        None => ()
+      }
+    }
+    if scanning_options && mv_supported_no_arg_option(arg) {
+      index += 1
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    operands.push(arg)
+    index += 1
+  }
+  match target_directory {
+    Some(dest) => Some({ sources: operands, dest: Some(dest) })
+    None =>
+      if operands.length() >= 2 {
+        let sources : Array[String] = []
+        for index in 0..<(operands.length() - 1) {
+          sources.push(operands[index])
+        }
+        Some({ sources, dest: Some(operands[operands.length() - 1]) })
+      } else {
+        Some({ sources: [], dest: None })
+      }
+  }
+}
+
+///|
+fn mv_option_consumes_next(arg : String) -> Bool {
+  arg == "-t" || arg == "--target-directory" || arg == "-S" || arg == "--suffix"
+}
+
+///|
+fn mv_attached_target_directory_option(arg : String) -> String? {
+  if arg.has_prefix("-t") && arg.length() > 2 {
+    Some(arg[2:].to_owned())
+  } else if arg.has_prefix("--target-directory=") {
+    Some(arg["--target-directory=".length():].to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+fn mv_supported_no_arg_option(arg : String) -> Bool {
+  if arg == "-" {
+    return false
+  }
+  if arg.has_prefix("--backup") || arg.has_prefix("--suffix=") {
+    return true
+  }
+  match arg {
+    "--debug"
+    | "--exchange"
+    | "--force"
+    | "--interactive"
+    | "--no-clobber"
+    | "--no-copy"
+    | "--no-target-directory"
+    | "--strip-trailing-slashes"
+    | "--update"
+    | "--verbose" => return true
+    _ => ()
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'b' | 'f' | 'i' | 'n' | 'v' | 'T' | 'u' | 'Z' => ()
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+async fn source_tree_cp_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  guard parse_cp_operands(argv, arg_start) is Some(operands) else {
+    return None
+  }
+  source_tree_copy_destination_target(
+    operands, real_workspace_root, cwd, predicted_dirs,
+  )
+}
+
+///|
+async fn source_tree_copy_destination_target(
+  operands : MvOperands,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  let dest_target = operands.dest.map(dest => {
+    resolve_source_write_redirect_target(cwd, dest)
+  })
+  match dest_target {
+    Some(dest) =>
+      match
+        existing_path_resolves_to_protected_workspace_source(
+          real_workspace_root, dest,
+        ) {
+        Some(resolved) => return Some(resolved)
+        None => ()
+      }
+    None => ()
+  }
+  for source in operands.sources {
+    match dest_target {
+      Some(dest) => {
+        let source_target = resolve_source_write_redirect_target(cwd, source)
+        let source_contains_protected = source_path_or_tree_contains_protected_source(
+          source_target,
+        )
+        if move_destination_can_create_workspace_source(
+            real_workspace_root,
+            dest,
+            source_target,
+            source_contains_protected~,
+            predicted_dirs~,
+          ) {
+          return Some(dest)
+        }
+      }
+      None => ()
+    }
+  }
+  match dest_target {
+    Some(target) =>
+      if is_protected_workspace_source_path(real_workspace_root, target) {
+        Some(target)
+      } else {
+        None
+      }
+    None => None
+  }
+}
+
+///|
+fn parse_cp_operands(argv : Array[String], arg_start : Int) -> MvOperands? {
+  let operands : Array[String] = []
+  let mut index = arg_start
+  let mut target_directory : String? = None
+  let mut scanning_options = true
+  while index < argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    if scanning_options && cp_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      if arg == "-t" || arg == "--target-directory" {
+        target_directory = Some(argv[index + 1])
+      }
+      index += 2
+      continue
+    }
+    if scanning_options {
+      match cp_attached_target_directory_option(arg) {
+        Some(dest) => {
+          target_directory = Some(dest)
+          index += 1
+          continue
+        }
+        None => ()
+      }
+    }
+    if scanning_options && cp_supported_no_arg_option(arg) {
+      index += 1
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    operands.push(arg)
+    index += 1
+  }
+  operands_with_optional_dest(operands, target_directory)
+}
+
+///|
+fn cp_option_consumes_next(arg : String) -> Bool {
+  arg == "-t" || arg == "--target-directory" || arg == "-S" || arg == "--suffix"
+}
+
+///|
+fn cp_attached_target_directory_option(arg : String) -> String? {
+  if arg.has_prefix("-t") && arg.length() > 2 {
+    Some(arg[2:].to_owned())
+  } else if arg.has_prefix("--target-directory=") {
+    Some(arg["--target-directory=".length():].to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+fn cp_supported_no_arg_option(arg : String) -> Bool {
+  if arg == "-" {
+    return false
+  }
+  if arg.has_prefix("--backup") ||
+    arg.has_prefix("--preserve") ||
+    arg.has_prefix("--reflink") ||
+    arg.has_prefix("--sparse") ||
+    arg.has_prefix("--suffix=") ||
+    arg.has_prefix("--context") {
+    return true
+  }
+  match arg {
+    "--archive"
+    | "--recursive"
+    | "--force"
+    | "--interactive"
+    | "--no-clobber"
+    | "--verbose"
+    | "--dereference"
+    | "--no-dereference"
+    | "--parents"
+    | "--remove-destination"
+    | "--strip-trailing-slashes"
+    | "--update"
+    | "--link"
+    | "--symbolic-link"
+    | "--one-file-system" => return true
+    _ => ()
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'R'
+      | 'r'
+      | 'a'
+      | 'p'
+      | 'f'
+      | 'i'
+      | 'n'
+      | 'v'
+      | 'L'
+      | 'P'
+      | 'H'
+      | 'T'
+      | 'u'
+      | 'l'
+      | 's'
+      | 'x'
+      | 'd' => ()
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+async fn source_tree_install_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+  predicted_dirs : Array[String],
+) -> String? {
+  guard parse_install_operands(argv, arg_start) is Some(operands) else {
+    return None
+  }
+  if operands.directory_mode {
+    for operand in operands.sources {
+      let target = resolve_source_write_redirect_target(cwd, operand)
+      if protected_workspace_source_or_tree_path(real_workspace_root, target) {
+        return Some(target)
+      }
+    }
+    return None
+  }
+  source_tree_copy_destination_target(
+    { sources: operands.sources, dest: operands.dest },
+    real_workspace_root,
+    cwd,
+    predicted_dirs,
+  )
+}
+
+///|
+priv struct InstallOperands {
+  sources : Array[String]
+  dest : String?
+  directory_mode : Bool
+}
+
+///|
+fn parse_install_operands(
+  argv : Array[String],
+  arg_start : Int,
+) -> InstallOperands? {
+  let operands : Array[String] = []
+  let mut index = arg_start
+  let mut target_directory : String? = None
+  let mut directory_mode = false
+  let mut scanning_options = true
+  while index < argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    if scanning_options && (arg == "-d" || arg == "--directory") {
+      directory_mode = true
+      index += 1
+      continue
+    }
+    if scanning_options && install_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      if install_short_cluster_has_directory_mode(arg) {
+        directory_mode = true
+      }
+      if arg == "-t" || arg == "--target-directory" {
+        target_directory = Some(argv[index + 1])
+      }
+      index += 2
+      continue
+    }
+    if scanning_options {
+      match install_attached_target_directory_option(arg) {
+        Some(dest) => {
+          target_directory = Some(dest)
+          index += 1
+          continue
+        }
+        None => ()
+      }
+      if install_attached_consuming_option(arg) {
+        if install_short_cluster_has_directory_mode(arg) {
+          directory_mode = true
+        }
+        index += 1
+        continue
+      }
+    }
+    if scanning_options && install_supported_no_arg_option(arg) {
+      if arg.contains("d") {
+        directory_mode = true
+      }
+      index += 1
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    operands.push(arg)
+    index += 1
+  }
+  if directory_mode {
+    Some({ sources: operands, dest: None, directory_mode })
+  } else {
+    match operands_with_optional_dest(operands, target_directory) {
+      Some(operands) =>
+        Some({ sources: operands.sources, dest: operands.dest, directory_mode })
+      None => None
+    }
+  }
+}
+
+///|
+fn install_option_consumes_next(arg : String) -> Bool {
+  arg == "-g" ||
+  arg == "--group" ||
+  arg == "-m" ||
+  arg == "--mode" ||
+  arg == "-o" ||
+  arg == "--owner" ||
+  arg == "-S" ||
+  arg == "--suffix" ||
+  arg == "-t" ||
+  arg == "--target-directory" ||
+  install_short_cluster_ends_with_consuming_option(arg)
+}
+
+///|
+fn install_attached_target_directory_option(arg : String) -> String? {
+  if arg.has_prefix("-t") && arg.length() > 2 {
+    Some(arg[2:].to_owned())
+  } else if arg.has_prefix("--target-directory=") {
+    Some(arg["--target-directory=".length():].to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+fn install_attached_consuming_option(arg : String) -> Bool {
+  arg.has_prefix("--group=") ||
+  arg.has_prefix("--mode=") ||
+  arg.has_prefix("--owner=") ||
+  arg.has_prefix("--suffix=") ||
+  install_short_cluster_has_attached_consuming_option(arg)
+}
+
+///|
+fn install_short_cluster_has_directory_mode(arg : String) -> Bool {
+  install_short_option_cluster_has(arg, 'd')
+}
+
+///|
+fn install_short_cluster_has_attached_consuming_option(arg : String) -> Bool {
+  match install_short_cluster_consuming_option_index(arg) {
+    Some(index) => index + 1 < arg.length()
+    None => false
+  }
+}
+
+///|
+fn install_short_cluster_ends_with_consuming_option(arg : String) -> Bool {
+  match install_short_cluster_consuming_option_index(arg) {
+    Some(index) => index + 1 == arg.length()
+    None => false
+  }
+}
+
+///|
+fn install_short_cluster_consuming_option_index(arg : String) -> Int? {
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg.length() <= 2 {
+    return None
+  }
+  let mut index = 1
+  for ch in arg[1:] {
+    match ch {
+      'g' | 'm' | 'o' | 'S' => return Some(index)
+      'C' | 'D' | 'd' | 'p' | 's' | 'v' => ()
+      _ => return None
+    }
+    index += 1
+  }
+  None
+}
+
+///|
+fn install_short_option_cluster_has(arg : String, needle : Char) -> Bool {
+  if !arg.has_prefix("-") || arg.has_prefix("--") {
+    return false
+  }
+  for ch in arg[1:] {
+    if ch == needle {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn install_supported_no_arg_option(arg : String) -> Bool {
+  if arg == "-" {
+    return false
+  }
+  if arg.has_prefix("--backup") || arg.has_prefix("--suffix=") {
+    return true
+  }
+  match arg {
+    "--compare"
+    | "--directory"
+    | "--preserve-timestamps"
+    | "--strip"
+    | "--verbose" => return true
+    _ => ()
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'C' | 'D' | 'd' | 'p' | 's' | 'v' => ()
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+async fn source_tree_touch_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  guard parse_touch_operands(argv, arg_start)
+    is Some((operands, follow_symlinks)) else {
+    return None
+  }
+  for operand in operands {
+    let target = resolve_source_write_redirect_target(cwd, operand)
+    if is_protected_workspace_source_path(real_workspace_root, target) {
+      return Some(target)
+    }
+    if follow_symlinks {
+      match
+        existing_path_resolves_to_protected_workspace_source(
+          real_workspace_root, target,
+        ) {
+        Some(resolved) => return Some(resolved)
+        None => ()
+      }
+    }
+  }
+  None
+}
+
+///|
+fn parse_touch_operands(
+  argv : Array[String],
+  arg_start : Int,
+) -> (Array[String], Bool)? {
+  let operands : Array[String] = []
+  let mut follow_symlinks = true
+  let mut index = arg_start
+  let mut scanning_options = true
+  while index < argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      index += 1
+      continue
+    }
+    if scanning_options && touch_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      index += 2
+      continue
+    }
+    if scanning_options && touch_attached_consuming_option(arg) {
+      index += 1
+      continue
+    }
+    if scanning_options && touch_supported_no_arg_option(arg) {
+      if arg == "--no-dereference" ||
+        (arg.has_prefix("-") && !arg.has_prefix("--") && arg.contains("h")) {
+        follow_symlinks = false
+      }
+      index += 1
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    operands.push(arg)
+    index += 1
+  }
+  Some((operands, follow_symlinks))
+}
+
+///|
+fn touch_option_consumes_next(arg : String) -> Bool {
+  arg == "-d" ||
+  arg == "--date" ||
+  arg == "-r" ||
+  arg == "--reference" ||
+  arg == "-t"
+}
+
+///|
+fn touch_attached_consuming_option(arg : String) -> Bool {
+  if arg.length() <= 2 {
+    return false
+  }
+  arg.has_prefix("-d") ||
+  arg.has_prefix("-r") ||
+  arg.has_prefix("-t") ||
+  arg.has_prefix("--date=") ||
+  arg.has_prefix("--reference=") ||
+  arg.has_prefix("--time=")
+}
+
+///|
+fn touch_supported_no_arg_option(arg : String) -> Bool {
+  match arg {
+    "--no-create" | "--no-dereference" | "--help" | "--version" => return true
+    _ => ()
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'a' | 'c' | 'm' | 'h' | 'f' => ()
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+async fn source_tree_tee_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  guard parse_tee_operands(argv, arg_start) is Some(operands) else {
+    return None
+  }
+  for operand in operands {
+    let target = resolve_source_write_redirect_target(cwd, operand)
+    if is_protected_workspace_source_path(real_workspace_root, target) {
+      return Some(target)
+    }
+    match
+      existing_path_resolves_to_protected_workspace_source(
+        real_workspace_root, target,
+      ) {
+      Some(resolved) => return Some(resolved)
+      None => ()
+    }
+  }
+  None
+}
+
+///|
+fn parse_tee_operands(argv : Array[String], arg_start : Int) -> Array[String]? {
+  let operands : Array[String] = []
+  let mut scanning_options = true
+  for index in arg_start..<argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      continue
+    }
+    if scanning_options && tee_supported_no_arg_option(arg) {
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    operands.push(arg)
+  }
+  Some(operands)
+}
+
+///|
+fn tee_supported_no_arg_option(arg : String) -> Bool {
+  if arg == "-" {
+    return false
+  }
+  if arg.has_prefix("--output-error") {
+    return true
+  }
+  match arg {
+    "--append" | "--ignore-interrupts" | "--help" | "--version" => return true
+    _ => ()
+  }
+  if !arg.has_prefix("-") || arg.has_prefix("--") {
+    return false
+  }
+  for ch in arg[1:] {
+    match ch {
+      'a' | 'i' | 'p' => ()
+      _ => return false
+    }
+  }
+  true
+}
+
+///|
+fn operands_with_optional_dest(
+  operands : Array[String],
+  target_directory : String?,
+) -> MvOperands? {
+  match target_directory {
+    Some(dest) => Some({ sources: operands, dest: Some(dest) })
+    None =>
+      if operands.length() >= 2 {
+        let sources : Array[String] = []
+        for index in 0..<(operands.length() - 1) {
+          sources.push(operands[index])
+        }
+        Some({ sources, dest: Some(operands[operands.length() - 1]) })
+      } else {
+        Some({ sources: [], dest: None })
+      }
+  }
+}
+
+///|
+async fn source_tree_rm_target(
+  argv : Array[String],
+  arg_start : Int,
+  real_workspace_root : String,
+  cwd : String,
+) -> String? {
+  let operands = parse_rm_operands(argv, arg_start)
+  for operand in operands {
+    let target = resolve_source_write_redirect_target(cwd, operand)
+    if protected_workspace_source_or_tree_path(real_workspace_root, target) {
+      return Some(target)
+    }
+  }
+  None
+}
+
+///|
+fn parse_rm_operands(argv : Array[String], arg_start : Int) -> Array[String] {
+  let operands : Array[String] = []
+  let mut scanning_options = true
+  for index in arg_start..<argv.length() {
+    let arg = argv[index]
+    if scanning_options && arg == "--" {
+      scanning_options = false
+      continue
+    }
+    if scanning_options && arg.has_prefix("-") && arg != "-" {
+      continue
+    }
+    operands.push(arg)
+  }
+  operands
+}
+
+///|
+fn cwd_command_effect_for_detection(
+  command : @shell_parse.SimpleCommand,
+  cwd : String?,
+) -> CwdCommandEffect {
+  match cwd {
+    Some(cwd) =>
+      match cwd_command_effect(command, cwd) {
+        UnknownCwd => static_relative_cd_command_effect(command, cwd)
+        effect => effect
+      }
+    None => cwd_command_effect_from_unknown_base(command)
+  }
+}
+
+///|
+fn static_relative_cd_command_effect(
+  command : @shell_parse.SimpleCommand,
+  base_cwd : String,
+) -> CwdCommandEffect {
+  let argv = command.argv
+  match command.command_index() {
+    Some(command_index) if command_index < argv.length() &&
+      argv[command_index] == "cd" =>
+      if command.env.length() > 0 {
+        UnknownCwd
+      } else {
+        static_relative_cd_target(argv, command_index + 1, base_cwd)
+      }
+    _ => UnknownCwd
+  }
+}
+
+///|
+fn static_relative_cd_target(
+  argv : Array[String],
+  arg_start : Int,
+  base_cwd : String,
+) -> CwdCommandEffect {
+  let remaining = argv.length() - arg_start
+  if remaining == 1 {
+    known_static_cd_target(argv[arg_start], base_cwd)
+  } else if remaining == 2 && argv[arg_start] == "--" {
+    known_static_cd_target(argv[arg_start + 1], base_cwd)
+  } else {
+    UnknownCwd
+  }
+}
+
+///|
+fn known_static_cd_target(
+  target : String,
+  base_cwd : String,
+) -> CwdCommandEffect {
+  if target == "" || target == "--" || target.has_prefix("-") {
+    UnknownCwd
+  } else {
+    KnownCwd(resolve_command_cwd(base_cwd, target))
+  }
+}
+
+///|
+fn cwd_command_effect_from_unknown_base(
+  command : @shell_parse.SimpleCommand,
+) -> CwdCommandEffect {
+  let argv = command.argv
+  if argv.length() > 0 && argv[0] == "env" {
+    return NotCwdCommand
+  }
+  match command.command_index() {
+    Some(command_index) if command_index < argv.length() =>
+      match argv[command_index] {
+        "cd" =>
+          if command.env.length() > 0 {
+            UnknownCwd
+          } else {
+            cd_command_effect_from_unknown_base(argv, command_index + 1)
+          }
+        "pushd" | "popd" => UnknownCwd
+        _ => NotCwdCommand
+      }
+    _ => NotCwdCommand
+  }
+}
+
+///|
+fn cd_command_effect_from_unknown_base(
+  argv : Array[String],
+  arg_start : Int,
+) -> CwdCommandEffect {
+  let remaining = argv.length() - arg_start
+  if remaining == 1 {
+    known_absolute_cd_target(argv[arg_start])
+  } else if remaining == 2 && argv[arg_start] == "--" {
+    known_absolute_cd_target(argv[arg_start + 1])
+  } else {
+    UnknownCwd
+  }
+}
+
+///|
+fn known_absolute_cd_target(target : String) -> CwdCommandEffect {
+  let target_path : @path.Path = target
+  if target == "--" || target.has_prefix("-") || !target_path.is_absolute() {
+    UnknownCwd
+  } else {
+    KnownCwd(target_path.normalize().to_string())
+  }
+}
+
+///|
+fn source_write_detection_cwd(
+  real_workspace_root : String,
+  cwd : String?,
+) -> String {
+  match cwd {
+    Some(cwd) => {
+      let cwd_path : @path.Path = cwd
+      if cwd_path.is_absolute() {
+        cwd_path.normalize().to_string()
+      } else {
+        @path.Path(real_workspace_root).join(cwd_path).normalize().to_string()
+      }
+    }
+    None => real_workspace_root
+  }
+}
+
+///|
+fn resolve_source_write_redirect_target(
+  cwd : String,
+  target : String,
+) -> String {
+  let target_path : @path.Path = target
+  if target_path.is_absolute() {
+    target_path.normalize().to_string()
+  } else {
+    @path.Path(cwd).join(target_path).normalize().to_string()
+  }
+}
+
+///|
+fn is_protected_workspace_source_path(
+  real_workspace_root : String,
+  target : String,
+) -> Bool {
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let target = @path.Path(target).normalize().to_string()
+  is_under_workspace_root(root, target) &&
+  !is_moon_managed_workspace_path(root, target) &&
+  is_protected_source_path(target)
+}
+
+///|
+fn is_under_workspace_root(root : String, path : String) -> Bool {
+  let root = workspace_compare_path(root)
+  let path = workspace_compare_path(path)
+  if path == root {
+    true
+  } else if root == "/" {
+    path.has_prefix("/")
+  } else {
+    path.has_prefix("\{root}/")
+  }
+}
+
+///|
+async fn protected_workspace_source_or_tree_path(
+  real_workspace_root : String,
+  target : String,
+) -> Bool {
+  if is_protected_workspace_source_path(real_workspace_root, target) {
+    return true
+  }
+  let root = strip_trailing_slash(
+    @path.Path(real_workspace_root).normalize().to_string(),
+  )
+  let target = @path.Path(target).normalize().to_string()
+  if !is_under_workspace_root(root, target) ||
+    is_moon_managed_workspace_path(root, target) {
+    return false
+  }
+  let kind = @fs.kind(target, follow_symlink=false) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  match kind {
+    Directory => directory_contains_protected_workspace_source(root, target)
+    _ => false
+  }
+}
+
+///|
+async fn directory_contains_protected_workspace_source(
+  root : String,
+  dir : String,
+) -> Bool {
+  let entries = @fs.readdir(dir, include_hidden=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  for entry in entries {
+    let child = @path.Path(dir).join(Path(entry)).normalize().to_string()
+    if is_protected_workspace_source_path(root, child) {
+      return true
+    }
+    let kind = @fs.kind(child, follow_symlink=false) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => continue
+    }
+    match kind {
+      Directory =>
+        if directory_contains_protected_workspace_source(root, child) {
+          return true
+        }
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+fn is_moon_managed_workspace_path(root : String, path : String) -> Bool {
+  let root = workspace_compare_path(root)
+  let path = workspace_compare_path(path)
+  if path == root {
+    return false
+  }
+  if !is_under_workspace_root(root, path) {
+    return false
+  }
+  let relative_start = if root == "/" { 1 } else { root.length() + 1 }
+  let relative = path[relative_start:].to_owned()
+  for part in relative.split("/") {
+    if part == "_build" || part == ".mooncakes" {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn workspace_compare_path(path : String) -> String {
+  strip_trailing_slash(path.replace_all(old="\\", new="/"))
+}
+
+///|
+fn is_protected_source_path(path : String) -> Bool {
+  let path = path.replace_all(old="\\", new="/")
+  path.has_suffix(".mbt.md") ||
+  path.has_suffix(".mbt") ||
+  path.has_suffix(".mbti") ||
+  path == "moon.mod" ||
+  path.has_suffix("/moon.mod") ||
+  path == "moon.pkg" ||
+  path.has_suffix("/moon.pkg") ||
+  path == "moon.mod.json" ||
+  path.has_suffix("/moon.mod.json") ||
+  path == "moon.pkg.json" ||
+  path.has_suffix("/moon.pkg.json") ||
+  path == "moon.work" ||
+  path.has_suffix("/moon.work")
+}
+
+///|
+fn direct_source_write_redirect_blocked_content(target : String) -> String {
+  (
+    $|shell sandbox: source file write redirect is blocked before execution: \{target}
+    $|\{SandboxSourceWriteFeedback}
+    $|<system>exit=blocked</system>
+  )
+}
+
+///|
+fn direct_source_tree_operation_blocked_content(target : String) -> String {
+  (
+    $|shell sandbox: source tree operation is blocked before execution: \{target}
+    $|\{SandboxSourceWriteFeedback}
+    $|<system>exit=blocked</system>
+  )
+}
+
+///|
+fn append_shell_sandbox_feedback_if_needed(
+  content : String,
+  agent_output : AgentShellOutput,
+) -> String {
+  if agent_output_has_shell_sandbox_denial(agent_output) {
+    insert_before_system_footer(content, SandboxSourceWriteFeedback)
+  } else {
+    content
+  }
+}
+
+///|
+fn agent_output_has_shell_sandbox_denial(
+  agent_output : AgentShellOutput,
+) -> Bool {
+  agent_output.source_write_sandboxed &&
+  sandbox_denied_source_write(
+    agent_output.output,
+    agent_output.sandbox_denial_subjects,
+  )
+}
+
+///|
+fn sandbox_denied_source_write(
+  output : ShellOutput,
+  denial_subjects : Array[String],
+) -> Bool {
+  output.text
+  .split("\n")
+  .any(line => {
+    sandbox_denial_line_mentions_denial(line) &&
+    (
+      sandbox_denial_line_mentions_source_path(line) ||
+      sandbox_denial_line_mentions_known_subject(line, denial_subjects)
+    )
+  })
+}
+
+///|
+fn sandbox_denial_line_mentions_known_subject(
+  line : StringView,
+  denial_subjects : Array[String],
+) -> Bool {
+  denial_subjects.any(subject => {
+    subject != "" && sandbox_denial_line_mentions_literal_subject(line, subject)
+  })
+}
+
+///|
+fn sandbox_denial_line_mentions_literal_subject(
+  line : StringView,
+  subject : String,
+) -> Bool {
+  line.contains("\{subject}:") ||
+  line.contains("\{subject}'") ||
+  line.contains("\{subject}\"") ||
+  line.contains("\{subject}`") ||
+  (
+    sandbox_denial_line_has_denial_colon_before_subject(line) &&
+    line.has_suffix(subject)
+  )
+}
+
+///|
+fn sandbox_denial_line_mentions_source_path(line : StringView) -> Bool {
+  sandbox_denial_line_mentions_source_suffix(line, ".mbt.md") ||
+  sandbox_denial_line_mentions_source_suffix(line, ".mbt") ||
+  sandbox_denial_line_mentions_source_suffix(line, ".mbti") ||
+  sandbox_denial_line_mentions_source_suffix(line, "moon.mod.json") ||
+  sandbox_denial_line_mentions_source_suffix(line, "moon.pkg.json") ||
+  sandbox_denial_line_mentions_source_suffix(line, "moon.mod") ||
+  sandbox_denial_line_mentions_source_suffix(line, "moon.pkg") ||
+  sandbox_denial_line_mentions_source_suffix(line, "moon.work")
+}
+
+///|
+fn sandbox_denial_line_mentions_source_suffix(
+  line : StringView,
+  suffix : String,
+) -> Bool {
+  line.contains("\{suffix}:") ||
+  line.contains("\{suffix}'") ||
+  line.contains("\{suffix}\"") ||
+  line.contains("\{suffix}`") ||
+  (
+    sandbox_denial_line_has_denial_colon_before_subject(line) &&
+    line.has_suffix(suffix)
+  )
+}
+
+///|
+fn sandbox_denial_line_mentions_denial(line : StringView) -> Bool {
+  line.contains("Operation not permitted") ||
+  line.contains("operation not permitted") ||
+  line.contains(": Permission denied") ||
+  line.contains("Permission denied:")
+}
+
+///|
+fn sandbox_denial_line_has_denial_colon_before_subject(
+  line : StringView,
+) -> Bool {
+  line.contains("Operation not permitted:") ||
+  line.contains("operation not permitted:") ||
+  line.contains("Permission denied:")
+}
+
+///|
+fn regex_escape(text : String) -> String {
+  let escaped = StringBuilder()
+  for ch in text {
+    match ch {
+      '\\'
+      | '.'
+      | '+'
+      | '*'
+      | '?'
+      | '^'
+      | '$'
+      | '('
+      | ')'
+      | '['
+      | ']'
+      | '{'
+      | '}'
+      | '|'
+      | '/' => {
+        escaped.write_char('\\')
+        escaped.write_char(ch)
+      }
+      _ => escaped.write_char(ch)
+    }
+  }
+  escaped.to_string()
+}
+
+///|
+fn sbpl_string_escape(text : String) -> String {
+  let escaped = StringBuilder()
+  for ch in text {
+    match ch {
+      '"' | '\\' => {
+        escaped.write_char('\\')
+        escaped.write_char(ch)
+      }
+      '\n' => escaped.write_string("\\n")
+      '\r' => escaped.write_string("\\r")
+      '\t' => escaped.write_string("\\t")
+      _ => escaped.write_char(ch)
+    }
+  }
+  escaped.to_string()
+}

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -236,15 +236,21 @@ async fn source_write_readonly_profile_data(
   let scan = protected_source_tree_profile_scan(real_workspace_root)
   let denial_subjects = source_write_denial_subjects(scan.literal_paths)
   let source_regex = source_write_regex(real_workspace_root)
-  let source_create_regex = source_write_create_regex(real_workspace_root)
+  let build_carveout_regex = source_write_build_carveout_regex(
+    real_workspace_root,
+  )
   let profile = StringBuilder()
   profile.write_string("(version 1)\n")
   profile.write_string("(allow default)\n")
-  profile.write_string(
-    "(deny file-write-create (regex \"\{sbpl_string_escape(source_create_regex)}\"))\n",
-  )
+  // `file-write*` already covers `file-write-create`, so this single deny blocks
+  // both rewriting existing source and creating new source files. SBPL is
+  // last-match-wins, so the following carve-out re-allows Moon-managed build and
+  // cache trees without the deny regex having to special-case them.
   profile.write_string(
     "(deny file-write* (regex \"\{sbpl_string_escape(source_regex)}\"))\n",
+  )
+  profile.write_string(
+    "(allow file-write* (regex \"\{sbpl_string_escape(build_carveout_regex)}\"))\n",
   )
   for dir in scan.literal_paths {
     profile.write_string(
@@ -294,22 +300,19 @@ async fn cached_source_write_profile_valid(
 ///|
 fn source_write_regex(real_workspace_root : String) -> String {
   let root = regex_escape(strip_trailing_slash(real_workspace_root))
-  let source_dir = protected_source_directory_component_regex()
   let source_file = "([^/]*(\\.mbt\\.md|\\.mbt|\\.mbti)|(moon\\.mod\\.json|moon\\.pkg\\.json|moon\\.mod|moon\\.pkg|moon\\.work))"
-  "^" + root + "(/|$)(\{source_dir}/)*\{source_file}$"
+  "^" + root + "(/|$)(.*/)?\{source_file}$"
 }
 
 ///|
-fn source_write_create_regex(real_workspace_root : String) -> String {
-  source_write_regex(real_workspace_root)
-}
-
-///|
-fn protected_source_directory_component_regex() -> String {
-  let normal = "[^/_.][^/]*"
-  let not_build = "(_|_b|_bu|_bui|_buil|_build[^/]+|_[^b/][^/]*|_b[^u/][^/]*|_bu[^i/][^/]*|_bui[^l/][^/]*|_buil[^d/][^/]*)"
-  let not_mooncakes = "(\\.|\\.m|\\.mo|\\.moo|\\.moon|\\.moonc|\\.moonca|\\.mooncak|\\.mooncake|\\.mooncakes[^/]+|\\.[^m/][^/]*|\\.m[^o/][^/]*|\\.mo[^o/][^/]*|\\.moo[^n/][^/]*|\\.moon[^c/][^/]*|\\.moonc[^a/][^/]*|\\.moonca[^k/][^/]*|\\.mooncak[^e/][^/]*|\\.mooncake[^s/][^/]*)"
-  "(\{normal}|\{not_build}|\{not_mooncakes})"
+/// Paths under a Moon-managed `_build` or `.mooncakes` directory, where Moon
+/// itself writes generated `.mbt` sources. Emitted as an `allow` rule after the
+/// source deny so the sandbox blocks hand-written source rewrites while leaving
+/// Moon's own build/cache writes untouched. Mirrors the component names in
+/// `is_moon_managed_workspace_path`.
+fn source_write_build_carveout_regex(real_workspace_root : String) -> String {
+  let root = regex_escape(strip_trailing_slash(real_workspace_root))
+  "^" + root + "/(.*/)?(_build|\\.mooncakes)(/|$)"
 }
 
 ///|
@@ -2715,8 +2718,7 @@ async fn powershell_write_target(
   guard parse_powershell_path_operands(argv, arg_start) is Some(operands) else {
     return git_workspace_scope_target(real_workspace_root, cwd)
   }
-  for path in operands.paths {
-    let target = resolve_source_write_redirect_target(cwd, path)
+  for target in powershell_new_item_targets(operands, cwd) {
     if is_protected_workspace_source_path(real_workspace_root, target) {
       return Some(target)
     }
@@ -2729,6 +2731,34 @@ async fn powershell_write_target(
     }
   }
   None
+}
+
+///|
+/// Resolve the path(s) a `New-Item` invocation creates. `-Name` names the leaf
+/// item created inside each `-Path` parent (or the cwd when no `-Path` is
+/// given), so `New-Item -Path . -Name main.mbt` creates `./main.mbt`, not `.`.
+/// Without `-Name`, each `-Path` value is itself the created item.
+fn powershell_new_item_targets(
+  operands : PowershellPathOperands,
+  cwd : String,
+) -> Array[String] {
+  let targets : Array[String] = []
+  match operands.new_name {
+    Some(name) =>
+      if operands.paths.length() == 0 {
+        targets.push(resolve_source_write_redirect_target(cwd, name))
+      } else {
+        for parent in operands.paths {
+          let parent_dir = resolve_source_write_redirect_target(cwd, parent)
+          targets.push(resolve_source_write_redirect_target(parent_dir, name))
+        }
+      }
+    None =>
+      for path in operands.paths {
+        targets.push(resolve_source_write_redirect_target(cwd, path))
+      }
+  }
+  targets
 }
 
 ///|

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1,0 +1,2377 @@
+///|
+test "sandbox trusts only narrow moon source-writing commands" {
+  assert_true(mode_for("moon fmt") is TrustedSourceWrite)
+  assert_true(mode_for("moon info") is TrustedSourceWrite)
+  assert_true(
+    mode_for("moon ide rename old new --loc main.mbt:1:8 --apply")
+    is TrustedSourceWrite,
+  )
+  assert_true(mode_for("moon fmt && moon check") is TrustedSourceWrite)
+  assert_true(mode_for("cd ./pkg && moon fmt") is TrustedSourceWrite)
+  assert_true(mode_for("moon fmt >/dev/null") is TrustedSourceWrite)
+  assert_true(mode_for("moon info > /tmp/log") is TrustedSourceWrite)
+  assert_true(mode_for("moon test --update 2>/tmp/err") is TrustedSourceWrite)
+  assert_true(mode_for("moon fmt > out.log") is TrustedSourceWrite)
+  assert_true(mode_for("moon check") is TrustedSourceWrite)
+  assert_true(mode_for("moon build") is TrustedSourceWrite)
+  assert_true(mode_for("moon test") is TrustedSourceWrite)
+  assert_true(mode_for("moon run cmd/main") is TrustedSourceWrite)
+  assert_true(mode_for("moon run cmd/main -- --help") is TrustedSourceWrite)
+  assert_true(mode_for("moon run cmd/main -- -u") is TrustedSourceWrite)
+  assert_true(mode_for("moon run cmd/main --help") is SourceReadOnly)
+  assert_true(
+    mode_for("moon run -e 'fn main { println(1) }'") is SourceReadOnly,
+  )
+  assert_true(mode_for("moon run -e'fn main { println(1) }'") is SourceReadOnly)
+  assert_true(
+    mode_for("moon run --target native -e 'fn main { println(1) }'")
+    is SourceReadOnly,
+  )
+  assert_true(mode_for("moon run -") is SourceReadOnly)
+  assert_true(mode_for("moon run -- -") is SourceReadOnly)
+  assert_true(mode_for("moon run --target native -") is SourceReadOnly)
+  assert_true(mode_for("moon run --target native -- -") is SourceReadOnly)
+  assert_true(mode_for("moon fmt --check") is SourceReadOnly)
+  assert_true(mode_for("moon check --help") is SourceReadOnly)
+  assert_true(mode_for("cd pkg && moon fmt") is TrustedSourceWrite)
+  assert_true(mode_for("moon fmt && git diff") is SourceReadOnly)
+  assert_true(mode_for("moon fmt > main.mbt") is SourceReadOnly)
+  assert_true(mode_for("moon fmt 2> main.mbt") is SourceReadOnly)
+  assert_true(mode_for("moon fmt 1>> main.mbt") is SourceReadOnly)
+  assert_true(mode_for("cd ./pkg && moon fmt > main.mbt") is SourceReadOnly)
+  assert_true(mode_for("moon fmt 2>&1") is TrustedSourceWrite)
+  assert_true(mode_for("sed -i '' 's/a/b/' *.mbt") is SourceReadOnly)
+}
+
+///|
+test "sandbox source write regex covers moonbit source and manifests" {
+  let regex = source_write_regex("/tmp/a.b")
+  let create_regex = source_write_create_regex("/tmp/a.b")
+  assert_eq(create_regex, regex)
+  assert_true(regex.contains("_build[^/]+"))
+  assert_true(regex.contains("\\.mooncakes[^/]+"))
+  assert_true(
+    is_protected_workspace_source_path("/workspace", "/workspace/moon.mod"),
+  )
+  assert_true(
+    is_protected_workspace_source_path("/workspace", "/workspace/pkg/moon.pkg"),
+  )
+  assert_true(
+    is_protected_workspace_source_path("/workspace", "/workspace/pkg/main.mbt"),
+  )
+  assert_true(
+    is_protected_workspace_source_path(
+      "/workspace", "/workspace/pkg/_build.mbt",
+    ),
+  )
+  assert_true(
+    is_protected_workspace_source_path(
+      "/workspace", "/workspace/.mooncakes.mbt",
+    ),
+  )
+  assert_false(
+    is_protected_workspace_source_path(
+      "/workspace", "/workspace/backup-moon.mod",
+    ),
+  )
+  assert_false(
+    is_protected_workspace_source_path(
+      "/workspace", "/workspace/_build/wasm-gc/release/format/main.mbt",
+    ),
+  )
+  assert_false(
+    is_protected_workspace_source_path(
+      "/workspace", "/workspace/.mooncakes/moonbitlang/core/main.mbt",
+    ),
+  )
+  assert_false(
+    is_protected_workspace_source_path(
+      "/workspace", "/workspace/pkg/_build/main.mbt",
+    ),
+  )
+  assert_false(
+    is_protected_workspace_source_path(
+      "/workspace", "/workspace/scripts/.mooncakes/pkg/main.mbt",
+    ),
+  )
+  assert_true(is_under_workspace_root("C:\\repo", "C:\\repo\\main.mbt"))
+  assert_true(
+    is_protected_workspace_source_path("C:\\repo", "C:\\repo\\main.mbt"),
+  )
+  assert_true(
+    is_protected_workspace_source_path("C:\\repo", "C:\\repo\\pkg\\moon.pkg"),
+  )
+  assert_false(
+    is_protected_workspace_source_path("C:\\repo", "C:\\repo\\_build\\main.mbt"),
+  )
+}
+
+///|
+async test "sandbox profile is cached per normalized workspace root" {
+  let profile = source_write_readonly_profile_data("/workspace").profile
+  let cached = source_write_readonly_profile_data("/workspace/").profile
+  assert_eq(cached, profile)
+  assert_true(profile.contains("(deny file-write*"))
+  assert_true(profile.contains("(deny file-write-create"))
+  assert_false(profile.contains("(literal \"/workspace\")"))
+}
+
+///|
+async test "sandbox profile blocks existing directories that contain source" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-source-tree-profile-", root => {
+    @fs.mkdir("\{root}/pkg")
+    @fs.mkdir("\{root}/assets")
+    @fs.mkdir("\{root}/.git")
+    @fs.mkdir("\{root}/_build")
+    @fs.write_file(
+      "\{root}/pkg/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{root}/assets/logo.txt",
+      "not MoonBit source\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{root}/_build/generated.mbt",
+      "pub fn generated() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{root}/.git/ignored.mbt",
+      "not part of the workspace source tree\n",
+      create_mode=CreateOrTruncate,
+    )
+    let profile = source_write_readonly_profile_data(root).profile
+    assert_true(profile.contains("(deny file-write*"))
+    assert_true(profile.contains("(literal \"\{root}/pkg\")"))
+    assert_false(profile.contains("(literal \"\{root}/assets\")"))
+    assert_false(profile.contains("(literal \"\{root}/.git\")"))
+    assert_false(profile.contains("(literal \"\{root}/_build\")"))
+  })
+}
+
+///|
+async test "sandbox profile cache invalidates when source tree changes" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-profile-invalidate-", root => {
+    @fs.mkdir("\{root}/assets")
+    @fs.write_file(
+      "\{root}/assets/logo.txt",
+      "not MoonBit source\n",
+      create_mode=CreateOrTruncate,
+    )
+    let first = source_write_readonly_profile_data(root).profile
+    assert_false(first.contains("(literal \"\{root}/assets\")"))
+    @async.sleep(5)
+    @fs.write_file(
+      "\{root}/assets/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let second = source_write_readonly_profile_data(root).profile
+    assert_true(second.contains("(literal \"\{root}/assets\")"))
+  })
+}
+
+///|
+async test "sandbox preblocks source-writing script snippets" {
+  let root = "/workspace"
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import os; os.makedirs(\"_build/gen\", exist_ok=True); open(\"_build/gen/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(\"_build/gen\", \"pkg\")'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import os; src=\"_build/gen\"; dst=\"pkg\"; os.makedirs(src, exist_ok=True); open(src + \"/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(src, dst)'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "mkdir -p _build/gen && printf source > _build/gen/main.mbt && python3 -c 'import os; os.rename(\"_build/gen\", \"pkg\")'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import os; open(\"_build/generated.txt\", \"w\").write(\"asset\"); os.rename(\"_build/generated.txt\", \"asset.txt\")'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import shutil; shutil.copyfile(\"replacement.txt\", \"main.mbt\")'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "node -e 'const fs = require(\"fs\"); fs.cpSync(\"_build/gen\", \"pkg\", { recursive: true })'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'print(open(\"main.mbt\").read())'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import sys; sys.stdout.write(open(\"main.mbt\").read())'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import sys; sys.stderr.write(open(\"main.mbt\").read())'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'print(\"w\"); print(open(\"main.mbt\").read())'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import sys; sys.stdout.buffer.write(open(\"main.mbt\", \"rb\").read())'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'open(\"/tmp/probe.mbt\", \"w\").write(\"x\")'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'print(\"main.mbt\".replace(\".mbt\", \".txt\"))'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'from pathlib import Path; Path(\"main.mbt\").write_text(\"pub fn answer() -> Int { 1 }\\\\n\")' 2>/dev/null || true",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "awk 'BEGIN { print \"pub fn answer() -> Int { 43 }\" > \"main.mbt\" }' 2>/dev/null || true",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "awk -v marker=.mbt 'BEGIN { if (1 > 0) print marker }'",
+      ),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "sh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "bash --noprofile -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "bash -o pipefail -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "dash -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "ksh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+  assert_true(
+    direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "node -e 'const fs = require(\"fs\"); fs.mkdirSync(\"_build/gen\", { recursive: true }); fs.writeFileSync(\"_build/gen/main.mbt\", \"pub fn generated() -> Int { 1 }\\\\n\"); fs.renameSync(\"_build/gen\", \"pkg\")'",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg"),
+  )
+}
+
+///|
+async test "sandbox preblocks command-line created source directories" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-created-dir-", root => {
+    @fs.write_file(
+      "\{root}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let target = direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "mkdir backup && cp main.mbt backup 2>/dev/null || true",
+      ),
+      root,
+      Some(root),
+    )
+    assert_true(target == Some("\{root}/backup"))
+  })
+}
+
+///|
+async test "sandbox preblocks scripted existing source tree moves" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-script-source-dir-", root => {
+    @fs.mkdir("\{root}/pkg")
+    @fs.write_file(
+      "\{root}/pkg/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let target = direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import os; os.rename(\"pkg\", \"pkg.bak\")' 2>/dev/null || true",
+      ),
+      root,
+      Some(root),
+    )
+    assert_true(target == Some("\{root}/pkg.bak"))
+  })
+}
+
+///|
+async test "sandbox keeps guarded cd cwd visible after semicolon" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-guarded-cd-", root => {
+    @fs.mkdir("\{root}/pkg")
+    @fs.mkdir("\{root}/pkg/sub")
+    @fs.write_file(
+      "\{root}/pkg/sub/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let target = direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy("cd ./pkg && true; rm -rf sub"),
+      root,
+      Some(root),
+    )
+    assert_true(target == Some("\{root}/pkg/sub"))
+  })
+}
+
+///|
+async test "sandbox preblocks scripted external source tree imports" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-script-external-dir-", root => {
+    let workspace = "\{root}/workspace"
+    let generated = "\{root}/generated_pkg"
+    let generated_file = "\{root}/generated.mbt"
+    @fs.mkdir(workspace)
+    @fs.mkdir(generated)
+    @fs.write_file(
+      "\{generated}/main.mbt",
+      "pub fn generated() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      generated_file,
+      "pub fn generated_file() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let target = direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import shutil; shutil.move(\"\{generated}\", \"pkg\")'",
+      ),
+      workspace,
+      Some(workspace),
+    )
+    assert_true(target == Some("\{workspace}/pkg"))
+    let copy_target = direct_source_tree_operation_target_for_root(
+      @shell_parse.parse_for_policy(
+        "python3 -c 'import shutil; shutil.copy(\"\{generated_file}\", \"pkg\")'",
+      ),
+      workspace,
+      Some(workspace),
+    )
+    assert_true(copy_target == Some("\{workspace}/pkg"))
+  })
+}
+
+///|
+async test "sandbox preblocks common source-writing commands" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-common-writers-", root => {
+    @fs.write_file(
+      "\{root}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{root}/replacement.txt",
+      "pub fn answer() -> Int { 43 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.mkdir("\{root}/pkg")
+    @fs.write_file(
+      "\{root}/pkg/main.mbt",
+      "pub fn package_answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.mkdir("\{root}/src")
+    @fs.mkdir("\{root}/src/pkg")
+    @fs.mkdir("\{root}/_build")
+    @fs.write_file(
+      "\{root}/src/pkg/main.mbt",
+      "pub fn nested_package_answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{root}/_build/main.mbt",
+      "pub fn generated() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.symlink(target="main.mbt", "\{root}/out.log")
+    let real_root = @fs.realpath(root)
+    let main_path = "\{real_root}/main.mbt"
+    let pkg_main_path = "\{real_root}/pkg/main.mbt"
+    let src_pkg_path = "\{real_root}/src/pkg"
+    let backup_path = "\{real_root}/backup.mbt"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "cp replacement.txt main.mbt 2>/dev/null || true",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "cp replacement.txt out.log 2>/dev/null || true",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("touch main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("touch out.log 2>/dev/null || true"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("touch -h out.log"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("touch --no-dereference out.log"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("touch --no-dereference main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("printf x | tee main.mbt >/dev/null"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("printf x | tee out.log >/dev/null"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("install replacement.txt out.log"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("install replacement.txt main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "install -Dm644 replacement.txt main.mbt",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "install -Dm 644 replacement.txt main.mbt",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("Set-Content main.mbt value"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "Add-Content -Path out.log -Value value",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("Out-File -FilePath main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("Tee-Object -FilePath out.log"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("Copy-Item replacement.txt out.log"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "Copy-Item _build/main.mbt src/main.mbt -ErrorAction SilentlyContinue",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/src/main.mbt",
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("Move-Item main.mbt backup"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("Remove-Item main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("Rename-Item main.mbt backup.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "New-Item -Path main.mbt -ItemType File",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    let powershell_remove_glob = "Remove-Item *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(powershell_remove_glob),
+          powershell_remove_glob,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git checkout -- ."),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git checkout feature/foo"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git switch feature/foo"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git checkout --help"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git --help checkout"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git switch --help"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git restore --help"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy("if true; then git switch --help; fi"),
+        "if true; then git switch --help; fi",
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy("if true; then git --help checkout; fi"),
+        "if true; then git --help checkout; fi",
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git checkout -- notes.txt"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git checkout -- ':!*.txt'"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git checkout -- ':(exclude)*.txt'"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git checkout -- deleted_pkg"),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/deleted_pkg",
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git checkout feature/foo -- main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git restore deleted_pkg"),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/deleted_pkg",
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git restore ':(top)moon.pkg'"),
+          real_root,
+          Some("\{real_root}/pkg"),
+        ),
+        "\{real_root}/moon.pkg",
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git restore ':(top)notes.txt'"),
+        real_root,
+        Some("\{real_root}/pkg"),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "git -C \{real_root}/pkg restore main.mbt",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        pkg_main_path,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy(
+          "git -C \{real_root}-external restore main.mbt",
+        ),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy(
+          "git -C \{real_root}-external switch feature/foo",
+        ),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git restore main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git restore ':^*.txt'"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git restore -- ':/!*.txt'"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git restore -- ':(top,exclude)*.txt'"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git restore -- notes.txt ':!*.txt'"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "git --literal-pathspecs restore main.mbt",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "git --no-optional-locks restore main.mbt",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git restore --staged ."),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git restore --staged main.mbt"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git restore -S main.mbt"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "git restore --staged --worktree main.mbt",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git restore -SW main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git reset --hard"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git rm main.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git rm --cached main.mbt"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git rm -n main.mbt"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git mv main.mbt backup.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git mv -n main.mbt backup.mbt"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git clean -fd"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git clean -fdn"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git clean -e -n -fd"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git clean -fde -n"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git clean -fne ignored"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git clean --interactive"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git clean --dry-run"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git clean --exclude -n -fd"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git apply --check patch.diff"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git apply --stat --apply patch.diff"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git apply --cached patch.diff"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("git apply --index patch.diff"),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let git_restore_source_glob = "git restore *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(git_restore_source_glob),
+          git_restore_source_glob,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let git_restore_expanded_source_glob = "git restore src/*"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(git_restore_expanded_source_glob),
+          git_restore_expanded_source_glob,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let git_checkout_source_glob = "git checkout -- *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(git_checkout_source_glob),
+          git_checkout_source_glob,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let git_checkout_expanded_branch = "git checkout $branch"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(git_checkout_expanded_branch),
+          git_checkout_expanded_branch,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let git_restore_staged_glob = "git restore --staged *.mbt"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(git_restore_staged_glob),
+        git_restore_staged_glob,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let git_restore_staged_expanded_glob = "git restore --staged src/*"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(git_restore_staged_expanded_glob),
+        git_restore_staged_expanded_glob,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let scoped_git_segments = "git restore --staged *.mbt && git apply --cached patch.diff"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(scoped_git_segments),
+        scoped_git_segments,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let find_sed_source = "find \{real_root} -name '*.mbt' -exec sed -i '' 's/42/43/' {} +"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(find_sed_source),
+          find_sed_source,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_env_sed_source = "find \{real_root} -name '*.mbt' -exec env FOO=bar sed -i '' 's/42/43/' {} + 2>/dev/null || true"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(find_env_sed_source),
+          find_env_sed_source,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_sed_source_case_insensitive = "find \{real_root} -iname '*.MBT' -exec sed -i '' 's/42/43/' {} +"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(find_sed_source_case_insensitive),
+          find_sed_source_case_insensitive,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_sed_readme_glob = "find \{real_root} -name README.* -exec sed -i '' 's/42/43/' '{}' +"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(find_sed_readme_glob),
+          find_sed_readme_glob,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let safe_find_then_sed = "find \{real_root} -name '*.txt' -print; sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(safe_find_then_sed),
+          safe_find_then_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let env_wrapped_sed = "env FOO=bar sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(env_wrapped_sed),
+          env_wrapped_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let env_assignment_sed = "FOO=bar sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(env_assignment_sed),
+          env_assignment_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let env_unset_wrapped_sed = "env -u FOO sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(env_unset_wrapped_sed),
+          env_unset_wrapped_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let env_long_unset_wrapped_sed = "env --unset FOO sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(env_long_unset_wrapped_sed),
+          env_long_unset_wrapped_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let command_wrapped_sed = "command sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(command_wrapped_sed),
+          command_wrapped_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_sed_text = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' {} +"
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy(find_sed_text),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(find_sed_text),
+        find_sed_text,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let find_sed_text_quoted = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' '{}' +"
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy(find_sed_text_quoted),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(find_sed_text_quoted),
+        find_sed_text_quoted,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let find_sed_filter_after_exec = "find \{real_root} -exec sed -i '' 's/42/43/' '{}' + -name '*.txt'"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(find_sed_filter_after_exec),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let broad_find_sed_text = "find \{real_root} -name '*' -exec sed -i '' 's/42/43/' '{}' +"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(broad_find_sed_text),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_sed_literal_source = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' main.mbt ';'"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(find_sed_literal_source),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_sed_comma_quoted = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' '{}' + , -exec sed -i '' 's/42/43/' '{}' +"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(find_sed_comma_quoted),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let readonly_sed_pipeline = "sed -n '1,5p' *.mbt | grep -i answer"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(readonly_sed_pipeline),
+        readonly_sed_pipeline,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let readonly_sed_file_named_i = "while true; do sed -f -i *.mbt\ndone"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(readonly_sed_file_named_i),
+        readonly_sed_file_named_i,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let multiline_sed = "while true; do printf ok\nsed -i '' 's/42/43/' *.mbt\ndone"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(multiline_sed),
+          multiline_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let background_sed = "sleep 1 & sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(background_sed),
+          background_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let nested_shell_sed = "sh -c \"sed -i '' 's/42/43/' *.mbt\""
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(nested_shell_sed),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let quoted_sed_text = "grep 'foo|sed -i' *.mbt"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(quoted_sed_text),
+        quoted_sed_text,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let generated_script_with_sed = "cat > script.sh <<EOF\nsed -i 's/42/43/' f\nEOF"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(generated_script_with_sed),
+        generated_script_with_sed,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let backslash_quoted_heredoc_then_copy = "cat <<\\EOF\nignored\nEOF\ncp main.mbt backup.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(backslash_quoted_heredoc_then_copy),
+          backslash_quoted_heredoc_then_copy,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let generated_script_then_executed = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(generated_script_then_executed),
+          generated_script_then_executed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let tee_generated_script_then_executed = "tee script.sh <<EOF >/dev/null\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(tee_generated_script_then_executed),
+          tee_generated_script_then_executed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let pipe_tee_generated_script_then_executed = "cat <<EOF | tee script.sh >/dev/null\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(pipe_tee_generated_script_then_executed),
+          pipe_tee_generated_script_then_executed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let generated_script_then_bash_with_option = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nbash -o pipefail script.sh"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(generated_script_then_bash_with_option),
+          generated_script_then_bash_with_option,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let generated_script_then_dot_sourced = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\n. script.sh"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(generated_script_then_dot_sourced),
+          generated_script_then_dot_sourced,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let generated_script_then_source_sourced = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nsource script.sh"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(generated_script_then_source_sourced),
+          generated_script_then_source_sourced,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let generated_script_then_shell_c_sourced = "cat > script.sh <<EOF\nmkdir -p _build/gen\ncp main.mbt _build/gen/main.mbt\nmv _build/gen pkg\nEOF\nsh -c '. ./script.sh'"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(generated_script_then_shell_c_sourced),
+          generated_script_then_shell_c_sourced,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let shell_heredoc_with_sed = "sh <<EOF\nsed -i '' 's/42/43/' *.mbt\nEOF"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(shell_heredoc_with_sed),
+          shell_heredoc_with_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let python_heredoc_generated_move = "python3 <<EOF\nimport shutil\nshutil.move('_build/pkg', 'pkg')\nEOF"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(python_heredoc_generated_move),
+          python_heredoc_generated_move,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let heredoc_source_redirect = "cat 2>/dev/null > main.mbt <<'EOF' || true\npub fn answer() -> Int { 43 }\nEOF"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(heredoc_source_redirect),
+          heredoc_source_redirect,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let fd_duplicate_source_redirect = "printf x >& main.mbt *.txt 2>/dev/null || true"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(fd_duplicate_source_redirect),
+          fd_duplicate_source_redirect,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let rm_glob_source = "rm *.mbt 2>/dev/null || true"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(rm_glob_source),
+          rm_glob_source,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let grep_mv_source = "grep mv *.mbt"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(grep_mv_source),
+        grep_mv_source,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let python_heredoc_source_write = "python3 - <<'PY'\nopen('main.mbt', 'w').write('pub fn answer() -> Int { 43 }\\n')\nPY"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(python_heredoc_source_write),
+          python_heredoc_source_write,
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    let outside_python_heredoc_source_write = "python3 - <<'PY'\nopen('/tmp/probe.mbt', 'w').write('x')\nPY"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(outside_python_heredoc_source_write),
+        outside_python_heredoc_source_write,
+        real_root,
+        Some("/tmp"),
+      )
+      is None,
+    )
+    let outside_python_c_source_write = "python3 -c 'open(\"/tmp/probe.mbt\", \"w\").write(\"x\")' *.txt"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(outside_python_c_source_write),
+        outside_python_c_source_write,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let cd_outside_glob_sed = "cd /tmp && sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(cd_outside_glob_sed),
+        cd_outside_glob_sed,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    let cd_workspace_glob_sed = "cd \{real_root} && sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(cd_workspace_glob_sed),
+          cd_workspace_glob_sed,
+          real_root,
+          Some("/tmp"),
+        ),
+        real_root,
+      ),
+    )
+    let versioned_python_source_write = "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")'"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(versioned_python_source_write),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    let python_exe_source_write = "Python.EXE -c 'open(\"main.mbt\", \"w+\").close()' 2>/dev/null || true"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(python_exe_source_write),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    let python_create_mode_source_write = "python -c 'open(\"main.mbt\", \"x\").close()' 2>/dev/null || true"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(python_create_mode_source_write),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    let masked_versioned_python_source_write = "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")' 2>/dev/null || true"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(masked_versioned_python_source_write),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    let find_sed_branch = "find \{real_root} -name '*.txt' -o -exec sed -i '' 's/42/43/' {} +"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(find_sed_branch),
+          find_sed_branch,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_sed_branch_quoted = "find \{real_root} -name '*.txt' -o -exec sed -i '' 's/42/43/' '{}' +"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(find_sed_branch_quoted),
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let find_sed_comma = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' {} + , -exec sed -i '' 's/42/43/' {} +"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(find_sed_comma),
+          find_sed_comma,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let grouped_sed = "{ sed -i '' 's/42/43/' *.mbt; }"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(grouped_sed),
+          grouped_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let until_sed = "until sed -i '' 's/42/43/' *.mbt; do true; done"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(until_sed),
+          until_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let elif_sed = "if false; then true; elif sed -i '' 's/42/43/' *.mbt; then true; fi"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(elif_sed),
+          elif_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let if_env_sed = "if env FOO=bar sed -i '' 's/42/43/' *.mbt; then true; fi"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(if_env_sed),
+          if_env_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let if_command_sed = "if command sed -i '' 's/42/43/' *.mbt; then true; fi"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(if_command_sed),
+          if_command_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let loop_sed = "while IFS= read -r f; do sed -i '' 's/42/43/' \"$f\"; done < /tmp/files.txt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(loop_sed),
+          loop_sed,
+          real_root,
+          Some(real_root),
+        ),
+        real_root,
+      ),
+    )
+    let cd_glob_sed = "cd pkg && sed -i '' 's/42/43/' *.mbt"
+    assert_true(
+      is_some_path(
+        dynamic_source_tree_operation_target(
+          @shell_parse.parse_for_policy(cd_glob_sed),
+          cd_glob_sed,
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/pkg",
+      ),
+    )
+    let mkdir_or_cp_source = "mkdir gen || true; cp /tmp/generated.mbt gen 2>/dev/null || true"
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(mkdir_or_cp_source),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/gen",
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "cd src && mv pkg pkg.bak 2>/dev/null || true",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        src_pkg_path,
+      ),
+    )
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy("cp main.mbt backup.txt"),
+        "cp main.mbt backup.txt",
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("cp main.mbt backup.txt"),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("cp main.mbt backup.mbt"),
+          real_root,
+          Some(real_root),
+        ),
+        backup_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy("mv --force pkg pkg.bak"),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/pkg",
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "mv -b main.mbt backup 2>/dev/null || true",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "mv --no-target-directory _build/gen pkg",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/pkg",
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "mkdir -p _build/gen.v1 && printf source > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg.v1",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/pkg.v1",
+      ),
+    )
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "mkdir -p assets _build/gen.tmp && printf source > _build/gen.tmp/main.mbt && mv _build/gen.tmp assets/pkg.tmp",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        "\{real_root}/assets/pkg.tmp",
+      ),
+    )
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy(
+          "mkdir -p assets _build && printf data > _build/logo.txt && mv _build/logo.txt assets/logo.txt",
+        ),
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+  })
+}
+
+///|
+fn is_some_path(value : String?, expected : String) -> Bool {
+  match value {
+    Some(path) => path == expected
+    None => false
+  }
+}
+
+///|
+test "sandbox denial detection ignores masked exit code" {
+  let output = {
+    exit_code: Some(0),
+    text: "sh: main.mbt: Operation not permitted\n",
+    output_limit_reached: false,
+  }
+  assert_true(sandbox_denied_source_write(output, []))
+  assert_true(
+    agent_output_has_shell_sandbox_denial({
+      output,
+      source_write_sandboxed: true,
+      sandbox_denial_subjects: [],
+    }),
+  )
+  assert_false(
+    agent_output_has_shell_sandbox_denial({
+      output,
+      source_write_sandboxed: false,
+      sandbox_denial_subjects: [],
+    }),
+  )
+  let generic = {
+    exit_code: Some(0),
+    text: "Permission denied\n",
+    output_limit_reached: false,
+  }
+  assert_false(sandbox_denied_source_write(generic, []))
+  let prose = {
+    exit_code: Some(0),
+    text: "Permission denied while reading main.mbt\n",
+    output_limit_reached: false,
+  }
+  assert_false(sandbox_denied_source_write(prose, []))
+  let quoted_prose = {
+    exit_code: Some(0),
+    text: "Permission denied while reading 'main.mbt'\n",
+    output_limit_reached: false,
+  }
+  assert_false(sandbox_denied_source_write(quoted_prose, []))
+  let python = {
+    exit_code: Some(0),
+    text: "PermissionError: [Errno 1] Operation not permitted: 'main.mbt'\n",
+    output_limit_reached: false,
+  }
+  assert_true(sandbox_denied_source_write(python, []))
+  let subject_after_denial = {
+    exit_code: Some(0),
+    text: "Operation not permitted: main.mbt\n",
+    output_limit_reached: false,
+  }
+  assert_true(sandbox_denied_source_write(subject_after_denial, []))
+  let permission_subject = {
+    exit_code: Some(0),
+    text: "Permission denied: main.mbt\n",
+    output_limit_reached: false,
+  }
+  assert_true(sandbox_denied_source_write(permission_subject, []))
+  let directory_rename_subject = {
+    exit_code: Some(0),
+    text: "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n",
+    output_limit_reached: false,
+  }
+  assert_false(sandbox_denied_source_write(directory_rename_subject, []))
+  assert_true(sandbox_denied_source_write(directory_rename_subject, ["pkg"]))
+  assert_true(
+    agent_output_has_shell_sandbox_denial({
+      output: directory_rename_subject,
+      source_write_sandboxed: true,
+      sandbox_denial_subjects: ["pkg"],
+    }),
+  )
+  let unrelated_readonly_output = {
+    exit_code: Some(0),
+    text: "foo: Operation not permitted\n",
+    output_limit_reached: false,
+  }
+  assert_false(sandbox_denied_source_write(unrelated_readonly_output, []))
+  assert_false(sandbox_denied_source_write(unrelated_readonly_output, ["pkg"]))
+  assert_false(
+    agent_output_has_shell_sandbox_denial({
+      output: unrelated_readonly_output,
+      source_write_sandboxed: true,
+      sandbox_denial_subjects: ["pkg"],
+    }),
+  )
+  let moon_work = {
+    exit_code: Some(0),
+    text: "sh: moon.work: Operation not permitted\n",
+    output_limit_reached: false,
+  }
+  assert_true(sandbox_denied_source_write(moon_work, []))
+  assert_false(
+    agent_output_has_shell_sandbox_denial({
+      output: generic,
+      source_write_sandboxed: true,
+      sandbox_denial_subjects: [],
+    }),
+  )
+}
+
+///|
+test "sandbox detects direct protected source write redirects" {
+  let root = "/workspace"
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("printf x 2>/dev/null > main.mbt || true"),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("cd ./pkg && printf x > main.mbt"),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy(
+        "cd /missing 2>/dev/null || printf x 2>/dev/null > main.mbt || true",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy(
+        "cd /definitely-missing && :; printf x > main.mbt",
+      ),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("cd /workspace; printf x > main.mbt"),
+      root,
+      Some("/tmp"),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy(
+        "cd /workspace; cd ./pkg && printf x > main.mbt",
+      ),
+      root,
+      Some("/tmp"),
+    )
+    is Some("/workspace/pkg/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("cd ./pkg && true; printf x > main.mbt"),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/pkg/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("cd /tmp && printf x > main.mbt"),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("printf x > moon.work"),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/moon.work"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("printf x >| main.mbt"),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy(": <> main.mbt"),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy(": 4<> main.mbt"),
+      root,
+      Some(root),
+    )
+    is Some("/workspace/main.mbt"),
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("printf x > _build/out"),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("printf x > _build/main.mbt"),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("printf x > .mooncakes/pkg/main.mbt"),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("cat < main.mbt"),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+  assert_true(
+    direct_source_write_redirect_target_for_root(
+      @shell_parse.parse_for_policy("printf x > /tmp/main.mbt"),
+      root,
+      Some(root),
+    )
+    is None,
+  )
+}
+
+///|
+fn mode_for(cmd : String) -> SourceWriteMode {
+  source_write_mode_for_parse(
+    @shell_parse.parse_for_policy(cmd),
+    "/workspace",
+    Some("/workspace"),
+  )
+}

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -46,10 +46,12 @@ test "sandbox trusts only narrow moon source-writing commands" {
 ///|
 test "sandbox source write regex covers moonbit source and manifests" {
   let regex = source_write_regex("/tmp/a.b")
-  let create_regex = source_write_create_regex("/tmp/a.b")
-  assert_eq(create_regex, regex)
-  assert_true(regex.contains("_build[^/]+"))
-  assert_true(regex.contains("\\.mooncakes[^/]+"))
+  // The deny regex matches source files at any depth and no longer special-cases
+  // build directories; `_build`/`.mooncakes` are re-allowed by the carve-out.
+  assert_true(regex.contains("\\.mbt\\.md|\\.mbt|\\.mbti"))
+  assert_false(regex.contains("_build"))
+  let carveout = source_write_build_carveout_regex("/tmp/a.b")
+  assert_true(carveout.contains("_build|\\.mooncakes"))
   assert_true(
     is_protected_workspace_source_path("/workspace", "/workspace/moon.mod"),
   )
@@ -112,7 +114,8 @@ async test "sandbox profile is cached per normalized workspace root" {
   let cached = source_write_readonly_profile_data("/workspace/").profile
   assert_eq(cached, profile)
   assert_true(profile.contains("(deny file-write*"))
-  assert_true(profile.contains("(deny file-write-create"))
+  assert_true(profile.contains("(allow file-write* (regex"))
+  assert_false(profile.contains("(deny file-write-create"))
   assert_false(profile.contains("(literal \"/workspace\")"))
 }
 
@@ -765,6 +768,20 @@ async test "sandbox preblocks common source-writing commands" {
         direct_source_tree_operation_target_for_root(
           @shell_parse.parse_for_policy(
             "New-Item -Path main.mbt -ItemType File",
+          ),
+          real_root,
+          Some(real_root),
+        ),
+        main_path,
+      ),
+    )
+    // `-Name` is the leaf created under `-Path`, so the target is `./main.mbt`,
+    // not the `.` directory.
+    assert_true(
+      is_some_path(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(
+            "New-Item -Path . -Name main.mbt -ItemType File",
           ),
           real_root,
           Some(real_root),

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -51,13 +51,13 @@ pub fn definition(
 ///|
 #cfg(platform="windows")
 fn shell_description() -> String {
-  "Run arguments.cmd through PowerShell (pwsh -NoProfile -Command), optionally in arguments.cwd, and return exit code plus output. Use PowerShell syntax and cmdlets in arguments.cmd."
+  "Run arguments.cmd through PowerShell (pwsh -NoProfile -Command), optionally in arguments.cwd, and return exit code plus output. Use PowerShell syntax and cmdlets in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit; do not use shell rewrites."
 }
 
 ///|
 #cfg(not(platform="windows"))
 fn shell_description() -> String {
-  "Run arguments.cmd through the POSIX shell (sh -c), optionally in arguments.cwd, and return exit code plus output. Use POSIX shell syntax in arguments.cmd."
+  "Run arguments.cmd through the POSIX shell (sh -c), optionally in arguments.cwd, and return exit code plus output. Use POSIX shell syntax in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit; do not use shell rewrites."
 }
 
 ///|
@@ -85,7 +85,7 @@ async fn execute_with_workspace(
     None => ()
   }
   let cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
-  shell(input, parsed_command, cwd) catch {
+  shell(input, parsed_command, cwd, workspace_root) catch {
     error =>
       @agent_tool.ToolAction::respond(
         "error running shell: \{error}",
@@ -99,6 +99,7 @@ async fn shell(
   input : @decode.ShellInput,
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
+  workspace_root : String,
 ) -> @agent_tool.ToolAction {
   if cwd is Some(cwd) {
     let exists = @fs.exists(cwd)
@@ -116,26 +117,46 @@ async fn shell(
       )
     }
   }
+  match
+    direct_source_write_redirect_target(parsed_command, workspace_root, cwd) {
+    Some(target) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_write_redirect_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
+    None => ()
+  }
   let result = match input.timeout_ms {
     Some(timeout_ms) =>
       @async.with_timeout_opt(timeout_ms, () => {
-        collect_shell_output(
+        run_agent_shell_with_tree_precheck(
+          workspace_root,
           input.cmd,
+          parsed_command,
           cwd?,
           max_output_chars=input.max_output_chars,
         )
       })
     None =>
       Some(
-        collect_shell_output(
+        run_agent_shell_with_tree_precheck(
+          workspace_root,
           input.cmd,
+          parsed_command,
           cwd?,
           max_output_chars=input.max_output_chars,
         ),
       )
   }
-  let output = match result {
-    Some(result) => result
+  let agent_output = match result {
+    Some(ShellExecuted(output)) => output
+    Some(ShellPreblockedSourceTree(target)) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_tree_operation_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
     None => {
       let timeout_ms = match input.timeout_ms {
         Some(timeout_ms) => timeout_ms
@@ -147,20 +168,64 @@ async fn shell(
       )
     }
   }
+  let output = agent_output.output
   let response = shell_response(output, input.max_output_chars)
+  let sandbox_denied = agent_output_has_shell_sandbox_denial(agent_output)
+  let content = append_shell_sandbox_feedback_if_needed(
+    response.content,
+    agent_output,
+  )
   let content = append_moon_command_check_summary(
     parsed_command,
     cwd,
-    response.content,
+    content,
     output,
     input.timeout_ms,
     input.max_output_chars,
   )
   @agent_tool.ToolAction::respond(
     content,
-    is_error=response.is_error,
+    is_error=response.is_error || sandbox_denied,
     brief=shell_brief(input.cmd, output.exit_code),
   )
+}
+
+///|
+priv enum ShellRunResult {
+  ShellPreblockedSourceTree(String)
+  ShellExecuted(AgentShellOutput)
+}
+
+///|
+async fn run_agent_shell_with_tree_precheck(
+  workspace_root : String,
+  cmd : String,
+  parsed_command : @shell_parse.ParseResult,
+  cwd? : String,
+  max_output_chars~ : Int,
+) -> ShellRunResult {
+  match
+    direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
+    Some(target) => ShellPreblockedSourceTree(target)
+    None => {
+      match
+        dynamic_source_tree_operation_target(
+          parsed_command, cmd, workspace_root, cwd,
+        ) {
+        Some(target) => return ShellPreblockedSourceTree(target)
+        None => ()
+      }
+      ShellExecuted(
+        collect_agent_shell_output(
+          workspace_root,
+          cmd,
+          parsed_command,
+          cwd?,
+          max_output_chars~,
+        ),
+      )
+    }
+  }
 }
 
 ///|
@@ -203,8 +268,21 @@ pub async fn collect_shell_output(
   cwd? : String,
   max_output_chars? : Int = @decode.default_max_output_chars,
 ) -> ShellOutput {
-  let program = PlatformShellProgram
-  let args = platform_shell_args(cmd)
+  collect_process_output(
+    PlatformShellProgram,
+    platform_shell_args(cmd),
+    cwd?,
+    max_output_chars~,
+  )
+}
+
+///|
+async fn collect_process_output(
+  program : String,
+  args : Array[String],
+  cwd? : String,
+  max_output_chars~ : Int,
+) -> ShellOutput {
   let (reader, writer) = @process.read_from_process()
   @async.with_task_group() <| group => {
     defer reader.close()

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -18,6 +18,65 @@ async fn run_shell_in_workspace(
 }
 
 ///|
+#cfg(not(platform="windows"))
+async fn sandbox_exec_usable_for_test() -> Bool {
+  if !@fs.exists("/usr/bin/sandbox-exec") {
+    return false
+  }
+  let probe_dir = @fs.tmpdir(prefix="openseek-shell-sandbox-probe-") catch {
+    _ => return false
+  }
+  let blocked = "\{probe_dir}/blocked"
+  let profile =
+    $|(version 1)
+    $|(allow default)
+    $|(deny file-write* (literal "\{blocked}"))
+  let (code, _) = @process.collect_output_merged("/usr/bin/sandbox-exec", [
+    "-p", profile, "sh", "-c", ":",
+  ]) catch {
+    _ => {
+      cleanup_sandbox_exec_test_probe(probe_dir, blocked)
+      return false
+    }
+  }
+  if code != 0 {
+    cleanup_sandbox_exec_test_probe(probe_dir, blocked)
+    return false
+  }
+  let (deny_code, _) = @process.collect_output_merged("/usr/bin/sandbox-exec", [
+    "-p",
+    profile,
+    "sh",
+    "-c",
+    "printf probe > \{test_shell_quote(blocked)}",
+  ]) catch {
+    _ => {
+      cleanup_sandbox_exec_test_probe(probe_dir, blocked)
+      return false
+    }
+  }
+  let denied = deny_code != 0 && !@fs.exists(blocked)
+  cleanup_sandbox_exec_test_probe(probe_dir, blocked)
+  denied
+}
+
+///|
+#cfg(not(platform="windows"))
+fn test_shell_quote(text : String) -> String {
+  "'\{text.replace_all(old="'", new="'\\''")}'"
+}
+
+///|
+#cfg(not(platform="windows"))
+async fn cleanup_sandbox_exec_test_probe(
+  dir : String,
+  blocked : String,
+) -> Unit {
+  ignore(@fs.remove(blocked) catch { _ => () })
+  ignore(@fs.rmdir(dir) catch { _ => () })
+}
+
+///|
 #cfg(platform="windows")
 test "shell description tells models to use PowerShell on Windows" {
   let description = @shell.definition().description
@@ -88,14 +147,16 @@ async test "shell honors cwd when non-empty" {
 ///|
 async test "shell uses the workspace root when cwd is omitted" {
   @vfs.with_tmpdir(prefix="openseek-shell-workspace-", dir => {
-    let result = run_shell_in_workspace(dir, {
-      "cmd": "echo root-ok > marker.txt",
-    })
-    let marker = @fs.read_file("\{dir}/marker.txt").text() catch { _ => "" }
+    @fs.write_file(
+      "\{dir}/marker.txt",
+      "root-ok\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, { "cmd": "cat marker.txt" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("exit=0"))
-    assert_eq(marker.trim(), "root-ok")
+    assert_true(output.content.contains("root-ok"))
   })
 }
 
@@ -406,6 +467,1373 @@ async test "shell rejects sed -i in-place editing" {
   assert_true(output.is_error)
   assert_true(output.content.contains("sed -i"))
   assert_true(output.content.contains("edit"))
+  assert_true(output.content.contains("line-anchored"))
+  assert_false(output.content.contains("`write`"))
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox blocks source writes and points to edit tools" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "awk 'BEGIN { print \"pub fn answer() -> Int { 43 }\" > \"main.mbt\" }'",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("Operation not permitted") ||
+      output.content.contains("Permission denied"),
+    )
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("edit"))
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox reports masked source write denials as errors" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-masked-denial-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "printf %s changed 2>/dev/null > main.mbt || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("<system>exit=blocked</system>"))
+    assert_true(output.content.contains("blocked before execution"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks source write through symlink redirect" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-symlink-redirect-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.symlink(target="main.mbt", "\{dir}/out.log")
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "moon fmt > out.log",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file write redirect is blocked"),
+    )
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks copy through symlinked source destination" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-symlink-copy-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/replacement.txt",
+      "pub fn answer() -> Int { 43 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.symlink(target="main.mbt", "\{dir}/out.log")
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cp replacement.txt out.log 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks tee through symlinked source destination" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-symlink-tee-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.symlink(target="main.mbt", "\{dir}/out.log")
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "printf changed | tee out.log >/dev/null",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox does not treat unrelated output as source denial" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-unrelated-denial-", dir => {
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "printf '%s\\n' 'foo: Operation not permitted'",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("foo: Operation not permitted"))
+    assert_false(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks source write after uncertain cd chain" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cd-chain-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cd /definitely-missing-openseek 2>/dev/null && :; printf changed > main.mbt",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("blocked before execution"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks source write after entering workspace from external cwd" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-external-cwd-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cd \{dir}; printf changed 2>/dev/null > main.mbt || true",
+      "cwd": "/tmp",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("blocked before execution"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks source directory moves" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-source-dir-", dir => {
+    @fs.mkdir("\{dir}/pkg")
+    @fs.write_file(
+      "\{dir}/pkg/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "mv pkg pkg.bak",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(output.content.contains("line-anchored"))
+    assert_true(@fs.exists("\{dir}/pkg/main.mbt"))
+    assert_false(@fs.exists("\{dir}/pkg.bak"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox tracks static relative cd before source directory move" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-static-cd-", dir => {
+    @fs.mkdir("\{dir}/src")
+    @fs.mkdir("\{dir}/src/pkg")
+    @fs.write_file(
+      "\{dir}/src/pkg/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cd src && mv pkg pkg.bak 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(@fs.exists("\{dir}/src/pkg/main.mbt"))
+    assert_false(@fs.exists("\{dir}/src/pkg.bak"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked cp source writes" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cp-masked-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/replacement.txt",
+      "pub fn answer() -> Int { 43 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cp replacement.txt main.mbt 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked mv backup source moves" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-backup-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "mv -b main.mbt backup 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(@fs.exists("\{dir}/main.mbt"))
+    assert_false(@fs.exists("\{dir}/backup"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked git source mutations" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-git-masked-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let rm_result = run_shell_in_workspace(dir, {
+      "cmd": "git rm main.mbt 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard rm_result is Respond(rm_output) else { fail("expected Respond") }
+    assert_true(rm_output.is_error)
+    assert_true(rm_output.content.contains("source tree operation is blocked"))
+    assert_true(
+      rm_output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+    let mv_result = run_shell_in_workspace(dir, {
+      "cmd": "git mv main.mbt backup.mbt 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard mv_result is Respond(mv_output) else { fail("expected Respond") }
+    assert_true(mv_output.is_error)
+    assert_true(mv_output.content.contains("source tree operation is blocked"))
+    assert_true(
+      mv_output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(@fs.exists("\{dir}/main.mbt"))
+    assert_false(@fs.exists("\{dir}/backup.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked awk source writes" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-awk-masked-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "awk 'BEGIN { print \"pub fn answer() -> Int { 43 }\" > \"main.mbt\" }' 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked dynamic source tree renames" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-dynamic-rename-", dir => {
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "src=_build/gen; mkdir -p \"$src\"; printf 'pub fn generated() -> Int { 1 }\\n' > \"$src/main.mbt\"; mv \"$src\" pkg 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(@fs.exists("\{dir}/pkg"))
+    assert_false(@fs.exists("\{dir}/_build"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked pathlib source writes" {
+  let (python_code, _) = @process.collect_output_merged("sh", [
+    "-c", "command -v python3 >/dev/null 2>&1",
+  ]) catch {
+    _ => return
+  }
+  if python_code != 0 {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-pathlib-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "python3 -c 'from pathlib import Path; Path(\"main.mbt\").write_text(\"pub fn answer() -> Int { 43 }\\\\n\")' 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked heredoc source redirects" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-heredoc-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cat 2>/dev/null > main.mbt <<'EOF' || true\npub fn answer() -> Int { 43 }\nEOF",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked python heredoc source writes" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-python-heredoc-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "python3 - <<'PY' 2>/dev/null || true\nopen('main.mbt', 'w').write('pub fn answer() -> Int { 43 }\\n')\nPY",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked versioned python source writes" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-python-versioned-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")' 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks python exe source write modes" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-python-exe-mode-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "python.exe -c 'open(\"main.mbt\", \"w+\").close()' 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks masked cp into created source directory" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cp-created-dir-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "mkdir backup && cp main.mbt backup 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_true(@fs.exists("\{dir}/main.mbt"))
+    assert_false(@fs.exists("\{dir}/backup/main.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preserves mkdir predictions across fallback branches" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cp-or-created-dir-", dir => {
+    @vfs.with_tmpdir(prefix="openseek-shell-sandbox-external-source-", external => {
+      @fs.write_file(
+        "\{dir}/main.mbt",
+        "pub fn answer() -> Int { 42 }\n",
+        create_mode=CreateOrTruncate,
+      )
+      @fs.write_file(
+        "\{external}/generated.mbt",
+        "pub fn generated() -> Int { 1 }\n",
+        create_mode=CreateOrTruncate,
+      )
+      let result = run_shell_in_workspace(dir, {
+        "cmd": "mkdir gen || true; cp \{external}/generated.mbt gen 2>/dev/null || true",
+        "cwd": dir,
+      })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("source tree operation is blocked"))
+      assert_true(
+        output.content.contains("source file writes from shell are blocked"),
+      )
+      assert_true(output.content.contains("line-anchored"))
+      assert_false(@fs.exists("\{dir}/gen/generated.mbt"))
+    })
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks nested shell source generation" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-nested-sh-source-", dir => {
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "sh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(@fs.exists("\{dir}/pkg/main.mbt"))
+    assert_false(@fs.exists("\{dir}/_build/gen/main.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks scripted source directory renames" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-python-rename-source-dir-", dir => {
+    @fs.mkdir("\{dir}/pkg")
+    @fs.write_file(
+      "\{dir}/pkg/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "python3 -c 'import os; os.rename(\"pkg\", \"pkg.bak\")' 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_true(@fs.exists("\{dir}/pkg/main.mbt"))
+    assert_false(@fs.exists("\{dir}/pkg.bak/main.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks scripted external source directory imports" {
+  @vfs.with_tmpdir(
+    prefix="openseek-shell-sandbox-python-external-source-dir-",
+    root => {
+      let workspace = "\{root}/workspace"
+      let generated = "\{root}/generated_pkg"
+      let generated_file = "\{root}/generated.mbt"
+      @fs.mkdir(workspace)
+      @fs.mkdir(generated)
+      @fs.write_file(
+        "\{generated}/main.mbt",
+        "pub fn generated() -> Int { 1 }\n",
+        create_mode=CreateOrTruncate,
+      )
+      @fs.write_file(
+        generated_file,
+        "pub fn generated_file() -> Int { 1 }\n",
+        create_mode=CreateOrTruncate,
+      )
+      let result = run_shell_in_workspace(workspace, {
+        "cmd": "python3 -c 'import shutil; shutil.move(\"\{generated}\", \"pkg\")'",
+        "cwd": workspace,
+      })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("source tree operation is blocked"))
+      assert_true(
+        output.content.contains("source file writes from shell are blocked"),
+      )
+      assert_true(output.content.contains("line-anchored"))
+      assert_true(@fs.exists("\{generated}/main.mbt"))
+      assert_false(@fs.exists("\{workspace}/pkg/main.mbt"))
+      let copy_result = run_shell_in_workspace(workspace, {
+        "cmd": "python3 -c 'import shutil; shutil.copy(\"\{generated_file}\", \"pkg\")'",
+        "cwd": workspace,
+      })
+      guard copy_result is Respond(copy_output) else {
+        fail("expected Respond")
+      }
+      assert_true(copy_output.is_error)
+      assert_true(
+        copy_output.content.contains("source tree operation is blocked"),
+      )
+      assert_true(
+        copy_output.content.contains(
+          "source file writes from shell are blocked",
+        ),
+      )
+      assert_true(@fs.exists(generated_file))
+      assert_false(@fs.exists("\{workspace}/pkg"))
+    },
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox blocks unrecognized incoming source directory renames" {
+  @vfs.with_tmpdir(
+    prefix="openseek-shell-sandbox-python-incoming-source-dir-",
+    dir => {
+      @fs.mkdir("\{dir}/_build")
+      let result = run_shell_in_workspace(dir, {
+        "cmd": "python3 -c 'import os; os.makedirs(\"_build/gen\", exist_ok=True); open(\"_build/gen/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(\"_build/gen\", \"pkg\")'",
+        "cwd": dir,
+      })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("source tree operation is blocked"))
+      assert_true(output.content.contains("line-anchored"))
+      assert_false(@fs.exists("\{dir}/_build/gen/main.mbt"))
+      assert_false(@fs.exists("\{dir}/pkg/main.mbt"))
+    },
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks script rename of generated source directory" {
+  @vfs.with_tmpdir(
+    prefix="openseek-shell-sandbox-python-generated-dir-rename-",
+    dir => {
+      let result = run_shell_in_workspace(dir, {
+        "cmd": "mkdir -p _build/gen && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen/main.mbt && python3 -c 'import os; os.rename(\"_build/gen\", \"pkg\")'",
+        "cwd": dir,
+      })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("source tree operation is blocked"))
+      assert_true(output.content.contains("line-anchored"))
+      assert_false(@fs.exists("\{dir}/_build/gen/main.mbt"))
+      assert_false(@fs.exists("\{dir}/pkg/main.mbt"))
+    },
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox allows non-source directory moves" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-assets-dir-", dir => {
+    @fs.mkdir("\{dir}/assets")
+    @fs.write_file(
+      "\{dir}/assets/logo.txt",
+      "not MoonBit source\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "mv assets pkg",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_false(output.content.contains("source tree operation is blocked"))
+    assert_true(@fs.exists("\{dir}/pkg/logo.txt"))
+    assert_false(@fs.exists("\{dir}/assets/logo.txt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks source directory move after uncertain cd chain" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-uncertain-cd-", dir => {
+    @fs.mkdir("\{dir}/pkg")
+    @fs.write_file(
+      "\{dir}/pkg/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cd /definitely-missing-openseek 2>/dev/null && :; mv pkg pkg.bak",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(@fs.exists("\{dir}/pkg/main.mbt"))
+    assert_false(@fs.exists("\{dir}/pkg.bak"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks source directory move after entering workspace from external cwd" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-external-cwd-", dir => {
+    @fs.mkdir("\{dir}/pkg")
+    @fs.write_file(
+      "\{dir}/pkg/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cd \{dir}; mv pkg pkg.bak",
+      "cwd": "/tmp",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(@fs.exists("\{dir}/pkg/main.mbt"))
+    assert_false(@fs.exists("\{dir}/pkg.bak"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks source directory removals" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-rm-source-dir-", dir => {
+    @fs.mkdir("\{dir}/pkg")
+    @fs.write_file(
+      "\{dir}/pkg/moon.pkg",
+      "warnings = \"\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, { "cmd": "rm -rf pkg", "cwd": dir })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(@fs.exists("\{dir}/pkg/moon.pkg"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks incoming source directory moves" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-incoming-dir-", root => {
+    let workspace = "\{root}/workspace"
+    let generated = "\{root}/generated_pkg"
+    @fs.mkdir(workspace)
+    @fs.mkdir(generated)
+    @fs.write_file(
+      "\{generated}/main.mbt",
+      "pub fn generated() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(workspace, {
+      "cmd": "mv \{generated} pkg",
+      "cwd": workspace,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(output.content.contains("line-anchored"))
+    assert_true(@fs.exists("\{generated}/main.mbt"))
+    assert_false(@fs.exists("\{workspace}/pkg/main.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks generated source directory moves from build output" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-dir-", workspace => {
+    @fs.mkdir("\{workspace}/_build")
+    let result = run_shell_in_workspace(workspace, {
+      "cmd": "mkdir -p _build/gen && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen/main.mbt && mv _build/gen pkg",
+      "cwd": workspace,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_false(@fs.exists("\{workspace}/_build/gen/main.mbt"))
+    assert_false(@fs.exists("\{workspace}/pkg/main.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks generated dotted source directory moves from build output" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-dot-dir-", workspace => {
+    @fs.mkdir("\{workspace}/_build")
+    let result = run_shell_in_workspace(workspace, {
+      "cmd": "mkdir -p _build/gen.v1 && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg",
+      "cwd": workspace,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_false(@fs.exists("\{workspace}/_build/gen.v1/main.mbt"))
+    assert_false(@fs.exists("\{workspace}/pkg/main.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks generated dotted source directory moves into existing directory" {
+  @vfs.with_tmpdir(
+    prefix="openseek-shell-sandbox-mv-generated-dot-dir-existing-",
+    workspace => {
+      @fs.mkdir("\{workspace}/_build")
+      @fs.mkdir("\{workspace}/pkg")
+      let result = run_shell_in_workspace(workspace, {
+        "cmd": "mkdir -p _build/gen.v1 && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg",
+        "cwd": workspace,
+      })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("source tree operation is blocked"))
+      assert_false(@fs.exists("\{workspace}/_build/gen.v1/main.mbt"))
+      assert_false(@fs.exists("\{workspace}/pkg/gen.v1/main.mbt"))
+    },
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks generated source directory moves to dotted destinations" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-dir-dot-dest-", workspace => {
+    @fs.mkdir("\{workspace}/_build")
+    let result = run_shell_in_workspace(workspace, {
+      "cmd": "mkdir -p _build/gen && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen/main.mbt && mv _build/gen pkg.v1",
+      "cwd": workspace,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_false(@fs.exists("\{workspace}/_build/gen/main.mbt"))
+    assert_false(@fs.exists("\{workspace}/pkg.v1/main.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks generated file-like source directory moves to file-like destinations" {
+  @vfs.with_tmpdir(
+    prefix="openseek-shell-sandbox-mv-generated-file-like-dir-",
+    workspace => {
+      @fs.mkdir("\{workspace}/_build")
+      let result = run_shell_in_workspace(workspace, {
+        "cmd": "mkdir -p assets _build/gen.tmp && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen.tmp/main.mbt && mv _build/gen.tmp assets/pkg.tmp",
+        "cwd": workspace,
+      })
+      guard result is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("source tree operation is blocked"))
+      assert_false(@fs.exists("\{workspace}/_build/gen.tmp/main.mbt"))
+      assert_false(@fs.exists("\{workspace}/assets/pkg.tmp/main.mbt"))
+    },
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox allows generated non-source file moves from build output" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-file-", workspace => {
+    let result = run_shell_in_workspace(workspace, {
+      "cmd": "mkdir -p assets _build && printf data > _build/logo.txt && mv _build/logo.txt assets/logo.txt",
+      "cwd": workspace,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_false(output.content.contains("source tree operation is blocked"))
+    assert_eq(@fs.read_file("\{workspace}/assets/logo.txt").text(), "data")
+    assert_false(@fs.exists("\{workspace}/_build/logo.txt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks incoming source files moved into workspace directories" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-incoming-file-", root => {
+    let workspace = "\{root}/workspace"
+    @fs.mkdir(workspace)
+    @fs.mkdir("\{workspace}/pkg")
+    let generated = "\{root}/generated.mbt"
+    @fs.write_file(
+      generated,
+      "pub fn generated() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(workspace, {
+      "cmd": "mv -t pkg \{generated}",
+      "cwd": workspace,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_true(@fs.exists(generated))
+    assert_false(@fs.exists("\{workspace}/pkg/generated.mbt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox blocks moon work writes" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-moon-work-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.work",
+      "members = []\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "printf 'members = [\".\"]' > moon.work",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(@fs.read_file("\{dir}/moon.work").text(), "members = []\n")
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox still permits moon check build outputs" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-moon-check-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/shell_sandbox_moon_check\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("<system>exit=0</system>"))
+    assert_false(output.content.contains("source file writes from shell"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell allows moon check pre-build source outputs" {
+  @vfs.with_tmpdir(prefix="openseek-shell-moon-check-prebuild-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/shell_moon_check_prebuild\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/moon.pkg",
+      (
+        #|options(
+        #|  "pre-build": [
+        #|    {
+        #|      "command": "printf 'pub fn generated() -> Int { 1 }\\n' > generated.mbt",
+        #|      "input": [],
+        #|      "output": "generated.mbt",
+        #|    },
+        #|  ],
+        #|)
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { generated() }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("<system>exit=0</system>"))
+    assert_true(@fs.exists("\{dir}/generated.mbt"))
+    assert_eq(
+      @fs.read_file("\{dir}/generated.mbt").text(),
+      "pub fn generated() -> Int { 1 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell trusts guarded package cd before moon check pre-build output" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-moon-check-cd-prebuild-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/shell_moon_check_cd_prebuild\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.mkdir("\{dir}/pkg")
+    @fs.write_file(
+      "\{dir}/pkg/moon.pkg",
+      (
+        #|options(
+        #|  "pre-build": [
+        #|    {
+        #|      "command": "printf 'pub fn generated() -> Int { 1 }\\n' > generated.mbt",
+        #|      "input": [],
+        #|      "output": "generated.mbt",
+        #|    },
+        #|  ],
+        #|)
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/pkg/main.mbt",
+      "pub fn answer() -> Int { generated() }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "cd pkg && moon check",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("<system>exit=0</system>"))
+    assert_true(@fs.exists("\{dir}/pkg/generated.mbt"))
+    assert_eq(
+      @fs.read_file("\{dir}/pkg/generated.mbt").text(),
+      "pub fn generated() -> Int { 1 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox blocks too-complex sed source rewrites" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-sed-glob-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { old }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "sed -i '' 's/old/new/' *.mbt",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { old }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox preblocks too-complex fd duplicate source redirect" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-fd-dup-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "printf changed >& main.mbt *.txt 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandbox allows read-only grep of source text" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-grep-mv-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "let mv_marker = 1\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "grep mv *.mbt",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("mv_marker"))
+    assert_false(output.content.contains("source tree operation is blocked"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell preblocks env unset sed source rewrites" {
+  @vfs.with_tmpdir(prefix="openseek-shell-env-sed-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { old }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "env -u FOO sed -i '' 's/old/new/' *.mbt 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { old }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell preblocks env assignment sed source rewrites" {
+  @vfs.with_tmpdir(prefix="openseek-shell-env-assign-sed-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { old }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "FOO=bar sed -i '' 's/old/new/' *.mbt 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { old }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell preblocks find exec sed source rewrites" {
+  @vfs.with_tmpdir(prefix="openseek-shell-find-sed-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { old }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "find \{dir} -name '*.mbt' -exec env FOO=bar sed -i '' 's/old/new/' {} + 2>/dev/null || true",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { old }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell preblocks looped sed source rewrites through path list" {
+  @vfs.with_tmpdir(prefix="openseek-shell-loop-sed-source-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { old }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/files.txt",
+      "\{dir}/main.mbt\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "while IFS= read -r f; do sed -i '' 's/old/new/' \"$f\"; done < files.txt",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { old }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell preblocks git source rollback" {
+  @vfs.with_tmpdir(prefix="openseek-shell-git-rollback-", dir => {
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "git checkout -- .",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_true(output.content.contains("line-anchored"))
+    assert_false(output.content.contains("`write`"))
+    assert_eq(
+      @fs.read_file("\{dir}/main.mbt").text(),
+      "pub fn answer() -> Int { 42 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell allows trusted moon fmt command" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-moon-fmt-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/shell_sandbox_moon_fmt\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer()->Int{42}\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell_in_workspace(dir, { "cmd": "moon fmt", "cwd": dir })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("<system>exit=0</system>"))
+    assert_false(output.content.contains("source file writes from shell"))
+    assert_true(@fs.read_file("\{dir}/main.mbt").text().contains("answer"))
+  })
 }
 
 ///|
@@ -448,6 +1876,40 @@ async test "shell appends moon check after applied moon ide rename" {
     let renamed = @fs.read_file("\{dir}/main.mbt").text()
     assert_true(renamed.contains("new_name"))
     assert_false(renamed.contains("old_name"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell appends moon check from moon.work workspace root" {
+  @vfs.with_tmpdir(prefix="openseek-shell-auto-check-workspace-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.work",
+      "members = [\"pkg\"]\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.mkdir("\{dir}/pkg")
+    @fs.write_file(
+      "\{dir}/pkg/moon.mod",
+      "name = \"tmp/shell_auto_check_workspace\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/pkg/moon.pkg",
+      "warnings = \"+unnecessary_annotation\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/pkg/main.mbt",
+      "pub fn broken()->Int{missing_from_workspace}\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_shell({ "cmd": "moon fmt", "cwd": dir })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("<system>exit=0</system>"))
+    assert_true(output.content.contains("\nmoon check:\nexit=255"))
+    assert_true(output.content.contains("missing_from_workspace"))
   })
 }
 

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -507,6 +507,31 @@ async test "shell sandbox blocks source writes and points to edit tools" {
 }
 
 ///|
+async test "shell sandbox allows generated source writes under _build" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-build-carveout-", dir => {
+    @fs.mkdir("\{dir}/_build")
+    // `_build/main.mbt` matches the source-file shape but lives under a
+    // Moon-managed build tree, so the SBPL carve-out must keep it writable.
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "awk 'BEGIN { print \"pub fn generated() -> Int { 1 }\" > \"_build/main.mbt\" }'",
+      "cwd": dir,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_false(
+      output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/_build/main.mbt").text(),
+      "pub fn generated() -> Int { 1 }\n",
+    )
+  })
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "shell sandbox reports masked source write denials as errors" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-masked-denial-", dir => {

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -21,7 +21,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="write",
-    description="Create or overwrite arguments.path with arguments.content (missing parent directories are created). If the file already exists, read it first so you do not discard content you have not seen, and prefer the edit tool for targeted changes. Do not create Markdown or README files unless the user explicitly asks for them.",
+    description="Create or overwrite arguments.path with arguments.content (missing parent directories are created). If the file already exists, read it first so you do not discard content you have not seen. Prefer line-anchored edit for targeted compiler-feedback changes, and do not use write to route shell-generated rewrites back into source files. Do not create Markdown or README files unless the user explicitly asks for them.",
     schema=JsonSchema({
       "type": "object",
       "properties": {

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -7,12 +7,12 @@ Run `moon check` through `shell` after every edit as the primary fast feedback
 loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
 generation, so it is much faster than `moon build` or `moon test`. Use
 `moon build` or `moon test` only when you need artifacts or test results.
-After `edit` or `write` changes `moon.mod`, `moon.pkg`, `.mbt`, or `.mbt.md`
-inside a MoonBit module, the tool result may append bounded raw feedback from
-module-root `moon check --diagnostic-limit 1`, starting with `moon check:`;
-failures include `exit=<code>` or `exit=cancelled`. Treat it as immediate
-compiler feedback, and run an explicit `moon check` when you need full
-diagnostics.
+After `edit` or `write` changes `moon.mod`, `moon.pkg`, `moon.work`, `.mbt`,
+or `.mbt.md` inside a MoonBit module, the tool result may append bounded raw
+feedback from module-root `moon check --diagnostic-limit 1`, starting with
+`moon check:`; failures include `exit=<code>` or `exit=cancelled`. Treat it as
+immediate compiler feedback, and run an explicit `moon check` when you need
+full diagnostics.
 
 ## Tool Protocol
 
@@ -23,8 +23,18 @@ diagnostics.
   - `shell` for all Moon commands, including `moon check` for compiler
     feedback; pass the tool's `cwd` field, or use `moon -C dir check` instead
     of embedding repeated `cd ... &&` strings.
+    If shell reports that source file writes are blocked, retry compiler
+    feedback fixes with line-anchored `edit`; use `write` only for intentional
+    whole-file replacements.
 - Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
   use `moon build` or `moon test` only when you need artifacts or test results.
+- When fixing compiler feedback, trust the diagnostic path and location. Use
+  `moon check --output-json` or focused `moon check --diagnostic-limit <N>` to
+  group repeated diagnostics, then edit the reported locations. Do not perform
+  broad source codemods with shell/Python/Perl/Ruby/Node/sed/awk scripts; use
+  scripts only to analyze or summarize diagnostics, and apply compiler-feedback
+  source changes through line-anchored `edit`. Do not generate rewritten source
+  files with shell and then overwrite the original files.
 - Keep reads focused. Use bounded reads for large files and logs.
 
 Common `moon` subcommands:

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -12,12 +12,12 @@ fn flash_prompt() -> String {
     #|loop; add `--diagnostic-limit 5` for focused diagnostics. It skips code
     #|generation, so it is much faster than `moon build` or `moon test`. Use
     #|`moon build` or `moon test` only when you need artifacts or test results.
-    #|After `edit` or `write` changes `moon.mod`, `moon.pkg`, `.mbt`, or `.mbt.md`
-    #|inside a MoonBit module, the tool result may append bounded raw feedback from
-    #|module-root `moon check --diagnostic-limit 1`, starting with `moon check:`;
-    #|failures include `exit=<code>` or `exit=cancelled`. Treat it as immediate
-    #|compiler feedback, and run an explicit `moon check` when you need full
-    #|diagnostics.
+    #|After `edit` or `write` changes `moon.mod`, `moon.pkg`, `moon.work`, `.mbt`,
+    #|or `.mbt.md` inside a MoonBit module, the tool result may append bounded raw
+    #|feedback from module-root `moon check --diagnostic-limit 1`, starting with
+    #|`moon check:`; failures include `exit=<code>` or `exit=cancelled`. Treat it as
+    #|immediate compiler feedback, and run an explicit `moon check` when you need
+    #|full diagnostics.
     #|
     #|## Tool Protocol
     #|
@@ -28,8 +28,18 @@ fn flash_prompt() -> String {
     #|  - `shell` for all Moon commands, including `moon check` for compiler
     #|    feedback; pass the tool's `cwd` field, or use `moon -C dir check` instead
     #|    of embedding repeated `cd ... &&` strings.
+    #|    If shell reports that source file writes are blocked, retry compiler
+    #|    feedback fixes with line-anchored `edit`; use `write` only for intentional
+    #|    whole-file replacements.
     #|- Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
     #|  use `moon build` or `moon test` only when you need artifacts or test results.
+    #|- When fixing compiler feedback, trust the diagnostic path and location. Use
+    #|  `moon check --output-json` or focused `moon check --diagnostic-limit <N>` to
+    #|  group repeated diagnostics, then edit the reported locations. Do not perform
+    #|  broad source codemods with shell/Python/Perl/Ruby/Node/sed/awk scripts; use
+    #|  scripts only to analyze or summarize diagnostics, and apply compiler-feedback
+    #|  source changes through line-anchored `edit`. Do not generate rewritten source
+    #|  files with shell and then overwrite the original files.
     #|- Keep reads focused. Use bounded reads for large files and logs.
     #|
     #|Common `moon` subcommands:


### PR DESCRIPTION
## Summary
- Run agent shell commands through a source-write sandbox when `sandbox-exec` is available, while preserving normal read/build output behavior.
- Pre-block obvious shell source rewrites such as redirects, `sed -i`, and scripted source tree moves before execution.
- Add sandbox feedback and prompt/tool-description guidance that routes compiler-feedback fixes through line-anchored `edit` rather than shell-generated rewrites.

This PR is intentionally independent of #252 and does not reference `multi_edit`.

## Validation
- `moon test agent_tool/shell agent_tool/shell/internal/command_policy agent_tool/shell/internal/shell_parse agent_tool/internal/auto_check agent_tool/write prompt --target native --diagnostic-limit 20`
- `moon info`
- `moon fmt --check agent_tool/shell agent_tool/shell/internal/command_policy agent_tool/shell/internal/shell_parse agent_tool/write prompt`