### PR TITLE
feat(read): use a ` |` gutter separator instead of a tab

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -16,7 +16,7 @@ read specific files.
 ## Design Rationale
 
 Every read has the **same shape** regardless of whether it is a whole-file read,
-a line range, or a capped read: right-aligned `<line-number>\t<content>` lines
+a line range, or a capped read: right-aligned `<line-number> |<content>` lines
 (the common numbered style used by other coding agents) followed by a single
 `<system>...</system>` status footer. The optional range and output-cap
 arguments exist for the failure mode seen in longer evaluations: large generated
@@ -74,11 +74,11 @@ The action is always `Respond(ToolOutput(...))` — the agent loop forwards
 `false` on success and `true` for read failures, argument failures, or automatic
 output truncation. The string body has one of these shapes:
 
-- On success: right-aligned `<line-number>\t<content>` lines, then a newline,
+- On success: right-aligned `<line-number> |<content>` lines, then a newline,
   then the footer `<system>start_line=<n> shown_lines=<k> total_lines=<t> truncated=<bool></system>`.
   When the selected body is empty (the range starts past EOF, or the budget is
   zero) only the footer is returned. A zero-byte file returns just the footer
-  with `total_lines=0 note=empty file`, rather than a phantom blank `1\t` line.
+  with `total_lines=0 note=empty file`, rather than a phantom blank `1 |` line.
   `truncated=true` — set when `max_output_chars` cut the numbered body — is the
   one case that flips `is_error` to `true`.
 - `"error reading <path>: <error>"` — a single-file read failed. Common
@@ -99,7 +99,7 @@ test "read tool advertises the expected schema" {
     content=(
       #|{
       #|  name: "read",
-      #|  description: "Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Output is right-aligned `<line-number>\\t<content>` numbered lines followed by a `<system>` status footer.",
+      #|  description: "Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Output is right-aligned `<line-number> |<content>` numbered lines followed by a `<system>` status footer.",
       #|  schema: JsonSchema(
       #|    Object(
       #|      {
@@ -158,7 +158,7 @@ async test "read tool reads a workspace note through the registry" {
     assert_eq(
       output.content,
       [
-        "1\tTask: summarize test failures", "2\tStatus: investigating", "3\t", "<system>start_line=1 shown_lines=3 total_lines=3 truncated=false</system>",
+        "1 |Task: summarize test failures", "2 |Status: investigating", "3 |", "<system>start_line=1 shown_lines=3 total_lines=3 truncated=false</system>",
       ].join("\n"),
     )
   })
@@ -191,7 +191,7 @@ async test "read tool supports focused range reads" {
     assert_eq(
       output.content,
       [
-        "2\tbeta", "3\tgamma", "<system>start_line=2 shown_lines=2 total_lines=4 truncated=false</system>",
+        "2 |beta", "3 |gamma", "<system>start_line=2 shown_lines=2 total_lines=4 truncated=false</system>",
       ].join("\n"),
     )
   })

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -18,9 +18,9 @@
 ///
 /// ## Result
 /// - `Respond(ToolOutput(<numbered lines> + "\n" + <footer>))` on success.
-///   Every read has the same shape regardless of range or cap: `<line-number>\t
-///   <content>` lines, with line numbers right-aligned to the selected range,
-///   followed by a single
+///   Every read has the same shape regardless of range or cap:
+///   `<line-number> |<content>` lines, with line numbers right-aligned to the
+///   selected range, followed by a single
 ///   `<system>start_line=.. shown_lines=.. total_lines=.. truncated=..</system>`
 ///   footer (footer only when the body is empty, e.g. a range past EOF). A
 ///   zero-byte file returns just that footer with `total_lines=0 note=empty
@@ -36,7 +36,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Output is right-aligned `<line-number>\\t<content>` numbered lines followed by a `<system>` status footer.",
+    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Output is right-aligned `<line-number> |<content>` numbered lines followed by a `<system>` status footer.",
     schema=JsonSchema({
       "type": "object",
       "required": ["path"],
@@ -95,7 +95,7 @@ async fn read_file(
         brief~,
       )
   }
-  // A zero-byte file would otherwise render as a phantom blank line `1\t`;
+  // A zero-byte file would otherwise render as a phantom blank line `1 |`;
   // report it explicitly so the model doesn't read that as real content. A file
   // containing only a newline is not empty (it has blank lines) and renders
   // normally.
@@ -135,7 +135,7 @@ async fn read_file(
       for index in start_index..<end_exclusive {
         let separator_units = if output.is_empty() { 0 } else { 1 }
         let line_number = input.start_line + index - start_index
-        let prefix = "\{line_number.to_string().pad_start(line_number_width, ' ')}\t"
+        let prefix = "\{line_number.to_string().pad_start(line_number_width, ' ')} |"
         let prefix_budget = separator_units + prefix.length()
         if remaining < prefix_budget {
           truncated = true
@@ -190,7 +190,7 @@ async test "read renders a whole file as numbered lines with a status footer" {
     assert_eq(
       output.content,
       [
-        "1\thello read", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
+        "1 |hello read", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
       ].join("\n"),
     )
   })
@@ -214,7 +214,7 @@ async test "read resolves relative paths under the workspace root" {
     assert_eq(
       output.content,
       [
-        "1\tworkspace read", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
+        "1 |workspace read", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
       ].join("\n"),
     )
   })
@@ -247,7 +247,7 @@ async test "read treats a single-newline file as one blank line, not empty" {
     assert_eq(
       output.content,
       [
-        "1\t", "2\t", "<system>start_line=1 shown_lines=2 total_lines=2 truncated=false</system>",
+        "1 |", "2 |", "<system>start_line=1 shown_lines=2 total_lines=2 truncated=false</system>",
       ].join("\n"),
     )
   })
@@ -268,7 +268,7 @@ async test "read numbers every line including a trailing blank from a final newl
     assert_eq(
       output.content,
       [
-        "1\tline one", "2\tline two", "3\tline three", "4\t", "<system>start_line=1 shown_lines=4 total_lines=4 truncated=false</system>",
+        "1 |line one", "2 |line two", "3 |line three", "4 |", "<system>start_line=1 shown_lines=4 total_lines=4 truncated=false</system>",
       ].join("\n"),
     )
   })
@@ -291,7 +291,7 @@ async test "read returns a requested line range and reports more lines remain" {
     assert_eq(
       output.content,
       [
-        "2\tline two", "3\tline three", "<system>start_line=2 shown_lines=2 total_lines=4 truncated=false</system>",
+        "2 |line two", "3 |line three", "<system>start_line=2 shown_lines=2 total_lines=4 truncated=false</system>",
       ].join("\n"),
     )
   })
@@ -317,13 +317,13 @@ async test "read caps oversized output and marks it as an error" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/capped.txt"
     @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate)
-    let result = execute({ "path": path, "max_output_chars": 3 })
+    let result = execute({ "path": path, "max_output_chars": 4 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_eq(
       output.content,
       [
-        "1\ta", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
+        "1 |a", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
       ].join("\n"),
     )
   })
@@ -338,15 +338,15 @@ async test "read counts the line-number gutter against the output budget" {
       [ for _ in 0..<80 => "x" ].join("\n"),
       create_mode=CreateOrTruncate,
     )
-    let result = execute({ "path": path, "max_output_chars": 20 })
+    let result = execute({ "path": path, "max_output_chars": 24 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
-    // 20 code units buys exactly four two-wide ` N\tx` lines (gutters
+    // 24 code units buys exactly four two-wide ` N |x` lines (gutters
     // included); the fifth gutter would overrun, so the body stops at line 4.
     assert_eq(
       output.content,
       [
-        " 1\tx", " 2\tx", " 3\tx", " 4\tx", "<system>start_line=1 shown_lines=4 total_lines=80 truncated=true</system>",
+        " 1 |x", " 2 |x", " 3 |x", " 4 |x", "<system>start_line=1 shown_lines=4 total_lines=80 truncated=true</system>",
       ].join("\n"),
     )
   })
@@ -358,27 +358,27 @@ async test "read caps unicode content on character boundaries" {
     let path = "\{dir}/unicode.txt"
     // "😀" is one code point but two UTF-16 code units; "😀Z" has length 3.
     @fs.write_file(path, "😀Z", create_mode=CreateOrTruncate)
-    // Budget 4 = "1\t" (2 units) + "😀" (2 units): the emoji fits whole, Z drops.
-    let fits = execute({ "path": path, "max_lines": 1, "max_output_chars": 4 })
+    // Budget 5 = "1 |" (3 units) + "😀" (2 units): the emoji fits whole, Z drops.
+    let fits = execute({ "path": path, "max_lines": 1, "max_output_chars": 5 })
     guard fits is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_eq(
       output.content,
       [
-        "1\t😀", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
+        "1 |😀", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
       ].join("\n"),
     )
-    // Budget 3 leaves one unit after the gutter, which would split "😀". Rather
+    // Budget 4 leaves one unit after the gutter, which would split "😀". Rather
     // than emit a lone surrogate (a slice mid-pair actually panics), the whole
     // emoji is dropped.
-    let splits = execute({ "path": path, "max_lines": 1, "max_output_chars": 3 })
+    let splits = execute({ "path": path, "max_lines": 1, "max_output_chars": 4 })
     guard splits is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_false(output.content.contains("😀"))
     assert_eq(
       output.content,
       [
-        "1\t", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
+        "1 |", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
       ].join("\n"),
     )
   })
@@ -393,10 +393,10 @@ async test "read numbers lines with an aligned gutter and no header block" {
     let result = execute({ "path": path, "start_line": 9, "max_lines": 103 })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_true(output.content.contains("  9\tline 9"))
-    assert_true(output.content.contains(" 99\tline 99"))
-    assert_true(output.content.contains("100\tline 100"))
-    assert_true(output.content.contains("111\tline 111"))
+    assert_true(output.content.contains("  9 |line 9"))
+    assert_true(output.content.contains(" 99 |line 99"))
+    assert_true(output.content.contains("100 |line 100"))
+    assert_true(output.content.contains("111 |line 111"))
     assert_true(
       output.content.has_suffix(
         "<system>start_line=9 shown_lines=103 total_lines=111 truncated=false</system>",
@@ -513,7 +513,7 @@ async test "a huge max_lines returns the remaining lines without overflow" {
     assert_eq(
       output.content,
       [
-        "2\tb", "3\tc", "<system>start_line=2 shown_lines=2 total_lines=3 truncated=false</system>",
+        "2 |b", "3 |c", "<system>start_line=2 shown_lines=2 total_lines=3 truncated=false</system>",
       ].join("\n"),
     )
   })


### PR DESCRIPTION
## What

Changes the `read` tool's numbered-line gutter from a tab to a right-aligned pipe separator:

```
before:  1\tlet x = 3        after:  1 |let x = 3
         2\tlet y = 2                2 |let y = 2
```

## Why

The leading tab renders as whitespace, and the model occasionally misread it as indentation belonging to the line's content. The `|` marks an unambiguous left margin — the first character after `|` is always the first real character of the line — while the right-aligned line numbers still form a clean column:

```
  9 |line 9
 99 |line 99
100 |line 100
```

## Notes

- The `|` gutter is one UTF-16 code unit wider than the tab, so the `max_output_chars` budget tests shift by one unit per rendered line. Their byte budgets and unit-count comments were updated accordingly (the truncation/boundary behavior is unchanged).
- Tool description and `README.mbt.md` updated to document the new format.
- `moon check` clean; full suite **793/793** passing (read package: 23/23, incl. README doc tests). No golden/transcript files reference the read output format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)