### PR TITLE
edit/multi_edit: support insertion via empty old_string

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -13,9 +13,12 @@ search when the caller wants a tighter inclusive 1-based line range. Because
 the line anchor carries the location, `old_string` can be the small exact span
 to replace instead of a large surrounding block.
 
-Rejecting empty `old_string` and identical replacements protects against
-no-op or explosive edits. The tool is designed for small surgical changes; if a
-file needs a complete rewrite, `write` is the clearer API.
+An empty `old_string` switches the tool to insertion: `new_string` is inserted
+at the start of `start_line` (use `start_line` = last line + 1 to append at end
+of file). Rejecting empty-and-empty (both `old_string` and `new_string` empty)
+and identical replacements protects against no-op edits. The tool is designed
+for small surgical changes; if a file needs a complete rewrite, `write` is the
+clearer API.
 
 MoonBit manifests get the same safety check as `write`: edits that would create
 legacy `moon.mod.json`, JSON-style `moon.mod` or `moon.pkg`, or `moon.pkg` with
@@ -52,8 +55,8 @@ and the edit should stay inside a tighter range:
 | Name          | Type    | Required | Notes |
 | ------------- | ------- | -------- | ----- |
 | `path`        | string  | yes | Filesystem path. Relative paths resolve against the agent process's current working directory. |
-| `old_string`  | string  | yes | Exact text to replace. Empty strings are rejected. |
-| `new_string`  | string  | yes | Replacement text. It must differ from `old_string`. |
+| `old_string`  | string  | yes | Exact text to replace. Empty string switches to insertion at `start_line`. |
+| `new_string`  | string  | yes | Replacement (or inserted) text. For replacement it must differ from `old_string`; empty-and-empty is rejected. |
 | `start_line`  | integer | yes | 1-based first line of the search/replace range. The first match at or after this line is replaced. |
 | `end_line`    | integer | no  | 1-based last line of the search/replace range. Defaults to the file end. |
 

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -24,7 +24,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
-    description="Replace the first exact text span at or after arguments.start_line in arguments.path with arguments.new_string. Optional end_line restricts the search to a 1-based inclusive line range. Because start_line anchors the location, old_string can be a small exact span instead of a large context block. For multiple compiler-feedback fixes in one file, use multi_edit with explicit line-anchored edits.",
+    description="Replace the first exact text span at or after arguments.start_line in arguments.path with arguments.new_string. Optional end_line restricts the search to a 1-based inclusive line range. Because start_line anchors the location, old_string can be a small exact span instead of a large context block. To INSERT new code instead of replacing, set old_string to the empty string: new_string is inserted at the start of start_line (use start_line = last line + 1 to append at end of file). For multiple compiler-feedback fixes in one file, use multi_edit with explicit line-anchored edits.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -73,9 +73,9 @@ async fn edit_file(
       brief=fail_brief,
     )
   }
-  if input.old_string == "" {
+  if input.old_string == "" && input.new_string == "" {
     return @agent_tool.ToolAction::respond(
-      "error editing \{path}: old_string must be non-empty",
+      "error editing \{path}: old_string and new_string are both empty",
       is_error=true,
       brief=fail_brief,
     )
@@ -95,6 +95,41 @@ async fn edit_file(
         is_error=true,
         brief=fail_brief,
       )
+  }
+  if input.old_string == "" {
+    // Insertion: insert new_string at the start of start_line (a zero-width
+    // edit); use start_line = last line + 1 to append at end of file.
+    let at = line_start_offset(content, input.start_line).clamp(
+      min=0,
+      max=content.length(),
+    )
+    let new_content = "\{content.unsafe_substring(start=0, end=at)}\{input.new_string}\{content.unsafe_substring(start=at, end=content.length())}"
+    match @manifest_error.write_error(path, new_content) {
+      Some(message) =>
+        return @agent_tool.ToolAction::respond(
+          "error editing \{path}: \{message}",
+          is_error=true,
+          brief=fail_brief,
+        )
+      None => ()
+    }
+    return try {
+      @fs.write_file(path, new_content, create_mode=CreateOrTruncate)
+      let summary = "ok: inserted at line \{input.start_line} in \{path}"
+      let response = @auto_check.append_summary(path, summary)
+      @agent_tool.ToolAction::respond(
+        response,
+        brief="edited \{@agent_tool.brief_basename(path)}:\{input.start_line} (insert)",
+      )
+    } catch {
+      error if @async.is_being_cancelled() => raise error
+      error =>
+        @agent_tool.ToolAction::respond(
+          "error editing \{path}: error writing file: \{error}",
+          is_error=true,
+          brief=fail_brief,
+        )
+    }
   }
   let region = select_edit_region(content, input)
   let parts = region.body

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -181,20 +181,57 @@ async test "edit rejects non-object arguments" {
 }
 
 ///|
-async test "edit rejects empty old_string" {
+async test "edit inserts when old_string is empty" {
   @vfs.with_tmpdir(dir => {
-    let path = "\{dir}/empty-old.txt"
+    let path = "\{dir}/insert.txt"
+    @fs.write_file(path, "line1\nline2\n", create_mode=CreateOrTruncate)
+    // insert before line 2
+    let result = run_edit({
+      "path": path,
+      "old_string": "",
+      "new_string": "inserted\n",
+      "start_line": 2,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("ok: inserted at line 2"))
+    let updated = @fs.read_file(path).text()
+    assert_eq(updated, "line1\ninserted\nline2\n")
+  })
+}
+
+///|
+async test "edit can append at end of file via start_line past the last line" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/append.txt"
+    @fs.write_file(path, "a\nb\n", create_mode=CreateOrTruncate)
+    let result = run_edit({
+      "path": path,
+      "old_string": "",
+      "new_string": "c\n",
+      "start_line": 99,
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_eq(@fs.read_file(path).text(), "a\nb\nc\n")
+  })
+}
+
+///|
+async test "edit rejects empty old_string and new_string" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/empty-both.txt"
     @fs.write_file(path, "content", create_mode=CreateOrTruncate)
     let result = run_edit({
       "path": path,
       "old_string": "",
-      "new_string": "replacement",
+      "new_string": "",
       "start_line": 1,
     })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
-      "error editing \{path}: old_string must be non-empty",
+      "error editing \{path}: old_string and new_string are both empty",
     )
     assert_true(output.is_error)
   })

--- a/agent_tool/multi_edit/README.mbt.md
+++ b/agent_tool/multi_edit/README.mbt.md
@@ -22,7 +22,10 @@ surrounding block. Each edit replaces the first matching span at or after its
 overlap — so when several changes fall on the same line (or in one tight span),
 the caller should combine them into a single edit whose `old_string` covers the
 whole span rather than emitting one edit per change, which would collide and
-fail the batch. The final file also passes the same MoonBit manifest guard used
+fail the batch. To insert new code rather than replace, set `old_string` to the
+empty string: `new_string` is inserted at the start of `start_line` (use
+`start_line` = last line + 1 to append at end of file). The final file also
+passes the same MoonBit manifest guard used
 by the other write tools, so generated `.mbti` files and known-bad manifest
 rewrites are rejected before the original file is overwritten.
 

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -12,7 +12,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="multi_edit",
-    description="Apply multiple exact line-anchored replacements to one file. Use this when compiler feedback identifies several known locations in the same file. Every edit must include old_string, new_string, and start_line; optional end_line bounds the search. Because each edit is line-anchored, old_string can be the small exact span to replace instead of a large context block. Each edit replaces the first matching span in its selected region. Do not emit separate edits for changes that are very close together: when several changes fall on the same line (or in one tight span), combine them into a single edit whose old_string covers the whole span, because adjacent or overlapping edits collide and the batch is rejected. All edits are validated against the original file and no changes are written if any edit fails.",
+    description="Apply multiple exact line-anchored replacements to one file. Use this when compiler feedback identifies several known locations in the same file. Every edit must include old_string, new_string, and start_line; optional end_line bounds the search. Because each edit is line-anchored, old_string can be the small exact span to replace instead of a large context block. Each edit replaces the first matching span in its selected region. To INSERT new code instead of replacing, set old_string to the empty string: new_string is inserted at the start of start_line (use start_line = last line + 1 to append at end of file). Do not emit separate edits for changes that are very close together: when several changes fall on the same line (or in one tight span), combine them into a single edit whose old_string covers the whole span, because adjacent or overlapping edits collide and the batch is rejected. All edits are validated against the original file and no changes are written if any edit fails.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -145,7 +145,27 @@ fn validate_edit(
 ) -> EditValidation {
   let range = line_range_label(item.start_line, item.end_line)
   if item.old_string == "" {
-    return Invalid({ index, range, message: "old_string must be non-empty" })
+    // Insertion: an empty old_string inserts new_string at the start of
+    // start_line (a zero-width edit). Use start_line = lastline + 1 to append at
+    // end of file. end_line is ignored for insertion.
+    if item.new_string == "" {
+      return Invalid({
+        index,
+        range,
+        message: "old_string and new_string are both empty",
+      })
+    }
+    let at = line_start_offset(content, item.start_line).clamp(
+      min=0,
+      max=content.length(),
+    )
+    return Valid({
+      index,
+      start: at,
+      end: at,
+      new_string: item.new_string,
+      range,
+    })
   }
   if item.old_string == item.new_string {
     return Invalid({

--- a/agent_tool/multi_edit/multi_edit_test.mbt
+++ b/agent_tool/multi_edit/multi_edit_test.mbt
@@ -49,6 +49,46 @@ async test "multi_edit applies multiple line-anchored replacements" {
 }
 
 ///|
+async test "multi_edit inserts when old_string is empty, alongside a replacement" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/insert.mbt"
+    @fs.write_file(
+      path,
+      "let a = old_a\nlet b = keep\nlet c = old_c\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = run_multi_edit({
+      "path": path,
+      "edits": [
+        { "old_string": "old_a", "new_string": "new_a", "start_line": 1 },
+        { "old_string": "", "new_string": "let x = new\n", "start_line": 2 },
+      ],
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_eq(
+      @fs.read_file(path).text(),
+      "let a = new_a\nlet x = new\nlet b = keep\nlet c = old_c\n",
+    )
+  })
+}
+
+///|
+async test "multi_edit rejects an edit with empty old_string and new_string" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/empty.mbt"
+    @fs.write_file(path, "let a = 1\n", create_mode=CreateOrTruncate)
+    let result = run_multi_edit({
+      "path": path,
+      "edits": [{ "old_string": "", "new_string": "", "start_line": 1 }],
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("both empty"))
+  })
+}
+
+///|
 async test "multi_edit applies edits against original offsets despite length changes" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/offsets.mbt"


### PR DESCRIPTION
## Summary

Add **insertion** to `edit` and `multi_edit`: an empty `old_string` inserts `new_string` at the start of `start_line` (a zero-width edit; use `start_line` = last line + 1 to append at EOF). Replacement and overlap semantics are unchanged. Both tools now reject only the empty-and-empty no-op (previously any empty `old_string` was rejected).

## Why

The edit tools could only *replace*; pure **insertion** (a new function, an import, a deprecation alias) forced the clumsy "anchor + append" trick — `old_string` = an existing line, `new_string` = that line plus the new code — which is verbose and breaks if the anchor isn't reproduced exactly.

This also completes the edit tools' coverage (replace **+** insert), so modifying existing source never needs a whole-file `write`. Concretely it unblocks the compiler-guided **rename-via-deprecation** workflow: add the new name *by insertion*, deprecate the old as an alias, then fix the flagged deprecations with `multi_edit`.

## Behavior

- `old_string == ""`, `new_string != ""` → insert `new_string` before `start_line`.
- `old_string == ""`, `new_string == ""` → rejected (`old_string and new_string are both empty`).
- `old_string != ""` → unchanged replace path.
- Inserts participate in `multi_edit`'s overlap detection as a zero-width span (insert at a boundary is fine; insert inside another edit's span is rejected).

## Tests

New tests cover: insert at a line, append past EOF, both-empty rejection (both tools), and insert combined with a replacement in one `multi_edit` batch. Full suite green (50/50 across edit + multi_edit + agent). Tool descriptions and READMEs updated. codex review: no correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
