### PR TITLE
review: headless code-review engine (--review -> JSON), reusable by other agents

### DIFF
--- a/agent_review/README.mbt.md
+++ b/agent_review/README.mbt.md
@@ -1,0 +1,111 @@
+# Code Review (`agent_review`)
+
+`agent_review` is OpenSeek's **code-review engine**. It runs a read-only,
+compiler-grounded review of a change set and returns a single structured
+`ReviewReport`. The engine is deliberately front-end-agnostic: the headless
+`openseek --review` CLI is one caller today, and the same `ReviewReport` JSON is
+the boundary other coding agents (e.g. Codex, Claude) spawn and consume when they
+dispatch a review to OpenSeek.
+
+## What it does
+
+`run_review(base, …)` reviews the diff between `base` and `HEAD`:
+
+1. drives a model over a **read-only** toolset (`read`, `shell` in read-only
+   mode, and `submit_review`) — no `edit`/`multi_edit`/`write`, so it reports
+   rather than rewrites;
+2. instructs the model to ground every finding in the compiler — run
+   `moon check`/`moon test` and cite real diagnostics, not opinion;
+3. captures the model's `submit_review` call into a validated `ReviewReport` and
+   returns it. If the model finishes without submitting, it raises `ReviewError`.
+
+## The contract: `ReviewReport`
+
+This stable, versioned, flat, string-typed JSON is the integration boundary —
+what every front-end returns and every external consumer parses:
+
+```json
+{
+  "schema_version": 1,
+  "scope": { "base": "origin/main", "head": "HEAD", "files": ["a/b.mbt"] },
+  "findings": [
+    {
+      "file": "a/b.mbt",
+      "line": 42,
+      "severity": "blocker | high | medium | low | nit",
+      "category": "correctness | safety | perf | style",
+      "title": "short summary",
+      "detail": "what and why, with evidence",
+      "suggestion": "optional concrete fix"
+    }
+  ],
+  "summary": "one-paragraph overview",
+  "stats": { "files_reviewed": 7, "findings": 3, "build": "pass", "tests": "pass" }
+}
+```
+
+`line` and `suggestion` are optional; everything else is required.
+`ReviewReport::validate` rejects malformed output (bad severity, empty
+file/title/category/detail/summary, wrong `schema_version`) so a review never
+returns a half-formed report — the `submit_review` tool re-prompts the model
+instead of finishing.
+
+## Design rationale
+
+- **Engine over `run_turn_in_scope`, not `@agent.run`.** A review needs to
+  *capture a typed result*, so the engine builds an ephemeral session, supplies a
+  custom tool registry, and reads the report back out of a captured ref —
+  `@agent.run` discards the session and returns `Unit`.
+- **Structured output is forced, not parsed.** `submit_review`'s JSON schema *is*
+  the contract, and the executor validates the arguments before ending the run.
+  The agent loop will otherwise accept a bare-text finish; the tool makes "no
+  structured report" a retryable error.
+- **Compiler-grounded.** The prompt makes the reviewer execute the build/tests
+  and report what they actually said — `stats.build` / `stats.tests` are observed
+  facts. The MoonBit compiler is reliable; the model's intuition is not.
+- **Strongest model.** Review is judgement-heavy, so it pins the Pro model;
+  flash is too shallow for the call.
+
+## Read-only stance (best-effort, not airtight)
+
+The review has no edit/write tools, and its `shell` runs in read-only mode: it
+refuses the obvious bulk source-rewriters (`moon fmt` / `moon info` /
+`moon test --update`) anywhere in the parsed command. It is **not** an airtight
+guarantee — `moon check`/`moon test` can trigger `pre-build` hooks that generate
+source — so the checkout is not promised byte-for-byte unchanged. By design, a
+review *reports* rather than *edits*.
+
+## Using it
+
+Headless, one JSON report on stdout (progress is suppressed so stdout stays
+clean), exit code by severity:
+
+```bash
+# 0 = clean or non-blocking findings, 1 = the review produced no report,
+# 2 = blocker findings present
+openseek --review --base origin/main
+```
+
+Because the report is a stable JSON document on stdout, any orchestrator that can
+run a subprocess can use it:
+
+```bash
+openseek --review --base origin/main | jq '.findings[] | select(.severity=="blocker")'
+```
+
+## Ensembling for confidence
+
+A single review run undersamples and varies run-to-run. Because the model is
+cheap to re-run, a useful pattern is to run the review **N times and rank
+findings by agreement**: a finding several runs surface independently is
+high-confidence, while singletons are usually noise. Voting across runs gives the
+report a calibrated confidence signal that one pass cannot.
+
+## Layout
+
+| file | role |
+| --- | --- |
+| `types.mbt` | `ReviewReport` / `Finding` / `ReviewScope` / `ReviewStats`, JSON, `validate` |
+| `submit.mbt` | the `submit_review` structured-output tool |
+| `prompt.mbt` | the review system prompt and task |
+| `engine.mbt` | `run_review` — the engine, and `ReviewError` |

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -12,9 +12,12 @@ pub let default_review_max_steps : Int = 120
 
 ///|
 /// Run a code review of the changes between `base` and HEAD and return the
-/// structured report. Read-only: the toolset is `read`, `shell`, and
-/// `submit_review` — no edit/multi_edit/write — so a review cannot mutate the
-/// source tree. Raises `ReviewError` if the model finishes without submitting a
+/// structured report. The toolset is `read`, `shell` (in read-only mode), and
+/// `submit_review` — no edit/multi_edit/write — so the review reports rather
+/// than edits. Read-only is best-effort: the shell refuses obvious
+/// source-mutating moon commands, but `moon check`/`moon test` may still trigger
+/// pre-build source generation, so the checkout is not guaranteed byte-for-byte
+/// unchanged. Raises `ReviewError` if the model finishes without submitting a
 /// report.
 pub async fn run_review(
   api_key : String,

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -28,7 +28,7 @@ pub async fn run_review(
   let captured : Ref[ReviewReport?] = { val: None }
   let tools = @agent_tool.Tools([
     @read.definition(workspace_root~),
-    @shell.definition(workspace_root~),
+    @shell.definition(workspace_root~, read_only=true),
     submit_review_tool(captured),
   ])
   let session = @agent_session.Session(

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -1,0 +1,62 @@
+///|
+/// Raised when a review run fails for an infrastructure reason (e.g. the model
+/// finished without producing a structured report), as opposed to completing
+/// with findings.
+pub suberror ReviewError {
+  ReviewError(String)
+}
+
+///|
+/// Default step budget for one review run.
+pub let default_review_max_steps : Int = 120
+
+///|
+/// Run a code review of the changes between `base` and HEAD and return the
+/// structured report. Read-only: the toolset is `read`, `shell`, and
+/// `submit_review` — no edit/multi_edit/write — so a review cannot mutate the
+/// source tree. Raises `ReviewError` if the model finishes without submitting a
+/// report.
+pub async fn run_review(
+  api_key : String,
+  model : @deepseek.Model,
+  base : String,
+  workspace_root? : String = ".",
+  max_steps? : Int = default_review_max_steps,
+  thinking? : @deepseek.ThinkingMode = Max,
+  api_url? : String,
+) -> ReviewReport {
+  let captured : Ref[ReviewReport?] = { val: None }
+  let tools = @agent_tool.Tools([
+    @read.definition(workspace_root~),
+    @shell.definition(workspace_root~),
+    submit_review_tool(captured),
+  ])
+  let session = @agent_session.Session(
+    @agent_session.SessionId("review"),
+    system_prompt=review_system_prompt(),
+  )
+  let task = review_task(base)
+  let final_session : @agent_session.Session = @async.with_task_group() <| group => {
+    @agent.run_turn_in_scope(
+      @agent_runtime.AgentRuntime(workspace_root~),
+      @agent_runtime.AgentTaskScope(group),
+      api_key,
+      model,
+      session,
+      task,
+      append_item=(s, i) => s.append(i),
+      max_steps~,
+      thinking~,
+      api_url?,
+      tools~,
+    )
+  }
+  ignore(final_session)
+  match captured.val {
+    Some(report) => report
+    None =>
+      raise ReviewError(
+        "review finished without calling submit_review (no structured report)",
+      )
+  }
+}

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -51,6 +51,7 @@ pub async fn run_review(
       tools~,
     )
   }
+  // Review is read-only and ephemeral; the final session is not persisted.
   ignore(final_session)
   match captured.val {
     Some(report) => report

--- a/agent_review/moon.pkg
+++ b/agent_review/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/core/json",
+}
+
+supported_targets = "+native"

--- a/agent_review/moon.pkg
+++ b/agent_review/moon.pkg
@@ -1,5 +1,12 @@
 import {
+  "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/read",
+  "bobzhang/openseek/agent_tool/shell",
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/async",
   "moonbitlang/core/json",
 }
 

--- a/agent_review/moon.pkg
+++ b/agent_review/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool",
   "moonbitlang/core/json",
 }
 

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -1,0 +1,70 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_review"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+  "moonbitlang/core/ref",
+}
+
+// Values
+pub let current_schema_version : Int
+
+pub let default_review_max_steps : Int
+
+pub fn review_system_prompt() -> String
+
+pub fn review_task(String) -> String
+
+pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String) -> ReviewReport
+
+pub fn severities() -> Array[String]
+
+pub fn submit_review_tool(@ref.Ref[ReviewReport?]) -> @agent_tool.AgentToolDefinition
+
+// Errors
+pub suberror ReviewError {
+  ReviewError(String)
+}
+
+// Types and methods
+pub(all) struct Finding {
+  file : String
+  line : Int?
+  severity : String
+  category : String
+  title : String
+  detail : String
+  suggestion : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ReviewReport {
+  schema_version : Int
+  scope : ReviewScope
+  findings : Array[Finding]
+  summary : String
+  stats : ReviewStats
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ReviewReport::parse(Json) -> Result[Self, String]
+pub fn ReviewReport::to_json_string(Self) -> String
+pub fn ReviewReport::validate(Self) -> Array[String]
+
+pub(all) struct ReviewScope {
+  base : String
+  head : String
+  files : Array[String]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ReviewStats {
+  files_reviewed : Int
+  findings : Int
+  build : String
+  tests : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+// Type aliases
+
+// Traits
+

--- a/agent_review/prompt.mbt
+++ b/agent_review/prompt.mbt
@@ -1,0 +1,21 @@
+///|
+/// System prompt for review mode: a read-only, compiler-grounded reviewer.
+pub fn review_system_prompt() -> String {
+  "You are OpenSeek in code-review mode. You review code changes; you do not modify them.\n\n" +
+  "Principles:\n" +
+  "- Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.\n" +
+  "- Report, do not rewrite. You have no edit tools. Point at exact file:line.\n" +
+  "- Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.\n" +
+  "- When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text."
+}
+
+///|
+/// The review task: inspect the change set between `base` and HEAD.
+pub fn review_task(base : String) -> String {
+  "Review the code changes between \{base} and HEAD in the current repository.\n\n" +
+  "Steps:\n" +
+  "1. Run `git diff \{base}...HEAD` and `git diff --name-only \{base}...HEAD` to see the change set.\n" +
+  "2. Read the changed files and enough surrounding context to judge correctness.\n" +
+  "3. Run `moon check --target all` to confirm it compiles across targets; run `moon test` if feasible. Treat compiler/test output as ground truth.\n" +
+  "4. Call submit_review once with findings (file, line when known, severity, category, title, detail, optional suggestion), a summary, and stats (set build/tests from what moon check/test actually reported)."
+}

--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -1,0 +1,94 @@
+///|
+/// `submit_review` is the structured-output tool for the review engine. The
+/// model calls it exactly once with the full report; the executor parses and
+/// validates the arguments, captures a valid report into `captured`, and ends
+/// the run via Finish. Malformed output is rejected with an error so the model
+/// retries instead of finishing with no report.
+pub fn submit_review_tool(
+  captured : Ref[ReviewReport?],
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="submit_review",
+    description="Submit the final structured code-review report and end the review. Call this exactly once, when the review is complete. Every finding must cite a file (and a line when known) and a severity of blocker|high|medium|low|nit.",
+    schema=JsonSchema(report_schema()),
+    execute=Sync(args => submit(captured, args)),
+  )
+}
+
+///|
+fn submit(captured : Ref[ReviewReport?], args : Json) -> @agent_tool.ToolAction {
+  match ReviewReport::parse(args) {
+    Err(msg) =>
+      @agent_tool.ToolAction::respond(
+        "submit_review rejected: \{msg}",
+        is_error=true,
+        brief="submit_review",
+      )
+    Ok(report) => {
+      let problems = report.validate()
+      if problems.length() > 0 {
+        @agent_tool.ToolAction::respond(
+          "submit_review rejected: \{problems.join("; ")}",
+          is_error=true,
+          brief="submit_review",
+        )
+      } else {
+        captured.val = Some(report)
+        @agent_tool.ToolAction::finish(
+          "review submitted (\{report.findings.length()} finding(s))",
+        )
+      }
+    }
+  }
+}
+
+///|
+/// JSON schema mirroring `ReviewReport`. `line` and `suggestion` are optional.
+fn report_schema() -> Json {
+  {
+    "type": "object",
+    "properties": {
+      "schema_version": { "type": "integer" },
+      "scope": {
+        "type": "object",
+        "properties": {
+          "base": { "type": "string" },
+          "head": { "type": "string" },
+          "files": { "type": "array", "items": { "type": "string" } },
+        },
+        "required": ["base", "head", "files"],
+      },
+      "findings": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "file": { "type": "string" },
+            "line": { "type": "integer" },
+            "severity": {
+              "type": "string",
+              "enum": ["blocker", "high", "medium", "low", "nit"],
+            },
+            "category": { "type": "string" },
+            "title": { "type": "string" },
+            "detail": { "type": "string" },
+            "suggestion": { "type": "string" },
+          },
+          "required": ["file", "severity", "category", "title", "detail"],
+        },
+      },
+      "summary": { "type": "string" },
+      "stats": {
+        "type": "object",
+        "properties": {
+          "files_reviewed": { "type": "integer" },
+          "findings": { "type": "integer" },
+          "build": { "type": "string" },
+          "tests": { "type": "string" },
+        },
+        "required": ["files_reviewed", "findings", "build", "tests"],
+      },
+    },
+    "required": ["schema_version", "scope", "findings", "summary", "stats"],
+  }
+}

--- a/agent_review/submit_wbtest.mbt
+++ b/agent_review/submit_wbtest.mbt
@@ -1,0 +1,30 @@
+///|
+test "submit captures a valid report and finishes" {
+  let captured : Ref[ReviewReport?] = { val: None }
+  let action = submit(captured, sample_report().to_json())
+  guard action is Control(Finish(_)) else { fail("expected Finish") }
+  guard captured.val is Some(_) else { fail("expected captured report") }
+}
+
+///|
+test "submit rejects an invalid report without capturing" {
+  let captured : Ref[ReviewReport?] = { val: None }
+  let bad = {
+    ..sample_report(),
+    findings: [
+      {
+        file: "",
+        line: None,
+        severity: "urgent",
+        category: "x",
+        title: "",
+        detail: "d",
+        suggestion: None,
+      },
+    ],
+  }
+  let action = submit(captured, bad.to_json())
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  guard captured.val is None else { fail("must not capture an invalid report") }
+}

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -81,6 +81,12 @@ pub fn ReviewReport::validate(self : ReviewReport) -> Array[String] {
     if finding.title == "" {
       problems.push("a finding has an empty title")
     }
+    if finding.category == "" {
+      problems.push("finding '\{finding.title}': empty category")
+    }
+    if finding.detail == "" {
+      problems.push("finding '\{finding.title}': empty detail")
+    }
   }
   problems
 }

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -1,0 +1,98 @@
+///|
+/// `ReviewReport` is the stable, versioned contract returned by every review
+/// front-end (the headless `--review` CLI today; TUI / MCP later) and consumed
+/// by external agents that dispatch a review to OpenSeek. The JSON shape is the
+/// integration boundary, so it is kept deliberately flat and string-typed.
+
+///|
+/// The schema version this build emits and accepts.
+pub let current_schema_version : Int = 1
+
+///|
+/// Allowed severity values, ordered most to least severe.
+pub fn severities() -> Array[String] {
+  ["blocker", "high", "medium", "low", "nit"]
+}
+
+///|
+/// A single review finding at an optional source location.
+pub(all) struct Finding {
+  file : String
+  line : Int?
+  severity : String
+  category : String
+  title : String
+  detail : String
+  suggestion : String?
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// The change set the review covered.
+pub(all) struct ReviewScope {
+  base : String
+  head : String
+  files : Array[String]
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// Deterministic preflight signals that ground the review in the compiler/tests
+/// rather than model opinion.
+pub(all) struct ReviewStats {
+  files_reviewed : Int
+  findings : Int
+  build : String
+  tests : String
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// The full review report.
+pub(all) struct ReviewReport {
+  schema_version : Int
+  scope : ReviewScope
+  findings : Array[Finding]
+  summary : String
+  stats : ReviewStats
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// Validate a report against the contract. Returns the list of problems; an
+/// empty list means the report is valid. The `submit_review` tool uses this to
+/// reject malformed model output and ask for a retry.
+pub fn ReviewReport::validate(self : ReviewReport) -> Array[String] {
+  let problems : Array[String] = []
+  if self.schema_version != current_schema_version {
+    problems.push(
+      "schema_version must be \{current_schema_version}, got \{self.schema_version}",
+    )
+  }
+  let allowed = severities()
+  for finding in self.findings {
+    if !allowed.contains(finding.severity) {
+      problems.push(
+        "finding '\{finding.title}': invalid severity '\{finding.severity}'",
+      )
+    }
+    if finding.file == "" {
+      problems.push("a finding has an empty file path")
+    }
+    if finding.title == "" {
+      problems.push("a finding has an empty title")
+    }
+  }
+  problems
+}
+
+///|
+/// Parse a report from JSON, returning the report or a human-readable error.
+pub fn ReviewReport::parse(json : Json) -> Result[ReviewReport, String] {
+  let report : ReviewReport = @json.from_json(json) catch {
+    e => return Err("invalid review report JSON: \{e}")
+  }
+  Ok(report)
+}
+
+///|
+/// Encode the report as a single-line JSON string (the CLI stdout contract).
+pub fn ReviewReport::to_json_string(self : ReviewReport) -> String {
+  self.to_json().stringify()
+}

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -65,6 +65,9 @@ pub fn ReviewReport::validate(self : ReviewReport) -> Array[String] {
       "schema_version must be \{current_schema_version}, got \{self.schema_version}",
     )
   }
+  if self.summary.trim() == "" {
+    problems.push("summary must not be empty")
+  }
   let allowed = severities()
   for finding in self.findings {
     if !allowed.contains(finding.severity) {

--- a/agent_review/types_wbtest.mbt
+++ b/agent_review/types_wbtest.mbt
@@ -77,6 +77,12 @@ test "validate rejects a wrong schema version" {
 }
 
 ///|
+test "validate rejects an empty summary" {
+  assert_true({ ..sample_report(), summary: "" }.validate().length() > 0)
+  assert_true({ ..sample_report(), summary: "   " }.validate().length() > 0)
+}
+
+///|
 test "parse reports an error on malformed json" {
   guard ReviewReport::parse(Json::null()) is Err(_) else {
     fail("expected parse error")

--- a/agent_review/types_wbtest.mbt
+++ b/agent_review/types_wbtest.mbt
@@ -1,0 +1,84 @@
+///|
+fn sample_report() -> ReviewReport {
+  {
+    schema_version: 1,
+    scope: { base: "origin/main", head: "HEAD", files: ["a.mbt", "b.mbt"] },
+    findings: [
+      {
+        file: "a.mbt",
+        line: Some(42),
+        severity: "high",
+        category: "correctness",
+        title: "off-by-one in loop bound",
+        detail: "uses < where <= is intended",
+        suggestion: Some("change < to <="),
+      },
+      {
+        file: "b.mbt",
+        line: None,
+        severity: "nit",
+        category: "style",
+        title: "unclear name",
+        detail: "rename x to count",
+        suggestion: None,
+      },
+    ],
+    summary: "two findings",
+    stats: { files_reviewed: 2, findings: 2, build: "pass", tests: "skipped" },
+  }
+}
+
+///|
+test "review report round-trips through json" {
+  let report = sample_report()
+  let json = report.to_json()
+  guard ReviewReport::parse(json) is Ok(parsed) else { fail("parse failed") }
+  assert_eq(parsed.to_json_string(), report.to_json_string())
+}
+
+///|
+test "json string carries the flat string-typed contract" {
+  let s = sample_report().to_json_string()
+  assert_true(s.contains("\"schema_version\""))
+  assert_true(s.contains("\"findings\""))
+  // severity renders as a plain string, not a tagged enum
+  assert_true(s.contains("\"high\""))
+  assert_true(s.contains("\"nit\""))
+}
+
+///|
+test "validate accepts a good report" {
+  assert_eq(sample_report().validate().length(), 0)
+}
+
+///|
+test "validate rejects a bad severity" {
+  let report = {
+    ..sample_report(),
+    findings: [
+      {
+        file: "a.mbt",
+        line: None,
+        severity: "urgent",
+        category: "correctness",
+        title: "t",
+        detail: "d",
+        suggestion: None,
+      },
+    ],
+  }
+  assert_true(report.validate().length() > 0)
+}
+
+///|
+test "validate rejects a wrong schema version" {
+  let report = { ..sample_report(), schema_version: 2 }
+  assert_true(report.validate().length() > 0)
+}
+
+///|
+test "parse reports an error on malformed json" {
+  guard ReviewReport::parse(Json::null()) is Err(_) else {
+    fail("expected parse error")
+  }
+}

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
 
-pub fn definition(workspace_root? : String) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, read_only? : Bool) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/shell/readonly_wbtest.mbt
+++ b/agent_tool/shell/readonly_wbtest.mbt
@@ -1,0 +1,23 @@
+///|
+/// Read-only mode (used by `--review`) must refuse source-mutating moon commands
+/// before they run, even though such commands are otherwise "trusted" and run
+/// unsandboxed. The guard fires before execution, so no subprocess is spawned.
+async test "read-only shell blocks source-mutating moon commands" {
+  let blocked = execute_with_workspace(
+    ".",
+    { "cmd": "moon fmt" },
+    read_only=true,
+  )
+  guard blocked is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("read-only review mode"))
+}
+
+///|
+test "read-only guard predicate matches fmt/info but not check" {
+  assert_true(should_auto_check_moon_command("moon fmt"))
+  assert_true(should_auto_check_moon_command("moon info"))
+  assert_false(should_auto_check_moon_command("moon check"))
+  assert_false(should_auto_check_moon_command("moon check --target all"))
+  assert_false(should_auto_check_moon_command("git diff origin/main"))
+}

--- a/agent_tool/shell/readonly_wbtest.mbt
+++ b/agent_tool/shell/readonly_wbtest.mbt
@@ -14,10 +14,58 @@ async test "read-only shell blocks source-mutating moon commands" {
 }
 
 ///|
-test "read-only guard predicate matches fmt/info but not check" {
-  assert_true(should_auto_check_moon_command("moon fmt"))
-  assert_true(should_auto_check_moon_command("moon info"))
-  assert_false(should_auto_check_moon_command("moon check"))
-  assert_false(should_auto_check_moon_command("moon check --target all"))
-  assert_false(should_auto_check_moon_command("git diff origin/main"))
+test "read-only guard blocks mutating moon anywhere; allows read-only commands" {
+  // mutating moon — plain, chained either way, and env-prefixed (all bypasses)
+  assert_true(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon fmt")),
+  )
+  assert_true(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon info")),
+  )
+  assert_true(
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon fmt && git diff"),
+    ),
+  )
+  assert_true(
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("git diff && moon fmt"),
+    ),
+  )
+  assert_true(
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon test --update; true"),
+    ),
+  )
+  assert_true(
+    review_read_only_blocks(@shell_parse.parse_for_policy("FOO=bar moon fmt")),
+  )
+  // a pipe segment that mutates is still caught (pipes parse as Simple)
+  assert_true(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon fmt | tee out")),
+  )
+  // a read-only pipe is allowed (no mutating segment)
+  assert_false(
+    review_read_only_blocks(@shell_parse.parse_for_policy("git diff | head")),
+  )
+  // read-only commands — allowed
+  assert_false(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon check")),
+  )
+  assert_false(
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon check --target all"),
+    ),
+  )
+  assert_false(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon test")),
+  )
+  assert_false(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon fmt --check")),
+  )
+  assert_false(
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("git diff origin/main"),
+    ),
+  )
 }

--- a/agent_tool/shell/review_guard.mbt
+++ b/agent_tool/shell/review_guard.mbt
@@ -1,0 +1,42 @@
+///|
+/// Whether a single parsed command is a source-mutating `moon` invocation
+/// (fmt / info / install / test --update / ...). Unlike
+/// `auto_check_cwd_for_moon_command`, this does NOT skip env-prefixed commands
+/// or depend on cwd: read-only enforcement must err toward blocking, so e.g.
+/// `FOO=bar moon fmt` is still caught.
+fn command_is_mutating_moon(command : @shell_parse.SimpleCommand) -> Bool {
+  match moon_command_start(command) {
+    Some(index) =>
+      match parse_moon_invocation(command.argv, index, ".") {
+        Some(invocation) =>
+          !invocation.dry_run &&
+          is_auto_check_moon_subcommand(
+            command.argv,
+            invocation.subcommand_index,
+          )
+        None => false
+      }
+    None => false
+  }
+}
+
+///|
+/// Whether read-only (review) mode must refuse this parsed command: any
+/// source-mutating moon command anywhere in a `Simple` parse — including `&&`/
+/// `;` chains, pipes, and env prefixes — or any command too complex to analyze
+/// statically (`TooComplex`: subshells, command substitution, backticks), which
+/// is refused wholesale so the read-only guarantee holds even on hosts without
+/// the kernel sandbox.
+fn review_read_only_blocks(parsed : @shell_parse.ParseResult) -> Bool {
+  match parsed {
+    Simple(commands) => {
+      for command in commands {
+        if command_is_mutating_moon(command) {
+          return true
+        }
+      }
+      false
+    }
+    _ => true
+  }
+}

--- a/agent_tool/shell/review_guard.mbt
+++ b/agent_tool/shell/review_guard.mbt
@@ -21,12 +21,15 @@ fn command_is_mutating_moon(command : @shell_parse.SimpleCommand) -> Bool {
 }
 
 ///|
-/// Whether read-only (review) mode must refuse this parsed command: any
-/// source-mutating moon command anywhere in a `Simple` parse — including `&&`/
-/// `;` chains, pipes, and env prefixes — or any command too complex to analyze
-/// statically (`TooComplex`: subshells, command substitution, backticks), which
-/// is refused wholesale so the read-only guarantee holds even on hosts without
-/// the kernel sandbox.
+/// Whether read-only (review) mode should refuse this parsed command. This is a
+/// best-effort guard, not an airtight guarantee: it blocks the obvious bulk
+/// source-rewriters — a source-mutating moon command (fmt / info / test
+/// --update / ...) anywhere in a `Simple` parse, including `&&`/`;` chains,
+/// pipes, and env prefixes — so a review does not reformat or regenerate the
+/// tree wholesale. Opaque commands (`TooComplex`: subshells, command
+/// substitution) are allowed: a review that runs `moon check`/`moon test` can
+/// already trigger pre-build source generation, so chasing every last mutation
+/// is not worth crippling the review's ability to investigate.
 fn review_read_only_blocks(parsed : @shell_parse.ParseResult) -> Bool {
   match parsed {
     Simple(commands) => {
@@ -37,6 +40,6 @@ fn review_read_only_blocks(parsed : @shell_parse.ParseResult) -> Bool {
       }
       false
     }
-    _ => true
+    _ => false
   }
 }

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -79,14 +79,15 @@ async fn execute_with_workspace(
     }
   }
   let parsed_command = @shell_parse.parse_for_policy(input.cmd)
-  // Read-only (review) mode: refuse any source-mutating moon command anywhere in
-  // the parsed command (including `&&`/`;` chains and env prefixes), and any
-  // command too complex to analyze statically (pipes, subshells). The sandbox
-  // already blocks non-moon source writes; this closes the trusted-moon-command
-  // path so a review cannot edit the checkout even without the kernel sandbox.
+  // Read-only (review) mode: refuse the obvious bulk source-rewriters — a
+  // source-mutating moon command (fmt / info / test --update) anywhere in the
+  // parsed command, including `&&`/`;` chains, pipes, and env prefixes. This is
+  // best-effort: opaque commands are allowed and `moon check`/`moon test` may
+  // still pre-build, so it only stops a review from reformatting/regenerating
+  // the tree wholesale, not every possible mutation.
   if read_only && review_read_only_blocks(parsed_command) {
     return @agent_tool.ToolAction::respond(
-      "blocked in read-only review mode: `\{input.cmd}` may mutate the checkout (a moon fmt/info/test --update command, or a command too complex to verify). A review must not modify source; use plain `moon check`/`moon test` (no --update), `git`, or `read`.",
+      "blocked in read-only review mode: `\{input.cmd}` runs a source-mutating moon command (fmt/info/test --update); a review reports rather than rewrites the tree. Use plain `moon check`/`moon test` (no --update), `git`, or `read`.",
       is_error=true,
     )
   }

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -78,16 +78,18 @@ async fn execute_with_workspace(
       )
     }
   }
-  // Read-only (review) mode: refuse source-mutating moon commands (fmt, info,
-  // test --update, ...). The sandbox already blocks non-moon source writes; this
-  // closes the trusted-moon-command path so a review cannot edit the checkout.
-  if read_only && should_auto_check_moon_command(input.cmd) {
+  let parsed_command = @shell_parse.parse_for_policy(input.cmd)
+  // Read-only (review) mode: refuse any source-mutating moon command anywhere in
+  // the parsed command (including `&&`/`;` chains and env prefixes), and any
+  // command too complex to analyze statically (pipes, subshells). The sandbox
+  // already blocks non-moon source writes; this closes the trusted-moon-command
+  // path so a review cannot edit the checkout even without the kernel sandbox.
+  if read_only && review_read_only_blocks(parsed_command) {
     return @agent_tool.ToolAction::respond(
-      "blocked in read-only review mode: `\{input.cmd}` runs a source-mutating moon command; a review must not modify the checkout. Use `moon check` or `moon test` (without --update).",
+      "blocked in read-only review mode: `\{input.cmd}` may mutate the checkout (a moon fmt/info/test --update command, or a command too complex to verify). A review must not modify source; use plain `moon check`/`moon test` (no --update), `git`, or `read`.",
       is_error=true,
     )
   }
-  let parsed_command = @shell_parse.parse_for_policy(input.cmd)
   match
     @command_policy.moonbit_command_policy_error_for_parse(
       input.cmd,

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -30,6 +30,7 @@
 ///   invalid arguments.
 pub fn definition(
   workspace_root? : String = ".",
+  read_only? : Bool = false,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell",
@@ -44,7 +45,9 @@ pub fn definition(
       },
       "required": ["cmd"],
     }),
-    execute=Async(arguments => execute_with_workspace(workspace_root, arguments)),
+    execute=Async(arguments => {
+      execute_with_workspace(workspace_root, arguments, read_only~)
+    }),
   )
 }
 
@@ -64,6 +67,7 @@ fn shell_description() -> String {
 async fn execute_with_workspace(
   workspace_root : String,
   arguments : Json,
+  read_only~ : Bool,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -73,6 +77,15 @@ async fn execute_with_workspace(
         is_error=true,
       )
     }
+  }
+  // Read-only (review) mode: refuse source-mutating moon commands (fmt, info,
+  // test --update, ...). The sandbox already blocks non-moon source writes; this
+  // closes the trusted-moon-command path so a review cannot edit the checkout.
+  if read_only && should_auto_check_moon_command(input.cmd) {
+    return @agent_tool.ToolAction::respond(
+      "blocked in read-only review mode: `\{input.cmd}` runs a source-mutating moon command; a review must not modify the checkout. Use `moon check` or `moon test` (without --update).",
+      is_error=true,
+    )
   }
   let parsed_command = @shell_parse.parse_for_policy(input.cmd)
   match

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -29,6 +29,18 @@ async fn run_cli() -> Unit {
     if flag(matches, "no-session") && session_id(matches) is Some(_) {
       fail("--no-session contradicts --session; pick one behavior")
     }
+    // Review is a read-only, ephemeral, single-report mode. It branches before
+    // workspace/session/serve handling and silences progress logging so stdout
+    // carries exactly one JSON ReviewReport.
+    if flag(matches, "review") {
+      if values(matches, "task").length() > 0 {
+        fail("--review reviews base...HEAD and does not take a task")
+      }
+      @xlog.global().set_handler(DiscardLog::{  })
+      let workspace_root = prepare_workspace_root(matches, log_created=false)
+      run_review_cli(matches, workspace_root~)
+      return
+    }
     // Best-of-N fleet mode owns its own workspace materialization and session
     // creation, so it branches before prepare_workspace_root (which would
     // create a single --dir) and the session/serve handling.
@@ -319,6 +331,12 @@ fn cli_command() -> @argparse.Command {
         about="Last event sequence covered by --session-compact-file.",
       ),
       OptionArg(
+        "base",
+        long="base",
+        default_values=["origin/main"],
+        about="Base ref for --review: review the diff base...HEAD.",
+      ),
+      OptionArg(
         "format",
         long="format",
         default_values=["text"],
@@ -326,6 +344,11 @@ fn cli_command() -> @argparse.Command {
       ),
     ],
     flags=[
+      FlagArg(
+        "review",
+        long="review",
+        about="Run a read-only code review of base...HEAD and print a JSON ReviewReport to stdout.",
+      ),
       FlagArg(
         "serve",
         long="serve",

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/jsonl",
   "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_review",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_skill",
   "bobzhang/openseek/agent_session",

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -22,7 +22,9 @@ async fn run_review_cli(
 ) -> Unit {
   let api_key = api_key(matches)
   let api_url = api_url(matches)
-  let model = @deepseek.Model::parse(value(matches, "model"))
+  // Reviews always run on the strongest model; flash is too shallow for the
+  // judgement a code review needs, so --model is not consulted here.
+  let model = @deepseek.V4Pro
   let max_steps = max_steps(matches)
   let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
   let base = value(matches, "base")

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -28,6 +28,11 @@ async fn run_review_cli(
   let max_steps = max_steps(matches)
   let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
   let base = value(matches, "base")
+  if base.trim() == "" {
+    @stdio.stderr.write("review failed: --base must be a non-empty git ref\n")
+    @sys.exit(1)
+    return
+  }
   let report = @agent_review.run_review(
     api_key,
     model,

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -37,6 +37,8 @@ async fn run_review_cli(
   ) catch {
     error => {
       @stdio.stderr.write("review failed: \{error}\n")
+      // `@sys.exit` never returns at runtime but is typed `Unit`, so this arm
+      // still needs a diverging expression to satisfy the report-branch type.
       @sys.exit(1)
       return
     }

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -1,0 +1,49 @@
+///|
+/// A logging handler that drops every entry. Review mode installs it so the
+/// agent's progress JSONL does not pollute stdout, which must carry exactly one
+/// JSON `ReviewReport`.
+priv struct DiscardLog {}
+
+///|
+impl @xlog.Handler for DiscardLog with fn handle(
+  _self : DiscardLog,
+  _entry : @xlog.Entry,
+) -> Unit raise {
+
+}
+
+///|
+/// Handle `--review`: run a read-only review of `base...HEAD` and print a single
+/// JSON `ReviewReport` to stdout. Exit code: 0 (clean or non-blocking findings),
+/// 1 (the review failed to produce a report), 2 (blocker findings present).
+async fn run_review_cli(
+  matches : @argparse.Matches,
+  workspace_root~ : String,
+) -> Unit {
+  let api_key = api_key(matches)
+  let api_url = api_url(matches)
+  let model = @deepseek.Model::parse(value(matches, "model"))
+  let max_steps = max_steps(matches)
+  let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
+  let base = value(matches, "base")
+  let report = @agent_review.run_review(
+    api_key,
+    model,
+    base,
+    workspace_root~,
+    max_steps~,
+    thinking~,
+    api_url?,
+  ) catch {
+    error => {
+      @stdio.stderr.write("review failed: \{error}\n")
+      @sys.exit(1)
+      return
+    }
+  }
+  @stdio.stdout.write(report.to_json_string() + "\n")
+  let blockers = report.findings.filter(f => f.severity == "blocker").length()
+  if blockers > 0 {
+    @sys.exit(2)
+  }
+}

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -25,6 +25,7 @@ Arguments:
 
 Options:
   -h, --help                                                   Show help information.
+  --review                                                     Run a read-only code review of base...HEAD and print a JSON ReviewReport to stdout.
   --serve                                                      Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.
   --no-session                                                 Run ephemerally: do not record this run to a durable session.
   --session-list                                               List durable sessions (see --format) and exit.
@@ -44,6 +45,7 @@ Options:
   --session-compact-file <session-compact-file>                Read summary text from this file, append it to --session, and exit. [default: ]
   --session-compact-from <session-compact-from>                First event sequence covered by --session-compact-file. [default: ]
   --session-compact-to <session-compact-to>                    Last event sequence covered by --session-compact-file. [default: ]
+  --base <base>                                                Base ref for --review: review the diff base...HEAD. [default: origin/main]
   --format <format>                                            Output format for --session-list: text or json. [default: text]
 ```
 


### PR DESCRIPTION
## Summary

Add a **code-review capability** to OpenSeek as a front-end-agnostic *engine*, with a headless CLI front-end so **other coding agents (codex, claude) can spawn a review and dispatch it to OpenSeek** and get back a structured report. This is **P0**: the engine + the headless `--review` mode. (TUI `/review` and MCP are deferred — see plan.)

```
openseek --review --base origin/main   →   one JSON ReviewReport on stdout, exit code by severity
```

## Architecture (grounded in codex's plan critique)

- **Engine** (`agent_review`): `run_review(base, ...)` built on `run_turn_in_scope` with a custom toolset — `read`, `shell` (read-only mode), `submit_review` — **no edit/multi_edit/write**. Captures the report into a `Ref` and returns it; raises `ReviewError` if the model never submits.
- **Contract** (`ReviewReport`): stable, versioned, flat, string-typed JSON — the integration boundary external agents consume. `validate()` rejects malformed model output.
- **Structured output**: a `submit_review` tool whose schema *is* the contract forces valid output (the loop otherwise accepts a bare-text finish).
- **CLI** (`--review`): ephemeral (no session), logs discarded so **stdout is exactly one report**; exit 0 (clean / non-blocking), 1 (no report), 2 (blockers).
- **Compiler-grounded**: the prompt makes the reviewer run `moon check`/`moon test` and cite real diagnostics — `stats.build`/`stats.tests` come from actual runs, not opinion.
- **Pinned to Pro**: flash is too shallow for review judgement.

## Read-only stance (best-effort, honest)

The review has no edit/write tools and the shell refuses obvious source-rewriters (`moon fmt`/`info`/`test --update`, anywhere in the parsed command). It is **not** an airtight guarantee: `moon check`/`moon test` can trigger `pre-build` source generation. Per maintainer decision, some mutation is acceptable — the review *reports* rather than *edits*, and we don't chase byte-for-byte immutability.

## Validation

- End-to-end smoke test (reviewing this branch): clean single-line JSON, 0 bytes on stderr, grounded stats (`811 native + 18 JS pass`).
- **Pro genuinely delivers insight**: 6 grounded findings on this branch (vs 1 from flash), and it **found two real robustness gaps in its own code** (`--base ""` and empty-summary validation) — both fixed here (dogfooding).
- **Codex-reviewed across 3 rounds**; each finding addressed (read-only registration → chained/env-prefixed bypass → pre-build hooks, resolved as best-effort per the decision above).
- 112 tests across `agent_review` + `shell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
