### PR TITLE
fix(shell/sandbox): close heredoc-scan false negatives + view-pattern refactor

### DIFF
--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -2370,6 +2370,25 @@ fn heredoc_delimiters_in_line(line : String) -> Array[HeredocDelimiter] {
           escaped = true
         } else if ch == '\'' || ch == '"' {
           quote = Some(ch)
+        } else if ch == '$' &&
+          index + 2 < chars.length() &&
+          chars[index + 1] == '(' &&
+          chars[index + 2] == '(' {
+          // Arithmetic expansion `$(( ... ))` never contains a here-document, so
+          // skip its balanced parentheses. Otherwise a left shift such as
+          // `$((1 << 8))` is misread as a here-document operator, and the bogus
+          // delimiter swallows every following line from the source-write scan.
+          index += 3
+          let mut depth = 2
+          while index < chars.length() && depth > 0 {
+            if chars[index] == '(' {
+              depth += 1
+            } else if chars[index] == ')' {
+              depth -= 1
+            }
+            index += 1
+          }
+          continue
         } else if ch == '<' &&
           index + 1 < chars.length() &&
           chars[index + 1] == '<' {
@@ -2449,6 +2468,7 @@ fn read_heredoc_delimiter(
 ///|
 fn heredoc_delimiter_char(ch : Char) -> Bool {
   !command_text_line_space(ch) &&
+  ch != '\r' &&
   ch != ';' &&
   ch != '&' &&
   ch != '|' &&

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1814,12 +1814,6 @@ priv struct HeredocDelimiter {
 }
 
 ///|
-priv struct HeredocReadResult {
-  marker : String
-  next : Int
-}
-
-///|
 priv struct CommandWordReadResult {
   word : String
   next : Int
@@ -2349,119 +2343,148 @@ fn strip_leading_dot_slash(path : String) -> String {
 fn heredoc_delimiters_in_line(line : String) -> Array[HeredocDelimiter] {
   let delimiters : Array[HeredocDelimiter] = []
   let chars = [ for ch in line => ch ]
-  let mut index = 0
-  let mut quote : Char? = None
-  let mut escaped = false
-  while index < chars.length() {
-    let ch = chars[index]
-    match quote {
-      Some(end_quote) =>
-        if escaped {
-          escaped = false
-        } else if end_quote == '"' && ch == '\\' {
-          escaped = true
-        } else if ch == end_quote {
-          quote = None
+  for view = chars[:] {
+    match view {
+      [] => break
+      // A backslash escapes the next code unit, so `\<\<` is not a here-document.
+      ['\\', _, .. rest] => continue rest
+      // Quoted spans never start a here-document or arithmetic expansion.
+      ['\'', .. rest] => continue heredoc_skip_single_quoted(rest)
+      ['"', .. rest] => continue heredoc_skip_double_quoted(rest)
+      // Arithmetic expansion `$(( ... ))` never contains a here-document, so skip
+      // its balanced parentheses. Otherwise a left shift such as `$((1 << 8))` is
+      // misread as a here-document operator whose delimiter swallows later lines.
+      ['$', '(', '(', .. rest] => continue heredoc_skip_arithmetic(rest)
+      // Here-document operator: `<<`, an optional `-`, optional blanks, then the
+      // delimiter word.
+      ['<', '<', .. rest] => {
+        let (strip_tabs, rest) = match rest {
+          ['-', .. after] => (true, after)
+          _ => (false, rest)
         }
-      None =>
-        if escaped {
-          escaped = false
-        } else if ch == '\\' {
-          escaped = true
-        } else if ch == '\'' || ch == '"' {
-          quote = Some(ch)
-        } else if ch == '$' &&
-          index + 2 < chars.length() &&
-          chars[index + 1] == '(' &&
-          chars[index + 2] == '(' {
-          // Arithmetic expansion `$(( ... ))` never contains a here-document, so
-          // skip its balanced parentheses. Otherwise a left shift such as
-          // `$((1 << 8))` is misread as a here-document operator, and the bogus
-          // delimiter swallows every following line from the source-write scan.
-          index += 3
-          let mut depth = 2
-          while index < chars.length() && depth > 0 {
-            if chars[index] == '(' {
-              depth += 1
-            } else if chars[index] == ')' {
-              depth -= 1
+        let rest = heredoc_skip_line_space(rest)
+        match read_heredoc_delimiter(rest) {
+          Some((marker, after)) => {
+            if marker != "" {
+              delimiters.push({ marker, strip_tabs })
             }
-            index += 1
+            continue after
           }
-          continue
-        } else if ch == '<' &&
-          index + 1 < chars.length() &&
-          chars[index + 1] == '<' {
-          index += 2
-          let strip_tabs = if index < chars.length() && chars[index] == '-' {
-            index += 1
-            true
-          } else {
-            false
-          }
-          while index < chars.length() && command_text_line_space(chars[index]) {
-            index += 1
-          }
-          match read_heredoc_delimiter(chars, index) {
-            Some(result) => {
-              if result.marker != "" {
-                delimiters.push({ marker: result.marker, strip_tabs })
-              }
-              index = result.next
-              continue
-            }
-            None => ()
-          }
+          None => continue rest
         }
+      }
+      [_, .. rest] => continue rest
     }
-    index += 1
   }
   delimiters
 }
 
 ///|
-fn read_heredoc_delimiter(
-  chars : Array[Char],
-  start : Int,
-) -> HeredocReadResult? {
-  if start >= chars.length() {
-    return None
+/// Consume a single-quoted span, returning the view after the closing `'`.
+/// Single quotes are literal in POSIX shells, so nothing is escaped inside.
+fn heredoc_skip_single_quoted(view : ArrayView[Char]) -> ArrayView[Char] {
+  for v = view {
+    match v {
+      ['\'', .. rest] => break rest
+      [_, .. rest] => continue rest
+      [] => break v
+    }
   }
+}
+
+///|
+/// Consume a double-quoted span, returning the view after the closing `"`. A
+/// backslash escapes the next code unit, so an escaped quote does not close it.
+fn heredoc_skip_double_quoted(view : ArrayView[Char]) -> ArrayView[Char] {
+  for v = view {
+    match v {
+      ['\\', _, .. rest] => continue rest
+      ['"', .. rest] => break rest
+      [_, .. rest] => continue rest
+      [] => break v
+    }
+  }
+}
+
+///|
+/// Consume an arithmetic expansion whose opening `$((` was already matched,
+/// returning the view after the balancing `))`.
+fn heredoc_skip_arithmetic(view : ArrayView[Char]) -> ArrayView[Char] {
+  for v = view, depth = 2 {
+    if depth == 0 {
+      break v
+    }
+    match v {
+      ['(', .. rest] => continue rest, depth + 1
+      [')', .. rest] => continue rest, depth - 1
+      [_, .. rest] => continue rest, depth
+      [] => break v
+    }
+  }
+}
+
+///|
+/// Drop leading shell blanks (space or tab) from `view`.
+fn heredoc_skip_line_space(view : ArrayView[Char]) -> ArrayView[Char] {
+  for v = view {
+    match v {
+      [ch, .. rest] if command_text_line_space(ch) => continue rest
+      _ => break v
+    }
+  }
+}
+
+///|
+/// Read the here-document delimiter word at the start of `view`, returning the
+/// unquoted marker and the view positioned after it, or `None` when there is no
+/// delimiter (empty input or an unterminated quote).
+fn read_heredoc_delimiter(view : ArrayView[Char]) -> (String, ArrayView[Char])? {
+  match view {
+    ['\'', .. rest] => read_quoted_heredoc_marker(rest, '\'')
+    ['"', .. rest] => read_quoted_heredoc_marker(rest, '"')
+    [] => None
+    _ => {
+      let marker = StringBuilder()
+      let rest = for v = view {
+        match v {
+          ['\\', ch, .. rest] if heredoc_delimiter_char(ch) => {
+            marker.write_char(ch)
+            continue rest
+          }
+          [ch, .. rest] if heredoc_delimiter_char(ch) => {
+            marker.write_char(ch)
+            continue rest
+          }
+          _ => break v
+        }
+      }
+      Some((marker.to_string(), rest))
+    }
+  }
+}
+
+///|
+/// Read a quoted here-document marker up to the closing `quote`, returning the
+/// marker and the view after the quote, or `None` if the quote never closes. A
+/// backslash escapes the next code unit only inside double quotes.
+fn read_quoted_heredoc_marker(
+  view : ArrayView[Char],
+  quote : Char,
+) -> (String, ArrayView[Char])? {
   let marker = StringBuilder()
-  let first = chars[start]
-  if first == '\'' || first == '"' {
-    let quote = first
-    let mut index = start + 1
-    let mut escaped = false
-    while index < chars.length() {
-      let ch = chars[index]
-      if escaped {
+  for v = view {
+    match v {
+      ['\\', ch, .. rest] if quote == '"' => {
         marker.write_char(ch)
-        escaped = false
-      } else if quote == '"' && ch == '\\' {
-        escaped = true
-      } else if ch == quote {
-        return Some({ marker: marker.to_string(), next: index + 1 })
-      } else {
+        continue rest
+      }
+      [ch, .. rest] if ch == quote => break Some((marker.to_string(), rest))
+      [ch, .. rest] => {
         marker.write_char(ch)
+        continue rest
       }
-      index += 1
+      [] => break None
     }
-    None
-  } else {
-    let mut index = start
-    while index < chars.length() && heredoc_delimiter_char(chars[index]) {
-      if chars[index] == '\\' &&
-        index + 1 < chars.length() &&
-        heredoc_delimiter_char(chars[index + 1]) {
-        marker.write_char(chars[index + 1])
-        index += 2
-        continue
-      }
-      marker.write_char(chars[index])
-      index += 1
-    }
-    Some({ marker: marker.to_string(), next: index })
   }
 }
 

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -2471,3 +2471,76 @@ fn mode_for(cmd : String) -> SourceWriteMode {
     Some("/workspace"),
   )
 }
+
+///|
+async test "sandbox scans source writes after CRLF here-documents" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-crlf-heredoc-", root => {
+    @fs.write_file(
+      "\{root}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let real_root = @fs.realpath(root)
+    // CRLF line endings must not break here-document terminator matching. The
+    // unquoted marker read used to keep the trailing `\r` while the closing-line
+    // match stripped it, so the body never terminated and swallowed the later
+    // in-place source edit.
+    let crlf_heredoc_then_sed = "cat <<EOF\r\nnote\r\nEOF\r\nsed -i 's/42/43/' main.mbt\r\n"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(crlf_heredoc_then_sed),
+        crlf_heredoc_then_sed,
+        real_root,
+        Some(real_root),
+      )
+      is Some(_),
+    )
+    // The LF form already worked; keep it as a control for the same shape.
+    let lf_heredoc_then_sed = "cat <<EOF\nnote\nEOF\nsed -i 's/42/43/' main.mbt\n"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(lf_heredoc_then_sed),
+        lf_heredoc_then_sed,
+        real_root,
+        Some(real_root),
+      )
+      is Some(_),
+    )
+  })
+}
+
+///|
+async test "sandbox scans source writes after arithmetic left shifts" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-arith-shift-", root => {
+    @fs.write_file(
+      "\{root}/main.mbt",
+      "pub fn answer() -> Int { 42 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let real_root = @fs.realpath(root)
+    // `$((1 << 8))` is arithmetic, not a here-document; the `<<` left shift must
+    // not be read as a here-document operator whose phantom delimiter hides the
+    // following in-place source edit.
+    let arith_then_sed = "SHIFT=$((1 << 8))\nsed -i 's/42/43/' main.mbt\n"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(arith_then_sed),
+        arith_then_sed,
+        real_root,
+        Some(real_root),
+      )
+      is Some(_),
+    )
+    // A bare arithmetic command with no source write stays allowed.
+    let arith_only = "echo $((1 << 8))\n"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(arith_only),
+        arith_only,
+        real_root,
+        Some(real_root),
+      )
+      is None,
+    )
+  })
+}

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -516,6 +516,7 @@ async test "shell sandbox blocks source writes and points to edit tools" {
 }
 
 ///|
+#cfg(not(platform="windows"))
 async test "shell sandbox allows generated source writes under _build" {
   if !sandbox_exec_usable_for_test() {
     return


### PR DESCRIPTION
Follow-up to #259 (already merged). Two commits.

## 1. `fix`: close heredoc-scan false negatives + Windows test build

The source-write text scanner (the static pre-block for `TooComplex` commands) had two false negatives that let a real source-writing command on a line *after* a here-document or arithmetic expansion slip past unblocked:

- **CRLF line endings** — `heredoc_delimiter_char` treated `\r` as part of an unquoted terminator, so `cat <<EOF\r` stored marker `EOF\r` while the closing-line match strips the `\r`. The body never terminated and swallowed the following command. Fix: exclude `\r` from delimiter chars so the marker read matches the close-line strip.
- **Arithmetic `$((1 << 8))`** — the `<<` left shift was read as a here-document operator (the `$` forces the `TooComplex` text path); its phantom delimiter swallowed the next line. Fix: skip balanced `$(( ... ))` regions.

Both are masked by `sandbox-exec` at runtime on macOS, but the text scan is the only defense on platforms without it.

Also gates the `_build` sandbox test with `#cfg(not(platform="windows"))`, matching its siblings — it calls the non-Windows-only `sandbox_exec_usable_for_test` helper and broke the Windows test build (**found by codex review**).

Regression tests added; verified they fail without the fix and pass with it.

## 2. `refactor`: rewrite the here-document scanner with view patterns

Replaces the index-based `heredoc_delimiters_in_line` / `read_heredoc_delimiter` (mutable `index`/`quote`/`escaped` state) with `ArrayView[Char]` pattern matching + functional `for` loops. Structural tokens now read as patterns (`['$','(','(', .. rest]`, `['<','<', .. rest]`, `['\'', .. rest]`), and quote/arithmetic/line-space/marker scanning each become a small view-consuming helper. Pure refactor — behavior unchanged (kept on `Char` views to preserve Unicode-correct marker reading).

## Validation
- `moon check` / `moon fmt --check` clean; `moon info` shows no `.mbti` (public API) change.
- `moon test agent_tool/shell`: all here-document/source-write tests pass (preblocks 42/42, heredoc 2/2, new CRLF + arithmetic regression tests pass). The only failures are 4 pre-existing flaky output-limit/utf8 timing tests that fail identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)