### PR TITLE
feat(shell/sandbox): relax git via a default-deny trust allowlist

### DIFF
--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -75,10 +75,12 @@ where the shell would otherwise hide the sandbox denial from the tool output.
 Direct `mv`/`rm` source-tree operations and obvious source-writing script
 snippets are also blocked before execution, including scripts that create
 MoonBit source under `_build` and then rename it into a package directory.
-`git apply` and `git am` are blocked before execution for the same reason: they
-write the worktree (or stage, with `--cached`) from an EXTERNAL patch, which is
-arbitrary content the source-write tools must keep out. Recoverable Git worktree
-subcommands are not blocked — see the trusted list below.
+Git subcommands that can place content from outside the object store into git's
+store or worktree are blocked before execution, because a later trusted
+`checkout`/`restore` would materialize it into source: `git apply` / `git am`
+(external patches, including `--cached`), and the plumbing feeders `update-index`,
+`read-tree`, and `fast-import`. Recoverable Git worktree subcommands are not
+blocked — see the trusted list below.
 Too-complex command strings with in-place `sed` edits are rejected even when the
 source paths are indirect, as in `while read f; do sed -i ... "$f"; done`.
 Too-complex commands with visible MoonBit source creation or tree transfer
@@ -95,12 +97,17 @@ Recoverable Git worktree subcommands also run outside the source-write sandbox,
 because every write they make sources from git's own object store (HEAD, the
 index, a commit/tree, or a stash) — recoverable and reviewable through git, never
 from an external file or stdin: `checkout`, `switch`, `restore`, `reset`,
-`stash`, `clean`, `rm`, and `mv`. Trust is withheld when the invocation could
-reconfigure git to synthesize arbitrary bytes — a custom environment
-(`GIT_CONFIG_*`, `env ... git`) or a config/dir/exec global option (`-c`,
-`--config-env`, `--git-dir`, `--namespace`, `--exec-path`) — and from `git apply`
-/ `git am` (external patches) and any unrecognized subcommand or alias, which
-stay under the sandbox.
+`stash`, `clean`, and `rm`. `mv` is excluded because it moves arbitrary worktree
+bytes onto the destination; `rm` only deletes, so it cannot inject. Trust is
+withheld when the invocation could reconfigure git to write from outside the
+workspace repo — a custom environment (`GIT_CONFIG_*`, `env ... git`) or a
+reconfiguring global option that repoints config (`-c`, `--config-env`), the exec
+path (`--exec-path`), the git dir (`--git-dir`, `--namespace`), or the cwd/worktree
+(`-C`, `--work-tree`) — and from the blocked store-feeders above plus any
+unrecognized subcommand or alias, which stay under the sandbox. This trusts git's
+own config: it is not a hard boundary, since a determined plumbing sequence
+(`replace`, `filter-branch`, `commit-tree`) can still seed the object store while
+`.git` is writable.
 
 ## Arguments
 

--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -81,8 +81,9 @@ not depend on the runtime sandbox: the external-patch/plumbing store feeders
 (`apply`/`am` including `--cached`, `update-index`, `read-tree`, `fast-import`),
 `mv` (moves arbitrary worktree bytes onto the destination), non-dry-run `clean`
 (permanently deletes untracked files), and any object-store writer that is
-reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). The recoverable
-worktree subcommands are not blocked — see the trusted list below.
+reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). Read-only patch
+validation (`git apply --check`/`--stat`) and dry-run `clean` (`-n`) are allowed.
+The recoverable worktree subcommands are not blocked — see the trusted list below.
 Too-complex command strings with in-place `sed` edits are rejected even when the
 source paths are indirect, as in `while read f; do sed -i ... "$f"; done`.
 Too-complex commands with visible MoonBit source creation or tree transfer

--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -94,11 +94,13 @@ moon check` is trusted, while a broad script or source rewrite through shell is
 not.
 
 Recoverable Git worktree subcommands also run outside the source-write sandbox,
-because every write they make sources from git's own object store (HEAD, the
-index, a commit/tree, or a stash) — recoverable and reviewable through git, never
-from an external file or stdin: `checkout`, `switch`, `restore`, `reset`,
-`stash`, `clean`, and `rm`. `mv` is excluded because it moves arbitrary worktree
-bytes onto the destination; `rm` only deletes, so it cannot inject. Trust is
+because every change they make either materializes content from git's own object
+store (HEAD, the index, a commit/tree, or a stash) or removes a tracked file
+recoverable from it — reviewable through git, never sourced from an external file
+or stdin: `checkout`, `switch`, `restore`, `reset`, `stash`, and `rm`. `mv` is
+excluded (it moves arbitrary worktree bytes onto the destination) and `clean` is
+excluded (it deletes untracked files with no object-store copy — permanent);
+`rm` stays because it only deletes tracked files. Trust is
 withheld when the invocation could reconfigure git to write from outside the
 workspace repo — a custom environment (`GIT_CONFIG_*`, `env ... git`) or a
 reconfiguring global option that repoints config (`-c`, `--config-env`), the exec

--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -75,12 +75,14 @@ where the shell would otherwise hide the sandbox denial from the tool output.
 Direct `mv`/`rm` source-tree operations and obvious source-writing script
 snippets are also blocked before execution, including scripts that create
 MoonBit source under `_build` and then rename it into a package directory.
-Git subcommands that can place content from outside the object store into git's
-store or worktree are blocked before execution, because a later trusted
-`checkout`/`restore` would materialize it into source: `git apply` / `git am`
-(external patches, including `--cached`), and the plumbing feeders `update-index`,
-`read-tree`, and `fast-import`. Recoverable Git worktree subcommands are not
-blocked — see the trusted list below.
+Git subcommands that mutate source but are not a recoverable object-store write
+are conservatively blocked before execution — a cross-platform guard that does
+not depend on the runtime sandbox: the external-patch/plumbing store feeders
+(`apply`/`am` including `--cached`, `update-index`, `read-tree`, `fast-import`),
+`mv` (moves arbitrary worktree bytes onto the destination), non-dry-run `clean`
+(permanently deletes untracked files), and any object-store writer that is
+reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). The recoverable
+worktree subcommands are not blocked — see the trusted list below.
 Too-complex command strings with in-place `sed` edits are rejected even when the
 source paths are indirect, as in `while read f; do sed -i ... "$f"; done`.
 Too-complex commands with visible MoonBit source creation or tree transfer

--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -75,9 +75,10 @@ where the shell would otherwise hide the sandbox denial from the tool output.
 Direct `mv`/`rm` source-tree operations and obvious source-writing script
 snippets are also blocked before execution, including scripts that create
 MoonBit source under `_build` and then rename it into a package directory.
-Source-mutating Git operations such as `git checkout -- .`, `git restore`,
-`git reset --hard`, non-dry-run `git clean`, and non-checking `git apply` are
-blocked for the same reason.
+`git apply` and `git am` are blocked before execution for the same reason: they
+write the worktree (or stage, with `--cached`) from an EXTERNAL patch, which is
+arbitrary content the source-write tools must keep out. Recoverable Git worktree
+subcommands are not blocked — see the trusted list below.
 Too-complex command strings with in-place `sed` edits are rejected even when the
 source paths are indirect, as in `while read f; do sed -i ... "$f"; done`.
 Too-complex commands with visible MoonBit source creation or tree transfer
@@ -89,6 +90,17 @@ metadata run outside the source-write sandbox: `moon fmt`, `moon info`,
 `moon ide rename ... --apply`. Compounds are conservative; `moon fmt &&
 moon check` is trusted, while a broad script or source rewrite through shell is
 not.
+
+Recoverable Git worktree subcommands also run outside the source-write sandbox,
+because every write they make sources from git's own object store (HEAD, the
+index, a commit/tree, or a stash) — recoverable and reviewable through git, never
+from an external file or stdin: `checkout`, `switch`, `restore`, `reset`,
+`stash`, `clean`, `rm`, and `mv`. Trust is withheld when the invocation could
+reconfigure git to synthesize arbitrary bytes — a custom environment
+(`GIT_CONFIG_*`, `env ... git`) or a config/dir/exec global option (`-c`,
+`--config-env`, `--git-dir`, `--namespace`, `--exec-path`) — and from `git apply`
+/ `git am` (external patches) and any unrecognized subcommand or alias, which
+stay under the sandbox.
 
 ## Arguments
 

--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -80,10 +80,14 @@ are conservatively blocked before execution — a cross-platform guard that does
 not depend on the runtime sandbox: the external-patch/plumbing store feeders
 (`apply`/`am` including `--cached`, `update-index`, `read-tree`, `fast-import`),
 `mv` (moves arbitrary worktree bytes onto the destination), non-dry-run `clean`
-(permanently deletes untracked files), and any object-store writer that is
-reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). Read-only patch
-validation (`git apply --check`/`--stat`) and dry-run `clean` (`-n`) are allowed.
-The recoverable worktree subcommands are not blocked — see the trusted list below.
+(permanently deletes untracked files), any object-store writer that is
+reconfigured by option (`git -c filter=… checkout`, `-C`, `--work-tree`) or by a
+custom environment (`GIT_DIR`/`GIT_WORK_TREE`/`GIT_CONFIG_*`, `env … git`), and
+`checkout`/`switch`/`restore` forms that can clobber an untracked file from
+another tree (`-f`/`--force`/`--source`/`--overlay`/`--ours`/`--theirs`).
+Read-only patch validation (`git apply --check`/`--stat`) and dry-run `clean`
+(`-n`) are allowed. The recoverable worktree subcommands are not blocked — see
+the trusted list below.
 Too-complex command strings with in-place `sed` edits are rejected even when the
 source paths are indirect, as in `while read f; do sed -i ... "$f"; done`.
 Too-complex commands with visible MoonBit source creation or tree transfer

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -170,14 +170,16 @@ fn overwrites_untracked_from_tree(
   start : Int,
   end : Int,
 ) -> Bool {
-  let mut positional_before_dash_dash = false
+  let mut positional_before_paths = false
   for index in start..<end {
     let arg = words[index]
-    if arg == "-f" ||
-      arg == "--force" ||
+    // Force / overlay / side-pick overwrite regardless of untracked state. `-f`
+    // may be clustered (`-fB`, `-fq`), so match it inside a short cluster too.
+    if arg == "--force" ||
       arg == "--overlay" ||
       arg == "--ours" ||
-      arg == "--theirs" {
+      arg == "--theirs" ||
+      short_cluster_has(arg, "f") {
       return true
     }
     // Explicit source tree-ish: `--source`, `--source=<t>`, `-s`, `-s<t>`.
@@ -187,15 +189,28 @@ fn overwrites_untracked_from_tree(
       (arg.has_prefix("-s") && !arg.has_prefix("--")) {
       return true
     }
-    if arg == "--" {
-      // A positional tree-ish before `--` sources the listed paths from it.
-      return positional_before_dash_dash
+    // `--`, or `--pathspec-from-file`, ends the tree-ish/pathspec boundary; a
+    // positional tree-ish before it (`git checkout HEAD~1 -- f`, or
+    // `git checkout HEAD~1 --pathspec-from-file=list`) sources the paths from it.
+    if arg == "--" ||
+      arg == "--pathspec-from-file" ||
+      arg.has_prefix("--pathspec-from-file=") {
+      return positional_before_paths
     }
     if !arg.has_prefix("-") {
-      positional_before_dash_dash = true
+      positional_before_paths = true
     }
   }
   false
+}
+
+///|
+/// True when `arg` is a short option cluster (`-…`, not `--…`) containing `flag`.
+fn short_cluster_has(arg : String, flag : String) -> Bool {
+  arg.has_prefix("-") &&
+  !arg.has_prefix("--") &&
+  arg != "-" &&
+  arg.contains(flag)
 }
 
 ///|

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -61,14 +61,15 @@ pub fn global_option_reconfigures(arg : String) -> Bool {
 }
 
 ///|
-/// Git subcommands whose every worktree write sources from git's own object
-/// store (HEAD, the index, a commit/tree, or a stash) — recoverable and
-/// reviewable through git, never from an external file or stdin. `mv` is excluded
-/// (it moves arbitrary worktree bytes onto the destination); `rm` only deletes.
+/// Git subcommands whose every worktree change either materializes content from
+/// git's own object store (HEAD, the index, a commit/tree, or a stash) or removes
+/// a tracked file recoverable from it — reviewable through git, never sourced from
+/// an external file or stdin. Excluded: `mv` (moves arbitrary worktree bytes onto
+/// the destination) and `clean` (deletes UNTRACKED files with no object-store
+/// copy — permanent). `rm` stays: it only deletes tracked files.
 pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
   match subcommand {
-    "checkout" | "switch" | "restore" | "reset" | "stash" | "clean" | "rm" =>
-      true
+    "checkout" | "switch" | "restore" | "reset" | "stash" | "rm" => true
     _ => false
   }
 }

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -75,20 +75,6 @@ pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
 }
 
 ///|
-/// Git subcommands that can place content from OUTSIDE the object store into
-/// git's store or worktree, which a later trusted `checkout`/`restore` would
-/// materialize into source: external-patch (`apply`/`am`) and the plumbing
-/// feeders `update-index`, `read-tree`, and `fast-import`. Not exhaustive —
-/// `replace`/`filter-branch`/`commit-tree` remain a residual channel while `.git`
-/// is writable.
-fn subcommand_is_store_feeder(subcommand : String) -> Bool {
-  match subcommand {
-    "apply" | "am" | "update-index" | "read-tree" | "fast-import" => true
-    _ => false
-  }
-}
-
-///|
 /// Whether a git invocation must be pre-blocked before execution — the
 /// cross-platform guard that does not depend on the runtime sandbox. Conservative
 /// by design: block the git that mutates source but is NOT a recoverable
@@ -120,11 +106,6 @@ pub fn text_should_preblock(
   guard text_subcommand_index(words, start, end) is Some(subcommand_index) else {
     return false
   }
-  let help_index = subcommand_index + 1
-  if help_index < end &&
-    (words[help_index] == "--help" || words[help_index] == "-h") {
-    return false
-  }
   preblock_for_subcommand(words, start, subcommand_index, end)
 }
 
@@ -135,17 +116,41 @@ fn preblock_for_subcommand(
   subcommand_index : Int,
   end : Int,
 ) -> Bool {
-  let subcommand = words[subcommand_index]
-  if subcommand_is_store_feeder(subcommand) || subcommand == "mv" {
-    return true
+  let args_start = subcommand_index + 1
+  if args_start < end &&
+    (words[args_start] == "--help" || words[args_start] == "-h") {
+    return false
   }
-  if subcommand == "clean" {
-    return !clean_args_request_dry_run(words, subcommand_index + 1, end)
+  match words[subcommand_index] {
+    // `apply` writes unless it is a read-only validation/info mode (`--check`,
+    // `--stat`, `--numstat`, `--summary`) with no forced application.
+    "apply" => apply_writes(words, args_start, end)
+    "am" | "update-index" | "read-tree" | "fast-import" | "mv" => true
+    // `clean` permanently deletes untracked files unless it is a dry run.
+    "clean" => !clean_args_request_dry_run(words, args_start, end)
+    // A recoverable object-store writer is only unsafe when reconfigured.
+    subcommand =>
+      subcommand_writes_from_object_store(subcommand) &&
+      region_reconfigures(words, global_start, subcommand_index)
   }
-  if subcommand_writes_from_object_store(subcommand) {
-    return region_reconfigures(words, global_start, subcommand_index)
+}
+
+///|
+/// `git apply` writes the worktree/index unless it runs in a read-only
+/// validation/info mode (`--check`/`--stat`/`--numstat`/`--summary`) and is not
+/// forced to apply (`--apply`/`--cached`/`--index`/`--3way`). Conservative: a
+/// read-only flag alongside any forcing flag is treated as writing.
+fn apply_writes(words : Array[String], start : Int, end : Int) -> Bool {
+  let mut read_only = false
+  let mut forced = false
+  for index in start..<end {
+    match words[index] {
+      "--check" | "--stat" | "--numstat" | "--summary" => read_only = true
+      "--apply" | "--cached" | "--index" | "--3way" | "-3" => forced = true
+      _ => ()
+    }
   }
-  false
+  forced || !read_only
 }
 
 ///|
@@ -159,23 +164,38 @@ fn region_reconfigures(words : Array[String], start : Int, end : Int) -> Bool {
 }
 
 ///|
-/// True when `git clean`'s arguments include a dry-run flag (`-n`, `--dry-run`,
-/// or a short cluster such as `-fdn`); in git clean `n` always means dry run.
+/// True when `git clean`'s arguments request a dry run (`-n`, `--dry-run`, or a
+/// short cluster such as `-fdn`; in git clean `n` always means dry run). An
+/// exclude option (`-e`/`--exclude`/a cluster with `e`) takes a pattern operand
+/// that could itself look like `-n` (`git clean -e -n -fd` is destructive), so
+/// rather than parse git's getopt clustering this conservatively treats any clean
+/// carrying an exclude as NOT a dry run — it stays blocked.
 fn clean_args_request_dry_run(
   words : Array[String],
   start : Int,
   end : Int,
 ) -> Bool {
+  let mut dry_run = false
   for index in start..<end {
     let arg = words[index]
-    if arg == "-n" || arg == "--dry-run" {
-      return true
+    if clean_arg_is_exclude(arg) {
+      return false
     }
-    if arg.has_prefix("-") && !arg.has_prefix("--") && arg.contains("n") {
-      return true
+    if arg == "-n" ||
+      arg == "--dry-run" ||
+      (arg.has_prefix("-") && !arg.has_prefix("--") && arg.contains("n")) {
+      dry_run = true
     }
   }
-  false
+  dry_run
+}
+
+///|
+fn clean_arg_is_exclude(arg : String) -> Bool {
+  arg == "-e" ||
+  arg == "--exclude" ||
+  arg.has_prefix("--exclude=") ||
+  (arg.has_prefix("-") && !arg.has_prefix("--") && arg.contains("e"))
 }
 
 ///|

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -110,6 +110,23 @@ pub fn text_should_preblock(
 }
 
 ///|
+/// Whether the git subcommand found in `words[start..end)` is a recoverable
+/// object-store writer (checkout/switch/restore/reset/stash/rm). The text path
+/// uses this to decide whether a custom environment before `git` (which it cannot
+/// see in `words[start..]`) makes the writer unsafe and must be pre-blocked.
+pub fn text_invocation_writes_from_object_store(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  match text_subcommand_index(words, start, end) {
+    Some(subcommand_index) =>
+      subcommand_writes_from_object_store(words[subcommand_index])
+    None => false
+  }
+}
+
+///|
 fn preblock_for_subcommand(
   words : Array[String],
   global_start : Int,
@@ -143,21 +160,39 @@ fn preblock_for_subcommand(
 }
 
 ///|
+/// True when a `checkout`/`switch`/`restore` form can overwrite an untracked file
+/// from another tree: a force/overlay/side flag, an explicit source tree-ish
+/// (`--source`/`--source=`/`-s`/`-s<tree>`), or a positional tree-ish before
+/// `--` (`git checkout <tree-ish> -- <path>`). Plain index restore
+/// (`git checkout -- f`, `git restore f`) and bare branch switch are excluded.
 fn overwrites_untracked_from_tree(
   words : Array[String],
   start : Int,
   end : Int,
 ) -> Bool {
+  let mut positional_before_dash_dash = false
   for index in start..<end {
     let arg = words[index]
     if arg == "-f" ||
       arg == "--force" ||
       arg == "--overlay" ||
       arg == "--ours" ||
-      arg == "--theirs" ||
-      arg == "--source" ||
-      arg.has_prefix("--source=") {
+      arg == "--theirs" {
       return true
+    }
+    // Explicit source tree-ish: `--source`, `--source=<t>`, `-s`, `-s<t>`.
+    if arg == "--source" ||
+      arg.has_prefix("--source=") ||
+      arg == "-s" ||
+      (arg.has_prefix("-s") && !arg.has_prefix("--")) {
+      return true
+    }
+    if arg == "--" {
+      // A positional tree-ish before `--` sources the listed paths from it.
+      return positional_before_dash_dash
+    }
+    if !arg.has_prefix("-") {
+      positional_before_dash_dash = true
     }
   }
   false

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -128,11 +128,39 @@ fn preblock_for_subcommand(
     "am" | "update-index" | "read-tree" | "fast-import" | "mv" => true
     // `clean` permanently deletes untracked files unless it is a dry run.
     "clean" => !clean_args_request_dry_run(words, args_start, end)
-    // A recoverable object-store writer is only unsafe when reconfigured.
+    // checkout/switch/restore can overwrite an UNTRACKED file at a path when
+    // forced or sourced from another tree (`-f`/`--force`/`--source`/`--overlay`/
+    // `--ours`/`--theirs`), permanently losing it (git's own untracked guard is
+    // bypassed). Plain index restore (`git checkout -- f`) is fine.
+    "checkout" | "switch" | "restore" =>
+      region_reconfigures(words, global_start, subcommand_index) ||
+      overwrites_untracked_from_tree(words, args_start, end)
+    // The other recoverable writers are only unsafe when reconfigured.
     subcommand =>
       subcommand_writes_from_object_store(subcommand) &&
       region_reconfigures(words, global_start, subcommand_index)
   }
+}
+
+///|
+fn overwrites_untracked_from_tree(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  for index in start..<end {
+    let arg = words[index]
+    if arg == "-f" ||
+      arg == "--force" ||
+      arg == "--overlay" ||
+      arg == "--ours" ||
+      arg == "--theirs" ||
+      arg == "--source" ||
+      arg.has_prefix("--source=") {
+      return true
+    }
+  }
+  false
 }
 
 ///|

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -81,7 +81,7 @@ pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
 /// feeders `update-index`, `read-tree`, and `fast-import`. Not exhaustive —
 /// `replace`/`filter-branch`/`commit-tree` remain a residual channel while `.git`
 /// is writable.
-pub fn subcommand_is_store_feeder(subcommand : String) -> Bool {
+fn subcommand_is_store_feeder(subcommand : String) -> Bool {
   match subcommand {
     "apply" | "am" | "update-index" | "read-tree" | "fast-import" => true
     _ => false
@@ -89,13 +89,99 @@ pub fn subcommand_is_store_feeder(subcommand : String) -> Bool {
 }
 
 ///|
-/// Find the git subcommand's index in a flat `words` list (the TooComplex text
-/// path), scanning `[start, end)` and skipping global options. Mirrors `parse`.
-pub fn text_subcommand_index(
+/// Whether a git invocation must be pre-blocked before execution — the
+/// cross-platform guard that does not depend on the runtime sandbox. Conservative
+/// by design: block the git that mutates source but is NOT a recoverable
+/// object-store write — store feeders (`apply`/`am`/`update-index`/`read-tree`/
+/// `fast-import`), `mv` (moves arbitrary worktree bytes), non-dry-run `clean`
+/// (permanently deletes untracked files), and any object-store writer that is
+/// reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). The recoverable
+/// writers (`checkout`/`switch`/`restore`/`reset`/`stash`/`rm`) and read-only git
+/// are not pre-blocked; they run (trusted, or sandboxed where they cannot harm).
+pub fn should_preblock(argv : Array[String], arg_start : Int) -> Bool {
+  guard parse(argv, arg_start) is Some(invocation) else { return false }
+  preblock_for_subcommand(
+    argv,
+    arg_start,
+    invocation.subcommand_index,
+    argv.length(),
+  )
+}
+
+///|
+/// The TooComplex text-path counterpart of `should_preblock`, scanning a flat
+/// `words` list over `[start, end)`. Returns false when the subcommand requests
+/// help.
+pub fn text_should_preblock(
   words : Array[String],
   start : Int,
   end : Int,
-) -> Int? {
+) -> Bool {
+  guard text_subcommand_index(words, start, end) is Some(subcommand_index) else {
+    return false
+  }
+  let help_index = subcommand_index + 1
+  if help_index < end &&
+    (words[help_index] == "--help" || words[help_index] == "-h") {
+    return false
+  }
+  preblock_for_subcommand(words, start, subcommand_index, end)
+}
+
+///|
+fn preblock_for_subcommand(
+  words : Array[String],
+  global_start : Int,
+  subcommand_index : Int,
+  end : Int,
+) -> Bool {
+  let subcommand = words[subcommand_index]
+  if subcommand_is_store_feeder(subcommand) || subcommand == "mv" {
+    return true
+  }
+  if subcommand == "clean" {
+    return !clean_args_request_dry_run(words, subcommand_index + 1, end)
+  }
+  if subcommand_writes_from_object_store(subcommand) {
+    return region_reconfigures(words, global_start, subcommand_index)
+  }
+  false
+}
+
+///|
+fn region_reconfigures(words : Array[String], start : Int, end : Int) -> Bool {
+  for index in start..<end {
+    if global_option_reconfigures(words[index]) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// True when `git clean`'s arguments include a dry-run flag (`-n`, `--dry-run`,
+/// or a short cluster such as `-fdn`); in git clean `n` always means dry run.
+fn clean_args_request_dry_run(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  for index in start..<end {
+    let arg = words[index]
+    if arg == "-n" || arg == "--dry-run" {
+      return true
+    }
+    if arg.has_prefix("-") && !arg.has_prefix("--") && arg.contains("n") {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Find the git subcommand's index in a flat `words` list (the TooComplex text
+/// path), scanning `[start, end)` and skipping global options. Mirrors `parse`.
+fn text_subcommand_index(words : Array[String], start : Int, end : Int) -> Int? {
   let mut index = start
   while index < end {
     let arg = words[index]
@@ -119,23 +205,6 @@ pub fn text_subcommand_index(
     return Some(index)
   }
   None
-}
-
-///|
-/// True when the git subcommand at `subcommand_index` in `words` is a store
-/// feeder that must be pre-blocked in the text path (false when its first
-/// argument requests help).
-pub fn text_subcommand_is_store_feeder(
-  words : Array[String],
-  subcommand_index : Int,
-  segment_end : Int,
-) -> Bool {
-  let help_index = subcommand_index + 1
-  if help_index < segment_end &&
-    (words[help_index] == "--help" || words[help_index] == "-h") {
-    return false
-  }
-  subcommand_is_store_feeder(words[subcommand_index])
 }
 
 ///|

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -1,0 +1,195 @@
+// Pure git command-line policy for the shell source-write sandbox: parse a git
+// invocation's subcommand and classify it. No filesystem, workspace, or
+// shell-parse dependencies — just argv/word grammar — so the policy can be read
+// and tested in isolation. The `shell` package supplies the workspace-path glue
+// and the trusted-command-class wiring.
+
+///|
+/// A parsed git invocation: the subcommand and its index in `argv`.
+pub(all) struct Invocation {
+  subcommand : String
+  subcommand_index : Int
+}
+
+///|
+/// Parse a git invocation starting at `arg_start` (the index just past `git`),
+/// skipping global options, and return its subcommand and that subcommand's argv
+/// index. Returns `None` for `--help`/`-h`, an explicit `--`, a missing argument
+/// to a value option, or an unrecognized `-option` (fail closed). Aliases are not
+/// resolved, so e.g. `git co` reports subcommand `co`.
+pub fn parse(argv : Array[String], arg_start : Int) -> Invocation? {
+  let mut index = arg_start
+  while index < argv.length() {
+    let arg = argv[index]
+    if arg == "--" || arg == "--help" || arg == "-h" {
+      return None
+    }
+    if arg == "-C" || arg == "--work-tree" || global_option_consumes_next(arg) {
+      if index + 1 >= argv.length() {
+        return None
+      }
+      index += 2
+      continue
+    }
+    if attached_cwd_option(arg) is Some(_) ||
+      attached_work_tree_option(arg) is Some(_) ||
+      global_option_with_attached_value(arg) ||
+      global_no_arg_option(arg) {
+      index += 1
+      continue
+    }
+    if arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    return Some({ subcommand: arg, subcommand_index: index })
+  }
+  None
+}
+
+///|
+/// True for a git global option that repoints config, the exec path, the git
+/// dir, the namespace, or the cwd/worktree — a precursor that could make an
+/// otherwise object-store subcommand write arbitrary bytes (via a smudge filter
+/// or merge driver) or write the workspace from a different repository.
+pub fn global_option_reconfigures(arg : String) -> Bool {
+  global_option_consumes_next(arg) ||
+  global_option_with_attached_value(arg) ||
+  arg == "-C" ||
+  arg == "--work-tree" ||
+  attached_cwd_option(arg) is Some(_) ||
+  attached_work_tree_option(arg) is Some(_)
+}
+
+///|
+/// Git subcommands whose every worktree write sources from git's own object
+/// store (HEAD, the index, a commit/tree, or a stash) — recoverable and
+/// reviewable through git, never from an external file or stdin. `mv` is excluded
+/// (it moves arbitrary worktree bytes onto the destination); `rm` only deletes.
+pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
+  match subcommand {
+    "checkout" | "switch" | "restore" | "reset" | "stash" | "clean" | "rm" =>
+      true
+    _ => false
+  }
+}
+
+///|
+/// Git subcommands that can place content from OUTSIDE the object store into
+/// git's store or worktree, which a later trusted `checkout`/`restore` would
+/// materialize into source: external-patch (`apply`/`am`) and the plumbing
+/// feeders `update-index`, `read-tree`, and `fast-import`. Not exhaustive —
+/// `replace`/`filter-branch`/`commit-tree` remain a residual channel while `.git`
+/// is writable.
+pub fn subcommand_is_store_feeder(subcommand : String) -> Bool {
+  match subcommand {
+    "apply" | "am" | "update-index" | "read-tree" | "fast-import" => true
+    _ => false
+  }
+}
+
+///|
+/// Find the git subcommand's index in a flat `words` list (the TooComplex text
+/// path), scanning `[start, end)` and skipping global options. Mirrors `parse`.
+pub fn text_subcommand_index(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Int? {
+  let mut index = start
+  while index < end {
+    let arg = words[index]
+    if arg == "--help" || arg == "-h" {
+      return None
+    }
+    if arg == "-C" || arg == "--work-tree" || global_option_consumes_next(arg) {
+      index += 2
+      continue
+    }
+    if attached_cwd_option(arg) is Some(_) ||
+      attached_work_tree_option(arg) is Some(_) ||
+      global_option_with_attached_value(arg) ||
+      global_no_arg_option(arg) {
+      index += 1
+      continue
+    }
+    if arg.has_prefix("-") && arg != "-" {
+      return None
+    }
+    return Some(index)
+  }
+  None
+}
+
+///|
+/// True when the git subcommand at `subcommand_index` in `words` is a store
+/// feeder that must be pre-blocked in the text path (false when its first
+/// argument requests help).
+pub fn text_subcommand_is_store_feeder(
+  words : Array[String],
+  subcommand_index : Int,
+  segment_end : Int,
+) -> Bool {
+  let help_index = subcommand_index + 1
+  if help_index < segment_end &&
+    (words[help_index] == "--help" || words[help_index] == "-h") {
+    return false
+  }
+  subcommand_is_store_feeder(words[subcommand_index])
+}
+
+///|
+fn global_option_consumes_next(arg : String) -> Bool {
+  arg == "-c" ||
+  arg == "--config-env" ||
+  arg == "--exec-path" ||
+  arg == "--git-dir" ||
+  arg == "--namespace"
+}
+
+///|
+fn global_option_with_attached_value(arg : String) -> Bool {
+  (arg.has_prefix("-c") && arg != "-c") ||
+  arg.has_prefix("--config-env=") ||
+  arg.has_prefix("--exec-path=") ||
+  arg.has_prefix("--git-dir=") ||
+  arg.has_prefix("--namespace=")
+}
+
+///|
+fn global_no_arg_option(arg : String) -> Bool {
+  match arg {
+    "--version"
+    | "--help"
+    | "-p"
+    | "--paginate"
+    | "-P"
+    | "--no-pager"
+    | "--no-replace-objects"
+    | "--no-optional-locks"
+    | "--no-lazy-fetch"
+    | "--literal-pathspecs"
+    | "--glob-pathspecs"
+    | "--noglob-pathspecs"
+    | "--icase-pathspecs"
+    | "--bare" => true
+    _ => false
+  }
+}
+
+///|
+fn attached_cwd_option(arg : String) -> String? {
+  if arg.has_prefix("-C") && arg != "-C" {
+    Some(arg[2:].to_owned())
+  } else {
+    None
+  }
+}
+
+///|
+fn attached_work_tree_option(arg : String) -> String? {
+  if arg.has_prefix("--work-tree=") {
+    Some(arg["--work-tree=".length():].to_owned())
+  } else {
+    None
+  }
+}

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -26,12 +26,39 @@ test "object-store-write classification excludes mv and plumbing" {
 }
 
 ///|
-test "store-feeder classification" {
-  for sub in ["apply", "am", "update-index", "read-tree", "fast-import"] {
-    assert_true(@git_policy.subcommand_is_store_feeder(sub))
+test "should_preblock: feeders, mv, non-dry-run clean, reconfigured writers" {
+  // Blocked: mutates source but is not a recoverable object-store write.
+  for
+    cmd in [
+      ["git", "apply", "patch"],
+      ["git", "am", "mbox"],
+      ["git", "update-index", "--cacheinfo", "100644,abc,main.mbt"],
+      ["git", "read-tree", "HEAD"],
+      ["git", "fast-import"],
+      ["git", "mv", "notes.md", "main.mbt"],
+      ["git", "clean", "-fd"],
+      ["git", "-c", "filter.f.smudge=cmd", "checkout", "--", "."],
+      ["git", "-C", "/tmp/x", "checkout", "--", "."],
+      ["git", "--work-tree=/tmp/x", "restore", "main.mbt"],
+    ] {
+    assert_true(@git_policy.should_preblock(cmd, 1))
   }
-  for sub in ["checkout", "restore", "status", "mv"] {
-    assert_false(@git_policy.subcommand_is_store_feeder(sub))
+  // Not blocked: recoverable writers, dry-run clean, read-only git, reconfigured
+  // read-only git, and help.
+  for
+    cmd in [
+      ["git", "checkout", "--", "main.mbt"],
+      ["git", "restore", "main.mbt"],
+      ["git", "reset", "--hard"],
+      ["git", "stash"],
+      ["git", "rm", "main.mbt"],
+      ["git", "clean", "-fdn"],
+      ["git", "clean", "--dry-run"],
+      ["git", "status"],
+      ["git", "-c", "core.pager=less", "status"],
+      ["git", "checkout", "--help"],
+    ] {
+    assert_false(@git_policy.should_preblock(cmd, 1))
   }
 }
 
@@ -50,21 +77,16 @@ test "reconfiguring global options" {
 }
 
 ///|
-test "text-path subcommand finding and feeder check" {
-  let words = ["git", "-C", "pkg", "apply", "patch"]
-  guard @git_policy.text_subcommand_index(words, 1, words.length()) is Some(i) else {
-    fail("expected Some")
-  }
-  assert_eq(words[i], "apply")
-  assert_true(
-    @git_policy.text_subcommand_is_store_feeder(words, i, words.length()),
-  )
-  // A help flag on the subcommand disables the feeder block.
-  let help = ["git", "apply", "--help"]
-  guard @git_policy.text_subcommand_index(help, 1, help.length()) is Some(j) else {
-    fail("expected Some")
-  }
+test "text_should_preblock mirrors should_preblock on a flat word list" {
+  let apply = ["git", "-C", "pkg", "apply", "patch"]
+  assert_true(@git_policy.text_should_preblock(apply, 1, apply.length()))
+  let mv = ["git", "mv", "a", "b"]
+  assert_true(@git_policy.text_should_preblock(mv, 1, mv.length()))
+  let recoverable = ["git", "checkout", "--", "f"]
   assert_false(
-    @git_policy.text_subcommand_is_store_feeder(help, j, help.length()),
+    @git_policy.text_should_preblock(recoverable, 1, recoverable.length()),
   )
+  // A help flag on the subcommand disables the block.
+  let help = ["git", "apply", "--help"]
+  assert_false(@git_policy.text_should_preblock(help, 1, help.length()))
 }

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -37,14 +37,19 @@ test "should_preblock: feeders, mv, non-dry-run clean, reconfigured writers" {
       ["git", "fast-import"],
       ["git", "mv", "notes.md", "main.mbt"],
       ["git", "clean", "-fd"],
+      // `-e -n` is an exclude pattern, not a dry run -> still destructive.
+      ["git", "clean", "-e", "-n", "-fd"],
+      // read-only apply flag forced back to applying.
+      ["git", "apply", "--stat", "--apply", "patch"],
+      ["git", "apply", "--cached", "patch"],
       ["git", "-c", "filter.f.smudge=cmd", "checkout", "--", "."],
       ["git", "-C", "/tmp/x", "checkout", "--", "."],
       ["git", "--work-tree=/tmp/x", "restore", "main.mbt"],
     ] {
     assert_true(@git_policy.should_preblock(cmd, 1))
   }
-  // Not blocked: recoverable writers, dry-run clean, read-only git, reconfigured
-  // read-only git, and help.
+  // Not blocked: recoverable writers, dry-run clean, read-only apply validation,
+  // read-only git, reconfigured read-only git, and help.
   for
     cmd in [
       ["git", "checkout", "--", "main.mbt"],
@@ -54,9 +59,12 @@ test "should_preblock: feeders, mv, non-dry-run clean, reconfigured writers" {
       ["git", "rm", "main.mbt"],
       ["git", "clean", "-fdn"],
       ["git", "clean", "--dry-run"],
+      ["git", "apply", "--check", "patch"],
+      ["git", "apply", "--stat", "patch"],
       ["git", "status"],
       ["git", "-c", "core.pager=less", "status"],
       ["git", "checkout", "--help"],
+      ["git", "clean", "--help"],
     ] {
     assert_false(@git_policy.should_preblock(cmd, 1))
   }

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -17,10 +17,10 @@ test "parse fails closed" {
 
 ///|
 test "object-store-write classification excludes mv and plumbing" {
-  for sub in ["checkout", "switch", "restore", "reset", "stash", "clean", "rm"] {
+  for sub in ["checkout", "switch", "restore", "reset", "stash", "rm"] {
     assert_true(@git_policy.subcommand_writes_from_object_store(sub))
   }
-  for sub in ["mv", "apply", "am", "status", "checkout-index", "co"] {
+  for sub in ["mv", "clean", "apply", "am", "status", "checkout-index", "co"] {
     assert_false(@git_policy.subcommand_writes_from_object_store(sub))
   }
 }

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -42,6 +42,10 @@ test "should_preblock: feeders, mv, non-dry-run clean, reconfigured writers" {
       // read-only apply flag forced back to applying.
       ["git", "apply", "--stat", "--apply", "patch"],
       ["git", "apply", "--cached", "patch"],
+      // checkout/restore that can clobber an untracked file from another tree.
+      ["git", "checkout", "-f", "other"],
+      ["git", "restore", "--source=HEAD~1", "--", "foo.mbt"],
+      ["git", "checkout", "--ours", "conflict.mbt"],
       ["git", "-c", "filter.f.smudge=cmd", "checkout", "--", "."],
       ["git", "-C", "/tmp/x", "checkout", "--", "."],
       ["git", "--work-tree=/tmp/x", "restore", "main.mbt"],

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -47,6 +47,8 @@ test "should_preblock: feeders, mv, non-dry-run clean, reconfigured writers" {
       ["git", "restore", "--source=HEAD~1", "--", "foo.mbt"],
       ["git", "restore", "-s", "HEAD~1", "foo.mbt"],
       ["git", "checkout", "HEAD~1", "--", "foo.mbt"],
+      ["git", "checkout", "-fB", "new", "other"],
+      ["git", "checkout", "HEAD~1", "--pathspec-from-file=list"],
       ["git", "checkout", "--ours", "conflict.mbt"],
       ["git", "-c", "filter.f.smudge=cmd", "checkout", "--", "."],
       ["git", "-C", "/tmp/x", "checkout", "--", "."],

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -1,0 +1,70 @@
+///|
+test "parse finds the subcommand past global options" {
+  let argv = ["git", "-C", "pkg", "--no-pager", "checkout", "--", "main.mbt"]
+  guard @git_policy.parse(argv, 1) is Some(inv) else { fail("expected Some") }
+  assert_eq(inv.subcommand, "checkout")
+  assert_eq(inv.subcommand_index, 4)
+}
+
+///|
+test "parse fails closed" {
+  assert_true(@git_policy.parse(["git", "--bogus", "checkout"], 1) is None)
+  assert_true(@git_policy.parse(["git", "--help", "checkout"], 1) is None)
+  assert_true(@git_policy.parse(["git", "--", "checkout"], 1) is None)
+  assert_true(@git_policy.parse(["git", "-c"], 1) is None)
+  assert_true(@git_policy.parse(["git"], 1) is None)
+}
+
+///|
+test "object-store-write classification excludes mv and plumbing" {
+  for sub in ["checkout", "switch", "restore", "reset", "stash", "clean", "rm"] {
+    assert_true(@git_policy.subcommand_writes_from_object_store(sub))
+  }
+  for sub in ["mv", "apply", "am", "status", "checkout-index", "co"] {
+    assert_false(@git_policy.subcommand_writes_from_object_store(sub))
+  }
+}
+
+///|
+test "store-feeder classification" {
+  for sub in ["apply", "am", "update-index", "read-tree", "fast-import"] {
+    assert_true(@git_policy.subcommand_is_store_feeder(sub))
+  }
+  for sub in ["checkout", "restore", "status", "mv"] {
+    assert_false(@git_policy.subcommand_is_store_feeder(sub))
+  }
+}
+
+///|
+test "reconfiguring global options" {
+  for
+    opt in [
+      "-c", "--config-env", "--git-dir", "--namespace", "--exec-path", "-C", "--work-tree",
+      "-Cpkg", "--git-dir=/x", "--work-tree=/x",
+    ] {
+    assert_true(@git_policy.global_option_reconfigures(opt))
+  }
+  for opt in ["--no-pager", "-p", "--literal-pathspecs", "checkout"] {
+    assert_false(@git_policy.global_option_reconfigures(opt))
+  }
+}
+
+///|
+test "text-path subcommand finding and feeder check" {
+  let words = ["git", "-C", "pkg", "apply", "patch"]
+  guard @git_policy.text_subcommand_index(words, 1, words.length()) is Some(i) else {
+    fail("expected Some")
+  }
+  assert_eq(words[i], "apply")
+  assert_true(
+    @git_policy.text_subcommand_is_store_feeder(words, i, words.length()),
+  )
+  // A help flag on the subcommand disables the feeder block.
+  let help = ["git", "apply", "--help"]
+  guard @git_policy.text_subcommand_index(help, 1, help.length()) is Some(j) else {
+    fail("expected Some")
+  }
+  assert_false(
+    @git_policy.text_subcommand_is_store_feeder(help, j, help.length()),
+  )
+}

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -45,6 +45,8 @@ test "should_preblock: feeders, mv, non-dry-run clean, reconfigured writers" {
       // checkout/restore that can clobber an untracked file from another tree.
       ["git", "checkout", "-f", "other"],
       ["git", "restore", "--source=HEAD~1", "--", "foo.mbt"],
+      ["git", "restore", "-s", "HEAD~1", "foo.mbt"],
+      ["git", "checkout", "HEAD~1", "--", "foo.mbt"],
       ["git", "checkout", "--ours", "conflict.mbt"],
       ["git", "-c", "filter.f.smudge=cmd", "checkout", "--", "."],
       ["git", "-C", "/tmp/x", "checkout", "--", "."],
@@ -57,6 +59,7 @@ test "should_preblock: feeders, mv, non-dry-run clean, reconfigured writers" {
   for
     cmd in [
       ["git", "checkout", "--", "main.mbt"],
+      ["git", "checkout", "feature/foo"],
       ["git", "restore", "main.mbt"],
       ["git", "reset", "--hard"],
       ["git", "stash"],

--- a/agent_tool/shell/internal/git_policy/moon.pkg
+++ b/agent_tool/shell/internal/git_policy/moon.pkg
@@ -1,0 +1,3 @@
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/shell/internal/git_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/git_policy/pkg.generated.mbti
@@ -1,0 +1,28 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell/internal/git_policy"
+
+// Values
+pub fn global_option_reconfigures(String) -> Bool
+
+pub fn parse(Array[String], Int) -> Invocation?
+
+pub fn subcommand_is_store_feeder(String) -> Bool
+
+pub fn subcommand_writes_from_object_store(String) -> Bool
+
+pub fn text_subcommand_index(Array[String], Int, Int) -> Int?
+
+pub fn text_subcommand_is_store_feeder(Array[String], Int, Int) -> Bool
+
+// Errors
+
+// Types and methods
+pub(all) struct Invocation {
+  subcommand : String
+  subcommand_index : Int
+}
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell/internal/git_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/git_policy/pkg.generated.mbti
@@ -6,13 +6,11 @@ pub fn global_option_reconfigures(String) -> Bool
 
 pub fn parse(Array[String], Int) -> Invocation?
 
-pub fn subcommand_is_store_feeder(String) -> Bool
+pub fn should_preblock(Array[String], Int) -> Bool
 
 pub fn subcommand_writes_from_object_store(String) -> Bool
 
-pub fn text_subcommand_index(Array[String], Int, Int) -> Int?
-
-pub fn text_subcommand_is_store_feeder(Array[String], Int, Int) -> Bool
+pub fn text_should_preblock(Array[String], Int, Int) -> Bool
 
 // Errors
 

--- a/agent_tool/shell/internal/git_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/git_policy/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub fn should_preblock(Array[String], Int) -> Bool
 
 pub fn subcommand_writes_from_object_store(String) -> Bool
 
+pub fn text_invocation_writes_from_object_store(Array[String], Int, Int) -> Bool
+
 pub fn text_should_preblock(Array[String], Int, Int) -> Bool
 
 // Errors

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -3,6 +3,7 @@ import {
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/shell/internal/command_policy",
   "bobzhang/openseek/agent_tool/shell/internal/decode",
+  "bobzhang/openseek/agent_tool/shell/internal/git_policy",
   "bobzhang/openseek/agent_tool/shell/internal/shell_parse",
   "bobzhang/openseek/internal/workspace_path",
   "moonbitlang/async",

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1286,6 +1286,33 @@ fn command_text_mentions_unsafe_git_source_operation(text : String) -> Bool {
       if @git_policy.text_should_preblock(words, index + 1, segment_end) {
         return true
       }
+      // A custom environment before `git` (e.g. `GIT_DIR=… git checkout -- *.mbt`)
+      // can repoint git's repo/worktree/config; the text path cannot see it from
+      // `words[index + 1..]`, so block object-store writers carrying one.
+      if command_text_segment_has_custom_env(words, index) &&
+        @git_policy.text_invocation_writes_from_object_store(
+          words,
+          index + 1,
+          segment_end,
+        ) {
+        return true
+      }
+    }
+  }
+  false
+}
+
+///|
+/// True when the command segment ending at the `git` word at `git_index` carries
+/// a custom environment — a leading `env` runner or a `VAR=value` assignment.
+fn command_text_segment_has_custom_env(
+  words : Array[String],
+  git_index : Int,
+) -> Bool {
+  for index in command_text_segment_start(words, git_index)..<git_index {
+    let word = words[index]
+    if command_basename(word) == "env" || command_text_env_assignment_word(word) {
+      return true
     }
   }
   false

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -2576,6 +2576,7 @@ async fn source_tree_operation_target_for_command(
         command_index + 1,
         real_workspace_root,
         cwd,
+        command_has_custom_environment(command),
       )
     "find" =>
       source_tree_find_target(
@@ -3154,8 +3155,9 @@ fn git_preblock_target(
   arg_start : Int,
   real_workspace_root : String,
   cwd : String,
+  has_custom_env : Bool,
 ) -> String? {
-  if @git_policy.should_preblock(argv, arg_start) {
+  if git_must_preblock(argv, arg_start, has_custom_env) {
     // Block unconditionally; do not condition on the resolved cwd (that would let
     // `git -C <workspace> ...` run from an outside cwd slip through). Prefer the
     // workspace-scoped target for the message; fall back to the workspace root.
@@ -3171,6 +3173,29 @@ fn git_preblock_target(
   } else {
     None
   }
+}
+
+///|
+fn git_must_preblock(
+  argv : Array[String],
+  arg_start : Int,
+  has_custom_env : Bool,
+) -> Bool {
+  if @git_policy.should_preblock(argv, arg_start) {
+    return true
+  }
+  // A custom environment (`GIT_DIR`/`GIT_WORK_TREE`/`GIT_CONFIG_*`, or `env ...
+  // git`) is the environment analogue of `-c`/`-C`: it can repoint git's config,
+  // git dir, or worktree, so a custom-env object-store writer can write workspace
+  // source from another repository. The trust path already demotes it, but on
+  // platforms without sandbox-exec SourceReadOnly still runs unsandboxed, so it
+  // must be pre-blocked too.
+  has_custom_env &&
+  (match @git_policy.parse(argv, arg_start) {
+    Some(invocation) =>
+      @git_policy.subcommand_writes_from_object_store(invocation.subcommand)
+    None => false
+  })
 }
 
 ///|

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -3175,7 +3175,19 @@ fn git_store_feeder_preblock_target(
     return None
   }
   if @git_policy.subcommand_is_store_feeder(invocation.subcommand) {
-    git_workspace_scope_target(real_workspace_root, cwd)
+    // Block feeders unconditionally. Conditioning on the resolved cwd would let
+    // `git -C <workspace> apply` run from an outside cwd slip through, and these
+    // are plumbing the agent never needs anyway. Prefer the workspace-scoped
+    // target for the message; fall back to the workspace root.
+    match git_workspace_scope_target(real_workspace_root, cwd) {
+      Some(target) => Some(target)
+      None =>
+        Some(
+          strip_trailing_slash(
+            @path.Path(real_workspace_root).normalize().to_string(),
+          ),
+        )
+    }
   } else {
     None
   }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1283,14 +1283,8 @@ fn command_text_mentions_unsafe_git_source_operation(text : String) -> Bool {
     if command_token_basename_is(words[index], "git") &&
       command_text_word_runs_as_command(words, index) {
       let segment_end = command_text_segment_end(words, index)
-      match @git_policy.text_subcommand_index(words, index + 1, segment_end) {
-        Some(subcommand_index) =>
-          if @git_policy.text_subcommand_is_store_feeder(
-              words, subcommand_index, segment_end,
-            ) {
-            return true
-          }
-        None => ()
+      if @git_policy.text_should_preblock(words, index + 1, segment_end) {
+        return true
       }
     }
   }
@@ -2577,7 +2571,7 @@ async fn source_tree_operation_target_for_command(
         predicted_dirs,
       )
     "git" =>
-      git_store_feeder_preblock_target(
+      git_preblock_target(
         command.argv,
         command_index + 1,
         real_workspace_root,
@@ -3146,39 +3140,25 @@ fn source_writing_awk_target(
 }
 
 ///|
-/// Pre-block git subcommands that can place content from OUTSIDE the object store
-/// into git's store or worktree, which a later trusted `checkout`/`restore` would
-/// then materialize into source:
-///
-/// - `apply` / `am` apply an external patch (also directly, or via `--cached`);
-/// - `update-index` can stage an arbitrary blob at a source path
-///   (`git hash-object -w` + `git update-index --cacheinfo … main.mbt`);
-/// - `read-tree` can write the worktree/index from an arbitrary (e.g. `mktree`d)
-///   tree;
-/// - `fast-import` streams arbitrary objects and refs.
-///
-/// These are plumbing the agent does not need, so blocking them is friction-free
-/// and reliable (subcommand name only). The runtime `sandbox-exec` profile also
-/// denies direct source writes on macOS; this static guard is the cross-platform
-/// backstop. NOTE: this is not exhaustive — `replace`, `filter-branch`, and
-/// `commit-tree`+`mktree` can also seed the object store, so a determined plumbing
-/// sequence remains a residual channel while `.git` itself is writable. Every
-/// other git subcommand sources writes from the object store and is handled by
-/// the trusted-source-write path (`trusted_git_command_class`).
-fn git_store_feeder_preblock_target(
+/// Pre-block, before execution and independent of the runtime sandbox, the git
+/// that mutates source but is not a recoverable object-store write —
+/// `@git_policy.should_preblock` (store feeders, `mv`, non-dry-run `clean`, and
+/// reconfigured writers). This is the cross-platform guard; on macOS `sandbox-exec`
+/// is a second layer. The recoverable writers and read-only git are handled by
+/// the trusted-source-write path (`trusted_git_command_class`) instead. NOTE: a
+/// determined plumbing sequence (`replace`, `filter-branch`, `commit-tree`) can
+/// still seed the object store while `.git` is writable — a residual channel, not
+/// a hard boundary.
+fn git_preblock_target(
   argv : Array[String],
   arg_start : Int,
   real_workspace_root : String,
   cwd : String,
 ) -> String? {
-  guard @git_policy.parse(argv, arg_start) is Some(invocation) else {
-    return None
-  }
-  if @git_policy.subcommand_is_store_feeder(invocation.subcommand) {
-    // Block feeders unconditionally. Conditioning on the resolved cwd would let
-    // `git -C <workspace> apply` run from an outside cwd slip through, and these
-    // are plumbing the agent never needs anyway. Prefer the workspace-scoped
-    // target for the message; fall back to the workspace root.
+  if @git_policy.should_preblock(argv, arg_start) {
+    // Block unconditionally; do not condition on the resolved cwd (that would let
+    // `git -C <workspace> ...` run from an outside cwd slip through). Prefer the
+    // workspace-scoped target for the message; fall back to the workspace root.
     match git_workspace_scope_target(real_workspace_root, cwd) {
       Some(target) => Some(target)
       None =>

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -493,19 +493,15 @@ fn trusted_command_class(
 /// Git subcommands trusted to run unsandboxed and write workspace source. Every
 /// worktree write these make sources its content from git's own object store —
 /// HEAD, the index, a commit/tree, or a stash — which is recoverable and
-/// reviewable through git, never from an external file or stdin. `apply`/`am`
-/// are deliberately absent (they apply an external patch — arbitrary content the
-/// source-write sandbox must keep out), as is everything unknown (fail closed).
+/// reviewable through git, never from an external file or stdin. `mv` is absent:
+/// it moves existing worktree bytes onto the destination, so `git mv notes.md
+/// main.mbt` would create source from arbitrary worktree content rather than the
+/// object store. `apply`/`am` are absent (they apply an external patch), as is
+/// everything unknown (fail closed). `rm` only deletes, so it cannot inject.
 fn git_subcommand_writes_from_object_store(subcommand : String) -> Bool {
   match subcommand {
-    "checkout"
-    | "switch"
-    | "restore"
-    | "reset"
-    | "stash"
-    | "clean"
-    | "rm"
-    | "mv" => true
+    "checkout" | "switch" | "restore" | "reset" | "stash" | "clean" | "rm" =>
+      true
     _ => false
   }
 }
@@ -513,10 +509,12 @@ fn git_subcommand_writes_from_object_store(subcommand : String) -> Bool {
 ///|
 /// Classify a `git` command for the trusted-source-write path. Trust is granted
 /// only to the recoverable worktree subcommands above, and only when the
-/// invocation cannot reconfigure git to synthesize arbitrary bytes: a custom
-/// environment (`GIT_CONFIG_*`, `env ... git`) or a config/dir/exec global option
-/// (`-c`, `--config-env`, `--git-dir`, `--namespace`, `--exec-path`) could enable
-/// a smudge filter or merge driver, so those fall through to the sandbox.
+/// invocation cannot reconfigure git to write from somewhere other than the
+/// workspace repo's object store: a custom environment (`GIT_CONFIG_*`,
+/// `env ... git`) or a relocating global option could repoint config (enabling a
+/// smudge filter or merge driver), the git dir, the exec path, or the worktree —
+/// e.g. `git -C /tmp/x --work-tree=. checkout` would write the workspace from a
+/// different repository. Those fall through to the sandbox.
 fn trusted_git_command_class(
   command : @shell_parse.SimpleCommand,
   git_index : Int,
@@ -542,11 +540,16 @@ fn trusted_git_command_class(
 
 ///|
 /// True for git global options that repoint git at different config, an external
-/// program path, or another git dir — precursors that could turn an otherwise
-/// object-store subcommand into an arbitrary-byte writer via filters or drivers.
+/// program path, another git dir, or another cwd/worktree — precursors that could
+/// turn an otherwise object-store subcommand into an arbitrary-byte writer via
+/// filters/drivers or write the workspace from a different repository.
 fn git_global_option_reconfigures(arg : String) -> Bool {
   git_global_option_consumes_next(arg) ||
-  git_global_option_with_attached_value(arg)
+  git_global_option_with_attached_value(arg) ||
+  arg == "-C" ||
+  arg == "--work-tree" ||
+  git_attached_cwd_option(arg) is Some(_) ||
+  git_attached_work_tree_option(arg) is Some(_)
 }
 
 ///|
@@ -1420,11 +1423,12 @@ fn command_text_git_subcommand_updates_source_tree(
     ) {
     return false
   }
-  // Only the external-patch subcommands are pre-blocked in the TooComplex text
-  // path; every other git worktree write sources from the object store and is
-  // handled by the trusted-source-write path (or, on macOS, the kernel sandbox).
+  // Only the store-feeder subcommands are pre-blocked in the TooComplex text
+  // path (see git_store_feeder_preblock_target); every other git worktree write
+  // sources from the object store and is handled by the trusted-source-write
+  // path (or, on macOS, the kernel sandbox).
   match words[subcommand_index] {
-    "apply" | "am" => true
+    "apply" | "am" | "update-index" | "read-tree" | "fast-import" => true
     _ => false
   }
 }
@@ -2670,7 +2674,7 @@ async fn source_tree_operation_target_for_command(
         predicted_dirs,
       )
     "git" =>
-      git_external_patch_preblock_target(
+      git_store_feeder_preblock_target(
         command.argv,
         command_index + 1,
         real_workspace_root,
@@ -3246,14 +3250,26 @@ priv struct GitInvocation {
 }
 
 ///|
-/// Pre-block `git apply` / `git am`: they write the worktree (or stage it, with
-/// `--cached`, which then feeds a later trusted `checkout`/`restore`) from an
-/// EXTERNAL patch — arbitrary content the source-write sandbox must keep out.
-/// The runtime `sandbox-exec` profile already denies this on macOS; this static
-/// guard is what blocks it on platforms without a kernel sandbox. Every other
-/// git subcommand sources its writes from the object store and is handled by the
-/// trusted-source-write path (`trusted_git_command_class`).
-fn git_external_patch_preblock_target(
+/// Pre-block git subcommands that can place content from OUTSIDE the object store
+/// into git's store or worktree, which a later trusted `checkout`/`restore` would
+/// then materialize into source:
+///
+/// - `apply` / `am` apply an external patch (also directly, or via `--cached`);
+/// - `update-index` can stage an arbitrary blob at a source path
+///   (`git hash-object -w` + `git update-index --cacheinfo … main.mbt`);
+/// - `read-tree` can write the worktree/index from an arbitrary (e.g. `mktree`d)
+///   tree;
+/// - `fast-import` streams arbitrary objects and refs.
+///
+/// These are plumbing the agent does not need, so blocking them is friction-free
+/// and reliable (subcommand name only). The runtime `sandbox-exec` profile also
+/// denies direct source writes on macOS; this static guard is the cross-platform
+/// backstop. NOTE: this is not exhaustive — `replace`, `filter-branch`, and
+/// `commit-tree`+`mktree` can also seed the object store, so a determined plumbing
+/// sequence remains a residual channel while `.git` itself is writable. Every
+/// other git subcommand sources writes from the object store and is handled by
+/// the trusted-source-write path (`trusted_git_command_class`).
+fn git_store_feeder_preblock_target(
   argv : Array[String],
   arg_start : Int,
   real_workspace_root : String,
@@ -3264,7 +3280,7 @@ fn git_external_patch_preblock_target(
     return None
   }
   match invocation.subcommand {
-    "apply" | "am" =>
+    "apply" | "am" | "update-index" | "read-tree" | "fast-import" =>
       git_workspace_scope_target(real_workspace_root, invocation.cwd)
     _ => None
   }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -490,23 +490,6 @@ fn trusted_command_class(
 }
 
 ///|
-/// Git subcommands trusted to run unsandboxed and write workspace source. Every
-/// worktree write these make sources its content from git's own object store —
-/// HEAD, the index, a commit/tree, or a stash — which is recoverable and
-/// reviewable through git, never from an external file or stdin. `mv` is absent:
-/// it moves existing worktree bytes onto the destination, so `git mv notes.md
-/// main.mbt` would create source from arbitrary worktree content rather than the
-/// object store. `apply`/`am` are absent (they apply an external patch), as is
-/// everything unknown (fail closed). `rm` only deletes, so it cannot inject.
-fn git_subcommand_writes_from_object_store(subcommand : String) -> Bool {
-  match subcommand {
-    "checkout" | "switch" | "restore" | "reset" | "stash" | "clean" | "rm" =>
-      true
-    _ => false
-  }
-}
-
-///|
 /// Classify a `git` command for the trusted-source-write path. Trust is granted
 /// only to the recoverable worktree subcommands above, and only when the
 /// invocation cannot reconfigure git to write from somewhere other than the
@@ -522,34 +505,19 @@ fn trusted_git_command_class(
   if command_has_custom_environment(command) {
     return UntrustedCommand
   }
-  guard git_invocation(command.argv, git_index + 1, ".", ".")
-    is Some(invocation) else {
+  guard @git_policy.parse(command.argv, git_index + 1) is Some(invocation) else {
     return UntrustedCommand
   }
   for index in (git_index + 1)..<invocation.subcommand_index {
-    if git_global_option_reconfigures(command.argv[index]) {
+    if @git_policy.global_option_reconfigures(command.argv[index]) {
       return UntrustedCommand
     }
   }
-  if git_subcommand_writes_from_object_store(invocation.subcommand) {
+  if @git_policy.subcommand_writes_from_object_store(invocation.subcommand) {
     TrustedCommandWrite
   } else {
     UntrustedCommand
   }
-}
-
-///|
-/// True for git global options that repoint git at different config, an external
-/// program path, another git dir, or another cwd/worktree — precursors that could
-/// turn an otherwise object-store subcommand into an arbitrary-byte writer via
-/// filters/drivers or write the workspace from a different repository.
-fn git_global_option_reconfigures(arg : String) -> Bool {
-  git_global_option_consumes_next(arg) ||
-  git_global_option_with_attached_value(arg) ||
-  arg == "-C" ||
-  arg == "--work-tree" ||
-  git_attached_cwd_option(arg) is Some(_) ||
-  git_attached_work_tree_option(arg) is Some(_)
 }
 
 ///|
@@ -1315,9 +1283,9 @@ fn command_text_mentions_unsafe_git_source_operation(text : String) -> Bool {
     if command_token_basename_is(words[index], "git") &&
       command_text_word_runs_as_command(words, index) {
       let segment_end = command_text_segment_end(words, index)
-      match command_text_git_subcommand_index(words, index + 1, segment_end) {
+      match @git_policy.text_subcommand_index(words, index + 1, segment_end) {
         Some(subcommand_index) =>
-          if command_text_git_subcommand_updates_source_tree(
+          if @git_policy.text_subcommand_is_store_feeder(
               words, subcommand_index, segment_end,
             ) {
             return true
@@ -1375,71 +1343,6 @@ fn powershell_source_writing_command_name(name : String) -> Bool {
     | "ni" => true
     _ => false
   }
-}
-
-///|
-fn command_text_git_subcommand_index(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Int? {
-  let mut index = start
-  while index < end {
-    let arg = words[index]
-    if arg == "--help" || arg == "-h" {
-      return None
-    }
-    if arg == "-C" ||
-      arg == "--work-tree" ||
-      git_global_option_consumes_next(arg) {
-      index += 2
-      continue
-    }
-    if git_attached_cwd_option(arg) is Some(_) ||
-      git_attached_work_tree_option(arg) is Some(_) ||
-      git_global_option_with_attached_value(arg) ||
-      git_global_no_arg_option(arg) {
-      index += 1
-      continue
-    }
-    if arg.has_prefix("-") && arg != "-" {
-      return None
-    }
-    return Some(index)
-  }
-  None
-}
-
-///|
-fn command_text_git_subcommand_updates_source_tree(
-  words : Array[String],
-  subcommand_index : Int,
-  segment_end : Int,
-) -> Bool {
-  if command_text_git_subcommand_args_request_help(
-      words,
-      subcommand_index + 1,
-      segment_end,
-    ) {
-    return false
-  }
-  // Only the store-feeder subcommands are pre-blocked in the TooComplex text
-  // path (see git_store_feeder_preblock_target); every other git worktree write
-  // sources from the object store and is handled by the trusted-source-write
-  // path (or, on macOS, the kernel sandbox).
-  match words[subcommand_index] {
-    "apply" | "am" | "update-index" | "read-tree" | "fast-import" => true
-    _ => false
-  }
-}
-
-///|
-fn command_text_git_subcommand_args_request_help(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  start < end && (words[start] == "--help" || words[start] == "-h")
 }
 
 ///|
@@ -3243,13 +3146,6 @@ fn source_writing_awk_target(
 }
 
 ///|
-priv struct GitInvocation {
-  subcommand : String
-  subcommand_index : Int
-  cwd : String
-}
-
-///|
 /// Pre-block git subcommands that can place content from OUTSIDE the object store
 /// into git's store or worktree, which a later trusted `checkout`/`restore` would
 /// then materialize into source:
@@ -3275,150 +3171,13 @@ fn git_store_feeder_preblock_target(
   real_workspace_root : String,
   cwd : String,
 ) -> String? {
-  guard git_invocation(argv, arg_start, real_workspace_root, cwd)
-    is Some(invocation) else {
+  guard @git_policy.parse(argv, arg_start) is Some(invocation) else {
     return None
   }
-  match invocation.subcommand {
-    "apply" | "am" | "update-index" | "read-tree" | "fast-import" =>
-      git_workspace_scope_target(real_workspace_root, invocation.cwd)
-    _ => None
-  }
-}
-
-///|
-fn git_invocation(
-  argv : Array[String],
-  arg_start : Int,
-  real_workspace_root : String,
-  cwd : String,
-) -> GitInvocation? {
-  let mut index = arg_start
-  let mut effective_cwd = source_write_detection_cwd(
-    real_workspace_root,
-    Some(cwd),
-  )
-  while index < argv.length() {
-    let arg = argv[index]
-    if arg == "--" {
-      return None
-    }
-    if arg == "--help" || arg == "-h" {
-      return None
-    }
-    if arg == "-C" {
-      if index + 1 >= argv.length() {
-        return None
-      }
-      effective_cwd = resolve_source_write_redirect_target(
-        effective_cwd,
-        argv[index + 1],
-      )
-      index += 2
-      continue
-    }
-    match git_attached_cwd_option(arg) {
-      Some(next_cwd) => {
-        effective_cwd = resolve_source_write_redirect_target(
-          effective_cwd, next_cwd,
-        )
-        index += 1
-        continue
-      }
-      None => ()
-    }
-    if arg == "--work-tree" {
-      if index + 1 >= argv.length() {
-        return None
-      }
-      effective_cwd = resolve_source_write_redirect_target(
-        effective_cwd,
-        argv[index + 1],
-      )
-      index += 2
-      continue
-    }
-    match git_attached_work_tree_option(arg) {
-      Some(work_tree) => {
-        effective_cwd = resolve_source_write_redirect_target(
-          effective_cwd, work_tree,
-        )
-        index += 1
-        continue
-      }
-      None => ()
-    }
-    if git_global_option_consumes_next(arg) {
-      index += 2
-      continue
-    }
-    if git_global_option_with_attached_value(arg) ||
-      git_global_no_arg_option(arg) {
-      index += 1
-      continue
-    }
-    if arg.has_prefix("-") && arg != "-" {
-      return None
-    }
-    return Some({ subcommand: arg, subcommand_index: index, cwd: effective_cwd })
-  }
-  None
-}
-
-///|
-fn git_attached_cwd_option(arg : String) -> String? {
-  if arg.has_prefix("-C") && arg != "-C" {
-    Some(arg[2:].to_owned())
+  if @git_policy.subcommand_is_store_feeder(invocation.subcommand) {
+    git_workspace_scope_target(real_workspace_root, cwd)
   } else {
     None
-  }
-}
-
-///|
-fn git_attached_work_tree_option(arg : String) -> String? {
-  if arg.has_prefix("--work-tree=") {
-    Some(arg["--work-tree=".length():].to_owned())
-  } else {
-    None
-  }
-}
-
-///|
-fn git_global_option_consumes_next(arg : String) -> Bool {
-  arg == "-c" ||
-  arg == "--config-env" ||
-  arg == "--exec-path" ||
-  arg == "--git-dir" ||
-  arg == "--namespace"
-}
-
-///|
-fn git_global_option_with_attached_value(arg : String) -> Bool {
-  (arg.has_prefix("-c") && arg != "-c") ||
-  arg.has_prefix("--config-env=") ||
-  arg.has_prefix("--exec-path=") ||
-  arg.has_prefix("--git-dir=") ||
-  arg.has_prefix("--namespace=")
-}
-
-///|
-fn git_global_no_arg_option(arg : String) -> Bool {
-  match arg {
-    "--version"
-    | "--help"
-    | "-p"
-    | "--paginate"
-    | "-P"
-    | "--no-pager"
-    | "--no-replace-objects"
-    | "--no-optional-locks"
-    | "--no-lazy-fetch"
-    | "--literal-pathspecs"
-    | "--glob-pathspecs"
-    | "--noglob-pathspecs"
-    | "--icase-pathspecs"
-    | "--bare" => true
-    _ => false
   }
 }
 

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -2,7 +2,7 @@
 const SandboxExecPath : String = "/usr/bin/sandbox-exec"
 
 ///|
-const SandboxSourceWriteFeedback : String = "shell sandbox: source file writes from shell are blocked. For compiler-feedback or mechanical code fixes, use line-anchored `edit` (or `multi_edit` for several fixes in one file) instead of shell-generated rewrites. Do not generate rewritten files in shell and then overwrite source files with another tool; keep `shell` for read-only analysis and validation commands."
+const SandboxSourceWriteFeedback : String = "shell sandbox: source file writes from shell are blocked. Editing source through the shell is not how this project works — it is discouraged, not a temporary obstacle to route around. Our practice is to make source changes with line-anchored `edit` (or `multi_edit` for several fixes in one file) so each change stays small and reviewable. For compiler-feedback or mechanical fixes, use `edit`, not shell-generated rewrites. Do NOT try to work around this block (redirects, `sed`/`awk`/scripts, `git apply`, or stage-then-checkout tricks) — apply the change with `edit`. Keep `shell` for read-only analysis and validation commands."
 
 ///|
 let source_write_profile_cache : Map[String, CachedSourceWriteProfile] = {}

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -482,10 +482,71 @@ fn trusted_command_class(
             UntrustedCommand
           }
         "moon" => trusted_moon_command_class(command, command_index)
+        "git" => trusted_git_command_class(command, command_index)
         _ => UntrustedCommand
       }
     _ => UntrustedCommand
   }
+}
+
+///|
+/// Git subcommands trusted to run unsandboxed and write workspace source. Every
+/// worktree write these make sources its content from git's own object store —
+/// HEAD, the index, a commit/tree, or a stash — which is recoverable and
+/// reviewable through git, never from an external file or stdin. `apply`/`am`
+/// are deliberately absent (they apply an external patch — arbitrary content the
+/// source-write sandbox must keep out), as is everything unknown (fail closed).
+fn git_subcommand_writes_from_object_store(subcommand : String) -> Bool {
+  match subcommand {
+    "checkout"
+    | "switch"
+    | "restore"
+    | "reset"
+    | "stash"
+    | "clean"
+    | "rm"
+    | "mv" => true
+    _ => false
+  }
+}
+
+///|
+/// Classify a `git` command for the trusted-source-write path. Trust is granted
+/// only to the recoverable worktree subcommands above, and only when the
+/// invocation cannot reconfigure git to synthesize arbitrary bytes: a custom
+/// environment (`GIT_CONFIG_*`, `env ... git`) or a config/dir/exec global option
+/// (`-c`, `--config-env`, `--git-dir`, `--namespace`, `--exec-path`) could enable
+/// a smudge filter or merge driver, so those fall through to the sandbox.
+fn trusted_git_command_class(
+  command : @shell_parse.SimpleCommand,
+  git_index : Int,
+) -> TrustedCommandClass {
+  if command_has_custom_environment(command) {
+    return UntrustedCommand
+  }
+  guard git_invocation(command.argv, git_index + 1, ".", ".")
+    is Some(invocation) else {
+    return UntrustedCommand
+  }
+  for index in (git_index + 1)..<invocation.subcommand_index {
+    if git_global_option_reconfigures(command.argv[index]) {
+      return UntrustedCommand
+    }
+  }
+  if git_subcommand_writes_from_object_store(invocation.subcommand) {
+    TrustedCommandWrite
+  } else {
+    UntrustedCommand
+  }
+}
+
+///|
+/// True for git global options that repoint git at different config, an external
+/// program path, or another git dir — precursors that could turn an otherwise
+/// object-store subcommand into an arbitrary-byte writer via filters or drivers.
+fn git_global_option_reconfigures(arg : String) -> Bool {
+  git_global_option_consumes_next(arg) ||
+  git_global_option_with_attached_value(arg)
 }
 
 ///|
@@ -1359,44 +1420,11 @@ fn command_text_git_subcommand_updates_source_tree(
     ) {
     return false
   }
+  // Only the external-patch subcommands are pre-blocked in the TooComplex text
+  // path; every other git worktree write sources from the object store and is
+  // handled by the trusted-source-write path (or, on macOS, the kernel sandbox).
   match words[subcommand_index] {
-    "checkout" | "switch" => true
-    "restore" =>
-      command_text_git_restore_updates_worktree(
-        words,
-        subcommand_index + 1,
-        segment_end,
-      )
-    "reset" =>
-      command_text_git_reset_updates_worktree(
-        words,
-        subcommand_index + 1,
-        segment_end,
-      )
-    "clean" =>
-      command_text_git_clean_updates_worktree(
-        words,
-        subcommand_index + 1,
-        segment_end,
-      )
-    "apply" =>
-      command_text_git_apply_updates_worktree(
-        words,
-        subcommand_index + 1,
-        segment_end,
-      )
-    "rm" =>
-      command_text_git_rm_updates_worktree(
-        words,
-        subcommand_index + 1,
-        segment_end,
-      )
-    "mv" =>
-      command_text_git_mv_updates_worktree(
-        words,
-        subcommand_index + 1,
-        segment_end,
-      )
+    "apply" | "am" => true
     _ => false
   }
 }
@@ -1408,132 +1436,6 @@ fn command_text_git_subcommand_args_request_help(
   end : Int,
 ) -> Bool {
   start < end && (words[start] == "--help" || words[start] == "-h")
-}
-
-///|
-fn command_text_git_restore_updates_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  let mut staged = false
-  let mut worktree = false
-  let mut index = start
-  while index < end {
-    let arg = words[index]
-    if arg == "--" {
-      break
-    }
-    if arg == "--staged" || git_restore_short_option_cluster_has(arg, "S") {
-      staged = true
-    }
-    if arg == "--worktree" || git_restore_short_option_cluster_has(arg, "W") {
-      worktree = true
-    }
-    if git_restore_option_consumes_next(arg) {
-      index += 2
-      continue
-    }
-    index += 1
-  }
-  worktree || !staged
-}
-
-///|
-fn command_text_git_reset_updates_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  let mut index = start
-  while index < end {
-    match words[index] {
-      "--hard" | "--merge" | "--keep" => return true
-      _ => index += 1
-    }
-  }
-  false
-}
-
-///|
-fn command_text_git_clean_updates_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  let mut dry_run = false
-  let mut index = start
-  while index < end {
-    let arg = words[index]
-    if git_clean_short_option_has_dry_run(arg) ||
-      git_clean_long_option_is_dry_run(arg) {
-      dry_run = true
-    }
-    if git_clean_option_consumes_next(arg) {
-      index += 2
-      continue
-    }
-    index += 1
-  }
-  !dry_run
-}
-
-///|
-fn command_text_git_apply_updates_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  let mut applies = true
-  let mut cached_only = false
-  let mut index = start
-  while index < end {
-    match words[index] {
-      "--check" | "--stat" | "--numstat" | "--summary" => applies = false
-      "--cached" => cached_only = true
-      "--index" => cached_only = false
-      "--apply" => applies = true
-      _ => ()
-    }
-    index += 1
-  }
-  applies && !cached_only
-}
-
-///|
-fn command_text_git_rm_updates_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  let mut cached_only = false
-  let mut dry_run = false
-  for index in start..<end {
-    let arg = words[index]
-    match arg {
-      "--cached" => cached_only = true
-      "-n" | "--dry-run" => dry_run = true
-      _ => if git_restore_short_option_cluster_has(arg, "n") { dry_run = true }
-    }
-  }
-  !cached_only && !dry_run
-}
-
-///|
-fn command_text_git_mv_updates_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  for index in start..<end {
-    let arg = words[index]
-    if arg == "-n" ||
-      arg == "--dry-run" ||
-      git_restore_short_option_cluster_has(arg, "n") {
-      return false
-    }
-  }
-  true
 }
 
 ///|
@@ -2768,7 +2670,7 @@ async fn source_tree_operation_target_for_command(
         predicted_dirs,
       )
     "git" =>
-      source_tree_git_target(
+      git_external_patch_preblock_target(
         command.argv,
         command_index + 1,
         real_workspace_root,
@@ -3344,7 +3246,14 @@ priv struct GitInvocation {
 }
 
 ///|
-async fn source_tree_git_target(
+/// Pre-block `git apply` / `git am`: they write the worktree (or stage it, with
+/// `--cached`, which then feeds a later trusted `checkout`/`restore`) from an
+/// EXTERNAL patch — arbitrary content the source-write sandbox must keep out.
+/// The runtime `sandbox-exec` profile already denies this on macOS; this static
+/// guard is what blocks it on platforms without a kernel sandbox. Every other
+/// git subcommand sources its writes from the object store and is handled by the
+/// trusted-source-write path (`trusted_git_command_class`).
+fn git_external_patch_preblock_target(
   argv : Array[String],
   arg_start : Int,
   real_workspace_root : String,
@@ -3354,49 +3263,9 @@ async fn source_tree_git_target(
     is Some(invocation) else {
     return None
   }
-  let subcommand_index = invocation.subcommand_index
-  let git_cwd = invocation.cwd
-  if git_subcommand_args_request_help(argv, subcommand_index + 1) {
-    return None
-  }
   match invocation.subcommand {
-    "checkout" =>
-      git_checkout_target(
-        argv,
-        subcommand_index + 1,
-        real_workspace_root,
-        git_cwd,
-      )
-    "switch" => git_workspace_scope_target(real_workspace_root, git_cwd)
-    "restore" =>
-      git_restore_target(
-        argv,
-        subcommand_index + 1,
-        real_workspace_root,
-        git_cwd,
-      )
-    "reset" =>
-      if git_reset_updates_worktree(argv, subcommand_index + 1) {
-        git_workspace_scope_target(real_workspace_root, git_cwd)
-      } else {
-        None
-      }
-    "clean" =>
-      if git_clean_updates_worktree(argv, subcommand_index + 1) {
-        git_workspace_scope_target(real_workspace_root, git_cwd)
-      } else {
-        None
-      }
-    "apply" =>
-      if git_apply_updates_worktree(argv, subcommand_index + 1) {
-        git_workspace_scope_target(real_workspace_root, git_cwd)
-      } else {
-        None
-      }
-    "rm" =>
-      git_rm_target(argv, subcommand_index + 1, real_workspace_root, git_cwd)
-    "mv" =>
-      git_mv_target(argv, subcommand_index + 1, real_workspace_root, git_cwd)
+    "apply" | "am" =>
+      git_workspace_scope_target(real_workspace_root, invocation.cwd)
     _ => None
   }
 }
@@ -3538,32 +3407,6 @@ fn git_global_no_arg_option(arg : String) -> Bool {
 }
 
 ///|
-fn git_subcommand_args_request_help(
-  argv : Array[String],
-  arg_start : Int,
-) -> Bool {
-  arg_start < argv.length() &&
-  (argv[arg_start] == "--help" || argv[arg_start] == "-h")
-}
-
-///|
-async fn git_checkout_target(
-  argv : Array[String],
-  arg_start : Int,
-  real_workspace_root : String,
-  cwd : String,
-) -> String? {
-  if git_command_has_dash_dash(argv, arg_start) {
-    return git_restore_pathspec_target(
-      git_pathspecs_after_dash_dash(argv, arg_start),
-      real_workspace_root,
-      cwd,
-    )
-  }
-  git_workspace_scope_target(real_workspace_root, cwd)
-}
-
-///|
 fn git_workspace_scope_target(
   real_workspace_root : String,
   cwd : String,
@@ -3576,450 +3419,6 @@ fn git_workspace_scope_target(
     Some(target)
   } else {
     None
-  }
-}
-
-///|
-fn git_command_has_dash_dash(argv : Array[String], arg_start : Int) -> Bool {
-  let mut index = arg_start
-  while index < argv.length() {
-    if argv[index] == "--" {
-      return true
-    }
-    index += 1
-  }
-  false
-}
-
-///|
-async fn git_restore_target(
-  argv : Array[String],
-  arg_start : Int,
-  real_workspace_root : String,
-  cwd : String,
-) -> String? {
-  if !git_restore_updates_worktree(argv, arg_start) {
-    return None
-  }
-  let paths = git_restore_paths(argv, arg_start)
-  git_restore_pathspec_target(paths, real_workspace_root, cwd)
-}
-
-///|
-fn git_restore_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
-  let mut staged = false
-  let mut worktree = false
-  let mut index = arg_start
-  while index < argv.length() {
-    let arg = argv[index]
-    if arg == "--" {
-      break
-    }
-    if arg == "--staged" || git_restore_short_option_cluster_has(arg, "S") {
-      staged = true
-    }
-    if arg == "--worktree" || git_restore_short_option_cluster_has(arg, "W") {
-      worktree = true
-    }
-    if git_restore_option_consumes_next(arg) {
-      index += 2
-      continue
-    }
-    index += 1
-  }
-  worktree || !staged
-}
-
-///|
-fn git_restore_short_option_cluster_has(arg : String, flag : String) -> Bool {
-  arg.has_prefix("-") &&
-  !arg.has_prefix("--") &&
-  arg != "-" &&
-  arg.contains(flag)
-}
-
-///|
-async fn git_restore_pathspec_target(
-  paths : Array[String],
-  real_workspace_root : String,
-  cwd : String,
-) -> String? {
-  if paths.length() == 0 {
-    return git_workspace_scope_target(real_workspace_root, cwd)
-  }
-  let mut has_positive_pathspec = false
-  for path in paths {
-    if !git_pathspec_is_exclude(path) {
-      has_positive_pathspec = true
-      break
-    }
-  }
-  if !has_positive_pathspec {
-    return git_workspace_scope_target(real_workspace_root, cwd)
-  }
-  for path in paths {
-    if git_pathspec_is_exclude(path) {
-      continue
-    }
-    guard git_positive_pathspec(path, real_workspace_root, cwd) is Some(spec) else {
-      continue
-    }
-    if spec.path == "" || spec.path == "." {
-      return git_workspace_scope_target(real_workspace_root, spec.base)
-    }
-    let target = resolve_source_write_redirect_target(spec.base, spec.path)
-    if protected_workspace_source_or_tree_path(real_workspace_root, target) {
-      return Some(target)
-    }
-    if git_pathspec_may_restore_workspace_source(real_workspace_root, target) {
-      return Some(target)
-    }
-  }
-  None
-}
-
-///|
-priv struct GitPositivePathspec {
-  base : String
-  path : String
-}
-
-///|
-fn git_positive_pathspec(
-  pathspec : String,
-  real_workspace_root : String,
-  cwd : String,
-) -> GitPositivePathspec? {
-  if pathspec.has_prefix(":/") {
-    return Some({ base: real_workspace_root, path: pathspec[2:].to_owned() })
-  }
-  if pathspec.has_prefix(":(") {
-    match pathspec.find(")") {
-      Some(close) => {
-        let magic = pathspec[2:close]
-        if git_long_pathspec_magic_is_exclude(magic) {
-          return None
-        }
-        let base = if git_long_pathspec_magic_is_top(magic) {
-          real_workspace_root
-        } else {
-          cwd
-        }
-        return Some({ base, path: pathspec[close + 1:].to_owned() })
-      }
-      None => ()
-    }
-  }
-  Some({ base: cwd, path: pathspec })
-}
-
-///|
-fn git_pathspec_is_exclude(pathspec : String) -> Bool {
-  if pathspec.has_prefix(":!") || pathspec.has_prefix(":^") {
-    return true
-  }
-  if pathspec.has_prefix(":/!") || pathspec.has_prefix(":/^") {
-    return true
-  }
-  if pathspec.has_prefix(":(") {
-    match pathspec.find(")") {
-      Some(close) =>
-        return git_long_pathspec_magic_is_exclude(pathspec[2:close])
-      None => return false
-    }
-  }
-  false
-}
-
-///|
-fn git_long_pathspec_magic_is_top(magic : StringView) -> Bool {
-  for part in magic.split(",") {
-    if part == "top" || part == "/" {
-      return true
-    }
-  }
-  false
-}
-
-///|
-fn git_long_pathspec_magic_is_exclude(magic : StringView) -> Bool {
-  for part in magic.split(",") {
-    if part == "exclude" || part == "!" || part == "^" {
-      return true
-    }
-  }
-  false
-}
-
-///|
-fn git_pathspecs_after_dash_dash(
-  argv : Array[String],
-  arg_start : Int,
-) -> Array[String] {
-  let paths : Array[String] = []
-  let mut index = arg_start
-  let mut after_dash_dash = false
-  while index < argv.length() {
-    let arg = argv[index]
-    if !after_dash_dash && arg == "--" {
-      after_dash_dash = true
-      index += 1
-      continue
-    }
-    if after_dash_dash {
-      paths.push(arg)
-    }
-    index += 1
-  }
-  paths
-}
-
-///|
-fn git_pathspec_may_restore_workspace_source(
-  real_workspace_root : String,
-  target : String,
-) -> Bool {
-  let root = strip_trailing_slash(
-    @path.Path(real_workspace_root).normalize().to_string(),
-  )
-  let target = @path.Path(target).normalize().to_string()
-  is_under_workspace_root(root, target) &&
-  !is_moon_managed_workspace_path(root, target) &&
-  !looks_like_non_source_file_path(target)
-}
-
-///|
-fn git_restore_paths(argv : Array[String], arg_start : Int) -> Array[String] {
-  let paths : Array[String] = []
-  let mut index = arg_start
-  let mut after_dash_dash = false
-  while index < argv.length() {
-    let arg = argv[index]
-    if !after_dash_dash && arg == "--" {
-      after_dash_dash = true
-      index += 1
-      continue
-    }
-    if !after_dash_dash && git_restore_option_consumes_next(arg) {
-      index += 2
-      continue
-    }
-    if !after_dash_dash && git_restore_option_with_attached_value(arg) {
-      index += 1
-      continue
-    }
-    if !after_dash_dash && arg.has_prefix("-") && arg != "-" {
-      index += 1
-      continue
-    }
-    if after_dash_dash || !arg.has_prefix("-") || arg == "-" {
-      paths.push(arg)
-    }
-    index += 1
-  }
-  paths
-}
-
-///|
-fn git_restore_option_consumes_next(arg : String) -> Bool {
-  arg == "--source" || arg == "-s" || arg == "--pathspec-from-file"
-}
-
-///|
-fn git_restore_option_with_attached_value(arg : String) -> Bool {
-  arg.has_prefix("--source=") || arg.has_prefix("--pathspec-from-file=")
-}
-
-///|
-fn git_reset_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
-  let mut index = arg_start
-  while index < argv.length() {
-    match argv[index] {
-      "--hard" | "--merge" | "--keep" => return true
-      _ => index += 1
-    }
-  }
-  false
-}
-
-///|
-fn git_clean_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
-  let mut dry_run = false
-  let mut index = arg_start
-  while index < argv.length() {
-    let arg = argv[index]
-    if git_clean_short_option_has_dry_run(arg) ||
-      git_clean_long_option_is_dry_run(arg) {
-      dry_run = true
-    }
-    if git_clean_option_consumes_next(arg) {
-      index += 2
-      continue
-    }
-    index += 1
-  }
-  !dry_run
-}
-
-///|
-fn git_clean_long_option_is_dry_run(arg : String) -> Bool {
-  arg == "--dry-run"
-}
-
-///|
-fn git_clean_option_consumes_next(arg : String) -> Bool {
-  arg == "--exclude" || git_clean_short_option_cluster_consumes_next(arg)
-}
-
-///|
-fn git_clean_short_option_cluster_consumes_next(arg : String) -> Bool {
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
-    return false
-  }
-  let chars = [ for ch in arg => ch ]
-  chars.length() >= 2 && chars[chars.length() - 1] == 'e'
-}
-
-///|
-fn git_clean_short_option_has_dry_run(arg : String) -> Bool {
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
-    return false
-  }
-  let chars = [ for ch in arg => ch ]
-  for index in 1..<chars.length() {
-    match chars[index] {
-      'n' => return true
-      'e' => return false
-      _ => ()
-    }
-  }
-  false
-}
-
-///|
-fn git_apply_updates_worktree(argv : Array[String], arg_start : Int) -> Bool {
-  let mut applies = true
-  let mut cached_only = false
-  let mut index = arg_start
-  while index < argv.length() {
-    match argv[index] {
-      "--check" | "--stat" | "--numstat" | "--summary" => applies = false
-      "--cached" => cached_only = true
-      "--index" => cached_only = false
-      "--apply" => applies = true
-      _ => ()
-    }
-    index += 1
-  }
-  applies && !cached_only
-}
-
-///|
-async fn git_rm_target(
-  argv : Array[String],
-  arg_start : Int,
-  real_workspace_root : String,
-  cwd : String,
-) -> String? {
-  let mut cached_only = false
-  let mut dry_run = false
-  let mut pathspec_from_file = false
-  let paths : Array[String] = []
-  let mut index = arg_start
-  let mut after_dash_dash = false
-  while index < argv.length() {
-    let arg = argv[index]
-    if !after_dash_dash && arg == "--" {
-      after_dash_dash = true
-      index += 1
-      continue
-    }
-    if !after_dash_dash {
-      match arg {
-        "--cached" => {
-          cached_only = true
-          index += 1
-          continue
-        }
-        "-n" | "--dry-run" => {
-          dry_run = true
-          index += 1
-          continue
-        }
-        "--pathspec-from-file" => {
-          if index + 1 >= argv.length() {
-            return None
-          }
-          pathspec_from_file = true
-          index += 2
-          continue
-        }
-        "--pathspec-file-nul" => {
-          index += 1
-          continue
-        }
-        _ =>
-          if git_restore_short_option_cluster_has(arg, "n") {
-            dry_run = true
-            index += 1
-            continue
-          } else if arg.has_prefix("--pathspec-from-file=") {
-            pathspec_from_file = true
-            index += 1
-            continue
-          } else if arg.has_prefix("-") && arg != "-" {
-            index += 1
-            continue
-          }
-      }
-    }
-    paths.push(arg)
-    index += 1
-  }
-  if cached_only || dry_run {
-    None
-  } else if pathspec_from_file {
-    git_workspace_scope_target(real_workspace_root, cwd)
-  } else {
-    git_restore_pathspec_target(paths, real_workspace_root, cwd)
-  }
-}
-
-///|
-async fn git_mv_target(
-  argv : Array[String],
-  arg_start : Int,
-  real_workspace_root : String,
-  cwd : String,
-) -> String? {
-  let paths : Array[String] = []
-  let mut index = arg_start
-  let mut after_dash_dash = false
-  while index < argv.length() {
-    let arg = argv[index]
-    if !after_dash_dash && arg == "--" {
-      after_dash_dash = true
-      index += 1
-      continue
-    }
-    if !after_dash_dash {
-      if arg == "-n" ||
-        arg == "--dry-run" ||
-        git_restore_short_option_cluster_has(arg, "n") {
-        return None
-      }
-      if arg.has_prefix("-") && arg != "-" {
-        index += 1
-        continue
-      }
-    }
-    paths.push(arg)
-    index += 1
-  }
-  if paths.length() < 2 {
-    None
-  } else {
-    git_restore_pathspec_target(paths, real_workspace_root, cwd)
   }
 }
 

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -532,7 +532,6 @@ async test "sandbox preblocks common source-writing commands" {
     @fs.symlink(target="main.mbt", "\{root}/out.log")
     let real_root = @fs.realpath(root)
     let main_path = "\{real_root}/main.mbt"
-    let pkg_main_path = "\{real_root}/pkg/main.mbt"
     let src_pkg_path = "\{real_root}/src/pkg"
     let backup_path = "\{real_root}/backup.mbt"
     assert_true(
@@ -801,554 +800,54 @@ async test "sandbox preblocks common source-writing commands" {
         real_root,
       ),
     )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git checkout -- ."),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git checkout feature/foo"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git switch feature/foo"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git checkout --help"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git --help checkout"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git switch --help"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git restore --help"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy("if true; then git switch --help; fi"),
-        "if true; then git switch --help; fi",
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy("if true; then git --help checkout; fi"),
-        "if true; then git --help checkout; fi",
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git checkout -- notes.txt"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git checkout -- ':!*.txt'"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git checkout -- ':(exclude)*.txt'"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git checkout -- deleted_pkg"),
-          real_root,
-          Some(real_root),
-        ),
-        "\{real_root}/deleted_pkg",
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git checkout feature/foo -- main.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git restore deleted_pkg"),
-          real_root,
-          Some(real_root),
-        ),
-        "\{real_root}/deleted_pkg",
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git restore ':(top)moon.pkg'"),
-          real_root,
-          Some("\{real_root}/pkg"),
-        ),
-        "\{real_root}/moon.pkg",
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git restore ':(top)notes.txt'"),
-        real_root,
-        Some("\{real_root}/pkg"),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "git -C \{real_root}/pkg restore main.mbt",
+    // git apply / git am apply an EXTERNAL patch and stay pre-blocked (the only
+    // remaining git pre-block; on macOS the runtime sandbox covers them too).
+    for
+      patch_cmd in [
+        "git apply patch.diff", "git am patch.mbox", "git apply --cached patch.diff",
+        "git apply --index patch.diff",
+      ] {
+      assert_true(
+        is_some_path(
+          direct_source_tree_operation_target_for_root(
+            @shell_parse.parse_for_policy(patch_cmd),
+            real_root,
+            Some(real_root),
           ),
           real_root,
-          Some(real_root),
         ),
-        pkg_main_path,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy(
-          "git -C \{real_root}-external restore main.mbt",
-        ),
-        real_root,
-        Some(real_root),
       )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy(
-          "git -C \{real_root}-external switch feature/foo",
-        ),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git restore main.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git restore ':^*.txt'"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git restore -- ':/!*.txt'"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git restore -- ':(top,exclude)*.txt'"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git restore -- notes.txt ':!*.txt'"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "git --literal-pathspecs restore main.mbt",
-          ),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "git --no-optional-locks restore main.mbt",
-          ),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git restore --staged ."),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git restore --staged main.mbt"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git restore -S main.mbt"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "git restore --staged --worktree main.mbt",
-          ),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git restore -SW main.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git reset --hard"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git rm main.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git rm --cached main.mbt"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git rm -n main.mbt"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git mv main.mbt backup.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git mv -n main.mbt backup.mbt"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git clean -fd"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git clean -fdn"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git clean -e -n -fd"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git clean -fde -n"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git clean -fne ignored"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git clean --interactive"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git clean --dry-run"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git clean --exclude -n -fd"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git apply --check patch.diff"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git apply --stat --apply patch.diff"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git apply --cached patch.diff"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("git apply --index patch.diff"),
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    let git_restore_source_glob = "git restore *.mbt"
+    }
+    // git apply is also caught in the TooComplex text path (e.g. globbed patches).
+    let git_apply_glob = "git apply *.patch"
     assert_true(
       is_some_path(
         dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(git_restore_source_glob),
-          git_restore_source_glob,
+          @shell_parse.parse_for_policy(git_apply_glob),
+          git_apply_glob,
           real_root,
           Some(real_root),
         ),
         real_root,
       ),
     )
-    let git_restore_expanded_source_glob = "git restore src/*"
-    assert_true(
-      is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(git_restore_expanded_source_glob),
-          git_restore_expanded_source_glob,
+    // Recoverable git worktree subcommands write from the object store and are no
+    // longer pre-blocked (they run as trusted source writers instead).
+    for
+      recoverable_git in [
+        "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
+        "git restore main.mbt", "git reset --hard", "git clean -fd", "git rm main.mbt",
+        "git mv main.mbt backup.mbt", "git stash",
+      ] {
+      assert_true(
+        direct_source_tree_operation_target_for_root(
+          @shell_parse.parse_for_policy(recoverable_git),
           real_root,
           Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    let git_checkout_source_glob = "git checkout -- *.mbt"
-    assert_true(
-      is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(git_checkout_source_glob),
-          git_checkout_source_glob,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    let git_checkout_expanded_branch = "git checkout $branch"
-    assert_true(
-      is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(git_checkout_expanded_branch),
-          git_checkout_expanded_branch,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
-    let git_restore_staged_glob = "git restore --staged *.mbt"
-    assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(git_restore_staged_glob),
-        git_restore_staged_glob,
-        real_root,
-        Some(real_root),
+        )
+        is None,
       )
-      is None,
-    )
-    let git_restore_staged_expanded_glob = "git restore --staged src/*"
-    assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(git_restore_staged_expanded_glob),
-        git_restore_staged_expanded_glob,
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    let scoped_git_segments = "git restore --staged *.mbt && git apply --cached patch.diff"
-    assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(scoped_git_segments),
-        scoped_git_segments,
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
+    }
     let find_sed_source = "find \{real_root} -name '*.mbt' -exec sed -i '' 's/42/43/' {} +"
     assert_true(
       is_some_path(
@@ -1451,13 +950,14 @@ async test "sandbox preblocks common source-writing commands" {
         real_root,
       ),
     )
-    // The same xargs-utility gap applied to git source-tree operations.
-    let xargs_git_checkout = "echo *.mbt | xargs git checkout --"
+    // The same xargs-utility gap still applies to `git apply` (the one blocked
+    // git op); recoverable git subcommands are trusted and not pre-blocked.
+    let xargs_git_apply = "echo *.patch | xargs git apply"
     assert_true(
       is_some_path(
         dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(xargs_git_checkout),
-          xargs_git_checkout,
+          @shell_parse.parse_for_policy(xargs_git_apply),
+          xargs_git_apply,
           real_root,
           Some(real_root),
         ),
@@ -2470,6 +1970,39 @@ fn mode_for(cmd : String) -> SourceWriteMode {
     "/workspace",
     Some("/workspace"),
   )
+}
+
+///|
+test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
+  // Recoverable worktree subcommands run unsandboxed (trusted to write source):
+  // every write they make comes from git's own object store.
+  for
+    cmd in [
+      "git checkout -- main.mbt", "git checkout feature/foo", "git switch main",
+      "git restore main.mbt", "git restore --source=HEAD~1 main.mbt", "git reset --hard",
+      "git stash", "git stash pop", "git clean -fd", "git rm main.mbt", "git mv a.mbt b.mbt",
+      "cd pkg && git checkout -- main.mbt",
+    ] {
+    assert_true(mode_for(cmd) is TrustedSourceWrite)
+  }
+  // git apply / git am apply an EXTERNAL patch, so they stay sandboxed.
+  for cmd in ["git apply patch.diff", "git am patch.mbox"] {
+    assert_true(mode_for(cmd) is SourceReadOnly)
+  }
+  // Config/dir/exec global options or a custom environment could enable a smudge
+  // filter or merge driver, so they drop git out of the trusted path.
+  for
+    cmd in [
+      "git -c core.editor=x checkout -- .", "git -c filter.f.smudge=cmd checkout -- .",
+      "git --git-dir=/tmp/x checkout -- .", "git --exec-path=/tmp checkout -- .",
+      "FOO=bar git checkout -- .", "env GIT_CONFIG_COUNT=1 git checkout -- .",
+    ] {
+    assert_true(mode_for(cmd) is SourceReadOnly)
+  }
+  // Unknown / plumbing / read-only git is not granted trust (fail closed).
+  for cmd in ["git status", "git diff", "git checkout-index -a", "git co -- ."] {
+    assert_true(mode_for(cmd) is SourceReadOnly)
+  }
 }
 
 ///|

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -819,6 +819,17 @@ async test "sandbox preblocks common source-writing commands" {
         ),
       )
     }
+    // A store feeder is blocked unconditionally — not conditioned on the resolved
+    // cwd — so it cannot slip through with a cwd outside the workspace (e.g. a
+    // `git -C <workspace>` run from elsewhere).
+    assert_true(
+      direct_source_tree_operation_target_for_root(
+        @shell_parse.parse_for_policy("git apply patch.diff"),
+        real_root,
+        Some("\{real_root}-external"),
+      )
+      is Some(_),
+    )
     // git apply is also caught in the TooComplex text path (e.g. globbed patches).
     let git_apply_glob = "git apply *.patch"
     assert_true(
@@ -837,8 +848,7 @@ async test "sandbox preblocks common source-writing commands" {
     for
       recoverable_git in [
         "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
-        "git restore main.mbt", "git reset --hard", "git clean -fd", "git rm main.mbt",
-        "git stash",
+        "git restore main.mbt", "git reset --hard", "git rm main.mbt", "git stash",
       ] {
       assert_true(
         direct_source_tree_operation_target_for_root(
@@ -1981,17 +1991,17 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
     cmd in [
       "git checkout -- main.mbt", "git checkout feature/foo", "git switch main",
       "git restore main.mbt", "git restore --source=HEAD~1 main.mbt", "git reset --hard",
-      "git stash", "git stash pop", "git clean -fd", "git rm main.mbt", "cd pkg && git checkout -- main.mbt",
+      "git stash", "git stash pop", "git rm main.mbt", "cd pkg && git checkout -- main.mbt",
     ] {
     assert_true(mode_for(cmd) is TrustedSourceWrite)
   }
-  // External-patch / store-feeder git, and `mv` (which moves arbitrary worktree
-  // bytes onto the destination rather than reading the object store), stay
-  // sandboxed.
+  // External-patch / store-feeder git stays sandboxed, as do `mv` (moves arbitrary
+  // worktree bytes onto the destination, not the object store) and `clean`
+  // (deletes UNTRACKED files with no object-store copy — permanent).
   for
     cmd in [
       "git apply patch.diff", "git am patch.mbox", "git update-index --cacheinfo 100644,abc,main.mbt",
-      "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt",
+      "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt", "git clean -fd",
     ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -800,18 +800,19 @@ async test "sandbox preblocks common source-writing commands" {
         real_root,
       ),
     )
-    // git apply / git am apply an EXTERNAL patch and stay pre-blocked (the only
-    // remaining git pre-block; on macOS the runtime sandbox covers them too).
+    // Conservatively pre-blocked git: store feeders (external patch + plumbing),
+    // mv, non-dry-run clean, and reconfigured writers (-c filter / -C / --work-tree).
     for
-      patch_cmd in [
+      blocked_git in [
         "git apply patch.diff", "git am patch.mbox", "git apply --cached patch.diff",
         "git apply --index patch.diff", "git update-index --cacheinfo 100644,abc,main.mbt",
-        "git read-tree HEAD", "git fast-import",
+        "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt", "git clean -fd",
+        "git -c filter.f.smudge=cmd checkout -- .", "git -C /tmp/x checkout -- .",
       ] {
       assert_true(
         is_some_path(
           direct_source_tree_operation_target_for_root(
-            @shell_parse.parse_for_policy(patch_cmd),
+            @shell_parse.parse_for_policy(blocked_git),
             real_root,
             Some(real_root),
           ),
@@ -843,12 +844,13 @@ async test "sandbox preblocks common source-writing commands" {
         real_root,
       ),
     )
-    // Recoverable git worktree subcommands write from the object store and are no
-    // longer pre-blocked (they run as trusted source writers instead).
+    // Recoverable git worktree subcommands (and dry-run clean) are not pre-blocked;
+    // they run as trusted source writers, or harmlessly sandboxed.
     for
       recoverable_git in [
         "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
         "git restore main.mbt", "git reset --hard", "git rm main.mbt", "git stash",
+        "git clean -fdn", "git status",
       ] {
       assert_true(
         direct_source_tree_operation_target_for_root(

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -807,7 +807,7 @@ async test "sandbox preblocks common source-writing commands" {
         "git apply patch.diff", "git am patch.mbox", "git apply --cached patch.diff",
         "git apply --index patch.diff", "git update-index --cacheinfo 100644,abc,main.mbt",
         "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt", "git clean -fd",
-        "git -c filter.f.smudge=cmd checkout -- .", "git -C /tmp/x checkout -- .",
+        "git clean -e -n -fd", "git -c filter.f.smudge=cmd checkout -- .", "git -C /tmp/x checkout -- .",
       ] {
       assert_true(
         is_some_path(
@@ -850,7 +850,7 @@ async test "sandbox preblocks common source-writing commands" {
       recoverable_git in [
         "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
         "git restore main.mbt", "git reset --hard", "git rm main.mbt", "git stash",
-        "git clean -fdn", "git status",
+        "git clean -fdn", "git status", "git apply --check patch.diff", "git apply --stat patch.diff",
       ] {
       assert_true(
         direct_source_tree_operation_target_for_root(

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -801,13 +801,16 @@ async test "sandbox preblocks common source-writing commands" {
       ),
     )
     // Conservatively pre-blocked git: store feeders (external patch + plumbing),
-    // mv, non-dry-run clean, and reconfigured writers (-c filter / -C / --work-tree).
+    // mv, non-dry-run clean, reconfigured writers (-c filter / -C / --work-tree /
+    // custom env), and checkout/restore forms that can clobber untracked source.
     for
       blocked_git in [
         "git apply patch.diff", "git am patch.mbox", "git apply --cached patch.diff",
         "git apply --index patch.diff", "git update-index --cacheinfo 100644,abc,main.mbt",
         "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt", "git clean -fd",
         "git clean -e -n -fd", "git -c filter.f.smudge=cmd checkout -- .", "git -C /tmp/x checkout -- .",
+        "git checkout -f other", "git restore --source=HEAD~1 -- main.mbt", "GIT_DIR=/tmp/x git checkout -- main.mbt",
+        "env GIT_WORK_TREE=. git restore main.mbt",
       ] {
       assert_true(
         is_some_path(
@@ -1992,8 +1995,8 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
   for
     cmd in [
       "git checkout -- main.mbt", "git checkout feature/foo", "git switch main",
-      "git restore main.mbt", "git restore --source=HEAD~1 main.mbt", "git reset --hard",
-      "git stash", "git stash pop", "git rm main.mbt", "cd pkg && git checkout -- main.mbt",
+      "git restore main.mbt", "git reset --hard", "git stash", "git stash pop", "git rm main.mbt",
+      "cd pkg && git checkout -- main.mbt",
     ] {
     assert_true(mode_for(cmd) is TrustedSourceWrite)
   }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -810,7 +810,8 @@ async test "sandbox preblocks common source-writing commands" {
         "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt", "git clean -fd",
         "git clean -e -n -fd", "git -c filter.f.smudge=cmd checkout -- .", "git -C /tmp/x checkout -- .",
         "git checkout -f other", "git restore --source=HEAD~1 -- main.mbt", "GIT_DIR=/tmp/x git checkout -- main.mbt",
-        "env GIT_WORK_TREE=. git restore main.mbt",
+        "env GIT_WORK_TREE=. git restore main.mbt", "git checkout HEAD~1 -- main.mbt",
+        "git restore -s HEAD~1 main.mbt",
       ] {
       assert_true(
         is_some_path(
@@ -846,6 +847,18 @@ async test "sandbox preblocks common source-writing commands" {
         ),
         real_root,
       ),
+    )
+    // A custom-env object-store writer is caught in the TooComplex text path too,
+    // even though the env assignment precedes the `git` word.
+    let git_env_glob = "GIT_DIR=/tmp/x git checkout -- *.mbt"
+    assert_true(
+      dynamic_source_tree_operation_target(
+        @shell_parse.parse_for_policy(git_env_glob),
+        git_env_glob,
+        real_root,
+        Some(real_root),
+      )
+      is Some(_),
     )
     // Recoverable git worktree subcommands (and dry-run clean) are not pre-blocked;
     // they run as trusted source writers, or harmlessly sandboxed.

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -805,7 +805,8 @@ async test "sandbox preblocks common source-writing commands" {
     for
       patch_cmd in [
         "git apply patch.diff", "git am patch.mbox", "git apply --cached patch.diff",
-        "git apply --index patch.diff",
+        "git apply --index patch.diff", "git update-index --cacheinfo 100644,abc,main.mbt",
+        "git read-tree HEAD", "git fast-import",
       ] {
       assert_true(
         is_some_path(
@@ -837,7 +838,7 @@ async test "sandbox preblocks common source-writing commands" {
       recoverable_git in [
         "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
         "git restore main.mbt", "git reset --hard", "git clean -fd", "git rm main.mbt",
-        "git mv main.mbt backup.mbt", "git stash",
+        "git stash",
       ] {
       assert_true(
         direct_source_tree_operation_target_for_root(
@@ -1980,22 +1981,29 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
     cmd in [
       "git checkout -- main.mbt", "git checkout feature/foo", "git switch main",
       "git restore main.mbt", "git restore --source=HEAD~1 main.mbt", "git reset --hard",
-      "git stash", "git stash pop", "git clean -fd", "git rm main.mbt", "git mv a.mbt b.mbt",
-      "cd pkg && git checkout -- main.mbt",
+      "git stash", "git stash pop", "git clean -fd", "git rm main.mbt", "cd pkg && git checkout -- main.mbt",
     ] {
     assert_true(mode_for(cmd) is TrustedSourceWrite)
   }
-  // git apply / git am apply an EXTERNAL patch, so they stay sandboxed.
-  for cmd in ["git apply patch.diff", "git am patch.mbox"] {
+  // External-patch / store-feeder git, and `mv` (which moves arbitrary worktree
+  // bytes onto the destination rather than reading the object store), stay
+  // sandboxed.
+  for
+    cmd in [
+      "git apply patch.diff", "git am patch.mbox", "git update-index --cacheinfo 100644,abc,main.mbt",
+      "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt",
+    ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }
-  // Config/dir/exec global options or a custom environment could enable a smudge
-  // filter or merge driver, so they drop git out of the trusted path.
+  // Reconfiguring global options (config/dir/exec/cwd/worktree) or a custom
+  // environment could repoint git or enable a filter/merge driver, so they drop
+  // git out of the trusted path.
   for
     cmd in [
       "git -c core.editor=x checkout -- .", "git -c filter.f.smudge=cmd checkout -- .",
       "git --git-dir=/tmp/x checkout -- .", "git --exec-path=/tmp checkout -- .",
-      "FOO=bar git checkout -- .", "env GIT_CONFIG_COUNT=1 git checkout -- .",
+      "git -C /tmp/x checkout -- .", "git --work-tree=/tmp/x checkout -- .", "FOO=bar git checkout -- .",
+      "env GIT_CONFIG_COUNT=1 git checkout -- .",
     ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -832,39 +832,31 @@ async test "shell sandbox preblocks masked mv backup source moves" {
 
 ///|
 #cfg(not(platform="windows"))
-async test "shell sandbox preblocks masked git source mutations" {
-  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-git-masked-source-", dir => {
+async test "shell sandbox preblocks masked git apply" {
+  @vfs.with_tmpdir(prefix="openseek-shell-sandbox-git-apply-source-", dir => {
     @fs.write_file(
       "\{dir}/main.mbt",
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
-    let rm_result = run_shell_in_workspace(dir, {
-      "cmd": "git rm main.mbt 2>/dev/null || true",
+    // `git apply` applies an EXTERNAL patch — arbitrary content — so it stays
+    // pre-blocked before execution even when the failure is masked. Recoverable
+    // git worktree subcommands (checkout/restore/reset/rm/mv/...) are no longer
+    // blocked; they run as trusted source writers.
+    let result = run_shell_in_workspace(dir, {
+      "cmd": "git apply change.patch 2>/dev/null || true",
       "cwd": dir,
     })
-    guard rm_result is Respond(rm_output) else { fail("expected Respond") }
-    assert_true(rm_output.is_error)
-    assert_true(rm_output.content.contains("source tree operation is blocked"))
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(
-      rm_output.content.contains("source file writes from shell are blocked"),
+      output.content.contains("source file writes from shell are blocked"),
     )
     assert_eq(
       @fs.read_file("\{dir}/main.mbt").text(),
       "pub fn answer() -> Int { 42 }\n",
     )
-    let mv_result = run_shell_in_workspace(dir, {
-      "cmd": "git mv main.mbt backup.mbt 2>/dev/null || true",
-      "cwd": dir,
-    })
-    guard mv_result is Respond(mv_output) else { fail("expected Respond") }
-    assert_true(mv_output.is_error)
-    assert_true(mv_output.content.contains("source tree operation is blocked"))
-    assert_true(
-      mv_output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(@fs.exists("\{dir}/main.mbt"))
-    assert_false(@fs.exists("\{dir}/backup.mbt"))
   })
 }
 
@@ -1824,24 +1816,39 @@ async test "shell preblocks looped sed source rewrites through path list" {
 
 ///|
 #cfg(not(platform="windows"))
-async test "shell preblocks git source rollback" {
+async test "shell allows recoverable git worktree rollback" {
   @vfs.with_tmpdir(prefix="openseek-shell-git-rollback-", dir => {
     @fs.write_file(
       "\{dir}/main.mbt",
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
+    // Build a tiny repo with a committed main.mbt. init/config/add/commit only
+    // touch `.git`, so they run (sandboxed) without being blocked.
+    let setup = run_shell_in_workspace(dir, {
+      "cmd": "git init -q && git config user.email a@b.c && git config user.name t && git add main.mbt && git commit -q -m init",
+      "cwd": dir,
+    })
+    guard setup is Respond(setup_output) else { fail("expected Respond") }
+    assert_false(
+      setup_output.content.contains("source file writes from shell are blocked"),
+    )
+    // Dirty the tracked source, then discard the change with `git checkout` — a
+    // trusted, recoverable worktree write that now runs unsandboxed and succeeds.
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn answer() -> Int { 999 }\n",
+      create_mode=CreateOrTruncate,
+    )
     let result = run_shell_in_workspace(dir, {
-      "cmd": "git checkout -- .",
+      "cmd": "git checkout -- main.mbt",
       "cwd": dir,
     })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(
+    assert_false(output.is_error)
+    assert_false(
       output.content.contains("source file writes from shell are blocked"),
     )
-    assert_true(output.content.contains("line-anchored"))
-    assert_false(output.content.contains("`write`"))
     assert_eq(
       @fs.read_file("\{dir}/main.mbt").text(),
       "pub fn answer() -> Int { 42 }\n",


### PR DESCRIPTION
Relaxes git so the agent can use it normally, without reopening the source-overwrite loophole — and replaces the ~600-line heuristic git-detection engine with a small, default-deny policy in a focused internal package. Hardened across 7 rounds of codex review + self-review.

## The policy — two layers

A git command passes two independent gates:

### 1. Sandbox launch decision — a default-deny **whitelist** (`trusted_git_command_class`)
A git command runs **unsandboxed** (allowed to write workspace source) *only* if **all** hold:
- subcommand ∈ `{checkout, switch, restore, reset, stash, rm}` — every change these make either materializes content from git's **own object store** (HEAD/index/commit/tree/stash) or removes a tracked file recoverable from it (`rm`);
- **not reconfigured** — no config/dir/exec/cwd/worktree global option (`-c`, `--config-env`, `--git-dir`, `--namespace`, `--exec-path`, `-C`, `--work-tree`) and **no custom environment** (`GIT_CONFIG_*`/`GIT_DIR`/`GIT_WORK_TREE`, `env … git`);
- (for `checkout`/`switch`/`restore`) **not a clobber form** — no `-f`/`--force` (incl. clustered `-fB`), `--overlay`/`--ours`/`--theirs`, no explicit source tree-ish (`--source`/`-s`), and no positional tree-ish before `--` or `--pathspec-from-file`.

**Everything else runs under `sandbox-exec`**, which makes workspace source read-only — the kernel denies the write. So the security model is a whitelist: on macOS the kernel protects source from *everything* except the trusted set.

### 2. Static pre-block — a conservative **denylist** for the known-unsafe (`@git_policy.should_preblock`)
Runs **before execution, cross-platform** (independent of the runtime sandbox), and blocks the git that mutates source but is *not* a recoverable object-store write, with a "use `edit`, don't work around this" message:
- store feeders (`apply`/`am`; `update-index`, `read-tree`, `fast-import`) — they place content from *outside* the object store, which a later trusted `checkout` would materialize. Read-only `apply --check`/`--stat` is allowed;
- `mv` (moves arbitrary worktree bytes); non-dry-run `clean` (permanently deletes untracked files);
- reconfigured writers and the clobber `checkout`/`restore` forms above.

**Why both:** the kernel sandbox (layer 1) is the sound enforcement but is **macOS-only**; the static pre-block (layer 2) is the **only** guard on Linux/Windows and gives a friendlier error than the kernel's raw denial. The pre-block is a *denylist* because a pure whitelist there would require enumerating every safe read-only git subcommand.

## Implementation
- New internal package `agent_tool/shell/internal/git_policy` holds the **pure git command-line grammar + classification** (no fs/workspace/shell-parse deps, own black-box tests): `parse`, `should_preblock`/`text_should_preblock`, `subcommand_writes_from_object_store`, `global_option_reconfigures`, `text_invocation_writes_from_object_store`.
- `sandbox.mbt` keeps only the glue (`TrustedCommandClass` wiring, workspace-path target, custom-env/text tokenization). Deletes `source_tree_git_target` + ~31 per-subcommand/pathspec helpers.

## Residuals (documented — guardrail, not a hard boundary)
- **Object-store plumbing**: while `.git` is writable, a determined sequence (`replace`, `filter-branch --tree-filter`, `commit-tree`+`mktree`) can seed the store for a later trusted checkout.
- **Branch switch + git-ignored source**: a bare `git checkout <branch>` / `git switch <branch>` overwrites a *git-ignored* untracked file the target branch tracks (git's default behavior, suppressed by `--no-overwrite-ignore`). Branch switch is kept trusted (a core operation); for MoonBit source this requires a `.gitignore`d `.mbt`, which is near-zero in practice.

## Validation
`moon check`/`fmt` clean, `moon info` shows only `git_policy`'s `.mbti`, `moon test agent_tool/shell agent_tool/shell/internal/git_policy` = **112/112**. CI green (nightly + stable). The block message tells the model the practice (source edits go through `edit`) and not to work around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)