### PR TITLE
feat(viz): synthesize a `generated_diff` for edit/multi_edit args

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -382,7 +382,7 @@ fn tool_call_view(
   }
   @html.details(class=cls) <| [
     @html.summary(class="tool-call-name") <| name_row,
-    render_args_friendly(call.arguments),
+    render_args_friendly(call.name, call.arguments),
     @html.pre(class="tool-call-args tool-call-args-original") <| original,
   ]
 }
@@ -394,10 +394,14 @@ fn tool_call_view(
 /// the pretty-printed JSON (in the same hidden-on-toggle block) when the arguments
 /// are not a JSON object — a bare value, an array, or text the model emitted that
 /// does not parse.
-fn render_args_friendly(raw : String) -> @html.Html {
+fn render_args_friendly(tool_name : String, raw : String) -> @html.Html {
   let json = @json.parse(raw) catch {
     _ => return @html.pre(class="tool-call-args tool-call-args-rendered") <| raw
   }
+  // For the edit tools, synthesize a `generated_diff` field so the change reads
+  // as a diff without hunting through separate old_string / new_string fields.
+  // The original fields are kept; the raw JSON (Original toggle) is untouched.
+  let json = augment_with_diffs(tool_name, json)
   match json {
     Object(fields) if !fields.is_empty() => {
       let rows : Array[@html.Html] = [
@@ -418,10 +422,127 @@ fn render_args_friendly(raw : String) -> @html.Html {
 /// single-line value inline. Non-string scalars render inline; nested arrays and
 /// objects keep their JSON form, which is rare for tool arguments.
 fn arg_field(key : String, value : Json) -> @html.Html {
+  // A synthesized `generated_diff` string renders as a colored diff block; every
+  // other field uses the generic recursive rendering.
+  let value_html = match value {
+    String(text) if key == "generated_diff" => diff_block(text)
+    _ => render_value(value)
+  }
   @html.div(class="arg-field") <| [
     @html.span(class="arg-key") <| key,
-    render_value(value),
+    value_html,
   ]
+}
+
+///|
+/// Add a synthesized `generated_diff` field to the arguments of the edit tools,
+/// leaving every other tool (and the raw JSON) untouched. `edit` gains one
+/// top-level diff; `multi_edit` gains one per edit inside its `edits` array. The
+/// parsed JSON is mutated in place — it is a throwaway parse used only to render
+/// the friendly view, never the stored arguments.
+fn augment_with_diffs(tool_name : String, json : Json) -> Json {
+  match tool_name {
+    "edit" => add_edit_diff(json)
+    "multi_edit" =>
+      match json {
+        Object(fields) => {
+          if fields.get("edits") is Some(Array(items)) {
+            for item in items {
+              add_edit_diff(item) |> ignore
+            }
+          }
+          json
+        }
+        _ => json
+      }
+    _ => json
+  }
+}
+
+///|
+/// Add a `generated_diff` field to one edit-shaped object (in place), derived
+/// from its `old_string` / `new_string`. Leaves the object unchanged when those
+/// are absent, not strings, or equal (a no-op the tool would reject anyway).
+fn add_edit_diff(json : Json) -> Json {
+  guard json is Object(fields) else { return json }
+  guard fields.get("old_string") is Some(String(old)) else { return json }
+  guard fields.get("new_string") is Some(String(new)) else { return json }
+  if old != new {
+    fields["generated_diff"] = Json::string(generate_diff(old, new))
+  }
+  json
+}
+
+///|
+/// A line-oriented diff of `old` → `new`: shared leading/trailing lines are
+/// context (`  `), the differing middle is removed (`- `) then added (`+ `). An
+/// insertion (empty `old`) is all `+` lines; a deletion (empty `new`) all `-`.
+fn generate_diff(old : String, new : String) -> String {
+  if old == "" {
+    return prefix_lines(new, "+ ")
+  }
+  if new == "" {
+    return prefix_lines(old, "- ")
+  }
+  let old_lines = string_lines(old)
+  let new_lines = string_lines(new)
+  let n = old_lines.length()
+  let m = new_lines.length()
+  let mut pre = 0
+  while pre < n && pre < m && old_lines[pre] == new_lines[pre] {
+    pre += 1
+  }
+  let mut suf = 0
+  while suf < n - pre &&
+        suf < m - pre &&
+        old_lines[n - 1 - suf] == new_lines[m - 1 - suf] {
+    suf += 1
+  }
+  let out : Array[String] = []
+  for i in 0..<pre {
+    out.push("  " + old_lines[i])
+  }
+  for i in pre..<(n - suf) {
+    out.push("- " + old_lines[i])
+  }
+  for i in pre..<(m - suf) {
+    out.push("+ " + new_lines[i])
+  }
+  for i in (n - suf)..<n {
+    out.push("  " + old_lines[i])
+  }
+  out.join("\n")
+}
+
+///|
+/// Split `text` into lines on `\n`.
+fn string_lines(text : String) -> Array[String] {
+  text.split("\n").map(line => line.to_owned()).collect()
+}
+
+///|
+/// Prefix every line of `text` with `marker` (for all-added / all-removed diffs).
+fn prefix_lines(text : String, marker : String) -> String {
+  string_lines(text).map(line => marker + line).join("\n")
+}
+
+///|
+/// Render a synthesized diff string as colored lines: `+ ` added (green), `- `
+/// removed (red), anything else context (muted). Shown verbatim, monospace.
+fn diff_block(text : String) -> @html.Html {
+  let lines : Array[@html.Html] = []
+  for raw in text.split("\n") {
+    let line = raw.to_owned()
+    let cls = if line.has_prefix("+ ") {
+      "diff-add"
+    } else if line.has_prefix("- ") {
+      "diff-del"
+    } else {
+      "diff-ctx"
+    }
+    lines.push(@html.div(class=cls) <| line)
+  }
+  @html.div(class="arg-value diff-block") <| lines
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -236,6 +236,76 @@ test "an array-of-objects argument renders one item per element" {
 }
 
 ///|
+test "edit args gain a synthesized generated_diff, keeping the originals" {
+  // The original old_string/new_string rows are kept AND a generated_diff field
+  // is added, rendered as a colored diff (- removed / + added).
+  let session = @agent_session.Session(SessionId("ed"), system_prompt="").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="e1",
+          name="edit",
+          arguments="{\"path\":\"lib/parser.mbt\",\"old_string\":\"args.length()\",\"new_string\":\"args.len()\",\"start_line\":12}",
+        ),
+      ]),
+    ),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  // Originals kept.
+  assert_true(html.contains("class=\"arg-key\">old_string"))
+  assert_true(html.contains("class=\"arg-key\">new_string"))
+  // New synthesized field, shown as a diff.
+  assert_true(html.contains("class=\"arg-key\">generated_diff"))
+  assert_true(html.contains("class=\"diff-del\">- args.length()"))
+  assert_true(html.contains("class=\"diff-add\">+ args.len()"))
+  // The raw JSON (Original toggle) is untouched — no synthesized field there.
+  assert_false(html.contains("\\\"generated_diff\\\""))
+}
+
+///|
+test "multi_edit gains a generated_diff per edit" {
+  let session = @agent_session.Session(SessionId("med"), system_prompt="").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="m1",
+          name="multi_edit",
+          arguments="{\"edits\":[{\"file\":\"a.mbt\",\"old_string\":\"foo\",\"new_string\":\"bar\",\"start_line\":1},{\"file\":\"b.mbt\",\"old_string\":\"x\",\"new_string\":\"y\",\"start_line\":2}]}",
+        ),
+      ]),
+    ),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  // One diff per edit.
+  assert_eq(occurrences(html, "class=\"arg-key\">generated_diff"), 2)
+  assert_true(html.contains("class=\"diff-del\">- foo"))
+  assert_true(html.contains("class=\"diff-add\">+ bar"))
+  assert_true(html.contains("class=\"diff-del\">- x"))
+  assert_true(html.contains("class=\"diff-add\">+ y"))
+}
+
+///|
+test "an insertion edit diffs as added-only lines" {
+  // Empty old_string → the generated_diff is all `+` lines, shown verbatim
+  // across real newlines, with no removed side.
+  let session = @agent_session.Session(SessionId("insd"), system_prompt="").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="i1",
+          name="edit",
+          arguments="{\"path\":\"a.mbt\",\"old_string\":\"\",\"new_string\":\"let x = 1\\nlet y = 2\",\"start_line\":5}",
+        ),
+      ]),
+    ),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("class=\"diff-add\">+ let x = 1"))
+  assert_true(html.contains("class=\"diff-add\">+ let y = 2"))
+  assert_false(html.contains("class=\"diff-del\""))
+}
+
+///|
 test "a failed tool call is tagged so errors-only keeps its call card" {
   // error_tool_session: c1 (shell) failed. Its call gets `tool-call-failed`, the
   // hook the errors-only stylesheet uses to keep the assistant card holding the

--- a/web/index.html
+++ b/web/index.html
@@ -22,6 +22,7 @@
       --assistant: #1a8f63;
       --tool: #8a6d10;
       --error: #c2334a;
+      --added: #1a8f63;
       --runtime: #6d4fb0;
       --summary: #b5701f;
       --terminal: #2b7e9e;
@@ -47,6 +48,7 @@
       --assistant: #36c08a;
       --tool: #c9a227;
       --error: #e0556b;
+      --added: #36c08a;
       --runtime: #9a7bd6;
       --summary: #d98a3a;
       --terminal: #5fa8c7;
@@ -73,6 +75,7 @@
         --assistant: #36c08a;
         --tool: #c9a227;
         --error: #e0556b;
+        --added: #36c08a;
         --runtime: #9a7bd6;
         --summary: #d98a3a;
         --terminal: #5fa8c7;
@@ -371,6 +374,17 @@
       margin: 3px 0; padding: 1px 0 1px 8px;
       border-left: 2px solid var(--border);
     }
+
+    /* synthesized `generated_diff`: colored per-line diff (+ added, - removed) */
+    .diff-block {
+      margin: 3px 0 0; padding: 4px 8px;
+      background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px;
+      font-family: ui-monospace, monospace; font-size: 12px;
+    }
+    .diff-add, .diff-del, .diff-ctx { white-space: pre-wrap; word-break: break-word; }
+    .diff-add { color: var(--added, #1a8f63); }
+    .diff-del { color: var(--error); }
+    .diff-ctx { color: var(--muted); }
 
     /* tool-args toggle: friendly form by default, raw JSON under .show-original */
     .tool-call-args-original { display: none; }


### PR DESCRIPTION
## What

**Builds on #277** (generic nested-arg rendering, merged). When the viz renders an `edit` or `multi_edit` tool call's JSON arguments, it now **synthesizes a `generated_diff` field** from the edit's `old_string`/`new_string` and shows it *alongside* the original fields.

- **Keep the original, add new stuff:** `old_string`/`new_string`/`start_line`/… all still render; `generated_diff` is added next to them. The raw JSON behind the **"Original"** toggle is untouched.
- `edit` gains **one** top-level diff; `multi_edit` gains **one per edit** inside its `edits` array.
- The diff is line-oriented (shared leading/trailing lines as context, the differing middle as `- removed` / `+ added`; an insertion is all `+`, a deletion all `-`) and renders as a **colored block**.

## Why this shape

Reusing #277's generic recursive renderer keeps this tiny: the field is injected into the *parsed* args (a throwaway parse used only for the friendly view), and any field named `generated_diff` renders as a diff — **no per-tool card machinery, no tool-specific gate on the renderer**. Works for both edit tools by construction.

> This replaces the earlier bespoke edit-card version of this PR with the `generated_diff` approach you asked for.

## Files

- `viz/view.mbt` — `render_args_friendly` threads the tool name; `augment_with_diffs` / `add_edit_diff` / `generate_diff` / `string_lines` / `prefix_lines`; a `diff_block` render for the `generated_diff` key.
- `web/index.html` — `.diff-*` styles + `--added` theme var.
- `viz/viz_test.mbt` — edit, per-edit multi_edit, and insertion tests (raw JSON stays untouched).

## Tests

`viz` + `cmd/viz_app` **51/51** (js); bundle builds; `moon fmt` clean; no `.mbti` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
