### PR TITLE
feat(viz): connect each tool call to its result in the log view

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -60,11 +60,12 @@ pub fn render_notices(parsed : @session_log.ParsedLog) -> @html.Html {
 fn render_raw(session : @agent_session.Session) -> @html.Html {
   let briefs = tool_call_briefs(session)
   let failed = raw_failed_call_ids(session)
+  let tags = raw_pair_tags(session)
   let step_labels = agent_step_labels(session)
   let turns = group_turns(session.events())
   let blocks : Array[@html.Html] = []
   for index, turn in turns {
-    blocks.push(turn_block(index + 1, turn, briefs, failed, step_labels))
+    blocks.push(turn_block(index + 1, turn, briefs, failed, tags, step_labels))
   }
   if blocks.is_empty() {
     return empty_state("This session has no events yet.")
@@ -162,6 +163,7 @@ fn turn_block(
   turn : Array[@agent_session.SessionEvent],
   briefs : Map[String, String],
   failed : Map[String, Unit],
+  tags : Map[String, Int],
   step_labels : Map[Int, String],
 ) -> @html.Html {
   // Offsets are relative to the turn's first stamped event: for reading a
@@ -175,6 +177,7 @@ fn turn_block(
         time=offset_label(base, event),
         briefs,
         failed,
+        tags,
         step_label=step_labels.get(event.sequence()).unwrap_or(""),
       )
     }
@@ -292,6 +295,7 @@ fn event_card(
   time~ : String,
   briefs : Map[String, String],
   failed : Map[String, Unit],
+  tags : Map[String, Int],
   step_label~ : String,
 ) -> @html.Html {
   let seq = event.sequence()
@@ -299,8 +303,8 @@ fn event_card(
     User(message) =>
       card("user", "User", seq, time~, [text_block(message.content())])
     Assistant(message) =>
-      assistant_card(seq, time, message, briefs, failed, step_label~)
-    Tool(result) => tool_card(seq, time, result)
+      assistant_card(seq, time, message, briefs, failed, tags, step_label~)
+    Tool(result) => tool_card(seq, time, result, tags)
     Runtime(notice) =>
       card("runtime", "Runtime notice", seq, time~, [
         text_block(notice.content()),
@@ -317,6 +321,7 @@ fn assistant_card(
   message : @agent_session.AssistantMessage,
   briefs : Map[String, String],
   failed : Map[String, Unit],
+  tags : Map[String, Int],
   step_label~ : String,
 ) -> @html.Html {
   let body : Array[@html.Html] = []
@@ -335,7 +340,7 @@ fn assistant_card(
   let calls = message.tool_calls()
   if !calls.is_empty() {
     let call_views : Array[@html.Html] = [
-      for call in calls => tool_call_view(call, briefs, failed)
+      for call in calls => tool_call_view(call, briefs, failed, tags)
     ]
     body.push(@html.div(class="tool-calls") <| call_views)
   }
@@ -361,6 +366,7 @@ fn tool_call_view(
   call : @deepseek.ToolCall,
   briefs : Map[String, String],
   failed : Map[String, Unit],
+  tags : Map[String, Int],
 ) -> @html.Html {
   let name_row : Array[@html.Html] = [
     @html.text("→ "),
@@ -369,6 +375,19 @@ fn tool_call_view(
   if briefs.get(call.id) is Some(brief) && !brief.trim().is_empty() {
     name_row.push(@html.span(class="tool-call-brief") <| " · \{brief}")
   }
+  // When this call forms an unambiguous pair with a result, tag it `call N` and
+  // link forward to that result's card; the same number labels the result.
+  let pair = tags.get(call.id)
+  if pair is Some(n) {
+    name_row.push(
+      pair_link(
+        n,
+        href="#\{tool_result_anchor(n)}",
+        title="Jump to this call's result (call \{n})",
+      ),
+    )
+  }
+  let anchor = pair.map(n => tool_call_anchor(n))
   let cls = if failed.contains(call.id) {
     "tool-call tool-call-failed"
   } else {
@@ -376,11 +395,11 @@ fn tool_call_view(
   }
   let original = pretty_json(call.arguments)
   if is_blank_args(original) {
-    return @html.div(class=cls) <| [
+    return @html.div(id?=anchor, class=cls) <| [
       @html.div(class="tool-call-name") <| name_row,
     ]
   }
-  @html.details(class=cls) <| [
+  @html.details(id?=anchor, class=cls) <| [
     @html.summary(class="tool-call-name") <| name_row,
     render_args_friendly(call.arguments),
     @html.pre(class="tool-call-args tool-call-args-original") <| original,
@@ -520,6 +539,7 @@ fn tool_card(
   seq : Int,
   time : String,
   result : @agent_session.ToolResult,
+  tags : Map[String, Int],
 ) -> @html.Html {
   let is_error = result.is_error()
   let kind = if is_error { "tool error" } else { "tool" }
@@ -533,8 +553,26 @@ fn tool_card(
   } else {
     @html.nothing
   }
-  @html.details(class="card \{kind}") <| [
-    @html.summary(class="card-label") <| card_head(label, seq, time~, flag~),
+  // Pair this result back to the call that produced it (same `call N` tag).
+  let pair = tags.get(result.tool_call_id())
+  let link = match pair {
+    Some(n) =>
+      pair_link(
+        n,
+        href="#\{tool_call_anchor(n)}",
+        title="Jump to the originating call (call \{n})",
+      )
+    None => @html.nothing
+  }
+  let anchor = pair.map(n => tool_result_anchor(n))
+  @html.details(id?=anchor, class="card \{kind}") <| [
+    @html.summary(class="card-label") <| card_head(
+      label,
+      seq,
+      time~,
+      flag~,
+      link~,
+    ),
     @html.div(class="card-body") <| [
       text_block(result.content()),
     ],
@@ -590,6 +628,7 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
   // brief would caption a healed/compacted call with a result the model never
   // saw. The raw view, which shows every event, uses all briefs.
   let briefs = model_tool_call_briefs(messages, tool_results)
+  let tags = model_pair_tags(messages)
   let cards : Array[@html.Html] = [
     for index, message in messages => {
       let time = if index < time_labels.length() {
@@ -602,7 +641,15 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
       } else {
         ""
       }
-      message_card(message, tool_results, failed, briefs, time~, step_label~)
+      message_card(
+        message,
+        tool_results,
+        failed,
+        briefs,
+        tags,
+        time~,
+        step_label~,
+      )
     }
   ]
   if cards.is_empty() {
@@ -836,6 +883,106 @@ fn raw_failed_call_ids(session : @agent_session.Session) -> Map[String, Unit] {
   ids
 }
 
+// ---- tool call ↔ result pairing --------------------------------------------
+
+///|
+/// A stable 1-based "pair number" for each tool call, so the view can show the
+/// same `call N` chip on a tool call and on its result and cross-link the two by
+/// DOM anchor — the whole point being that one assistant turn can emit several
+/// tool calls and, without this, the separate result cards read only as `Tool
+/// result · <name>` with no visible tie back to which call produced them.
+///
+/// A number is assigned only to an id that forms an unambiguous 1:1 pair in the
+/// rendered view: it must be non-empty and appear exactly once among the calls
+/// AND exactly once among the results. That deliberately skips empty ids (a
+/// streaming glitch can leave `id=""`), duplicate ids, orphan results (a result
+/// with no matching call), and dangling calls (a call with no result) — so a chip
+/// never links to a missing anchor and no DOM id is ever emitted twice. Numbers
+/// run in call order for readability.
+fn assign_pair_tags(
+  call_ids : Array[String],
+  result_ids : Array[String],
+) -> Map[String, Int] {
+  let call_counts : Map[String, Int] = Map([])
+  for id in call_ids {
+    call_counts.set(id, call_counts.get(id).unwrap_or(0) + 1)
+  }
+  let result_counts : Map[String, Int] = Map([])
+  for id in result_ids {
+    result_counts.set(id, result_counts.get(id).unwrap_or(0) + 1)
+  }
+  let tags : Map[String, Int] = Map([])
+  let mut next = 1
+  // A call_count of 1 means the id occurs exactly once in `call_ids`, so the loop
+  // reaches each tagged id once and assigns it a unique number in call order.
+  for id in call_ids {
+    if id != "" &&
+      call_counts.get(id).unwrap_or(0) == 1 &&
+      result_counts.get(id).unwrap_or(0) == 1 {
+      tags.set(id, next)
+      next += 1
+    }
+  }
+  tags
+}
+
+///|
+/// Pair numbers for the raw view, drawn from every durable event it renders.
+fn raw_pair_tags(session : @agent_session.Session) -> Map[String, Int] {
+  let call_ids : Array[String] = []
+  let result_ids : Array[String] = []
+  for event in session.events() {
+    match event.item() {
+      Assistant(message) =>
+        for call in message.tool_calls() {
+          call_ids.push(call.id)
+        }
+      Tool(result) => result_ids.push(result.tool_call_id())
+      _ => ()
+    }
+  }
+  assign_pair_tags(call_ids, result_ids)
+}
+
+///|
+/// Pair numbers for the model view, drawn from the projected messages it renders
+/// (so a healed synthetic tool message is a valid result partner, and a call
+/// compacted away contributes nothing). Only the structural id feeds this — the
+/// error flag, tool name, and brief still come solely through `model_shown_result`.
+fn model_pair_tags(messages : Array[@deepseek.ChatMessage]) -> Map[String, Int] {
+  let call_ids : Array[String] = []
+  let result_ids : Array[String] = []
+  for message in messages {
+    for call in message.tool_calls {
+      call_ids.push(call.id)
+    }
+    if message.role is Tool(id) {
+      result_ids.push(id)
+    }
+  }
+  assign_pair_tags(call_ids, result_ids)
+}
+
+///|
+/// DOM anchor id for a tool call, keyed by pair number.
+fn tool_call_anchor(n : Int) -> String {
+  "tool-call-\{n}"
+}
+
+///|
+/// DOM anchor id for a tool result, keyed by pair number.
+fn tool_result_anchor(n : Int) -> String {
+  "tool-result-\{n}"
+}
+
+///|
+/// The `call N` chip shown on both a tool call and its result. It is an anchor
+/// that jumps to its partner (`href`), so clicking the chip on a call scrolls to
+/// its result card and vice versa; `title` states the direction.
+fn pair_link(n : Int, href~ : String, title~ : String) -> @html.Html {
+  @html.a(class="tool-link", href~, title~) <| "call \{n}"
+}
+
 ///|
 /// Ids of tool calls whose result the model view both showed and saw fail (see
 /// `model_shown_result`). Mirrors the model view's error cards so a tagged call
@@ -862,6 +1009,7 @@ fn message_card(
   tool_results : Map[String, @agent_session.ToolResult],
   failed : Map[String, Unit],
   briefs : Map[String, String],
+  tags : Map[String, Int],
   time~ : String,
   step_label~ : String,
 ) -> @html.Html {
@@ -877,7 +1025,16 @@ fn message_card(
         ],
       ]
     User =>
-      model_card("user", "User", message, briefs, failed, time~, step_label~)
+      model_card(
+        "user",
+        "User",
+        message,
+        briefs,
+        failed,
+        tags,
+        time~,
+        step_label~,
+      )
     Assistant =>
       model_card(
         "assistant",
@@ -885,11 +1042,17 @@ fn message_card(
         message,
         briefs,
         failed,
+        tags,
         time~,
         step_label~,
       )
     Tool(_) =>
-      model_tool_card(message, model_shown_result(message, tool_results), time~)
+      model_tool_card(
+        message,
+        model_shown_result(message, tool_results),
+        tags,
+        time~,
+      )
   }
 }
 
@@ -959,6 +1122,7 @@ pub fn rendered_error_count(
 fn model_tool_card(
   message : @deepseek.ChatMessage,
   shown : @agent_session.ToolResult?,
+  tags : Map[String, Int],
   time~ : String,
 ) -> @html.Html {
   let is_error = shown is Some(r) && r.is_error()
@@ -972,7 +1136,23 @@ fn model_tool_card(
     (true, false) => "Tool error · \{name}"
     (false, false) => "Tool result · \{name}"
   }
-  @html.details(class="card \{kind}") <| [
+  // The pair tag comes from the message's own id (structural), independent of
+  // whether `model_shown_result` trusts the durable result for enrichment.
+  let pair = match message.role {
+    Tool(id) => tags.get(id)
+    _ => None
+  }
+  let link = match pair {
+    Some(n) =>
+      pair_link(
+        n,
+        href="#\{tool_call_anchor(n)}",
+        title="Jump to the originating call (call \{n})",
+      )
+    None => @html.nothing
+  }
+  let anchor = pair.map(n => tool_result_anchor(n))
+  @html.details(id?=anchor, class="card \{kind}") <| [
     @html.summary(class="card-label") <| model_card_head(
       label,
       time~,
@@ -981,6 +1161,7 @@ fn model_tool_card(
       } else {
         @html.nothing
       },
+      link~,
     ),
     @html.div(class="card-body") <| [
       text_block(message.content),
@@ -995,6 +1176,7 @@ fn model_card(
   message : @deepseek.ChatMessage,
   briefs : Map[String, String],
   failed : Map[String, Unit],
+  tags : Map[String, Int],
   time~ : String,
   step_label~ : String,
 ) -> @html.Html {
@@ -1013,7 +1195,9 @@ fn model_card(
   }
   if !message.tool_calls.is_empty() {
     let call_views : Array[@html.Html] = [
-      for call in message.tool_calls => tool_call_view(call, briefs, failed)
+      for call in message.tool_calls => {
+        tool_call_view(call, briefs, failed, tags)
+      }
     ]
     body.push(@html.div(class="tool-calls") <| call_views)
   }
@@ -1030,9 +1214,10 @@ fn model_card_head(
   label : String,
   time~ : String,
   flag? : @html.Html = @html.nothing,
+  link? : @html.Html = @html.nothing,
   step_label? : String = "",
 ) -> Array[@html.Html] {
-  let head : Array[@html.Html] = [flag, @html.text(label)]
+  let head : Array[@html.Html] = [flag, @html.text(label), link]
   if !step_label.is_empty() {
     head.push(@html.span(class="card-step") <| step_label)
   }
@@ -1067,12 +1252,14 @@ fn card_head(
   seq : Int,
   time~ : String,
   flag? : @html.Html = @html.nothing,
+  link? : @html.Html = @html.nothing,
   step_label? : String = "",
 ) -> Array[@html.Html] {
   let head : Array[@html.Html] = [
     @html.span(class="card-seq") <| "#\{seq}",
     flag,
     @html.text(label),
+    link,
   ]
   if !step_label.is_empty() {
     head.push(@html.span(class="card-step") <| step_label)

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -96,6 +96,77 @@ fn occurrences(text : String, needle : String) -> Int {
 }
 
 ///|
+/// Two calls to the same tool in one assistant turn, each with its own result —
+/// the exact case where the separate result cards were previously
+/// indistinguishable (both just `Tool result · read`).
+fn multi_call_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("mc"), system_prompt="")
+  .append(User(UserMessage("read both")))
+  .append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="r1", name="read", arguments="{\"path\":\"a.txt\"}"),
+        ToolCall(id="r2", name="read", arguments="{\"path\":\"b.txt\"}"),
+      ]),
+    ),
+  )
+  .append(Tool(ToolResult(tool_call_id="r1", tool_name="read", content="AAA")))
+  .append(Tool(ToolResult(tool_call_id="r2", tool_name="read", content="BBB")))
+  .append(Terminal(Finished("done")))
+}
+
+///|
+/// Ids that must NOT be paired: an empty id (a streaming glitch can leave one),
+/// a duplicate call id, and an orphan result whose id matches no call.
+fn unpairable_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("edge"), system_prompt="")
+  .append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="", name="noop", arguments="{}"),
+        ToolCall(id="dup", name="a", arguments="{}"),
+        ToolCall(id="dup", name="b", arguments="{}"),
+      ]),
+    ),
+  )
+  .append(
+    Tool(ToolResult(tool_call_id="orphan", tool_name="ghost", content="?")),
+  )
+}
+
+///|
+/// One call whose id has TWO results — the result side is ambiguous, so the raw
+/// view (which shows both results) must not pair it.
+fn duplicate_result_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("dupres"), system_prompt="")
+  .append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="d", name="read", arguments="{\"path\":\"x\"}"),
+      ]),
+    ),
+  )
+  .append(Tool(ToolResult(tool_call_id="d", tool_name="read", content="one")))
+  .append(Tool(ToolResult(tool_call_id="d", tool_name="read", content="two")))
+}
+
+///|
+/// A unique, non-empty call id with no result event: raw has no result to pair,
+/// but the model projection heals the dangling call with a synthetic result, so
+/// the model view can (and should) pair the two.
+fn dangling_call_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("dangle"), system_prompt="")
+  .append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="only", name="read", arguments="{\"path\":\"x\"}"),
+      ]),
+    ),
+  )
+  .append(Terminal(Aborted("stopped")))
+}
+
+///|
 fn finish_tool_session() -> @agent_session.Session {
   @agent_session.Session(SessionId("finish"), system_prompt="system")
   .append(User(UserMessage("start")))
@@ -128,7 +199,12 @@ test "tool calls fold their arguments, empty args stay flat" {
   // A call with arguments folds: the name becomes a <summary>, args hide in the
   // collapsed <details> (no `open` attribute) yet are still in the DOM.
   // c1 (shell) has args and its result failed, so its fold carries the failed tag.
-  assert_true(html.contains("<details class=\"tool-call tool-call-failed\">"))
+  // It also pairs with a result, so it gets a `tool-call-1` anchor.
+  assert_true(
+    html.contains(
+      "<details class=\"tool-call tool-call-failed\" id=\"tool-call-1\">",
+    ),
+  )
   assert_true(html.contains("<summary class=\"tool-call-name\">"))
   assert_true(html.contains("shell"))
   assert_true(html.contains("cmd"))
@@ -260,8 +336,14 @@ test "failed tool result is folded and red-flagged" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   // Folded by default (a <details> with no `open`), tagged as an error, and the
   // summary carries the red flag so a collapsed failure still stands out.
-  assert_true(html.contains("<details class=\"card tool error\">"))
-  assert_false(html.contains("<details class=\"card tool error\" open>"))
+  assert_true(
+    html.contains("<details class=\"card tool error\" id=\"tool-result-1\">"),
+  )
+  assert_false(
+    html.contains(
+      "<details class=\"card tool error\" id=\"tool-result-1\" open>",
+    ),
+  )
   assert_true(html.contains("class=\"tool-flag\">🚩 failed"))
   assert_true(html.contains("Tool error · shell"))
   assert_true(html.contains("boom"))
@@ -273,7 +355,9 @@ test "model view recovers the error flag the projection drops" {
   // the view correlates back to the durable ToolResult, so a failed tool (e.g. a
   // non-zero exit) is red-flagged in the model view too — with its tool name.
   let model = render(@viz.render_session(error_tool_session(), ModelView))
-  assert_true(model.contains("<details class=\"card tool error\">"))
+  assert_true(
+    model.contains("<details class=\"card tool error\" id=\"tool-result-1\">"),
+  )
   assert_true(model.contains("class=\"tool-flag\">🚩 failed"))
   assert_true(model.contains("Tool error · shell"))
 }
@@ -358,11 +442,15 @@ test "successful tool result folds without a flag" {
     system_prompt="",
   )
   let raw = render(@viz.render_session(session, RawLog))
-  assert_true(raw.contains("<details class=\"card tool\">"))
+  assert_true(
+    raw.contains("<details class=\"card tool\" id=\"tool-result-1\">"),
+  )
   assert_false(raw.contains("tool-flag"))
   // Model view folds its tool result too (no flag — the projection drops it).
   let model = render(@viz.render_session(session, ModelView))
-  assert_true(model.contains("<details class=\"card tool\">"))
+  assert_true(
+    model.contains("<details class=\"card tool\" id=\"tool-result-1\">"),
+  )
   assert_true(model.contains("Tool result"))
 }
 
@@ -594,6 +682,75 @@ test "notices surface partial tails and bad lines" {
   let html = render(@viz.render_notices(parsed))
   assert_true(html.contains("could not be decoded"))
   assert_true(html.contains("trailing partial line"))
+}
+
+///|
+test "each tool call and its result share a pairing anchor and cross-link" {
+  // Both raw and model view must connect each call to its own result so two
+  // same-tool calls in one turn are no longer ambiguous.
+  for mode in [@viz.RawLog, ModelView] {
+    let html = render(@viz.render_session(multi_call_session(), mode))
+    // Each call and its result carry the anchor the other links to.
+    assert_true(html.contains("id=\"tool-call-1\""))
+    assert_true(html.contains("id=\"tool-call-2\""))
+    assert_true(html.contains("id=\"tool-result-1\""))
+    assert_true(html.contains("id=\"tool-result-2\""))
+    // The call links forward to its result; the result links back to the call.
+    assert_true(html.contains("href=\"#tool-result-1\""))
+    assert_true(html.contains("href=\"#tool-result-2\""))
+    assert_true(html.contains("href=\"#tool-call-1\""))
+    assert_true(html.contains("href=\"#tool-call-2\""))
+    // The same `call N` chip labels both sides of each pair (call + result).
+    inspect(occurrences(html, ">call 1</a>"), content="2")
+    inspect(occurrences(html, ">call 2</a>"), content="2")
+    inspect(occurrences(html, "class=\"tool-link\""), content="4")
+    // Each anchor id is emitted exactly once (no duplicate DOM ids), and there is
+    // no stray third pair — so every `href="#tool-*-N"` resolves to one target.
+    inspect(occurrences(html, "id=\"tool-call-1\""), content="1")
+    inspect(occurrences(html, "id=\"tool-call-2\""), content="1")
+    inspect(occurrences(html, "id=\"tool-result-1\""), content="1")
+    inspect(occurrences(html, "id=\"tool-result-2\""), content="1")
+    assert_false(html.contains("tool-call-3"))
+    assert_false(html.contains("tool-result-3"))
+  }
+}
+
+///|
+test "empty, duplicate, and orphan ids get no pairing chip or anchor" {
+  // A pairing chip must never link to a missing anchor, and no DOM id may be
+  // emitted twice, so none of these unpairable ids may produce pairing markup.
+  for mode in [@viz.RawLog, ModelView] {
+    let html = render(@viz.render_session(unpairable_session(), mode))
+    assert_false(html.contains("id=\"tool-call-"))
+    assert_false(html.contains("id=\"tool-result-"))
+    assert_false(html.contains("class=\"tool-link\""))
+  }
+}
+
+///|
+test "one call with two results is not paired in the raw view" {
+  // Two results for id `d` make the result side ambiguous; the raw view shows
+  // both, so it must not pair (which would need a single `tool-result-N` anchor).
+  let raw = render(@viz.render_session(duplicate_result_session(), RawLog))
+  assert_false(raw.contains("id=\"tool-call-"))
+  assert_false(raw.contains("id=\"tool-result-"))
+  assert_false(raw.contains("class=\"tool-link\""))
+}
+
+///|
+test "a dangling call pairs only in the model view, where it is healed" {
+  let session = dangling_call_session()
+  // Raw has no result event for `only`, so nothing to pair.
+  let raw = render(@viz.render_session(session, RawLog))
+  assert_false(raw.contains("id=\"tool-call-"))
+  assert_false(raw.contains("id=\"tool-result-"))
+  // The model projection heals the dangling call with a synthetic result, giving
+  // it a valid partner — so the call and its healed result cross-link here.
+  let model = render(@viz.render_session(session, ModelView))
+  assert_true(model.contains("id=\"tool-call-1\""))
+  assert_true(model.contains("id=\"tool-result-1\""))
+  assert_true(model.contains("href=\"#tool-result-1\""))
+  assert_true(model.contains("href=\"#tool-call-1\""))
 }
 
 ///|

--- a/web/index.html
+++ b/web/index.html
@@ -381,6 +381,21 @@
        errors-only keep the assistant card that holds it. */
     .tool-call-failed { border-color: var(--error); }
 
+    /* call <-> result pairing: the same `call N` chip on a tool call and its
+       result, each an anchor that jumps to its partner. When one assistant turn
+       fires several tool calls, this is what ties each result card back to the
+       call that produced it. */
+    .tool-link {
+      font-family: ui-monospace, monospace; font-size: 11px;
+      color: var(--accent); text-decoration: none; margin-left: 8px;
+      text-transform: none; letter-spacing: 0; opacity: .85; white-space: nowrap;
+    }
+    .tool-link:hover { text-decoration: underline; opacity: 1; }
+    /* highlight the call/result you jumped to via a pairing chip */
+    .tool-call:target, .card:target {
+      outline: 2px solid var(--accent); outline-offset: 2px;
+    }
+
     /* folded tool-result cards: the label is the toggle, body hides until clicked */
     details.card > summary.card-label { cursor: pointer; }
     details.card > summary.card-label:hover { color: var(--text); }
@@ -405,5 +420,28 @@
 <body>
   <div id="app"></div>
   <script src="/viz_app.js"></script>
+  <script>
+    // A pairing chip (`.tool-link`) lives inside a <summary>, so a bare click on
+    // it would both navigate AND toggle the enclosing <details>. Cancel the
+    // default (which suppresses the fold toggle and the native jump) when the
+    // target anchor exists, then drive :target + scroll ourselves. Delegated on
+    // document, so it survives the app's virtual-DOM re-renders. Missing targets
+    // fall through to native navigation.
+    document.addEventListener("click", function (e) {
+      // Leave modified / non-primary clicks to the browser (open-in-new-tab etc.).
+      if (e.defaultPrevented || e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      if (!(e.target instanceof Element)) return;
+      var link = e.target.closest("a.tool-link");
+      if (!link) return;
+      var href = link.getAttribute("href") || "";
+      if (href.charAt(0) !== "#") return;
+      var el = document.getElementById(href.slice(1));
+      if (!el) return;
+      e.preventDefault();
+      if (location.hash !== href) location.hash = href;
+      el.scrollIntoView({ block: "center" });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

In the browser viz log viewer, when one assistant turn emits **multiple tool calls**, the tool-call rows render together inside the assistant card, while each tool *result* renders as a separate top-level card whose header shows only the tool **name** (`Tool result · <name>`). With two calls to the same tool in one turn (e.g. two `read`s), the result cards were distinguishable only by order and content — there was no visible tie back to which call produced them.

## Approach

The call↔result linkage already exists in the data model (`@deepseek.ToolCall.id` / `ToolResult.tool_call_id`, matched by the projection), so **this is a rendering-only change** — no data-model changes.

- Assign each tool call a stable, 1-based **pair number** and show the same `call N` chip on both the tool-call row and its result card.
- Each chip is an anchor that **jumps to its partner** (call → result, result → call), with a `:target` outline on arrival.
- A number is assigned only to an id that forms an **unambiguous 1:1 pair** in the rendered view: non-empty, appearing exactly once among the calls *and* exactly once among the results. This deliberately skips:
  - empty ids (a streaming glitch can leave `id=""`),
  - duplicate ids,
  - orphan results (a result with no matching call),
  - dangling calls (a call with no result).

  So a chip never links to a missing anchor and no DOM id is ever emitted twice.
- **Raw view** pairs from durable events; **model view** pairs from the projected messages (so a healed synthetic tool message is a valid partner) and uses only the *structural id* — the error flag, tool name, and brief still flow solely through `model_shown_result`, preserving the model-view enrichment invariant.

## Files

- `viz/view.mbt` — pairing helpers (`assign_pair_tags`, `raw_pair_tags`, `model_pair_tags`, anchor/`pair_link` helpers); thread the id→N map through the raw and model render paths; add anchor `id`s and `call N` chips to tool calls and results.
- `web/index.html` — `.tool-link` chip styling + `:target` highlight for `.tool-call` / `.card`.
- `viz/viz_test.mbt` — update the exact-markup assertions that now carry an `id`; add tests for the two-same-tool-calls case (reciprocal anchors + shared chip, in both raw and model view) and for the unpairable edge cases (empty / duplicate / orphan ids produce no pairing markup).

## Testing

- `moon test viz --target js` — 30 passed
- `moon test cmd/viz_server` — 15 passed; `moon test cmd/viz_app --target js` — 18 passed
- `moon check --target js` + `moon check` (native) clean; `moon fmt` clean
- `moon build cmd/viz_app --target js` — JS bundle builds

## Known minor

The chip lives inside a `<summary>` (so it stays visible when the card/call is folded). Clicking a link inside a `<summary>` may also toggle that `<details>` in some browsers, in addition to navigating — a cosmetic side effect on the element you're leaving; navigation to the partner still works.

## Plan review

This was designed and reviewed against a fresh Codex CLI pass before implementation (which surfaced the empty/duplicate/orphan-id handling now enforced by the 1:1 pairing rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)