### PR TITLE
feat(viz): render nested object/array tool args instead of a JSON blob

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -418,20 +418,39 @@ fn render_args_friendly(raw : String) -> @html.Html {
 /// single-line value inline. Non-string scalars render inline; nested arrays and
 /// objects keep their JSON form, which is rare for tool arguments.
 fn arg_field(key : String, value : Json) -> @html.Html {
-  let row : Array[@html.Html] = [@html.span(class="arg-key") <| key]
+  @html.div(class="arg-field") <| [
+    @html.span(class="arg-key") <| key,
+    render_value(value),
+  ]
+}
+
+///|
+/// Render a JSON value in the friendly view, recursing into nested objects and
+/// arrays rather than dumping them as one escaped `stringify` blob. A string
+/// leaf shows verbatim — a multi-line body (e.g. a `write_file` content) as a
+/// preformatted block, otherwise inline. A nested object becomes an indented
+/// block of the same `key: value` rows; an array becomes a list of rendered
+/// items; other scalars render inline. Empty containers collapse to `{}` / `[]`.
+fn render_value(value : Json) -> @html.Html {
   match value {
     String(text) =>
       if text.contains("\n") {
-        row.push(@html.pre(class="arg-value") <| text)
+        @html.pre(class="arg-value") <| text
       } else {
-        row.push(@html.span(class="arg-value-inline") <| text)
+        @html.span(class="arg-value-inline") <| text
       }
-    Array(_) | Object(_) =>
-      row.push(@html.pre(class="arg-value") <| value.stringify(indent=2))
-    scalar =>
-      row.push(@html.span(class="arg-value-inline") <| scalar_text(scalar))
+    Object(fields) if !fields.is_empty() =>
+      @html.div(class="arg-object") <| [
+        for key, field in fields => arg_field(key, field)
+      ]
+    Array(items) if !items.is_empty() =>
+      @html.div(class="arg-array") <| [
+        for item in items => @html.div(class="arg-item") <| render_value(item)
+      ]
+    Object(_) => @html.span(class="arg-value-inline") <| "{}"
+    Array(_) => @html.span(class="arg-value-inline") <| "[]"
+    scalar => @html.span(class="arg-value-inline") <| scalar_text(scalar)
   }
-  @html.div(class="arg-field") <| row
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -187,6 +187,55 @@ test "non-object tool args fall back to JSON in both forms" {
 }
 
 ///|
+test "a nested object argument recurses into indented key/value rows" {
+  // A nested object must not collapse to one escaped JSON blob: it recurses
+  // into the same key/value rows, indented, with string leaves shown verbatim.
+  let session = @agent_session.Session(SessionId("nest"), system_prompt="").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="n1",
+          name="configure",
+          arguments="{\"name\":\"probe\",\"opts\":{\"retries\":3,\"label\":\"fast\"}}",
+        ),
+      ]),
+    ),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("class=\"arg-key\">name"))
+  assert_true(html.contains("class=\"arg-key\">opts"))
+  // The nested object recurses rather than dumping stringified JSON.
+  assert_true(html.contains("class=\"arg-object\""))
+  assert_true(html.contains("class=\"arg-key\">retries"))
+  assert_true(html.contains("class=\"arg-key\">label"))
+  assert_true(html.contains("class=\"arg-value-inline\">fast"))
+}
+
+///|
+test "an array-of-objects argument renders one item per element" {
+  // Each array element renders as its own item, recursing into the element's
+  // fields — the general shape `multi_edit`'s `edits` benefits from.
+  let session = @agent_session.Session(SessionId("arr2"), system_prompt="").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="a2",
+          name="batch",
+          arguments="{\"steps\":[{\"op\":\"add\",\"n\":1},{\"op\":\"del\",\"n\":2}]}",
+        ),
+      ]),
+    ),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("class=\"arg-key\">steps"))
+  assert_true(html.contains("class=\"arg-array\""))
+  // Two elements → two items, each with its own recursed fields.
+  assert_eq(occurrences(html, "class=\"arg-item\""), 2)
+  assert_true(html.contains("class=\"arg-value-inline\">add"))
+  assert_true(html.contains("class=\"arg-value-inline\">del"))
+}
+
+///|
 test "a failed tool call is tagged so errors-only keeps its call card" {
   // error_tool_session: c1 (shell) failed. Its call gets `tool-call-failed`, the
   // hook the errors-only stylesheet uses to keep the assistant card holding the

--- a/web/index.html
+++ b/web/index.html
@@ -364,6 +364,14 @@
       white-space: pre-wrap; word-break: break-word;
       font-family: ui-monospace, monospace; font-size: 12px;
     }
+    /* nested args: objects/arrays recurse into indented rows, not a JSON blob */
+    .arg-object { margin: 2px 0 2px 2px; padding-left: 8px; border-left: 1px solid var(--border); }
+    .arg-array { margin: 2px 0 2px 2px; }
+    .arg-item {
+      margin: 3px 0; padding: 1px 0 1px 8px;
+      border-left: 2px solid var(--border);
+    }
+
     /* tool-args toggle: friendly form by default, raw JSON under .show-original */
     .tool-call-args-original { display: none; }
     .session-view.show-original .tool-call-args-original { display: block; }


### PR DESCRIPTION
## What

The viz "friendly" tool-args view renders each top-level field as a `key: value` row, but its generic branch dumped any nested `Array`/`Object` value as one `stringify(indent=2)` blob. Tools whose arguments nest — notably `multi_edit`'s `edits` (an array of edit objects) — therefore rendered as a deeply-nested, JSON-escaped wall of text.

This makes the value renderer **recurse**:

- a nested **object** becomes the same indented `key: value` rows,
- an **array** becomes a list of rendered items,
- **string leaves** still show verbatim (real newlines, e.g. a `write_file` body),
- empty containers collapse to `{}` / `[]`.

It's tool-agnostic, so every tool with structured arguments benefits, and the **"Original"** toggle still shows the full pretty-printed JSON for debugging. All text routes through the escaping `@html` builder.

## Context

This is the **foundation PR**. A follow-up will add a `multi_edit`-specific diff view (`- old` / `+ new`, grouped by file) layered on top of this generic rendering.

## Files

- `viz/view.mbt` — `arg_field` delegates to a new recursive `render_value`.
- `web/index.html` — `.arg-object` / `.arg-array` / `.arg-item` indentation.
- `viz/viz_test.mbt` — nested-object and array-of-objects tests.

## Tests

`viz` + `cmd/viz_app` **48/48** (js); bundle builds; `moon fmt` clean; no `.mbti` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
