### PR TITLE
feat(cli): single binary — host the terminal UI as `openseek tui`

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -17,7 +17,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
-| `bobzhang/openseek/cmd/tui` | Native-only terminal UI that drives the engine per prompt. | `cmd/tui/README.md` |
+| `bobzhang/openseek/cmd/tui` | Native-only terminal UI library, launched as the `openseek tui` subcommand. | `cmd/tui/README.md` |
 | `bobzhang/openseek/testkit/filesystem` | JSON-backed virtual filesystem for tests and eval fixtures. | `testkit/filesystem/README.mbt.md` |
 | `bobzhang/openseek/eval/report` | Shared Markdown/JSON report primitive for deterministic and model evals. | `eval/report/README.mbt.md` |
 | `bobzhang/openseek/eval/tool_harness` | Deterministic host-side harness that dispatches every built-in tool. | `eval/tool_harness/README.mbt.md` |
@@ -83,15 +83,15 @@ OpenSeek creates it and logs `workspace_created`.
 
 ## Terminal UI
 
-The `cmd/tui` package is the interactive interface: a scrolling transcript with
-a live composer. It spawns the `openseek` engine binary fresh for every prompt
-and renders its JSONL event stream — streamed thinking and answer text appear
-live on the activity line, and each turn's reasoning is kept as a dim `✻`
+The terminal UI is the `openseek tui` subcommand of the single `openseek`
+binary: a scrolling transcript with a live composer. It spawns the `openseek`
+engine and renders its JSONL event stream — streamed thinking and answer text
+appear live on the activity line, and each turn's reasoning is kept as a dim `✻`
 transcript aside above its answer.
 
 ```bash
 export DEEPSEEK=sk-...
-moon run cmd/tui
+moon run cmd/openseek -- tui
 ```
 
 **Every launch converses in a durable session.** The engine only carries
@@ -101,8 +101,8 @@ and stores the conversation under `--session-root` (default `.openseek/`).
 Follow-up prompts remember earlier ones, and a conversation outlives the
 process:
 
-- `moon run cmd/tui -- --continue` resumes the most recently active session.
-- `moon run cmd/tui -- --session <id>` resumes (or creates) a specific one.
+- `moon run cmd/openseek -- tui --continue` resumes the most recently active session.
+- `moon run cmd/openseek -- tui --session <id>` resumes (or creates) a specific one.
 - `moon run cmd/openseek -- --session-list` shows what is resumable —
   tab-separated id, last-activity time, and the session's first prompt,
   newest first.
@@ -114,13 +114,13 @@ notes.
 
 The CLI behaviour is documented as executable cram tests under `tests/`, built
 and run with `moon cram test`. The wrapper compiles the native `cmd/*` packages
-and exposes each on `PATH` as `<name>.exe` (e.g. `openseek.exe`, `tui.exe`).
+and exposes each on `PATH` as `<name>.exe` (e.g. `openseek.exe`).
 
 - [`tests/cram/cli.md`](tests/cram/cli.md) — offline `cmd/openseek` examples (the
   full help banner and the missing-API-key error). They make no network calls,
   use no output-processing tools, and run in CI via `moon cram test tests/cram`.
-- [`tests/cram/tui.md`](tests/cram/tui.md) — offline `cmd/tui` examples (the help
-  banner and the missing-API-key error). The argument parser runs before the
+- [`tests/cram/tui.md`](tests/cram/tui.md) — offline `openseek tui` examples (the
+  help banner and the missing-API-key error). The argument parser runs before the
   terminal UI starts, so these need no API key and no TTY.
 - [`tests/live/deepseek.md`](tests/live/deepseek.md) — a real, non-mock DeepSeek
   round trip. It is opt-in (`DEEPSEEK=sk-... moon cram test tests/live`) and

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -5,6 +5,15 @@ arguments with `moonbitlang/core/argparse`, reads defaults from environment
 variables, and calls `bobzhang/openseek/agent.run` for one-shot tasks or
 `agent.run_turn_with_append` for durable sessions.
 
+## The `tui` subcommand
+
+This is the single OpenSeek binary — there is no separate TUI executable.
+Invoked as `openseek tui …` it launches the interactive terminal UI (see
+[`cmd/tui`](../tui/README.md)), which spawns this same binary in `--serve` mode
+as its engine; every other invocation is the engine / CLI documented below. The
+first argument `tui` is therefore reserved: to run a task whose text starts with
+`tui`, stop option parsing first, e.g. `openseek -- tui is broken`.
+
 ## Command
 
 ```bash

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1,11 +1,28 @@
 ///|
+/// Single-binary entry point. The first argument selects the mode: `openseek tui`
+/// launches the interactive UI (`@tui.run`); anything else is the agent engine /
+/// CLI (`run_cli`, which owns stdout for its JSONL event stream). The `tui` token
+/// is peeled here rather than modeled as an argparse subcommand because the engine
+/// takes a free-form positional task, which a subcommand would make ambiguous.
 async fn main {
-  run_cli() catch {
-    error => {
-      @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
-        _ => ()
+  let args = @env.args()
+  if args.length() >= 2 && args[1] == "tui" {
+    @tui.run(argv=args[2:], env=@env.get_env_vars()) catch {
+      error => {
+        @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
+          _ => ()
+        }
+        @sys.exit(1)
       }
-      @sys.exit(1)
+    }
+  } else {
+    run_cli() catch {
+      error => {
+        @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
+          _ => ()
+        }
+        @sys.exit(1)
+      }
     }
   }
 }

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -7,6 +7,7 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/agent_session/compact",
+  "bobzhang/openseek/cmd/tui",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/prompt",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -5,16 +5,18 @@ on the reusable [`tui`](../../tui/README.md) controller package. It ships as a
 library launched by the single `openseek` binary as the `openseek tui`
 subcommand (there is no separate `tui` executable).
 
-The TUI runs no agent code itself. It spawns the `openseek` engine — by default
-this same binary, re-launched in `--serve` mode (so the UI and engine can never
-drift out of sync), resolved via argv[0] when invoked by path and otherwise from
-`PATH`; override with `--engine` or `OPENSEEK_ENGINE` — **once per session** and
-drives it over stdin commands, rendering the engine's JSONL event stream: streamed thinking and answer text move live on
-the activity line, each turn's reasoning is kept as a dim `✻` transcript
-aside above its answer, and tool results land as `⏺` blocks. Pressing Enter
-while a task runs steers it mid-turn; Ctrl-C cancels the turn (a second
-Ctrl-C kills the engine, and the next prompt respawns it on the same
-session).
+The TUI runs no agent code itself. It spawns the `openseek` engine **once per
+session** in `--serve` mode and drives it over stdin commands, rendering the
+engine's JSONL event stream: streamed thinking and answer text move live on the
+activity line, each turn's reasoning is kept as a dim `✻` transcript aside above
+its answer, and tool results land as `⏺` blocks. Pressing Enter while a task
+runs steers it mid-turn; Ctrl-C cancels the turn (a second Ctrl-C kills the
+engine, and the next prompt respawns it on the same session).
+
+By default the engine is this same binary re-launched (resolved from argv[0]
+when invoked by path, otherwise `openseek` on `PATH`), so the UI and engine are
+one artifact and never drift out of sync. Override it with `--engine` or
+`OPENSEEK_ENGINE`.
 
 A custom or recorded-stream engine that only speaks the original
 one-process-per-prompt protocol still works with `--engine-mode oneshot`

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -1,12 +1,13 @@
 # bobzhang/openseek/cmd/tui
 
 The OpenSeek terminal UI: a scrolling transcript with a live composer, built
-on the reusable [`tui`](../../tui/README.md) controller package.
+on the reusable [`tui`](../../tui/README.md) controller package. It ships as a
+library launched by the single `openseek` binary as the `openseek tui`
+subcommand (there is no separate `tui` executable).
 
-The TUI runs no agent code itself. It spawns the engine binary (`openseek`
-from `PATH`; override with `--engine` or `OPENSEEK_ENGINE`) **once per
-session** in `--serve` mode and drives it over stdin commands, rendering the
-engine's JSONL event stream: streamed thinking and answer text move live on
+The TUI runs no agent code itself. It spawns the `openseek` engine (override
+with `--engine` or `OPENSEEK_ENGINE`) **once per session** in `--serve` mode and
+drives it over stdin commands, rendering the engine's JSONL event stream: streamed thinking and answer text move live on
 the activity line, each turn's reasoning is kept as a dim `✻` transcript
 aside above its answer, and tool results land as `⏺` blocks. Pressing Enter
 while a task runs steers it mid-turn; Ctrl-C cancels the turn (a second

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -5,8 +5,10 @@ on the reusable [`tui`](../../tui/README.md) controller package. It ships as a
 library launched by the single `openseek` binary as the `openseek tui`
 subcommand (there is no separate `tui` executable).
 
-The TUI runs no agent code itself. It spawns the `openseek` engine (override
-with `--engine` or `OPENSEEK_ENGINE`) **once per session** in `--serve` mode and
+The TUI runs no agent code itself. It spawns the `openseek` engine — by default
+this same binary, re-launched in `--serve` mode (so the UI and engine can never
+drift out of sync), resolved via argv[0] when invoked by path and otherwise from
+`PATH`; override with `--engine` or `OPENSEEK_ENGINE` — **once per session** and
 drives it over stdin commands, rendering the engine's JSONL event stream: streamed thinking and answer text move live on
 the activity line, each turn's reasoning is kept as a dim `✻` transcript
 aside above its answer, and tool results land as `⏺` blocks. Pressing Enter

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -1,7 +1,7 @@
 ///|
 fn cli_command() -> @argparse.Command {
   Command(
-    "openseek-tui",
+    "openseek tui",
     about="OpenSeek terminal UI.",
     options=[
       OptionArg(
@@ -297,8 +297,11 @@ async fn engine_launchable(engine : String) -> Bool {
 }
 
 ///|
-async fn main {
-  let matches = cli_command().parse(env=@env.get_env_vars())
+/// Run the interactive terminal UI — the `openseek tui` subcommand. `argv` is the
+/// argument list *after* the `tui` selector and `env` the process environment;
+/// both are supplied by the single-binary dispatcher in `cmd/openseek`.
+pub async fn run(argv~ : ArrayView[String], env~ : Map[String, String]) -> Unit {
+  let matches = cli_command().parse(argv~, env~)
   let mut config = parse_config(matches)
   if continue_requested(matches) {
     config = with_latest_session(config)

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -224,6 +224,34 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
 }
 
 ///|
+/// Resolve the engine command when it is still the built-in default `openseek`:
+/// re-launch *this* executable as the engine so `openseek tui` never spawns a
+/// separately-installed, possibly stale binary. An explicit `--engine` /
+/// `OPENSEEK_ENGINE` value (anything other than the default) is left untouched.
+fn with_engine_self_default(config : AppConfig) -> AppConfig {
+  if config.engine == "openseek" {
+    { ..config, engine: default_engine(@sys.get_cli_args()) }
+  } else {
+    config
+  }
+}
+
+///|
+/// The engine command derived from the process arguments. `args[0]` (argv0) with
+/// a path separator (`/` or, on Windows, `\`) is used directly — spawn resolves
+/// it against the launch cwd (the TUI never `chdir`s; the engine's workspace is
+/// set via `OPENSEEK_DIR`), so `./openseek` or an absolute path re-launches the
+/// same file. A bare name is left as `openseek` for a PATH lookup, which for a
+/// single binary is the same file we are running. Split out so it is
+/// unit-testable without a real argv0.
+fn default_engine(args : ArrayView[String]) -> String {
+  match args {
+    [argv0, ..] if argv0.contains("/") || argv0.contains("\\") => argv0
+    _ => "openseek"
+  }
+}
+
+///|
 fn initial_task(matches : @argparse.Matches) -> String? {
   let task = values(matches, "task").join(" ").trim().to_owned()
   if task.is_empty() {
@@ -302,7 +330,7 @@ async fn engine_launchable(engine : String) -> Bool {
 /// both are supplied by the single-binary dispatcher in `cmd/openseek`.
 pub async fn run(argv~ : ArrayView[String], env~ : Map[String, String]) -> Unit {
   let matches = cli_command().parse(argv~, env~)
-  let mut config = parse_config(matches)
+  let mut config = with_engine_self_default(parse_config(matches))
   if continue_requested(matches) {
     config = with_latest_session(config)
   }
@@ -459,6 +487,29 @@ test "cli overrides the engine binary" {
     "DEEPSEEK": "test-key",
   })
   assert_eq(parse_config(parsed).engine, "./fake-engine")
+}
+
+///|
+test "default_engine re-launches a path argv0 and falls back to PATH for a bare name" {
+  // A path (absolute or relative) is used directly so we re-exec the same file.
+  assert_eq(
+    default_engine(["/usr/local/bin/openseek"]),
+    "/usr/local/bin/openseek",
+  )
+  assert_eq(default_engine(["./openseek"]), "./openseek")
+  assert_eq(
+    default_engine(["target/native/openseek"]),
+    "target/native/openseek",
+  )
+  // Windows-style separators count as a path too.
+  assert_eq(
+    default_engine(["target\\native\\openseek.exe"]),
+    "target\\native\\openseek.exe",
+  )
+  // A bare name (found via PATH) or a missing argv0 falls back to `openseek`,
+  // which for a single binary resolves to the same file we are running.
+  assert_eq(default_engine(["openseek"]), "openseek")
+  assert_eq(default_engine([]), "openseek")
 }
 
 ///|

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -28,7 +28,3 @@ import {
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 
 supported_targets = "+native"
-
-options(
-  "is-main": true,
-)

--- a/cmd/tui/pkg.generated.mbti
+++ b/cmd/tui/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/cmd/tui"
 
 // Values
+pub async fn run(argv~ : ArrayView[String], env~ : Map[String, String]) -> Unit
 
 // Errors
 

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -14,8 +14,10 @@ priv struct AppConfig {
   session_id : @agent_session.SessionId
   session_root : String
   // The agent engine the TUI spawns and reads JSONL events from. Defaults to
-  // the `openseek` binary on `PATH`; override (e.g. to a recorded-stream
-  // replayer) with `--engine` or `OPENSEEK_ENGINE`.
+  // this running `openseek` binary re-launched as the engine (see
+  // `with_engine_self_default`), so `openseek tui` never spawns a stale,
+  // separately-built engine; override (e.g. to a recorded-stream replayer) with
+  // `--engine` or `OPENSEEK_ENGINE`.
   engine : String
   engine_mode : EngineMode
 }

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -1,8 +1,9 @@
 # Verified OpenSeek TUI CLI Documentation
 
 These examples are executed by `moon cram test tests/cram`. The Moon wrapper
-builds the native package at `cmd/tui` first, then exposes the executable on
-`PATH` as `tui.exe`.
+builds the native package at `cmd/openseek` first, then exposes the executable on
+`PATH` as `openseek.exe`. The interactive terminal UI is the `tui` subcommand of
+that single binary.
 
 Both commands are offline: they exercise only the argument parser, which runs
 before the terminal UI starts, so the suite needs no API key, no TTY, and makes
@@ -15,8 +16,8 @@ no network calls. The live, API-backed examples live in
 and defaults behind each one, then exits successfully.
 
 ```mooncram
-$ tui.exe --help
-Usage: openseek-tui --api-key <api-key> [options] [task...]
+$ openseek.exe tui --help
+Usage: openseek tui --api-key <api-key> [options] [task...]
 
 OpenSeek terminal UI.
 
@@ -44,10 +45,10 @@ the missing required argument, prints the usage, and exits non-zero — before t
 terminal UI ever starts.
 
 ```mooncram
-$ env -u DEEPSEEK tui.exe "summarize this project"
+$ env -u DEEPSEEK openseek.exe tui "summarize this project" 2>&1
 error: the following required argument was not provided: 'api-key'
 
-Usage: openseek-tui --api-key <api-key> [options] [task...]
+Usage: openseek tui --api-key <api-key> [options] [task...]
 
 OpenSeek terminal UI.
 
@@ -79,14 +80,14 @@ the normal `--` delimiter stops option parsing.
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env DEEPSEEK=test-key tui.exe --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
-> sed -n '1p' "$stdout"
-> if test -s "$stderr"; then echo stderr-not-empty; else echo stderr-empty; fi
+> if env DEEPSEEK=test-key openseek.exe tui --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' "$stderr"
+> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
 > EOF
 exit-non-zero
 error: unexpected argument '--xxy' found
-stderr-empty
+stdout-empty
 ```
 
 When the initial task itself must start with `-`, use `--`. This gets past
@@ -94,7 +95,7 @@ argument parsing; the fake engine then fails the preflight check before the TUI
 takes over the terminal.
 
 ```mooncram
-$ env DEEPSEEK=test-key tui.exe --engine openseek-not-a-real-binary -- '--xxy he'
+$ env DEEPSEEK=test-key openseek.exe tui --engine openseek-not-a-real-binary -- '--xxy he'
 error: engine 'openseek-not-a-real-binary' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
 Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
 [1]


### PR DESCRIPTION
## Problem

OpenSeek shipped **two** native binaries — `cmd/openseek` (the agent engine/CLI)
and `cmd/tui` (the terminal UI) — which made distribution awkward and created a
stale-binary footgun: the TUI spawned `openseek` from `PATH`, so a rebuilt engine
that wasn't reinstalled was silently mismatched.

## Approach

Consolidate into **one** `openseek` binary while keeping the good design — the UI
drives the engine over the existing stdio-JSONL `--serve` protocol as a
subprocess (crash isolation, `--engine` override for replay/fakes all preserved).

- **`openseek tui …`** launches the UI; every other invocation is the engine/CLI
  exactly as before. `cmd/tui` becomes a library exposing `pub async fn run(argv~, env~)`;
  `cmd/openseek`'s `main` peels the first `tui` token and dispatches. It's peeled
  before argparse (not modeled as an argparse subcommand) because the engine takes
  a free-form positional task that a subcommand would make ambiguous.
- **Self-relaunch (no C stub).** When `--engine`/`OPENSEEK_ENGINE` isn't set, the
  TUI defaults its engine to *this* running binary via `argv[0]`: a path-like
  `argv[0]` (`./openseek`, an absolute path, a `moon run` build path) is used
  directly, and a bare name falls back to `openseek` on `PATH` — which, for a
  single binary, is the same file. Combined with consolidation this removes the
  stale-engine footgun with pure MoonBit (no new FFI). An earlier draft used a
  `/proc/self/exe` + `_NSGetExecutablePath` C stub; dropped per review feedback to
  avoid stubs.

## Commits

1. `feat(cli)` — host the TUI as `openseek tui` (make `cmd/tui` a library, dispatch, rename the argparse command to `openseek tui`, update cram + docs).
2. `feat(tui)` — default the engine to this running binary via `argv[0]` (`with_engine_self_default` / `default_engine`, both unit-tested; handles `/` and Windows `\`).
3. `docs` — document the reserved `tui` token (`openseek -- tui …` escape) and clarify the engine paragraph.

## Behavior notes

- `--engine` / `OPENSEEK_ENGINE` still win (replay/fake engines unaffected).
- Engine-path behavior is otherwise unchanged; `parse_config`'s static default
  stays `openseek`, so `--help` output and the cram suite are stable.
- The first argument `tui` is reserved; run a task literally starting with `tui`
  via `openseek -- tui …`.
- TUI arg errors now flow through the shared dispatcher to **stderr**, matching
  the engine's own CLI (the old standalone `tui` printed to stdout); `tests/cram/tui.md`
  updated accordingly and now drives `openseek.exe tui`.

## Testing

- `moon test` — 850 passed (native)
- `moon check --deny-warn`, `moon fmt --check`, `moon info` (no `.mbti` drift) — clean
- `moon cram test tests/cram` — 18/18 (help banner, missing-key, unknown-option, fake-engine preflight, all via `openseek tui`)

## Review

Plan and each commit were reviewed by a fresh Codex CLI pass; the final holistic
review returned **no blockers** ("ready to merge"). Feedback incorporated: dropped
the C stub in favor of `argv[0]`, folded the tui→lib + dispatch + cram/docs into
one green commit, Windows separator handling, and the reserved-token doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)