### PR TITLE
feat(kimi): support K2.7 Code models

### DIFF
--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -35,10 +35,12 @@ moon run cmd/openseek -- run [--api-key sk-...] [--model deepseek-v4-pro] [--api
 ```
 
 Runs require `--api-key` or `DEEPSEEK`. `--model` can also be supplied with
-`DEEPSEEK_MODEL`; it defaults to `deepseek-v4-pro`. `--max-steps` can also be
-supplied with `OPENSEEK_MAX_STEPS`; it defaults to `1000`.
-`--api-url` can also be supplied with `OPENSEEK_API_URL`; when omitted, OpenSeek
-uses the default DeepSeek chat completions endpoint.
+`DEEPSEEK_MODEL`; it accepts `deepseek-v4-flash`, `deepseek-v4-pro`,
+`kimi-k2.7-code`, and `kimi-k2.7-code-highspeed`, and defaults to
+`deepseek-v4-pro`. `--max-steps` can also be supplied with
+`OPENSEEK_MAX_STEPS`; it defaults to `1000`. `--api-url` can also be supplied
+with `OPENSEEK_API_URL`; when omitted, OpenSeek uses the default DeepSeek chat
+completions endpoint, or the Kimi endpoint for Kimi models.
 `--dir` can also be supplied with `OPENSEEK_DIR`; it defaults to `.` and becomes
 the workspace root for relative prompt files, sessions, workspace skills, and
 agent tools. If the directory itself is missing but its parent exists, OpenSeek
@@ -59,8 +61,8 @@ list` / `openseek sessions show <id>` (or the viz server) and resumable with
 `--session <id>`. Pass `--no-session` to run ephemerally; combining it with
 `--session` is rejected.
 
-Without an explicit prompt file, the CLI uses the Flash built-in prompt for both
-`deepseek-v4-flash` and `deepseek-v4-pro`. The older base prompt remains in
+Without an explicit prompt file, the CLI uses the Flash built-in prompt for the
+supported DeepSeek and Kimi model names. The older base prompt remains in
 `prompt/base_prompt.mbt.md` for comparison and experiments, but it is not
 selected by default.
 

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -24,7 +24,7 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
       env="DEEPSEEK_MODEL",
       default_values=[@deepseek.V4Pro.to_string()],
       global~,
-      about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
+      about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
     ),
     OptionArg(
       "api-url",

--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -2,14 +2,16 @@
 
 This pure package provides strongly typed DeepSeek chat data and JSON
 encoding/decoding. Use it when constructing requests, parsing responses, or
-testing DeepSeek chat behavior without network access.
+testing DeepSeek chat behavior without network access. The typed model list
+also covers Kimi K2.7 Code models where their request policy differs from
+DeepSeek's.
 
 The HTTP client lives in `bobzhang/openseek/deepseek/client`.
 
 ## API Shape
 
-- `Model`: current DeepSeek chat model names, with `Show` for wire strings and
-  `Debug` for inspection.
+- `Model`: DeepSeek chat model names plus Kimi K2.7 Code compatibility variants,
+  with `Show` for wire strings and `Debug` for inspection.
 - `ThinkingMode`: typed control for DeepSeek V4 thinking (`No`, `High`, or
   `Max`).
 - `Role`: `System`, `User`, `Assistant`, and `Tool(tool_call_id)`, with `Show`
@@ -22,7 +24,9 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
   object.
 - `encode_chat_request(tools?, thinking?, stream?, response_format?,
   model?=V4Pro) <| messages`: builds the full DeepSeek chat completions request
-  body. Streaming requests include usage-bearing stream options. The per-value
+  body. Streaming requests include usage-bearing stream options. Kimi K2.7 Code
+  requests omit DeepSeek-specific thinking fields, set a large default
+  `max_tokens`, and preserve assistant `reasoning_content`. The per-value
   encoders for messages, tool definitions, and tool calls are package-private
   implementation details.
 - `ToolDefinition(name, description, parameters, strict?)`: a native DeepSeek

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -28,7 +28,9 @@ The package depends on `moonbitlang/async/http` and is native-only.
 
 The default endpoint is `https://api.deepseek.com/chat/completions`, the default
 model is `deepseek-v4-pro`, and `thinking=No` is sent unless a different mode is
-provided. Pass `thinking=Max` for explicit max-effort thinking-mode requests.
+provided. Kimi K2.7 Code models default to
+`https://api.moonshot.cn/v1/chat/completions` and omit DeepSeek-specific
+thinking fields when the request body is encoded.
 
 Retries cover transient failures: transport errors, HTTP 429, and HTTP 5xx.
 Other HTTP 4xx responses fail immediately. `retry_attempts` counts total tries;
@@ -135,9 +137,9 @@ then append one `Tool(call.id)` result message per call before the next request.
 ## Streaming Chat
 
 Pass `stream=StreamHandler(...)` to `Client::chat` to send `stream=true` plus
-`stream_options={"include_usage":true}`. The transport pins `Accept-Encoding:
-identity` so a gzip-compressing intermediary cannot buffer and re-batch SSE
-deltas.
+`stream_options={"include_usage":true}` for usage-bearing streams. The transport
+pins `Accept-Encoding: identity` so a gzip-compressing intermediary cannot
+buffer and re-batch SSE deltas.
 
 The stream reader:
 
@@ -204,6 +206,9 @@ Run the package tests with:
 moon test deepseek/client
 ```
 
-The blackbox test suite includes a real API smoke test when `DEEPSEEK` is set.
-Without that environment variable, the smoke test prints a skip message and
-returns successfully.
+The blackbox test suite includes a real DeepSeek API smoke test when `DEEPSEEK`
+is set. Kimi smoke tests are opt-in: set `KIMI` to a Kimi API key. The normal
+Kimi smoke also uses `DEEPSEEK_MODEL` to choose the Kimi model; streaming,
+tool-call, and multi-turn reasoning-content smokes use `kimi-k2.7-code`.
+Without those environment variables, the smoke tests print skip messages and
+return successfully.

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -1,8 +1,19 @@
 ///|
-let default_api_url : String = "https://api.deepseek.com/chat/completions"
+const DeepSeekDefaultApiUrl : String = "https://api.deepseek.com/chat/completions"
+
+///|
+const KimiDefaultApiUrl : String = "https://api.moonshot.cn/v1/chat/completions"
 
 ///|
 let default_model : @deepseek.Model = V4Pro
+
+///|
+fn default_api_url_for_model(model : @deepseek.Model) -> String {
+  match model {
+    KimiK27Code | KimiK27CodeHighSpeed => KimiDefaultApiUrl
+    V4Flash | V4Pro => DeepSeekDefaultApiUrl
+  }
+}
 
 ///|
 type API_KEY = String
@@ -22,8 +33,8 @@ pub struct Client {
 /// Constructs a DeepSeek HTTP client.
 ///
 /// `model` defaults to `deepseek-v4-pro`; `api_url` defaults to the DeepSeek
-/// chat completions endpoint. `thinking` defaults to `No`; pass `High` or
-/// `Max` to enable DeepSeek V4 thinking mode explicitly.
+/// endpoint, or the Kimi endpoint for Kimi models. `thinking` defaults to
+/// `No`; pass `High` or `Max` to enable DeepSeek V4 thinking mode explicitly.
 ///
 /// Transient failures — transport errors, HTTP 429, and 5xx — are retried up
 /// to `retry_attempts` total tries with exponential backoff starting at
@@ -33,7 +44,7 @@ pub struct Client {
 pub fn Client::Client(
   api_key~ : String,
   model? : @deepseek.Model = default_model,
-  api_url? : String = default_api_url,
+  api_url? : String = default_api_url_for_model(model),
   thinking? : @deepseek.ThinkingMode = No,
   retry_attempts? : Int = 3,
   retry_backoff_ms? : Int = 500,

--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -30,3 +30,162 @@ async test "realworld DeepSeek API smoke test" {
   assert_true(response.content.contains("pong"))
   assert_true(response.usage.total_tokens > 0)
 }
+
+///|
+async test "realworld Kimi API smoke test" {
+  guard @env.get_env_var("DEEPSEEK_MODEL") is Some(model_name) &&
+    (model_name == "kimi-k2.7-code" || model_name == "kimi-k2.7-code-highspeed") else {
+    println(
+      "DEEPSEEK_MODEL is not a Kimi model; skipping realworld Kimi API smoke test",
+    )
+    return
+  }
+  guard @env.get_env_var("KIMI") is Some(api_key) && api_key != "" else {
+    println(
+      "KIMI environment variable is not set or is empty; skipping realworld Kimi API smoke test",
+    )
+    return
+  }
+
+  let model = @deepseek.Model::parse(model_name)
+  let client = @client.Client(api_key~, model~)
+  let response = client.chat([
+    ChatMessage(
+      System,
+      content="Reply with exactly this plain text and no markdown: pong",
+    ),
+    ChatMessage(User, content="ping"),
+  ])
+  assert_true(response.content.contains("pong"))
+  assert_true(response.usage.total_tokens > 0)
+}
+
+///|
+async test "realworld Kimi API streaming smoke test" {
+  guard @env.get_env_var("KIMI") is Some(api_key) && api_key != "" else {
+    println(
+      "KIMI environment variable is not set or is empty; skipping realworld Kimi API streaming smoke test",
+    )
+    return
+  }
+
+  let model = @deepseek.KimiK27Code
+  let client = @client.Client(api_key~, model~)
+  let deltas : Array[String] = []
+  let response = client.chat(
+    [
+      ChatMessage(
+        System,
+        content="Reply with exactly this plain text and no markdown: pong",
+      ),
+      ChatMessage(User, content="ping"),
+    ],
+    stream=StreamHandler(on_content_delta=delta => deltas.push(delta)),
+  )
+  assert_true(deltas.join("").contains("pong"))
+  assert_true(response.content.contains("pong"))
+  assert_true(response.usage.total_tokens > 0)
+}
+
+///|
+async test "realworld Kimi API tool-call smoke test" {
+  guard @env.get_env_var("KIMI") is Some(api_key) && api_key != "" else {
+    println(
+      "KIMI environment variable is not set or is empty; skipping realworld Kimi API tool-call smoke test",
+    )
+    return
+  }
+
+  let model = @deepseek.KimiK27Code
+  let client = @client.Client(api_key~, model~)
+  let tool = @deepseek.ToolDefinition(
+    "return_token",
+    "Return the exact token requested by the user.",
+    {
+      "type": "object",
+      "properties": { "token": { "type": "string" } },
+      "required": ["token"],
+    },
+  )
+  let response = client.chat(
+    [
+      ChatMessage(
+        System,
+        content=(
+          #|You must call the return_token tool exactly once. Do not answer in text.
+        ),
+      ),
+      ChatMessage(User, content="Call return_token with token pong."),
+    ],
+    tools=[tool],
+  )
+  assert_true(response.tool_calls.length() > 0)
+  assert_eq(response.tool_calls[0].name, "return_token")
+  assert_true(response.tool_calls[0].id != "")
+  assert_true(response.tool_calls[0].arguments.contains("pong"))
+  assert_true(response.usage.total_tokens > 0)
+}
+
+///|
+async test "realworld Kimi API multi-turn reasoning-content smoke test" {
+  guard @env.get_env_var("KIMI") is Some(api_key) && api_key != "" else {
+    println(
+      "KIMI environment variable is not set or is empty; skipping realworld Kimi API multi-turn reasoning-content smoke test",
+    )
+    return
+  }
+
+  let model = @deepseek.KimiK27Code
+  let client = @client.Client(api_key~, model~)
+  let tool = @deepseek.ToolDefinition(
+    "return_token",
+    "Return the exact token requested by the user.",
+    {
+      "type": "object",
+      "properties": { "token": { "type": "string" } },
+      "required": ["token"],
+    },
+  )
+  let first_user : @deepseek.ChatMessage = ChatMessage(
+    User,
+    content="Call return_token with token pong.",
+  )
+  let first = client.chat(
+    [
+      ChatMessage(
+        System,
+        content=(
+          #|You must call the return_token tool exactly once. Do not answer in text.
+        ),
+      ),
+      first_user,
+    ],
+    tools=[tool],
+  )
+  assert_true(first.reasoning_content != "")
+  assert_true(first.tool_calls.length() > 0)
+  let call = first.tool_calls[0]
+  let second = client.chat(
+    [
+      ChatMessage(
+        System,
+        content=(
+          #|After the tool result is available, do not call any tool again. Reply exactly: done
+        ),
+      ),
+      first_user,
+      ChatMessage(
+        Assistant,
+        content=first.content,
+        tool_calls=first.tool_calls,
+        reasoning_content=first.reasoning_content,
+      ),
+      ChatMessage(Tool(call.id), content="{\"token\":\"pong\"}"),
+      ChatMessage(User, content="Use the tool result now."),
+    ],
+    tools=[tool],
+  )
+  assert_true(second.tool_calls.length() == 0)
+  assert_true(second.content.contains("done"))
+  assert_true(second.usage.total_tokens > 0)
+}

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -141,6 +141,31 @@ async test "streaming chat retries a pre-stream 429 and then streams" {
 }
 
 ///|
+async test "streaming Kimi chat retries a pre-stream 502 and then streams" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=1, status=502, sse=true)
+      is Some((url, hits)) else {
+      return
+    }
+    let client = @client.Client(
+      api_key="test-key",
+      model=KimiK27Code,
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let deltas : Array[String] = []
+    let response = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta)),
+    )
+    assert_eq(response.content, "ok")
+    assert_eq(deltas.join("|"), "ok")
+    assert_eq(hits.val, 2)
+  }
+}
+
+///|
 /// A 2xx connection that dies before any event is transport-shaped: with no
 /// delta delivered, the stream call retries and the second connection
 /// serves the full stream.

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -2,6 +2,7 @@
 async fn stream_test_server(
   group : @async.TaskGroup[Unit],
   finish? : Bool = true,
+  kimi_usage? : Bool = false,
 ) -> String? {
   let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
     error => {
@@ -23,7 +24,12 @@ async fn stream_test_server(
         assert_true(request.headers.get("accept-encoding") is Some("identity"))
         let request_body = body.read_all().text()
         assert_true(request_body.contains("\"stream\":true"))
-        assert_true(request_body.contains("\"include_usage\":true"))
+        if kimi_usage {
+          assert_true(request_body.contains("\"model\":\"kimi-k2.7-code\""))
+          assert_true(request_body.contains("\"include_usage\":true"))
+        } else {
+          assert_true(request_body.contains("\"include_usage\":true"))
+        }
         assert_false(request_body.contains("\"response_format\""))
         conn.send_response(200, "OK", extra_headers={
           "Content-Type": "text/event-stream",
@@ -36,7 +42,11 @@ async fn stream_test_server(
           "data: {\"choices\":[{\"delta\":{\"content\":\" world\",\"reasoning_content\":\"hidden\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n",
         )
         conn.write(
-          "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"moon.mod\\\"}\"}}]}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+          if kimi_usage {
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"moon.mod\\\"}\"}}]},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8}}\n\n"
+          } else {
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"moon.mod\\\"}\"}}]}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n"
+          },
         )
         if finish {
           conn.write("data: [DONE]\n\n")
@@ -74,6 +84,28 @@ async test "chat stream handler accumulates SSE content, tool calls, and usage" 
     assert_eq(response.usage.total_tokens, 8)
     assert_eq(response.usage.prompt_cache_hit_tokens, 1)
     assert_eq(response.usage.prompt_cache_miss_tokens, 2)
+  }
+}
+
+///|
+async test "chat stream handler accumulates Kimi stream_options usage" {
+  @async.with_task_group() <| group => {
+    guard stream_test_server(group, kimi_usage=true) is Some(url) else {
+      return
+    }
+    let client = @client.Client(
+      api_key="test-key",
+      model=KimiK27Code,
+      api_url=url,
+    )
+    let response = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    )
+    assert_eq(response.content, "Hello world")
+    assert_eq(response.usage.prompt_tokens, 3)
+    assert_eq(response.usage.completion_tokens, 5)
+    assert_eq(response.usage.total_tokens, 8)
   }
 }
 

--- a/deepseek/client/client_test.mbt
+++ b/deepseek/client/client_test.mbt
@@ -7,6 +7,18 @@ test "client defaults" {
 }
 
 ///|
+test "client endpoint defaults follow selected model" {
+  let kimi = @client.Client(api_key="test-key", model=KimiK27Code)
+  assert_eq(kimi.api_url, "https://api.moonshot.cn/v1/chat/completions")
+  let proxied = @client.Client(
+    api_key="test-key",
+    model=KimiK27CodeHighSpeed,
+    api_url="https://proxy.example/v1/chat/completions",
+  )
+  assert_eq(proxied.api_url, "https://proxy.example/v1/chat/completions")
+}
+
+///|
 test "client debug redacts api key" {
   let client = @client.Client(api_key="test-key", thinking=Max)
   debug_inspect(

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -1,26 +1,40 @@
 ///|
-/// DeepSeek chat model names accepted by the chat completions API.
+/// DeepSeek chat model names plus supported Kimi K2.7 Code model names.
 pub(all) enum Model {
   V4Flash
   V4Pro
+  KimiK27Code
+  KimiK27CodeHighSpeed
 } derive(Eq, Debug)
 
 ///|
-/// Returns the DeepSeek wire name for a chat model.
+/// Returns the wire name for a chat model.
 pub impl Show for Model with fn to_string(self : Model) -> String {
   match self {
     V4Flash => "deepseek-v4-flash"
     V4Pro => "deepseek-v4-pro"
+    KimiK27Code => "kimi-k2.7-code"
+    KimiK27CodeHighSpeed => "kimi-k2.7-code-highspeed"
   }
 }
 
 ///|
-/// Parses a DeepSeek wire model name into a typed model.
+/// Parses a wire model name into a typed model.
 pub fn Model::parse(input : String) -> Model raise {
   match input {
     "deepseek-v4-flash" => V4Flash
     "deepseek-v4-pro" => V4Pro
-    other => fail("unknown DeepSeek model: \{other}")
+    "kimi-k2.7-code" => KimiK27Code
+    "kimi-k2.7-code-highspeed" => KimiK27CodeHighSpeed
+    other => fail("unknown model: \{other}")
+  }
+}
+
+///|
+fn Model::is_kimi_k27_code(self : Model) -> Bool {
+  match self {
+    KimiK27Code | KimiK27CodeHighSpeed => true
+    V4Flash | V4Pro => false
   }
 }
 

--- a/deepseek/deepseek_test.mbt
+++ b/deepseek/deepseek_test.mbt
@@ -38,6 +38,14 @@ test "model parsing" {
     @deepseek.Model::parse("deepseek-v4-pro").to_string(),
     "deepseek-v4-pro",
   )
+  assert_eq(
+    @deepseek.Model::parse("kimi-k2.7-code").to_string(),
+    "kimi-k2.7-code",
+  )
+  assert_eq(
+    @deepseek.Model::parse("kimi-k2.7-code-highspeed").to_string(),
+    "kimi-k2.7-code-highspeed",
+  )
 }
 
 ///|

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -137,6 +137,70 @@ test "thinking=No disables reasoning and omits reasoning_effort" {
 }
 
 ///|
+test "kimi code omits thinking and preserves assistant reasoning" {
+  let call = @deepseek.ToolCall(
+    id="call_42",
+    name="shell",
+    arguments="{\"cmd\":\"moon test\"}",
+  )
+  let body = @deepseek.encode_chat_request(
+    model=KimiK27Code,
+    thinking=Max,
+    stream=true,
+  ) <| [
+    ChatMessage(User, content="run tests"),
+    ChatMessage(
+      Assistant,
+      content="",
+      tool_calls=[call],
+      reasoning_content="need to validate first",
+    ),
+    ChatMessage(Tool("call_42"), content="exit=0\nok"),
+  ]
+  json_inspect(body, content={
+    "model": "kimi-k2.7-code",
+    "messages": [
+      { "role": "user", "content": "run tests" },
+      {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_42",
+            "type": "function",
+            "function": {
+              "name": "shell",
+              "arguments": "{\"cmd\":\"moon test\"}",
+            },
+          },
+        ],
+        "reasoning_content": "need to validate first",
+      },
+      { "role": "tool", "content": "exit=0\nok", "tool_call_id": "call_42" },
+    ],
+    "stream": true,
+    "stream_options": { "include_usage": true },
+    "max_tokens": 32000,
+  })
+}
+
+///|
+test "kimi highspeed uses the same code-model request policy" {
+  let body = @deepseek.encode_chat_request(
+    model=KimiK27CodeHighSpeed,
+    thinking=No,
+  ) <| [
+    ChatMessage(User, content="solve"),
+  ]
+  json_inspect(body, content={
+    "model": "kimi-k2.7-code-highspeed",
+    "messages": [{ "role": "user", "content": "solve" }],
+    "stream": false,
+    "max_tokens": 32000,
+  })
+}
+
+///|
 test "tools and thinking are omitted when absent" {
   let body = @deepseek.encode_chat_request(model=V4Flash) <| [
     ChatMessage(User, content="hi"),

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -1,15 +1,31 @@
 ///|
-/// Encodes a `ChatMessage` as the DeepSeek chat completions wire object.
+/// Keep assistant reasoning_content for Kimi K2.7 Code as per their documentation:
+///
+/// > Because Preserved Thinking is always on, in multi-turn conversations you
+/// > must keep the `reasoning_content` of every historical assistant message in
+/// > `messages` as-is.
+///
+/// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
+fn ChatMessage::reasoning_json_fields(
+  message : ChatMessage,
+  model : Model,
+) -> Array[(String, Json)] {
+  if !model.is_kimi_k27_code() {
+    return []
+  }
+  if message.role is Assistant && message.reasoning_content is Some(reasoning) {
+    [("reasoning_content", Json::string(reasoning))]
+  } else {
+    []
+  }
+}
+
+///|
+/// Encodes a `ChatMessage` for a selected chat-completions model.
 ///
 /// Assistant messages whose `content` is empty but carry tool calls are
 /// encoded with JSON `content: null`, as the API requires.
-///
-/// `reasoning_content` is deliberately never encoded: it is response-side
-/// data the model does not read back (DeepSeek's docs say not to return it),
-/// and resending it grows every request — a real 156-step run accumulated
-/// 64KB of dead reasoning, 11% of its final 141K-token context. Sessions
-/// still store it for the TUI transcript and the visualizer.
-impl ToJson for ChatMessage with fn to_json(message : ChatMessage) -> Json {
+fn ChatMessage::to_json_for_model(message : ChatMessage, model : Model) -> Json {
   let content = match message.role {
     Assistant if message.tool_calls.length() > 0 && message.content == "" =>
       Json::null()
@@ -29,6 +45,7 @@ impl ToJson for ChatMessage with fn to_json(message : ChatMessage) -> Json {
         } else {
           []
         },
+        ..message.reasoning_json_fields(model),
       ],
     ),
   )
@@ -65,6 +82,44 @@ impl ToJson for ToolCall with fn to_json(call : ToolCall) -> Json {
 }
 
 ///|
+/// Omit `thinking` parameter for Kimi K2.7 Code.
+///
+/// > When using kimi-k2.7-code you do not need to (and should not) pass the
+/// > thinking parameter ...
+///
+/// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
+fn thinking_json_fields(
+  model : Model,
+  thinking : ThinkingMode?,
+) -> Array[(String, Json)] {
+  if model.is_kimi_k27_code() {
+    return []
+  }
+  match thinking {
+    Some(No) => [("thinking", { "type": "disabled" })]
+    Some(High) =>
+      [("thinking", { "type": "enabled" }), ("reasoning_effort", "high")]
+    Some(Max) =>
+      [("thinking", { "type": "enabled" }), ("reasoning_effort", "max")]
+    None => []
+  }
+}
+
+///|
+const KimiDefaultMaxTokens : Int = 32_000
+
+///|
+fn max_tokens_json_fields(model : Model) -> Array[(String, Json)] {
+  if model.is_kimi_k27_code() {
+    // Keep the default aligned with kimi-cli's Kimi provider:
+    // https://github.com/MoonshotAI/kimi-cli/blob/2c34efbbc6c7cfe40770623281e87c138ff8eb6c/packages/kosong/src/kosong/chat_provider/kimi.py#L163-L166
+    [("max_tokens", Json::number(KimiDefaultMaxTokens.to_double()))]
+  } else {
+    []
+  }
+}
+
+///|
 /// Encodes a DeepSeek chat completions request body.
 ///
 /// `response_format`, `tools`, and `thinking` are omitted when empty / `None`.
@@ -80,7 +135,12 @@ pub fn encode_chat_request(
     Map(
       [
         ("model", Json::string(model.to_string())),
-        ("messages", ([ for message in messages => message ] : Json)),
+        (
+          "messages",
+          [
+            for message in messages => message.to_json_for_model(model)
+          ],
+        ),
         ("stream", Json::boolean(stream)),
         ..match response_format {
           Some(format) =>
@@ -97,20 +157,8 @@ pub fn encode_chat_request(
         } else {
           []
         },
-        ..match thinking {
-          Some(No) => [("thinking", ({ "type": "disabled" } : Json))]
-          Some(High) =>
-            [
-              ("thinking", ({ "type": "enabled" } : Json)),
-              ("reasoning_effort", Json::string("high")),
-            ]
-          Some(Max) =>
-            [
-              ("thinking", ({ "type": "enabled" } : Json)),
-              ("reasoning_effort", Json::string("max")),
-            ]
-          None => []
-        },
+        ..thinking_json_fields(model, thinking),
+        ..max_tokens_json_fields(model),
       ],
     ),
   )

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -167,7 +167,7 @@ pub fn encode_chat_request(
 ///|
 test "tool messages include tool call id" {
   let body = ChatMessage(Tool("call_123"), content="tool result")
-  json_inspect(body, content={
+  json_inspect(body.to_json_for_model(V4Pro), content={
     "role": "tool",
     "content": "tool result",
     "tool_call_id": "call_123",
@@ -217,7 +217,7 @@ test "assistant tool call messages encode tool_calls, never reasoning" {
     ],
     reasoning_content="checked available tools",
   )
-  json_inspect(body, content={
+  json_inspect(body.to_json_for_model(V4Pro), content={
     "role": "assistant",
     "content": null,
     "tool_calls": [
@@ -234,6 +234,37 @@ test "assistant tool call messages encode tool_calls, never reasoning" {
 }
 
 ///|
+test "kimi assistant messages preserve reasoning content" {
+  let body = ChatMessage(
+    Assistant,
+    content="",
+    tool_calls=[
+      ToolCall(
+        id="call_123",
+        name="get_weather",
+        arguments="{\"location\":\"Hangzhou\"}",
+      ),
+    ],
+    reasoning_content="checked available tools",
+  )
+  json_inspect(body.to_json_for_model(KimiK27Code), content={
+    "role": "assistant",
+    "content": null,
+    "tool_calls": [
+      {
+        "id": "call_123",
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "arguments": "{\"location\":\"Hangzhou\"}",
+        },
+      },
+    ],
+    "reasoning_content": "checked available tools",
+  })
+}
+
+///|
 test "assistant tool call messages preserve content when present" {
   let body = ChatMessage(Assistant, content="I will check that now.", tool_calls=[
     ToolCall(
@@ -242,7 +273,7 @@ test "assistant tool call messages preserve content when present" {
       arguments="{\"location\":\"Hangzhou\"}",
     ),
   ])
-  json_inspect(body, content={
+  json_inspect(body.to_json_for_model(V4Pro), content={
     "role": "assistant",
     "content": "I will check that now.",
     "tool_calls": [
@@ -266,7 +297,7 @@ test "tool call arguments pass through as opaque strings" {
     arguments="not even valid json{",
   )
   let body = ChatMessage(Assistant, content="", tool_calls=[call])
-  json_inspect(body, content={
+  json_inspect(body.to_json_for_model(V4Pro), content={
     "role": "assistant",
     "content": null,
     "tool_calls": [

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -31,6 +31,8 @@ pub impl @json.FromJson for ChatResponse
 pub(all) enum Model {
   V4Flash
   V4Pro
+  KimiK27Code
+  KimiK27CodeHighSpeed
 } derive(Eq, @debug.Debug)
 pub fn Model::parse(String) -> Self raise
 pub impl Show for Model

--- a/eval/file_edit/cmd/main/main.mbt
+++ b/eval/file_edit/cmd/main/main.mbt
@@ -24,7 +24,7 @@ fn cli_command() -> @argparse.Command {
         "model",
         long="model",
         default_values=[@deepseek.V4Flash.to_string()],
-        about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
+        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
       ),
       OptionArg(
         "runs",

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -49,7 +49,7 @@ fn cli_command() -> @argparse.Command {
         "model",
         long="model",
         default_values=[@deepseek.V4Flash.to_string()],
-        about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
+        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
       ),
       OptionArg(
         "runs",

--- a/prompt/README.mbt.md
+++ b/prompt/README.mbt.md
@@ -6,15 +6,16 @@ functions through the module-level `md_to_mbt_string` dev-build rule.
 
 ## Prompt Sources
 
-- `flash_prompt.mbt.md`: the default built-in prompt used by DeepSeek V4
-  Flash and DeepSeek V4 Pro.
+- `flash_prompt.mbt.md`: the default built-in prompt used by the supported
+  DeepSeek and Kimi model names.
 - `base_prompt.mbt.md`: the older built-in prompt, retained for comparison and
   prompt experiments but not selected by default.
 
 ## API Shape
 
 - `system_prompt_for_model(model)`: return the default built-in prompt for a
-  DeepSeek model. Both current V4 models use the Flash prompt.
+  supported chat model. The supported DeepSeek and Kimi model names use the
+  Flash prompt.
 
 The agent package depends on this package for its default prompt, while the CLI
 can still override or append prompt files for A/B experiments.

--- a/prompt/prompt.mbt
+++ b/prompt/prompt.mbt
@@ -1,9 +1,9 @@
 ///|
-/// Selects the built-in system prompt for a DeepSeek model.
+/// Selects the built-in system prompt for a supported chat model.
 ///
-/// Both DeepSeek V4 models currently share the Flash prompt. The older base
-/// prompt remains in the package for comparison and prompt experiments, but it
-/// is not selected by default.
+/// Supported DeepSeek and Kimi model names currently share the Flash prompt.
+/// The older base prompt remains in the package for comparison and prompt
+/// experiments, but it is not selected by default.
 pub fn system_prompt_for_model(_model : @deepseek.Model) -> String {
   flash_prompt()
 }

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -33,7 +33,7 @@ Commands:
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK] [default: ]
-  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
@@ -129,7 +129,7 @@ Arguments:
 Options:
   -h, --help                                                   Show help information.
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
-  --model <model>                                              DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -24,7 +24,7 @@ OpenSeek terminal UI.
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK] [default: ]
-  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]


### PR DESCRIPTION
This PR adds support for Kimi K2.7 Code model to OpenSeek.

The API_KEY can be read from either environment variable `KIMI` or command line argument `--kimi-api-key`. `cmd/openseek` requires `DEEPSEEK` to be set for DeepSeek V4 Flash/Pro models, or `KIMI` to set to use Kimi K2.7 Code models.

A notable difference between Kimi K2.7 Code and DeepSeek V4 Flash/Pro is how they handle the reasoning content. Kimi K2.7 Code requires all `reasoning_content` to keep as-is when echoing back conversation history back to API, while DeepSeek V4 Flash/Pro requires `reasongin_content` only in multi-turn tool call. See

- Kimi K2.7 Code: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- DeepSeek V4 Flash/Pro: https://api-docs.deepseek.com/guides/thinking_mode

Therefore we modify `ChatMessage::to_json` so that it takes an extra `model` parameter to decide if to include `reasoning_content` when serializing to JSON before requests.

We didn't introduce a provider layer in order to keep the PR small. If we are going to add more models in the future, it might be better to introduce a proper provider-based model resolution mechanism.