### PR TITLE
feat(cli): one `openseek` binary — subcommand-first, TUI-default CLI

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -17,7 +17,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
-| `bobzhang/openseek/cmd/tui` | Native-only terminal UI that drives the engine per prompt. | `cmd/tui/README.md` |
+| `bobzhang/openseek/cmd/tui` | Native-only terminal UI library, the default mode of `openseek` (and `openseek tui`). | `cmd/tui/README.md` |
 | `bobzhang/openseek/testkit/filesystem` | JSON-backed virtual filesystem for tests and eval fixtures. | `testkit/filesystem/README.mbt.md` |
 | `bobzhang/openseek/eval/report` | Shared Markdown/JSON report primitive for deterministic and model evals. | `eval/report/README.mbt.md` |
 | `bobzhang/openseek/eval/tool_harness` | Deterministic host-side harness that dispatches every built-in tool. | `eval/tool_harness/README.mbt.md` |
@@ -63,13 +63,15 @@ filesystem, and process APIs.
 
 ## Agent CLI
 
-The `cmd/openseek` package is the CLI entry point. It parses arguments and runs
-the agent package. The agent sends DeepSeek native function tools and supports
-six local tools: `shell`, `read`, `edit`, `multi_edit`, `write`, and `finish`.
+The `cmd/openseek` package is the single-binary entry point — a subcommand tree
+(default: the terminal UI; `run`/`serve`/`review`/`sessions` for the headless
+engine). `openseek run` parses arguments and runs the agent package. The agent
+sends DeepSeek native function tools and supports six local tools: `shell`,
+`read`, `edit`, `multi_edit`, `write`, and `finish`.
 
 ```bash
 export DEEPSEEK=sk-...
-moon run cmd/openseek -- "inspect this project and finish with a short summary"
+moon run cmd/openseek -- run "inspect this project and finish with a short summary"
 ```
 
 `DEEPSEEK_MODEL` is optional and defaults to `deepseek-v4-pro`.
@@ -83,27 +85,27 @@ OpenSeek creates it and logs `workspace_created`.
 
 ## Terminal UI
 
-The `cmd/tui` package is the interactive interface: a scrolling transcript with
-a live composer. It spawns the `openseek` engine binary fresh for every prompt
-and renders its JSONL event stream — streamed thinking and answer text appear
-live on the activity line, and each turn's reasoning is kept as a dim `✻`
-transcript aside above its answer.
+The terminal UI is the **default** mode of the single `openseek` binary (the
+`cmd/tui` library, also reachable as `openseek tui`): a scrolling transcript with
+a live composer. It spawns the `openseek` engine (by default this same binary in
+`serve` mode) and renders its JSONL event stream — streamed thinking and answer
+text appear live on the activity line, and each turn's reasoning is kept as a dim
+`✻` transcript aside above its answer.
 
 ```bash
 export DEEPSEEK=sk-...
-moon run cmd/tui
+moon run cmd/openseek -- tui
 ```
 
 **Every launch converses in a durable session.** The engine only carries
-context between prompts through the session store, so the TUI generates a
-session id per launch (`tui-YYYYMMDD-HHMMSS-mmm`, named in the startup banner)
-and stores the conversation under `--session-root` (default `.openseek/`).
-Follow-up prompts remember earlier ones, and a conversation outlives the
-process:
+context between prompts through the session store, so the UI generates a session
+id per launch (`tui-YYYYMMDD-HHMMSS-mmm`, named in the startup banner) and stores
+the conversation under `--session-root` (default `.openseek/`). Follow-up prompts
+remember earlier ones, and a conversation outlives the process:
 
-- `moon run cmd/tui -- --continue` resumes the most recently active session.
-- `moon run cmd/tui -- --session <id>` resumes (or creates) a specific one.
-- `moon run cmd/openseek -- --session-list` shows what is resumable —
+- `moon run cmd/openseek -- tui --continue` resumes the most recently active session.
+- `moon run cmd/openseek -- tui --session <id>` resumes (or creates) a specific one.
+- `moon run cmd/openseek -- sessions list` shows what is resumable —
   tab-separated id, last-activity time, and the session's first prompt,
   newest first.
 
@@ -114,13 +116,14 @@ notes.
 
 The CLI behaviour is documented as executable cram tests under `tests/`, built
 and run with `moon cram test`. The wrapper compiles the native `cmd/*` packages
-and exposes each on `PATH` as `<name>.exe` (e.g. `openseek.exe`, `tui.exe`).
+and exposes each on `PATH` as `<name>.exe` (e.g. `openseek.exe`).
 
-- [`tests/cram/cli.md`](tests/cram/cli.md) — offline `cmd/openseek` examples (the
-  full help banner and the missing-API-key error). They make no network calls,
-  use no output-processing tools, and run in CI via `moon cram test tests/cram`.
-- [`tests/cram/tui.md`](tests/cram/tui.md) — offline `cmd/tui` examples (the help
-  banner and the missing-API-key error). The argument parser runs before the
+- [`tests/cram/cli.md`](tests/cram/cli.md) — offline `openseek` subcommand
+  examples (top-level and `run` help, and the `run`/`serve`/`sessions` behaviors).
+  They make no network calls, use no output-processing tools, and run in CI via
+  `moon cram test tests/cram`.
+- [`tests/cram/tui.md`](tests/cram/tui.md) — offline `openseek tui` examples (the
+  help banner and the missing-API-key error). The argument parser runs before the
   terminal UI starts, so these need no API key and no TTY.
 - [`tests/live/deepseek.md`](tests/live/deepseek.md) — a real, non-mock DeepSeek
   round trip. It is opt-in (`DEEPSEEK=sk-... moon cram test tests/live`) and

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -1,17 +1,33 @@
 # OpenSeek CLI
 
-This package is the native-only command-line entry point for OpenSeek. It parses
-arguments with `moonbitlang/core/argparse`, reads defaults from environment
-variables, and calls `bobzhang/openseek/agent.run` for one-shot tasks or
-`agent.run_turn_with_append` for durable sessions.
+This package is the native-only entry point for OpenSeek — the single `openseek`
+binary. It is a subcommand tree: the interactive terminal UI is the **default**
+(see [`cmd/tui`](../tui/README.md)), and the headless engine lives under named
+subcommands. It parses arguments with `moonbitlang/core/argparse`, reads defaults
+from environment variables, and calls `bobzhang/openseek/agent.run` for one-shot
+tasks or `agent.run_turn_with_append` for durable sessions.
 
-## Command
-
-```bash
-moon run cmd/openseek -- [--api-key sk-...] [--model deepseek-v4-pro] [--api-url https://api.deepseek.com/chat/completions] [--dir .] [--max-steps 1000] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
+```
+openseek [PROMPT...]           interactive UI (default), optionally with a prompt
+openseek tui [PROMPT...]       the UI, explicitly
+openseek run [options] TASK    run one task headlessly; JSONL events on stdout
+openseek serve                 JSONL command server (stdin: prompt/steer/cancel/compact)
+openseek review [--base REF]   read-only code review of REF...HEAD → one JSON report
+openseek sessions list|show <id>|compact <id> …   manage durable sessions
 ```
 
-Agent runs require `--api-key` or `DEEPSEEK`. `--model` can also be supplied with
+The first token is a reserved subcommand only when it exactly matches one above;
+any other first token (or none) launches the UI, so `openseek "fix the bug"` is a
+prompt. Use `openseek -- PROMPT` to force a prompt that begins with a subcommand
+word (e.g. `openseek -- run the tests`).
+
+## `openseek run`
+
+```bash
+moon run cmd/openseek -- run [--api-key sk-...] [--model deepseek-v4-pro] [--api-url https://api.deepseek.com/chat/completions] [--dir .] [--max-steps 1000] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
+```
+
+Runs require `--api-key` or `DEEPSEEK`. `--model` can also be supplied with
 `DEEPSEEK_MODEL`; it defaults to `deepseek-v4-pro`. `--max-steps` can also be
 supplied with `OPENSEEK_MAX_STEPS`; it defaults to `1000`.
 `--api-url` can also be supplied with `OPENSEEK_API_URL`; when omitted, OpenSeek
@@ -25,46 +41,49 @@ exists.
 `--system-prompt-file` and `--system-prompt-addendum-file` can also be supplied
 with `OPENSEEK_SYSTEM_PROMPT_FILE` and
 `OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`. `--session` can also be supplied with
-`OPENSEEK_SESSION`; when set, the CLI creates or resumes that session under
+`OPENSEEK_SESSION`; when set, the run creates or resumes that session under
 `--session-root` / `OPENSEEK_SESSION_ROOT` (default `.openseek`). Relative
 session roots are resolved under `--dir`.
 
 Every run records a durable session: without `--session`, a generated
-`cli-YYYYMMDD-HHMMSS-mmm` id is used and announced by a `session_started`
-event on stdout, so the conversation is reviewable afterwards with
-`--session-list` / `--session-show` (or the viz server) and resumable with
+`cli-YYYYMMDD-HHMMSS-mmm` id is used and announced by a `session_started` event
+on stdout, so the conversation is reviewable afterwards with `openseek sessions
+list` / `openseek sessions show <id>` (or the viz server) and resumable with
 `--session <id>`. Pass `--no-session` to run ephemerally; combining it with
 `--session` is rejected.
 
-Without an explicit prompt file, the CLI uses the Flash built-in prompt for
-both `deepseek-v4-flash` and `deepseek-v4-pro`. The older base prompt remains
-in `prompt/base_prompt.mbt.md` for comparison and experiments, but it is not
+Without an explicit prompt file, the CLI uses the Flash built-in prompt for both
+`deepseek-v4-flash` and `deepseek-v4-pro`. The older base prompt remains in
+`prompt/base_prompt.mbt.md` for comparison and experiments, but it is not
 selected by default.
 
-## Session Management
+## `openseek sessions`
 
-The session-management commands are offline and do not require `--api-key`:
+The session-management subcommands are offline and do not require `--api-key`:
 
 ```bash
-moon run cmd/openseek -- --session-list --session-root .openseek
-moon run cmd/openseek -- --session-list --format=json --session-root .openseek
-moon run cmd/openseek -- --session-show --session parser-fix --session-root .openseek
-moon run cmd/openseek -- --session parser-fix --session-compact-file summary.txt --session-compact-from 1 --session-compact-to 120
+moon run cmd/openseek -- sessions list --session-root .openseek
+moon run cmd/openseek -- sessions list --format=json --session-root .openseek
+moon run cmd/openseek -- sessions show parser-fix --session-root .openseek
+moon run cmd/openseek -- sessions compact parser-fix --file summary.txt --from 1 --to 120
 ```
 
-`--session-list --format=json` is the machine-readable form of the listing,
+`sessions list --format=json` is the machine-readable form of the listing,
 consumed by clients such as the desktop app's sidebar: one JSON array of
-`{id, title, updated_at_ms}` objects, most recently active first. `title` is
-the first line of the session's first user prompt; `updated_at_ms` is `null`
-for a directory whose session files cannot be stat-ed (such husks sort last,
-like the human-readable listing).
+`{id, title, updated_at_ms}` objects, most recently active first. `title` is the
+first line of the session's first user prompt; `updated_at_ms` is `null` for a
+directory whose session files cannot be stat-ed (such husks sort last, like the
+human-readable listing).
 
-`--session-compact-file` appends a typed summary event. It does not delete raw
-events from `events.jsonl`; `agent_session.Session::chat_messages` uses the
-summary to compact model context on replay.
+`sessions compact <id> --file <f> --from <n> --to <n>` appends a typed summary
+event. It does not delete raw events from `events.jsonl`;
+`agent_session.Session::chat_messages` uses the summary to compact model context
+on replay.
 
-In `--serve` mode, controllers can ask the engine to generate and append a
-summary without using a temporary file:
+## `openseek serve`
+
+In `serve` mode, controllers can ask the engine to generate and append a summary
+without using a temporary file:
 
 ```jsonl
 {"command":"compact"}
@@ -73,31 +92,34 @@ summary without using a temporary file:
 The engine handles this in command order, waits for any active turn to finish,
 generates the summary with the configured model endpoint, appends a `Summary`
 event covering the current session, and emits `compaction_started`,
-`compaction_finished`, or `compaction_failed` JSONL events. With `--session`,
-the summary is persisted to the durable session log. With `--no-session`, it
-only updates the live in-memory session for the current serve process.
+`compaction_finished`, or `compaction_failed` JSONL events. With `--session`, the
+summary is persisted to the durable session log. With `--no-session`, it only
+updates the live in-memory session for the current serve process.
+
+`serve` is what the terminal UI spawns for each session; it is also the stable
+protocol for other integrations.
 
 ## Examples
 
 ```bash
 export DEEPSEEK=sk-...
-moon run cmd/openseek -- "run moon test and summarize the result"
+moon run cmd/openseek -- run "run moon test and summarize the result"
 ```
 
 ```bash
-DEEPSEEK_MODEL=deepseek-v4-flash moon run cmd/openseek -- "inspect the package docs"
+DEEPSEEK_MODEL=deepseek-v4-flash moon run cmd/openseek -- run "inspect the package docs"
 ```
 
 ```bash
-moon run cmd/openseek -- --max-steps 200 "write tests, fix failures, and summarize"
+moon run cmd/openseek -- run --max-steps 200 "write tests, fix failures, and summarize"
 ```
 
 ```bash
-moon run cmd/openseek -- --dir ../another-workspace "run moon test"
+moon run cmd/openseek -- run --dir ../another-workspace "run moon test"
 ```
 
 ```bash
-moon run cmd/openseek -- --session parser-fix "continue from the last run"
+moon run cmd/openseek -- run --session parser-fix "continue from the last run"
 ```
 
 Best-of-N: run the same task in N sibling copies of `--dir` concurrently, each
@@ -113,18 +135,20 @@ original repo. Each run's session lives under its run directory.
 
 ```bash
 # 3 attempts at the same fix in dir_run_1 / dir_run_2 / dir_run_3
-moon run cmd/openseek -- --concurrency 3 --dir myproject "fix the failing test"
+moon run cmd/openseek -- run --concurrency 3 --dir myproject "fix the failing test"
 ```
 
-`--concurrency` (env `OPENSEEK_CONCURRENCY`, default `1`) cannot be combined with
-`--serve`, `--session`, `--no-session`, or the `--session-*` commands.
+`run --concurrency` (env `OPENSEEK_CONCURRENCY`, default `1`) cannot be combined
+with `--session` or `--no-session`.
 
 ## Package Boundary
 
-This package should stay thin: argument parsing, environment-backed defaults,
-model parsing, prompt override file loading, session-store setup, and
-delegation to the agent package. The prompt package owns built-in prompt
-selection; the agent package owns tool definitions and the execution loop.
+This package should stay thin: subcommand dispatch, argument parsing,
+environment-backed defaults, model parsing, prompt override file loading,
+session-store setup, and delegation to the agent package. The interactive UI is
+the `cmd/tui` library, launched via the `tui` subcommand; the prompt package owns
+built-in prompt selection; the agent package owns tool definitions and the
+execution loop.
 
 Run the package tests with:
 

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -7,20 +7,12 @@
 /// file extension) so the run directories are unambiguous and easy to recognize.
 async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
   // Fleet mode owns session creation and is a one-shot batch, so it conflicts
-  // with the server and the single-session/no-session/session-subcommand modes.
-  guard !flag(matches, "serve") else {
-    fail("--concurrency cannot be combined with --serve")
-  }
+  // with the single-session and no-session modes of `openseek run`.
   guard session_id(matches) is None else {
     fail("--concurrency runs independent sessions; remove --session")
   }
   guard !flag(matches, "no-session") else {
     fail("--concurrency records each run; remove --no-session")
-  }
-  guard session_command_count(matches) == 0 else {
-    fail(
-      "--concurrency cannot be combined with --session-list/--session-show/--session-compact-file",
-    )
   }
   let task = task_text(matches)
   let api_key = api_key(matches)

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -333,7 +333,7 @@ fn has_shebang(data : Bytes) -> Bool {
 ///|
 /// The summary's "inspect a run" command. Includes `--session-root` only when it
 /// is non-default, since each run records its session under that root inside its
-/// run directory, and `--session-show` resolves the root relative to `--dir`.
+/// run directory, and `sessions show` resolves the root relative to `--dir`.
 fn inspect_hint(session_root_value : String) -> String {
   let root = session_root_value.trim()
   let extra = if root == "" || root == ".openseek" {
@@ -341,7 +341,7 @@ fn inspect_hint(session_root_value : String) -> String {
   } else {
     " --session-root \{root}"
   }
-  "openseek --dir <run-dir> --session <id> --session-show\{extra}"
+  "openseek sessions show <id> --dir <run-dir>\{extra}"
 }
 
 ///|

--- a/cmd/openseek/concurrent_wbtest.mbt
+++ b/cmd/openseek/concurrent_wbtest.mbt
@@ -53,11 +53,11 @@ test "has_shebang detects #! scripts" {
 test "inspect_hint adds --session-root only when non-default" {
   assert_eq(
     inspect_hint(".openseek"),
-    "openseek --dir <run-dir> --session <id> --session-show",
+    "openseek sessions show <id> --dir <run-dir>",
   )
   assert_eq(
     inspect_hint("myroot"),
-    "openseek --dir <run-dir> --session <id> --session-show --session-root myroot",
+    "openseek sessions show <id> --dir <run-dir> --session-root myroot",
   )
 }
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -229,6 +229,11 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
 /// `openseek serve` — the persistent JSONL command server the TUI drives: read
 /// prompt/steer/cancel/compact on stdin, stream events on stdout.
 async fn run_serve_command(matches : @argparse.Matches) -> Unit {
+  // Serve is ephemeral by default (durable only with --session); --no-session
+  // makes that explicit and, as in every mode, contradicts an explicit --session.
+  if flag(matches, "no-session") && session_id(matches) is Some(_) {
+    fail("--no-session contradicts --session; pick one behavior")
+  }
   with_jsonl_stdout(() => {
     let workspace_root = prepare_workspace_root(matches, log_created=true)
     run_serve(matches, workspace_root~)
@@ -540,6 +545,13 @@ fn engine_command() -> @argparse.Command {
         "serve",
         about="Session server: read JSONL commands (prompt/steer/cancel/compact) from stdin.",
         options=agent_options(),
+        flags=[
+          FlagArg(
+            "no-session",
+            long="no-session",
+            about="Run ephemerally: do not record this server's conversation to a durable session.",
+          ),
+        ],
       ),
       Command(
         "review",
@@ -749,7 +761,7 @@ fn session_root(
 }
 
 ///|
-/// Longest first-prompt label a `--session-list` row carries; enough to
+/// Longest first-prompt label a `sessions list` row carries; enough to
 /// recognize a conversation without wrapping a normal terminal row.
 const PromptLabelMaxChars : Int = 60
 
@@ -802,10 +814,10 @@ fn format_utc_minute(seconds : Int64) -> String {
 }
 
 ///|
-/// One `--session-list` row: tab-separated id, last-activity stamp (UTC,
+/// One `sessions list` row: tab-separated id, last-activity stamp (UTC,
 /// minute precision; `-` for an unreadable session), and the first user
 /// prompt as a one-line label. Tab separation keeps the listing scriptable —
-/// `--session-list | cut -f1` recovers the bare ids the old format printed.
+/// `sessions list | cut -f1` recovers the bare ids the old format printed.
 fn format_session_listing(listing : @store.SessionListing) -> String {
   let when = match listing.last_active_unix_seconds() {
     Some(seconds) => format_utc_minute(seconds)

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1,6 +1,12 @@
 ///|
+/// Single-binary entry point. `openseek` is a subcommand tree: the interactive
+/// TUI is the default (bare `openseek`, `openseek "PROMPT…"`, or explicit
+/// `openseek tui`), and the headless engine lives under `run`/`serve`/`review`/
+/// `sessions`. The first token is peeled here — rather than sharing one argparse
+/// root with the TUI — so the TUI keeps its own parser and the engine's
+/// stdout-JSONL logging is only installed on engine paths, never the UI path.
 async fn main {
-  run_cli() catch {
+  dispatch() catch {
     error => {
       @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
         _ => ()
@@ -11,39 +17,144 @@ async fn main {
 }
 
 ///|
-async fn run_cli() -> Unit {
+/// The hand-written top-level help. The peel means argparse never sees the root,
+/// so `openseek --help` (and the TUI's `<engine> --help` launchability probe)
+/// is served here — exiting 0 with no TTY or API key required.
+fn top_level_help() -> String {
+  (
+    #|openseek — DeepSeek-backed MoonBit coding agent
+    #|
+    #|Usage:
+    #|  openseek [PROMPT...]           Launch the interactive terminal UI (default),
+    #|                                 optionally with an initial prompt.
+    #|  openseek tui [PROMPT...]       The interactive UI, explicitly.
+    #|  openseek run [options] TASK    Run one task headlessly; stream JSONL on stdout.
+    #|  openseek serve                 JSONL command server (stdin: prompt/steer/cancel/compact).
+    #|  openseek review [--base REF]   Read-only code review of REF...HEAD; one JSON report.
+    #|  openseek sessions <list|show|compact>   Manage durable sessions.
+    #|
+    #|Run `openseek <subcommand> --help` for a subcommand's options.
+    #|Use `openseek -- PROMPT` to pass a prompt that begins with a subcommand word.
+  )
+}
+
+///|
+async fn dispatch() -> Unit {
+  let args = @env.args()
+  let env = @env.get_env_vars()
+  guard args.length() >= 2 else {
+    // Bare `openseek`: the interactive UI with no initial prompt.
+    return launch_tui([], env)
+  }
+  let first = args[1]
+  if first == "--help" || first == "-h" {
+    // Served without a TTY/key so the engine-launchability probe works.
+    println(top_level_help())
+  } else if first == "tui" {
+    // Explicit UI; drop the `tui` selector so a prompt beginning with a reserved
+    // word survives (`openseek tui "serve the request"`).
+    launch_tui(args[2:], env)
+  } else if is_engine_subcommand(first) {
+    run_engine(args[1:], env)
+  } else {
+    // A bare prompt (or `--`): the whole tail is the TUI's initial prompt.
+    launch_tui(args[1:], env)
+  }
+}
+
+///|
+/// Names reserved as engine subcommands; every other first token (or none) is the
+/// interactive TUI, so `openseek "fix the bug"` opens the UI with that prompt.
+fn is_engine_subcommand(name : String) -> Bool {
+  name == "run" || name == "serve" || name == "review" || name == "sessions"
+}
+
+///|
+/// Test helper: parse `run <argv>` and return the `run` subcommand's `Matches`
+/// (what `run_task_command` and the accessors see). Mirrors real invocation.
+fn run_matches(
+  argv~ : Array[String],
+  env~ : Map[String, String],
+) -> @argparse.Matches raise {
+  guard engine_command().parse(argv=["run", ..argv], env~).subcommand
+    is Some((_, sm)) else {
+    fail("expected a run subcommand")
+  }
+  sm
+}
+
+///|
+/// Test helper: parse `sessions <sub> <argv>` and return the leaf subcommand's
+/// `Matches` (what `sessions_list`/`sessions_show`/`sessions_compact` see).
+fn sessions_leaf_matches(
+  sub~ : String,
+  argv~ : Array[String],
+  env~ : Map[String, String],
+) -> @argparse.Matches raise {
+  guard engine_command().parse(argv=["sessions", sub, ..argv], env~).subcommand
+    is Some((_, ssm)) else {
+    fail("expected a sessions subcommand")
+  }
+  guard ssm.subcommand is Some((_, leaf)) else {
+    fail("expected a sessions leaf subcommand")
+  }
+  leaf
+}
+
+///|
+/// Launch the interactive UI. Arg parsing and the `--help`/error and non-TTY
+/// guards live in `@tui.run`, so `--help` still works when stdout is piped.
+async fn launch_tui(
+  argv : ArrayView[String],
+  env : Map[String, String],
+) -> Unit {
+  @tui.run(argv~, env~)
+}
+
+///|
+/// Parse and dispatch the headless engine subcommands. `argv` includes the
+/// subcommand token (e.g. `["run", "task"]`).
+async fn run_engine(
+  argv : ArrayView[String],
+  env : Map[String, String],
+) -> Unit {
+  let matches = engine_command().parse(argv~, env~)
+  match matches.subcommand {
+    Some(("run", m)) => run_task_command(m)
+    Some(("serve", m)) => run_serve_command(m)
+    Some(("review", m)) => run_review_command(m)
+    Some(("sessions", m)) => run_sessions_command(m)
+    // Peeled by `is_engine_subcommand`, so this is unreachable in practice.
+    _ => fail("unknown engine subcommand")
+  }
+}
+
+///|
+/// Run `body` with the stdout JSONL drain installed: it owns all stdout writes,
+/// and — spawned without `no_wait` — the group only completes once the queue
+/// (closed by the `defer`, on success and error alike) is fully written, so the
+/// terminal event is never lost to an early process exit.
+async fn with_jsonl_stdout(body : async () -> Unit) -> Unit {
   let stdout_log = configure_logging()
   @async.with_task_group(group => {
-    // The drain owns all stdout JSONL writes for the run. It is spawned
-    // without `no_wait`, so the group only completes once the queue — closed
-    // by the `defer` when this body exits, on success and error alike — has
-    // been written out in full; the terminal event is never lost to an early
-    // process exit.
     group.spawn_bg() <| () => { stdout_log.drain() }
     defer stdout_log.close()
-    let matches = cli_command().parse(env=@env.get_env_vars())
-    // --no-session contradicts an explicit --session in every mode. Checked
-    // before the session-command and serve branches: serve loads its store
-    // on its own path, so a later check could not stop it from recording
-    // anyway (Codex review).
+    body()
+  })
+}
+
+///|
+/// `openseek run [TASK…]` — a headless one-shot agent run (best-of-N under
+/// `--concurrency`), streaming JSONL events on stdout.
+async fn run_task_command(matches : @argparse.Matches) -> Unit {
+  with_jsonl_stdout(() => {
+    // --no-session contradicts an explicit --session; reject up front.
     if flag(matches, "no-session") && session_id(matches) is Some(_) {
       fail("--no-session contradicts --session; pick one behavior")
     }
-    // Review is a read-only, ephemeral, single-report mode. It branches before
-    // workspace/session/serve handling and silences progress logging so stdout
-    // carries exactly one JSON ReviewReport.
-    if flag(matches, "review") {
-      if values(matches, "task").length() > 0 {
-        fail("--review reviews base...HEAD and does not take a task")
-      }
-      @xlog.global().set_handler(DiscardLog::{  })
-      let workspace_root = prepare_workspace_root(matches, log_created=false)
-      run_review_cli(matches, workspace_root~)
-      return
-    }
     // Best-of-N fleet mode owns its own workspace materialization and session
     // creation, so it branches before prepare_workspace_root (which would
-    // create a single --dir) and the session/serve handling.
+    // create a single --dir).
     let concurrency = parse_positive_int(
       value(matches, "concurrency"),
       "--concurrency",
@@ -52,21 +163,7 @@ async fn run_cli() -> Unit {
       run_fleet(matches, concurrency~)
       return
     }
-    let session_commands = session_command_count(matches)
-    let workspace_root = prepare_workspace_root(
-      matches,
-      log_created=session_commands == 0,
-    )
-    if handle_session_command(matches, workspace_root~) {
-      return
-    }
-    if flag(matches, "serve") {
-      if values(matches, "task").length() > 0 {
-        fail("--serve reads commands from stdin; it does not take a task")
-      }
-      run_serve(matches, workspace_root~)
-      return
-    }
+    let workspace_root = prepare_workspace_root(matches, log_created=true)
     let api_key = api_key(matches)
     let api_url = api_url(matches)
     let model = @deepseek.Model::parse(value(matches, "model"))
@@ -94,7 +191,7 @@ async fn run_cli() -> Unit {
       Some(id) => {
         // Name the recording up front so a user scanning the event stream —
         // or its OPENSEEK_LOG_FILE mirror — knows where to find this run
-        // later (--session-show, the viz server, or resuming by id).
+        // later (`sessions show`, the viz server, or resuming by id).
         @xlog.info() <?
           {
             "event": "session_started",
@@ -126,6 +223,92 @@ async fn run_cli() -> Unit {
       }
     }
   })
+}
+
+///|
+/// `openseek serve` — the persistent JSONL command server the TUI drives: read
+/// prompt/steer/cancel/compact on stdin, stream events on stdout.
+async fn run_serve_command(matches : @argparse.Matches) -> Unit {
+  with_jsonl_stdout(() => {
+    let workspace_root = prepare_workspace_root(matches, log_created=true)
+    run_serve(matches, workspace_root~)
+  })
+}
+
+///|
+/// `openseek review [--base <ref>]` — a read-only, ephemeral code review of
+/// `base…HEAD`; stdout carries exactly one JSON ReviewReport, so progress logging
+/// is discarded rather than drained.
+async fn run_review_command(matches : @argparse.Matches) -> Unit {
+  @xlog.global().set_handler(DiscardLog::{  })
+  let workspace_root = prepare_workspace_root(matches, log_created=false)
+  run_review_cli(matches, workspace_root~)
+}
+
+///|
+/// `openseek sessions <list|show|compact>` — durable-session management. Prints
+/// directly to stdout, so it does not install the JSONL drain.
+async fn run_sessions_command(matches : @argparse.Matches) -> Unit {
+  match matches.subcommand {
+    Some(("list", m)) => sessions_list(m)
+    Some(("show", m)) => sessions_show(m)
+    Some(("compact", m)) => sessions_compact(m)
+    _ => fail("usage: openseek sessions <list|show|compact>")
+  }
+}
+
+///|
+fn sessions_target_id(
+  matches : @argparse.Matches,
+) -> @agent_session.SessionId raise {
+  match values(matches, "id") {
+    [id, ..] if !id.trim().is_empty() => SessionId(id.trim().to_owned())
+    _ => fail("a session id is required (e.g. `openseek sessions show <id>`)")
+  }
+}
+
+///|
+async fn sessions_list(matches : @argparse.Matches) -> Unit {
+  let workspace_root = prepare_workspace_root(matches, log_created=false)
+  let store = @store.SessionStore(session_root(matches, workspace_root~))
+  match session_list_format(matches) {
+    Text =>
+      for listing in store.listings() {
+        println(format_session_listing(listing))
+      }
+    Json => println(session_list_json(store).stringify())
+  }
+}
+
+///|
+async fn sessions_show(matches : @argparse.Matches) -> Unit {
+  let workspace_root = prepare_workspace_root(matches, log_created=false)
+  let store = @store.SessionStore(session_root(matches, workspace_root~))
+  println(store.load(sessions_target_id(matches)).to_json().stringify())
+}
+
+///|
+async fn sessions_compact(matches : @argparse.Matches) -> Unit {
+  let workspace_root = prepare_workspace_root(matches, log_created=false)
+  let store = @store.SessionStore(session_root(matches, workspace_root~))
+  let id = sessions_target_id(matches)
+  let compact_file = value(matches, "file").trim().to_owned()
+  if compact_file.is_empty() {
+    fail("`openseek sessions compact` requires --file")
+  }
+  let from_sequence = required_positive_int(value(matches, "from"), "--from")
+  let to_sequence = required_positive_int(value(matches, "to"), "--to")
+  let summary_path = @workspace_path.resolve(workspace_root, compact_file)
+  let summary = @fs.read_file(summary_path).text()
+  let compacted = store.compact(
+    store.load(id),
+    content=summary,
+    from_sequence~,
+    to_sequence~,
+  )
+  println(
+    "compacted session \{id.value()} events \{from_sequence}..\{to_sequence}; last_sequence=\{compacted.last_sequence()}",
+  )
 }
 
 ///|
@@ -223,160 +406,208 @@ test "failure_message avoids duplicating argparse error prefix" {
 }
 
 ///|
-fn cli_command() -> @argparse.Command {
+fn dir_option() -> @argparse.OptionArg {
+  OptionArg(
+    "dir",
+    long="dir",
+    env="OPENSEEK_DIR",
+    default_values=["."],
+    about="Workspace directory for relative paths; creates only the final path component if its parent exists.",
+  )
+}
+
+///|
+fn session_root_option() -> @argparse.OptionArg {
+  OptionArg(
+    "session-root",
+    long="session-root",
+    env="OPENSEEK_SESSION_ROOT",
+    default_values=[".openseek"],
+    about="Directory containing durable OpenSeek sessions.",
+  )
+}
+
+///|
+/// Options shared by the agent-running subcommands (`run`, `serve`, `review`).
+fn agent_options() -> Array[@argparse.OptionArg] {
+  [
+    OptionArg(
+      "api-key",
+      long="api-key",
+      env="DEEPSEEK",
+      default_values=[""],
+      about="DeepSeek API key.",
+    ),
+    OptionArg(
+      "model",
+      long="model",
+      env="DEEPSEEK_MODEL",
+      default_values=[@deepseek.V4Pro.to_string()],
+      about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
+    ),
+    OptionArg(
+      "api-url",
+      long="api-url",
+      env="OPENSEEK_API_URL",
+      default_values=[""],
+      about="DeepSeek-compatible chat completions endpoint.",
+    ),
+    dir_option(),
+    OptionArg(
+      "max-steps",
+      long="max-steps",
+      env="OPENSEEK_MAX_STEPS",
+      default_values=["1000"],
+      about="Maximum number of agent loop steps before stopping.",
+    ),
+    OptionArg(
+      "thinking",
+      long="thinking",
+      env="OPENSEEK_THINKING",
+      default_values=["max"],
+      about="DeepSeek thinking mode: no, high, or max.",
+    ),
+    OptionArg(
+      "system-prompt-file",
+      long="system-prompt-file",
+      env="OPENSEEK_SYSTEM_PROMPT_FILE",
+      default_values=[""],
+      about="Read the complete system prompt from this file instead of the built-in prompt.",
+    ),
+    OptionArg(
+      "system-prompt-addendum-file",
+      long="system-prompt-addendum-file",
+      env="OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE",
+      default_values=[""],
+      about="Append this file to the selected system prompt for prompt experiments.",
+    ),
+    OptionArg(
+      "global-skills-dir",
+      long="global-skills-dir",
+      env="OPENSEEK_GLOBAL_SKILLS_DIR",
+      default_values=[""],
+      about="User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows.",
+    ),
+    OptionArg(
+      "session",
+      long="session",
+      env="OPENSEEK_SESSION",
+      default_values=[""],
+      about="Create or resume this durable session id.",
+    ),
+    session_root_option(),
+  ]
+}
+
+///|
+/// The headless engine command: a subcommand tree parsed by `run_engine` after
+/// the top-level peel. `disable_help_subcommand` keeps `help` from shadowing a
+/// prompt word; each subcommand still has its own `--help`.
+fn engine_command() -> @argparse.Command {
   Command(
     "openseek",
-    about="DeepSeek-backed MoonBit coding agent.",
-    options=[
-      OptionArg(
-        "api-key",
-        long="api-key",
-        env="DEEPSEEK",
-        default_values=[""],
-        about="DeepSeek API key.",
+    about="OpenSeek headless engine.",
+    subcommands=[
+      Command(
+        "run",
+        about="Run one task headlessly; stream JSONL events on stdout.",
+        options=[
+          ..agent_options(),
+          OptionArg(
+            "concurrency",
+            long="concurrency",
+            env="OPENSEEK_CONCURRENCY",
+            default_values=["1"],
+            about="Run the task in N sibling copies of --dir concurrently (best-of-N); 1 means a single run.",
+          ),
+        ],
+        flags=[
+          FlagArg(
+            "no-session",
+            long="no-session",
+            about="Run ephemerally: do not record this run to a durable session.",
+          ),
+        ],
+        positionals=[
+          PositionArg(
+            "task",
+            num_args=ValueRange(lower=0),
+            about="Task description.",
+          ),
+        ],
       ),
-      OptionArg(
-        "model",
-        long="model",
-        env="DEEPSEEK_MODEL",
-        default_values=[@deepseek.V4Pro.to_string()],
-        about="DeepSeek model: deepseek-v4-flash or deepseek-v4-pro.",
-      ),
-      OptionArg(
-        "api-url",
-        long="api-url",
-        env="OPENSEEK_API_URL",
-        default_values=[""],
-        about="DeepSeek-compatible chat completions endpoint.",
-      ),
-      OptionArg(
-        "dir",
-        long="dir",
-        env="OPENSEEK_DIR",
-        default_values=["."],
-        about="Workspace directory for relative paths; creates only the final path component if its parent exists.",
-      ),
-      OptionArg(
-        "max-steps",
-        long="max-steps",
-        env="OPENSEEK_MAX_STEPS",
-        default_values=["1000"],
-        about="Maximum number of agent loop steps before stopping.",
-      ),
-      OptionArg(
-        "concurrency",
-        long="concurrency",
-        env="OPENSEEK_CONCURRENCY",
-        default_values=["1"],
-        about="Run the task in N sibling copies of --dir concurrently (best-of-N); 1 means a single run.",
-      ),
-      OptionArg(
-        "thinking",
-        long="thinking",
-        env="OPENSEEK_THINKING",
-        default_values=["max"],
-        about="DeepSeek thinking mode: no, high, or max.",
-      ),
-      OptionArg(
-        "system-prompt-file",
-        long="system-prompt-file",
-        env="OPENSEEK_SYSTEM_PROMPT_FILE",
-        default_values=[""],
-        about="Read the complete system prompt from this file instead of the built-in prompt.",
-      ),
-      OptionArg(
-        "system-prompt-addendum-file",
-        long="system-prompt-addendum-file",
-        env="OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE",
-        default_values=[""],
-        about="Append this file to the selected system prompt for prompt experiments.",
-      ),
-      OptionArg(
-        "global-skills-dir",
-        long="global-skills-dir",
-        env="OPENSEEK_GLOBAL_SKILLS_DIR",
-        default_values=[""],
-        about="User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows.",
-      ),
-      OptionArg(
-        "session",
-        long="session",
-        env="OPENSEEK_SESSION",
-        default_values=[""],
-        about="Create or resume this durable session id.",
-      ),
-      OptionArg(
-        "session-root",
-        long="session-root",
-        env="OPENSEEK_SESSION_ROOT",
-        default_values=[".openseek"],
-        about="Directory containing durable OpenSeek sessions.",
-      ),
-      OptionArg(
-        "session-compact-file",
-        long="session-compact-file",
-        default_values=[""],
-        about="Read summary text from this file, append it to --session, and exit.",
-      ),
-      OptionArg(
-        "session-compact-from",
-        long="session-compact-from",
-        default_values=[""],
-        about="First event sequence covered by --session-compact-file.",
-      ),
-      OptionArg(
-        "session-compact-to",
-        long="session-compact-to",
-        default_values=[""],
-        about="Last event sequence covered by --session-compact-file.",
-      ),
-      OptionArg(
-        "base",
-        long="base",
-        default_values=["origin/main"],
-        about="Base ref for --review: review the diff base...HEAD.",
-      ),
-      OptionArg(
-        "format",
-        long="format",
-        default_values=["text"],
-        about="Output format for --session-list: text or json.",
-      ),
-    ],
-    flags=[
-      FlagArg(
-        "review",
-        long="review",
-        about="Run a read-only code review of base...HEAD and print a JSON ReviewReport to stdout.",
-      ),
-      FlagArg(
+      Command(
         "serve",
-        long="serve",
-        about="Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.",
+        about="Session server: read JSONL commands (prompt/steer/cancel/compact) from stdin.",
+        options=agent_options(),
       ),
-      FlagArg(
-        "no-session",
-        long="no-session",
-        about="Run ephemerally: do not record this run to a durable session.",
+      Command(
+        "review",
+        about="Read-only code review of base...HEAD; prints a JSON ReviewReport.",
+        options=[
+          ..agent_options(),
+          OptionArg(
+            "base",
+            long="base",
+            default_values=["origin/main"],
+            about="Base ref: review the diff base...HEAD.",
+          ),
+        ],
       ),
-      FlagArg(
-        "session-list",
-        long="session-list",
-        about="List durable sessions (see --format) and exit.",
-      ),
-      FlagArg(
-        "session-show",
-        long="session-show",
-        about="Print the durable session JSON for --session and exit.",
+      Command(
+        "sessions",
+        about="Manage durable sessions.",
+        subcommand_required=true,
+        disable_help_subcommand=true,
+        subcommands=[
+          Command("list", about="List durable sessions (see --format).", options=[
+            dir_option(),
+            session_root_option(),
+            OptionArg(
+              "format",
+              long="format",
+              default_values=["text"],
+              about="Output format: text or json.",
+            ),
+          ]),
+          Command(
+            "show",
+            about="Print the durable session JSON for <id>.",
+            options=[dir_option(), session_root_option()],
+            positionals=[PositionArg("id", about="Session id.")],
+          ),
+          Command(
+            "compact",
+            about="Append a summary to <id> covering a sequence range.",
+            options=[
+              dir_option(),
+              session_root_option(),
+              OptionArg(
+                "file",
+                long="file",
+                default_values=[""],
+                about="Read summary text from this file.",
+              ),
+              OptionArg(
+                "from",
+                long="from",
+                default_values=[""],
+                about="First event sequence covered by the summary.",
+              ),
+              OptionArg(
+                "to",
+                long="to",
+                default_values=[""],
+                about="Last event sequence covered by the summary.",
+              ),
+            ],
+            positionals=[PositionArg("id", about="Session id.")],
+          ),
+        ],
       ),
     ],
-    positionals=[
-      PositionArg(
-        "task",
-        num_args=ValueRange(lower=0),
-        about="Task description.",
-      ),
-    ],
+    subcommand_required=true,
+    disable_help_subcommand=true,
   )
 }
 
@@ -584,78 +815,6 @@ fn format_session_listing(listing : @store.SessionListing) -> String {
 }
 
 ///|
-async fn handle_session_command(
-  matches : @argparse.Matches,
-  workspace_root? : String = ".",
-) -> Bool {
-  let command_count = session_command_count(matches)
-  if command_count == 0 {
-    return false
-  }
-  if command_count > 1 {
-    fail(
-      "choose only one of --session-list, --session-show, or --session-compact-file",
-    )
-  }
-  let list_sessions = flag(matches, "session-list")
-  let show_session = flag(matches, "session-show")
-  let compact_file = value(matches, "session-compact-file").trim()
-  let compact_from = value(matches, "session-compact-from").trim()
-  let compact_to = value(matches, "session-compact-to").trim()
-  let store = @store.SessionStore(session_root(matches, workspace_root~))
-  if list_sessions {
-    match session_list_format(matches) {
-      Text =>
-        for listing in store.listings() {
-          println(format_session_listing(listing))
-        }
-      Json => println(session_list_json(store).stringify())
-    }
-    return true
-  }
-  let id = required_session_id(matches)
-  if show_session {
-    println(store.load(id).to_json().stringify())
-    return true
-  }
-  if compact_file.is_empty() {
-    fail("--session-compact-file is required for session compaction")
-  }
-  let from_sequence = required_positive_int(
-    "\{compact_from}",
-    "--session-compact-from",
-  )
-  let to_sequence = required_positive_int(
-    "\{compact_to}",
-    "--session-compact-to",
-  )
-  let summary_path = @workspace_path.resolve(workspace_root, "\{compact_file}")
-  let summary = @fs.read_file(summary_path).text()
-  let compacted = store.compact(
-    store.load(id),
-    content=summary,
-    from_sequence~,
-    to_sequence~,
-  )
-  println(
-    "compacted session \{id.value()} events \{from_sequence}..\{to_sequence}; last_sequence=\{compacted.last_sequence()}",
-  )
-  true
-}
-
-///|
-fn session_command_count(matches : @argparse.Matches) -> Int raise {
-  let compact_session = !value(matches, "session-compact-file")
-    .trim()
-    .is_empty() ||
-    !value(matches, "session-compact-from").trim().is_empty() ||
-    !value(matches, "session-compact-to").trim().is_empty()
-  (if flag(matches, "session-list") { 1 } else { 0 }) +
-  (if flag(matches, "session-show") { 1 } else { 0 }) +
-  (if compact_session { 1 } else { 0 })
-}
-
-///|
 priv enum SessionListFormat {
   Text
   Json
@@ -723,16 +882,6 @@ fn session_title(first_prompt : String) -> String {
     None => content
   }
   "\{title}"
-}
-
-///|
-fn required_session_id(
-  matches : @argparse.Matches,
-) -> @agent_session.SessionId raise {
-  match session_id(matches) {
-    Some(id) => id
-    None => fail("--session is required for this session management command")
-  }
 }
 
 ///|
@@ -1034,7 +1183,7 @@ test "session listing rows are tab-separated and survive odd prompts" {
 
 ///|
 test "cli parses env backed options and task" {
-  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
     "DEEPSEEK_MODEL": "deepseek-v4-pro",
     "OPENSEEK_API_URL": "https://proxy.example/v1/chat/completions",
@@ -1061,7 +1210,7 @@ test "cli parses env backed options and task" {
 
 ///|
 test "cli defaults model and max steps" {
-  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
   assert_eq(api_key(parsed), "test-key")
@@ -1075,7 +1224,7 @@ test "cli defaults model and max steps" {
 
 ///|
 test "cli rejects unknown options before task text" {
-  let _ = cli_command().parse(argv=["--xxy", "he"], env={}) catch {
+  let _ = run_matches(argv=["--xxy", "he"], env={}) catch {
     error => {
       assert_true("\{error}".contains("unexpected argument '--xxy' found"))
       return
@@ -1086,26 +1235,26 @@ test "cli rejects unknown options before task text" {
 
 ///|
 test "cli accepts hyphen-leading task text after option delimiter" {
-  let parsed = cli_command().parse(argv=["--", "--xxy", "he"], env={})
+  let parsed = run_matches(argv=["--", "--xxy", "he"], env={})
   assert_eq(task_text(parsed), "--xxy he")
 }
 
 ///|
-test "cli allows session management without api key or task" {
-  let parsed = cli_command().parse(argv=["--session-list"], env={})
-  assert_true(flag(parsed, "session-list"))
-  assert_eq(value(parsed, "api-key"), "")
-  assert_eq(values(parsed, "task").length(), 0)
+test "sessions list needs no api key or task" {
+  // The `sessions` subcommands do not declare api-key/task at all, so listing
+  // works with no DeepSeek setup.
+  let parsed = sessions_leaf_matches(sub="list", argv=[], env={})
+  assert_eq(value(parsed, "format"), "text")
+  assert_eq(value(parsed, "session-root"), ".openseek")
 }
 
 ///|
 async test "--dir creates a missing final component when its parent exists" {
   @vfs.with_tmpdir(prefix="openseek-dir-parent-", parent => {
     let child = "\{parent}/child"
-    let parsed = cli_command().parse(
-      argv=["--dir", child, "write", "MoonBit"],
-      env={ "DEEPSEEK": "test-key" },
-    )
+    let parsed = run_matches(argv=["--dir", child, "write", "MoonBit"], env={
+      "DEEPSEEK": "test-key",
+    })
     let root = prepare_workspace_root(parsed)
     assert_true(@fs.exists(child))
     assert_eq(root, @fs.realpath(child))
@@ -1116,10 +1265,9 @@ async test "--dir creates a missing final component when its parent exists" {
 async test "--dir creates a missing final component with trailing separator" {
   @vfs.with_tmpdir(prefix="openseek-dir-trailing-", parent => {
     let child = "\{parent}/child"
-    let parsed = cli_command().parse(
-      argv=["--dir", "\{child}/", "write", "MoonBit"],
-      env={ "DEEPSEEK": "test-key" },
-    )
+    let parsed = run_matches(argv=["--dir", "\{child}/", "write", "MoonBit"], env={
+      "DEEPSEEK": "test-key",
+    })
     let root = prepare_workspace_root(parsed)
     assert_true(@fs.exists(child))
     assert_eq(root, @fs.realpath(child))
@@ -1140,10 +1288,9 @@ test "--dir trailing separator trim preserves roots" {
 async test "--dir rejects missing parents instead of creating recursively" {
   @vfs.with_tmpdir(prefix="openseek-dir-missing-parent-", root => {
     let child = "\{root}/missing/child"
-    let parsed = cli_command().parse(
-      argv=["--dir", child, "write", "MoonBit"],
-      env={ "DEEPSEEK": "test-key" },
-    )
+    let parsed = run_matches(argv=["--dir", child, "write", "MoonBit"], env={
+      "DEEPSEEK": "test-key",
+    })
     let _ = prepare_workspace_root(parsed) catch {
       error => {
         assert_true(
@@ -1163,7 +1310,7 @@ async test "--dir rejects existing non-directories" {
   @vfs.with_tmpdir(prefix="openseek-dir-file-", root => {
     let path = "\{root}/file"
     @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
-    let parsed = cli_command().parse(argv=["--dir", path, "write", "MoonBit"], env={
+    let parsed = run_matches(argv=["--dir", path, "write", "MoonBit"], env={
       "DEEPSEEK": "test-key",
     })
     let _ = prepare_workspace_root(parsed) catch {
@@ -1178,14 +1325,14 @@ async test "--dir rejects existing non-directories" {
 
 ///|
 test "session root resolves relative to workspace root" {
-  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
   assert_eq(
     session_root(parsed, workspace_root="/tmp/openseek-workspace"),
     "/tmp/openseek-workspace/.openseek",
   )
-  let custom = cli_command().parse(
+  let custom = run_matches(
     argv=["--session-root", "sessions", "write", "MoonBit"],
     env={ "DEEPSEEK": "test-key" },
   )
@@ -1197,11 +1344,8 @@ test "session root resolves relative to workspace root" {
 
 ///|
 async test "session commands reject empty session root" {
-  let parsed = cli_command().parse(
-    argv=["--session-root", "", "--session-list"],
-    env={},
-  )
-  let _ = handle_session_command(parsed) catch {
+  let parsed = sessions_leaf_matches(sub="list", argv=["--session-root", ""], env={})
+  let _ = sessions_list(parsed) catch {
     error => {
       assert_true("\{error}".contains("--session-root"))
       return
@@ -1212,7 +1356,7 @@ async test "session commands reject empty session root" {
 
 ///|
 test "agent runs require api key" {
-  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={})
+  let parsed = run_matches(argv=["write", "MoonBit"], env={})
   let _ = api_key(parsed) catch {
     error => {
       assert_true("\{error}".contains("--api-key or DEEPSEEK is required"))
@@ -1224,7 +1368,7 @@ test "agent runs require api key" {
 
 ///|
 test "agent runs require task text" {
-  let parsed = cli_command().parse(argv=[], env={ "DEEPSEEK": "test-key" })
+  let parsed = run_matches(argv=[], env={ "DEEPSEEK": "test-key" })
   let _ = task_text(parsed) catch {
     error => {
       assert_true("\{error}".contains("task description is required"))
@@ -1236,7 +1380,7 @@ test "agent runs require task text" {
 
 ///|
 async test "one-shot runs record to a generated salted cli session by default" {
-  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
   guard resolved_session_id(parsed) is Some(id) else {
@@ -1251,7 +1395,7 @@ async test "one-shot runs record to a generated salted cli session by default" {
 
 ///|
 async test "--no-session restores the ephemeral one-shot" {
-  let parsed = cli_command().parse(argv=["--no-session", "write", "MoonBit"], env={
+  let parsed = run_matches(argv=["--no-session", "write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
   assert_true(resolved_session_id(parsed) is None)
@@ -1259,10 +1403,9 @@ async test "--no-session restores the ephemeral one-shot" {
 
 ///|
 async test "an explicit --session id is used verbatim" {
-  let parsed = cli_command().parse(
-    argv=["--session", "demo", "write", "MoonBit"],
-    env={ "DEEPSEEK": "test-key" },
-  )
+  let parsed = run_matches(argv=["--session", "demo", "write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+  })
   guard resolved_session_id(parsed) is Some(id) else {
     fail("expected the explicit id")
   }
@@ -1271,7 +1414,7 @@ async test "an explicit --session id is used verbatim" {
 
 ///|
 async test "--session with --no-session is a contradiction" {
-  let parsed = cli_command().parse(
+  let parsed = run_matches(
     argv=["--session", "demo", "--no-session", "write", "MoonBit"],
     env={ "DEEPSEEK": "test-key" },
   )
@@ -1286,10 +1429,9 @@ async test "--session with --no-session is a contradiction" {
 
 ///|
 test "cli parses max steps option" {
-  let parsed = cli_command().parse(
-    argv=["--max-steps", "25", "write", "MoonBit"],
-    env={ "DEEPSEEK": "test-key" },
-  )
+  let parsed = run_matches(argv=["--max-steps", "25", "write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+  })
   assert_eq(max_steps(parsed), 25)
 }
 
@@ -1300,7 +1442,7 @@ async test "configured system prompt can replace and append files" {
     let addendum_path = "\{dir}/addendum.md"
     @fs.write_file(prompt_path, "base prompt\n", create_mode=CreateOrTruncate)
     @fs.write_file(addendum_path, "addendum\n", create_mode=CreateOrTruncate)
-    let parsed = cli_command().parse(
+    let parsed = run_matches(
       argv=[
         "--system-prompt-file", prompt_path, "--system-prompt-addendum-file", addendum_path,
         "write", "MoonBit",
@@ -1339,7 +1481,7 @@ async test "configured system prompt advertises global skills" {
     )
     let prompt_path = "\{dir}/prompt.md"
     @fs.write_file(prompt_path, "base\n", create_mode=CreateOrTruncate)
-    let parsed = cli_command().parse(
+    let parsed = run_matches(
       argv=["--system-prompt-file", prompt_path, "write", "MoonBit"],
       env={
         "DEEPSEEK": "test-key",
@@ -1377,7 +1519,7 @@ async test "configured system prompt uses the selected workspace root" {
       ),
       create_mode=CreateOrTruncate,
     )
-    let parsed = cli_command().parse(
+    let parsed = run_matches(
       argv=[
         "--dir", workspace, "--system-prompt-file", "prompt.md", "write", "MoonBit",
       ],
@@ -1403,7 +1545,7 @@ async test "configured system prompt uses the selected workspace root" {
 
 ///|
 async test "configured system prompt defaults to the flash prompt" {
-  let parsed = cli_command().parse(argv=["write", "MoonBit"], env={
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
   })
   assert_true(
@@ -1425,7 +1567,7 @@ async test "load_or_new_session defers first durable write until append" {
     let id : @agent_session.SessionId = SessionId("cli-test")
     let prompt_path = "\{root}/prompt.md"
     @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
-    let parsed = cli_command().parse(
+    let parsed = run_matches(
       argv=[
         "--session-root", root, "--session", "cli-test", "--system-prompt-file",
         prompt_path, "write", "MoonBit",
@@ -1468,7 +1610,7 @@ async test "new durable session header persists project layout" {
     let real_workspace = @fs.realpath(workspace)
     let store = @store.SessionStore("\{real_workspace}/.openseek")
     let id : @agent_session.SessionId = SessionId("cli-test")
-    let parsed = cli_command().parse(
+    let parsed = run_matches(
       argv=[
         "--dir",
         workspace,
@@ -1511,7 +1653,7 @@ async test "load_or_new_session recovers empty interrupted session directory" {
     @fs.mkdir("\{root}/sessions/\{id.value()}", recursive=true)
     let prompt_path = "\{root}/prompt.md"
     @fs.write_file(prompt_path, "system", create_mode=CreateOrTruncate)
-    let parsed = cli_command().parse(
+    let parsed = run_matches(
       argv=[
         "--session-root",
         root,
@@ -1546,24 +1688,27 @@ async test "session list command does not require deepseek setup" {
     let store = @store.SessionStore(root)
     store.create(Session(SessionId("b"), system_prompt="system"))
     store.create(Session(SessionId("a"), system_prompt="system"))
-    let parsed = cli_command().parse(
-      argv=["--session-root", root, "--session-list"],
+    let parsed = sessions_leaf_matches(
+      sub="list",
+      argv=["--session-root", root],
       env={},
     )
-    assert_true(handle_session_command(parsed))
+    // Prints the listing and succeeds with no DeepSeek setup.
+    sessions_list(parsed)
   })
 }
 
 ///|
 test "session list format defaults to text and rejects unknown values" {
-  let default_format = cli_command().parse(argv=["--session-list"], env={})
+  let default_format = sessions_leaf_matches(sub="list", argv=[], env={})
   assert_true(session_list_format(default_format) is Text)
-  let json_format = cli_command().parse(
-    argv=["--session-list", "--format", "json"],
+  let json_format = sessions_leaf_matches(
+    sub="list",
+    argv=["--format", "json"],
     env={},
   )
   assert_true(session_list_format(json_format) is Json)
-  let bogus = cli_command().parse(argv=["--session-list", "--format", "yaml"], env={})
+  let bogus = sessions_leaf_matches(sub="list", argv=["--format", "yaml"], env={})
   let _ = session_list_format(bogus) catch {
     error => {
       assert_true("\{error}".contains("--format must be text or json"))
@@ -1646,14 +1791,15 @@ async test "session compact command appends summary without api key" {
       "summarized turn",
       create_mode=CreateOrTruncate,
     )
-    let parsed = cli_command().parse(
+    let parsed = sessions_leaf_matches(
+      sub="compact",
       argv=[
-        "--session-root", root, "--session", "cli-test", "--session-compact-file",
-        summary_path, "--session-compact-from", "1", "--session-compact-to", "2",
+        "cli-test", "--session-root", root, "--file", summary_path, "--from", "1",
+        "--to", "2",
       ],
       env={},
     )
-    assert_true(handle_session_command(parsed))
+    sessions_compact(parsed)
     let loaded = store.load(SessionId("cli-test"))
     assert_eq(loaded.events().length(), 3)
     guard loaded.events()[2].item() is Summary(summary) else {
@@ -1680,14 +1826,15 @@ async test "session compact file resolves relative to workspace root" {
       "workspace summary",
       create_mode=CreateOrTruncate,
     )
-    let parsed = cli_command().parse(
+    let parsed = sessions_leaf_matches(
+      sub="compact",
       argv=[
-        "--session", "cli-test", "--session-compact-file", "summary.txt", "--session-compact-from",
-        "1", "--session-compact-to", "2",
+        "cli-test", "--dir", workspace, "--file", "summary.txt", "--from", "1", "--to",
+        "2",
       ],
       env={},
     )
-    assert_true(handle_session_command(parsed, workspace_root=workspace))
+    sessions_compact(parsed)
     let loaded = store.load(SessionId("cli-test"))
     guard loaded.events()[2].item() is Summary(summary) else {
       fail("expected summary")
@@ -1698,16 +1845,14 @@ async test "session compact file resolves relative to workspace root" {
 
 ///|
 async test "session compaction rejects missing summary file" {
-  let parsed = cli_command().parse(
-    argv=[
-      "--session", "cli-test", "--session-compact-from", "1", "--session-compact-to",
-      "2", "write", "MoonBit",
-    ],
-    env={ "DEEPSEEK": "test-key" },
+  let parsed = sessions_leaf_matches(
+    sub="compact",
+    argv=["cli-test", "--from", "1", "--to", "2"],
+    env={},
   )
-  let _ = handle_session_command(parsed) catch {
+  let _ = sessions_compact(parsed) catch {
     error => {
-      assert_true("\{error}".contains("--session-compact-file is required"))
+      assert_true("\{error}".contains("--file"))
       return
     }
   }
@@ -1716,10 +1861,9 @@ async test "session compaction rejects missing summary file" {
 
 ///|
 test "cli rejects invalid max steps" {
-  let parsed = cli_command().parse(
-    argv=["--max-steps", "0", "write", "MoonBit"],
-    env={ "DEEPSEEK": "test-key" },
-  )
+  let parsed = run_matches(argv=["--max-steps", "0", "write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+  })
   let _ = max_steps(parsed) catch {
     error => {
       assert_true("\{error}".contains("--max-steps must be a positive integer"))

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -7,6 +7,7 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/agent_session/compact",
+  "bobzhang/openseek/cmd/tui",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/prompt",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -1,21 +1,30 @@
 # bobzhang/openseek/cmd/tui
 
-The OpenSeek terminal UI: a scrolling transcript with a live composer, built
-on the reusable [`tui`](../../tui/README.md) controller package.
+The OpenSeek terminal UI: a scrolling transcript with a live composer, built on
+the reusable [`tui`](../../tui/README.md) controller package. It ships as a
+library launched by the single `openseek` binary — it is the **default** mode
+(bare `openseek`, `openseek "PROMPT"`) and the explicit `openseek tui`
+subcommand. There is no separate `tui` executable.
 
-The TUI runs no agent code itself. It spawns the engine binary (`openseek`
-from `PATH`; override with `--engine` or `OPENSEEK_ENGINE`) **once per
-session** in `--serve` mode and drives it over stdin commands, rendering the
-engine's JSONL event stream: streamed thinking and answer text move live on
-the activity line, each turn's reasoning is kept as a dim `✻` transcript
-aside above its answer, and tool results land as `⏺` blocks. Pressing Enter
-while a task runs steers it mid-turn; Ctrl-C cancels the turn (a second
-Ctrl-C kills the engine, and the next prompt respawns it on the same
-session).
+The UI runs no agent code itself. It spawns the `openseek` engine — by default
+this same binary, re-launched in `serve` mode (so the UI and engine can never
+drift out of sync), resolved from `argv[0]` when invoked by path and otherwise
+from `PATH`; override with `--engine` or `OPENSEEK_ENGINE` — **once per session**
+and drives it over stdin commands, rendering the engine's JSONL event stream:
+streamed thinking and answer text move live on the activity line, each turn's
+reasoning is kept as a dim `✻` transcript aside above its answer, and tool
+results land as `⏺` blocks. Pressing Enter while a task runs steers it mid-turn;
+Ctrl-C cancels the turn (a second Ctrl-C kills the engine, and the next prompt
+respawns it on the same session).
 
 A custom or recorded-stream engine that only speaks the original
-one-process-per-prompt protocol still works with `--engine-mode oneshot`
-(env `OPENSEEK_ENGINE_MODE`); steering is unavailable there.
+one-process-per-prompt protocol works with `--engine-mode oneshot` (env
+`OPENSEEK_ENGINE_MODE`); it spawns `<engine> run -- <task>` per prompt, steering
+is unavailable, and it requires an explicit `--engine` (re-launching this binary
+in oneshot would only lose steering for no gain).
+
+Because the UI takes over the terminal, launching it without a TTY (a pipe, CI
+log, or cron) is refused with a pointer to `openseek run` / `openseek serve`.
 
 ## Sessions
 
@@ -28,13 +37,13 @@ startup banner) stores the conversation under `--session-root` (default
 - `--continue` resumes the most recently active session.
 - `--session <id>` resumes (or creates) a specific one; combining it with
   `--continue` is rejected.
-- `openseek --session-list` (on the engine CLI) lists what is resumable.
+- `openseek sessions list` lists what is resumable.
 
 ## Configuration
 
-`--api-key` (env `DEEPSEEK`) is required. `--model`, `--api-url`,
-`--max-steps`, and `--thinking` mirror the engine's flags and are forwarded to
-it through the environment, alongside the session settings.
+`--api-key` (env `DEEPSEEK`) is required. `--model`, `--api-url`, `--max-steps`,
+and `--thinking` mirror the engine's flags and are forwarded to it through the
+environment, alongside the session settings.
 
 The full flag reference lives in the executable help — verified verbatim in
 [`tests/cram/tui.md`](../../tests/cram/tui.md).

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -64,7 +64,7 @@ async fn[G] EngineClient::start(
   let proc = @process.spawn(
     group,
     self.config.engine,
-    ["--serve"],
+    ["serve"],
     inherit_env=false,
     extra_env=child_env,
     stdin=child_stdin,

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -15,7 +15,7 @@ priv struct EngineProcess {
 }
 
 ///|
-/// The TUI's connection to one long-lived `--serve` engine process — the
+/// The TUI's connection to one long-lived `serve` engine process — the
 /// client half of the persistent-engine design.
 ///
 /// One engine serves every prompt of a TUI session: prompts, steers, and

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -151,8 +151,11 @@ fn engine_env(
 }
 
 ///|
+/// One-shot engine invocation: `<engine> run -- <task>`. The `run` subcommand is
+/// the headless one-shot mode; `--` stops option parsing so a task starting with
+/// `-` is taken literally.
 fn engine_args(task : String) -> Array[String] {
-  ["--", task]
+  ["run", "--", task]
 }
 
 ///|

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -1,7 +1,7 @@
 ///|
 fn cli_command() -> @argparse.Command {
   Command(
-    "openseek-tui",
+    "openseek tui",
     about="OpenSeek terminal UI.",
     options=[
       OptionArg(
@@ -297,8 +297,12 @@ async fn engine_launchable(engine : String) -> Bool {
 }
 
 ///|
-async fn main {
-  let matches = cli_command().parse(env=@env.get_env_vars())
+/// Run the interactive terminal UI — the default mode of the `openseek` binary
+/// (bare `openseek`, `openseek "PROMPT"`, or the explicit `openseek tui`). `argv`
+/// is the argument list after any `tui` selector and `env` the process
+/// environment; both come from the single-binary dispatcher in `cmd/openseek`.
+pub async fn run(argv~ : ArrayView[String], env~ : Map[String, String]) -> Unit {
+  let matches = cli_command().parse(argv~, env~)
   let mut config = parse_config(matches)
   if continue_requested(matches) {
     config = with_latest_session(config)
@@ -314,7 +318,30 @@ async fn main {
     )
     @sys.exit(1)
   }
+  // The UI takes over the terminal, so refuse when stdin/stdout is not a TTY (a
+  // pipe, CI log, or cron) — otherwise it would garble a non-interactive stream.
+  // Checked after parsing and the engine probe so `--help`, argument errors, and
+  // the engine-usability error still surface when piped.
+  guard is_tty(@stdio.stdin) && is_tty(@stdio.stdout) else {
+    // To stderr: this guard exists precisely to keep a piped/redirected stdout
+    // clean, so the diagnostic must not land on it.
+    @stdio.stderr.write(
+      "error: the interactive UI needs a terminal; run a headless task with `openseek run \"…\"` (or `openseek serve` for the JSONL protocol).\n",
+    ) catch {
+      _ => ()
+    }
+    @sys.exit(1)
+  }
   run_tui(config, initial_task(matches))
+}
+
+///|
+/// Whether `fd` is an interactive terminal; a probe error counts as "not a TTY"
+/// so a missing capability degrades to the headless guidance rather than crashes.
+fn[T : @tty.Fd] is_tty(fd : T) -> Bool {
+  @tty.isatty(fd) catch {
+    _ => false
+  }
 }
 
 ///|

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -43,8 +43,7 @@ fn cli_command() -> @argparse.Command {
         "engine",
         long="engine",
         env="OPENSEEK_ENGINE",
-        default_values=["openseek"],
-        about="Agent engine binary to spawn; reads its JSONL event stream from stdout.",
+        about="Agent engine to spawn (default: this openseek binary); reads its JSONL event stream from stdout.",
       ),
       OptionArg(
         "engine-mode",
@@ -204,6 +203,23 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
       root
     }
   }
+  // An explicit --engine / OPENSEEK_ENGINE wins; otherwise re-launch this binary
+  // as the engine (see `default_engine`). Presence of a non-blank value, not a
+  // magic default string, decides — which also gates oneshot below. A blank
+  // `--engine ""` counts as unset rather than an empty command.
+  let explicit_engine : String? = match values(matches, "engine") {
+    [engine, ..] if !engine.trim().is_empty() => Some(engine)
+    _ => None
+  }
+  let engine_mode = EngineMode::parse(value(matches, "engine-mode"))
+  // `oneshot` only makes sense for a custom/replay engine that cannot speak the
+  // persistent `serve` protocol; re-launching ourselves in oneshot buys nothing
+  // and loses steering/compaction, so require an explicit engine.
+  if engine_mode is OneShot && explicit_engine is None {
+    fail(
+      "--engine-mode oneshot requires an explicit --engine / OPENSEEK_ENGINE (it is for replay/custom engines)",
+    )
+  }
   {
     api_key: value(matches, "api-key"),
     api_url: api_url(matches),
@@ -218,8 +234,26 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
       None => generated_session_id(@env.now().reinterpret_as_int64())
     },
     session_root: session_root_value,
-    engine: value(matches, "engine"),
-    engine_mode: EngineMode::parse(value(matches, "engine-mode")),
+    engine: match explicit_engine {
+      Some(engine) => engine
+      None => default_engine(@sys.get_cli_args())
+    },
+    engine_mode,
+  }
+}
+
+///|
+/// The engine command when `--engine`/`OPENSEEK_ENGINE` is unset: re-launch *this*
+/// executable so `openseek tui` never spawns a separately-installed, stale engine.
+/// `args[0]` (argv0) with a path separator (`/` or, on Windows, `\`) is used
+/// directly — spawn resolves it against the launch cwd (which the UI never
+/// changes) — so `./openseek` or an absolute path re-execs the same file; a bare
+/// name is left as `openseek` for a PATH lookup, which for a single binary is the
+/// same file. Split out so it is unit-testable without a real argv0.
+fn default_engine(args : ArrayView[String]) -> String {
+  match args {
+    [argv0, ..] if argv0.contains("/") || argv0.contains("\\") => argv0
+    _ => "openseek"
   }
 }
 
@@ -352,7 +386,9 @@ test "cli accepts no initial task" {
   assert_eq(config.api_key, "test-key")
   assert_true(config.api_url is None)
   assert_eq(config.max_steps, 1000)
-  assert_eq(config.engine, "openseek")
+  // With no --engine, the engine falls through to re-launching this binary
+  // (`default_engine` of the process args), not a hardcoded string.
+  assert_eq(config.engine, default_engine(@sys.get_cli_args()))
   // No --session still converses in a session: a generated per-launch id, so
   // consecutive prompts share context instead of running amnesiac one-shots.
   assert_true(config.session_id.value().has_prefix("tui-"))
@@ -475,6 +511,77 @@ test "cli accepts --continue and rejects combining it with --session" {
     }
   }
   fail("--continue with --session accepted")
+}
+
+///|
+test "default_engine re-launches a path argv0 and falls back to PATH otherwise" {
+  assert_eq(
+    default_engine(["/usr/local/bin/openseek"]),
+    "/usr/local/bin/openseek",
+  )
+  assert_eq(default_engine(["./openseek"]), "./openseek")
+  assert_eq(
+    default_engine(["target/native/openseek"]),
+    "target/native/openseek",
+  )
+  assert_eq(
+    default_engine(["target\\native\\openseek.exe"]),
+    "target\\native\\openseek.exe",
+  )
+  assert_eq(default_engine(["openseek"]), "openseek")
+  assert_eq(default_engine([]), "openseek")
+}
+
+///|
+async test "engine defaults to this binary; --engine/OPENSEEK_ENGINE override it" {
+  // No --engine and no env: fall through to re-launching this binary.
+  let default_cfg = parse_config(
+    cli_command().parse(argv=[], env={ "DEEPSEEK": "k" }),
+  )
+  assert_eq(default_cfg.engine, default_engine(@sys.get_cli_args()))
+  // OPENSEEK_ENGINE is treated as an explicit engine.
+  let env_cfg = parse_config(
+    cli_command().parse(argv=[], env={
+      "DEEPSEEK": "k",
+      "OPENSEEK_ENGINE": "./fake-engine",
+    }),
+  )
+  assert_eq(env_cfg.engine, "./fake-engine")
+}
+
+///|
+async test "oneshot engine mode requires an explicit engine" {
+  let _ = parse_config(
+    cli_command().parse(argv=["--engine-mode", "oneshot"], env={
+      "DEEPSEEK": "k",
+    }),
+  ) catch {
+    error => {
+      assert_true("\{error}".contains("oneshot requires an explicit"))
+      return
+    }
+  }
+  fail("oneshot without an explicit engine was accepted")
+}
+
+///|
+async test "oneshot with an explicit engine (flag or env) is accepted" {
+  let flag_cfg = parse_config(
+    cli_command().parse(
+      argv=["--engine-mode", "oneshot", "--engine", "./fake-engine"],
+      env={ "DEEPSEEK": "k" },
+    ),
+  )
+  assert_true(flag_cfg.engine_mode is OneShot)
+  assert_eq(flag_cfg.engine, "./fake-engine")
+  let env_cfg = parse_config(
+    cli_command().parse(argv=[], env={
+      "DEEPSEEK": "k",
+      "OPENSEEK_ENGINE": "./fake-engine",
+      "OPENSEEK_ENGINE_MODE": "oneshot",
+    }),
+  )
+  assert_true(env_cfg.engine_mode is OneShot)
 }
 
 ///|

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -11,9 +11,11 @@ import {
   "bobzhang/openseek/tui/doc",
   "bobzhang/openseek/tui/style",
   "moonbit-community/displaytext",
+  "moonbit-community/tty",
   "moonbitlang/async",
   "moonbitlang/async/os_error",
   "moonbitlang/async/process",
+  "moonbitlang/async/stdio",
   "moonbitlang/core/argparse",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
@@ -28,7 +30,3 @@ import {
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 
 supported_targets = "+native"
-
-options(
-  "is-main": true,
-)

--- a/cmd/tui/pkg.generated.mbti
+++ b/cmd/tui/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/cmd/tui"
 
 // Values
+pub async fn run(argv~ : ArrayView[String], env~ : Map[String, String]) -> Unit
 
 // Errors
 

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -14,8 +14,10 @@ priv struct AppConfig {
   session_id : @agent_session.SessionId
   session_root : String
   // The agent engine the TUI spawns and reads JSONL events from. Defaults to
-  // the `openseek` binary on `PATH`; override (e.g. to a recorded-stream
-  // replayer) with `--engine` or `OPENSEEK_ENGINE`.
+  // this running `openseek` binary re-launched as the engine (see
+  // `default_engine`), so it never spawns a stale, separately-built engine;
+  // override (e.g. to a recorded-stream replayer) with `--engine` or
+  // `OPENSEEK_ENGINE`.
   engine : String
   engine_mode : EngineMode
 }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -24,7 +24,7 @@ priv struct AppConfig {
 
 ///|
 /// How the TUI talks to its engine. `Serve` (the default) keeps one
-/// persistent `--serve` process per session — warm watchers, steering,
+/// persistent `serve` process per session — warm watchers, steering,
 /// polite cancel. `OneShot` spawns the engine once per prompt with the task
 /// as an argument: the escape hatch for replay or custom engines that only
 /// speak the original protocol; steering is unavailable there.

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -74,10 +74,14 @@ async fn run_trial(
   // isolated trial workspace. This keeps launcher-relative paths stable while
   // ensuring the agent's session store and tool cwd live under the workspace.
   let repo_root = @fs.realpath(config.repo_root)
+  // `run` is the headless one-shot subcommand of the single `openseek` binary.
   let (program, args) = if config.engine != "" {
-    (@fs.realpath(config.engine), [])
+    (@fs.realpath(config.engine), ["run"])
   } else {
-    ("moon", ["run", "--target", "native", "\{repo_root}/cmd/openseek", "--"])
+    (
+      "moon",
+      ["run", "--target", "native", "\{repo_root}/cmd/openseek", "--", "run"],
+    )
   }
   args.append([
     "--max-steps",

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -4,61 +4,75 @@ These examples are executed by `moon cram test tests/cram`. The Moon wrapper
 builds the native package at `cmd/openseek` first, then exposes the executable
 on `PATH` as `openseek.exe`.
 
-Every command here is offline: it either prints help or fails argument
-validation before the agent contacts DeepSeek, so the suite needs no API key and
-makes no network calls. The live, API-backed examples live in
-[`tests/live/deepseek.md`](../live/deepseek.md).
+`openseek` is a subcommand tree: the interactive terminal UI is the default
+(documented in [`tui.md`](tui.md)), and the headless engine lives under `run`,
+`serve`, `review`, and `sessions`. Every command here is offline: it either
+prints help or fails argument validation before the agent contacts DeepSeek, so
+the suite needs no API key and makes no network calls. The live, API-backed
+examples live in [`tests/live/deepseek.md`](../live/deepseek.md).
 
-## Help Banner
+## Top-Level Help
 
-`--help` prints the full usage, the available options, and the environment
-variables and defaults behind each one, then exits successfully.
+`openseek --help` lists the subcommands and exits successfully.
 
 ```mooncram
 $ openseek.exe --help
-Usage: openseek [options] [task...]
+openseek — DeepSeek-backed MoonBit coding agent
 
-DeepSeek-backed MoonBit coding agent.
+Usage:
+  openseek [PROMPT...]           Launch the interactive terminal UI (default),
+                                 optionally with an initial prompt.
+  openseek tui [PROMPT...]       The interactive UI, explicitly.
+  openseek run [options] TASK    Run one task headlessly; stream JSONL on stdout.
+  openseek serve                 JSONL command server (stdin: prompt/steer/cancel/compact).
+  openseek review [--base REF]   Read-only code review of REF...HEAD; one JSON report.
+  openseek sessions <list|show|compact>   Manage durable sessions.
+
+Run `openseek <subcommand> --help` for a subcommand's options.
+Use `openseek -- PROMPT` to pass a prompt that begins with a subcommand word.
+```
+
+## `openseek run` Runs One Task Headlessly
+
+`openseek run --help` prints the options, environment variables, and defaults
+behind a headless run.
+
+```mooncram
+$ openseek.exe run --help
+Usage: openseek run [options] [task...]
+
+Run one task headlessly; stream JSONL events on stdout.
 
 Arguments:
   task...  Task description.
 
 Options:
   -h, --help                                                   Show help information.
-  --review                                                     Run a read-only code review of base...HEAD and print a JSON ReviewReport to stdout.
-  --serve                                                      Run as a session server: read JSONL commands (prompt/steer/cancel) from stdin.
   --no-session                                                 Run ephemerally: do not record this run to a durable session.
-  --session-list                                               List durable sessions (see --format) and exit.
-  --session-show                                               Print the durable session JSON for --session and exit.
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
   --model <model>                                              DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --dir <dir>                                                  Workspace directory for relative paths; creates only the final path component if its parent exists. [env: OPENSEEK_DIR] [default: .]
   --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N); 1 means a single run. [env: OPENSEEK_CONCURRENCY] [default: 1]
   --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
   --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
   --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION] [default: ]
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
-  --session-compact-file <session-compact-file>                Read summary text from this file, append it to --session, and exit. [default: ]
-  --session-compact-from <session-compact-from>                First event sequence covered by --session-compact-file. [default: ]
-  --session-compact-to <session-compact-to>                    Last event sequence covered by --session-compact-file. [default: ]
-  --base <base>                                                Base ref for --review: review the diff base...HEAD. [default: origin/main]
-  --format <format>                                            Output format for --session-list: text or json. [default: text]
+  --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N); 1 means a single run. [env: OPENSEEK_CONCURRENCY] [default: 1]
 ```
 
 ## A DeepSeek API Key Is Required For Agent Runs
 
-With no `--api-key` flag and no `DEEPSEEK` in the environment, an agent run
-reports the missing key and exits non-zero.
+With no `--api-key` flag and no `DEEPSEEK` in the environment, a run reports the
+missing key and exits non-zero.
 
 ```mooncram
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe "summarize this project" > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u DEEPSEEK openseek.exe run "summarize this project" > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > cat "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
@@ -78,7 +92,7 @@ instead of silently turning them into prompt text.
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u DEEPSEEK openseek.exe run --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
@@ -95,7 +109,7 @@ Here parsing succeeds and the run reaches the later API-key validation.
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe -- '--xxy he' > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u DEEPSEEK openseek.exe run -- '--xxy he' > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > cat "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
@@ -105,12 +119,12 @@ error: --api-key or DEEPSEEK is required for agent runs
 stdout-empty
 ```
 
-## Session Management Is Offline
+## `openseek sessions` Is Offline
 
 Session inspection and compaction operate on typed session files and do not
-require a DeepSeek API key. Hand-written log lines carry the 0 sentinel
-stamp; the summary event the compaction *appends* is stamped with the wall
-clock, so both `--session-show` calls strip `ts` to stay deterministic.
+require a DeepSeek API key. Hand-written log lines carry the 0 sentinel stamp;
+the summary event the compaction *appends* is stamped with the wall clock, so
+both `sessions show` calls strip `ts` to stay deterministic.
 
 ```mooncram
 $ sh <<'EOF'
@@ -122,10 +136,10 @@ $ sh <<'EOF'
 > {"sequence":2,"ts":0,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
 > JSONL
 > printf 'hello and answer' > "$tmp/summary.txt"
-> env -u DEEPSEEK openseek.exe --session-list --session-root "$tmp" | cut -f1
-> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
-> env -u DEEPSEEK openseek.exe --session demo --session-root "$tmp" --session-compact-file "$tmp/summary.txt" --session-compact-from 1 --session-compact-to 2
-> env -u DEEPSEEK openseek.exe --session-show --session demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
+> env -u DEEPSEEK openseek.exe sessions list --session-root "$tmp" | cut -f1
+> env -u DEEPSEEK openseek.exe sessions show demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
+> env -u DEEPSEEK openseek.exe sessions compact demo --session-root "$tmp" --file "$tmp/summary.txt" --from 1 --to 2
+> env -u DEEPSEEK openseek.exe sessions show demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
 > rm -rf "$tmp"
 > EOF
 demo
@@ -134,29 +148,28 @@ compacted session demo events 1..2; last_sequence=3
 {"version":1,"id":"demo","system_prompt":"system","events":[{"sequence":1,"item":{"kind":"user","payload":{"content":"hello"}}},{"sequence":2,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}},{"sequence":3,"item":{"kind":"summary","payload":{"content":"hello and answer","from_sequence":1,"to_sequence":2}}}]}
 ```
 
-## One-Shot Runs Record A Session By Default
+## `openseek run` Records A Session By Default
 
-A bare `openseek "task"` records its conversation to a generated
-`cli-YYYYMMDD-HHMMSS-mmm` session under `--session-root` (default
-`.openseek`), exactly as if `--session` had been passed — "what did the agent
-do?" is usually asked after the run, when an unrecorded answer is gone for
-good. The run announces the recording with a `session_started` event on
-stdout, so the id is in the log stream (and any `OPENSEEK_LOG_FILE` mirror);
-afterwards the run is visible to `--session-list`, `--session-show`, the viz
-server, and `--session <id>` resumption.
+`openseek run "task"` records its conversation to a generated
+`cli-YYYYMMDD-HHMMSS-mmm` session under `--session-root` (default `.openseek`),
+exactly as if `--session` had been passed — "what did the agent do?" is usually
+asked after the run, when an unrecorded answer is gone for good. The run
+announces the recording with a `session_started` event on stdout, so the id is
+in the log stream (and any `OPENSEEK_LOG_FILE` mirror); afterwards the run is
+visible to `sessions list`, `sessions show`, the viz server, and `--session
+<id>` resumption.
 
-This example stays offline by pointing `--api-url` at a closed local port:
-the engine names its session, durably records the user prompt, and only then
-fails to reach the API. The generated id's timestamp is normalized for
-determinism.
+This example stays offline by pointing `--api-url` at a closed local port: the
+engine names its session, durably records the user prompt, and only then fails
+to reach the API. The generated id's timestamp is normalized for determinism.
 
 ```mooncram
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
-> if env DEEPSEEK=test-key openseek.exe --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env DEEPSEEK=test-key openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > grep -c '"event":"session_started"' out.jsonl
-> env -u DEEPSEEK openseek.exe --session-list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
+> env -u DEEPSEEK openseek.exe sessions list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
 > rm -rf "$tmp"
 > EOF
 exit-non-zero
@@ -164,14 +177,14 @@ exit-non-zero
 cli-<stamp>
 ```
 
-`--no-session` turns recording off: the same failing run leaves no session
-root behind.
+`--no-session` turns recording off: the same failing run leaves no session root
+behind.
 
 ```mooncram
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
-> env DEEPSEEK=test-key openseek.exe --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" >/dev/null 2>&1
+> env DEEPSEEK=test-key openseek.exe run --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" >/dev/null 2>&1
 > if test -d .openseek; then echo recorded; else echo ephemeral; fi
 > rm -rf "$tmp"
 > EOF
@@ -180,20 +193,20 @@ ephemeral
 
 ## `--dir` Selects The Workspace Root
 
-`--dir` defaults to `.`, but it can point a one-shot run at another workspace.
-When the final path component is missing and the parent exists, OpenSeek
-creates that one directory, logs `workspace_created`, and resolves the default
-session root under it.
+`--dir` defaults to `.`, but it can point a run at another workspace. When the
+final path component is missing and the parent exists, OpenSeek creates that one
+directory, logs `workspace_created`, and resolves the default session root under
+it.
 
 ```mooncram
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > mkdir -p "$tmp/parent"
-> if env DEEPSEEK=test-key openseek.exe --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env DEEPSEEK=test-key openseek.exe run --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > if test -d "$tmp/parent/new"; then echo dir-created; else echo dir-missing; fi
 > grep -c '"event":"workspace_created"' "$tmp/out.jsonl"
-> env -u DEEPSEEK openseek.exe --dir "$tmp/parent/new" --session-list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
-> env -u DEEPSEEK openseek.exe --dir "$tmp/parent/fresh" --session-list > "$tmp/session-list.out"
+> env -u DEEPSEEK openseek.exe sessions list --dir "$tmp/parent/new" | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
+> env -u DEEPSEEK openseek.exe sessions list --dir "$tmp/parent/fresh" > "$tmp/session-list.out"
 > if test -d "$tmp/parent/fresh"; then echo session-dir-created; else echo session-dir-missing; fi
 > wc -l < "$tmp/session-list.out" | tr -d ' '
 > rm -rf "$tmp"
@@ -206,57 +219,52 @@ session-dir-created
 0
 ```
 
-Asking for both behaviors at once is rejected before any work happens.
+Asking for both recording behaviors at once is rejected before any work happens.
 
 ```mooncram
-$ env DEEPSEEK=test-key openseek.exe --session demo --no-session "say hi" 2>&1
+$ env DEEPSEEK=test-key openseek.exe run --session demo --no-session "say hi" 2>&1
 error: --no-session contradicts --session; pick one behavior
 [1]
 ```
 
-The same contradiction is caught in every mode — including `--serve`, which
-loads its session store on its own code path.
+## `openseek serve` Speaks JSONL Commands On Stdin
+
+`serve` turns the engine into a long-lived session server: prompts, steers, and
+cancels arrive as JSONL commands on stdin, and the usual event stream leaves on
+stdout. The command surface is testable offline — a malformed command is
+reported as a `command_error` event rather than killing the server, an idle
+`cancel` is a no-op, and stdin EOF shuts the server down cleanly (exit 0)
+without ever touching the network. The `grep -o` keeps only the stable event
+tag, since event lines carry timestamps.
 
 ```mooncram
-$ printf '' | env DEEPSEEK=test-key openseek.exe --serve --session demo --no-session 2>&1
-error: --no-session contradicts --session; pick one behavior
-[1]
-```
-
-## Serve Mode Speaks JSONL Commands On Stdin
-
-`--serve` turns the engine into a long-lived session server: prompts, steers,
-and cancels arrive as JSONL commands on stdin, and the usual event stream
-leaves on stdout. The command surface is testable offline — a malformed
-command is reported as a `command_error` event rather than killing the
-server, an idle `cancel` is a no-op, and stdin EOF shuts the server down
-cleanly (exit 0) without ever touching the network. The `grep -o` keeps only
-the stable event tag, since event lines carry timestamps.
-
-```mooncram
-$ printf '{"command":"reboot"}\n{"command":"cancel"}\n' | env DEEPSEEK=test-key openseek.exe --serve 2>/dev/null | grep -o '"event":"command_error"'
+$ printf '{"command":"reboot"}\n{"command":"cancel"}\n' | env DEEPSEEK=test-key openseek.exe serve 2>/dev/null | grep -o '"event":"command_error"'
 "event":"command_error"
 ```
 
-A steer with no turn to land in is rejected rather than converted into a
-prompt: it can only arrive idle by racing a turn's terminal event through
-the pipes, and an engine must never start a turn the controller did not ask
-for. The rejection carries a `steer_dropped` event so the controller can
-ask the user to resubmit — and, usefully for this offline test, no turn
-means no network.
+A steer with no turn to land in is rejected rather than converted into a prompt:
+it can only arrive idle by racing a turn's terminal event through the pipes, and
+an engine must never start a turn the controller did not ask for. The rejection
+carries a `steer_dropped` event so the controller can ask the user to resubmit —
+and, usefully for this offline test, no turn means no network.
 
 ```mooncram
-$ printf '{"command":"steer","text":"too late"}\n' | env DEEPSEEK=test-key openseek.exe --serve 2>/dev/null | grep -o '"event":"steer_dropped"'
+$ printf '{"command":"steer","text":"too late"}\n' | env DEEPSEEK=test-key openseek.exe serve 2>/dev/null | grep -o '"event":"steer_dropped"'
 "event":"steer_dropped"
 ```
 
-A task positional contradicts serve mode and is rejected before anything
-runs.
+`serve` takes no positional; a stray task is rejected by the parser before
+anything runs.
 
 ```mooncram
-$ env DEEPSEEK=test-key openseek.exe --serve "do something" 2>&1
-error: --serve reads commands from stdin; it does not take a task
-[1]
+$ sh <<'EOF'
+> stderr=$(mktemp)
+> if env DEEPSEEK=test-key openseek.exe serve "do something" 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' "$stderr"
+> rm -f "$stderr"
+> EOF
+exit-non-zero
+error: unexpected value 'do something' found; no more were expected
 ```
 
 ## MoonBit CLI Argument Parsing Pattern

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -31,7 +31,7 @@ Options:
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
-  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
+  --engine <engine>              Agent engine to spawn (default: this openseek binary); reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE]
   --engine-mode <engine-mode>    Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]
   --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -1,22 +1,22 @@
 # Verified OpenSeek TUI CLI Documentation
 
 These examples are executed by `moon cram test tests/cram`. The Moon wrapper
-builds the native package at `cmd/tui` first, then exposes the executable on
-`PATH` as `tui.exe`.
+builds the native package at `cmd/openseek` and exposes the executable on `PATH`
+as `openseek.exe`. The interactive terminal UI is the **default** mode of that
+single binary; `openseek tui …` is the explicit form.
 
-Both commands are offline: they exercise only the argument parser, which runs
-before the terminal UI starts, so the suite needs no API key, no TTY, and makes
-no network calls. The live, API-backed examples live in
-[`tests/live/deepseek.md`](../live/deepseek.md).
+These commands are offline: they exercise only the argument parser and the
+engine-usability preflight, which run before the terminal UI starts, so the
+suite needs no API key, no TTY, and makes no network calls. The live,
+API-backed examples live in [`tests/live/deepseek.md`](../live/deepseek.md).
 
 ## Help Banner
 
-`--help` prints the usage, the available options, and the environment variables
-and defaults behind each one, then exits successfully.
+`openseek tui --help` prints the UI's options and exits successfully.
 
 ```mooncram
-$ tui.exe --help
-Usage: openseek-tui --api-key <api-key> [options] [task...]
+$ openseek.exe tui --help
+Usage: openseek tui --api-key <api-key> [options] [task...]
 
 OpenSeek terminal UI.
 
@@ -39,62 +39,52 @@ Options:
 
 ## A DeepSeek API Key Is Required
 
-With no `--api-key` flag and no `DEEPSEEK` in the environment, the CLI reports
-the missing required argument, prints the usage, and exits non-zero — before the
-terminal UI ever starts.
-
-```mooncram
-$ env -u DEEPSEEK tui.exe "summarize this project"
-error: the following required argument was not provided: 'api-key'
-
-Usage: openseek-tui --api-key <api-key> [options] [task...]
-
-OpenSeek terminal UI.
-
-Arguments:
-  task...  Optional initial task description.
-
-Options:
-  -h, --help                     Show help information.
-  --continue                     Resume the most recently active session in --session-root.
-  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK]
-  --model <model>                DeepSeek model: deepseek-v4-flash or deepseek-v4-pro. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
-  --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
-  --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
-  --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
-  --engine <engine>              Agent engine binary to spawn; reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE] [default: openseek]
-  --engine-mode <engine-mode>    Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]
-  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
-
-[1]
-```
-
-## Unknown Options Are Rejected Before Initial Task Text
-
-Like the one-shot CLI, the TUI treats option-looking tokens as options until
-the normal `--` delimiter stops option parsing.
+With no `--api-key` flag and no `DEEPSEEK` in the environment, the UI reports the
+missing required argument on stderr and exits non-zero — before the terminal UI
+ever starts.
 
 ```mooncram
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env DEEPSEEK=test-key tui.exe --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
-> sed -n '1p' "$stdout"
-> if test -s "$stderr"; then echo stderr-not-empty; else echo stderr-empty; fi
+> if env -u DEEPSEEK openseek.exe tui "summarize this project" > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' "$stderr"
+> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
+> rm -f "$stdout" "$stderr"
+> EOF
+exit-non-zero
+error: the following required argument was not provided: 'api-key'
+stdout-empty
+```
+
+## Unknown Options Are Rejected Before Initial Task Text
+
+Like the headless CLI, the UI treats option-looking tokens as options until the
+normal `--` delimiter stops option parsing.
+
+```mooncram
+$ sh <<'EOF'
+> stdout=$(mktemp)
+> stderr=$(mktemp)
+> if env DEEPSEEK=test-key openseek.exe tui --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' "$stderr"
+> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
 > EOF
 exit-non-zero
 error: unexpected argument '--xxy' found
-stderr-empty
+stdout-empty
 ```
 
-When the initial task itself must start with `-`, use `--`. This gets past
-argument parsing; the fake engine then fails the preflight check before the TUI
-takes over the terminal.
+## The Engine Is Probed Before The UI Starts
+
+The UI spawns the `openseek` engine (by default this same binary, in `serve`
+mode; override with `--engine`/`OPENSEEK_ENGINE`) and probes it with `--help`
+first. A missing engine fails fast, before the UI takes over the terminal. Here
+`--` also lets the initial prompt begin with a dash.
 
 ```mooncram
-$ env DEEPSEEK=test-key tui.exe --engine openseek-not-a-real-binary -- '--xxy he'
+$ env DEEPSEEK=test-key openseek.exe tui --engine openseek-not-a-real-binary -- '--xxy he'
 error: engine 'openseek-not-a-real-binary' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
 Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
 [1]

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -36,7 +36,7 @@ invoked the `finish` tool with the requested answer (`finished_with_DONE`). The
 count, and a `=~ re"…"` regex match for the answer text.
 
 ```mooncram
-$ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
+$ openseek.exe run --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",
@@ -70,7 +70,7 @@ run, and asserting the full set would break every time the engine grows a new
 event kind.
 
 ```mooncram
-$ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
+$ openseek.exe run --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",
@@ -97,7 +97,7 @@ match the event tag and bind the answer at once, pulling the value straight out
 of the log — here it is exactly what we asked the model to finish with.
 
 ```mooncram
-$ openseek.exe --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
+$ openseek.exe run --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",
@@ -123,7 +123,7 @@ its `tool_name`, and use a regex on its `content` to confirm the command really
 ran and its output flowed back.
 
 ```mooncram
-$ openseek.exe --model deepseek-v4-flash --max-steps 6 "Use the shell tool to run exactly: echo openseek-cram. Then call finish with the word done." 2>/dev/null \
+$ openseek.exe run --model deepseek-v4-flash --max-steps 6 "Use the shell tool to run exactly: echo openseek-cram. Then call finish with the word done." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",


### PR DESCRIPTION
## Summary

Collapse the two native binaries (`cmd/openseek` engine + `cmd/tui` UI) into a **single `openseek`** executable shaped as a git-style **subcommand tree**, with the interactive TUI as the **default**. This makes distribution one artifact and removes the stale-engine footgun (the UI now re-launches *itself* as the engine). Clean-slate off `main`; **supersedes #278** (closed).

```
openseek                       interactive UI (bare)          # non-TTY → guided error to stderr
openseek "fix the bug"         UI with an initial prompt
openseek tui [PROMPT…]         the UI, explicitly
openseek run [opts] TASK       headless one-shot; JSONL on stdout
openseek serve                 JSONL command server (stdin: prompt/steer/cancel/compact)
openseek review [--base R]     read-only code review → one JSON report
openseek sessions list | show <id> | compact <id> --file --from --to
openseek -- "serve is broken"  escape a prompt that starts with a subcommand word
```

## Design (validated + codex-reviewed)

- **Top-level peel, engine argparse subtree.** `main` peels the first token: `tui`/bare-prompt → the TUI; `run`/`serve`/`review`/`sessions` → an argparse subcommand tree (`engine_command`, `sessions` nested). Peeling (vs one shared argparse root) keeps the two parsers self-contained, installs the engine's stdout-JSONL logging only on engine paths (never the UI), and sidesteps global-option inheritance. An argparse probe confirmed the fall-through/`--` semantics; a **hand-written top-level `--help`** (served with no TTY/key, so the TUI's engine-launch probe works) lists the subcommands, and `disable_help_subcommand` stops a bare `help` word from shadowing a prompt.
- **`cmd/tui` is now a library** (`pub async fn run`); there is no separate `tui` binary.
- **Self-relaunch, no C stub.** The UI spawns `<engine> serve` / `<engine> run -- <task>`; the default engine is *this* binary resolved from `argv[0]` (path-like used directly, else `openseek` on PATH). Presence of an explicit `--engine`/`OPENSEEK_ENGINE` decides. `oneshot` requires an explicit `--engine` (replay/custom engines only).
- **Non-TTY guard** in `@tui.run` (after parse + engine probe, before the UI takes the screen) points piped/CI callers at `openseek run`, on stderr.

## Also

- Engine mode-flags → subcommands (`--serve`→`serve`, `--review`→`review`, `--session-*`→`sessions …` with a positional id); `run` keeps `--no-session`/`--concurrency` (fleet stays `run --concurrency N`).
- **eval harness** (`eval/prompt_task`) now drives `openseek run … -- task`.
- **cram suite rewritten as the verified, described CLI reference** (`cli.md` per subcommand; `tui.md` for `openseek tui`).

## Commits (each codex-reviewed, no blockers)

1. `feat(cli)` — the atomic restructure (subcommands + TUI default + peel + spawn args + `cmd/tui`→lib + hand-written help + eval + cram).
2. `feat(tui)` — argv0 engine self-relaunch + `oneshot` guard (presence-based; unit-tested).
3. `docs` — READMEs for the new shape.

## Testing

- `moon test` — **853 passed** (native)
- `moon cram test tests/cram` — **18/18**
- `moon check --deny-warn`, `moon fmt --check`, `moon info` (no `.mbti` drift) — clean

## Reserved-word note

`tui`/`run`/`serve`/`review`/`sessions` are reserved as the *first* token; a prompt that starts with one needs `openseek -- "…"` (or `openseek tui "…"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)