### PR TITLE
feat(multi_edit): pre-write moonc gate over the rendered batch

### DIFF
--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -23,6 +23,9 @@ pub struct MultiEditArgs {
   // tool clamps it to a host-enforced range, so the model can tighten the
   // guardrail but not raise it past the cap.
   revert_when_errors_above : Int?
+  // Pre-write syntax gate (default true): reject the batch when any edited
+  // `.mbt` file would gain new lex/parse errors.
+  revert_on_parse_errors : Bool
 } derive(Debug)
 
 ///|
@@ -60,7 +63,12 @@ pub fn decode_args(arguments : Json) -> MultiEditArgs raise {
         Some(Null) | None => None
         Some(_) => fail("arguments.revert_when_errors_above to be an integer")
       }
-      { inline, edits_file, revert_when_errors_above }
+      let revert_on_parse_errors = match fields.get("revert_on_parse_errors") {
+        Some(True) | Some(Null) | None => true
+        Some(False) => false
+        Some(_) => fail("arguments.revert_on_parse_errors to be a boolean")
+      }
+      { inline, edits_file, revert_when_errors_above, revert_on_parse_errors }
     }
     _ => fail("object arguments")
   }

--- a/agent_tool/multi_edit/internal/decode/decode_test.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode_test.mbt
@@ -269,3 +269,22 @@ test "decode rejects non-object arguments" {
     _ => fail("non-object decoded")
   }
 }
+
+///|
+test "decode reads revert_on_parse_errors" {
+  let off = @decode.decode_args({
+    "edits": [
+      { "file": "a.mbt", "old_string": "x", "new_string": "y", "start_line": 1 },
+    ],
+    "revert_on_parse_errors": false,
+  })
+  assert_false(off.revert_on_parse_errors)
+  let default_on = @decode.decode_args({ "edits": [] })
+  assert_true(default_on.revert_on_parse_errors)
+  try @decode.decode_args({ "edits": [], "revert_on_parse_errors": 1 }) catch {
+    error =>
+      assert_true("\{error}".contains("arguments.revert_on_parse_errors"))
+  } noraise {
+    _ => fail("non-boolean flag decoded")
+  }
+}

--- a/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub struct MultiEditArgs {
   inline : Array[MultiEditItem]
   edits_file : String?
   revert_when_errors_above : Int?
+  revert_on_parse_errors : Bool
 } derive(@debug.Debug)
 
 pub struct MultiEditItem {

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -13,7 +13,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="multi_edit",
-    description="Apply many exact line-anchored replacements across one or more files in a single validated batch — the efficient path for compiler-feedback repair: when `moon check` (or another analyzer) reports several known locations, fix them all in one call instead of many separate `edit` calls. Supply the edits two ways and either or both are used (they are concatenated): `edits` is an inline array of edit objects; `edits_file` is the path to a JSON file holding an array of the same objects — for large batches, generate that file from compiler diagnostics with a script and pass its path. Each edit is {file, old_string, new_string, start_line, optional end_line}: `file` is the path to change; `start_line` (1-based) anchors the search and `end_line` bounds it, so old_string can be the small exact span instead of a large context block; each edit replaces the first matching span in its range. Make old_string uniquely identify the flagged code — include the receiver, e.g. `args.length()` — so a rename cannot stray onto a same-named call elsewhere on the line. List all edits for a given file contiguously. To INSERT instead of replace, set old_string to the empty string: new_string is inserted at the start of start_line (use start_line = last line + 1 to append at end of file). Combine changes on the same line (or one tight span) into a single edit, because adjacent or overlapping edits collide and the whole batch is rejected. Every edit is validated against the original files before anything is written; if any edit fails, no files are changed.",
+    description="Apply many exact line-anchored replacements across one or more files in a single validated batch — the efficient path for compiler-feedback repair: when `moon check` (or another analyzer) reports several known locations, fix them all in one call instead of many separate `edit` calls. Supply the edits two ways and either or both are used (they are concatenated): `edits` is an inline array of edit objects; `edits_file` is the path to a JSON file holding an array of the same objects — for large batches, generate that file from compiler diagnostics with a script and pass its path. Each edit is {file, old_string, new_string, start_line, optional end_line}: `file` is the path to change; `start_line` (1-based) anchors the search and `end_line` bounds it, so old_string can be the small exact span instead of a large context block; each edit replaces the first matching span in its range. Make old_string uniquely identify the flagged code — include the receiver, e.g. `args.length()` — so a rename cannot stray onto a same-named call elsewhere on the line. List all edits for a given file contiguously. To INSERT instead of replace, set old_string to the empty string: new_string is inserted at the start of start_line (use start_line = last line + 1 to append at end of file). Combine changes on the same line (or one tight span) into a single edit, because adjacent or overlapping edits collide and the whole batch is rejected. Every edit is validated against the original files before anything is written; a batch that would introduce lex/parse errors into a .mbt file is also rejected BEFORE writing (see revert_on_parse_errors); if any edit fails, no files are changed.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -52,6 +52,11 @@ pub fn definition(
           "description": "Auto-revert safety net. After the batch is written, `moon check` runs; if this batch INTRODUCES more than this many new compile errors (measured against the pre-batch error count, so pre-existing errors and all warnings are ignored), the entire batch is rolled back to its pre-batch contents and the call returns an error listing the first few new errors — so an over-matching replace cannot leave a broken tree to untangle. Default 5; the host caps the effective value (you can make it stricter, e.g. 0 to revert on any new error, but cannot disable it). A batch that keeps or reduces the error count is never reverted.",
           "examples": [5],
         },
+        "revert_on_parse_errors": {
+          "type": "boolean",
+          "description": "Syntax gate, on by default. Before the batch is written, each edited .mbt file's rendered result is parsed standalone (moonc -stop-after-parsing); if any file would gain new lex/parse errors — measured against its pre-batch content parsed the same way, so pre-existing parse errors are ignored — the WHOLE batch is rejected with no files changed, and the call returns the errors with excerpts of the would-be content. Type errors never trigger this gate (the post-write revert_when_errors_above guard covers those), and .mbt.md files are not gated. Set false only to intentionally produce content that does not parse (e.g. a fixture).",
+          "examples": [false],
+        },
       },
     }),
     execute=Async(arguments => execute_with_workspace(workspace_root, arguments)),
@@ -89,7 +94,12 @@ async fn execute_with_workspace(
       is_error=true,
     )
   }
-  multi_edit_files(workspace_root, edits, args.revert_when_errors_above)
+  multi_edit_files(
+    workspace_root,
+    edits,
+    args.revert_when_errors_above,
+    revert_on_parse_errors=args.revert_on_parse_errors,
+  )
 }
 
 ///|
@@ -168,6 +178,7 @@ async fn multi_edit_files(
   workspace_root : String,
   edits : Array[@decode.MultiEditItem],
   revert_when_errors_above : Int?,
+  revert_on_parse_errors~ : Bool,
 ) -> @agent_tool.ToolAction {
   let brief = "multi_edit"
   // Resolve every edit's path up front and key contiguity and grouping on the
@@ -251,6 +262,17 @@ async fn multi_edit_files(
       brief~,
     )
   }
+  // Pre-write syntax gate over the rendered batch (see parse_gate.mbt): if
+  // any edited `.mbt` file would gain new lex/parse errors, reject the whole
+  // batch before anything touches disk — the same all-or-nothing contract as
+  // the validation above. Type-error regressions stay the post-write
+  // moon-check guard's job below.
+  if revert_on_parse_errors {
+    match parse_gate_batch_rejection(writes) {
+      Some(rejection) => return rejection
+      None => ()
+    }
+  }
   for write in writes {
     @fs.write_file(write.path, write.new_content, create_mode=CreateOrTruncate) catch {
       error if @async.is_being_cancelled() => raise error
@@ -282,6 +304,126 @@ async fn multi_edit_files(
         brief=success_brief(writes),
       )
   }
+}
+
+///|
+/// How many offending files a batch reject report details in full; the rest
+/// are named in a summary line so a wide batch cannot flood the transcript.
+const RejectedFileDisplayLimit : Int = 3
+
+///|
+/// One file the parse gate rejected: how many new parse errors the batch
+/// would introduce there, and the formatted excerpts.
+priv struct FileRejection {
+  path : String
+  introduced : Int
+  truncated : Bool
+  section : String
+}
+
+///|
+/// Pre-write syntax gate over the rendered batch: parse each edited `.mbt`
+/// file's would-be result standalone (moonc -stop-after-parsing, see
+/// parse_gate.mbt) and reject the whole batch when any file would gain new
+/// parse errors versus its pre-batch content parsed the same way. The same
+/// soundness rules as `edit`'s gate apply per file: fail open when the gate
+/// cannot run or the baseline is missing/truncated, accept a truncated
+/// new-content capture as a lower bound, and resolve symlinked targets before
+/// deciding whether a file is gateable.
+async fn parse_gate_batch_rejection(
+  writes : Array[PreparedWrite],
+) -> @agent_tool.ToolAction? {
+  let rejections : Array[FileRejection] = []
+  for write in writes {
+    let target = @fs.realpath(write.path) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => write.path
+    }
+    if !@auto_check.is_gateable_path(write.path) &&
+      !@auto_check.is_gateable_path(target) {
+      continue
+    }
+    let gate = @auto_check.content_parse_errors(write.new_content) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => None
+    }
+    guard gate is Some(gate) && gate.errors.length() > 0 else { continue }
+    let before = @auto_check.content_parse_errors(write.original_content) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => None
+    }
+    guard before is Some(before) && !before.truncated else { continue }
+    let before_count = before.errors.length()
+    let introduced = gate.errors.length() - before_count
+    if introduced <= 0 {
+      continue
+    }
+    let bound = if gate.truncated { "at least " } else { "" }
+    let pre_existing = if before_count > 0 {
+      " (already has \{before_count} parse error(s); excerpts may include pre-existing ones)"
+    } else {
+      ""
+    }
+    let formatted = @auto_check.format_parse_gate_errors(
+      write.path,
+      write.new_content,
+      gate.errors,
+    )
+    rejections.push({
+      path: write.path,
+      introduced,
+      truncated: gate.truncated,
+      section: "\{write.path}: would gain \{bound}\{introduced} new parse error(s)\{pre_existing}:\n\{formatted.join("\n")}",
+    })
+  }
+  if rejections.is_empty() {
+    return None
+  }
+  let mut total = 0
+  let mut any_truncated = false
+  for rejection in rejections {
+    total += rejection.introduced
+    if rejection.truncated {
+      any_truncated = true
+    }
+  }
+  let bound = if any_truncated { "≥" } else { "" }
+  Some(
+    @agent_tool.ToolAction::respond(
+      batch_reject_report(rejections, total~, any_truncated~),
+      is_error=true,
+      brief="multi_edit rejected (\{bound}\{total} parse error(s))",
+    ),
+  )
+}
+
+///|
+/// The rejected-batch report: no files were changed, per-file excerpts of the
+/// would-be content (capped), and how to retry.
+fn batch_reject_report(
+  rejections : Array[FileRejection],
+  total~ : Int,
+  any_truncated~ : Bool,
+) -> String {
+  let total_label = if any_truncated { "at least \{total}" } else { "\{total}" }
+  let head = "rejected: the batch would introduce \{total_label} new parse error(s) across \{rejections.length()} file(s), so NO files were changed."
+  let shown = if rejections.length() < RejectedFileDisplayLimit {
+    rejections.length()
+  } else {
+    RejectedFileDisplayLimit
+  }
+  let sections = [ for rejection in rejections[0:shown] => rejection.section ]
+  let overflow = if rejections.length() > shown {
+    let hidden = [
+      for rejection in rejections[shown:rejections.length()] => rejection.path
+    ]
+    "\n…and \{hidden.length()} more file(s): \{hidden.join(", ")}"
+  } else {
+    ""
+  }
+  let retry = "\nre-issue with corrected new_strings (check delimiters against the excerpts above), or split the batch and check after each step."
+  let opt_out = "\n(To intentionally produce content that does not parse, e.g. a fixture, pass revert_on_parse_errors=false.)"
+  "\{head}\nexcerpts are from the WOULD-BE content (not what is on disk):\n\{sections.join("\n")}\{overflow}\{retry}\{opt_out}"
 }
 
 ///|

--- a/agent_tool/multi_edit/multi_edit_gate_test.mbt
+++ b/agent_tool/multi_edit/multi_edit_gate_test.mbt
@@ -1,0 +1,74 @@
+///|
+/// End-to-end through real moonc: the parse gate needs no moon project, so a
+/// plain tmpdir exercises the batch reject (all-or-nothing), the clean batch,
+/// and the opt-out. `run_multi_edit` comes from multi_edit_test.mbt (same
+/// blackbox package).
+async test "multi_edit gates the whole batch through moonc before writing" {
+  @vfs.with_tmpdir(prefix="openseek-multi-edit-gate-", dir => {
+    let a_original = "///|\npub fn f() -> Int {\n  42\n}\n"
+    let b_original = "///|\npub fn g() -> Int {\n  7\n}\n"
+    @fs.write_file("\{dir}/a.mbt", a_original, create_mode=CreateOrTruncate)
+    @fs.write_file("\{dir}/b.mbt", b_original, create_mode=CreateOrTruncate)
+    // One clean edit (a.mbt) plus one that would break b.mbt: the WHOLE batch
+    // is rejected and neither file changes.
+    let broken = run_multi_edit({
+      "edits": [
+        {
+          "file": "\{dir}/a.mbt",
+          "old_string": "  42",
+          "new_string": "  43",
+          "start_line": 3,
+        },
+        {
+          "file": "\{dir}/b.mbt",
+          "old_string": "  7",
+          "new_string": "  match 7 {",
+          "start_line": 3,
+        },
+      ],
+    })
+    guard broken is Respond(out) else { fail("expected Respond") }
+    assert_true(out.is_error)
+    assert_true(out.content.contains("rejected: the batch would introduce"))
+    assert_true(out.content.contains("NO files were changed"))
+    assert_true(out.content.contains("b.mbt: would gain 1 new parse error(s)"))
+    assert_eq(@fs.read_file("\{dir}/a.mbt").text(), a_original)
+    assert_eq(@fs.read_file("\{dir}/b.mbt").text(), b_original)
+    // A clean batch applies to both files.
+    let clean = run_multi_edit({
+      "edits": [
+        {
+          "file": "\{dir}/a.mbt",
+          "old_string": "  42",
+          "new_string": "  43",
+          "start_line": 3,
+        },
+        {
+          "file": "\{dir}/b.mbt",
+          "old_string": "  7",
+          "new_string": "  8",
+          "start_line": 3,
+        },
+      ],
+    })
+    guard clean is Respond(ok) else { fail("expected Respond") }
+    assert_false(ok.is_error)
+    assert_true(@fs.read_file("\{dir}/a.mbt").text().contains("  43"))
+    assert_true(@fs.read_file("\{dir}/b.mbt").text().contains("  8"))
+    // Opt-out: the breaking batch lands.
+    let fixture = run_multi_edit({
+      "edits": [
+        {
+          "file": "\{dir}/b.mbt",
+          "old_string": "  8",
+          "new_string": "  match 8 {",
+          "start_line": 3,
+        },
+      ],
+      "revert_on_parse_errors": false,
+    })
+    guard fixture is Respond(fx) else { fail("expected Respond") }
+    assert_false(fx.is_error)
+    assert_true(@fs.read_file("\{dir}/b.mbt").text().contains("match 8 {"))
+  })
+}

--- a/agent_tool/multi_edit/multi_edit_wbtest.mbt
+++ b/agent_tool/multi_edit/multi_edit_wbtest.mbt
@@ -112,3 +112,30 @@ test "revert_report marks a truncated count and a failed restore" {
   assert_true(report.contains("reported ≥400 error(s)"))
   assert_true(report.contains("WARNING: could not restore 1 file(s): a.mbt"))
 }
+
+///|
+test "batch_reject_report caps detailed files and labels lower bounds" {
+  let rejections : Array[FileRejection] = [
+    for index in 0..<5 => {
+      (
+        {
+          path: "lib/f\{index}.mbt",
+          introduced: 1,
+          truncated: index == 0,
+          section: "lib/f\{index}.mbt: would gain 1 new parse error(s):\nlib/f\{index}.mbt:1:1: e",
+        } : FileRejection)
+    }
+  ]
+  let report = batch_reject_report(rejections, total=5, any_truncated=true)
+  assert_true(
+    report.contains(
+      "rejected: the batch would introduce at least 5 new parse error(s) across 5 file(s), so NO files were changed.",
+    ),
+  )
+  // Only the first RejectedFileDisplayLimit files are detailed; the rest are
+  // named in the overflow line.
+  assert_true(report.contains("lib/f2.mbt: would gain"))
+  assert_false(report.contains("lib/f3.mbt: would gain"))
+  assert_true(report.contains("…and 2 more file(s): lib/f3.mbt, lib/f4.mbt"))
+  assert_true(report.contains("revert_on_parse_errors=false"))
+}


### PR DESCRIPTION
## What

Follow-up to #283: extends the moonc pre-write syntax gate to `multi_edit`, closing the last tool path that could land a lex/parse error in a plain `.mbt` file.

After batch validation renders every file's would-be content (and before anything touches disk), each edited `.mbt` file is parsed standalone (`moonc -stop-after-parsing` via the shared `parse_gate` helper). If any file would gain new parse errors versus its pre-batch content parsed the same way, the **whole batch is rejected with no files changed** — the same all-or-nothing contract as the existing edit validation. The reject report excerpts the would-be content per offending file (detailed sections capped at 3, the rest named in an overflow line).

- `revert_on_parse_errors` (boolean, default true) opts out for deliberately non-parsing fixtures.
- The post-write `revert_when_errors_above` moon-check guard is unchanged — it remains the semantic (type-error) safety net; the parse gate is purely syntactic and runs pre-write.
- Same soundness rules as the `edit` gate: fail open when the gate cannot run or the baseline is missing/truncated; a truncated new-content capture is a lower bound (`at least N` / `≥N` labels); symlinked targets resolved before deciding gateability; pre-existing parse errors never block a batch.

With `write`, `edit`, and `multi_edit` all gated, no tool path can introduce a syntax error into a `.mbt` file. Remaining escape hatches, all explicit: gate fail-open, `revert_on_parse_errors=false`, `.mbt.md` (TODO in todo.md — moonc cannot parse markdown-hosted blocks), and non-tool writes (the shell sandbox blocks source writes).

## Validation

- 876/876 tests green, `moon fmt` + `moon info` clean.
- New coverage: decode of the flag, batch reject report formatting (file cap, overflow line, lower-bound labels), and a real-moonc blackbox e2e in a plain tmpdir — mixed clean+breaking batch rejected with both files untouched, clean batch applied, opt-out lands.
- Codex CLI review of the commit: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)