### PR TITLE
refactor(agent_tool/read): idiomatic slice iteration in the render loop

### DIFF
--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -132,9 +132,9 @@ async fn read_file(
       truncated = true
     } else {
       let mut remaining = input.max_output_chars
-      for index in start_index..<end_exclusive {
+      for offset, line in lines[start_index:end_exclusive] {
         let separator_units = if output.is_empty() { 0 } else { 1 }
-        let line_number = input.start_line + index - start_index
+        let line_number = input.start_line + offset
         let prefix = "\{line_number.to_string().pad_start(line_number_width, ' ')} |"
         let prefix_budget = separator_units + prefix.length()
         if remaining < prefix_budget {
@@ -145,7 +145,6 @@ async fn read_file(
           output <+ "\n"
         }
         let available = remaining - prefix_budget
-        let line = lines[index]
         let line_units = line.length()
         if line_units <= available {
           output <+ "\{prefix}\{line}"


### PR DESCRIPTION
Obvious idiomatic win (part of a repo-wide "obvious wins only" simplification pass).

`read.mbt` render loop: `for index in start_index..<end_exclusive { … lines[index] … }` → `for offset, line in lines[start_index:end_exclusive] { … }`. The 0-based `offset` lets `input.start_line + index - start_index` become `input.start_line + offset`, dropping the correction arithmetic and the manual bounds-checked index access. `lines[start_index:end_exclusive]` is an `ArrayView` (O(1), no copy), so behavior and performance are identical.

## Validation
`moon fmt` clean, `moon check agent_tool/read` 0 warnings/errors, `moon test agent_tool/read` 23/23, `moon info` shows **no `pkg.generated.mbti` change** (public API intact). Only `read.mbt` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)