### PR TITLE
refactor(shell_parse): idiomatic pattern-match/comprehension simplifications

### DIFF
--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -49,10 +49,7 @@ fn LexerWord::flush_and_reset(self : LexerWord, tokens : Array[Token]) -> Unit {
 
 ///|
 fn lex(command : String) -> LexResult {
-  let chars : Array[Char] = []
-  for ch in command {
-    chars.push(ch)
-  }
+  let chars : Array[Char] = [ for ch in command => ch ]
   let tokens : Array[Token] = []
   let word = LexerWord::new()
   let mut state = Plain
@@ -295,11 +292,8 @@ fn lex(command : String) -> LexResult {
 
 ///|
 fn push_newline_separator(tokens : Array[Token]) -> Unit {
-  if tokens.length() == 0 {
-    return
-  }
-  match tokens[tokens.length() - 1] {
-    Op("&&" | "||" | ";" | "|", _) => ()
+  match tokens {
+    [] | [.., Op("&&" | "||" | ";" | "|", _)] => ()
     _ => tokens.push(Op(";", false))
   }
 }

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -77,10 +77,8 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
         if !saw_part {
           return SyntaxError("operator \{op} has no preceding command")
         }
-        match too_complex_shell_control_word(argv) {
-          Some(word) =>
-            return TooComplex("shell control command is not supported: \{word}")
-          None => ()
+        if too_complex_shell_control_word(argv) is Some(word) {
+          return TooComplex("shell control command is not supported: \{word}")
         }
         push_command(commands, env, argv, redirects, separator_before)
         env = []
@@ -111,10 +109,8 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
       Some(op) => return SyntaxError("operator \{op} has no following command")
     }
   } else {
-    match too_complex_shell_control_word(argv) {
-      Some(word) =>
-        return TooComplex("shell control command is not supported: \{word}")
-      None => ()
+    if too_complex_shell_control_word(argv) is Some(word) {
+      return TooComplex("shell control command is not supported: \{word}")
     }
     push_command(commands, env, argv, redirects, separator_before)
   }
@@ -221,12 +217,7 @@ fn split_env_assignment(word : String) -> EnvAssignment? {
   if !is_valid_env_name(name) {
     return None
   }
-  let values : Array[String] = []
-  for index, part in parts {
-    if index > 0 {
-      values.push(part.to_owned())
-    }
-  }
+  let values = [ for part in parts[1:] => part.to_owned() ]
   Some({ name, value: values.join("=") })
 }
 
@@ -240,8 +231,7 @@ fn is_valid_env_name(name : String) -> Bool {
   if name == "" {
     return false
   }
-  let mut index = 0
-  for ch in name {
+  for index, ch in name {
     let valid = if index == 0 {
       ch is ('a'..='z') || ch is ('A'..='Z') || ch == '_'
     } else {
@@ -250,7 +240,6 @@ fn is_valid_env_name(name : String) -> Bool {
     if !valid {
       return false
     }
-    index += 1
   }
   true
 }


### PR DESCRIPTION
Obvious idiomatic wins (repo-wide "obvious wins only" simplification pass), all in `lexer.mbt`/`parser.mbt`, each behavior-identical:

- **lexer.mbt** `for ch in command { chars.push(ch) }` → `[for ch in command => ch]` (loop that only builds an array).
- **lexer.mbt** `push_newline_separator`: early-return + last-element `match tokens[len-1]` → view pattern `match tokens { [] | [.., Op(..)] => () ; _ => push }` (empty case folds into the no-op arm).
- **parser.mbt** (×2) `match f(argv) { Some(w) => return …; None => () }` → `if f(argv) is Some(w) { return … }`.
- **parser.mbt** `split_env_assignment`: `for i, part in parts { if i > 0 { … } }` → `[for part in parts[1:] => part.to_owned()]` (slice replaces the `i > 0` filter).
- **parser.mbt** `is_valid_env_name`: manual `let mut index` counter → `for index, ch in name`.

Deliberately **not** changed (not strict wins): string-equality `||` chains (`is_separator`/`is_redirect_op`), `peek_char` inlining, the nested `builtin`/`command` scanners.

## Validation
`moon fmt` clean, `moon check` 0 warnings/errors, `moon test agent_tool/shell/internal/shell_parse` 22/22, `moon info` shows **no `pkg.generated.mbti` change**. Only `lexer.mbt`/`parser.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)