### PR TITLE
refactor(tui/internal/render): idiomatic array-spread + slice iteration

### DIFF
--- a/tui/internal/render/queued.mbt
+++ b/tui/internal/render/queued.mbt
@@ -69,14 +69,14 @@ fn queued_input_rows(
   )
   let item_budget = max_rows - 1
   if count <= item_budget {
-    for index in 0..<count {
-      rows.push(queued_input_line(inputs[index], index~, cols~, indent~))
+    for index, input in inputs {
+      rows.push(queued_input_line(input, index~, cols~, indent~))
     }
   } else {
     // Reserve the last row for the summary of everything that did not fit.
     let shown = item_budget - 1
-    for index in 0..<shown {
-      rows.push(queued_input_line(inputs[index], index~, cols~, indent~))
+    for index, input in inputs[:shown] {
+      rows.push(queued_input_line(input, index~, cols~, indent~))
     }
     rows.push(
       indented_dim_line(

--- a/tui/internal/render/render.mbt
+++ b/tui/internal/render/render.mbt
@@ -132,11 +132,7 @@ fn indent_line(line : @surface.Line, indent~ : Int) -> @surface.Line {
     return line
   }
   let indent = @displaytext.DisplayText(String::make(indent, ' '))
-  let spans : Array[@surface.Span] = [Span(indent, style=@style.default)]
-  for span in line.spans() {
-    spans.push(span)
-  }
-  @surface.Line::new(spans)
+  @surface.Line::new([Span(indent, style=@style.default), ..line.spans()])
 }
 
 ///|


### PR DESCRIPTION
Obvious idiomatic wins (repo-wide "obvious wins only" simplification pass), behavior-identical:

- **render.mbt** `indent_line`: seed array + `for span in line.spans() { spans.push(span) }` → array spread `@surface.Line::new([Span(indent, …), ..line.spans()])` (same idiom as `tui/doc/doc.mbt`).
- **queued.mbt** (first branch): `for index in 0..<count { … inputs[index] }` → `for index, input in inputs` (`count == inputs.length()`).
- **queued.mbt** (else branch): `for index in 0..<shown { … inputs[index] }` → `for index, input in inputs[:shown]` (0-based prefix view; `index + 1` display number unchanged).

Left unchanged (not strict wins): `completion_menu_rows`' loop (its `index == selected` compares an absolute index, so slicing would break it), the functional-sum loop, and accumulation loops.

## Validation
`moon fmt` clean, `moon check tui/internal/render` 0 warnings/errors, `moon test tui/internal/render` 17/17, `moon info` shows **no `pkg.generated.mbti` change**. Only `queued.mbt`/`render.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)