### PR TITLE
refactor(deepseek/client): unwrap_or for the SSE CR strip

### DIFF
--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -158,10 +158,7 @@ async fn apply_stream_json(
 
 ///|
 fn sse_data_fragment(raw : String) -> String? {
-  let line = match raw.strip_suffix("\r") {
-    Some(line) => line
-    None => raw
-  }
+  let line = raw.strip_suffix("\r").unwrap_or(raw)
   match line.strip_prefix("data:") {
     Some(data) => Some("\{data.trim()}")
     None => None


### PR DESCRIPTION
Obvious idiomatic win (repo-wide "obvious wins only" simplification pass):

`stream.mbt` `sse_data_fragment`: a 4-line unwrap-or-default `match raw.strip_suffix("\r") { Some(line) => line; None => raw }` → `raw.strip_suffix("\r").unwrap_or(raw)`. `raw` is an already-evaluated parameter (no side effects), so `unwrap_or`'s eager evaluation is behavior- and performance-identical.

Deliberately **not** changed (not strict wins): `strip_prefix("data:")` → `.map(...)` (a lambda risks a closure alloc on the per-SSE-line hot path); `retryable_status`'s arithmetic range check → `is` range pattern (debatable); test files untouched.

## Validation
`moon fmt` clean, `moon check deepseek/client` 0 warnings/errors, `moon test deepseek/client` 15/15, `moon info` shows **no `pkg.generated.mbti` change**. Only `stream.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)