### PR TITLE
refactor(tui/internal/text): array-pattern match in sanitize_oneline

### DIFF
--- a/tui/internal/text/text.mbt
+++ b/tui/internal/text/text.mbt
@@ -60,12 +60,10 @@ pub fn sanitize_lines(text : String) -> Array[@displaytext.DisplayText] {
 /// use this so a multi-line value never writes a newline to the terminal while
 /// the surface still counts it as one row.
 pub fn sanitize_oneline(text : String) -> @displaytext.DisplayText {
-  let lines = sanitize_lines(text)
-  guard lines is [first, ..] else { return DisplayText("") }
-  if lines.length() > 1 {
-    DisplayText("\{first.text()} …")
-  } else {
-    first
+  match sanitize_lines(text) {
+    [] => DisplayText("")
+    [first] => first
+    [first, ..] => DisplayText("\{first.text()} …")
   }
 }
 


### PR DESCRIPTION
Obvious idiomatic win (repo-wide "obvious wins only" simplification pass):

`text.mbt` `sanitize_oneline`: `guard lines is [first, ..] else { return … }` + `if lines.length() > 1 { … } else { first }` → a single exhaustive 3-arm `match` over `[] / [first] / [first, ..]`. Collapses guard-plus-`length()`-comparison branching into one array-pattern match; drops the `lines` binding and the `.length()` call. Behavior identical (the three shapes are non-overlapping and exhaustive).

Deliberately **not** changed: the `<+` logger-interpolation builders (stripping `"\{}"` isn't guaranteed identical), and the stateful `while … is Some(end)` scan loop.

## Validation
`moon fmt` clean, `moon check tui/internal/text` 0 warnings/errors, `moon test tui/internal/text` 3/3, `moon info` shows **no `pkg.generated.mbti` change**. Only `text.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)