### PR TITLE
feat(agent_tool): pitfall hints in parse-gate rejects + missing prompt rules

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -324,13 +324,15 @@ fn edit_reject_report(
   } else {
     "\nfirst \{formatted.length()} parse error(s), excerpted from the WOULD-BE content (not what is on disk):\n\{formatted.join("\n")}"
   }
+  let hints = @auto_check.pitfall_hints(gate.errors)
+  let hint_lines = if hints.is_empty() { "" } else { "\n\{hints.join("\n")}" }
   let retry = if introduced >= SmallerEditsHintThreshold {
     "\n\{introduced_label} new parse errors usually means the replacement would break the file's structure (an unbalanced brace, a misplaced insertion, or non-MoonBit text). Do not re-issue the same edit: split it into smaller pieces — multi_edit applies several small line-anchored edits in one validated call — and check after each step."
   } else {
     "\nre-issue the edit with a corrected new_string (check delimiters against the excerpt above)."
   }
   let opt_out = "\n(To intentionally produce content that does not parse, e.g. a fixture, pass revert_on_parse_errors=false.)"
-  "\{head}\{pre_existing}\{listed}\{retry}\{opt_out}"
+  "\{head}\{pre_existing}\{listed}\{hint_lines}\{retry}\{opt_out}"
 }
 
 ///|

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -482,9 +482,17 @@ async test "content_parse_errors gates real content through moonc" {
   }
   assert_true(gate.errors.length() > 0)
   assert_true(gate.errors[0].message.contains("Parse error"))
-  // The scratch-dir invocation (relative file name, cwd inside the dir) makes
-  // moonc emit its own context excerpt; the formatter prefers it.
-  assert_true(gate.errors[0].context != "")
+  // Nightly moonc emits its own context excerpt in this invocation shape;
+  // stable does not — the contract is only that the formatter renders a
+  // numbered excerpt either way (compiler context preferred, loc-based
+  // synthesis as the fallback), so assert at that level.
+  let rendered = format_parse_gate_errors(
+    "gate.mbt",
+    "///|\npub fn bad() -> Int {\n  let x =\n}\n",
+    gate.errors,
+  )
+  assert_true(rendered.length() > 0)
+  assert_true(rendered[0].contains(" |"))
   // moonc EXITS 0 when its parser recovers from an error (e.g. `&mut` in a
   // parameter type), so the gate must trust captured diagnostics, never the
   // exit code — this content must still be rejected.

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -219,6 +219,42 @@ pub fn format_parse_gate_errors(
 }
 
 ///|
+/// One-line MoonBit idiom corrections for parse-error classes that models
+/// repeatedly produce from Rust or legacy-MoonBit priors, matched against the
+/// diagnostic message. Recorded eval sessions showed these three classes
+/// accounted for every gate rejection, and prompt rules alone did not prevent
+/// them — the correction lands best at the moment of failure. Each hint
+/// appears at most once per report.
+pub fn pitfall_hints(errors : Array[ParseGateError]) -> Array[String] {
+  let hints : Array[String] = []
+  fn add(hint : String) {
+    for existing in hints {
+      if existing == hint {
+        return
+      }
+    }
+    hints.push(hint)
+  }
+  for error in errors {
+    if error.message.contains("unexpected token `mut`") {
+      add(
+        "hint: MoonBit parameters and receivers cannot be `mut` (unlike Rust). Rebind inside the body (`let mut x = param`), use a `mut` field on a struct you pass in, or `Ref[T]`.",
+      )
+    } else if error.message.contains("unrecognized character u32:0x7e") {
+      add(
+        "hint: `~` before an argument (`f(~label)`) is legacy MoonBit. Pass `label=value`, or `label~` to pun a same-named variable.",
+      )
+    } else if error.message.contains("unexpected token `?`") ||
+      error.message.contains("unexpected token `!`") {
+      add(
+        "hint: postfix `f(...)?` / `f(...)!` error propagation is legacy MoonBit. Inside a function declaring `raise`, a plain call `f(...)` propagates automatically; handle locally with `f(...) catch { ... }`.",
+      )
+    }
+  }
+  hints
+}
+
+///|
 /// Indent the compiler's `context` excerpt (numbered source lines, one per
 /// `\n`) by two spaces, dropping only the trailing blank line the final `\n`
 /// produces — interior blank lines, should moonc ever emit them, are kept so
@@ -456,4 +492,40 @@ async test "content_parse_errors gates real content through moonc" {
     fail("expected the gate to run (is moonc on PATH?)")
   }
   assert_true(recovered.errors.length() > 0)
+}
+
+///|
+test "pitfall_hints maps known error classes and dedupes" {
+  let hints = pitfall_hints([
+    {
+      loc: "2:6-2:9",
+      message: "Parse error, unexpected token `mut`, you may expect parameter name or label.",
+      context: "",
+    },
+    {
+      loc: "6:12-6:15",
+      message: "Parse error, unexpected token `mut`, you may expect parameter name or label.",
+      context: "",
+    },
+    {
+      loc: "3:3-3:4",
+      message: "Lexing error: unrecognized character u32:0x7e",
+      context: "",
+    },
+    {
+      loc: "4:15-4:16",
+      message: "Parse error, unexpected token `?`, you may expect `;` or `}`.",
+      context: "",
+    },
+  ])
+  // One hint per class, in first-seen order, duplicates collapsed.
+  assert_eq(hints.length(), 3)
+  assert_true(hints[0].contains("cannot be `mut`"))
+  assert_true(hints[1].contains("`f(~label)`"))
+  assert_true(hints[2].contains("error propagation is legacy"))
+  // Unknown classes produce no hint.
+  let none = pitfall_hints([
+    { loc: "1:1", message: "Parse error, unexpected token `}`.", context: "" },
+  ])
+  assert_eq(none.length(), 0)
 }

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -246,8 +246,11 @@ pub fn pitfall_hints(errors : Array[ParseGateError]) -> Array[String] {
       )
     } else if error.message.contains("unexpected token `?`") ||
       error.message.contains("unexpected token `!`") {
+      // The `?` token has several wrong-prior sources (Rust `expr?`
+      // propagation/unwrap, C ternary `c ? a : b`), so the hint names the
+      // MoonBit idiom for each rather than guessing which one was meant.
       add(
-        "hint: postfix `f(...)?` / `f(...)!` error propagation is legacy MoonBit. Inside a function declaring `raise`, a plain call `f(...)` propagates automatically; handle locally with `f(...) catch { ... }`.",
+        "hint: MoonBit has no postfix `?`/`!` operator and no `?:` ternary. Errors propagate automatically inside a function declaring `raise` (just call `f(...)`; handle locally with `f(...) catch { ... }`); unwrap an Option by matching (`guard x is Some(v) else { ... }`); write conditionals with `if`/`match`.",
       )
     }
   }
@@ -522,7 +525,7 @@ test "pitfall_hints maps known error classes and dedupes" {
   assert_eq(hints.length(), 3)
   assert_true(hints[0].contains("cannot be `mut`"))
   assert_true(hints[1].contains("`f(~label)`"))
-  assert_true(hints[2].contains("error propagation is legacy"))
+  assert_true(hints[2].contains("no postfix `?`/`!` operator"))
   // Unknown classes produce no hint.
   let none = pitfall_hints([
     { loc: "1:1", message: "Parse error, unexpected token `}`.", context: "" },

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -20,6 +20,8 @@ pub fn format_parse_gate_errors(String, String, Array[ParseGateError]) -> Array[
 
 pub fn is_gateable_path(String) -> Bool
 
+pub fn pitfall_hints(Array[ParseGateError]) -> Array[String]
+
 pub fn tally_diagnostics(String, truncated~ : Bool) -> CheckErrors
 
 // Errors

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -334,6 +334,7 @@ async fn parse_gate_batch_rejection(
   writes : Array[PreparedWrite],
 ) -> @agent_tool.ToolAction? {
   let rejections : Array[FileRejection] = []
+  let all_errors : Array[@auto_check.ParseGateError] = []
   for write in writes {
     let target = @fs.realpath(write.path) catch {
       error if @async.is_being_cancelled() => raise error
@@ -375,6 +376,9 @@ async fn parse_gate_batch_rejection(
       truncated: gate.truncated,
       section: "\{write.path}: would gain \{bound}\{introduced} new parse error(s)\{pre_existing}:\n\{formatted.join("\n")}",
     })
+    for error in gate.errors {
+      all_errors.push(error)
+    }
   }
   if rejections.is_empty() {
     return None
@@ -390,7 +394,12 @@ async fn parse_gate_batch_rejection(
   let bound = if any_truncated { "≥" } else { "" }
   Some(
     @agent_tool.ToolAction::respond(
-      batch_reject_report(rejections, total~, any_truncated~),
+      batch_reject_report(
+        rejections,
+        total~,
+        any_truncated~,
+        hints=@auto_check.pitfall_hints(all_errors),
+      ),
       is_error=true,
       brief="multi_edit rejected (\{bound}\{total} parse error(s))",
     ),
@@ -404,6 +413,7 @@ fn batch_reject_report(
   rejections : Array[FileRejection],
   total~ : Int,
   any_truncated~ : Bool,
+  hints~ : Array[String],
 ) -> String {
   let total_label = if any_truncated { "at least \{total}" } else { "\{total}" }
   let head = "rejected: the batch would introduce \{total_label} new parse error(s) across \{rejections.length()} file(s), so NO files were changed."
@@ -421,9 +431,10 @@ fn batch_reject_report(
   } else {
     ""
   }
+  let hint_lines = if hints.is_empty() { "" } else { "\n\{hints.join("\n")}" }
   let retry = "\nre-issue with corrected new_strings (check delimiters against the excerpts above), or split the batch and check after each step."
   let opt_out = "\n(To intentionally produce content that does not parse, e.g. a fixture, pass revert_on_parse_errors=false.)"
-  "\{head}\nexcerpts are from the WOULD-BE content (not what is on disk):\n\{sections.join("\n")}\{overflow}\{retry}\{opt_out}"
+  "\{head}\nexcerpts are from the WOULD-BE content (not what is on disk):\n\{sections.join("\n")}\{overflow}\{hint_lines}\{retry}\{opt_out}"
 }
 
 ///|

--- a/agent_tool/multi_edit/multi_edit_wbtest.mbt
+++ b/agent_tool/multi_edit/multi_edit_wbtest.mbt
@@ -126,7 +126,7 @@ test "batch_reject_report caps detailed files and labels lower bounds" {
         } : FileRejection)
     }
   ]
-  let report = batch_reject_report(rejections, total=5, any_truncated=true)
+  let report = batch_reject_report(rejections, total=5, any_truncated=true, hints=[])
   assert_true(
     report.contains(
       "rejected: the batch would introduce at least 5 new parse error(s) across 5 file(s), so NO files were changed.",

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -219,13 +219,15 @@ fn write_reject_report(
   } else {
     "\nfirst \{formatted.length()} parse error(s), with the rejected content excerpted:\n\{formatted.join("\n")}"
   }
+  let hints = @auto_check.pitfall_hints(gate.errors)
+  let hint_lines = if hints.is_empty() { "" } else { "\n\{hints.join("\n")}" }
   let retry = if count >= SmallerPartsHintThreshold {
     "\n\{count_label} parse errors usually means the content is malformed wholesale (truncated or not valid MoonBit). Do not re-issue the same content: write a smaller file first — a minimal skeleton that parses — then grow it in small pieces with edit (an empty old_string inserts), checking after each step."
   } else {
     "\nre-issue write with the corrected full content."
   }
   let opt_out = "\n(To intentionally create a file that does not parse, e.g. a test fixture, pass revert_on_parse_errors=false.)"
-  "\{head}\{listed}\{retry}\{opt_out}"
+  "\{head}\{listed}\{hint_lines}\{retry}\{opt_out}"
 }
 
 ///|

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -302,9 +302,9 @@ EOF
   `raise ParseError` may only let `ParseError` escape; if it calls a broader
   raising function, catch that error and translate it.
 - To propagate an error from a raising call, call it normally from a function
-  marked with `raise`. The postfix forms `f(...)!` and `f(...)?` are legacy and
-  do not parse; there is no `?` operator. Handle an error locally with
-  `f(...) catch { ... }`.
+  marked with `raise`. There is no `?` operator: postfix `f(...)?` does not
+  parse, and the legacy bang call form `f!(...)` is deprecated. Handle an error
+  locally with `f(...) catch { ... }`.
 - In success tests, call raising functions directly; if they raise, the test
   fails with the error and the message is usually enough. Do not wrap successful
   parser tests in extra error plumbing.

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -106,6 +106,10 @@ Common `moon` subcommands:
 ## MoonBit Project Setup
 
 - Current MoonBit modules use `moon.mod`.
+- Build the project at the workspace root: write `moon.mod` in the directory
+  you were started in. Do not nest the module in a fresh subdirectory
+  (`moon new <name>` creates one) — every later command would need a
+  `cd <name> &&` prefix.
 - Create `moon.mod` before running `moon info`; otherwise `moon` may walk up to
   an unrelated parent module.
 - `moon.mod` is the module manifest: keep module `name`, `version`,
@@ -212,6 +216,9 @@ options(
 - Use `let mut x = ...` only for local rebinding. Mutable maps/arrays can be
   updated without rebinding. Use `mut field : T` only on struct fields that you
   assign, e.g. `self.field = value`.
+- Labeled arguments are passed as `label=value`, or `label~` to pun a
+  same-named variable. The prefix form `f(~label)` is legacy and does not
+  parse.
 - Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
 - Match arms are separated by newlines or semicolons, not `|`:
 
@@ -295,7 +302,9 @@ EOF
   `raise ParseError` may only let `ParseError` escape; if it calls a broader
   raising function, catch that error and translate it.
 - To propagate an error from a raising call, call it normally from a function
-  marked with `raise`.
+  marked with `raise`. The postfix forms `f(...)!` and `f(...)?` are legacy and
+  do not parse; there is no `?` operator. Handle an error locally with
+  `f(...) catch { ... }`.
 - In success tests, call raising functions directly; if they raise, the test
   fails with the error and the message is usually enough. Do not wrap successful
   parser tests in extra error plumbing.


### PR DESCRIPTION
## What

Analysis of four recorded one-shot eval sessions (TOML/YAML parsers, regex engine, tiny compiler; ~110 attempted source mutations) showed that **three legacy/Rust-prior syntax classes caused every parse-gate rejection**:

1. Rust-style `mut` parameters/receivers — `fn f(mut pos : Int)`, `fn P::advance(mut self : P)` (3 of 4 runs)
2. Postfix `?` — Rust-style propagation/unwrap (`stack.pop()?`) and related legacy forms
3. Prefix `~label` arguments — `f(~label)` (14 errors in one file)

Notably, the flash prompt **already contains the `mut` rule** and the model violated it in 3 of 4 runs — prompt rules alone don't stick under generation pressure, so the correction has to land at the moment of failure.

### Changes

- **`pitfall_hints()`** in `auto_check/parse_gate.mbt`: maps gate diagnostics to one-line MoonBit idiom corrections (deduped, one per class), appended to the reject reports of `write`, `edit`, and `multi_edit` (the batch report aggregates diagnostics across rejected files). The `?`/`!` hint names all three wrong-prior causes (raise-propagation, Option unwrap, C ternary) rather than guessing which was meant.
- **Flash prompt**: adds the two genuinely missing rules — `label=value`/`label~` vs legacy `~label`, and "there is no `?` operator; `f!(...)` is deprecated" — plus a workspace-root rule (one eval nested its project via `moon new` and then paid a `cd <dir> &&` prefix on 34 of 35 shell commands).

### Verified against the installed toolchain

Wordings were probed against moonc (not docs): `f(...)?` hard-fails with a 3002 parse error, `f!(...)` parses with a deprecation warning, `~label` is a 3001 lexing error, `try?` itself is deprecated. Codex CLI review findings (over-broad `?` hint, wrong legacy-bang form) are addressed in the follow-up commit.

## Validation

877/877 tests green; new unit tests cover class mapping, dedupe, and no-hint-for-unknown-classes. Next step (separate): N=20 A/B bench of this change against baseline on fixed tasks, measuring steps/tokens/rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)