### PR TITLE
refactor(agent_session): collapse duplicate match arms + de-dup status message

### DIFF
--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -25,8 +25,7 @@ fn string_field(
 ) -> String raise @json.JsonDecodeError {
   match fields.get(key) {
     Some(String(value)) => value
-    Some(_) => json_decode_error(path.add_key(key), "expected string")
-    None => json_decode_error(path.add_key(key), "expected string")
+    _ => json_decode_error(path.add_key(key), "expected string")
   }
 }
 
@@ -38,8 +37,7 @@ fn int_field(
 ) -> Int raise @json.JsonDecodeError {
   match fields.get(key) {
     Some(Number(value, ..)) => value.to_int()
-    Some(_) => json_decode_error(path.add_key(key), "expected int")
-    None => json_decode_error(path.add_key(key), "expected int")
+    _ => json_decode_error(path.add_key(key), "expected int")
   }
 }
 

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -8,19 +8,28 @@ fn summary_model_content(summary : SessionSummary) -> String {
 }
 
 ///|
+/// A status line for a non-finished turn: the bare `label` when `reason` is
+/// blank, otherwise the label followed by the reason on its own line.
+fn agent_status_message(label : String, reason : String) -> String? {
+  if reason.trim().is_empty() {
+    Some(label)
+  } else {
+    Some("\{label}\n\{reason}")
+  }
+}
+
+///|
 fn terminal_model_message(terminal : TurnTerminal) -> String? {
   match terminal {
-    Finished(answer) if !answer.trim().is_empty() => Some(answer)
-    Finished(_) => None
-    Aborted(reason) if !reason.trim().is_empty() =>
-      Some("[agent aborted]\n\{reason}")
-    Aborted(_) => Some("[agent aborted]")
-    Interrupted(reason) if !reason.trim().is_empty() =>
-      Some("[agent interrupted]\n\{reason}")
-    Interrupted(_) => Some("[agent interrupted]")
-    Failed(message) if !message.trim().is_empty() =>
-      Some("[agent failed]\n\{message}")
-    Failed(_) => Some("[agent failed]")
+    Finished(answer) =>
+      if answer.trim().is_empty() {
+        None
+      } else {
+        Some(answer)
+      }
+    Aborted(reason) => agent_status_message("[agent aborted]", reason)
+    Interrupted(reason) => agent_status_message("[agent interrupted]", reason)
+    Failed(reason) => agent_status_message("[agent failed]", reason)
   }
 }
 
@@ -60,8 +69,8 @@ fn remove_pending_tool_call(
   pending : Array[@deepseek.ToolCall],
   tool_call_id : String,
 ) -> Bool {
-  for index in 0..<pending.length() {
-    if pending[index].id == tool_call_id {
+  for index, call in pending {
+    if call.id == tool_call_id {
       ignore(pending.remove(index))
       return true
     }


### PR DESCRIPTION
Obvious idiomatic + de-dup wins (repo-wide "obvious wins only" pass), behavior-identical, all private/internal:

- **json.mbt** `string_field`/`int_field`: two identical error arms `Some(_) => …` and `None => …` (same `json_decode_error(…, "expected string"/"expected int")`) → a single `_ =>` wildcard.
- **projection.mbt** `remove_pending_tool_call`: `for index in 0..<pending.length() { … pending[index].id }` → `for index, call in pending { … call.id }` (index still available for `pending.remove(index)`; loop returns right after removal).
- **projection.mbt** `terminal_model_message`: the `Aborted`/`Interrupted`/`Failed` arms were three near-identical guarded pairs differing only in the label → private `agent_status_message(label, reason)`; 8 arms → 4 arms + a 5-line helper. `Finished` keeps its distinct behavior inline.

## Validation
`moon fmt` clean, `moon check agent_session` 0 warnings/errors, `moon test agent_session` 17/17, `moon info` shows **no `pkg.generated.mbti` change** (all helpers private). Only `json.mbt`/`projection.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)