### PR TITLE
refactor(agent_tool/shell): unwrap_or + for-index loops + de-dup mv/cp operand split

### DIFF
--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -3956,17 +3956,11 @@ async fn script_generated_tree_transfer_literal_pair_target(
   cwd : String,
 ) -> String? {
   let literals = script_quoted_literals(text)
-  for source_index in 0..<literals.length() {
-    for dest_index in 0..<literals.length() {
+  for source_index, source_literal in literals {
+    for dest_index, dest_literal in literals {
       if source_index != dest_index {
-        let source = resolve_source_write_redirect_target(
-          cwd,
-          literals[source_index],
-        )
-        let dest = resolve_source_write_redirect_target(
-          cwd,
-          literals[dest_index],
-        )
+        let source = resolve_source_write_redirect_target(cwd, source_literal)
+        let dest = resolve_source_write_redirect_target(cwd, dest_literal)
         if script_generated_tree_transfer_literal_pair_can_create_workspace_source(
             root, source, dest,
           ) {
@@ -4618,19 +4612,7 @@ fn parse_mv_operands(argv : Array[String], arg_start : Int) -> MvOperands? {
     operands.push(arg)
     index += 1
   }
-  match target_directory {
-    Some(dest) => Some({ sources: operands, dest: Some(dest) })
-    None =>
-      if operands.length() >= 2 {
-        let sources : Array[String] = []
-        for index in 0..<(operands.length() - 1) {
-          sources.push(operands[index])
-        }
-        Some({ sources, dest: Some(operands[operands.length() - 1]) })
-      } else {
-        Some({ sources: [], dest: None })
-      }
-  }
+  operands_with_optional_dest(operands, target_directory)
 }
 
 ///|

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -174,10 +174,7 @@ async fn shell(
         brief=shell_brief(input.cmd, None),
       )
     None => {
-      let timeout_ms = match input.timeout_ms {
-        Some(timeout_ms) => timeout_ms
-        None => 0
-      }
+      let timeout_ms = input.timeout_ms.unwrap_or(0)
       return @agent_tool.ToolAction::respond(
         "error: shell command timed out after \{timeout_ms}ms",
         is_error=true,
@@ -422,10 +419,7 @@ fn shell_response(
     let footer = "<system>\{exit_header(output.exit_code)} truncated=true output_limit_reached=true shown_chars=\{output.text.char_length()} max_output_chars=\{max_output_chars}</system>"
     { content: with_system_footer(output.text, footer), is_error: true }
   } else {
-    let code = match output.exit_code {
-      Some(code) => code
-      None => 0
-    }
+    let code = output.exit_code.unwrap_or(0)
     {
       content: with_system_footer(output.text, "<system>exit=\{code}</system>"),
       is_error: code != 0,


### PR DESCRIPTION
Obvious idiomatic + de-dup wins (repo-wide "obvious wins only" pass), net **+7/−31**, behavior-identical, no public API change:

- **shell.mbt** (×2): `match input.timeout_ms { Some(x) => x; None => 0 }` / `match output.exit_code { … }` → `.unwrap_or(0)` (constant default, no closure).
- **sandbox.mbt** `script_generated_tree_transfer_literal_pair_target`: nested `for source_index in 0..<literals.length() { for dest_index in 0..<… }` → `for source_index, source_literal in literals { for dest_index, dest_literal in literals … }` (indices still bound for the `!=` guard).
- **sandbox.mbt** (de-dup) `parse_mv_operands`: its trailing `match target_directory { … }` block was byte-for-byte identical to the private helper `operands_with_optional_dest` → replaced with a call to it, mirroring what `parse_cp_operands` already does (removes ~13 duplicated lines).

Left alone (debatable): `is_fd_redirect_target` vs `command_redirect_target_is_fd` (byte-identical but name two distinct scanner layers), and the char-index parser loops (code-unit vs char semantics).

## Validation
`moon fmt` clean, `moon check agent_tool/shell` 0 warnings/errors, `moon test agent_tool/shell` 106/106, `moon info` shows **no `pkg.generated.mbti` change**. Only `shell.mbt`/`sandbox.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)