### PR TITLE
refactor(cmd/tui): or-pattern + slice-spread + de-dup engine-exit error

### DIFF
--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -134,12 +134,11 @@ async fn[G] EngineClient::start(
     // only ever sees its own process's bookkeeping.
     if engine.run_open {
       let diagnostics = stderr_task.wait().trim()
-      let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
       engine.run_open = false
       self.messages.put(
         AgentProgress(
           run_id=engine.latest_run,
-          AgentError("engine exited (code \{code}) without a result\{detail}"),
+          engine_exit_without_result(code, diagnostics),
         ),
       )
     }

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -125,6 +125,18 @@ fn is_terminal_event(event : @event.AgentEvent) -> Bool {
 }
 
 ///|
+/// The `AgentError` for an engine that closed its stdout without a terminal
+/// event: the exit `code` plus the captured stderr `diagnostics` (already
+/// trimmed) as detail, or no detail when there were none.
+fn engine_exit_without_result(
+  code : Int,
+  diagnostics : StringView,
+) -> @event.AgentEvent {
+  let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
+  AgentError("engine exited (code \{code}) without a result\{detail}")
+}
+
+///|
 fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   {
     "DEEPSEEK": config.api_key,
@@ -238,12 +250,8 @@ async fn run_agent_task(
       // The engine produced no terminal event. Its stderr is the only clue to
       // why (a crash, a network/API error), so fold it into the reported error.
       let diagnostics = stderr_task.wait().trim()
-      let detail = if diagnostics.is_empty() { "" } else { ":\n\{diagnostics}" }
       messages.put(
-        AgentProgress(
-          run_id~,
-          AgentError("engine exited (code \{code}) without a result\{detail}"),
-        ),
+        AgentProgress(run_id~, engine_exit_without_result(code, diagnostics)),
       )
     }
   }) catch {

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -152,8 +152,7 @@ fn streaming_activity_spans(
 fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
   let started_ms = match state.run {
     Idle => return None
-    Running(started_ms) => started_ms
-    Interrupting(started_ms) => started_ms
+    Running(started_ms) | Interrupting(started_ms) => started_ms
   }
   let steer_segment = pending_steer_segment(state.pending_steers)
   // The acknowledgment sits at the row's end, where the renderer clips on

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -27,15 +27,7 @@ fn compact_lines(source : String, limit : Int) -> Array[String] {
   let head = limit / 2
   let tail = limit - head - 1
   let omitted = lines.length() - head - tail
-  let compacted : Array[String] = []
-  for index in 0..<head {
-    compacted.push(lines[index])
-  }
-  compacted.push("... +\{omitted} lines")
-  for index in (lines.length() - tail)..<lines.length() {
-    compacted.push(lines[index])
-  }
-  compacted
+  [..lines[:head], "... +\{omitted} lines", ..lines[lines.length() - tail:]]
 }
 
 ///|


### PR DESCRIPTION
Obvious idiomatic + de-dup wins (repo-wide "obvious wins only" pass), behavior-identical, no public API change:

- **status_view.mbt** `format_activity_text`: two identical arms `Running(started_ms) => started_ms` / `Interrupting(started_ms) => started_ms` → one or-pattern `Running(started_ms) | Interrupting(started_ms) => started_ms`.
- **tool_view.mbt** `compact_lines`: mutable `compacted` array + two index loops → a single slice-spread literal `[..lines[:head], "... +N lines", ..lines[len-tail:]]` (same O(head+tail) work).
- **loop.mbt / engine_client.mbt** (de-dup): the byte-identical "engine exited (code N) without a result" block (no-terminal-event path and EOF-mid-turn path) → a private `engine_exit_without_result(code, diagnostics)`; the user-facing string is now single-sourced.

Left alone (debatable): String if-else ladders (outside the enum/ADT idiom), the `prompt`/`compact`/`steer` start blocks (differ in cancellation/error handling), and a filter-map loop (comprehension can't cleanly bind the `is Some` yield).

## Validation
`moon fmt` clean, `moon check cmd/tui` 0 warnings/errors, `moon test cmd/tui` 60/60, `moon info` shows **no `pkg.generated.mbti` change**. Only `cmd/tui` own files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)