### PR TITLE
refactor(agent_tool/moon_cmd): is-pattern + unwrap_or

### DIFF
--- a/agent_tool/moon_cmd/moon_cmd.mbt
+++ b/agent_tool/moon_cmd/moon_cmd.mbt
@@ -92,12 +92,9 @@ async fn execute(arguments : Json) -> @agent_tool.ToolAction {
 ///|
 fn command_args(input : @decode.MoonCommandInput) -> Array[String] {
   let args : Array[String] = [input.command]
-  match input.target {
-    Some(target) => {
-      args.push("--target")
-      args.push(target)
-    }
-    None => ()
+  if input.target is Some(target) {
+    args.push("--target")
+    args.push(target)
   }
   for arg in input.args {
     args.push(arg)
@@ -118,10 +115,7 @@ fn command_args(input : @decode.MoonCommandInput) -> Array[String] {
 async fn moon_cmd(input : @decode.MoonCommandInput) -> @agent_tool.ToolAction {
   let args = command_args(input)
   let (code, output) = collect_moon_output(args, input.cwd, input.stdin)
-  let cwd_text = match input.cwd {
-    Some(cwd) => cwd
-    None => "."
-  }
+  let cwd_text = input.cwd.unwrap_or(".")
   let update_review = match (input.test_update_kind, input.test_update_reason) {
     (Some(kind), Some(reason)) => "\nsnapshot_update=\{kind}: \{reason}"
     _ => ""


### PR DESCRIPTION
Obvious idiomatic wins (repo-wide "obvious wins only" pass), behavior-identical:

- `command_args`: `match input.target { Some(target) => {…}; None => () }` → `if input.target is Some(target) { … }`.
- `moon_cmd`: `match input.cwd { Some(cwd) => cwd; None => "." }` → `input.cwd.unwrap_or(".")` (constant default, no closure).

Both idioms are already established elsewhere in the repo (`cwd.unwrap_or(".")` in `moon_auto_check.mbt`, `if cwd is Some(cwd)` in `shell.mbt`).

Left alone (debatable): `stdin_review`/`update_review` tuple/`.map` matches, the `brief` if/else, and the genuine nested branching in `collect_moon_output`.

## Validation
`moon fmt` clean, `moon check agent_tool/moon_cmd` 0 warnings/errors, `moon test agent_tool/moon_cmd` 21/21, `moon info` shows **no `pkg.generated.mbti` change**. Only `moon_cmd.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)