### PR TITLE
refactor(tui/slash): comprehension for completion_items

### DIFF
--- a/tui/slash/slash_command.mbt
+++ b/tui/slash/slash_command.mbt
@@ -59,17 +59,15 @@ pub fn SlashCommands::get(
 pub fn SlashCommands::completion_items(
   self : SlashCommands,
 ) -> Array[@completion.CompletionItem] {
-  let items : Array[@completion.CompletionItem] = []
-  for command in self.0 {
-    items.push(
+  [
+    for command in self.0 => {
       @completion.CompletionItem::new(
         label="/\{command.name()}",
         insert_text=command.name(),
         description=command.description(),
-      ),
-    )
-  }
-  items
+      )
+    }
+  ]
 }
 
 ///|


### PR DESCRIPTION
Obvious idiomatic win (repo-wide "obvious wins only" pass):

`SlashCommands::completion_items`: `let items = []; for command in self.0 { items.push(CompletionItem::new(...)) }; items` → `[for command in self.0 => { CompletionItem::new(...) }]`. Same result and iteration order; drops the mutable accumulator.

De-dup: none genuinely applicable (the accessors are on distinct types). Left alone (not strict wins): `get` (already idiomatic `for … return Some`), `parse` (StringBuilder up to first whitespace — no clean slice helper), `has_arguments` (already `.any(...)`).

## Validation
`moon fmt` clean, `moon check tui/slash` 0 warnings/errors, `moon test tui/slash` 2/2, `moon info` shows **no `pkg.generated.mbti` change**. Only `slash_command.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)