### PR TITLE
refactor(deepseek): de-dup Usage::from_json field lookups

### DIFF
--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -1,26 +1,25 @@
 ///|
+/// Reads an integer-valued field from a JSON object, returning 0 when the field
+/// is absent or is not a number.
+fn json_object_int(json : Json, key : String) -> Int {
+  match json {
+    Object(fields) =>
+      match fields.get(key) {
+        Some(Number(n, ..)) => n.to_int()
+        _ => 0
+      }
+    _ => 0
+  }
+}
+
+///|
 fn Usage::from_json(json : Json) -> Usage {
   {
-    prompt_tokens: match json {
-      { "prompt_tokens": Number(n, ..), .. } => n.to_int()
-      _ => 0
-    },
-    completion_tokens: match json {
-      { "completion_tokens": Number(n, ..), .. } => n.to_int()
-      _ => 0
-    },
-    total_tokens: match json {
-      { "total_tokens": Number(n, ..), .. } => n.to_int()
-      _ => 0
-    },
-    prompt_cache_hit_tokens: match json {
-      { "prompt_cache_hit_tokens": Number(n, ..), .. } => n.to_int()
-      _ => 0
-    },
-    prompt_cache_miss_tokens: match json {
-      { "prompt_cache_miss_tokens": Number(n, ..), .. } => n.to_int()
-      _ => 0
-    },
+    prompt_tokens: json_object_int(json, "prompt_tokens"),
+    completion_tokens: json_object_int(json, "completion_tokens"),
+    total_tokens: json_object_int(json, "total_tokens"),
+    prompt_cache_hit_tokens: json_object_int(json, "prompt_cache_hit_tokens"),
+    prompt_cache_miss_tokens: json_object_int(json, "prompt_cache_miss_tokens"),
   }
 }
 


### PR DESCRIPTION
Obvious de-dup win (repo-wide "obvious wins only" pass), behavior-identical:

`Usage::from_json` had 5 near-identical inline `match json { { "<key>": Number(n, ..), .. } => n.to_int(); _ => 0 }` blocks differing only by the field key → extracted a private `json_object_int(json, key)`; the body is now 5 one-line calls. `Json::Object` + `Map::get` reproduces the record-pattern lookup exactly (missing / non-number → 0 in both).

Left alone (intentional / not clear wins): `ToolCall::from_json`'s error-path taxonomy (verbose by design), the `thinking` High/Max match, and the `ToolDefinition::to_json` conditional-field if/else. Rest of the package is already idiomatic.

## Validation
`moon fmt` clean, `moon check deepseek` 0 warnings/errors, `moon test deepseek` 37/37, `moon info` shows **no `pkg.generated.mbti` change**. Only `json_decode.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)