### PR TITLE
refactor(tui): de-dup single-line-input guard + spread literal

### DIFF
--- a/tui/completion.mbt
+++ b/tui/completion.mbt
@@ -28,17 +28,23 @@ fn CompletionState::reset(self : CompletionState) -> Unit {
 }
 
 ///|
+/// The composer's text when it holds a single-line entry in input mode — the
+/// precondition shared by completion, slash-command parsing, and slash-entry
+/// detection. None in shell mode or for multi-line input, neither of which is a
+/// slash context.
+fn single_line_input_text(composer : @composer.Model) -> String? {
+  guard composer.mode().is_input() else { return None }
+  let text = composer.text()
+  guard !text.contains("\n") else { return None }
+  Some(text)
+}
+
+///|
 fn completion_menu_for_composer(
   commands : @slash.SlashCommands,
   composer : @composer.Model,
 ) -> CompletionMenu? {
-  if !composer.mode().is_input() {
-    return None
-  }
-  let text = composer.text()
-  if text.contains("\n") {
-    return None
-  }
+  guard single_line_input_text(composer) is Some(text) else { return None }
   guard text.strip_prefix("/") is Some(rest) else { return None }
   let rest = rest.to_owned()
   // A doubled leading slash (`//`, `//e`) is not a command-name prefix: the
@@ -80,13 +86,7 @@ fn slash_command_invocation_for_composer(
   if commands.is_empty() {
     return None
   }
-  if !composer.mode().is_input() {
-    return None
-  }
-  let text = composer.text()
-  if text.contains("\n") {
-    return None
-  }
+  guard single_line_input_text(composer) is Some(text) else { return None }
   @slash.SlashCommandInvocation::parse(text)
 }
 
@@ -226,13 +226,7 @@ fn composer_is_slash_entry(
   if commands.is_empty() {
     return false
   }
-  if !composer.mode().is_input() {
-    return false
-  }
-  let text = composer.text()
-  if text.contains("\n") {
-    return false
-  }
+  guard single_line_input_text(composer) is Some(text) else { return false }
   text.has_prefix("/")
 }
 

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -48,11 +48,7 @@ async fn Ui::redraw(self : Self) -> Unit {
 /// are visually spaced apart (matching the Codex TUI). The separator is plain,
 /// outside any item background block.
 fn item_rows(doc : @doc.Doc, cols~ : Int) -> Array[@surface.Line] {
-  let rows : Array[@surface.Line] = [@surface.Line::new([])]
-  for row in doc.layout(width=cols) {
-    rows.push(row)
-  }
-  rows
+  [@surface.Line::new([]), ..doc.layout(width=cols)]
 }
 
 ///|


### PR DESCRIPTION
Obvious de-dup + idiomatic wins (repo-wide "obvious wins only" pass), behavior-identical, helper is private.

**De-dup (completion.mbt):** the "in input mode AND single-line → return the text" precondition was duplicated verbatim in three functions (`completion_menu_for_composer`, `slash_command_invocation_for_composer`, `composer_is_slash_entry`) → extracted a private `single_line_input_text(composer) -> String?`; each site becomes one `guard … is Some(text)`. Same checks, same short-circuit order, `composer.text()` still evaluated once after the mode check.

**Idiom (terminal.mbt):** `item_rows` seed-array-plus-push loop → spread literal `[@surface.Line::new([]), ..doc.layout(width=cols)]`.

Left alone: `transcript_rows` nested loop (MoonBit comprehensions don't take multiple generators), and `.map().unwrap_or()` conversions that would add a closure where `match` is already clear.

## Validation
`moon fmt` clean, `moon check tui` 0 warnings/errors, `moon test tui` 14/14, `moon info` shows **no `pkg.generated.mbti` change**. Only `completion.mbt`/`terminal.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)