### PR TITLE
refactor(cmd/openseek): array-view pattern + unwrap_or in arg/flag helpers

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -334,21 +334,14 @@ async fn random_salt() -> String {
 
 ///|
 fn failure_message(error_text : String) -> String {
-  match error_text.strip_prefix("error: ") {
-    Some(message) => return "\{message}"
-    None => ()
+  if error_text.strip_prefix("error: ") is Some(message) {
+    return "\{message}"
   }
   let marker = " FAILED: "
-  let pieces = error_text.split(marker).collect()
-  if pieces.length() < 2 {
+  guard error_text.split(marker).collect() is [_, .., last] else {
     return error_text
   }
-  let message = pieces[pieces.length() - 1]
-  let message = match message.strip_suffix(")") {
-    Some(trimmed) => trimmed
-    None => message
-  }
-  "\{message}"
+  "\{last.strip_suffix(")").unwrap_or(last)}"
 }
 
 ///|
@@ -572,8 +565,7 @@ fn root_command() -> @argparse.Command {
 ///|
 fn value(matches : @argparse.Matches, name : String) -> String raise {
   match matches.values.get(name) {
-    Some([value]) => value
-    Some(values) if values.length() > 0 => values[0]
+    Some([value, ..]) => value
     _ => fail("missing parsed argument: \{name}")
   }
 }
@@ -588,10 +580,7 @@ fn values(matches : @argparse.Matches, name : String) -> Array[String] {
 
 ///|
 fn flag(matches : @argparse.Matches, name : String) -> Bool {
-  match matches.flags.get(name) {
-    Some(value) => value
-    None => false
-  }
+  matches.flags.get(name).unwrap_or(false)
 }
 
 ///|


### PR DESCRIPTION
Obvious idiomatic wins (repo-wide "obvious wins only" pass), net **+6/−17**, behavior-identical:

- `failure_message` (3 in one function): `match strip_prefix { Some => return …; None => () }` → `if … is Some(message)`; `collect(); if len<2 { return } … pieces[len-1]` → `guard …collect() is [_, .., last] else { return error_text }` (view pattern folds the length guard + last-index); `match strip_suffix(")") { … }` → `last.strip_suffix(")").unwrap_or(last)`.
- `value`: `Some([value]) => value` + `Some(values) if values.length() > 0 => values[0]` → one `Some([value, ..]) => value` (None/empty still fall to `_ => fail`); matches the convention in sibling `cmd/tui`/`cmd/viz_server` mains.
- `flag`: `match … { Some(v) => v; None => false }` → `matches.flags.get(name).unwrap_or(false)` (literal default, zero alloc).

Left alone (debatable): `prepare_workspace_root`/`resolve_run_dirs` dir-validation and the fleet-outcome loops (differing shapes / perf nuance), `values`→`unwrap_or([])` (eager alloc), and the windows-cfg dir helper (can't validate on native).

## Validation
`moon fmt` clean, `moon check cmd/openseek` 0 warnings/errors, `moon test cmd/openseek` 57/57, `moon info` shows **no `pkg.generated.mbti` change**. Only `main.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)