### PR TITLE
refactor(agent_review): de-dup submit rejection into a reject helper

### DIFF
--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -18,20 +18,11 @@ pub fn submit_review_tool(
 ///|
 fn submit(captured : Ref[ReviewReport?], args : Json) -> @agent_tool.ToolAction {
   match ReviewReport::parse(args) {
-    Err(msg) =>
-      @agent_tool.ToolAction::respond(
-        "submit_review rejected: \{msg}",
-        is_error=true,
-        brief="submit_review",
-      )
+    Err(msg) => reject(msg)
     Ok(report) => {
       let problems = report.validate()
       if problems.length() > 0 {
-        @agent_tool.ToolAction::respond(
-          "submit_review rejected: \{problems.join("; ")}",
-          is_error=true,
-          brief="submit_review",
-        )
+        reject(problems.join("; "))
       } else {
         captured.val = Some(report)
         @agent_tool.ToolAction::finish(
@@ -40,6 +31,17 @@ fn submit(captured : Ref[ReviewReport?], args : Json) -> @agent_tool.ToolAction 
       }
     }
   }
+}
+
+///|
+/// Reject malformed `submit_review` output with an error response so the model
+/// retries instead of finishing with no report.
+fn reject(reason : String) -> @agent_tool.ToolAction {
+  @agent_tool.ToolAction::respond(
+    "submit_review rejected: \{reason}",
+    is_error=true,
+    brief="submit_review",
+  )
 }
 
 ///|


### PR DESCRIPTION
Obvious de-dup win (repo-wide "obvious wins only" pass), behavior-identical:

`submit.mbt`: the two rejection branches each inlined an identical `@agent_tool.ToolAction::respond("submit_review rejected: …", is_error=true, brief="submit_review")`, differing only in the reason string → extracted a private `reject(reason)`. `Err(msg)` → `reject(msg)`; `problems.length() > 0` → `reject(problems.join("; "))`. Names the reject-and-retry intent; helper is private.

Left alone (already idiomatic / not wins): `engine.mbt` matches and `with_task_group`, `types.mbt` accumulator, `prompt.mbt` string assembly.

## Validation
`moon fmt` clean, `moon check agent_review` 0 warnings/errors, `moon test agent_review` 9/9, `moon info` shows **no `pkg.generated.mbti` change**. Only `submit.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)