### PR TITLE
refactor(agent_skill): is-pattern in parse_frontmatter

### DIFF
--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -50,17 +50,14 @@ fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) 
     if line.trim() == "---" {
       break
     }
-    match line.split_once(":") {
-      Some((key, value)) => {
-        let key = key.trim()
-        let value = value.trim()
-        match key {
-          "name" => if value != "" { name = "\{value}" }
-          "description" => description = "\{value}"
-          _ => ()
-        }
+    if line.split_once(":") is Some((key, value)) {
+      let key = key.trim()
+      let value = value.trim()
+      match key {
+        "name" => if value != "" { name = "\{value}" }
+        "description" => description = "\{value}"
+        _ => ()
       }
-      None => ()
     }
   }
   (name, description)


### PR DESCRIPTION
Obvious idiomatic win (repo-wide "obvious wins only" pass):

`parse_frontmatter`: `match line.split_once(":") { Some((key, value)) => {…}; None => () }` → `if line.split_once(":") is Some((key, value)) {…}` (drops the no-op `None` arm).

Deliberately left (not strict wins): the `"\{value}"`/`"\{stem}"`/`"\{base}"` interpolations are load-bearing `StringView`→`String` conversions, `.to_owned()` in the split (allocation behavior), and the genuine two-arm value matches in `file_stem`/`add_skill_file`.

## Validation
`moon fmt` clean, `moon check agent_skill` 0 warnings/errors, `moon test agent_skill` 5/5, `moon info` shows **no `pkg.generated.mbti` change**. Only `skill.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)