### PR TITLE
refactor(tui/internal/surface): clamp + prefix-slice copy in with_max_rows

### DIFF
--- a/tui/internal/surface/surface.mbt
+++ b/tui/internal/surface/surface.mbt
@@ -166,17 +166,8 @@ pub fn Surface::cursor(self : Surface) -> Cursor {
 /// width and cursor. Used to fit a surface into a bounded terminal region; the
 /// caller decides the bound.
 pub fn Surface::with_max_rows(self : Surface, max_rows : Int) -> Surface {
-  let row_count = if max_rows < 0 {
-    0
-  } else if max_rows > self.rows.length() {
-    self.rows.length()
-  } else {
-    max_rows
-  }
-  let rows : Array[Line] = []
-  for index in 0..<row_count {
-    rows.push(self.rows[index])
-  }
+  let row_count = max_rows.clamp(min=0, max=self.rows.length())
+  let rows = self.rows[:row_count].to_owned()
   Surface::new(width=self.width, rows~, cursor=self.cursor)
 }
 


### PR DESCRIPTION
Obvious idiomatic wins (repo-wide "obvious wins only" pass), net **−9**, behavior-identical:

- `Surface::with_max_rows`: 7-line `if max_rows < 0 {0} else if max_rows > self.rows.length() {…} else {max_rows}` → `max_rows.clamp(min=0, max=self.rows.length())` (exactly a clamp; same package already uses `.clamp` in `normalize_surface_index`).
- Same function: `let rows = []; for index in 0..<row_count { rows.push(self.rows[index]) }` → `self.rows[:row_count].to_owned()` (same shallow copy of the leading rows).

Left alone (not strict wins): the `<+ "\{…}"` template-op interpolation (dropping it is a parse error), `line_at`/`unwrap_or` (eager alloc on hit path), and plain-Int comparisons.

## Validation
`moon fmt` clean, `moon check tui/internal/surface` 0 warnings/errors, `moon test tui/internal/surface` 3/3, `moon info` shows **no `pkg.generated.mbti` change**. Only `surface.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)