### PR TITLE
refactor(agent_tool/finish): de-dup finish test assertions

### DIFF
--- a/agent_tool/finish/finish.mbt
+++ b/agent_tool/finish/finish.mbt
@@ -35,43 +35,40 @@ fn finish(input : @decode.FinishInput) -> @agent_tool.ToolAction {
 }
 
 ///|
+/// Asserts that `execute(arguments)` yields `Control(Finish(expected))`.
+fn assert_finish(arguments : Json, expected : String) -> Unit raise {
+  guard execute(arguments) is Control(Finish(answer)) else {
+    fail("expected Finish")
+  }
+  assert_eq(answer, expected)
+}
+
+///|
 test "finish returns Finish with the answer" {
-  let result = execute({ "answer": "all done" })
-  guard result is Control(Finish(answer)) else { fail("expected Finish") }
-  assert_eq(answer, "all done")
+  assert_finish({ "answer": "all done" }, "all done")
 }
 
 ///|
 test "finish preserves multiline answers" {
-  let result = execute({ "answer": "line one\nline two" })
-  guard result is Control(Finish(answer)) else { fail("expected Finish") }
-  assert_eq(answer, "line one\nline two")
+  assert_finish({ "answer": "line one\nline two" }, "line one\nline two")
 }
 
 ///|
 test "finish ignores extra fields on the payload" {
-  let result = execute({ "answer": "done", "extra": "ignored" })
-  guard result is Control(Finish(answer)) else { fail("expected Finish") }
-  assert_eq(answer, "done")
+  assert_finish({ "answer": "done", "extra": "ignored" }, "done")
 }
 
 ///|
 test "finish returns empty Finish when answer is missing" {
-  let result = execute({})
-  guard result is Control(Finish(answer)) else { fail("expected Finish") }
-  assert_eq(answer, "")
+  assert_finish({}, "")
 }
 
 ///|
 test "finish returns empty Finish when answer is non-string" {
-  let result = execute({ "answer": 42 })
-  guard result is Control(Finish(answer)) else { fail("expected Finish") }
-  assert_eq(answer, "")
+  assert_finish({ "answer": 42 }, "")
 }
 
 ///|
 test "finish returns empty Finish on non-object arguments" {
-  let result = execute(Json::null())
-  guard result is Control(Finish(answer)) else { fail("expected Finish") }
-  assert_eq(answer, "")
+  assert_finish(Json::null(), "")
 }


### PR DESCRIPTION
Obvious de-dup win (repo-wide "obvious wins only" pass), test-meaning preserved:

The 6 test blocks each repeated the identical 3-line `let result = execute(...)` / `guard result is Control(Finish(answer)) else { fail("expected Finish") }` / `assert_eq(answer, …)` → extracted a private `assert_finish(arguments, expected)`; each test is now a single call. Same guard, same `fail` message, same `assert_eq` — identical assertions.

Left alone: non-test code (`definition`/`execute`/`finish`) is already idiomatic; did NOT inline the doc-referenced `finish` decode layer (debatable).

## Validation
`moon fmt` clean, `moon check agent_tool/finish` 0 warnings/errors, `moon test agent_tool/finish` 8/8, `moon info` shows **no `pkg.generated.mbti` change** (helper is private). Only `finish.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)