### PR TITLE
refactor(tui/internal/history): flatten push guard, de-dup the push call

### DIFF
--- a/tui/internal/history/history.mbt
+++ b/tui/internal/history/history.mbt
@@ -65,14 +65,9 @@ pub fn History::reset_navigation(self : History) -> Unit {
 /// Append `entry` (unless empty or a duplicate of the most recent one) and reset
 /// navigation to the fresh draft.
 pub fn History::push(self : History, entry : Entry) -> Unit {
-  if entry.text.length() > 0 {
-    if self.entries.last() is Some(last) {
-      if !last.same_as(entry) {
-        self.entries.push(entry)
-      }
-    } else {
-      self.entries.push(entry)
-    }
+  if entry.text.length() > 0 &&
+    !(self.entries.last() is Some(last) && last.same_as(entry)) {
+    self.entries.push(entry)
   }
   self.reset_navigation()
 }


### PR DESCRIPTION
Obvious de-dup + idiomatic win (repo-wide "obvious wins only" pass), behavior-identical:

`History::push`: nested `if entry.text.length()>0 { if last is Some(last) { if !same → push } else { push } }` (with `self.entries.push(entry)` duplicated across two branches) → a single flat guard `if entry.text.length()>0 && !(self.entries.last() is Some(last) && last.same_as(entry)) { push }`. Pushes iff text non-empty AND not a consecutive duplicate (verified all four cases); `&&` short-circuits so `last()`/`same_as` are still skipped for empty text.

Left alone (not strict wins): `match self.entries.last()` would need a no-op skip arm; the `previous`/`next` early returns are genuine guard clauses.

## Validation
`moon fmt` clean, `moon check tui/internal/history` 0 warnings/errors, `moon test tui/internal/history` 3/3, `moon info` shows **no `pkg.generated.mbti` change**. Only `history.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)