### PR TITLE
refactor(cmd/viz_server): array-spread + method-call idioms

### DIFF
--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -287,7 +287,7 @@ async fn session_list_reply(catalog : SessionCatalog) -> Reply {
     }
   }
   rows.sort_by(compare_session_list_rows)
-  json_reply(Array::map(rows, row => row.to_json()).to_json())
+  json_reply(rows.map(row => row.to_json()).to_json())
 }
 
 ///|
@@ -382,10 +382,7 @@ async fn session_catalog(
   }
   // Scan the --session-root as well as the --search-dirs, so nested stores under
   // a container root are surfaced the same way search-dir trees are.
-  let scan_dirs = [session_root]
-  for dir in search_dirs {
-    scan_dirs.push(dir)
-  }
+  let scan_dirs = [session_root, ..search_dirs]
   for root in discover_session_roots(scan_dirs, session_root_name) {
     paths.push(root)
   }


### PR DESCRIPTION
Obvious idiomatic wins (repo-wide "obvious wins only" pass), net **−5**, behavior-identical:

- `session_catalog`: `let scan_dirs = [session_root]; for dir in search_dirs { scan_dirs.push(dir) }` → `[session_root, ..search_dirs]`.
- `session_list_reply`: `Array::map(rows, row => row.to_json())` → `rows.map(row => row.to_json())` (uniform method-call form; not a hot path).

Left alone (debatable / perf): the struct-literal push loops (comprehension form is parser-ambiguous), `compare_session_list_rows` sign-only compare, and the `seen.contains` O(n²) uniqueness (a Set would change perf).

## Validation
`moon fmt` clean, `moon check cmd/viz_server` 0 warnings/errors, `moon test cmd/viz_server` 15/15, `moon info` shows **no `pkg.generated.mbti` change**. Only `main.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)