### PR TITLE
refactor(command_policy): slice iteration in is_sed_in_place_flag

### DIFF
--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -139,12 +139,7 @@ fn is_sed_in_place_flag(arg : String) -> Bool {
   if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
     return false
   }
-  let mut first = true
-  for ch in arg {
-    if first {
-      first = false
-      continue
-    }
+  for ch in arg[1:] {
     match ch {
       'i' => return true
       'e' | 'f' => return false


### PR DESCRIPTION
Obvious idiomatic win (repo-wide "obvious wins only" pass), behavior-identical:

`is_sed_in_place_flag`: `let mut first = true; for ch in arg { if first { first = false; continue }; match ch {…} }` → `for ch in arg[1:] { match ch {…} }`. The guards above the loop guarantee `arg` starts with a single-code-unit `"-"`, so `arg[1:]` skips exactly that dash; slicing a `StringView` is O(1). Matches the sibling read-only-sed helpers in `sandbox.mbt` (which already use `for ch in arg[1:]`) — this was the lone `mut first` hold-out.

Left alone (debatable): `sed_option_consumes_next` (codepoint-last check → magic offset), the heterogeneous-predicate if/else in `moonbit_command_policy_error_for_parse`, and `shell_words` (comprehension would double-compute).

## Validation
`moon fmt` clean, `moon check agent_tool/shell/internal/command_policy` 0 warnings/errors, `moon test` 9/9, `moon info` shows **no `pkg.generated.mbti` change**. Only `command_policy.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)