### PR TITLE
refactor(command_context): unwrap_or + drop single-use bindings

### DIFF
--- a/cmd/tui/internal/command_context/command_context.mbt
+++ b/cmd/tui/internal/command_context/command_context.mbt
@@ -49,7 +49,7 @@ pub fn encode(
     Ok(result) => shell_result_text(result)
     Err(error) => "error running shell: \{error}"
   }
-  let text =
+  (
     $|<user_shell_command>
     $|<command>
     $|\{command}
@@ -58,7 +58,7 @@ pub fn encode(
     $|\{result_text}
     $|</result>
     $|</user_shell_command>
-  text
+  )
 }
 
 ///|
@@ -102,23 +102,20 @@ fn exit_header(exit_code : Int?) -> String {
 fn shell_result_text(result : @shell.ShellOutput) -> String {
   if result.output_limit_reached {
     let shown_chars = result.text.char_length()
-    let text =
+    (
       $|\{exit_header(result.exit_code)}
       $|truncated=true
       $|output_limit_reached=true
       $|shown_chars=\{shown_chars}
       $|max_output_chars=\{shown_chars}
       $|\{result.text}
-    text
+    )
   } else {
-    let code = match result.exit_code {
-      Some(code) => code
-      None => 0
-    }
-    let text =
+    let code = result.exit_code.unwrap_or(0)
+    (
       $|exit=\{code}
       $|\{result.text}
-    text
+    )
   }
 }
 


### PR DESCRIPTION
Obvious idiomatic wins (repo-wide "obvious wins only" pass), behavior-identical:

- `shell_result_text`: `match result.exit_code { Some(code) => code; None => 0 }` → `result.exit_code.unwrap_or(0)` (literal default; matches house style in `cmd/tui/loop.mbt`).
- `encode` and `shell_result_text`: removed the redundant `let text = <$| multiline>; text` bindings (name used once, immediately) — return the multiline literal directly.

Left alone: `exit_header`'s `if exit_code is Some(code) … else …` (the `is`-pattern if/else is already idiomatic); no de-dup opportunities.

## Validation
`moon fmt` clean, `moon check cmd/tui/internal/command_context` 0 warnings/errors, `moon test cmd/tui/internal/command_context` 5/5, `moon info` shows **no `pkg.generated.mbti` change**. Only `command_context.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)