### PR TITLE
refactor(cmd/viz_app): reuse session_label helper in current_error_count

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1058,10 +1058,7 @@ fn session_log_view(
 fn current_error_count(model : Model) -> Int {
   guard model.selected is Some(key) else { return 0 }
   guard model.parsed is Some(parsed) else { return 0 }
-  let id = match session_row(model, key) {
-    Some(row) => row.id
-    None => key
-  }
+  let id = session_label(model, key)
   let session = @viz.session_from_parse(
     parsed,
     id~,


### PR DESCRIPTION
Obvious de-dup win (repo-wide "obvious wins only" pass), behavior-identical:

`current_error_count` inlined `match session_row(model, key) { Some(row) => row.id; None => key }` — a byte-for-byte duplicate of the private `session_label`'s body → `let id = session_label(model, key)`. Both call `session_row(model, key)` exactly once, so call count and behavior are identical (4 lines → 1).

Left alone (not strict wins): the `.map().unwrap_or()` conversions of the Option-matches (closure/no clearer), and folding `running_ms`/`last_event_ms` scan loops (would add a per-iteration comparison — not identical perf).

## Validation
`cmd/viz_app` is js-only (`supported_targets = "js"`), validated on **js**: `moon fmt` clean, `moon check cmd/viz_app --target js` 0 warnings/errors, `moon test cmd/viz_app --target js` 18/18, `moon info` shows **no `pkg.generated.mbti` change**. Only `app.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)