### PR TITLE
refactor(testkit/filesystem): String::repeat + de-dup object_fields unwrap

### DIFF
--- a/testkit/filesystem/filesystem.mbt
+++ b/testkit/filesystem/filesystem.mbt
@@ -50,6 +50,17 @@ pub fn FileSystem::to_json(self : FileSystem) -> Json {
 }
 
 ///|
+/// The underlying JSON object's fields, raising when the top-level JSON is not
+/// an object as the convention requires.
+fn FileSystem::object_fields(self : FileSystem) -> Map[String, Json] raise {
+  let FileSystem(json) = self
+  guard json is Object(fields) else {
+    fail("file system must be a JSON object")
+  }
+  fields
+}
+
+///|
 /// Check the whole filesystem against the convention, raising on the first
 /// violation. Equivalent to `entries()` with the result discarded.
 pub fn FileSystem::validate(self : FileSystem) -> Unit raise {
@@ -60,10 +71,7 @@ pub fn FileSystem::validate(self : FileSystem) -> Unit raise {
 /// Every file as a `FileEntry`, sorted by path for deterministic iteration.
 /// Raises when the JSON violates the filesystem convention.
 pub fn FileSystem::entries(self : FileSystem) -> Array[FileEntry] raise {
-  let FileSystem(json) = self
-  guard json is Object(fields) else {
-    fail("file system must be a JSON object")
-  }
+  let fields = self.object_fields()
   let paths = fields.keys().collect()
   paths.sort()
   [
@@ -91,10 +99,7 @@ pub fn FileSystem::paths(self : FileSystem) -> Array[String] raise {
 /// "absent".
 pub fn FileSystem::get(self : FileSystem, path : String) -> String? raise {
   validate_relative_path(path)
-  let FileSystem(json) = self
-  guard json is Object(fields) else {
-    fail("file system must be a JSON object")
-  }
+  let fields = self.object_fields()
   match fields.get(path) {
     Some(String(content)) => Some(content)
     Some(_) => fail("file content for `\{path}` must be a string")

--- a/testkit/filesystem/outline.mbt
+++ b/testkit/filesystem/outline.mbt
@@ -84,11 +84,7 @@ fn skip_outline_dir(name : String) -> Bool {
 
 ///|
 fn outline_indent(depth : Int) -> String {
-  let sb = StringBuilder()
-  for _ in 0..<depth {
-    sb.write_string("  ")
-  }
-  sb.to_string()
+  "  ".repeat(depth)
 }
 
 ///|


### PR DESCRIPTION
Obvious idiomatic + de-dup wins (repo-wide "obvious wins only" pass), behavior-identical:

- **outline.mbt** `outline_indent`: `StringBuilder` + `for _ in 0..<depth { sb.write_string("  ") }` → `"  ".repeat(depth)` (`repeat(0)` → `""`, matching a zero-iteration loop).
- **filesystem.mbt** (de-dup): the verbatim `let FileSystem(json) = self; guard json is Object(fields) else { fail("file system must be a JSON object") }` appeared in both `entries` and `get` → private `FileSystem::object_fields(self)`; both call `self.object_fields()`. Removes the duplicated unwrap and error-message literal.

Left alone (not identical behavior): `sanitize_name`'s manual counter (it's a code-unit offset used for slicing, not a char count), and `from_pairs`'s tuple binding.

## Validation
`moon fmt` clean, `moon check testkit/filesystem` 0 warnings/errors, `moon test testkit/filesystem` 17/17, `moon info` shows **no `pkg.generated.mbti` change** (helper is private). Only the two `.mbt` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)