### PR TITLE
refactor(auto_check): guard-is unwrap + de-dup split_owned

### DIFF
--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -25,10 +25,7 @@ pub async fn append_summary(path : String, content : String) -> String {
 
 ///|
 async fn auto_check_summary(path : String) -> String? {
-  let cwd = match moon_check_cwd(path) {
-    Some(cwd) => cwd
-    None => return None
-  }
+  guard moon_check_cwd(path) is Some(cwd) else { return None }
   let result = @async.with_timeout_opt(MoonCheckTimeoutMs, () => {
     @shell.collect_shell_output(
       MoonCheckCommand,
@@ -82,10 +79,7 @@ pub(all) struct CheckErrors {
 /// (timed out / failed to spawn) — in every `None` case the caller keeps the
 /// batch unguarded, matching `append_summary`'s fail-open behavior.
 pub async fn count_errors(path : String) -> CheckErrors? {
-  let cwd = match moon_check_cwd(path) {
-    Some(cwd) => cwd
-    None => return None
-  }
+  guard moon_check_cwd(path) is Some(cwd) else { return None }
   let result = @async.with_timeout_opt(MoonCheckTimeoutMs, () => {
     @shell.collect_shell_output(
       MoonCheckJsonCommand,

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -180,6 +180,12 @@ fn decide_parse_gate(
 }
 
 ///|
+/// Split `text` on `sep`, returning each piece as an owned `String`.
+fn split_owned(text : String, sep : StringView) -> Array[String] {
+  text.split(sep).map(s => s.to_owned()).collect()
+}
+
+///|
 /// Render up to `ParseErrorDisplayLimit` gate errors as
 /// `path:loc: message` lines, each followed by a numbered excerpt of the
 /// offending lines — the rejected content never lands at its destination, so
@@ -191,7 +197,7 @@ pub fn format_parse_gate_errors(
   content : String,
   errors : Array[ParseGateError],
 ) -> Array[String] {
-  let lines = content.split("\n").map(line => line.to_owned()).collect()
+  let lines = split_owned(content, "\n")
   let shown = if errors.length() < ParseErrorDisplayLimit {
     errors.length()
   } else {
@@ -224,7 +230,7 @@ pub fn format_parse_gate_errors(
 /// produces — interior blank lines, should moonc ever emit them, are kept so
 /// the excerpt stays faithful.
 fn indent_context(context : String) -> String {
-  let lines = context.split("\n").map(line => line.to_owned()).collect()
+  let lines = split_owned(context, "\n")
   if !lines.is_empty() && lines[lines.length() - 1] == "" {
     let _ = lines.pop()
   }
@@ -267,7 +273,7 @@ fn excerpt_for_loc(lines : Array[String], loc : String) -> String {
 /// The inclusive 1-based `(first, last)` line pair named by a compiler `loc`
 /// like `7:1-9:2` (or a bare `7:1`). `None` when the loc is malformed.
 fn loc_line_span(loc : String) -> (Int, Int)? {
-  let parts = loc.split("-").map(part => part.to_owned()).collect()
+  let parts = split_owned(loc, "-")
   guard parts.length() >= 1 && parts[0] != "" else { return None }
   guard leading_line_number(parts[0]) is Some(start) else { return None }
   let end = if parts.length() >= 2 {


### PR DESCRIPTION
Obvious idiomatic + de-dup wins (repo-wide "obvious wins only" pass), behavior-identical, all private/internal:

- **auto_check.mbt** (×2, `auto_check_summary`/`count_errors`): `let cwd = match moon_check_cwd(path) { Some(cwd) => cwd; None => return None }` → `guard moon_check_cwd(path) is Some(cwd) else { return None }`.
- **parse_gate.mbt** (de-dup): three identical `X.split(sep).map(x => x.to_owned()).collect()` blocks (`format_parse_gate_errors`/`indent_context`/`loc_line_span`) → private `split_owned(text, sep)`.

Left alone (fails "identical performance"): a JSON-lines scaffold helper (would add a per-line closure/box on a hot path), a `matches_manifest` helper (would add interpolation where literals are used), and borderline stylistic tweaks.

## Validation
`moon fmt` clean, `moon check agent_tool/internal/auto_check` 0 warnings/errors, `moon test agent_tool/internal/auto_check` 23/23, `moon info` shows **no `pkg.generated.mbti` change**. Only the two `.mbt` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)