### PR TITLE
refactor(internal/workspace_path): de-dup default-root check

### DIFF
--- a/internal/workspace_path/workspace_path.mbt
+++ b/internal/workspace_path/workspace_path.mbt
@@ -1,11 +1,17 @@
 ///|
+/// Whether `workspace_root` selects the default (pre-workspace) behavior: both
+/// an empty root and "." mean "leave paths as-is".
+fn is_default_root(workspace_root : String) -> Bool {
+  workspace_root == "" || workspace_root == "."
+}
+
+///|
 /// Resolve a tool path against the agent workspace root. Absolute paths are
 /// already explicit, and the default root "." intentionally preserves the
 /// pre-workspace behavior and output text.
 pub fn resolve(workspace_root : String, path : String) -> String {
   if path == "" ||
-    workspace_root == "" ||
-    workspace_root == "." ||
+    is_default_root(workspace_root) ||
     @path.Path(path).is_absolute() {
     path
   } else {
@@ -19,7 +25,7 @@ pub fn resolve(workspace_root : String, path : String) -> String {
 pub fn resolve_cwd(workspace_root : String, cwd : String?) -> String? {
   match cwd {
     Some(cwd) if cwd != "" => Some(resolve(workspace_root, cwd))
-    _ if workspace_root == "" || workspace_root == "." => None
+    _ if is_default_root(workspace_root) => None
     _ => Some(workspace_root)
   }
 }


### PR DESCRIPTION
Obvious de-dup win (repo-wide "obvious wins only" pass), behavior-identical:

The 2-term boolean `workspace_root == "" || workspace_root == "."` was duplicated in `resolve` and `resolve_cwd` → extracted a private `is_default_root(workspace_root)`, naming the "default root" concept already used in the doc comments. Helper is private (off the interface).

## Validation
`moon fmt` clean, `moon check internal/workspace_path` 0 warnings/errors, `moon test internal/workspace_path` 2/2, `moon info` shows **no `pkg.generated.mbti` change**. Only `workspace_path.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)