### PR TITLE
refactor(markdown_comments): guard-is flattening + de-dup loc_is_absent

### DIFF
--- a/scripts/internal/markdown_comments/markdown_comments.mbt
+++ b/scripts/internal/markdown_comments/markdown_comments.mbt
@@ -103,10 +103,7 @@ fn push_html_block_ranges(
   guard block.0.get(block.0.length() - 1) is Some(last_line) else { return }
   let first_loc = first_line.meta.loc
   let last_loc = last_line.meta.loc
-  if first_loc.is_none() ||
-    first_loc.is_empty() ||
-    last_loc.is_none() ||
-    last_loc.is_empty() {
+  if loc_is_absent(first_loc) || loc_is_absent(last_loc) {
     return
   }
   let len = markdown.length()
@@ -130,9 +127,14 @@ fn is_html_comment(text : StringView) -> Bool {
 }
 
 ///|
+fn loc_is_absent(loc : @cmark_base.TextLoc) -> Bool {
+  loc.is_none() || loc.is_empty()
+}
+
+///|
 fn push_loc_range(ranges : Array[SourceRange], meta : @cmark_base.Meta) -> Unit {
   let loc = meta.loc
-  if loc.is_none() || loc.is_empty() {
+  if loc_is_absent(loc) {
     return
   }
   ranges.push({ first: loc.first_ccode, last_exclusive: loc.last_ccode + 1 })
@@ -149,17 +151,15 @@ fn push_html_comment_ranges(
   let stop = stop.clamp(min=0, max=len)
   let mut cursor = start.clamp(min=0, max=stop)
   while cursor < stop {
-    match find_html_comment_open(markdown, start=cursor, stop~) {
-      Some(first) =>
-        match find_html_comment_close(markdown, start=first + 4, stop~) {
-          Some(last_exclusive) => {
-            ranges.push({ first, last_exclusive })
-            cursor = last_exclusive
-          }
-          None => break
-        }
-      None => break
+    guard find_html_comment_open(markdown, start=cursor, stop~) is Some(first) else {
+      break
     }
+    guard find_html_comment_close(markdown, start=first + 4, stop~)
+      is Some(last_exclusive) else {
+      break
+    }
+    ranges.push({ first, last_exclusive })
+    cursor = last_exclusive
   }
 }
 


### PR DESCRIPTION
Obvious idiomatic + de-dup wins (repo-wide "obvious wins only" pass), behavior-identical, helper is private:

- `push_html_comment_ranges`: doubly-nested `match { Some => match { Some => …; None => break }; None => break }` → two sequential `guard find_html_comment_open(...) is Some(first) else { break }` / `guard … is Some(last_exclusive) else { break }`. Both `None` arms already broke the `while`; matches the `guard … is Some(x) else { break }` idiom already in `agent_session/store`.
- De-dup: `loc.is_none() || loc.is_empty()` appeared 3× → private `loc_is_absent(loc)`.

Left alone (not strict wins): tuple-pattern `for` (no repo precedent), merging the comment-open/close scanners (per-char closure on a hot path), and multi-term guards.

## Validation
`moon fmt` clean, `moon check scripts/internal/markdown_comments` 0 warnings/errors, `moon test` 18/18, `moon info` shows **no `pkg.generated.mbti` change**. Only `markdown_comments.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)