### PR TITLE
refactor(read/internal/decode): de-dup optional_positive_int via the Option variant

### DIFF
--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -83,17 +83,7 @@ fn optional_positive_int(
   name : String,
   default : Int,
 ) -> Int raise {
-  match fields.get(name) {
-    Some(Number(value, ..)) => {
-      let int_value = value.to_int()
-      if int_value <= 0 {
-        fail("arguments.\{name} to be a positive number")
-      }
-      int_value
-    }
-    Some(Null) | None => default
-    _ => fail("arguments.\{name} to be a number")
-  }
+  optional_positive_int_option(fields, name).unwrap_or(default)
 }
 
 ///|


### PR DESCRIPTION
Obvious de-dup win (repo-wide "obvious wins only" pass), behavior-identical:

`optional_positive_int` inlined a ~10-line `match`/`to_int`/`<= 0`/fail body byte-for-byte identical to `optional_positive_int_option` (except returning bare `Int`/`default` vs `Some`/`None`) → `optional_positive_int_option(fields, name).unwrap_or(default)`. Same fail branches raise before returning; `None` → `default`; `default` is an already-evaluated `Int` arg (no closure). Single source of truth.

Left alone (debatable): `cap_max_output_chars`'s `if value > x` (clear as-is), and `parse_fields`'s `match`→`guard is` (pure style).

## Validation
`moon fmt` clean, `moon check agent_tool/read/internal/decode` 0 warnings/errors, `moon test agent_tool/read/internal/decode` 6/6, `moon info` shows **no `pkg.generated.mbti` change**. Only `decode.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)