### PR TITLE
refactor(moon_check/internal/decode): is-pattern for optional target validation

### DIFF
--- a/agent_tool/moon_check/internal/decode/decode.mbt
+++ b/agent_tool/moon_check/internal/decode/decode.mbt
@@ -30,9 +30,8 @@ pub fn decode(arguments : Json) -> MoonCheckInput raise {
 fn parse_fields(fields : Map[String, Json]) -> MoonCheckInput raise {
   let cwd = optional_string(fields, "cwd")
   let target = optional_string(fields, "target")
-  match target {
-    Some(value) => @moon_target.validate_target(value)
-    None => ()
+  if target is Some(value) {
+    @moon_target.validate_target(value)
   }
   let warn_list = optional_string(fields, "warn_list")
   {


### PR DESCRIPTION
Obvious idiomatic win (repo-wide "obvious wins only" pass), behavior-identical:

`parse_fields`: `match target { Some(value) => @moon_target.validate_target(value); None => () }` → `if target is Some(value) { @moon_target.validate_target(value) }` (drops the no-op `None` arm; `validate_target` returns `Unit raise`).

Left alone: `optional_string`/`optional_bool` (clean matches over different JSON shapes, no clean de-dup); the `.map` route would introduce a raising hot-path closure.

## Validation
`moon fmt` clean, `moon check agent_tool/moon_check/internal/decode` 0 warnings/errors, `moon test` 5/5, `moon info` shows **no `pkg.generated.mbti` change**. Only `decode.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)