### PR TITLE
refactor(shell/internal/decode): de-dup optional_positive_int_or_default

### DIFF
--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -92,17 +92,7 @@ fn optional_positive_int_or_default(
   name : String,
   default : Int,
 ) -> Int raise {
-  match fields.get(name) {
-    Some(Number(value, ..)) => {
-      let int_value = value.to_int()
-      if int_value <= 0 {
-        fail("arguments.\{name} to be a positive number")
-      }
-      int_value
-    }
-    Some(Null) | None => default
-    _ => fail("arguments.\{name} to be a number")
-  }
+  optional_positive_int(fields, name).unwrap_or(default)
 }
 
 ///|


### PR DESCRIPTION
Obvious de-dup win (repo-wide "obvious wins only" pass), net **−10**, behavior-identical:

`optional_positive_int_or_default` inlined a body byte-identical to the `Int?`-returning `optional_positive_int` (modulo `Some(v)`→`v`, `None`→`default`) → `optional_positive_int(fields, name).unwrap_or(default)`. Same raises propagate; `unwrap_or` takes a value (no closure).

Left alone: `required_string` vs `optional_string` (required *fails* where optional returns `None` — not delegatable); `cap_max_output_chars` (`min` would add an import).

## Validation
`moon fmt` clean, `moon check agent_tool/shell/internal/decode` 0 warnings/errors, `moon test` 6/6, `moon info` shows **no `pkg.generated.mbti` change**. Only `decode.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)