### PR TITLE
refactor(moon_cmd/internal/decode): de-dup parse_string_list + is-pattern

### DIFF
--- a/agent_tool/moon_cmd/internal/decode/decode.mbt
+++ b/agent_tool/moon_cmd/internal/decode/decode.mbt
@@ -48,15 +48,12 @@ fn parse_fields(fields : Map[String, Json]) -> MoonCommandInput raise {
   validate_command(command)
   let cwd = optional_string(fields, "cwd")
   let target = optional_string(fields, "target")
-  match target {
-    Some(value) => {
-      @moon_target.validate_target(value)
-      validate_target_supported(command)
-    }
-    None => ()
+  if target is Some(value) {
+    @moon_target.validate_target(value)
+    validate_target_supported(command)
   }
-  let args = parse_arg_list(fields)
-  let paths = parse_paths(fields)
+  let args = parse_string_list(fields, "arg", "args")
+  let paths = parse_string_list(fields, "path", "paths")
   let program_args = optional_string_array(fields, "program_args")
   if program_args.length() > 0 && command != "run" {
     fail("arguments.program_args only with command run")
@@ -106,31 +103,23 @@ fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
 }
 
 ///|
-fn parse_arg_list(fields : Map[String, Json]) -> Array[String] raise {
-  let args : Array[String] = []
-  match fields.get("arg") {
-    Some(String(arg)) if arg != "" => args.push(arg)
+/// Collect a string list from a singular field (`singular`) followed by a
+/// plural array field (`plural`), skipping empty/null entries.
+fn parse_string_list(
+  fields : Map[String, Json],
+  singular : String,
+  plural : String,
+) -> Array[String] raise {
+  let values : Array[String] = []
+  match fields.get(singular) {
+    Some(String(value)) if value != "" => values.push(value)
     Some(String(_)) | Some(Null) | None => ()
-    _ => fail("arguments.arg to be a string")
+    _ => fail("arguments.\{singular} to be a string")
   }
-  for arg in optional_string_array(fields, "args") {
-    args.push(arg)
+  for value in optional_string_array(fields, plural) {
+    values.push(value)
   }
-  args
-}
-
-///|
-fn parse_paths(fields : Map[String, Json]) -> Array[String] raise {
-  let paths : Array[String] = []
-  match fields.get("path") {
-    Some(String(path)) if path != "" => paths.push(path)
-    Some(String(_)) | Some(Null) | None => ()
-    _ => fail("arguments.path to be a string")
-  }
-  for path in optional_string_array(fields, "paths") {
-    paths.push(path)
-  }
-  paths
+  values
 }
 
 ///|


### PR DESCRIPTION
Obvious de-dup + idiomatic wins (repo-wide "obvious wins only" pass), net **−11**, behavior-identical:

- De-dup: `parse_arg_list` and `parse_paths` were byte-identical modulo the field-name strings (`"arg"/"args"` vs `"path"/"paths"`) → private `parse_string_list(fields, singular, plural)` (error message derived via `"arguments.\{singular} to be a string"`). Call sites become `parse_string_list(fields, "arg", "args")` / `("path", "paths")`.
- `parse_fields` target: `match target { Some(value) => {…}; None => () }` → `if target is Some(value) { … }` (mirrors the file's own `if stdin is Some(_) && …` idiom).

Left alone (debatable / perf): `validate_test_update_guard`'s `reason` match (keeps parallelism with the adjacent 3-arm match), `uses_test_update`'s loop (`.contains` changes iteration passes), and plain-Bool conditionals.

## Validation
`moon fmt` clean, `moon check agent_tool/moon_cmd/internal/decode` 0 warnings/errors, `moon test` 11/11, `moon info` shows **no `pkg.generated.mbti` change**. Only `decode.mbt` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)