### PR TITLE
fix(openseek): rename model env var to OPENSEEK_MODEL

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -74,7 +74,7 @@ export DEEPSEEK=sk-...
 moon run cmd/openseek -- run "inspect this project and finish with a short summary"
 ```
 
-`DEEPSEEK_MODEL` is optional and defaults to `deepseek-v4-pro`.
+`OPENSEEK_MODEL` is optional and defaults to `deepseek-v4-pro`.
 `OPENSEEK_MAX_STEPS` is optional and defaults to `1000`; pass `--max-steps` on
 the CLI to override it for one run. `--thinking no|high|max` controls DeepSeek
 thinking mode and effort (default: max).

--- a/agent_tool/shell/internal/command_policy/README.mbt.md
+++ b/agent_tool/shell/internal/command_policy/README.mbt.md
@@ -105,7 +105,7 @@ test "command policy allows moon subcommands through shell" {
   )
   assert_true(
     @command_policy.moonbit_command_policy_error(
-      "DEEPSEEK_MODEL=x moon run cmd/main",
+      "OPENSEEK_MODEL=x moon run cmd/main",
     )
     is None,
   )

--- a/agent_tool/shell/internal/command_policy/command_policy_test.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy_test.mbt
@@ -19,7 +19,7 @@ test "command policy allows moon subcommands through shell" {
   )
   assert_true(
     @command_policy.moonbit_command_policy_error(
-      "DEEPSEEK_MODEL=x moon run cmd/main",
+      "OPENSEEK_MODEL=x moon run cmd/main",
     )
     is None,
   )
@@ -41,8 +41,8 @@ test "command policy still redirects the moon_cmd tool name" {
 test "command policy detects moon_cmd in simple shell compounds" {
   for
     cmd in [
-      "cd demo && moon_cmd check", "DEEPSEEK_MODEL=x moon_cmd run cmd/main", "env DEEPSEEK_MODEL=x moon_cmd check",
-      "env -- DEEPSEEK_MODEL=x moon_cmd check", "command moon_cmd check", "command -- moon_cmd check",
+      "cd demo && moon_cmd check", "OPENSEEK_MODEL=x moon_cmd run cmd/main", "env OPENSEEK_MODEL=x moon_cmd check",
+      "env -- OPENSEEK_MODEL=x moon_cmd check", "command moon_cmd check", "command -- moon_cmd check",
       "command -p moon_cmd check", "true || moon_cmd test", "moon_cmd check > out.log",
       "cd demo && moon_cmd check # trailing note", "true;\nmoon_cmd check",
     ] {
@@ -70,7 +70,7 @@ test "command policy does not match moon_cmd as data" {
   )
   assert_true(
     @command_policy.moonbit_command_policy_error(
-      "env DEEPSEEK_MODEL=x -i moon_cmd check",
+      "env OPENSEEK_MODEL=x -i moon_cmd check",
     )
     is None,
   )

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -35,7 +35,7 @@ moon run cmd/openseek -- run [--api-key sk-...] [--model deepseek-v4-pro] [--api
 ```
 
 Runs require `--api-key` or `DEEPSEEK`. `--model` can also be supplied with
-`DEEPSEEK_MODEL`; it accepts `deepseek-v4-flash`, `deepseek-v4-pro`,
+`OPENSEEK_MODEL`; it accepts `deepseek-v4-flash`, `deepseek-v4-pro`,
 `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed`, and defaults to
 `deepseek-v4-pro`. `--max-steps` can also be supplied with
 `OPENSEEK_MAX_STEPS`; it defaults to `1000`. `--api-url` can also be supplied
@@ -116,7 +116,7 @@ moon run cmd/openseek -- run "run moon test and summarize the result"
 ```
 
 ```bash
-DEEPSEEK_MODEL=deepseek-v4-flash moon run cmd/openseek -- run "inspect the package docs"
+OPENSEEK_MODEL=deepseek-v4-flash moon run cmd/openseek -- run "inspect the package docs"
 ```
 
 ```bash

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1137,7 +1137,7 @@ test "session listing rows are tab-separated and survive odd prompts" {
 test "cli parses env backed options and task" {
   let parsed = run_matches(argv=["write", "MoonBit"], env={
     "DEEPSEEK": "test-key",
-    "DEEPSEEK_MODEL": "deepseek-v4-pro",
+    "OPENSEEK_MODEL": "deepseek-v4-pro",
     "OPENSEEK_API_URL": "https://proxy.example/v1/chat/completions",
     "OPENSEEK_DIR": "/tmp/openseek-workspace",
     "OPENSEEK_MAX_STEPS": "120",

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -141,7 +141,7 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   {
     "DEEPSEEK": config.api_key,
     "OPENSEEK_API_URL": config.api_url.unwrap_or(""),
-    "DEEPSEEK_MODEL": config.model.to_string(),
+    "OPENSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
     "OPENSEEK_THINKING": config.thinking.to_string(),
     "OPENSEEK_SESSION": config.session_id.value(),

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -21,7 +21,7 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
     OptionArg(
       "model",
       long="model",
-      env="DEEPSEEK_MODEL",
+      env="OPENSEEK_MODEL",
       default_values=[@deepseek.V4Pro.to_string()],
       global~,
       about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -208,7 +208,7 @@ moon test deepseek/client
 
 The blackbox test suite includes a real DeepSeek API smoke test when `DEEPSEEK`
 is set. Kimi smoke tests are opt-in: set `KIMI` to a Kimi API key. The normal
-Kimi smoke also uses `DEEPSEEK_MODEL` to choose the Kimi model; streaming,
+Kimi smoke also uses `OPENSEEK_MODEL` to choose the Kimi model; streaming,
 tool-call, and multi-turn reasoning-content smokes use `kimi-k2.7-code`.
 Without those environment variables, the smoke tests print skip messages and
 return successfully.

--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -33,10 +33,10 @@ async test "realworld DeepSeek API smoke test" {
 
 ///|
 async test "realworld Kimi API smoke test" {
-  guard @env.get_env_var("DEEPSEEK_MODEL") is Some(model_name) &&
+  guard @env.get_env_var("OPENSEEK_MODEL") is Some(model_name) &&
     (model_name == "kimi-k2.7-code" || model_name == "kimi-k2.7-code-highspeed") else {
     println(
-      "DEEPSEEK_MODEL is not a Kimi model; skipping realworld Kimi API smoke test",
+      "OPENSEEK_MODEL is not a Kimi model; skipping realworld Kimi API smoke test",
     )
     return
   }

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -148,7 +148,7 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
     args,
     extra_env={
       "DEEPSEEK": config.api_key,
-      "DEEPSEEK_MODEL": config.model.to_string(),
+      "OPENSEEK_MODEL": config.model.to_string(),
       "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
       // Trials inherit the developer's env, so point the global skills
       // lookup at a workspace path that does not exist — the developer's

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -133,7 +133,7 @@ fn trial_extra_env(
 ) -> Map[String, String] {
   {
     "DEEPSEEK": config.api_key,
-    "DEEPSEEK_MODEL": config.model.to_string(),
+    "OPENSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
     "OPENSEEK_SESSION_ROOT": ".openseek",
     "OPENSEEK_GLOBAL_SKILLS_DIR": "\{real_workspace}/.no-global-skills",

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -33,7 +33,7 @@ Commands:
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK] [default: ]
-  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
@@ -129,7 +129,7 @@ Arguments:
 Options:
   -h, --help                                                   Show help information.
   --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
-  --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -24,7 +24,7 @@ OpenSeek terminal UI.
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK] [default: ]
-  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: DEEPSEEK_MODEL] [default: deepseek-v4-pro]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]

--- a/todo.md
+++ b/todo.md
@@ -4,7 +4,7 @@
 
 - Status: failed/incomplete as of 2026-05-22 11:17 CST.
 - Task: use the OpenSeek agent with `deepseek-v4-pro` reasoning mode to create a MoonBit TOML parser plus CLI that dumps parsed TOML as JSON.
-- Model setting: `DEEPSEEK_MODEL=deepseek-v4-pro`; OpenSeek defaults used reasoning mode with max reasoning effort.
+- Model setting: `OPENSEEK_MODEL=deepseek-v4-pro`; OpenSeek defaults used reasoning mode with max reasoning effort.
 - Log: `.moonagent/eval_runs/results/openseek_toml_cli_d4pro_reasoning.log`
 - Log size: 2,283 lines / 99,169 bytes.
 - Output workspace: `.moonagent/eval_runs/toml_cli_task`
@@ -54,7 +54,7 @@
 
 - Status: failed/incomplete as of 2026-05-22 20:14 CST.
 - Task: same TOML parser plus JSON-dump CLI task, using `--max-steps 1000`, `moon_check`, and `moon_cmd`.
-- Model setting: `DEEPSEEK_MODEL=deepseek-v4-flash`.
+- Model setting: `OPENSEEK_MODEL=deepseek-v4-flash`.
 - First attempt log: `.moonagent/eval_runs/results/openseek_toml_cli_d4flash_v1.log`
 - First attempt size: 23 lines / 645 bytes.
 - First attempt result: failed at step 1 by returning a JSON-like plan as assistant text instead of calling tools. No task files were created.
@@ -74,7 +74,7 @@
 
 - Status: partial success/incomplete as of 2026-05-22 21:10 CST.
 - Task: create a more complex MoonBit JSON Schema validator library plus native CLI under `.moonagent/eval_runs/json_schema_validator_pro_v1`.
-- Model setting: `DEEPSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
+- Model setting: `OPENSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
 - Log: `.moonagent/eval_runs/results/openseek_json_schema_d4pro_reasoning_v1.log`
 - Log size: 73,791 lines / 3,389,910 bytes.
 - Output workspace: `.moonagent/eval_runs/json_schema_validator_pro_v1`
@@ -88,7 +88,7 @@
 
 - Status: partial success/incomplete as of 2026-05-22 23:05 CST.
 - Task: repeat the JSON Schema validator library plus native CLI task after adding `moon_ide` and prompt guidance for flat MoonBit packages and small-file generation.
-- Model setting: `DEEPSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
+- Model setting: `OPENSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
 - Log: `.moonagent/eval_runs/results/openseek_json_schema_d4pro_reasoning_v2_moon_ide.log`
 - Log size: 72,627 lines / 3,191,156 bytes.
 - Output workspace: `.moonagent/eval_runs/json_schema_validator_pro_v2_moon_ide`
@@ -102,7 +102,7 @@
 
 - Status: succeeded as of 2026-05-22 23:33 CST.
 - Task: repeat the JSON Schema validator library plus native CLI task after adding command output caps and native CLI argument guidance.
-- Model setting: `DEEPSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
+- Model setting: `OPENSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
 - Log: `.moonagent/eval_runs/results/openseek_json_schema_d4pro_reasoning_v3_output_caps.log`
 - Log size: 3,200 lines / 179,082 bytes (196K on disk).
 - Output workspace: `.moonagent/eval_runs/json_schema_validator_pro_v3_output_caps`
@@ -117,7 +117,7 @@
 
 - Status: partial success/incomplete as of 2026-05-23 14:22 CST.
 - Task: repeat the JSON Schema validator library plus native CLI task after adding bounded `read` output for ranged and character-capped file inspection.
-- Model setting: `DEEPSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
+- Model setting: `OPENSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
 - Log: `.moonagent/eval_runs/results/openseek_json_schema_d4pro_reasoning_v4_bounded_read.log`
 - Log size: 3,345 lines / 303,726 bytes (328K on disk).
 - Output workspace: `.moonagent/eval_runs/json_schema_validator_pro_v4_bounded_read`
@@ -148,7 +148,7 @@
 
 ## DeepSeek V4 Pro Extensive Six-Task Eval
 
-- Status: completed as of 2026-05-23 after six parallel challenging runs with `DEEPSEEK_MODEL=deepseek-v4-pro` and `--max-steps 1000`.
+- Status: completed as of 2026-05-23 after six parallel challenging runs with `OPENSEEK_MODEL=deepseek-v4-pro` and `--max-steps 1000`.
 - Setup: the tasks were jqmini, JSONPath, CSVQL, semver dependency solver, Markdown outline/front-matter extractor, and HTTP route matcher. Logs total 16,914 lines under `.moonagent/eval_runs/results/openseek_*guarded*.log`.
 - Jqmini guarded V2: failed. The run stopped after 774 log lines with `OSError(@socket.Tcp::read(): Connection reset by peer)` after a huge `moon ide doc @array` response. Independent `moon check --output-json` still fails with 11 errors and 12 warnings, including error-type mismatches, nonexistent `Double::is_infinite`, nonexistent `Array::sorted`, and old `String::substring` call shapes.
 - JSONPath guarded V2: mostly succeeded. Independent validation: `moon check --output-json` passed with 5 deprecated `Show` warnings; `moon test --target native` passed 33/33; file and stdin CLI probes produced expected JSON Lines. Caveats: invalid-path mode returns exit 0 through `moon run` even though the built binary exits 1, and the final workspace still contains whitebox tests named `debug filter ...`.


### PR DESCRIPTION
## Summary

- Rename the model-selection environment variable from `DEEPSEEK_MODEL` to `OPENSEEK_MODEL` across runtime config, harness propagation, docs, and snapshots.
- Keep the missing-env default as `deepseek-v4-pro` through the existing `@deepseek.V4Pro.to_string()` option default.
- Update command-policy examples and real-world Kimi smoke-test gating text to use the OpenSeek-scoped name.

## Validation

- `moon info && moon fmt`
- `moon check`
- `moon test cmd/tui`
- `moon test cmd/openseek`
- `moon test agent_tool/shell/internal/command_policy`
- `moon test eval/file_edit/cmd/main`
- `moon test eval/prompt_task/cmd/main`
- `zsh -lic 'OPENSEEK_MODEL=kimi-k2.7-code moon test deepseek/client'`
- `zsh -lic 'OPENSEEK_MODEL=kimi-k2.7-code moon test'`