### PR TITLE
feat(tui): /loop — recurring scheduled prompts

### DIFF
--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -447,18 +447,22 @@ fn handle_agent_event(
       if !already_appended && !answer.trim().is_empty() {
         cmds.push(AppendItem(Response(answer)))
       }
+      scheduler_on_run_end(state, LoopRunFinished, cmds)
       state.finish_run()
     }
     AgentAborted(reason) => {
       cmds.push(AppendItem(Error("aborted: \{reason}")))
+      scheduler_on_run_end(state, LoopRunFailed("was aborted"), cmds)
       state.finish_run()
     }
     MaxStepsExhausted => {
       cmds.push(AppendItem(Error("max steps exhausted")))
+      scheduler_on_run_end(state, LoopRunFailed("hit max steps"), cmds)
       state.finish_run()
     }
     AgentError(message) => {
       cmds.push(AppendItem(Error(message)))
+      scheduler_on_run_end(state, LoopRunFailed("errored"), cmds)
       state.finish_run()
     }
     // A rejected control command keeps the engine serving and carries no
@@ -551,6 +555,7 @@ fn handle_slash_command(
         cmds.push(AppendItem(Error("/exit does not accept arguments")))
       }
     "compact" => handle_compact_command(state, arguments, cmds)
+    "loop" => handle_loop_command(state, arguments, cmds)
     other => cmds.push(AppendItem(Error("Unknown slash command: /\{other}")))
   }
 }
@@ -636,7 +641,14 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
               // `$ command`, and that card is the only form persisted, so an
               // echo here would double the command line live and diverge from a
               // resumed session, which only re-renders the card.
-              Command(command) => cmds.push(RunCommand(run_id=None, command))
+              Command(command) => {
+                // Its eventual completion hands command context to the engine;
+                // a scheduled `/loop` fire must not slip in between (the
+                // context would land in the scheduled turn instead of this
+                // conversation), so track it as busy until the result arrives.
+                state.background_commands += 1
+                cmds.push(RunCommand(run_id=None, command))
+              }
             }
           }
         Queue(input) => state.queued.push(input)
@@ -667,6 +679,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     AgentProgress(event, ..) => handle_agent_event(state, event, cmds)
     AgentCancelled(..) => {
       cmds.push(AppendItem(Error("interrupted")))
+      scheduler_on_run_end(state, LoopRunFailed("was interrupted"), cmds)
       state.finish_run()
     }
     CommandCancelled(command~, ..) => {
@@ -675,6 +688,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     }
     AgentFailed(error, ..) => {
       cmds.push(AppendItem(Error("agent failed: \{error}")))
+      scheduler_on_run_end(state, LoopRunFailed("failed"), cmds)
       state.finish_run()
     }
     CommandResult(command~, run_id~, result) => {
@@ -691,9 +705,12 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
       // finished, which the immediate card exists to avoid.
       cmds.push(AppendItem(command_item(command, result)))
       // Only a foreground command (launched while idle) owns the run slot; a
-      // background command running alongside a live agent turn must leave it be.
+      // background command running alongside a live agent turn must leave it be
+      // — it only releases its hold on the `/loop` fire gate.
       if run_id is Some(_) {
         state.finish_run()
+      } else {
+        state.background_commands = (state.background_commands - 1).max(0)
       }
       // Serve appends the `!` output as durable user-shell context at its
       // current session boundary. OneShot has no live engine session to append
@@ -719,10 +736,11 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // The engine process is gone, and its watchers with it: an old
     // `moon_check running` segment would be a lie on the status bar.
     EngineExited => state.watcher_status = ""
-    // No state change: Tick is a 1s heartbeat that just keeps the message loop
-    // turning so the trailing refresh_ui re-runs and the elapsed-time activity
-    // line ("Working (12s)") keeps advancing during quiet stretches.
-    Tick => ()
+    // Tick is a 1s heartbeat: it keeps the message loop turning so the trailing
+    // refresh_ui re-runs (the elapsed-time activity line keeps advancing during
+    // quiet stretches) and steps the `/loop` countdown. Bookkeeping only — a
+    // due schedule is dispatched at the post-update choke point.
+    Tick => scheduler_tick(state)
   }
   // One input runs at a time: whenever the TUI is idle and inputs are waiting,
   // start the next one. A prompt is dispatched to the agent engine; a `!` shell

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -3,6 +3,12 @@ async fn read_ui_events(ui : @ui.Ui, messages : @async.Queue[Msg]) -> Unit {
   for ;; {
     let event = ui.read_event()
     messages.put(UiInput(event))
+    // The event is in the queue: any submission it (or an earlier event)
+    // carried is now visible to the message loop's drain, so the UI's
+    // mid-flight window can close. Unconditional on purpose — the reader is
+    // sequential, so by the time any later event lands here, every earlier
+    // submission is already delivered.
+    ui.submission_delivered()
     if event is Quit {
       break
     }
@@ -802,7 +808,7 @@ async fn[G] run_message_loop(
     // gate `update` cannot see — whether the user has draft text in the
     // composer. A due fire appends its StartAgent here, after any
     // command-context steer the updates produced.
-    scheduler_maybe_fire(state, composer_empty=ui.composer_is_empty(), cmds)
+    scheduler_maybe_fire(state, input_idle=ui.input_idle(), cmds)
     for cmd in cmds {
       match cmd {
         AppendItem(item) => ui.append_item(item)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -781,13 +781,27 @@ async fn[G] run_message_loop(
   let engine = EngineClient(state.config, messages)
   let mut running_task : @async.Task[Unit]? = None
   outer~: for ;; {
-    let message = messages.get()
-    let cmds = update(state, message)
-    // The `/loop` dispatch choke point: runs after every update, once lifecycle
-    // changes are applied and queued input has drained, with the one gate
-    // `update` cannot see — whether the user has draft text in the composer. A
-    // due fire appends its StartAgent here, after any command-context steer the
-    // update produced.
+    // Apply every message already enqueued before deciding anything further:
+    // `read_event` resets the composer before its UiInput reaches this queue,
+    // so a due `/loop` fire deciding on composer emptiness alone could
+    // overtake a just-pressed Enter still in flight (or a `/loop pause` racing
+    // the very fire it meant to prevent). Updates are synchronous — nothing
+    // new can arrive mid-drain — so after the drain the queue is provably
+    // empty and the composer check cannot contradict pending input.
+    let cmds : Array[Cmd] = []
+    let mut message = messages.get()
+    drain_updates~: for ;; {
+      cmds.append(update(state, message))
+      match messages.try_get() {
+        Some(next) => message = next
+        None => break drain_updates~
+      }
+    }
+    // The `/loop` dispatch choke point: runs once per drained batch, after
+    // lifecycle changes are applied and queued input has drained, with the one
+    // gate `update` cannot see — whether the user has draft text in the
+    // composer. A due fire appends its StartAgent here, after any
+    // command-context steer the updates produced.
     scheduler_maybe_fire(state, composer_empty=ui.composer_is_empty(), cmds)
     for cmd in cmds {
       match cmd {

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -782,7 +782,14 @@ async fn[G] run_message_loop(
   let mut running_task : @async.Task[Unit]? = None
   outer~: for ;; {
     let message = messages.get()
-    for cmd in update(state, message) {
+    let cmds = update(state, message)
+    // The `/loop` dispatch choke point: runs after every update, once lifecycle
+    // changes are applied and queued input has drained, with the one gate
+    // `update` cannot see — whether the user has draft text in the composer. A
+    // due fire appends its StartAgent here, after any command-context steer the
+    // update produced.
+    scheduler_maybe_fire(state, composer_empty=ui.composer_is_empty(), cmds)
+    for cmd in cmds {
       match cmd {
         AppendItem(item) => ui.append_item(item)
         StartAgent(run_id~, task) =>

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -3,12 +3,15 @@ async fn read_ui_events(ui : @ui.Ui, messages : @async.Queue[Msg]) -> Unit {
   for ;; {
     let event = ui.read_event()
     messages.put(UiInput(event))
-    // The event is in the queue: any submission it (or an earlier event)
-    // carried is now visible to the message loop's drain, so the UI's
-    // mid-flight window can close. Unconditional on purpose — the reader is
-    // sequential, so by the time any later event lands here, every earlier
-    // submission is already delivered.
-    ui.submission_delivered()
+    // A delivered submission is now visible to the message loop's drain, so
+    // its slice of the UI's mid-flight window can close. Exactly the
+    // submission events pair with `pending_submissions` increments (both
+    // submit helpers emit precisely one of these three); other events must
+    // not decrement, or a rapid second Enter still sitting in the UI's
+    // internal event queue would be masked and a due /loop could overtake it.
+    if event is (Steer(_) | Queue(_) | SlashCommand(_)) {
+      ui.submission_delivered()
+    }
     if event is Quit {
       break
     }

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -330,6 +330,10 @@ async fn run_tui(config : AppConfig, initial : String?) -> Unit {
         name="compact",
         description="summarize and compact the conversation",
       ),
+      @ui.SlashCommandSpec::new(
+        name="loop",
+        description="recurring prompt: /loop [--max <n>] <interval> <prompt> | off | status | pause | resume",
+      ),
     ]),
     ui => run_app(config, initial, ui),
   )

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -314,11 +314,12 @@ fn parse_loop_interval(text : StringView) -> Int? {
     (text, 1)
   }
   guard parse_loop_number(digits) is Some(value) else { return None }
-  let seconds = value * unit
-  if seconds > MaxLoopIntervalSecs {
+  // Bound before multiplying: `604800h * 3600` would overflow Int and wrap
+  // negative, dodging a post-multiplication ceiling check entirely.
+  if value > MaxLoopIntervalSecs / unit {
     None
   } else {
-    Some(seconds)
+    Some(value * unit)
   }
 }
 

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -122,6 +122,53 @@ fn scheduler_on_run_end(
 }
 
 ///|
+/// The single dispatch choke point: invoked by the message loop after **every**
+/// `update` returns — after lifecycle changes have been applied and any queued
+/// user input has been drained — so every idle boundary (Tick, agent terminals,
+/// foreground `!` terminals, background-command completions) is covered with no
+/// per-site fire logic. `composer_empty` is the one gate `update` cannot see
+/// (the composer is private to the UI); the caller passes
+/// `ui.composer_is_empty()`.
+///
+/// A due schedule fires only at a fully idle moment: no run in flight, nothing
+/// queued, no unconfirmed steers, no background `!` command whose context is
+/// still owed to the engine, and no draft under the user's cursor. Anything
+/// less defers — the fire stays due and dispatches at the next idle boundary.
+fn scheduler_maybe_fire(
+  state : State,
+  composer_empty~ : Bool,
+  cmds : Array[Cmd],
+) -> Unit {
+  guard state.schedule is Some(schedule) else { return }
+  guard !schedule.paused &&
+    schedule.remaining_secs == 0 &&
+    schedule.fired_run_id is None else {
+    return
+  }
+  guard state.run is Idle &&
+    state.queued.is_empty() &&
+    state.pending_steers.is_empty() &&
+    state.background_commands == 0 &&
+    composer_empty else {
+    return
+  }
+  let run_id = state.start_run(@async.now())
+  schedule.fired_run_id = Some(run_id)
+  // Attribution lives in the notice; the prompt itself is echoed — and reaches
+  // the engine — verbatim, so the model sees exactly what the user stored and
+  // a resumed session replays a plain user message (documented trade-off).
+  cmds.push(
+    AppendItem(
+      command_notice(
+        "⟳ loop fire \{schedule.fires + 1} of \{schedule.max_fires}",
+      ),
+    ),
+  )
+  cmds.push(AppendItem(Input(Prompt(schedule.prompt))))
+  cmds.push(StartAgent(run_id~, schedule.prompt))
+}
+
+///|
 /// Render seconds in the interval grammar's own units — `45s`, `5m`, `2h` —
 /// composing where needed (`1m30s`, `2h5m`).
 fn format_loop_interval(seconds : Int) -> String {

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -1,0 +1,329 @@
+///|
+/// `/loop` — a recurring scheduled prompt, driven entirely by the TUI.
+///
+/// This file holds the pure pieces of the scheduler: the interval grammar and
+/// the `/loop` argument parser. The countdown itself is `Tick`-message-driven
+/// (see `scheduler_tick`), so nothing here touches wall-clock time.
+
+///|
+/// The floor for `/loop` intervals: an accidental `/loop 1 …` must not turn the
+/// agent into a hot loop of unattended model calls.
+const MinLoopIntervalSecs = 10
+
+///|
+/// Fires before a loop auto-disarms unless the user raises it with `--max`.
+/// An unattended recurring task should run out, not run forever.
+const DefaultMaxLoopFires = 20
+
+///|
+/// Intervals a week and beyond are almost certainly typos, and the bound keeps
+/// the digit accumulator far from overflow.
+const MaxLoopIntervalSecs = 604_800
+
+///|
+/// A parsed `/loop` invocation.
+priv enum LoopCommand {
+  Arm(interval_secs~ : Int, max_fires~ : Int, prompt~ : String)
+  Off
+  Status
+  Pause
+  Resume
+}
+
+///|
+/// An armed `/loop`. Mutated only by the bookkeeping helpers below
+/// (`scheduler_tick`, `scheduler_on_run_end`, `handle_loop_command`); the
+/// fire itself is dispatched at the single post-update choke point,
+/// `scheduler_maybe_fire`.
+priv struct Schedule {
+  prompt : String
+  interval_secs : Int
+  max_fires : Int
+  // Seconds until due; 0 means due (and possibly deferred while busy). Held
+  // un-counted while the loop's own run is in flight — re-armed to a full
+  // interval when that run finishes, so cadence is fixed-delay-from-completion
+  // and a run longer than the interval never overlaps the next fire.
+  mut remaining_secs : Int
+  mut fires : Int
+  // Armed but not counting: set by `/loop pause` or automatically when a
+  // loop-fired run ends in anything but success (repeating a failing task
+  // unattended helps nobody). `/loop resume` restarts a full interval.
+  mut paused : Bool
+  // The `run_id` of the loop's own run in flight, if any — the key that ties
+  // scheduler bookkeeping to the existing monotonic run-ownership scheme, so
+  // user-initiated runs never re-arm or pause the loop.
+  mut fired_run_id : Int?
+}
+
+///|
+/// How a loop-fired run ended, reduced to what the scheduler cares about.
+priv enum LoopRunOutcome {
+  LoopRunFinished
+  // Carries a short human label ("was interrupted", "failed", …) for the
+  // pause notice.
+  LoopRunFailed(String)
+}
+
+///|
+/// One countdown step, driven by the 1/s `Tick` heartbeat. Pure bookkeeping:
+/// never dispatches (that is `scheduler_maybe_fire`'s job, which has access to
+/// the composer state `update` cannot see).
+fn scheduler_tick(state : State) -> Unit {
+  guard state.schedule is Some(schedule) else { return }
+  if !schedule.paused &&
+    schedule.fired_run_id is None &&
+    schedule.remaining_secs > 0 {
+    schedule.remaining_secs -= 1
+  }
+}
+
+///|
+/// Settle scheduler bookkeeping at a terminal transition of the run that is
+/// ending right now (the update loop's stale-message guard has already
+/// established ownership, so `state.run_id` names that run). A no-op unless
+/// the ending run is the loop's own fire.
+fn scheduler_on_run_end(
+  state : State,
+  outcome : LoopRunOutcome,
+  cmds : Array[Cmd],
+) -> Unit {
+  guard state.schedule is Some(schedule) else { return }
+  guard schedule.fired_run_id is Some(fired) && fired == state.run_id else {
+    return
+  }
+  schedule.fired_run_id = None
+  match outcome {
+    LoopRunFinished => {
+      schedule.fires += 1
+      if schedule.fires >= schedule.max_fires {
+        state.schedule = None
+        cmds.push(
+          AppendItem(
+            command_notice(
+              "⟳ loop done: ran \{schedule.fires} of \{schedule.max_fires} times; disarmed",
+            ),
+          ),
+        )
+      } else {
+        schedule.remaining_secs = schedule.interval_secs
+      }
+    }
+    LoopRunFailed(reason) => {
+      schedule.paused = true
+      cmds.push(
+        AppendItem(
+          command_notice(
+            "⟳ loop paused: the last run \{reason}. Use /loop resume to continue or /loop off to stop.",
+          ),
+        ),
+      )
+    }
+  }
+}
+
+///|
+/// Render seconds in the interval grammar's own units — `45s`, `5m`, `2h` —
+/// composing where needed (`1m30s`, `2h5m`).
+fn format_loop_interval(seconds : Int) -> String {
+  let hours = seconds / 3600
+  let minutes = seconds % 3600 / 60
+  let secs = seconds % 60
+  let parts : Array[String] = []
+  if hours > 0 {
+    parts.push("\{hours}h")
+  }
+  if minutes > 0 {
+    parts.push("\{minutes}m")
+  }
+  if secs > 0 || parts.is_empty() {
+    parts.push("\{secs}s")
+  }
+  parts.join("")
+}
+
+///|
+/// Handle a `/loop` invocation. Arming (or replacing) a schedule never starts
+/// work by itself — the first fire happens a full interval later, and only at
+/// an idle moment.
+fn handle_loop_command(
+  state : State,
+  arguments : String,
+  cmds : Array[Cmd],
+) -> Unit {
+  match parse_loop_command(arguments) {
+    Err(message) => cmds.push(AppendItem(Error(message)))
+    Ok(Arm(interval_secs~, max_fires~, prompt~)) => {
+      let verb = if state.schedule is Some(_) { "replaced" } else { "armed" }
+      state.schedule = Some({
+        prompt,
+        interval_secs,
+        max_fires,
+        remaining_secs: interval_secs,
+        fires: 0,
+        paused: false,
+        fired_run_id: None,
+      })
+      cmds.push(
+        AppendItem(
+          command_notice(
+            "⟳ loop \{verb}: every \{format_loop_interval(interval_secs)}, up to \{max_fires} runs — \{prompt}",
+          ),
+        ),
+      )
+    }
+    Ok(Off) =>
+      match state.schedule {
+        Some(_) => {
+          state.schedule = None
+          cmds.push(AppendItem(command_notice("⟳ loop off")))
+        }
+        None => cmds.push(AppendItem(Error("No loop is armed.")))
+      }
+    Ok(Status) =>
+      match state.schedule {
+        Some(schedule) => {
+          let position = if schedule.fired_run_id is Some(_) {
+            "running now"
+          } else if schedule.paused {
+            "paused"
+          } else {
+            "next in \{format_loop_interval(schedule.remaining_secs.max(1))}"
+          }
+          cmds.push(
+            AppendItem(
+              command_notice(
+                "⟳ loop: every \{format_loop_interval(schedule.interval_secs)}, \{position}, ran \{schedule.fires} of \{schedule.max_fires} — \{schedule.prompt}",
+              ),
+            ),
+          )
+        }
+        None => cmds.push(AppendItem(Error("No loop is armed.")))
+      }
+    Ok(Pause) =>
+      match state.schedule {
+        Some(schedule) =>
+          if schedule.paused {
+            cmds.push(AppendItem(Error("The loop is already paused.")))
+          } else {
+            schedule.paused = true
+            cmds.push(AppendItem(command_notice("⟳ loop paused")))
+          }
+        None => cmds.push(AppendItem(Error("No loop is armed.")))
+      }
+    Ok(Resume) =>
+      match state.schedule {
+        Some(schedule) =>
+          if schedule.paused {
+            schedule.paused = false
+            schedule.remaining_secs = schedule.interval_secs
+            cmds.push(
+              AppendItem(
+                command_notice(
+                  "⟳ loop resumed: next in \{format_loop_interval(schedule.interval_secs)}",
+                ),
+              ),
+            )
+          } else {
+            cmds.push(AppendItem(Error("The loop is not paused.")))
+          }
+        None => cmds.push(AppendItem(Error("No loop is armed.")))
+      }
+  }
+}
+
+///|
+/// Parse a bare positive decimal, bounded by `MaxLoopIntervalSecs` (which also
+/// keeps the accumulator far from overflow). `None` for anything else.
+fn parse_loop_number(digits : StringView) -> Int? {
+  guard !digits.is_empty() else { return None }
+  let mut value = 0
+  for ch in digits {
+    guard ch >= '0' && ch <= '9' else { return None }
+    value = value * 10 + (ch.to_int() - '0'.to_int())
+    if value > MaxLoopIntervalSecs {
+      return None
+    }
+  }
+  if value == 0 {
+    None
+  } else {
+    Some(value)
+  }
+}
+
+///|
+/// Parse an interval token: bare seconds (`300`) or a single `s`/`m`/`h`
+/// suffix (`30s`, `5m`, `2h`). `None` for anything else, zero, or beyond
+/// `MaxLoopIntervalSecs`. The `MinLoopIntervalSecs` floor is enforced by the
+/// caller so it can name the limit in its error message.
+fn parse_loop_interval(text : StringView) -> Int? {
+  let (digits, unit) = if text.strip_suffix("s") is Some(digits) {
+    (digits, 1)
+  } else if text.strip_suffix("m") is Some(digits) {
+    (digits, 60)
+  } else if text.strip_suffix("h") is Some(digits) {
+    (digits, 3600)
+  } else {
+    (text, 1)
+  }
+  guard parse_loop_number(digits) is Some(value) else { return None }
+  let seconds = value * unit
+  if seconds > MaxLoopIntervalSecs {
+    None
+  } else {
+    Some(seconds)
+  }
+}
+
+///|
+/// Split the leading whitespace-delimited word off `text`, returning the word
+/// and the remainder with surrounding whitespace trimmed.
+fn split_loop_word(text : StringView) -> (StringView, StringView) {
+  match text.split_once(" ") {
+    Some((word, rest)) => (word, rest.trim())
+    None => (text, "")
+  }
+}
+
+///|
+const LoopUsage = "usage: /loop [--max <n>] <interval> <prompt> — or /loop off | status | pause | resume"
+
+///|
+/// Parse the `/loop` argument string. The grammar keeps prompts unambiguous:
+/// `--max <n>` is only recognized *before* the interval token, so a prompt
+/// containing `--max` later is passed through verbatim.
+fn parse_loop_command(arguments : String) -> Result[LoopCommand, String] {
+  let trimmed = arguments.trim()
+  match trimmed {
+    "" => return Err(LoopUsage)
+    "off" => return Ok(Off)
+    "status" => return Ok(Status)
+    "pause" => return Ok(Pause)
+    "resume" => return Ok(Resume)
+    _ => ()
+  }
+  let mut rest = trimmed
+  let mut max_fires = DefaultMaxLoopFires
+  let (head, tail) = split_loop_word(rest)
+  if head is "--max" {
+    let (count_word, after_count) = split_loop_word(tail)
+    guard parse_loop_number(count_word) is Some(count) else {
+      return Err("expected a positive count after --max. \{LoopUsage}")
+    }
+    max_fires = count
+    rest = after_count
+  }
+  let (interval_word, prompt) = split_loop_word(rest)
+  guard parse_loop_interval(interval_word) is Some(interval_secs) else {
+    return Err(
+      "invalid interval '\{interval_word}' (use seconds, or 30s/5m/2h). \{LoopUsage}",
+    )
+  }
+  if interval_secs < MinLoopIntervalSecs {
+    return Err("interval must be at least \{MinLoopIntervalSecs}s")
+  }
+  if prompt.is_empty() {
+    return Err("a prompt is required. \{LoopUsage}")
+  }
+  Ok(Arm(interval_secs~, max_fires~, prompt=prompt.to_owned()))
+}

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -154,14 +154,20 @@ fn scheduler_maybe_fire(
     input_idle else {
     return
   }
-  // Never fire into a batch that is tearing something down: a drained batch
-  // can hold a second Ctrl-C's KillEngine (or a Quit) together with the dying
-  // run's terminal event, leaving `run` idle here — but a StartAgent appended
-  // now would execute right after the kill and prompt a dead engine (or an
-  // exiting TUI). Let the teardown land; the fire stays due for the next
-  // batch.
+  // Never fire into a batch that is tearing something down or still carrying
+  // the user's voice. A drained batch can hold a second Ctrl-C's KillEngine
+  // (or a Quit) together with the dying run's terminal event, leaving `run`
+  // idle here — but a StartAgent appended now would execute right after the
+  // kill and prompt a dead engine (or an exiting TUI). Likewise a
+  // prompt steer emitted earlier in this batch, with the turn's terminal
+  // behind it having already cleared `pending_steers`: that steer is about to
+  // bounce off the closed turn and come back as a resubmit notice, and firing
+  // now would put the loop's run in front of the user's still-unsettled text.
+  // Command-context steers are the designed exception — the fire is
+  // deliberately ordered after them. Either way the fire stays due for the
+  // next batch.
   for cmd in cmds {
-    if cmd is (CancelAgent | KillEngine | Quit) {
+    if cmd is (CancelAgent | KillEngine | Quit | SteerAgent(Prompt(_))) {
       return
     }
   }

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -1,9 +1,13 @@
 ///|
-/// `/loop` — a recurring scheduled prompt, driven entirely by the TUI.
+/// `/loop` — a recurring scheduled prompt, driven entirely by the TUI (the
+/// engine never knows a scheduler exists; fires are ordinary prompt turns).
 ///
-/// This file holds the pure pieces of the scheduler: the interval grammar and
-/// the `/loop` argument parser. The countdown itself is `Tick`-message-driven
-/// (see `scheduler_tick`), so nothing here touches wall-clock time.
+/// The whole scheduler lives here: the interval/argument grammar, the armed
+/// `Schedule` and its bookkeeping (`scheduler_tick` on the 1/s heartbeat,
+/// `scheduler_on_run_end` at run terminals — nothing touches wall-clock
+/// time), the `/loop` command handler, and the single dispatch choke point
+/// `scheduler_maybe_fire`, which the message loop invokes once per drained
+/// batch and which fires only at a provably idle moment.
 
 ///|
 /// The floor for `/loop` intervals: an accidental `/loop 1 …` must not turn the

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -126,17 +126,19 @@ fn scheduler_on_run_end(
 /// `update` returns — after lifecycle changes have been applied and any queued
 /// user input has been drained — so every idle boundary (Tick, agent terminals,
 /// foreground `!` terminals, background-command completions) is covered with no
-/// per-site fire logic. `composer_empty` is the one gate `update` cannot see
-/// (the composer is private to the UI); the caller passes
-/// `ui.composer_is_empty()`.
+/// per-site fire logic. `input_idle` is the one gate `update` cannot see —
+/// the composer state and any submission still in flight toward the message
+/// queue are private to the UI; the caller passes `ui.input_idle()`.
 ///
 /// A due schedule fires only at a fully idle moment: no run in flight, nothing
 /// queued, no unconfirmed steers, no background `!` command whose context is
-/// still owed to the engine, and no draft under the user's cursor. Anything
-/// less defers — the fire stays due and dispatches at the next idle boundary.
+/// still owed to the engine, and no user interaction on the input surface
+/// (draft text, shell mode, or a just-submitted event still in flight).
+/// Anything less defers — the fire stays due and dispatches at the next idle
+/// boundary.
 fn scheduler_maybe_fire(
   state : State,
-  composer_empty~ : Bool,
+  input_idle~ : Bool,
   cmds : Array[Cmd],
 ) -> Unit {
   guard state.schedule is Some(schedule) else { return }
@@ -149,7 +151,7 @@ fn scheduler_maybe_fire(
     state.queued.is_empty() &&
     state.pending_steers.is_empty() &&
     state.background_commands == 0 &&
-    composer_empty else {
+    input_idle else {
     return
   }
   let run_id = state.start_run(@async.now())

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -154,6 +154,17 @@ fn scheduler_maybe_fire(
     input_idle else {
     return
   }
+  // Never fire into a batch that is tearing something down: a drained batch
+  // can hold a second Ctrl-C's KillEngine (or a Quit) together with the dying
+  // run's terminal event, leaving `run` idle here — but a StartAgent appended
+  // now would execute right after the kill and prompt a dead engine (or an
+  // exiting TUI). Let the teardown land; the fire stays due for the next
+  // batch.
+  for cmd in cmds {
+    if cmd is (CancelAgent | KillEngine | Quit) {
+      return
+    }
+  }
   let run_id = state.start_run(@async.now())
   schedule.fired_run_id = Some(run_id)
   // Attribution lives in the notice; the prompt itself is echoed — and reaches
@@ -188,6 +199,23 @@ fn format_loop_interval(seconds : Int) -> String {
     parts.push("\{secs}s")
   }
   parts.join("")
+}
+
+///|
+/// The `/loop status` phrase for where the schedule stands. A due-but-deferred
+/// fire is reported as exactly that — inventing a "next in 1s" would conflict
+/// with the status bar's `⟳ due` and could stay false indefinitely while the
+/// loop waits out a long run.
+fn loop_status_position(schedule : Schedule) -> String {
+  if schedule.fired_run_id is Some(_) {
+    "running now"
+  } else if schedule.paused {
+    "paused"
+  } else if schedule.remaining_secs == 0 {
+    "due, waiting for an idle moment"
+  } else {
+    "next in \{format_loop_interval(schedule.remaining_secs)}"
+  }
 }
 
 ///|
@@ -231,13 +259,7 @@ fn handle_loop_command(
     Ok(Status) =>
       match state.schedule {
         Some(schedule) => {
-          let position = if schedule.fired_run_id is Some(_) {
-            "running now"
-          } else if schedule.paused {
-            "paused"
-          } else {
-            "next in \{format_loop_interval(schedule.remaining_secs.max(1))}"
-          }
+          let position = loop_status_position(schedule)
           cmds.push(
             AppendItem(
               command_notice(

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -442,3 +442,47 @@ test "loop segment precedes the clippable variable-length fields" {
   }
   assert_true(loop_index < cwd_index)
 }
+
+///|
+test "a due loop never fires into a teardown batch" {
+  let state = armed_state("30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  schedule.remaining_secs = 0
+  // The drained batch carries a KillEngine (second Ctrl-C) alongside the dying
+  // run's terminal: run is idle again, but firing now would prompt a process
+  // the same batch kills.
+  let killing : Array[Cmd] = [KillEngine]
+  scheduler_maybe_fire(state, input_idle=true, killing)
+  assert_eq(start_agent_count(killing), 0)
+  let cancelling : Array[Cmd] = [CancelAgent]
+  scheduler_maybe_fire(state, input_idle=true, cancelling)
+  assert_eq(start_agent_count(cancelling), 0)
+  let quitting : Array[Cmd] = [Quit]
+  scheduler_maybe_fire(state, input_idle=true, quitting)
+  assert_eq(start_agent_count(quitting), 0)
+  // The fire stayed due: a clean batch dispatches it.
+  let clean : Array[Cmd] = []
+  scheduler_maybe_fire(state, input_idle=true, clean)
+  assert_eq(start_agent_count(clean), 1)
+}
+
+///|
+test "loop status reports a deferred fire as due" {
+  let schedule : Schedule = {
+    prompt: "do x",
+    interval_secs: 30,
+    max_fires: 20,
+    remaining_secs: 30,
+    fires: 0,
+    paused: false,
+    fired_run_id: None,
+  }
+  assert_eq(loop_status_position(schedule), "next in 30s")
+  schedule.remaining_secs = 0
+  assert_eq(loop_status_position(schedule), "due, waiting for an idle moment")
+  schedule.fired_run_id = Some(3)
+  assert_eq(loop_status_position(schedule), "running now")
+  schedule.fired_run_id = None
+  schedule.paused = true
+  assert_eq(loop_status_position(schedule), "paused")
+}

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -413,3 +413,26 @@ test "loop status segment mirrors schedule state" {
   schedule.paused = true
   assert_eq(loop_segment_text(Some(schedule)), "⟳ paused")
 }
+
+///|
+test "loop segment precedes the clippable variable-length fields" {
+  // The status line clips at terminal width from the right; an armed loop's
+  // countdown must sit ahead of a long cwd so it cannot be pushed off-screen.
+  let state = armed_state("5m do x")
+  let segments = status_segments(state)
+  let loop_index = for index, segment in segments {
+    if segment.text.has_prefix("⟳") {
+      break index
+    }
+  } nobreak {
+    fail("expected the loop segment")
+  }
+  let cwd_index = for index, segment in segments {
+    if segment.text == state.config.cwd {
+      break index
+    }
+  } nobreak {
+    fail("expected the cwd segment")
+  }
+  assert_true(loop_index < cwd_index)
+}

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -16,6 +16,12 @@ test "loop interval grammar" {
   assert_true(parse_loop_interval("m") is None)
   assert_true(parse_loop_interval("999999999") is None)
   assert_true(parse_loop_interval("200h") is None)
+  // Would overflow Int if multiplied before the ceiling check.
+  assert_true(parse_loop_interval("604800h") is None)
+  assert_true(parse_loop_interval("604800m") is None)
+  // The exact ceiling itself is accepted.
+  assert_true(parse_loop_interval("604800") is Some(604_800))
+  assert_true(parse_loop_interval("168h") is Some(604_800))
 }
 
 ///|

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -486,3 +486,21 @@ test "loop status reports a deferred fire as due" {
   schedule.paused = true
   assert_eq(loop_status_position(schedule), "paused")
 }
+
+///|
+test "a due loop defers behind a prompt steer racing the turn's terminal" {
+  let state = armed_state("30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  schedule.remaining_secs = 0
+  // The drained batch carries the user's prompt steer (emitted while the turn
+  // still ran) with the terminal event behind it having already cleared
+  // pending_steers: the steer is about to bounce off the closed turn, so the
+  // fire must wait rather than jump ahead of the user's unsettled text.
+  let steering : Array[Cmd] = [SteerAgent(Prompt("user text"))]
+  scheduler_maybe_fire(state, input_idle=true, steering)
+  assert_eq(start_agent_count(steering), 0)
+  // A command-context steer keeps the designed ordering: fire after it.
+  let command_context : Array[Cmd] = [SteerAgent(Command("ls output"))]
+  scheduler_maybe_fire(state, input_idle=true, command_context)
+  assert_eq(start_agent_count(command_context), 1)
+}

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -1,0 +1,249 @@
+///|
+test "loop interval grammar" {
+  // Bare seconds and unit suffixes.
+  assert_true(parse_loop_interval("300") is Some(300))
+  assert_true(parse_loop_interval("30s") is Some(30))
+  assert_true(parse_loop_interval("5m") is Some(300))
+  assert_true(parse_loop_interval("2h") is Some(7200))
+  assert_true(parse_loop_interval("10") is Some(10))
+  // Rejected: empty, zero, garbage, mixed, negative-looking, over the bound.
+  assert_true(parse_loop_interval("") is None)
+  assert_true(parse_loop_interval("0") is None)
+  assert_true(parse_loop_interval("0s") is None)
+  assert_true(parse_loop_interval("abc") is None)
+  assert_true(parse_loop_interval("5m3") is None)
+  assert_true(parse_loop_interval("-5") is None)
+  assert_true(parse_loop_interval("m") is None)
+  assert_true(parse_loop_interval("999999999") is None)
+  assert_true(parse_loop_interval("200h") is None)
+}
+
+///|
+test "loop command grammar: arm forms" {
+  guard parse_loop_command("5m check CI status")
+    is Ok(Arm(interval_secs~, max_fires~, prompt~)) else {
+    fail("expected Arm")
+  }
+  assert_eq(interval_secs, 300)
+  assert_eq(max_fires, DefaultMaxLoopFires)
+  assert_eq(prompt, "check CI status")
+
+  // --max before the interval is an option…
+  guard parse_loop_command("--max 5 30s do the thing")
+    is Ok(Arm(interval_secs=interval2, max_fires=max2, prompt=prompt2)) else {
+    fail("expected Arm with --max")
+  }
+  assert_eq(interval2, 30)
+  assert_eq(max2, 5)
+  assert_eq(prompt2, "do the thing")
+
+  // …but after the interval it is literal prompt text.
+  guard parse_loop_command("30s run --max 5 times")
+    is Ok(Arm(prompt=prompt3, ..)) else {
+    fail("expected Arm with literal --max in prompt")
+  }
+  assert_eq(prompt3, "run --max 5 times")
+}
+
+///|
+test "loop command grammar: subcommands" {
+  assert_true(parse_loop_command("off") is Ok(Off))
+  assert_true(parse_loop_command("status") is Ok(Status))
+  assert_true(parse_loop_command("pause") is Ok(Pause))
+  assert_true(parse_loop_command("resume") is Ok(Resume))
+  assert_true(parse_loop_command("  off  ") is Ok(Off))
+}
+
+///|
+fn scheduler_test_state() -> State {
+  State::new({
+    api_key: "k",
+    api_url: Some("https://proxy.example/v1/chat/completions"),
+    model: V4Pro,
+    cwd: ".",
+    max_steps: 10,
+    thinking: Max,
+    session_id: SessionId("loop-test"),
+    session_root: ".openseek",
+    engine: "openseek",
+    engine_mode: Serve,
+  })
+}
+
+///|
+fn armed_state(arguments : String) -> State {
+  let state = scheduler_test_state()
+  let _ = update(state, UiInput(SlashCommand(name="loop", arguments~)))
+  state
+}
+
+///|
+fn notice_count(cmds : Array[Cmd]) -> Int {
+  [ for cmd in cmds if cmd is AppendItem(Notice(_)) => cmd ].length()
+}
+
+///|
+fn error_count(cmds : Array[Cmd]) -> Int {
+  [ for cmd in cmds if cmd is AppendItem(Error(_)) => cmd ].length()
+}
+
+///|
+test "loop arm/off/status/pause/resume lifecycle" {
+  let state = scheduler_test_state()
+  // Arm: schedule set, notice appended, full countdown.
+  let armed = update(
+    state,
+    UiInput(SlashCommand(name="loop", arguments="5m check CI")),
+  )
+  assert_eq(notice_count(armed), 1)
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  assert_eq(schedule.remaining_secs, 300)
+  assert_eq(schedule.fires, 0)
+  assert_false(schedule.paused)
+  // Re-arm replaces.
+  let replaced = update(
+    state,
+    UiInput(SlashCommand(name="loop", arguments="30s other task")),
+  )
+  assert_eq(notice_count(replaced), 1)
+  guard state.schedule is Some(second) else { fail("expected a schedule") }
+  assert_eq(second.interval_secs, 30)
+  // Status reports without mutating.
+  let status = update(
+    state,
+    UiInput(SlashCommand(name="loop", arguments="status")),
+  )
+  assert_eq(notice_count(status), 1)
+  assert_eq(second.remaining_secs, 30)
+  // Pause stops the countdown; resume restarts a full interval.
+  let _ = update(state, UiInput(SlashCommand(name="loop", arguments="pause")))
+  assert_true(second.paused)
+  let _ = update(state, Tick)
+  assert_eq(second.remaining_secs, 30)
+  let _ = update(state, UiInput(SlashCommand(name="loop", arguments="resume")))
+  assert_false(second.paused)
+  // Off clears; off again errors.
+  let _ = update(state, UiInput(SlashCommand(name="loop", arguments="off")))
+  assert_true(state.schedule is None)
+  let again = update(state, UiInput(SlashCommand(name="loop", arguments="off")))
+  assert_eq(error_count(again), 1)
+}
+
+///|
+test "loop countdown ticks only while armed, unpaused, and not mid-fire" {
+  let state = armed_state("30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  let _ = update(state, Tick)
+  let _ = update(state, Tick)
+  assert_eq(schedule.remaining_secs, 28)
+  // A fire in flight holds the countdown even at zero.
+  schedule.remaining_secs = 0
+  schedule.fired_run_id = Some(41)
+  let _ = update(state, Tick)
+  assert_eq(schedule.remaining_secs, 0)
+  // Held at zero once due (never negative).
+  schedule.fired_run_id = None
+  let _ = update(state, Tick)
+  assert_eq(schedule.remaining_secs, 0)
+}
+
+///|
+test "loop re-arms after its own run finishes and pauses on failures" {
+  let state = armed_state("30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  // Simulate the choke point having fired: the loop owns the run in flight.
+  let run_id = state.start_run(0)
+  schedule.remaining_secs = 0
+  schedule.fired_run_id = Some(run_id)
+  // Success re-arms a full interval and counts the fire.
+  let done = update(state, AgentProgress(run_id~, AgentFinished("ok")))
+  assert_eq(schedule.remaining_secs, 30)
+  assert_eq(schedule.fires, 1)
+  assert_true(schedule.fired_run_id is None)
+  assert_false(schedule.paused)
+  ignore(done)
+  // A failing fire pauses instead of re-arming.
+  let run2 = state.start_run(0)
+  schedule.fired_run_id = Some(run2)
+  let failed = update(state, AgentProgress(run_id=run2, AgentError("boom")))
+  assert_true(schedule.paused)
+  assert_true(schedule.fired_run_id is None)
+  assert_eq(notice_count(failed), 1)
+  // An interrupt of a resumed fire also pauses.
+  schedule.paused = false
+  let run3 = state.start_run(0)
+  schedule.fired_run_id = Some(run3)
+  let _ = update(state, AgentCancelled(run_id=run3))
+  assert_true(schedule.paused)
+}
+
+///|
+test "loop cap disarms after the last fire" {
+  let state = armed_state("--max 2 30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  schedule.fires = 1
+  let run_id = state.start_run(0)
+  schedule.fired_run_id = Some(run_id)
+  let done = update(state, AgentProgress(run_id~, AgentFinished("ok")))
+  assert_true(state.schedule is None)
+  assert_eq(notice_count(done), 1)
+}
+
+///|
+test "user runs never touch the schedule" {
+  let state = armed_state("30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  // A user prompt runs and fails; the schedule is not the owner, so nothing
+  // pauses and nothing re-arms.
+  let _ = update(state, UiInput(Steer(Prompt("user task"))))
+  guard state.run is Running(_) else { fail("expected a user run") }
+  let before = schedule.remaining_secs
+  let _ = update(state, AgentProgress(run_id=state.run_id, AgentError("boom")))
+  assert_false(schedule.paused)
+  assert_eq(schedule.remaining_secs, before)
+  assert_eq(schedule.fires, 0)
+}
+
+///|
+test "background command counter tracks spawn and completion" {
+  let state = scheduler_test_state()
+  // Start a user run, then a background `!` alongside it.
+  let _ = update(state, UiInput(Steer(Prompt("task"))))
+  let cmds = update(state, UiInput(Steer(Command("ls"))))
+  assert_true(
+    [ for cmd in cmds if cmd is RunCommand(run_id=None, _) => cmd ].length() ==
+    1,
+  )
+  assert_eq(state.background_commands, 1)
+  let _ = update(
+    state,
+    CommandResult(command="ls", run_id=None, Err(Failure::Failure("boom"))),
+  )
+  assert_eq(state.background_commands, 0)
+}
+
+///|
+test "loop command grammar: rejections name the problem" {
+  guard parse_loop_command("") is Err(usage) else { fail("expected usage") }
+  assert_true(usage.contains("usage:"))
+  guard parse_loop_command("5m") is Err(no_prompt) else {
+    fail("expected prompt-required")
+  }
+  assert_true(no_prompt.contains("prompt is required"))
+  guard parse_loop_command("9s do x") is Err(too_short) else {
+    fail("expected minimum-interval rejection")
+  }
+  assert_true(too_short.contains("at least 10s"))
+  guard parse_loop_command("soon do x") is Err(bad_interval) else {
+    fail("expected invalid-interval rejection")
+  }
+  assert_true(bad_interval.contains("invalid interval 'soon'"))
+  guard parse_loop_command("--max nope 5m do x") is Err(bad_count) else {
+    fail("expected bad --max rejection")
+  }
+  assert_true(bad_count.contains("--max"))
+  guard parse_loop_command("--max 0 5m do x") is Err(zero_count) else {
+    fail("expected zero --max rejection")
+  }
+  assert_true(zero_count.contains("--max"))
+}

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -384,3 +384,32 @@ test "loop command grammar: rejections name the problem" {
   }
   assert_true(zero_count.contains("--max"))
 }
+
+///|
+test "loop status segment mirrors schedule state" {
+  // No loop: the segment is empty and leaves no dangling separator.
+  assert_eq(loop_segment_text(None), "")
+  // Counting: a compact countdown.
+  let schedule : Schedule = {
+    prompt: "do x",
+    interval_secs: 300,
+    max_fires: 20,
+    remaining_secs: 277,
+    fires: 0,
+    paused: false,
+    fired_run_id: None,
+  }
+  assert_eq(loop_segment_text(Some(schedule)), "⟳ 4m 37s")
+  schedule.remaining_secs = 45
+  assert_eq(loop_segment_text(Some(schedule)), "⟳ 45s")
+  schedule.remaining_secs = 3725
+  assert_eq(loop_segment_text(Some(schedule)), "⟳ 1h 02m 05s")
+  // Due but deferred, its own fire in flight, and paused.
+  schedule.remaining_secs = 0
+  assert_eq(loop_segment_text(Some(schedule)), "⟳ due")
+  schedule.fired_run_id = Some(7)
+  assert_eq(loop_segment_text(Some(schedule)), "⟳ running")
+  schedule.fired_run_id = None
+  schedule.paused = true
+  assert_eq(loop_segment_text(Some(schedule)), "⟳ paused")
+}

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -231,9 +231,9 @@ test "background command counter tracks spawn and completion" {
 ///|
 /// Drive the countdown to due and invoke the choke point once, mirroring the
 /// message loop's `update`-then-`scheduler_maybe_fire` shape for a `Tick`.
-fn tick_and_fire(state : State, composer_empty~ : Bool) -> Array[Cmd] {
+fn tick_and_fire(state : State, input_idle~ : Bool) -> Array[Cmd] {
   let cmds = update(state, Tick)
-  scheduler_maybe_fire(state, composer_empty~, cmds)
+  scheduler_maybe_fire(state, input_idle~, cmds)
   cmds
 }
 
@@ -243,12 +243,12 @@ test "a due loop fires exactly once at an idle tick" {
   guard state.schedule is Some(schedule) else { fail("expected a schedule") }
   // 29 ticks: armed but not due; the choke point stays silent.
   for _ in 0..<29 {
-    let cmds = tick_and_fire(state, composer_empty=true)
+    let cmds = tick_and_fire(state, input_idle=true)
     assert_eq(start_agent_count(cmds), 0)
   }
   assert_eq(schedule.remaining_secs, 1)
   // The 30th tick fires: notice + verbatim prompt echo + StartAgent.
-  let fired = tick_and_fire(state, composer_empty=true)
+  let fired = tick_and_fire(state, input_idle=true)
   assert_eq(start_agent_count(fired), 1)
   assert_eq(notice_count(fired), 1)
   let echoes = [
@@ -263,7 +263,7 @@ test "a due loop fires exactly once at an idle tick" {
     fail("expected the fired run in flight")
   }
   // Still due-held, not counting, while its own run is in flight.
-  let during = tick_and_fire(state, composer_empty=true)
+  let during = tick_and_fire(state, input_idle=true)
   assert_eq(start_agent_count(during), 0)
 }
 
@@ -274,12 +274,12 @@ test "a due loop defers while anything is busy and fires at the idle boundary" {
   // A user prompt occupies the run slot; the countdown reaches due beneath it.
   let _ = update(state, UiInput(Steer(Prompt("user work"))))
   schedule.remaining_secs = 1
-  let held = tick_and_fire(state, composer_empty=true)
+  let held = tick_and_fire(state, input_idle=true)
   assert_eq(start_agent_count(held), 0)
   assert_eq(schedule.remaining_secs, 0)
   // More ticks while busy: still exactly zero fires (no accumulation).
   for _ in 0..<5 {
-    assert_eq(start_agent_count(tick_and_fire(state, composer_empty=true)), 0)
+    assert_eq(start_agent_count(tick_and_fire(state, input_idle=true)), 0)
   }
   // The user run's terminal is an idle boundary: the deferred fire dispatches
   // in the very same update cycle, no Tick needed.
@@ -287,7 +287,7 @@ test "a due loop defers while anything is busy and fires at the idle boundary" {
     state,
     AgentProgress(run_id=state.run_id, AgentFinished("done")),
   )
-  scheduler_maybe_fire(state, composer_empty=true, boundary)
+  scheduler_maybe_fire(state, input_idle=true, boundary)
   assert_eq(start_agent_count(boundary), 1)
   assert_true(schedule.fired_run_id is Some(id) && id == state.run_id)
 }
@@ -299,9 +299,9 @@ test "each busy source individually holds a due fire" {
   guard drafting.schedule is Some(draft_schedule) else { fail("no schedule") }
   draft_schedule.remaining_secs = 0
   let held = update(drafting, Tick)
-  scheduler_maybe_fire(drafting, composer_empty=false, held)
+  scheduler_maybe_fire(drafting, input_idle=false, held)
   assert_eq(start_agent_count(held), 0)
-  scheduler_maybe_fire(drafting, composer_empty=true, held)
+  scheduler_maybe_fire(drafting, input_idle=true, held)
   assert_eq(start_agent_count(held), 1)
 
   // A background `!` command whose context is still owed to the engine.
@@ -316,7 +316,7 @@ test "each busy source individually holds a due fire" {
   wait_schedule.remaining_secs = 0
   // Run slot idle, but the background command is still out.
   assert_eq(waiting.background_commands, 1)
-  let blocked = tick_and_fire(waiting, composer_empty=true)
+  let blocked = tick_and_fire(waiting, input_idle=true)
   assert_eq(start_agent_count(blocked), 0)
   // Its completion is itself an idle boundary: the fire rides the same cycle,
   // ordered after the command-context steer.
@@ -324,7 +324,7 @@ test "each busy source individually holds a due fire" {
     waiting,
     CommandResult(command="ls", run_id=None, Err(Failure::Failure("x"))),
   )
-  scheduler_maybe_fire(waiting, composer_empty=true, after)
+  scheduler_maybe_fire(waiting, input_idle=true, after)
   assert_eq(start_agent_count(after), 1)
   let steer_index = for index, cmd in after {
     if cmd is SteerAgent(_) {
@@ -347,7 +347,7 @@ test "each busy source individually holds a due fire" {
   guard paused.schedule is Some(pause_schedule) else { fail("no schedule") }
   pause_schedule.remaining_secs = 0
   pause_schedule.paused = true
-  assert_eq(start_agent_count(tick_and_fire(paused, composer_empty=true)), 0)
+  assert_eq(start_agent_count(tick_and_fire(paused, input_idle=true)), 0)
 }
 
 ///|
@@ -355,7 +355,7 @@ test "a fired loop run steers like any other run" {
   let state = armed_state("30s do x")
   guard state.schedule is Some(schedule) else { fail("expected a schedule") }
   schedule.remaining_secs = 0
-  let fired = tick_and_fire(state, composer_empty=true)
+  let fired = tick_and_fire(state, input_idle=true)
   assert_eq(start_agent_count(fired), 1)
   // The fired run is a normal engine turn: a typed prompt steers it rather
   // than being rejected — the ownership discipline is shared, not special.

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -223,6 +223,143 @@ test "background command counter tracks spawn and completion" {
 }
 
 ///|
+/// Drive the countdown to due and invoke the choke point once, mirroring the
+/// message loop's `update`-then-`scheduler_maybe_fire` shape for a `Tick`.
+fn tick_and_fire(state : State, composer_empty~ : Bool) -> Array[Cmd] {
+  let cmds = update(state, Tick)
+  scheduler_maybe_fire(state, composer_empty~, cmds)
+  cmds
+}
+
+///|
+test "a due loop fires exactly once at an idle tick" {
+  let state = armed_state("30s do the rounds")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  // 29 ticks: armed but not due; the choke point stays silent.
+  for _ in 0..<29 {
+    let cmds = tick_and_fire(state, composer_empty=true)
+    assert_eq(start_agent_count(cmds), 0)
+  }
+  assert_eq(schedule.remaining_secs, 1)
+  // The 30th tick fires: notice + verbatim prompt echo + StartAgent.
+  let fired = tick_and_fire(state, composer_empty=true)
+  assert_eq(start_agent_count(fired), 1)
+  assert_eq(notice_count(fired), 1)
+  let echoes = [
+    for cmd in fired if cmd is AppendItem(Input(Prompt("do the rounds"))) => cmd
+  ]
+  assert_eq(echoes.length(), 1)
+  guard fired[fired.length() - 1] is StartAgent(run_id~, "do the rounds") else {
+    fail("expected the fire's StartAgent last")
+  }
+  assert_true(schedule.fired_run_id is Some(fired_id) && fired_id == run_id)
+  guard state.run is Running(_) else {
+    fail("expected the fired run in flight")
+  }
+  // Still due-held, not counting, while its own run is in flight.
+  let during = tick_and_fire(state, composer_empty=true)
+  assert_eq(start_agent_count(during), 0)
+}
+
+///|
+test "a due loop defers while anything is busy and fires at the idle boundary" {
+  let state = armed_state("30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  // A user prompt occupies the run slot; the countdown reaches due beneath it.
+  let _ = update(state, UiInput(Steer(Prompt("user work"))))
+  schedule.remaining_secs = 1
+  let held = tick_and_fire(state, composer_empty=true)
+  assert_eq(start_agent_count(held), 0)
+  assert_eq(schedule.remaining_secs, 0)
+  // More ticks while busy: still exactly zero fires (no accumulation).
+  for _ in 0..<5 {
+    assert_eq(start_agent_count(tick_and_fire(state, composer_empty=true)), 0)
+  }
+  // The user run's terminal is an idle boundary: the deferred fire dispatches
+  // in the very same update cycle, no Tick needed.
+  let boundary = update(
+    state,
+    AgentProgress(run_id=state.run_id, AgentFinished("done")),
+  )
+  scheduler_maybe_fire(state, composer_empty=true, boundary)
+  assert_eq(start_agent_count(boundary), 1)
+  assert_true(schedule.fired_run_id is Some(id) && id == state.run_id)
+}
+
+///|
+test "each busy source individually holds a due fire" {
+  // Draft text under the cursor.
+  let drafting = armed_state("30s do x")
+  guard drafting.schedule is Some(draft_schedule) else { fail("no schedule") }
+  draft_schedule.remaining_secs = 0
+  let held = update(drafting, Tick)
+  scheduler_maybe_fire(drafting, composer_empty=false, held)
+  assert_eq(start_agent_count(held), 0)
+  scheduler_maybe_fire(drafting, composer_empty=true, held)
+  assert_eq(start_agent_count(held), 1)
+
+  // A background `!` command whose context is still owed to the engine.
+  let waiting = armed_state("30s do x")
+  guard waiting.schedule is Some(wait_schedule) else { fail("no schedule") }
+  let _ = update(waiting, UiInput(Steer(Prompt("user work"))))
+  let _ = update(waiting, UiInput(Steer(Command("ls"))))
+  let _ = update(
+    waiting,
+    AgentProgress(run_id=waiting.run_id, AgentFinished("done")),
+  )
+  wait_schedule.remaining_secs = 0
+  // Run slot idle, but the background command is still out.
+  assert_eq(waiting.background_commands, 1)
+  let blocked = tick_and_fire(waiting, composer_empty=true)
+  assert_eq(start_agent_count(blocked), 0)
+  // Its completion is itself an idle boundary: the fire rides the same cycle,
+  // ordered after the command-context steer.
+  let after = update(
+    waiting,
+    CommandResult(command="ls", run_id=None, Err(Failure::Failure("x"))),
+  )
+  scheduler_maybe_fire(waiting, composer_empty=true, after)
+  assert_eq(start_agent_count(after), 1)
+  let steer_index = for index, cmd in after {
+    if cmd is SteerAgent(_) {
+      break index
+    }
+  } nobreak {
+    fail("expected the command-context steer")
+  }
+  let start_index = for index, cmd in after {
+    if cmd is StartAgent(_, ..) {
+      break index
+    }
+  } nobreak {
+    fail("expected the fire's StartAgent")
+  }
+  assert_true(steer_index < start_index)
+
+  // A paused loop never fires, even when due and idle.
+  let paused = armed_state("30s do x")
+  guard paused.schedule is Some(pause_schedule) else { fail("no schedule") }
+  pause_schedule.remaining_secs = 0
+  pause_schedule.paused = true
+  assert_eq(start_agent_count(tick_and_fire(paused, composer_empty=true)), 0)
+}
+
+///|
+test "a fired loop run steers like any other run" {
+  let state = armed_state("30s do x")
+  guard state.schedule is Some(schedule) else { fail("expected a schedule") }
+  schedule.remaining_secs = 0
+  let fired = tick_and_fire(state, composer_empty=true)
+  assert_eq(start_agent_count(fired), 1)
+  // The fired run is a normal engine turn: a typed prompt steers it rather
+  // than being rejected — the ownership discipline is shared, not special.
+  let steered = update(state, UiInput(Steer(Prompt("also check the docs"))))
+  assert_true(
+    [ for cmd in steered if cmd is SteerAgent(_) => cmd ].length() == 1,
+  )
+}
+
+///|
 test "loop command grammar: rejections name the problem" {
   guard parse_loop_command("") is Err(usage) else { fail("expected usage") }
   assert_true(usage.contains("usage:"))

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -91,6 +91,16 @@ priv struct State {
   // from the most recent `runtime_update` for the status bar. Empty until the
   // first watcher update arrives.
   mut watcher_status : String
+  // The `/loop` schedule, when one is armed. Bookkeeping (countdown, re-arm,
+  // pause) lives in `update`; dispatch happens only at the post-update choke
+  // point `scheduler_maybe_fire`, which also needs the composer state that
+  // `update` cannot see.
+  mut schedule : Schedule?
+  // Outstanding fire-and-forget background `!` commands (run alongside a live
+  // turn, `run_id=None`). Their completion hands command context to the engine,
+  // so a scheduled fire must wait for them or that context would leak into the
+  // scheduled turn instead of the conversation it belongs to.
+  mut background_commands : Int
 }
 
 ///|
@@ -108,6 +118,8 @@ fn State::new(config : AppConfig) -> State {
     streaming_reasoning: None,
     usage: None,
     watcher_status: "",
+    schedule: None,
+    background_commands: 0,
   }
 }
 

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -45,7 +45,32 @@ fn status_segments(state : State) -> Array[Segment] {
       text: watcher_segment_text(state.watcher_status),
       style: Style(foreground=Basic(Cyan)),
     },
+    {
+      text: loop_segment_text(state.schedule),
+      style: Style(foreground=Basic(Blue)),
+    },
   ]
+}
+
+///|
+/// The `/loop` slot on the status bar: a live countdown while armed, its
+/// state while it cannot count ("paused", "running" during its own fire,
+/// "due" while deferred behind other activity), and empty — vanishing like
+/// an absent usage segment — when no loop is armed.
+fn loop_segment_text(schedule : Schedule?) -> String {
+  match schedule {
+    None => ""
+    Some(schedule) =>
+      if schedule.fired_run_id is Some(_) {
+        "⟳ running"
+      } else if schedule.paused {
+        "⟳ paused"
+      } else if schedule.remaining_secs == 0 {
+        "⟳ due"
+      } else {
+        "⟳ \{format_elapsed_compact(schedule.remaining_secs.to_int64())}"
+      }
+  }
 }
 
 ///|

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -36,6 +36,13 @@ fn status_segments(state : State) -> Array[Segment] {
       text: state.config.model.to_string(),
       style: Style(foreground=Basic(Yellow)),
     },
+    // The loop slot sits ahead of the variable-length fields: the status line
+    // clips at the terminal width from the right, so a long cwd must not be
+    // able to push an armed loop's countdown out of view.
+    {
+      text: loop_segment_text(state.schedule),
+      style: Style(foreground=Basic(Blue)),
+    },
     { text: state.config.cwd, style: Style(foreground=Basic(Green)) },
     {
       text: format_usage_segment(state.usage),
@@ -44,10 +51,6 @@ fn status_segments(state : State) -> Array[Segment] {
     {
       text: watcher_segment_text(state.watcher_status),
       style: Style(foreground=Basic(Cyan)),
-    },
-    {
-      text: loop_segment_text(state.schedule),
-      style: Style(foreground=Basic(Blue)),
     },
   ]
 }

--- a/tui/completion.mbt
+++ b/tui/completion.mbt
@@ -183,8 +183,8 @@ async fn Ui::submit_slash_command(
   let text = slash_command_text(name~, arguments~)
   self.history.push(@history.Entry::new(text, self.composer.mode()))
   // Mid-flight until the app's queue receives the event (the redraw below
-  // awaits); see `submission_in_flight`.
-  self.submission_in_flight = true
+  // awaits); see `pending_submissions`.
+  self.pending_submissions += 1
   self.composer.reset()
   self.history.reset_navigation()
   self.notice = None

--- a/tui/completion.mbt
+++ b/tui/completion.mbt
@@ -182,6 +182,9 @@ async fn Ui::submit_slash_command(
   // re-select the first match and run a different command.
   let text = slash_command_text(name~, arguments~)
   self.history.push(@history.Entry::new(text, self.composer.mode()))
+  // Mid-flight until the app's queue receives the event (the redraw below
+  // awaits); see `submission_in_flight`.
+  self.submission_in_flight = true
   self.composer.reset()
   self.history.reset_navigation()
   self.notice = None

--- a/tui/input.mbt
+++ b/tui/input.mbt
@@ -25,7 +25,7 @@ async fn Ui::submit_current_input(self : Self) -> Input? {
     // From this reset until the returned event reaches the app's queue, the
     // submission is mid-flight (the redraw below awaits): `input_idle` must
     // read as engaged so nothing acts past the Enter the user just pressed.
-    self.submission_in_flight = true
+    self.pending_submissions += 1
     self.composer.reset()
     self.notice = None
     self.completion.reset()

--- a/tui/input.mbt
+++ b/tui/input.mbt
@@ -22,6 +22,10 @@ async fn Ui::submit_current_input(self : Self) -> Input? {
     let text = self.composer.text()
     let mode = self.composer.mode()
     self.history.push(@history.Entry::new(text, mode))
+    // From this reset until the returned event reaches the app's queue, the
+    // submission is mid-flight (the redraw below awaits): `input_idle` must
+    // read as engaged so nothing acts past the Enter the user just pressed.
+    self.submission_in_flight = true
     self.composer.reset()
     self.notice = None
     self.completion.reset()

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int, slash_comman
 type Ui
 pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
 pub fn Ui::columns(Self) -> Int
+pub fn Ui::composer_is_empty(Self) -> Bool
 pub async fn Ui::read_event(Self) -> @core.Event
 #deprecated
 pub async fn Ui::set_activity(Self, @doc.Text?) -> Unit

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -20,7 +20,7 @@ pub fn Config::new(esc_timeout_ms? : Int, composer_max_rows? : Int, slash_comman
 type Ui
 pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
 pub fn Ui::columns(Self) -> Int
-pub fn Ui::composer_is_empty(Self) -> Bool
+pub fn Ui::input_idle(Self) -> Bool
 pub async fn Ui::read_event(Self) -> @core.Event
 #deprecated
 pub async fn Ui::set_activity(Self, @doc.Text?) -> Unit
@@ -29,6 +29,7 @@ pub async fn Ui::set_live_view(Self, status~ : @doc.Text, activity~ : @doc.Text?
 pub async fn Ui::set_queued_inputs(Self, Array[@core.Input]) -> Unit
 #deprecated
 pub async fn Ui::set_status(Self, @doc.Text) -> Unit
+pub fn Ui::submission_delivered(Self) -> Unit
 
 // Type aliases
 pub using @completion {type CompletionItem}

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -141,18 +141,20 @@ pub fn Ui::columns(self : Self) -> Int {
 /// user — the composer is private to the UI, so the update loop cannot see
 /// any of this directly.
 pub fn Ui::input_idle(self : Self) -> Bool {
-  !self.submission_in_flight &&
+  self.pending_submissions == 0 &&
   self.composer.text().is_empty() &&
   self.composer.mode().is_input()
 }
 
 ///|
-/// The app's event reader confirms a submitted event has reached its message
-/// queue: any earlier submission is now visible to queue drains, so the
-/// mid-flight window is over. Called after every delivered event — the reader
-/// is sequential, so at most one submission is ever in flight.
+/// The app's event reader confirms one submitted event has reached its
+/// message queue and is visible to queue drains. Called once per delivered
+/// *submission* event (a prompt, queued input, or slash command) — rapid
+/// submits can stack several in the UI's internal event queue while the app
+/// loop is busy, so deliveries and submissions must pair one-to-one. The
+/// floor guards a spurious call; it must never mask a real pending submit.
 pub fn Ui::submission_delivered(self : Self) -> Unit {
-  self.submission_in_flight = false
+  self.pending_submissions = (self.pending_submissions - 1).max(0)
 }
 
 ///|

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -130,14 +130,29 @@ pub fn Ui::columns(self : Self) -> Int {
 }
 
 ///|
-/// Whether the composer is in its untouched default state: no draft text and
-/// plain input mode. Shell mode counts as engaged even with an empty buffer —
-/// a user sitting at a bare `! ` prompt is still mid-composition. Lets a
-/// scheduler (e.g. `/loop`) avoid starting a turn under a user who is halfway
-/// through typing — the composer is private to the UI, so the update loop
-/// cannot see it directly.
-pub fn Ui::composer_is_empty(self : Self) -> Bool {
-  self.composer.text().is_empty() && self.composer.mode().is_input()
+/// Whether the user is not interacting with the input surface at all: no
+/// draft text, plain input mode, and no submitted event still in flight
+/// toward the app's queue. Shell mode counts as engaged even with an empty
+/// buffer — a user sitting at a bare `! ` prompt is mid-composition — and so
+/// does the reset-to-delivery window of a just-pressed Enter (the submit
+/// helpers await a redraw between clearing the composer and returning the
+/// event, so an empty composer alone can lie about pending input). Lets a
+/// scheduler (e.g. `/loop`) avoid starting a turn under, or ahead of, the
+/// user — the composer is private to the UI, so the update loop cannot see
+/// any of this directly.
+pub fn Ui::input_idle(self : Self) -> Bool {
+  !self.submission_in_flight &&
+  self.composer.text().is_empty() &&
+  self.composer.mode().is_input()
+}
+
+///|
+/// The app's event reader confirms a submitted event has reached its message
+/// queue: any earlier submission is now visible to queue drains, so the
+/// mid-flight window is over. Called after every delivered event — the reader
+/// is sequential, so at most one submission is ever in flight.
+pub fn Ui::submission_delivered(self : Self) -> Unit {
+  self.submission_in_flight = false
 }
 
 ///|

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -130,11 +130,14 @@ pub fn Ui::columns(self : Self) -> Int {
 }
 
 ///|
-/// Whether the composer holds no draft text. Lets a scheduler (e.g. `/loop`)
-/// avoid starting a turn under a user who is halfway through typing — the
-/// composer is private to the UI, so the update loop cannot see it directly.
+/// Whether the composer is in its untouched default state: no draft text and
+/// plain input mode. Shell mode counts as engaged even with an empty buffer —
+/// a user sitting at a bare `! ` prompt is still mid-composition. Lets a
+/// scheduler (e.g. `/loop`) avoid starting a turn under a user who is halfway
+/// through typing — the composer is private to the UI, so the update loop
+/// cannot see it directly.
 pub fn Ui::composer_is_empty(self : Self) -> Bool {
-  self.composer.text().is_empty()
+  self.composer.text().is_empty() && self.composer.mode().is_input()
 }
 
 ///|

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -130,6 +130,14 @@ pub fn Ui::columns(self : Self) -> Int {
 }
 
 ///|
+/// Whether the composer holds no draft text. Lets a scheduler (e.g. `/loop`)
+/// avoid starting a turn under a user who is halfway through typing — the
+/// composer is private to the UI, so the update loop cannot see it directly.
+pub fn Ui::composer_is_empty(self : Self) -> Bool {
+  self.composer.text().is_empty()
+}
+
+///|
 /// Replace the live view around the composer — the persistent status line
 /// below it, the transient activity line above it (`None` hides it; it never
 /// enters the transcript), and the queued-inputs preview (copied defensively)

--- a/tui/ui.mbt
+++ b/tui/ui.mbt
@@ -15,6 +15,14 @@ struct Ui {
   mut notice : @doc.Text?
   commands : @task.Queue
   events : @aqueue.Queue[Result[Event, Error]]
+  // A submitted input is mid-flight: the composer was reset but the event has
+  // not yet been delivered to the app's message queue (the submit helpers
+  // await a redraw in between). Consumers that infer "the user is not
+  // interacting" from an empty composer (see `Ui::input_idle`) must treat
+  // this window as engaged, or they can act past input that is about to
+  // arrive. The event reader is sequential, so at most one submission is in
+  // flight at a time; the app confirms delivery with `submission_delivered`.
+  mut submission_in_flight : Bool
 }
 
 ///|
@@ -37,6 +45,7 @@ fn Ui::new(tty : @tty.Tty, config : Config) -> Ui {
     notice: None,
     commands: Queue(kind=Unbounded),
     events: Queue(kind=Unbounded),
+    submission_in_flight: false,
   }
 }
 

--- a/tui/ui.mbt
+++ b/tui/ui.mbt
@@ -15,14 +15,15 @@ struct Ui {
   mut notice : @doc.Text?
   commands : @task.Queue
   events : @aqueue.Queue[Result[Event, Error]]
-  // A submitted input is mid-flight: the composer was reset but the event has
+  // Submitted inputs mid-flight: the composer was reset but the events have
   // not yet been delivered to the app's message queue (the submit helpers
-  // await a redraw in between). Consumers that infer "the user is not
-  // interacting" from an empty composer (see `Ui::input_idle`) must treat
-  // this window as engaged, or they can act past input that is about to
-  // arrive. The event reader is sequential, so at most one submission is in
-  // flight at a time; the app confirms delivery with `submission_delivered`.
-  mut submission_in_flight : Bool
+  // await a redraw, and the internal `events` queue can hold several
+  // submissions while the app loop is busy). Consumers that infer "the user
+  // is not interacting" from an empty composer (see `Ui::input_idle`) must
+  // treat this window as engaged, or they can act past input that is about
+  // to arrive. A count, not a flag: rapid submits stack, and the app confirms
+  // each delivery with `submission_delivered`.
+  mut pending_submissions : Int
 }
 
 ///|
@@ -45,7 +46,7 @@ fn Ui::new(tty : @tty.Tty, config : Config) -> Ui {
     notice: None,
     commands: Queue(kind=Unbounded),
     events: Queue(kind=Unbounded),
-    submission_in_flight: false,
+    pending_submissions: 0,
   }
 }
 


### PR DESCRIPTION
`/loop` arms a recurring scheduled prompt in the TUI. Design doc → 2 codex review rounds → implementation (each commit codex-reviewed) → 7 whole-branch codex rounds, final round clean.

## How it works, high level

**The user's mental model.** `/loop 5m check CI and summarize failures` arms a schedule; a `⟳ 5m 00s` countdown appears on the status bar. Every five minutes — but only when nothing else is going on — the TUI submits that prompt *as if the user had typed it*. The countdown restarts when the run finishes (fixed delay, so a slow run never overlaps the next). `/loop status | pause | resume | off` manage it; `--max <n>` caps total runs (default 20, then auto-disarm). If a fired run fails or is interrupted, the loop pauses itself with a notice instead of re-firing a broken task unattended.

**Where it lives.** Entirely in the TUI process (`cmd/tui/scheduler.mbt` + a few wiring lines); the engine never knows a scheduler exists. A fire goes through the exact dispatch path as typed input — same `run_id` ownership, steering, interrupt, and compaction interlocks — so a loop-fired run behaves like any other turn (you can steer it, Ctrl-C it, etc.).

**Time.** No wall clock. The TUI already has a 1-second `Tick` heartbeat message; the schedule holds `remaining_secs` and decrements per Tick. That makes the entire core suite synchronous and sleep-free — tests fast-forward time by injecting Ticks.

**The two-role split.** Everything the scheduler does is either:
- *bookkeeping* inside the pure `update(state, msg)` state machine — countdown on Tick, re-arm/count/cap on a successful terminal, auto-pause on a failed one (hooked at every terminal path, keyed to the run-ownership id so user runs never touch the loop); or
- *dispatch* at one choke point, `scheduler_maybe_fire`, invoked once per **drained message batch** — the loop first applies every already-enqueued message, so the fire decision can never contradict input that is already in flight.

**The fire gate.** A due fire dispatches only when the user's input is provably absent at every stage of its lifecycle:

| stage | guard |
|---|---|
| in the composer | `Ui::input_idle` — no draft text, plain input mode (a bare `! ` shell prompt counts as engaged) |
| submitted but not yet delivered | `pending_submissions` counter (set with the composer reset, cleared per delivered submission event; rapid submits stack; leaks defer, never fire) |
| in the message queue | the pre-fire drain has already applied it to state |
| in app state | run slot idle, `queued` empty, no pending steers, no background `!` command whose output is still owed to the engine |
| in this batch's commands | teardown (`CancelAgent`/`KillEngine`/`Quit`) or a prompt steer racing the turn's terminal → defer (command-context steers keep the designed fire-after ordering) |

Anything short of fully idle holds the fire at "due" — the status bar shows `⟳ due` — and it dispatches at the next idle boundary. At most one deferred fire; no catch-up bursts.

**What the model sees.** The stored prompt, verbatim — attribution (`⟳ loop fire N of M`) lives in TUI notices and the live echo only, never in model input. Trade-off: a resumed session replays fired prompts as plain user messages (documented).

## Not in this PR (phased design)
Auto-compact between fires · model-callable `schedule_wakeup` tool (needs capability-gated registration + a lossless transport) · headless `openseek run --loop` · persistence across restarts.

## Validation
- `cmd/tui` 79/79 (19 new, sleep-free: grammar/overflow tables, lifecycle, countdown gating, fire sequencing, per-source defer/release, teardown/steer batch gating, outcome table, status states + clip-ordering); `tui` 14/14; full suite 901/901 at branch point; `moon check`/`fmt` clean.
- `.mbti`: intentional additive delta on `tui` — `Ui::input_idle`, `Ui::submission_delivered`.
- **CI: nightly ✅ every push**; `check (stable)` red repo-wide (pre-existing `parse_gate`-vs-stable-moonc drift, also on `main`) — expected per maintainer.
- Plan deviation: the tty-integration smoke was dropped (`Ui` has no headless construction precedent); the pure suite covers everything except the loop wiring lines.

## Review history (all findings fixed)
- Per-commit: shell-mode composer gate hole; status-segment clipping behind long cwds.
- Whole-branch r1: interval unit-multiply overflow.
- r2–r6: one input-overtaking race class peeled layer by layer — queued-input TOCTOU → submit-redraw window → multi-submit stacking → teardown-batch ordering (+ honest due-status phrasing) → prompt-steer-vs-terminal batch.
- r7: clean — "no actionable correctness issues"; converged.
- Final self-review: lifecycle edges traced (off/re-arm mid-fire, pause across re-arm, interrupt escalation, OneShot); stale file header fixed; the pause-notice-on-manual-pause repeat kept deliberately (it carries the failure reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)