### PR TITLE
fix(openseek): use OpenSeek API key env

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -70,8 +70,15 @@ sends DeepSeek native function tools and supports six local tools: `shell`,
 `read`, `edit`, `multi_edit`, `write`, and `finish`.
 
 ```bash
-export DEEPSEEK=sk-...
+export OPENSEEK_API_KEY=sk-...
 moon run cmd/openseek -- run "inspect this project and finish with a short summary"
+```
+
+For Kimi models, `KIMI` is also accepted:
+
+```bash
+export KIMI=sk-...
+moon run cmd/openseek -- --model kimi-k2.7-code-highspeed run "inspect this project"
 ```
 
 `OPENSEEK_MODEL` is optional and defaults to `deepseek-v4-pro`.
@@ -93,7 +100,7 @@ text appear live on the activity line, and each turn's reasoning is kept as a di
 `✻` transcript aside above its answer.
 
 ```bash
-export DEEPSEEK=sk-...
+export OPENSEEK_API_KEY=sk-...
 moon run cmd/openseek -- tui
 ```
 
@@ -126,7 +133,7 @@ and exposes each on `PATH` as `<name>.exe` (e.g. `openseek.exe`).
   help banner and the missing-API-key error). The argument parser runs before the
   terminal UI starts, so these need no API key and no TTY.
 - [`tests/live/deepseek.md`](tests/live/deepseek.md) — a real, non-mock DeepSeek
-  round trip. It is opt-in (`DEEPSEEK=sk-... moon cram test tests/live`) and
+  round trip. It is opt-in (`OPENSEEK_API_KEY=sk-... moon cram test tests/live`) and
   parses the agent's JSONL log with MoonBit itself: a `moon run -e` script reads
   the stream through the published [`bobzhang/jsonl`](https://mooncakes.io/docs/bobzhang/jsonl)
   package and asserts on typed `Json` values — no `jq` — without pinning

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -34,7 +34,8 @@ globals; the UI's own options (`--prompt`, `--engine`, `--continue`) live on the
 moon run cmd/openseek -- run [--api-key sk-...] [--model deepseek-v4-pro] [--api-url https://api.deepseek.com/chat/completions] [--dir .] [--max-steps 1000] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
 ```
 
-Runs require `--api-key` or `DEEPSEEK`. `--model` can also be supplied with
+Runs require `--api-key` or `OPENSEEK_API_KEY`. For Kimi models, `KIMI` is also
+accepted as the provider-specific API key. `--model` can also be supplied with
 `OPENSEEK_MODEL`; it accepts `deepseek-v4-flash`, `deepseek-v4-pro`,
 `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed`, and defaults to
 `deepseek-v4-pro`. `--max-steps` can also be supplied with
@@ -111,7 +112,7 @@ protocol for other integrations.
 ## Examples
 
 ```bash
-export DEEPSEEK=sk-...
+export OPENSEEK_API_KEY=sk-...
 moon run cmd/openseek -- run "run moon test and summarize the result"
 ```
 

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -15,9 +15,9 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
     fail("--concurrency records each run; remove --no-session")
   }
   let task = task_text(matches)
-  let api_key = api_key(matches)
   let api_url = api_url(matches)
   let model = @deepseek.Model::parse(value(matches, "model"))
+  let api_key = api_key(matches, model)
   let max_steps = max_steps(matches)
   let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
   let dir = trim_trailing_path_separators("\{value(matches, "dir").trim()}")

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -115,9 +115,9 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
       return
     }
     let workspace_root = prepare_workspace_root(matches, log_created=true)
-    let api_key = api_key(matches)
     let api_url = api_url(matches)
     let model = @deepseek.Model::parse(value(matches, "model"))
+    let api_key = api_key(matches, model)
     let max_steps = max_steps(matches)
     let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
     let task = task_text(matches)
@@ -370,13 +370,13 @@ test "root command rejects an unknown subcommand" {
 
 ///|
 test "bare parse selects no subcommand (the UI default)" {
-  let m = root_command().parse(argv=[], env={ "DEEPSEEK": "k" })
+  let m = root_command().parse(argv=[], env={ "OPENSEEK_API_KEY": "k" })
   assert_true(m.subcommand is None)
 }
 
 ///|
 test "tui is an explicit subcommand" {
-  guard root_command().parse(argv=["tui"], env={ "DEEPSEEK": "k" }).subcommand
+  guard root_command().parse(argv=["tui"], env={ "OPENSEEK_API_KEY": "k" }).subcommand
     is Some(("tui", _)) else {
     fail("expected tui subcommand")
   }
@@ -584,12 +584,44 @@ fn flag(matches : @argparse.Matches, name : String) -> Bool {
 }
 
 ///|
-fn api_key(matches : @argparse.Matches) -> String raise {
-  let key = value(matches, "api-key").trim()
-  if key.is_empty() {
-    fail("--api-key or DEEPSEEK is required for agent runs")
+fn uses_kimi_api_key_fallback(model : @deepseek.Model) -> Bool {
+  match model {
+    KimiK27Code | KimiK27CodeHighSpeed => true
+    V4Flash | V4Pro => false
   }
-  "\{key}"
+}
+
+///|
+fn non_empty_value(matches : @argparse.Matches, name : String) -> String? raise {
+  let key = value(matches, name).trim()
+  if key.is_empty() {
+    None
+  } else {
+    Some("\{key}")
+  }
+}
+
+///|
+fn api_key(
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+) -> String raise {
+  match non_empty_value(matches, "api-key") {
+    Some(key) => return key
+    None => ()
+  }
+  if uses_kimi_api_key_fallback(model) {
+    match non_empty_value(matches, "kimi-api-key") {
+      Some(key) => return key
+      None => ()
+    }
+  }
+  if uses_kimi_api_key_fallback(model) {
+    fail(
+      "an API key is required for Kimi models: pass --api-key or set OPENSEEK_API_KEY or KIMI",
+    )
+  }
+  fail("an API key is required: pass --api-key or set OPENSEEK_API_KEY")
 }
 
 ///|
@@ -1136,7 +1168,7 @@ test "session listing rows are tab-separated and survive odd prompts" {
 ///|
 test "cli parses env backed options and task" {
   let parsed = run_matches(argv=["write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
     "OPENSEEK_MODEL": "deepseek-v4-pro",
     "OPENSEEK_API_URL": "https://proxy.example/v1/chat/completions",
     "OPENSEEK_DIR": "/tmp/openseek-workspace",
@@ -1146,7 +1178,7 @@ test "cli parses env backed options and task" {
     "OPENSEEK_SESSION": "demo",
     "OPENSEEK_SESSION_ROOT": "/tmp/openseek-sessions",
   })
-  assert_eq(api_key(parsed), "test-key")
+  assert_eq(api_key(parsed, V4Pro), "test-key")
   assert_eq(value(parsed, "model"), "deepseek-v4-pro")
   guard api_url(parsed) is Some(url) else { fail("expected api url") }
   assert_eq(url, "https://proxy.example/v1/chat/completions")
@@ -1163,15 +1195,34 @@ test "cli parses env backed options and task" {
 ///|
 test "cli defaults model and max steps" {
   let parsed = run_matches(argv=["write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
-  assert_eq(api_key(parsed), "test-key")
+  assert_eq(api_key(parsed, V4Pro), "test-key")
   assert_eq(value(parsed, "model"), "deepseek-v4-pro")
   assert_true(api_url(parsed) is None)
   assert_eq(value(parsed, "dir"), ".")
   assert_eq(max_steps(parsed), 1000)
   assert_true(session_id(parsed) is None)
   assert_eq(session_root(parsed), ".openseek")
+}
+
+///|
+test "cli uses KIMI only for Kimi models" {
+  let kimi = run_matches(argv=["write", "MoonBit"], env={
+    "KIMI": "kimi-key",
+    "OPENSEEK_MODEL": "kimi-k2.7-code-highspeed",
+  })
+  assert_eq(api_key(kimi, KimiK27CodeHighSpeed), "kimi-key")
+  let deepseek = run_matches(argv=["write", "MoonBit"], env={
+    "KIMI": "kimi-key",
+  })
+  let _ = api_key(deepseek, V4Pro) catch {
+    error => {
+      assert_true("\{error}".contains("OPENSEEK_API_KEY"))
+      return
+    }
+  }
+  fail("KIMI was accepted for a DeepSeek model")
 }
 
 ///|
@@ -1205,7 +1256,7 @@ async test "--dir creates a missing final component when its parent exists" {
   @vfs.with_tmpdir(prefix="openseek-dir-parent-", parent => {
     let child = "\{parent}/child"
     let parsed = run_matches(argv=["--dir", child, "write", "MoonBit"], env={
-      "DEEPSEEK": "test-key",
+      "OPENSEEK_API_KEY": "test-key",
     })
     let root = prepare_workspace_root(parsed)
     assert_true(@fs.exists(child))
@@ -1218,7 +1269,7 @@ async test "--dir creates a missing final component with trailing separator" {
   @vfs.with_tmpdir(prefix="openseek-dir-trailing-", parent => {
     let child = "\{parent}/child"
     let parsed = run_matches(argv=["--dir", "\{child}/", "write", "MoonBit"], env={
-      "DEEPSEEK": "test-key",
+      "OPENSEEK_API_KEY": "test-key",
     })
     let root = prepare_workspace_root(parsed)
     assert_true(@fs.exists(child))
@@ -1241,7 +1292,7 @@ async test "--dir rejects missing parents instead of creating recursively" {
   @vfs.with_tmpdir(prefix="openseek-dir-missing-parent-", root => {
     let child = "\{root}/missing/child"
     let parsed = run_matches(argv=["--dir", child, "write", "MoonBit"], env={
-      "DEEPSEEK": "test-key",
+      "OPENSEEK_API_KEY": "test-key",
     })
     let _ = prepare_workspace_root(parsed) catch {
       error => {
@@ -1263,7 +1314,7 @@ async test "--dir rejects existing non-directories" {
     let path = "\{root}/file"
     @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
     let parsed = run_matches(argv=["--dir", path, "write", "MoonBit"], env={
-      "DEEPSEEK": "test-key",
+      "OPENSEEK_API_KEY": "test-key",
     })
     let _ = prepare_workspace_root(parsed) catch {
       error => {
@@ -1278,7 +1329,7 @@ async test "--dir rejects existing non-directories" {
 ///|
 test "session root resolves relative to workspace root" {
   let parsed = run_matches(argv=["write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   assert_eq(
     session_root(parsed, workspace_root="/tmp/openseek-workspace"),
@@ -1286,7 +1337,7 @@ test "session root resolves relative to workspace root" {
   )
   let custom = run_matches(
     argv=["--session-root", "sessions", "write", "MoonBit"],
-    env={ "DEEPSEEK": "test-key" },
+    env={ "OPENSEEK_API_KEY": "test-key" },
   )
   assert_eq(
     session_root(custom, workspace_root="/tmp/openseek-workspace"),
@@ -1309,9 +1360,9 @@ async test "session commands reject empty session root" {
 ///|
 test "agent runs require api key" {
   let parsed = run_matches(argv=["write", "MoonBit"], env={})
-  let _ = api_key(parsed) catch {
+  let _ = api_key(parsed, V4Pro) catch {
     error => {
-      assert_true("\{error}".contains("--api-key or DEEPSEEK is required"))
+      assert_true("\{error}".contains("OPENSEEK_API_KEY"))
       return
     }
   }
@@ -1320,7 +1371,7 @@ test "agent runs require api key" {
 
 ///|
 test "agent runs require task text" {
-  let parsed = run_matches(argv=[], env={ "DEEPSEEK": "test-key" })
+  let parsed = run_matches(argv=[], env={ "OPENSEEK_API_KEY": "test-key" })
   let _ = task_text(parsed) catch {
     error => {
       assert_true("\{error}".contains("task description is required"))
@@ -1333,7 +1384,7 @@ test "agent runs require task text" {
 ///|
 async test "one-shot runs record to a generated salted cli session by default" {
   let parsed = run_matches(argv=["write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   guard resolved_session_id(parsed) is Some(id) else {
     fail("expected a generated session id")
@@ -1348,7 +1399,7 @@ async test "one-shot runs record to a generated salted cli session by default" {
 ///|
 async test "--no-session restores the ephemeral one-shot" {
   let parsed = run_matches(argv=["--no-session", "write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   assert_true(resolved_session_id(parsed) is None)
 }
@@ -1356,7 +1407,7 @@ async test "--no-session restores the ephemeral one-shot" {
 ///|
 async test "an explicit --session id is used verbatim" {
   let parsed = run_matches(argv=["--session", "demo", "write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   guard resolved_session_id(parsed) is Some(id) else {
     fail("expected the explicit id")
@@ -1368,7 +1419,7 @@ async test "an explicit --session id is used verbatim" {
 async test "--session with --no-session is a contradiction" {
   let parsed = run_matches(
     argv=["--session", "demo", "--no-session", "write", "MoonBit"],
-    env={ "DEEPSEEK": "test-key" },
+    env={ "OPENSEEK_API_KEY": "test-key" },
   )
   let _ = resolved_session_id(parsed) catch {
     error => {
@@ -1382,7 +1433,7 @@ async test "--session with --no-session is a contradiction" {
 ///|
 test "cli parses max steps option" {
   let parsed = run_matches(argv=["--max-steps", "25", "write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   assert_eq(max_steps(parsed), 25)
 }
@@ -1403,7 +1454,7 @@ async test "configured system prompt can replace and append files" {
       // machine-independent: without it, a developer's ~/.openseek/skills
       // would append a ## Skills section (Codex review).
       env={
-        "DEEPSEEK": "test-key",
+        "OPENSEEK_API_KEY": "test-key",
         "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/no-global-skills",
       },
     )
@@ -1436,7 +1487,7 @@ async test "configured system prompt advertises global skills" {
     let parsed = run_matches(
       argv=["--system-prompt-file", prompt_path, "write", "MoonBit"],
       env={
-        "DEEPSEEK": "test-key",
+        "OPENSEEK_API_KEY": "test-key",
         "OPENSEEK_GLOBAL_SKILLS_DIR": "\{dir}/skills",
       },
     )
@@ -1476,7 +1527,7 @@ async test "configured system prompt uses the selected workspace root" {
         "--dir", workspace, "--system-prompt-file", "prompt.md", "write", "MoonBit",
       ],
       env={
-        "DEEPSEEK": "test-key",
+        "OPENSEEK_API_KEY": "test-key",
         "OPENSEEK_GLOBAL_SKILLS_DIR": "\{workspace}/no-global-skills",
       },
     )
@@ -1498,7 +1549,7 @@ async test "configured system prompt uses the selected workspace root" {
 ///|
 async test "configured system prompt defaults to the flash prompt" {
   let parsed = run_matches(argv=["write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   assert_true(
     configured_system_prompt(parsed, V4Flash).contains(
@@ -1526,7 +1577,7 @@ async test "load_or_new_session defers first durable write until append" {
       ],
       // Pinned so the exact-prompt assertions stay machine-independent.
       env={
-        "DEEPSEEK": "test-key",
+        "OPENSEEK_API_KEY": "test-key",
         "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
       },
     )
@@ -1576,7 +1627,7 @@ async test "new durable session header persists project layout" {
         "MoonBit",
       ],
       env={
-        "DEEPSEEK": "test-key",
+        "OPENSEEK_API_KEY": "test-key",
         "OPENSEEK_GLOBAL_SKILLS_DIR": "\{workspace}/no-global-skills",
       },
     )
@@ -1618,7 +1669,7 @@ async test "load_or_new_session recovers empty interrupted session directory" {
       ],
       // Pinned so the exact-prompt assertion stays machine-independent.
       env={
-        "DEEPSEEK": "test-key",
+        "OPENSEEK_API_KEY": "test-key",
         "OPENSEEK_GLOBAL_SKILLS_DIR": "\{root}/no-global-skills",
       },
     )
@@ -1814,7 +1865,7 @@ async test "session compaction rejects missing summary file" {
 ///|
 test "cli rejects invalid max steps" {
   let parsed = run_matches(argv=["--max-steps", "0", "write", "MoonBit"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   let _ = max_steps(parsed) catch {
     error => {

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -20,11 +20,11 @@ async fn run_review_cli(
   matches : @argparse.Matches,
   workspace_root~ : String,
 ) -> Unit {
-  let api_key = api_key(matches)
   let api_url = api_url(matches)
   // Reviews always run on the strongest model; flash is too shallow for the
   // judgement a code review needs, so --model is not consulted here.
   let model = @deepseek.V4Pro
+  let api_key = api_key(matches, model)
   let max_steps = max_steps(matches)
   let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
   let base = value(matches, "base")

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -189,9 +189,9 @@ async fn run_serve(
   matches : @argparse.Matches,
   workspace_root~ : String,
 ) -> Unit {
-  let api_key = api_key(matches)
   let api_url = api_url(matches)
   let model = @deepseek.Model::parse(value(matches, "model"))
+  let api_key = api_key(matches, model)
   let max_steps = max_steps(matches)
   let thinking = @deepseek.ThinkingMode::parse(value(matches, "thinking"))
   let (store, initial_session) = match session_id(matches) {

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -41,9 +41,10 @@ startup banner) stores the conversation under `--session-root` (default
 
 ## Configuration
 
-`--api-key` (env `DEEPSEEK`) is required. `--model`, `--api-url`, `--max-steps`,
-and `--thinking` mirror the engine's flags and are forwarded to it through the
-environment, alongside the session settings.
+`--api-key` (env `OPENSEEK_API_KEY`) is required; for Kimi models, `KIMI` is
+also accepted as the provider-specific API key. `--model`, `--api-url`,
+`--max-steps`, and `--thinking` mirror the engine's flags and are forwarded to
+it through the environment, alongside the session settings.
 
 The full flag reference lives in the executable help — verified verbatim in
 [`tests/cram/tui.md`](../../tests/cram/tui.md).

--- a/cmd/tui/continue_wbtest.mbt
+++ b/cmd/tui/continue_wbtest.mbt
@@ -9,7 +9,7 @@ async test "--continue resolves the most recently active session" {
       store.create(Session(SessionId("newer"), system_prompt="system"))
       let parsed = cli_command().parse(
         argv=["--continue", "--session-root", root],
-        env={ "DEEPSEEK": "test-key" },
+        env={ "OPENSEEK_API_KEY": "test-key" },
       )
       let config = with_latest_session(parse_config(parsed))
       assert_eq(config.session_id.value(), "newer")
@@ -17,7 +17,7 @@ async test "--continue resolves the most recently active session" {
       // so the TUI starts a new conversation instead of refusing to launch.
       let parsed = cli_command().parse(
         argv=["--continue", "--session-root", empty_root],
-        env={ "DEEPSEEK": "test-key" },
+        env={ "OPENSEEK_API_KEY": "test-key" },
       )
       let fresh = with_latest_session(parse_config(parsed))
       assert_true(fresh.session_id.value().has_prefix("tui-"))

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -96,6 +96,7 @@ test "engine configuration travels through the environment" {
   assert_eq(session_id, "test")
   assert_eq(session_root, ".openseek")
   assert_eq(dir, ".")
+  assert_true(env.get("OPENSEEK_API_KEY") == Some(config.api_key))
   assert_true(env.get("OPENSEEK_THINKING") == Some("max"))
   assert_true(
     env.get("OPENSEEK_API_URL") ==

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -139,7 +139,7 @@ fn engine_exit_without_result(
 ///|
 fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   {
-    "DEEPSEEK": config.api_key,
+    "OPENSEEK_API_KEY": config.api_key,
     "OPENSEEK_API_URL": config.api_url.unwrap_or(""),
     "OPENSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -13,10 +13,18 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
     OptionArg(
       "api-key",
       long="api-key",
-      env="DEEPSEEK",
+      env="OPENSEEK_API_KEY",
       default_values=[""],
       global~,
-      about="DeepSeek API key.",
+      about="API key for the selected chat provider.",
+    ),
+    OptionArg(
+      "kimi-api-key",
+      long="kimi-api-key",
+      env="KIMI",
+      default_values=[""],
+      global~,
+      hidden=true,
     ),
     OptionArg(
       "model",
@@ -268,14 +276,12 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     )
   }
   // Enforced here rather than via argparse `required`: see `tui_shared_options`.
-  let api_key = value(matches, "api-key")
-  if api_key.trim().is_empty() {
-    fail("a DeepSeek API key is required: pass --api-key or set DEEPSEEK")
-  }
+  let model = @deepseek.Model::parse(value(matches, "model"))
+  let api_key = api_key_for_model(matches, model)
   {
     api_key,
     api_url: api_url(matches),
-    model: @deepseek.Model::parse(value(matches, "model")),
+    model,
     cwd,
     max_steps: parse_positive_int(value(matches, "max-steps"), "--max-steps"),
     // Parsed eagerly so a typo fails at launch with a CLI error instead of
@@ -430,8 +436,51 @@ fn[T : @tty.Fd] is_tty(fd : T) -> Bool {
 }
 
 ///|
+fn uses_kimi_api_key_fallback(model : @deepseek.Model) -> Bool {
+  match model {
+    KimiK27Code | KimiK27CodeHighSpeed => true
+    V4Flash | V4Pro => false
+  }
+}
+
+///|
+fn non_empty_value(matches : @argparse.Matches, name : String) -> String? raise {
+  let key = value(matches, name).trim()
+  if key.is_empty() {
+    None
+  } else {
+    Some("\{key}")
+  }
+}
+
+///|
+fn api_key_for_model(
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+) -> String raise {
+  match non_empty_value(matches, "api-key") {
+    Some(key) => return key
+    None => ()
+  }
+  if uses_kimi_api_key_fallback(model) {
+    match non_empty_value(matches, "kimi-api-key") {
+      Some(key) => return key
+      None => ()
+    }
+  }
+  if uses_kimi_api_key_fallback(model) {
+    fail(
+      "an API key is required for Kimi models: pass --api-key or set OPENSEEK_API_KEY or KIMI",
+    )
+  }
+  fail("an API key is required: pass --api-key or set OPENSEEK_API_KEY")
+}
+
+///|
 test "cli accepts no initial task" {
-  let parsed = cli_command().parse(argv=[], env={ "DEEPSEEK": "test-key" })
+  let parsed = cli_command().parse(argv=[], env={
+    "OPENSEEK_API_KEY": "test-key",
+  })
   assert_true(initial_task(parsed) is None)
   let config = parse_config(parsed)
   assert_eq(config.api_key, "test-key")
@@ -449,13 +498,32 @@ test "cli accepts no initial task" {
 ///|
 test "cli parses api url" {
   let parsed = cli_command().parse(argv=[], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
     "OPENSEEK_API_URL": " https://proxy.example/v1/chat/completions ",
   })
   guard parse_config(parsed).api_url is Some(url) else {
     fail("expected api url")
   }
   assert_eq(url, "https://proxy.example/v1/chat/completions")
+}
+
+///|
+test "cli uses KIMI only for Kimi models" {
+  let kimi = cli_command().parse(argv=[], env={
+    "KIMI": "kimi-key",
+    "OPENSEEK_MODEL": "kimi-k2.7-code-highspeed",
+  })
+  let kimi_config = parse_config(kimi)
+  assert_eq(kimi_config.api_key, "kimi-key")
+  assert_true(kimi_config.model is KimiK27CodeHighSpeed)
+  let deepseek = cli_command().parse(argv=[], env={ "KIMI": "kimi-key" })
+  let _ = parse_config(deepseek) catch {
+    error => {
+      assert_true("\{error}".contains("OPENSEEK_API_KEY"))
+      return
+    }
+  }
+  fail("KIMI was accepted for a DeepSeek model")
 }
 
 ///|
@@ -472,12 +540,12 @@ test "generated session ids are timestamped and directory-safe" {
 ///|
 test "cli parses and validates thinking controls" {
   let parsed = cli_command().parse(argv=["--thinking", "high"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   let config = parse_config(parsed)
   assert_true(config.thinking is High)
   let bad = cli_command().parse(argv=["--thinking", "sometimes"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   let _ = parse_config(bad) catch {
     error => {
@@ -492,7 +560,7 @@ test "cli parses and validates thinking controls" {
 test "cli accepts an initial prompt and max steps" {
   let parsed = cli_command().parse(
     argv=["--max-steps", "5", "--prompt", "inspect project"],
-    env={ "DEEPSEEK": "test-key" },
+    env={ "OPENSEEK_API_KEY": "test-key" },
   )
   assert_true(initial_task(parsed) == Some("inspect project"))
   assert_eq(parse_config(parsed).max_steps, 5)
@@ -501,7 +569,7 @@ test "cli accepts an initial prompt and max steps" {
 ///|
 test "cli rejects unknown option before initial task" {
   let _ = cli_command().parse(argv=["--xxy", "he"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   }) catch {
     error => {
       assert_true("\{error}".contains("unexpected argument '--xxy' found"))
@@ -513,7 +581,9 @@ test "cli rejects unknown option before initial task" {
 
 ///|
 test "no --prompt means no initial task" {
-  let parsed = cli_command().parse(argv=[], env={ "DEEPSEEK": "test-key" })
+  let parsed = cli_command().parse(argv=[], env={
+    "OPENSEEK_API_KEY": "test-key",
+  })
   assert_true(initial_task(parsed) is None)
 }
 
@@ -521,7 +591,7 @@ test "no --prompt means no initial task" {
 test "cli accepts session configuration" {
   let parsed = cli_command().parse(
     argv=["--session", "demo", "--session-root", "/tmp/openseek-sessions"],
-    env={ "DEEPSEEK": "test-key" },
+    env={ "OPENSEEK_API_KEY": "test-key" },
   )
   let config = parse_config(parsed)
   assert_eq(config.session_id.value(), "demo")
@@ -532,7 +602,7 @@ test "cli accepts session configuration" {
 test "cli rejects empty session root when session is active" {
   let parsed = cli_command().parse(
     argv=["--session", "demo", "--session-root", ""],
-    env={ "DEEPSEEK": "test-key" },
+    env={ "OPENSEEK_API_KEY": "test-key" },
   )
   let _ = parse_config(parsed) catch {
     error => {
@@ -546,12 +616,12 @@ test "cli rejects empty session root when session is active" {
 ///|
 test "cli accepts --continue and rejects combining it with --session" {
   let parsed = cli_command().parse(argv=["--continue"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   assert_true(continue_requested(parsed))
   let conflicted = cli_command().parse(
     argv=["--continue", "--session", "demo"],
-    env={ "DEEPSEEK": "test-key" },
+    env={ "OPENSEEK_API_KEY": "test-key" },
   )
   let _ = continue_requested(conflicted) catch {
     error => {
@@ -585,13 +655,13 @@ test "default_engine re-launches a path argv0 and falls back to PATH otherwise" 
 async test "engine defaults to this binary; --engine/OPENSEEK_ENGINE override it" {
   // No --engine and no env: fall through to re-launching this binary.
   let default_cfg = parse_config(
-    cli_command().parse(argv=[], env={ "DEEPSEEK": "k" }),
+    cli_command().parse(argv=[], env={ "OPENSEEK_API_KEY": "k" }),
   )
   assert_eq(default_cfg.engine, default_engine(@sys.get_cli_args()))
   // OPENSEEK_ENGINE is treated as an explicit engine.
   let env_cfg = parse_config(
     cli_command().parse(argv=[], env={
-      "DEEPSEEK": "k",
+      "OPENSEEK_API_KEY": "k",
       "OPENSEEK_ENGINE": "./fake-engine",
     }),
   )
@@ -602,7 +672,7 @@ async test "engine defaults to this binary; --engine/OPENSEEK_ENGINE override it
 async test "oneshot engine mode requires an explicit engine" {
   let _ = parse_config(
     cli_command().parse(argv=["--engine-mode", "oneshot"], env={
-      "DEEPSEEK": "k",
+      "OPENSEEK_API_KEY": "k",
     }),
   ) catch {
     error => {
@@ -618,14 +688,14 @@ async test "oneshot with an explicit engine (flag or env) is accepted" {
   let flag_cfg = parse_config(
     cli_command().parse(
       argv=["--engine-mode", "oneshot", "--engine", "./fake-engine"],
-      env={ "DEEPSEEK": "k" },
+      env={ "OPENSEEK_API_KEY": "k" },
     ),
   )
   assert_true(flag_cfg.engine_mode is OneShot)
   assert_eq(flag_cfg.engine, "./fake-engine")
   let env_cfg = parse_config(
     cli_command().parse(argv=[], env={
-      "DEEPSEEK": "k",
+      "OPENSEEK_API_KEY": "k",
       "OPENSEEK_ENGINE": "./fake-engine",
       "OPENSEEK_ENGINE_MODE": "oneshot",
     }),
@@ -636,7 +706,7 @@ async test "oneshot with an explicit engine (flag or env) is accepted" {
 ///|
 test "cli overrides the engine binary" {
   let parsed = cli_command().parse(argv=["--engine", "./fake-engine"], env={
-    "DEEPSEEK": "test-key",
+    "OPENSEEK_API_KEY": "test-key",
   })
   assert_eq(parse_config(parsed).engine, "./fake-engine")
 }

--- a/eval/README.md
+++ b/eval/README.md
@@ -87,7 +87,7 @@ The checked-in prompt-task runner supports five concurrent repeats:
 
 ```bash
 moon run --target native eval/prompt_task/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --model deepseek-v4-flash \
   --runs 5 \
   --concurrency 5 \

--- a/eval/file_edit/README.md
+++ b/eval/file_edit/README.md
@@ -18,7 +18,7 @@ The default baseline is cheap Flash:
 
 ```bash
 moon run --target native eval/file_edit/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --model deepseek-v4-flash \
   --runs 10 \
   --concurrency 1 \
@@ -39,7 +39,7 @@ Run A with the built-in prompt:
 
 ```bash
 moon run --target native eval/file_edit/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --model deepseek-v4-flash \
   --runs 10 \
   --concurrency 1 \
@@ -53,7 +53,7 @@ Run B with an addendum:
 
 ```bash
 moon run --target native eval/file_edit/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --model deepseek-v4-flash \
   --runs 10 \
   --concurrency 1 \
@@ -74,7 +74,7 @@ five Flash repeats with five concurrent agent processes:
 
 ```bash
 moon run --target native eval/file_edit/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --model deepseek-v4-flash \
   --runs 5 \
   --concurrency 5 \

--- a/eval/file_edit/cmd/main/main.mbt
+++ b/eval/file_edit/cmd/main/main.mbt
@@ -18,7 +18,7 @@ fn cli_command() -> @argparse.Command {
         "api-key",
         long="api-key",
         required=true,
-        about="DeepSeek API key.",
+        about="API key for the selected chat provider.",
       ),
       OptionArg(
         "model",

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -147,7 +147,7 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
     "moon",
     args,
     extra_env={
-      "DEEPSEEK": config.api_key,
+      "OPENSEEK_API_KEY": config.api_key,
       "OPENSEEK_MODEL": config.model.to_string(),
       "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
       // Trials inherit the developer's env, so point the global skills

--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -24,7 +24,7 @@ Run five Flash TOML trials concurrently:
 
 ```bash
 moon run --target native eval/prompt_task/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --model deepseek-v4-flash \
   --runs 5 \
   --concurrency 5 \
@@ -46,7 +46,7 @@ Run a multi-problem suite:
 
 ```bash
 moon run --target native eval/prompt_task/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --suite-file .repos/openseek-eval-experiments/suites/moonbit_cli_suite_v1/suite.json \
   --out .repos/openseek-eval-experiments/runs/moonbit_cli_suite_v1_100x \
   --repo-root .
@@ -63,7 +63,7 @@ Run an A/B comparison by using different output directories and prompt labels:
 
 ```bash
 moon run --target native eval/prompt_task/cmd/main -- \
-  --api-key "$DEEPSEEK" \
+  --api-key "$OPENSEEK_API_KEY" \
   --model deepseek-v4-flash \
   --runs 5 \
   --concurrency 5 \

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -43,7 +43,7 @@ fn cli_command() -> @argparse.Command {
         "api-key",
         long="api-key",
         default_values=[""],
-        about="DeepSeek API key.",
+        about="API key for the selected chat provider.",
       ),
       OptionArg(
         "model",

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -132,7 +132,7 @@ fn trial_extra_env(
   real_workspace : String,
 ) -> Map[String, String] {
   {
-    "DEEPSEEK": config.api_key,
+    "OPENSEEK_API_KEY": config.api_key,
     "OPENSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_MAX_STEPS": config.max_steps.to_string(),
     "OPENSEEK_SESSION_ROOT": ".openseek",

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -32,7 +32,7 @@ Commands:
 
 Options:
   -h, --help                     Show help information.
-  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK] [default: ]
+  --api-key <api-key>            API key for the selected chat provider. [env: OPENSEEK_API_KEY] [default: ]
   --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
@@ -57,7 +57,7 @@ rejection for now.)
 ```mooncram
 $ sh <<'EOF'
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe serv 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u OPENSEEK_API_KEY openseek.exe serv 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > rm -f "$stderr"
 > EOF
@@ -75,7 +75,7 @@ subcommand. So `openseek --prompt x run â€¦` is an error; use `openseek tui
 ```mooncram
 $ sh <<'EOF'
 > stderr=$(mktemp)
-> if env DEEPSEEK=test-key openseek.exe --prompt x run TASK 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env OPENSEEK_API_KEY=test-key openseek.exe --prompt x run TASK 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > rm -f "$stderr"
 > EOF
@@ -89,7 +89,7 @@ is rejected by the parser rather than opening the UI.
 ```mooncram
 $ sh <<'EOF'
 > stderr=$(mktemp)
-> if env DEEPSEEK=test-key openseek.exe -- something 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env OPENSEEK_API_KEY=test-key openseek.exe -- something 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > rm -f "$stderr"
 > EOF
@@ -106,7 +106,7 @@ engine pre-flight fail deterministically, proving the env var is honored for a
 bare launch.
 
 ```mooncram
-$ env DEEPSEEK=test-key OPENSEEK_ENGINE=does-not-exist openseek.exe 2>&1
+$ env OPENSEEK_API_KEY=test-key OPENSEEK_ENGINE=does-not-exist openseek.exe 2>&1
 error: engine 'does-not-exist' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
 Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
 [1]
@@ -128,7 +128,7 @@ Arguments:
 
 Options:
   -h, --help                                                   Show help information.
-  --api-key <api-key>                                          DeepSeek API key. [env: DEEPSEEK] [default: ]
+  --api-key <api-key>                                          API key for the selected chat provider. [env: OPENSEEK_API_KEY] [default: ]
   --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                                      Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
@@ -143,22 +143,22 @@ Options:
   --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N); 1 means a single run. [env: OPENSEEK_CONCURRENCY] [default: 1]
 ```
 
-## A DeepSeek API Key Is Required For Agent Runs
+## API Key Is Required For Agent Runs
 
-With no `--api-key` flag and no `DEEPSEEK` in the environment, a run reports the
+With no `--api-key` flag and no `OPENSEEK_API_KEY` in the environment, a run reports the
 missing key and exits non-zero.
 
 ```mooncram
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe run "summarize this project" > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u OPENSEEK_API_KEY -u KIMI -u OPENSEEK_MODEL openseek.exe run "summarize this project" > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > cat "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
 > EOF
 exit-non-zero
-error: --api-key or DEEPSEEK is required for agent runs
+error: an API key is required: pass --api-key or set OPENSEEK_API_KEY
 stdout-empty
 ```
 
@@ -172,7 +172,7 @@ instead of silently turning them into prompt text.
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe run --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u OPENSEEK_API_KEY openseek.exe run --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
@@ -189,20 +189,20 @@ Here parsing succeeds and the run reaches the later API-key validation.
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe run -- '--xxy he' > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u OPENSEEK_API_KEY -u KIMI -u OPENSEEK_MODEL openseek.exe run -- '--xxy he' > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > cat "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
 > EOF
 exit-non-zero
-error: --api-key or DEEPSEEK is required for agent runs
+error: an API key is required: pass --api-key or set OPENSEEK_API_KEY
 stdout-empty
 ```
 
 ## `openseek sessions` Is Offline
 
 Session inspection and compaction operate on typed session files and do not
-require a DeepSeek API key. Hand-written log lines carry the 0 sentinel stamp;
+require a API key for the selected chat provider. Hand-written log lines carry the 0 sentinel stamp;
 the summary event the compaction *appends* is stamped with the wall clock, so
 both `sessions show` calls strip `ts` to stay deterministic.
 
@@ -216,10 +216,10 @@ $ sh <<'EOF'
 > {"sequence":2,"ts":0,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
 > JSONL
 > printf 'hello and answer' > "$tmp/summary.txt"
-> env -u DEEPSEEK openseek.exe sessions list --session-root "$tmp" | cut -f1
-> env -u DEEPSEEK openseek.exe sessions show demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
-> env -u DEEPSEEK openseek.exe sessions compact demo --session-root "$tmp" --file "$tmp/summary.txt" --from 1 --to 2
-> env -u DEEPSEEK openseek.exe sessions show demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
+> env -u OPENSEEK_API_KEY openseek.exe sessions list --session-root "$tmp" | cut -f1
+> env -u OPENSEEK_API_KEY openseek.exe sessions show demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
+> env -u OPENSEEK_API_KEY openseek.exe sessions compact demo --session-root "$tmp" --file "$tmp/summary.txt" --from 1 --to 2
+> env -u OPENSEEK_API_KEY openseek.exe sessions show demo --session-root "$tmp" | sed -E 's/"ts":[0-9]+,//g'
 > rm -rf "$tmp"
 > EOF
 demo
@@ -247,9 +247,9 @@ to reach the API. The generated id's timestamp is normalized for determinism.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
-> if env DEEPSEEK=test-key openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env OPENSEEK_API_KEY=test-key openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > grep -c '"event":"session_started"' out.jsonl
-> env -u DEEPSEEK openseek.exe sessions list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
+> env -u OPENSEEK_API_KEY openseek.exe sessions list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
 > rm -rf "$tmp"
 > EOF
 exit-non-zero
@@ -264,7 +264,7 @@ behind.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
-> env DEEPSEEK=test-key openseek.exe run --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" >/dev/null 2>&1
+> env OPENSEEK_API_KEY=test-key openseek.exe run --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" >/dev/null 2>&1
 > if test -d .openseek; then echo recorded; else echo ephemeral; fi
 > rm -rf "$tmp"
 > EOF
@@ -282,11 +282,11 @@ it.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > mkdir -p "$tmp/parent"
-> if env DEEPSEEK=test-key openseek.exe run --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env OPENSEEK_API_KEY=test-key openseek.exe run --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > if test -d "$tmp/parent/new"; then echo dir-created; else echo dir-missing; fi
 > grep -c '"event":"workspace_created"' "$tmp/out.jsonl"
-> env -u DEEPSEEK openseek.exe sessions list --dir "$tmp/parent/new" | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
-> env -u DEEPSEEK openseek.exe sessions list --dir "$tmp/parent/fresh" > "$tmp/session-list.out"
+> env -u OPENSEEK_API_KEY openseek.exe sessions list --dir "$tmp/parent/new" | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
+> env -u OPENSEEK_API_KEY openseek.exe sessions list --dir "$tmp/parent/fresh" > "$tmp/session-list.out"
 > if test -d "$tmp/parent/fresh"; then echo session-dir-created; else echo session-dir-missing; fi
 > wc -l < "$tmp/session-list.out" | tr -d ' '
 > rm -rf "$tmp"
@@ -302,7 +302,7 @@ session-dir-created
 Asking for both recording behaviors at once is rejected before any work happens.
 
 ```mooncram
-$ env DEEPSEEK=test-key openseek.exe run --session demo --no-session "say hi" 2>&1
+$ env OPENSEEK_API_KEY=test-key openseek.exe run --session demo --no-session "say hi" 2>&1
 error: --no-session contradicts --session; pick one behavior
 [1]
 ```
@@ -318,7 +318,7 @@ without ever touching the network. The `grep -o` keeps only the stable event
 tag, since event lines carry timestamps.
 
 ```mooncram
-$ printf '{"command":"reboot"}\n{"command":"cancel"}\n' | env DEEPSEEK=test-key openseek.exe serve 2>/dev/null | grep -o '"event":"command_error"'
+$ printf '{"command":"reboot"}\n{"command":"cancel"}\n' | env OPENSEEK_API_KEY=test-key openseek.exe serve 2>/dev/null | grep -o '"event":"command_error"'
 "event":"command_error"
 ```
 
@@ -329,7 +329,7 @@ carries a `steer_dropped` event so the controller can ask the user to resubmit â
 and, usefully for this offline test, no turn means no network.
 
 ```mooncram
-$ printf '{"command":"steer","text":"too late"}\n' | env DEEPSEEK=test-key openseek.exe serve 2>/dev/null | grep -o '"event":"steer_dropped"'
+$ printf '{"command":"steer","text":"too late"}\n' | env OPENSEEK_API_KEY=test-key openseek.exe serve 2>/dev/null | grep -o '"event":"steer_dropped"'
 "event":"steer_dropped"
 ```
 
@@ -339,7 +339,7 @@ anything runs.
 ```mooncram
 $ sh <<'EOF'
 > stderr=$(mktemp)
-> if env DEEPSEEK=test-key openseek.exe serve "do something" 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env OPENSEEK_API_KEY=test-key openseek.exe serve "do something" 2> "$stderr" >/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > rm -f "$stderr"
 > EOF

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -23,7 +23,7 @@ OpenSeek terminal UI.
 
 Options:
   -h, --help                     Show help information.
-  --api-key <api-key>            DeepSeek API key. [env: DEEPSEEK] [default: ]
+  --api-key <api-key>            API key for the selected chat provider. [env: OPENSEEK_API_KEY] [default: ]
   --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum number of agent loop steps before stopping. [env: OPENSEEK_MAX_STEPS] [default: 1000]
@@ -36,9 +36,9 @@ Options:
   --prompt <prompt>              Initial prompt to send once the UI opens.
 ```
 
-## A DeepSeek API Key Is Required
+## API Key Is Required
 
-With no `--api-key` flag and no `DEEPSEEK` in the environment, the UI reports the
+With no `--api-key` flag and no `OPENSEEK_API_KEY` in the environment, the UI reports the
 missing key on stderr and exits non-zero — before the terminal UI ever starts.
 (The key is validated in the UI path rather than via argparse `required`, so the
 root command can stay key-optional for offline engine subcommands like
@@ -48,13 +48,13 @@ root command can stay key-optional for offline engine subcommands like
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env -u DEEPSEEK openseek.exe tui > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env -u OPENSEEK_API_KEY -u KIMI -u OPENSEEK_MODEL openseek.exe tui > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
 > EOF
 exit-non-zero
-error: a DeepSeek API key is required: pass --api-key or set DEEPSEEK
+error: an API key is required: pass --api-key or set OPENSEEK_API_KEY
 stdout-empty
 ```
 
@@ -66,7 +66,7 @@ Option-looking tokens are validated by the parser before the UI starts.
 $ sh <<'EOF'
 > stdout=$(mktemp)
 > stderr=$(mktemp)
-> if env DEEPSEEK=test-key openseek.exe tui --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
+> if env OPENSEEK_API_KEY=test-key openseek.exe tui --xxy he > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > sed -n '1p' "$stderr"
 > if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
 > rm -f "$stdout" "$stderr"
@@ -83,7 +83,7 @@ mode; override with `--engine`/`OPENSEEK_ENGINE`) and probes it with `--help`
 first. A missing engine fails fast, before the UI takes over the terminal.
 
 ```mooncram
-$ env DEEPSEEK=test-key openseek.exe tui --engine openseek-not-a-real-binary
+$ env OPENSEEK_API_KEY=test-key openseek.exe tui --engine openseek-not-a-real-binary
 error: engine 'openseek-not-a-real-binary' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
 Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
 [1]
@@ -96,7 +96,7 @@ Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
 prompt path is wired — there is no free-form positional.
 
 ```mooncram
-$ env DEEPSEEK=test-key openseek.exe tui --engine does-not-exist --prompt "inspect project"
+$ env OPENSEEK_API_KEY=test-key openseek.exe tui --engine does-not-exist --prompt "inspect project"
 error: engine 'does-not-exist' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
 Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
 [1]

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -5,7 +5,7 @@ DeepSeek API calls — there is no mocking. They live in a separate directory so
 the offline suite can run in CI without credentials, while these are opt-in:
 
 ```bash
-export DEEPSEEK=sk-...            # a real DeepSeek API key
+export OPENSEEK_API_KEY=sk-...            # a real provider API key
 moon cram test tests/live
 ```
 


### PR DESCRIPTION
## Summary

- switch OpenSeek CLI/TUI `--api-key` env wiring from `DEEPSEEK` to `OPENSEEK_API_KEY`
- allow Kimi models to use `KIMI` when `--api-key` / `OPENSEEK_API_KEY` is not set
- remove the legacy `DEEPSEEK` fallback from CLI/runtime paths
- forward `OPENSEEK_API_KEY` through TUI and eval harness child processes
- update OpenSeek docs/cram tests for the new env var while leaving low-level provider-specific DeepSeek smoke-test docs alone

## Validation

- `moon check`
- `moon test cmd/openseek`
- `moon test cmd/tui`
- `moon test eval/file_edit/cmd/main`
- `moon test eval/prompt_task/cmd/main`
- `moon cram test tests/cram`
- `moon info && moon fmt`
- `moon test`
- `env -u OPENSEEK_API_KEY moon run cmd/openseek -- --model kimi-k2.7-code-highspeed run --no-session --max-steps 3 "reply with exactly: hi"`
- `env -u OPENSEEK_API_KEY moon run cmd/openseek -- run --no-session --max-steps 1 "hi"` exits with the expected missing `OPENSEEK_API_KEY` error, confirming `KIMI` is not used for non-Kimi models.