### PR TITLE
refactor(agent_session): collapse session storage to one file per session

### DIFF
--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -233,13 +233,12 @@ The store layout is:
 
 ```text
 <root>/sessions/<session-id>/
-  session.json
-  events.jsonl
+  openseek_session.jsonl
 ```
 
-`session.json` is a small header containing the id, system prompt, last
-sequence, and an event-log fingerprint. `events.jsonl` is the append-only event
-log. Loading replays JSONL events into a `Session`.
+`openseek_session.jsonl` holds the whole session: a header record
+(`{"version":1,"id":...,"system_prompt":...}`) on the first line, then one
+append-only event per line. Loading replays the event lines into a `Session`.
 
 Use the store for durable callers:
 

--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -1,4 +1,50 @@
 ///|
+/// The version of the session-file header record this package understands.
+let session_file_version : Int = 1
+
+///|
+/// The header record on the first line of a session file: the session identity
+/// and system prompt for the event lines that follow. The system prompt lives
+/// only here — it is a `Session` field, not an event — so a session file is
+/// self-contained.
+pub(all) struct SessionFileHeader {
+  id : String
+  system_prompt : String
+} derive(Debug)
+
+///|
+/// Encode a header record as the JSON stored on a session file's first line.
+///
+/// The shape is `{ "version": 1, "id": <id>, "system_prompt": <text> }`.
+pub impl ToJson for SessionFileHeader with fn to_json(
+  header : SessionFileHeader,
+) -> Json {
+  {
+    "version": session_file_version,
+    "id": header.id,
+    "system_prompt": header.system_prompt,
+  }
+}
+
+///|
+/// Decode a session-file header record, or `None` when `json` is not a
+/// version-1 header object. Header and event records are structurally
+/// disjoint (events carry `sequence`/`item`, never `version`), so this is
+/// also how a reader tells the two apart.
+pub fn parse_header(json : Json) -> SessionFileHeader? {
+  guard json is Object(fields) else { return None }
+  guard fields.get("version") is Some(Number(version, ..)) &&
+    version.to_int() == session_file_version else {
+    return None
+  }
+  guard fields.get("id") is Some(String(id)) else { return None }
+  guard fields.get("system_prompt") is Some(String(system_prompt)) else {
+    return None
+  }
+  Some({ id, system_prompt })
+}
+
+///|
 /// One JSONL line that could not be decoded into a `SessionEvent`. Kept so
 /// downstream tools can surface the offending line instead of silently
 /// dropping it or aborting the whole load.
@@ -9,34 +55,57 @@ pub(all) struct LineError {
 } derive(Debug)
 
 ///|
-/// The result of parsing an `events.jsonl` log line by line. `events` are the
-/// records that decoded cleanly (in file order); `errors` are individual lines
-/// that failed to decode; `partial_tail` is true when the final line looked
-/// like a half-written record from a process that exited mid-append.
+/// The result of parsing a session file line by line. `header` is the
+/// identity record found on the first content line, when present; `events`
+/// are the records that decoded cleanly (in file order); `errors` are
+/// individual lines that failed to decode; `partial_tail` is true when the
+/// final line looked like a half-written record from a process that exited
+/// mid-append.
 pub(all) struct ParsedLog {
+  header : SessionFileHeader?
   events : Array[@agent_session.SessionEvent]
   errors : Array[LineError]
   partial_tail : Bool
 } derive(Debug)
 
 ///|
-/// Parse an `events.jsonl` log into typed `SessionEvent`s, tolerating a
-/// truncated trailing line and per-line decode failures. Blank lines are
-/// ignored. A decode failure on any line other than an unterminated final line
-/// is recorded as a `LineError` and parsing continues.
+/// Parse a session file into a header record and typed `SessionEvent`s,
+/// tolerating a truncated trailing line and per-line decode failures. Blank
+/// lines are ignored. The first content line is read as the header when it is
+/// one; a header-less text (a bare event log) still parses with
+/// `header=None`. A decode failure on any line other than an unterminated
+/// final line is recorded as a `LineError` and parsing continues.
 pub fn parse_events(text : String) -> ParsedLog {
+  let mut header : SessionFileHeader? = None
   let events : Array[@agent_session.SessionEvent] = []
   let errors : Array[LineError] = []
   let ends_with_newline = text.has_suffix("\n")
   let lines = text.split("\n").map(line => line.to_owned()).collect()
   let mut partial_tail = false
+  let mut first_content_line = true
   for index, line in lines {
     let line_number = index + 1
     if line.trim().is_empty() {
       continue
     }
+    let may_be_header = first_content_line
+    first_content_line = false
     let is_last_segment = index == lines.length() - 1
-    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
+    let json = @json.parse(line) catch {
+      error => {
+        if is_last_segment && !ends_with_newline {
+          partial_tail = true
+        } else {
+          errors.push({ line_number, content: line, message: "\{error}" })
+        }
+        continue
+      }
+    }
+    if may_be_header && parse_header(json) is Some(parsed_header) {
+      header = Some(parsed_header)
+      continue
+    }
+    let event : @agent_session.SessionEvent = @json.from_json(json) catch {
       error => {
         if is_last_segment && !ends_with_newline {
           partial_tail = true
@@ -48,12 +117,12 @@ pub fn parse_events(text : String) -> ParsedLog {
     }
     events.push(event)
   }
-  { events, errors, partial_tail }
+  { header, events, errors, partial_tail }
 }
 
 ///|
 /// Build an immutable `Session` from parsed events plus the header values the
-/// caller wants to use. When no `session.json` header is available, pass a
+/// caller wants to use. When no header record is available, pass a
 /// placeholder id and an empty system prompt.
 pub fn session_from_parse(
   parsed : ParsedLog,

--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -48,6 +48,7 @@ test "parse round-trips every event kind" {
     @log.parse_events(events_jsonl(sample_session())),
     content=(
       #|{
+      #|  header: None,
       #|  events: [
       #|    { sequence: 1, ts: 0, item: User({ content: "list the files" }) },
       #|    {
@@ -101,6 +102,7 @@ test "parse tolerates a truncated final line" {
     @log.parse_events(text),
     content=(
       #|{
+      #|  header: None,
       #|  events: [{ sequence: 1, ts: 0, item: User({ content: "hi" }) }],
       #|  errors: [],
       #|  partial_tail: true,
@@ -138,6 +140,32 @@ test "parse records a bad interior line without aborting" {
       #|false
     ),
   )
+}
+
+///|
+test "parse lifts the header record from the first line" {
+  // A session file as the store writes it: header line first, events after.
+  let header : @log.SessionFileHeader = {
+    id: "demo",
+    system_prompt: "You are a helpful agent.",
+  }
+  let text = "\{header.to_json().stringify()}\n\{events_jsonl(sample_session())}"
+  let parsed = @log.parse_events(text)
+  debug_inspect(
+    parsed.header,
+    content=(
+      #|Some({ id: "demo", system_prompt: "You are a helpful agent." })
+    ),
+  )
+  assert_eq(parsed.events.length(), 5)
+  assert_eq(parsed.errors.length(), 0)
+  // A header record is only recognized on the first content line; later
+  // header-shaped lines are ordinary bad lines.
+  let trailing = "\{events_jsonl(sample_session())}\{header.to_json().stringify()}\n"
+  let reparsed = @log.parse_events(trailing)
+  debug_inspect(reparsed.header, content="None")
+  assert_eq(reparsed.events.length(), 5)
+  assert_eq(reparsed.errors.length(), 1)
 }
 
 ///|

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -9,6 +9,8 @@ import {
 // Values
 pub fn parse_events(String) -> ParsedLog
 
+pub fn parse_header(Json) -> SessionFileHeader?
+
 pub fn session_from_parse(ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
 
 // Errors
@@ -21,10 +23,17 @@ pub(all) struct LineError {
 } derive(@debug.Debug)
 
 pub(all) struct ParsedLog {
+  header : SessionFileHeader?
   events : Array[@agent_session.SessionEvent]
   errors : Array[LineError]
   partial_tail : Bool
 } derive(@debug.Debug)
+
+pub(all) struct SessionFileHeader {
+  id : String
+  system_prompt : String
+} derive(@debug.Debug)
+pub impl ToJson for SessionFileHeader
 
 // Type aliases
 

--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -14,15 +14,14 @@ Each session lives under:
 
 ```text
 <root>/sessions/<session-id>/
-  session.json
-  events.jsonl
+  openseek_session.jsonl
   session.lock
 ```
 
-`session.json` stores the small header: session id, system prompt, last
-sequence, and a fingerprint of the event-log prefix it describes.
-`events.jsonl` is the append-only stream of typed `SessionEvent` records. Loading
-replays the JSONL log into an immutable `agent_session.Session`.
+`openseek_session.jsonl` is the whole durable session: its first line is a
+header record (`{"version":1,"id":...,"system_prompt":...}`) and every
+following line is one typed `SessionEvent`. Events are append-only. Loading
+replays the event lines into an immutable `agent_session.Session`.
 
 `session.lock` is an implementation detail used to serialize writers and keep a
 reader from seeing a half-updated session.
@@ -47,31 +46,30 @@ let session = store.compact(
 
 Use `create` when writing a complete session snapshot. Use `append` for normal
 agent progress. `append` is the safe save path: it checks that the caller's
-in-memory session still matches disk, appends exactly one timestamped event, and
-updates the header.
+in-memory session still matches disk, then appends exactly one timestamped
+event line.
 
 `load` takes a `SessionId` because `SessionStore(root)` is a directory-backed
 collection, not a handle to one current session. The id selects
-`<root>/sessions/<id>/session.json` and
-`<root>/sessions/<id>/events.jsonl`; the store intentionally does not keep a
-hidden "current" session. When the caller needs to discover a session first,
-use `list`, `listings`, or `latest`, then pass the chosen id to `load`.
+`<root>/sessions/<id>/openseek_session.jsonl`; the store intentionally does not
+keep a hidden "current" session. When the caller needs to discover a session
+first, use `list`, `listings`, or `latest`, then pass the chosen id to `load`.
 
 ## Create And Load
 
-`create` writes a complete session. It is useful for new sessions, test
-fixtures, or deliberate rewrites. `load` reads the header, replays the JSONL
-events for the requested id, validates sequence numbers, and rebuilds the
-immutable `Session`.
+`create` writes a complete session atomically (temp file, then rename). It is
+useful for new sessions, test fixtures, or deliberate rewrites. `load` reads
+the single session file, replays the event lines for the requested id,
+validates sequence numbers, and rebuilds the immutable `Session`.
 
 More pedantically, `load(id)`:
 
 - validates `id` before using it in a path;
 - takes a shared session lock when the session directory exists;
-- reads `session.json` and checks that the header id equals the requested id;
-- parses every JSON line in `events.jsonl` as a typed `SessionEvent`;
+- reads `openseek_session.jsonl` and checks that the first line is a header
+  record whose id equals the requested id;
+- parses every following JSON line as a typed `SessionEvent`;
 - checks that event sequence numbers are contiguous;
-- validates the header's event-log fingerprint against the replayed log;
 - returns a rebuilt immutable `Session`;
 - does not create a missing session, choose a latest session, or mutate disk.
 
@@ -199,8 +197,8 @@ async test "append rejects a stale in-memory session" {
 
 ## Compact
 
-`compact` appends a validated `Summary` event. It does not rewrite
-`events.jsonl`; the raw covered events remain durable. The compaction effect is
+`compact` appends a validated `Summary` event. It does not rewrite earlier
+lines of the session file; the raw covered events remain durable. The compaction effect is
 visible when `Session::chat_messages` projects model context: covered earlier
 events are skipped and the later summary message is used instead.
 
@@ -282,28 +280,27 @@ them up. `latest` uses loadability as the resume gate.
 
 ## File Path Helpers
 
-`header_file` and `event_log_file` expose absolute paths for read-only tooling
-such as the visualizer server. They still validate the session id before
+`session_file` exposes the absolute path of a session's file for read-only
+tooling such as the visualizer server. It still validates the session id before
 constructing the path.
 
 ```mbt nocheck
 ///|
-let header = store.header_file(@agent_session.SessionId("demo"))
-
-///|
-let log = store.event_log_file(@agent_session.SessionId("demo"))
+let path = store.session_file(@agent_session.SessionId("demo"))
 ```
 
 ## Failure Model
 
-The store is designed around append-only progress and crash recovery:
+The whole session is one file, so there is no cross-file consistency to
+maintain:
 
-- `append` writes the JSONL event first, then the header. A log that is ahead of
-  the header is accepted on load.
-- `create` writes a restrictive header before rewriting the log, then writes a
-  permissive header after the rewrite succeeds. A stale tail after a rewrite is
-  rejected.
-- Every load checks contiguous sequence numbers and header/log fingerprints.
+- `append` is a single `O_APPEND` write of one event line. The first durable
+  write for a session (no file yet) writes the header line and the first event
+  atomically, so a session file can never exist without its header.
+- `create` rewrites the file atomically (temp file, then rename); an
+  interrupted rewrite leaves the previous file intact.
+- Every load checks the header record and contiguous sequence numbers; a torn
+  trailing line fails the load rather than being silently dropped.
 - Every append or compact checks that the caller's session still matches disk.
 
 These rules keep persistence concerns out of `agent_session.Session` while

--- a/agent_session/store/moon.pkg
+++ b/agent_session/store/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/log" @session_log,
   "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
   "moonbitlang/core/env",

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -25,14 +25,13 @@ pub fn SessionStore::SessionStore(String) -> Self
 pub async fn SessionStore::append(Self, @agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session
 pub async fn SessionStore::compact(Self, @agent_session.Session, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> @agent_session.Session
 pub async fn SessionStore::create(Self, @agent_session.Session) -> Unit
-pub fn SessionStore::event_log_file(Self, @agent_session.SessionId) -> String raise
 pub async fn SessionStore::exists(Self, @agent_session.SessionId) -> Bool
-pub fn SessionStore::header_file(Self, @agent_session.SessionId) -> String raise
 pub async fn SessionStore::latest(Self) -> @agent_session.SessionId?
 pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]
 pub async fn SessionStore::listings(Self) -> Array[SessionListing]
 pub async fn SessionStore::load(Self, @agent_session.SessionId) -> @agent_session.Session
 pub fn SessionStore::root(Self) -> String
+pub fn SessionStore::session_file(Self, @agent_session.SessionId) -> String raise
 
 // Type aliases
 

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -1,36 +1,20 @@
 ///|
-let session_header_version : Int = 1
-
-///|
 let session_dir_name : String = "sessions"
 
 ///|
-let header_file_name : String = "session.json"
-
-///|
-let event_log_file_name : String = "events.jsonl"
+let session_file_name : String = "openseek_session.jsonl"
 
 ///|
 let lock_file_name : String = "session.lock"
 
 ///|
-priv struct SessionHeader {
-  id : @agent_session.SessionId
-  system_prompt : String
-  last_sequence : Int
-  event_log_length : Int?
-  event_log_hash : Int?
-  allow_event_log_ahead : Bool?
-}
-
-///|
 /// Native filesystem-backed collection of durable OpenSeek sessions.
 ///
 /// A `SessionStore` owns only a root path string. Under that root, each session
-/// is stored in `sessions/<id>/` with three files: `session.json`,
-/// `events.jsonl`, and `session.lock`. The store is not a handle to one current
-/// session; APIs that operate on a session either take a `SessionId` or a
-/// `Session` carrying its id.
+/// is stored in `sessions/<id>/` with two files: `openseek_session.jsonl` (a
+/// header line followed by append-only event lines) and `session.lock`. The
+/// store is not a handle to one current session; APIs that operate on a session
+/// either take a `SessionId` or a `Session` carrying its id.
 pub struct SessionStore {
   priv root : String
 } derive(Debug)
@@ -85,19 +69,11 @@ fn SessionStore::session_dir(
 }
 
 ///|
-fn SessionStore::header_path(
+fn SessionStore::session_file_path(
   self : SessionStore,
   id : @agent_session.SessionId,
 ) -> String raise {
-  "\{self.session_dir(id)}/\{header_file_name}"
-}
-
-///|
-fn SessionStore::event_log_path(
-  self : SessionStore,
-  id : @agent_session.SessionId,
-) -> String raise {
-  "\{self.session_dir(id)}/\{event_log_file_name}"
+  "\{self.session_dir(id)}/\{session_file_name}"
 }
 
 ///|
@@ -109,127 +85,12 @@ fn SessionStore::lock_path(
 }
 
 ///|
-fn event_log_hash(text : StringView) -> Int {
-  Hash::hash(text)
-}
-
-///|
-fn session_header_json(
-  session : @agent_session.Session,
-  events_text : String,
-  allow_event_log_ahead : Bool,
-) -> Json {
-  {
-    "version": session_header_version,
-    "id": session.id(),
-    "system_prompt": session.system_prompt(),
-    "last_sequence": session.last_sequence(),
-    "event_log_length": events_text.length(),
-    "event_log_hash": event_log_hash(events_text),
-    "allow_event_log_ahead": allow_event_log_ahead,
+fn header_line(session : @agent_session.Session) -> String {
+  let header : @session_log.SessionFileHeader = {
+    id: session.id().value(),
+    system_prompt: session.system_prompt(),
   }
-}
-
-///|
-fn[T] json_decode_error(
-  path : @json.JsonPath,
-  message : String,
-) -> T raise @json.JsonDecodeError {
-  raise JsonDecodeError((path, message))
-}
-
-///|
-fn header_string_field(
-  fields : Map[String, Json],
-  path : @json.JsonPath,
-  key : String,
-) -> String raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(String(value)) => value
-    _ => json_decode_error(path.add_key(key), "expected string")
-  }
-}
-
-///|
-fn header_int_field(
-  fields : Map[String, Json],
-  path : @json.JsonPath,
-  key : String,
-) -> Int raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(Number(value, ..)) => value.to_int()
-    _ => json_decode_error(path.add_key(key), "expected int")
-  }
-}
-
-///|
-fn header_optional_int_field(
-  fields : Map[String, Json],
-  path : @json.JsonPath,
-  key : String,
-) -> Int? raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(Number(value, ..)) => Some(value.to_int())
-    Some(_) => json_decode_error(path.add_key(key), "expected int")
-    None => None
-  }
-}
-
-///|
-fn header_optional_bool_field(
-  fields : Map[String, Json],
-  path : @json.JsonPath,
-  key : String,
-) -> Bool? raise @json.JsonDecodeError {
-  match fields.get(key) {
-    Some(True) => Some(true)
-    Some(False) => Some(false)
-    Some(_) => json_decode_error(path.add_key(key), "expected bool")
-    None => None
-  }
-}
-
-///|
-fn decode_session_header(
-  json : Json,
-  path : @json.JsonPath,
-) -> SessionHeader raise @json.JsonDecodeError {
-  let fields = match json {
-    Object(fields) => fields
-    _ => json_decode_error(path, "expected session header object")
-  }
-  match header_int_field(fields, path, "version") {
-    1 => ()
-    other =>
-      json_decode_error(
-        path.add_key("version"),
-        "unsupported session header version: \{other}",
-      )
-  }
-  let id : @agent_session.SessionId = match fields.get("id") {
-    Some(id) => @json.from_json(id, path=path.add_key("id"))
-    None => json_decode_error(path.add_key("id"), "expected id")
-  }
-  {
-    id,
-    system_prompt: header_string_field(fields, path, "system_prompt"),
-    last_sequence: header_int_field(fields, path, "last_sequence"),
-    event_log_length: header_optional_int_field(
-      fields, path, "event_log_length",
-    ),
-    event_log_hash: header_optional_int_field(fields, path, "event_log_hash"),
-    allow_event_log_ahead: header_optional_bool_field(
-      fields, path, "allow_event_log_ahead",
-    ),
-  }
-}
-
-///|
-impl FromJson for SessionHeader with fn from_json(
-  json : Json,
-  path : @json.JsonPath,
-) -> SessionHeader {
-  decode_session_header(json, path)
+  "\{header.to_json().stringify()}\n"
 }
 
 ///|
@@ -239,6 +100,13 @@ fn events_jsonl(events : @vector.Vector[@agent_session.SessionEvent]) -> String 
     builder <+ "\{event.to_json().stringify()}\n"
   }
   builder.to_string()
+}
+
+///|
+/// The complete durable form of a session: one header line followed by one
+/// line per event.
+fn session_file_text(session : @agent_session.Session) -> String {
+  "\{header_line(session)}\{events_jsonl(session.events())}"
 }
 
 ///|
@@ -270,79 +138,38 @@ fn checked_last_sequence_in_events(
 }
 
 ///|
-async fn durable_last_sequence(
-  store : SessionStore,
-  id : @agent_session.SessionId,
-) -> Int {
-  let events_text = read_event_log_text(store.event_log_path(id))
-  checked_last_sequence_in_events(parse_events_jsonl(events_text))
-}
-
-///|
-async fn read_session_header(
-  store : SessionStore,
-  id : @agent_session.SessionId,
-) -> SessionHeader {
-  @json.from_json(@json.parse(@fs.read_file(store.header_path(id)).text()))
-}
-
-///|
-fn validate_loaded_header(
-  header : SessionHeader,
+/// Rebuild a session from the durable single-file form: the first line must be
+/// a header record, every following non-blank line must decode as an event,
+/// and event sequences must be contiguous from 1.
+fn session_from_file_text(
   requested_id : @agent_session.SessionId,
-) -> Unit raise {
-  if header.id.value() != requested_id.value() {
-    fail(
-      "session header id mismatch: requested \{requested_id.value()}, found \{header.id.value()}",
-    )
-  }
-}
-
-///|
-fn validate_event_log_fingerprint(
-  header : SessionHeader,
-  events_text : String,
-) -> Unit raise {
-  match (header.event_log_length, header.event_log_hash) {
-    (Some(length), Some(hash)) => {
-      if events_text.length() < length ||
-        event_log_hash(events_text[:length]) != hash {
-        fail("session event log fingerprint mismatch for \{header.id.value()}")
-      }
-      if header.allow_event_log_ahead == Some(false) &&
-        events_text.length() != length {
-        fail(
-          "session event log stale tail after replacement for \{header.id.value()}",
-        )
-      }
-      let prefix_last_sequence = checked_last_sequence_in_events(
-        parse_events_jsonl(events_text[:length].to_owned()),
-      )
-      if prefix_last_sequence != header.last_sequence {
-        fail(
-          "session header fingerprint tail mismatch: header last sequence \{header.last_sequence}, fingerprint last sequence \{prefix_last_sequence}",
-        )
-      }
-    }
-    (None, None) => ()
-    _ => fail("session header event log fingerprint is incomplete")
-  }
-}
-
-///|
-fn session_from_replayed_events(
-  header : SessionHeader,
-  events_text : String,
-  events : @vector.Vector[@agent_session.SessionEvent],
+  text : String,
 ) -> @agent_session.Session raise {
-  validate_event_log_fingerprint(header, events_text)
-  let replayed_last_sequence = checked_last_sequence_in_events(events)
-  if replayed_last_sequence < header.last_sequence {
+  let (first, rest) = match text.split_once("\n") {
+    Some((first, rest)) => (first.to_owned(), rest.to_owned())
+    None => (text, "")
+  }
+  let header_json = @json.parse(first) catch {
+    error =>
+      fail(
+        "session file for \{requested_id.value()} does not start with a header line: \{error}",
+      )
+  }
+  let header = match @session_log.parse_header(header_json) {
+    Some(header) => header
+    None =>
+      fail(
+        "session file for \{requested_id.value()} does not start with a header record",
+      )
+  }
+  if header.id != requested_id.value() {
     fail(
-      "session event log tail mismatch: header last sequence \{header.last_sequence}, replayed last sequence \{replayed_last_sequence}",
+      "session header id mismatch: requested \{requested_id.value()}, found \{header.id}",
     )
   }
-  Session(header.id, system_prompt=header.system_prompt, events~)
+  let events = parse_events_jsonl(rest)
+  ignore(checked_last_sequence_in_events(events))
+  Session(SessionId(header.id), system_prompt=header.system_prompt, events~)
 }
 
 ///|
@@ -350,27 +177,7 @@ async fn load_persisted_session(
   store : SessionStore,
   id : @agent_session.SessionId,
 ) -> @agent_session.Session {
-  let header = read_session_header(store, id)
-  validate_loaded_header(header, id)
-  let events_text = read_event_log_text(store.event_log_path(id))
-  session_from_replayed_events(
-    header,
-    events_text,
-    parse_events_jsonl(events_text),
-  )
-}
-
-///|
-async fn ensure_empty_missing_session(
-  store : SessionStore,
-  session : @agent_session.Session,
-) -> Unit {
-  let durable_last = durable_last_sequence(store, session.id())
-  if durable_last != 0 || session.last_sequence() != 0 {
-    fail(
-      "stale session snapshot for \{session.id().value()}: no persisted header, in-memory last sequence \{session.last_sequence()}, durable last sequence \{durable_last}",
-    )
-  }
+  session_from_file_text(id, @fs.read_file(store.session_file_path(id)).text())
 }
 
 ///|
@@ -380,7 +187,11 @@ async fn ensure_session_is_current(
 ) -> Unit {
   let persisted = load_persisted_session(store, session.id()) catch {
     @os_error.OSError(_) as error if error.is_ENOENT() => {
-      ensure_empty_missing_session(store, session)
+      if session.last_sequence() != 0 {
+        fail(
+          "stale session snapshot for \{session.id().value()}: no durable session file, in-memory last sequence \{session.last_sequence()}",
+        )
+      }
       return
     }
     error => raise error
@@ -392,48 +203,28 @@ async fn ensure_session_is_current(
 }
 
 ///|
-async fn write_header(
-  store : SessionStore,
-  session : @agent_session.Session,
-  allow_event_log_ahead : Bool,
-) -> Unit {
-  let events_text = events_jsonl(session.events())
-  write_text_atomic(
-    store.header_path(session.id()),
-    session_header_json(session, events_text, allow_event_log_ahead).stringify(),
-  )
-}
-
-///|
-async fn write_event_log(
-  store : SessionStore,
-  session : @agent_session.Session,
-) -> Unit {
-  write_text_atomic(
-    store.event_log_path(session.id()),
-    events_jsonl(session.events()),
-  )
-}
-
-///|
-async fn append_event(
+/// Persist one new event for `session`. The common case is a single
+/// `O_APPEND` write of one line. The first durable write for a session (no
+/// file yet) instead writes the header line and the first event atomically,
+/// so a session file can never exist without its header. Callers hold the
+/// exclusive session lock and have already verified the snapshot is current,
+/// which for the missing-file case means `session` contains exactly the
+/// events being persisted.
+async fn append_durable_event(
   store : SessionStore,
   session : @agent_session.Session,
   event : @agent_session.SessionEvent,
 ) -> Unit {
-  @fs.write_file(
-    store.event_log_path(session.id()),
-    "\{event.to_json().stringify()}\n",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
-}
-
-///|
-async fn read_event_log_text(path : String) -> String {
-  @fs.read_file(path).text() catch {
-    @os_error.OSError(_) as error if error.is_ENOENT() => ""
-    error => raise error
+  let path = store.session_file_path(session.id())
+  if @fs.exists(path) {
+    @fs.write_file(
+      path,
+      "\{event.to_json().stringify()}\n",
+      create_mode=OpenOrCreate,
+      append=true,
+    )
+  } else {
+    write_text_atomic(path, session_file_text(session))
   }
 }
 
@@ -505,10 +296,10 @@ async fn[T] with_existing_session_lock(
 ///|
 /// Return whether the directory for `id` exists.
 ///
-/// This checks only `root/sessions/<id>/`; it does not require `session.json` or
-/// `events.jsonl` to exist and does not validate that the session is loadable.
-/// Invalid ids raise before any filesystem probe, rather than being silently
-/// treated as absent.
+/// This checks only `root/sessions/<id>/`; it does not require
+/// `openseek_session.jsonl` to exist and does not validate that the session is
+/// loadable. Invalid ids raise before any filesystem probe, rather than being
+/// silently treated as absent.
 pub async fn SessionStore::exists(
   self : SessionStore,
   id : @agent_session.SessionId,
@@ -517,39 +308,27 @@ pub async fn SessionStore::exists(
 }
 
 ///|
-/// Return the absolute or relative path to a session's `events.jsonl` file.
+/// Return the absolute or relative path to a session's
+/// `openseek_session.jsonl` file.
 ///
 /// The path is formed from the store root and `id`; the file is not opened and
 /// may not exist. Invalid ids raise. This helper exists for read-only tooling,
-/// such as the visualizer server, that wants to stream the raw append-only log
+/// such as the visualizer server, that wants to stream the raw session file
 /// without duplicating the store layout rules.
-pub fn SessionStore::event_log_file(
+pub fn SessionStore::session_file(
   self : SessionStore,
   id : @agent_session.SessionId,
 ) -> String raise {
-  self.event_log_path(id)
-}
-
-///|
-/// Return the absolute or relative path to a session's `session.json` header.
-///
-/// The path is formed from the store root and `id`; the file is not opened and
-/// may not exist. Invalid ids raise. The header is a small snapshot containing
-/// the id, system prompt, last durable sequence, and an event-log fingerprint.
-pub fn SessionStore::header_file(
-  self : SessionStore,
-  id : @agent_session.SessionId,
-) -> String raise {
-  self.header_path(id)
+  self.session_file_path(id)
 }
 
 ///|
 /// List known session ids under `root/sessions`, sorted by directory name.
 ///
-/// This is a directory listing only. It does not open headers, parse logs, or
-/// check loadability. A missing `root/sessions` directory returns an empty
-/// array. Other filesystem errors raise. Returned ids are raw directory names
-/// wrapped as `SessionId`.
+/// This is a directory listing only. It does not open session files, parse
+/// logs, or check loadability. A missing `root/sessions` directory returns an
+/// empty array. Other filesystem errors raise. Returned ids are raw directory
+/// names wrapped as `SessionId`.
 pub async fn SessionStore::list(
   self : SessionStore,
 ) -> Array[@agent_session.SessionId] {
@@ -578,8 +357,8 @@ pub struct SessionListing {
 ///|
 /// Return the listed session id.
 ///
-/// Pass this id to `load`, `exists`, `header_file`, or `event_log_file` when the
-/// caller chooses this row.
+/// Pass this id to `load`, `exists`, or `session_file` when the caller chooses
+/// this row.
 pub fn SessionListing::id(self : SessionListing) -> @agent_session.SessionId {
   self.id
 }
@@ -587,9 +366,9 @@ pub fn SessionListing::id(self : SessionListing) -> @agent_session.SessionId {
 ///|
 /// Return the listing timestamp in unix seconds.
 ///
-/// For normal sessions this is the modification time of `events.jsonl`; if the
-/// log is absent, listing falls back to `session.json`. `None` means neither
-/// file could be stat-ed. The value is for sorting/display and is not a durable
+/// This is the modification time of `openseek_session.jsonl`. `None` means the
+/// file could not be stat-ed — a damaged directory or one written by an
+/// incompatible layout. The value is for sorting/display and is not a durable
 /// session field.
 pub fn SessionListing::last_active_unix_seconds(
   self : SessionListing,
@@ -601,28 +380,30 @@ pub fn SessionListing::last_active_unix_seconds(
 /// Return the first user prompt found near the start of the event log.
 ///
 /// The value is a display label, not a validated session field. It is `""` when
-/// no user event is found within the scan limit, when the log cannot be read,
-/// or when the session directory is damaged.
+/// no user event is found within the scan limit, when the session file cannot
+/// be read, or when the session directory is damaged.
 pub fn SessionListing::first_prompt(self : SessionListing) -> String {
   self.first_prompt
 }
 
 ///|
-/// Lines scanned from the front of an event log while looking for the first
-/// user prompt. The agent appends the user turn as a session's first event,
-/// so this is normally one line; the cap keeps a pathological log from
-/// turning a listing into a full read.
+/// Lines scanned from the front of a session file while looking for the first
+/// user prompt, not counting the header line. The agent appends the user turn
+/// as a session's first event, so this is normally one line; the cap keeps a
+/// pathological log from turning a listing into a full read.
 let first_prompt_scan_limit : Int = 50
 
 ///|
-/// The first user prompt recorded in the event log at `path`, or `""` when
-/// none is found within the scan limit (or the log cannot be read). Streams
+/// The first user prompt recorded in the session file at `path`, or `""` when
+/// none is found within the scan limit (or the file cannot be read). Streams
 /// line by line instead of loading the session: a listing only needs a
 /// label, and long or compacted histories should not make `--session-list`
 /// deserialize every event ever appended.
 async fn first_prompt_in_log(path : String) -> String {
   let file = @fs.open(path, mode=ReadOnly) catch { _ => return "" }
   defer file.close()
+  // The first line is the session header; the prompt scan starts after it.
+  let _ = file.read_until("\n") catch { _ => return "" }
   for _ in 0..<first_prompt_scan_limit {
     let next = file.read_until("\n") catch { _ => return "" }
     guard next is Some(line) else { break }
@@ -666,19 +447,12 @@ pub async fn SessionStore::listings(
   let stamped : Array[(SessionListing, Int64, Int)] = []
   let unreadable : Array[SessionListing] = []
   for id in self.list() {
-    let log_path = self.event_log_path(id) catch { _ => continue }
-    let stamp = @fs.mtime(log_path) catch {
-      _ =>
-        @fs.mtime(self.header_path(id) catch { _ => continue }) catch {
-          _ => {
-            unreadable.push({
-              id,
-              last_active_unix_seconds: None,
-              first_prompt: "",
-            })
-            continue
-          }
-        }
+    let path = self.session_file_path(id) catch { _ => continue }
+    let stamp = @fs.mtime(path) catch {
+      _ => {
+        unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
+        continue
+      }
     }
     let (seconds, nanoseconds) = stamp
     stamped.push(
@@ -686,7 +460,7 @@ pub async fn SessionStore::listings(
         {
           id,
           last_active_unix_seconds: Some(seconds),
-          first_prompt: first_prompt_in_log(log_path),
+          first_prompt: first_prompt_in_log(path),
         },
         seconds,
         nanoseconds,
@@ -706,24 +480,18 @@ pub async fn SessionStore::listings(
 /// The most recently active session id that can actually be resumed, or
 /// `None` for an empty store.
 ///
-/// Recency is the event log's modification time: the header is written once
-/// at creation while the log is touched on every append, so its mtime tracks
-/// the last turn of actual conversation. A session directory whose log is
-/// missing falls back to its header's mtime (created but never appended to).
-///
-/// Candidates are probed newest-first with a real `load`: a directory can
-/// stat fine yet hold a torn session (a crash between log append and header
-/// write), and resuming demands a loadable conversation — one broken
-/// directory must not make every older, valid session unresumable. In the
-/// common case the newest candidate loads and the probe costs one load.
+/// Recency is the session file's modification time, which the single-file
+/// layout touches on every append. Candidates are probed newest-first with a
+/// real `load`: a directory can stat fine yet hold a corrupt file, and
+/// resuming demands a loadable conversation — one broken directory must not
+/// make every older, valid session unresumable. In the common case the newest
+/// candidate loads and the probe costs one load.
 pub async fn SessionStore::latest(
   self : SessionStore,
 ) -> @agent_session.SessionId? {
   let stamped : Array[(@agent_session.SessionId, Int64, Int)] = []
   for id in self.list() {
-    let stamp = @fs.mtime(self.event_log_path(id)) catch {
-      _ => @fs.mtime(self.header_path(id)) catch { _ => continue }
-    }
+    let stamp = @fs.mtime(self.session_file_path(id)) catch { _ => continue }
     let (seconds, nanoseconds) = stamp
     stamped.push((id, seconds, nanoseconds))
   }
@@ -740,12 +508,11 @@ pub async fn SessionStore::latest(
 ///|
 /// Persist a complete session snapshot, replacing prior contents for its id.
 ///
-/// `create` ensures the session directory exists, takes an exclusive lock,
-/// rewrites `session.json` and `events.jsonl`, and leaves a header fingerprint
-/// that allows normal append-ahead recovery. Use it for new sessions, fixtures,
-/// import tools, or deliberate full rewrites. Do not use it for ordinary agent
-/// progress; `append` preserves stale-snapshot detection and writes only one
-/// new event.
+/// `create` ensures the session directory exists, takes an exclusive lock, and
+/// atomically rewrites `openseek_session.jsonl` (write to a temp file, then
+/// rename). Use it for new sessions, fixtures, import tools, or deliberate
+/// full rewrites. Do not use it for ordinary agent progress; `append`
+/// preserves stale-snapshot detection and writes only one new event.
 ///
 /// The call raises on invalid ids, filesystem errors, JSON encoding/write
 /// failures, or lock failures.
@@ -755,10 +522,10 @@ pub async fn SessionStore::create(
 ) -> Unit {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
-    // Exact header-first rewrites fail closed on stale old-log tails.
-    write_header(self, session, false)
-    write_event_log(self, session)
-    write_header(self, session, true)
+    write_text_atomic(
+      self.session_file_path(session.id()),
+      session_file_text(session),
+    )
   })
 }
 
@@ -766,22 +533,22 @@ pub async fn SessionStore::create(
 /// Load one persisted session selected by `id`.
 ///
 /// A `SessionStore` is a directory-backed collection, not a handle to one
-/// current session. For a store rooted at `root`, the id selects the files under
-/// `root/sessions/<id>/`: `session.json`, `events.jsonl`, and `session.lock`.
+/// current session. For a store rooted at `root`, the id selects the files
+/// under `root/sessions/<id>/`: `openseek_session.jsonl` and `session.lock`.
 ///
 /// `load` validates the id before constructing paths, takes a shared lock when
-/// the session directory already exists, reads `session.json`, checks that the
-/// header id is exactly the requested id, parses and replays every event in
-/// `events.jsonl`, checks that event sequence numbers are contiguous, and
-/// validates the header/log fingerprint. The returned value is a rebuilt
-/// immutable `Session`.
+/// the session directory already exists, reads `openseek_session.jsonl`,
+/// checks that the header line's id is exactly the requested id, parses and
+/// replays every event line, and checks that event sequence numbers are
+/// contiguous. The returned value is a rebuilt immutable `Session`.
 ///
 /// `load` never chooses a session implicitly and never mutates the store. Use
 /// `list` or `listings` when presenting choices, or `latest` when implementing
-/// "resume the newest loadable session", then pass the chosen id to `load`.
+/// "resume the newest session", then pass the chosen id to `load`.
 ///
-/// The call raises if the id is invalid, the files cannot be read, the JSON is
-/// invalid, or the header and event log do not describe one consistent session.
+/// The call raises if the id is invalid, the file cannot be read (including a
+/// missing file), the header line is absent or malformed, or any event line is
+/// invalid.
 pub async fn SessionStore::load(
   self : SessionStore,
   id : @agent_session.SessionId,
@@ -796,14 +563,15 @@ pub async fn SessionStore::load(
 ///
 /// The input `session` is the caller's current in-memory snapshot. `append`
 /// ensures the directory exists, takes an exclusive lock, loads the durable
-/// snapshot, and verifies that the durable system prompt and event log match the
-/// supplied snapshot. If another writer has already changed the session, this
-/// raises a stale-snapshot error instead of forking the log.
+/// snapshot, and verifies that it matches the supplied snapshot. If another
+/// writer has already changed the session, this raises a stale-snapshot error
+/// instead of forking the log.
 ///
 /// On success the item is assigned the next sequence number and the current
-/// wall-clock timestamp, one JSONL line is appended to `events.jsonl`, the
-/// header is rewritten with the new last sequence and fingerprint, and the new
-/// immutable `Session` is returned. The input session is unchanged.
+/// wall-clock timestamp, one JSONL line is appended to
+/// `openseek_session.jsonl`, and the new immutable `Session` is returned. The
+/// first append for a session id creates the file, writing the header line and
+/// the first event together. The input session is unchanged.
 pub async fn SessionStore::append(
   self : SessionStore,
   session : @agent_session.Session,
@@ -816,8 +584,7 @@ pub async fn SessionStore::append(
       item,
       unix_ms=@env.now().reinterpret_as_int64(),
     )
-    append_event(self, next, event)
-    write_header(self, next, true)
+    append_durable_event(self, next, event)
     next
   })
 }
@@ -830,7 +597,7 @@ pub async fn SessionStore::append(
 /// `from_sequence` must be positive, `to_sequence` must be at least
 /// `from_sequence`, and the range must already exist in the supplied session.
 ///
-/// The covered raw events remain in `events.jsonl`; only
+/// The covered raw events remain in `openseek_session.jsonl`; only
 /// `Session::chat_messages` applies the compaction by skipping covered earlier
 /// events and emitting the summary. On success, the returned session includes
 /// the new `Summary` event with a wall-clock timestamp.
@@ -854,8 +621,7 @@ pub async fn SessionStore::compact(
       Some(event) => event
       None => fail("compacted session did not append a summary event")
     }
-    append_event(self, next, event)
-    write_header(self, next, true)
+    append_durable_event(self, next, event)
     next
   })
 }

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -5,34 +5,12 @@ async fn new_store() -> @store.SessionStore {
 }
 
 ///|
-fn session_events_jsonl(session : @agent_session.Session) -> String {
-  let builder = StringBuilder()
-  for event in session.events() {
-    builder <+ "\{event.to_json().stringify()}\n"
-  }
-  builder.to_string()
+fn session_file(store : @store.SessionStore, id : String) -> String {
+  "\{store.root()}/sessions/\{id}/openseek_session.jsonl"
 }
 
 ///|
-fn session_header_jsonl(
-  session : @agent_session.Session,
-  allow_event_log_ahead? : Bool = true,
-) -> String {
-  let events_text = session_events_jsonl(session)
-  let header : Json = {
-    "version": 1,
-    "id": session.id(),
-    "system_prompt": session.system_prompt(),
-    "last_sequence": session.last_sequence(),
-    "event_log_length": events_text.length(),
-    "event_log_hash": Hash::hash(events_text[:]),
-    "allow_event_log_ahead": allow_event_log_ahead,
-  }
-  header.stringify()
-}
-
-///|
-async test "store creates and loads a session from header and event log" {
+async test "store creates and loads a session from one session file" {
   let store = new_store()
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("hello")))
@@ -44,6 +22,20 @@ async test "store creates and loads a session from header and event log" {
   assert_eq(loaded.system_prompt(), "system")
   assert_eq(loaded.events().length(), 2)
   assert_eq(loaded.last_sequence(), 2)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store writes the header record on the first line" {
+  let store = new_store()
+  store.create(Session(SessionId("s1"), system_prompt="system"))
+  let text = @fs.read_file(session_file(store, "s1")).text()
+  assert_eq(
+    text, "{\"version\":1,\"id\":\"s1\",\"system_prompt\":\"system\"}\n",
+  )
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.events().length(), 0)
+  assert_eq(loaded.system_prompt(), "system")
   @fs.rmdir(store.root(), recursive=true)
 }
 
@@ -141,8 +133,8 @@ async test "listings order by recency and keep husk directories visible" {
   store.create(older.append(User(UserMessage("  first\n prompt  here "))))
   @async.sleep(50)
   store.create(Session(SessionId("newer"), system_prompt="system"))
-  // A directory with neither header nor event log — e.g. an interrupted
-  // creation — has no stamp to order by but must stay discoverable.
+  // A directory with no session file — e.g. an interrupted creation or an
+  // incompatible layout — has no stamp to order by but must stay discoverable.
   @fs.mkdir("\{store.root()}/sessions/husk", recursive=true)
   let listings = store.listings()
   assert_eq(listings.length(), 3)
@@ -158,14 +150,17 @@ async test "listings order by recency and keep husk directories visible" {
 }
 
 ///|
-async test "latest skips a torn newest session in favor of a loadable one" {
+async test "latest skips a corrupt newest session in favor of a loadable one" {
   let store = new_store()
   store.create(Session(SessionId("valid"), system_prompt="system"))
   @async.sleep(50)
-  store.create(Session(SessionId("torn"), system_prompt="system"))
-  // Simulate a crash between the event-log write and the header write: the
-  // newest directory stats fine but cannot be loaded.
-  @fs.remove("\{store.root()}/sessions/torn/session.json")
+  store.create(Session(SessionId("corrupt"), system_prompt="system"))
+  // The newest directory stats fine but cannot be loaded.
+  @fs.write_file(
+    session_file(store, "corrupt"),
+    "not a header line\n",
+    create_mode=CreateOrTruncate,
+  )
   guard store.latest() is Some(id) else { fail("expected a latest session") }
   assert_eq(id.value(), "valid")
   @fs.rmdir(store.root(), recursive=true)
@@ -209,6 +204,64 @@ async test "store appends one event without rewriting the in-memory caller value
   // The store stamps each appended event with the wall clock, and the stamp
   // survives a reload.
   assert_true(loaded.events()[0].unix_ms() > 0)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "first append creates the session file with its header" {
+  let store = new_store()
+  // No create(): the CLI resumes-or-starts sessions whose first durable write
+  // is an append. The header line and the first event must land together.
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let next = store.append(session, User(UserMessage("first")))
+  assert_eq(next.events().length(), 1)
+  let text = @fs.read_file(session_file(store, "s1")).text()
+  assert_true(
+    text.has_prefix(
+      "{\"version\":1,\"id\":\"s1\",\"system_prompt\":\"system\"}\n",
+    ),
+  )
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.system_prompt(), "system")
+  assert_eq(loaded.events().length(), 1)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "store serializes concurrent first appends from empty snapshots" {
+  let store = new_store()
+  // Two writers race to be the first durable write for the same id. The
+  // exclusive lock serializes them; the loser sees the winner's file and gets
+  // a stale-snapshot error instead of clobbering the first event.
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let results : Array[String] = []
+  @async.with_task_group() <| group => {
+    group.spawn_bg() <| () => {
+      try store.append(session, User(UserMessage("first"))) catch {
+        error => {
+          assert_true("\{error}".contains("stale session snapshot"))
+          results.push("stale")
+        }
+      } noraise {
+        _ => results.push("ok")
+      }
+    }
+    group.spawn_bg() <| () => {
+      try store.append(session, Runtime(RuntimeNotice("second"))) catch {
+        error => {
+          assert_true("\{error}".contains("stale session snapshot"))
+          results.push("stale")
+        }
+      } noraise {
+        _ => results.push("ok")
+      }
+    }
+  }
+  assert_eq(results.filter(r => r == "ok").length(), 1)
+  assert_eq(results.filter(r => r == "stale").length(), 1)
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.events().length(), 1)
+  assert_eq(loaded.last_sequence(), 1)
   @fs.rmdir(store.root(), recursive=true)
 }
 
@@ -258,54 +311,22 @@ async test "store rejects divergent snapshots with the same sequence" {
 }
 
 ///|
-async test "store rejects mixed header and event log from interrupted rewrites" {
+async test "store rejects non-empty snapshots when the session file is missing" {
   let store = new_store()
-  let original = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
-    User(UserMessage("old")),
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("hello")),
   )
-  let rewrite = @agent_session.Session(
-    SessionId("s1"),
-    system_prompt="rewritten system",
-  ).append(User(UserMessage("new")))
-  store.create(original)
-  @fs.write_file(
-    "\{store.root()}/sessions/s1/session.json",
-    session_header_jsonl(rewrite),
-    create_mode=CreateOrTruncate,
-  )
-  let _ = store.load(SessionId("s1")) catch {
+  store.create(session)
+  @fs.remove(session_file(store, "s1"))
+  let _ = store.append(session, Runtime(RuntimeNotice("more"))) catch {
     error => {
-      assert_true("\{error}".contains("fingerprint mismatch"))
+      assert_true("\{error}".contains("stale session snapshot"))
       @fs.rmdir(store.root(), recursive=true)
       return
     }
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("mixed rewrite header and event log was accepted")
-}
-
-///|
-async test "store rejects stale tails after interrupted prefix rewrites" {
-  let store = new_store()
-  let original = @agent_session.Session(SessionId("s1"), system_prompt="system")
-    .append(User(UserMessage("first")))
-    .append(Runtime(RuntimeNotice("stale tail")))
-  let rewrite = @agent_session.Session(SessionId("s1"), system_prompt="system")
-  store.create(original)
-  @fs.write_file(
-    "\{store.root()}/sessions/s1/session.json",
-    session_header_jsonl(rewrite, allow_event_log_ahead=false),
-    create_mode=CreateOrTruncate,
-  )
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
-      assert_true("\{error}".contains("stale tail after replacement"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
-  }
-  @fs.rmdir(store.root(), recursive=true)
-  fail("stale tail from interrupted prefix rewrite was accepted")
+  fail("append onto a missing session file was accepted")
 }
 
 ///|
@@ -380,63 +401,10 @@ async test "store rejects stale snapshots before compacting" {
 }
 
 ///|
-async test "store loads when the append-only log is ahead of the header" {
-  let store = new_store()
-  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
-  let (_, event) = session.append_event(User(UserMessage("first")))
-  store.create(session)
-  @fs.write_file(
-    "\{store.root()}/sessions/s1/events.jsonl",
-    "\{event.to_json().stringify()}\n",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
-  let loaded = store.load(SessionId("s1"))
-  assert_eq(loaded.system_prompt(), "system")
-  assert_eq(loaded.events().length(), 1)
-  assert_eq(loaded.last_sequence(), 1)
-  @fs.rmdir(store.root(), recursive=true)
-}
-
-///|
-async test "store loads an empty session when the event log is missing" {
+async test "store fails load when the session file is missing" {
   let store = new_store()
   store.create(Session(SessionId("s1"), system_prompt="system"))
-  @fs.remove("\{store.root()}/sessions/s1/events.jsonl")
-  let loaded = store.load(SessionId("s1"))
-  assert_eq(loaded.events().length(), 0)
-  @fs.rmdir(store.root(), recursive=true)
-}
-
-///|
-async test "store rejects missing event logs for non-empty sessions" {
-  let store = new_store()
-  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
-    User(UserMessage("hello")),
-  )
-  store.create(session)
-  @fs.remove("\{store.root()}/sessions/s1/events.jsonl")
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
-      assert_true("\{error}".contains("fingerprint mismatch"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
-  }
-  @fs.rmdir(store.root(), recursive=true)
-  fail("missing non-empty event log was accepted")
-}
-
-///|
-async test "store propagates unreadable event logs instead of dropping history" {
-  let store = new_store()
-  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
-    User(UserMessage("hello")),
-  )
-  store.create(session)
-  let event_log = "\{store.root()}/sessions/s1/events.jsonl"
-  @fs.remove(event_log)
-  @fs.mkdir(event_log)
+  @fs.remove(session_file(store, "s1"))
   let _ = store.load(SessionId("s1")) catch {
     error => {
       assert_true("\{error}" != "")
@@ -445,7 +413,119 @@ async test "store propagates unreadable event logs instead of dropping history" 
     }
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("unreadable event log was silently accepted")
+  fail("missing session file was accepted")
+}
+
+///|
+async test "store rejects a session file without a header record" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let (_, event) = session.append_event(User(UserMessage("first")))
+  @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
+  // A bare event log — the pre-header layout, or a file whose header line was
+  // lost — must fail loudly rather than load with a fabricated identity.
+  @fs.write_file(
+    session_file(store, "s1"),
+    "\{event.to_json().stringify()}\n",
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}".contains("does not start with a header record"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("header-less session file was accepted")
+}
+
+///|
+async test "store rejects a malformed header line" {
+  let store = new_store()
+  @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
+  @fs.write_file(
+    session_file(store, "s1"),
+    "not json at all\n",
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}".contains("does not start with a header line"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("malformed header line was accepted")
+}
+
+///|
+async test "store rejects a header whose id does not match the directory" {
+  let store = new_store()
+  store.create(Session(SessionId("other"), system_prompt="system"))
+  @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
+  @fs.write_file(
+    session_file(store, "s1"),
+    @fs.read_file(session_file(store, "other")).text(),
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}".contains("session header id mismatch"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("mismatched header id was accepted")
+}
+
+///|
+async test "store fails load on a torn trailing event line" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("first")),
+  )
+  store.create(session)
+  // A crash mid-append leaves a half-written last line; load is strict and
+  // refuses to silently drop it.
+  @fs.write_file(
+    session_file(store, "s1"),
+    "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}" != "")
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("torn trailing line was accepted")
+}
+
+///|
+async test "store propagates unreadable session files instead of dropping history" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("hello")),
+  )
+  store.create(session)
+  let path = session_file(store, "s1")
+  @fs.remove(path)
+  @fs.mkdir(path)
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}" != "")
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("unreadable session file was silently accepted")
 }
 
 ///|

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -85,7 +85,7 @@ directory whose session files cannot be stat-ed (such husks sort last, like the
 human-readable listing).
 
 `sessions compact <id> --file <f> --from <n> --to <n>` appends a typed summary
-event. It does not delete raw events from `events.jsonl`;
+event. It does not delete raw events from the session file;
 `agent_session.Session::chat_messages` uses the summary to compact model context
 on replay.
 

--- a/cmd/openseek/concurrent_wbtest.mbt
+++ b/cmd/openseek/concurrent_wbtest.mbt
@@ -151,7 +151,7 @@ async test "copy_tree keeps files, .git dir, skills; skips build and sessions" {
       create_mode=CreateOrTruncate,
     )
     @fs.write_file(
-      "\{src}/.openseek/sessions/old/events.jsonl",
+      "\{src}/.openseek/sessions/old/openseek_session.jsonl",
       "{}",
       create_mode=CreateOrTruncate,
     )

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -812,9 +812,7 @@ async fn session_listing_updated_at_ms(
   listing : @store.SessionListing,
 ) -> Int64? {
   let id = listing.id()
-  let stamp = @fs.mtime(store.event_log_file(id)) catch {
-    _ => @fs.mtime(store.header_file(id)) catch { _ => return None }
-  }
+  let stamp = @fs.mtime(store.session_file(id)) catch { _ => return None }
   let (seconds, nanoseconds) = stamp
   Some(mtime_to_unix_millis(seconds, nanoseconds))
 }

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -16,9 +16,9 @@ struct SessionRow {
 
 ///|
 /// The whole viewer state. The current session is kept as the parsed log plus a
-/// system prompt fetched from `session.json`; the typed `Session` and its model
-/// projection are rebuilt in `view` so the two view modes always agree with the
-/// bytes on disk.
+/// system prompt lifted from the session file's header line; the typed
+/// `Session` and its model projection are rebuilt in `view` so the two view
+/// modes always agree with the bytes on disk.
 struct Model {
   sessions : Array[SessionRow]
   selected : String?
@@ -745,9 +745,9 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
 ///|
 fn header_strip(model : Model, id : String, root_label : String?) -> @html.Html {
   let prompt_note = if model.header_present {
-    "session.json loaded"
+    "session header loaded"
   } else {
-    "no session.json (events only)"
+    "no session header (events only)"
   }
   let root_note = match root_label {
     Some(root) => " · \{root}"
@@ -1124,9 +1124,10 @@ fn session_row_of(json : Json) -> SessionRow? {
 }
 
 ///|
-/// Decode the `/api/sessions/<id>` envelope into a `LoadOutcome`. `header` is
-/// the parsed `session.json` (or null); its `system_prompt` is lifted out when
-/// present so the viewer can label the header strip and seed the model view.
+/// Decode the `/api/sessions/<id>` envelope into a `LoadOutcome`. `events` is
+/// the raw session-file text; the header record on its first line carries the
+/// system prompt, lifted out so the viewer can label the header strip and seed
+/// the model view.
 fn parse_load(text : String) -> LoadOutcome {
   let json = @json.parse(text) catch { _ => return Malformed }
   guard json is Object(fields) else { return Malformed }
@@ -1143,16 +1144,9 @@ fn parse_load(text : String) -> LoadOutcome {
     _ => return Malformed
   }
   let parsed = @viz.parse_events(events_text)
-  let (system_prompt, header_present) = match fields.get("header") {
-    Some(Object(header)) =>
-      (
-        match header.get("system_prompt") {
-          Some(String(prompt)) => prompt
-          _ => ""
-        },
-        true,
-      )
-    _ => ("", false)
+  let (system_prompt, header_present) = match parsed.header {
+    Some(header) => (header.system_prompt, true)
+    None => ("", false)
   }
   let log_bytes = match fields.get("events_bytes") {
     Some(Number(value, ..)) => value.to_int64()

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -1,7 +1,7 @@
 ///|
-test "parse_load reads a found envelope with header" {
+test "parse_load lifts the system prompt from the header line" {
   let text =
-    #|{"found":true,"events":"{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","events_bytes":77,"header":{"version":1,"system_prompt":"SYS"}}
+    #|{"found":true,"events":"{\"version\":1,\"id\":\"demo\",\"system_prompt\":\"SYS\"}\n{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","events_bytes":77}
   match parse_load(text) {
     Loaded(parsed, system_prompt, header_present, log_bytes) => {
       inspect(parsed.events.length(), content="1")
@@ -14,9 +14,9 @@ test "parse_load reads a found envelope with header" {
 }
 
 ///|
-test "parse_load treats a null header as events-only" {
+test "parse_load treats a header-less file as events-only" {
   let text =
-    #|{"found":true,"events":"","header":null}
+    #|{"found":true,"events":""}
   match parse_load(text) {
     Loaded(_, system_prompt, header_present, log_bytes) => {
       inspect(system_prompt, content="")
@@ -30,6 +30,7 @@ test "parse_load treats a null header as events-only" {
 ///|
 fn parsed_log(session : @agent_session.Session) -> @session_log.ParsedLog {
   {
+    header: None,
     events: [
       for event in session.events() => event
     ],
@@ -41,7 +42,7 @@ fn parsed_log(session : @agent_session.Session) -> @session_log.ParsedLog {
 ///|
 test "session metadata counts steps and total runtime" {
   let text =
-    #|{"found":true,"events":"{\"sequence\":1,\"ts\":100000,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":101500,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"\",\"tool_calls\":[]}}}\n{\"sequence\":3,\"ts\":170300,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n","events_bytes":307,"header":null}
+    #|{"found":true,"events":"{\"sequence\":1,\"ts\":100000,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":101500,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"\",\"tool_calls\":[]}}}\n{\"sequence\":3,\"ts\":170300,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n","events_bytes":307}
   match parse_load(text) {
     Loaded(parsed, _, _, log_bytes) => {
       inspect(format_log_size(log_bytes), content="307 B")

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -1,13 +1,12 @@
 ///|
-/// Read-only web server for the events.jsonl visualizer. Serves the static
+/// Read-only web server for the session-file visualizer. Serves the static
 /// frontend bundle plus a tiny JSON/raw-file API over a `SessionStore`:
 ///
 /// - `GET /`                                  → the viewer shell (web/index.html)
 /// - `GET /viz_app.js`                        → the compiled frontend bundle
 /// - `GET /api/sessions`                      → JSON listing across known roots
-/// - `GET /api/sessions/<key>`                → `{found, events, header}` envelope
-/// - `GET /api/sessions/<key>/events.jsonl`   → raw append-only event log
-/// - `GET /api/sessions/<key>/session.json`   → raw header (404 when absent)
+/// - `GET /api/sessions/<key>`                → `{found, events, events_bytes}` envelope
+/// - `GET /api/sessions/<key>/openseek_session.jsonl` → raw session file (header line + events)
 ///
 /// It never writes to the stores, so pointing it at live session roots is safe.
 async fn main {
@@ -202,13 +201,11 @@ async fn session_path_reply(catalog : SessionCatalog, rest : String) -> Reply {
   let id = @agent_session.SessionId(id_value)
   match file {
     None => session_envelope_reply(root.store, id)
-    Some("events.jsonl") =>
+    Some("openseek_session.jsonl") =>
       asset_reply(
-        root.store.event_log_file(id),
+        root.store.session_file(id),
         "application/x-ndjson; charset=utf-8",
       )
-    Some("session.json") =>
-      asset_reply(root.store.header_file(id), "application/json; charset=utf-8")
     Some(other) =>
       text_reply(404, "Not Found", "no such session file: \{other}")
   }
@@ -227,45 +224,25 @@ fn valid_session_id(value : String) -> Bool {
 
 ///|
 /// Serve one session as a single JSON envelope:
-/// `{ "found": Bool, "events": String, "events_bytes": Number, "header": Json|null }`.
+/// `{ "found": Bool, "events": String, "events_bytes": Number }`.
 ///
 /// The frontend's HTTP client (`rabbita/http`) resolves any completed response
 /// as success regardless of status code, so absence and content must be encoded
-/// in the body rather than signalled by 404. `events` is the raw `events.jsonl`
-/// text; `header` is the parsed `session.json` or `null` when it is absent.
+/// in the body rather than signalled by 404. `events` is the raw session-file
+/// text — the header line followed by event lines — which the frontend parser
+/// splits apart itself.
 async fn session_envelope_reply(
   store : @store.SessionStore,
   id : @agent_session.SessionId,
 ) -> Reply {
-  let events_path = store.event_log_file(id)
-  let header_path = store.header_file(id)
-  let events_exists = @fs.exists(events_path)
-  let header_exists = @fs.exists(header_path)
-  // A session with only a header (e.g. a crash between the first header write
-  // and the empty-log write) is still loadable — `SessionStore::load` treats a
-  // missing log as empty — and `listings()` can surface it, so treat either
-  // file existing as found rather than reporting a listed session as missing.
-  if !events_exists && !header_exists {
+  let path = store.session_file(id)
+  if !@fs.exists(path) {
     return json_reply({ "found": false })
-  }
-  let events_text = if events_exists {
-    read_text_lossy(events_path)
-  } else {
-    ""
-  }
-  let events_bytes = if events_exists { file_size(events_path) } else { 0L }
-  let header : Json = if header_exists {
-    @json.parse(read_text_lossy(header_path)) catch {
-      _ => Json::null()
-    }
-  } else {
-    Json::null()
   }
   json_reply({
     "found": true,
-    "events": events_text,
-    "events_bytes": Json::number(events_bytes.to_double()),
-    "header": header,
+    "events": read_text_lossy(path),
+    "events_bytes": Json::number(file_size(path).to_double()),
   })
 }
 
@@ -650,7 +627,7 @@ async fn asset_reply(path : String, content_type : String) -> Reply {
 
 ///|
 /// Read a file as text, decoding invalid UTF-8 lossily rather than raising. A
-/// live `events.jsonl` can be torn mid-codepoint by a concurrent append; strict
+/// live session file can be torn mid-codepoint by a concurrent append; strict
 /// decoding would 500 the whole fetch, hiding the valid prefix. Lossy decoding
 /// keeps that prefix, and the torn final line then fails to parse client-side
 /// and is reported as a benign truncated tail.
@@ -739,7 +716,7 @@ fn hex_val(c : Char) -> Int? {
 fn cli_command() -> @argparse.Command {
   Command(
     "openseek-viz",
-    about="Read-only web server for the OpenSeek events.jsonl visualizer.",
+    about="Read-only web server for the OpenSeek session visualizer.",
     options=[
       OptionArg(
         "port",

--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -1,7 +1,7 @@
 # Prompt Task Eval
 
 This harness runs a MoonBit prompt task through the real OpenSeek agent with
-isolated workspaces, per-trial raw logs, durable session `events.jsonl` logs,
+isolated workspaces, per-trial raw logs, durable `openseek_session.jsonl` session files,
 and bounded parallelism. Reporting is a separate analyzer pass, so reports can
 be regenerated without rerunning model/API trials.
 

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -425,7 +425,7 @@ async fn resolve_events_path(trial : TrialArtifact) -> String {
     trial.workspace +
     "/.openseek/sessions/" +
     trial.session_id +
-    "/events.jsonl"
+    "/openseek_session.jsonl"
   }
 }
 

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -219,7 +219,7 @@ test "same output dir preserves absolute workspace paths" {
         workspace="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01",
         log_path=".moonagent/eval_runs/default/logs/01.log",
         session_id="trial-01",
-        events_path="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01/.openseek/sessions/trial-01/events.jsonl",
+        events_path="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl",
         exit_code=0,
       ),
     ],
@@ -240,9 +240,9 @@ async test "analyze run writes reports to caller output directory" {
     let stale_dir = root + "/stale"
     @fs.mkdir(out_dir, recursive=true)
     let actual_events_path = out_dir +
-      "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
+      "/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl"
     let stale_events_path = stale_dir +
-      "/workspaces/01/.openseek/sessions/trial-01/events.jsonl"
+      "/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl"
     @fs.mkdir(
       out_dir + "/workspaces/01/.openseek/sessions/trial-01",
       recursive=true,

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Run the prompt task `config.runs` times, `config.concurrency` at a time,
 /// writing only durable artifacts: workspaces, raw process logs, recorded
-/// session `events.jsonl` files, and a run manifest. No validation or report
+/// session `openseek_session.jsonl` files, and a run manifest. No validation or report
 /// analysis is performed in this phase.
 pub async fn run_experiments(config : Config) -> RunManifest {
   if config.api_key == "" {
@@ -114,7 +114,7 @@ async fn run_trial(
   let events_path = discover_session_events(
     real_workspace,
     session_id,
-    fallback="\{real_workspace}/.openseek/sessions/\{session_id}/events.jsonl",
+    fallback="\{real_workspace}/.openseek/sessions/\{session_id}/openseek_session.jsonl",
   )
   TrialArtifact(
     index=index + 1,
@@ -170,7 +170,7 @@ async fn collect_session_events(
     let path = "\{dir}/\{name}"
     if is_directory(path) {
       collect_session_events(path, session_id, matches)
-    } else if name == "events.jsonl" &&
+    } else if name == "openseek_session.jsonl" &&
       path.contains("/sessions/\{session_id}/") {
       matches.push(path)
     }

--- a/eval/prompt_task/harness/manifest_wbtest.mbt
+++ b/eval/prompt_task/harness/manifest_wbtest.mbt
@@ -24,7 +24,7 @@ async test "manifest round trips run artifacts" {
           log_path: root + "/logs/01.log",
           session_id: "trial-01",
           events_path: root +
-          "/workspaces/01/.openseek/sessions/trial-01/events.jsonl",
+          "/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl",
           exit_code: 0,
         },
       ],

--- a/eval/prompt_task/harness/suite_wbtest.mbt
+++ b/eval/prompt_task/harness/suite_wbtest.mbt
@@ -178,7 +178,7 @@ fn eval_result_for_suite_test(index : Int, success : Bool) -> EvalResult {
     padded_index(index) +
     "/.openseek/sessions/trial-" +
     padded_index(index) +
-    "/events.jsonl",
+    "/openseek_session.jsonl",
     exit_code: 0,
     steps: index * 2,
     tool_results: index,

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -210,8 +210,8 @@ both `sessions show` calls strip `ts` to stay deterministic.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > mkdir -p "$tmp/sessions/demo"
-> printf '{"version":1,"id":"demo","system_prompt":"system","last_sequence":2}' > "$tmp/sessions/demo/session.json"
-> cat > "$tmp/sessions/demo/events.jsonl" <<'JSONL'
+> cat > "$tmp/sessions/demo/openseek_session.jsonl" <<'JSONL'
+> {"version":1,"id":"demo","system_prompt":"system"}
 > {"sequence":1,"ts":0,"item":{"kind":"user","payload":{"content":"hello"}}}
 > {"sequence":2,"ts":0,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
 > JSONL

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -1,7 +1,7 @@
 # OpenSeek session visualizer
 
 A browser viewer for OpenSeek's durable session logs. It renders the
-`events.jsonl` append-only log of a session two ways, side by side behind a
+`openseek_session.jsonl` file of a session (a header line plus append-only event lines) two ways, side by side behind a
 toggle:
 
 - **Raw log** — every event in file order, grouped into turns (user prompt →
@@ -17,7 +17,7 @@ System follows the OS via `prefers-color-scheme`).
 
 | Package          | Target | Role                                                                 |
 |------------------|--------|---------------------------------------------------------------------|
-| `viz`            | js     | Pure parse + render: `events.jsonl` text → typed events → `@html.Html`. Reuses `agent_session` decoders and projection, so it stays correct as the format evolves. |
+| `viz`            | js     | Pure parse + render: session-file text → typed events → `@html.Html`. Reuses `agent_session` decoders and projection, so it stays correct as the format evolves. |
 | `cmd/viz_app`    | js     | The rabbita (TEA) frontend: session browser, fetch, mode toggle.    |
 | `cmd/viz_server` | native | Read-only web server (`moonbitlang/async/http`) exposing a JSON/raw-file API over a `SessionStore`. It never writes, so pointing it at a live session root is safe. |
 
@@ -30,9 +30,8 @@ no browser needed in CI.
 - `GET /` → the viewer shell (`web/index.html`)
 - `GET /viz_app.js` → the compiled frontend bundle (auto-located from the moon build output)
 - `GET /api/sessions` → `[{key, id, root, root_label, last_active, first_prompt}, …]`, most recent first across all roots
-- `GET /api/sessions/<key>` → `{found, events, events_bytes, header}` envelope for the frontend
-- `GET /api/sessions/<key>/events.jsonl` → raw append-only log
-- `GET /api/sessions/<key>/session.json` → raw header (404 when absent; the frontend degrades to events-only)
+- `GET /api/sessions/<key>` → `{found, events, events_bytes}` envelope for the frontend (`events` is the raw session-file text; its first line is the header record)
+- `GET /api/sessions/<key>/openseek_session.jsonl` → raw session file
 
 ## Running it
 

--- a/viz/parse.mbt
+++ b/viz/parse.mbt
@@ -1,15 +1,15 @@
 ///|
-/// Parse an `events.jsonl` log into typed `SessionEvent`s, tolerating a
-/// truncated trailing line and per-line decode failures.
+/// Parse a session file (header line plus event lines) into typed
+/// `SessionEvent`s, tolerating a truncated trailing line and per-line decode
+/// failures. A header-less bare event log still parses with `header=None`.
 pub fn parse_events(text : String) -> @session_log.ParsedLog {
   @session_log.parse_events(text)
 }
 
 ///|
 /// Build an immutable `Session` from parsed events plus an optional header.
-/// When the header is absent (no `session.json`), a placeholder id and an empty
-/// system prompt are used so the viewer can still render the event log. The
-/// header's id and system prompt win when present.
+/// When no header record was found on the first line, pass a placeholder id
+/// and an empty system prompt so the viewer can still render the event log.
 pub fn session_from_parse(
   parsed : @session_log.ParsedLog,
   id~ : String,

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1,6 +1,6 @@
 ///|
 /// Build a session that exercises every event kind, then serialize it back to
-/// the on-disk `events.jsonl` form so the parser is tested against exactly what
+/// the on-disk session-file event form so the parser is tested against exactly what
 /// the store writes.
 fn sample_session() -> @agent_session.Session {
   let s0 = @agent_session.Session(


### PR DESCRIPTION
## What

Replaces the two-file session layout (`session.json` header + `events.jsonl` log) with a single `openseek_session.jsonl` per session:

- **Line 1** is a header record `{"version":1,"id":...,"system_prompt":...}` (the system prompt is the only data that lived nowhere but the old header; everything else was derivable or cross-file-consistency machinery).
- **Every following line** is one append-only `SessionEvent`, unchanged.

`session.lock` stays (you cannot flock a file that `create` replaces via rename).

## Why

The old header's fingerprint fields (`event_log_length`/`event_log_hash`/`allow_event_log_ahead`), the header-first triple write in `create`, and the header rewrite on **every append** all existed solely because two files cannot be updated atomically together. With one file the problem disappears rather than moving:

- `append` = one `O_APPEND` write (was: append + full atomic header rewrite)
- `create` = one tmp+rename (was: header, log, header again)
- `load` stays strict: header record required, header id must match the directory, sequences contiguous from 1

The first durable write for a session (the CLI's resume-or-start path appends without `create`) atomically writes header + first event under the exclusive lock, so a session file can never exist without its header.

## Compatibility

Deliberately none: the new file name differs from `events.jsonl` precisely so the new CLI never half-loads old-format session directories — they are simply not loadable (surface as blank "husk" rows in listings).

## Consumers updated

- `agent_session/log`: owns the shared header codec (`SessionFileHeader`, `parse_header`); the tolerant parser lifts the header from the first content line
- `cmd/viz_server`: drops the `session.json` endpoint; envelope is now `{found, events, events_bytes}` with the raw file text; raw route is `/api/sessions/<key>/openseek_session.jsonl`
- `cmd/viz_app`: system prompt comes from the parsed header line
- `cmd/openseek`: listing mtime helper; eval harness path discovery; offline cram docs

## Validation

- `moon check` / `moon build` / `moon build cmd/viz_app --target js` clean
- `moon test`: 887/891 — the 4 failures are the known pre-existing `agent_tool/shell` output-limit timing flakes, proven unrelated (clean `origin/main` fails them identically in the same directory; this diff passes all 106 shell tests in a fresh checkout)
- `moon cram test tests/cram`: 23/23
- `moon info` / `moon fmt` applied
- Design + final diff reviewed by Codex CLI (gpt-5.5, xhigh): no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)