### PR TITLE
fix(agent_session): recover sessions with a torn trailing record

### DIFF
--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -47,7 +47,9 @@ let session = store.compact(
 Use `create` when writing a complete session snapshot. Use `append` for normal
 agent progress. `append` is the safe save path: it checks that the caller's
 in-memory session still matches disk, then appends exactly one timestamped
-event line.
+event line — except when a crash left the file's tail unterminated, in which
+case it rewrites the file atomically, repairing the tail as it persists the
+new event.
 
 `load` takes a `SessionId` because `SessionStore(root)` is a directory-backed
 collection, not a handle to one current session. The id selects
@@ -299,8 +301,13 @@ maintain:
   atomically, so a session file can never exist without its header.
 - `create` rewrites the file atomically (temp file, then rename); an
   interrupted rewrite leaves the previous file intact.
-- Every load checks the header record and contiguous sequence numbers; a torn
-  trailing line fails the load rather than being silently dropped.
+- Every load checks the header record and contiguous sequence numbers.
+- A crash can tear the final append mid-line. `load` tolerates exactly that —
+  an unterminated final record is dropped (or kept when only its newline is
+  missing) so the session stays resumable — while `load` itself never writes.
+  The next `append` or `compact` repairs the file by rewriting it atomically,
+  discarding the uncommitted tail. Corruption anywhere else still fails the
+  load.
 - Every append or compact checks that the caller's session still matches disk.
 
 These rules keep persistence concerns out of `agent_session.Session` while

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -110,18 +110,6 @@ fn session_file_text(session : @agent_session.Session) -> String {
 }
 
 ///|
-fn parse_events_jsonl(
-  text : String,
-) -> @vector.Vector[@agent_session.SessionEvent] raise {
-  let events : Array[@agent_session.SessionEvent] = [
-    for line in text.split("\n") if !line.trim().is_empty() => {
-      @json.from_json(@json.parse(line))
-    }
-  ]
-  @vector.from_array(events)
-}
-
-///|
 fn checked_last_sequence_in_events(
   events : @vector.Vector[@agent_session.SessionEvent],
 ) -> Int raise {
@@ -138,13 +126,34 @@ fn checked_last_sequence_in_events(
 }
 
 ///|
-/// Rebuild a session from the durable single-file form: the first line must be
-/// a header record, every following non-blank line must decode as an event,
-/// and event sequences must be contiguous from 1.
-fn session_from_file_text(
+/// A session rebuilt from durable text, plus whether that text ends in an
+/// unterminated final record — a torn write from a crash mid-append, or a
+/// record missing only its newline. Either way the next durable write must
+/// rewrite the file instead of appending, or the new record would glue onto
+/// the unterminated tail.
+priv struct ParsedSessionFile {
+  session : @agent_session.Session
+  needs_tail_repair : Bool
+}
+
+///|
+/// Rebuild a session from the durable single-file form: the first line must
+/// be a header record, every following non-blank line must decode as an
+/// event, and event sequences must be contiguous from 1.
+///
+/// The only tolerated deviation is an unterminated final record. A crash can
+/// tear the last append mid-line, and refusing to load would make the whole
+/// session unresumable over bytes no writer ever committed. A torn final
+/// record is dropped; a final record that decodes but merely lacks its
+/// newline is kept. Both are reported via `needs_tail_repair` so writers can
+/// rewrite. The rule is uniform: in a zero-event file the header is the final
+/// record, so a decodable header without its newline also loads (and gets
+/// repaired). A bad line *followed by more lines* (or by a final newline) is
+/// interior corruption, not a torn append, and still fails the load.
+fn parse_session_file(
   requested_id : @agent_session.SessionId,
   text : String,
-) -> @agent_session.Session raise {
+) -> ParsedSessionFile raise {
   let (first, rest) = match text.split_once("\n") {
     Some((first, rest)) => (first.to_owned(), rest.to_owned())
     None => (text, "")
@@ -167,56 +176,85 @@ fn session_from_file_text(
       "session header id mismatch: requested \{requested_id.value()}, found \{header.id}",
     )
   }
-  let events = parse_events_jsonl(rest)
+  let ends_with_newline = text.has_suffix("\n")
+  let segments = rest.split("\n").map(line => line.to_owned()).collect()
+  let decoded : Array[@agent_session.SessionEvent] = []
+  for index, line in segments {
+    if line.trim().is_empty() {
+      continue
+    }
+    let unterminated_last = index == segments.length() - 1 && !ends_with_newline
+    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
+      error => if unterminated_last { continue } else { raise error }
+    }
+    decoded.push(event)
+  }
+  let events = @vector.from_array(decoded)
   ignore(checked_last_sequence_in_events(events))
-  Session(SessionId(header.id), system_prompt=header.system_prompt, events~)
+  {
+    session: Session(
+      SessionId(header.id),
+      system_prompt=header.system_prompt,
+      events~,
+    ),
+    needs_tail_repair: !ends_with_newline,
+  }
 }
 
 ///|
-async fn load_persisted_session(
+async fn read_session_file(
   store : SessionStore,
   id : @agent_session.SessionId,
-) -> @agent_session.Session {
-  session_from_file_text(id, @fs.read_file(store.session_file_path(id)).text())
+) -> ParsedSessionFile {
+  parse_session_file(id, @fs.read_file(store.session_file_path(id)).text())
 }
 
 ///|
+/// Verify that `session` still matches the durable state, and report whether
+/// the durable file ends in an unterminated record that the next write must
+/// repair. A missing file is current only for an empty snapshot.
 async fn ensure_session_is_current(
   store : SessionStore,
   session : @agent_session.Session,
-) -> Unit {
-  let persisted = load_persisted_session(store, session.id()) catch {
+) -> Bool {
+  let parsed = read_session_file(store, session.id()) catch {
     @os_error.OSError(_) as error if error.is_ENOENT() => {
       if session.last_sequence() != 0 {
         fail(
           "stale session snapshot for \{session.id().value()}: no durable session file, in-memory last sequence \{session.last_sequence()}",
         )
       }
-      return
+      return false
     }
     error => raise error
   }
+  let persisted = parsed.session
   if persisted.system_prompt() != session.system_prompt() ||
     events_jsonl(persisted.events()) != events_jsonl(session.events()) {
     fail("stale session snapshot for \{session.id().value()}")
   }
+  parsed.needs_tail_repair
 }
 
 ///|
 /// Persist one new event for `session`. The common case is a single
 /// `O_APPEND` write of one line. The first durable write for a session (no
 /// file yet) instead writes the header line and the first event atomically,
-/// so a session file can never exist without its header. Callers hold the
-/// exclusive session lock and have already verified the snapshot is current,
-/// which for the missing-file case means `session` contains exactly the
-/// events being persisted.
-async fn append_durable_event(
+/// so a session file can never exist without its header. When the durable
+/// tail is unterminated (`repair_tail`), appending would glue the new record
+/// onto the torn bytes, so the whole file is rewritten atomically from the
+/// snapshot — which discards the uncommitted tail and includes the new event.
+/// Callers hold the exclusive session lock and have already verified the
+/// snapshot is current, so for the missing-file and repair cases `session`
+/// contains exactly the events being persisted.
+async fn persist_event(
   store : SessionStore,
   session : @agent_session.Session,
   event : @agent_session.SessionEvent,
+  repair_tail~ : Bool,
 ) -> Unit {
   let path = store.session_file_path(session.id())
-  if @fs.exists(path) {
+  if !repair_tail && @fs.exists(path) {
     @fs.write_file(
       path,
       "\{event.to_json().stringify()}\n",
@@ -546,15 +584,21 @@ pub async fn SessionStore::create(
 /// `list` or `listings` when presenting choices, or `latest` when implementing
 /// "resume the newest session", then pass the chosen id to `load`.
 ///
+/// One deviation is tolerated: an unterminated final record — a torn write
+/// from a crash mid-append. The torn bytes are dropped (or kept, when the
+/// record is complete and only its newline is missing) so the session stays
+/// resumable; `load` itself never mutates the file, and the next `append` or
+/// `compact` repairs the tail on disk.
+///
 /// The call raises if the id is invalid, the file cannot be read (including a
-/// missing file), the header line is absent or malformed, or any event line is
-/// invalid.
+/// missing file), the header line is absent or malformed, or any event line
+/// other than an unterminated final record is invalid.
 pub async fn SessionStore::load(
   self : SessionStore,
   id : @agent_session.SessionId,
 ) -> @agent_session.Session {
   with_existing_session_lock(self, id, Shared, () => {
-    load_persisted_session(self, id)
+    read_session_file(self, id).session
   })
 }
 
@@ -571,7 +615,9 @@ pub async fn SessionStore::load(
 /// wall-clock timestamp, one JSONL line is appended to
 /// `openseek_session.jsonl`, and the new immutable `Session` is returned. The
 /// first append for a session id creates the file, writing the header line and
-/// the first event together. The input session is unchanged.
+/// the first event together; and when a crash left the durable tail
+/// unterminated, the append rewrites the file atomically instead, repairing
+/// the tail as it persists the new event. The input session is unchanged.
 pub async fn SessionStore::append(
   self : SessionStore,
   session : @agent_session.Session,
@@ -579,12 +625,12 @@ pub async fn SessionStore::append(
 ) -> @agent_session.Session {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
-    ensure_session_is_current(self, session)
+    let repair_tail = ensure_session_is_current(self, session)
     let (next, event) = session.append_event(
       item,
       unix_ms=@env.now().reinterpret_as_int64(),
     )
-    append_durable_event(self, next, event)
+    persist_event(self, next, event, repair_tail~)
     next
   })
 }
@@ -610,7 +656,7 @@ pub async fn SessionStore::compact(
 ) -> @agent_session.Session {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
-    ensure_session_is_current(self, session)
+    let repair_tail = ensure_session_is_current(self, session)
     let next = session.compact(
       content~,
       from_sequence~,
@@ -621,7 +667,7 @@ pub async fn SessionStore::compact(
       Some(event) => event
       None => fail("compacted session did not append a summary event")
     }
-    append_durable_event(self, next, event)
+    persist_event(self, next, event, repair_tail~)
     next
   })
 }

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -482,29 +482,284 @@ async test "store rejects a header whose id does not match the directory" {
 }
 
 ///|
-async test "store fails load on a torn trailing event line" {
+async test "load drops a torn trailing record without mutating the file" {
   let store = new_store()
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
     User(UserMessage("first")),
   )
   store.create(session)
-  // A crash mid-append leaves a half-written last line; load is strict and
-  // refuses to silently drop it.
+  // A crash mid-append leaves a half-written last line. The uncommitted tail
+  // is dropped so the session stays resumable, and load itself is read-only.
   @fs.write_file(
     session_file(store, "s1"),
     "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
     create_mode=OpenOrCreate,
     append=true,
   )
-  let _ = store.load(SessionId("s1")) catch {
+  let text_before = @fs.read_file(session_file(store, "s1")).text()
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.events().length(), 1)
+  assert_eq(loaded.last_sequence(), 1)
+  assert_eq(@fs.read_file(session_file(store, "s1")).text(), text_before)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "load keeps a complete final record that lost only its newline" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let (_, event) = session.append_event(User(UserMessage("first")))
+  store.create(session)
+  // The append was torn exactly at the newline boundary: the record is whole.
+  @fs.write_file(
+    session_file(store, "s1"),
+    event.to_json().stringify(),
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.events().length(), 1)
+  guard loaded.events()[0].item() is User(message) else {
+    fail("expected the unterminated user event")
+  }
+  assert_eq(message.content(), "first")
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "append repairs a torn tail before persisting the next event" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("first")),
+  )
+  store.create(session)
+  @fs.write_file(
+    session_file(store, "s1"),
+    "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let resumed = store.load(SessionId("s1"))
+  let next = store.append(resumed, Runtime(RuntimeNotice("recovered")))
+  assert_eq(next.events().length(), 2)
+  assert_eq(next.last_sequence(), 2)
+  // The rewrite discarded the torn bytes and terminated every line.
+  let text = @fs.read_file(session_file(store, "s1")).text()
+  assert_true(text.has_suffix("\n"))
+  assert_true(!text.contains("assi"))
+  let reloaded = store.load(SessionId("s1"))
+  assert_eq(reloaded.events().length(), 2)
+  assert_eq(reloaded.last_sequence(), 2)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "append repairs and keeps a complete unterminated final event" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let (_, event) = session.append_event(User(UserMessage("first")))
+  store.create(session)
+  @fs.write_file(
+    session_file(store, "s1"),
+    event.to_json().stringify(),
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let resumed = store.load(SessionId("s1"))
+  assert_eq(resumed.events().length(), 1)
+  let next = store.append(resumed, Runtime(RuntimeNotice("second")))
+  assert_eq(next.last_sequence(), 2)
+  let text = @fs.read_file(session_file(store, "s1")).text()
+  assert_true(text.has_suffix("\n"))
+  let reloaded = store.load(SessionId("s1"))
+  assert_eq(reloaded.events().length(), 2)
+  guard reloaded.events()[0].item() is User(message) else {
+    fail("expected the recovered user event to survive the repair")
+  }
+  assert_eq(message.content(), "first")
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "append rejects a stale snapshot against an unterminated durable event" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  let (_, event) = session.append_event(User(UserMessage("first")))
+  store.create(session)
+  // Another writer committed an event; only its newline is missing. The
+  // pre-commit empty snapshot is stale, and tail repair must not become a
+  // path that discards that writer's data.
+  @fs.write_file(
+    session_file(store, "s1"),
+    event.to_json().stringify(),
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let _ = store.append(session, Runtime(RuntimeNotice("stale"))) catch {
     error => {
-      assert_true("\{error}" != "")
+      assert_true("\{error}".contains("stale session snapshot"))
+      let loaded = store.load(SessionId("s1"))
+      assert_eq(loaded.events().length(), 1)
+      guard loaded.events()[0].item() is User(message) else {
+        fail("expected the durable user event to survive")
+      }
+      assert_eq(message.content(), "first")
       @fs.rmdir(store.root(), recursive=true)
       return
     }
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("torn trailing line was accepted")
+  fail("stale append onto an unterminated durable event was accepted")
+}
+
+///|
+async test "load tolerates unterminated tails in every torn shape" {
+  let store = new_store()
+  // Valid JSON that is not a valid event: torn exactly inside the payload in
+  // a way that still balances braces.
+  store.create(Session(SessionId("json"), system_prompt="system"))
+  @fs.write_file(
+    session_file(store, "json"),
+    "{\"not\":\"an event\"}",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  assert_eq(store.load(SessionId("json")).events().length(), 0)
+  // Whitespace-only unterminated tail.
+  let one_event = @agent_session.Session(
+    SessionId("blank"),
+    system_prompt="system",
+  ).append(User(UserMessage("hello")))
+  store.create(one_event)
+  @fs.write_file(
+    session_file(store, "blank"),
+    "   ",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  assert_eq(store.load(SessionId("blank")).events().length(), 1)
+  // Torn garbage after zero events.
+  store.create(Session(SessionId("zero"), system_prompt="system"))
+  @fs.write_file(
+    session_file(store, "zero"),
+    "{\"seq",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  assert_eq(store.load(SessionId("zero")).events().length(), 0)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "load keeps a header-only file that lost its newline" {
+  let store = new_store()
+  // `create` can never produce this (tmp+rename is atomic), but the tolerance
+  // rule is uniform: in a zero-event file the header is the final record.
+  @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
+  @fs.write_file(
+    session_file(store, "s1"),
+    "{\"version\":1,\"id\":\"s1\",\"system_prompt\":\"system\"}",
+    create_mode=CreateOrTruncate,
+  )
+  let loaded = store.load(SessionId("s1"))
+  assert_eq(loaded.events().length(), 0)
+  assert_eq(loaded.system_prompt(), "system")
+  // The next append terminates the header line as it persists the event.
+  ignore(store.append(loaded, User(UserMessage("first"))))
+  let text = @fs.read_file(session_file(store, "s1")).text()
+  assert_true(text.has_suffix("\n"))
+  assert_eq(store.load(SessionId("s1")).events().length(), 1)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "compact repairs a torn tail before persisting the summary" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("first")))
+    .append(Assistant(AssistantMessage("second")))
+  store.create(session)
+  @fs.write_file(
+    session_file(store, "s1"),
+    "{\"sequence\":3,\"ts\":0,\"item\":{\"kind\":\"runt",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let resumed = store.load(SessionId("s1"))
+  let compacted = store.compact(
+    resumed,
+    content="first two events",
+    from_sequence=1,
+    to_sequence=2,
+  )
+  assert_eq(compacted.events().length(), 3)
+  let text = @fs.read_file(session_file(store, "s1")).text()
+  assert_true(text.has_suffix("\n"))
+  assert_true(!text.contains("runt"))
+  assert_eq(store.load(SessionId("s1")).events().length(), 3)
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "latest can resume a session whose newest write was torn" {
+  let store = new_store()
+  store.create(Session(SessionId("older"), system_prompt="system"))
+  @async.sleep(50)
+  let newest = @agent_session.Session(
+    SessionId("newest"),
+    system_prompt="system",
+  ).append(User(UserMessage("hello")))
+  store.create(newest)
+  @fs.write_file(
+    session_file(store, "newest"),
+    "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  guard store.latest() is Some(id) else { fail("expected a latest session") }
+  assert_eq(id.value(), "newest")
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "load still fails on corruption that is not a torn tail" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    User(UserMessage("first")),
+  )
+  store.create(session)
+  // Terminated garbage is interior-style corruption, not an interrupted
+  // append: something after the bad line committed a newline.
+  @fs.write_file(
+    session_file(store, "s1"),
+    "not an event\n",
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}" != "")
+      // A bad line with valid lines after it fails the same way.
+      let (_, event) = session.append_event(Runtime(RuntimeNotice("later")))
+      @fs.write_file(
+        session_file(store, "s1"),
+        "\{event.to_json().stringify()}\n",
+        create_mode=OpenOrCreate,
+        append=true,
+      )
+      let _ = store.load(SessionId("s1")) catch {
+        error => {
+          assert_true("\{error}" != "")
+          @fs.rmdir(store.root(), recursive=true)
+          return
+        }
+      }
+      @fs.rmdir(store.root(), recursive=true)
+      fail("interior corruption was accepted")
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("terminated garbage line was accepted")
 }
 
 ///|


### PR DESCRIPTION
First of four scoped store-hardening PRs (torn-tail recovery → append-path cost → rename durability → input hardening).

## Problem

A crash mid-append can tear the final line of `openseek_session.jsonl` — one logical event write can span multiple `write` syscalls. `load` was strict, so the whole session became **permanently unresumable** over bytes no writer ever committed, and `latest()` silently skipped it as if the session didn't exist. There was no repair path.

## Fix

`load` now tolerates exactly one deviation: an **unterminated final record** (the file's text doesn't end in a newline).

- Torn/undecodable trailing bytes are dropped; a final record that decodes and lost only its newline is kept.
- The rule is uniform: in a zero-event file the header is the final record, so a decodable unterminated header also loads.
- `load` itself stays read-only. The next `append`/`compact` repairs the file — an `O_APPEND` write would glue the new record onto the torn bytes, so the store rewrites the file atomically (tmp+rename) from the verified snapshot, discarding the uncommitted tail as it persists the new event.
- Everything else stays strict: interior corruption, terminated garbage lines, sequence gaps, missing/malformed header.
- Stale-snapshot detection runs before any repair, so tail repair can never discard another writer's committed data (pinned by test).

## Validation

- 40/40 store tests, incl. new coverage: torn-tail load is read-only; decodable-unterminated event survives repair; stale snapshot vs unterminated durable event; every torn shape (valid-JSON-non-event, whitespace, zero-event, header-only); `latest()` resumes a torn newest session; interior corruption still fails
- Full suite: 894/898 (4 = known env-specific `agent_tool/shell` timing flakes, fail identically on clean main in this checkout)
- Codex CLI review, two passes: first pass found 5 items (header-only edge under-specified, 3 coverage gaps, doc drift) — all addressed; re-review: "Findings: none."

🤖 Generated with [Claude Code](https://claude.com/claude-code)