### PR TITLE
refactor(viz): two-var loop in remove_pending_tool_id

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -814,8 +814,8 @@ fn remove_pending_tool_id(
   pending : Array[String],
   tool_call_id : String,
 ) -> Bool {
-  for index in 0..<pending.length() {
-    if pending[index] == tool_call_id {
+  for index, id in pending {
+    if id == tool_call_id {
       ignore(pending.remove(index))
       return true
     }


### PR DESCRIPTION
Repo-level simplification sweep, round 2 — the one index loop the first sweep left behind.

`remove_pending_tool_id` kept `for index in 0..<pending.length() { … pending[index] … }` while its exact sibling `remove_pending_tool_call` in `agent_session/projection.mbt` was converted to the two-var form by the first sweep. Same conversion here: `for index, id in pending` — the index stays bound for `pending.remove(index)`, and the loop returns immediately after the removal, so mutation-during-iteration is not a concern (identical reasoning to the sibling's sweep PR #296).

## Validation
`viz` is js-only: `moon fmt` clean, `moon check viz --target js` 0 warnings/errors, `moon test viz --target js` 37/37, `moon info` — **no `pkg.generated.mbti` change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)