### PR TITLE
refactor(agent_tool): consolidate duplicated decode helpers into internal/decode_common

### DIFF
--- a/agent_tool/edit/internal/decode/decode.mbt
+++ b/agent_tool/edit/internal/decode/decode.mbt
@@ -37,10 +37,12 @@ fn parse_fields(fields : Map[String, Json]) -> EditInput raise {
   let path = required_string(fields, "path")
   let old_string = required_string(fields, "old_string")
   let new_string = required_string(fields, "new_string")
-  let replace_all = optional_bool(fields, "replace_all", false)
+  let replace_all = @decode_common.optional_bool(fields, "replace_all", false)
   let start_line = required_positive_int(fields, "start_line", "arguments")
-  let end_line = optional_positive_int_option(fields, "end_line")
-  let revert_on_parse_errors = optional_bool(
+  let end_line = @decode_common.optional_positive_int_option(
+    fields, "end_line", "arguments",
+  )
+  let revert_on_parse_errors = @decode_common.optional_bool(
     fields, "revert_on_parse_errors", true,
   )
   if end_line is Some(end) && end < start_line {
@@ -68,51 +70,14 @@ fn required_string(fields : Map[String, Json], name : String) -> String raise {
 }
 
 ///|
-fn optional_bool(
-  fields : Map[String, Json],
-  name : String,
-  default : Bool,
-) -> Bool raise {
-  match fields.get(name) {
-    Some(True) => true
-    Some(False) => false
-    Some(Null) | None => default
-    _ => fail("arguments.\{name} to be a boolean")
-  }
-}
-
-///|
-fn positive_int(value : Double, name : String, prefix : String) -> Int raise {
-  let int_value = value.to_int()
-  if int_value.to_double() != value {
-    fail("\{prefix}.\{name} to be an integer")
-  }
-  if int_value <= 0 {
-    fail("\{prefix}.\{name} to be a positive integer")
-  }
-  int_value
-}
-
-///|
-fn optional_positive_int_option(
-  fields : Map[String, Json],
-  name : String,
-) -> Int? raise {
-  match fields.get(name) {
-    Some(Number(value, ..)) => Some(positive_int(value, name, "arguments"))
-    Some(Null) | None => None
-    _ => fail("arguments.\{name} to be an integer")
-  }
-}
-
-///|
 fn required_positive_int(
   fields : Map[String, Json],
   name : String,
   prefix : String,
 ) -> Int raise {
   match fields.get(name) {
-    Some(Number(value, ..)) => positive_int(value, name, prefix)
+    Some(Number(value, ..)) =>
+      @decode_common.positive_int_of_number(value, name, prefix)
     _ => fail("\{prefix}.\{name} to be an integer")
   }
 }

--- a/agent_tool/internal/decode_common/decode_common.mbt
+++ b/agent_tool/internal/decode_common/decode_common.mbt
@@ -1,0 +1,128 @@
+///|
+/// Shared JSON argument-decoder helpers for the per-tool `internal/decode`
+/// packages. Every helper fails with a message naming the offending field so
+/// the error fed back to the model says exactly which argument to fix. The
+/// exact failure-message bytes are load-bearing: the tool layer surfaces them
+/// verbatim, so changing them changes what the model sees.
+
+///|
+/// Read an optional string field. An empty string, `null`, or an absent field
+/// all decode to `None`; any other non-string JSON value is an error.
+pub fn optional_string(
+  fields : Map[String, Json],
+  name : String,
+) -> String? raise {
+  match fields.get(name) {
+    Some(String(value)) if value != "" => Some(value)
+    Some(String(_)) | Some(Null) | None => None
+    _ => fail("arguments.\{name} to be a string")
+  }
+}
+
+///|
+/// Read a required, non-empty string field. An empty string, `null`, or an
+/// absent field fails with just the field path; a non-string value fails with
+/// a type message.
+pub fn required_nonempty_string(
+  fields : Map[String, Json],
+  name : String,
+) -> String raise {
+  match fields.get(name) {
+    Some(String(value)) if value != "" => value
+    Some(String(_)) | Some(Null) | None => fail("arguments.\{name}")
+    _ => fail("arguments.\{name} to be a string")
+  }
+}
+
+///|
+/// Read an optional boolean field, substituting `default` when the field is
+/// `null` or absent.
+pub fn optional_bool(
+  fields : Map[String, Json],
+  name : String,
+  default : Bool,
+) -> Bool raise {
+  match fields.get(name) {
+    Some(True) => true
+    Some(False) => false
+    Some(Null) | None => default
+    _ => fail("arguments.\{name} to be a boolean")
+  }
+}
+
+///|
+/// Read a JSON number as a positive 1-based integer, failing when it is
+/// fractional or non-positive. `prefix` names the enclosing argument path
+/// (e.g. `arguments` or `arguments.edits[0]`) in failure messages.
+pub fn positive_int_of_number(
+  value : Double,
+  name : String,
+  prefix : String,
+) -> Int raise {
+  let int_value = value.to_int()
+  if int_value.to_double() != value {
+    fail("\{prefix}.\{name} to be an integer")
+  }
+  if int_value <= 0 {
+    fail("\{prefix}.\{name} to be a positive integer")
+  }
+  int_value
+}
+
+///|
+/// Read an optional field as a positive integer (rejecting fractional
+/// values), decoding `null`/absent to `None`. Failure messages say
+/// "integer" and are prefixed with `prefix`.
+pub fn optional_positive_int_option(
+  fields : Map[String, Json],
+  name : String,
+  prefix : String,
+) -> Int? raise {
+  match fields.get(name) {
+    Some(Number(value, ..)) => Some(positive_int_of_number(value, name, prefix))
+    Some(Null) | None => None
+    _ => fail("\{prefix}.\{name} to be an integer")
+  }
+}
+
+///|
+/// Read an optional field as a positive number truncated to `Int` (no
+/// fractional check), decoding `null`/absent to `None`. Failure messages say
+/// "number" and are rooted at `arguments`.
+pub fn optional_positive_number_option(
+  fields : Map[String, Json],
+  name : String,
+) -> Int? raise {
+  match fields.get(name) {
+    Some(Number(value, ..)) => {
+      let int_value = value.to_int()
+      if int_value <= 0 {
+        fail("arguments.\{name} to be a positive number")
+      }
+      Some(int_value)
+    }
+    Some(Null) | None => None
+    _ => fail("arguments.\{name} to be a number")
+  }
+}
+
+///|
+/// Like `optional_positive_number_option`, but substituting `default` when
+/// the field is `null` or absent.
+pub fn optional_positive_number(
+  fields : Map[String, Json],
+  name : String,
+  default : Int,
+) -> Int raise {
+  optional_positive_number_option(fields, name).unwrap_or(default)
+}
+
+///|
+/// Clamp an output-budget value to a hard `cap`.
+pub fn cap_output_chars(value : Int, cap : Int) -> Int {
+  if value > cap {
+    cap
+  } else {
+    value
+  }
+}

--- a/agent_tool/internal/decode_common/moon.pkg
+++ b/agent_tool/internal/decode_common/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "bobzhang/openseek/agent_tool/internal/decode_common",
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/internal/decode_common/pkg.generated.mbti
+++ b/agent_tool/internal/decode_common/pkg.generated.mbti
@@ -1,0 +1,28 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/decode_common"
+
+// Values
+pub fn cap_output_chars(Int, Int) -> Int
+
+pub fn optional_bool(Map[String, Json], String, Bool) -> Bool raise
+
+pub fn optional_positive_int_option(Map[String, Json], String, String) -> Int? raise
+
+pub fn optional_positive_number(Map[String, Json], String, Int) -> Int raise
+
+pub fn optional_positive_number_option(Map[String, Json], String) -> Int? raise
+
+pub fn optional_string(Map[String, Json], String) -> String? raise
+
+pub fn positive_int_of_number(Double, String, String) -> Int raise
+
+pub fn required_nonempty_string(Map[String, Json], String) -> String raise
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/moon_check/internal/decode/decode.mbt
+++ b/agent_tool/moon_check/internal/decode/decode.mbt
@@ -28,36 +28,18 @@ pub fn decode(arguments : Json) -> MoonCheckInput raise {
 
 ///|
 fn parse_fields(fields : Map[String, Json]) -> MoonCheckInput raise {
-  let cwd = optional_string(fields, "cwd")
-  let target = optional_string(fields, "target")
+  let cwd = @decode_common.optional_string(fields, "cwd")
+  let target = @decode_common.optional_string(fields, "target")
   if target is Some(value) {
     @moon_target.validate_target(value)
   }
-  let warn_list = optional_string(fields, "warn_list")
+  let warn_list = @decode_common.optional_string(fields, "warn_list")
   {
     cwd,
     target,
     warn_list,
-    deny_warn: optional_bool(fields, "deny_warn"),
-    fmt: optional_bool(fields, "fmt"),
-    explain: optional_bool(fields, "explain"),
-  }
-}
-
-///|
-fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => Some(value)
-    Some(String(_)) | Some(Null) | None => None
-    _ => fail("arguments.\{name} to be a string")
-  }
-}
-
-///|
-fn optional_bool(fields : Map[String, Json], name : String) -> Bool raise {
-  match fields.get(name) {
-    Some(True) => true
-    Some(False) | Some(Null) | None => false
-    _ => fail("arguments.\{name} to be a boolean")
+    deny_warn: @decode_common.optional_bool(fields, "deny_warn", false),
+    fmt: @decode_common.optional_bool(fields, "fmt", false),
+    explain: @decode_common.optional_bool(fields, "explain", false),
   }
 }

--- a/agent_tool/moon_check/internal/decode/moon.pkg
+++ b/agent_tool/moon_check/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/decode_common",
   "bobzhang/openseek/agent_tool/internal/moon_target",
   "moonbitlang/core/json",
 }

--- a/agent_tool/moon_cmd/internal/decode/decode.mbt
+++ b/agent_tool/moon_cmd/internal/decode/decode.mbt
@@ -44,10 +44,10 @@ pub fn decode(arguments : Json) -> MoonCommandInput raise {
 
 ///|
 fn parse_fields(fields : Map[String, Json]) -> MoonCommandInput raise {
-  let command = required_string(fields, "command")
+  let command = @decode_common.required_nonempty_string(fields, "command")
   validate_command(command)
-  let cwd = optional_string(fields, "cwd")
-  let target = optional_string(fields, "target")
+  let cwd = @decode_common.optional_string(fields, "cwd")
+  let target = @decode_common.optional_string(fields, "target")
   if target is Some(value) {
     @moon_target.validate_target(value)
     validate_target_supported(command)
@@ -58,13 +58,17 @@ fn parse_fields(fields : Map[String, Json]) -> MoonCommandInput raise {
   if program_args.length() > 0 && command != "run" {
     fail("arguments.program_args only with command run")
   }
-  let stdin = optional_string(fields, "stdin")
+  let stdin = @decode_common.optional_string(fields, "stdin")
   if stdin is Some(_) && command != "run" {
     fail("arguments.stdin only with command run")
   }
-  let test_update_kind = optional_string(fields, "test_update_kind")
-  let test_update_reason = optional_string(fields, "test_update_reason")
-  let max_output_chars = optional_positive_int(
+  let test_update_kind = @decode_common.optional_string(
+    fields, "test_update_kind",
+  )
+  let test_update_reason = @decode_common.optional_string(
+    fields, "test_update_reason",
+  )
+  let max_output_chars = @decode_common.optional_positive_number(
     fields, "max_output_chars", default_max_output_chars,
   )
   validate_test_update_guard(
@@ -80,25 +84,9 @@ fn parse_fields(fields : Map[String, Json]) -> MoonCommandInput raise {
     stdin,
     test_update_kind,
     test_update_reason,
-    max_output_chars: cap_max_output_chars(max_output_chars),
-  }
-}
-
-///|
-fn required_string(fields : Map[String, Json], name : String) -> String raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => value
-    Some(String(_)) | Some(Null) | None => fail("arguments.\{name}")
-    _ => fail("arguments.\{name} to be a string")
-  }
-}
-
-///|
-fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => Some(value)
-    Some(String(_)) | Some(Null) | None => None
-    _ => fail("arguments.\{name} to be a string")
+    max_output_chars: @decode_common.cap_output_chars(
+      max_output_chars, hard_max_output_chars,
+    ),
   }
 }
 
@@ -141,34 +129,6 @@ fn optional_string_array(
     _ => fail("arguments.\{name} to be an array of strings")
   }
   values
-}
-
-///|
-fn optional_positive_int(
-  fields : Map[String, Json],
-  name : String,
-  default : Int,
-) -> Int raise {
-  match fields.get(name) {
-    Some(Number(value, ..)) => {
-      let int_value = value.to_int()
-      if int_value <= 0 {
-        fail("arguments.\{name} to be a positive number")
-      }
-      int_value
-    }
-    Some(Null) | None => default
-    _ => fail("arguments.\{name} to be a number")
-  }
-}
-
-///|
-fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
-  }
 }
 
 ///|

--- a/agent_tool/moon_cmd/internal/decode/moon.pkg
+++ b/agent_tool/moon_cmd/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/decode_common",
   "bobzhang/openseek/agent_tool/internal/moon_target",
   "moonbitlang/core/json",
 }

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -63,11 +63,9 @@ pub fn decode_args(arguments : Json) -> MultiEditArgs raise {
         Some(Null) | None => None
         Some(_) => fail("arguments.revert_when_errors_above to be an integer")
       }
-      let revert_on_parse_errors = match fields.get("revert_on_parse_errors") {
-        Some(True) | Some(Null) | None => true
-        Some(False) => false
-        Some(_) => fail("arguments.revert_on_parse_errors to be a boolean")
-      }
+      let revert_on_parse_errors = @decode_common.optional_bool(
+        fields, "revert_on_parse_errors", true,
+      )
       { inline, edits_file, revert_when_errors_above, revert_on_parse_errors }
     }
     _ => fail("object arguments")
@@ -102,7 +100,9 @@ fn decode_edit_item(item : Json, index : Int) -> MultiEditItem raise {
       let old_string = required_string_with_prefix(fields, "old_string", prefix)
       let new_string = required_string_with_prefix(fields, "new_string", prefix)
       let start_line = required_positive_int(fields, "start_line", prefix)
-      let end_line = optional_positive_int(fields, "end_line", prefix)
+      let end_line = @decode_common.optional_positive_int_option(
+        fields, "end_line", prefix,
+      )
       if end_line is Some(end) && end < start_line {
         fail(
           "\{prefix}.end_line to be greater than or equal to \{prefix}.start_line",
@@ -142,45 +142,15 @@ fn missing_field(
 }
 
 ///|
-/// Read a JSON number as a positive 1-based integer, failing when it is
-/// fractional or non-positive.
-fn positive_int_of_number(
-  value : Double,
-  name : String,
-  prefix : String,
-) -> Int raise {
-  let int_value = value.to_int()
-  if int_value.to_double() != value {
-    fail("\{prefix}.\{name} to be an integer")
-  }
-  if int_value <= 0 {
-    fail("\{prefix}.\{name} to be a positive integer")
-  }
-  int_value
-}
-
-///|
 fn required_positive_int(
   fields : Map[String, Json],
   name : String,
   prefix : String,
 ) -> Int raise {
   match fields.get(name) {
-    Some(Number(value, ..)) => positive_int_of_number(value, name, prefix)
+    Some(Number(value, ..)) =>
+      @decode_common.positive_int_of_number(value, name, prefix)
     Some(Null) | None => fail(missing_field(fields, name, prefix))
     Some(_) => fail("\{prefix}.\{name} to be an integer")
-  }
-}
-
-///|
-fn optional_positive_int(
-  fields : Map[String, Json],
-  name : String,
-  prefix : String,
-) -> Int? raise {
-  match fields.get(name) {
-    Some(Number(value, ..)) => Some(positive_int_of_number(value, name, prefix))
-    Some(Null) | None => None
-    _ => fail("\{prefix}.\{name} to be an integer")
   }
 }

--- a/agent_tool/multi_edit/internal/decode/moon.pkg
+++ b/agent_tool/multi_edit/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/decode_common",
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -43,16 +43,22 @@ fn parse_fields(fields : Map[String, Json]) -> ReadInput raise {
     Some(path) => path
     None => fail("arguments.path")
   }
-  let start_line = optional_positive_int(fields, "start_line", 1)
-  let max_lines = optional_positive_int_option(fields, "max_lines")
-  let max_output_chars = optional_positive_int(
+  let start_line = @decode_common.optional_positive_number(
+    fields, "start_line", 1,
+  )
+  let max_lines = @decode_common.optional_positive_number_option(
+    fields, "max_lines",
+  )
+  let max_output_chars = @decode_common.optional_positive_number(
     fields, "max_output_chars", default_max_output_chars,
   )
   {
     path,
     start_line,
     max_lines,
-    max_output_chars: cap_max_output_chars(max_output_chars),
+    max_output_chars: @decode_common.cap_output_chars(
+      max_output_chars, hard_max_output_chars,
+    ),
   }
 }
 
@@ -74,41 +80,5 @@ fn reject_paths(fields : Map[String, Json]) -> Unit raise {
       fail(
         "arguments.paths is not supported; batch separate read calls in one assistant response",
       )
-  }
-}
-
-///|
-fn optional_positive_int(
-  fields : Map[String, Json],
-  name : String,
-  default : Int,
-) -> Int raise {
-  optional_positive_int_option(fields, name).unwrap_or(default)
-}
-
-///|
-fn optional_positive_int_option(
-  fields : Map[String, Json],
-  name : String,
-) -> Int? raise {
-  match fields.get(name) {
-    Some(Number(value, ..)) => {
-      let int_value = value.to_int()
-      if int_value <= 0 {
-        fail("arguments.\{name} to be a positive number")
-      }
-      Some(int_value)
-    }
-    Some(Null) | None => None
-    _ => fail("arguments.\{name} to be a number")
-  }
-}
-
-///|
-fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
   }
 }

--- a/agent_tool/read/internal/decode/moon.pkg
+++ b/agent_tool/read/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/decode_common",
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -36,70 +36,20 @@ pub fn decode(arguments : Json) -> ShellInput raise {
 
 ///|
 fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
-  let cmd = required_string(fields, "cmd")
-  let cwd = optional_string(fields, "cwd")
-  let timeout_ms = optional_positive_int(fields, "timeout_ms")
-  let max_output_chars = optional_positive_int_or_default(
+  let cmd = @decode_common.required_nonempty_string(fields, "cmd")
+  let cwd = @decode_common.optional_string(fields, "cwd")
+  let timeout_ms = @decode_common.optional_positive_number_option(
+    fields, "timeout_ms",
+  )
+  let max_output_chars = @decode_common.optional_positive_number(
     fields, "max_output_chars", default_max_output_chars,
   )
   {
     cmd,
     cwd,
     timeout_ms,
-    max_output_chars: cap_max_output_chars(max_output_chars),
-  }
-}
-
-///|
-fn required_string(fields : Map[String, Json], name : String) -> String raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => value
-    Some(String(_)) | Some(Null) | None => fail("arguments.\{name}")
-    _ => fail("arguments.\{name} to be a string")
-  }
-}
-
-///|
-fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => Some(value)
-    Some(String(_)) | Some(Null) | None => None
-    _ => fail("arguments.\{name} to be a string")
-  }
-}
-
-///|
-fn optional_positive_int(
-  fields : Map[String, Json],
-  name : String,
-) -> Int? raise {
-  match fields.get(name) {
-    Some(Number(value, ..)) => {
-      let int_value = value.to_int()
-      if int_value <= 0 {
-        fail("arguments.\{name} to be a positive number")
-      }
-      Some(int_value)
-    }
-    Some(Null) | None => None
-    _ => fail("arguments.\{name} to be a number")
-  }
-}
-
-///|
-fn optional_positive_int_or_default(
-  fields : Map[String, Json],
-  name : String,
-  default : Int,
-) -> Int raise {
-  optional_positive_int(fields, name).unwrap_or(default)
-}
-
-///|
-fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
+    max_output_chars: @decode_common.cap_output_chars(
+      max_output_chars, hard_max_output_chars,
+    ),
   }
 }

--- a/agent_tool/shell/internal/decode/moon.pkg
+++ b/agent_tool/shell/internal/decode/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/decode_common",
   "moonbitlang/core/json",
 }
 


### PR DESCRIPTION
Repo-level simplification sweep, round 2 — cross-package de-dup (the first sweep deliberately stayed within-package; this finishes the job it exposed: the per-package decode helpers had drifted into byte-identical copies, including two identical `positive_int` cores the first sweep created independently in `edit` and `multi_edit`).

## What

New shared package **`agent_tool/internal/decode_common`** with eight helpers, bodies byte-for-byte from their (verified-identical) sources; six decode packages now delegate:

| shared helper | replaces copies in |
|---|---|
| `optional_string` (empty→None) | shell, moon_check, moon_cmd |
| `required_nonempty_string` | shell, moon_cmd |
| `optional_bool(…, default)` | edit, moon_check (false), multi_edit (true, was inline) |
| `positive_int_of_number` (integer core) | edit ≡ multi_edit (byte-identical pair) |
| `optional_positive_int_option(…, prefix)` (integer family) | edit ("arguments"), multi_edit |
| `optional_positive_number_option` (number family) | read ≡ shell (byte-identical pair) |
| `optional_positive_number(…, default)` | read, shell, moon_cmd |
| `cap_output_chars(value, cap)` | read, shell, moon_cmd (per-package `hard_max_output_chars` stays public, passed as the cap) |

**Deliberately kept local** (behavior genuinely differs): read's reject-empty `optional_string`; edit's accept-empty `required_string` and its terse-message `required_positive_int`; multi_edit's `required_string_with_prefix` + "present keys" `missing_field` diagnostics and its ≤0-accepting `revert_when_errors_above` parse; write (whole-Json match) and finish (lenient, non-raising) untouched. The **integer** family (`"to be an integer"`, fractional check) and **number** family (`"to be a number"`, no fractional check) remain two helpers — merging them would change message bytes. A same-name trap was avoided: `optional_positive_int_option` is the *number* family in read but the *integer* family in edit; merged by body, not by name.

## Error-message discipline
The decoder `fail(…)` strings surface verbatim to the model via `@tool_error.failure_message`, so every literal was diffed before/after (`grep | sort | uniq -c`): pure duplicate-count reductions; the two source-form changes (prefix-parameterization) are runtime-byte-identical and pinned by existing decode tests.

## Validation
`moon fmt` clean; repo-wide `moon check` 0 warnings/errors; touched packages 174/174; **full suite 913/913**; `moon info`: only the new package's `.mbti` added — **zero diffs to any existing `.mbti`** (all consolidated helpers were private).

Net **−36 lines** (−64 excluding the new generated `.mbti`); ~204 duplicated lines now have one home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)