### PR TITLE
perf(agent_session): O(1) stale-snapshot fast path for append

### DIFF
--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -309,6 +309,10 @@ maintain:
   discarding the uncommitted tail. Corruption anywhere else still fails the
   load.
 - Every append or compact checks that the caller's session still matches disk.
+  When the snapshot is physically the value this store instance last synced
+  and the file's size+mtime+ctime fingerprint is unchanged, that check is
+  O(1); any other snapshot — or any on-disk change — falls back to a full
+  read-and-compare, so the guarantee is the same either way.
 
 These rules keep persistence concerns out of `agent_session.Session` while
 giving CLI, TUI, serve mode, and visualization code one shared durable boundary.

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -10,14 +10,42 @@ let lock_file_name : String = "session.lock"
 ///|
 /// Native filesystem-backed collection of durable OpenSeek sessions.
 ///
-/// A `SessionStore` owns only a root path string. Under that root, each session
-/// is stored in `sessions/<id>/` with two files: `openseek_session.jsonl` (a
-/// header line followed by append-only event lines) and `session.lock`. The
-/// store is not a handle to one current session; APIs that operate on a session
-/// either take a `SessionId` or a `Session` carrying its id.
+/// A `SessionStore` owns a root path string plus an in-memory sync cache.
+/// Under that root, each session is stored in `sessions/<id>/` with two files:
+/// `openseek_session.jsonl` (a header line followed by append-only event
+/// lines) and `session.lock`. The store is not a handle to one current
+/// session; APIs that operate on a session either take a `SessionId` or a
+/// `Session` carrying its id.
 pub struct SessionStore {
   priv root : String
+  // The last session value this store instance loaded from or persisted to
+  // disk, per id, with the file fingerprint at that moment. Purely an
+  // optimization: it lets the stale-snapshot check skip re-reading the whole
+  // file on the common append path. Never required for correctness — a
+  // missing or mismatching mark falls back to the full comparison.
+  priv marks : Map[String, DurableMark]
 } derive(Debug)
+
+///|
+priv struct DurableMark {
+  session : @agent_session.Session
+  fingerprint : FileFingerprint
+} derive(Debug)
+
+///|
+/// Metadata that changes whenever the session file is visibly touched. Size
+/// catches every append (the file grows). mtime catches rewrites. ctime —
+/// which user space cannot set, unlike mtime — additionally changes on every
+/// data write and is freshly stamped by the kernel on the inode a rename
+/// installs, so even a rewrite forged to preserve size and mtime does not
+/// reproduce it.
+priv struct FileFingerprint {
+  size : Int64
+  mtime_seconds : Int64
+  mtime_nanoseconds : Int
+  ctime_seconds : Int64
+  ctime_nanoseconds : Int
+} derive(Debug, Eq)
 
 ///|
 /// Construct a store rooted at `root`.
@@ -28,7 +56,7 @@ pub struct SessionStore {
 /// treat a missing `root/sessions` directory as an empty store where that makes
 /// sense.
 pub fn SessionStore::SessionStore(root : String) -> SessionStore {
-  { root, }
+  { root, marks: {} }
 }
 
 ///|
@@ -210,13 +238,73 @@ async fn read_session_file(
 }
 
 ///|
+/// The fingerprint of the file at `path`, or `None` when it cannot be
+/// stat-ed. Two equal fingerprints mean the file was not visibly touched
+/// between them.
+async fn file_fingerprint(path : String) -> FileFingerprint? {
+  let file = @fs.open(path, mode=ReadOnly) catch { _ => return None }
+  defer file.close()
+  let size = file.size() catch { _ => return None }
+  let (mtime_seconds, mtime_nanoseconds) = file.mtime() catch {
+    _ => return None
+  }
+  let (ctime_seconds, ctime_nanoseconds) = file.ctime() catch {
+    _ => return None
+  }
+  Some({
+    size,
+    mtime_seconds,
+    mtime_nanoseconds,
+    ctime_seconds,
+    ctime_nanoseconds,
+  })
+}
+
+///|
+/// Remember `session` as the value this store last synced with disk for its
+/// id. Called with the write lock (or the shared read lock) held, so the
+/// fingerprint taken here describes exactly the bytes that were just written
+/// or read. Best-effort: a failed stat only costs the fast path.
+async fn record_mark(
+  store : SessionStore,
+  session : @agent_session.Session,
+) -> Unit {
+  let path = store.session_file_path(session.id()) catch { _ => return }
+  match file_fingerprint(path) {
+    Some(fingerprint) =>
+      store.marks[session.id().value()] = { session, fingerprint }
+    None => store.marks.remove(session.id().value())
+  }
+}
+
+///|
 /// Verify that `session` still matches the durable state, and report whether
 /// the durable file ends in an unterminated record that the next write must
 /// repair. A missing file is current only for an empty snapshot.
+///
+/// Fast path: when `session` is physically the exact value this store last
+/// loaded from or persisted to disk, and the file fingerprint is unchanged
+/// since that sync, the durable state cannot have diverged — the full
+/// read/parse/compare is skipped, turning the per-append cost from O(file)
+/// to O(1). Any mismatch, and any snapshot this store did not hand out,
+/// falls through to the full comparison, so the guarantees are unchanged.
 async fn ensure_session_is_current(
   store : SessionStore,
   session : @agent_session.Session,
 ) -> Bool {
+  match store.marks.get(session.id().value()) {
+    Some(mark) if physical_equal(mark.session, session) =>
+      match file_fingerprint(store.session_file_path(session.id())) {
+        Some(fingerprint) =>
+          if fingerprint == mark.fingerprint {
+            // The store only ever syncs newline-terminated text, so an
+            // unchanged file needs no tail repair.
+            return false
+          }
+        None => ()
+      }
+    _ => ()
+  }
   let parsed = read_session_file(store, session.id()) catch {
     @os_error.OSError(_) as error if error.is_ENOENT() => {
       if session.last_sequence() != 0 {
@@ -564,6 +652,7 @@ pub async fn SessionStore::create(
       self.session_file_path(session.id()),
       session_file_text(session),
     )
+    record_mark(self, session)
   })
 }
 
@@ -598,7 +687,12 @@ pub async fn SessionStore::load(
   id : @agent_session.SessionId,
 ) -> @agent_session.Session {
   with_existing_session_lock(self, id, Shared, () => {
-    read_session_file(self, id).session
+    let parsed = read_session_file(self, id)
+    // A torn file must keep taking the full path so the next write repairs it.
+    if !parsed.needs_tail_repair {
+      record_mark(self, parsed.session)
+    }
+    parsed.session
   })
 }
 
@@ -631,6 +725,7 @@ pub async fn SessionStore::append(
       unix_ms=@env.now().reinterpret_as_int64(),
     )
     persist_event(self, next, event, repair_tail~)
+    record_mark(self, next)
     next
   })
 }
@@ -668,6 +763,7 @@ pub async fn SessionStore::compact(
       None => fail("compacted session did not append a summary event")
     }
     persist_event(self, next, event, repair_tail~)
+    record_mark(self, next)
     next
   })
 }

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -266,6 +266,83 @@ async test "store serializes concurrent first appends from empty snapshots" {
 }
 
 ///|
+async test "chained appends on returned values persist every event" {
+  // The common agent loop: each append's return value feeds the next call,
+  // which is exactly the shape the fingerprint fast path accelerates.
+  let store = new_store()
+  let mut session = @agent_session.Session(
+    SessionId("s1"),
+    system_prompt="system",
+  )
+  store.create(session)
+  for step in 0..<5 {
+    session = store.append(session, Runtime(RuntimeNotice("step \{step}")))
+  }
+  assert_eq(session.last_sequence(), 5)
+  let events = store.load(SessionId("s1")).events()
+  assert_eq(events.length(), 5)
+  for index in 0..<events.length() {
+    let event = events[index]
+    assert_eq(event.sequence(), index + 1)
+    guard event.item() is Runtime(notice) else { fail("expected notice") }
+    assert_eq(notice.content(), "step \{index}")
+  }
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "another store instance's write defeats the fingerprint fast path" {
+  // store_a syncs a snapshot, then store_b (another process, in effect)
+  // appends. store_a's snapshot is physically the value it last synced, so
+  // only the on-disk fingerprint reveals the divergence.
+  let store_a = new_store()
+  let store_b : @store.SessionStore = SessionStore(store_a.root())
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  store_a.create(session)
+  let from_a = store_a.append(session, User(UserMessage("from a")))
+  let loaded_by_b = store_b.load(SessionId("s1"))
+  ignore(store_b.append(loaded_by_b, Runtime(RuntimeNotice("from b"))))
+  let _ = store_a.append(from_a, Runtime(RuntimeNotice("stale from a"))) catch {
+    error => {
+      assert_true("\{error}".contains("stale session snapshot"))
+      let loaded = store_a.load(SessionId("s1"))
+      assert_eq(loaded.events().length(), 2)
+      @fs.rmdir(store_a.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store_a.root(), recursive=true)
+  fail("stale append past the fast path was accepted")
+}
+
+///|
+async test "a same-size rewrite by another store is still detected" {
+  let store_a = new_store()
+  let store_b : @store.SessionStore = SessionStore(store_a.root())
+  let session = @agent_session.Session(
+    SessionId("s1"),
+    system_prompt="prompt A",
+  )
+  store_a.create(session)
+  // Same byte length, different content: the size component of the
+  // fingerprint cannot see this rewrite — only its timestamps can (mtime,
+  // plus ctime, which user space cannot forge). Filesystem mtimes need a
+  // beat between writes to order reliably.
+  @async.sleep(50)
+  store_b.create(Session(SessionId("s1"), system_prompt="prompt B"))
+  let _ = store_a.append(session, User(UserMessage("stale"))) catch {
+    error => {
+      assert_true("\{error}".contains("stale session snapshot"))
+      assert_eq(store_a.load(SessionId("s1")).system_prompt(), "prompt B")
+      @fs.rmdir(store_a.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store_a.root(), recursive=true)
+  fail("same-size rewrite slipped past the fingerprint fast path")
+}
+
+///|
 async test "store rejects stale snapshots before appending" {
   let store = new_store()
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")


### PR DESCRIPTION
Second of four scoped store-hardening PRs (#336 merged). Rebased onto main; independent, self-contained diff.

## Problem

`ensure_session_is_current` read and JSON-parsed the **entire session file**, then re-serialized both event vectors to compare — on every `append` and `compact`. That's O(file) per event and quadratic over a session's life; with tool-result events in the tens-of-kilobytes range, a long session pays real I/O and parse cost on every single step.

## Fix

The store remembers, per session id, the exact `Session` value it last loaded from or persisted to disk, together with the file's size+mtime fingerprint at that moment. When the caller passes that very value back — the common agent loop, where each append's return feeds the next call — and the fingerprint is unchanged, the durable state cannot have diverged, so the full comparison is skipped: the stale check drops from O(file) to a stat.

Correctness is unchanged, only proven differently on the fast path:

- physical identity has no false positives — any snapshot the store did not hand out takes the full compare (the existing divergent-snapshot test still passes through that path)
- a cross-process append grows the file → size breaks the fingerprint (test: "another store instance's write defeats the fingerprint fast path")
- a same-size rewrite is caught by mtime (test added at Codex's suggestion)
- any stat failure falls back to the full compare
- torn files never enter the cache, so the repair path from #336 keeps taking the full read

## Validation

- 43/43 store tests (3 new: chained appends, cross-instance write, same-size rewrite); agent_session suite green
- Codex CLI review with adversarial prompts on mark lifecycle, fingerprint collisions, shared-lock recording, and tail-repair interplay: "Findings: None." — its one hardening suggestion (the same-size-rewrite test) is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
