### PR TITLE
fix(agent_session): make session creation durable across power loss

### DIFF
--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -301,6 +301,20 @@ maintain:
   atomically, so a session file can never exist without its header.
 - `create` rewrites the file atomically (temp file, then rename); an
   interrupted rewrite leaves the previous file intact.
+- Durability policy: event appends and temp-file writes are flushed with
+  `fdatasync` before they return, and every file-creating write (create,
+  first append, tail repair) syncs the directory chain — session directory,
+  `sessions/`, root — itself, rather than trusting whichever process created
+  those directories. On POSIX-style local filesystems this makes a session
+  that `create` or `append` just reported durable survive a power loss, not
+  only a process crash. The directory syncs are best-effort: on platforms
+  where a directory cannot be opened or synced (notably Windows), power-loss
+  durability degrades to the filesystem's own guarantees, while
+  process-crash safety is unaffected. Two scope limits: the store root's own
+  directory entry lives in its parent, outside the store's ownership — when
+  the root is created lazily by the store, making the root itself durable is
+  the caller's setup concern; and an append to an existing file assumes that
+  file's creation was already durably completed by its creator.
 - Every load checks the header record and contiguous sequence numbers.
 - A crash can tear the final append mid-line. `load` tolerates exactly that —
   an unterminated final record is dropped (or kept when only its newline is

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -255,22 +255,71 @@ async fn persist_event(
 ) -> Unit {
   let path = store.session_file_path(session.id())
   if !repair_tail && @fs.exists(path) {
+    // `sync=Data` (fdatasync) is the durability policy for event appends: a
+    // returned append survives an OS crash, not just a process crash. It is
+    // also the `write_file` default today — stated explicitly so the policy
+    // does not silently follow an upstream default change.
     @fs.write_file(
       path,
       "\{event.to_json().stringify()}\n",
       create_mode=OpenOrCreate,
       append=true,
+      sync=Data,
     )
   } else {
-    write_text_atomic(path, session_file_text(session))
+    write_text_atomic(
+      path,
+      session_file_text(session),
+      dirs=store.session_dir_chain(session.id()),
+    )
   }
 }
 
 ///|
-async fn write_text_atomic(path : String, text : String) -> Unit {
+/// Atomically replace `path` with `text`, then make the result durable by
+/// syncing `dirs` innermost-first.
+///
+/// The temp file is flushed (`sync=Data`) before the rename, so the rename
+/// can never install a file whose data blocks are still unwritten. The
+/// directory syncs are what make the rename — and, for a brand-new session,
+/// the directory entries above it — survive a power loss. The writer that
+/// claims durability syncs the whole chain itself rather than trusting
+/// whichever process happened to `mkdir` the directories moments earlier.
+/// Syncs are best-effort: on filesystems or platforms where a directory
+/// cannot be opened or synced, crash-consistency degrades only for power
+/// loss, never for process crashes.
+async fn write_text_atomic(
+  path : String,
+  text : String,
+  dirs~ : Array[String],
+) -> Unit {
   let tmp_path = "\{path}.tmp"
-  @fs.write_file(tmp_path, text, create_mode=CreateOrTruncate)
+  @fs.write_file(tmp_path, text, create_mode=CreateOrTruncate, sync=Data)
   @fs.rename(tmp_path, path, replace=true)
+  for dir in dirs {
+    sync_dir_best_effort(dir)
+  }
+}
+
+///|
+/// The directory chain whose entries a durable session write depends on,
+/// innermost first: the session directory (holds the file), `sessions/`
+/// (holds the session directory), and the root (holds `sessions/`). The
+/// root's own entry lives in its parent, outside the store's ownership.
+fn SessionStore::session_dir_chain(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> Array[String] raise {
+  [self.session_dir(id), self.sessions_dir(), self.root]
+}
+
+///|
+async fn sync_dir_best_effort(dir : String) -> Unit {
+  let file = @fs.open(dir, mode=ReadOnly) catch { _ => return }
+  defer file.close()
+  file.sync() catch {
+    _ => ()
+  }
 }
 
 ///|
@@ -563,6 +612,7 @@ pub async fn SessionStore::create(
     write_text_atomic(
       self.session_file_path(session.id()),
       session_file_text(session),
+      dirs=self.session_dir_chain(session.id()),
     )
   })
 }


### PR DESCRIPTION
Third of four scoped store-hardening PRs (#336 merged). Rebased onto main; independent, self-contained diff. Note: touches the same functions as #339, so whichever of the two merges second may need a trivial rebase.

## Problem

`write_text_atomic` (used by `create`, first-append bootstrap, and tail repair) renamed the temp file into place but never synced any directory. After the call returned, a power loss could forget the rename — the file's data blocks were durable but its directory entry was not, and the **whole session vanished** despite the store having reported success. Brand-new session directories had the same hole one level up (`sessions/`, store root). Event appends were already effectively `fdatasync`'d because `write_file` defaults to `sync=Data`.

## Fix

- The temp file is flushed (`sync=Data`) before the rename, so a rename can never install a file with unwritten data blocks.
- Every file-creating write syncs the directory chain — session dir, `sessions/`, root, innermost first — **itself**, rather than trusting whichever process happened to `mkdir` those directories moments earlier. (Codex's review caught that syncing at `mkdir` time leaves a race: of two concurrent first-writers, the one that skipped creation could return "durable" while the entries above it were still unsynced.)
- The per-append hot path is untouched: `sync=Data` is now stated explicitly (pinning today's default as policy), and no directory sync runs there.
- Guarantee is scoped honestly: POSIX-style local filesystems, best-effort directory syncs (Windows degrades to the filesystem's own guarantees; process-crash safety unaffected). Two documented scope limits: the store root's own entry belongs to the caller's environment, and appends assume the file's creation was already durably completed.

## Validation

- 43/43 store tests; agent_session suite green (behavioral surface unchanged — this PR changes when data hits the platters, not what is written)
- Directory-fd `File::sync` verified working on macOS via a live probe before adopting the approach
- Codex CLI review, three passes: pass 1 found the missing parent-directory syncs and the overclaiming README; pass 2 found the concurrent-first-create race in the mkdir-time approach (redesigned to writer-owned chain sync); pass 3 confirmed the race closed and the hot path clean, with only the two documentation caveats above, now included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
