### PR TITLE
fix(agent_session): name unsupported session-file versions; reject NUL ids

### DIFF
--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -27,21 +27,48 @@ pub impl ToJson for SessionFileHeader with fn to_json(
 }
 
 ///|
-/// Decode a session-file header record, or `None` when `json` is not a
-/// version-1 header object. Header and event records are structurally
-/// disjoint (events carry `sequence`/`item`, never `version`), so this is
-/// also how a reader tells the two apart.
-pub fn parse_header(json : Json) -> SessionFileHeader? {
-  guard json is Object(fields) else { return None }
-  guard fields.get("version") is Some(Number(version, ..)) &&
-    version.to_int() == session_file_version else {
-    return None
+/// How a would-be header record classified. `UnsupportedVersion` is kept
+/// distinct from `NotHeader` so a reader confronted with a file written by a
+/// newer format can say so, instead of misreporting it as a file that has no
+/// header at all.
+pub(all) enum HeaderParse {
+  Header(SessionFileHeader)
+  UnsupportedVersion(Int)
+  NotHeader
+} derive(Debug)
+
+///|
+/// Classify `json` as a session-file header record.
+///
+/// Header and event records are structurally disjoint (events carry
+/// `sequence`/`item`, never `version`), so this is also how a reader tells
+/// the two apart. Any object carrying a numeric `version` other than 1 is a
+/// header from a format this build does not read — `UnsupportedVersion` —
+/// even though its remaining fields cannot be interpreted.
+pub fn classify_header(json : Json) -> HeaderParse {
+  guard json is Object(fields) else { return NotHeader }
+  guard fields.get("version") is Some(Number(version, ..)) else {
+    return NotHeader
   }
-  guard fields.get("id") is Some(String(id)) else { return None }
+  if version.to_int() != session_file_version {
+    return UnsupportedVersion(version.to_int())
+  }
+  guard fields.get("id") is Some(String(id)) else { return NotHeader }
   guard fields.get("system_prompt") is Some(String(system_prompt)) else {
-    return None
+    return NotHeader
   }
-  Some({ id, system_prompt })
+  Header({ id, system_prompt })
+}
+
+///|
+/// Decode a session-file header record, or `None` when `json` is not a
+/// header this build can read. Use `classify_header` to distinguish an
+/// unsupported version from a non-header.
+pub fn parse_header(json : Json) -> SessionFileHeader? {
+  match classify_header(json) {
+    Header(header) => Some(header)
+    UnsupportedVersion(_) | NotHeader => None
+  }
 }
 
 ///|

--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -169,6 +169,46 @@ test "parse lifts the header record from the first line" {
 }
 
 ///|
+test "classify_header separates versions, headers, and non-headers" {
+  debug_inspect(
+    @log.classify_header({ "version": 1, "id": "demo", "system_prompt": "SYS" }),
+    content=(
+      #|Header({ id: "demo", system_prompt: "SYS" })
+    ),
+  )
+  // A file written by a newer format is named as such, not misreported as
+  // header-less.
+  debug_inspect(
+    @log.classify_header({ "version": 2, "whatever": "future shape" }),
+    content="UnsupportedVersion(2)",
+  )
+  // An event record is structurally not a header.
+  debug_inspect(
+    @log.classify_header({
+      "sequence": 1,
+      "ts": 0,
+      "item": { "kind": "user", "payload": { "content": "hi" } },
+    }),
+    content="NotHeader",
+  )
+  // A version-1 object missing required fields is malformed, not a header.
+  debug_inspect(
+    @log.classify_header({ "version": 1, "id": "demo" }),
+    content="NotHeader",
+  )
+  // The tolerant parser records an unsupported-version first line as a bad
+  // line rather than adopting it as the header.
+  let parsed = @log.parse_events(
+    (
+      #|{"version":2,"id":"demo","system_prompt":"SYS"}
+      #|
+    ),
+  )
+  debug_inspect(parsed.header, content="None")
+  assert_eq(parsed.errors.length(), 1)
+}
+
+///|
 test "session from parse uses supplied header values" {
   let session = @log.session_from_parse(
     @log.parse_events(events_jsonl(sample_session())),

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -7,6 +7,8 @@ import {
 }
 
 // Values
+pub fn classify_header(Json) -> HeaderParse
+
 pub fn parse_events(String) -> ParsedLog
 
 pub fn parse_header(Json) -> SessionFileHeader?
@@ -16,6 +18,12 @@ pub fn session_from_parse(ParsedLog, id~ : String, system_prompt~ : String) -> @
 // Errors
 
 // Types and methods
+pub(all) enum HeaderParse {
+  Header(SessionFileHeader)
+  UnsupportedVersion(Int)
+  NotHeader
+} derive(@debug.Debug)
+
 pub(all) struct LineError {
   line_number : Int
   content : String

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -49,6 +49,11 @@ fn validate_session_id(id : @agent_session.SessionId) -> Unit raise {
   if value.contains("/") || value.contains("\\") {
     fail("session id must not contain path separators: \{value}")
   }
+  if value.contains("\u{0}") {
+    // A NUL truncates the path at the C boundary, silently mapping distinct
+    // ids onto one directory.
+    fail("session id must not contain a NUL character")
+  }
   if value == "." || value == ".." {
     fail("session id must not be `.` or `..`")
   }
@@ -164,9 +169,13 @@ fn parse_session_file(
         "session file for \{requested_id.value()} does not start with a header line: \{error}",
       )
   }
-  let header = match @session_log.parse_header(header_json) {
-    Some(header) => header
-    None =>
+  let header = match @session_log.classify_header(header_json) {
+    Header(header) => header
+    UnsupportedVersion(version) =>
+      fail(
+        "session file for \{requested_id.value()} uses unsupported session file version \{version}; this build reads version 1",
+      )
+    NotHeader =>
       fail(
         "session file for \{requested_id.value()} does not start with a header record",
       )

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -784,6 +784,40 @@ async test "store propagates unreadable session files instead of dropping histor
 }
 
 ///|
+async test "store names an unsupported session file version on load" {
+  let store = new_store()
+  @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
+  @fs.write_file(
+    session_file(store, "s1"),
+    "{\"version\":2,\"id\":\"s1\",\"system_prompt\":\"system\"}\n",
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.load(SessionId("s1")) catch {
+    error => {
+      assert_true("\{error}".contains("unsupported session file version 2"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("version-2 session file was accepted")
+}
+
+///|
+async test "store rejects session ids containing NUL" {
+  let store = new_store()
+  let _ = store.exists(SessionId("bad\u{0}id")) catch {
+    error => {
+      assert_true("\{error}".contains("NUL"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("NUL in session id accepted")
+}
+
+///|
 async test "store rejects path-like session ids" {
   let store = new_store()
   let _ = store.exists(SessionId("../bad")) catch {


### PR DESCRIPTION
Fourth and last of the scoped store-hardening PRs (#336 merged). Rebased onto main; independent, self-contained diff.

## Problem

A session file written by a future format version failed to load as "does not start with a header record" — misleading exactly when the message matters most, on a version skew between builds. `parse_header` collapsed every non-v1 shape into `None`, so the store couldn't tell "not a header" from "a header this build cannot read". Separately, session ids allowed NUL characters, which truncate the path at the C boundary and would silently map distinct ids onto one directory.

## Fix

- `agent_session/log` gains `classify_header : Json -> HeaderParse { Header, UnsupportedVersion(Int), NotHeader }`; `parse_header` is now a thin wrapper (API additive, no consumer breaks — verified against viz and viz_app).
- Any object with a numeric `version` other than 1 classifies as `UnsupportedVersion` — safe against false positives because event records carry `sequence`/`ts`/`item` and never `version`.
- The store's load error now reads: `uses unsupported session file version 2; this build reads version 1`.
- The tolerant viz parser is unchanged: an unsupported-version first line stays a recorded bad line rather than being adopted as a header.
- `validate_session_id` rejects NUL.

## Validation

- 51/51 log+store tests (new: classification matrix incl. malformed-v1 and event-shaped objects; unsupported-version load wording; NUL rejection); JS consumers (viz, viz_app) 78/78; full suite 903/907 (4 = known env-specific shell timing flakes); cram 23/23
- Codex CLI review across false-positive risk, API compatibility, and UTF-16 NUL semantics: "No findings."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
