### PR TITLE
fix(deepseek/client): bound streaming reads with an idle timeout

### DIFF
--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -57,6 +57,7 @@ test "construct DeepSeek client configuration" {
       #|  thinking: Max,
       #|  retry_attempts: 5,
       #|  retry_backoff_ms: 200,
+      #|  idle_timeout_ms: 120000,
       #|}
     ),
   )

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -50,9 +50,13 @@ pub struct Client {
 /// converted to the same retryable class as a mid-stream drop — so a stall
 /// before any event is retried on a fresh connection, while one after output
 /// bails to a clean failure rather than duplicating a half-consumed completion.
-/// It is an *idle* bound, reset by every byte, so a long-but-progressing
-/// completion never trips it. Pass `0` (or less) to disable. Defaults to 120s;
-/// it applies to the streaming path only (the mode the agent and TUI use).
+/// The bound is measured per read — the header line, then each SSE event line —
+/// so it resets on every event, not on every byte: a stream that keeps
+/// delivering events never trips it. (The clock therefore covers one whole line;
+/// with real DeepSeek deltas, which are small and sub-second apart, a single
+/// line never approaches the default anyway.) Pass `0` (or less) to disable.
+/// Defaults to 120s; it applies to the streaming path only (the mode the agent
+/// and TUI use).
 pub fn Client::Client(
   api_key~ : String,
   model? : @deepseek.Model = default_model,

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -27,6 +27,7 @@ pub struct Client {
   thinking : @deepseek.ThinkingMode
   retry_attempts : Int
   retry_backoff_ms : Int
+  idle_timeout_ms : Int
 } derive(Debug(ignore=API_KEY))
 
 ///|
@@ -41,6 +42,17 @@ pub struct Client {
 /// `retry_backoff_ms` (doubling per retry, capped at 60s). Client errors
 /// other than 429 never retry, and a streaming call never retries once the
 /// stream has produced any event — text, tool-call, or usage alike.
+///
+/// `idle_timeout_ms` bounds how long a streaming request may sit with no
+/// progress: it caps both the wait for response headers and the wait between
+/// SSE events. A silent stall (a connection the peer accepts then never feeds,
+/// which TCP alone will not surface for a long time) trips it, and the stall is
+/// converted to the same retryable class as a mid-stream drop — so a stall
+/// before any event is retried on a fresh connection, while one after output
+/// bails to a clean failure rather than duplicating a half-consumed completion.
+/// It is an *idle* bound, reset by every byte, so a long-but-progressing
+/// completion never trips it. Pass `0` (or less) to disable. Defaults to 120s;
+/// it applies to the streaming path only (the mode the agent and TUI use).
 pub fn Client::Client(
   api_key~ : String,
   model? : @deepseek.Model = default_model,
@@ -48,8 +60,17 @@ pub fn Client::Client(
   thinking? : @deepseek.ThinkingMode = No,
   retry_attempts? : Int = 3,
   retry_backoff_ms? : Int = 500,
+  idle_timeout_ms? : Int = 120_000,
 ) -> Client {
-  { api_key, model, api_url, thinking, retry_attempts, retry_backoff_ms }
+  {
+    api_key,
+    model,
+    api_url,
+    thinking,
+    retry_attempts,
+    retry_backoff_ms,
+    idle_timeout_ms,
+  }
 }
 
 ///|
@@ -240,7 +261,15 @@ async fn Client::chat_stream_attempt(
   })
   defer client.close()
   client.write(body.stringify())
-  let resp = client.end_request()
+  // Bound the wait for response headers the same way the SSE loop bounds the
+  // wait between events: a peer that accepts the connection then never sends a
+  // status line would otherwise block here forever, before any event, with no
+  // error for the retry loop to see.
+  let resp = with_idle_timeout(
+    self.idle_timeout_ms,
+    "DeepSeek response headers",
+    () => client.end_request(),
+  )
   guard resp.code >= 200 && resp.code < 300 else {
     let text = client.read_all().text()
     let message = "DeepSeek API error \{resp.code}: \{text}"
@@ -255,6 +284,7 @@ async fn Client::chat_stream_attempt(
   // decides whether retrying is allowed.
   read_chat_stream(
     client,
+    idle_timeout_ms=self.idle_timeout_ms,
     on_stream_event~,
     on_content_delta=stream.on_content_delta,
     on_reasoning_delta=stream.on_reasoning_delta,

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -230,6 +230,68 @@ async test "streaming chat fails an idle stall after a delta without retrying" {
 }
 
 ///|
+/// Regression (Codex review): a `data:` line received WITHOUT its blank-line
+/// terminator, then an idle stall, is buffered-but-unflushed model output. The
+/// idle path must flush it first — firing on_stream_event and delivering the
+/// content — so the delivered-event bail keeps the failure final instead of
+/// replaying a half-consumed completion. Exactly one hit; the delta is seen.
+async test "streaming chat does not retry an idle stall after an unterminated data line" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+      error => {
+        let message = "\{error}"
+        if message.contains("Operation not permitted") {
+          println("local TCP bind unavailable; skipping idle-stall test")
+          return
+        }
+        raise error
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val = hits.val + 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          // One data line, then a single newline — NO blank-line terminator —
+          // then silence. The delta sits buffered in data_lines.
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n",
+          )
+          conn.flush()
+          @async.sleep(3_000)
+        },
+        max_connections=8,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+      idle_timeout_ms=100,
+    )
+    let deltas : Array[String] = []
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta)),
+    ) catch {
+      error => {
+        assert_true("\{error}".contains("idle"))
+        assert_eq(deltas.join("|"), "partial")
+        assert_eq(hits.val, 1)
+        return
+      }
+    }
+    fail("expected an idle-stall failure without retry")
+  }
+}
+
+///|
 async test "chat stream handler rejects EOF before done" {
   @async.with_task_group() <| group => {
     guard stream_test_server(group, finish=false) is Some(url) else { return }

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -110,6 +110,126 @@ async test "chat stream handler accumulates Kimi stream_options usage" {
 }
 
 ///|
+/// A 2xx connection that goes silent — headers sent, then neither an SSE event
+/// nor a close — must not hang the client forever. The idle timeout trips;
+/// because nothing was delivered the stall counts as pre-event, so the request
+/// retries and the second connection serves the full stream. Without the idle
+/// bound this `read_until` blocks indefinitely (the observed production hang).
+async test "streaming chat retries an idle stall before any event" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+      error => {
+        let message = "\{error}"
+        if message.contains("Operation not permitted") {
+          println("local TCP bind unavailable; skipping idle-stall test")
+          return
+        }
+        raise error
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val = hits.val + 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.flush()
+          if hits.val > 1 {
+            conn.write(
+              "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+            )
+            conn.write("data: [DONE]\n\n")
+          } else {
+            // Hold the connection open but silent, well past the client's idle
+            // timeout, without sending an event or closing it.
+            @async.sleep(3_000)
+          }
+        },
+        max_connections=8,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+      idle_timeout_ms=100,
+    )
+    let response = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    )
+    assert_eq(response.content, "ok")
+    assert_eq(hits.val, 2)
+  }
+}
+
+///|
+/// Once an event has been delivered, an idle stall must surface as a failure
+/// rather than retry — replaying the stream would hand the consumer duplicate
+/// content. The server streams one delta, then goes silent forever; the idle
+/// timeout trips but the delivered-event bail keeps the failure final, so there
+/// is no second hit.
+async test "streaming chat fails an idle stall after a delta without retrying" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+      error => {
+        let message = "\{error}"
+        if message.contains("Operation not permitted") {
+          println("local TCP bind unavailable; skipping idle-stall test")
+          return
+        }
+        raise error
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val = hits.val + 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+          )
+          conn.flush()
+          // Never send [DONE]; hold the connection open and silent.
+          @async.sleep(3_000)
+        },
+        max_connections=8,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+      idle_timeout_ms=100,
+    )
+    let deltas : Array[String] = []
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta)),
+    ) catch {
+      error => {
+        assert_true("\{error}".contains("idle"))
+        assert_eq(deltas.join("|"), "partial")
+        assert_eq(hits.val, 1)
+        return
+      }
+    }
+    fail("expected an idle-stall failure")
+  }
+}
+
+///|
 async test "chat stream handler rejects EOF before done" {
   @async.with_task_group() <| group => {
     guard stream_test_server(group, finish=false) is Some(url) else { return }

--- a/deepseek/client/client_test.mbt
+++ b/deepseek/client/client_test.mbt
@@ -31,6 +31,7 @@ test "client debug redacts api key" {
       #|  thinking: Max,
       #|  retry_attempts: 3,
       #|  retry_backoff_ms: 500,
+      #|  idle_timeout_ms: 120000,
       #|}
     ),
   )

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -17,9 +17,10 @@ pub struct Client {
   thinking : @deepseek.ThinkingMode
   retry_attempts : Int
   retry_backoff_ms : Int
+  idle_timeout_ms : Int
   // private fields
 } derive(@debug.Debug)
-pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int) -> Self
+pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int, idle_timeout_ms? : Int) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
 
 pub struct StreamHandler {

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -208,15 +208,13 @@ async fn flush_sse_event(
 }
 
 ///|
-/// Runs `read` under an idle bound: if it produces nothing within
-/// `idle_timeout_ms`, the stall is converted to `RetryableApiError` so the
-/// client's retry loop can re-run the request on a fresh connection — subject
-/// to the same delivered-event bail as a mid-stream drop, so a stall after any
-/// output surfaces as a failure rather than replaying a half-consumed
-/// completion. `read`'s own errors propagate unchanged; a non-positive budget
-/// disables the bound. The clock covers a single `read`, so on the SSE loop it
-/// measures the gap between events and never trips on a long, progressing
-/// completion.
+/// Runs `read` under an idle bound, raising `RetryableApiError` directly if it
+/// produces nothing within `idle_timeout_ms`. Use it only where a stall leaves
+/// no buffered state to reconcile — the response-header read, where nothing has
+/// been produced yet so retrying on a fresh connection is unconditionally safe.
+/// The SSE body loop instead uses `read_stream_line`, which must flush a
+/// buffered event before raising. `read`'s own errors propagate unchanged; a
+/// non-positive budget disables the bound.
 async fn[T] with_idle_timeout(
   idle_timeout_ms : Int,
   what : String,
@@ -233,6 +231,23 @@ async fn[T] with_idle_timeout(
 }
 
 ///|
+/// One SSE line under the idle bound: `Some(Some(line))` is a line,
+/// `Some(None)` is EOF, and `None` is an idle timeout — kept distinct from EOF
+/// only so the caller can label the retry reason, since both are handled the
+/// same way (flush any buffered event first). A non-positive budget disables
+/// the bound.
+async fn read_stream_line(
+  reader : @http.Client,
+  idle_timeout_ms : Int,
+) -> String?? {
+  if idle_timeout_ms <= 0 {
+    Some(reader.read_until("\n"))
+  } else {
+    @async.with_timeout_opt(idle_timeout_ms, () => reader.read_until("\n"))
+  }
+}
+
+///|
 async fn read_chat_stream(
   reader : @http.Client,
   idle_timeout_ms~ : Int,
@@ -243,27 +258,13 @@ async fn read_chat_stream(
   let acc = StreamAccumulator::StreamAccumulator()
   let data_lines : Array[String] = []
   for ;; {
-    match
-      with_idle_timeout(idle_timeout_ms, "DeepSeek stream", () => {
-        reader.read_until("\n")
-      }) {
-      None => {
-        if flush_sse_event(
-            acc,
-            data_lines,
-            on_stream_event~,
-            on_content_delta~,
-            on_reasoning_delta~,
-          ) {
-          break
-        }
-        // A connection that dies before [DONE] is transport-shaped; raise
-        // the retryable class so the client's retry loop may re-run the
-        // request — its delivered-delta bail makes this final whenever any
-        // output already reached the consumer.
-        raise RetryableApiError("DeepSeek stream ended before [DONE]")
-      }
-      Some(raw) => {
+    // An interrupted read — EOF or idle timeout — must flush any buffered event
+    // before raising: a `data:` line received without its blank-line terminator
+    // is model output already produced (and billed), so flushing fires
+    // on_stream_event and keeps the retry loop from replaying a half-consumed
+    // completion. EOF and timeout differ only in the retry reason.
+    let reason = match read_stream_line(reader, idle_timeout_ms) {
+      Some(Some(raw)) => {
         let trimmed = raw.trim()
         if trimmed.is_empty() {
           if flush_sse_event(
@@ -278,8 +279,21 @@ async fn read_chat_stream(
         } else if sse_data_fragment(raw) is Some(data) {
           data_lines.push(data)
         }
+        continue
       }
+      Some(None) => "DeepSeek stream ended before [DONE]"
+      None => "DeepSeek stream idle for \{idle_timeout_ms}ms"
     }
+    if flush_sse_event(
+        acc,
+        data_lines,
+        on_stream_event~,
+        on_content_delta~,
+        on_reasoning_delta~,
+      ) {
+      break
+    }
+    raise RetryableApiError(reason)
   }
   acc.response()
 }

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -208,8 +208,34 @@ async fn flush_sse_event(
 }
 
 ///|
+/// Runs `read` under an idle bound: if it produces nothing within
+/// `idle_timeout_ms`, the stall is converted to `RetryableApiError` so the
+/// client's retry loop can re-run the request on a fresh connection — subject
+/// to the same delivered-event bail as a mid-stream drop, so a stall after any
+/// output surfaces as a failure rather than replaying a half-consumed
+/// completion. `read`'s own errors propagate unchanged; a non-positive budget
+/// disables the bound. The clock covers a single `read`, so on the SSE loop it
+/// measures the gap between events and never trips on a long, progressing
+/// completion.
+async fn[T] with_idle_timeout(
+  idle_timeout_ms : Int,
+  what : String,
+  read : async () -> T,
+) -> T {
+  if idle_timeout_ms <= 0 {
+    read()
+  } else {
+    match @async.with_timeout_opt(idle_timeout_ms, read) {
+      Some(value) => value
+      None => raise RetryableApiError("\{what} idle for \{idle_timeout_ms}ms")
+    }
+  }
+}
+
+///|
 async fn read_chat_stream(
   reader : @http.Client,
+  idle_timeout_ms~ : Int,
   on_stream_event~ : () -> Unit,
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
@@ -217,7 +243,10 @@ async fn read_chat_stream(
   let acc = StreamAccumulator::StreamAccumulator()
   let data_lines : Array[String] = []
   for ;; {
-    match reader.read_until("\n") {
+    match
+      with_idle_timeout(idle_timeout_ms, "DeepSeek stream", () => {
+        reader.read_until("\n")
+      }) {
       None => {
         if flush_sse_event(
             acc,


### PR DESCRIPTION
## Problem

A streaming chat request could block **forever** on `read_until` when a peer
accepted the connection then went silent — no bytes, no EOF, no error. The
retry loop only fires on a *raised* error, so a silent stall never engaged it.
Observed in a long agent run as a ~108-minute wedge at the start of a new turn
(0% CPU, no events, empty stderr).

## Fix

Add `Client.idle_timeout_ms` (default **120s**; `0` disables). A new
`with_idle_timeout` helper wraps **both** the response-header read and each SSE
`read_until` in `@async.with_timeout_opt`, converting a stall into the existing
`RetryableApiError`:

- a stall **before any event** → retried on a fresh connection;
- a stall **after output** → bails to a clean failure (never replays a
  half-consumed completion).

It is an *idle* bound measured **per read** — the header line, then each SSE
event line — so it resets on every event (not every byte); a stream that keeps
delivering events never trips it. Applies to the streaming path (the mode the
agent and TUI use).

## Tests

- `streaming chat retries an idle stall before any event` → retries, `hits==2`.
- `streaming chat fails an idle stall after a delta without retrying` → `hits==1`.
- `streaming chat does not retry an idle stall after an unterminated data line`
  → flushes the buffered delta, fails without retry (`hits==1`).

`moon test deepseek/client` passes (incl. the live DeepSeek smoke test with a
valid key); `moon info`/`fmt` clean; `.mbti` diff is one field + one optional
constructor param.

## Validation in a real run

Rebuilt the agent with this fix and ran a 301-step / ~35-min task: it finished
in a **single pass with zero hangs** (before the fix, the analogous run hung
~108 min).

## Review

Reviewed twice with `codex exec review`; both findings addressed on the branch
(flush buffered SSE before an idle retry; per-event vs per-byte doc accuracy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
