### PR TITLE
agent: inject a plan staleness reminder after ten silent requests

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -2,6 +2,30 @@
 let default_max_steps : Int = 1000
 
 ///|
+/// Model requests since the last successful `plan` call — and since the last
+/// reminder — before the loop injects a plan staleness reminder. Both
+/// thresholds mirror the 10-turn / 10-turn cadence Claude Code uses for its
+/// todo reminder: long enough that short tasks never see a nag, and the
+/// second threshold caps re-nagging of a model that ignores the first at
+/// once per ten requests.
+let plan_reminder_after_steps : Int = 10
+
+///|
+/// The staleness reminder injected when the `plan` tool has gone unused for
+/// `plan_reminder_after_steps` model requests. With a known current plan the
+/// reminder re-surfaces it — the last plan call may sit dozens of steps back
+/// in context — and otherwise it nudges once toward recording a plan, while
+/// staying explicit that trivial work should ignore it.
+fn plan_reminder_text(checklist : String?) -> String {
+  match checklist {
+    Some(lines) =>
+      "[plan reminder]\nThe plan tool has not been called in a while. If progress was made, update step statuses; if the plan no longer matches the work, replace it or clear it with steps: []. Current plan:\n\{lines}"
+    None =>
+      "[plan reminder]\nThe plan tool has not been used in this turn. If this task takes several distinct steps, record a plan with the plan tool and keep step statuses current. If not, ignore this reminder."
+  }
+}
+
+///|
 /// Queue `text` as steering input for the turn running on `runtime`.
 ///
 /// This is a thin public wrapper over `AgentRuntime::queue_steer(Prompt(...))`.
@@ -234,12 +258,16 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// The loop appends `task` as a user message before the first model request.
 /// At each step boundary it first drains and applies pending non-blank steers,
 /// then drains runtime events and turns known tool updates into model-visible
-/// runtime notices. It sends the current DeepSeek chat projection with the
-/// active tool schemas, records assistant responses, executes tool calls in
-/// order, and records tool results. The turn ends when the model answers with
-/// no tool calls, the `finish` tool returns `Control(Finish)`, a tool returns
-/// `Control(Abort)`, `max_steps` is exhausted, the task is cancelled, or an
-/// unexpected error escapes.
+/// runtime notices. When the registry includes the `plan` tool and
+/// `plan_reminder_after_steps` model requests pass without a successful
+/// `plan` call, the loop also injects a durable plan staleness reminder that
+/// re-surfaces the recorded plan (rate-limited by the same threshold). It
+/// sends the current DeepSeek chat projection with the active tool schemas,
+/// records assistant responses, executes tool calls in order, and records
+/// tool results. The turn ends when the model answers with no tool calls, the
+/// `finish` tool returns `Control(Finish)`, a tool returns `Control(Abort)`,
+/// `max_steps` is exhausted, the task is cancelled, or an unexpected error
+/// escapes.
 ///
 /// A steer that arrives while the model's apparent final answer or a `finish`
 /// tool call is in flight keeps the turn alive. The would-be final answer is
@@ -284,6 +312,14 @@ pub async fn[X] run_turn_in_scope(
     }
     let messages = session.chat_messages()
     let watcher_fingerprints : Map[String, String] = {}
+    // Plan staleness tracking: counters advance once per model request and
+    // reset when a `plan` call succeeds, so the reminder fires only after
+    // `plan_reminder_after_steps` requests of plan silence. Turn-local by
+    // design — a fresh user turn resets the cadence.
+    let plan_registered = tools.find("plan") is Some(_)
+    let mut steps_since_plan = 0
+    let mut steps_since_reminder = 0
+    let mut plan_checklist : String? = None
     steps~: for step in 0..<max_steps {
       // Steering first: user-visible mid-turn input should precede runtime
       // chatter the model reads alongside it.
@@ -320,6 +356,17 @@ pub async fn[X] run_turn_in_scope(
         session = append_item(session, Runtime(RuntimeNotice(notice)))
         messages.push(ChatMessage(User, content=notice))
       }
+      if plan_registered &&
+        steps_since_plan >= plan_reminder_after_steps &&
+        steps_since_reminder >= plan_reminder_after_steps {
+        let reminder = plan_reminder_text(plan_checklist)
+        @xlog.info() <? { "event": "plan_reminder", "content": reminder }
+        session = append_item(session, Runtime(RuntimeNotice(reminder)))
+        messages.push(ChatMessage(User, content=reminder))
+        steps_since_reminder = 0
+      }
+      steps_since_plan += 1
+      steps_since_reminder += 1
       @xlog.info() <? { "event": "agent_step", "step": step + 1 }
       let response = client.chat(
         messages,
@@ -494,6 +541,13 @@ pub async fn[X] run_turn_in_scope(
             return next
           }
           Respond(output) => output
+        }
+        if tool_call.name == "plan" && !output.is_error {
+          // A successful plan write restarts the staleness cadence and
+          // refreshes the checklist the next reminder would re-surface; a
+          // cleared plan drops back to the plan-free nudge.
+          steps_since_plan = 0
+          plan_checklist = @plan.reminder_checklist(tool_call.arguments)
         }
         @xlog.info() <?
           {

--- a/agent/plan_reminder_test.mbt
+++ b/agent/plan_reminder_test.mbt
@@ -1,0 +1,196 @@
+///|
+/// A scripted DeepSeek stand-in that keeps a turn alive with `plan` calls
+/// whose arguments are invalid — each yields an error tool result, which
+/// never resets the staleness cadence. The server only records request
+/// bodies and scripts responses by request number; all assertions happen in
+/// the test body after the run, so a client retry shows up as a hard
+/// request-count mismatch instead of silently shifting the cadence.
+async fn stale_plan_test_server(
+  group : @async.TaskGroup[Unit],
+  bodies : Array[String],
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping plan reminder test")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        bodies.push(body.read_all().text())
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        if bodies.length() <= 11 {
+          conn.write(
+            (
+              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
+            ),
+          )
+          conn.write("\n\n")
+        } else {
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
+          )
+        }
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=2,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "a plan-silent turn gets one staleness reminder after ten requests" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard stale_plan_test_server(group, bodies) is Some(url) else { return }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("plan-reminder"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "do a long task",
+      append_item=(session, item) => session.append(item),
+      max_steps=20,
+      api_url=url,
+    )
+    // Exactly 12 requests: 11 tool-call steps plus the finishing answer. A
+    // retry would inflate the count and fail here rather than skew the
+    // cadence assertions below.
+    assert_eq(bodies.length(), 12)
+    for index in 0..<10 {
+      assert_false(
+        bodies[index].contains("[plan reminder]"),
+        msg="request \{index + 1} must not carry the reminder yet",
+      )
+    }
+    assert_true(
+      bodies[10].contains("[plan reminder]"),
+      msg="request 11 should carry the reminder",
+    )
+    assert_true(bodies[10].contains("has not been used in this turn"))
+    // The reminder is durable exactly once, in its plan-free nag variant.
+    let reminders = [
+      for event in result.events() if event.item() is Runtime(notice) &&
+      notice.content().contains("[plan reminder]") => notice.content()
+    ]
+    assert_eq(reminders.length(), 1)
+    assert_true(reminders[0].contains("has not been used in this turn"))
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "done")
+  }
+}
+
+///|
+/// A scripted stand-in where request 1 records a valid plan. The successful
+/// write resets the cadence, so the reminder fires ten requests later — in
+/// request 12 — and re-surfaces the recorded checklist. Assertions live in
+/// the test body, as above.
+async fn recorded_plan_test_server(
+  group : @async.TaskGroup[Unit],
+  bodies : Array[String],
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping plan reminder test")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        bodies.push(body.read_all().text())
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        if bodies.length() == 1 {
+          conn.write(
+            (
+              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"}]}"}}]}}]}
+            ),
+          )
+          conn.write("\n\n")
+        } else if bodies.length() <= 12 {
+          conn.write(
+            (
+              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
+            ),
+          )
+          conn.write("\n\n")
+        } else {
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
+          )
+        }
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=2,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+async test "a recorded plan delays the reminder and is re-surfaced by it" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard recorded_plan_test_server(group, bodies) is Some(url) else { return }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("plan-reminder-checklist"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "do a long task",
+      append_item=(session, item) => session.append(item),
+      max_steps=20,
+      api_url=url,
+    )
+    // Exactly 13 requests: the plan write, 11 more tool-call steps, the
+    // finishing answer.
+    assert_eq(bodies.length(), 13)
+    assert_false(
+      bodies[10].contains("[plan reminder]"),
+      msg="the successful plan write must delay the reminder past request 11",
+    )
+    assert_true(
+      bodies[11].contains("[plan reminder]"),
+      msg="request 12 should carry the reminder",
+    )
+    assert_true(bodies[11].contains("Current plan:"))
+    assert_true(bodies[11].contains("1. [in_progress] fix the parser"))
+    let reminders = [
+      for event in result.events() if event.item() is Runtime(notice) &&
+      notice.content().contains("[plan reminder]") => notice.content()
+    ]
+    assert_eq(reminders.length(), 1)
+    assert_true(reminders[0].contains("1. [in_progress] fix the parser"))
+  }
+}

--- a/agent_tool/plan/pkg.generated.mbti
+++ b/agent_tool/plan/pkg.generated.mbti
@@ -8,6 +8,8 @@ import {
 // Values
 pub fn definition() -> @agent_tool.AgentToolDefinition
 
+pub fn reminder_checklist(Json) -> String?
+
 // Errors
 
 // Types and methods

--- a/agent_tool/plan/plan.mbt
+++ b/agent_tool/plan/plan.mbt
@@ -69,6 +69,55 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
 }
 
 ///|
+/// Best-effort numbered rendering of `plan` tool-call arguments for host-side
+/// staleness reminders: `1. [in_progress] fix the parser` lines. Returns
+/// `None` for arguments that do not decode as a plan, or that cleared it, so
+/// callers fall back to a plan-free nudge. Lives here so the agent loop never
+/// grows its own copy of the plan argument syntax.
+pub fn reminder_checklist(arguments : Json) -> String? {
+  let input = @decode.decode(arguments) catch { _ => return None }
+  if input.steps.length() == 0 {
+    return None
+  }
+  let lines = StringBuilder::new()
+  for index, step in input.steps {
+    let status = match step.status {
+      Pending => "pending"
+      InProgress => "in_progress"
+      Completed => "completed"
+    }
+    if index > 0 {
+      lines.write_char('\n')
+    }
+    lines.write_string("\{index + 1}. [\{status}] \{step.title}")
+  }
+  Some(lines.to_string())
+}
+
+///|
+test "reminder_checklist renders numbered statuses and falls back to None" {
+  guard reminder_checklist({
+      "steps": [
+        { "title": "read the failing test", "status": "completed" },
+        { "title": "fix the parser", "status": "in_progress" },
+      ],
+    })
+    is Some(lines) else {
+    fail("expected a checklist")
+  }
+  assert_eq(
+    lines,
+    (
+      #|1. [completed] read the failing test
+      #|2. [in_progress] fix the parser
+    ),
+  )
+  // A cleared plan and undecodable arguments both yield None.
+  assert_true(reminder_checklist({ "steps": [] }) is None)
+  assert_true(reminder_checklist({ "nonsense": true }) is None)
+}
+
+///|
 fn execute(arguments : Json) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {


### PR DESCRIPTION
Follow-up to #344 (merged). Rebased onto main; single self-contained commit.

## What

Ports the mechanism behind Claude Code's `todo_reminder` attachment (reference: `.repos/claude-code-rev` — `attachments.ts` `getTodoReminderAttachments`, `messages.ts` rendering) to the agent loop:

- **Cadence**: turn-local counters advance once per model request and reset on a successful `plan` call. When both "requests since last plan write" and "requests since last reminder" reach **10** — Claude Code's exact 10/10 thresholds — the loop injects a `[plan reminder]` notice before the next request. The second threshold caps re-nagging at once per ten requests.
- **Two variants**, as in the reference: with a recorded plan the reminder **re-surfaces it** as a numbered checklist (`1. [in_progress] fix the parser` — the last plan call may sit dozens of steps back in context); without one it nudges once toward planning and explicitly says to ignore it for non-multi-step work.
- **Checklist rendering lives in the plan package** (`@plan.reminder_checklist`, tolerant decode, `None` for cleared/undecodable plans) so the loop never grows its own copy of the plan argument syntax.
- **Durable, not ephemeral**: unlike Claude Code's attachment, the reminder is a `RuntimeNotice` + pushed chat message — the repo's lockstep invariant between session and model-facing messages (same shape as `moon_check` update notices), so resumed turns replay exactly what the model saw. Cost is bounded by the cadence.
- **Gated** on the `plan` tool actually being registered, mirroring the reference's tool-availability gate.

## Validation

- Two scripted-SSE-server integration tests pin the cadence end to end: request 11 carries the nag variant when every plan call errors; a successful plan write at request 1 delays the reminder to request 12 and re-surfaces the recorded checklist. Per Codex's review, all assertions run in the test body over recorded request bodies with exact request-count checks, so a client retry fails loudly instead of skewing the cadence.
- `agent` 14/14, `agent_tool/plan` (+decode) tests green, full `moon check`/`fmt`/`info` clean.
- Codex CLI review (gpt-5.5, xhigh): traced the counter arithmetic through the steer/finish override paths, protocol placement, plan detection, projection replay, and the public API — **"I did not find a production correctness defect in the reminder implementation. Verdict: approve the loop/helper behavior, but tighten the integration tests before relying on them as cadence pins."** The test tightening it requested is included.

## Not ported (deliberately)

The reference's suppression-when-competing-channel gate (no equivalent channel here) and host-side persistence across turns — the cadence is per-turn, which also means a fresh user turn never opens with a nag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
