### PR TITLE
fix(cmd/viz_server): don't scan cwd when --session-root is explicit

### DIFF
--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -26,7 +26,7 @@ async fn main {
       "--session-root-name or OPENSEEK_VIZ_SESSION_ROOT_NAME must not be empty",
     )
   }
-  let search_dirs = non_empty_values(matches, "search-dir")
+  let search_dirs = effective_search_dirs(matches)
   let web_dir = value(matches, "web-dir")
   let bundle = value(matches, "bundle")
   let module_root = match @env.args() {
@@ -745,7 +745,7 @@ fn cli_command() -> @argparse.Command {
         env="OPENSEEK_VIZ_SEARCH_DIR",
         action=Append,
         default_values=["."],
-        about="Directory to scan recursively for session roots; repeat to scan several trees.",
+        about="Directory to scan recursively for session roots; repeat to scan several trees. The default '.' scan is skipped when --session-root is given explicitly.",
       ),
       OptionArg(
         "session-root-name",
@@ -778,6 +778,29 @@ fn value(matches : @argparse.Matches, name : String) -> String raise {
     Some([value, ..]) => value
     _ => fail("missing parsed argument: \{name}")
   }
+}
+
+///|
+/// The directories to scan recursively for session roots. An explicit
+/// `--session-root` (flag or env) narrows serving to that root, so the
+/// default `.` scan is dropped — pointing the server at another project's
+/// sessions must not also pull in whatever tree it was started from. An
+/// explicit `--search-dir` always wins: giving both flags means "that root,
+/// plus these scans".
+fn effective_search_dirs(matches : @argparse.Matches) -> Array[String] {
+  if explicitly_provided(matches, "session-root") &&
+    !explicitly_provided(matches, "search-dir") {
+    []
+  } else {
+    non_empty_values(matches, "search-dir")
+  }
+}
+
+///|
+/// Whether the user supplied `name` on the command line or via its
+/// environment variable, rather than the built-in default filling it in.
+fn explicitly_provided(matches : @argparse.Matches, name : String) -> Bool {
+  matches.sources.get(name) is (Some(Argv) | Some(Env))
 }
 
 ///|

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -139,6 +139,40 @@ test "valid_session_id mirrors the store's id rules" {
 }
 
 ///|
+test "explicit --session-root drops the default cwd scan" {
+  // Default invocation keeps the `.` scan so nearby stores are discovered.
+  let default_run = cli_command().parse(argv=[], env={})
+  @debug.debug_inspect(
+    effective_search_dirs(default_run),
+    content=(
+      #|["."]
+    ),
+  )
+  // An explicit root means "serve this", not "this plus wherever I'm standing".
+  let flag_root = cli_command().parse(
+    argv=["--session-root", "/srv/app/.openseek"],
+    env={},
+  )
+  @debug.debug_inspect(effective_search_dirs(flag_root), content="[]")
+  // The env var counts as explicit too.
+  let env_root = cli_command().parse(argv=[], env={
+    "OPENSEEK_SESSION_ROOT": "/srv/app/.openseek",
+  })
+  @debug.debug_inspect(effective_search_dirs(env_root), content="[]")
+  // An explicit --search-dir always wins: both flags means root plus scans.
+  let both = cli_command().parse(
+    argv=["--session-root", "/srv/app/.openseek", "--search-dir", "/srv/lib"],
+    env={},
+  )
+  @debug.debug_inspect(
+    effective_search_dirs(both),
+    content=(
+      #|["/srv/lib"]
+    ),
+  )
+}
+
+///|
 async test "discover_session_roots scans recursively and skips heavy dirs" {
   @vfs.with_tmpdir(prefix="openseek-viz-scan-", root => {
     @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)


### PR DESCRIPTION
## Problem

`moon run cmd/viz_server -- --session-root <path>` still served every session store discovered under the current directory, because the `--search-dir` default of `.` was applied unconditionally. Pointing the server at another project's sessions is exactly when you don't want your own cwd's stores mixed in.

## Fix

Use argparse's per-argument value sources (`Matches.sources`: `Argv`/`Env`/`Default`) to distinguish an explicit `--session-root` (flag or `OPENSEEK_SESSION_ROOT`) from the built-in default:

- `--session-root X` explicit, no `--search-dir` → the default `.` scan is dropped; only `X` (and stores nested under it) are served.
- `--search-dir` explicit → always honored; both flags mean "that root, plus these scans".
- No flags → unchanged: serve `.openseek` and discover roots under `.`.

## Validation

- New wbtest covering the four cases (default, flag, env var, both flags); `moon test cmd/viz_server` — 16/16 pass.
- Verified end-to-end: `--session-root .repos/toml01/.openseek` serves only that root; a no-flag run still discovers all nearby stores.
- `moon fmt` / `moon info` clean; no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)