### PR TITLE
fix(cmd/openseek): make explicit --concurrency 1 copy --dir like N>=2

### DIFF
--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -1,7 +1,8 @@
 ///|
-/// "Best-of-N" fleet mode (`--concurrency N`): run the same task in N sibling
-/// copies of `--dir` concurrently, each recording its own durable session, then
-/// print a summary. The original `--dir` is never written to.
+/// "Best-of-N" fleet mode (`--concurrency N`, any explicit N including 1): run
+/// the same task in N sibling copies of `--dir` concurrently, each recording
+/// its own durable session, then print a summary. The original `--dir` is
+/// never written to.
 ///
 /// Naming uses `<base>_run_<i>` (underscores, not a dotted suffix that reads as a
 /// file extension) so the run directories are unambiguous and easy to recognize.

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -110,7 +110,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
       value(matches, "concurrency"),
       "--concurrency",
     )
-    if concurrency >= 2 {
+    if fleet_mode(matches, concurrency) {
       run_fleet(matches, concurrency~)
       return
     }
@@ -464,7 +464,7 @@ fn root_command() -> @argparse.Command {
             long="concurrency",
             env="OPENSEEK_CONCURRENCY",
             default_values=["1"],
-            about="Run the task in N sibling copies of --dir concurrently (best-of-N); 1 means a single run.",
+            about="Run the task in N sibling copies of --dir concurrently (best-of-N). Any explicit value, including 1, copies --dir into <dir>_run_<i> and never writes to --dir itself; omit the flag for a single in-place run.",
           ),
         ],
         flags=[
@@ -581,6 +581,22 @@ fn values(matches : @argparse.Matches, name : String) -> Array[String] {
 ///|
 fn flag(matches : @argparse.Matches, name : String) -> Bool {
   matches.flags.get(name).unwrap_or(false)
+}
+
+///|
+/// Whether `openseek run` should use fleet mode: any N >= 2, or an explicit
+/// `--concurrency` at any value. `--concurrency 1` still means "one run in a
+/// copied `<dir>_run_1` workspace" — the flag always protects `--dir` from
+/// writes, at every N. Only the flagless default runs in place.
+fn fleet_mode(matches : @argparse.Matches, concurrency : Int) -> Bool {
+  concurrency >= 2 || explicitly_provided(matches, "concurrency")
+}
+
+///|
+/// Whether the user supplied `name` on the command line or via its
+/// environment variable, rather than the built-in default filling it in.
+fn explicitly_provided(matches : @argparse.Matches, name : String) -> Bool {
+  matches.sources.get(name) is (Some(Argv) | Some(Env))
 }
 
 ///|
@@ -1232,6 +1248,21 @@ test "cli uses KIMI only for Kimi models" {
     }
   }
   fail("KIMI was accepted for a DeepSeek model")
+}
+
+///|
+test "explicit --concurrency selects fleet mode even at 1" {
+  // Any explicit --concurrency copies --dir; 1 is not an in-place special case.
+  let explicit_one = run_matches(argv=["--concurrency", "1", "task"], env={})
+  assert_true(fleet_mode(explicit_one, 1))
+  // The env var counts as explicit too.
+  let via_env = run_matches(argv=["task"], env={ "OPENSEEK_CONCURRENCY": "1" })
+  assert_true(fleet_mode(via_env, 1))
+  // Only the flagless default runs in place.
+  let default_run = run_matches(argv=["task"], env={})
+  assert_false(fleet_mode(default_run, 1))
+  // N >= 2 is fleet mode regardless of how it was set.
+  assert_true(fleet_mode(default_run, 2))
 }
 
 ///|

--- a/eval/swe_agi/README.mbt.md
+++ b/eval/swe_agi/README.mbt.md
@@ -37,10 +37,9 @@ binary gate. The `passed/total` count is a useful partial-credit signal. A bare
 
 Notes:
 
-- **`--concurrency 1` writes in place.** A single run mutates `--dir` directly
-  (the agent writes its implementation there), dirtying the vendored task. For a
-  one-off, copy the task first (`cp -r eval/swe_agi/tasks/csv /tmp/csv && …
-  --dir /tmp/csv`). `--concurrency ≥ 2` needs no copy.
+- **`--concurrency 1` also copies.** Any explicit `--concurrency` — including
+  1 — runs in `<task>_run_<i>` copies and never writes to `--dir` itself. Only
+  a flagless `openseek run --dir <task>` mutates the task directory in place.
 - **For a strict grade**, restore the shipped tests before `moon test` — the
   agent works in a copy where the tests are writable and may add or edit
   `*_test.mbt`. Drop the run's `*_test.mbt` and copy the task's originals back.

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -140,7 +140,7 @@ Options:
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
   --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
-  --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N); 1 means a single run. [env: OPENSEEK_CONCURRENCY] [default: 1]
+  --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N). Any explicit value, including 1, copies --dir into <dir>_run_<i> and never writes to --dir itself; omit the flag for a single in-place run. [env: OPENSEEK_CONCURRENCY] [default: 1]
 ```
 
 ## API Key Is Required For Agent Runs


### PR DESCRIPTION
## Problem

`--concurrency N` promises the original `--dir` is never written to — but only delivered for N ≥ 2. An explicit `--concurrency 1` fell through to the plain in-place run and mutated `--dir` directly, dirtying the vendored SWE-AGI task directory the flag was meant to protect (this is how `eval/swe_agi/tasks/csv/` picked up an agent-written implementation and session store).

## Fix

Any explicit `--concurrency` (flag or `OPENSEEK_CONCURRENCY`), including 1, now routes through fleet mode: the task runs in a copied `<dir>_run_1` workspace with its own durable session and the usual fleet summary. Only the flagless default still runs in place. Explicit-vs-default is distinguished via argparse's per-argument value sources (`Matches.sources`), the same mechanism as #347.

Behavior notes:
- `--concurrency 1` now rejects `--session` / `--no-session`, exactly like every other fleet run (previously it accepted them in the in-place path).
- The `eval/swe_agi` README note about "`--concurrency 1` writes in place" is updated; a one-off no longer needs the manual `cp -r` workaround.

## Validation

- New test covering the routing predicate: explicit flag → fleet, env var → fleet, flagless default → in place, N ≥ 2 → always fleet. `moon test cmd/openseek` — 59/59 pass.
- `moon fmt` / `moon info` clean; no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)