### PR TITLE
Auto-compaction: bound the prompt for long runs (--compact-threshold)

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -2,6 +2,14 @@
 let default_max_steps : Int = 1000
 
 ///|
+/// Minimum number of steps between auto-compactions in one turn. Normally
+/// the trigger self-resets — the first post-compaction prompt is a fraction
+/// of the threshold — so this only bounds the pathological case where the
+/// summary plus recent history still exceeds the threshold, and it spaces
+/// out retries after a failed summarizer call.
+let compaction_cooldown_steps : Int = 8
+
+///|
 /// Queue `text` as steering input for the turn running on `runtime`.
 ///
 /// This is a thin public wrapper over `AgentRuntime::queue_steer(Prompt(...))`.
@@ -74,6 +82,7 @@ pub async fn run(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
+  compact_threshold? : Int,
 ) -> Unit {
   let session = @agent_session.Session(
     SessionId("one-shot"),
@@ -89,6 +98,7 @@ pub async fn run(
       thinking~,
       api_url?,
       workspace_root~,
+      compact_threshold?,
     ),
   )
 }
@@ -121,6 +131,7 @@ pub async fn run_turn(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
+  compact_threshold? : Int,
 ) -> @agent_session.Session {
   run_turn_with_append(
     api_key,
@@ -132,6 +143,7 @@ pub async fn run_turn(
     thinking~,
     api_url?,
     workspace_root~,
+    compact_threshold?,
   )
 }
 
@@ -165,6 +177,7 @@ pub async fn run_turn_with_append(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
+  compact_threshold? : Int,
 ) -> @agent_session.Session {
   @async.with_task_group() <| group => {
     run_turn_in_scope(
@@ -178,6 +191,7 @@ pub async fn run_turn_with_append(
       max_steps~,
       thinking~,
       api_url?,
+      compact_threshold?,
     )
   }
 }
@@ -265,6 +279,7 @@ pub async fn[X] run_turn_in_scope(
   api_url? : String,
   tools? : @agent_tool.Tools,
   goal_cell? : @goal_tool.GoalCell,
+  compact_threshold? : Int,
 ) -> @agent_session.Session {
   run_opened_turn_in_scope(
     runtime,
@@ -279,6 +294,7 @@ pub async fn[X] run_turn_in_scope(
     api_url?,
     tools?,
     goal_cell?,
+    compact_threshold?,
   )
 }
 
@@ -301,6 +317,7 @@ async fn[X] run_opened_turn_in_scope(
   api_url? : String,
   tools? : @agent_tool.Tools,
   goal_cell? : @goal_tool.GoalCell,
+  compact_threshold? : Int,
 ) -> @agent_session.Session {
   let client = @client.Client(api_key~, model~, thinking~, api_url?)
   let mut session = append_item(session, opening)
@@ -334,8 +351,13 @@ async fn[X] run_opened_turn_in_scope(
           }
         }
     }
-    let messages = session.chat_messages()
+    let mut messages = session.chat_messages()
     let watcher_fingerprints : Map[String, String] = {}
+    // Seeded from the log, not zero: a continuation or resumed turn whose
+    // projection is already past the threshold compacts before its first
+    // model call instead of after it.
+    let mut last_prompt_tokens = last_recorded_prompt_tokens(session)
+    let mut last_compaction_step = -compaction_cooldown_steps
     steps~: for step in 0..<max_steps {
       // Budget gate at the step boundary: a goal turn whose budget ran out
       // stops before the next model call instead of running to max_steps.
@@ -347,6 +369,102 @@ async fn[X] run_opened_turn_in_scope(
         let next = append_item(session, Terminal(Finished(note)))
         @xlog.warn() <? { "event": "goal_budget_step_stop", "step": step }
         return next
+      }
+      // Auto-compaction at the same safe boundary: every tool call has its
+      // result recorded, so the whole log can be summarized without
+      // orphaning a pending call. Triggered by the previous response's
+      // observed prompt size — the provider's own count, no local
+      // tokenizing. The cooldown bounds re-compaction when the summary plus
+      // recent history still exceeds the threshold; normally the trigger
+      // self-resets because the next prompt shrinks far below it.
+      if compact_threshold is Some(threshold) &&
+        threshold > 0 &&
+        last_prompt_tokens >= threshold &&
+        step - last_compaction_step >= compaction_cooldown_steps {
+        last_compaction_step = step
+        let prompt_tokens_before = last_prompt_tokens
+        // Only an active goal's objective belongs in the summary prompt: a
+        // goal that just completed or blocked must not be preserved by the
+        // summarizer as work still in progress.
+        let objective = match goal_cell.current() {
+          Some(goal) if goal.status() is Active => Some(goal.objective())
+          _ => None
+        }
+        // Compaction is an optimization; its failure must never end a turn
+        // that could still make progress. The cooldown above also spaces
+        // out retries after a failure.
+        let compaction = try
+          @compact.generate_summary(
+            api_key~,
+            model~,
+            session,
+            api_url?,
+            objective?,
+            unread_opening=step == 0,
+          )
+        catch {
+          error => {
+            @xlog.error() <?
+              {
+                "event": "compaction_failed",
+                "step": step,
+                "error": "\{error}",
+              }
+            None
+          }
+        } noraise {
+          result => Some(result)
+        }
+        if compaction is Some((summary, usage)) {
+          // Mirror `@compact.compact_session`: capture the covered range
+          // first, record the summarizer's own spend (budget folds must
+          // see it), then append the summary as the range's terminator —
+          // all through `append_item`, the loop's single durable path.
+          let to_sequence = session.last_sequence()
+          session = append_item(session, Usage(usage))
+          refresh_goal_cell(goal_cell, session)
+          session = append_item(
+            session,
+            Summary(
+              SessionSummary(content=summary, from_sequence=1, to_sequence~),
+            ),
+          )
+          if step == 0 {
+            // The turn's opening (a user task or a goal continuation
+            // envelope) was appended before this boundary, so the model has
+            // not read it yet. The projection emits uncovered events in log
+            // order, so re-deliver the opening after the checkpoint —
+            // otherwise the summary would land after the fresh instruction
+            // and could take precedence over it. The summarizer was told to
+            // leave the instruction to this verbatim copy.
+            session = append_item(session, opening)
+          }
+          // The projection changed shape: rebuild the model-facing messages
+          // from the compacted session, and forget watcher fingerprints —
+          // the notices they describe are now behind the summary, so the
+          // next runtime update must be emitted in full, not collapsed to
+          // a "results unchanged" marker.
+          messages = session.chat_messages()
+          watcher_fingerprints.clear()
+          last_prompt_tokens = 0
+          @xlog.info() <?
+            {
+              "event": "auto_compaction",
+              "step": step,
+              "to_sequence": to_sequence,
+              "prompt_tokens_before": prompt_tokens_before,
+            }
+          // The summarizer's own spend counts against the goal budget (the
+          // usage above was folded into the cell), so re-run the budget gate:
+          // compaction must not buy one extra model call past the budget.
+          // The summary stays durable either way — it was already paid for.
+          if goal_cell.budget_exhausted() {
+            let note = "stopping: the goal token budget is exhausted"
+            let next = append_item(session, Terminal(Finished(note)))
+            @xlog.warn() <? { "event": "goal_budget_step_stop", "step": step }
+            return next
+          }
+        }
       }
       // Steering first: user-visible mid-turn input should precede runtime
       // chatter the model reads alongside it.
@@ -420,6 +538,7 @@ async fn[X] run_opened_turn_in_scope(
         ),
       )
       refresh_goal_cell(goal_cell, session)
+      last_prompt_tokens = response.usage.prompt_tokens
       let reasoning_content = match response.reasoning_content {
         "" => None
         content => Some(content)
@@ -726,4 +845,37 @@ async fn drain_goal_updates(
     refresh_goal_cell(cell, session)
   }
   session
+}
+
+///|
+/// The prompt size the provider reported for the session's most recent model
+/// response, folded from durable `Usage` events. Seeds the auto-compaction
+/// trigger at turn open so continuation and resumed turns inherit the real
+/// projection size instead of starting blind at zero.
+fn last_recorded_prompt_tokens(session : @agent_session.Session) -> Int {
+  let mut last = 0
+  let mut last_sequence = 0
+  for event in session.events() {
+    match event.item() {
+      Usage(usage) => {
+        last = usage.prompt_tokens()
+        last_sequence = event.sequence()
+      }
+      // A summary shrinks the projection, so a usage it covers — the
+      // summarizer's own call included — no longer describes the prompt the
+      // next request will send; drop it. But a partial summary (e.g. from
+      // `sessions compact --from/--to`) can be appended after a usage it does
+      // not cover, and that usage still describes the prompt a resumed run
+      // will replay — so reset only when the summary actually covers it.
+      Summary(summary) =>
+        if last_sequence != 0 &&
+          summary.from_sequence() <= last_sequence &&
+          last_sequence <= summary.to_sequence() {
+          last = 0
+          last_sequence = 0
+        }
+      _ => ()
+    }
+  }
+  last
 }

--- a/agent/compaction_test.mbt
+++ b/agent/compaction_test.mbt
@@ -1,0 +1,241 @@
+///|
+/// Auto-compaction tests against the scripted DeepSeek stand-in from
+/// `goal_loop_test.mbt` (test files in one package share definitions).
+async test "auto-compaction summarizes at the step boundary and rebuilds the projection" {
+  @async.with_task_group() <| group => {
+    let request_bodies : Array[String] = []
+    let responses = [
+      // Step 1: prompt usage above the threshold plus a tool call, so the
+      // turn survives to the next step boundary.
+      [
+        tool_call_chunk(
+          "call_1", "read", "{\\\"path\\\":\\\"missing-compaction-probe.txt\\\"}",
+          150, 10,
+        ),
+      ],
+      // The auto-compaction request: the summarizer's answer.
+      [content_chunk("checkpoint summary of prior work", 40, 12)],
+      // Step 2: the model finishes the turn.
+      [content_chunk("done", 5, 1)],
+    ]
+    guard goal_test_server(group, responses, request_bodies) is Some(url) else {
+      return
+    }
+    let session = @agent_session.Session(
+      SessionId("compact-turn"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_with_append(
+      "test-key",
+      V4Flash,
+      session,
+      "task-alpha",
+      append_item=(session, item) => session.append(item),
+      max_steps=4,
+      api_url=url,
+      compact_threshold=100,
+    )
+    assert_eq(request_bodies.length(), 3)
+    // The compaction request carries the checkpoint prompt; without a goal
+    // there is no objective section.
+    assert_true(request_bodies[1].contains("CONTEXT CHECKPOINT COMPACTION"))
+    assert_false(request_bodies[1].contains("<objective>"))
+    // The post-compaction step projects the summary instead of the covered
+    // history: the original user task no longer reaches the model.
+    assert_true(request_bodies[2].contains("checkpoint summary of prior work"))
+    assert_false(request_bodies[2].contains("task-alpha"))
+    // Durable shape mirrors `compact_session`: the summarizer's own usage is
+    // recorded first, then the summary terminates the covered range.
+    let events = result.events()
+    let mut summary_index = -1
+    let mut cursor = 0
+    for event in events {
+      if event.item() is Summary(_) {
+        summary_index = cursor
+      }
+      cursor += 1
+    }
+    guard summary_index >= 1 else { fail("expected a summary event") }
+    guard events[summary_index].item() is Summary(summary) else {
+      fail("expected a summary item")
+    }
+    assert_eq(summary.from_sequence(), 1)
+    guard events[summary_index - 1].item() is Usage(_) else {
+      fail("expected the summarizer usage event before the summary")
+    }
+    // The summary covers everything before the summarizer usage event.
+    assert_eq(summary.to_sequence(), events[summary_index - 1].sequence() - 1)
+    guard events[events.length() - 1].item() is Terminal(Finished(answer)) else {
+      fail("expected a finished terminal")
+    }
+    assert_eq(answer, "done")
+  }
+}
+
+///|
+async test "goal turns pass the objective into auto-compaction" {
+  @async.with_task_group() <| group => {
+    let request_bodies : Array[String] = []
+    let responses = [
+      // Turn step 1: prompt usage above the threshold plus a tool call.
+      [
+        tool_call_chunk(
+          "call_1", "read", "{\\\"path\\\":\\\"missing-goal-probe.txt\\\"}", 150,
+          10,
+        ),
+      ],
+      // The auto-compaction request.
+      [content_chunk("goal checkpoint summary", 20, 8)],
+      // Step 2: the model completes the goal.
+      [
+        tool_call_chunk(
+          "call_2", "update_goal", "{\\\"status\\\":\\\"complete\\\"}", 6, 2,
+        ),
+      ],
+      // Step 3: the model finishes the turn; the run ends on Complete.
+      [content_chunk("goal wrapped up", 6, 1)],
+    ]
+    guard goal_test_server(group, responses, request_bodies) is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("compact-goal"),
+      system_prompt="system",
+    )
+    let result = @agent.run_goal_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "pursue the objective",
+      append_item=(session, item) => session.append(item),
+      objective="obj-compaction",
+      max_steps=6,
+      max_continuations=1,
+      api_url=url,
+      compact_threshold=100,
+    )
+    assert_eq(request_bodies.length(), 4)
+    // The summarizer sees the active goal's objective, enveloped.
+    assert_true(request_bodies[1].contains("CONTEXT CHECKPOINT COMPACTION"))
+    assert_true(request_bodies[1].contains("<objective>"))
+    assert_true(request_bodies[1].contains("obj-compaction"))
+    // The goal completed durably despite the mid-turn compaction.
+    let goals = goal_events_of(result)
+    assert_true(goals[goals.length() - 1].status() is Complete)
+  }
+}
+
+///|
+async test "a continuation turn compacts before its first model call" {
+  @async.with_task_group() <| group => {
+    let request_bodies : Array[String] = []
+    let responses = [
+      // Turn 1: a single over-threshold response finishes the turn — no
+      // step boundary ever sees it, so only the seeded next turn can react.
+      [content_chunk("worked on it", 150, 10)],
+      // Continuation turn, step 0: the seeded trigger compacts first.
+      [content_chunk("continuation checkpoint", 20, 5)],
+      // Continuation turn, step 0 model call: complete the goal.
+      [
+        tool_call_chunk(
+          "call_1", "update_goal", "{\\\"status\\\":\\\"complete\\\"}", 6, 2,
+        ),
+      ],
+      [content_chunk("all done", 6, 1)],
+    ]
+    guard goal_test_server(group, responses, request_bodies) is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("compact-continuation"),
+      system_prompt="system",
+    )
+    let result = @agent.run_goal_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "pursue the objective",
+      append_item=(session, item) => session.append(item),
+      objective="obj-continuation",
+      max_steps=4,
+      max_continuations=1,
+      api_url=url,
+      compact_threshold=100,
+    )
+    assert_eq(request_bodies.length(), 4)
+    // Request 1 is the summarizer; request 2 is the continuation's first
+    // real model call: it sees the summary AND the verbatim continuation
+    // envelope (the unread opening stays outside the covered range), while
+    // turn 1's content is gone.
+    assert_true(request_bodies[1].contains("CONTEXT CHECKPOINT COMPACTION"))
+    assert_true(request_bodies[2].contains("continuation checkpoint"))
+    assert_true(request_bodies[2].contains("openseek_internal_context"))
+    assert_false(request_bodies[2].contains("worked on it"))
+    let goals = goal_events_of(result)
+    assert_true(goals[goals.length() - 1].status() is Complete)
+  }
+}
+
+///|
+async test "summarizer spend that crosses the goal budget stops the turn" {
+  @async.with_task_group() <| group => {
+    let request_bodies : Array[String] = []
+    let responses = [
+      // Step 1: 160 tokens spent — under the 170 budget, over the
+      // compaction threshold.
+      [
+        tool_call_chunk(
+          "call_1", "read", "{\\\"path\\\":\\\"missing-budget-probe.txt\\\"}", 150,
+          10,
+        ),
+      ],
+      // The auto-compaction request: its 52 tokens push spend to 212,
+      // past the budget. No third model call may happen.
+      [content_chunk("checkpoint before the budget line", 40, 12)],
+    ]
+    guard goal_test_server(group, responses, request_bodies) is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("compact-budget"),
+      system_prompt="system",
+    )
+    let result = @agent.run_goal_in_scope(
+      runtime,
+      scope,
+      "test-key",
+      V4Flash,
+      session,
+      "pursue the objective",
+      append_item=(session, item) => session.append(item),
+      objective="obj-budget",
+      token_budget=170,
+      max_steps=6,
+      max_continuations=1,
+      api_url=url,
+      compact_threshold=100,
+    )
+    // Exactly two requests: the summary is durable, the budget gate re-ran
+    // after the summarizer's usage, and the run ended BudgetLimited.
+    assert_eq(request_bodies.length(), 2)
+    let mut has_summary = false
+    for event in result.events() {
+      if event.item() is Summary(_) {
+        has_summary = true
+      }
+    }
+    assert_true(has_summary)
+    let goals = goal_events_of(result)
+    assert_true(goals[goals.length() - 1].status() is BudgetLimited)
+  }
+}

--- a/agent/compaction_wbtest.mbt
+++ b/agent/compaction_wbtest.mbt
@@ -1,0 +1,34 @@
+///|
+/// A partial summary — e.g. from `sessions compact --from/--to` — can be
+/// appended after a high-token usage it does not cover. That usage still
+/// describes the prompt a resumed run will replay, so the auto-compaction seed
+/// must survive it and reset only when a summary actually covers the tracked
+/// usage.
+test "last_recorded_prompt_tokens keeps a usage a partial summary does not cover" {
+  let base = @agent_session.Session(
+    SessionId("compaction-seed"),
+    system_prompt="system",
+  )
+  let filler = base.append(
+    Usage(TurnUsage(prompt_tokens=100, completion_tokens=1)),
+  )
+  let high = filler.append(
+    Usage(TurnUsage(prompt_tokens=300_000, completion_tokens=10)),
+  )
+  let usage_seq = high.last_sequence()
+
+  // A summary over an earlier range that leaves the high usage uncovered: the
+  // seed survives, so a resumed run still auto-compacts before its first call.
+  let uncovered = high.append(
+    Summary(
+      SessionSummary(content="x", from_sequence=1, to_sequence=usage_seq - 1),
+    ),
+  )
+  assert_eq(last_recorded_prompt_tokens(uncovered), 300_000)
+
+  // A summary that covers the high usage resets the seed to zero.
+  let covered = high.append(
+    Summary(SessionSummary(content="x", from_sequence=1, to_sequence=usage_seq)),
+  )
+  assert_eq(last_recorded_prompt_tokens(covered), 0)
+}

--- a/agent/goal_loop.mbt
+++ b/agent/goal_loop.mbt
@@ -67,6 +67,7 @@ pub async fn[X] run_goal_in_scope(
   host_token_budget? : Int = DEFAULT_GOAL_TOKEN_BUDGET,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  compact_threshold? : Int,
 ) -> @agent_session.Session {
   // Host-created goal (`--goal`): the user set the objective directly, so
   // the goal exists before the first turn instead of waiting for the model
@@ -159,6 +160,7 @@ pub async fn[X] run_goal_in_scope(
     api_url?,
     tools~,
     goal_cell~,
+    compact_threshold?,
   )
   for continuation in 0..<max_continuations {
     guard last_turn_finished(session) else { return session }
@@ -206,6 +208,7 @@ pub async fn[X] run_goal_in_scope(
       api_url?,
       tools~,
       goal_cell~,
+      compact_threshold?,
     )
   }
   if session.current_goal() is Some(snapshot) && snapshot.is_active() {
@@ -302,6 +305,7 @@ pub async fn run_goal_with_append(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
+  compact_threshold? : Int,
 ) -> @agent_session.Session {
   @async.with_task_group() <| group => {
     run_goal_in_scope(
@@ -319,6 +323,7 @@ pub async fn run_goal_with_append(
       host_token_budget~,
       thinking~,
       api_url?,
+      compact_threshold?,
     )
   }
 }

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/compact",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/edit",

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -16,17 +16,17 @@ pub const DEFAULT_MAX_CONTINUATIONS : Int = 25
 
 pub fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], goal_cell? : @goal.GoalCell) -> @agent_tool.Tools raise
 
-pub async fn run(String, @deepseek.Model, String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
+pub async fn run(String, @deepseek.Model, String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, compact_threshold? : Int) -> Unit
 
-pub async fn[X] run_goal_in_scope(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, objective? : String, token_budget? : Int, max_steps? : Int, max_continuations? : Int, host_token_budget? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String) -> @agent_session.Session
+pub async fn[X] run_goal_in_scope(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, objective? : String, token_budget? : Int, max_steps? : Int, max_continuations? : Int, host_token_budget? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, compact_threshold? : Int) -> @agent_session.Session
 
-pub async fn run_goal_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, objective? : String, token_budget? : Int, max_steps? : Int, max_continuations? : Int, host_token_budget? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
+pub async fn run_goal_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, objective? : String, token_budget? : Int, max_steps? : Int, max_continuations? : Int, host_token_budget? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, compact_threshold? : Int) -> @agent_session.Session
 
-pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
+pub async fn run_turn(String, @deepseek.Model, @agent_session.Session, String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, compact_threshold? : Int) -> @agent_session.Session
 
-pub async fn[X] run_turn_in_scope(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, goal_cell? : @goal.GoalCell) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, goal_cell? : @goal.GoalCell, compact_threshold? : Int) -> @agent_session.Session
 
-pub async fn run_turn_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
+pub async fn run_turn_with_append(String, @deepseek.Model, @agent_session.Session, String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, compact_threshold? : Int) -> @agent_session.Session
 
 pub fn steer(@agent_runtime.AgentRuntime, String) -> Unit
 

--- a/agent_session/compact/compact.mbt
+++ b/agent_session/compact/compact.mbt
@@ -15,19 +15,57 @@ const CompactionUserPrompt : String =
 ///|
 fn compaction_messages(
   session : @agent_session.Session,
+  objective? : String,
+  unread_opening~ : Bool,
 ) -> Array[@deepseek.ChatMessage] {
-  session.chat_messages()..push(ChatMessage(User, content=CompactionUserPrompt))
+  let mut prompt = match objective {
+    Some(objective) => {
+      let prompt =
+        $|\{CompactionUserPrompt}
+        $|
+        $|An active session goal is in progress. Preserve everything needed to
+        $|keep pursuing this exact objective:
+        $|<objective>
+        $|\{objective}
+        $|</objective>
+      prompt
+    }
+    None => CompactionUserPrompt
+  }
+  if unread_opening {
+    prompt = (
+      $|\{prompt}
+      $|
+      $|The final user-role message before this one is a fresh instruction the
+      $|assistant has not acted on yet. It will be re-delivered verbatim right
+      $|after your summary: do not summarize, paraphrase, or restate any part
+      $|of it.
+    )
+  }
+  session.chat_messages()..push(ChatMessage(User, content=prompt))
 }
 
 ///|
-async fn generate_compaction_summary(
+/// Generate a checkpoint summary through the model without appending
+/// anything: the caller owns durability of both the summary and the
+/// summarizer's own token spend. `objective` (an active goal's objective)
+/// makes the summary preserve goal-relevant state explicitly.
+///
+/// The request streams with a silent handler so it rides the client's
+/// idle-timeout protection — the same mode the agent loop uses.
+pub async fn generate_summary(
   api_key~ : String,
   model~ : @deepseek.Model,
   session : @agent_session.Session,
   api_url? : String,
+  objective? : String,
+  unread_opening? : Bool = false,
 ) -> (String, @agent_session.TurnUsage) {
   let client = @client.Client(api_key~, model~, api_url?, thinking=No)
-  let response = client.chat(compaction_messages(session))
+  let response = client.chat(
+    compaction_messages(session, objective?, unread_opening~),
+    stream=StreamHandler(on_content_delta=_ => ()),
+  )
   let summary = response.content.trim().to_owned()
   if summary.is_empty() {
     fail("compaction summary was empty")
@@ -95,12 +133,7 @@ pub async fn compact_session(
       "from_sequence": from_sequence,
       "to_sequence": to_sequence,
     }
-  let (summary, usage) = generate_compaction_summary(
-    api_key~,
-    model~,
-    session,
-    api_url?,
-  )
+  let (summary, usage) = generate_summary(api_key~, model~, session, api_url?)
   // The summarizer call is real model spend: record it durably so budget
   // accounting (a fold over Usage events) cannot undercount compaction.
   // Appended before the Summary so the summary stays the range's terminator.

--- a/agent_session/compact/compact_wbtest.mbt
+++ b/agent_session/compact/compact_wbtest.mbt
@@ -4,7 +4,7 @@ test "compaction messages use projected history plus checkpoint prompt" {
     .append(User(UserMessage("first")))
     .append(Assistant(AssistantMessage("answer")))
     .append(User(UserMessage("next")))
-  let messages = compaction_messages(session)
+  let messages = compaction_messages(session, unread_opening=false)
   assert_eq(messages.length(), 5)
   assert_true(messages[0].role is System)
   assert_eq(messages[0].content, "system")

--- a/agent_session/compact/pkg.generated.mbti
+++ b/agent_session/compact/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 // Values
 pub async fn compact_session(store? : @store.SessionStore, @agent_session.Session, api_key~ : String, model~ : @deepseek.Model, api_url? : String) -> @agent_session.Session
 
+pub async fn generate_summary(api_key~ : String, model~ : @deepseek.Model, @agent_session.Session, api_url? : String, objective? : String, unread_opening? : Bool) -> (String, @agent_session.TurnUsage)
+
 // Errors
 
 // Types and methods

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -39,7 +39,13 @@ Runs require `--api-key` or the provider-specific environment variable:
 be supplied with `OPENSEEK_MODEL`; it accepts `deepseek-v4-flash`,
 `deepseek-v4-pro`, `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed`, and
 defaults to `deepseek-v4-pro`. `--max-steps` can also be supplied with
-`OPENSEEK_MAX_STEPS`; it defaults to `1000`. `--api-url` can also be supplied
+`OPENSEEK_MAX_STEPS`; it defaults to `1000`. `--compact-threshold` can also be
+supplied with `OPENSEEK_COMPACT_THRESHOLD`; it defaults to `200000`. Once a
+model response reports at least that many prompt tokens, the run summarizes the
+session through the model at the next step boundary, appends the summary as a
+durable `Summary` event (the summarizer's own usage is recorded first), and
+continues with the compacted context — long `--goal` runs no longer grow their
+prompt without bound. Pass `--compact-threshold 0` to disable auto-compaction. `--api-url` can also be supplied
 with `OPENSEEK_API_URL`; when omitted, OpenSeek uses the default DeepSeek chat
 completions endpoint, or the Kimi endpoint for Kimi models.
 `--dir` can also be supplied with `OPENSEEK_DIR`; it defaults to `.` and becomes

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -177,6 +177,7 @@ async fn run_one_attempt(
       thinking~,
       api_url?,
       workspace_root=run_dir,
+      compact_threshold?=compact_threshold(matches),
     )
     let (status, detail) = terminal_summary(completed)
     {

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -110,6 +110,9 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
       value(matches, "concurrency"),
       "--concurrency",
     )
+    // Validated before the fleet branch so an invalid value fails in every
+    // mode instead of being silently ignored by best-of-N runs.
+    let compact_threshold = compact_threshold(matches)
     if concurrency >= 2 {
       run_fleet(matches, concurrency~)
       return
@@ -151,6 +154,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
               thinking~,
               api_url?,
               workspace_root~,
+              compact_threshold?,
             ),
           )
         } else {
@@ -163,6 +167,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
             thinking~,
             api_url?,
             workspace_root~,
+            compact_threshold?,
           )
         }
       }
@@ -199,6 +204,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
               thinking~,
               api_url?,
               workspace_root~,
+              compact_threshold?,
             ),
           )
         } else {
@@ -213,6 +219,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
               thinking~,
               api_url?,
               workspace_root~,
+              compact_threshold?,
             ),
           )
         }
@@ -517,6 +524,13 @@ fn root_command() -> @argparse.Command {
             default_values=[""],
             about="Token budget for --goal, enforced at step boundaries: the run stops and marks the goal budget-limited once spent (a turn may overshoot by at most one model response).",
           ),
+          OptionArg(
+            "compact-threshold",
+            long="compact-threshold",
+            env="OPENSEEK_COMPACT_THRESHOLD",
+            default_values=["200000"],
+            about="Auto-compact the session once a model response reports at least this many prompt tokens; 0 disables auto-compaction.",
+          ),
         ],
         flags=[
           FlagArg(
@@ -708,6 +722,19 @@ fn goal_budget(matches : @argparse.Matches) -> Int? raise {
     None
   } else {
     Some(parse_positive_int(raw.to_owned(), "--goal-budget"))
+  }
+}
+
+///|
+fn compact_threshold(matches : @argparse.Matches) -> Int? raise {
+  // Only the documented "0" disables compaction; an explicitly empty value
+  // (e.g. OPENSEEK_COMPACT_THRESHOLD=) is invalid input, not a silent
+  // opt-out of the safety default, and fails in parse_positive_int.
+  let raw = value(matches, "compact-threshold").trim().to_owned()
+  if raw is "0" {
+    None
+  } else {
+    Some(parse_positive_int(raw, "--compact-threshold"))
   }
 }
 

--- a/cmd/openseek/main_compact_threshold_wbtest.mbt
+++ b/cmd/openseek/main_compact_threshold_wbtest.mbt
@@ -1,0 +1,55 @@
+///|
+test "compact-threshold defaults to 200000" {
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+  })
+  assert_true(compact_threshold(parsed) is Some(200000))
+}
+
+///|
+test "compact-threshold 0 disables auto-compaction" {
+  let parsed = run_matches(
+    argv=["--compact-threshold", "0", "write", "MoonBit"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  assert_true(compact_threshold(parsed) is None)
+}
+
+///|
+test "compact-threshold reads the environment" {
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+    "OPENSEEK_COMPACT_THRESHOLD": "50000",
+  })
+  assert_true(compact_threshold(parsed) is Some(50000))
+}
+
+///|
+test "compact-threshold rejects non-numeric values" {
+  let parsed = run_matches(
+    argv=["--compact-threshold", "lots", "write", "MoonBit"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let _ = compact_threshold(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("--compact-threshold"))
+      return
+    }
+  }
+  fail("non-numeric --compact-threshold accepted")
+}
+
+///|
+test "compact-threshold rejects explicitly empty values" {
+  let parsed = run_matches(
+    argv=["--compact-threshold", "", "write", "MoonBit"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  let _ = compact_threshold(parsed) catch {
+    error => {
+      assert_true("\{error}".contains("--compact-threshold"))
+      return
+    }
+  }
+  fail("empty --compact-threshold accepted")
+}


### PR DESCRIPTION
## Summary

Long `--goal` runs currently grow their prompt without bound: a live 487-step goal run on this branch's base reached a **414k-token peak prompt**, and **98–99.5% of its gross token spend was cache-hit re-reads of history**. Compaction existed (`@compact.compact_session`) but was reachable only through TUI `/compact`, serve's `compact` command, and `sessions compact` — never from the headless run/goal loop, which is exactly the unattended surface that needs it.

This PR wires automatic compaction into the agent loop, on top of #345 (`goal-feature`):

- **Trigger**: at the step boundary (same safe point as the goal budget gate — every tool call has a recorded result), when the previous response's provider-reported `prompt_tokens` reaches `--compact-threshold` (default **200000**, env `OPENSEEK_COMPACT_THRESHOLD`, `0` disables).
- **Mechanics**: the summary is generated through the new public `@compact.generate_summary` (`compact_session` now delegates to it); the summarizer's own usage is recorded durably first (budget folds must see it), then the `Summary` terminates the covered range — all through `append_item`, the loop's single durable path. The projection is rebuilt afterwards.
- **Goal-aware**: an Active goal's objective is enveloped into the summarizer prompt so goal state survives the checkpoint; completed/blocked goals are not misrepresented as active.
- **Turn/resume boundaries**: the trigger seeds from the log's last post-summary `Usage` event, so a continuation or resumed turn whose projection is already oversized compacts *before* its first model call; the unread opening (user task or continuation envelope) is re-delivered verbatim after the checkpoint so it stays the latest instruction.
- **Safety**: budget re-checked after the summarizer's spend (compaction cannot buy an extra model call past a goal budget); compaction failure never ends a turn; a cooldown bounds pathological re-compaction; watcher fingerprints reset so post-compaction runtime updates are emitted in full.
- **CLI**: threshold validated before the fleet branch (invalid values fail in every mode, unlike the `--goal` fleet gap found in #345's review) and threaded through fleet attempts. serve/TUI keep their controller-driven `/compact` unchanged.

## Review process

Each commit was reviewed with codex CLI; three rounds surfaced 7 findings, all fixed and mostly pinned with tests: post-compaction budget bypass, non-active objective leakage, turn-boundary trigger blindness, silent disable via empty env value, stale watcher fingerprints, summarizer paraphrasing the unread opening, and summary-after-opening precedence.

## Validation

- `moon check` clean; `moon fmt` + `moon info` applied; **977 tests pass** (7 new: step-boundary compaction shape + projection rebuild, goal-objective threading, budget-crossing summarizer stop, continuation step-0 compaction, and 5 CLI parse cases).
- Live end-to-end on DeepSeek: a `--goal` run with `--compact-threshold 6000` fired `auto_compaction` at step 1 (9,127-token prompt), appended durable `Usage`+`Summary` (handoff summary leads with the objective), rebuilt the projection, and completed its goal with the artifact verified externally.

## Motivating data (from the C89 compiler goal e2e on the base branch)

| run | budget | steps | gross tokens | genuinely new | outcome |
|---|---|---|---|---|---|
| 1 | 250k | 16 | 274k | ~30k (11%) | budget-limited mid-scaffold |
| 2 (resume) | 600k | 10 | +330k | ~30k (9%) | budget-limited |
| 3 (resume) | 2B | 487 | +140.2M | ~714k (0.5%) | completed; 414k peak prompt |

With a 200k threshold those runs would have compacted ~2x/‌~70x cheaper in prompt re-reads and stayed far from the context wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)