### PR TITLE
fix(agent_tool/read): report a truncated read as success, not error

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -30,9 +30,10 @@ afterward), and the footer always reports the range it saw (`start_line`,
 follow), and whether the budget cut the body (`truncated`). This matches the
 lean, content-first convention used by Claude Code and the kimi agents, which
 keep status metadata in a small footer rather than a verbose header.
-Automatic output truncation is marked as a tool error even when the file was
-read successfully; that makes lossy context visible to the loop instead of
-silently pretending the returned prefix is complete.
+Automatic output truncation is not a tool error — the file was read
+successfully and the returned prefix is real content. The cut stays visible
+twice over: the footer's `truncated=true` tells the model the prefix is
+incomplete, and the transcript brief gains a `(truncated)` marker for humans.
 
 For several known independent files, issue several independent `read` calls in
 the same assistant response. That avoids extra model round trips while
@@ -71,16 +72,17 @@ large file and relying on truncation.
 
 The action is always `Respond(ToolOutput(...))` — the agent loop forwards
 `ToolOutput.content` to the model as a tool-call response. `is_error` is
-`false` on success and `true` for read failures, argument failures, or automatic
-output truncation. The string body has one of these shapes:
+`false` on success and `true` for read failures or argument failures. The
+string body has one of these shapes:
 
 - On success: right-aligned `<line-number> |<content>` lines, then a newline,
   then the footer `<system>start_line=<n> shown_lines=<k> total_lines=<t> truncated=<bool></system>`.
   When the selected body is empty (the range starts past EOF, or the budget is
   zero) only the footer is returned. A zero-byte file returns just the footer
   with `total_lines=0 note=empty file`, rather than a phantom blank `1 |` line.
-  `truncated=true` — set when `max_output_chars` cut the numbered body — is the
-  one case that flips `is_error` to `true`.
+  `truncated=true` — set when `max_output_chars` cut the numbered body — keeps
+  `is_error` `false`: the prefix is real content, so the model reads the
+  footer, and the brief gains a `(truncated)` marker for the transcript.
 - `"error reading <path>: <error>"` — a single-file read failed. Common
   causes: the file is missing, the agent doesn't have read permissions, or
   the bytes aren't valid UTF-8.

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -24,8 +24,10 @@
 ///   `<system>start_line=.. shown_lines=.. total_lines=.. truncated=..</system>`
 ///   footer (footer only when the body is empty, e.g. a range past EOF). A
 ///   zero-byte file returns just that footer with `total_lines=0 note=empty
-///   file`. `is_error` is `true` only when the `max_output_chars` budget cut the
-///   body (`truncated=true`).
+///   file`. A body cut by the `max_output_chars` budget is still a successful
+///   read, not a tool error: the footer's `truncated=true` tells the model the
+///   prefix is incomplete, and the brief gains a `(truncated)` marker for the
+///   human transcript.
 /// - `Respond(ToolOutput("error reading <path>: <error>", is_error=true))`
 ///   if a single-file read fails (missing file, permission denied, invalid
 ///   UTF-8, directory path, etc.).
@@ -171,10 +173,14 @@ async fn read_file(
   }
   output <+
     "<system>start_line=\{input.start_line} shown_lines=\{shown_lines} total_lines=\{total_lines} truncated=\{truncated}</system>"
+  // A truncated body is a successful read of a prefix, not a failure: the
+  // model sees `truncated=true` in the footer, so treating it as a tool error
+  // would only teach the loop to retry a read that worked. The brief carries
+  // the marker so a human scanning the transcript sees the cut too.
   @agent_tool.ToolAction::respond(
     output.to_string(),
-    is_error=truncated,
-    brief~,
+    is_error=false,
+    brief=if truncated { "\{brief} (truncated)" } else { brief },
   )
 }
 
@@ -186,6 +192,9 @@ async test "read renders a whole file as numbered lines with a status footer" {
     let result = execute({ "path": path })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
+    // An untruncated read keeps the plain brief — no `(truncated)` marker.
+    guard output.brief is Some(brief) else { fail("expected a brief") }
+    assert_eq(brief, "read test.txt")
     assert_eq(
       output.content,
       [
@@ -312,13 +321,17 @@ async test "read returns a footer only when the range starts past EOF" {
 }
 
 ///|
-async test "read caps oversized output and marks it as an error" {
+async test "read caps oversized output without marking it as an error" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/capped.txt"
     @fs.write_file(path, "abcdef", create_mode=CreateOrTruncate)
     let result = execute({ "path": path, "max_output_chars": 4 })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
+    // The prefix was read successfully; the footer (for the model) and the
+    // brief (for the human transcript) carry the truncation, not is_error.
+    assert_false(output.is_error)
+    guard output.brief is Some(brief) else { fail("expected a brief") }
+    assert_eq(brief, "read capped.txt (truncated)")
     assert_eq(
       output.content,
       [
@@ -339,7 +352,7 @@ async test "read counts the line-number gutter against the output budget" {
     )
     let result = execute({ "path": path, "max_output_chars": 24 })
     guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
+    assert_false(output.is_error)
     // 24 code units buys exactly four two-wide ` N |x` lines (gutters
     // included); the fifth gutter would overrun, so the body stops at line 4.
     assert_eq(
@@ -360,7 +373,7 @@ async test "read caps unicode content on character boundaries" {
     // Budget 5 = "1 |" (3 units) + "😀" (2 units): the emoji fits whole, Z drops.
     let fits = execute({ "path": path, "max_lines": 1, "max_output_chars": 5 })
     guard fits is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
+    assert_false(output.is_error)
     assert_eq(
       output.content,
       [
@@ -372,7 +385,7 @@ async test "read caps unicode content on character boundaries" {
     // emoji is dropped.
     let splits = execute({ "path": path, "max_lines": 1, "max_output_chars": 4 })
     guard splits is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
+    assert_false(output.is_error)
     assert_false(output.content.contains("😀"))
     assert_eq(
       output.content,


### PR DESCRIPTION
## Problem

When `max_output_chars` cuts a read's body, the tool returned the prefix plus a `truncated=true` footer — but flagged the whole result `is_error=true`. The read *worked*; treating it as a tool error teaches the loop to retry a successful call, and makes a truncated read indistinguishable from a genuinely failed one in error handling and the transcript.

## Fix

- A truncated body is now a normal success (`is_error=false`). The model already gets everything it needs from the footer: `truncated=true`, plus `shown_lines` / `total_lines` to continue reading from where the cut happened.
- The cut stays visible to humans: the transcript brief becomes `read <file> (truncated)`.
- `is_error=true` remains for actual failures — missing file, permission/UTF-8 errors, directory paths, invalid arguments.
- Docs updated (tool docstring + `agent_tool/read/README.mbt.md`, which previously documented the truncation-is-error rationale).

## Validation

- Updated the three truncation tests to assert non-error and the `(truncated)` brief; added a plain-brief assertion for the untruncated case.
- Full suite: `moon test` — 966/966 pass. `moon fmt` / `moon info` clean, no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)