### PR TITLE
feat(agent_session/store): suffix session file names with the session id

### DIFF
--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -233,10 +233,10 @@ The store layout is:
 
 ```text
 <root>/sessions/<session-id>/
-  openseek_session.jsonl
+  openseek_session-<session-id>.jsonl
 ```
 
-`openseek_session.jsonl` holds the whole session: a header record
+`openseek_session-<session-id>.jsonl` holds the whole session: a header record
 (`{"version":1,"id":...,"system_prompt":...}`) on the first line, then one
 append-only event per line. Loading replays the event lines into a `Session`.
 

--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -14,17 +14,21 @@ Each session lives under:
 
 ```text
 <root>/sessions/<session-id>/
-  openseek_session.jsonl
+  openseek_session-<session-id>.jsonl
   session.lock
 ```
 
-`openseek_session.jsonl` is the whole durable session: its first line is a
-header record (`{"version":1,"id":...,"system_prompt":...}`) and every
-following line is one typed `SessionEvent`. Events are append-only. Loading
-replays the event lines into an immutable `agent_session.Session`.
+`openseek_session-<session-id>.jsonl` is the whole durable session: its first
+line is a header record (`{"version":1,"id":...,"system_prompt":...}`) and
+every following line is one typed `SessionEvent`. Events are append-only.
+Loading replays the event lines into an immutable `agent_session.Session`.
+The file name carries the session id so files collected out of their
+directories — for cross-session visualization or comparison — stay
+self-naming.
 
 `session.lock` is an implementation detail used to serialize writers and keep a
-reader from seeing a half-updated session.
+reader from seeing a half-updated session. It carries no id suffix: it already
+lives inside the per-id directory and is never collected alongside the jsonl.
 
 ## API Shape
 
@@ -53,8 +57,8 @@ new event.
 
 `load` takes a `SessionId` because `SessionStore(root)` is a directory-backed
 collection, not a handle to one current session. The id selects
-`<root>/sessions/<id>/openseek_session.jsonl`; the store intentionally does not
-keep a hidden "current" session. When the caller needs to discover a session
+`<root>/sessions/<id>/openseek_session-<id>.jsonl`; the store intentionally
+does not keep a hidden "current" session. When the caller needs to discover a session
 first, use `list`, `listings`, or `latest`, then pass the chosen id to `load`.
 
 ## Create And Load
@@ -68,8 +72,8 @@ More pedantically, `load(id)`:
 
 - validates `id` before using it in a path;
 - takes a shared session lock when the session directory exists;
-- reads `openseek_session.jsonl` and checks that the first line is a header
-  record whose id equals the requested id;
+- reads `openseek_session-<id>.jsonl` and checks that the first line is a
+  header record whose id equals the requested id;
 - parses every following JSON line as a typed `SessionEvent`;
 - checks that event sequence numbers are contiguous;
 - returns a rebuilt immutable `Session`;

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]
 pub async fn SessionStore::listings(Self) -> Array[SessionListing]
 pub async fn SessionStore::load(Self, @agent_session.SessionId) -> @agent_session.Session
 pub fn SessionStore::root(Self) -> String
-pub async fn SessionStore::session_file(Self, @agent_session.SessionId) -> String
+pub fn SessionStore::session_file(Self, @agent_session.SessionId) -> String raise
 
 // Type aliases
 

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]
 pub async fn SessionStore::listings(Self) -> Array[SessionListing]
 pub async fn SessionStore::load(Self, @agent_session.SessionId) -> @agent_session.Session
 pub fn SessionStore::root(Self) -> String
-pub fn SessionStore::session_file(Self, @agent_session.SessionId) -> String raise
+pub async fn SessionStore::session_file(Self, @agent_session.SessionId) -> String
 
 // Type aliases
 

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -4,21 +4,15 @@ let session_dir_name : String = "sessions"
 ///|
 /// Session files carry their id in the name so files collected out of their
 /// directories — for cross-session visualization or comparison — stay
-/// self-naming. Stores written before this naming used a fixed
-/// `openseek_session.jsonl`; reads fall back to it and writes migrate it.
-let legacy_session_file_name : String = "openseek_session.jsonl"
-
-///|
+/// self-naming.
 fn session_file_name(id : @agent_session.SessionId) -> String {
   "openseek_session-\{id.value()}.jsonl"
 }
 
 ///|
-/// The lock file name is deliberately fixed, with no id suffix: it is
-/// transient local coordination, never collected, and keeping its path
-/// identical across layout generations means binaries from before and after
-/// the suffixed naming still contend on the same lock instead of writing
-/// concurrently.
+/// The lock file carries no id suffix: it already lives inside the per-id
+/// session directory, and it is transient local coordination that is never
+/// collected alongside the jsonl.
 let lock_file_name : String = "session.lock"
 
 ///|
@@ -121,93 +115,6 @@ fn SessionStore::session_file_path(
   id : @agent_session.SessionId,
 ) -> String raise {
   "\{self.session_dir(id)}/\{session_file_name(id)}"
-}
-
-///|
-fn SessionStore::legacy_session_file_path(
-  self : SessionStore,
-  id : @agent_session.SessionId,
-) -> String raise {
-  "\{self.session_dir(id)}/\{legacy_session_file_name}"
-}
-
-///|
-/// The on-disk path of a session's jsonl: the id-suffixed name when it
-/// exists — or when neither layout does, since that is the name new writes
-/// create — otherwise the legacy fixed name from stores written before the
-/// suffix. Readers resolve instead of migrating, so read-only tooling (the
-/// visualizer server, listings) can point at old stores without writing.
-async fn SessionStore::resolved_session_file_path(
-  self : SessionStore,
-  id : @agent_session.SessionId,
-) -> String {
-  let path = self.session_file_path(id)
-  if @fs.exists(path) {
-    return path
-  }
-  let legacy = self.legacy_session_file_path(id)
-  if @fs.exists(legacy) {
-    legacy
-  } else {
-    path
-  }
-}
-
-///|
-async fn mtime_or_none(path : String) -> (Int64, Int)? {
-  Some(@fs.mtime(path)) catch {
-    _ => None
-  }
-}
-
-///|
-/// Stat a session's jsonl mtime together with the path that produced it,
-/// without holding the session lock. Probes the suffixed name, the legacy
-/// name, then the suffixed name once more: a concurrent writer's migration
-/// renames legacy to suffixed atomically, and it can do so at most once
-/// between the first two probes, so a third miss means no session file
-/// exists. `None` when the file is absent; invalid ids raise.
-async fn SessionStore::stat_session_file(
-  self : SessionStore,
-  id : @agent_session.SessionId,
-) -> (String, Int64, Int)? {
-  let path = self.session_file_path(id)
-  if mtime_or_none(path) is Some((seconds, nanoseconds)) {
-    return Some((path, seconds, nanoseconds))
-  }
-  let legacy = self.legacy_session_file_path(id)
-  if mtime_or_none(legacy) is Some((seconds, nanoseconds)) {
-    return Some((legacy, seconds, nanoseconds))
-  }
-  if mtime_or_none(path) is Some((seconds, nanoseconds)) {
-    return Some((path, seconds, nanoseconds))
-  }
-  None
-}
-
-///|
-/// Move a legacy fixed-name session file to its id-suffixed name. Called
-/// with the exclusive session lock held, so no other writer races the
-/// rename; the lock path itself is layout-independent. Writers converge a
-/// store on the suffixed layout as sessions are touched. Finding both
-/// layouts is ambiguous corruption — better to stop than to guess which
-/// file is the session.
-async fn migrate_legacy_session_file(
-  store : SessionStore,
-  id : @agent_session.SessionId,
-) -> Unit {
-  let legacy = store.legacy_session_file_path(id)
-  if !@fs.exists(legacy) {
-    return
-  }
-  let path = store.session_file_path(id)
-  if @fs.exists(path) {
-    fail(
-      "both session file layouts exist for \{id.value()}: remove \{legacy} or \{path}",
-    )
-  }
-  @fs.rename(legacy, path)
-  sync_dir_best_effort(store.session_dir(id))
 }
 
 ///|
@@ -344,10 +251,7 @@ async fn read_session_file(
   store : SessionStore,
   id : @agent_session.SessionId,
 ) -> ParsedSessionFile {
-  parse_session_file(
-    id,
-    @fs.read_file(store.resolved_session_file_path(id)).text(),
-  )
+  parse_session_file(id, @fs.read_file(store.session_file_path(id)).text())
 }
 
 ///|
@@ -382,9 +286,7 @@ async fn record_mark(
   store : SessionStore,
   session : @agent_session.Session,
 ) -> Unit {
-  let path = store.resolved_session_file_path(session.id()) catch {
-    _ => return
-  }
+  let path = store.session_file_path(session.id()) catch { _ => return }
   match file_fingerprint(path) {
     Some(fingerprint) =>
       store.marks[session.id().value()] = { session, fingerprint }
@@ -409,7 +311,7 @@ async fn ensure_session_is_current(
 ) -> Bool {
   match store.marks.get(session.id().value()) {
     Some(mark) if physical_equal(mark.session, session) =>
-      match file_fingerprint(store.resolved_session_file_path(session.id())) {
+      match file_fingerprint(store.session_file_path(session.id())) {
         Some(fingerprint) =>
           if fingerprint == mark.fingerprint {
             // The store only ever syncs newline-terminated text, so an
@@ -599,19 +501,17 @@ pub async fn SessionStore::exists(
 
 ///|
 /// Return the absolute or relative path to a session's
-/// `openseek_session-<id>.jsonl` file, falling back to the legacy fixed-name
-/// `openseek_session.jsonl` when only that exists.
+/// `openseek_session-<id>.jsonl` file.
 ///
-/// The path is probed but the file is not opened, and the returned path may
-/// not exist (a missing session resolves to the id-suffixed name). Invalid
-/// ids raise. This helper exists for read-only tooling, such as the
-/// visualizer server, that wants to stream the raw session file without
-/// duplicating the store layout rules.
-pub async fn SessionStore::session_file(
+/// The path is formed from the store root and `id`; the file is not opened and
+/// may not exist. Invalid ids raise. This helper exists for read-only tooling,
+/// such as the visualizer server, that wants to stream the raw session file
+/// without duplicating the store layout rules.
+pub fn SessionStore::session_file(
   self : SessionStore,
   id : @agent_session.SessionId,
-) -> String {
-  self.resolved_session_file_path(id)
+) -> String raise {
+  self.session_file_path(id)
 }
 
 ///|
@@ -739,11 +639,14 @@ pub async fn SessionStore::listings(
   let stamped : Array[(SessionListing, Int64, Int)] = []
   let unreadable : Array[SessionListing] = []
   for id in self.list() {
-    let stat = self.stat_session_file(id) catch { _ => continue }
-    guard stat is Some((path, seconds, nanoseconds)) else {
-      unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
-      continue
+    let path = self.session_file_path(id) catch { _ => continue }
+    let stamp = @fs.mtime(path) catch {
+      _ => {
+        unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
+        continue
+      }
     }
+    let (seconds, nanoseconds) = stamp
     stamped.push(
       (
         {
@@ -780,10 +683,8 @@ pub async fn SessionStore::latest(
 ) -> @agent_session.SessionId? {
   let stamped : Array[(@agent_session.SessionId, Int64, Int)] = []
   for id in self.list() {
-    guard (self.stat_session_file(id) catch { _ => None })
-      is Some((_, seconds, nanoseconds)) else {
-      continue
-    }
+    let stamp = @fs.mtime(self.session_file_path(id)) catch { _ => continue }
+    let (seconds, nanoseconds) = stamp
     stamped.push((id, seconds, nanoseconds))
   }
   // Newest first.
@@ -813,7 +714,6 @@ pub async fn SessionStore::create(
 ) -> Unit {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
-    migrate_legacy_session_file(self, session.id())
     write_text_atomic(
       self.session_file_path(session.id()),
       session_file_text(session),
@@ -828,8 +728,8 @@ pub async fn SessionStore::create(
 ///
 /// A `SessionStore` is a directory-backed collection, not a handle to one
 /// current session. For a store rooted at `root`, the id selects the files
-/// under `root/sessions/<id>/`: `openseek_session-<id>.jsonl` (or the legacy
-/// `openseek_session.jsonl`) and `session.lock`.
+/// under `root/sessions/<id>/`: `openseek_session-<id>.jsonl` and
+/// `session.lock`.
 ///
 /// `load` validates the id before constructing paths, takes a shared lock when
 /// the session directory already exists, reads the session jsonl file,
@@ -888,7 +788,6 @@ pub async fn SessionStore::append(
 ) -> @agent_session.Session {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
-    migrate_legacy_session_file(self, session.id())
     let repair_tail = ensure_session_is_current(self, session)
     let (next, event) = session.append_event(
       item,
@@ -921,7 +820,6 @@ pub async fn SessionStore::compact(
 ) -> @agent_session.Session {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
-    migrate_legacy_session_file(self, session.id())
     let repair_tail = ensure_session_is_current(self, session)
     let next = session.compact(
       content~,

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -2,9 +2,23 @@
 let session_dir_name : String = "sessions"
 
 ///|
-let session_file_name : String = "openseek_session.jsonl"
+/// Session files carry their id in the name so files collected out of their
+/// directories — for cross-session visualization or comparison — stay
+/// self-naming. Stores written before this naming used a fixed
+/// `openseek_session.jsonl`; reads fall back to it and writes migrate it.
+let legacy_session_file_name : String = "openseek_session.jsonl"
 
 ///|
+fn session_file_name(id : @agent_session.SessionId) -> String {
+  "openseek_session-\{id.value()}.jsonl"
+}
+
+///|
+/// The lock file name is deliberately fixed, with no id suffix: it is
+/// transient local coordination, never collected, and keeping its path
+/// identical across layout generations means binaries from before and after
+/// the suffixed naming still contend on the same lock instead of writing
+/// concurrently.
 let lock_file_name : String = "session.lock"
 
 ///|
@@ -12,7 +26,7 @@ let lock_file_name : String = "session.lock"
 ///
 /// A `SessionStore` owns a root path string plus an in-memory sync cache.
 /// Under that root, each session is stored in `sessions/<id>/` with two files:
-/// `openseek_session.jsonl` (a header line followed by append-only event
+/// `openseek_session-<id>.jsonl` (a header line followed by append-only event
 /// lines) and `session.lock`. The store is not a handle to one current
 /// session; APIs that operate on a session either take a `SessionId` or a
 /// `Session` carrying its id.
@@ -106,7 +120,62 @@ fn SessionStore::session_file_path(
   self : SessionStore,
   id : @agent_session.SessionId,
 ) -> String raise {
-  "\{self.session_dir(id)}/\{session_file_name}"
+  "\{self.session_dir(id)}/\{session_file_name(id)}"
+}
+
+///|
+fn SessionStore::legacy_session_file_path(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  "\{self.session_dir(id)}/\{legacy_session_file_name}"
+}
+
+///|
+/// The on-disk path of a session's jsonl: the id-suffixed name when it
+/// exists — or when neither layout does, since that is the name new writes
+/// create — otherwise the legacy fixed name from stores written before the
+/// suffix. Readers resolve instead of migrating, so read-only tooling (the
+/// visualizer server, listings) can point at old stores without writing.
+async fn SessionStore::resolved_session_file_path(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String {
+  let path = self.session_file_path(id)
+  if @fs.exists(path) {
+    return path
+  }
+  let legacy = self.legacy_session_file_path(id)
+  if @fs.exists(legacy) {
+    legacy
+  } else {
+    path
+  }
+}
+
+///|
+/// Move a legacy fixed-name session file to its id-suffixed name. Called
+/// with the exclusive session lock held, so no other writer races the
+/// rename; the lock path itself is layout-independent. Writers converge a
+/// store on the suffixed layout as sessions are touched. Finding both
+/// layouts is ambiguous corruption — better to stop than to guess which
+/// file is the session.
+async fn migrate_legacy_session_file(
+  store : SessionStore,
+  id : @agent_session.SessionId,
+) -> Unit {
+  let legacy = store.legacy_session_file_path(id)
+  if !@fs.exists(legacy) {
+    return
+  }
+  let path = store.session_file_path(id)
+  if @fs.exists(path) {
+    fail(
+      "both session file layouts exist for \{id.value()}: remove \{legacy} or \{path}",
+    )
+  }
+  @fs.rename(legacy, path)
+  sync_dir_best_effort(store.session_dir(id))
 }
 
 ///|
@@ -243,7 +312,10 @@ async fn read_session_file(
   store : SessionStore,
   id : @agent_session.SessionId,
 ) -> ParsedSessionFile {
-  parse_session_file(id, @fs.read_file(store.session_file_path(id)).text())
+  parse_session_file(
+    id,
+    @fs.read_file(store.resolved_session_file_path(id)).text(),
+  )
 }
 
 ///|
@@ -278,7 +350,9 @@ async fn record_mark(
   store : SessionStore,
   session : @agent_session.Session,
 ) -> Unit {
-  let path = store.session_file_path(session.id()) catch { _ => return }
+  let path = store.resolved_session_file_path(session.id()) catch {
+    _ => return
+  }
   match file_fingerprint(path) {
     Some(fingerprint) =>
       store.marks[session.id().value()] = { session, fingerprint }
@@ -303,7 +377,7 @@ async fn ensure_session_is_current(
 ) -> Bool {
   match store.marks.get(session.id().value()) {
     Some(mark) if physical_equal(mark.session, session) =>
-      match file_fingerprint(store.session_file_path(session.id())) {
+      match file_fingerprint(store.resolved_session_file_path(session.id())) {
         Some(fingerprint) =>
           if fingerprint == mark.fingerprint {
             // The store only ever syncs newline-terminated text, so an
@@ -480,10 +554,10 @@ async fn[T] with_existing_session_lock(
 ///|
 /// Return whether the directory for `id` exists.
 ///
-/// This checks only `root/sessions/<id>/`; it does not require
-/// `openseek_session.jsonl` to exist and does not validate that the session is
-/// loadable. Invalid ids raise before any filesystem probe, rather than being
-/// silently treated as absent.
+/// This checks only `root/sessions/<id>/`; it does not require the session
+/// jsonl file to exist and does not validate that the session is loadable.
+/// Invalid ids raise before any filesystem probe, rather than being silently
+/// treated as absent.
 pub async fn SessionStore::exists(
   self : SessionStore,
   id : @agent_session.SessionId,
@@ -493,17 +567,19 @@ pub async fn SessionStore::exists(
 
 ///|
 /// Return the absolute or relative path to a session's
-/// `openseek_session.jsonl` file.
+/// `openseek_session-<id>.jsonl` file, falling back to the legacy fixed-name
+/// `openseek_session.jsonl` when only that exists.
 ///
-/// The path is formed from the store root and `id`; the file is not opened and
-/// may not exist. Invalid ids raise. This helper exists for read-only tooling,
-/// such as the visualizer server, that wants to stream the raw session file
-/// without duplicating the store layout rules.
-pub fn SessionStore::session_file(
+/// The path is probed but the file is not opened, and the returned path may
+/// not exist (a missing session resolves to the id-suffixed name). Invalid
+/// ids raise. This helper exists for read-only tooling, such as the
+/// visualizer server, that wants to stream the raw session file without
+/// duplicating the store layout rules.
+pub async fn SessionStore::session_file(
   self : SessionStore,
   id : @agent_session.SessionId,
-) -> String raise {
-  self.session_file_path(id)
+) -> String {
+  self.resolved_session_file_path(id)
 }
 
 ///|
@@ -550,8 +626,8 @@ pub fn SessionListing::id(self : SessionListing) -> @agent_session.SessionId {
 ///|
 /// Return the listing timestamp in unix seconds.
 ///
-/// This is the modification time of `openseek_session.jsonl`. `None` means the
-/// file could not be stat-ed — a damaged directory or one written by an
+/// This is the modification time of the session's jsonl file. `None` means
+/// the file could not be stat-ed — a damaged directory or one written by an
 /// incompatible layout. The value is for sorting/display and is not a durable
 /// session field.
 pub fn SessionListing::last_active_unix_seconds(
@@ -631,7 +707,7 @@ pub async fn SessionStore::listings(
   let stamped : Array[(SessionListing, Int64, Int)] = []
   let unreadable : Array[SessionListing] = []
   for id in self.list() {
-    let path = self.session_file_path(id) catch { _ => continue }
+    let path = self.resolved_session_file_path(id) catch { _ => continue }
     let stamp = @fs.mtime(path) catch {
       _ => {
         unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
@@ -675,7 +751,9 @@ pub async fn SessionStore::latest(
 ) -> @agent_session.SessionId? {
   let stamped : Array[(@agent_session.SessionId, Int64, Int)] = []
   for id in self.list() {
-    let stamp = @fs.mtime(self.session_file_path(id)) catch { _ => continue }
+    let stamp = @fs.mtime(self.resolved_session_file_path(id)) catch {
+      _ => continue
+    }
     let (seconds, nanoseconds) = stamp
     stamped.push((id, seconds, nanoseconds))
   }
@@ -693,8 +771,8 @@ pub async fn SessionStore::latest(
 /// Persist a complete session snapshot, replacing prior contents for its id.
 ///
 /// `create` ensures the session directory exists, takes an exclusive lock, and
-/// atomically rewrites `openseek_session.jsonl` (write to a temp file, then
-/// rename). Use it for new sessions, fixtures, import tools, or deliberate
+/// atomically rewrites `openseek_session-<id>.jsonl` (write to a temp file,
+/// then rename). Use it for new sessions, fixtures, import tools, or deliberate
 /// full rewrites. Do not use it for ordinary agent progress; `append`
 /// preserves stale-snapshot detection and writes only one new event.
 ///
@@ -706,6 +784,7 @@ pub async fn SessionStore::create(
 ) -> Unit {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
+    migrate_legacy_session_file(self, session.id())
     write_text_atomic(
       self.session_file_path(session.id()),
       session_file_text(session),
@@ -720,10 +799,11 @@ pub async fn SessionStore::create(
 ///
 /// A `SessionStore` is a directory-backed collection, not a handle to one
 /// current session. For a store rooted at `root`, the id selects the files
-/// under `root/sessions/<id>/`: `openseek_session.jsonl` and `session.lock`.
+/// under `root/sessions/<id>/`: `openseek_session-<id>.jsonl` (or the legacy
+/// `openseek_session.jsonl`) and `session.lock`.
 ///
 /// `load` validates the id before constructing paths, takes a shared lock when
-/// the session directory already exists, reads `openseek_session.jsonl`,
+/// the session directory already exists, reads the session jsonl file,
 /// checks that the header line's id is exactly the requested id, parses and
 /// replays every event line, and checks that event sequence numbers are
 /// contiguous. The returned value is a rebuilt immutable `Session`.
@@ -766,7 +846,8 @@ pub async fn SessionStore::load(
 ///
 /// On success the item is assigned the next sequence number and the current
 /// wall-clock timestamp, one JSONL line is appended to
-/// `openseek_session.jsonl`, and the new immutable `Session` is returned. The
+/// `openseek_session-<id>.jsonl`, and the new immutable `Session` is
+/// returned. The
 /// first append for a session id creates the file, writing the header line and
 /// the first event together; and when a crash left the durable tail
 /// unterminated, the append rewrites the file atomically instead, repairing
@@ -778,6 +859,7 @@ pub async fn SessionStore::append(
 ) -> @agent_session.Session {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
+    migrate_legacy_session_file(self, session.id())
     let repair_tail = ensure_session_is_current(self, session)
     let (next, event) = session.append_event(
       item,
@@ -797,7 +879,7 @@ pub async fn SessionStore::append(
 /// `from_sequence` must be positive, `to_sequence` must be at least
 /// `from_sequence`, and the range must already exist in the supplied session.
 ///
-/// The covered raw events remain in `openseek_session.jsonl`; only
+/// The covered raw events remain in the session jsonl file; only
 /// `Session::chat_messages` applies the compaction by skipping covered earlier
 /// events and emitting the summary. On success, the returned session includes
 /// the new `Summary` event with a wall-clock timestamp.
@@ -810,6 +892,7 @@ pub async fn SessionStore::compact(
 ) -> @agent_session.Session {
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
+    migrate_legacy_session_file(self, session.id())
     let repair_tail = ensure_session_is_current(self, session)
     let next = session.compact(
       content~,

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -154,6 +154,38 @@ async fn SessionStore::resolved_session_file_path(
 }
 
 ///|
+async fn mtime_or_none(path : String) -> (Int64, Int)? {
+  Some(@fs.mtime(path)) catch {
+    _ => None
+  }
+}
+
+///|
+/// Stat a session's jsonl mtime together with the path that produced it,
+/// without holding the session lock. Probes the suffixed name, the legacy
+/// name, then the suffixed name once more: a concurrent writer's migration
+/// renames legacy to suffixed atomically, and it can do so at most once
+/// between the first two probes, so a third miss means no session file
+/// exists. `None` when the file is absent; invalid ids raise.
+async fn SessionStore::stat_session_file(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> (String, Int64, Int)? {
+  let path = self.session_file_path(id)
+  if mtime_or_none(path) is Some((seconds, nanoseconds)) {
+    return Some((path, seconds, nanoseconds))
+  }
+  let legacy = self.legacy_session_file_path(id)
+  if mtime_or_none(legacy) is Some((seconds, nanoseconds)) {
+    return Some((legacy, seconds, nanoseconds))
+  }
+  if mtime_or_none(path) is Some((seconds, nanoseconds)) {
+    return Some((path, seconds, nanoseconds))
+  }
+  None
+}
+
+///|
 /// Move a legacy fixed-name session file to its id-suffixed name. Called
 /// with the exclusive session lock held, so no other writer races the
 /// rename; the lock path itself is layout-independent. Writers converge a
@@ -707,14 +739,11 @@ pub async fn SessionStore::listings(
   let stamped : Array[(SessionListing, Int64, Int)] = []
   let unreadable : Array[SessionListing] = []
   for id in self.list() {
-    let path = self.resolved_session_file_path(id) catch { _ => continue }
-    let stamp = @fs.mtime(path) catch {
-      _ => {
-        unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
-        continue
-      }
+    let stat = self.stat_session_file(id) catch { _ => continue }
+    guard stat is Some((path, seconds, nanoseconds)) else {
+      unreadable.push({ id, last_active_unix_seconds: None, first_prompt: "" })
+      continue
     }
-    let (seconds, nanoseconds) = stamp
     stamped.push(
       (
         {
@@ -751,10 +780,10 @@ pub async fn SessionStore::latest(
 ) -> @agent_session.SessionId? {
   let stamped : Array[(@agent_session.SessionId, Int64, Int)] = []
   for id in self.list() {
-    let stamp = @fs.mtime(self.resolved_session_file_path(id)) catch {
-      _ => continue
+    guard (self.stat_session_file(id) catch { _ => None })
+      is Some((_, seconds, nanoseconds)) else {
+      continue
     }
-    let (seconds, nanoseconds) = stamp
     stamped.push((id, seconds, nanoseconds))
   }
   // Newest first.

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -10,23 +10,6 @@ fn session_file(store : @store.SessionStore, id : String) -> String {
 }
 
 ///|
-fn legacy_session_file(store : @store.SessionStore, id : String) -> String {
-  "\{store.root()}/sessions/\{id}/openseek_session.jsonl"
-}
-
-///|
-/// Lay down a session in the pre-suffix layout: create it normally, then move
-/// the jsonl to the legacy fixed name.
-async fn create_legacy_layout_session(
-  store : @store.SessionStore,
-  session : @agent_session.Session,
-) -> Unit {
-  store.create(session)
-  let id = session.id().value()
-  @fs.rename(session_file(store, id), legacy_session_file(store, id))
-}
-
-///|
 async test "store creates and loads a session from one session file" {
   let store = new_store()
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
@@ -922,96 +905,6 @@ async test "store rejects path-like session ids" {
     }
   }
   fail("invalid session id accepted")
-}
-
-///|
-async test "store reads sessions written in the legacy fixed-name layout" {
-  let store = new_store()
-  let session = @agent_session.Session(SessionId("old"), system_prompt="system").append(
-    User(UserMessage("hello")),
-  )
-  create_legacy_layout_session(store, session)
-  // A fresh store instance sees only the legacy file.
-  let reader : @store.SessionStore = SessionStore(store.root())
-  let loaded = reader.load(SessionId("old"))
-  assert_eq(loaded.events().length(), 1)
-  assert_eq(loaded.system_prompt(), "system")
-  // Read-only surfaces resolve the legacy path without renaming anything.
-  assert_eq(
-    reader.session_file(SessionId("old")),
-    legacy_session_file(store, "old"),
-  )
-  let listings = reader.listings()
-  assert_eq(listings.length(), 1)
-  assert_true(listings[0].last_active_unix_seconds() is Some(_))
-  assert_eq(listings[0].first_prompt(), "hello")
-  guard reader.latest() is Some(id) else { fail("expected a latest session") }
-  assert_eq(id.value(), "old")
-  assert_true(@fs.exists(legacy_session_file(store, "old")))
-  assert_false(@fs.exists(session_file(store, "old")))
-  @fs.rmdir(store.root(), recursive=true)
-}
-
-///|
-async test "append migrates a legacy session file to the id-suffixed name" {
-  let store = new_store()
-  let session = @agent_session.Session(SessionId("old"), system_prompt="system").append(
-    User(UserMessage("hello")),
-  )
-  create_legacy_layout_session(store, session)
-  let writer : @store.SessionStore = SessionStore(store.root())
-  let resumed = writer.load(SessionId("old"))
-  let next = writer.append(resumed, Runtime(RuntimeNotice("migrated")))
-  assert_eq(next.events().length(), 2)
-  assert_false(@fs.exists(legacy_session_file(store, "old")))
-  assert_true(@fs.exists(session_file(store, "old")))
-  let reloaded = writer.load(SessionId("old"))
-  assert_eq(reloaded.events().length(), 2)
-  guard reloaded.events()[0].item() is User(message) else {
-    fail("expected the pre-migration event to survive")
-  }
-  assert_eq(message.content(), "hello")
-  @fs.rmdir(store.root(), recursive=true)
-}
-
-///|
-async test "create replaces a legacy session file instead of leaving both layouts" {
-  let store = new_store()
-  create_legacy_layout_session(
-    store,
-    Session(SessionId("old"), system_prompt="system"),
-  )
-  let writer : @store.SessionStore = SessionStore(store.root())
-  writer.create(Session(SessionId("old"), system_prompt="rewritten"))
-  assert_false(@fs.exists(legacy_session_file(store, "old")))
-  assert_eq(writer.load(SessionId("old")).system_prompt(), "rewritten")
-  @fs.rmdir(store.root(), recursive=true)
-}
-
-///|
-async test "writes fail loudly when both session file layouts exist" {
-  let store = new_store()
-  let session = @agent_session.Session(
-    SessionId("both"),
-    system_prompt="system",
-  )
-  store.create(session)
-  // A second file in the other layout is ambiguous corruption: refusing to
-  // write beats guessing which file is the session.
-  @fs.write_file(
-    legacy_session_file(store, "both"),
-    @fs.read_file(session_file(store, "both")).text(),
-    create_mode=CreateOrTruncate,
-  )
-  let _ = store.append(session, User(UserMessage("boom"))) catch {
-    error => {
-      assert_true("\{error}".contains("both session file layouts"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
-  }
-  @fs.rmdir(store.root(), recursive=true)
-  fail("ambiguous double-layout store accepted a write")
 }
 
 ///|

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -6,7 +6,24 @@ async fn new_store() -> @store.SessionStore {
 
 ///|
 fn session_file(store : @store.SessionStore, id : String) -> String {
+  "\{store.root()}/sessions/\{id}/openseek_session-\{id}.jsonl"
+}
+
+///|
+fn legacy_session_file(store : @store.SessionStore, id : String) -> String {
   "\{store.root()}/sessions/\{id}/openseek_session.jsonl"
+}
+
+///|
+/// Lay down a session in the pre-suffix layout: create it normally, then move
+/// the jsonl to the legacy fixed name.
+async fn create_legacy_layout_session(
+  store : @store.SessionStore,
+  session : @agent_session.Session,
+) -> Unit {
+  store.create(session)
+  let id = session.id().value()
+  @fs.rename(session_file(store, id), legacy_session_file(store, id))
 }
 
 ///|
@@ -905,6 +922,96 @@ async test "store rejects path-like session ids" {
     }
   }
   fail("invalid session id accepted")
+}
+
+///|
+async test "store reads sessions written in the legacy fixed-name layout" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("old"), system_prompt="system").append(
+    User(UserMessage("hello")),
+  )
+  create_legacy_layout_session(store, session)
+  // A fresh store instance sees only the legacy file.
+  let reader : @store.SessionStore = SessionStore(store.root())
+  let loaded = reader.load(SessionId("old"))
+  assert_eq(loaded.events().length(), 1)
+  assert_eq(loaded.system_prompt(), "system")
+  // Read-only surfaces resolve the legacy path without renaming anything.
+  assert_eq(
+    reader.session_file(SessionId("old")),
+    legacy_session_file(store, "old"),
+  )
+  let listings = reader.listings()
+  assert_eq(listings.length(), 1)
+  assert_true(listings[0].last_active_unix_seconds() is Some(_))
+  assert_eq(listings[0].first_prompt(), "hello")
+  guard reader.latest() is Some(id) else { fail("expected a latest session") }
+  assert_eq(id.value(), "old")
+  assert_true(@fs.exists(legacy_session_file(store, "old")))
+  assert_false(@fs.exists(session_file(store, "old")))
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "append migrates a legacy session file to the id-suffixed name" {
+  let store = new_store()
+  let session = @agent_session.Session(SessionId("old"), system_prompt="system").append(
+    User(UserMessage("hello")),
+  )
+  create_legacy_layout_session(store, session)
+  let writer : @store.SessionStore = SessionStore(store.root())
+  let resumed = writer.load(SessionId("old"))
+  let next = writer.append(resumed, Runtime(RuntimeNotice("migrated")))
+  assert_eq(next.events().length(), 2)
+  assert_false(@fs.exists(legacy_session_file(store, "old")))
+  assert_true(@fs.exists(session_file(store, "old")))
+  let reloaded = writer.load(SessionId("old"))
+  assert_eq(reloaded.events().length(), 2)
+  guard reloaded.events()[0].item() is User(message) else {
+    fail("expected the pre-migration event to survive")
+  }
+  assert_eq(message.content(), "hello")
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "create replaces a legacy session file instead of leaving both layouts" {
+  let store = new_store()
+  create_legacy_layout_session(
+    store,
+    Session(SessionId("old"), system_prompt="system"),
+  )
+  let writer : @store.SessionStore = SessionStore(store.root())
+  writer.create(Session(SessionId("old"), system_prompt="rewritten"))
+  assert_false(@fs.exists(legacy_session_file(store, "old")))
+  assert_eq(writer.load(SessionId("old")).system_prompt(), "rewritten")
+  @fs.rmdir(store.root(), recursive=true)
+}
+
+///|
+async test "writes fail loudly when both session file layouts exist" {
+  let store = new_store()
+  let session = @agent_session.Session(
+    SessionId("both"),
+    system_prompt="system",
+  )
+  store.create(session)
+  // A second file in the other layout is ambiguous corruption: refusing to
+  // write beats guessing which file is the session.
+  @fs.write_file(
+    legacy_session_file(store, "both"),
+    @fs.read_file(session_file(store, "both")).text(),
+    create_mode=CreateOrTruncate,
+  )
+  let _ = store.append(session, User(UserMessage("boom"))) catch {
+    error => {
+      assert_true("\{error}".contains("both session file layouts"))
+      @fs.rmdir(store.root(), recursive=true)
+      return
+    }
+  }
+  @fs.rmdir(store.root(), recursive=true)
+  fail("ambiguous double-layout store accepted a write")
 }
 
 ///|

--- a/cmd/openseek/concurrent_wbtest.mbt
+++ b/cmd/openseek/concurrent_wbtest.mbt
@@ -151,7 +151,7 @@ async test "copy_tree keeps files, .git dir, skills; skips build and sessions" {
       create_mode=CreateOrTruncate,
     )
     @fs.write_file(
-      "\{src}/.openseek/sessions/old/openseek_session.jsonl",
+      "\{src}/.openseek/sessions/old/openseek_session-old.jsonl",
       "{}",
       create_mode=CreateOrTruncate,
     )

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -868,9 +868,9 @@ fn main_pane(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
       }
     (None, None) =>
       @html.div(class="placeholder") <| (if model.sidebar_visible {
-        "Select a session from the left to view it, or drop an openseek_session.jsonl file anywhere in this window."
+        "Select a session from the left to view it, or drop an openseek session .jsonl file anywhere in this window."
       } else {
-        "Show sessions to select a session, or drop an openseek_session.jsonl file anywhere in this window."
+        "Show sessions to select a session, or drop an openseek session .jsonl file anywhere in this window."
       })
     (None, Some(key)) =>
       match model.parsed {

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -6,8 +6,7 @@
 /// - `GET /viz_app.js`                        → the compiled frontend bundle
 /// - `GET /api/sessions`                      → JSON listing across known roots
 /// - `GET /api/sessions/<key>`                → `{found, events, events_bytes}` envelope
-/// - `GET /api/sessions/<key>/openseek_session-<id>.jsonl` → raw session file (header line
-///   + events); the pre-suffix name `openseek_session.jsonl` is kept as an alias
+/// - `GET /api/sessions/<key>/openseek_session-<id>.jsonl` → raw session file (header line + events)
 ///
 /// It never writes to the stores, so pointing it at live session roots is safe.
 async fn main {
@@ -202,10 +201,7 @@ async fn session_path_reply(catalog : SessionCatalog, rest : String) -> Reply {
   let id = @agent_session.SessionId(id_value)
   match file {
     None => session_envelope_reply(root.store, id)
-    // Both the id-suffixed session file name and the legacy fixed name are
-    // accepted URLs; the store resolves whichever layout is actually on disk.
-    Some(name) if name == "openseek_session-\{id_value}.jsonl" ||
-      name == "openseek_session.jsonl" =>
+    Some(name) if name == "openseek_session-\{id_value}.jsonl" =>
       asset_reply(
         root.store.session_file(id),
         "application/x-ndjson; charset=utf-8",

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -6,7 +6,8 @@
 /// - `GET /viz_app.js`                        → the compiled frontend bundle
 /// - `GET /api/sessions`                      → JSON listing across known roots
 /// - `GET /api/sessions/<key>`                → `{found, events, events_bytes}` envelope
-/// - `GET /api/sessions/<key>/openseek_session.jsonl` → raw session file (header line + events)
+/// - `GET /api/sessions/<key>/openseek_session-<id>.jsonl` → raw session file (header line
+///   + events); the pre-suffix name `openseek_session.jsonl` is kept as an alias
 ///
 /// It never writes to the stores, so pointing it at live session roots is safe.
 async fn main {
@@ -199,7 +200,10 @@ async fn session_path_reply(catalog : SessionCatalog, rest : String) -> Reply {
   let id = @agent_session.SessionId(id_value)
   match file {
     None => session_envelope_reply(root.store, id)
-    Some("openseek_session.jsonl") =>
+    // Both the id-suffixed session file name and the legacy fixed name are
+    // accepted URLs; the store resolves whichever layout is actually on disk.
+    Some(name) if name == "openseek_session-\{id_value}.jsonl" ||
+      name == "openseek_session.jsonl" =>
       asset_reply(
         root.store.session_file(id),
         "application/x-ndjson; charset=utf-8",

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -179,14 +179,16 @@ async fn build_reply(
 ///|
 /// Resolve `<key>` (envelope) or `<key>/<file>` (raw) after the
 /// `/api/sessions/` route prefix. A key is either legacy `<id>` for the first
-/// root, or `<root>|<id>` for a discovered root. The segment is percent-decoded, so ids containing
-/// URL-reserved characters (spaces, `?`, `#`) still resolve to the right
-/// session. The store's own id validation rejects path separators and `..`, so
-/// a crafted id cannot escape the session directory.
+/// root, or `<root>|<id>` for a discovered root. Both segments are
+/// percent-decoded — the file name embeds the session id, so ids containing
+/// URL-reserved characters (spaces, `?`, `#`) must decode in both positions
+/// to resolve the right session. The store's own id validation rejects path
+/// separators and `..`, so a crafted id cannot escape the session directory.
 async fn session_path_reply(catalog : SessionCatalog, rest : String) -> Reply {
   let (key, file) = match rest.split_once("/") {
     None => (percent_decode(rest), None)
-    Some((key, file)) => (percent_decode("\{key}"), Some("\{file}"))
+    Some((key, file)) =>
+      (percent_decode("\{key}"), Some(percent_decode("\{file}")))
   }
   let (root, id_value) = match catalog.lookup(key) {
     Some(found) => found

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -324,6 +324,39 @@ async test "session_list_reply includes root metadata and composite keys" {
 }
 
 ///|
+async test "raw session file route decodes the file segment like the key" {
+  @vfs.with_tmpdir(prefix="openseek-viz-raw-", root => {
+    let store = @store.SessionStore("\{root}/.openseek")
+    // An id with a space forces percent-encoding in both URL segments.
+    let session = @agent_session.Session(SessionId("run 1"), system_prompt="").append(
+      User(UserMessage("hi")),
+    )
+    store.create(session)
+    let catalog : SessionCatalog = {
+      roots: [
+        {
+          key: "0",
+          path: "\{root}/.openseek",
+          label: ".openseek",
+          is_marker: true,
+          store,
+        },
+      ],
+    }
+    let reply = session_path_reply(
+      catalog, "0%7Crun%201/openseek_session-run%201.jsonl",
+    )
+    inspect(reply.code, content="200")
+    assert_true(reply.body.contains("\"id\":\"run 1\""))
+    // The pre-suffix fixed name stays served as an alias.
+    let alias_reply = session_path_reply(
+      catalog, "0%7Crun%201/openseek_session.jsonl",
+    )
+    inspect(alias_reply.code, content="200")
+  })
+}
+
+///|
 async test "session_envelope_reply includes event log byte size" {
   @vfs.with_tmpdir(prefix="openseek-viz-envelope-", root => {
     let store = @store.SessionStore("\{root}/.openseek")

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -348,11 +348,6 @@ async test "raw session file route decodes the file segment like the key" {
     )
     inspect(reply.code, content="200")
     assert_true(reply.body.contains("\"id\":\"run 1\""))
-    // The pre-suffix fixed name stays served as an alias.
-    let alias_reply = session_path_reply(
-      catalog, "0%7Crun%201/openseek_session.jsonl",
-    )
-    inspect(alias_reply.code, content="200")
   })
 }
 

--- a/eval/prompt_task/README.md
+++ b/eval/prompt_task/README.md
@@ -1,7 +1,7 @@
 # Prompt Task Eval
 
 This harness runs a MoonBit prompt task through the real OpenSeek agent with
-isolated workspaces, per-trial raw logs, durable `openseek_session.jsonl` session files,
+isolated workspaces, per-trial raw logs, durable `openseek_session-<id>.jsonl` session files,
 and bounded parallelism. Reporting is a separate analyzer pass, so reports can
 be regenerated without rerunning model/API trials.
 

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -425,7 +425,9 @@ async fn resolve_events_path(trial : TrialArtifact) -> String {
     trial.workspace +
     "/.openseek/sessions/" +
     trial.session_id +
-    "/openseek_session.jsonl"
+    "/openseek_session-" +
+    trial.session_id +
+    ".jsonl"
   }
 }
 

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -219,7 +219,7 @@ test "same output dir preserves absolute workspace paths" {
         workspace="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01",
         log_path=".moonagent/eval_runs/default/logs/01.log",
         session_id="trial-01",
-        events_path="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl",
+        events_path="/tmp/openseek/.moonagent/eval_runs/default/workspaces/01/.openseek/sessions/trial-01/openseek_session-trial-01.jsonl",
         exit_code=0,
       ),
     ],
@@ -240,9 +240,9 @@ async test "analyze run writes reports to caller output directory" {
     let stale_dir = root + "/stale"
     @fs.mkdir(out_dir, recursive=true)
     let actual_events_path = out_dir +
-      "/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl"
+      "/workspaces/01/.openseek/sessions/trial-01/openseek_session-trial-01.jsonl"
     let stale_events_path = stale_dir +
-      "/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl"
+      "/workspaces/01/.openseek/sessions/trial-01/openseek_session-trial-01.jsonl"
     @fs.mkdir(
       out_dir + "/workspaces/01/.openseek/sessions/trial-01",
       recursive=true,

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -68,7 +68,13 @@ async fn run_trial(
   let workspace = "\{config.out_dir}/workspaces/\{trial_name}"
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
-  let session_id = "trial-\{trial_name}"
+  // Run-unique: the timestamp keeps trial sessions from colliding when jsonl
+  // files from several runs are collected side by side; the trial index keeps
+  // them unique within a run.
+  let session_id = @agent_session.SessionId::generated(
+    prefix="trial-\{trial_name}",
+    now_ms=@env.now().reinterpret_as_int64(),
+  ).value()
   let task = task_template.replace_all(old="{{WORKSPACE}}", new=real_workspace)
   // The engine runs from the OpenSeek checkout and receives --dir for the
   // isolated trial workspace. This keeps launcher-relative paths stable while
@@ -179,13 +185,8 @@ async fn collect_session_events(
     let path = "\{dir}/\{name}"
     if is_directory(path) {
       collect_session_events(path, session_id, matches)
-    } else if (
-        name == "openseek_session-\{session_id}.jsonl" ||
-        name == "openseek_session.jsonl"
-      ) &&
+    } else if name == "openseek_session-\{session_id}.jsonl" &&
       path.contains("/sessions/\{session_id}/") {
-      // Both the id-suffixed name and the legacy fixed name match, so the
-      // analyzer keeps reading run directories produced before the suffix.
       matches.push(path)
     }
   }

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -1,8 +1,8 @@
 ///|
 /// Run the prompt task `config.runs` times, `config.concurrency` at a time,
 /// writing only durable artifacts: workspaces, raw process logs, recorded
-/// session `openseek_session.jsonl` files, and a run manifest. No validation or report
-/// analysis is performed in this phase.
+/// session `openseek_session-<id>.jsonl` files, and a run manifest. No
+/// validation or report analysis is performed in this phase.
 pub async fn run_experiments(config : Config) -> RunManifest {
   if config.api_key == "" {
     fail("api_key is required for running trials")
@@ -114,7 +114,7 @@ async fn run_trial(
   let events_path = discover_session_events(
     real_workspace,
     session_id,
-    fallback="\{real_workspace}/.openseek/sessions/\{session_id}/openseek_session.jsonl",
+    fallback="\{real_workspace}/.openseek/sessions/\{session_id}/openseek_session-\{session_id}.jsonl",
   )
   TrialArtifact(
     index=index + 1,
@@ -179,8 +179,13 @@ async fn collect_session_events(
     let path = "\{dir}/\{name}"
     if is_directory(path) {
       collect_session_events(path, session_id, matches)
-    } else if name == "openseek_session.jsonl" &&
+    } else if (
+        name == "openseek_session-\{session_id}.jsonl" ||
+        name == "openseek_session.jsonl"
+      ) &&
       path.contains("/sessions/\{session_id}/") {
+      // Both the id-suffixed name and the legacy fixed name match, so the
+      // analyzer keeps reading run directories produced before the suffix.
       matches.push(path)
     }
   }

--- a/eval/prompt_task/harness/manifest_wbtest.mbt
+++ b/eval/prompt_task/harness/manifest_wbtest.mbt
@@ -24,7 +24,7 @@ async test "manifest round trips run artifacts" {
           log_path: root + "/logs/01.log",
           session_id: "trial-01",
           events_path: root +
-          "/workspaces/01/.openseek/sessions/trial-01/openseek_session.jsonl",
+          "/workspaces/01/.openseek/sessions/trial-01/openseek_session-trial-01.jsonl",
           exit_code: 0,
         },
       ],

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -8,6 +8,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
+  "moonbitlang/core/env",
   "moonbitlang/core/json",
 }
 

--- a/eval/prompt_task/harness/suite_wbtest.mbt
+++ b/eval/prompt_task/harness/suite_wbtest.mbt
@@ -178,7 +178,9 @@ fn eval_result_for_suite_test(index : Int, success : Bool) -> EvalResult {
     padded_index(index) +
     "/.openseek/sessions/trial-" +
     padded_index(index) +
-    "/openseek_session.jsonl",
+    "/openseek_session-trial-" +
+    padded_index(index) +
+    ".jsonl",
     exit_code: 0,
     steps: index * 2,
     tool_results: index,

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -210,7 +210,7 @@ both `sessions show` calls strip `ts` to stay deterministic.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > mkdir -p "$tmp/sessions/demo"
-> cat > "$tmp/sessions/demo/openseek_session.jsonl" <<'JSONL'
+> cat > "$tmp/sessions/demo/openseek_session-demo.jsonl" <<'JSONL'
 > {"version":1,"id":"demo","system_prompt":"system"}
 > {"sequence":1,"ts":0,"item":{"kind":"user","payload":{"content":"hello"}}}
 > {"sequence":2,"ts":0,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -1,7 +1,7 @@
 # OpenSeek session visualizer
 
 A browser viewer for OpenSeek's durable session logs. It renders the
-`openseek_session.jsonl` file of a session (a header line plus append-only event lines) two ways, side by side behind a
+`openseek_session-<id>.jsonl` file of a session (a header line plus append-only event lines) two ways, side by side behind a
 toggle:
 
 - **Raw log** — every event in file order, grouped into turns (user prompt →
@@ -31,13 +31,13 @@ no browser needed in CI.
 - `GET /viz_app.js` → the compiled frontend bundle (auto-located from the moon build output)
 - `GET /api/sessions` → `[{key, id, root, root_label, last_active, first_prompt}, …]`, most recent first across all roots
 - `GET /api/sessions/<key>` → `{found, events, events_bytes}` envelope for the frontend (`events` is the raw session-file text; its first line is the header record)
-- `GET /api/sessions/<key>/openseek_session.jsonl` → raw session file
+- `GET /api/sessions/<key>/openseek_session-<id>.jsonl` → raw session file
 
 ## Drag and drop
 
 A session file is self-contained (the header line carries the id and system
 prompt), so the viewer also renders files that are not in any scanned store:
-drop an `openseek_session.jsonl` anywhere in the window and it is read and
+drop any session `.jsonl` anywhere in the window and it is read and
 rendered entirely client-side — nothing is uploaded. Selecting a session from
 the sidebar returns to the served view.
 


### PR DESCRIPTION
## What

Name each durable session file after its session id — `sessions/<id>/openseek_session-<id>.jsonl` instead of the fixed `sessions/<id>/openseek_session.jsonl` — so files collected out of their directories (for cross-session visualization or comparison) stay self-naming. The per-session directory remains the home for future per-session artifacts, and `session.lock` keeps its fixed name: it already lives inside the per-id directory and is never collected alongside the jsonl.

This is a **clean break**, not a migration: there are no external users yet, so there is no legacy read-fallback, no migrate-on-write, and no alias URL. Stores written before this change simply are not loadable by the new binary (delete them or regenerate).

## Run-unique eval trial ids

Eval trial sessions previously used `trial-01`, `trial-02`, … — identical across every run by construction, which defeats flat collection for exactly the run-vs-run comparison this PR enables. Trial ids now embed a wall-clock stamp via `SessionId::generated` (`trial-01-YYYYMMDD-HHMMSS-mmm`), so any two runs' session files can sit in one directory without colliding.

## Details

- The viz server serves the raw file at `GET /api/sessions/<key>/openseek_session-<id>.jsonl`; the file segment is percent-decoded like the key segment, so ids with URL-reserved characters resolve correctly (regression-tested with an id containing a space).
- The eval harness scanner matches the suffixed name; fixtures updated to match.
- No public API changes (`pkg.generated.mbti` untouched).

## Testing

Full native suite green; `agent_session/store`, `eval/prompt_task/harness`, `cmd/viz_server`, `cmd/openseek`, and the JS `cmd/viz_app` suites all pass; `moon fmt` and `moon info` clean. Two fresh Codex CLI review passes ran during development; both findings (URL decoding of the file segment; a stat race that only existed because of the migration path, now deleted) are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
