### PR TITLE
refactor(eval,agentcli): inline single-use helpers; share the API-key env lookup

### DIFF
--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -177,16 +177,8 @@ fn trial_extra_env(
     // own ~/.openseek/skills must never reach a trial prompt.
     "OPENSEEK_GLOBAL_SKILLS_DIR": "\{real_workspace}/.no-global-skills",
   }
-  env[api_key_env_for_model(config.model)] = config.api_key
+  env[@agentcli.api_key_env_for_model(config.model)] = config.api_key
   env
-}
-
-///|
-fn api_key_env_for_model(model : @deepseek.Model) -> String {
-  match model {
-    KimiK27Code | KimiK27CodeHighSpeed => "KIMI"
-    V4Flash | V4Pro => "DEEPSEEK"
-  }
 }
 
 ///|

--- a/eval/file_edit/harness/moon.pkg
+++ b/eval/file_edit/harness/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/internal/agentcli",
   "bobzhang/openseek/eval/file_edit/cases",
   "bobzhang/openseek/eval/internal/metrics",
   "bobzhang/openseek/eval/report",

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -494,7 +494,11 @@ async fn run_validation_probe(
   }
   if spec.write_file != "" {
     @fs.write_file(
-      workspace_path(workspace, spec.write_file),
+      if spec.write_file.has_prefix("/") {
+        spec.write_file
+      } else {
+        workspace + "/" + spec.write_file
+      },
       replace_workspace(spec.write_content, workspace),
       create_mode=CreateOrTruncate,
     )
@@ -605,15 +609,6 @@ fn validation_passed_by_name(
     }
   }
   false
-}
-
-///|
-fn workspace_path(workspace : String, path : String) -> String {
-  if path.has_prefix("/") {
-    path
-  } else {
-    workspace + "/" + path
-  }
 }
 
 ///|

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -143,16 +143,8 @@ fn trial_extra_env(
     "OPENSEEK_SESSION_ROOT": ".openseek",
     "OPENSEEK_GLOBAL_SKILLS_DIR": "\{real_workspace}/.no-global-skills",
   }
-  env[api_key_env_for_model(config.model)] = config.api_key
+  env[@agentcli.api_key_env_for_model(config.model)] = config.api_key
   env
-}
-
-///|
-fn api_key_env_for_model(model : @deepseek.Model) -> String {
-  match model {
-    KimiK27Code | KimiK27CodeHighSpeed => "KIMI"
-    V4Flash | V4Pro => "DEEPSEEK"
-  }
 }
 
 ///|
@@ -179,7 +171,10 @@ async fn collect_session_events(
   guard is_directory(dir) else { return }
   let names = @fs.readdir(dir, sort=true) catch { _ => return }
   for name in names {
-    if should_skip_scan_dir(name) {
+    if name == ".git" ||
+      name == "node_modules" ||
+      name == ".mooncakes" ||
+      name == "_build" {
       continue
     }
     let path = "\{dir}/\{name}"
@@ -196,14 +191,6 @@ async fn collect_session_events(
 async fn is_directory(path : String) -> Bool {
   (@fs.kind(path, follow_symlink=false) catch { _ => return false }) ==
   Directory
-}
-
-///|
-fn should_skip_scan_dir(name : String) -> Bool {
-  name == ".git" ||
-  name == "node_modules" ||
-  name == ".mooncakes" ||
-  name == "_build"
 }
 
 ///|

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/deepseek",
+  "bobzhang/openseek/internal/agentcli",
   "bobzhang/openseek/eval/internal/metrics",
   "bobzhang/openseek/eval/report",
   "bobzhang/openseek/eval/session_analyzer",

--- a/eval/prompt_task/harness/report.mbt
+++ b/eval/prompt_task/harness/report.mbt
@@ -7,18 +7,13 @@ async fn write_report_files(report : EvalReport) -> Unit {
     html=report.html(),
   )
   for result in report.results {
-    write_eval_result_files(report.out_dir, result)
+    @report.write_files(
+      report.out_dir + "/eval_results/" + eval_result_artifact_name(result),
+      result.markdown(),
+      result.to_json(),
+      html=result.html(),
+    )
   }
-}
-
-///|
-async fn write_eval_result_files(out_dir : String, result : EvalResult) -> Unit {
-  @report.write_files(
-    out_dir + "/eval_results/" + eval_result_artifact_name(result),
-    result.markdown(),
-    result.to_json(),
-    html=result.html(),
-  )
 }
 
 ///|
@@ -191,7 +186,7 @@ fn eval_result_row(
   include_eval_link~ : Bool,
 ) -> @report.ReportRow {
   ReportRow(
-    index=display_index(result),
+    index=if result.index > 0 { result.index } else { 1 },
     name=eval_result_name(result),
     success=result.success,
     reason=result.reason,
@@ -202,7 +197,14 @@ fn eval_result_row(
       Metric(name="Tool Errors", value=result.tool_errors.to_string()),
       Metric(name="Shell Failures", value=result.shell_failures.to_string()),
       Metric(name="Finished", value=result.finished.to_string()),
-      Metric(name="Validation", value=validation_status(result.validation)),
+      Metric(
+        name="Validation",
+        value=if result.validation.ran {
+          result.validation.passed.to_string()
+        } else {
+          "not run"
+        },
+      ),
       Metric(name="Exit Code", value=result.exit_code.to_string()),
     ],
     details=eval_details(result, out_dir~, include_eval_link~),
@@ -328,24 +330,6 @@ fn eval_result_artifact_name(result : EvalResult) -> String {
   .replace_all(old="\\", new="_")
   .replace_all(old=":", new="_")
   .replace_all(old=" ", new="_")
-}
-
-///|
-fn display_index(result : EvalResult) -> Int {
-  if result.index > 0 {
-    result.index
-  } else {
-    1
-  }
-}
-
-///|
-fn validation_status(validation : ValidationResult) -> String {
-  if !validation.ran {
-    "not run"
-  } else {
-    validation.passed.to_string()
-  }
 }
 
 ///|

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -317,7 +317,14 @@ fn ProblemSpec::from_json(json : Json, base_dir : String) -> ProblemSpec raise {
   ProblemSpec(
     id~,
     prompt_label=string_field_default(fields, "prompt_label", id),
-    task_file=resolve_relative_path(base_dir, string_field(fields, "task_file")),
+    task_file={
+      let task_file = string_field(fields, "task_file")
+      if task_file.has_prefix("/") || base_dir == "." {
+        task_file
+      } else {
+        base_dir + "/" + task_file
+      }
+    },
     validation_probes=probes,
   )
 }
@@ -329,7 +336,10 @@ pub async fn run_suite(config : SuiteConfig) -> SuiteManifest {
   if config.api_key == "" {
     fail("api_key is required for running suite trials")
   }
-  prepare_suite_output_dir(config.out_dir)
+  if @fs.exists(config.out_dir) {
+    @fs.rmdir(config.out_dir, recursive=true)
+  }
+  @fs.mkdir(config.out_dir + "/combos", recursive=true)
   let jobs = suite_jobs(config)
   prepare_combo_output_dirs(jobs)
   let artifacts = run_indexed_with_concurrency(
@@ -343,18 +353,10 @@ pub async fn run_suite(config : SuiteConfig) -> SuiteManifest {
 }
 
 ///|
-async fn prepare_suite_output_dir(out_dir : String) -> Unit {
-  if @fs.exists(out_dir) {
-    @fs.rmdir(out_dir, recursive=true)
-  }
-  @fs.mkdir(out_dir + "/combos", recursive=true)
-}
-
-///|
 async fn prepare_combo_output_dirs(jobs : Array[SuiteJob]) -> Unit {
   let seen : Array[String] = []
   for job in jobs {
-    if !string_array_contains(seen, job.out_dir) {
+    if !seen.contains(job.out_dir) {
       seen.push(job.out_dir)
       prepare_output_dir(job.out_dir)
     }
@@ -483,7 +485,12 @@ pub async fn analyze_suite(out_dir : String) -> SuiteReport {
     concurrency=manifest.concurrency,
     reports~,
   )
-  write_suite_report_files(report)
+  @report.write_files(
+    report.out_dir,
+    report.markdown(),
+    report.to_json(),
+    html=report.html(),
+  )
   report
 }
 
@@ -572,7 +579,11 @@ fn SuiteManifest::from_json(json : Json) -> SuiteManifest raise {
     max_steps=int_field(fields, "max_steps"),
     models=string_array_field(fields, "models"),
     problems=suite_manifest_problems(fields),
-    combos=suite_manifest_combos(fields),
+    combos=match fields.get("combos") {
+      Some(Array(items)) => [ for item in items => ComboRun::from_json(item) ]
+      Some(_) => fail("suite manifest combos must be an array")
+      None => fail("suite manifest combos is missing")
+    },
   )
 }
 
@@ -587,15 +598,6 @@ fn suite_manifest_problems(
       ]
     Some(_) => fail("suite manifest problems must be an array")
     None => fail("suite manifest problems is missing")
-  }
-}
-
-///|
-fn suite_manifest_combos(fields : Map[String, Json]) -> Array[ComboRun] raise {
-  match fields.get("combos") {
-    Some(Array(items)) => [ for item in items => ComboRun::from_json(item) ]
-    Some(_) => fail("suite manifest combos must be an array")
-    None => fail("suite manifest combos is missing")
   }
 }
 
@@ -675,16 +677,6 @@ fn string_array_field(
     Some(_) => fail("\{key} must be an array")
     None => fail("\{key} is missing")
   }
-}
-
-///|
-async fn write_suite_report_files(report : SuiteReport) -> Unit {
-  @report.write_files(
-    report.out_dir,
-    report.markdown(),
-    report.to_json(),
-    html=report.html(),
-  )
 }
 
 ///|
@@ -777,11 +769,27 @@ fn suite_report_row(
     warnings=suite_combo_warnings(report),
     metrics=[
       Metric(name="Model", value=report.model),
-      Metric(name="Problem", value=problem_id_from_report(report)),
+      Metric(
+        name="Problem",
+        // The problem id is the prompt label's `problem[:variant]` head.
+        value=match report.prompt_label.split_once(":") {
+          Some((problem, _)) => "\{problem}"
+          None => report.prompt_label
+        },
+      ),
       Metric(name="Successes", value="\{report.successes}/\{report.runs}"),
-      Metric(name="Avg Steps", value=average_steps(report)),
-      Metric(name="Avg Tool Errors", value=average_tool_errors(report)),
-      Metric(name="Avg Shell Failures", value=average_shell_failures(report)),
+      Metric(
+        name="Avg Steps",
+        value=average_result_metric(report, result => result.steps),
+      ),
+      Metric(
+        name="Avg Tool Errors",
+        value=average_result_metric(report, result => result.tool_errors),
+      ),
+      Metric(
+        name="Avg Shell Failures",
+        value=average_result_metric(report, result => result.shell_failures),
+      ),
       Metric(name="Finished", value=finished_summary(report)),
       Metric(name="Validation", value=validation_summary(report)),
     ],
@@ -817,31 +825,6 @@ fn suite_success_summary(report : SuiteReport) -> String {
 }
 
 ///|
-fn problem_id_from_report(report : EvalReport) -> String {
-  let pieces = report.prompt_label.split(":").collect()
-  if pieces.length() > 0 {
-    pieces[0].to_owned()
-  } else {
-    report.prompt_label
-  }
-}
-
-///|
-fn average_steps(report : EvalReport) -> String {
-  average_result_metric(report, result => result.steps)
-}
-
-///|
-fn average_tool_errors(report : EvalReport) -> String {
-  average_result_metric(report, result => result.tool_errors)
-}
-
-///|
-fn average_shell_failures(report : EvalReport) -> String {
-  average_result_metric(report, result => result.shell_failures)
-}
-
-///|
 fn average_result_metric(
   report : EvalReport,
   metric : (EvalResult) -> Int,
@@ -854,15 +837,9 @@ fn average_result_metric(
   } nobreak {
     total
   }
-  format_average(total, report.results.length())
-}
-
-///|
-fn format_average(total : Int, count : Int) -> String {
-  if count == 0 {
-    return "0.0"
-  }
-  let tenths = (total * 10 + count / 2) / count
+  // Round half-up to one decimal place.
+  let tenths = (total * 10 + report.results.length() / 2) /
+    report.results.length()
   "\{tenths / 10}.\{tenths % 10}"
 }
 
@@ -921,25 +898,6 @@ fn combo_out_dir(
   sanitize_artifact_name(model) +
   "/" +
   sanitize_artifact_name(problem_id)
-}
-
-///|
-fn string_array_contains(items : Array[String], value : String) -> Bool {
-  for item in items {
-    if item == value {
-      return true
-    }
-  }
-  false
-}
-
-///|
-fn resolve_relative_path(base_dir : String, path : String) -> String {
-  if path.has_prefix("/") || base_dir == "." {
-    path
-  } else {
-    base_dir + "/" + path
-  }
 }
 
 ///|

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -201,7 +201,7 @@ pub fn Report::html(self : Report) -> String {
     out.write_string("</td></tr>")
   }
   out.write_string("</tbody></table></div>")
-  if has_detail_section(self.rows) {
+  if self.rows.any(row => row.has_details()) {
     out.write_string(
       "<section><h2>Trial Details</h2><div class=\"trial-grid\">",
     )
@@ -388,16 +388,6 @@ fn detail_section_lines(rows : Array[ReportRow]) -> Array[String] {
     }
   }
   lines
-}
-
-///|
-fn has_detail_section(rows : Array[ReportRow]) -> Bool {
-  for row in rows {
-    if row.has_details() {
-      return true
-    }
-  }
-  false
 }
 
 ///|

--- a/internal/agentcli/agentcli.mbt
+++ b/internal/agentcli/agentcli.mbt
@@ -7,15 +7,6 @@
 /// package removes.
 
 ///|
-/// CLI option that carries the provider-specific API key for `model`.
-fn api_key_arg_for_model(model : @deepseek.Model) -> String {
-  match model {
-    KimiK27Code | KimiK27CodeHighSpeed => "kimi-api-key"
-    V4Flash | V4Pro => "deepseek-api-key"
-  }
-}
-
-///|
 /// Environment variable that carries the API key for `model`'s provider.
 /// Spawned engine processes inherit their key through this variable, so it
 /// must stay in lockstep with `api_key`'s lookup order.
@@ -23,15 +14,6 @@ pub fn api_key_env_for_model(model : @deepseek.Model) -> String {
   match model {
     KimiK27Code | KimiK27CodeHighSpeed => "KIMI"
     V4Flash | V4Pro => "DEEPSEEK"
-  }
-}
-
-///|
-/// Human-readable provider name for `model`, used in error guidance.
-fn api_key_provider_for_model(model : @deepseek.Model) -> String {
-  match model {
-    KimiK27Code | KimiK27CodeHighSpeed => "Kimi"
-    V4Flash | V4Pro => "DeepSeek"
   }
 }
 
@@ -47,11 +29,21 @@ pub fn api_key(
   if @cli.non_empty_value(matches, "api-key") is Some(key) {
     return key
   }
-  if @cli.non_empty_value(matches, api_key_arg_for_model(model)) is Some(key) {
+  // The provider-specific option name and the human-readable provider name
+  // key off the same model split as the env lookup below.
+  let arg = match model {
+    KimiK27Code | KimiK27CodeHighSpeed => "kimi-api-key"
+    V4Flash | V4Pro => "deepseek-api-key"
+  }
+  if @cli.non_empty_value(matches, arg) is Some(key) {
     return key
   }
+  let provider = match model {
+    KimiK27Code | KimiK27CodeHighSpeed => "Kimi"
+    V4Flash | V4Pro => "DeepSeek"
+  }
   fail(
-    "an API key is required for \{api_key_provider_for_model(model)} models: pass --api-key or set \{api_key_env_for_model(model)}",
+    "an API key is required for \{provider} models: pass --api-key or set \{api_key_env_for_model(model)}",
   )
 }
 


### PR DESCRIPTION
Part of the single-use-helper sweep: a private function called exactly once, whose body reads as well at the call site, is indirection rather than abstraction.

- **eval/prompt_task/harness** (15 inlined): path resolution (`workspace_path`, `resolve_relative_path`), scan filter (`should_skip_scan_dir`), report writers (`write_eval_result_files`, `write_suite_report_files`, `prepare_suite_output_dir`), metric formatting (`display_index`, `validation_status`, `format_average`, the three `average_*` wrappers), and manifest decoding (`suite_manifest_combos`, `problem_id_from_report` — the split/collect/index collapses to `split_once`). `string_array_contains` was hand-rolled `Array::contains` — replaced with the stdlib method.
- **eval/report**: `has_detail_section` → `self.rows.any(row => row.has_details())`.
- **internal/agentcli**: `api_key_arg_for_model` / `api_key_provider_for_model` inlined into `api_key`, the only caller.
- **De-dup**: `api_key_env_for_model` existed byte-for-byte in both eval harnesses while `internal/agentcli` already exports it — the exact drift hazard agentcli's package header describes. Both harnesses now import the shared copy.

Deliberately kept: `run_finish_case` in eval/tool_harness — one of eight symmetric `run_*_case` builders; breaking the family for the one short member costs more than the indirection.

No public API changes, no behavior changes. Tests: prompt_task/harness 18/18, file_edit/harness 7/7, report 4/4, cmd/tui 80/80 (agentcli consumer); `moon fmt`/`moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)