### PR TITLE
refactor(agent_session,store,agent,agent_skill): inline single-use helpers

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -11,21 +11,6 @@ let default_max_steps : Int = 1000
 let plan_reminder_after_steps : Int = 10
 
 ///|
-/// The staleness reminder injected when the `plan` tool has gone unused for
-/// `plan_reminder_after_steps` model requests. With a known current plan the
-/// reminder re-surfaces it — the last plan call may sit dozens of steps back
-/// in context — and otherwise it nudges once toward recording a plan, while
-/// staying explicit that trivial work should ignore it.
-fn plan_reminder_text(checklist : String?) -> String {
-  match checklist {
-    Some(lines) =>
-      "[plan reminder]\nThe plan tool has not been called in a while. If progress was made, update step statuses; if the plan no longer matches the work, replace it or clear it with steps: []. Current plan:\n\{lines}"
-    None =>
-      "[plan reminder]\nThe plan tool has not been used in this turn. If this task takes several distinct steps, record a plan with the plan tool and keep step statuses current. If not, ignore this reminder."
-  }
-}
-
-///|
 /// Queue `text` as steering input for the turn running on `runtime`.
 ///
 /// This is a thin public wrapper over `AgentRuntime::queue_steer(Prompt(...))`.
@@ -359,7 +344,16 @@ pub async fn[X] run_turn_in_scope(
       if plan_registered &&
         steps_since_plan >= plan_reminder_after_steps &&
         steps_since_reminder >= plan_reminder_after_steps {
-        let reminder = plan_reminder_text(plan_checklist)
+        // With a known current plan the reminder re-surfaces it — the last
+        // plan call may sit dozens of steps back in context — and otherwise
+        // it nudges once toward recording a plan, while staying explicit
+        // that trivial work should ignore it.
+        let reminder = match plan_checklist {
+          Some(lines) =>
+            "[plan reminder]\nThe plan tool has not been called in a while. If progress was made, update step statuses; if the plan no longer matches the work, replace it or clear it with steps: []. Current plan:\n\{lines}"
+          None =>
+            "[plan reminder]\nThe plan tool has not been used in this turn. If this task takes several distinct steps, record a plan with the plan tool and keep step statuses current. If not, ignore this reminder."
+        }
         @xlog.info() <? { "event": "plan_reminder", "content": reminder }
         session = append_item(session, Runtime(RuntimeNotice(reminder)))
         messages.push(ChatMessage(User, content=reminder))

--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -66,32 +66,18 @@ pub impl FromJson for SessionId with fn from_json(
 }
 
 ///|
-fn terminal_kind(terminal : TurnTerminal) -> String {
-  match terminal {
-    Finished(_) => "finished"
-    Aborted(_) => "aborted"
-    Interrupted(_) => "interrupted"
-    Failed(_) => "failed"
-  }
-}
-
-///|
-fn terminal_message(terminal : TurnTerminal) -> String {
-  match terminal {
-    Finished(message)
-    | Aborted(message)
-    | Interrupted(message)
-    | Failed(message) => message
-  }
-}
-
-///|
 /// Encode a terminal status as `{ "kind": ..., "message": ... }`.
 ///
 /// `kind` is one of `finished`, `aborted`, `interrupted`, or `failed`. The
 /// variant payload is stored in `message`.
 pub impl ToJson for TurnTerminal with fn to_json(terminal : TurnTerminal) -> Json {
-  { "kind": terminal_kind(terminal), "message": terminal_message(terminal) }
+  let (kind, message) = match terminal {
+    Finished(message) => ("finished", message)
+    Aborted(message) => ("aborted", message)
+    Interrupted(message) => ("interrupted", message)
+    Failed(message) => ("failed", message)
+  }
+  { "kind": kind, "message": message }
 }
 
 ///|

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -1,13 +1,4 @@
 ///|
-fn summary_model_content(summary : SessionSummary) -> String {
-  (
-    $|[conversation summary]
-    $|source_events=\{summary.from_sequence()}..\{summary.to_sequence()}
-    $|\{summary.content()}
-  )
-}
-
-///|
 /// A status line for a non-finished turn: the bare `label` when `reason` is
 /// blank, otherwise the label followed by the reason on its own line.
 fn agent_status_message(label : String, reason : String) -> String? {
@@ -43,7 +34,16 @@ fn append_item_message(
     Runtime(notice) =>
       messages.push(ChatMessage(User, content=notice.content()))
     Summary(summary) =>
-      messages.push(ChatMessage(User, content=summary_model_content(summary)))
+      messages.push(
+        ChatMessage(
+          User,
+          content=(
+            $|[conversation summary]
+            $|source_events=\{summary.from_sequence()}..\{summary.to_sequence()}
+            $|\{summary.content()}
+          ),
+        ),
+      )
     Assistant(message) =>
       messages.push(
         ChatMessage(
@@ -95,20 +95,15 @@ fn flush_pending_tool_calls(
 }
 
 ///|
-fn summary_covers_event(summary_event : SessionEvent, sequence : Int) -> Bool {
-  guard summary_event.item() is Summary(summary) else { return false }
-  summary_event.sequence() > sequence &&
-  summary.from_sequence() <= sequence &&
-  sequence <= summary.to_sequence()
-}
-
-///|
 fn is_covered_by_later_summary(
   event : SessionEvent,
   events : @vector.Vector[SessionEvent],
 ) -> Bool {
   for candidate in events {
-    if summary_covers_event(candidate, event.sequence()) {
+    guard candidate.item() is Summary(summary) else { continue }
+    if candidate.sequence() > event.sequence() &&
+      summary.from_sequence() <= event.sequence() &&
+      event.sequence() <= summary.to_sequence() {
       return true
     }
   }

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -2,14 +2,6 @@
 let session_dir_name : String = "sessions"
 
 ///|
-/// Session files carry their id in the name so files collected out of their
-/// directories — for cross-session visualization or comparison — stay
-/// self-naming.
-fn session_file_name(id : @agent_session.SessionId) -> String {
-  "openseek_session-\{id.value()}.jsonl"
-}
-
-///|
 /// The lock file carries no id suffix: it already lives inside the per-id
 /// session directory, and it is transient local coordination that is never
 /// collected alongside the jsonl.
@@ -110,11 +102,14 @@ fn SessionStore::session_dir(
 }
 
 ///|
+/// Session files carry their id in the name so files collected out of their
+/// directories — for cross-session visualization or comparison — stay
+/// self-naming.
 fn SessionStore::session_file_path(
   self : SessionStore,
   id : @agent_session.SessionId,
 ) -> String raise {
-  "\{self.session_dir(id)}/\{session_file_name(id)}"
+  "\{self.session_dir(id)}/openseek_session-\{id.value()}.jsonl"
 }
 
 ///|
@@ -123,15 +118,6 @@ fn SessionStore::lock_path(
   id : @agent_session.SessionId,
 ) -> String raise {
   "\{self.session_dir(id)}/\{lock_file_name}"
-}
-
-///|
-fn header_line(session : @agent_session.Session) -> String {
-  let header : @session_log.SessionFileHeader = {
-    id: session.id().value(),
-    system_prompt: session.system_prompt(),
-  }
-  "\{header.to_json().stringify()}\n"
 }
 
 ///|
@@ -147,7 +133,11 @@ fn events_jsonl(events : @vector.Vector[@agent_session.SessionEvent]) -> String 
 /// The complete durable form of a session: one header line followed by one
 /// line per event.
 fn session_file_text(session : @agent_session.Session) -> String {
-  "\{header_line(session)}\{events_jsonl(session.events())}"
+  let header : @session_log.SessionFileHeader = {
+    id: session.id().value(),
+    system_prompt: session.system_prompt(),
+  }
+  "\{header.to_json().stringify()}\n\{events_jsonl(session.events())}"
 }
 
 ///|
@@ -402,7 +392,11 @@ async fn write_text_atomic(
   @fs.write_file(tmp_path, text, create_mode=CreateOrTruncate, sync=Data)
   @fs.rename(tmp_path, path, replace=true)
   for dir in dirs {
-    sync_dir_best_effort(dir)
+    let file = @fs.open(dir, mode=ReadOnly) catch { _ => continue }
+    file.sync() catch {
+      _ => ()
+    }
+    file.close()
   }
 }
 
@@ -416,20 +410,6 @@ fn SessionStore::session_dir_chain(
   id : @agent_session.SessionId,
 ) -> Array[String] raise {
   [self.session_dir(id), self.sessions_dir(), self.root]
-}
-
-///|
-async fn sync_dir_best_effort(dir : String) -> Unit {
-  let file = @fs.open(dir, mode=ReadOnly) catch { _ => return }
-  defer file.close()
-  file.sync() catch {
-    _ => ()
-  }
-}
-
-///|
-async fn ensure_dir_exists(dir : String) -> Unit {
-  ensure_dir_exists_with_retry(dir, attempts=4)
 }
 
 ///|
@@ -450,7 +430,7 @@ async fn ensure_session_dir(
   id : @agent_session.SessionId,
 ) -> Unit {
   let dir = store.session_dir(id)
-  ensure_dir_exists(dir)
+  ensure_dir_exists_with_retry(dir, attempts=4)
 }
 
 ///|

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -92,11 +92,6 @@ priv struct SessionToolCall {
 } derive(Debug, ToJson, FromJson)
 
 ///|
-fn SessionToolCall::from_deepseek(call : @deepseek.ToolCall) -> SessionToolCall {
-  { id: call.id, name: call.name, arguments: call.arguments }
-}
-
-///|
 fn SessionToolCall::to_deepseek(self : SessionToolCall) -> @deepseek.ToolCall {
   ToolCall(id=self.id, name=self.name, arguments=self.arguments)
 }
@@ -144,7 +139,9 @@ pub fn AssistantMessage::AssistantMessage(
   {
     content,
     tool_calls: [
-      for call in tool_calls => SessionToolCall::from_deepseek(call)
+      for call in tool_calls => {
+        { id: call.id, name: call.name, arguments: call.arguments }
+      }
     ],
     reasoning_content,
   }
@@ -380,15 +377,6 @@ pub struct SessionEvent {
 } derive(Debug, ToJson, FromJson)
 
 ///|
-fn SessionEvent::SessionEvent(
-  sequence~ : Int,
-  item~ : SessionItem,
-  unix_ms? : Int64 = 0,
-) -> SessionEvent {
-  { sequence, ts: unix_ms.to_double(), item }
-}
-
-///|
 /// Return this event's one-based position in the session log.
 pub fn SessionEvent::sequence(self : SessionEvent) -> Int {
   self.sequence
@@ -510,7 +498,11 @@ pub fn Session::append_event(
   item : SessionItem,
   unix_ms? : Int64 = 0,
 ) -> (Session, SessionEvent) {
-  let event = SessionEvent(sequence=self.next_sequence(), item~, unix_ms~)
+  let event : SessionEvent = {
+    sequence: self.next_sequence(),
+    ts: unix_ms.to_double(),
+    item,
+  }
   (
     {
       id: self.id,

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -11,11 +11,6 @@ pub struct Skill {
 } derive(Debug)
 
 ///|
-fn Skill::Skill(name~ : String, description~ : String, path~ : String) -> Skill {
-  { name, description, path }
-}
-
-///|
 /// The skill's short identifier, from frontmatter `name:` or the file stem.
 pub fn Skill::name(self : Skill) -> String {
   self.name
@@ -124,7 +119,7 @@ async fn add_skill_file(skills : Array[Skill], path : String) -> Unit {
     stem => stem
   }
   let (name, description) = parse_frontmatter(text, fallback)
-  skills.push(Skill(name~, description~, path~))
+  skills.push({ name, description, path })
 }
 
 ///|


### PR DESCRIPTION
Part of the single-use-helper sweep: a private function called exactly once, whose body reads as well at the call site, is indirection rather than abstraction.

- **agent_session**: `terminal_kind` + `terminal_message` collapse into one match extracting `(kind, message)` in `TurnTerminal::to_json`; `summary_model_content` and `summary_covers_event` inline into the projection (`is_covered_by_later_summary` gains a `guard … is Summary` + range check in place of the predicate call); single-site named constructors `SessionEvent::SessionEvent` and `SessionToolCall::from_deepseek` become struct literals.
- **agent_session/store**: `session_file_name`, `header_line`, `sync_dir_best_effort`, and the `ensure_dir_exists` attempts-defaulting wrapper fold into their only callers, doc comments moving with them.
- **agent**: `plan_reminder_text` inlines into the reminder-injection site with its rationale comment.
- **agent_skill**: the `Skill::Skill` constructor's one construction site uses a struct literal.

Deliberately out of scope: **deepseek/client** (4 candidates) — the open `fix/deepseek-idle-timeout` branch rewrites its stream internals, and sweeping it now would manufacture conflicts. It can follow once that branch lands.

No public API changes, no behavior changes. Tests: agent_session 17/17, store 45/45, agent 14/14, agent_skill 5/5; `moon fmt`/`moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)