### PR TITLE
refactor(agent_tool): inline single-use helpers outside shell

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -133,8 +133,12 @@ async fn edit_file(
     .map(part => part.to_owned())
     .collect()
   if parts.length() <= 1 {
+    let range_detail = match input.end_line {
+      Some(end) => " in line range \{input.start_line}-\{end}"
+      None => " from line \{input.start_line}"
+    }
     return @agent_tool.ToolAction::respond(
-      "error editing \{path}: old_string not found\{range_detail(input)}",
+      "error editing \{path}: old_string not found\{range_detail}",
       is_error=true,
       brief=fail_brief,
     )
@@ -400,14 +404,6 @@ fn line_number_at_offset(content : String, offset : Int) -> Int {
     }
   }
   line
-}
-
-///|
-fn range_detail(input : @decode.EditInput) -> String {
-  match input.end_line {
-    Some(end) => " in line range \{input.start_line}-\{end}"
-    None => " from line \{input.start_line}"
-  }
 }
 
 ///|

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -37,7 +37,14 @@ async fn auto_check_summary(path : String) -> String? {
     _ => return Some("moon check: failed to run")
   }
   match result {
-    Some(output) => Some(format_moon_check_output(output))
+    Some(output) =>
+      Some(
+        format_moon_check_output_parts(
+          output.exit_code,
+          output.text,
+          output.output_limit_reached,
+        ),
+      )
     None => Some("moon check: timed out")
   }
 }
@@ -158,16 +165,13 @@ async fn moon_check_cwd(path : String) -> String? {
   if !is_relevant_moonbit_path(path) {
     return None
   }
-  nearest_moon_project_dir(containing_dir(path))
-}
-
-///|
-fn format_moon_check_output(output : @shell.ShellOutput) -> String {
-  format_moon_check_output_parts(
-    output.exit_code,
-    output.text,
-    output.output_limit_reached,
-  )
+  let normalized = path.replace_all(old="\\", new="/")
+  let dir = match normalized.rev_find("/") {
+    Some(0) => "/"
+    Some(cut) => normalized[:cut].to_owned()
+    None => "."
+  }
+  nearest_moon_project_dir(dir)
 }
 
 ///|
@@ -202,23 +206,10 @@ fn is_relevant_moonbit_path(path : String) -> Bool {
   path.has_suffix("/moon.pkg") ||
   path == "moon.work" ||
   path.has_suffix("/moon.work") ||
-  is_moonbit_source_path(path)
-}
-
-///|
-fn is_moonbit_source_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
-  path.has_suffix(".mbt") || path.has_suffix(".mbt.md")
-}
-
-///|
-fn containing_dir(path : String) -> String {
-  let path = path.replace_all(old="\\", new="/")
-  match path.rev_find("/") {
-    Some(0) => "/"
-    Some(cut) => path[:cut].to_owned()
-    None => "."
-  }
+  ({
+    let normalized = path.replace_all(old="\\", new="/")
+    normalized.has_suffix(".mbt") || normalized.has_suffix(".mbt.md")
+  })
 }
 
 ///|
@@ -241,7 +232,7 @@ fn parent_dir(dir : String) -> String? {
   if normalized == "" ||
     normalized == "." ||
     normalized == "/" ||
-    is_windows_drive_root(normalized) {
+    (normalized.length() == 2 && normalized[1] == ':') {
     return None
   }
   match normalized.rev_find("/") {
@@ -249,11 +240,6 @@ fn parent_dir(dir : String) -> String? {
     Some(cut) => Some(normalized[:cut].to_owned())
     None => Some(".")
   }
-}
-
-///|
-fn is_windows_drive_root(path : String) -> Bool {
-  path.length() == 2 && path[1] == ':'
 }
 
 ///|

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -213,7 +213,15 @@ pub fn format_parse_gate_errors(
       let excerpt = if error.context == "" {
         excerpt_for_loc(lines, error.loc)
       } else {
-        indent_context(error.context)
+        // Indent the compiler's context excerpt (numbered source lines) by
+        // two spaces, dropping only the trailing blank line its final `\n`
+        // produces — interior blank lines stay so the excerpt is faithful.
+        let context_lines = split_owned(error.context, "\n")
+        if !context_lines.is_empty() &&
+          context_lines[context_lines.length() - 1] == "" {
+          let _ = context_lines.pop()
+        }
+        [ for line in context_lines => "  \{line}" ].join("\n")
       }
       if excerpt == "" {
         header
@@ -222,19 +230,6 @@ pub fn format_parse_gate_errors(
       }
     }
   ]
-}
-
-///|
-/// Indent the compiler's `context` excerpt (numbered source lines, one per
-/// `\n`) by two spaces, dropping only the trailing blank line the final `\n`
-/// produces — interior blank lines, should moonc ever emit them, are kept so
-/// the excerpt stays faithful.
-fn indent_context(context : String) -> String {
-  let lines = split_owned(context, "\n")
-  if !lines.is_empty() && lines[lines.length() - 1] == "" {
-    let _ = lines.pop()
-  }
-  [ for line in lines => "  \{line}" ].join("\n")
 }
 
 ///|
@@ -263,7 +258,7 @@ fn excerpt_for_loc(lines : Array[String], loc : String) -> String {
   let width = "\{last}".length()
   let rendered = [
     for number in first..<=last => {
-      "  \{pad_line_number(number, width)} |\{lines[number - 1]}"
+      "  \{"\{number}".pad_start(width, ' ')} |\{lines[number - 1]}"
     }
   ]
   rendered.join("\n")
@@ -304,11 +299,6 @@ fn leading_line_number(part : String) -> Int? {
     value = value * 10 + (ch.to_int() - '0'.to_int())
   }
   Some(value)
-}
-
-///|
-fn pad_line_number(number : Int, width : Int) -> String {
-  "\{number}".pad_start(width, ' ')
 }
 
 ///|

--- a/agent_tool/moon_check/output.mbt
+++ b/agent_tool/moon_check/output.mbt
@@ -54,15 +54,6 @@ fn moon_check_output_is_crash(output : String) -> Bool {
 }
 
 ///|
-fn ensure_trailing_newline(output : String) -> String {
-  if output == "" || output.has_suffix("\n") {
-    output
-  } else {
-    "\{output}\n"
-  }
-}
-
-///|
 /// Reduce a `moon` panic banner into a few lines the agent can act on:
 /// exit code, crash flag, the `panicked at ...` line, the underlying detail,
 /// and the restart budget. The full upstream "Please report it at ..." block

--- a/agent_tool/moon_check/watcher.mbt
+++ b/agent_tool/moon_check/watcher.mbt
@@ -263,7 +263,12 @@ async fn[X] handle_moon_check_exit(
         key,
         restart_count=stopped_snapshot.restart_count + 1,
         restart_reason=Some("auto restart after exit \{exit_code}"),
-        initial_output=ensure_trailing_newline(stopped_snapshot.output),
+        initial_output=if stopped_snapshot.output == "" ||
+          stopped_snapshot.output.has_suffix("\n") {
+          stopped_snapshot.output
+        } else {
+          "\{stopped_snapshot.output}\n"
+        },
       ),
     )
   }

--- a/agent_tool/moon_cmd/internal/decode/decode.mbt
+++ b/agent_tool/moon_cmd/internal/decode/decode.mbt
@@ -44,13 +44,21 @@ pub fn decode(arguments : Json) -> MoonCommandInput raise {
 
 ///|
 fn parse_fields(fields : Map[String, Json]) -> MoonCommandInput raise {
-  let command = required_string(fields, "command")
-  validate_command(command)
+  let command = match fields.get("command") {
+    Some(String(value)) if value != "" => value
+    Some(String(_)) | Some(Null) | None => fail("arguments.command")
+    _ => fail("arguments.command to be a string")
+  }
+  if !["check", "test", "run", "info", "fmt", "build"].contains(command) {
+    fail("arguments.command to be one of check, test, run, info, fmt, build")
+  }
   let cwd = optional_string(fields, "cwd")
   let target = optional_string(fields, "target")
   if target is Some(value) {
     @moon_target.validate_target(value)
-    validate_target_supported(command)
+    if command == "fmt" {
+      fail("arguments.target is not supported for command fmt")
+    }
   }
   let args = parse_string_list(fields, "arg", "args")
   let paths = parse_string_list(fields, "path", "paths")
@@ -80,16 +88,11 @@ fn parse_fields(fields : Map[String, Json]) -> MoonCommandInput raise {
     stdin,
     test_update_kind,
     test_update_reason,
-    max_output_chars: cap_max_output_chars(max_output_chars),
-  }
-}
-
-///|
-fn required_string(fields : Map[String, Json], name : String) -> String raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => value
-    Some(String(_)) | Some(Null) | None => fail("arguments.\{name}")
-    _ => fail("arguments.\{name} to be a string")
+    max_output_chars: if max_output_chars > hard_max_output_chars {
+      hard_max_output_chars
+    } else {
+      max_output_chars
+    },
   }
 }
 
@@ -159,30 +162,6 @@ fn optional_positive_int(
     }
     Some(Null) | None => default
     _ => fail("arguments.\{name} to be a number")
-  }
-}
-
-///|
-fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
-  }
-}
-
-///|
-fn validate_command(command : String) -> Unit raise {
-  let allowed = ["check", "test", "run", "info", "fmt", "build"]
-  if !allowed.contains(command) {
-    fail("arguments.command to be one of check, test, run, info, fmt, build")
-  }
-}
-
-///|
-fn validate_target_supported(command : String) -> Unit raise {
-  if command == "fmt" {
-    fail("arguments.target is not supported for command fmt")
   }
 }
 

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -714,7 +714,10 @@ fn validate_edit(
   index : Int,
   file~ : String,
 ) -> EditValidation {
-  let range = line_range_label(item.start_line, item.end_line)
+  let range = match item.end_line {
+    Some(end) => "line range \{item.start_line}-\{end}"
+    None => "from line \{item.start_line}"
+  }
   if item.old_string == "" {
     // Insertion: an empty old_string inserts new_string at the start of
     // start_line (a zero-width edit). Use start_line = lastline + 1 to append at
@@ -830,17 +833,16 @@ fn apply_plans(content : String, plans : Array[PlannedEdit]) -> String {
 
 ///|
 fn failure_report(failures : Array[EditFailure]) -> String {
-  let lines = [ for failure in failures => format_failure(failure) ]
+  let lines = [
+    for failure in failures => {
+      match failure.index {
+        Some(index) =>
+          "\{failure.file} edit[\{index}] \{failure.range}: \{failure.message}"
+        None => "\{failure.file}: \{failure.message}"
+      }
+    }
+  ]
   "error multi_editing: \{failures.length()} problem(s); no changes applied\n\{lines.join("\n")}"
-}
-
-///|
-fn format_failure(failure : EditFailure) -> String {
-  match failure.index {
-    Some(index) =>
-      "\{failure.file} edit[\{index}] \{failure.range}: \{failure.message}"
-    None => "\{failure.file}: \{failure.message}"
-  }
 }
 
 ///|
@@ -898,13 +900,5 @@ fn line_end_offset(content : String, line : Int) -> Int {
     }
   } nobreak {
     len
-  }
-}
-
-///|
-fn line_range_label(start_line : Int, end_line : Int?) -> String {
-  match end_line {
-    Some(end) => "line range \{start_line}-\{end}"
-    None => "from line \{start_line}"
   }
 }

--- a/agent_tool/plan/plan.mbt
+++ b/agent_tool/plan/plan.mbt
@@ -132,19 +132,6 @@ fn execute(arguments : Json) -> @agent_tool.ToolAction {
 }
 
 ///|
-/// Step titles that read as verification work. Deciding "did the plan end
-/// without a verification step" only needs a coarse net: false positives just
-/// suppress a reminder the model did not need.
-fn is_verification_title(title : String) -> Bool {
-  let lowered = title.to_lower()
-  lowered.contains("test") ||
-  lowered.contains("check") ||
-  lowered.contains("verify") ||
-  lowered.contains("validate") ||
-  lowered.contains("lint")
-}
-
-///|
 /// Renders the decoded plan as a terse acknowledgment: progress count plus
 /// the in-progress step. The full plan already lives in the tool-call
 /// arguments that the session replays on every request, so the result adds
@@ -167,7 +154,14 @@ fn render(input : @decode.PlanInput) -> @agent_tool.ToolAction {
       InProgress => in_progress = Some(step.title)
       Pending => ()
     }
-    if is_verification_title(step.title) {
+    // Titles that read as verification work; a coarse net is enough —
+    // false positives just suppress a reminder the model did not need.
+    let lowered = step.title.to_lower()
+    if lowered.contains("test") ||
+      lowered.contains("check") ||
+      lowered.contains("verify") ||
+      lowered.contains("validate") ||
+      lowered.contains("lint") {
       has_verification = true
     }
   }

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -39,9 +39,11 @@ pub fn decode(arguments : Json) -> ReadInput raise {
 ///|
 fn parse_fields(fields : Map[String, Json]) -> ReadInput raise {
   reject_paths(fields)
-  let path = match optional_string(fields, "path") {
-    Some(path) => path
-    None => fail("arguments.path")
+  let path = match fields.get("path") {
+    Some(String(value)) if value != "" => value
+    Some(String(_)) => fail("arguments.path to be a non-empty string")
+    Some(Null) | None => fail("arguments.path")
+    _ => fail("arguments.path to be a string")
   }
   let start_line = optional_positive_int(fields, "start_line", 1)
   let max_lines = optional_positive_int_option(fields, "max_lines")
@@ -52,17 +54,11 @@ fn parse_fields(fields : Map[String, Json]) -> ReadInput raise {
     path,
     start_line,
     max_lines,
-    max_output_chars: cap_max_output_chars(max_output_chars),
-  }
-}
-
-///|
-fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => Some(value)
-    Some(String(_)) => fail("arguments.\{name} to be a non-empty string")
-    Some(Null) | None => None
-    _ => fail("arguments.\{name} to be a string")
+    max_output_chars: if max_output_chars > hard_max_output_chars {
+      hard_max_output_chars
+    } else {
+      max_output_chars
+    },
   }
 }
 
@@ -101,14 +97,5 @@ fn optional_positive_int_option(
     }
     Some(Null) | None => None
     _ => fail("arguments.\{name} to be a number")
-  }
-}
-
-///|
-fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
   }
 }

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -129,7 +129,15 @@ async fn write_file(
         )
       }
     }
-    create_parent_dirs(path)
+    // Create the parent directory (recursively) when missing, so a write to
+    // `dir/moon.pkg` works without a separate mkdir; `path` is already
+    // resolved under the workspace root. A mkdir failure propagates to the
+    // caller's `error writing` path — the write would fail anyway, so the
+    // real cause is useful.
+    let parent = parent_dir(path)
+    if parent != "" && !@fs.exists(parent) {
+      @fs.mkdir(parent, recursive=true)
+    }
     // Probe before writing so the result can tell the model whether it created a
     // new file or clobbered an existing one — a wholesale `write` over content it
     // never read is a common way to lose work. A non-ENOENT `exists` error (e.g.
@@ -229,19 +237,6 @@ fn write_reject_report(
 /// by the manifest guard, and hand-maintained ones are rare and editable.
 fn is_mbt_source(path : String) -> Bool {
   path.has_suffix(".mbt") || path.has_suffix(".mbt.md")
-}
-
-///|
-/// Create the parent directory of `path` (recursively) when it is missing, so a
-/// write to `dir/moon.pkg` works without a separate `mkdir`. The path is already
-/// resolved under the workspace root, so this stays inside the workspace. A
-/// mkdir failure propagates to the caller's `error writing` path rather than
-/// being swallowed — the write would fail anyway, so the real cause is useful.
-async fn create_parent_dirs(path : String) -> Unit {
-  let parent = parent_dir(path)
-  if parent != "" && !@fs.exists(parent) {
-    @fs.mkdir(parent, recursive=true)
-  }
 }
 
 ///|


### PR DESCRIPTION
Part of the single-use-helper sweep: a private function called exactly once, whose body reads as well at the call site, is indirection rather than abstraction.

- **internal/auto_check**: `format_moon_check_output` (arg-splat wrapper), `containing_dir`, `is_moonbit_source_path`, `is_windows_drive_root` fold into their conditions/callers; `indent_context` and `pad_line_number` inline into the parse-gate excerpt rendering with the rationale comment preserved.
- **moon_check**: `ensure_trailing_newline` becomes the if-expression at its one `initial_output=` site.
- **moon_cmd/internal/decode**: `required_string`, `validate_command`, `validate_target_supported`, `cap_max_output_chars` fold into `parse_fields`, where the field order already narrates the validation. `optional_string` stays — five callers.
- **read/internal/decode**: its single-use `optional_string` and `cap_max_output_chars` copies inline away (removing two of the three cross-package duplicates of the latter).
- **multi_edit / plan / edit / write**: message formatters (`format_failure`, `line_range_label`, `range_detail`), the `is_verification_title` heuristic, and `create_parent_dirs` inline with their doc comments as call-site comments.

The shell package (48 candidates) is deliberately a separate PR — its helper names document a dense policy engine and need case-by-case judgment.

No public API changes, no behavior changes. Tests: auto_check 23, moon_check 19, moon_cmd 21, multi_edit 30, plan 12, read 23, edit 29, write 26 — all green; `moon fmt`/`moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)