### PR TITLE
refactor(cmd/openseek): inline single-use helpers

### DIFF
--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -278,18 +278,13 @@ async fn copy_regular(s : String, d : String) -> Unit {
 /// skipped to avoid loops or escaping `--dir`.
 async fn copy_symlink(s : String, d : String, root : String) -> Unit {
   let resolved = @fs.realpath(s) catch { _ => return }
-  guard within_root(resolved, root) else { return }
+  // Only targets that are the workspace root or nested under it.
+  guard resolved == root || resolved.has_prefix("\{root}/") else { return }
   let target_kind = @fs.kind(s, follow_symlink=true) catch { _ => return }
   match target_kind {
     Regular => copy_regular(s, d)
     _ => () // directory/other targets skipped (loop-safe)
   }
-}
-
-///|
-/// Whether absolute `path` is `root` or nested under it.
-fn within_root(path : String, root : String) -> Bool {
-  path == root || path.has_prefix("\{root}/")
 }
 
 ///|

--- a/cmd/openseek/logging.mbt
+++ b/cmd/openseek/logging.mbt
@@ -18,13 +18,6 @@ priv struct FlushedStdout {
 }
 
 ///|
-fn FlushedStdout::FlushedStdout(
-  format? : @xlog.Format = Jsonl,
-) -> FlushedStdout {
-  { format, lines: Queue(kind=Unbounded) }
-}
-
-///|
 impl @xlog.Handler for FlushedStdout with fn handle(
   self : FlushedStdout,
   entry : @xlog.Entry,
@@ -67,7 +60,7 @@ fn FlushedStdout::close(self : FlushedStdout) -> Unit {
 /// live. Best-effort: if the file cannot be opened, logging stays
 /// stdout-only rather than failing the run.
 fn configure_logging() -> FlushedStdout {
-  let stdout = FlushedStdout()
+  let stdout : FlushedStdout = { format: Jsonl, lines: Queue(kind=Unbounded) }
   guard @env.get_env_var("OPENSEEK_LOG_FILE") is Some(path) && path != "" else {
     @xlog.global().set_handler(stdout)
     return stdout

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -233,8 +233,17 @@ async fn sessions_list(matches : @argparse.Matches) -> Unit {
   let store = @store.SessionStore(session_root(matches, workspace_root~))
   match session_list_format(matches) {
     Text =>
+      // Tab-separated id, last-activity stamp (UTC, minute precision; `-` for
+      // an unreadable session), and the first user prompt as a one-line
+      // label — `sessions list | cut -f1` recovers the bare ids.
       for listing in store.listings() {
-        println(format_session_listing(listing))
+        let when = match listing.last_active_unix_seconds() {
+          Some(seconds) => format_utc_minute(seconds)
+          None => "-"
+        }
+        println(
+          "\{listing.id().value()}\t\{when}\t\{compact_prompt_label(listing.first_prompt())}",
+        )
       }
     Json => println(session_list_json(store).stringify())
   }
@@ -575,14 +584,10 @@ fn root_command() -> @argparse.Command {
 /// copied `<dir>_run_1` workspace" — the flag always protects `--dir` from
 /// writes, at every N. Only the flagless default runs in place.
 fn fleet_mode(matches : @argparse.Matches, concurrency : Int) -> Bool {
-  concurrency >= 2 || explicitly_provided(matches, "concurrency")
-}
-
-///|
-/// Whether the user supplied `name` on the command line or via its
-/// environment variable, rather than the built-in default filling it in.
-fn explicitly_provided(matches : @argparse.Matches, name : String) -> Bool {
-  matches.sources.get(name) is (Some(Argv) | Some(Env))
+  // Explicit means supplied on the command line or via its environment
+  // variable, rather than the built-in default filling it in.
+  concurrency >= 2 ||
+  matches.sources.get("concurrency") is (Some(Argv) | Some(Env))
 }
 
 ///|
@@ -648,14 +653,12 @@ fn is_path_root(path : String) -> Bool {
   path == "\\" ||
   path == "//" ||
   path == "\\\\" ||
-  is_windows_drive_root(path)
-}
-
-///|
-fn is_windows_drive_root(path : String) -> Bool {
-  path.length() == 3 &&
-  path[1] == ':' &&
-  (path.has_suffix("/") || path.has_suffix("\\"))
+  // A Windows drive root: `C:/` or `C:\`.
+  (
+    path.length() == 3 &&
+    path[1] == ':' &&
+    (path.has_suffix("/") || path.has_suffix("\\"))
+  )
 }
 
 ///|
@@ -720,19 +723,6 @@ fn format_utc_minute(seconds : Int64) -> String {
 
   let time = @time.unix(seconds) catch { _ => return "-" }
   "\{time.year()}-\{pad2(time.month())}-\{pad2(time.day())} \{pad2(time.hour())}:\{pad2(time.minute())}"
-}
-
-///|
-/// One `sessions list` row: tab-separated id, last-activity stamp (UTC,
-/// minute precision; `-` for an unreadable session), and the first user
-/// prompt as a one-line label. Tab separation keeps the listing scriptable —
-/// `sessions list | cut -f1` recovers the bare ids the old format printed.
-fn format_session_listing(listing : @store.SessionListing) -> String {
-  let when = match listing.last_active_unix_seconds() {
-    Some(seconds) => format_utc_minute(seconds)
-    None => "-"
-  }
-  "\{listing.id().value()}\t\{when}\t\{compact_prompt_label(listing.first_prompt())}"
 }
 
 ///|


### PR DESCRIPTION
Part of the single-use-helper sweep: a private function called exactly once, whose body reads as well at the call site, is indirection rather than abstraction.

Inlined: `within_root` (guard in `copy_symlink`), the `FlushedStdout` constructor, `explicitly_provided` (argv/env source check), `format_session_listing` (the tab-separated row moves into the `sessions list` loop with its scriptability comment), and `is_windows_drive_root` (absorbed into `is_path_root`, its only caller, as a commented clause).

Deliberately kept, and why:
- `run_task_command` / `run_serve_command` / `run_review_command` / `run_sessions_command` and `sessions_show` — symmetric dispatcher families; the one short member reads better matching its siblings, and the docstrings carry per-command logging policy.
- `default_global_skills_dir` — a `#cfg(platform)` pair; the function *is* the conditional-compilation dispatch.

No public API changes, no behavior changes. Tests: cmd/openseek 59/59, cram suite 23/23 (CLI behavior unchanged); `moon fmt`/`moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)