### PR TITLE
refactor(tui,cmd/tui): inline single-use helpers

### DIFF
--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -38,14 +38,6 @@ priv struct EngineClient {
 }
 
 ///|
-fn EngineClient::EngineClient(
-  config : AppConfig,
-  messages : @async.Queue[Msg],
-) -> EngineClient {
-  { config, messages, live: None }
-}
-
-///|
 /// Spawn the serve-mode engine and its stream readers inside `group`.
 ///
 /// The stdout reader runs for the engine's lifetime, decoding events and

--- a/cmd/tui/internal/command_context/command_context.mbt
+++ b/cmd/tui/internal/command_context/command_context.mbt
@@ -90,20 +90,11 @@ pub fn parse(content : String) -> ShellCommand? {
 }
 
 ///|
-fn exit_header(exit_code : Int?) -> String {
-  if exit_code is Some(code) {
-    "exit=\{code}"
-  } else {
-    "exit=cancelled"
-  }
-}
-
-///|
 fn shell_result_text(result : @shell.ShellOutput) -> String {
   if result.output_limit_reached {
     let shown_chars = result.text.char_length()
     (
-      $|\{exit_header(result.exit_code)}
+      $|\{if result.exit_code is Some(code) { "exit=\{code}" } else { "exit=cancelled" }}
       $|truncated=true
       $|output_limit_reached=true
       $|shown_chars=\{shown_chars}

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -19,14 +19,6 @@ async fn read_ui_events(ui : @ui.Ui, messages : @async.Queue[Msg]) -> Unit {
 }
 
 ///|
-async fn tick_ui(messages : @async.Queue[Msg]) -> Unit {
-  for ;; {
-    @async.sleep(1000)
-    messages.put(Tick)
-  }
-}
-
-///|
 /// Cap on the engine stderr we retain to surface in a no-terminal-event error.
 /// We still read past it so the child can never block writing to a full stderr
 /// pipe (which would deadlock the `proc.wait()` below), but only this many bytes
@@ -173,14 +165,6 @@ fn engine_env(
 }
 
 ///|
-/// One-shot engine invocation: `<engine> run -- <task>`. The `run` subcommand is
-/// the headless one-shot mode; `--` stops option parsing so a task starting with
-/// `-` is taken literally.
-fn engine_args(task : String) -> Array[String] {
-  ["run", "--", task]
-}
-
-///|
 /// Spawn the agent engine for one input and stream its JSONL stdout into the
 /// message loop.
 ///
@@ -211,7 +195,9 @@ async fn run_agent_task(
       // settings go through a fully materialized environment so custom replay
       // engines do not need to accept OpenSeek-specific flags, and inherited
       // session vars cannot shadow explicit TUI config.
-      engine_args(task),
+      // `run` is the headless one-shot mode; `--` stops option parsing so
+      // a task starting with `-` is taken literally.
+      ["run", "--", task],
       inherit_env=false,
       extra_env=child_env,
       stdout=child_stdout,
@@ -788,7 +774,7 @@ async fn[G] run_message_loop(
   // prompt of this TUI session. Prompts, steers, and cancels are commands on
   // its stdin; a `!` shell command remains a local task, tracked by
   // `running_task` so an interrupt can cancel it directly.
-  let engine = EngineClient(state.config, messages)
+  let engine : EngineClient = { config: state.config, messages, live: None }
   let mut running_task : @async.Task[Unit]? = None
   outer~: for ;; {
     // Apply every message already enqueued before deciding anything further:

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -165,13 +165,6 @@ async fn with_latest_session(config : AppConfig) -> AppConfig {
 }
 
 ///|
-fn session_root(matches : @argparse.Matches) -> String raise {
-  @cli.require_non_empty(
-    matches, "session-root", "--session-root or OPENSEEK_SESSION_ROOT must not be empty",
-  )
-}
-
-///|
 /// Session id for a TUI launch that did not pick one.
 ///
 /// Conversation continuity is the TUI's default. The engine runs once per
@@ -192,7 +185,9 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   }
   let explicit_session = @agentcli.session_id(matches)
   let session_root_value = if explicit_session is Some(_) {
-    session_root(matches)
+    @cli.require_non_empty(
+      matches, "session-root", "--session-root or OPENSEEK_SESSION_ROOT must not be empty",
+    )
   } else {
     let root = @cli.value(matches, "session-root").trim().to_owned()
     if root.is_empty() {
@@ -312,7 +307,13 @@ async fn run_app(config : AppConfig, initial : String?, ui : @ui.Ui) -> Unit {
   refresh_ui(ui, state)
   @async.with_task_group(group => {
     group.spawn_bg(no_wait=true) <| () => { read_ui_events(ui, messages) }
-    group.spawn_bg(no_wait=true) <| () => { tick_ui(messages) }
+    // The 1/s Tick heartbeat driving countdowns and elapsed displays.
+    group.spawn_bg(no_wait=true) <| () => {
+      for ;; {
+        @async.sleep(1000)
+        messages.put(Tick)
+      }
+    }
     match initial {
       Some(task) => messages.put(UiInput(Steer(Prompt(task))))
       None => ()

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -89,11 +89,6 @@ fn notice_count(cmds : Array[Cmd]) -> Int {
 }
 
 ///|
-fn error_count(cmds : Array[Cmd]) -> Int {
-  [ for cmd in cmds if cmd is AppendItem(Error(_)) => cmd ].length()
-}
-
-///|
 test "loop arm/off/status/pause/resume lifecycle" {
   let state = scheduler_test_state()
   // Arm: schedule set, notice appended, full countdown.
@@ -132,7 +127,10 @@ test "loop arm/off/status/pause/resume lifecycle" {
   let _ = update(state, UiInput(SlashCommand(name="loop", arguments="off")))
   assert_true(state.schedule is None)
   let again = update(state, UiInput(SlashCommand(name="loop", arguments="off")))
-  assert_eq(error_count(again), 1)
+  assert_eq(
+    [ for cmd in again if cmd is AppendItem(Error(_)) => cmd ].length(),
+    1,
+  )
 }
 
 ///|

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -1,14 +1,4 @@
 ///|
-fn session_tool_item(result : @agent_session.ToolResult) -> @ui.TranscriptItem {
-  let event : @event.ToolResultEvent = {
-    name: result.tool_name(),
-    content: result.content(),
-    is_error: result.is_error(),
-  }
-  tool_item(event)
-}
-
-///|
 fn summary_item(summary : @agent_session.SessionSummary) -> @ui.TranscriptItem {
   Notice(
     ToolCall(
@@ -47,7 +37,14 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
       } else {
         Some(Response(message.content()))
       }
-    Tool(result) => Some(session_tool_item(result))
+    Tool(result) =>
+      Some(
+        tool_item({
+          name: result.tool_name(),
+          content: result.content(),
+          is_error: result.is_error(),
+        }),
+      )
     Runtime(notice) =>
       Some(runtime_item(parse_runtime_update(notice.content())))
     Summary(summary) => Some(summary_item(summary))

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -22,14 +22,6 @@ fn format_status_segments(segments : Array[Segment]) -> @doc.Text {
 }
 
 ///|
-fn format_usage_segment(usage : @event.UsageInfo?) -> String {
-  match usage {
-    None => ""
-    Some(usage) => "tokens \{usage.total_tokens}"
-  }
-}
-
-///|
 fn status_segments(state : State) -> Array[Segment] {
   [
     {
@@ -45,7 +37,10 @@ fn status_segments(state : State) -> Array[Segment] {
     },
     { text: state.config.cwd, style: Style(foreground=Basic(Green)) },
     {
-      text: format_usage_segment(state.usage),
+      text: match state.usage {
+        None => ""
+        Some(usage) => "tokens \{usage.total_tokens}"
+      },
       style: Style(foreground=Basic(Magenta)),
     },
     {
@@ -77,11 +72,6 @@ fn loop_segment_text(schedule : Schedule?) -> String {
 }
 
 ///|
-fn format_status_bar_text(state : State) -> @doc.Text {
-  format_status_segments(status_segments(state))
-}
-
-///|
 fn format_two_digits(value : Int64) -> String {
   if value < 10L {
     "0\{value}"
@@ -104,12 +94,6 @@ fn format_elapsed_compact(elapsed_seconds : Int64) -> String {
     let seconds = elapsed_seconds % 60L
     "\{hours}h \{format_two_digits(minutes)}m \{format_two_digits(seconds)}s"
   }
-}
-
-///|
-fn elapsed_seconds(started_ms : Int64, now_ms : Int64) -> Int64 {
-  let elapsed_ms = if now_ms > started_ms { now_ms - started_ms } else { 0L }
-  elapsed_ms / 1000L
 }
 
 ///|
@@ -215,8 +199,9 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
     )
     return Some(Text(spans + steer_segment))
   }
+  let now_ms = @async.now()
   let elapsed = format_elapsed_compact(
-    elapsed_seconds(started_ms, @async.now()),
+    (if now_ms > started_ms { now_ms - started_ms } else { 0L }) / 1000L,
   )
   let spans : Array[@doc.Span] = [
     @doc.Span::plain("Working"),
@@ -228,7 +213,7 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
 ///|
 async fn refresh_ui(ui : @ui.Ui, state : State) -> Unit {
   ui.set_live_view(
-    status=format_status_bar_text(state),
+    status=format_status_segments(status_segments(state)),
     activity=format_activity_text(state, cols=ui.columns()),
     queued_inputs=state.queued,
   )

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -38,16 +38,11 @@ fn detail_texts(lines : Array[String]) -> Array[@doc.Text] {
 }
 
 ///|
-fn tool_title(result : @event.ToolResultEvent) -> @doc.Text {
-  let label = if result.is_error { "Tool failed" } else { "Tool" }
-  @doc.Text::plain("\{label} \{result.name}")
-}
-
-///|
 fn tool_item(result : @event.ToolResultEvent) -> @ui.TranscriptItem {
+  let label = if result.is_error { "Tool failed" } else { "Tool" }
   ToolCall(
     ToolCall(
-      tool_title(result),
+      @doc.Text::plain("\{label} \{result.name}"),
       status=if result.is_error { Failed } else { Completed },
       details=detail_texts(compact_lines(result.content, ToolOutputLineLimit)),
     ),

--- a/tui/internal/composer/composer.mbt
+++ b/tui/internal/composer/composer.mbt
@@ -12,14 +12,6 @@ pub const DefaultMaxTextRows : Int = 4
 const PromptWidth : Int = 2
 
 ///|
-/// Editable content width for a composer rendered at `cols` terminal columns,
-/// i.e. the room left once the two-column prompt prefix is reserved.
-fn compute_content_width(cols~ : Int) -> Int {
-  let width = cols - PromptWidth
-  width.max(1)
-}
-
-///|
 /// Content width assumed before the composer has been laid out against a real
 /// terminal. The renderer calls `Model::resize` on every frame, so this only
 /// governs editing that happens before the first draw.
@@ -355,7 +347,8 @@ pub fn Model::resize(self : Model, cols~ : Int, max_rows? : Int) -> Unit {
     Some(max_rows) => max_rows.clamp(min=MinTextRows, max=self.max_text_rows)
     None => self.max_text_rows
   }
-  self.content_width = compute_content_width(cols~)
+  // Editable width once the two-column prompt prefix is reserved.
+  self.content_width = (cols - PromptWidth).max(1)
   self.visual_rows = wrap_visual_rows(
     self.logical_lines,
     content_width=self.content_width,
@@ -603,7 +596,7 @@ pub fn Model::move_right(self : Model) -> Unit {
 /// then the run of word units. Matches readline's `forward-word` (Alt-F).
 pub fn Model::move_word_right(self : Model) -> Unit {
   self.set_cursor(
-    cursor=move_cursor_word_right(self.logical_lines, self.cursor),
+    cursor=move_cursor_word(self.logical_lines, self.cursor, direction=Forward),
   )
 }
 
@@ -612,7 +605,9 @@ pub fn Model::move_word_right(self : Model) -> Unit {
 /// delimiters, then the run of word units. Matches readline's `backward-word`
 /// (Alt-B).
 pub fn Model::move_word_left(self : Model) -> Unit {
-  self.set_cursor(cursor=move_cursor_word_left(self.logical_lines, self.cursor))
+  self.set_cursor(
+    cursor=move_cursor_word(self.logical_lines, self.cursor, direction=Backward),
+  )
 }
 
 ///|

--- a/tui/internal/composer/text_cursor.mbt
+++ b/tui/internal/composer/text_cursor.mbt
@@ -207,19 +207,3 @@ fn move_cursor_word(
   }
   cursor
 }
-
-///|
-fn move_cursor_word_right(
-  logical_lines : Array[LogicLine],
-  cursor : TextCursor,
-) -> TextCursor {
-  move_cursor_word(logical_lines, cursor, direction=Forward)
-}
-
-///|
-fn move_cursor_word_left(
-  logical_lines : Array[LogicLine],
-  cursor : TextCursor,
-) -> TextCursor {
-  move_cursor_word(logical_lines, cursor, direction=Backward)
-}

--- a/tui/internal/composer/visual_row.mbt
+++ b/tui/internal/composer/visual_row.mbt
@@ -84,11 +84,6 @@ fn find_cursor_visual_row(
 }
 
 ///|
-fn is_row_start_at_cursor(row~ : VisualRow, cursor~ : TextCursor) -> Bool {
-  row.logic_start == cursor.position
-}
-
-///|
 /// Resolve the cursor to a wrapped row index.
 ///
 /// A cursor sitting exactly on a soft-wrap boundary is ambiguous: the same text
@@ -104,7 +99,7 @@ fn resolve_cursor(
   let index = find_cursor_visual_row(logical_lines, rows~, cursor~)
   let line = logical_lines[cursor.line]
   if at_wrap_end &&
-    is_row_start_at_cursor(row=rows[index], cursor~) &&
+    rows[index].logic_start == cursor.position &&
     index > line.row_start {
     index - 1
   } else {

--- a/tui/internal/history/history_test.mbt
+++ b/tui/internal/history/history_test.mbt
@@ -5,33 +5,10 @@ fn prompt_entry(text : String) -> @history.Entry {
 }
 
 ///|
-fn shell_entry(text : String) -> @history.Entry {
-  let composer = @composer.Model::new("")
-  composer.insert_user_text("!\{text}")
-  @history.Entry::new(composer.text(), composer.mode())
-}
-
-///|
 fn recalled_text(entry : @history.Entry?) -> String {
   match entry {
     Some(entry) => entry.text()
     None => "<none>"
-  }
-}
-
-///|
-fn recalled_is_shell(entry : @history.Entry?) -> Bool {
-  match entry {
-    Some(entry) => entry.mode().is_shell()
-    None => false
-  }
-}
-
-///|
-fn recalled_is_input(entry : @history.Entry?) -> Bool {
-  match entry {
-    Some(entry) => entry.mode().is_input()
-    None => false
   }
 }
 
@@ -71,9 +48,13 @@ test "history skips empty and adjacent duplicate entries" {
 test "history distinguishes shell and prompt entries" {
   let history = @history.History::new()
   history.push(prompt_entry("pwd"))
-  history.push(shell_entry("pwd"))
+  let shell_composer = @composer.Model::new("")
+  shell_composer.insert_user_text("!pwd")
+  history.push(
+    @history.Entry::new(shell_composer.text(), shell_composer.mode()),
+  )
   let previous = history.previous(prompt_entry("draft"))
-  inspect(recalled_is_shell(previous), content="true")
+  assert_true(previous is Some(entry) && entry.mode().is_shell())
   let previous = history.previous(prompt_entry("ignored"))
-  inspect(recalled_is_input(previous), content="true")
+  assert_true(previous is Some(entry) && entry.mode().is_input())
 }

--- a/tui/internal/render/render.mbt
+++ b/tui/internal/render/render.mbt
@@ -35,15 +35,6 @@ fn prompt_line(
 }
 
 ///|
-fn status_line(
-  status : @doc.Text,
-  notice : @doc.Text?,
-  cols~ : Int,
-) -> @surface.Line {
-  notice.unwrap_or(status).first_line(width=cols)
-}
-
-///|
 const MaxCompletionMenuRows : Int = 6
 
 ///|
@@ -275,7 +266,10 @@ pub fn composer_surface(
     rows.push(row)
   }
   rows.push(
-    indent_line(status_line(status, notice, cols=cols - indent), indent~),
+    indent_line(
+      notice.unwrap_or(status).first_line(width=cols - indent),
+      indent~,
+    ),
   )
   @surface.Surface::new(
     width=cols,

--- a/tui/internal/surface/surface.mbt
+++ b/tui/internal/surface/surface.mbt
@@ -108,15 +108,6 @@ pub fn Cursor::col(self : Cursor) -> Int {
 }
 
 ///|
-fn normalize_surface_width(width : Int) -> Int {
-  if width < 1 {
-    1
-  } else {
-    width
-  }
-}
-
-///|
 fn normalize_surface_index(value : Int, max_value : Int) -> Int {
   value.clamp(min=0, max=max_value)
 }
@@ -144,7 +135,7 @@ pub fn Surface::new(
   rows~ : Array[Line],
   cursor~ : Cursor,
 ) -> Surface {
-  let width = normalize_surface_width(width)
+  let width = width.max(1)
   let cursor = normalize_surface_cursor(rows, width, cursor)
   { width, rows, cursor }
 }

--- a/tui/internal/viewport/viewport.mbt
+++ b/tui/internal/viewport/viewport.mbt
@@ -1,17 +1,4 @@
 ///|
-/// Full reset before a from-scratch redraw: drop any scroll region and text
-/// style, then erase both the visible screen and the scrollback, leaving the
-/// cursor at the home position.
-async fn clear_screen_and_scrollback(tty : @tty.Tty) -> Unit {
-  tty.reset_top_bottom_margins()
-  tty.reset_style()
-  tty.set_cursor_position(1, 1)
-  tty.erase_display()
-  tty.erase_scrollback()
-  tty.set_cursor_position(1, 1)
-}
-
-///|
 struct Viewport {
   mut size : @terminal_size.TerminalSize
   size_source : SizeSource
@@ -299,13 +286,6 @@ async fn apply_style(tty : @tty.Tty, style : @style.Style) -> Unit {
 }
 
 ///|
-async fn write_span(tty : @tty.Tty, span : @surface.Span) -> Unit {
-  apply_style(tty, span.style())
-  tty.write(span.text())
-  tty.reset_style()
-}
-
-///|
 /// Run `body` with terminal auto-wrap disabled, restoring it even if drawing
 /// raises.
 async fn without_auto_wrap(tty : @tty.Tty, body : async () -> Unit) -> Unit {
@@ -331,7 +311,9 @@ async fn draw_surface_line_at_cursor(
   erase_cursor_row(tty)
   if line is Some(line) {
     for span in line.spans() {
-      write_span(tty, span)
+      apply_style(tty, span.style())
+      tty.write(span.text())
+      tty.reset_style()
     }
   }
 }
@@ -554,7 +536,15 @@ pub async fn Viewport::replay_scrollback(
   surface~ : @surface.Surface,
 ) -> Unit {
   tty.hide_cursor()
-  clear_screen_and_scrollback(tty)
+  // Full reset before a from-scratch redraw: drop any scroll region and
+  // text style, then erase both the visible screen and the scrollback,
+  // leaving the cursor at home.
+  tty.reset_top_bottom_margins()
+  tty.reset_style()
+  tty.set_cursor_position(1, 1)
+  tty.erase_display()
+  tty.erase_scrollback()
+  tty.set_cursor_position(1, 1)
   // `set_geometry` clamps the height to the screen itself.
   self.set_geometry(top=1, height=surface.height())
   let surface = surface.with_max_rows(self.height())


### PR DESCRIPTION
Part of the single-use-helper sweep: a private function called exactly once, whose body reads as well at the call site, is indirection rather than abstraction.

- **cmd/tui**: `EngineClient` constructor → struct literal; `tick_ui` → the heartbeat loop in its spawn closure; `engine_args`, `session_root`, `session_tool_item`, `format_usage_segment`, `format_status_bar_text`, `elapsed_seconds`, `tool_title`, and the wbtest `error_count` helper inline at their sites.
- **cmd/tui/internal/command_context**: `exit_header` becomes an interpolated if-expression in the shell-result template.
- **tui/internal**: composer's `compute_content_width`, the `move_cursor_word_right/left` direction wrappers, and `is_row_start_at_cursor`; history-test helpers; render's `status_line`; surface's `normalize_surface_width` (→ `width.max(1)`); viewport's `write_span` and `clear_screen_and_scrollback` tty sequences.

Deliberately kept, and why:
- `scheduler_tick` — the scheduler module's seam into the update loop; that bookkeeping was recently debugged (loop-fire ordering fixes) and belongs in `scheduler.mbt` next to `scheduler_maybe_fire`, not scattered into `loop.mbt`'s match.
- `reasoning_item` / `compaction_item` / `command_cancelled_item` — view-layer builders called from `loop.mbt`; their doc comments carry UX rationale and inlining would move rendering into event dispatch.

No public API changes, no behavior changes. Tests: cmd/tui 80/80, command_context 5/5, composer 24/24, history 3/3, render 17/17, surface 3/3, viewport 5/5; `moon fmt`/`moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)