### PR TITLE
refactor(scripts,testkit): inline single-use helpers

### DIFF
--- a/scripts/internal/markdown_comments/markdown_comments.mbt
+++ b/scripts/internal/markdown_comments/markdown_comments.mbt
@@ -6,18 +6,12 @@ priv struct SourceRange {
 
 ///|
 pub fn without_comments(markdown : String) -> String {
-  let ranges = comment_ranges(markdown)
-  guard !ranges.is_empty() else { markdown }
-  ranges.sort_by(fn(left, right) { left.first.compare(right.first) })
-  remove_source_ranges(markdown, ranges)
-}
-
-///|
-fn comment_ranges(markdown : String) -> Array[SourceRange] {
   let ranges = []
   let doc = @cmark.Doc::from_string(locs=true, markdown)
   collect_block_comment_ranges(markdown, doc.block, ranges)
-  ranges
+  guard !ranges.is_empty() else { markdown }
+  ranges.sort_by(fn(left, right) { left.first.compare(right.first) })
+  remove_source_ranges(markdown, ranges)
 }
 
 ///|
@@ -76,10 +70,19 @@ fn collect_inline_comment_ranges(
   ranges : Array[SourceRange],
 ) -> Unit {
   match inline {
-    RawHtml(node) =>
-      if inline_raw_html_is_comment(node.v) {
-        push_loc_range(ranges, node.meta)
+    RawHtml(node) => {
+      let text = StringBuilder()
+      for tight in node.v.0.iter() {
+        text.write_string(tight.to_string())
       }
+      let loc = node.meta.loc
+      if is_html_comment(text.to_string()) && !loc_is_absent(loc) {
+        ranges.push({
+          first: loc.first_ccode,
+          last_exclusive: loc.last_ccode + 1,
+        })
+      }
+    }
     Inlines(node) =>
       for child in node.v.iter() {
         collect_inline_comment_ranges(child, ranges)
@@ -113,15 +116,6 @@ fn push_html_block_ranges(
 }
 
 ///|
-fn inline_raw_html_is_comment(raw : @cmark.InlineRawHtml) -> Bool {
-  let text = StringBuilder()
-  for tight in raw.0.iter() {
-    text.write_string(tight.to_string())
-  }
-  is_html_comment(text.to_string())
-}
-
-///|
 fn is_html_comment(text : StringView) -> Bool {
   text.trim_start().has_prefix("<!--")
 }
@@ -129,15 +123,6 @@ fn is_html_comment(text : StringView) -> Bool {
 ///|
 fn loc_is_absent(loc : @cmark_base.TextLoc) -> Bool {
   loc.is_none() || loc.is_empty()
-}
-
-///|
-fn push_loc_range(ranges : Array[SourceRange], meta : @cmark_base.Meta) -> Unit {
-  let loc = meta.loc
-  if loc_is_absent(loc) {
-    return
-  }
-  ranges.push({ first: loc.first_ccode, last_exclusive: loc.last_ccode + 1 })
 }
 
 ///|

--- a/scripts/md_to_mbt_string/main.mbt
+++ b/scripts/md_to_mbt_string/main.mbt
@@ -55,19 +55,15 @@ fn @path.Path::basename(path : @path.Path) -> StringView {
   }
   for view = trimmed {
     match view {
-      [] => break trim_windows_drive_prefix(trimmed)
+      [] =>
+        // A bare drive prefix (`C:`) has no basename to recover.
+        break match trimmed {
+          ['a'..='z' | 'A'..='Z', ':', .. rest] => rest
+          _ => trimmed
+        }
       [.., '/' | '\\'] as prefix => break trimmed[prefix.length():]
       [.. rest, _] => continue rest
     }
-  }
-}
-
-///|
-#cfg(platform="windows")
-fn trim_windows_drive_prefix(path : StringView) -> StringView {
-  match path {
-    ['a'..='z' | 'A'..='Z', ':', .. rest] => rest
-    _ => path
   }
 }
 

--- a/testkit/filesystem/outline.mbt
+++ b/testkit/filesystem/outline.mbt
@@ -36,13 +36,17 @@ async fn collect_dirs(
   let names = @fs.readdir(dir, sort=true) catch { _ => return }
   for name in names {
     guard out.length() < max_dirs else { return }
-    if skip_outline_dir(name) {
+    // Hidden dirs plus build output and vendored deps stay out of outlines.
+    if name.has_prefix(".") ||
+      name == "node_modules" ||
+      name == "_build" ||
+      name == "target" {
       continue
     }
     let child = "\{dir}/\{name}"
     let kind = @fs.kind(child, follow_symlink=false) catch { _ => continue }
     guard kind is Directory else { continue }
-    out.push(outline_indent(depth) + sanitize_name(name) + "/")
+    out.push("  ".repeat(depth) + sanitize_name(name) + "/")
     collect_dirs(child, depth + 1, max_depth, max_dirs, out)
   }
 }
@@ -70,21 +74,6 @@ fn sanitize_name(name : String) -> String {
     count += 1
   }
   sb.to_string()
-}
-
-///|
-/// Directories left out of the outline: hidden dirs plus build output and
-/// vendored deps.
-fn skip_outline_dir(name : String) -> Bool {
-  name.has_prefix(".") ||
-  name == "node_modules" ||
-  name == "_build" ||
-  name == "target"
-}
-
-///|
-fn outline_indent(depth : Int) -> String {
-  "  ".repeat(depth)
 }
 
 ///|


### PR DESCRIPTION
Part of the single-use-helper sweep: a private function called exactly once, whose body reads as well at the call site, is indirection rather than abstraction.

- **scripts/internal/markdown_comments**: `comment_ranges`, `inline_raw_html_is_comment`, and `push_loc_range` fold into their single call sites; the comment test and the loc-presence guard merge into one condition. `is_html_comment` stays — it has two callers (the initial sweep scan miscounted it; verified by grep before touching).
- **scripts/md_to_mbt_string**: `trim_windows_drive_prefix` inlines into the windows-only `basename` arm — the caller is already `#cfg(platform="windows")`, so this leaves one cfg block instead of two.
- **testkit/filesystem**: the outline dir filter and `outline_indent` inline with their comments.

Note: four `md_to_mbt_string` expect tests fail identically on clean `origin/main` (pre-existing snapshot drift, verified by stashing the diff and re-running on the baseline) — unrelated to this change. The markdown_comments and testkit suites pass.

No public API changes, no behavior changes. `moon fmt` (both modules) and `moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)