### PR TITLE
refactor(agent_tool/shell): inline the mechanical single-use helpers

### DIFF
--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -27,7 +27,9 @@ pub fn moonbit_command_policy_error_for_parse(
     Some(moon_cmd_error_message())
   } else if parsed is Simple(commands) {
     if commands.any(sed_edits_files) {
-      Some(sed_in_place_error_message())
+      Some(
+        "error: `sed -i` edits files in place and is unreliable for code changes; use line-anchored `edit` (or `multi_edit` for several fixes in one file) for source changes",
+      )
     } else {
       None
     }
@@ -52,18 +54,20 @@ fn moon_cmd_error_message() -> String {
 }
 
 ///|
-fn sed_in_place_error_message() -> String {
-  "error: `sed -i` edits files in place and is unreliable for code changes; use line-anchored `edit` (or `multi_edit` for several fixes in one file) for source changes"
-}
-
-///|
 /// True when `command` is `sed` (after any `env`/`command`/`builtin` wrapper,
 /// and ignoring a `/usr/bin/` style path) invoked with an in-place edit flag.
 /// Read-only `sed` — `sed -n '1,5p' file`, `... | sed s/a/b/`, or a non-`sed`
 /// `-i` such as `grep -i` / `env -i sed ...` — is left alone.
 fn sed_edits_files(command : @shell_parse.SimpleCommand) -> Bool {
   guard command.command_name() is Some(name) else { return false }
-  guard command_basename(name) == "sed" else { return false }
+  // Compare the final path component so `/usr/bin/sed` and `.\sed` equal
+  // `sed` on both separators.
+  let normalized = name.replace_all(old="\\", new="/")
+  let basename = match normalized.rev_find("/") {
+    Some(slash) => normalized[slash + 1:].to_owned()
+    None => name
+  }
+  guard basename == "sed" else { return false }
   guard command.command_index() is Some(start) else { return false }
   // `command_index` skips the wrapper, so scan only `sed`'s own arguments; the
   // argv is already unquoted by the parser.
@@ -117,17 +121,6 @@ fn sed_option_consumes_next(arg : String) -> Bool {
 }
 
 ///|
-/// The final path component of a command word, so a path-qualified `sed`
-/// (`/usr/bin/sed`, `./sed`) compares equal to `sed`. Handles both separators.
-fn command_basename(name : String) -> String {
-  let normalized = name.replace_all(old="\\", new="/")
-  match normalized.rev_find("/") {
-    Some(slash) => normalized[slash + 1:].to_owned()
-    None => name
-  }
-}
-
-///|
 /// Whether a single `sed` argument requests in-place editing: the long
 /// `--in-place[=suffix]` form, or a short cluster containing `i` (`-i`, `-i.bak`,
 /// `-Ei`). `-e`/`-f` consume the rest of the token as their value, so an `i`
@@ -153,17 +146,12 @@ fn is_sed_in_place_flag(arg : String) -> Bool {
 fn shell_words(cmd : String) -> Array[String] {
   let words : Array[String] = []
   for piece in cmd.split(" ") {
-    let word = clean_shell_word(piece.to_owned())
+    let word = "\{piece.trim(chars="\t\r\n ").trim(chars=";&|()")}"
     if word != "" {
       words.push(word)
     }
   }
   words
-}
-
-///|
-fn clean_shell_word(word : String) -> String {
-  "\{word.trim(chars="\t\r\n ").trim(chars=";&|()")}"
 }
 
 ///|

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -36,35 +36,29 @@ pub fn decode(arguments : Json) -> ShellInput raise {
 
 ///|
 fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
-  let cmd = required_string(fields, "cmd")
-  let cwd = optional_string(fields, "cwd")
+  let cmd = match fields.get("cmd") {
+    Some(String(value)) if value != "" => value
+    Some(String(_)) | Some(Null) | None => fail("arguments.cmd")
+    _ => fail("arguments.cmd to be a string")
+  }
+  let cwd = match fields.get("cwd") {
+    Some(String(value)) if value != "" => Some(value)
+    Some(String(_)) | Some(Null) | None => None
+    _ => fail("arguments.cwd to be a string")
+  }
   let timeout_ms = optional_positive_int(fields, "timeout_ms")
-  let max_output_chars = optional_positive_int_or_default(
-    fields, "max_output_chars", default_max_output_chars,
+  let max_output_chars = optional_positive_int(fields, "max_output_chars").unwrap_or(
+    default_max_output_chars,
   )
   {
     cmd,
     cwd,
     timeout_ms,
-    max_output_chars: cap_max_output_chars(max_output_chars),
-  }
-}
-
-///|
-fn required_string(fields : Map[String, Json], name : String) -> String raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => value
-    Some(String(_)) | Some(Null) | None => fail("arguments.\{name}")
-    _ => fail("arguments.\{name} to be a string")
-  }
-}
-
-///|
-fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
-  match fields.get(name) {
-    Some(String(value)) if value != "" => Some(value)
-    Some(String(_)) | Some(Null) | None => None
-    _ => fail("arguments.\{name} to be a string")
+    max_output_chars: if max_output_chars > hard_max_output_chars {
+      hard_max_output_chars
+    } else {
+      max_output_chars
+    },
   }
 }
 
@@ -83,23 +77,5 @@ fn optional_positive_int(
     }
     Some(Null) | None => None
     _ => fail("arguments.\{name} to be a number")
-  }
-}
-
-///|
-fn optional_positive_int_or_default(
-  fields : Map[String, Json],
-  name : String,
-  default : Int,
-) -> Int raise {
-  optional_positive_int(fields, name).unwrap_or(default)
-}
-
-///|
-fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
   }
 }

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -179,7 +179,12 @@ fn overwrites_untracked_from_tree(
       arg == "--overlay" ||
       arg == "--ours" ||
       arg == "--theirs" ||
-      short_cluster_has(arg, "f") {
+      (
+        arg.has_prefix("-") &&
+        !arg.has_prefix("--") &&
+        arg != "-" &&
+        arg.contains("f")
+      ) {
       return true
     }
     // Explicit source tree-ish: `--source`, `--source=<t>`, `-s`, `-s<t>`.
@@ -202,15 +207,6 @@ fn overwrites_untracked_from_tree(
     }
   }
   false
-}
-
-///|
-/// True when `arg` is a short option cluster (`-…`, not `--…`) containing `flag`.
-fn short_cluster_has(arg : String, flag : String) -> Bool {
-  arg.has_prefix("-") &&
-  !arg.has_prefix("--") &&
-  arg != "-" &&
-  arg.contains(flag)
 }
 
 ///|
@@ -256,7 +252,11 @@ fn clean_args_request_dry_run(
   let mut dry_run = false
   for index in start..<end {
     let arg = words[index]
-    if clean_arg_is_exclude(arg) {
+    // `-e`/`--exclude[=…]`, including `e` inside a short cluster.
+    if arg == "-e" ||
+      arg == "--exclude" ||
+      arg.has_prefix("--exclude=") ||
+      (arg.has_prefix("-") && !arg.has_prefix("--") && arg.contains("e")) {
       return false
     }
     if arg == "-n" ||
@@ -266,14 +266,6 @@ fn clean_args_request_dry_run(
     }
   }
   dry_run
-}
-
-///|
-fn clean_arg_is_exclude(arg : String) -> Bool {
-  arg == "-e" ||
-  arg == "--exclude" ||
-  arg.has_prefix("--exclude=") ||
-  (arg.has_prefix("-") && !arg.has_prefix("--") && arg.contains("e"))
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -58,7 +58,7 @@ fn lex(command : String) -> LexResult {
     let ch = chars[index]
     match state {
       Plain => {
-        if is_shell_space(ch) {
+        if ch is (' ' | '\t') {
           word.flush_and_reset(tokens)
           index += 1
           continue
@@ -305,11 +305,6 @@ fn peek_char(chars : Array[Char], index : Int) -> Char? {
   } else {
     None
   }
-}
-
-///|
-fn is_shell_space(ch : Char) -> Bool {
-  ch == ' ' || ch == '\t'
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -73,7 +73,7 @@ fn parse_tokens(tokens : Array[Token]) -> ParseResult {
         saw_part = true
         index += 1
       }
-      Op(op, _) if is_separator(op) => {
+      Op(op, _) if op is ("&&" | "||" | ";" | "|") => {
         if !saw_part {
           return SyntaxError("operator \{op} has no preceding command")
         }
@@ -163,11 +163,6 @@ fn render_source(
     parts.push("\{redirect.op} \{redirect.target}")
   }
   parts.join(" ")
-}
-
-///|
-fn is_separator(op : String) -> Bool {
-  op == "&&" || op == "||" || op == ";" || op == "|"
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/query.mbt
+++ b/agent_tool/shell/internal/shell_parse/query.mbt
@@ -95,12 +95,16 @@ fn env_wrapped_command_index(argv : Array[String]) -> Int? {
       index += 1
       continue
     }
-    if scanning_options && env_option_consumes_next(arg) {
+    if scanning_options && (arg == "-u" || arg == "--unset") {
       index += 2
       continue
     }
     if scanning_options &&
-      (env_option_with_attached_value(arg) || env_no_arg_option(arg)) {
+      (
+        (arg.has_prefix("-u") && arg != "-u") ||
+        arg.has_prefix("--unset=") ||
+        arg is ("--ignore-environment" | "-0" | "--null" | "--debug")
+      ) {
       index += 1
       continue
     }
@@ -118,23 +122,5 @@ fn env_wrapped_command_index(argv : Array[String]) -> Int? {
     Some(index)
   } else {
     Some(0)
-  }
-}
-
-///|
-fn env_option_consumes_next(arg : String) -> Bool {
-  arg == "-u" || arg == "--unset"
-}
-
-///|
-fn env_option_with_attached_value(arg : String) -> Bool {
-  (arg.has_prefix("-u") && arg != "-u") || arg.has_prefix("--unset=")
-}
-
-///|
-fn env_no_arg_option(arg : String) -> Bool {
-  match arg {
-    "--ignore-environment" | "-0" | "--null" | "--debug" => true
-    _ => false
   }
 }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -178,7 +178,8 @@ async fn probe_sandbox_exec_available() -> Bool {
     return false
   }
   let write_args = ["-p", probe_profile, PlatformShellProgram]
-  for arg in platform_shell_args("printf probe > \{shell_quote(blocked_path)}") {
+  let quoted_path = "'\{blocked_path.replace_all(old="'", new="'\\''")}'"
+  for arg in platform_shell_args("printf probe > \{quoted_path}") {
     write_args.push(arg)
   }
   let write_output = collect_process_output(
@@ -212,11 +213,6 @@ fn sandbox_denial_probe_profile(blocked_path : String) -> String {
     $|(allow default)
     $|(deny file-write* (literal "\{sbpl_string_escape(blocked_path)}"))
   )
-}
-
-///|
-fn shell_quote(text : String) -> String {
-  "'\{text.replace_all(old="'", new="'\\''")}'"
 }
 
 ///|
@@ -1904,21 +1900,16 @@ fn command_line_after_first_post_heredoc_pipe(line : String) -> String? {
           ch == '|' &&
           !(index > 0 && chars[index - 1] == '|') &&
           !(index + 1 < chars.length() && chars[index + 1] == '|') {
-          return Some(chars_to_string(chars, index + 1))
+          let target = StringBuilder()
+          for rest in (index + 1)..<chars.length() {
+            target.write_char(chars[rest])
+          }
+          return Some(target.to_string())
         }
     }
     index += 1
   }
   None
-}
-
-///|
-fn chars_to_string(chars : Array[Char], start : Int) -> String {
-  let output = StringBuilder()
-  for index in start..<chars.length() {
-    output.write_char(chars[index])
-  }
-  output.to_string()
 }
 
 ///|
@@ -2336,18 +2327,13 @@ fn heredoc_line_matches_delimiter(
   line : String,
   delimiter : HeredocDelimiter,
 ) -> Bool {
-  let line = strip_trailing_cr(line)
-  let line = if delimiter.strip_tabs { strip_leading_tabs(line) } else { line }
-  line == delimiter.marker
-}
-
-///|
-fn strip_trailing_cr(line : String) -> String {
-  if line.has_suffix("\r") {
+  let line = if line.has_suffix("\r") {
     line[:line.length() - 1].to_owned()
   } else {
     line
   }
+  let line = if delimiter.strip_tabs { strip_leading_tabs(line) } else { line }
+  line == delimiter.marker
 }
 
 ///|

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -376,7 +376,10 @@ async fn read_output_prefix(
         let text = decode_valid_utf8_prefix(buffer.to_bytes())
         if text.char_length() > max_output_chars {
           return {
-            text: text_prefix_by_chars(text, max_output_chars),
+            text: match text.offset_of_nth_char(max_output_chars) {
+              Some(end) => "\{text[:end]}"
+              None => text
+            },
             output_limit_reached: true,
           }
         } else {
@@ -384,14 +387,6 @@ async fn read_output_prefix(
         }
       }
     }
-  }
-}
-
-///|
-fn text_prefix_by_chars(text : String, max_chars : Int) -> String {
-  match text.offset_of_nth_char(max_chars) {
-    Some(end) => "\{text[:end]}"
-    None => text
   }
 }
 
@@ -416,7 +411,11 @@ fn shell_response(
   max_output_chars : Int,
 ) -> ShellResponse {
   if output.output_limit_reached {
-    let footer = "<system>\{exit_header(output.exit_code)} truncated=true output_limit_reached=true shown_chars=\{output.text.char_length()} max_output_chars=\{max_output_chars}</system>"
+    let exit_header = match output.exit_code {
+      Some(code) => "exit=\{code}"
+      None => "exit=cancelled"
+    }
+    let footer = "<system>\{exit_header} truncated=true output_limit_reached=true shown_chars=\{output.text.char_length()} max_output_chars=\{max_output_chars}</system>"
     { content: with_system_footer(output.text, footer), is_error: true }
   } else {
     let code = output.exit_code.unwrap_or(0)
@@ -424,14 +423,6 @@ fn shell_response(
       content: with_system_footer(output.text, "<system>exit=\{code}</system>"),
       is_error: code != 0,
     }
-  }
-}
-
-///|
-fn exit_header(exit_code : Int?) -> String {
-  match exit_code {
-    Some(code) => "exit=\{code}"
-    None => "exit=cancelled"
   }
 }
 

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -54,7 +54,7 @@ async fn sandbox_exec_usable_for_test() -> Bool {
     profile,
     "sh",
     "-c",
-    "printf probe > \{test_shell_quote(blocked)}",
+    "printf probe > '\{blocked.replace_all(old="'", new="'\\''")}'",
   ]) catch {
     _ => {
       cleanup_sandbox_exec_test_probe(probe_dir, blocked)
@@ -64,12 +64,6 @@ async fn sandbox_exec_usable_for_test() -> Bool {
   let denied = deny_code != 0 && !@fs.exists(blocked)
   cleanup_sandbox_exec_test_probe(probe_dir, blocked)
   denied
-}
-
-///|
-#cfg(not(platform="windows"))
-fn test_shell_quote(text : String) -> String {
-  "'\{text.replace_all(old="'", new="'\\''")}'"
 }
 
 ///|


### PR DESCRIPTION
Final part of the single-use-helper sweep, and the one where the rule needed the most judgment.

**Inlined (18)** — bodies that read as well at the call site:
- String utilities: `shell_quote`, `chars_to_string`, `strip_trailing_cr`, `text_prefix_by_chars`, `exit_header`, and the `test_shell_quote` duplicate in the test file.
- `internal/decode`: `required_string`, `optional_string`, `optional_positive_int_or_default`, `cap_max_output_chars` fold into `parse_fields`.
- `internal/command_policy`: `sed_in_place_error_message` (a constant), `command_basename` (guard with comment), `clean_shell_word`.
- `internal/git_policy`: `short_cluster_has`, `clean_arg_is_exclude` (commented condition clauses).
- `internal/shell_parse`: `is_shell_space` and `is_separator` become is-patterns (`ch is (' ' | '\t')`, `op is ("&&" | "||" | ";" | "|")`); the three `env_option_*` predicates merge into their two scan conditions.

**Deliberately kept (~35)** — the policy predicates in `sandbox.mbt` and `moon_auto_check.mbt` (`heredoc_*`, `find_*`, `awk_*`, `install_*`, `powershell_*`, `sandbox_denial_*`, `*_option_consumes_next`, …). Their names *are* the documentation of the sandbox policy engine; the bodies are token-index arithmetic that reads far worse inlined into the scanning loops. Also kept: `shell_description` (a `#cfg` platform pair — the function is the dispatch) and `first_command_word` (a search loop that cannot sit inside its `else if` condition; its callee `looks_like_env_assignment` has two callers).

No public API changes, no behavior changes. Tests: shell 106/106, command_policy 9/9, git_policy 6/6, shell_parse 22/22, decode 6/6; `moon fmt`/`moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)