### PR TITLE
refactor(agent): apply_steer_inputs as an accumulator-loop local Session method

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -290,9 +290,8 @@ pub async fn[X] run_turn_in_scope(
     steps~: for step in 0..<max_steps {
       // Steering first: user-visible mid-turn input should precede runtime
       // chatter the model reads alongside it.
-      session = apply_steer_inputs(
+      session = session.apply_steer_inputs(
         pending_steers(runtime),
-        session,
         messages,
         append_item~,
       )
@@ -381,9 +380,8 @@ pub async fn[X] run_turn_in_scope(
           session,
           Assistant(AssistantMessage(response.content, reasoning_content?)),
         )
-        session = apply_steer_inputs(
+        session = session.apply_steer_inputs(
           steer_inputs,
-          session,
           messages,
           append_item~,
         )
@@ -483,9 +481,8 @@ pub async fn[X] run_turn_in_scope(
                 ),
               )
             }
-            session = apply_steer_inputs(
+            session = session.apply_steer_inputs(
               steer_inputs,
-              session,
               messages,
               append_item~,
             )
@@ -573,12 +570,12 @@ fn pending_steers(
 /// message and a model-visible chat message. Both variants emit
 /// `steer_applied`; the `kind` field distinguishes prompt steering from
 /// command context.
-async fn apply_steer_inputs(
+async fn @agent_session.Session::apply_steer_inputs(
+  session : Self,
   inputs : Array[@agent_runtime.SteerInput],
-  session : @agent_session.Session,
   messages : Array[@deepseek.ChatMessage],
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
-) -> @agent_session.Session {
+) -> Self {
   for input in inputs; current = session {
     let (kind, text) = match input {
       Prompt(text) => ("prompt", text)

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -579,17 +579,18 @@ async fn apply_steer_inputs(
   messages : Array[@deepseek.ChatMessage],
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
 ) -> @agent_session.Session {
-  let mut current = session
-  for input in inputs {
+  for input in inputs; current = session {
     let (kind, text) = match input {
       Prompt(text) => ("prompt", text)
       Command(text) => ("command", text)
     }
-    current = append_item(current, User(UserMessage(text)))
+    let next = append_item(current, User(UserMessage(text)))
     messages.push(ChatMessage(User, content=text))
     @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
+    continue next
+  } nobreak {
+    current
   }
-  current
 }
 
 ///|


### PR DESCRIPTION
## Summary

Follow-up to #361 (these two commits were pushed to that branch after it was squash-merged, so they never landed):

- **Accumulator `for-in` loop.** `apply_steer_inputs` threads the session through the loop as functional state — `for input in inputs; current = session { ... continue next } nobreak { current }` — replacing the `let mut current` reassignment. The appended session is bound before the chat-message push and the `steer_applied` log line, so the effect order when `append_item` raises is unchanged.
- **Local method on `@agent_session.Session`.** The helper is now `async fn @agent_session.Session::apply_steer_inputs(session : Self, ...)` with the session receiver first; the three agent-loop call sites use dot notation. It stays package-private, so there is no public API change (`pkg.generated.mbti` untouched).

## Validation

- `moon check` clean
- `moon test agent`: 14/14 passing
- `moon fmt` stable, `moon info` shows no `.mbti` diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)