### PR TITLE
refactor(deepseek,agent,tui): usage log event embeds ToJson-encoded Usage

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -592,12 +592,5 @@ async fn @agent_session.Session::apply_steer_inputs(
 
 ///|
 fn print_usage(usage : @deepseek.Usage) -> Unit {
-  @xlog.info() <?
-    {
-      "event": "usage",
-      "prompt_tokens": usage.prompt_tokens,
-      "completion_tokens": usage.completion_tokens,
-      "cache_hit_tokens": usage.prompt_cache_hit_tokens,
-      "cache_miss_tokens": usage.prompt_cache_miss_tokens,
-    }
+  @xlog.info() <? { "event": "usage", "usage": usage }
 }

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -28,9 +28,15 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "runtime_update" => Some(RuntimeUpdate(@jsonx.string(object, "content")))
     "session_error" => Some(SessionError(@jsonx.string(object, "error")))
     "usage" => {
-      let prompt = @jsonx.int(object, "prompt_tokens")
-      let completion = @jsonx.int(object, "completion_tokens")
-      Some(Usage({ total_tokens: prompt + completion }))
+      let usage : @deepseek.Usage = @json.from_json(
+        @jsonx.field(object, "usage").unwrap_or(Json::null()),
+      ) catch {
+        // Unreachable with the lenient Usage impl; drop rather than crash.
+        _ => return None
+      }
+      Some(
+        Usage({ total_tokens: usage.prompt_tokens + usage.completion_tokens }),
+      )
     }
     "tool_result" =>
       Some(

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -29,7 +29,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "session_error" => Some(SessionError(@jsonx.string(object, "error")))
     "usage" => {
       let usage : @deepseek.Usage = @json.from_json(
-        @jsonx.field(object, "usage").unwrap_or(Json::null()),
+        @jsonx.field(object, "usage").unwrap_or_default(),
       ) catch {
         // Unreachable with the lenient Usage impl; drop rather than crash.
         _ => return None

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -142,10 +142,13 @@ test "usage total is derived from prompt and completion tokens" {
   match
     @event.decode_event({
       "event": "usage",
-      "prompt_tokens": 100,
-      "completion_tokens": 23,
-      "cache_hit_tokens": 0,
-      "cache_miss_tokens": 100,
+      "usage": {
+        "prompt_tokens": 100,
+        "completion_tokens": 23,
+        "total_tokens": 123,
+        "prompt_cache_hit_tokens": 0,
+        "prompt_cache_miss_tokens": 100,
+      },
     }) {
     Some(Usage(usage)) => assert_eq(usage.total_tokens, 123)
     _ => fail("expected Usage")

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -1,59 +1,50 @@
 ///|
 test "decode maps each engine event kind" {
   assert_true(
-    @event.decode_event(Json::object({ "event": "agent_step", "step": 3 }))
-    is Some(AgentStep),
+    @event.decode_event({ "event": "agent_step", "step": 3 }) is Some(AgentStep),
   )
   assert_true(
-    @event.decode_event(Json::object({ "event": "max_steps_exhausted" }))
+    @event.decode_event({ "event": "max_steps_exhausted" })
     is Some(MaxStepsExhausted),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "assistant_delta", "content": "tok" }),
-    )
+    @event.decode_event({ "event": "assistant_delta", "content": "tok" })
     is Some(AssistantDelta("tok")),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "reasoning_delta", "content": "hmm" }),
-    )
+    @event.decode_event({ "event": "reasoning_delta", "content": "hmm" })
     is Some(ReasoningDelta("hmm")),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "reasoning_message", "content": "full thought" }),
-    )
+    @event.decode_event({
+      "event": "reasoning_message",
+      "content": "full thought",
+    })
     is Some(ReasoningMessage("full thought")),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "agent_finished", "answer": "done" }),
-    )
+    @event.decode_event({ "event": "agent_finished", "answer": "done" })
     is Some(AgentFinished("done")),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "runtime_update", "content": "checked: 1 error" }),
-    )
+    @event.decode_event({
+      "event": "runtime_update",
+      "content": "checked: 1 error",
+    })
     is Some(RuntimeUpdate("checked: 1 error")),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "session_error", "error": "stale session" }),
-    )
+    @event.decode_event({ "event": "session_error", "error": "stale session" })
     is Some(SessionError("stale session")),
   )
   match
-    @event.decode_event(
-      Json::object({
-        "event": "tool_result",
-        "tool_call_id": "c1",
-        "tool_name": "bash",
-        "is_error": true,
-        "content": "boom",
-      }),
-    ) {
+    @event.decode_event({
+      "event": "tool_result",
+      "tool_call_id": "c1",
+      "tool_name": "bash",
+      "is_error": true,
+      "content": "boom",
+    }) {
     Some(ToolResult(result)) => {
       assert_eq(result.name, "bash")
       assert_eq(result.content, "boom")
@@ -66,35 +57,27 @@ test "decode maps each engine event kind" {
 ///|
 test "steer wire events decode to their applied and dropped forms" {
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "steer_applied", "content": "go left" }),
-    )
+    @event.decode_event({ "event": "steer_applied", "content": "go left" })
     is Some(SteerApplied(Prompt("go left"))),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({
-        "event": "steer_applied",
-        "kind": "prompt",
-        "content": "go right",
-      }),
-    )
+    @event.decode_event({
+      "event": "steer_applied",
+      "kind": "prompt",
+      "content": "go right",
+    })
     is Some(SteerApplied(Prompt("go right"))),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({
-        "event": "steer_applied",
-        "kind": "command",
-        "content": "<user_shell_command>",
-      }),
-    )
+    @event.decode_event({
+      "event": "steer_applied",
+      "kind": "command",
+      "content": "<user_shell_command>",
+    })
     is Some(SteerApplied(Command("<user_shell_command>"))),
   )
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "steer_dropped", "content": "too late" }),
-    )
+    @event.decode_event({ "event": "steer_dropped", "content": "too late" })
     is Some(SteerDropped("too late")),
   )
 }
@@ -102,9 +85,10 @@ test "steer wire events decode to their applied and dropped forms" {
 ///|
 test "a failed serve turn decodes to a terminal agent error" {
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "turn_failed", "error": "DeepSeek API error" }),
-    )
+    @event.decode_event({
+      "event": "turn_failed",
+      "error": "DeepSeek API error",
+    })
     is Some(AgentError("turn failed: DeepSeek API error")),
   )
 }
@@ -116,12 +100,10 @@ test "a rejected command decodes to a non-terminal CommandRejected" {
   // whether it ends a run (only `/compact` needs that), so it is not decoded as
   // a terminal `AgentError`.
   assert_true(
-    @event.decode_event(
-      Json::object({
-        "event": "command_error",
-        "error": "unknown command: compact",
-      }),
-    )
+    @event.decode_event({
+      "event": "command_error",
+      "error": "unknown command: compact",
+    })
     is Some(CommandRejected("unknown command: compact")),
   )
 }
@@ -130,27 +112,21 @@ test "a rejected command decodes to a non-terminal CommandRejected" {
 test "compaction wire events decode to their terminal forms" {
   // Success carries the summary so the controller can preview the new context.
   assert_true(
-    @event.decode_event(
-      Json::object({
-        "event": "compaction_finished",
-        "from_sequence": 1,
-        "to_sequence": 42,
-        "summary": "handoff",
-      }),
-    )
+    @event.decode_event({
+      "event": "compaction_finished",
+      "from_sequence": 1,
+      "to_sequence": 42,
+      "summary": "handoff",
+    })
     is Some(CompactionFinished("handoff")),
   )
   // Failure folds into the general agent-error category like a failed turn.
   assert_true(
-    @event.decode_event(
-      Json::object({ "event": "compaction_failed", "error": "cancelled" }),
-    )
+    @event.decode_event({ "event": "compaction_failed", "error": "cancelled" })
     is Some(AgentError("compaction failed: cancelled")),
   )
   // The start marker carries no controller state, so it drops like any unknown.
-  assert_true(
-    @event.decode_event(Json::object({ "event": "compaction_started" })) is None,
-  )
+  assert_true(@event.decode_event({ "event": "compaction_started" }) is None)
 }
 
 ///|
@@ -158,23 +134,19 @@ test "decode returns None for a non-object value or unknown event" {
   // `@jsonl` handles blank and malformed lines before decoding; the mapping only
   // has to tolerate a non-object value and a newer engine's unknown event kind.
   assert_true(@event.decode_event(Json::string("not an object")) is None)
-  assert_true(
-    @event.decode_event(Json::object({ "event": "future_event_kind" })) is None,
-  )
+  assert_true(@event.decode_event({ "event": "future_event_kind" }) is None)
 }
 
 ///|
 test "usage total is derived from prompt and completion tokens" {
   match
-    @event.decode_event(
-      Json::object({
-        "event": "usage",
-        "prompt_tokens": 100,
-        "completion_tokens": 23,
-        "cache_hit_tokens": 0,
-        "cache_miss_tokens": 100,
-      }),
-    ) {
+    @event.decode_event({
+      "event": "usage",
+      "prompt_tokens": 100,
+      "completion_tokens": 23,
+      "cache_hit_tokens": 0,
+      "cache_miss_tokens": 100,
+    }) {
     Some(Usage(usage)) => assert_eq(usage.total_tokens, 123)
     _ => fail("expected Usage")
   }

--- a/cmd/tui/internal/event/moon.pkg
+++ b/cmd/tui/internal/event/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/cmd/tui/internal/jsonx",
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/json",
 }
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -192,10 +192,10 @@ test "a runtime_update event surfaces as a ↻ tool-style notice" {
   // metadata preamble, then the captured watcher output.
   append_items(
     state,
-    Json::object({
+    {
       "event": "runtime_update",
       "content": "[moon_check update]\nevents=3\nid=moon-check-1\ncwd=.\ncommand=moon check --watch --diagnostic-limit 10\nstatus=running\nseq=3\nWarning: unused variable x\nFinished.",
-    }),
+    },
     items,
   )
   // The metadata preamble is stripped: the watcher status is lifted out and only
@@ -265,31 +265,19 @@ test "assistant_delta accumulates live text and commits only the final message" 
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
   let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "Hel" }),
-    items,
-  )
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "lo" }),
-    items,
-  )
+  append_items(state, { "event": "assistant_delta", "content": "Hel" }, items)
+  append_items(state, { "event": "assistant_delta", "content": "lo" }, items)
   assert_eq(items.length(), 0)
   assert_true(state.streaming_response is Some("Hello"))
   assert_true(state.step_response is None)
   append_items(
     state,
-    Json::object({ "event": "assistant_message", "content": "Hello" }),
+    { "event": "assistant_message", "content": "Hello" },
     items,
   )
   assert_true(state.streaming_response is None)
   assert_true(state.step_response is Some("Hello"))
-  append_items(
-    state,
-    Json::object({ "event": "agent_finished", "answer": "Hello" }),
-    items,
-  )
+  append_items(state, { "event": "agent_finished", "answer": "Hello" }, items)
   debug_inspect(items, content="[Response(\"Hello\")]")
 }
 
@@ -300,13 +288,13 @@ test "assistant_message clears live streaming text while tools continue" {
   let items : Array[@ui.TranscriptItem] = []
   append_items(
     state,
-    Json::object({ "event": "assistant_delta", "content": "Need tool" }),
+    { "event": "assistant_delta", "content": "Need tool" },
     items,
   )
   assert_true(state.streaming_response is Some("Need tool"))
   append_items(
     state,
-    Json::object({ "event": "assistant_message", "content": "Need tool" }),
+    { "event": "assistant_message", "content": "Need tool" },
     items,
   )
   assert_true(state.run is Running(_))
@@ -322,10 +310,10 @@ test "assistant_delta live preview keeps the newest tail within the cap" {
   let items : Array[@ui.TranscriptItem] = []
   append_items(
     state,
-    Json::object({
+    {
       "event": "assistant_delta",
       "content": String::make(StreamingPreviewMaxColumns * 4, 'x'),
-    }),
+    },
     items,
   )
   guard state.streaming_response is Some(first) else {
@@ -337,11 +325,7 @@ test "assistant_delta live preview keeps the newest tail within the cap" {
   assert_true(first.has_prefix("…"))
   // The preview is a tail window: new deltas keep showing up at its end
   // (instead of freezing once the cap is reached, as a head truncation would).
-  append_items(
-    state,
-    Json::object({ "event": "assistant_delta", "content": "more" }),
-    items,
-  )
+  append_items(state, { "event": "assistant_delta", "content": "more" }, items)
   guard state.streaming_response is Some(second) else {
     fail("expected streaming preview")
   }
@@ -359,12 +343,12 @@ test "streamed newlines collapse so the preview stays one line" {
   let items : Array[@ui.TranscriptItem] = []
   append_items(
     state,
-    Json::object({ "event": "assistant_delta", "content": "fn main {\n" }),
+    { "event": "assistant_delta", "content": "fn main {\n" },
     items,
   )
   append_items(
     state,
-    Json::object({ "event": "assistant_delta", "content": "  println(1)\n}" }),
+    { "event": "assistant_delta", "content": "  println(1)\n}" },
     items,
   )
   // The run of newline + indentation spanning the two deltas collapses to a
@@ -379,7 +363,7 @@ test "reasoning_message commits a thought item and clears the preview" {
   let items : Array[@ui.TranscriptItem] = []
   append_items(
     state,
-    Json::object({ "event": "reasoning_delta", "content": "Let me think" }),
+    { "event": "reasoning_delta", "content": "Let me think" },
     items,
   )
   assert_true(state.streaming_reasoning is Some("Let me think"))
@@ -387,20 +371,16 @@ test "reasoning_message commits a thought item and clears the preview" {
   // is finished with.
   append_items(
     state,
-    Json::object({
+    {
       "event": "reasoning_message",
       "content": "Let me think about names.\nThe user said Hongbo.",
-    }),
+    },
     items,
   )
   assert_true(state.streaming_reasoning is None)
   guard items is [Thought(_)] else { fail("expected a single Thought item") }
   // Blank reasoning never appends an empty aside.
-  append_items(
-    state,
-    Json::object({ "event": "reasoning_message", "content": "  " }),
-    items,
-  )
+  append_items(state, { "event": "reasoning_message", "content": "  " }, items)
   assert_eq(items.length(), 1)
 }
 
@@ -411,7 +391,7 @@ test "reasoning_delta drives the thinking preview until content arrives" {
   let items : Array[@ui.TranscriptItem] = []
   append_items(
     state,
-    Json::object({ "event": "reasoning_delta", "content": "Let me think" }),
+    { "event": "reasoning_delta", "content": "Let me think" },
     items,
   )
   assert_true(state.streaming_reasoning is Some("Let me think"))
@@ -421,7 +401,7 @@ test "reasoning_delta drives the thinking preview until content arrives" {
   // replaces the reasoning one.
   append_items(
     state,
-    Json::object({ "event": "assistant_delta", "content": "Answer" }),
+    { "event": "assistant_delta", "content": "Answer" },
     items,
   )
   assert_true(state.streaming_reasoning is None)
@@ -429,7 +409,7 @@ test "reasoning_delta drives the thinking preview until content arrives" {
   // The committed message clears both previews.
   append_items(
     state,
-    Json::object({ "event": "assistant_message", "content": "Answer" }),
+    { "event": "assistant_message", "content": "Answer" },
     items,
   )
   assert_true(state.streaming_response is None)
@@ -445,40 +425,37 @@ test "replaying a recorded engine session renders the transcript" {
 
   // A realistic one-step session: think, report usage, run a tool, finish.
   let items : Array[@ui.TranscriptItem] = []
-  append_items(state, Json::object({ "event": "agent_step", "step": 1 }), items)
+  append_items(state, { "event": "agent_step", "step": 1 }, items)
   append_items(
     state,
-    Json::object({
-      "event": "assistant_message",
-      "content": "Let me check the project.",
-    }),
+    { "event": "assistant_message", "content": "Let me check the project." },
     items,
   )
   append_items(
     state,
-    Json::object({
+    {
       "event": "usage",
       "prompt_tokens": 100,
       "completion_tokens": 20,
       "cache_hit_tokens": 0,
       "cache_miss_tokens": 100,
-    }),
+    },
     items,
   )
   append_items(
     state,
-    Json::object({
+    {
       "event": "tool_result",
       "tool_call_id": "c1",
       "tool_name": "bash",
       "is_error": false,
       "content": "ok",
-    }),
+    },
     items,
   )
   append_items(
     state,
-    Json::object({ "event": "agent_finished", "answer": "all done" }),
+    { "event": "agent_finished", "answer": "all done" },
     items,
   )
 

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -435,10 +435,13 @@ test "replaying a recorded engine session renders the transcript" {
     state,
     {
       "event": "usage",
-      "prompt_tokens": 100,
-      "completion_tokens": 20,
-      "cache_hit_tokens": 0,
-      "cache_miss_tokens": 100,
+      "usage": {
+        "prompt_tokens": 100,
+        "completion_tokens": 20,
+        "total_tokens": 120,
+        "prompt_cache_hit_tokens": 0,
+        "prompt_cache_miss_tokens": 100,
+      },
     },
     items,
   )

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -150,7 +150,7 @@ pub struct Usage {
   total_tokens : Int
   prompt_cache_hit_tokens : Int
   prompt_cache_miss_tokens : Int
-} derive(Debug)
+} derive(Debug, ToJson)
 
 ///|
 /// Decoded DeepSeek chat response content, tool calls, and token usage.

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -43,7 +43,13 @@ fn[T] json_decode_error(
 }
 
 ///|
-impl FromJson for Usage with fn from_json(json : Json, _path : @json.JsonPath) -> Usage {
+/// Public so wire consumers (the TUI decodes the engine's `usage` log event)
+/// can round-trip the same schema `ToJson` emits. Lenient by design: absent
+/// or malformed fields decode as 0, and no shape ever raises.
+pub impl FromJson for Usage with fn from_json(
+  json : Json,
+  _path : @json.JsonPath,
+) -> Usage {
   Usage::from_json(json)
 }
 

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -79,7 +79,8 @@ pub struct Usage {
   total_tokens : Int
   prompt_cache_hit_tokens : Int
   prompt_cache_miss_tokens : Int
-} derive(@debug.Debug)
+} derive(ToJson, @debug.Debug)
+pub impl @json.FromJson for Usage
 
 // Type aliases
 


### PR DESCRIPTION
## Summary

Two commits, ordered for review:

1. **`test(tui): drop redundant Json::object wrappers in event fixtures`** — pure mechanical cleanup. `append_items` and `decode_event` take `Json`, so map literals coerce via Json literal overloading; 42 wrappers removed across `jsonl_wbtest.mbt` and `decode_test.mbt`. The one survivor is `Json::string("not an object")`, where non-object-ness is the point of the test. No behavior change; validated green in isolation.

2. **`refactor(deepseek,agent,tui): usage log event embeds ToJson-encoded Usage`** — the actual schema change:
   - `@deepseek.Usage` derives `ToJson`; `print_usage` becomes `@xlog.info() <? { "event": "usage", "usage": usage }`. The log line now nests the struct verbatim — raw field names (`prompt_cache_hit_tokens`, not the old renamed `cache_hit_tokens`) and `total_tokens` included.
   - The package's existing lenient `FromJson` impl for `Usage` (absent/malformed fields → 0, never raises) becomes `pub`, and the TUI decoder round-trips the nested object through it instead of hand-reading fields — the wire schema is owned by `deepseek` in both directions.
   - TUI decode stays crash-free by construction; fixtures updated to the nested shape.

## Design note: `ToJson` derived, `FromJson` manual — intentional asymmetry

`derive(FromJson)` was considered and rejected:

- A derived decoder is strict — it raises `JsonDecodeError` on a missing field. The manual impl decodes absent/malformed fields as 0 and never raises.
- That leniency is load-bearing beyond the TUI: `ChatResponse`'s decoder routes API usage objects through this impl, including the streaming client's accumulated envelope (`stream.mbt`). `client_stream_test.mbt` fixtures a usage object with only `prompt_tokens`/`completion_tokens`/`total_tokens` — the shape OpenAI-compatible endpoints send when they lack DeepSeek's cache-token extension. A derived impl would raise on those streams.
- Derive's per-field `default=` argument is deprecated (the compiler's advice: "Use a manual trait implementation instead") and still raises on wrong-typed fields, which `json_object_int` tolerates.

So: `ToJson` derived (we own the writer; the struct is the schema), `FromJson` manual (we don't own every producer; tolerance required). The doc comment on the now-`pub` impl states this contract so it doesn't get "simplified" into a derive later.

## Public API impact

`deepseek/pkg.generated.mbti`: `Usage` gains `derive(ToJson)` and `pub impl @json.FromJson for Usage`. Both additive.

**Log schema note:** the `usage` JSONL event changes shape (nested + original field names). Engine and TUI are updated together here; viz (`viz/`, `cmd/viz_server`, `cmd/viz_app`) does not consume this event. An older TUI binary reading a newer engine would show 0 tokens (the decoder is deliberately tolerant), not crash.

## Validation

- `moon check` clean; `moon fmt` stable; `moon info` shows only the additive API above
- `moon test deepseek agent cmd/tui`: 134/134
- Full `moon test`: 964/968 — the 4 failures are the known pre-existing `agent_tool/shell` output-limit tests, unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)