### PR TITLE
eval: DeepSeek-vs-Kimi coding-agent benchmark (+ cross-provider suite auth)

### DIFF
--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -6,8 +6,10 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
     "--min-successes",
   )
   guard min_successes <= runs else { fail("--min-successes must be <= --runs") }
+  // An empty --api-key is allowed: the harness falls back to the provider's
+  // environment variable (DEEPSEEK/KIMI), which is the only way a cross-provider
+  // run authenticates each model with its own key.
   let api_key = value(matches, "api-key")
-  guard api_key != "" else { fail("--api-key is required for running trials") }
   Config(
     api_key~,
     model=@deepseek.Model::parse(value(matches, "model")),
@@ -34,8 +36,9 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
 async fn suite_config_from_matches(
   matches : @argparse.Matches,
 ) -> @harness.SuiteConfig {
+  // Empty --api-key means "inherit each model's provider key from the
+  // environment"; run_suite validates every listed provider up front.
   let api_key = value(matches, "api-key")
-  guard api_key != "" else { fail("--api-key is required for running trials") }
   @harness.suite_config_from_file(
     value(matches, "suite-file"),
     api_key~,

--- a/eval/prompt_task/cmd/main/main_wbtest.mbt
+++ b/eval/prompt_task/cmd/main/main_wbtest.mbt
@@ -43,15 +43,14 @@ test "cli parses suite file option" {
 }
 
 ///|
-test "running trials requires an api key" {
+test "empty api key parses through for environment fallback" {
+  // An empty --api-key is no longer rejected here: the harness falls back to
+  // the provider's environment variable so one suite can span providers. The
+  // key-presence check moved to run time (require_api_access), which names the
+  // exact missing variable.
   let matches = cli_command().parse(argv=[])
-  let _ = config_from_matches(matches) catch {
-    error => {
-      assert_true("\{error}".contains("--api-key is required"))
-      return
-    }
-  }
-  fail("missing api key parsed")
+  let config = config_from_matches(matches)
+  assert_eq(config.api_key, "")
 }
 
 ///|

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -4,9 +4,7 @@
 /// session `openseek_session-<id>.jsonl` files, and a run manifest. No
 /// validation or report analysis is performed in this phase.
 pub async fn run_experiments(config : Config) -> RunManifest {
-  if config.api_key == "" {
-    fail("api_key is required for running trials")
-  }
+  require_api_access(config.api_key, config.model)
   prepare_output_dir(config.out_dir)
   let task_template = @fs.read_file(config.task_file).text()
   let trials = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
@@ -143,7 +141,15 @@ fn trial_extra_env(
     "OPENSEEK_SESSION_ROOT": ".openseek",
     "OPENSEEK_GLOBAL_SKILLS_DIR": "\{real_workspace}/.no-global-skills",
   }
-  env[api_key_env_for_model(config.model)] = config.api_key
+  // An explicit `api_key` overrides this model's provider key for every trial.
+  // An empty one means "let the engine inherit its provider key from the
+  // parent environment" — the only way one suite can span providers, since
+  // DeepSeek reads DEEPSEEK and Kimi reads KIMI and a single shared key cannot
+  // authenticate both. Overriding unconditionally would clobber the inherited
+  // KIMI (or DEEPSEEK) of the other provider's trials with the wrong key.
+  if config.api_key != "" {
+    env[api_key_env_for_model(config.model)] = config.api_key
+  }
   env
 }
 
@@ -153,6 +159,24 @@ fn api_key_env_for_model(model : @deepseek.Model) -> String {
     KimiK27Code | KimiK27CodeHighSpeed => "KIMI"
     V4Flash | V4Pro => "DEEPSEEK"
   }
+}
+
+///|
+/// Fail fast when no key path exists for `model`: a trial authenticates either
+/// through an explicit `api_key` or the inherited provider environment
+/// variable. Checking here surfaces a clear message instead of letting every
+/// trial spawn an engine that immediately errors on the missing key.
+fn require_api_access(api_key : String, model : @deepseek.Model) -> Unit raise {
+  if api_key != "" {
+    return
+  }
+  let env_var = api_key_env_for_model(model)
+  if @env.get_env_var(env_var) is Some(value) && value != "" {
+    return
+  }
+  fail(
+    "no API key for \{model}: pass --api-key or export \{env_var} so trials can inherit it",
+  )
 }
 
 ///|

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -61,3 +61,35 @@ test "trial environment pins workspace-local session root" {
   }
   assert_eq(skills_dir, "/tmp/workspace/.no-global-skills")
 }
+
+///|
+test "empty api key leaves provider keys to the inherited environment" {
+  // A cross-provider suite runs with an empty key so each trial inherits its
+  // own DEEPSEEK/KIMI from the parent env; the harness must not pin either
+  // variable to an empty string, which would shadow the inherited key.
+  let config = Config(
+    api_key="",
+    model=V4Pro,
+    problem_id="expr_eval",
+    runs=1,
+    concurrency=1,
+    min_successes=0,
+    max_steps=12,
+    out_dir="out",
+    repo_root=".",
+    prompt_label="label",
+    task_file="task.md",
+    validation_probes=default_toml_validation_probes(),
+    system_prompt_file="",
+    system_prompt_addendum_file="",
+  )
+  let env = trial_extra_env(config, "/tmp/workspace")
+  assert_true(env.get("DEEPSEEK") is None)
+  assert_true(env.get("KIMI") is None)
+  let kimi_env = trial_extra_env(
+    { ..config, model: KimiK27Code },
+    "/tmp/workspace",
+  )
+  assert_true(kimi_env.get("KIMI") is None)
+  assert_true(kimi_env.get("DEEPSEEK") is None)
+}

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -326,8 +326,11 @@ fn ProblemSpec::from_json(json : Json, base_dir : String) -> ProblemSpec raise {
 /// Run every `(model, problem, repeat)` job with one suite-level concurrency
 /// budget. Each model/problem combo still gets a normal `run_manifest.json`.
 pub async fn run_suite(config : SuiteConfig) -> SuiteManifest {
-  if config.api_key == "" {
-    fail("api_key is required for running suite trials")
+  // Validate every provider up front: a cross-provider suite (`deepseek-*` and
+  // `kimi-*` together) runs with an empty `api_key` and inherits DEEPSEEK/KIMI
+  // from the environment, so each listed model needs its own key path.
+  for model in config.models {
+    require_api_access(config.api_key, model)
   }
   prepare_suite_output_dir(config.out_dir)
   let jobs = suite_jobs(config)

--- a/eval/prompt_tasks/deepseek_vs_kimi_benchmark.md
+++ b/eval/prompt_tasks/deepseek_vs_kimi_benchmark.md
@@ -1,0 +1,100 @@
+# DeepSeek vs Kimi Coding-Agent Benchmark
+
+A head-to-head evaluation of `deepseek-v4-pro` and `kimi-k2.7-code` driving the
+**identical** OpenSeek agent loop. Only the model swaps; the agent loop, tools,
+system prompt, task text, workspace scaffold, validation probes, step budget,
+and concurrency are held constant. What remains is a measurement of model
+reasoning, tool use, instruction-following, and MoonBit familiarity.
+
+It reuses the checked-in `eval/prompt_task` suite runner, which drives every
+`(model × problem × repeat)` combo through the real `openseek` engine and emits
+a combined Markdown/JSON/HTML comparison. Artifacts:
+
+- Task set: `eval/prompt_tasks/*.md`
+- Suite config: `eval/prompt_tasks/deepseek_vs_kimi_suite.json`
+
+## Why these tasks
+
+Each task isolates one capability and is scored by **hidden** validation probes
+(CLI behavior on inputs the agent never sees), not by grading prose. Every task
+fixes a `stdin`-primary CLI contract so probes are deterministic.
+
+| # | Task file | Axis it isolates | What the hidden probes catch |
+|---|-----------|------------------|------------------------------|
+| A1 | `json_patch_cli.md` | Long-horizon spec fidelity | `~0`/`~1` pointer escaping, array `-` append, failed `test` op → clean error, diff emits valid JSON |
+| A2 | `uri_normalizer_cli.md` | Spec / state-machine fidelity (RFC 3986) | dot-segment removal, scheme+host case folding, relative resolution (§5.4.1), malformed input → error |
+| B1 | `expr_eval_cli.md` | Algorithmic reasoning | precedence, right-associative `^`, float division, variables, parse error → error |
+| B2 | `sat_solver_cli.md` | Algorithmic depth (language-agnostic) | SAT + model line, UNSAT contradiction, comment lines, empty clause → UNSAT |
+| C1 | `rpn_repair.md` | Debugging + minimal-diff discipline | operand order, div-by-zero / underflow / leftover / unknown-token all → clean error (no panic) |
+| D1 | `dir_stats_cli.md` | Ecosystem fluency (`moonbitlang/async`, native) | exact concurrent byte/line counts, empty file, unreadable path → error |
+| E1 | `utf8_decode_cli.md` | Byte-level robustness / defensive parsing | 4-byte decode, ASCII, overlong / truncated / surrogate all rejected |
+
+C1 is a genuine repair task: the prompt ships a small, verified-buggy `eval`
+(reversed operand order, no zero check, no underflow/leftover/unknown-token
+handling) and asks the agent to fix it behind a fixed public signature. Its
+hidden probes go beyond the two visible failing tests, so an agent that only
+games the visible tests still fails.
+
+E1 replaces the originally-considered Git loose-object decoder: a real loose
+object needs a zlib-compressed **binary** fixture, which the text-only probe
+harness (`write_content` is a string) cannot supply cleanly. A hex-in UTF-8
+decoder exercises the same byte-level / defensive axis with pure-text fixtures.
+
+## Fairness controls
+
+- **Same everything but the model.** The suite runner guarantees identical task
+  text, probes, `max_steps`, and concurrency across models; do not pass a
+  model-specific `--system-prompt-file`.
+- **Both models reason at full effort.** `deepseek-v4-pro` runs at the default
+  `--thinking max`. `kimi-k2.7-code` ignores the thinking parameter entirely
+  because its "Preserved Thinking" is always on (see `deepseek/json_encode.mbt`).
+  So the default already pits full-strength reasoning against full-strength
+  reasoning.
+- **Repeats, not a single bit.** Agent runs are nondeterministic; the suite runs
+  `runs_per_combo = 3` and reports a success *rate* per `(model, problem)`.
+- **`min_successes = 0`.** The run is a measurement, not a pass/fail gate, so it
+  never exits non-zero on a weak combo — every trial's data is retained.
+
+## Metrics
+
+The analyzer records, per trial: overall success, agent `steps`, `tool_errors`,
+`shell_uses`/`shell_failures`, `finished`, per-probe validation pass/fail,
+`parse_errors`, and a set of MoonBit-idiom counters. The suite report surfaces,
+per `(model, problem)`: Successes, Avg Steps, Avg Tool Errors, Avg Shell
+Failures, Finished, and Validation.
+
+## Running it
+
+Both providers authenticate from the environment. This is enabled by a small
+harness change: an empty `--api-key` means "inherit each model's provider key
+from the environment" (`DEEPSEEK` for `deepseek-*`, `KIMI` for `kimi-*`) — the
+only way one suite can span providers, since a single shared key cannot
+authenticate both. `run_suite` validates every listed provider up front.
+
+```bash
+export DEEPSEEK=<deepseek key>
+export KIMI=<kimi key>
+
+# Build a prebuilt engine once so trials exec it directly instead of
+# recompiling cmd/openseek per trial.
+moon build --target native cmd/openseek
+ENGINE="$PWD/_build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.exe"
+
+# Run the full suite (7 problems × 2 models × 3 repeats). No --api-key: keys are
+# inherited from the environment per provider.
+moon run --target native eval/prompt_task/cmd/main -- \
+  --suite-file eval/prompt_tasks/deepseek_vs_kimi_suite.json \
+  --engine "$ENGINE" \
+  --out .moonagent/eval_runs/deepseek_vs_kimi \
+  --repo-root .
+
+# Re-generate the comparison report from a completed run without re-running any
+# agents.
+moon run --target native eval/prompt_task/cmd/main -- \
+  --analyze-only \
+  --out .moonagent/eval_runs/deepseek_vs_kimi
+```
+
+The suite writes `report.md`, `report.json`, and `report.html` under `--out`,
+plus per-combo run manifests, workspaces, raw process logs, and recorded session
+`openseek_session-<id>.jsonl` transcripts for deeper inspection.

--- a/eval/prompt_tasks/deepseek_vs_kimi_suite.json
+++ b/eval/prompt_tasks/deepseek_vs_kimi_suite.json
@@ -1,0 +1,287 @@
+{
+  "name": "deepseek-vs-kimi",
+  "models": ["deepseek-v4-pro", "kimi-k2.7-code"],
+  "runs_per_combo": 3,
+  "concurrency": 6,
+  "min_successes": 0,
+  "max_steps": 160,
+  "problems": [
+    {
+      "id": "json_patch",
+      "prompt_label": "JSON Pointer/Patch/diff CLI",
+      "task_file": "json_patch_cli.md",
+      "validation_probes": [
+        { "name": "moon check", "command": ["moon", "check", "--target", "native"] },
+        { "name": "moon test", "command": ["moon", "test", "--target", "native"] },
+        {
+          "name": "pointer escaping",
+          "command": ["moon", "run", "--target", "native", "cmd/jsonpatch", "--", "pointer", "/a~1b/c~0d"],
+          "stdin": "{\"a/b\":{\"c~d\":5}}",
+          "stdout_json": true,
+          "output_contains": "5"
+        },
+        {
+          "name": "patch replace",
+          "command": ["moon", "run", "--target", "native", "cmd/jsonpatch", "--", "patch", "patch.json"],
+          "write_file": "patch.json",
+          "write_content": "[{\"op\":\"replace\",\"path\":\"/x\",\"value\":9}]",
+          "stdin": "{\"x\":1}",
+          "stdout_json": true,
+          "output_contains": "9"
+        },
+        {
+          "name": "patch array append",
+          "command": ["moon", "run", "--target", "native", "cmd/jsonpatch", "--", "patch", "append.json"],
+          "write_file": "append.json",
+          "write_content": "[{\"op\":\"add\",\"path\":\"/a/-\",\"value\":3}]",
+          "stdin": "{\"a\":[1,2]}",
+          "stdout_json": true,
+          "output_contains": "3"
+        },
+        {
+          "name": "failed test op",
+          "command": ["moon", "run", "--target", "native", "cmd/jsonpatch", "--", "patch", "bad.json"],
+          "write_file": "bad.json",
+          "write_content": "[{\"op\":\"test\",\"path\":\"/x\",\"value\":2}]",
+          "stdin": "{\"x\":1}",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        },
+        {
+          "name": "structural diff",
+          "command": ["moon", "run", "--target", "native", "cmd/jsonpatch", "--", "diff", "b.json"],
+          "write_file": "b.json",
+          "write_content": "{\"x\":2}",
+          "stdin": "{\"x\":1}",
+          "stdout_json": true
+        }
+      ]
+    },
+    {
+      "id": "uri_normalizer",
+      "prompt_label": "URI normalizer/resolver CLI",
+      "task_file": "uri_normalizer_cli.md",
+      "validation_probes": [
+        { "name": "moon check", "command": ["moon", "check", "--target", "native"] },
+        { "name": "moon test", "command": ["moon", "test", "--target", "native"] },
+        {
+          "name": "dot segments",
+          "command": ["moon", "run", "--target", "native", "cmd/urinorm", "--", "normalize"],
+          "stdin": "http://a/b/c/../g",
+          "stdout_contains": "http://a/b/g"
+        },
+        {
+          "name": "case folding",
+          "command": ["moon", "run", "--target", "native", "cmd/urinorm", "--", "normalize"],
+          "stdin": "HTTP://Example.COM/",
+          "stdout_contains": "http://example.com/"
+        },
+        {
+          "name": "relative resolution",
+          "command": ["moon", "run", "--target", "native", "cmd/urinorm", "--", "resolve", "http://a/b/c/d;p?q"],
+          "stdin": "../../g",
+          "stdout_contains": "http://a/g"
+        },
+        {
+          "name": "malformed input",
+          "command": ["moon", "run", "--target", "native", "cmd/urinorm", "--", "normalize"],
+          "stdin": "http://[oops",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        }
+      ]
+    },
+    {
+      "id": "expr_eval",
+      "prompt_label": "Expression parser/evaluator CLI",
+      "task_file": "expr_eval_cli.md",
+      "validation_probes": [
+        { "name": "moon check", "command": ["moon", "check", "--target", "native"] },
+        { "name": "moon test", "command": ["moon", "test", "--target", "native"] },
+        {
+          "name": "precedence",
+          "command": ["moon", "run", "--target", "native", "cmd/expr"],
+          "stdin": "2 + 3 * 4",
+          "stdout_contains": "14"
+        },
+        {
+          "name": "right-associative power",
+          "command": ["moon", "run", "--target", "native", "cmd/expr"],
+          "stdin": "2 ^ 3 ^ 2",
+          "stdout_contains": "512"
+        },
+        {
+          "name": "float division",
+          "command": ["moon", "run", "--target", "native", "cmd/expr"],
+          "stdin": "10 / 4",
+          "stdout_contains": "2.5"
+        },
+        {
+          "name": "variables",
+          "command": ["moon", "run", "--target", "native", "cmd/expr"],
+          "stdin": "let x = 5;\nx * x",
+          "stdout_contains": "25"
+        },
+        {
+          "name": "parse error",
+          "command": ["moon", "run", "--target", "native", "cmd/expr"],
+          "stdin": "1 + * 2",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        }
+      ]
+    },
+    {
+      "id": "sat_solver",
+      "prompt_label": "DPLL SAT solver CLI",
+      "task_file": "sat_solver_cli.md",
+      "validation_probes": [
+        { "name": "moon check", "command": ["moon", "check", "--target", "native"] },
+        { "name": "moon test", "command": ["moon", "test", "--target", "native"] },
+        {
+          "name": "satisfiable",
+          "command": ["moon", "run", "--target", "native", "cmd/sat"],
+          "stdin": "p cnf 1 1\n1 0\n",
+          "stdout_contains": "v 1"
+        },
+        {
+          "name": "contradiction",
+          "command": ["moon", "run", "--target", "native", "cmd/sat"],
+          "stdin": "p cnf 1 2\n1 0\n-1 0\n",
+          "stdout_contains": "UNSATISFIABLE"
+        },
+        {
+          "name": "comments and propagation",
+          "command": ["moon", "run", "--target", "native", "cmd/sat"],
+          "stdin": "c example\np cnf 2 2\n1 2 0\n-1 2 0\n",
+          "stdout_contains": "v "
+        },
+        {
+          "name": "empty clause",
+          "command": ["moon", "run", "--target", "native", "cmd/sat"],
+          "stdin": "p cnf 1 1\n0\n",
+          "stdout_contains": "UNSATISFIABLE"
+        }
+      ]
+    },
+    {
+      "id": "rpn_repair",
+      "prompt_label": "RPN calculator repair",
+      "task_file": "rpn_repair.md",
+      "validation_probes": [
+        { "name": "moon check", "command": ["moon", "check", "--target", "native"] },
+        { "name": "moon test", "command": ["moon", "test", "--target", "native"] },
+        {
+          "name": "division result",
+          "command": ["moon", "run", "--target", "native", "cmd/rpn"],
+          "stdin": "8 2 /",
+          "stdout_contains": "4"
+        },
+        {
+          "name": "division by zero",
+          "command": ["moon", "run", "--target", "native", "cmd/rpn"],
+          "stdin": "1 0 /",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        },
+        {
+          "name": "stack underflow",
+          "command": ["moon", "run", "--target", "native", "cmd/rpn"],
+          "stdin": "1 +",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        },
+        {
+          "name": "leftover operands",
+          "command": ["moon", "run", "--target", "native", "cmd/rpn"],
+          "stdin": "1 2",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        },
+        {
+          "name": "unknown token",
+          "command": ["moon", "run", "--target", "native", "cmd/rpn"],
+          "stdin": "1 x +",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        }
+      ]
+    },
+    {
+      "id": "dir_stats",
+      "prompt_label": "Async directory statistics CLI",
+      "task_file": "dir_stats_cli.md",
+      "validation_probes": [
+        { "name": "moon check", "command": ["moon", "check", "--target", "native"] },
+        { "name": "moon test", "command": ["moon", "test", "--target", "native"] },
+        {
+          "name": "stdin file list",
+          "command": ["moon", "run", "--target", "native", "cmd/dirstats", "--", "--stdin"],
+          "write_file": "probe_a.txt",
+          "write_content": "one\ntwo\nthree\n",
+          "stdin": "probe_a.txt\n",
+          "stdout_json": true,
+          "output_contains": "{\"files\":1,\"lines\":3,\"bytes\":14}"
+        },
+        {
+          "name": "empty file",
+          "command": ["moon", "run", "--target", "native", "cmd/dirstats", "--", "--stdin"],
+          "write_file": "probe_empty.txt",
+          "write_content": "",
+          "stdin": "probe_empty.txt\n",
+          "stdout_json": true,
+          "output_contains": "{\"files\":1,\"lines\":0,\"bytes\":0}"
+        },
+        {
+          "name": "missing path",
+          "command": ["moon", "run", "--target", "native", "cmd/dirstats", "--", "--stdin"],
+          "stdin": "does_not_exist.txt\n",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        }
+      ]
+    },
+    {
+      "id": "utf8_decode",
+      "prompt_label": "UTF-8 decoder/validator CLI",
+      "task_file": "utf8_decode_cli.md",
+      "validation_probes": [
+        { "name": "moon check", "command": ["moon", "check", "--target", "native"] },
+        { "name": "moon test", "command": ["moon", "test", "--target", "native"] },
+        {
+          "name": "four-byte sequence",
+          "command": ["moon", "run", "--target", "native", "cmd/utf8", "--", "decode"],
+          "stdin": "f09f9880",
+          "stdout_contains": "U+1F600"
+        },
+        {
+          "name": "ascii",
+          "command": ["moon", "run", "--target", "native", "cmd/utf8", "--", "decode"],
+          "stdin": "48656C6C6F",
+          "stdout_contains": "U+0048"
+        },
+        {
+          "name": "overlong encoding",
+          "command": ["moon", "run", "--target", "native", "cmd/utf8", "--", "decode"],
+          "stdin": "c0af",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        },
+        {
+          "name": "truncated sequence",
+          "command": ["moon", "run", "--target", "native", "cmd/utf8", "--", "decode"],
+          "stdin": "f09f98",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        },
+        {
+          "name": "surrogate code point",
+          "command": ["moon", "run", "--target", "native", "cmd/utf8", "--", "decode"],
+          "stdin": "eda080",
+          "expect_exit": -1,
+          "stderr_contains": "error"
+        }
+      ]
+    }
+  ]
+}

--- a/eval/prompt_tasks/dir_stats_cli.md
+++ b/eval/prompt_tasks/dir_stats_cli.md
@@ -1,0 +1,44 @@
+You are running a MoonBit coding-agent benchmark.
+
+Workspace: {{WORKSPACE}}
+
+Build a native-only MoonBit async CLI in that workspace that computes file
+statistics by reading many files concurrently. This measures discovery and
+correct use of the `moonbitlang/async` file/process APIs plus deterministic
+output under concurrency.
+
+Requirements:
+
+- Create a current MoonBit project using `moon.mod`, not `moon.mod.json`.
+- Depend on `moonbitlang/async`. The program is native-only.
+- Implement a native CLI at `cmd/dirstats` with two modes:
+  - `cmd/dirstats -- <dir>` — recursively walk `<dir>` and gather every regular
+    file.
+  - `cmd/dirstats -- --stdin` — read a newline-separated list of file paths
+    from stdin.
+- In both modes, read the files **concurrently** (with a bounded number of
+  in-flight reads, not one giant unbounded fan-out) and print a single compact
+  JSON object on stdout with exactly these keys in this order and no spaces:
+  `{"files":<N>,"lines":<L>,"bytes":<B>}` where
+  - `N` is the number of files read,
+  - `L` is the total number of newline (`\n`) bytes across all files,
+  - `B` is the total number of bytes across all files.
+- The output must be identical regardless of the order in which concurrent
+  reads complete.
+- If a listed or walked path cannot be read, print a clean, single-line error
+  to stderr containing the word `error`, then exit non-zero. A MoonBit panic,
+  abort, or debug stack must never reach the output.
+- Add black-box tests that build a small fixture tree and assert the counts,
+  including an empty file and a nested directory.
+
+Validation expectations before finishing:
+
+- Run `moon check --target native`.
+- Run `moon test --target native`.
+- Run `moon info` and `moon fmt`.
+- Run at least these CLI probes:
+  - `--stdin` listing one file with known content, checking the exact JSON.
+  - `--stdin` listing an empty file → `{"files":1,"lines":0,"bytes":0}`.
+  - `--stdin` listing a nonexistent path (must error, not panic).
+- Finish only after reporting the validation commands you ran and any remaining
+  caveats.

--- a/eval/prompt_tasks/expr_eval_cli.md
+++ b/eval/prompt_tasks/expr_eval_cli.md
@@ -1,0 +1,49 @@
+You are running a MoonBit coding-agent benchmark.
+
+Workspace: {{WORKSPACE}}
+
+Build a small MoonBit arithmetic expression parser and evaluator library and
+native CLI in that workspace. This measures algorithmic reasoning — precedence,
+associativity, and error reporting — largely independent of MoonBit-library
+familiarity.
+
+Requirements:
+
+- Create a current MoonBit project using `moon.mod`, not `moon.mod.json`.
+- Implement a parser (precedence-climbing or Pratt) and evaluator over `Double`
+  values supporting:
+  - integer and floating-point literals,
+  - binary `+`, `-`, `*`, `/` with the usual precedence and left associativity,
+  - `^` for exponentiation, which is **right** associative and binds tighter
+    than unary minus,
+  - unary minus,
+  - parenthesised sub-expressions,
+  - `let <name> = <expr>;` statements that bind variables usable in later
+    expressions; the program is zero or more `let` statements followed by one
+    final expression whose value is the result.
+- `/` is floating-point division.
+- Print the result so that an integer-valued result has no decimal point (e.g.
+  `14`) and a non-integer result is printed in its shortest exact decimal form
+  (e.g. `2.5`).
+- Add black-box tests covering precedence, associativity, unary minus,
+  variables, and malformed input.
+- Add a native CLI at `cmd/expr` that reads the whole program from **stdin**
+  (no subcommand) and prints the result value.
+- On a parse error, an unknown variable, or division by zero, the CLI must
+  print a clean, single-line error to stderr containing the word `error`, then
+  exit non-zero. A MoonBit panic, abort, or debug stack must never reach the
+  output.
+
+Validation expectations before finishing:
+
+- Run `moon check --target native`.
+- Run `moon test --target native`.
+- Run `moon info` and `moon fmt`.
+- Run at least these CLI probes (stdin → expected stdout):
+  - `2 + 3 * 4` → `14` (precedence).
+  - `2 ^ 3 ^ 2` → `512` (right associativity).
+  - `10 / 4` → `2.5` (float division).
+  - `let x = 5;` then `x * x` → `25` (variables).
+  - `1 + * 2` → an error (must error, not panic).
+- Finish only after reporting the validation commands you ran and any remaining
+  caveats.

--- a/eval/prompt_tasks/json_patch_cli.md
+++ b/eval/prompt_tasks/json_patch_cli.md
@@ -1,0 +1,48 @@
+You are running a MoonBit coding-agent benchmark.
+
+Workspace: {{WORKSPACE}}
+
+Build a small MoonBit JSON Pointer / JSON Patch library and native CLI in that
+workspace. This measures long-horizon adherence to a specification with many
+independent rules.
+
+Requirements:
+
+- Create a current MoonBit project using `moon.mod`, not `moon.mod.json`.
+- Implement, over `Json` values, a subset of:
+  - RFC 6901 JSON Pointer resolution, including the escapes `~1` → `/` and
+    `~0` → `~`, unescaped in that order.
+  - RFC 6902 JSON Patch application supporting the ops `add`, `remove`,
+    `replace`, `move`, `copy`, and `test`.
+  - A structural `diff` that produces a JSON Patch (an array of ops)
+    transforming one document into another.
+- For array paths, `-` as the final reference token means "append" for `add`.
+- Add black-box tests for successful operations and for malformed input, and a
+  round-trip test that applying `diff(a, b)` to `a` yields `b`.
+- Add a native CLI at `cmd/jsonpatch`. The primary JSON **document is read from
+  stdin**. The first argument selects the mode:
+  - `pointer <ptr>` — resolve the pointer against the stdin document and print
+    the referenced value as compact JSON.
+  - `patch <patchfile>` — apply the JSON Patch array read from `<patchfile>` to
+    the stdin document and print the resulting document as compact JSON.
+  - `diff <otherfile>` — print a JSON Patch array transforming the stdin
+    document into the document read from `<otherfile>`.
+- Successful CLI stdout must be valid JSON only.
+- On any invalid input — an unresolved pointer, a failed `test` op, an
+  out-of-range array index, or a malformed patch/JSON document — the CLI must
+  print a clean, single-line error to stderr containing the word `error`, then
+  exit non-zero. A MoonBit panic, abort, or debug stack must never reach the
+  output.
+
+Validation expectations before finishing:
+
+- Run `moon check --target native`.
+- Run `moon test --target native`.
+- Run `moon info` and `moon fmt`.
+- Run at least these CLI probes:
+  - `pointer /a~1b/c~0d` on the document `{"a/b":{"c~d":5}}` (escaping).
+  - a `replace` patch and an array `add` with the `-` append token.
+  - a failing `test` op (must error, not panic).
+  - `diff` between two documents (stdout must be a valid JSON array).
+- Finish only after reporting the validation commands you ran and any remaining
+  caveats.

--- a/eval/prompt_tasks/rpn_repair.md
+++ b/eval/prompt_tasks/rpn_repair.md
@@ -1,0 +1,93 @@
+You are running a MoonBit coding-agent benchmark.
+
+Workspace: {{WORKSPACE}}
+
+Repair a small, buggy MoonBit reverse-Polish (RPN) calculator and wrap it in a
+native CLI. This measures debugging discipline: finding and fixing specific
+defects while keeping a fixed public API, rather than rewriting from scratch.
+
+Start from this exact implementation. It compiles, but it is wrong. Recreate it
+verbatim in your library, then fix only what is needed to satisfy the contract
+below. Keep the public signature `pub fn eval(input : String) -> Double raise`
+unchanged.
+
+```moonbit
+///| Evaluate a whitespace-separated reverse-Polish expression.
+pub fn eval(input : String) -> Double raise {
+  let stack : Array[Double] = []
+  for token in input.split(" ") {
+    let tok = token.to_owned()
+    if tok == "" {
+      continue
+    }
+    match tok {
+      "+" => {
+        let a = stack.pop().unwrap()
+        let b = stack.pop().unwrap()
+        stack.push(a + b)
+      }
+      "-" => {
+        let a = stack.pop().unwrap()
+        let b = stack.pop().unwrap()
+        stack.push(a - b)
+      }
+      "*" => {
+        let a = stack.pop().unwrap()
+        let b = stack.pop().unwrap()
+        stack.push(a * b)
+      }
+      "/" => {
+        let a = stack.pop().unwrap()
+        let b = stack.pop().unwrap()
+        stack.push(a / b)
+      }
+      _ => stack.push(@string.parse_double(tok))
+    }
+  }
+  stack.pop().unwrap()
+}
+```
+
+Include these two black-box tests unchanged; they currently fail and must pass
+after your repair:
+
+```moonbit
+test "subtraction order" {
+  assert_eq(eval("5 3 -"), 2.0)
+}
+
+test "division order" {
+  assert_eq(eval("6 2 /"), 3.0)
+}
+```
+
+Contract the repaired code must satisfy:
+
+- Correct RPN operand order: `x y -` computes `x - y` and `x y /` computes
+  `x / y` (the two provided tests encode this).
+- Division by zero, a stack underflow (an operator with too few operands), an
+  expression that leaves more than one value on the stack, and an unrecognised
+  token must each be reported as a clean, single-line error to stderr containing
+  the word `error`, followed by a non-zero exit. A MoonBit panic, abort, or
+  debug stack must never reach the output.
+- Requirements:
+  - Create a current MoonBit project using `moon.mod`, not `moon.mod.json`.
+  - Add a native CLI at `cmd/rpn` that reads the whole RPN expression from
+    **stdin** and prints the numeric result. Print an integer-valued result with
+    no decimal point (e.g. `4`).
+  - Do not change the two provided tests or the `eval` signature. Prefer a
+    minimal, targeted diff over a rewrite.
+
+Validation expectations before finishing:
+
+- Run `moon check --target native`.
+- Run `moon test --target native`.
+- Run `moon info` and `moon fmt`.
+- Run at least these CLI probes:
+  - `8 2 /` → `4`.
+  - `1 0 /` (division by zero → error, not `inf` or a panic).
+  - `1 +` (underflow → error, not a panic).
+  - `1 2` (leftover operands → error).
+  - `1 x +` (unknown token → error, not a panic).
+- Finish only after reporting the validation commands you ran and any remaining
+  caveats.

--- a/eval/prompt_tasks/sat_solver_cli.md
+++ b/eval/prompt_tasks/sat_solver_cli.md
@@ -1,0 +1,42 @@
+You are running a MoonBit coding-agent benchmark.
+
+Workspace: {{WORKSPACE}}
+
+Build a small MoonBit DIMACS CNF parser and DPLL SAT solver library and native
+CLI in that workspace. This measures algorithmic depth with objective answers,
+and is deliberately light on MoonBit-specific APIs.
+
+Requirements:
+
+- Create a current MoonBit project using `moon.mod`, not `moon.mod.json`.
+- Parse DIMACS CNF: `c ...` comment lines, a `p cnf <vars> <clauses>` header,
+  and clauses given as space-separated non-zero signed integers terminated by
+  `0`. A clause consisting only of `0` is the empty clause.
+- Implement a DPLL solver with unit propagation and pure-literal elimination.
+- Add black-box tests covering satisfiable and unsatisfiable formulas,
+  comments, the empty clause, and a larger propagation chain. For a satisfiable
+  formula, a test should verify the reported assignment actually satisfies every
+  clause.
+- Add a native CLI at `cmd/sat` that reads a DIMACS CNF from **stdin** and
+  prints the verdict:
+  - If satisfiable, print `SATISFIABLE` on the first line and, on the second
+    line, `v ` followed by a space-separated satisfying assignment as signed
+    literals (positive for true, negative for false) terminated by ` 0`.
+  - If unsatisfiable, print exactly `UNSATISFIABLE`.
+- An empty clause makes the whole formula unsatisfiable.
+- On malformed DIMACS input the CLI must print a clean, single-line error to
+  stderr containing the word `error`, then exit non-zero. A MoonBit panic,
+  abort, or debug stack must never reach the output.
+
+Validation expectations before finishing:
+
+- Run `moon check --target native`.
+- Run `moon test --target native`.
+- Run `moon info` and `moon fmt`.
+- Run at least these CLI probes:
+  - a satisfiable formula (must print a `v ` assignment line).
+  - a contradiction such as `(x1) ∧ (¬x1)` → `UNSATISFIABLE`.
+  - a formula containing `c` comment lines.
+  - a formula containing the empty clause → `UNSATISFIABLE`.
+- Finish only after reporting the validation commands you ran and any remaining
+  caveats.

--- a/eval/prompt_tasks/uri_normalizer_cli.md
+++ b/eval/prompt_tasks/uri_normalizer_cli.md
@@ -1,0 +1,44 @@
+You are running a MoonBit coding-agent benchmark.
+
+Workspace: {{WORKSPACE}}
+
+Build a small MoonBit URI parser / normalizer / resolver library and native CLI
+in that workspace. This measures fidelity to a compact state-machine
+specification (RFC 3986) with many corner cases.
+
+Requirements:
+
+- Create a current MoonBit project using `moon.mod`, not `moon.mod.json`.
+- Implement a standards-informed URI parser splitting scheme, authority
+  (userinfo, host, port), path, query, and fragment.
+- Implement `normalize`, applying at least:
+  - lowercase the scheme and the host,
+  - remove dot-segments (`.` and `..`) from the path per RFC 3986 §5.2.4,
+  - uppercase the hex digits of percent-encoded octets (`%3a` → `%3A`) and
+    decode percent-encoded unreserved characters,
+  - drop a default port (`:80` for `http`, `:443` for `https`).
+- Implement `resolve`, computing the target of a relative reference against a
+  base URI per RFC 3986 §5.2 (the reference-resolution algorithm).
+- Add black-box tests, including the normal examples from RFC 3986 §5.4.1.
+- Add a native CLI at `cmd/urinorm`. The input URI (or relative reference) is
+  read from **stdin**. The first argument selects the mode:
+  - `normalize` — print the normalized form of the stdin URI.
+  - `resolve <base>` — print the stdin relative reference resolved against
+    `<base>`.
+- Successful CLI stdout must be the single resulting URI only.
+- On invalid input the CLI must print a clean, single-line error to stderr
+  containing the word `error`, then exit non-zero. A MoonBit panic, abort, or
+  debug stack must never reach the output.
+
+Validation expectations before finishing:
+
+- Run `moon check --target native`.
+- Run `moon test --target native`.
+- Run `moon info` and `moon fmt`.
+- Run at least these CLI probes:
+  - `normalize` of `http://a/b/c/../g` → `http://a/b/g` (dot-segments).
+  - `normalize` of `HTTP://Example.COM/` → `http://example.com/` (case).
+  - `resolve http://a/b/c/d;p?q` on the reference `../../g` → `http://a/g`.
+  - an unparseable input (must error, not panic).
+- Finish only after reporting the validation commands you ran and any remaining
+  caveats.

--- a/eval/prompt_tasks/utf8_decode_cli.md
+++ b/eval/prompt_tasks/utf8_decode_cli.md
@@ -1,0 +1,42 @@
+You are running a MoonBit coding-agent benchmark.
+
+Workspace: {{WORKSPACE}}
+
+Build a small MoonBit UTF-8 decoder / validator library and native CLI in that
+workspace. This measures byte-level care and defensive handling of adversarial
+input.
+
+Requirements:
+
+- Create a current MoonBit project using `moon.mod`, not `moon.mod.json`.
+- Implement a strict UTF-8 decoder that turns a byte sequence into Unicode code
+  points and rejects, as invalid:
+  - continuation bytes without a valid leading byte,
+  - truncated multi-byte sequences,
+  - overlong encodings (e.g. `C0 AF` for `/`),
+  - encodings of surrogate code points `U+D800`–`U+DFFF`,
+  - code points above `U+10FFFF`.
+- Add a native CLI at `cmd/utf8` with mode `decode`: read a hex string from
+  **stdin** (an even number of hex digits, ASCII whitespace ignored), interpret
+  the bytes as UTF-8, and print the decoded code points as space-separated
+  `U+XXXX` tokens using uppercase hex, zero-padded to at least four digits (more
+  when needed, e.g. `U+1F600`).
+- Add black-box tests covering ASCII, multi-byte sequences, and each rejection
+  category above.
+- On invalid UTF-8, on odd-length input, or on non-hex input, the CLI must print
+  a clean, single-line error to stderr containing the word `error`, then exit
+  non-zero. A MoonBit panic, abort, or debug stack must never reach the output.
+
+Validation expectations before finishing:
+
+- Run `moon check --target native`.
+- Run `moon test --target native`.
+- Run `moon info` and `moon fmt`.
+- Run at least these CLI probes (stdin hex → expected):
+  - `f09f9880` → contains `U+1F600` (a 4-byte sequence).
+  - `48656C6C6F` → contains `U+0048` (ASCII "Hello").
+  - `c0af` → an error (overlong).
+  - `f09f98` → an error (truncated).
+  - `eda080` → an error (surrogate).
+- Finish only after reporting the validation commands you ran and any remaining
+  caveats.


### PR DESCRIPTION
## What

A head-to-head benchmark that drives `deepseek-v4-pro` and `kimi-k2.7-code` through the **identical** OpenSeek agent loop — only the model swaps — plus the one harness change needed to make a cross-provider suite actually authenticate.

Reuses the existing `eval/prompt_task` suite runner: it drives every `(model × problem × repeat)` combo through the real `openseek` engine and emits a combined Markdown/JSON/HTML comparison.

## Why the harness change

The suite runner already accepted a `models` array mixing `deepseek-*` and `kimi-*`, but couldn't authenticate them together: `trial_extra_env` forced the model's provider key variable to the single shared `--api-key`, and an empty key was rejected. DeepSeek reads `DEEPSEEK` and Kimi reads `KIMI` (distinct keys), so a cross-provider suite was impossible.

This treats an empty `api_key` as "inherit each model's provider key from the environment": skip the override so the child inherits both `DEEPSEEK` and `KIMI`, and replace the empty-key guards with a per-model `require_api_access` preflight that names the exact missing variable.

## The benchmark

Seven tasks, each isolating one capability and scored by **hidden** CLI probes (behavior on inputs the agent never sees), with a stdin-primary contract for determinism:

| Task | Axis it isolates |
|------|------------------|
| `json_patch_cli.md` | Long-horizon RFC 6901/6902 spec fidelity |
| `uri_normalizer_cli.md` | RFC 3986 normalization/resolution state machine |
| `expr_eval_cli.md` | Precedence / associativity / error reasoning |
| `sat_solver_cli.md` | DPLL algorithmic depth (language-agnostic) |
| `rpn_repair.md` | Debugging a seeded-buggy `eval` behind a fixed API |
| `dir_stats_cli.md` | `moonbitlang/async` concurrency + deterministic output |
| `utf8_decode_cli.md` | Byte-level defensive parsing of adversarial input |

`deepseek_vs_kimi_suite.json` wires all 45 probes for both models at 3 repeats; `deepseek_vs_kimi_benchmark.md` documents the capability matrix, metrics, run/analyze recipe, and the fairness controls — notably that `deepseek-v4-pro` runs at `--thinking max` while `kimi-k2.7-code` ignores the thinking param (its "Preserved Thinking" is always on), so both reason at full effort by default.

## Testing

- `moon test eval/prompt_task/harness eval/prompt_task/cmd/main --target native` → 25 passed (adds coverage for the empty-key env-inheritance path).
- `moon fmt` clean.
- Smoke-validated end to end: both providers authenticate from the environment and produce real work; a finished `deepseek-v4-pro` solution passed all `expr_eval` probes. A full 42-trial run is in progress.

Run artifacts live under the gitignored `.moonagent/`, so nothing generated is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)