### PR TITLE
refactor(agent): extract tool-call batch execution

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -365,153 +365,24 @@ pub async fn[X] run_turn_in_scope(
         )
         continue loop_steps~
       }
-      let assistant_message : @deepseek.ChatMessage = ChatMessage(
-        Assistant,
-        content=response.content,
-        tool_calls=response.tool_calls,
-        reasoning_content?,
-      )
-      messages.push(assistant_message)
-      session = append_item(
-        session,
-        Assistant(
-          AssistantMessage(
-            response.content,
-            tool_calls=response.tool_calls,
-            reasoning_content?,
-          ),
-        ),
-      )
-      for call_index, native_call in response.tool_calls {
-        let tool_call = @agent_tool.AgentToolCall(native_call) catch {
-          error => {
-            @xlog.error() <?
-              {
-                "event": "tool_call_decode_error",
-                "tool_call_id": native_call.id,
-                "tool_name": native_call.name,
-                "error": "\{error}",
-              }
-            messages.push(
-              ChatMessage(Tool(native_call.id), content="error: \{error}"),
-            )
-            session = append_item(
-              session,
-              Tool(
-                ToolResult(
-                  tool_call_id=native_call.id,
-                  tool_name=native_call.name,
-                  content="error: \{error}",
-                  is_error=true,
-                ),
-              ),
-            )
-            continue
-          }
-        }
-        let result = @agent_tool.execute_tool_call(tool_call, tools)
-        let output = match result {
-          Control(Finish(answer)) => {
-            session = append_item(
-              session,
-              Tool(
-                ToolResult(
-                  tool_call_id=native_call.id,
-                  tool_name=tool_call.name,
-                  content="finished: \{answer}",
-                ),
-              ),
-            )
-            let steer_inputs = pending_steers(runtime)
-            if steer_inputs.is_empty() {
-              let next = append_item(session, Terminal(Finished(answer)))
-              @xlog.info() <? { "event": "agent_finished", "answer": answer }
-              return next
-            }
-            // User input wins over the finish tool as well. Continuing the turn
-            // must keep the conversation API-valid: every call in the
-            // assistant's batch needs a result message, so the finish call's
-            // result and skipped notes for the unexecuted remainder are pushed
-            // before the new input.
-            messages.push(
-              ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
-            )
-            for skipped in response.tool_calls[call_index + 1:] {
-              let note = "skipped: user input arrived before this call ran"
-              @xlog.info() <?
-                {
-                  "event": "tool_result",
-                  "tool_call_id": skipped.id,
-                  "tool_name": skipped.name,
-                  "is_error": true,
-                  "content": note,
-                }
-              messages.push(ChatMessage(Tool(skipped.id), content=note))
-              session = append_item(
-                session,
-                Tool(
-                  ToolResult(
-                    tool_call_id=skipped.id,
-                    tool_name=skipped.name,
-                    content=note,
-                    is_error=true,
-                  ),
-                ),
-              )
-            }
-            session = session.apply_steer_inputs(
-              steer_inputs,
-              messages,
-              append_item~,
-            )
-            continue loop_steps~
-          }
-          Control(Abort(reason)) => {
-            session = append_item(
-              session,
-              Tool(
-                ToolResult(
-                  tool_call_id=native_call.id,
-                  tool_name=tool_call.name,
-                  content="aborted: \{reason}",
-                  is_error=true,
-                ),
-              ),
-            )
-            let next = append_item(session, Terminal(Aborted(reason)))
-            @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
-            return next
-          }
-          Respond(output) => output
-        }
-        if tool_call.name == "plan" && !output.is_error {
-          // A successful plan write restarts the staleness cadence and
-          // refreshes the checklist the next reminder would re-surface; a
-          // cleared plan drops back to the plan-free nudge.
-          cadence.steps_since_plan = 0
-          cadence.checklist = @plan.reminder_checklist(tool_call.arguments)
-        }
-        @xlog.info() <?
-          {
-            "event": "tool_result",
-            "tool_call_id": native_call.id,
-            "tool_name": tool_call.name,
-            "is_error": output.is_error,
-            "content": output.content,
-          }
-        messages.push(ChatMessage(Tool(native_call.id), content=output.content))
-        session = append_item(
-          session,
-          Tool(
-            ToolResult(
-              tool_call_id=native_call.id,
-              tool_name=tool_call.name,
-              content=output.content,
-              is_error=output.is_error,
-              brief?=output.brief,
-            ),
-          ),
-        )
+      let append_batch_item = (current, item) => {
+        let next = append_item(current, item)
+        // The catch below appends failure terminals against this snapshot.
+        // Keep it current if a helper raises after a partial batch commit.
+        session = next
+        next
+      }
+      match
+        session.run_tool_batch(
+          response,
+          messages,
+          tools,
+          runtime,
+          cadence,
+          append_item=append_batch_item,
+        ) {
+        Done(next) => return next
+        Continue(next) => session = next
       }
     }
     let next = append_item(session, Terminal(Failed("max steps exhausted")))

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -19,6 +19,7 @@ import {
 import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_tool",
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/async/socket",

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -300,6 +300,73 @@ async fn terminal_batch_test_server(
 }
 
 ///|
+fn assert_no_synthetic_missing_tool_result(
+  session : @agent_session.Session,
+) -> Unit raise {
+  for message in session.chat_messages() {
+    assert_false(message.content.contains("previous agent process exited"))
+  }
+}
+
+///|
+async test "finish closes later tool calls as skipped before terminating" {
+  @async.with_task_group() <| group => {
+    guard terminal_batch_test_server(
+        group,
+        (
+          #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_finish","function":{"name":"finish","arguments":"{\"answer\":\"done\"}"}},{"index":1,"id":"call_read","function":{"name":"read","arguments":"{\"path\":\"moon.mod\"}"}}]}}]}
+        ),
+      )
+      is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("finish-batch"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope~,
+      api_key="test-key",
+      model=V4Flash,
+      session~,
+      task="finish then read",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      api_url=url,
+    )
+    let events = result.events()
+    assert_eq(events.length(), 5)
+    guard events[1].item() is Assistant(message) else {
+      fail("expected assistant tool-call message")
+    }
+    assert_eq(message.tool_calls().length(), 2)
+    guard events[2].item() is Tool(finish_result) else {
+      fail("expected finish tool result")
+    }
+    assert_eq(finish_result.tool_call_id(), "call_finish")
+    assert_eq(finish_result.content(), "finished: done")
+    guard events[3].item() is Tool(skipped) else {
+      fail("expected skipped tool result")
+    }
+    assert_eq(skipped.tool_call_id(), "call_read")
+    assert_eq(skipped.tool_name(), "read")
+    assert_eq(
+      skipped.content(),
+      "skipped: finish ended the turn before this call ran",
+    )
+    assert_true(skipped.is_error())
+    guard events[4].item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "done")
+    assert_no_synthetic_missing_tool_result(result)
+  }
+}
+
+///|
 fn abort_batch_tools() -> @agent_tool.Tools raise {
   Tools([
     AgentToolDefinition(
@@ -315,6 +382,63 @@ fn abort_batch_tools() -> @agent_tool.Tools raise {
       execute=Sync(_args => @agent_tool.ToolAction::respond("echoed")),
     ),
   ])
+}
+
+///|
+async test "abort closes later tool calls as skipped before terminating" {
+  @async.with_task_group() <| group => {
+    guard terminal_batch_test_server(
+        group,
+        (
+          #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abort","function":{"name":"abort","arguments":"{}"}},{"index":1,"id":"call_echo","function":{"name":"echo","arguments":"{}"}}]}}]}
+        ),
+      )
+      is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("abort-batch"),
+      system_prompt="system",
+    )
+    let tools = abort_batch_tools()
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope~,
+      api_key="test-key",
+      model=V4Flash,
+      session~,
+      task="abort then echo",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      api_url=url,
+      tools~,
+    )
+    let events = result.events()
+    assert_eq(events.length(), 5)
+    guard events[2].item() is Tool(abort_result) else {
+      fail("expected abort tool result")
+    }
+    assert_eq(abort_result.tool_call_id(), "call_abort")
+    assert_eq(abort_result.content(), "aborted: stop now")
+    assert_true(abort_result.is_error())
+    guard events[3].item() is Tool(skipped) else {
+      fail("expected skipped tool result")
+    }
+    assert_eq(skipped.tool_call_id(), "call_echo")
+    assert_eq(skipped.tool_name(), "echo")
+    assert_eq(
+      skipped.content(),
+      "skipped: abort ended the turn before this call ran",
+    )
+    assert_true(skipped.is_error())
+    guard events[4].item() is Terminal(Aborted(reason)) else {
+      fail("expected aborted terminal")
+    }
+    assert_eq(reason, "stop now")
+    assert_no_synthetic_missing_tool_result(result)
+  }
 }
 
 ///|

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -268,6 +268,118 @@ async test "inject racing the final call keeps the turn alive" {
 }
 
 ///|
+async fn terminal_batch_test_server(
+  group : @async.TaskGroup[Unit],
+  response_line : String,
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping terminal batch test")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        let _ = body.read_all()
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write(response_line)
+        conn.write("\n\n")
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=1,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+fn abort_batch_tools() -> @agent_tool.Tools raise {
+  Tools([
+    AgentToolDefinition(
+      name="abort",
+      description="Abort the turn.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::abort("stop now")),
+    ),
+    AgentToolDefinition(
+      name="echo",
+      description="Echo.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::respond("echoed")),
+    ),
+  ])
+}
+
+///|
+async test "tool batch append failure preserves committed assistant before failure terminal" {
+  @async.with_task_group() <| group => {
+    guard terminal_batch_test_server(
+        group,
+        (
+          #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_echo","function":{"name":"echo","arguments":"{}"}}]}}]}
+        ),
+      )
+      is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("batch-append-failure"),
+      system_prompt="system",
+    )
+    let tools = abort_batch_tools()
+    let mut calls = 0
+    let mut persisted = session
+    let _ = @agent.run_turn_in_scope(
+      runtime~,
+      scope~,
+      api_key="test-key",
+      model=V4Flash,
+      session~,
+      task="echo once",
+      append_item=(current, item) => {
+        calls = calls + 1
+        if calls == 3 {
+          fail("persist tool result failed")
+        }
+        let next = current.append(item)
+        persisted = next
+        next
+      },
+      max_steps=1,
+      api_url=url,
+      tools~,
+    ) catch {
+      error => {
+        assert_true("\{error}".contains("persist tool result failed"))
+        assert_eq(calls, 4)
+        let events = persisted.events()
+        assert_eq(events.length(), 3)
+        assert_true(events[0].item() is User(_))
+        guard events[1].item() is Assistant(message) else {
+          fail("expected committed assistant before failure terminal")
+        }
+        assert_eq(message.tool_calls().length(), 1)
+        guard events[2].item() is Terminal(Failed(message)) else {
+          fail("expected failed terminal")
+        }
+        assert_true(message.contains("persist tool result failed"))
+        return
+      }
+    }
+    fail("expected failed append to be re-raised")
+  }
+}
+
+///|
 async test "blank steering input is dropped at the boundary" {
   @async.with_task_group() <| group => {
     guard steer_test_server(group) is Some(url) else { return }

--- a/agent/tool_batch.mbt
+++ b/agent/tool_batch.mbt
@@ -1,13 +1,14 @@
 // Executing one assistant tool-call batch. Extracted from the step loop in
 // `run_turn_in_scope` (agent.mbt) so the loop reads as a narrative; the batch
 // mechanics — decode errors, finish/abort control results, steering
-// overrides, plan cadence resets — live here.
+// overrides, plan cadence updates — live here.
 
 ///|
 /// Outcome of one assistant tool-call batch.
 priv enum BatchResult {
-  // Every call got a result — or a steering override cut the batch short —
-  // and the turn takes another model step with the carried session.
+  // Every call got a result, even if terminal control or a steering override
+  // prevented later calls in the batch from running; the turn takes another
+  // model step with the carried session.
   Continue(@agent_session.Session)
   // A terminal event was appended; the turn is over.
   Done(@agent_session.Session)
@@ -19,14 +20,49 @@ priv enum BatchResult {
 ///
 /// The conversation must stay API-valid: every tool call in the assistant
 /// message gets exactly one result message — real output, a decode error, a
-/// finish or abort note, or a skipped note for calls a steering override
-/// prevented from running.
+/// finish or abort note, or a skipped note for calls terminal control or a
+/// steering override prevented from running.
 ///
 /// A `finish` control result ends the turn only when no steering is pending;
 /// user input wins over model-initiated completion, so a pending steer turns
 /// the finish into an ordinary result, marks the unexecuted remainder
 /// skipped, folds the steer in, and continues. An abort always ends the
-/// turn. A successful `plan` write resets `cadence`.
+/// turn, after marking the unexecuted remainder skipped. A successful `plan`
+/// write resets the plan-silence counter and refreshes the checklist.
+async fn @agent_session.Session::append_skipped_tool_results(
+  session : Self,
+  messages : Array[@deepseek.ChatMessage],
+  calls : ArrayView[@deepseek.ToolCall],
+  note : String,
+  append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
+) -> @agent_session.Session {
+  let mut session = session
+  for skipped in calls {
+    @xlog.info() <?
+      {
+        "event": "tool_result",
+        "tool_call_id": skipped.id,
+        "tool_name": skipped.name,
+        "is_error": true,
+        "content": note,
+      }
+    messages.push(ChatMessage(Tool(skipped.id), content=note))
+    session = append_item(
+      session,
+      Tool(
+        ToolResult(
+          tool_call_id=skipped.id,
+          tool_name=skipped.name,
+          content=note,
+          is_error=true,
+        ),
+      ),
+    )
+  }
+  session
+}
+
+///|
 async fn @agent_session.Session::run_tool_batch(
   session : Self,
   response : @deepseek.ChatResponse,
@@ -101,6 +137,12 @@ async fn @agent_session.Session::run_tool_batch(
         )
         let steer_inputs = pending_steers(runtime)
         if steer_inputs.is_empty() {
+          session = session.append_skipped_tool_results(
+            messages,
+            response.tool_calls[call_index + 1:],
+            "skipped: finish ended the turn before this call ran",
+            append_item~,
+          )
           let next = append_item(session, Terminal(Finished(answer)))
           @xlog.info() <? { "event": "agent_finished", "answer": answer }
           return Done(next)
@@ -113,29 +155,12 @@ async fn @agent_session.Session::run_tool_batch(
         messages.push(
           ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
         )
-        for skipped in response.tool_calls[call_index + 1:] {
-          let note = "skipped: user input arrived before this call ran"
-          @xlog.info() <?
-            {
-              "event": "tool_result",
-              "tool_call_id": skipped.id,
-              "tool_name": skipped.name,
-              "is_error": true,
-              "content": note,
-            }
-          messages.push(ChatMessage(Tool(skipped.id), content=note))
-          session = append_item(
-            session,
-            Tool(
-              ToolResult(
-                tool_call_id=skipped.id,
-                tool_name=skipped.name,
-                content=note,
-                is_error=true,
-              ),
-            ),
-          )
-        }
+        session = session.append_skipped_tool_results(
+          messages,
+          response.tool_calls[call_index + 1:],
+          "skipped: user input arrived before this call ran",
+          append_item~,
+        )
         session = session.apply_steer_inputs(
           steer_inputs,
           messages,
@@ -154,6 +179,12 @@ async fn @agent_session.Session::run_tool_batch(
               is_error=true,
             ),
           ),
+        )
+        session = session.append_skipped_tool_results(
+          messages,
+          response.tool_calls[call_index + 1:],
+          "skipped: abort ended the turn before this call ran",
+          append_item~,
         )
         let next = append_item(session, Terminal(Aborted(reason)))
         @xlog.warn() <? { "event": "agent_aborted", "reason": reason }

--- a/agent/tool_batch.mbt
+++ b/agent/tool_batch.mbt
@@ -1,0 +1,194 @@
+// Executing one assistant tool-call batch. Extracted from the step loop in
+// `run_turn_in_scope` (agent.mbt) so the loop reads as a narrative; the batch
+// mechanics — decode errors, finish/abort control results, steering
+// overrides, plan cadence resets — live here.
+
+///|
+/// Outcome of one assistant tool-call batch.
+priv enum BatchResult {
+  // Every call got a result — or a steering override cut the batch short —
+  // and the turn takes another model step with the carried session.
+  Continue(@agent_session.Session)
+  // A terminal event was appended; the turn is over.
+  Done(@agent_session.Session)
+}
+
+///|
+/// Record the assistant's tool-call response and execute every call in the
+/// batch, in order.
+///
+/// The conversation must stay API-valid: every tool call in the assistant
+/// message gets exactly one result message — real output, a decode error, a
+/// finish or abort note, or a skipped note for calls a steering override
+/// prevented from running.
+///
+/// A `finish` control result ends the turn only when no steering is pending;
+/// user input wins over model-initiated completion, so a pending steer turns
+/// the finish into an ordinary result, marks the unexecuted remainder
+/// skipped, folds the steer in, and continues. An abort always ends the
+/// turn. A successful `plan` write resets `cadence`.
+async fn @agent_session.Session::run_tool_batch(
+  session : Self,
+  response : @deepseek.ChatResponse,
+  messages : Array[@deepseek.ChatMessage],
+  tools : @agent_tool.Tools,
+  runtime : @agent_runtime.AgentRuntime,
+  cadence : PlanCadence,
+  append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
+) -> BatchResult {
+  let mut session = session
+  let reasoning_content = match response.reasoning_content {
+    "" => None
+    content => Some(content)
+  }
+  messages.push(
+    ChatMessage(
+      Assistant,
+      content=response.content,
+      tool_calls=response.tool_calls,
+      reasoning_content?,
+    ),
+  )
+  session = append_item(
+    session,
+    Assistant(
+      AssistantMessage(
+        response.content,
+        tool_calls=response.tool_calls,
+        reasoning_content?,
+      ),
+    ),
+  )
+  for call_index, native_call in response.tool_calls {
+    let tool_call = @agent_tool.AgentToolCall(native_call) catch {
+      error => {
+        @xlog.error() <?
+          {
+            "event": "tool_call_decode_error",
+            "tool_call_id": native_call.id,
+            "tool_name": native_call.name,
+            "error": "\{error}",
+          }
+        messages.push(
+          ChatMessage(Tool(native_call.id), content="error: \{error}"),
+        )
+        session = append_item(
+          session,
+          Tool(
+            ToolResult(
+              tool_call_id=native_call.id,
+              tool_name=native_call.name,
+              content="error: \{error}",
+              is_error=true,
+            ),
+          ),
+        )
+        continue
+      }
+    }
+    let result = @agent_tool.execute_tool_call(tool_call, tools)
+    let output = match result {
+      Control(Finish(answer)) => {
+        session = append_item(
+          session,
+          Tool(
+            ToolResult(
+              tool_call_id=native_call.id,
+              tool_name=tool_call.name,
+              content="finished: \{answer}",
+            ),
+          ),
+        )
+        let steer_inputs = pending_steers(runtime)
+        if steer_inputs.is_empty() {
+          let next = append_item(session, Terminal(Finished(answer)))
+          @xlog.info() <? { "event": "agent_finished", "answer": answer }
+          return Done(next)
+        }
+        // User input wins over the finish tool as well. Continuing the turn
+        // must keep the conversation API-valid: every call in the
+        // assistant's batch needs a result message, so the finish call's
+        // result and skipped notes for the unexecuted remainder are pushed
+        // before the new input.
+        messages.push(
+          ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
+        )
+        for skipped in response.tool_calls[call_index + 1:] {
+          let note = "skipped: user input arrived before this call ran"
+          @xlog.info() <?
+            {
+              "event": "tool_result",
+              "tool_call_id": skipped.id,
+              "tool_name": skipped.name,
+              "is_error": true,
+              "content": note,
+            }
+          messages.push(ChatMessage(Tool(skipped.id), content=note))
+          session = append_item(
+            session,
+            Tool(
+              ToolResult(
+                tool_call_id=skipped.id,
+                tool_name=skipped.name,
+                content=note,
+                is_error=true,
+              ),
+            ),
+          )
+        }
+        session = session.apply_steer_inputs(
+          steer_inputs,
+          messages,
+          append_item~,
+        )
+        return Continue(session)
+      }
+      Control(Abort(reason)) => {
+        session = append_item(
+          session,
+          Tool(
+            ToolResult(
+              tool_call_id=native_call.id,
+              tool_name=tool_call.name,
+              content="aborted: \{reason}",
+              is_error=true,
+            ),
+          ),
+        )
+        let next = append_item(session, Terminal(Aborted(reason)))
+        @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
+        return Done(next)
+      }
+      Respond(output) => output
+    }
+    if tool_call.name == "plan" && !output.is_error {
+      // A successful plan write restarts the staleness cadence and
+      // refreshes the checklist the next reminder would re-surface; a
+      // cleared plan drops back to the plan-free nudge.
+      cadence.steps_since_plan = 0
+      cadence.checklist = @plan.reminder_checklist(tool_call.arguments)
+    }
+    @xlog.info() <?
+      {
+        "event": "tool_result",
+        "tool_call_id": native_call.id,
+        "tool_name": tool_call.name,
+        "is_error": output.is_error,
+        "content": output.content,
+      }
+    messages.push(ChatMessage(Tool(native_call.id), content=output.content))
+    session = append_item(
+      session,
+      Tool(
+        ToolResult(
+          tool_call_id=native_call.id,
+          tool_name=tool_call.name,
+          content=output.content,
+          is_error=output.is_error,
+          brief?=output.brief,
+        ),
+      ),
+    )
+  }
+  Continue(session)
+}


### PR DESCRIPTION
## Summary

Stacked on #364.

- extract assistant tool-call batch handling into Session::run_tool_batch
- keep skipped-tool-result recording as a local Session method
- fix finish/abort batches so trailing tool calls get explicit skipped results instead of synthetic projection repair
- add regression tests for finish and abort batches with later calls

## Validation

- moon info && moon fmt
- moon check --diagnostic-limit 20
- moon test agent/steer_test.mbt
- moon test agent
