### PR TITLE
[codex] remove stale moon_check runtime updates

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -4,13 +4,13 @@
 lower-level packages:
 
 - `agent_session`: immutable conversation state and model-message projection;
-- `agent_runtime`: per-loop runtime state, steering, and background events;
+- `agent_runtime`: per-loop workspace state and steering;
 - `agent_tool`: local tool registry and tool dispatch results;
 - `deepseek` and `deepseek/client`: model types and chat-completion requests.
 
 The package owns the orchestration policy: when to append session events, when
-to call the model, how to execute tool calls, how to fold in runtime updates,
-and how mid-turn steering changes the active turn.
+to call the model, how to execute tool calls, and how mid-turn steering changes
+the active turn.
 
 Prompt text is deliberately outside this package. Applications choose or build
 the system prompt, then pass it to `run` or store it in the `Session` supplied
@@ -145,9 +145,9 @@ async test "standard tools are registered in dispatch order" {
 }
 ```
 
-Build the registry once for a long-lived engine. Stateful tool records live in
-the registry value, not in `AgentRuntime`; rebuilding it every turn can orphan
-old watcher records and start duplicate watchers.
+Build the registry once for a long-lived engine. If a custom registry contains
+stateful tools, their records live in the registry value, not in
+`AgentRuntime`; rebuilding it every turn can orphan that tool state.
 
 ## Steering
 
@@ -256,16 +256,16 @@ async test "run_turn_with_append calls the persistence hook for each item" {
 `run_turn_in_scope` is the API for serve mode and other controllers that keep an
 engine alive across prompts. The caller supplies:
 
-- one shared `AgentRuntime` for steering and runtime event queues;
+- one shared `AgentRuntime` for workspace-root context and steering;
 - one `AgentTaskScope` from an enclosing `@async.with_task_group`;
 - an `append_item` callback for in-memory or durable session updates;
 - usually one shared `Tools` registry from `build_tools(runtime, scope)`.
 
-At each step boundary the loop first applies non-blank steering, then converts
-known runtime events into model-visible notices, then calls DeepSeek with the
-current session projection and tool schemas. Tool calls are executed in order.
-The turn ends on a direct model answer, `finish`, `abort`, cancellation,
-unexpected failure, or exhausted `max_steps`.
+At each step boundary the loop first applies non-blank steering, then may inject
+a plan reminder before calling DeepSeek with the current session projection and
+tool schemas. Tool calls are executed in order. The turn ends on a direct model
+answer, `finish`, `abort`, cancellation, unexpected failure, or exhausted
+`max_steps`.
 
 ## Operational Notes
 

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -227,9 +227,9 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// Runs one user turn inside a caller-owned runtime and task scope.
 ///
 /// This is the building block for callers that keep an engine alive across
-/// turns (serve mode): the shared `runtime` carries steering input and
-/// runtime updates across the turn boundary, and a `tools` registry can be
-/// built once with `build_tools` and reused across turns. When `tools` is
+/// turns (serve mode): the shared `runtime` carries steering input across the
+/// turn boundary, and a `tools` registry can be built once with `build_tools`
+/// and reused across turns. When `tools` is
 /// omitted a fresh registry is built for this turn only. `scope` bounds
 /// background work the turn's tools spawn, so it must outlive every turn that
 /// may have spawned some. One-shot callers should prefer
@@ -237,9 +237,8 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// of a single turn.
 ///
 /// The loop appends `task` as a user message before the first model request.
-/// At each step boundary it first drains and applies pending non-blank steers,
-/// then drains runtime events and turns known tool updates into model-visible
-/// runtime notices. When the registry includes the `plan` tool and
+/// At each step boundary it first drains and applies pending non-blank steers.
+/// When the registry includes the `plan` tool and
 /// `plan_reminder_after_steps` model requests pass without a successful
 /// `plan` call, the loop also injects a durable plan staleness reminder that
 /// re-surfaces the recorded plan (rate-limited by the same threshold). It
@@ -287,7 +286,6 @@ pub async fn[X] run_turn_in_scope(
       }
     }
     let messages = session.chat_messages()
-    let watcher_fingerprints : Map[String, String] = {}
     let plan_registered = tools.find("plan") is Some(_)
     let cadence : PlanCadence = {
       steps_since_plan: 0,
@@ -295,40 +293,13 @@ pub async fn[X] run_turn_in_scope(
       checklist: None,
     }
     loop_steps~: for step in 0..<max_steps {
-      // Steering first: user-visible mid-turn input should precede runtime
-      // chatter the model reads alongside it.
+      // Steering first: user-visible mid-turn input should be applied before
+      // plan reminders or the next model request.
       session = session.apply_steer_inputs(
         pending_steers(runtime),
         messages,
         append_item~,
       )
-      let runtime_events = runtime.drain_events()
-      if @moon_check.runtime_update_text(runtime_events) is Some(update) {
-        // A batch in which every watcher reproduces its previous notice
-        // (volatile counters aside) is collapsed to a one-line marker: the
-        // model still learns its edit was processed with an unchanged
-        // result, without re-paying for the full block — the analyzed
-        // 156-step session appended 61 near-identical update notices, 11%
-        // of its final context. Fingerprints are tracked per watcher so
-        // alternating multi-cwd batches cannot thrash the comparison.
-        let sections = @moon_check.update_fingerprints(runtime_events)
-        let mut fresh = sections.is_empty()
-        for pair in sections {
-          let (key, fingerprint) = pair
-          if watcher_fingerprints.get(key) != Some(fingerprint) {
-            fresh = true
-          }
-          watcher_fingerprints[key] = fingerprint
-        }
-        let notice = if fresh {
-          update
-        } else {
-          "[moon_check update]\nwatchers re-ran; results unchanged from the previous update"
-        }
-        @xlog.info() <? { "event": "runtime_update", "content": notice }
-        session = append_item(session, Runtime(RuntimeNotice(notice)))
-        messages.push(ChatMessage(User, content=notice))
-      }
       if plan_registered &&
         cadence.steps_since_plan >= plan_reminder_after_steps &&
         cadence.steps_since_reminder >= plan_reminder_after_steps {

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -4,7 +4,6 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/edit",
   "bobzhang/openseek/agent_tool/finish",
-  "bobzhang/openseek/agent_tool/moon_check",
   "bobzhang/openseek/agent_tool/multi_edit",
   "bobzhang/openseek/agent_tool/plan",
   "bobzhang/openseek/agent_tool/read",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -175,10 +175,9 @@ test "pending prompt helpers ignore queued compactions" {
 /// persistent-engine design — one process per conversation instead of one
 /// per prompt.
 ///
-/// The runtime and the tool registry are built once and shared by every
-/// turn, so stateful tools survive turn boundaries (a `moon_check` watcher
-/// started in turn 1 keeps reporting in turn 5). `steer` rides the
-/// runtime's lossless steering queue into the running (or already
+/// The runtime and the tool registry are built once and shared by every turn,
+/// so any registry-local tool state can survive turn boundaries. `steer` rides
+/// the runtime's lossless steering queue into the running (or already
 /// submitted) turn; with no turn to land in it is rejected with a
 /// `steer_dropped` event — that only happens by racing the terminal event
 /// through the pipes, and an engine must never start a turn the controller
@@ -224,9 +223,8 @@ async fn run_serve(
   @async.with_task_group(group => {
     let runtime = @agent_runtime.AgentRuntime(workspace_root~)
     let scope = @agent_runtime.AgentTaskScope(group)
-    // Built once: stateful tool records live in this registry, and
-    // rebuilding it per turn would orphan running watchers (see
-    // @agent.build_tools).
+    // Built once so registry-local tool state can survive turn boundaries
+    // (see @agent.build_tools).
     let tools = @agent.build_tools(runtime, scope)
     // All scheduling flows through one ordered queue with one consumer:
     // wire commands from the reader, plus the internal turn-completion and


### PR DESCRIPTION
## Summary

- Remove the stale `@moon_check.runtime_update_text` bridge from the agent loop.
- Drop the now-unused `agent_tool/moon_check` import from the `agent` package.
- Update agent and serve-mode docs/comments so they no longer describe model-visible runtime-update notices or watcher state in the standard tool path.

## Why

`build_tools` no longer registers `moon_check`; compiler feedback now comes through the shell tool. The agent loop was still carrying moon-check-specific runtime update rendering and fingerprinting code even though the standard registry cannot emit those updates.

## Impact

The default agent loop no longer depends on `agent_tool/moon_check` and has a smaller step-boundary path. Public `agent` APIs are unchanged.

## Validation

- `moon check --warn-list +unnecessary_annotation` (completed with existing warning 73 diagnostics outside this change)
- `moon info && moon fmt && moon test`
- Fresh `codex exec review --uncommitted` review: no blocking correctness issues found
