### PR TITLE
[codex] fix viz session discovery from jsonl files

### DIFF
--- a/cmd/viz_server/README.md
+++ b/cmd/viz_server/README.md
@@ -47,8 +47,14 @@ Useful options:
 moon run --target native cmd/viz_server -- --port 8081
 moon run --target native cmd/viz_server -- --host 127.0.0.1   # local only
 moon run --target native cmd/viz_server -- --search-dir path/to/project
+moon run --target native cmd/viz_server -- --session-root path/to/copied-jsonl-dir
 moon run --target native cmd/viz_server -- --session-root-name .openroot
 ```
+
+Session rows come from files named `openseek_session-*.jsonl`. The server
+ignores `.DS_Store`, lock files, and malformed/husk directories, and it can
+serve a normal `.openseek` store, a directory of copied JSONL files, or a single
+matching JSONL file.
 
 If the server cannot find the generated JavaScript bundle, pass it explicitly:
 

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -1,6 +1,7 @@
 ///|
 /// Read-only web server for the session-file visualizer. Serves the static
-/// frontend bundle plus a tiny JSON/raw-file API over a `SessionStore`:
+/// frontend bundle plus a tiny JSON/raw-file API over discovered session
+/// `.jsonl` files:
 ///
 /// - `GET /`                                  → the viewer shell (web/index.html)
 /// - `GET /viz_app.js`                        → the compiled frontend bundle
@@ -9,6 +10,9 @@
 /// - `GET /api/sessions/<key>/openseek_session-<id>.jsonl` → raw session file (header line + events)
 ///
 /// It never writes to the stores, so pointing it at live session roots is safe.
+/// Session discovery is intentionally file-oriented: only
+/// `openseek_session-*.jsonl` files are listed, so `.DS_Store`, lock files, and
+/// malformed/husk directories do not show up as sessions.
 async fn main {
   let matches = cli_command().parse(env=@env.get_env_vars())
   let port = parse_port(@cli.value(matches, "port"))
@@ -116,6 +120,20 @@ struct Reply {
 }
 
 ///|
+let sessions_dir_name : String = "sessions"
+
+///|
+let session_file_prefix : String = "openseek_session-"
+
+///|
+let session_file_suffix : String = ".jsonl"
+
+///|
+fn session_file_name(id : String) -> String {
+  "\{session_file_prefix}\{id}\{session_file_suffix}"
+}
+
+///|
 /// Handle one request: compute the reply (catching any failure as a 500), then
 /// send it exactly once. A failure during the send — e.g. the client closed the
 /// connection mid-body — is swallowed: the response was already started, so
@@ -178,46 +196,41 @@ async fn build_reply(
 ///|
 /// Resolve `<key>` (envelope) or `<key>/<file>` (raw) after the
 /// `/api/sessions/` route prefix. A key is either legacy `<id>` for the first
-/// root, or `<root>|<id>` for a discovered root. Both segments are
-/// percent-decoded — the file name embeds the session id, so ids containing
-/// URL-reserved characters (spaces, `?`, `#`) must decode in both positions
-/// to resolve the right session. The store's own id validation rejects path
-/// separators and `..`, so a crafted id cannot escape the session directory.
+/// matching file, or an opaque key returned by `/api/sessions`. Both segments
+/// are percent-decoded — ids containing URL-reserved characters (spaces, `?`,
+/// `#`) must decode in both positions to resolve the right session. The
+/// resolved path always comes from the catalog scan, never from the URL file
+/// segment.
 async fn session_path_reply(catalog : SessionCatalog, rest : String) -> Reply {
   let (key, file) = match rest.split_once("/") {
     None => (percent_decode(rest), None)
     Some((key, file)) =>
       (percent_decode("\{key}"), Some(percent_decode("\{file}")))
   }
-  let (root, id_value) = match catalog.lookup(key) {
+  let row = match catalog.lookup(key) {
     Some(found) => found
-    None => return text_reply(404, "Not Found", "session root not found")
+    None => return text_reply(404, "Not Found", "session file not found")
   }
-  // Validate the id ourselves so a malformed request is a 400, not a 500 from
-  // the store's path-building assertion. These are the store's own id rules.
-  guard valid_session_id(id_value) else {
+  guard valid_session_id(row.id) else {
     return text_reply(400, "Bad Request", "invalid session id")
   }
-  let id = @agent_session.SessionId(id_value)
   match file {
-    None => session_envelope_reply(root.store, id)
-    Some(name) if name == "openseek_session-\{id_value}.jsonl" =>
-      asset_reply(
-        root.store.session_file(id),
-        "application/x-ndjson; charset=utf-8",
-      )
+    None => session_envelope_reply(row.path)
+    Some(name) if name == session_file_name(row.id) =>
+      asset_reply(row.path, "application/x-ndjson; charset=utf-8")
     Some(other) =>
       text_reply(404, "Not Found", "no such session file: \{other}")
   }
 }
 
 ///|
-/// Mirror `SessionStore`'s id validation so a bad URL id is rejected as a client
-/// error before any store path is built (which would otherwise raise → 500).
+/// Mirror the session-store id validation enough for URL handling. File scan
+/// paths are catalog-derived, but a legacy bare-id URL still needs an id check.
 fn valid_session_id(value : String) -> Bool {
   value != "" &&
   !value.contains("/") &&
   !value.contains("\\") &&
+  !value.contains("\u{0}") &&
   value != "." &&
   value != ".."
 }
@@ -231,11 +244,7 @@ fn valid_session_id(value : String) -> Bool {
 /// in the body rather than signalled by 404. `events` is the raw session-file
 /// text — the header line followed by event lines — which the frontend parser
 /// splits apart itself.
-async fn session_envelope_reply(
-  store : @store.SessionStore,
-  id : @agent_session.SessionId,
-) -> Reply {
-  let path = store.session_file(id)
+async fn session_envelope_reply(path : String) -> Reply {
   if !@fs.exists(path) {
     return json_reply({ "found": false })
   }
@@ -248,36 +257,21 @@ async fn session_envelope_reply(
 
 ///|
 async fn session_list_reply(catalog : SessionCatalog) -> Reply {
-  let rows : Array[SessionListRow] = []
-  for root in catalog.roots {
-    for listing in root.store.listings() {
-      let id = listing.id().value()
-      rows.push({
-        key: session_key(root.key, id),
-        id,
-        root: root.path,
-        root_label: root.label,
-        is_marker: root.is_marker,
-        last_active: listing.last_active_unix_seconds(),
-        first_prompt: listing.first_prompt(),
-      })
-    }
-  }
-  rows.sort_by(compare_session_list_rows)
+  let rows = catalog.rows()
   json_reply(rows.map(row => row.to_json()).to_json())
 }
 
 ///|
 priv struct SessionRoot {
-  key : String
   path : String
+  scan_path : String
   label : String
+  recursive : Bool
   // Whether this root is a discovered marker store (its directory is named like
-  // the root marker, e.g. `.openseek`) rather than a direct store the user
-  // pointed `--session-root` at. The sidebar uses this to decide whether the
-  // path's last segment is a marker to strip when grouping by directory.
+  // the root marker, e.g. `.openseek`) rather than a direct directory/file of
+  // copied JSONL logs. The sidebar uses this to decide whether the path's last
+  // segment is a marker to strip when grouping by directory.
   is_marker : Bool
-  store : @store.SessionStore
 }
 
 ///|
@@ -292,7 +286,9 @@ priv struct SessionListRow {
   root : String
   root_label : String
   is_marker : Bool
+  path : String
   last_active : Int64?
+  last_active_nanoseconds : Int
   first_prompt : String
 }
 
@@ -318,7 +314,13 @@ fn compare_session_list_rows(a : SessionListRow, b : SessionListRow) -> Int {
   match (a.last_active, b.last_active) {
     (Some(a_time), Some(b_time)) =>
       if a_time == b_time {
-        compare_session_list_row_labels(a, b)
+        if a.last_active_nanoseconds == b.last_active_nanoseconds {
+          compare_session_list_row_labels(a, b)
+        } else if a.last_active_nanoseconds > b.last_active_nanoseconds {
+          -1
+        } else {
+          1
+        }
       } else if a_time > b_time {
         -1
       } else {
@@ -349,31 +351,25 @@ async fn session_catalog(
   search_dirs : Array[String],
   session_root_name : String,
 ) -> SessionCatalog {
-  let paths : Array[String] = []
-  // Serve the explicit --session-root directly only when it is actually a store
-  // (named like the root marker, or holding a `sessions/` directory). Otherwise
-  // it is a container — e.g. a directory of best-of-N run workspaces, each with
-  // its own nested store — and announcing it as a root would list zero sessions.
-  if is_session_store(session_root, session_root_name) {
-    paths.push(session_root)
-  }
-  // Scan the --session-root as well as the --search-dirs, so nested stores under
-  // a container root are surfaced the same way search-dir trees are.
-  let scan_dirs = [session_root, ..search_dirs]
-  for root in discover_session_roots(scan_dirs, session_root_name) {
-    paths.push(root)
-  }
-  let unique = unique_paths(paths)
   let roots : Array[SessionRoot] = []
-  for index, path in unique {
-    roots.push({
-      key: index.to_string(),
-      path,
-      label: root_label(path),
-      is_marker: path_tail(path) == session_root_name,
-      store: @store.SessionStore(path),
-    })
+  // Serve the explicit --session-root directly when it is a store, a directory
+  // of copied `openseek_session-*.jsonl` files, or a single matching file.
+  for root in session_root_sources(session_root, session_root_name) {
+    roots.push(root)
   }
+  // Scan the --session-root only when it is a container, so nested stores under
+  // a container root and standalone copied-log directories are surfaced the same
+  // way search-dir trees are. A direct store root is already served above; do
+  // not recurse into its `sessions/<id>` directories as copied-log roots.
+  let scan_dirs = if is_session_store(session_root, session_root_name) {
+    search_dirs
+  } else {
+    [session_root, ..search_dirs]
+  }
+  for root in discover_session_roots(scan_dirs, session_root_name) {
+    roots.push(root)
+  }
+  let roots = unique_roots(roots)
   { roots, }
 }
 
@@ -381,8 +377,8 @@ async fn session_catalog(
 async fn discover_session_roots(
   search_dirs : Array[String],
   session_root_name : String,
-) -> Array[String] {
-  let roots : Array[String] = []
+) -> Array[SessionRoot] {
+  let roots : Array[SessionRoot] = []
   for dir in search_dirs {
     scan_session_roots(dir, session_root_name, roots)
   }
@@ -393,16 +389,27 @@ async fn discover_session_roots(
 async fn scan_session_roots(
   dir : String,
   session_root_name : String,
-  roots : Array[String],
+  roots : Array[SessionRoot],
 ) -> Unit {
-  guard is_directory(dir) else { return }
+  guard is_directory(dir) else {
+    if is_session_jsonl_file(dir) {
+      roots.push(jsonl_collection_root(dir))
+    }
+    return
+  }
   if path_tail(dir) == session_root_name {
-    roots.push(dir)
+    if contains_direct_session_file(dir) {
+      roots.push(jsonl_collection_root(dir))
+    }
+    roots.push(store_root(dir, session_root_name))
     return
   }
   let direct = join_path(dir, session_root_name)
   if is_directory(direct) {
-    roots.push(direct)
+    roots.push(store_root(direct, session_root_name))
+  }
+  if contains_direct_session_file(dir) {
+    roots.push(jsonl_collection_root(dir))
   }
   let names = @fs.readdir(dir, sort=true) catch { _ => return }
   for name in names {
@@ -423,12 +430,77 @@ async fn is_directory(path : String) -> Bool {
 }
 
 ///|
+async fn is_regular_file(path : String) -> Bool {
+  (@fs.kind(path, follow_symlink=false) catch { _ => return false }) == Regular
+}
+
+///|
 /// Whether `path` is itself a session store (servable directly) rather than a
 /// container to scan: it is named like the root marker (e.g. `.openseek`), or it
 /// already holds a `sessions/` directory.
 async fn is_session_store(path : String, session_root_name : String) -> Bool {
   path_tail(path) == session_root_name ||
-  is_directory(join_path(path, "sessions"))
+  is_directory(join_path(path, sessions_dir_name))
+}
+
+///|
+async fn session_root_sources(
+  path : String,
+  session_root_name : String,
+) -> Array[SessionRoot] {
+  let roots : Array[SessionRoot] = []
+  if is_session_jsonl_source(path) {
+    roots.push(jsonl_collection_root(path))
+  }
+  if is_session_store(path, session_root_name) {
+    roots.push(store_root(path, session_root_name))
+  }
+  roots
+}
+
+///|
+fn store_root(path : String, session_root_name : String) -> SessionRoot {
+  {
+    path,
+    scan_path: join_path(path, sessions_dir_name),
+    label: root_label(path),
+    recursive: true,
+    is_marker: path_tail(path) == session_root_name,
+  }
+}
+
+///|
+fn jsonl_collection_root(path : String) -> SessionRoot {
+  {
+    path,
+    scan_path: path,
+    label: root_label(path),
+    recursive: false,
+    is_marker: false,
+  }
+}
+
+///|
+async fn is_session_jsonl_source(path : String) -> Bool {
+  is_session_jsonl_file(path) || contains_direct_session_file(path)
+}
+
+///|
+async fn is_session_jsonl_file(path : String) -> Bool {
+  is_regular_file(path) && session_id_from_file_name(path_tail(path)) is Some(_)
+}
+
+///|
+async fn contains_direct_session_file(dir : String) -> Bool {
+  guard is_directory(dir) else { return false }
+  let names = @fs.readdir(dir, sort=true) catch { _ => return false }
+  for name in names {
+    let child = join_path(dir, name)
+    if session_id_from_file_name(name) is Some(_) && is_regular_file(child) {
+      return true
+    }
+  }
+  false
 }
 
 ///|
@@ -441,45 +513,179 @@ fn should_skip_scan_dir(name : String, session_root_name : String) -> Bool {
 }
 
 ///|
-async fn unique_paths(paths : Array[String]) -> Array[String] {
+fn should_skip_session_file_scan_dir(name : String) -> Bool {
+  name == ".git" ||
+  name == "node_modules" ||
+  name == ".mooncakes" ||
+  name == "_build"
+}
+
+///|
+let first_prompt_scan_limit : Int = 50
+
+///|
+async fn unique_roots(roots : Array[SessionRoot]) -> Array[SessionRoot] {
   let seen : Array[String] = []
-  let unique : Array[String] = []
-  for path in paths {
-    let key = @fs.realpath(path) catch { _ => path }
+  let unique : Array[SessionRoot] = []
+  for root in roots {
+    let key = @fs.realpath(root.scan_path) catch { _ => root.scan_path }
     if !seen.contains(key) {
       seen.push(key)
-      unique.push(path)
+      unique.push(root)
     }
   }
   unique
 }
 
 ///|
-fn session_key(root_key : String, id : String) -> String {
-  "\{root_key}|\{id}"
+async fn first_prompt_in_log(path : String) -> String {
+  let file = @fs.open(path, mode=ReadOnly) catch { _ => return "" }
+  defer file.close()
+  let _ = file.read_until("\n") catch { _ => return "" }
+  for _ in 0..<first_prompt_scan_limit {
+    let next = file.read_until("\n") catch { _ => return "" }
+    guard next is Some(line) else { break }
+    if line.trim().is_empty() {
+      continue
+    }
+    let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
+      _ => return ""
+    }
+    if event.item() is User(message) {
+      return message.content()
+    }
+  }
+  ""
 }
 
 ///|
-fn SessionCatalog::lookup(
-  self : SessionCatalog,
-  key : String,
-) -> (SessionRoot, String)? {
-  match key.split_once("|") {
-    Some((root_key, id)) => {
-      let root_key = "\{root_key}"
-      for root in self.roots {
-        if root.key == root_key {
-          return Some((root, "\{id}"))
+async fn SessionCatalog::rows(self : SessionCatalog) -> Array[SessionListRow] {
+  let rows : Array[SessionListRow] = []
+  for root in self.roots {
+    for path in session_files_under(root.scan_path, root.recursive) {
+      match session_id_from_file_name(path_tail(path)) {
+        Some(id) => {
+          let (last_active, last_active_nanoseconds) = session_file_stamp(path)
+          rows.push({
+            key: stable_session_key(path),
+            id,
+            root: root.path,
+            root_label: root.label,
+            is_marker: root.is_marker,
+            path,
+            last_active,
+            last_active_nanoseconds,
+            first_prompt: first_prompt_in_log(path),
+          })
+        }
+        None => ()
+      }
+    }
+  }
+  rows.sort_by(compare_session_list_rows)
+  rows
+}
+
+///|
+async fn session_files_under(path : String, recursive : Bool) -> Array[String] {
+  let files : Array[String] = []
+  collect_session_files(path, files, recursive)
+  files.sort()
+  files
+}
+
+///|
+async fn collect_session_files(
+  path : String,
+  files : Array[String],
+  recursive : Bool,
+) -> Unit {
+  let kind = @fs.kind(path, follow_symlink=false) catch { _ => return }
+  match kind {
+    Regular =>
+      if session_id_from_file_name(path_tail(path)) is Some(_) {
+        files.push(path)
+      }
+    Directory => {
+      let names = @fs.readdir(path, sort=true) catch { _ => return }
+      for name in names {
+        if should_skip_session_file_scan_dir(name) {
+          continue
+        }
+        let child = join_path(path, name)
+        let child_kind = @fs.kind(child, follow_symlink=false) catch {
+          _ => continue
+        }
+        match child_kind {
+          Regular =>
+            if session_id_from_file_name(name) is Some(_) {
+              files.push(child)
+            }
+          Directory =>
+            if recursive {
+              collect_session_files(child, files, recursive)
+            }
+          _ => ()
         }
       }
-      None
     }
-    None =>
-      match self.roots {
-        [root, ..] => Some((root, key))
-        [] => None
-      }
+    _ => ()
   }
+}
+
+///|
+fn stable_session_key(path : String) -> String {
+  let builder = StringBuilder()
+  builder <+ "file-"
+  for byte in @utf8.encode(path) {
+    let value = byte.to_int()
+    if value < 16 {
+      builder <+ "0"
+    }
+    builder <+ "\{value.to_string(radix=16)}"
+  }
+  builder.to_string()
+}
+
+///|
+fn session_id_from_file_name(name : String) -> String? {
+  guard name.has_prefix(session_file_prefix) &&
+    name.has_suffix(session_file_suffix) else {
+    return None
+  }
+  let id = name[session_file_prefix.length():name.length() -
+  session_file_suffix.length()].to_owned()
+  if valid_session_id(id) {
+    Some(id)
+  } else {
+    None
+  }
+}
+
+///|
+async fn session_file_stamp(path : String) -> (Int64?, Int) {
+  let stamp = @fs.mtime(path) catch { _ => return (None, 0) }
+  let (seconds, nanoseconds) = stamp
+  (Some(seconds), nanoseconds)
+}
+
+///|
+async fn SessionCatalog::lookup(
+  self : SessionCatalog,
+  key : String,
+) -> SessionListRow? {
+  let rows = self.rows()
+  for row in rows {
+    if row.key == key {
+      return Some(row)
+    }
+  }
+  for row in rows {
+    if row.id == key {
+      return Some(row)
+    }
+  }
+  None
 }
 
 ///|

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -181,8 +181,8 @@ async test "discover_session_roots scans recursively and skips heavy dirs" {
     @fs.mkdir("\{root}/node_modules/ignored/.openseek/sessions", recursive=true)
     @fs.mkdir("\{root}/.mooncakes/ignored/.openseek/sessions", recursive=true)
     @fs.mkdir("\{root}/_build/ignored/.openseek/sessions", recursive=true)
-    let roots = discover_session_roots([root], ".openseek").map(path => {
-      path.replace_all(old=root, new="<root>")
+    let roots = discover_session_roots([root], ".openseek").map(source => {
+      source.path.replace_all(old=root, new="<root>")
     })
     @debug.debug_inspect(
       roots,
@@ -198,8 +198,8 @@ async test "discover_session_roots supports a custom root marker" {
   @vfs.with_tmpdir(prefix="openseek-viz-openroot-", root => {
     @fs.mkdir("\{root}/app/.openroot/sessions", recursive=true)
     @fs.mkdir("\{root}/app/.openseek/sessions", recursive=true)
-    let roots = discover_session_roots([root], ".openroot").map(path => {
-      path.replace_all(old=root, new="<root>")
+    let roots = discover_session_roots([root], ".openroot").map(source => {
+      source.path.replace_all(old=root, new="<root>")
     })
     @debug.debug_inspect(
       roots,
@@ -249,42 +249,178 @@ async test "session_catalog serves a direct store named like the root marker" {
 }
 
 ///|
-test "session catalog lookup supports composite and legacy keys" {
-  let catalog : SessionCatalog = {
-    roots: [
-      {
-        key: "0",
-        path: "app/.openseek",
-        label: "app/.openseek",
-        is_marker: true,
-        store: @store.SessionStore("app/.openseek"),
-      },
-      {
-        key: "1",
-        path: "lib/.openseek",
-        label: "lib/.openseek",
-        is_marker: true,
-        store: @store.SessionStore("lib/.openseek"),
-      },
-    ],
-  }
-  guard catalog.lookup("1|demo") is Some((root, id)) else {
-    fail("expected composite lookup")
-  }
-  inspect(root.path, content="lib/.openseek")
-  inspect(id, content="demo")
-  guard catalog.lookup("legacy") is Some((root, id)) else {
-    fail("expected legacy lookup")
-  }
-  inspect(root.path, content="app/.openseek")
-  inspect(id, content="legacy")
-  guard catalog.lookup("9|missing") is None else {
-    fail("unexpected missing root lookup")
-  }
+async test "session_catalog serves a non-marker direct store without duplicates" {
+  @vfs.with_tmpdir(prefix="openseek-viz-non-marker-store-", root => {
+    let store = @store.SessionStore("\{root}/store")
+    store.create(@agent_session.Session(SessionId("only"), system_prompt=""))
+    let catalog = session_catalog("\{root}/store", [], ".openseek")
+    let rows = catalog.rows()
+    guard rows is [row] else { fail("expected one direct-store row") }
+    inspect(row.id, content="only")
+    inspect(row.root, content="\{root}/store")
+  })
 }
 
 ///|
-async test "session_list_reply includes root metadata and composite keys" {
+async test "session listing uses jsonl files and ignores junk entries" {
+  @vfs.with_tmpdir(prefix="openseek-viz-flat-jsonl-", root => {
+    let source_store = @store.SessionStore("\{root}/source/.openseek")
+    source_store.create(
+      @agent_session.Session(SessionId("flat-a"), system_prompt=""),
+    )
+    source_store.create(
+      @agent_session.Session(SessionId("flat-b"), system_prompt="").append(
+        User(UserMessage("copied prompt")),
+      ),
+    )
+    let sessions = "\{root}/.openseek/sessions"
+    @fs.mkdir(sessions, recursive=true)
+    @fs.write_file(
+      "\{sessions}/openseek_session-flat-a.jsonl",
+      @fs.read_file(source_store.session_file(SessionId("flat-a"))).text(),
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{sessions}/openseek_session-flat-b.jsonl",
+      @fs.read_file(source_store.session_file(SessionId("flat-b"))).text(),
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{sessions}/.DS_Store",
+      "not a session",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.mkdir("\{sessions}/tui-20260705-131715-289", recursive=true)
+    let catalog = session_catalog("\{root}/.openseek", [], ".openseek")
+    let reply = session_list_reply(catalog)
+    let text = reply.body
+    assert_true(text.contains("\"id\":\"flat-a\""))
+    assert_true(text.contains("\"id\":\"flat-b\""))
+    assert_true(text.contains("\"first_prompt\":\"copied prompt\""))
+    assert_true(!text.contains(".DS_Store"))
+    assert_true(!text.contains("tui-20260705-131715-289"))
+    let load = session_path_reply(catalog, "flat-a")
+    inspect(load.code, content="200")
+    guard @json.parse(load.body) is Object(fields) else {
+      fail("expected envelope JSON")
+    }
+    guard fields.get("events") is Some(String(events)) else {
+      fail("expected events text")
+    }
+    assert_true(events.contains("\"id\":\"flat-a\""))
+  })
+}
+
+///|
+async test "session_catalog serves a direct directory of copied jsonl files" {
+  @vfs.with_tmpdir(prefix="openseek-viz-jsonl-dir-", root => {
+    let source_store = @store.SessionStore("\{root}/source/.openseek")
+    source_store.create(
+      @agent_session.Session(SessionId("copied"), system_prompt=""),
+    )
+    let copied_dir = "\{root}/copied"
+    @fs.mkdir(copied_dir, recursive=true)
+    @fs.write_file(
+      "\{copied_dir}/openseek_session-copied.jsonl",
+      @fs.read_file(source_store.session_file(SessionId("copied"))).text(),
+      create_mode=CreateOrTruncate,
+    )
+    let catalog = session_catalog(copied_dir, [], ".openseek")
+    let reply = session_list_reply(catalog)
+    let text = reply.body
+    assert_true(text.contains("\"id\":\"copied\""))
+    assert_true(text.contains("\"is_marker\":false"))
+    let rows = catalog.rows()
+    guard rows is [row] else { fail("expected one copied row") }
+    let load = session_path_reply(catalog, row.key)
+    inspect(load.code, content="200")
+  })
+}
+
+///|
+async test "session_catalog serves marker-named copied jsonl directories" {
+  @vfs.with_tmpdir(prefix="openseek-viz-marker-jsonl-", root => {
+    let source_store = @store.SessionStore("\{root}/source/.openseek")
+    source_store.create(
+      @agent_session.Session(SessionId("marker-copy"), system_prompt=""),
+    )
+    let copied_dir = "\{root}/.openseek"
+    @fs.mkdir(copied_dir, recursive=true)
+    @fs.write_file(
+      "\{copied_dir}/openseek_session-marker-copy.jsonl",
+      @fs.read_file(source_store.session_file(SessionId("marker-copy"))).text(),
+      create_mode=CreateOrTruncate,
+    )
+    let catalog = session_catalog(copied_dir, [], ".openseek")
+    let reply = session_list_reply(catalog)
+    let text = reply.body
+    assert_true(text.contains("\"id\":\"marker-copy\""))
+  })
+}
+
+///|
+async test "session catalog lookup supports stable and legacy keys" {
+  @vfs.with_tmpdir(prefix="openseek-viz-lookup-", root => {
+    let app_store = @store.SessionStore("\{root}/app/.openseek")
+    let lib_store = @store.SessionStore("\{root}/lib/.openseek")
+    app_store.create(
+      @agent_session.Session(SessionId("legacy"), system_prompt=""),
+    )
+    lib_store.create(
+      @agent_session.Session(SessionId("demo"), system_prompt=""),
+    )
+    let catalog : SessionCatalog = {
+      roots: [
+        {
+          path: "\{root}/app/.openseek",
+          scan_path: "\{root}/app/.openseek/sessions",
+          label: "app/.openseek",
+          recursive: true,
+          is_marker: true,
+        },
+        {
+          path: "\{root}/lib/.openseek",
+          scan_path: "\{root}/lib/.openseek/sessions",
+          label: "lib/.openseek",
+          recursive: true,
+          is_marker: true,
+        },
+      ],
+    }
+    let rows = catalog.rows()
+    let mut demo_key = ""
+    for row in rows {
+      if row.id == "demo" {
+        demo_key = row.key
+      }
+    }
+    guard demo_key != "" else { fail("expected demo key") }
+    guard catalog.lookup(demo_key) is Some(row) else {
+      fail("expected stable key lookup")
+    }
+    inspect(row.root, content="\{root}/lib/.openseek")
+    inspect(row.id, content="demo")
+    app_store.create(
+      @agent_session.Session(SessionId("newer"), system_prompt=""),
+    )
+    guard catalog.lookup(demo_key) is Some(row) else {
+      fail("expected stable key lookup after file addition")
+    }
+    inspect(row.root, content="\{root}/lib/.openseek")
+    inspect(row.id, content="demo")
+    guard catalog.lookup("legacy") is Some(row) else {
+      fail("expected legacy lookup")
+    }
+    inspect(row.root, content="\{root}/app/.openseek")
+    inspect(row.id, content="legacy")
+    guard catalog.lookup("9|missing") is None else {
+      fail("unexpected missing root lookup")
+    }
+  })
+}
+
+///|
+async test "session_list_reply includes root metadata and stable keys" {
   @vfs.with_tmpdir(prefix="openseek-viz-list-", root => {
     let app_store = @store.SessionStore("\{root}/app/.openseek")
     let lib_store = @store.SessionStore("\{root}/lib/.openseek")
@@ -297,25 +433,28 @@ async test "session_list_reply includes root metadata and composite keys" {
     let catalog : SessionCatalog = {
       roots: [
         {
-          key: "0",
           path: "\{root}/app/.openseek",
+          scan_path: "\{root}/app/.openseek/sessions",
           label: "app/.openseek",
+          recursive: true,
           is_marker: true,
-          store: app_store,
         },
         {
-          key: "1",
           path: "\{root}/lib/.openseek",
+          scan_path: "\{root}/lib/.openseek/sessions",
           label: "lib/.openseek",
+          recursive: true,
           is_marker: true,
-          store: lib_store,
         },
       ],
     }
     let reply = session_list_reply(catalog)
     let text = reply.body
-    assert_true(text.contains("\"key\":\"0|same\""))
-    assert_true(text.contains("\"key\":\"1|same\""))
+    let rows = catalog.rows()
+    assert_eq(rows.length(), 2)
+    assert_true(rows[0].key.has_prefix("file-"))
+    assert_true(rows[1].key.has_prefix("file-"))
+    assert_true(rows[0].key != rows[1].key)
     assert_true(text.contains("\"root_label\":\"app/.openseek\""))
     assert_true(text.contains("\"root_label\":\"lib/.openseek\""))
     // The marker flag rides along so the sidebar can group by directory.
@@ -335,16 +474,16 @@ async test "raw session file route decodes the file segment like the key" {
     let catalog : SessionCatalog = {
       roots: [
         {
-          key: "0",
           path: "\{root}/.openseek",
+          scan_path: "\{root}/.openseek/sessions",
           label: ".openseek",
+          recursive: true,
           is_marker: true,
-          store,
         },
       ],
     }
     let reply = session_path_reply(
-      catalog, "0%7Crun%201/openseek_session-run%201.jsonl",
+      catalog, "run%201/openseek_session-run%201.jsonl",
     )
     inspect(reply.code, content="200")
     assert_true(reply.body.contains("\"id\":\"run 1\""))
@@ -359,7 +498,7 @@ async test "session_envelope_reply includes event log byte size" {
       User(UserMessage("hi")),
     )
     store.create(session)
-    let reply = session_envelope_reply(store, SessionId("demo"))
+    let reply = session_envelope_reply(store.session_file(SessionId("demo")))
     guard @json.parse(reply.body) is Object(fields) else {
       fail("expected JSON object")
     }

--- a/cmd/viz_server/moon.pkg
+++ b/cmd/viz_server/moon.pkg
@@ -1,10 +1,10 @@
 import {
+  "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/testkit/filesystem" @vfs,
 } for "wbtest"
 
 import {
   "bobzhang/openseek/agent_session",
-  "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/internal/cli",
   "moonbitlang/async",
   "moonbitlang/async/http",

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -19,7 +19,7 @@ System follows the OS via `prefers-color-scheme`).
 |------------------|--------|---------------------------------------------------------------------|
 | `viz`            | js     | Pure parse + render: session-file text → typed events → `@html.Html`. Reuses `agent_session` decoders and projection, so it stays correct as the format evolves. |
 | `cmd/viz_app`    | js     | The rabbita (TEA) frontend: session browser, fetch, mode toggle.    |
-| `cmd/viz_server` | native | Read-only web server (`moonbitlang/async/http`) exposing a JSON/raw-file API over a `SessionStore`. It never writes, so pointing it at a live session root is safe. |
+| `cmd/viz_server` | native | Read-only web server (`moonbitlang/async/http`) exposing a JSON/raw-file API over discovered `openseek_session-*.jsonl` files. It never writes, so pointing it at a live session root is safe. |
 
 The `viz` library is headless-testable: `render_session` returns `@html.Html`,
 which `@rabbita.render_to_string` turns into a string for snapshot assertions —
@@ -54,10 +54,14 @@ moon run cmd/viz_server --target native -- --search-dir . --port 8080
 ```
 
 By default the server scans `.` recursively for `.openseek` directories and
-also includes the compatibility `--session-root` (default `.openseek`). The
-scanner skips `.git`, `node_modules`, `.mooncakes`, and `_build`. Repeat
-`--search-dir` to scan several trees, and use `--session-root-name` when a
-different marker such as `.openroot` should be treated as the session root.
+also includes the compatibility `--session-root` (default `.openseek`). Session
+rows are discovered from `openseek_session-*.jsonl` files under each root's
+`sessions/` tree, so stray files like `.DS_Store` and husk directories are not
+listed. A directory or single file of copied `openseek_session-*.jsonl` logs can
+also be passed directly as `--session-root`. The scanner skips `.git`,
+`node_modules`, `.mooncakes`, and `_build`. Repeat `--search-dir` to scan
+several trees, and use `--session-root-name` when a different marker such as
+`.openroot` should be treated as the session root.
 
 `--session-root`, `--search-dir`, `--session-root-name`, `--port`,
 `--web-dir`, and `--bundle` all have env-var fallbacks


### PR DESCRIPTION
## Summary

Fix the visualizer server so session discovery is driven by `openseek_session-*.jsonl` files rather than directory names returned by `SessionStore::listings`.

## Why

When copied session JSONL files are placed together in one directory, the previous server path still treated arbitrary entries under `sessions/` as session ids. That made files like `.DS_Store` and malformed/husk directories appear as broken sessions, while directly copied JSONL files were not served reliably.

## Changes

- Discover and list only files named `openseek_session-*.jsonl`.
- Serve normal `.openseek` stores, direct directories of copied JSONL logs, and single matching JSONL files.
- Keep raw file and envelope routes resolving through catalog-derived paths instead of URL-derived paths.
- Add regression coverage for copied JSONL directories with `.DS_Store` and stray directories.
- Update visualizer docs to describe file-oriented discovery.

## Validation

- `moon check cmd/viz_server --target native --diagnostic-limit 200`
- `moon test cmd/viz_server --target native`
- `moon info && moon fmt`
- `moon test`
- `git diff --check`

Also manually verified `/api/sessions` against `/Users/hongbozhang/git/seeks/.openseek`, which returned only the two copied JSONL sessions and omitted `.DS_Store` plus stray directories.