### PR TITLE
feat(viz): standalone self-contained HTML export for sessions

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -311,8 +311,25 @@ fn fetch_text(
   url : String,
   to_msg : (Result[String, Error]) -> Msg,
 ) -> @cmd.Cmd {
-  @http.get(url).expect_text(emit.map(to_msg))
+  // A standalone export bakes the API responses into `window.__OPENSEEK_DATA__`,
+  // so answer from there when present and skip the network entirely; a normal
+  // server build has no such global and falls through to HTTP unchanged.
+  if embedded_has(url) {
+    emit(to_msg(Ok(embedded_get(url))))
+  } else {
+    @http.get(url).expect_text(emit.map(to_msg))
+  }
 }
+
+///|
+/// Whether a self-contained export (see `cmd/viz_server --export`) baked a
+/// response for `url` into `window.__OPENSEEK_DATA__`. False in a normal server
+/// build, where the global is absent and every lookup misses.
+extern "js" fn embedded_has(url : String) -> Bool = "(url) => (typeof window !== 'undefined') && !!window.__OPENSEEK_DATA__ && Object.prototype.hasOwnProperty.call(window.__OPENSEEK_DATA__, url)"
+
+///|
+/// The baked response body for `url`. Only called after `embedded_has` is true.
+extern "js" fn embedded_get(url : String) -> String = "(url) => window.__OPENSEEK_DATA__[url]"
 
 ///|
 /// Switch the viewer to a locally dropped session file. Everything comes from

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -9,11 +9,11 @@ fn main {
     view~,
   )
   let app = @rabbita.new(app_cell)
+  // Route the initial listing through fetch_text so a standalone export answers
+  // it from the embedded data map instead of the (absent) server.
   app.with_init(
     @cmd.batch([
-      @http.get("/api/sessions").expect_text(
-        emit.map(result => SessionsFetched(result)),
-      ),
+      fetch_text(emit, "/api/sessions", result => SessionsFetched(result)),
       install_shortcuts(emit),
     ]),
   )

--- a/cmd/viz_server/README.md
+++ b/cmd/viz_server/README.md
@@ -56,6 +56,25 @@ ignores `.DS_Store`, lock files, and malformed/husk directories, and it can
 serve a normal `.openseek` store, a directory of copied JSONL files, or a single
 matching JSONL file.
 
+## Standalone export
+
+`--export <path>` writes a single self-contained HTML file with every discovered
+session baked in, then exits without serving:
+
+```sh
+moon run --target native cmd/viz_server -- \
+  --session-root path/to/archive --export sessions.html
+```
+
+The exported file inlines the compiled frontend bundle and bakes each API
+response the server would return — the `/api/sessions` listing plus one envelope
+per session — into a `window.__OPENSEEK_DATA__` map. The frontend answers its two
+fetches from that map before touching the network, so the file opens directly
+from disk (`file://`), with no server and no network. Because the bundle that
+understands these logs ships alongside them, an export keeps rendering unchanged
+as the live `.jsonl` format and parser evolve — it is a frozen archive, not a
+live view.
+
 If the server cannot find the generated JavaScript bundle, pass it explicitly:
 
 ```sh

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -38,6 +38,19 @@ async fn main {
   let shell = shell_candidates(web_dir, module_root)
   let bundle_paths = bundle_candidates(bundle, web_dir, module_root)
   let catalog = session_catalog(session_root, search_dirs, session_root_name)
+  // Export mode: freeze the sessions the server would serve into one standalone
+  // HTML and exit, rather than run_forever. The exported file is decoupled from
+  // this server and from the current parser — it carries its own bundle + data.
+  let export_path = @cli.value(matches, "export")
+  if export_path != "" {
+    let rows = catalog.rows()
+    let html = build_export_html(rows, shell, bundle_paths)
+    @fs.write_file(export_path, html, create_mode=CreateOrTruncate)
+    println(
+      "openseek viz: wrote standalone export '\{export_path}' (\{rows.length()} session(s), \{html.length()} chars)",
+    )
+    return
+  }
   let addr = @socket.Addr::parse("\{host}:\{port}") catch {
     _ => fail("invalid --host/--port: \{host}:\{port}")
   }
@@ -245,20 +258,158 @@ fn valid_session_id(value : String) -> Bool {
 /// text — the header line followed by event lines — which the frontend parser
 /// splits apart itself.
 async fn session_envelope_reply(path : String) -> Reply {
+  json_reply(session_envelope_body(path))
+}
+
+///|
+/// The `{found, events, events_bytes}` payload for one session, factored out of
+/// `session_envelope_reply` so the standalone exporter can bake the exact same
+/// body the live server would return into the embedded data map.
+async fn session_envelope_body(path : String) -> Json {
   if !@fs.exists(path) {
-    return json_reply({ "found": false })
+    return { "found": false }
   }
-  json_reply({
+  {
     "found": true,
     "events": read_text_lossy(path),
     "events_bytes": Json::number(file_size(path).to_double()),
-  })
+  }
 }
 
 ///|
 async fn session_list_reply(catalog : SessionCatalog) -> Reply {
-  let rows = catalog.rows()
-  json_reply(rows.map(row => row.to_json()).to_json())
+  json_reply(session_list_json(catalog.rows()))
+}
+
+///|
+/// The `/api/sessions` listing as JSON, shared by the live route and the
+/// standalone exporter so both encode the sidebar rows identically.
+fn session_list_json(rows : Array[SessionListRow]) -> Json {
+  rows.map(row => row.to_json()).to_json()
+}
+
+///|
+/// Assemble a single self-contained HTML file: the viewer shell with the
+/// compiled frontend bundle inlined and every API response the server would
+/// serve — the `/api/sessions` listing plus one envelope per session — baked
+/// into a `window.__OPENSEEK_DATA__` map, keyed by request path. The frontend's
+/// transport checks that map before hitting the network, so the exported file
+/// renders every session offline, with no server and no dependence on the
+/// current parser: the bundle that understands these logs ships alongside them.
+async fn build_export_html(
+  rows : Array[SessionListRow],
+  shell : Array[String],
+  bundle : Array[String],
+) -> String {
+  let shell_html = read_first_existing(
+    shell, "index.html shell (build with `moon build` or pass --web-dir)",
+  )
+  let bundle_js = read_first_existing(
+    bundle, "viz_app.js bundle (build with `moon build` or pass --bundle)",
+  )
+  // Bake the two live endpoints the frontend fetches: the sidebar listing and
+  // one envelope per session, keyed exactly as the frontend requests them.
+  let data : Map[String, Json] = Map([])
+  data["/api/sessions"] = Json::string(session_list_json(rows).stringify())
+  for row in rows {
+    data["/api/sessions/\{row.key}"] = Json::string(
+      session_envelope_body(row.path).stringify(),
+    )
+  }
+  // Escape every `<` in the data to its JSON unicode escape so no `<!--`,
+  // `<script`, or `</script` in session text can drive HTML's script-data
+  // tokenizer out of the inline block — the `<!--`+`<script` double-escape trap
+  // would otherwise swallow the following bundle and blank the page. The escape
+  // decodes back to `<` in the JS/JSON parser, so the data round-trips unchanged.
+  let blob = escape_json_for_html(data.to_json().stringify())
+  let bundle_inline = escape_script_close(bundle_js)
+  let scripts = "<script>window.__OPENSEEK_DATA__ = \{blob};</script>\n<script>\n\{bundle_inline}\n</script>"
+  let marker = "<script src=\"/viz_app.js\"></script>"
+  match shell_html.split_once(marker) {
+    Some((before, after)) => "\{before}\{scripts}\{after}"
+    None =>
+      fail(
+        "index.html shell is missing the \{marker} tag; cannot inline the bundle",
+      )
+  }
+}
+
+///|
+/// Read the first existing candidate as text, or fail naming what was missing.
+async fn read_first_existing(
+  candidates : Array[String],
+  what : String,
+) -> String {
+  for candidate in candidates {
+    if candidate != "" && @fs.exists(candidate) {
+      return read_text_lossy(candidate)
+    }
+  }
+  fail("could not locate \{what}")
+}
+
+///|
+/// Rewrite every `<` in a stringified JSON payload to its `<` escape, so an
+/// inline `<script>…</script>` data block carrying it cannot be pushed out of
+/// HTML's script-data state. Every state transition there begins with `<`, so
+/// escaping `<` alone defeats `<!--`, `<script`, and `</script` (including the
+/// `<!--`+`<script` double-escape trap). The escape decodes back to `<` in the
+/// JS/JSON parser, so the embedded data is unchanged. A `<` only ever appears
+/// inside a string value here (keys and structure have none), so this is safe.
+fn escape_json_for_html(json : String) -> String {
+  let builder = StringBuilder()
+  for c in json {
+    if c == '<' {
+      builder <+ "\\u003c"
+    } else {
+      builder.write_char(c)
+    }
+  }
+  builder.to_string()
+}
+
+///|
+/// Neutralise any literal `</script` in inlined JavaScript so it cannot close
+/// the enclosing `<script>` block early. The match is case-insensitive because
+/// an HTML parser closes the tag on `</script` in any letter case; a backslash
+/// after `<` yields `<\/script`, the same token to a JS parser (a backslash
+/// before `/` is a no-op outside a regex/string, and legal inside both), so the
+/// bundle's behaviour is unchanged.
+fn escape_script_close(js : String) -> String {
+  let chars = js.to_array()
+  let builder = StringBuilder()
+  let n = chars.length()
+  let mut i = 0
+  while i < n {
+    if chars[i] == '<' && is_script_close_tail(chars, i + 1) {
+      builder <+ "<\\/"
+      i += 2
+    } else {
+      builder.write_char(chars[i])
+      i += 1
+    }
+  }
+  builder.to_string()
+}
+
+///|
+/// Whether `chars[at..]` begins with `/script` case-insensitively — the tail of
+/// a `</script` close tag once the leading `<` has matched. HTML matches the tag
+/// name in any case, so `</SCRIPT` and `</Script` must be caught too.
+fn is_script_close_tail(chars : Array[Char], at : Int) -> Bool {
+  let tail = ['/', 's', 'c', 'r', 'i', 'p', 't']
+  guard at + tail.length() <= chars.length() else { return false }
+  for k in 0..<tail.length() {
+    let actual = chars[at + k]
+    let want = tail[k]
+    // Uppercase of an ASCII letter is its lowercase minus 32; `/` has no case.
+    let matches = actual == want ||
+      (want >= 'a' && want <= 'z' && actual.to_int() == want.to_int() - 32)
+    if !matches {
+      return false
+    }
+  }
+  true
 }
 
 ///|
@@ -973,6 +1124,13 @@ fn cli_command() -> @argparse.Command {
         env="OPENSEEK_VIZ_BUNDLE",
         default_values=[""],
         about="Path to the compiled viz_app.js; defaults to auto-locating the moon build output.",
+      ),
+      OptionArg(
+        "export",
+        long="export",
+        env="OPENSEEK_VIZ_EXPORT",
+        default_values=[""],
+        about="Write a self-contained standalone HTML (all discovered sessions embedded, no server needed) to this path and exit, instead of serving.",
       ),
     ],
   )


### PR DESCRIPTION
## Why

`cmd/viz_server` is great, but as OpenSeek evolves the session `.jsonl` format drifts and old logs stop rendering — backwards-compat in the parser is a growing burden. This adds a way to **freeze a session into a single self-contained HTML file** that carries its own frontend bundle + data, so it keeps rendering regardless of later format/parser changes. It shifts the durability contract off the live `.jsonl` (ephemeral working format) and onto a frozen archive.

## What

```sh
moon run --target native cmd/viz_server -- --session-root <archive> --export sessions.html
```

- **`viz_app`**: the frontend's two fetches (`/api/sessions` + per-session envelope) now check `window.__OPENSEEK_DATA__` before hitting the network, falling back to HTTP. A normal server build has no such global, so live behavior is unchanged.
- **`viz_server --export`**: freezes every discovered session into one HTML file and exits instead of serving. It **reuses the live catalog and reply builders** — the same `/api/sessions` listing and `{found,events,events_bytes}` envelopes the server would serve — so baked payloads are byte-identical. The compiled bundle is inlined; responses are baked into the embedded map the frontend reads. Opens from `file://` with no server, fully interactive (sidebar, Raw/Model/Rendered toggles, theme, error-jump).

Single self-contained file by default; batches all discovered sessions.

## Safety

Untrusted session text is inlined into `<script>` blocks, so:
- every `<` in the data is rewritten to its JSON unicode escape (backslash-`u003c`) — a `<` the HTML parser never sees but that JS/JSON decode back to `<`. This defeats `<!--`, `<script`, and `</script` in session text, including the `<!--`+`<script>` double-escape trap that a bare `</script>` escape misses and that would otherwise swallow the bundle and blank the page.
- the inlined bundle's `</script` (any case, as HTML matches it) is rewritten to `<` + backslash + `/script`, the same token to a JS parser.

## Testing

Exercised against a real 41-session eval archive:
- Export → one ~11MB file, 41 sessions, exactly 3 `<script>` blocks, 0 raw `<` in the data blob, blob round-trips through `JSON.parse`.
- Headless Chrome over `file://` (no server): sidebar renders 41 sessions across 14 roots; opening a session shows the full conversation (event counts, badges, tool-error jump, markdown), no network.
- Reproduced the `<!--`+`<script>` trap in a real session and confirmed the export still runs the bundle and renders the text as safe escaped content.

Reviewed commit-by-commit with `codex review`; the two escaping issues above were found there, fixed, and re-reviewed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)