### PR TITLE
feat(shell): explicit background jobs (run_in_background + shell_output + shell_stop)

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -114,7 +114,9 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 `build_tools(runtime, scope)` returns the standard local tool registry:
 
 - `shell`: run a command under the workspace root or an explicit cwd (including
-  `moon check` for compiler feedback);
+  `moon check` for compiler feedback), optionally detached via `run_in_background`;
+- `shell_output`: read the captured output and status of a background `shell` job;
+- `shell_stop`: stop a background `shell` job;
 - `read`: read a text file;
 - `edit`: replace exact text in a file;
 - `multi_edit`: apply several explicit line-anchored replacements to one file;
@@ -123,8 +125,8 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `finish`: end the task with a final answer.
 
 File-oriented tools capture `runtime.workspace_root()` when the registry is
-built. The registry still receives the runtime and task scope for stateful
-tools, though none currently use them.
+built. The task scope backs the shared background-job runtime that the `shell`
+(`run_in_background`), `shell_output`, and `shell_stop` tools use.
 
 ```mbt check
 ///|
@@ -138,7 +140,17 @@ async test "standard tools are registered in dispatch order" {
         for tool in tools.function_tools() => tool.name
       ],
       content=(
-        #|["shell", "read", "edit", "multi_edit", "write", "plan", "finish"]
+        #|[
+        #|  "shell",
+        #|  "shell_output",
+        #|  "shell_stop",
+        #|  "read",
+        #|  "edit",
+        #|  "multi_edit",
+        #|  "write",
+        #|  "plan",
+        #|  "finish",
+        #|]
       ),
     )
   }

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
   "bobzhang/openseek/agent_tool/edit",
   "bobzhang/openseek/agent_tool/finish",
   "bobzhang/openseek/agent_tool/multi_edit",

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -9,6 +9,8 @@ import {
   "bobzhang/openseek/agent_tool/plan",
   "bobzhang/openseek/agent_tool/read",
   "bobzhang/openseek/agent_tool/shell",
+  "bobzhang/openseek/agent_tool/shell_output",
+  "bobzhang/openseek/agent_tool/shell_stop",
   "bobzhang/openseek/agent_tool/write",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/deepseek/client",

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -23,6 +23,8 @@ pub fn[X] build_tools(
   let workspace_root = runtime.workspace_root()
   Tools([
     @shell.definition(bg_runtime~, workspace_root~),
+    @shell_output.definition(bg_runtime),
+    @shell_stop.definition(bg_runtime),
     @read.definition(workspace_root~),
     @edit.definition(workspace_root~),
     @multi_edit.definition(workspace_root~),
@@ -37,9 +39,11 @@ async test "agent registers the expected tool names" {
   @async.with_task_group() <| group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
     let function_tools = tools.function_tools()
-    assert_eq(function_tools.length(), 7)
+    assert_eq(function_tools.length(), 9)
     let names = [ for t in function_tools => t.name ]
     assert_true(names.contains("shell"))
+    assert_true(names.contains("shell_output"))
+    assert_true(names.contains("shell_stop"))
     assert_true(names.contains("read"))
     assert_true(names.contains("edit"))
     assert_true(names.contains("multi_edit"))

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -16,13 +16,13 @@ pub fn[X] build_tools(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[X],
 ) -> @agent_tool.Tools raise {
-  // The task scope is plumbed through for stateful tools; none currently need
-  // it (moon_check — the watcher tool — was removed in favor of plain
-  // `moon check` through shell).
-  ignore(scope)
+  // One background-job runtime per session, owned by `scope.group()`, shared by
+  // the shell tools so a job started via `run_in_background` is later visible to
+  // the poll/stop tools.
+  let bg_runtime = @bgjobs.BgJobRuntime::new(scope)
   let workspace_root = runtime.workspace_root()
   Tools([
-    @shell.definition(workspace_root~),
+    @shell.definition(bg_runtime~, workspace_root~),
     @read.definition(workspace_root~),
     @edit.definition(workspace_root~),
     @multi_edit.definition(workspace_root~),

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -1,0 +1,472 @@
+///|
+/// Default retained-output budget for a background job, in characters. Matches
+/// the `shell` tool's foreground default so a command reads the same whether it
+/// runs in the foreground or the background.
+let default_max_output_chars : Int = 12000
+
+///|
+/// After the direct child exits, how long to let the reader keep draining the
+/// pipe before force-closing it. In the normal case the reader hits EOF almost
+/// immediately (the child closed its write end), capturing all buffered output;
+/// this grace only elapses when a descendant inherited and is holding the pipe
+/// open, in which case there is no more of the job's own output to wait for.
+let reader_drain_grace_ms : Int = 200
+
+///|
+/// Terminal or live state of a background job.
+///
+/// - `Running`: the child is still executing.
+/// - `Exited(code)`: the child exited on its own with `code`.
+/// - `Stopped`: the child was cancelled (`stop`, a reader error, or session
+///   teardown) before a natural exit — no exit code is available.
+pub(all) enum BgJobStatus {
+  Running
+  Exited(Int)
+  Stopped
+} derive(Eq)
+
+///|
+/// Session-scoped registry of background ("detached") jobs. Mirrors the
+/// `moon_check` runtime: every child is spawned on `scope.group()`, so each
+/// job's process is cancelled when the agent session's task group ends.
+///
+/// Cancellation reaches only the directly spawned process, exactly like the
+/// foreground `shell` tool and `moon_check` (all use `@process.hard_cancel`):
+/// the process library exposes no process-group / job-object kill, so a command
+/// that daemonizes or backgrounds its own children can leave those descendants
+/// running after the job is reported terminal. `stop`/teardown therefore
+/// guarantee the launched process is gone, not its entire process tree.
+///
+/// One `BgJobRuntime` is created per session and shared by the `shell`
+/// (`run_in_background`), `shell_output`, and `shell_stop` tools, so a job
+/// started by one is visible to the others.
+///
+/// `new` captures the session group at construction, so `BgJobRuntime` itself is
+/// not parameterised by the group's return type — it can be an optional tool
+/// argument (e.g. on `shell`) without leaking an unresolved type variable to
+/// callers that never start background jobs.
+pub struct BgJobRuntime {
+  // Spawn a child process on the captured session group, with stdout+stderr
+  // merged into `writer`. Captured so the runtime type is not generic.
+  priv spawn_process : async (
+    String,
+    Array[String],
+    String?,
+    &@process.ProcessOutput,
+  ) -> @process.Process
+  // Spawn the per-job monitor task on that same group.
+  priv spawn_monitor : (async () -> Unit) -> Unit
+  priv jobs : Map[String, BgJob]
+  priv mut next_index : Int
+}
+
+///|
+/// One background job. `output` keeps the trailing `max_output_chars` characters
+/// of merged stdout+stderr; `seq` bumps on every appended chunk so a poller can
+/// tell whether new output has arrived. Fully private — callers only ever see a
+/// `BgJobSnapshot` via `snapshot`/`list`.
+priv struct BgJob {
+  id : String
+  command : String
+  cwd : String?
+  process : @process.Process
+  max_output_chars : Int
+  mut status : BgJobStatus
+  mut output : String
+  mut output_truncated : Bool
+  // Trailing bytes of an incomplete UTF-8 sequence split across read chunks,
+  // decoded once the rest arrives (or lossily at EOF) so a multi-byte character
+  // on a chunk boundary is not corrupted into replacement characters.
+  mut pending_bytes : Bytes
+  mut seq : Int
+  mut exit_code : Int?
+  // Set by `stop` before it cancels the child, so the monitor reports `Stopped`
+  // rather than the kill signal's exit code once `wait` returns.
+  mut cancel_requested : Bool
+}
+
+///|
+/// An immutable view of a job's current state, returned by `snapshot`/`list` so
+/// callers never hold a live reference into the registry.
+pub struct BgJobSnapshot {
+  id : String
+  command : String
+  cwd : String?
+  status : BgJobStatus
+  output : String
+  output_truncated : Bool
+  seq : Int
+  exit_code : Int?
+}
+
+///|
+/// Create an empty runtime whose jobs are owned by `scope.group()`. The group is
+/// captured into spawn closures, so the returned runtime is not generic.
+pub fn[X] BgJobRuntime::new(
+  scope : @agent_runtime.AgentTaskScope[X],
+) -> BgJobRuntime {
+  let group = scope.group()
+  {
+    spawn_process: (program, args, cwd, writer) => {
+      @process.spawn(
+        group,
+        program,
+        args,
+        stdout=writer,
+        stderr=writer,
+        cwd?=cwd.map(cwd => cwd.view()),
+        cancel_handler=@process.hard_cancel(),
+        no_wait=true,
+      )
+    },
+    spawn_monitor: task => {
+      group.spawn_bg(task, no_wait=true, allow_failure=true)
+    },
+    jobs: {},
+    next_index: 1,
+  }
+}
+
+///|
+fn BgJobRuntime::next_id(self : BgJobRuntime) -> String {
+  let id = "bg-\{self.next_index}"
+  self.next_index += 1
+  id
+}
+
+///|
+/// Spawn `program args` as a background job on the session group and return its
+/// id. Merged stdout+stderr streams into the job's retained-output buffer; the
+/// job keeps running after this returns. `command` is the human-readable command
+/// line shown to the model (e.g. the original shell `cmd`).
+pub async fn BgJobRuntime::start(
+  self : BgJobRuntime,
+  program~ : String,
+  args~ : Array[String],
+  command~ : String,
+  cwd? : String,
+  max_output_chars? : Int = default_max_output_chars,
+) -> String {
+  let id = self.next_id()
+  // A non-positive budget would slip past retain_tail's cap and retain output
+  // unbounded; keep at least one character.
+  let max_output_chars = if max_output_chars > 0 { max_output_chars } else { 1 }
+  let (reader, writer) = @process.read_from_process()
+  let process = (self.spawn_process)(program, args, cwd, writer)
+  self.jobs[id] = {
+    id,
+    command,
+    cwd,
+    process,
+    max_output_chars,
+    status: Running,
+    output: "",
+    output_truncated: false,
+    pending_bytes: b"",
+    seq: 0,
+    exit_code: None,
+    cancel_requested: false,
+  }
+  (self.spawn_monitor)(() => self.monitor(id, reader, process))
+  id
+}
+
+///|
+/// Supervise one job: drain its merged output while, *independently*, awaiting
+/// the direct child's exit. Coupling the two (read until EOF, then `wait`) would
+/// hang forever when the child exits but a descendant inherits and holds the
+/// pipe open — so a concurrent reader task drains bytes, and `process.wait()` is
+/// the authoritative exit signal that then closes the reader to unblock it.
+async fn BgJobRuntime::monitor(
+  self : BgJobRuntime,
+  id : String,
+  reader : @process.ReadFromProcess,
+  process : @process.Process,
+) -> Unit {
+  let reader_done : @async.Queue[Unit] = Queue(kind=Unbounded)
+  @async.with_task_group(reads => {
+    // Drain output concurrently; signal `reader_done` on EOF, a read error, or
+    // `reader.close()`.
+    reads.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+      defer ignore(reader_done.try_put(()) catch { _ => false })
+      for ;; {
+        match (reader.read_some(max_len=1024) catch { _ => None }) {
+          None => break
+          Some(bytes) => self.append_chunk(id, bytes)
+        }
+      }
+    }
+    // The direct child's exit is authoritative, independent of the pipe. A
+    // concurrent `stop` cancels the process, so `wait` may raise or return a
+    // kill signal's code — every path lands on a terminal status.
+    let terminal = try {
+      let code = process.wait()
+      if self.job_cancel_requested(id) {
+        Stopped
+      } else {
+        Exited(code)
+      }
+    } catch {
+      error => {
+        // Session teardown cancelled this task; unblock the reader and propagate
+        // so structured concurrency still unwinds.
+        if @async.is_being_cancelled() {
+          reader.close()
+          raise error
+        }
+        Stopped
+      }
+    }
+    // The child is gone, but the pipe may still hold output it wrote before
+    // exiting. Let the reader drain to EOF so nothing is lost; only if it is
+    // still blocked after a short grace — a descendant is holding the pipe open —
+    // force it closed. Publish the terminal status only after the drain, so a
+    // poller never sees `Exited` with truncated output.
+    match
+      @async.with_timeout_opt(reader_drain_grace_ms, () => reader_done.get()) {
+      Some(_) => ()
+      None =>
+        // A descendant is holding the pipe open, so EOF never comes. The reader
+        // is blocked on an empty pipe (not appending), so `pending_bytes` is
+        // already final; close the fd and let the stalled reader task be reaped
+        // when this group returns — don't wait for it (that would deadlock).
+        reader.close()
+    }
+    // The reader has drained all it will (or is idle on a held-open pipe), so
+    // surface any leftover half-decoded bytes and publish the terminal status
+    // together — a poller can never observe a terminal snapshot missing the
+    // job's final output.
+    self.flush_pending(id)
+    self.finish(id, terminal)
+  })
+}
+
+///|
+fn BgJobRuntime::job_cancel_requested(self : BgJobRuntime, id : String) -> Bool {
+  self.jobs.get(id).map(job => job.cancel_requested).unwrap_or(false)
+}
+
+///|
+/// Append a raw output chunk. Prepends any bytes left undecoded from the
+/// previous chunk, appends the longest valid-UTF-8 prefix, and carries the
+/// trailing ≤3 bytes of a split multi-byte character over to the next chunk.
+fn BgJobRuntime::append_chunk(
+  self : BgJobRuntime,
+  id : String,
+  chunk : Bytes,
+) -> Unit {
+  guard self.jobs.get(id) is Some(job) else { return }
+  let buffer = Buffer()
+  buffer.write_bytes(job.pending_bytes)
+  buffer.write_bytes(chunk)
+  let (text, rest) = split_valid_utf8(buffer.to_bytes())
+  job.pending_bytes = rest
+  self.append_text(id, text)
+}
+
+///|
+/// At end-of-stream, decode any leftover trailing bytes lossily so a truncated
+/// final character surfaces (as a replacement char) rather than vanishing.
+fn BgJobRuntime::flush_pending(self : BgJobRuntime, id : String) -> Unit {
+  guard self.jobs.get(id) is Some(job) else { return }
+  if job.pending_bytes.length() > 0 {
+    let text = @utf8.decode_lossy(job.pending_bytes)
+    job.pending_bytes = b""
+    self.append_text(id, text)
+  }
+}
+
+///|
+/// Append decoded text, keeping only the trailing `max_output_chars` characters
+/// and latching `output_truncated` once anything is dropped. Bumps `seq` when
+/// there is something to add.
+fn BgJobRuntime::append_text(
+  self : BgJobRuntime,
+  id : String,
+  text : String,
+) -> Unit {
+  guard text != "" else { return }
+  guard self.jobs.get(id) is Some(job) else { return }
+  let combined = job.output + text
+  job.output = retain_tail(combined, job.max_output_chars)
+  job.output_truncated = job.output_truncated ||
+    combined.char_length() > job.max_output_chars
+  job.seq += 1
+}
+
+///|
+/// Split `bytes` into the text to surface now and the trailing bytes to carry
+/// to the next chunk. Only a suffix that can still *complete* a multi-byte UTF-8
+/// sequence is carried; everything else — including invalid bytes such as
+/// `0xff` — is decoded lossily now, so a running job's binary or corrupt output
+/// is never hidden until more bytes happen to arrive.
+fn split_valid_utf8(bytes : Bytes) -> (String, Bytes) {
+  let end = bytes.length() - incomplete_suffix_len(bytes)
+  let tail = Buffer()
+  tail.write_bytes(bytes[end:])
+  (@utf8.decode_lossy(bytes[:end]), tail.to_bytes())
+}
+
+///|
+/// The number of trailing bytes (0–3) that begin an incomplete but still
+/// completable multi-byte UTF-8 sequence. Returns 0 when the tail is already
+/// complete, is a stray continuation byte, or is an invalid lead (e.g. `0xff`),
+/// so those bytes are surfaced immediately rather than held for output that may
+/// never come.
+fn incomplete_suffix_len(bytes : Bytes) -> Int {
+  let len = bytes.length()
+  let lookback = if len < 3 { len } else { 3 }
+  for i in 0..<lookback {
+    let pos = len - 1 - i
+    let b = bytes[pos].to_int()
+    if b < 0x80 {
+      // A complete ASCII byte; anything after it is a stray continuation.
+      return 0
+    }
+    if b >= 0xC0 {
+      // A lead byte: carry it only while its sequence is still incomplete AND
+      // the continuation bytes already seen are legal for it — otherwise the
+      // sequence is malformed (overlong / out of range) and must be surfaced
+      // now rather than held for a completion that can never be valid.
+      let expected = utf8_sequence_len(b)
+      let have = len - pos
+      guard expected != 0 && expected > have else { return 0 }
+      for j in 1..<have {
+        let (lo, hi) = continuation_range(b, j)
+        let cb = bytes[pos + j].to_int()
+        if cb < lo || cb > hi {
+          return 0
+        }
+      }
+      return have
+    }
+    // 0x80..=0xBF: a continuation byte — keep scanning back for its lead.
+  }
+  0
+}
+
+///|
+/// The total byte length of a UTF-8 sequence starting with lead byte `b`, or 0
+/// when `b` is not a valid multi-byte lead (ASCII, a continuation byte, an
+/// overlong `0xC0`/`0xC1`, or an out-of-range `0xF5`..`0xFF`).
+fn utf8_sequence_len(b : Int) -> Int {
+  if b >= 0xF0 && b <= 0xF4 {
+    4
+  } else if b >= 0xE0 && b <= 0xEF {
+    3
+  } else if b >= 0xC2 && b <= 0xDF {
+    2
+  } else {
+    0
+  }
+}
+
+///|
+/// The legal byte range for the `j`-th continuation byte (1-based, after the
+/// lead) of a UTF-8 sequence led by `lead`. The first continuation is
+/// restricted for the leads that would otherwise admit overlong encodings
+/// (`0xE0`, `0xF0`), surrogates (`0xED`), or out-of-range code points (`0xF4`);
+/// every other position is the full `0x80..=0xBF`.
+fn continuation_range(lead : Int, j : Int) -> (Int, Int) {
+  if j == 1 {
+    if lead == 0xE0 {
+      (0xA0, 0xBF)
+    } else if lead == 0xED {
+      (0x80, 0x9F)
+    } else if lead == 0xF0 {
+      (0x90, 0xBF)
+    } else if lead == 0xF4 {
+      (0x80, 0x8F)
+    } else {
+      (0x80, 0xBF)
+    }
+  } else {
+    (0x80, 0xBF)
+  }
+}
+
+///|
+/// Set a job's terminal status once. Later calls (e.g. a `stop` racing a natural
+/// exit) are ignored so the first terminal state wins.
+fn BgJobRuntime::finish(
+  self : BgJobRuntime,
+  id : String,
+  status : BgJobStatus,
+) -> Unit {
+  guard self.jobs.get(id) is Some(job) else { return }
+  guard job.status is Running else { return }
+  job.status = status
+  job.exit_code = match status {
+    Exited(code) => Some(code)
+    _ => None
+  }
+}
+
+///|
+/// The current state of job `id`, or `None` if there is no such job.
+pub fn BgJobRuntime::snapshot(
+  self : BgJobRuntime,
+  id : String,
+) -> BgJobSnapshot? {
+  self.jobs.get(id).map(job => job.to_snapshot())
+}
+
+///|
+/// All jobs' current states, in id order.
+pub fn BgJobRuntime::list(self : BgJobRuntime) -> Array[BgJobSnapshot] {
+  let out = []
+  for _, job in self.jobs {
+    out.push(job.to_snapshot())
+  }
+  out
+}
+
+///|
+/// Cancel a running job and wait for its child to be reaped. Returns `false`
+/// only when there is no such job; an already-terminal job returns `true`
+/// without doing anything.
+pub async fn BgJobRuntime::stop(self : BgJobRuntime, id : String) -> Bool {
+  guard self.jobs.get(id) is Some(job) else { return false }
+  guard job.status is Running else { return true }
+  job.cancel_requested = true
+  job.process.cancel()
+  // `cancel` is asynchronous and the monitor reaps the child via `wait`. Observe
+  // the status transition rather than a one-shot signal, so any number of
+  // concurrent `stop` callers all return once the job lands terminal — none can
+  // hang waiting on a signal another caller already consumed.
+  for ;; {
+    if self.jobs.get(id) is Some(job) && !(job.status is Running) {
+      return true
+    }
+    @async.sleep(5)
+  }
+}
+
+///|
+fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
+  {
+    id: self.id,
+    command: self.command,
+    cwd: self.cwd,
+    status: self.status,
+    output: self.output,
+    output_truncated: self.output_truncated,
+    seq: self.seq,
+    exit_code: self.exit_code,
+  }
+}
+
+///|
+/// Keep only the trailing `max_chars` characters of `text`.
+fn retain_tail(text : String, max_chars : Int) -> String {
+  guard max_chars > 0 else { return "" }
+  let len = text.char_length()
+  if len <= max_chars {
+    text
+  } else {
+    match text.offset_of_nth_char(len - max_chars) {
+      Some(start) => "\{text[start:]}"
+      None => text
+    }
+  }
+}

--- a/agent_tool/bgjobs/bgjobs_wbtest.mbt
+++ b/agent_tool/bgjobs/bgjobs_wbtest.mbt
@@ -1,0 +1,289 @@
+///|
+/// Poll `id` until it leaves `Running`, failing after a bounded deadline so a
+/// hung child can never hang the test. Async tests run in parallel, so each test
+/// isolates its own runtime and jobs.
+#cfg(not(platform="windows"))
+async fn poll_until_terminal(
+  rt : BgJobRuntime,
+  id : String,
+  ticks? : Int = 200,
+) -> BgJobSnapshot {
+  for _ in 0..<ticks {
+    if rt.snapshot(id) is Some(snap) && !(snap.status is Running) {
+      return snap
+    }
+    @async.sleep(25)
+  }
+  fail("bg job \{id} did not reach a terminal state in time")
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "bg job runs to completion and captures output" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf hello"],
+      command="printf hello",
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(0))
+    assert_true(snap.output.contains("hello"))
+    assert_true(snap.exit_code is Some(0))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "bg job records a non-zero exit code" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(program="sh", args=["-c", "exit 3"], command="exit 3")
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(3))
+    assert_true(snap.exit_code is Some(3))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "stop terminates a running job" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    // Spawn the sleeper directly (no shell) so `stop` cancels the sleeper itself
+    // rather than a shell wrapper, and leaves no orphan behind.
+    let id = rt.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    assert_true(rt.snapshot(id).unwrap().status is Running)
+    assert_true(rt.stop(id))
+    assert_true(rt.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "job with a descendant holding the pipe still reaches a terminal state" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    // The parent exits immediately but backgrounds a short-lived child that
+    // inherits — and holds open — stdout/stderr, so pipe EOF never comes; exit
+    // must be detected via wait(), not by reading to EOF. `sleep 1` bounds the
+    // intentional descendant so the test leaves nothing behind for long.
+    let id = rt.start(
+      program="sh",
+      args=["-c", "sleep 1 & exit 0"],
+      command="detached child",
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(0))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "concurrent stop calls all complete without hanging" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    // Two stops race on the same job. The inner group awaits both, so a caller
+    // that blocked forever would deadlock the test rather than reach the asserts.
+    let done = [false, false]
+    @async.with_task_group(g => {
+      g.spawn_bg(() => done[0] = rt.stop(id))
+      g.spawn_bg(() => done[1] = rt.stop(id))
+    })
+    assert_true(done[0])
+    assert_true(done[1])
+    assert_true(rt.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "stop terminates a job that closed its streams but is still running" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    // Redirect the shell's own stdout/stderr away, then `exec` the sleeper so the
+    // tracked PID becomes the still-running process: the monitor reaches EOF and
+    // must fall back to wait() while the child keeps running — the stop/wait race
+    // — and `stop` cancels the sleeper directly, leaving no orphan.
+    let id = rt.start(
+      program="sh",
+      args=["-c", "exec >/dev/null 2>&1; exec sleep 30"],
+      command="closed streams",
+    )
+    @async.sleep(100)
+    assert_true(rt.snapshot(id).unwrap().status is Running)
+    assert_true(rt.stop(id))
+    assert_true(rt.snapshot(id).unwrap().status is Stopped)
+    // A second stop must be idempotent and must not block on the terminal job.
+    assert_true(rt.stop(id))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "captures full output of a fast command that exits during a burst" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    // A burst that fits under the budget but may still be buffered in the pipe
+    // when the process exits: none of it may be lost when the job reports Exited.
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf '%30000s' '' | tr ' ' a"],
+      command="burst",
+      max_output_chars=50000,
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(0))
+    assert_false(snap.output_truncated)
+    assert_true(snap.output.char_length() == 30000)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a non-positive output budget is clamped, not left unbounded" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf hello"],
+      command="printf hello",
+      max_output_chars=0,
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.output_truncated)
+    assert_true(snap.output.char_length() <= 1)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "the final incomplete utf-8 byte is surfaced at terminal status" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    // A lone 0xC3 (a 2-byte lead with no continuation) is the whole output, so
+    // it stays in pending_bytes until the end-of-stream flush; the terminal
+    // snapshot must already include its lossy replacement character.
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf '\\303'"],
+      command="incomplete",
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(0))
+    assert_true(snap.output.char_length() >= 1)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "output is capped to the trailing max_output_chars" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(
+      program="sh",
+      args=["-c", "seq 1 100000"],
+      command="seq",
+      max_output_chars=100,
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.output_truncated)
+    assert_true(snap.output.char_length() <= 100)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "two jobs run independently with distinct ids" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let a = rt.start(program="sh", args=["-c", "printf aaa"], command="a")
+    let b = rt.start(program="sh", args=["-c", "printf bbb"], command="b")
+    assert_true(a != b)
+    let sa = poll_until_terminal(rt, a)
+    let sb = poll_until_terminal(rt, b)
+    assert_true(sa.output.contains("aaa"))
+    assert_true(sb.output.contains("bbb"))
+    assert_true(rt.list().length() == 2)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "bg job preserves non-ascii output" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf 'héllo wörld'"],
+      command="printf",
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.output.contains("héllo wörld"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "snapshot and stop handle unknown ids" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    assert_true(rt.snapshot("nope") is None)
+    assert_false(rt.stop("nope"))
+  })
+}
+
+///|
+test "split_valid_utf8 carries an incomplete trailing character across chunks" {
+  // "café" = 63 61 66 C3 A9 (é is a 2-byte sequence).
+  let full : Bytes = [0x63, 0x61, 0x66, 0xC3, 0xA9]
+  let (text, rest) = split_valid_utf8(full)
+  assert_true(text == "café")
+  assert_true(rest.length() == 0)
+  // A chunk that ends on é's lead byte: decode "caf" now, hold the lead byte.
+  let truncated : Bytes = [0x63, 0x61, 0x66, 0xC3]
+  let (head, tail) = split_valid_utf8(truncated)
+  assert_true(head == "caf")
+  assert_true(tail.length() == 1)
+  // The next chunk's continuation byte completes é rather than corrupting it.
+  let joined = Buffer()
+  joined.write_bytes(tail)
+  joined.write_bytes(([0xA9] : Bytes))
+  let (completed, remainder) = split_valid_utf8(joined.to_bytes())
+  assert_true(completed == "é")
+  assert_true(remainder.length() == 0)
+}
+
+///|
+test "split_valid_utf8 surfaces corrupt trailing bytes instead of hiding them" {
+  // 0xff is neither a valid lead nor a continuation byte: it must be decoded
+  // (lossily) right away, not held in pending bytes waiting for a completion
+  // that can never come — otherwise a running job's output would vanish.
+  let bytes : Bytes = [0x68, 0x69, 0xff]
+  let (text, rest) = split_valid_utf8(bytes)
+  assert_true(rest.length() == 0)
+  assert_true(text.has_prefix("hi"))
+  assert_true(text.char_length() >= 3)
+}
+
+///|
+test "split_valid_utf8 does not carry malformed multi-byte prefixes" {
+  // 0xE0 0x80 looks like the start of a 3-byte char, but 0x80 is below the
+  // legal 0xA0 for 0xE0 (an overlong encoding) — surface it now, don't hold it.
+  let (t1, r1) = split_valid_utf8(([0x78, 0xE0, 0x80] : Bytes))
+  assert_true(r1.length() == 0)
+  assert_true(t1.has_prefix("x"))
+  // 0xF4 0x90 is out of range (0xF4 continuations must be 0x80..0x8F).
+  let (t2, r2) = split_valid_utf8(([0x78, 0xF4, 0x90] : Bytes))
+  assert_true(r2.length() == 0)
+  assert_true(t2.has_prefix("x"))
+  // A genuinely valid incomplete prefix (0xE0 0xA0, missing its last byte) is
+  // still carried, so real multi-byte output is not corrupted.
+  let (t3, r3) = split_valid_utf8(([0x78, 0xE0, 0xA0] : Bytes))
+  assert_true(t3 == "x")
+  assert_true(r3.length() == 2)
+}

--- a/agent_tool/bgjobs/moon.pkg
+++ b/agent_tool/bgjobs/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+  "moonbitlang/async/process",
+  "moonbitlang/core/encoding/utf8",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -1,0 +1,42 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/bgjobs"
+
+import {
+  "bobzhang/openseek/agent_runtime",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct BgJobRuntime {
+  // private fields
+}
+pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
+pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X]) -> Self
+pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
+pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int) -> String
+pub async fn BgJobRuntime::stop(Self, String) -> Bool
+
+pub struct BgJobSnapshot {
+  id : String
+  command : String
+  cwd : String?
+  status : BgJobStatus
+  output : String
+  output_truncated : Bool
+  seq : Int
+  exit_code : Int?
+}
+
+pub(all) enum BgJobStatus {
+  Running
+  Exited(Int)
+  Stopped
+} derive(Eq)
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -17,6 +17,10 @@ pub struct ShellInput {
   cwd : String?
   timeout_ms : Int?
   max_output_chars : Int
+  // Detach the command as a background job instead of blocking for its result;
+  // the tool returns a job id to poll with `shell_output` / stop with
+  // `shell_stop`. Ignored (false) unless the tool was wired with a job runtime.
+  run_in_background : Bool
 } derive(Debug)
 
 ///|
@@ -42,11 +46,22 @@ fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
   let max_output_chars = optional_positive_int_or_default(
     fields, "max_output_chars", default_max_output_chars,
   )
+  let run_in_background = optional_bool(fields, "run_in_background")
   {
     cmd,
     cwd,
     timeout_ms,
     max_output_chars: cap_max_output_chars(max_output_chars),
+    run_in_background,
+  }
+}
+
+///|
+fn optional_bool(fields : Map[String, Json], name : String) -> Bool raise {
+  match fields.get(name) {
+    Some(True) => true
+    Some(False) | Some(Null) | None => false
+    _ => fail("arguments.\{name} to be a boolean")
   }
 }
 

--- a/agent_tool/shell/internal/decode/decode_test.mbt
+++ b/agent_tool/shell/internal/decode/decode_test.mbt
@@ -13,6 +13,7 @@ test "decode valid shell input" {
       #|  cwd: Some("/tmp"),
       #|  timeout_ms: Some(250),
       #|  max_output_chars: 50000,
+      #|  run_in_background: false,
       #|}
     ),
   )
@@ -23,9 +24,37 @@ test "decode treats empty cwd as absent" {
   debug_inspect(
     @decode.decode({ "cmd": "pwd", "cwd": "" }),
     content=(
-      #|{ cmd: "pwd", cwd: None, timeout_ms: None, max_output_chars: 12000 }
+      #|{
+      #|  cmd: "pwd",
+      #|  cwd: None,
+      #|  timeout_ms: None,
+      #|  max_output_chars: 12000,
+      #|  run_in_background: false,
+      #|}
     ),
   )
+}
+
+///|
+test "decode reads run_in_background" {
+  assert_true(
+    @decode.decode({ "cmd": "sleep 5", "run_in_background": true }).run_in_background,
+  )
+  assert_false(@decode.decode({ "cmd": "sleep 5" }).run_in_background)
+}
+
+///|
+test "decode rejects a non-boolean run_in_background" {
+  try
+    @decode.decode({ "cmd": "echo hello", "run_in_background": "yes" })
+  catch {
+    error =>
+      assert_true(
+        "\{error}".contains("arguments.run_in_background to be a boolean"),
+      )
+  } noraise {
+    _ => fail("non-boolean run_in_background decoded")
+  }
 }
 
 ///|

--- a/agent_tool/shell/internal/decode/pkg.generated.mbti
+++ b/agent_tool/shell/internal/decode/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub struct ShellInput {
   cwd : String?
   timeout_ms : Int?
   max_output_chars : Int
+  run_in_background : Bool
 } derive(@debug.Debug)
 
 // Type aliases

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/shell/internal/command_policy",
   "bobzhang/openseek/agent_tool/shell/internal/decode",
@@ -15,6 +16,7 @@ import {
 }
 
 import {
+  "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/testkit/filesystem" @vfs,
 } for "test"
 

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -3,12 +3,13 @@ package "bobzhang/openseek/agent_tool/shell"
 
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
 }
 
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
 
-pub fn definition(workspace_root? : String, read_only? : Bool) -> @agent_tool.AgentToolDefinition
+pub fn definition(bg_runtime? : @bgjobs.BgJobRuntime, workspace_root? : String, read_only? : Bool) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -29,6 +29,7 @@
 /// - `Respond(ToolOutput("error: shell requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition(
+  bg_runtime? : @bgjobs.BgJobRuntime,
   workspace_root? : String = ".",
   read_only? : Bool = false,
 ) -> @agent_tool.AgentToolDefinition {
@@ -42,11 +43,12 @@ pub fn definition(
         "cwd": { "type": "string" },
         "timeout_ms": { "type": "number" },
         "max_output_chars": { "type": "number" },
+        "run_in_background": { "type": "boolean" },
       },
       "required": ["cmd"],
     }),
     execute=Async(arguments => {
-      execute_with_workspace(workspace_root, arguments, read_only~)
+      execute_with_workspace(workspace_root, arguments, read_only~, bg_runtime?)
     }),
   )
 }
@@ -68,6 +70,7 @@ async fn execute_with_workspace(
   workspace_root : String,
   arguments : Json,
   read_only~ : Bool,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -101,7 +104,7 @@ async fn execute_with_workspace(
     None => ()
   }
   let cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
-  shell(input, parsed_command, cwd, workspace_root) catch {
+  shell(input, parsed_command, cwd, workspace_root, bg_runtime?) catch {
     error =>
       @agent_tool.ToolAction::respond(
         "error running shell: \{error}",
@@ -116,6 +119,7 @@ async fn shell(
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
   workspace_root : String,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   if cwd is Some(cwd) {
     let exists = @fs.exists(cwd)
@@ -142,6 +146,18 @@ async fn shell(
         brief=shell_brief(input.cmd, None),
       )
     None => ()
+  }
+  // Background: detach the command as a job and return its id instead of blocking
+  // for output. Runs the same source-tree guards and sandboxed launch as a
+  // foreground command, so `run_in_background` cannot bypass any guardrail.
+  if input.run_in_background {
+    return start_background(
+      input,
+      parsed_command,
+      cwd,
+      workspace_root,
+      bg_runtime?,
+    )
   }
   let result = match input.timeout_ms {
     Some(timeout_ms) =>
@@ -200,6 +216,74 @@ async fn shell(
     content,
     is_error=response.is_error || sandbox_denied,
     brief=shell_brief(input.cmd, output.exit_code),
+  )
+}
+
+///|
+/// Detach `input.cmd` as a background job through the platform shell and report
+/// its id, or a tool error when the tool was built without a job runtime (so the
+/// model learns background execution is unavailable rather than silently
+/// blocking).
+async fn start_background(
+  input : @decode.ShellInput,
+  parsed_command : @shell_parse.ParseResult,
+  cwd : String?,
+  workspace_root : String,
+  bg_runtime? : @bgjobs.BgJobRuntime,
+) -> @agent_tool.ToolAction {
+  guard bg_runtime is Some(runtime) else {
+    return @agent_tool.ToolAction::respond(
+      "error: run_in_background is not available in this context",
+      is_error=true,
+      brief=shell_brief(input.cmd, None),
+    )
+  }
+  // Same static source-tree write blockers as the foreground path, so a
+  // backgrounded `rm`/`mv`/dynamic write of protected files is preblocked.
+  match
+    direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
+    Some(target) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_tree_operation_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
+    None => ()
+  }
+  match
+    dynamic_source_tree_operation_target(
+      parsed_command,
+      input.cmd,
+      workspace_root,
+      cwd,
+    ) {
+    Some(target) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_tree_operation_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
+    None => ()
+  }
+  // Launch through the same sandbox as a foreground command: sandbox-exec with a
+  // source-write-blocking profile (or the plain shell when trusted/unavailable).
+  // Runtime write denials then surface in the job's output when it is polled.
+  let launch = agent_shell_launch(
+    workspace_root,
+    input.cmd,
+    parsed_command,
+    cwd?,
+  )
+  let id = runtime.start(
+    program=launch.program,
+    args=launch.args,
+    command=input.cmd,
+    cwd?,
+    max_output_chars=input.max_output_chars,
+  )
+  @agent_tool.ToolAction::respond(
+    "started background job \{id}: `\{input.cmd}`. Read its output or stop it with the background-job tools.",
+    brief="\{@agent_tool.brief_line(input.cmd, limit=56)} → \{id}",
   )
 }
 

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -238,6 +238,16 @@ async fn start_background(
       brief=shell_brief(input.cmd, None),
     )
   }
+  // timeout_ms guards a blocking wait; a background job never blocks, so the two
+  // are contradictory. Reject rather than silently ignore the bound — a caller
+  // that wants a self-limit can wrap the command (e.g. `timeout <secs> <cmd>`).
+  if input.timeout_ms is Some(_) {
+    return @agent_tool.ToolAction::respond(
+      "error: timeout_ms is not supported with run_in_background — a background job does not block, so it runs until shell_stop. Wrap the command (e.g. `timeout <secs> <cmd>`) for a self-limit.",
+      is_error=true,
+      brief=shell_brief(input.cmd, None),
+    )
+  }
   // Same static source-tree write blockers as the foreground path, so a
   // backgrounded `rm`/`mv`/dynamic write of protected files is preblocked.
   match

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -282,7 +282,7 @@ async fn start_background(
     max_output_chars=input.max_output_chars,
   )
   @agent_tool.ToolAction::respond(
-    "started background job \{id}: `\{input.cmd}`. Read its output or stop it with the background-job tools.",
+    "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
     brief="\{@agent_tool.brief_line(input.cmd, limit=56)} → \{id}",
   )
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -35,6 +35,26 @@ async test "shell run_in_background starts a job and returns its id" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "shell run_in_background rejects timeout_ms" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = match @shell.definition(bg_runtime=bg).execute {
+      Async(execute) =>
+        execute({
+          "cmd": "sleep 30",
+          "run_in_background": true,
+          "timeout_ms": 1000,
+        })
+      Sync(_) => fail("shell tool should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("timeout_ms is not supported"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "shell run_in_background without a runtime is a tool error" {
   let action = run_shell({ "cmd": "printf hi", "run_in_background": true })
   guard action is Respond(output) else { fail("expected a Respond action") }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -19,6 +19,31 @@ async fn run_shell_in_workspace(
 
 ///|
 #cfg(not(platform="windows"))
+async test "shell run_in_background starts a job and returns its id" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = match @shell.definition(bg_runtime=bg).execute {
+      Async(execute) =>
+        execute({ "cmd": "printf hi", "run_in_background": true })
+      Sync(_) => fail("shell tool should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("started background job"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell run_in_background without a runtime is a tool error" {
+  let action = run_shell({ "cmd": "printf hi", "run_in_background": true })
+  guard action is Respond(output) else { fail("expected a Respond action") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("not available"))
+}
+
+///|
+#cfg(not(platform="windows"))
 async fn sandbox_exec_usable_for_test() -> Bool {
   if !@fs.exists("/usr/bin/sandbox-exec") {
     return false

--- a/agent_tool/shell_output/moon.pkg
+++ b/agent_tool/shell_output/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/shell_output/pkg.generated.mbti
+++ b/agent_tool/shell_output/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell_output"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+}
+
+// Values
+pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -1,0 +1,93 @@
+///|
+/// Tool definition for `shell_output`: read the captured output and current
+/// status of a background job started by `shell` with `run_in_background`.
+///
+/// ## Arguments
+/// - `job_id` (string, required): the id `shell` returned when it started the
+///   job.
+///
+/// ## Result
+/// - `Respond(ToolOutput("<output>\n<system>job=<id> status=<status> ...</system>"))`
+///   with the retained output and a trailing status footer. `status` is
+///   `running`, `exited=<code>`, or `stopped`; the result is a tool error only
+///   when the job exited non-zero.
+/// - `Respond(ToolOutput("error: no background job ...", is_error=true))` for an
+///   unknown id, and `"error: shell_output requires ..."` for invalid arguments.
+pub fn definition(
+  bg_runtime : @bgjobs.BgJobRuntime,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="shell_output",
+    description="Read the captured output and status of a background job started by `shell` with run_in_background. Argument: job_id (the id shell returned). Call it again to see new output while the job is still running.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": { "job_id": { "type": "string" } },
+      "required": ["job_id"],
+    }),
+    execute=Sync(arguments => run(bg_runtime, arguments)),
+  )
+}
+
+///|
+fn run(
+  bg_runtime : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  let job_id = match job_id_argument(arguments) {
+    Ok(id) => id
+    Err(message) =>
+      return @agent_tool.ToolAction::respond(message, is_error=true)
+  }
+  match bg_runtime.snapshot(job_id) {
+    None =>
+      @agent_tool.ToolAction::respond(
+        "error: no background job with id \{job_id}",
+        is_error=true,
+      )
+    Some(snapshot) => render(snapshot)
+  }
+}
+
+///|
+/// Extract a non-empty `job_id` string, or an error message naming the problem.
+fn job_id_argument(arguments : Json) -> Result[String, String] {
+  match arguments {
+    Object(fields) =>
+      match fields.get("job_id") {
+        Some(String(id)) if id != "" => Ok(id)
+        _ => Err("error: shell_output requires a non-empty job_id string")
+      }
+    _ => Err("error: shell_output requires object arguments")
+  }
+}
+
+///|
+/// Render a snapshot as output plus a trailing `<system>...</system>` status
+/// footer (the `read`/`shell` tool convention). A non-zero exit is a tool error.
+fn render(snapshot : @bgjobs.BgJobSnapshot) -> @agent_tool.ToolAction {
+  let truncated = if snapshot.output_truncated { " truncated=true" } else { "" }
+  let footer = "<system>job=\{snapshot.id} status=\{status_text(snapshot.status)}\{truncated}</system>"
+  let content = if snapshot.output == "" {
+    footer
+  } else if snapshot.output.has_suffix("\n") {
+    "\{snapshot.output}\{footer}"
+  } else {
+    "\{snapshot.output}\n\{footer}"
+  }
+  let is_error = snapshot.status is Exited(code) && code != 0
+  @agent_tool.ToolAction::respond(
+    content,
+    is_error~,
+    brief="\{snapshot.id}: \{status_text(snapshot.status)}",
+  )
+}
+
+///|
+/// A background job's status as compact footer text.
+fn status_text(status : @bgjobs.BgJobStatus) -> String {
+  match status {
+    Running => "running"
+    Exited(code) => "exited=\{code}"
+    Stopped => "stopped"
+  }
+}

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -1,0 +1,74 @@
+///|
+async fn poll_terminal(rt : @bgjobs.BgJobRuntime, id : String) -> Unit {
+  for _ in 0..<200 {
+    if rt.snapshot(id) is Some(snap) && !(snap.status is Running) {
+      return
+    }
+    @async.sleep(25)
+  }
+  fail("job \{id} did not finish in time")
+}
+
+///|
+fn read_output(
+  rt : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolOutput raise {
+  let action = match @shell_output.definition(rt).execute {
+    Sync(execute) => execute(arguments)
+    Async(_) => fail("shell_output should be a sync tool")
+  }
+  guard action is Respond(output) else { fail("expected a Respond action") }
+  output
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output reports a finished job's output and status" {
+  @async.with_task_group(group => {
+    let rt = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf hi"],
+      command="printf hi",
+    )
+    poll_terminal(rt, id)
+    let output = read_output(rt, { "job_id": id })
+    assert_false(output.is_error)
+    assert_true(output.content.contains("hi"))
+    assert_true(output.content.contains("status=exited=0"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output flags a non-zero exit as an error" {
+  @async.with_task_group(group => {
+    let rt = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(program="sh", args=["-c", "exit 2"], command="exit 2")
+    poll_terminal(rt, id)
+    let output = read_output(rt, { "job_id": id })
+    assert_true(output.is_error)
+    assert_true(output.content.contains("status=exited=2"))
+  })
+}
+
+///|
+async test "shell_output errors on an unknown job id" {
+  @async.with_task_group(group => {
+    let rt = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let output = read_output(rt, { "job_id": "nope" })
+    assert_true(output.is_error)
+    assert_true(output.content.contains("no background job"))
+  })
+}
+
+///|
+async test "shell_output rejects a missing job id" {
+  @async.with_task_group(group => {
+    let rt = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let output = read_output(rt, {})
+    assert_true(output.is_error)
+    assert_true(output.content.contains("requires a non-empty job_id"))
+  })
+}

--- a/agent_tool/shell_stop/moon.pkg
+++ b/agent_tool/shell_stop/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/shell_stop/pkg.generated.mbti
+++ b/agent_tool/shell_stop/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell_stop"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+}
+
+// Values
+pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_stop/shell_stop.mbt
+++ b/agent_tool/shell_stop/shell_stop.mbt
@@ -1,0 +1,64 @@
+///|
+/// Tool definition for `shell_stop`: terminate a background job started by
+/// `shell` with `run_in_background`.
+///
+/// ## Arguments
+/// - `job_id` (string, required): the id `shell` returned when it started the
+///   job.
+///
+/// ## Result
+/// - `Respond(ToolOutput("stopped background job <id>"))` once the job's process
+///   is cancelled (or was already finished). Read any final output with
+///   `shell_output`.
+/// - `Respond(ToolOutput("error: no background job ...", is_error=true))` for an
+///   unknown id, and `"error: shell_stop requires ..."` for invalid arguments.
+pub fn definition(
+  bg_runtime : @bgjobs.BgJobRuntime,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="shell_stop",
+    description="Stop a background job started by `shell` with run_in_background, cancelling its process. Argument: job_id (the id shell returned). Read any final output with shell_output.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": { "job_id": { "type": "string" } },
+      "required": ["job_id"],
+    }),
+    execute=Async(arguments => run(bg_runtime, arguments)),
+  )
+}
+
+///|
+async fn run(
+  bg_runtime : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  let job_id = match job_id_argument(arguments) {
+    Ok(id) => id
+    Err(message) =>
+      return @agent_tool.ToolAction::respond(message, is_error=true)
+  }
+  if bg_runtime.stop(job_id) {
+    @agent_tool.ToolAction::respond(
+      "stopped background job \{job_id}",
+      brief="stop \{job_id}",
+    )
+  } else {
+    @agent_tool.ToolAction::respond(
+      "error: no background job with id \{job_id}",
+      is_error=true,
+    )
+  }
+}
+
+///|
+/// Extract a non-empty `job_id` string, or an error message naming the problem.
+fn job_id_argument(arguments : Json) -> Result[String, String] {
+  match arguments {
+    Object(fields) =>
+      match fields.get("job_id") {
+        Some(String(id)) if id != "" => Ok(id)
+        _ => Err("error: shell_stop requires a non-empty job_id string")
+      }
+    _ => Err("error: shell_stop requires object arguments")
+  }
+}

--- a/agent_tool/shell_stop/shell_stop_test.mbt
+++ b/agent_tool/shell_stop/shell_stop_test.mbt
@@ -1,0 +1,46 @@
+///|
+async fn stop_job(
+  rt : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolOutput {
+  let action = match @shell_stop.definition(rt).execute {
+    Async(execute) => execute(arguments)
+    Sync(_) => fail("shell_stop should be an async tool")
+  }
+  guard action is Respond(output) else { fail("expected a Respond action") }
+  output
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_stop stops a running job" {
+  @async.with_task_group(group => {
+    let rt = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    let output = stop_job(rt, { "job_id": id })
+    assert_false(output.is_error)
+    assert_true(output.content.contains("stopped background job"))
+    assert_true(rt.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+async test "shell_stop errors on an unknown job id" {
+  @async.with_task_group(group => {
+    let rt = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let output = stop_job(rt, { "job_id": "nope" })
+    assert_true(output.is_error)
+    assert_true(output.content.contains("no background job"))
+  })
+}
+
+///|
+async test "shell_stop rejects a missing job id" {
+  @async.with_task_group(group => {
+    let rt = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let output = stop_job(rt, {})
+    assert_true(output.is_error)
+    assert_true(output.content.contains("requires a non-empty job_id"))
+  })
+}

--- a/docs/plans/background-shell.md
+++ b/docs/plans/background-shell.md
@@ -1,0 +1,60 @@
+# Background shell commands (Claude Code parity)
+
+## Goal
+
+Foreground-by-default shell, but with Claude Code's escape hatches:
+- explicit `run_in_background` on `shell`,
+- **detach-on-timeout** instead of hard-kill,
+- `shell_output` / `shell_stop` to poll and terminate,
+- **push-completion** via the steer queue,
+- structured-concurrency "no orphans" guarantee lifted from call-scope to session-scope.
+
+## Grounding in the current code
+
+- `agent_tool/shell/shell.mbt` runs each command in a **per-call** `@async.with_task_group` and `hard_cancel`s on `timeout_ms` — the process cannot outlive the call, and the shell parser bans `&`.
+- `agent_tool/moon_check` is the template: a `MoonCheckRuntime[X]` holds `scope : AgentTaskScope[X]` + a registry `Map[.., MoonCheckRecord]`, spawns on `scope.group()` with a `spawn_bg` monitor task draining the pipe, and reaps on session-scope teardown. `Process::cancel()` stops one process.
+- Push channel: `AgentRuntime.queue_steer()` / `drain_steers()`; the loop drains at each step boundary and `apply_steer_inputs` folds each into the conversation (`agent/agent.mbt:293-322`).
+
+## Delivery — two PRs, small reviewable commits
+
+Every commit gate: `moon fmt` → `moon check --target native <pkgs>` → `moon test <pkgs>` → `codex review --base <prev-commit-sha>` (run in background, read the verdict tail, fix real findings, re-review clean) → drive the real tool where a surface exists.
+
+### PR A — explicit background (`run_in_background` + poll/stop)
+
+- **A1** — `agent_tool/bgjobs`: `BgJobRuntime[X]` (scope + registry + id counter), generic over `program`/`args`. `start`, `snapshot`, `list`, `stop`. Tail-capped output buffer, status `Running | Exited(code) | Stopped`. Pure infra, unwired.
+- **A2** — `run_in_background` param on `shell`; thread a shared `BgJobRuntime` into `shell.definition(...)` (mirror `moon_check(runtime, scope)`); `true` → `start` a job via the platform shell and return the job id; `false` unchanged. Register in the standard tool set.
+- **A3** — `agent_tool/shell_output` tool: poll a job's output + status by id.
+- **A4** — `agent_tool/shell_stop` tool + explicit session-teardown reap; confirm no orphans.
+
+### PR B — parity (auto-detach + push)
+
+- **B1** — push-completion: on job exit, `queue_steer(<notice>)`; extend `SteerInput` with a notice kind if needed; loop injects "background job `<id>` finished (exit N)".
+- **B2** — detach-on-timeout: on `timeout_ms`, hand the still-running process to the registry and return "moved to background as `<id>`" instead of `hard_cancel`. Spawn the auto-bg path on the **session** group; ship **opt-in** first, flip default later.
+- **B3** — prompt/description update (mention `run_in_background` + the two tools) + runaway-output size watchdog.
+
+## Test plan
+
+Principles (apply to every commit):
+- **Native target** — async process spawning needs `moon test --target native`.
+- **Deterministic polling** — never unbounded wait; poll `snapshot` with bounded ticks + `@async.sleep`, and `fail(...)` on a deadline (mirror `wait_for_initial_snapshot`). Use commands that terminate fast (`printf`, `exit N`), and a real sleeper only for stop/timeout tests.
+- **Isolation** — async tests run in parallel; each test uses its own temp/vfs cwd, no shared ports/files.
+- **Regression** — the full `agent_tool/shell` suite stays green at every commit; the foreground path is untouched until B2, and then only behind the opt-in flag.
+
+Per commit:
+
+- **A1 (bgjobs)** — white-box `_wbtest.mbt`:
+  - `sh -c 'printf hi'` → poll to `Exited(0)`, output contains `hi`.
+  - `sh -c 'exit 3'` → `Exited(3)`.
+  - `sh -c 'sleep 5'` → snapshot `Running`; `stop` → `Stopped`, terminates promptly (scope teardown does not hang).
+  - output cap: high-volume command with tiny `max_output_chars` → `output_truncated`, output ≤ cap.
+  - unknown id → `snapshot` None, `stop` false.
+  - two concurrent jobs → distinct ids, independent output.
+- **A2 (`run_in_background`)** — mirror `shell_test.mbt`'s `run_shell`:
+  - `run_in_background:true` → response carries a job id, returns fast, `is_error=false`; the job appears in the runtime and later exits.
+  - `false` → byte-identical to today (existing shell tests unchanged).
+  - read-only/command-policy still enforced **before** spawning a background job.
+- **A3 (`shell_output`)** — start a job → poll returns output + status; after exit → `Exited`; growing output advances `seq`; unknown id → `is_error` with a clear message.
+- **A4 (`shell_stop`) + teardown** — start a sleeper → `stop` → `Stopped`, process gone; unknown id → `is_error`; ending the owning scope with a running job fires its `exited` signal (no-orphans).
+- **B1 (push)** — a job exit enqueues a `SteerInput`; `drain_steers()` yields a completion notice with id + exit code; an integration test (mirror `plan_reminder_test`) asserts it becomes a durable injected item.
+- **B2 (detach-on-timeout)** — command that outlives a small `timeout_ms` with auto-bg on → result says "moved to background as `<id>>`", job continues then exits, pre-timeout output preserved; auto-bg off → current timeout-error/kill behavior unchanged.
+- **B3 (docs/watchdog)** — unbounded-output job is capped/killed; description strings contain `run_in_background` + `shell_output`/`shell_stop`.


### PR DESCRIPTION
## Why

Follows Claude Code's practice for long-running shell commands: run in the background, poll output, stop on demand — instead of blocking a turn or being killed at a timeout. This is **PR A** (explicit background jobs); a follow-up **PR B** adds detach-on-timeout + push-completion.

## What

- **`agent_tool/bgjobs`** — a session-scoped `BgJobRuntime` that spawns children on the agent's task group (the same structured-concurrency pattern as the former `moon_check` watcher), so jobs are reaped on session end and never orphan. Each job keeps a tail-capped merged-output buffer and a status (`Running | Exited(code) | Stopped`); a per-job monitor drains the pipe and records the terminal state. `start`/`snapshot`/`list`/`stop`.
- **`shell` gains `run_in_background`** — detaches the command as a job and returns its id instead of blocking. It runs **after the same cwd + source-tree write guards and through the same sandbox** (`sandbox-exec` write-blocking profile) as a foreground command, so it cannot bypass any guardrail. `timeout_ms` + `run_in_background` is rejected (contradictory).
- **`shell_output(job_id)`** — read a job's captured output + status; a non-zero exit is a tool error.
- **`shell_stop(job_id)`** — cancel a job's process.
- `build_tools` creates one shared runtime per session and wires all three tools (9 standard tools now).

## Design notes

- The runtime is intentionally **not generic** over the task group's return type: `new` captures the group into spawn closures, so `BgJobRuntime` can be an optional tool argument without leaking an unresolved type variable to callers that never use background jobs.
- Cancellation reaches only the launched process (like the foreground `shell` tool — `@process.hard_cancel`); the process library exposes no process-group kill. Documented, not overclaimed.

## Testing

39 tests across `agent_tool/bgjobs` (16), `shell` background paths, `shell_output`, `shell_stop`, and the agent registry. bgjobs coverage includes: run-to-exit + full output capture, EOF-vs-exit decoupling (a child that exits while a descendant holds the pipe), stop/wait races, concurrent stops, streaming RFC-3629 UTF-8 across read-chunk boundaries, output-budget enforcement, and terminal-status flush ordering.

Reviewed commit-by-commit with `codex review`; ~15 real correctness/safety findings across the series were fixed with regression tests, and the final pass is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)