### PR TITLE
feat: push-completion notices for background jobs (stacked on #375)

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -296,7 +296,7 @@ fn @agent_runtime.AgentRuntime::pending_steers(
 ) -> Array[@agent_runtime.SteerInput] {
   [
     for input in runtime.drain_steers() if input
-    is (Prompt(text) | Command(text)) &&
+    is (Prompt(text) | Command(text) | Notice(text)) &&
     !text.trim().is_empty() => input
   ]
 }
@@ -313,11 +313,16 @@ async fn @agent_session.Session::apply_steer_inputs(
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
 ) -> Self {
   for input in inputs; current = session {
-    let (kind, text) = match input {
-      Prompt(text) => ("prompt", text)
-      Command(text) => ("command", text)
+    // A notice is persisted as a `Runtime` item, not a `User` message: both
+    // project to user-role model content, but on resume `Runtime` renders as a
+    // notice rather than user-authored input.
+    let (kind, text, item) : (String, String, @agent_session.SessionItem) = match
+      input {
+      Prompt(text) => ("prompt", text, User(UserMessage(text)))
+      Command(text) => ("command", text, User(UserMessage(text)))
+      Notice(text) => ("notice", text, Runtime(RuntimeNotice(text)))
     }
-    let next = append_item(current, User(UserMessage(text)))
+    let next = append_item(current, item)
     messages.push(ChatMessage(User, content=text))
     @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
     continue next

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 }
 
 // Values
-pub fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X]) -> @agent_tool.Tools raise
+pub fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], on_background_wake? : () -> Unit) -> @agent_tool.Tools raise
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -15,11 +15,18 @@
 pub fn[X] build_tools(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[X],
+  on_background_wake? : () -> Unit = () => (),
 ) -> @agent_tool.Tools raise {
   // One background-job runtime per session, owned by `scope.group()`, shared by
   // the shell tools so a job started via `run_in_background` is later visible to
-  // the poll/stop tools.
-  let bg_runtime = @bgjobs.BgJobRuntime::new(scope)
+  // the poll/stop tools. When a job finishes on its own, push a completion
+  // notice as steering (the loop surfaces it to the model, which reads the full
+  // output with `shell_output`) and call `on_background_wake` — a serve engine
+  // uses it to wake an idle loop so the notice is delivered between turns.
+  let bg_runtime = @bgjobs.BgJobRuntime::new(scope, on_job_exit=snapshot => {
+    runtime.queue_steer(Notice(background_job_notice(snapshot)))
+    on_background_wake()
+  })
   let workspace_root = runtime.workspace_root()
   Tools([
     @shell.definition(bg_runtime~, workspace_root~),
@@ -32,6 +39,18 @@ pub fn[X] build_tools(
     @plan.definition(),
     @finish.definition(),
   ])
+}
+
+///|
+/// A one-line completion notice for a finished background job, pushed to the
+/// model as steering so it knows the job is done and can read its output.
+fn background_job_notice(snapshot : @bgjobs.BgJobSnapshot) -> String {
+  let status = match snapshot.status {
+    Running => "is still running"
+    Exited(code) => "exited with code \{code}"
+    Stopped => "was stopped"
+  }
+  "background job \{snapshot.id} (`\{snapshot.command}`) \{status}. Read its output with shell_output (job_id=\"\{snapshot.id}\")."
 }
 
 ///|

--- a/agent_runtime/pkg.generated.mbti
+++ b/agent_runtime/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub fn[X] AgentTaskScope::group(Self[X]) -> @async.TaskGroup[X]
 pub(all) enum SteerInput {
   Prompt(String)
   Command(String)
+  Notice(String)
 }
 
 // Type aliases

--- a/agent_runtime/runtime.mbt
+++ b/agent_runtime/runtime.mbt
@@ -16,11 +16,14 @@ pub let default_agent_event_capacity : Int = 32
 ///
 /// Prompt steering is ordinary user redirection. Command steering is contextual
 /// output collected by the controller, such as an explicit TUI `!` shell
-/// command. Both variants are delivered to the model as user-role content, but
-/// consumers may render/acknowledge them differently.
+/// command. Notice steering is a system notification pushed by a tool, such as a
+/// background job announcing it has finished. All variants are delivered to the
+/// model as user-role content, but consumers may render/acknowledge them
+/// differently.
 pub(all) enum SteerInput {
   Prompt(String)
   Command(String)
+  Notice(String)
 }
 
 ///|

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -56,6 +56,10 @@ pub struct BgJobRuntime {
   ) -> @process.Process
   // Spawn the per-job monitor task on that same group.
   priv spawn_monitor : (async () -> Unit) -> Unit
+  // Called once, with the terminal snapshot, when a job reaches a terminal
+  // status on its own (not on session teardown) — e.g. to push a completion
+  // notice back into the agent loop.
+  priv on_job_exit : ((BgJobSnapshot) -> Unit)?
   priv jobs : Map[String, BgJob]
   priv mut next_index : Int
 }
@@ -104,6 +108,7 @@ pub struct BgJobSnapshot {
 /// captured into spawn closures, so the returned runtime is not generic.
 pub fn[X] BgJobRuntime::new(
   scope : @agent_runtime.AgentTaskScope[X],
+  on_job_exit? : (BgJobSnapshot) -> Unit,
 ) -> BgJobRuntime {
   let group = scope.group()
   {
@@ -122,6 +127,7 @@ pub fn[X] BgJobRuntime::new(
     spawn_monitor: task => {
       group.spawn_bg(task, no_wait=true, allow_failure=true)
     },
+    on_job_exit,
     jobs: {},
     next_index: 1,
   }
@@ -239,6 +245,14 @@ async fn BgJobRuntime::monitor(
     self.flush_pending(id)
     self.finish(id, terminal)
   })
+  // Notify once when the job exited on its own. A `stop`-ped job is skipped —
+  // the caller that stopped it already knows — and a teardown cancellation
+  // raised out of the group above and never reaches here.
+  if self.on_job_exit is Some(callback) &&
+    self.snapshot(id) is Some(snapshot) &&
+    snapshot.status is Exited(_) {
+    callback(snapshot)
+  }
 }
 
 ///|

--- a/agent_tool/bgjobs/bgjobs_wbtest.mbt
+++ b/agent_tool/bgjobs/bgjobs_wbtest.mbt
@@ -229,6 +229,49 @@ async test "bg job preserves non-ascii output" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "on_job_exit fires once with the terminal snapshot of a natural exit" {
+  @async.with_task_group(group => {
+    let seen : Array[BgJobSnapshot] = []
+    let rt = BgJobRuntime::new(AgentTaskScope(group), on_job_exit=snapshot => {
+      seen.push(snapshot)
+    })
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf done"],
+      command="printf done",
+    )
+    for _ in 0..<200 {
+      if seen.length() > 0 {
+        break
+      }
+      @async.sleep(25)
+    }
+    assert_true(seen.length() == 1)
+    assert_true(seen[0].id == id)
+    assert_true(seen[0].status is Exited(0))
+    assert_true(seen[0].output.contains("done"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "on_job_exit does not fire for a stopped job" {
+  @async.with_task_group(group => {
+    let count = [0]
+    let rt = BgJobRuntime::new(AgentTaskScope(group), on_job_exit=_snapshot => {
+      count[0] = count[0] + 1
+    })
+    let id = rt.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    assert_true(rt.stop(id))
+    // Give any (incorrect) notification a chance to fire before asserting none.
+    @async.sleep(50)
+    assert_true(count[0] == 0)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "snapshot and stop handle unknown ids" {
   @async.with_task_group(group => {
     let rt = BgJobRuntime::new(AgentTaskScope(group))

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -14,7 +14,7 @@ pub struct BgJobRuntime {
   // private fields
 }
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
-pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X]) -> Self
+pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -12,7 +12,12 @@
 ///   process is cancelled and the result is reported as a tool error.
 /// - `timeout_ms` (number, optional): positive timeout in milliseconds. If the
 ///   command is still running after the timeout, the process is cancelled and
-///   reported as a tool error.
+///   reported as a tool error. Not supported together with `run_in_background`.
+/// - `run_in_background` (boolean, optional): detach the command as a background
+///   job and return its job id instead of blocking for output. Read the job's
+///   output with the `shell_output` tool and stop it with `shell_stop`; the job
+///   is reaped when the session ends. When the job finishes on its own, a
+///   completion notice is delivered so the model can collect the result.
 ///
 /// ## Result
 /// Metadata is a trailing `<system>...</system>` footer (the `read` tool
@@ -56,13 +61,13 @@ pub fn definition(
 ///|
 #cfg(platform="windows")
 fn shell_description() -> String {
-  "Run arguments.cmd through PowerShell (pwsh -NoProfile -Command), optionally in arguments.cwd, and return exit code plus output. Use PowerShell syntax and cmdlets in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit (or multi_edit for several fixes in one file); do not use shell rewrites."
+  "Run arguments.cmd through PowerShell (pwsh -NoProfile -Command), optionally in arguments.cwd, and return exit code plus output. Use PowerShell syntax and cmdlets in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit (or multi_edit for several fixes in one file); do not use shell rewrites. Set run_in_background:true to detach a long-running command and get a job id back instead of blocking; read its output with shell_output and stop it with shell_stop."
 }
 
 ///|
 #cfg(not(platform="windows"))
 fn shell_description() -> String {
-  "Run arguments.cmd through the POSIX shell (sh -c), optionally in arguments.cwd, and return exit code plus output. Use POSIX shell syntax in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit (or multi_edit for several fixes in one file); do not use shell rewrites."
+  "Run arguments.cmd through the POSIX shell (sh -c), optionally in arguments.cwd, and return exit code plus output. Use POSIX shell syntax in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit (or multi_edit for several fixes in one file); do not use shell rewrites. Set run_in_background:true to detach a long-running command and get a job id back instead of blocking; read its output with shell_output and stop it with shell_stop."
 }
 
 ///|

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -32,6 +32,9 @@ priv enum ServeStep {
   Wire(ServeCommand)
   TurnDone
   CompactDone(@agent_session.Session)
+  // A background job finished; wake the loop to drain and surface its notice
+  // even when no turn is active.
+  BackgroundNotice
   Shutdown
 }
 
@@ -223,9 +226,6 @@ async fn run_serve(
   @async.with_task_group(group => {
     let runtime = @agent_runtime.AgentRuntime(workspace_root~)
     let scope = @agent_runtime.AgentTaskScope(group)
-    // Built once so registry-local tool state can survive turn boundaries
-    // (see @agent.build_tools).
-    let tools = @agent.build_tools(runtime, scope)
     // All scheduling flows through one ordered queue with one consumer:
     // wire commands from the reader, plus the internal turn-completion and
     // shutdown markers. A second scheduler (e.g. acting on commands inside
@@ -233,6 +233,13 @@ async fn run_serve(
     // controller writing `prompt\nsteer\n` in one buffer must have its
     // steer land in that prompt's turn, exactly as the wire order says.
     let steps : @async.Queue[ServeStep] = Queue(kind=Unbounded)
+    // Built once so registry-local tool state can survive turn boundaries
+    // (see @agent.build_tools). A background job finishing wakes this loop with
+    // a `BackgroundNotice` step, so even a fully idle engine surfaces the
+    // completion instead of leaving it queued until the next prompt.
+    let tools = @agent.build_tools(runtime, scope, on_background_wake=() => {
+      ignore(steps.try_put(BackgroundNotice) catch { _ => false })
+    })
     group.spawn_bg(no_wait=true) <| () => {
       @jsonl.each(@stdio.stdin, json => {
         match decode_serve_command(json) {
@@ -267,7 +274,7 @@ async fn run_serve(
       }
     }
 
-    async fn append_command_context(text : String) -> Unit {
+    async fn append_command_context(text : String, kind : String) -> Unit {
       session = if store is Some(store) {
         store.append(session, User(UserMessage(text))) catch {
           error if @async.is_being_cancelled() ||
@@ -285,7 +292,32 @@ async fn run_serve(
         session.append(User(UserMessage(text)))
       }
       @xlog.info() <?
-        { "event": "steer_applied", "kind": "command", "content": text }
+        { "event": "steer_applied", "kind": kind, "content": text }
+    }
+
+    // Surface a background-job completion notice while the engine is idle
+    // (between turns). Persist it as a `Runtime` item — on resume it renders as
+    // a notice, not user input — and emit it untagged: the TUI drops run-tagged
+    // events once a turn closes, so a between-turns notice must ride an untagged
+    // event like `steer_dropped`.
+    async fn append_background_notice(text : String) -> Unit {
+      session = if store is Some(store) {
+        store.append(session, Runtime(RuntimeNotice(text))) catch {
+          error if @async.is_being_cancelled() ||
+            @async.is_cancellation_error(error) => raise error
+          error => {
+            @xlog.error() <?
+              {
+                "event": "session_error",
+                "error": "failed to append background notice: \{error}",
+              }
+            return
+          }
+        }
+      } else {
+        session.append(Runtime(RuntimeNotice(text)))
+      }
+      @xlog.info() <? { "event": "background_notice", "content": text }
     }
 
     // Steers still queued when work ends: prompt steering must not leak into a
@@ -298,7 +330,8 @@ async fn run_serve(
         match input {
           Prompt(text) =>
             @xlog.warn() <? { "event": "steer_dropped", "content": text }
-          Command(text) => append_command_context(text)
+          Command(text) => append_command_context(text, "command")
+          Notice(text) => append_background_notice(text)
         }
       }
     }
@@ -424,8 +457,11 @@ async fn run_serve(
               if active_work is Some(_) || has_pending_prompt(pending) {
                 runtime.queue_steer(Command(text))
               } else {
-                append_command_context(text)
+                append_command_context(text, "command")
               }
+            // A notice is engine-internal and never actually arrives over the
+            // wire; queue it losslessly for completeness.
+            Notice(text) => runtime.queue_steer(Notice(text))
           }
         Wire(Cancel) =>
           match active_work {
@@ -444,6 +480,10 @@ async fn run_serve(
           } else {
             active_work = Some(ActiveCompact(start_compaction(session)))
           }
+        // A background job finished. If a turn is active, its next step boundary
+        // drains and applies the queued notice live; only drain here when idle,
+        // so an idle engine still surfaces the completion.
+        BackgroundNotice => if active_work is None { drain_command_context() }
         TurnDone => {
           drain_command_context()
           active_work = None

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -94,6 +94,11 @@ async fn[G] EngineClient::start(
           // always reaches the user.
           SteerDropped(text) =>
             self.messages.try_put(EngineSteerDropped(text)) |> ignore
+          // A background job finished between turns: the engine already emitted
+          // this untagged, so post it untagged too — a run-tagged message would
+          // be swept by the stale-run guard once the turn closed.
+          BackgroundNotice(text) =>
+            self.messages.try_put(EngineBackgroundNotice(text)) |> ignore
           // A command context's delivery ack. The output is already rendered as
           // a local card and the engine appended it synchronously, so there is
           // nothing to do — in particular, do not echo it like a prompt steer.
@@ -214,7 +219,9 @@ async fn[G] EngineClient::steer(
   input : @agent_runtime.SteerInput,
 ) -> Unit {
   match input {
-    Prompt(text) =>
+    // A `Notice` is engine-internal (a tool pushing a completion notice); it is
+    // not something the TUI sends, but route it like a prompt for completeness.
+    Prompt(text) | Notice(text) =>
       match self.live {
         Some(live) if live.run_open =>
           self.send(live.latest_run, {

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -19,10 +19,13 @@ pub fn decode_event(object : Json) -> AgentEvent? {
       let content = @jsonx.string(object, "content")
       match @jsonx.string(object, "kind") {
         "command" => Some(SteerApplied(Command(content)))
+        "notice" => Some(SteerApplied(Notice(content)))
         _ => Some(SteerApplied(Prompt(content)))
       }
     }
     "steer_dropped" => Some(SteerDropped(@jsonx.string(object, "content")))
+    "background_notice" =>
+      Some(BackgroundNotice(@jsonx.string(object, "content")))
     "assistant_message" =>
       Some(AssistantMessage(@jsonx.string(object, "content")))
     "session_error" => Some(SessionError(@jsonx.string(object, "error")))

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -70,6 +70,21 @@ test "steer wire events decode to their applied and dropped forms" {
     is Some(SteerApplied(Command("<user_shell_command>"))),
   )
   assert_true(
+    @event.decode_event({
+      "event": "steer_applied",
+      "kind": "notice",
+      "content": "background job bg-1 finished",
+    })
+    is Some(SteerApplied(Notice("background job bg-1 finished"))),
+  )
+  assert_true(
+    @event.decode_event({
+      "event": "background_notice",
+      "content": "background job bg-1 finished",
+    })
+    is Some(BackgroundNotice("background job bg-1 finished")),
+  )
+  assert_true(
     @event.decode_event({ "event": "steer_dropped", "content": "too late" })
     is Some(SteerDropped("too late")),
   )

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -39,6 +39,9 @@ pub(all) enum AgentEvent {
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)
+  // A background job finished while the engine was idle. Emitted untagged (no
+  // run id) so it survives the TUI's stale-run guard between turns.
+  BackgroundNotice(String)
   AssistantMessage(String)
   SessionError(String)
   Usage(UsageInfo)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub(all) enum AgentEvent {
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)
+  BackgroundNotice(String)
   AssistantMessage(String)
   SessionError(String)
   Usage(UsageInfo)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -416,6 +416,12 @@ fn handle_agent_event(
     // Command context is already rendered as a local shell result; its applied
     // event is only a delivery acknowledgment.
     SteerApplied(Command(_)) => ()
+    // A notice (e.g. a background job finishing) originates in the engine, not
+    // from a pending local steer, so just render it in the transcript.
+    SteerApplied(Notice(text)) => cmds.push(AppendItem(Input(Notice(text))))
+    // Idle background notices arrive untagged (as EngineBackgroundNotice); this
+    // tagged path is unreachable, but render it the same way for completeness.
+    BackgroundNotice(text) => cmds.push(AppendItem(Input(Notice(text))))
     // Normally unreachable from the wire: the engine client routes
     // steer_dropped events to the untagged message (they always trail the
     // racing turn's terminal, so a run-tagged copy would be stale-filtered).
@@ -645,6 +651,8 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
                 state.background_commands += 1
                 cmds.push(RunCommand(run_id=None, command))
               }
+              // A notice is engine-internal, never user-submitted steering.
+              Notice(_) => ()
             }
           }
         Queue(input) => state.queued.push(input)
@@ -728,6 +736,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // swept its acknowledgments, and a text match here could only steal a
     // fresh identical-text steer's entry from the next turn.
     EngineSteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
+    EngineBackgroundNotice(text) => cmds.push(AppendItem(Input(Notice(text))))
     EngineSessionError(error) => cmds.push(AppendItem(Error(error)))
     EngineExited => ()
     // Tick is a 1s heartbeat: it keeps the message loop turning so the trailing
@@ -756,6 +765,8 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
         state.run_is_command = true
         cmds.push(RunCommand(run_id=Some(run_id), command))
       }
+      // A notice is engine-internal, never a user-submitted queued input.
+      Notice(_) => ()
     }
   }
   cmds

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -217,6 +217,10 @@ priv enum Msg {
   // nothing — a fresh identical-text steer of the next turn keeps its own
   // acknowledgment.
   EngineSteerDropped(String)
+  // A background job finished while the engine was idle. Reported without a run
+  // id (like a session error) so it is never swept by the stale-run guard, and
+  // rendered as a notice line in the transcript.
+  EngineBackgroundNotice(String)
   // Session errors are not tied to a model turn, so they are reported without a
   // run id and never affect run lifecycle.
   EngineSessionError(String)
@@ -239,6 +243,7 @@ fn Msg::run_id(self : Msg) -> Int? {
     UiInput(_)
     | SteerDropped(_)
     | EngineSteerDropped(_)
+    | EngineBackgroundNotice(_)
     | EngineSessionError(_)
     | EngineExited
     | Tick => None

--- a/docs/plans/background-shell.md
+++ b/docs/plans/background-shell.md
@@ -6,55 +6,198 @@ Foreground-by-default shell, but with Claude Code's escape hatches:
 - explicit `run_in_background` on `shell`,
 - **detach-on-timeout** instead of hard-kill,
 - `shell_output` / `shell_stop` to poll and terminate,
-- **push-completion** via the steer queue,
+- **push-completion** when a job finishes,
 - structured-concurrency "no orphans" guarantee lifted from call-scope to session-scope.
 
-## Grounding in the current code
+## The architecture to match (Claude Code)
 
-- `agent_tool/shell/shell.mbt` runs each command in a **per-call** `@async.with_task_group` and `hard_cancel`s on `timeout_ms` — the process cannot outlive the call, and the shell parser bans `&`.
-- `agent_tool/moon_check` is the template: a `MoonCheckRuntime[X]` holds `scope : AgentTaskScope[X]` + a registry `Map[.., MoonCheckRecord]`, spawns on `scope.group()` with a `spawn_bg` monitor task draining the pipe, and reaps on session-scope teardown. `Process::cancel()` stops one process.
-- Push channel: `AgentRuntime.queue_steer()` / `drain_steers()`; the loop drains at each step boundary and `apply_steer_inputs` folds each into the conversation (`agent/agent.mbt:293-322`).
+Reverse-engineered from `.repos/claude-code-rev/src/utils/ShellCommand.ts`. The
+whole design turns on **one idea: a command has a single execution and a single
+output sink; "background" is a status flag, and detaching is flipping it.** There
+is no separate foreground vs background execution path, so there is nothing to
+reconcile.
 
-## Delivery — two PRs, small reviewable commits
+- **One process object, one status.** `ShellCommandImpl` holds
+  `#status: 'running' | 'backgrounded' | 'completed' | 'killed'` and a
+  `TaskOutput` that *owns* all stdout/stderr. Foreground vs background is only
+  *"is the current tool call still awaiting it, with a timeout?"*.
+- **Output has one owner, and the medium follows whether the parent inspects it
+  live.** `TaskOutput` owns a command's stdout+stderr either way. For plain bash
+  (no in-flight inspection) it uses **file mode** — the child writes both fds
+  **directly to a file** (`childProcess.stdout/.stderr` are `null`), the parent
+  is blind, and small output is read back and the file deleted
+  (`outputFileRedundant`) while large output stays as a pointer. For hooks (which
+  must pattern-match output as it streams) it uses **pipe mode** — buffer in
+  memory via `StreamWrapper`s and **spill to disk only on background**. Same
+  owner, one retention story per command; the file-vs-memory choice is downstream
+  of "does the parent need to see the bytes live?".
+- **Detach = flip the flag** (`background(taskId)`): `running → backgrounded`,
+  and the process + file are untouched (the child is already writing to the
+  file). It only (a) starts a **size watchdog** — with the foreground timeout
+  gone, a stuck append loop could fill the disk (their comment cites a *"768GB
+  incident"*) — and (b) in pipe mode spills the in-memory buffer to disk so
+  readers can find it.
+- **Timeout decides detach vs kill** (`#handleTimeout`): if `#shouldAutoBackground`
+  and an `onTimeout` callback is set, call `background()`; otherwise kill.
+- **Inline output is full-or-pointer, never a lossy cap.** On completion, small
+  output is returned inline and the file deleted (`outputFileRedundant`); output
+  over `MAX_TASK_OUTPUT_BYTES` returns an `outputFilePath` + `outputFileSize`
+  pointer instead. A backgrounded job whose file exceeds the cap is killed
+  ("output file exceeded …").
 
-Every commit gate: `moon fmt` → `moon check --target native <pkgs>` → `moon test <pkgs>` → `codex review --base <prev-commit-sha>` (run in background, read the verdict tail, fix real findings, re-review clean) → drive the real tool where a surface exists.
+**Why OpenSeek's first cut hit a wall.** OpenSeek has *two* output models —
+foreground (in-memory, **prefix**-capped, **kill** on limit) and `bgjobs`
+(in-memory, **tail**-capped, **keep running**). The dropped B2 tried to detach by
+routing a foreground command *through* `bgjobs` on timeout, which forces those
+two models to meet: prefix↔tail, kill↔run, notify↔don't. Every `codex review`
+pass surfaced another mismatch. Claude Code never has this problem because a
+command has **one** output owner with a single retention story — full output,
+rendered inline-or-pointer — so "how much to show inline" is a *rendering*
+decision, identical for foreground and background, not an execution decision.
+(The *medium* underneath — file vs buffer-then-spill — varies, per the note
+above, but that is invisible to callers.)
 
-### PR A — explicit background (`run_in_background` + poll/stop)
+## Grounding in the current OpenSeek code
 
-- **A1** — `agent_tool/bgjobs`: `BgJobRuntime[X]` (scope + registry + id counter), generic over `program`/`args`. `start`, `snapshot`, `list`, `stop`. Tail-capped output buffer, status `Running | Exited(code) | Stopped`. Pure infra, unwired.
-- **A2** — `run_in_background` param on `shell`; thread a shared `BgJobRuntime` into `shell.definition(...)` (mirror `moon_check(runtime, scope)`); `true` → `start` a job via the platform shell and return the job id; `false` unchanged. Register in the standard tool set.
-- **A3** — `agent_tool/shell_output` tool: poll a job's output + status by id.
-- **A4** — `agent_tool/shell_stop` tool + explicit session-teardown reap; confirm no orphans.
+- `agent_tool/shell/shell.mbt` runs each command in a **per-call**
+  `@async.with_task_group` and `hard_cancel`s on `timeout_ms` — the process
+  cannot outlive the call; the shell parser bans `&`. Output is captured in
+  memory as a **prefix** (`read_output_prefix`), cancelled on the char budget.
+  Source-tree guards, the sandboxed launch (`agent_shell_launch`), moon command
+  policy, and read-only review mode all run **before** spawn.
+- `agent_tool/bgjobs` (shipped) is a session-scoped registry of jobs spawned on
+  `scope.group()`, each with a `spawn_bg` monitor draining the pipe into an
+  in-memory **tail** buffer; `on_job_exit` fires on natural exit.
+- Push channel: `AgentRuntime.queue_steer()` / `drain_steers()`, drained at each
+  step boundary; `apply_steer_inputs` folds each into the conversation.
 
-### PR B — parity (auto-detach + push)
+## Status
 
-- **B1** — push-completion: on job exit, `queue_steer(<notice>)`; extend `SteerInput` with a notice kind if needed; loop injects "background job `<id>` finished (exit N)".
-- **B2** — detach-on-timeout: on `timeout_ms`, hand the still-running process to the registry and return "moved to background as `<id>`" instead of `hard_cancel`. Spawn the auto-bg path on the **session** group; ship **opt-in** first, flip default later.
-- **B3** — prompt/description update (mention `run_in_background` + the two tools) + runaway-output size watchdog.
+Shipped (both open, `codex`-reviewed commit-by-commit; nothing merged):
+
+- **PR #375** (`feat/background-shell`) — explicit background jobs: `bgjobs`
+  runtime, `shell` `run_in_background`, `shell_output`, `shell_stop`.
+- **PR #378** (`feat/background-shell-parity`, stacked) — push-completion:
+  `on_job_exit → SteerInput::Notice`, injected live mid-turn or (idle serve
+  engine) via a `BackgroundNotice` wake + an untagged `background_notice` event;
+  persisted as `Runtime(RuntimeNotice)`. Plus `shell` docs.
+
+These deliver the **tool surface and the push mechanism** — and they stay stable.
+What is *not* yet Claude-Code-shaped is the **execution/output model
+underneath**: two buffers (prefix vs tail), and no shared process object. The
+work below re-bases the surface onto one shared execution with one output owner,
+which is what makes detach-on-timeout fall out cleanly instead of fighting the
+two models.
+
+## Design decision — output medium: buffer-then-spill, not always-file
+
+The unified sink (C1) keeps output **in memory up to the inline cap and spills to
+a file past it** (and immediately on background) — i.e. Claude Code's *pipe/hooks*
+medium, **not** its *always-file bash* medium. This is a deliberate divergence:
+
+- **OpenSeek's shell inspects output in-flight** — sandbox-denial detection, the
+  output-limit-and-cancel check, and TUI streaming all read bytes as they arrive.
+  That needs the parent to see the stream; always-file (child → fd, parent blind)
+  fights it. Claude Code itself buffers-then-spills exactly on the path that needs
+  live inspection (hooks); OpenSeek's single shell path is on that side of the
+  line, not the no-inspection bash side.
+- **Command volume** — an agent runs a flood of tiny commands (`ls`, `git
+  status`, `moon check`); always-file taxes every one with a temp file
+  create/write/delete to optimize detach, which hits ~1 command in 1000.
+- **Fewer files to orphan** — only large-or-backgrounded output ever touches
+  disk, so there is far less temp state to clean up (Claude Code carries an
+  explicit "another process deleted my output file" fallback for the always-file
+  case).
+
+Memory stays bounded because the spill threshold *is* the inline cap: anything
+too big to show inline is already on disk. Always-file's one real edge — a
+sustained huge stream never held in RAM — is captured this way too, without
+paying disk cost on the common small command.
+
+## Remaining work — converge on the single-execution model
+
+Same commit gate as before: `moon fmt` → `moon check --target native <pkgs>` →
+`moon test <pkgs>` → `codex review --base <prev-sha>` (background, read the
+verdict, fix real findings, re-review clean) → drive the real tool where a
+surface exists. A working-but-flawed detach spike is on `spike/detach-on-timeout`.
+
+- **C1 — one output sink (`TaskOutput` analog).** Introduce a `ShellOutputSink`
+  that owns a command's merged stdout+stderr: buffer in memory up to the inline
+  cap, **spill to a file** under a session temp dir past it (or on background) —
+  the buffer-then-spill medium from the design decision above, so the parent
+  keeps reading the stream and in-flight inspection (sandbox denial, output
+  limit) still works. Expose full read, tail-since-`seq`/offset, byte size, and
+  an `inline_or_pointer` view (full text when small; a `<system>output_file=…
+  size=…>` pointer when over the cap). This is the **one** retention policy — it
+  replaces both the foreground prefix-cap and `bgjobs`' tail-cap. Keep the
+  streaming-UTF-8 decode already in `bgjobs`. Pure infra + white-box tests;
+  unwired.
+- **C2 — one execution object (`ShellCommand` analog).** A `ShellExecution` with
+  `status: Running | Backgrounded | Exited(Int) | Killed`, spawned on the
+  **session group**, owning a `ShellOutputSink` and a monitor (reader task +
+  `wait()`, as `bgjobs` already does). Foreground execution = start it, then
+  await terminal-or-timeout. Re-point `bgjobs` at this: a backgrounded job is
+  just a `ShellExecution` with `status = Backgrounded`, so `start`/`snapshot`/
+  `list`/`stop` and `on_job_exit` become thin wrappers. The pre-spawn guards
+  (source tree, sandbox, policy, read-only) are unchanged and still run in front.
+- **C3 — foreground on the shared object.** Route `shell`'s foreground path
+  through `ShellExecution` too (await it, render via `inline_or_pointer`), so
+  foreground and background produce byte-identical results for the same output.
+  The existing foreground output-limit **error** semantics are preserved as the
+  small/complete case; large output becomes the file pointer (a behavior change
+  worth its own note — the model reads the rest with `shell_output`).
+- **C4 — detach-on-timeout = flip the status.** On `timeout_ms`, if auto-bg is
+  on, `background()` the execution: `Running → Backgrounded`, keep the process +
+  sink, return "moved to the background as `<id>`"; else cancel as today. No
+  re-route, no second buffer — the mismatch that sank the first attempt is gone.
+  Ship auto-bg **opt-in** first, flip the default once C1–C3 are proven.
+- **C5 — size watchdog.** With the foreground timeout gone, a backgrounded
+  execution watches its sink's byte size and kills the process past a hard cap
+  (Claude Code's disk-fill guard). This is only load-bearing once a backgrounded
+  job's output spills to a file (C1); until then `bgjobs`' bounded in-memory tail
+  has no disk risk, which is why the shipped PRs omit it.
+- **C6 — reconcile the tools + prompt.** `shell_output` tails the sink;
+  `shell_stop` kills; push-completion fires from the terminal transition (B1's
+  mechanism, unchanged). Update the `shell` description to state that a timed-out
+  command detaches (not errors) and that large output returns a file pointer.
 
 ## Test plan
 
-Principles (apply to every commit):
-- **Native target** — async process spawning needs `moon test --target native`.
-- **Deterministic polling** — never unbounded wait; poll `snapshot` with bounded ticks + `@async.sleep`, and `fail(...)` on a deadline (mirror `wait_for_initial_snapshot`). Use commands that terminate fast (`printf`, `exit N`), and a real sleeper only for stop/timeout tests.
-- **Isolation** — async tests run in parallel; each test uses its own temp/vfs cwd, no shared ports/files.
-- **Regression** — the full `agent_tool/shell` suite stays green at every commit; the foreground path is untouched until B2, and then only behind the opt-in flag.
+Principles (every commit): **native target** (async spawn); **deterministic
+polling** — bounded ticks + `@async.sleep`, `fail(...)` on a deadline, fast
+commands (`printf`, `exit N`) with a real sleeper only for stop/timeout;
+**isolation** — parallel async tests, per-test temp cwd/sink dir, no shared
+files; **regression** — the full `agent_tool/shell` suite stays green, and
+foreground results stay byte-identical for the same output until the C3/C4
+behavior notes land (large-output pointer; timeout-detach), each gated behind its
+flag/commit.
 
-Per commit:
+Shipped coverage (keep green): `bgjobs` white-box (exit codes, stop, output cap,
+descendant-holds-pipe, closed-streams stop race, UTF-8 boundary, `on_job_exit`
+fires once on natural exit / never on stop); `shell` `run_in_background`
+(id + fast return, guards enforced before spawn, `timeout_ms` rejected with it);
+`shell_output`/`shell_stop` (poll, unknown id, stop → Stopped); the push path
+(notice decode, serve idle-wake untagged event, TUI `⚙` render).
 
-- **A1 (bgjobs)** — white-box `_wbtest.mbt`:
-  - `sh -c 'printf hi'` → poll to `Exited(0)`, output contains `hi`.
-  - `sh -c 'exit 3'` → `Exited(3)`.
-  - `sh -c 'sleep 5'` → snapshot `Running`; `stop` → `Stopped`, terminates promptly (scope teardown does not hang).
-  - output cap: high-volume command with tiny `max_output_chars` → `output_truncated`, output ≤ cap.
-  - unknown id → `snapshot` None, `stop` false.
-  - two concurrent jobs → distinct ids, independent output.
-- **A2 (`run_in_background`)** — mirror `shell_test.mbt`'s `run_shell`:
-  - `run_in_background:true` → response carries a job id, returns fast, `is_error=false`; the job appears in the runtime and later exits.
-  - `false` → byte-identical to today (existing shell tests unchanged).
-  - read-only/command-policy still enforced **before** spawning a background job.
-- **A3 (`shell_output`)** — start a job → poll returns output + status; after exit → `Exited`; growing output advances `seq`; unknown id → `is_error` with a clear message.
-- **A4 (`shell_stop`) + teardown** — start a sleeper → `stop` → `Stopped`, process gone; unknown id → `is_error`; ending the owning scope with a running job fires its `exited` signal (no-orphans).
-- **B1 (push)** — a job exit enqueues a `SteerInput`; `drain_steers()` yields a completion notice with id + exit code; an integration test (mirror `plan_reminder_test`) asserts it becomes a durable injected item.
-- **B2 (detach-on-timeout)** — command that outlives a small `timeout_ms` with auto-bg on → result says "moved to background as `<id>>`", job continues then exits, pre-timeout output preserved; auto-bg off → current timeout-error/kill behavior unchanged.
-- **B3 (docs/watchdog)** — unbounded-output job is capped/killed; description strings contain `run_in_background` + `shell_output`/`shell_stop`.
+Per new commit:
+
+- **C1 (sink)** — small output → inline, no file, `inline_or_pointer` is full
+  text; output over the cap → spills to a file, `inline_or_pointer` is a pointer
+  with the right size, full read returns everything (prefix intact — the *start*
+  of errors is visible, unlike a tail); tail-since-`seq` returns only new bytes;
+  UTF-8 split across the spill boundary is not corrupted.
+- **C2 (execution)** — a `ShellExecution` reaches `Exited(code)`; `bgjobs` wrappers
+  still pass every shipped test unchanged; teardown reaps a `Backgrounded` job.
+- **C3 (foreground on shared object)** — a foreground command returns the same
+  bytes as before for small output; a command over the cap returns the file
+  pointer and `shell_output` reads the remainder; the output-limit **error** case
+  is preserved for the small/complete path.
+- **C4 (detach-on-timeout)** — command outliving a small `timeout_ms` with auto-bg
+  on → "moved to the background as `<id>`", job continues then exits, **prefix**
+  output preserved (not a tail); auto-bg off → today's timeout-error/kill; a
+  runaway producer is killed on the size cap, not silently backgrounded forever.
+- **C5 (watchdog)** — a backgrounded unbounded producer is killed once its file
+  passes the hard cap; a bounded one is not.
+- **C6 (tools/prompt)** — `shell_output` tails a live job and returns the full
+  file after exit; description strings mention detach-on-timeout + the file
+  pointer + `shell_output`/`shell_stop`.

--- a/tui/core/input.mbt
+++ b/tui/core/input.mbt
@@ -6,6 +6,7 @@
 pub(all) enum Input {
   Prompt(String)
   Command(String)
+  Notice(String)
 } derive(Eq, Debug)
 
 ///|
@@ -17,12 +18,17 @@ pub let prompt_prefix : @displaytext.DisplayText = DisplayText("❯ ")
 let command_prefix : @displaytext.DisplayText = DisplayText("$ ")
 
 ///|
+/// The marker shown before a system notice (e.g. a background job finishing).
+let notice_prefix : @displaytext.DisplayText = DisplayText("⚙ ")
+
+///|
 /// The prefix marker shown before this input (`❯ ` for prompts, `$ ` for shell
 /// commands).
 pub fn Input::prefix(self : Input) -> @displaytext.DisplayText {
   match self {
     Prompt(_) => prompt_prefix
     Command(_) => command_prefix
+    Notice(_) => notice_prefix
   }
 }
 
@@ -32,6 +38,7 @@ pub fn Input::text(self : Input) -> String {
   match self {
     Prompt(text) => text
     Command(command) => command
+    Notice(text) => text
   }
 }
 

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub(all) enum Event {
 pub(all) enum Input {
   Prompt(String)
   Command(String)
+  Notice(String)
 } derive(Eq, @debug.Debug)
 pub fn Input::prefix(Self) -> @displaytext.DisplayText
 pub fn Input::text(Self) -> String


### PR DESCRIPTION
## Why

**PR B**, stacked on #375 (explicit background jobs). Adds Claude Code's *push-notification* behavior: when a background job finishes, the model is told — it doesn't have to poll `shell_output`.

Base this PR on `feat/background-shell` (PR #375); rebase onto `main` once that merges.

## What

- **`bgjobs` gains an `on_job_exit` callback** — fired once when a job exits on its own (not when stopped, not on session teardown).
- **`build_tools` wires it to `runtime.queue_steer(Notice(...))`** and an `on_background_wake` hook. A `Notice` variant is added to `SteerInput` (delivered as user-role model content, like `Prompt`/`Command`) and persisted as a `Runtime(RuntimeNotice)` item so it renders as a notice — not user input — on resume.
- **Two delivery paths, both correct:**
  - Job finishes **mid-turn** → the loop injects it live at the next step boundary (run-id-tagged, shown).
  - Job finishes while the engine is **fully idle** (serve mode) → a new `BackgroundNotice` serve step wakes the loop, persists the notice, and emits it as an **untagged** `background_notice` event that survives the TUI's stale-run guard → renders as a `⚙` transcript line.
- **`shell` tool docs** describe `run_in_background` and the `shell_output`/`shell_stop` companions.

## Not included

**Detach-on-timeout** (moving a timed-out command to the background instead of killing it) is intentionally **not** here. Routing foreground commands through `bgjobs` hit irreducible foreground/background semantic mismatches (output retention is prefix-vs-tail, cancel-on-limit vs keep-running, notify semantics). The correct implementation is a deeper refactor — run in the foreground but spawned on the session group, hand the process off to `bgjobs` on timeout — which preserves foreground semantics natively. That's a focused follow-up (a spike is on `spike/detach-on-timeout`).

## Testing

The `Notice` path was hardened over several review passes across the queue filter, serve loop (idle drain + wake), TUI decode/render, and session persistence. Full touched-package suites pass (agent, bgjobs, shell, serve, tui, tui/core, event); the only failures are the pre-existing flaky shell output-limit/UTF-8 timing tests that fail on `main` too.

Reviewed commit-by-commit with `codex review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)