### PR TITLE
feat(auto_check): gate writes/edits with moonc syncheck

### DIFF
--- a/agent_tool/edit/README.mbt.md
+++ b/agent_tool/edit/README.mbt.md
@@ -24,18 +24,17 @@ MoonBit manifests get the same safety check as `write`: edits that would create
 legacy `moon.mod.json`, JSON-style `moon.mod` or `moon.pkg`, or `moon.pkg` with
 `#` comments are rejected before the original file is overwritten.
 
-Edits to `.mbt` files get a pre-write syntax gate: the edited result is parsed
-standalone (`moonc compile -stop-after-parsing` in a scratch file, no project
-context needed), and an edit that would introduce new lex/parse errors is
-rejected with the file left untouched — the call fails with the errors and
-numbered excerpts synthesized from the would-be content. "Introduced" compares
-parse-error *counts* against the original content parsed the same way (not
-diagnostic identities, because an edit shifts the line numbers of every
-pre-existing error below it), so a file that already fails to parse still
-accepts edits, including partial fixes. Type errors never trigger the gate, and
-`.mbt.md` files are not gated (moonc cannot parse markdown-hosted code blocks;
-see the TODO in `agent_tool/internal/auto_check/parse_gate.mbt`).
-`revert_on_parse_errors=false` opts out.
+Edits to syncheck inputs (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`) get a
+pre-write syntax gate: the edited result is parsed standalone (`moonc syncheck`
+in a scratch file, no project context needed), and an edit that would introduce
+new lex/parse errors is rejected with the file left untouched — the call fails
+with the errors and numbered excerpts synthesized from the would-be content.
+"Introduced" compares parse-error *counts* against the original content parsed
+the same way (not diagnostic identities, because an edit shifts the line numbers
+of every pre-existing error below it), so a file that already fails to parse
+still accepts edits, including partial fixes. Type errors never trigger the
+gate; in `.mbt.md` only the checked (`mbt check` / `moonbit check`) fenced blocks
+are parsed. `revert_on_parse_errors=false` opts out.
 
 ## API Style
 
@@ -72,7 +71,7 @@ and the edit should stay inside a tighter range:
 | `new_string`  | string  | yes | Replacement (or inserted) text. For replacement it must differ from `old_string`; empty-and-empty is rejected. |
 | `start_line`  | integer | yes | 1-based first line of the search/replace range. The first match at or after this line is replaced. |
 | `end_line`    | integer | no  | 1-based last line of the search/replace range. Defaults to the file end. |
-| `revert_on_parse_errors` | boolean | no (default `true`) | Reject an edit whose result would introduce new lex/parse errors into a `.mbt` file, leaving the file untouched and returning the errors with excerpts. `.mbt.md` is not gated. Set `false` only to intentionally produce non-parsing content. |
+| `revert_on_parse_errors` | boolean | no (default `true`) | Reject an edit whose result would introduce new lex/parse errors into a syncheck input (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`), leaving the file untouched and returning the errors with excerpts. In `.mbt.md` only the checked fenced blocks are parsed. Set `false` only to intentionally produce non-parsing content. |
 
 Legacy calls with `replace_all=false` are tolerated, but `replace_all=true` is
 rejected. Use `multi_edit` when a compiler diagnostic suggests several known

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -32,7 +32,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
-    description="Replace the first exact text span at or after arguments.start_line in arguments.path with arguments.new_string. Optional end_line restricts the search to a 1-based inclusive line range. Because start_line anchors the location, old_string can be a small exact span instead of a large context block. To INSERT new code instead of replacing, set old_string to the empty string: new_string is inserted at the start of start_line (use start_line = last line + 1 to append at end of file). An edit that would introduce lex/parse errors into a .mbt file is rejected BEFORE writing and the parse errors are returned — see revert_on_parse_errors. For multiple compiler-feedback fixes in one file, use multi_edit with explicit line-anchored edits.",
+    description="Replace the first exact text span at or after arguments.start_line in arguments.path with arguments.new_string. Optional end_line restricts the search to a 1-based inclusive line range. Because start_line anchors the location, old_string can be a small exact span instead of a large context block. To INSERT new code instead of replacing, set old_string to the empty string: new_string is inserted at the start of start_line (use start_line = last line + 1 to append at end of file). An edit that would introduce lex/parse errors into a syntax-checkable file (.mbt, .mbt.md, moon.mod, moon.pkg) is rejected BEFORE writing and the parse errors are returned — see revert_on_parse_errors. For multiple compiler-feedback fixes in one file, use multi_edit with explicit line-anchored edits.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -245,9 +245,16 @@ async fn parse_gate_rejection(
     _ => path
   }
   // Gate against whichever of the literal path or its symlink target names a
-  // syncheck input; that path's kind (`.mbt`, `.mbt.md`, `moon.mod`,
-  // `moon.pkg`) selects how the candidate content is parsed.
-  let gate_path = if @auto_check.is_gateable_path(path) { path } else { target }
+  // syncheck input, PREFERRING the target: the file that actually gets compiled
+  // is the realpath, so its kind (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`)
+  // decides how the candidate content is parsed. Preferring the link name would
+  // let a `doc.mbt.md -> lib.mbt` alias parse raw source as markdown (only
+  // checked fences gated), passing malformed `.mbt` content through.
+  let gate_path = if @auto_check.is_gateable_path(target) {
+    target
+  } else {
+    path
+  }
   if !@auto_check.is_gateable_path(gate_path) {
     return None
   }

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -225,8 +225,9 @@ const SmallerEditsHintThreshold : Int = 3
 /// false-fire constantly; the blind spot (an edit that fixes one parse error
 /// while introducing another, keeping the count flat) is accepted. The gate
 /// applies to every syncheck input — `.mbt`, `.mbt.md` (checked fenced blocks
-/// only), `moon.mod`, `moon.pkg` — keyed off `path`'s kind. Fail-open: when the
-/// gate cannot run, the edit proceeds as before the gate existed.
+/// only), `moon.mod`, `moon.pkg` — under each kind the file could be classified
+/// as (a cross-kind symlink is checked under both). Fail-open: when the gate
+/// cannot run, the edit proceeds as before the gate existed.
 async fn parse_gate_rejection(
   path : String,
   original_content~ : String,
@@ -244,52 +245,46 @@ async fn parse_gate_rejection(
     error if @async.is_being_cancelled() => raise error
     _ => path
   }
-  // Gate against whichever of the literal path or its symlink target names a
-  // syncheck input, PREFERRING the target: the file that actually gets compiled
-  // is the realpath, so its kind (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`)
-  // decides how the candidate content is parsed. Preferring the link name would
-  // let a `doc.mbt.md -> lib.mbt` alias parse raw source as markdown (only
-  // checked fences gated), passing malformed `.mbt` content through.
-  let gate_path = if @auto_check.is_gateable_path(target) {
-    target
-  } else {
-    path
+  // Gate under every syncheck kind this file could be classified as. A regular
+  // file yields one kind; a symlink that crosses kinds (e.g. `link.mbt ->
+  // doc.mbt.md`) yields two, and moon's classification of such a link is
+  // ambiguous, so reject on the FIRST kind under which the edit introduces new
+  // parse errors — that covers both interpretations. See `gate_paths`.
+  for gate_path in @auto_check.gate_paths(path, target) {
+    let gate = @auto_check.content_parse_errors(gate_path, new_content) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => None
+    }
+    guard gate is Some(gate) && gate.errors.length() > 0 else { continue }
+    // The edited result has parse errors under this kind; reject only when the
+    // edit makes the file WORSE than its original content parsed the same way.
+    let before = @auto_check.content_parse_errors(gate_path, original_content) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => None
+    }
+    // The comparison is only sound against a COMPLETE baseline: a missing one
+    // (transient tmpdir/moonc failure) gives no honest "introduced" answer, and
+    // a truncated one is a lower bound whose subtraction could over-count the
+    // introduced errors and false-reject. Fail open in both cases — the gate
+    // must never reject on a comparison it could not actually make. A truncated
+    // NEW capture is fine: its count is a lower bound, so exceeding the complete
+    // baseline still proves the edit made things worse.
+    guard before is Some(before) && !before.truncated else { continue }
+    let before_count = before.errors.length()
+    let introduced = gate.errors.length() - before_count
+    if introduced <= 0 {
+      continue
+    }
+    let bound = if gate.truncated { "≥" } else { "" }
+    return Some(
+      @agent_tool.ToolAction::respond(
+        edit_reject_report(path, new_content, gate, introduced~, before_count~),
+        is_error=true,
+        brief="edit rejected (\{bound}\{introduced} parse error(s))",
+      ),
+    )
   }
-  if !@auto_check.is_gateable_path(gate_path) {
-    return None
-  }
-  let gate = @auto_check.content_parse_errors(gate_path, new_content) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => None
-  }
-  guard gate is Some(gate) && gate.errors.length() > 0 else { return None }
-  // The edited result has parse errors; reject only when the edit makes the
-  // file WORSE than its original content parsed the same way.
-  let before = @auto_check.content_parse_errors(gate_path, original_content) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => None
-  }
-  // The comparison is only sound against a COMPLETE baseline: a missing one
-  // (transient tmpdir/moonc failure) gives no honest "introduced" answer, and
-  // a truncated one is a lower bound whose subtraction could over-count the
-  // introduced errors and false-reject. Fail open in both cases — the gate
-  // must never reject on a comparison it could not actually make. A truncated
-  // NEW capture is fine: its count is a lower bound, so exceeding the complete
-  // baseline still proves the edit made things worse.
-  guard before is Some(before) && !before.truncated else { return None }
-  let before_count = before.errors.length()
-  let introduced = gate.errors.length() - before_count
-  if introduced <= 0 {
-    return None
-  }
-  let bound = if gate.truncated { "≥" } else { "" }
-  Some(
-    @agent_tool.ToolAction::respond(
-      edit_reject_report(path, new_content, gate, introduced~, before_count~),
-      is_error=true,
-      brief="edit rejected (\{bound}\{introduced} parse error(s))",
-    ),
-  )
+  None
 }
 
 ///|

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -12,11 +12,11 @@
 /// - `replace_all=true` is rejected. Use `multi_edit` for multiple explicit
 ///   line-anchored replacements.
 /// - `revert_on_parse_errors` (boolean, optional, default true): before an
-///   edit to a `.mbt` file is written, the edited result is parsed standalone
-///   (`moonc -stop-after-parsing`); an edit that would introduce new
-///   lex/parse errors is rejected and the file is left untouched. Pre-existing
-///   parse errors never trigger the gate, and `.mbt.md` is not gated (moonc
-///   cannot parse markdown; see parse_gate.mbt).
+///   edit to a syncheck input (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`) is
+///   written, the edited result is parsed standalone (`moonc syncheck`); an
+///   edit that would introduce new lex/parse errors is rejected and the file is
+///   left untouched. Pre-existing parse errors never trigger the gate; in
+///   `.mbt.md` only the checked fenced blocks are parsed.
 ///
 /// ## Result
 /// - `Respond(ToolOutput("ok: replaced <n> occurrence(s) at line <line> in <path>"))`
@@ -43,7 +43,7 @@ pub fn definition(
         "end_line": { "type": "integer" },
         "revert_on_parse_errors": {
           "type": "boolean",
-          "description": "Syntax gate, on by default. Before the edit is written to a .mbt file, the edited result is parsed standalone (moonc -stop-after-parsing); an edit that would INTRODUCE new lex/parse errors — measured against the pre-edit content parsed the same way, so pre-existing parse errors are ignored — is REJECTED, the file is left untouched, and the call returns the errors with excerpts of the would-be content. Type errors never trigger the gate (they may be a legitimate transient state), and .mbt.md files are not gated. Set false only to intentionally produce content that does not parse (e.g. a fixture).",
+          "description": "Syntax gate, on by default. Before the edit is written to a syntax-checkable file (.mbt, .mbt.md, moon.mod, moon.pkg), the edited result is parsed standalone (moonc syncheck); an edit that would INTRODUCE new lex/parse errors — measured against the pre-edit content parsed the same way, so pre-existing parse errors are ignored — is REJECTED, the file is left untouched, and the call returns the errors with excerpts of the would-be content. Type errors never trigger the gate (they may be a legitimate transient state); in .mbt.md only the checked (`mbt check` / `moonbit check`) fenced blocks are parsed. Set false only to intentionally produce content that does not parse (e.g. a fixture).",
           "examples": [false],
         },
       },
@@ -214,8 +214,8 @@ async fn commit_edit(
 const SmallerEditsHintThreshold : Int = 3
 
 ///|
-/// Pre-write syntax gate for `.mbt` edits: parse the candidate result in a
-/// scratch file (moonc -stop-after-parsing, no project context) and reject
+/// Pre-write syntax gate for syncheck-input edits: parse the candidate result
+/// in a scratch file (moonc syncheck, no project context) and reject
 /// the edit — leaving the file untouched — when it would introduce new parse
 /// errors. "Introduced" compares parse-error counts against the ORIGINAL
 /// content parsed the same way, so a file that already fails to parse can
@@ -223,9 +223,10 @@ const SmallerEditsHintThreshold : Int = 3
 /// identities, on purpose: an edit shifts the line numbers of every
 /// pre-existing error below it, so identity matching keyed on locations would
 /// false-fire constantly; the blind spot (an edit that fixes one parse error
-/// while introducing another, keeping the count flat) is accepted. `.mbt.md`
-/// is not gated (see the TODO in parse_gate.mbt). Fail-open: when the gate
-/// cannot run, the edit proceeds as before the gate existed.
+/// while introducing another, keeping the count flat) is accepted. The gate
+/// applies to every syncheck input — `.mbt`, `.mbt.md` (checked fenced blocks
+/// only), `moon.mod`, `moon.pkg` — keyed off `path`'s kind. Fail-open: when the
+/// gate cannot run, the edit proceeds as before the gate existed.
 async fn parse_gate_rejection(
   path : String,
   original_content~ : String,
@@ -243,18 +244,21 @@ async fn parse_gate_rejection(
     error if @async.is_being_cancelled() => raise error
     _ => path
   }
-  if !@auto_check.is_gateable_path(path) &&
-    !@auto_check.is_gateable_path(target) {
+  // Gate against whichever of the literal path or its symlink target names a
+  // syncheck input; that path's kind (`.mbt`, `.mbt.md`, `moon.mod`,
+  // `moon.pkg`) selects how the candidate content is parsed.
+  let gate_path = if @auto_check.is_gateable_path(path) { path } else { target }
+  if !@auto_check.is_gateable_path(gate_path) {
     return None
   }
-  let gate = @auto_check.content_parse_errors(new_content) catch {
+  let gate = @auto_check.content_parse_errors(gate_path, new_content) catch {
     error if @async.is_being_cancelled() => raise error
     _ => None
   }
   guard gate is Some(gate) && gate.errors.length() > 0 else { return None }
   // The edited result has parse errors; reject only when the edit makes the
   // file WORSE than its original content parsed the same way.
-  let before = @auto_check.content_parse_errors(original_content) catch {
+  let before = @auto_check.content_parse_errors(gate_path, original_content) catch {
     error if @async.is_being_cancelled() => raise error
     _ => None
   }

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -553,3 +553,28 @@ async test "edit gates a breaking edit made through a non-mbt symlink" {
     assert_eq(@fs.read_file(src).text(), original)
   })
 }
+
+///|
+/// The gate keys off the symlink TARGET's kind, not the link name: a
+/// `.mbt.md`-spelled link to a `.mbt` target must parse the result as source,
+/// not markdown. Parsing it as `.mbt.md` would ignore everything outside checked
+/// fences and let a broken edit to the real `.mbt` file slip through.
+async test "edit gates by the target kind through a .mbt.md-named symlink" {
+  @vfs.with_tmpdir(prefix="openseek-edit-gate-mdlink-", dir => {
+    let src = "\{dir}/lib.mbt"
+    let original = "///|\npub fn f() -> Int {\n  42\n}\n"
+    @fs.write_file(src, original, create_mode=CreateOrTruncate)
+    let link = "\{dir}/doc.mbt.md"
+    @fs.symlink(target="lib.mbt", link)
+    let broken = run_edit({
+      "path": link,
+      "old_string": "  42",
+      "new_string": "  match 42 {",
+      "start_line": 3,
+    })
+    guard broken is Respond(out) else { fail("expected Respond") }
+    assert_true(out.is_error)
+    assert_true(out.content.contains("rejected: the edit would introduce"))
+    assert_eq(@fs.read_file(src).text(), original)
+  })
+}

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -578,3 +578,30 @@ async test "edit gates by the target kind through a .mbt.md-named symlink" {
     assert_eq(@fs.read_file(src).text(), original)
   })
 }
+
+///|
+/// The reverse mismatch: a `.mbt`-spelled link to a `.mbt.md` target. moon may
+/// classify the link by its `.mbt` entry name, so a break that is invalid as
+/// source must be caught even though the target is named `.mbt.md`. Gating only
+/// the target kind would parse the result as markdown (checked fences only) and
+/// miss it — the gate must cover BOTH kinds. The target body is valid MoonBit
+/// source, so it parses clean under both kinds until the edit breaks it.
+async test "edit gates by the link kind through a .mbt-named symlink" {
+  @vfs.with_tmpdir(prefix="openseek-edit-gate-mbtlink-", dir => {
+    let target = "\{dir}/notes.mbt.md"
+    let original = "///|\npub fn f() -> Int {\n  42\n}\n"
+    @fs.write_file(target, original, create_mode=CreateOrTruncate)
+    let link = "\{dir}/link.mbt"
+    @fs.symlink(target="notes.mbt.md", link)
+    let broken = run_edit({
+      "path": link,
+      "old_string": "  42",
+      "new_string": "  match 42 {",
+      "start_line": 3,
+    })
+    guard broken is Respond(out) else { fail("expected Respond") }
+    assert_true(out.is_error)
+    assert_true(out.content.contains("rejected: the edit would introduce"))
+    assert_eq(@fs.read_file(target).text(), original)
+  })
+}

--- a/agent_tool/internal/auto_check/moon.pkg
+++ b/agent_tool/internal/auto_check/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/manifest_path",
   "bobzhang/openseek/agent_tool/shell",
   "moonbitlang/async",
   "moonbitlang/async/fs",

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -94,6 +94,31 @@ pub fn is_gateable_path(path : String) -> Bool {
 }
 
 ///|
+/// The distinct syncheck input KINDS named by `path` and its resolved symlink
+/// `target`, as representative paths to hand to `content_parse_errors`. Usually
+/// one entry: a regular file (where `target` is the same file), or a symlink
+/// whose link and target share a kind, or where only one side is a syncheck
+/// input. Two entries when a symlink CROSSES kinds, e.g. `link.mbt ->
+/// doc.mbt.md`: moon's classification of such a link is ambiguous — it may key
+/// off the directory entry it globs OR the file it resolves to — so the gate
+/// checks BOTH kinds and a caller rejects if either flags the candidate. `path`
+/// is listed first so a reject prefers the caller's own spelling. Pass the same
+/// value for `path` and `target` when there is no symlink to resolve.
+pub fn gate_paths(path : String, target : String) -> Array[String] {
+  let paths : Array[String] = []
+  let names : Array[String] = []
+  for candidate in [path, target] {
+    guard gate_scratch_name(candidate) is Some(name) else { continue }
+    if names.contains(name) {
+      continue
+    }
+    names.push(name)
+    paths.push(candidate)
+  }
+  paths
+}
+
+///|
 /// One moonc run over candidate content: the captured lex/parse errors plus
 /// whether the output capture was truncated — a truncated capture makes
 /// `errors` a LOWER BOUND, not an exact tally, and callers that compare

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -55,17 +55,19 @@ const MooncParseMaxOutputChars : Int = 200000
 /// `None` when `path` is not a syncheck input (so the gate does not apply).
 /// syncheck keys off the name: `.mbt` / `.mbt.md` match by suffix, while
 /// `moon.mod` / `moon.pkg` must be that EXACT basename (a `foo.moon.pkg` or a
-/// `moon.pkg.json` is not recognized). The command always runs from the scratch
-/// directory against this bare name, so the command line never embeds a host
-/// path that would need platform-specific quoting.
+/// `moon.pkg.json` is not recognized). The manifest classifiers are shared with
+/// the write/edit tools, so they normalize Windows separators the same way. The
+/// command always runs from the scratch directory against this bare name, so the
+/// command line never embeds a host path that would need platform-specific
+/// quoting.
 fn gate_scratch_name(path : String) -> String? {
   if path.has_suffix(".mbt.md") {
     Some("parse_gate.mbt.md")
   } else if path.has_suffix(".mbt") {
     Some("parse_gate.mbt")
-  } else if path == "moon.mod" || path.has_suffix("/moon.mod") {
+  } else if @manifest_path.is_moon_mod_path(path) {
     Some("moon.mod")
-  } else if path == "moon.pkg" || path.has_suffix("/moon.pkg") {
+  } else if @manifest_path.is_moon_pkg_path(path) {
     Some("moon.pkg")
   } else {
     None
@@ -509,6 +511,9 @@ test "is_gateable_path covers syncheck input kinds only" {
   assert_true(is_gateable_path("README.mbt.md"))
   assert_true(is_gateable_path("moon.mod"))
   assert_true(is_gateable_path("sub/pkg/moon.pkg"))
+  // Windows separators classify like their POSIX form (shared manifest helpers).
+  assert_true(is_gateable_path("C:\\ws\\pkg\\moon.pkg"))
+  assert_true(is_gateable_path("C:\\ws\\moon.mod"))
   // Not syncheck inputs.
   assert_false(is_gateable_path("notes.md"))
   assert_false(is_gateable_path("moon.work"))

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -1,17 +1,18 @@
 ///|
-/// Standalone syntax gate for `.mbt` content, built on
-/// `moonc compile -stop-after-parsing`: the compiler parses one file with no
-/// project context, so candidate content can be validated in a scratch file
-/// BEFORE it is written to its destination — a reject leaves no broken file to
-/// delete or restore. `-stop-after-parsing` reports only lexer/parser
-/// diagnostics (type errors never appear), making this a pure syntax check.
+/// Standalone syntax gate built on `moonc syncheck`, moonc's dedicated
+/// parse-only front end: it lexes and parses one file with no project context
+/// and reports lexer/parser diagnostics as JSON (type and resolution errors do
+/// not gate — see `is_parse_error_code`), so candidate content can be validated
+/// in a scratch file BEFORE it lands at its destination — a reject leaves no
+/// broken file to delete or restore.
 ///
-/// TODO(.mbt.md): raw moonc lexes markdown files as MoonBit source (the `#`
-/// heading and ``` fences themselves become lexing errors), so `.mbt.md`
-/// content cannot be gated this way. Gating doc files would need moon's own
-/// fenced-block extraction (```moonbit check vs plain fences, nocheck
-/// attributes); until then `.mbt.md` writes and edits are not parse-gated.
-const MooncParseCommand : String = "moonc compile -no-intermediate-file -stop-after-parsing -error-format json"
+/// `syncheck` recognizes its input kind by name (see `gate_scratch_name`):
+/// `.mbt` source; `.mbt.md` doc files, where it parses only the ` ```mbt check `
+/// and ` ```moonbit check ` fenced blocks and skips plain and `nocheck` fences,
+/// matching moon's own extraction; and the textual `moon.mod` / `moon.pkg`
+/// config files. `moon.work` and the legacy `*.json` config files are not
+/// `syncheck` inputs, so they are not gated.
+const MooncSyncheckCommand : String = "moonc syncheck -error-format json"
 
 ///|
 /// How many lex/parse errors a reject report surfaces. Each entry carries a
@@ -22,8 +23,11 @@ pub const ParseErrorDisplayLimit : Int = 5
 ///|
 /// The `error_code` range for lexer and parser diagnostics (e.g. 3001 "Lexing
 /// error", 3002 "Parse error"). Codes at 4000 and above are type/resolution
-/// errors, which never appear under `-stop-after-parsing` anyway; the range
-/// check keeps the gate honest if that ever changes.
+/// errors — including the `moon.pkg` / `moon.mod` config-validation diagnostics
+/// (e.g. 4192 "Invalid configuration") that syncheck emits alongside genuine
+/// parse errors. Those are semantic, not syntactic, and may be a legitimate
+/// transient state mid-edit, so the range check keeps the gate to pure syntax,
+/// matching how `.mbt` type errors never gate.
 const ParseErrorCodeMin : Int = 3000
 
 ///|
@@ -47,10 +51,26 @@ const MooncParseTimeoutMs : Int = 10000
 const MooncParseMaxOutputChars : Int = 200000
 
 ///|
-/// The scratch file is always named this and the command runs from the scratch
-/// directory, so the command line never embeds a host path that would need
-/// platform-specific quoting.
-const ParseGateFileName : String = "parse_gate.mbt"
+/// The scratch-file basename `moonc syncheck` needs for `path`'s input kind, or
+/// `None` when `path` is not a syncheck input (so the gate does not apply).
+/// syncheck keys off the name: `.mbt` / `.mbt.md` match by suffix, while
+/// `moon.mod` / `moon.pkg` must be that EXACT basename (a `foo.moon.pkg` or a
+/// `moon.pkg.json` is not recognized). The command always runs from the scratch
+/// directory against this bare name, so the command line never embeds a host
+/// path that would need platform-specific quoting.
+fn gate_scratch_name(path : String) -> String? {
+  if path.has_suffix(".mbt.md") {
+    Some("parse_gate.mbt.md")
+  } else if path.has_suffix(".mbt") {
+    Some("parse_gate.mbt")
+  } else if path == "moon.mod" || path.has_suffix("/moon.mod") {
+    Some("moon.mod")
+  } else if path == "moon.pkg" || path.has_suffix("/moon.pkg") {
+    Some("moon.pkg")
+  } else {
+    None
+  }
+}
 
 ///|
 /// One lex/parse diagnostic from the gate. `loc` keeps the compiler's
@@ -65,10 +85,10 @@ pub(all) struct ParseGateError {
 } derive(Debug)
 
 ///|
-/// Whether the parse gate applies to `path`: plain `.mbt` only. `.mbt.md` is
-/// excluded — see the TODO above.
+/// Whether the parse gate applies to `path` — i.e. `moonc syncheck` accepts its
+/// input kind: `.mbt`, `.mbt.md`, or an exact `moon.mod` / `moon.pkg`.
 pub fn is_gateable_path(path : String) -> Bool {
-  path.has_suffix(".mbt") && !path.has_suffix(".mbt.md")
+  gate_scratch_name(path) is Some(_)
 }
 
 ///|
@@ -82,11 +102,17 @@ pub(all) struct ParseGate {
 } derive(Debug)
 
 ///|
-/// Parse `content` as a single standalone `.mbt` file and return its
-/// lex/parse errors (empty `errors` = parses cleanly). Returns `None` when
-/// the gate could not run — moonc missing, scratch dir unwritable, timeout —
-/// so callers fail open, matching the other auto-check guards.
-pub async fn content_parse_errors(content : String) -> ParseGate? {
+/// Parse `content` as the standalone `moonc syncheck` input named by `path`'s
+/// kind and return its lex/parse errors (empty `errors` = parses cleanly).
+/// `path` only selects the scratch-file name (its input kind) — it is never
+/// read from disk. Returns `None` when the gate could not run — `path` is not a
+/// syncheck input, moonc missing, scratch dir unwritable, timeout — so callers
+/// fail open, matching the other auto-check guards.
+pub async fn content_parse_errors(
+  path : String,
+  content : String,
+) -> ParseGate? {
+  guard gate_scratch_name(path) is Some(scratch_name) else { return None }
   let dir = @fs.tmpdir(prefix="openseek-parse-gate-") catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
@@ -101,13 +127,13 @@ pub async fn content_parse_errors(content : String) -> ParseGate? {
   }
   try {
     @fs.write_file(
-      "\{dir}/\{ParseGateFileName}",
+      "\{dir}/\{scratch_name}",
       content,
       create_mode=CreateOrTruncate,
     )
     let result = @async.with_timeout_opt(MooncParseTimeoutMs, () => {
       @shell.collect_shell_output(
-        "\{MooncParseCommand} \{ParseGateFileName}",
+        "\{MooncSyncheckCommand} \{scratch_name}",
         cwd=dir,
         max_output_chars=MooncParseMaxOutputChars,
       )
@@ -437,14 +463,14 @@ test "loc_line_span reads spans, single points, and rejects junk" {
 /// Real-moonc round trips: unlike `moon check`, the standalone gate can run
 /// inside `moon test` safely (no project build lock is involved).
 async test "content_parse_errors gates real content through moonc" {
-  guard content_parse_errors("///|\npub fn ok() -> Int {\n  42\n}\n")
+  guard content_parse_errors("a.mbt", "///|\npub fn ok() -> Int {\n  42\n}\n")
     is Some(clean) else {
     fail("expected the gate to run (is moonc on PATH?)")
   }
   assert_eq(clean.errors.length(), 0)
   assert_false(clean.truncated)
   let bad_content = "///|\npub fn bad() -> Int {\n  let x =\n}\n"
-  guard content_parse_errors(bad_content) is Some(gate) else {
+  guard content_parse_errors("a.mbt", bad_content) is Some(gate) else {
     fail("expected the gate to run (is moonc on PATH?)")
   }
   assert_true(gate.errors.length() > 0)
@@ -465,10 +491,81 @@ async test "content_parse_errors gates real content through moonc" {
   // parameter type), so the gate must trust captured diagnostics, never the
   // exit code — this content must still be rejected.
   guard content_parse_errors(
-      "///|\nfn f(input : String, pos : &mut Int) -> Unit {\n  ignore(input)\n}\n",
+      "a.mbt", "///|\nfn f(input : String, pos : &mut Int) -> Unit {\n  ignore(input)\n}\n",
     )
     is Some(recovered) else {
     fail("expected the gate to run (is moonc on PATH?)")
   }
   assert_true(recovered.errors.length() > 0)
+}
+
+///|
+/// `is_gateable_path` matches exactly the input kinds `moonc syncheck` accepts:
+/// `.mbt`, `.mbt.md`, and an exact `moon.mod` / `moon.pkg` basename. Nested
+/// config files count; prefixed names (`x.moon.pkg`) and the legacy JSON /
+/// `moon.work` files do not.
+test "is_gateable_path covers syncheck input kinds only" {
+  assert_true(is_gateable_path("lib/a.mbt"))
+  assert_true(is_gateable_path("README.mbt.md"))
+  assert_true(is_gateable_path("moon.mod"))
+  assert_true(is_gateable_path("sub/pkg/moon.pkg"))
+  // Not syncheck inputs.
+  assert_false(is_gateable_path("notes.md"))
+  assert_false(is_gateable_path("moon.work"))
+  assert_false(is_gateable_path("moon.mod.json"))
+  assert_false(is_gateable_path("moon.pkg.json"))
+  assert_false(is_gateable_path("x.moon.pkg"))
+  assert_false(is_gateable_path("config.json"))
+}
+
+///|
+/// Real-syncheck round trips for the non-`.mbt` kinds. `.mbt.md` gates only the
+/// checked fenced blocks: a broken ` ```mbt check ` block is rejected, while the
+/// same break behind a plain (unchecked) fence is not, matching moon's own
+/// extraction. `moon.mod` / `moon.pkg` gate the textual config grammar.
+async test "content_parse_errors gates .mbt.md, moon.mod and moon.pkg" {
+  let checked_bad =
+    #|# Title
+    #|
+    #|```mbt check
+    #|///|
+    #|pub fn bad() -> Int {
+    #|  let x =
+    #|}
+    #|```
+  guard content_parse_errors("README.mbt.md", checked_bad) is Some(md) else {
+    fail("expected the gate to run (is moonc on PATH?)")
+  }
+  assert_true(md.errors.length() > 0)
+  assert_true(md.errors[0].message.contains("Parse error"))
+  // The same break behind a plain fence is display-only: syncheck skips it.
+  let plain_bad = checked_bad.replace(old="```mbt check", new="```mbt")
+  guard content_parse_errors("README.mbt.md", plain_bad) is Some(plain) else {
+    fail("expected the gate to run (is moonc on PATH?)")
+  }
+  assert_eq(plain.errors.length(), 0)
+  // Textual moon.mod / moon.pkg: clean parses, then real lex/parse breakage.
+  guard content_parse_errors(
+      "moon.mod", "name = \"me/proj\"\nversion = \"0.1.0\"\n",
+    )
+    is Some(mod_ok) else {
+    fail("expected the gate to run (is moonc on PATH?)")
+  }
+  assert_eq(mod_ok.errors.length(), 0)
+  guard content_parse_errors("moon.mod", "name = \"me/proj\n") is Some(mod_bad) else {
+    fail("expected the gate to run (is moonc on PATH?)")
+  }
+  assert_true(mod_bad.errors.length() > 0)
+  guard content_parse_errors("moon.pkg", "import {\n  \"me/proj/lib\",\n}\n")
+    is Some(pkg_ok) else {
+    fail("expected the gate to run (is moonc on PATH?)")
+  }
+  assert_eq(pkg_ok.errors.length(), 0)
+  guard content_parse_errors("moon.pkg", "import {\n  \"me/proj/lib\"\n")
+    is Some(pkg_bad) else {
+    fail("expected the gate to run (is moonc on PATH?)")
+  }
+  assert_true(pkg_bad.errors.length() > 0)
+  // A non-syncheck path never runs the gate — the caller fails open.
+  assert_true(content_parse_errors("moon.work", "members = [ ]\n") is None)
 }

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -12,7 +12,7 @@ pub const RevertErrorDisplayLimit : Int = 10
 
 pub async fn append_summary(String, String) -> String
 
-pub async fn content_parse_errors(String) -> ParseGate?
+pub async fn content_parse_errors(String, String) -> ParseGate?
 
 pub async fn count_errors(String) -> CheckErrors?
 

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -18,6 +18,8 @@ pub async fn count_errors(String) -> CheckErrors?
 
 pub fn format_parse_gate_errors(String, String, Array[ParseGateError]) -> Array[String]
 
+pub fn gate_paths(String, String) -> Array[String]
+
 pub fn is_gateable_path(String) -> Bool
 
 pub fn tally_diagnostics(String, truncated~ : Bool) -> CheckErrors

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -329,53 +329,50 @@ async fn parse_gate_batch_rejection(
       error if @async.is_being_cancelled() => raise error
       _ => write.path
     }
-    // Prefer the symlink target's kind: the file that actually gets compiled is
-    // the realpath, so its kind decides how the candidate content is parsed (a
-    // `doc.mbt.md -> lib.mbt` alias must gate raw source as `.mbt`, not
-    // markdown). See the note in `edit`'s parse gate.
-    let gate_path = if @auto_check.is_gateable_path(target) {
-      target
-    } else {
-      write.path
+    // Gate under every syncheck kind this file could be classified as. A
+    // regular file yields one kind; a symlink that crosses kinds (e.g.
+    // `link.mbt -> doc.mbt.md`) yields two, and moon's classification of such a
+    // link is ambiguous, so check both and reject on the first that regresses.
+    // See `gate_paths`.
+    for gate_path in @auto_check.gate_paths(write.path, target) {
+      let gate = @auto_check.content_parse_errors(gate_path, write.new_content) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => None
+      }
+      guard gate is Some(gate) && gate.errors.length() > 0 else { continue }
+      let before = @auto_check.content_parse_errors(
+        gate_path,
+        write.original_content,
+      ) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => None
+      }
+      guard before is Some(before) && !before.truncated else { continue }
+      let before_count = before.errors.length()
+      let introduced = gate.errors.length() - before_count
+      if introduced <= 0 {
+        continue
+      }
+      let bound = if gate.truncated { "at least " } else { "" }
+      let pre_existing = if before_count > 0 {
+        " (already has \{before_count} parse error(s); excerpts may include pre-existing ones)"
+      } else {
+        ""
+      }
+      let formatted = @auto_check.format_parse_gate_errors(
+        write.path,
+        write.new_content,
+        gate.errors,
+      )
+      rejections.push({
+        path: write.path,
+        introduced,
+        truncated: gate.truncated,
+        section: "\{write.path}: would gain \{bound}\{introduced} new parse error(s)\{pre_existing}:\n\{formatted.join("\n")}",
+      })
+      // One rejection per file: the first kind that regresses is enough.
+      break
     }
-    if !@auto_check.is_gateable_path(gate_path) {
-      continue
-    }
-    let gate = @auto_check.content_parse_errors(gate_path, write.new_content) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => None
-    }
-    guard gate is Some(gate) && gate.errors.length() > 0 else { continue }
-    let before = @auto_check.content_parse_errors(
-      gate_path,
-      write.original_content,
-    ) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => None
-    }
-    guard before is Some(before) && !before.truncated else { continue }
-    let before_count = before.errors.length()
-    let introduced = gate.errors.length() - before_count
-    if introduced <= 0 {
-      continue
-    }
-    let bound = if gate.truncated { "at least " } else { "" }
-    let pre_existing = if before_count > 0 {
-      " (already has \{before_count} parse error(s); excerpts may include pre-existing ones)"
-    } else {
-      ""
-    }
-    let formatted = @auto_check.format_parse_gate_errors(
-      write.path,
-      write.new_content,
-      gate.errors,
-    )
-    rejections.push({
-      path: write.path,
-      introduced,
-      truncated: gate.truncated,
-      section: "\{write.path}: would gain \{bound}\{introduced} new parse error(s)\{pre_existing}:\n\{formatted.join("\n")}",
-    })
   }
   if rejections.is_empty() {
     return None

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -54,7 +54,7 @@ pub fn definition(
         },
         "revert_on_parse_errors": {
           "type": "boolean",
-          "description": "Syntax gate, on by default. Before the batch is written, each edited .mbt file's rendered result is parsed standalone (moonc -stop-after-parsing); if any file would gain new lex/parse errors — measured against its pre-batch content parsed the same way, so pre-existing parse errors are ignored — the WHOLE batch is rejected with no files changed, and the call returns the errors with excerpts of the would-be content. Type errors never trigger this gate (the post-write revert_when_errors_above guard covers those), and .mbt.md files are not gated. Set false only to intentionally produce content that does not parse (e.g. a fixture).",
+          "description": "Syntax gate, on by default. Before the batch is written, each edited syntax-checkable file's (.mbt, .mbt.md, moon.mod, moon.pkg) rendered result is parsed standalone (moonc syncheck); if any file would gain new lex/parse errors — measured against its pre-batch content parsed the same way, so pre-existing parse errors are ignored — the WHOLE batch is rejected with no files changed, and the call returns the errors with excerpts of the would-be content. Type errors never trigger this gate (the post-write revert_when_errors_above guard covers those); in .mbt.md only the checked (`mbt check` / `moonbit check`) fenced blocks are parsed. Set false only to intentionally produce content that does not parse (e.g. a fixture).",
           "examples": [false],
         },
       },
@@ -313,14 +313,13 @@ priv struct FileRejection {
 }
 
 ///|
-/// Pre-write syntax gate over the rendered batch: parse each edited `.mbt`
-/// file's would-be result standalone (moonc -stop-after-parsing, see
-/// parse_gate.mbt) and reject the whole batch when any file would gain new
-/// parse errors versus its pre-batch content parsed the same way. The same
-/// soundness rules as `edit`'s gate apply per file: fail open when the gate
-/// cannot run or the baseline is missing/truncated, accept a truncated
-/// new-content capture as a lower bound, and resolve symlinked targets before
-/// deciding whether a file is gateable.
+/// Pre-write syntax gate over the rendered batch: parse each edited syncheck
+/// input's would-be result standalone (moonc syncheck, see parse_gate.mbt) and
+/// reject the whole batch when any file would gain new parse errors versus its
+/// pre-batch content parsed the same way. The same soundness rules as `edit`'s
+/// gate apply per file: fail open when the gate cannot run or the baseline is
+/// missing/truncated, accept a truncated new-content capture as a lower bound,
+/// and resolve symlinked targets before deciding whether a file is gateable.
 async fn parse_gate_batch_rejection(
   writes : Array[PreparedWrite],
 ) -> @agent_tool.ToolAction? {
@@ -330,16 +329,23 @@ async fn parse_gate_batch_rejection(
       error if @async.is_being_cancelled() => raise error
       _ => write.path
     }
-    if !@auto_check.is_gateable_path(write.path) &&
-      !@auto_check.is_gateable_path(target) {
+    let gate_path = if @auto_check.is_gateable_path(write.path) {
+      write.path
+    } else {
+      target
+    }
+    if !@auto_check.is_gateable_path(gate_path) {
       continue
     }
-    let gate = @auto_check.content_parse_errors(write.new_content) catch {
+    let gate = @auto_check.content_parse_errors(gate_path, write.new_content) catch {
       error if @async.is_being_cancelled() => raise error
       _ => None
     }
     guard gate is Some(gate) && gate.errors.length() > 0 else { continue }
-    let before = @auto_check.content_parse_errors(write.original_content) catch {
+    let before = @auto_check.content_parse_errors(
+      gate_path,
+      write.original_content,
+    ) catch {
       error if @async.is_being_cancelled() => raise error
       _ => None
     }

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -329,10 +329,14 @@ async fn parse_gate_batch_rejection(
       error if @async.is_being_cancelled() => raise error
       _ => write.path
     }
-    let gate_path = if @auto_check.is_gateable_path(write.path) {
-      write.path
-    } else {
+    // Prefer the symlink target's kind: the file that actually gets compiled is
+    // the realpath, so its kind decides how the candidate content is parsed (a
+    // `doc.mbt.md -> lib.mbt` alias must gate raw source as `.mbt`, not
+    // markdown). See the note in `edit`'s parse gate.
+    let gate_path = if @auto_check.is_gateable_path(target) {
       target
+    } else {
+      write.path
     }
     if !@auto_check.is_gateable_path(gate_path) {
       continue

--- a/agent_tool/write/README.mbt.md
+++ b/agent_tool/write/README.mbt.md
@@ -42,19 +42,19 @@ as are `moon.pkg` rewrites that use JSON-style syntax or `#` comments. Generated
 `*.generated.mbti` interface files are rejected too; refresh them with `moon info`
 instead.
 
-New `.mbt` content gets a pre-write syntax gate: the content is parsed
-standalone (`moonc compile -stop-after-parsing` in a scratch file, no project
-context needed), and content with lex/parse errors is rejected before anything —
-parent directories included — is created on disk. The call fails with the errors
-and numbered excerpts synthesized from the rejected content. A non-parsing file
-is never a valid intermediate state, and `write` refuses to overwrite existing
-source, so the natural retry is another `write` with corrected content. Three or
-more parse errors switch the retry hint to writing a smaller skeleton first and
-growing it with `edit`. Type errors never trigger the gate — they can be a
-legitimate transient state during multi-file work — and `.mbt.md` files are not
-gated (moonc cannot parse markdown-hosted code blocks; see the TODO in
-`agent_tool/internal/auto_check/parse_gate.mbt`). `revert_on_parse_errors=false`
-opts out for deliberately non-parsing fixtures.
+New syncheck inputs (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`) get a pre-write
+syntax gate: the content is parsed standalone (`moonc syncheck` in a scratch
+file, no project context needed), and content with lex/parse errors is rejected
+before anything — parent directories included — is created on disk. The call
+fails with the errors and numbered excerpts synthesized from the rejected
+content. A non-parsing file is never a valid intermediate state, and `write`
+refuses to overwrite existing source, so the natural retry is another `write`
+with corrected content. Three or more parse errors switch the retry hint to
+writing a smaller skeleton first and growing it with `edit`. Type errors never
+trigger the gate — they can be a legitimate transient state during multi-file
+work; in `.mbt.md` only the checked (`mbt check` / `moonbit check`) fenced blocks
+are parsed. `revert_on_parse_errors=false` opts out for deliberately non-parsing
+fixtures.
 
 ## Arguments
 
@@ -62,7 +62,7 @@ opts out for deliberately non-parsing fixtures.
 | --------- | ------ | -------- | ----- |
 | `path`    | string | yes | Filesystem path. Relative paths resolve against the agent process's current working directory. |
 | `content` | string | yes | Full file body. Empty strings are accepted and produce a zero-byte file. |
-| `revert_on_parse_errors` | boolean | no (default `true`) | Reject new `.mbt` content that fails to lex/parse before anything is written, returning the errors with excerpts. `.mbt.md` is not gated. Set `false` only to intentionally create a non-parsing file (e.g. a fixture). |
+| `revert_on_parse_errors` | boolean | no (default `true`) | Reject new syncheck-input content (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`) that fails to lex/parse before anything is written, returning the errors with excerpts. In `.mbt.md` only the checked fenced blocks are parsed. Set `false` only to intentionally create a non-parsing file (e.g. a fixture). |
 
 ## Action
 

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -113,28 +113,26 @@ async fn write_file(
     // `moon.pkg`): parse the candidate content in a scratch file first (moonc
     // syncheck needs no project context), so malformed content is rejected
     // before anything — parent directories included — is created on disk. Gate
-    // by the target's kind so malformed content written THROUGH a link (e.g.
+    // under every kind this file could be classified as (from both the path and
+    // its symlink target), so malformed content written THROUGH a link (e.g.
     // `alias.txt -> moon.pkg`) is caught too. A non-parsing file is never a
     // valid intermediate state, and since `write` refuses to overwrite existing
     // source, the natural retry is another `write` with corrected content.
     // Fail-open: when the gate cannot run (moonc missing), write as usual.
-    let gate_path = if @auto_check.is_gateable_path(target) {
-      target
-    } else {
-      path
-    }
-    if input.revert_on_parse_errors && @auto_check.is_gateable_path(gate_path) {
-      let gate = @auto_check.content_parse_errors(gate_path, input.content) catch {
-        error if @async.is_being_cancelled() => raise error
-        _ => None
-      }
-      if gate is Some(gate) && gate.errors.length() > 0 {
-        let bound = if gate.truncated { "≥" } else { "" }
-        return @agent_tool.ToolAction::respond(
-          write_reject_report(path, input.content, gate),
-          is_error=true,
-          brief="write rejected (\{bound}\{gate.errors.length()} parse error(s))",
-        )
+    if input.revert_on_parse_errors {
+      for gate_path in @auto_check.gate_paths(path, target) {
+        let gate = @auto_check.content_parse_errors(gate_path, input.content) catch {
+          error if @async.is_being_cancelled() => raise error
+          _ => None
+        }
+        if gate is Some(gate) && gate.errors.length() > 0 {
+          let bound = if gate.truncated { "≥" } else { "" }
+          return @agent_tool.ToolAction::respond(
+            write_reject_report(path, input.content, gate),
+            is_error=true,
+            brief="write rejected (\{bound}\{gate.errors.length()} parse error(s))",
+          )
+        }
       }
     }
     create_parent_dirs(path)

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -22,7 +22,7 @@
 ///   created; the message gains ` (overwrote existing file)` when the path
 ///   already existed, so the model can tell it clobbered prior content.
 /// - `Respond(ToolOutput("rejected: the content for <path> ...", is_error=true))`
-///   when the parse gate refused non-parsing `.mbt` content.
+///   when the parse gate refused non-parsing content.
 /// - `Respond(ToolOutput("error writing <path>: <error>", is_error=true))`
 ///   if the write fails.
 /// - `Respond(ToolOutput("error: write requires ...", is_error=true))` for
@@ -86,38 +86,45 @@ async fn write_file(
         brief="write \{@agent_tool.brief_basename(path)}",
       )
     }
+    // Resolve symlinks once, up front: the realpath decides both whether this
+    // is an existing-source overwrite to reject and — for the syntax gate below
+    // — what KIND the written file really is. A brand-new path has no target, so
+    // realpath fails and it falls back to its own name.
+    let target = @fs.realpath(path) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => path
+    }
     // Guard the last unguarded source-write path: `write` is not sandboxed (it
     // is an in-process file write, unlike `shell`), so overwriting an existing
     // `.mbt`/`.mbt.md` file here would bypass the line-anchored edit discipline
     // and risk silently dropping content. Existing source must change through
     // `edit`/`multi_edit` (which also insert). Creating a NEW source file, or
-    // writing non-source files, is still allowed.
-    // Resolve symlinks before treating a path as a safe non-source overwrite: a
-    // link named `x.txt` pointing at `lib.mbt` would otherwise slip past the
-    // suffix check and truncate the source through CreateOrTruncate below.
-    if @fs.exists(path) {
-      let target = @fs.realpath(path) catch {
-        error if @async.is_being_cancelled() => raise error
-        _ => path
-      }
-      if is_mbt_source(path) || is_mbt_source(target) {
-        return @agent_tool.ToolAction::respond(
-          "error writing \{path}: existing source file — use edit or multi_edit to change it (an empty old_string inserts new code); write is for creating new files",
-          is_error=true,
-          brief="write \{@agent_tool.brief_basename(path)}",
-        )
-      }
+    // writing non-source files, is still allowed. Resolving the symlink first
+    // stops a link named `x.txt` pointing at `lib.mbt` from slipping past the
+    // suffix check and truncating the source through CreateOrTruncate below.
+    if @fs.exists(path) && (is_mbt_source(path) || is_mbt_source(target)) {
+      return @agent_tool.ToolAction::respond(
+        "error writing \{path}: existing source file — use edit or multi_edit to change it (an empty old_string inserts new code); write is for creating new files",
+        is_error=true,
+        brief="write \{@agent_tool.brief_basename(path)}",
+      )
     }
     // Pre-write syntax gate for syncheck inputs (`.mbt`, `.mbt.md`, `moon.mod`,
     // `moon.pkg`): parse the candidate content in a scratch file first (moonc
     // syncheck needs no project context), so malformed content is rejected
-    // before anything — parent directories included — is created on disk. A
-    // non-parsing file is never a valid intermediate state, and since `write`
-    // refuses to overwrite existing source, the natural retry is another
-    // `write` with corrected content. Fail-open: when the gate cannot run
-    // (moonc missing), write as usual.
-    if input.revert_on_parse_errors && @auto_check.is_gateable_path(path) {
-      let gate = @auto_check.content_parse_errors(path, input.content) catch {
+    // before anything — parent directories included — is created on disk. Gate
+    // by the target's kind so malformed content written THROUGH a link (e.g.
+    // `alias.txt -> moon.pkg`) is caught too. A non-parsing file is never a
+    // valid intermediate state, and since `write` refuses to overwrite existing
+    // source, the natural retry is another `write` with corrected content.
+    // Fail-open: when the gate cannot run (moonc missing), write as usual.
+    let gate_path = if @auto_check.is_gateable_path(target) {
+      target
+    } else {
+      path
+    }
+    if input.revert_on_parse_errors && @auto_check.is_gateable_path(gate_path) {
+      let gate = @auto_check.content_parse_errors(gate_path, input.content) catch {
         error if @async.is_being_cancelled() => raise error
         _ => None
       }
@@ -545,6 +552,26 @@ async test "write fails on a dangling symlink instead of creating its target" {
     assert_true(output.is_error)
     assert_true(output.content.contains("error writing"))
     assert_false(@fs.exists("\{dir}/lib/new.mbt"))
+  })
+}
+
+///|
+/// Writing through a link whose own name is not a syncheck input still gates by
+/// the target's kind: `alias.txt -> moon.pkg` must not let malformed manifest
+/// content land in the real `moon.pkg` (the write would otherwise follow the
+/// link and truncate it). The existing manifest is left untouched.
+async test "write parse-gates manifest content written through a symlink" {
+  @vfs.with_tmpdir(prefix="openseek-write-manifest-link-", dir => {
+    let manifest = "\{dir}/moon.pkg"
+    let original = "import {}\n"
+    @fs.write_file(manifest, original, create_mode=CreateOrTruncate)
+    let link = "\{dir}/alias.txt"
+    @fs.symlink(target="moon.pkg", link)
+    let result = execute({ "path": link, "content": "x" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    // The malformed content never reached the manifest.
+    assert_eq(@fs.read_file(manifest).text(), original)
   })
 }
 

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -10,11 +10,12 @@
 /// - `content` (string, required): text to write. The file is truncated
 ///   before writing.
 /// - `revert_on_parse_errors` (boolean, optional, default true): before a new
-///   `.mbt` file is written, its content is parsed standalone (`moonc
-///   -stop-after-parsing`); content with lex/parse errors is rejected and the
-///   errors are returned with excerpts — nothing lands on disk. `.mbt.md` is
-///   not gated (moonc cannot parse markdown; see parse_gate.mbt). Set false
-///   only to intentionally create a file that does not parse (e.g. a fixture).
+///   syncheck input (`.mbt`, `.mbt.md`, `moon.mod`, `moon.pkg`) is written, its
+///   content is parsed standalone (`moonc syncheck`); content with lex/parse
+///   errors is rejected and the errors are returned with excerpts — nothing
+///   lands on disk. In `.mbt.md` only the checked fenced blocks are parsed. Set
+///   false only to intentionally create a file that does not parse (e.g. a
+///   fixture).
 ///
 /// ## Result
 /// - `Respond(ToolOutput("ok: wrote <n> chars to <path>"))` when a new file is
@@ -31,7 +32,7 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="write",
-    description="Create a new file at arguments.path with arguments.content (missing parent directories are created), or overwrite an existing non-source file. Overwriting an existing .mbt/.mbt.md source file is rejected: use edit or multi_edit to change existing source (an empty old_string inserts new code). New .mbt content that fails to lex/parse is rejected BEFORE writing and the parse errors are returned — see revert_on_parse_errors. Do not use write to route shell-generated rewrites back into source files. Do not create Markdown or README files unless the user explicitly asks for them.",
+    description="Create a new file at arguments.path with arguments.content (missing parent directories are created), or overwrite an existing non-source file. Overwriting an existing .mbt/.mbt.md source file is rejected: use edit or multi_edit to change existing source (an empty old_string inserts new code). New syntax-checkable content (.mbt, .mbt.md, moon.mod, moon.pkg) that fails to lex/parse is rejected BEFORE writing and the parse errors are returned — see revert_on_parse_errors. Do not use write to route shell-generated rewrites back into source files. Do not create Markdown or README files unless the user explicitly asks for them.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -39,7 +40,7 @@ pub fn definition(
         "content": { "type": "string" },
         "revert_on_parse_errors": {
           "type": "boolean",
-          "description": "Syntax gate, on by default. Before a new .mbt file is written, its content is parsed standalone (moonc -stop-after-parsing); content with lex/parse errors is REJECTED — nothing is written — and the call returns the errors with excerpts of the offending lines. A file that does not parse is never a valid intermediate state, and write cannot overwrite existing source, so the retry is another write with corrected content. Type errors never trigger the gate (they may be a legitimate transient state during multi-file work), and .mbt.md files are not gated. Set false only to intentionally create a file that does not parse (e.g. a test fixture).",
+          "description": "Syntax gate, on by default. Before a new syntax-checkable file (.mbt, .mbt.md, moon.mod, moon.pkg) is written, its content is parsed standalone (moonc syncheck); content with lex/parse errors is REJECTED — nothing is written — and the call returns the errors with excerpts of the offending lines. A file that does not parse is never a valid intermediate state, and write cannot overwrite existing source, so the retry is another write with corrected content. Type errors never trigger the gate (they may be a legitimate transient state during multi-file work); in .mbt.md only the checked (`mbt check` / `moonbit check`) fenced blocks are parsed. Set false only to intentionally create a file that does not parse (e.g. a test fixture).",
           "examples": [false],
         },
       },
@@ -107,16 +108,16 @@ async fn write_file(
         )
       }
     }
-    // Pre-write syntax gate for plain `.mbt` files: parse the candidate
-    // content in a scratch file first (moonc -stop-after-parsing needs no
-    // project context), so malformed content is rejected before anything —
-    // parent directories included — is created on disk. A non-parsing file is
-    // never a valid intermediate state, and since `write` refuses to overwrite
-    // existing source, the natural retry is another `write` with corrected
-    // content. `.mbt.md` is not gated (see the TODO in parse_gate.mbt).
-    // Fail-open: when the gate cannot run (moonc missing), write as usual.
+    // Pre-write syntax gate for syncheck inputs (`.mbt`, `.mbt.md`, `moon.mod`,
+    // `moon.pkg`): parse the candidate content in a scratch file first (moonc
+    // syncheck needs no project context), so malformed content is rejected
+    // before anything — parent directories included — is created on disk. A
+    // non-parsing file is never a valid intermediate state, and since `write`
+    // refuses to overwrite existing source, the natural retry is another
+    // `write` with corrected content. Fail-open: when the gate cannot run
+    // (moonc missing), write as usual.
     if input.revert_on_parse_errors && @auto_check.is_gateable_path(path) {
-      let gate = @auto_check.content_parse_errors(input.content) catch {
+      let gate = @auto_check.content_parse_errors(path, input.content) catch {
         error if @async.is_being_cancelled() => raise error
         _ => None
       }
@@ -548,17 +549,18 @@ async test "write fails on a dangling symlink instead of creating its target" {
 }
 
 ///|
-async test "write rejects suspiciously tiny moon.pkg" {
+/// `moon.pkg` now flows through the syntax gate too, so malformed config is
+/// rejected before anything lands. Tininess alone is not the trigger — the
+/// manifest guard's commented-out "suspiciously small" heuristic stays off, and
+/// a valid dummy (`import {}`) still writes (see the parent-directories test) —
+/// invalid syntax is. A bare `x` is not a valid package statement.
+async test "write parse-gates a malformed moon.pkg" {
   @vfs.with_tmpdir(prefix="openseek-write-manifest-", dir => {
     let path = "\{dir}/moon.pkg"
     let result = execute({ "path": path, "content": "x" })
     guard result is Respond(output) else { fail("expected Respond") }
-    debug_inspect(
-      output.is_error,
-      content=(
-        #|false
-      ),
-    )
+    assert_true(output.is_error)
+    assert_false(@fs.exists(path))
   })
 }
 
@@ -620,7 +622,8 @@ test "write_reject_report pushes smaller parts when parse errors cascade" {
 
 ///|
 /// End-to-end through real moonc: the gate needs no moon project, so a plain
-/// tmpdir exercises the reject, the opt-out, and the ungated `.mbt.md` path.
+/// tmpdir exercises the reject, the opt-out, and the `.mbt.md` doc path (whose
+/// checked fenced blocks are now gated too).
 async test "write gates .mbt content through moonc before writing" {
   @vfs.with_tmpdir(prefix="openseek-write-gate-", dir => {
     // Broken .mbt: rejected, nothing on disk (not even parent dirs).
@@ -651,7 +654,7 @@ async test "write gates .mbt content through moonc before writing" {
     guard fixture is Respond(fx) else { fail("expected Respond") }
     assert_false(fx.is_error)
     assert_true(@fs.exists("\{dir}/lib/fixture.mbt"))
-    // .mbt.md is not gated: markdown content is written untouched.
+    // .mbt.md prose (no checked block): parses clean, written untouched.
     let doc = execute({
       "path": "\{dir}/lib/doc.mbt.md",
       "content": "# Doc\n\nprose only\n",
@@ -659,6 +662,14 @@ async test "write gates .mbt content through moonc before writing" {
     guard doc is Respond(md) else { fail("expected Respond") }
     assert_false(md.is_error)
     assert_true(@fs.exists("\{dir}/lib/doc.mbt.md"))
+    // .mbt.md with a broken ```mbt check block: gated like source, rejected.
+    let broken_doc = execute({
+      "path": "\{dir}/lib/broken.mbt.md",
+      "content": "# Doc\n\n```mbt check\n///|\npub fn h() -> Int {\n  let x =\n}\n```\n",
+    })
+    guard broken_doc is Respond(bad) else { fail("expected Respond") }
+    assert_true(bad.is_error)
+    assert_false(@fs.exists("\{dir}/lib/broken.mbt.md"))
   })
 }
 

--- a/todo.md
+++ b/todo.md
@@ -236,4 +236,3 @@
 - Make tool schemas/descriptions sharper for conditional required fields such as `moon_ide.action = "doc"` requiring `query`.
 - Keep temporary debug code outside compiled packages, or provide a dedicated scratch package that cannot regress the deliverable package.
 - Make `moon_ide` failures clearer when `cwd` does not exist, or teach the prompt to create the workspace before semantic IDE calls against it.
-- Gate `.mbt.md` writes/edits on parse errors like `.mbt`. The moonc pre-write gate (`moonc compile -stop-after-parsing`) cannot parse markdown-hosted code blocks (it lexes the `#` headings and ``` fences as MoonBit), so `.mbt.md` is currently not parse-gated; gating it needs moon's own fenced-block extraction rules (```moonbit check vs plain fences, nocheck attributes) or an upstream moonc/moon flag for single-file .mbt.md checking.


### PR DESCRIPTION
## What

Switches the pre-write **parse gate** from `moonc compile -stop-after-parsing` to moonc's dedicated **`moonc syncheck`** front end, and extends gating from plain `.mbt` to every input kind syncheck accepts.

| Input | Gated? | Notes |
|---|---|---|
| `.mbt` | ✅ (unchanged) | |
| `.mbt.md` | ✅ **new** | only ` ```mbt check ` / ` ```moonbit check ` blocks are parsed — plain and `nocheck` fences skipped, matching moon's own extraction |
| `moon.mod` (textual) | ✅ **new** | exact basename |
| `moon.pkg` (textual) | ✅ **new** | exact basename |
| `moon.work` | ❌ | not a syncheck input |
| `*.json` configs | ❌ | legacy format, not a syncheck input |

This closes the long-standing **`.mbt.md` TODO**: raw `moonc` lexed markdown headings/fences as source, so doc files could not be parse-gated. `syncheck` extracts the checked fenced blocks natively.

## How

- `content_parse_errors` now takes the destination `path` and derives the scratch-file name from the path's *kind*, so syncheck interprets the candidate content correctly (`.mbt` → `parse_gate.mbt`, `.mbt.md` → `parse_gate.mbt.md`, exact `moon.mod`/`moon.pkg`).
- `write` / `edit` / `multi_edit` pass the effective gateable path (literal path, or its symlink target).
- Config-validation diagnostics (4xxx, e.g. *"Invalid configuration"*) stay outside the gate's 3xxx lex/parse range — they're semantic and may be transient mid-edit, mirroring how `.mbt` type errors never gate.
- The `moon.mod`/`moon.pkg` **manifest guard is retained**: it catches what syncheck cannot (empty `moon.mod`, missing `name =`) and gives actionable *JSON-vs-text* / *`#`-vs-`//`* hints ahead of the generic gate.

## Testing

- `moon check` clean; `moon test` **973/973** native; `moon cram test tests/cram` **23/23**.
- New `auto_check` tests: `is_gateable_path` coverage; real-syncheck round-trips for `.mbt.md` (checked block rejected, plain fence clean), `moon.mod`, `moon.pkg`, and the ungated `moon.work`.
- New `write` test: a broken ` ```mbt check ` block in a `.mbt.md` is now rejected before writing; a malformed `moon.pkg` is parse-gated.

## Note

`moon.work` is **not** a supported `moonc syncheck` input (`supported suffixes: .mbt, .mbt.md, moon.pkg, moon.mod`). Filing a moonbitlang/moon issue to track adding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)