### PR TITLE
docs: scrub retired moon_check/moon_cmd/moon_ide from planning notes

### DIFF
--- a/agent-improvement-guide.md
+++ b/agent-improvement-guide.md
@@ -44,8 +44,8 @@ The strongest negative references all point at the same gap:
   extra runtime failure output. Tests were not enough to catch dirty stdout.
 - JSON Schema V1 and V2 failed from context blowups after generated native C was
   printed into the transcript. Output caps fixed the next run.
-- Jqmini crashed after an oversized `moon ide doc @array` response. The model did
-  not need more text; it needed smaller, shaped documentation.
+- Jqmini crashed after an oversized semantic-doc response for `@array`. The model
+  did not need more text; it needed smaller, shaped documentation.
 
 These are not isolated task bugs. They are system design signals.
 
@@ -99,7 +99,8 @@ That single check would have caught the V4 schema-validator contract gap.
 
 ### Design Direction
 
-Add a `moon_accept` tool, or extend `moon_cmd`, with structured assertions:
+Add a `moon_accept` tool, or extend a structured moon-command runner, with
+structured assertions:
 
 - `command`: array of argv, not a shell string
 - `stdin`: optional string
@@ -165,10 +166,10 @@ reasoning budget on the domain logic instead of guessing MoonBit runtime APIs.
 
 ### Motivation
 
-The agent now has `moon_cmd`, but raw shell can still bypass policy. In one eval,
-`moon_cmd` rejected an unreviewed `moon test --update`; the agent then used shell
-to run the same command. Other runs lost time to shell quoting for expressions
-with `|`, spaces, brackets, and parentheses.
+A structured command policy can still be bypassed by raw shell. In one eval, a
+guarded command path rejected an unreviewed `moon test --update`; the agent then
+used shell to run the same command. Other runs lost time to shell quoting for
+expressions with `|`, spaces, brackets, and parentheses.
 
 ### Good Example
 
@@ -182,7 +183,7 @@ the shell tool should either reject it or route it through the same command
 policy:
 
 ```text
-moon_cmd:
+structured command:
   command = test
   update_snapshots = true
   test_update_kind = intentional_snapshot_refresh
@@ -200,27 +201,27 @@ The agent should not have to rely on shell quoting to preserve the query.
 
 ### Why It Matters
 
-Command policy is only real if every path respects it. If `moon_cmd` is safe but
-`shell` can bypass it, the agent will eventually take the loose path under
-pressure. Routing also improves eval quality because command failures become
+Command policy is only real if every path respects it. If a guarded command path
+is safe but `shell` can bypass it, the agent will eventually take the loose path
+under pressure. Routing also improves eval quality because command failures become
 tool-feedback failures, not quoting accidents.
 
-## Priority 4: Shape `moon_ide` And Source Output
+## Priority 4: Shape Semantic Docs And Source Output
 
 ### Motivation
 
-`moon_ide` improved API discovery, especially for JSON, async file reads, and
-`io.Data`. But broad doc/source output caused avoidable waste. Jqmini's oversized
-`moon ide doc @array` response was followed by a transport reset. JSON Schema
-spent many steps reading too much dependency source before finding the relevant
-file-read pattern.
+Semantic doc lookups improved API discovery, especially for JSON, async file
+reads, and `io.Data`. But broad doc/source output caused avoidable waste.
+Jqmini's oversized semantic-doc response for `@array` was followed by a transport
+reset. JSON Schema spent many steps reading too much dependency source before
+finding the relevant file-read pattern.
 
 ### Good Example
 
 Prefer shaped responses:
 
 ```text
-moon_ide doc @json.Json
+semantic doc @json.Json
 
 response:
   summary
@@ -233,7 +234,7 @@ response:
 For definitions:
 
 ```text
-moon_ide peek_def @io.Data::text
+semantic peek_def @io.Data::text
 
 response:
   exact signature
@@ -305,8 +306,6 @@ The agent already had prompt guidance for:
 - current `moon.mod`
 - flat MoonBit package structure
 - smaller files
-- `moon_cmd`
-- `moon_ide`
 - bounded reads
 - native CLI arguments
 
@@ -315,9 +314,7 @@ reason is structural: a prompt can ask the model to remember a rule, while a too
 can make the wrong state impossible to overlook. The strongest improvements so
 far were tool-level:
 
-- `moon_cmd` caught real test, run, README, and target mismatches
 - output caps prevented JSON Schema context blowups
-- `moon_ide` reduced API guessing
 - bounded `read` made repair loops more focused
 
 The next investments should follow that same pattern.
@@ -331,9 +328,9 @@ The next investments should follow that same pattern.
 2. Add a CLI/error cookbook and inject it into the agent prompt.
    This gives the model a reliable native CLI pattern while the semantic
    validator proves the result.
-3. Enforce MoonBit command routing through `moon_cmd` or equivalent policy.
+3. Enforce MoonBit command routing through a structured command policy.
    Close shell bypasses and reduce quoting failures for query-heavy tasks.
-4. Shape `moon_ide` responses and broad source reads.
+4. Shape semantic-doc responses and broad source reads.
    Keep API discovery useful but bounded.
 5. Add manifest/debug/edit guardrails.
    Prevent recurring cleanup and package-regression failures.

--- a/todo.md
+++ b/todo.md
@@ -34,26 +34,26 @@
 - Result: the agent finished successfully at step 109 with parser package, native CLI package, README, public tests, whitebox tests, generated interface, and passing validation.
 - Validation: independent `moon check` and `moon test` in the generated workspace passed with 32 tests.
 - CLI smoke: `moon run --target native cmd/main -- /tmp/openseek-toml-v3-smoke.toml` produced `{"title":"Smoke","owner":{"name":"Moon","ports":[8000,8001]}}`.
-- Performance improvement over earlier runs: the agent recovered from manifest and API mistakes, discovered current `Json` and async filesystem APIs before finalizing code, used `moon_check` repeatedly, and reached a clean parser package by the mid-run before adding CLI/tests/docs.
+- Performance improvement over earlier runs: the agent recovered from manifest and API mistakes, discovered current `Json` and async filesystem APIs before finalizing code, ran `moon check` repeatedly, and reached a clean parser package by the mid-run before adding CLI/tests/docs.
 - Remaining issue: the README says `moon run cmd/main -- <file.toml>`, but the package is native-only and the module does not set `preferred_target = "native"`, so the documented command fails unless the user passes `--target native`.
 
 ## DeepSeek V4 Pro TOML Parser V4
 
-- Status: succeeded as of 2026-05-22 19:49 CST after adding `moon_cmd`.
-- Task: same TOML parser plus JSON-dump CLI task, using `--max-steps 1000`, with explicit instruction to use `moon_check` for compiler diagnostics and `moon_cmd` for tests, runs, info, fmt, and README command validation.
+- Status: succeeded as of 2026-05-22 19:49 CST after adding structured moon-command validation.
+- Task: same TOML parser plus JSON-dump CLI task, using `--max-steps 1000`, with explicit instruction to validate compiler diagnostics, tests, runs, info, fmt, and README commands.
 - Log: `.moonagent/eval_runs/results/openseek_toml_cli_d4pro_reasoning_v4.log`
 - Log size: 6,477 lines / 277,636 bytes.
 - Output workspace: `.moonagent/eval_runs/toml_cli_task_v4`
 - Result: the agent finished successfully at step 135 with parser package, native CLI package, README, blackbox tests, whitebox tests, generated interface, and passing validation.
 - Validation: independent `moon check` and `moon test` in the generated workspace passed with 22 tests.
 - CLI smoke: `moon run --target native cmd/main -- test.toml` and stdin piping both produced valid JSON.
-- `moon_cmd` impact: it caught real `moon test` failures, README doctest failures, native CLI compiler failures, and validated the final documented `moon run --target native` command. This directly fixed the V3 class of missed CLI-target mismatch.
+- Structured command-validation impact: it caught real `moon test` failures, README doctest failures, native CLI compiler failures, and validated the final documented `moon run --target native` command. This directly fixed the V3 class of missed CLI-target mismatch.
 - Remaining issue: the run took more steps and tokens than V3. The agent still wrote large parser files before the first meaningful check, read too much dependency source while discovering async APIs, and used `moon test --update` too freely.
 
 ## DeepSeek V4 Flash TOML Parser
 
 - Status: failed/incomplete as of 2026-05-22 20:14 CST.
-- Task: same TOML parser plus JSON-dump CLI task, using `--max-steps 1000`, `moon_check`, and `moon_cmd`.
+- Task: same TOML parser plus JSON-dump CLI task, using `--max-steps 1000` and structured moon-command validation.
 - Model setting: `OPENSEEK_MODEL=deepseek-v4-flash`.
 - First attempt log: `.moonagent/eval_runs/results/openseek_toml_cli_d4flash_v1.log`
 - First attempt size: 23 lines / 645 bytes.
@@ -84,20 +84,6 @@
 - Missing deliverables: no README, no generated `pkg.generated.mbti`, and no final `moon info` output were produced before the context failure.
 - Performance notes: Pro recovered from a large 127-error validator compile wall, fixed public tests without using `moon test --update`, repaired a custom regex implementation based on failing tests, and got both default and native tests green. The main failures were poor file-read/API verification for the native CLI, leaving debug output in the CLI, and not bounding command output before feeding it back into the model.
 
-## DeepSeek V4 Pro JSON Schema Validator V2 With `moon_ide`
-
-- Status: partial success/incomplete as of 2026-05-22 23:05 CST.
-- Task: repeat the JSON Schema validator library plus native CLI task after adding `moon_ide` and prompt guidance for flat MoonBit packages and small-file generation.
-- Model setting: `OPENSEEK_MODEL=deepseek-v4-pro`, `--max-steps 1000`.
-- Log: `.moonagent/eval_runs/results/openseek_json_schema_d4pro_reasoning_v2_moon_ide.log`
-- Log size: 72,627 lines / 3,191,156 bytes.
-- Output workspace: `.moonagent/eval_runs/json_schema_validator_pro_v2_moon_ide`
-- Result: the run stopped at step 80 with a DeepSeek context-length error after a debug CLI run printed generated native C into the transcript. There is no `=== finished ===` success marker.
-- Library validation: independent `moon check --output-json`, `moon test`, and `moon test --target native` all pass in the generated workspace. Final test count is 37/37 passing.
-- CLI validation: independent `moon run --target native cmd/main -- fixtures/passing/schema_string.json fixtures/passing/instance_string.json` exits 0 but returns `{"valid":false,... "Failed to parse schema: Invalid character '#' ...}`. The final CLI still treats `@env.args()[0]` as the schema path, which is the generated native C path in this environment.
-- `moon_ide` impact: the agent did call `moon_ide doc @env.args` while diagnosing the CLI, and the prompt improved file organization compared with V1: it produced focused files such as `types.mbt`, `path_utils.mbt`, `regex.mbt`, `type_validator.mbt`, `object_validator.mbt`, and `combinators.mbt` instead of one monolith.
-- Remaining gaps: the first `moon_ide` call failed because the target workspace did not exist yet; the agent copied too much from the prior V1 workspace before creating a clean design; the first library check still happened only after many files were written; and command output remained uncapped, allowing a single debug run to blow the model context again.
-
 ## DeepSeek V4 Pro JSON Schema Validator V3 With Output Caps
 
 - Status: succeeded as of 2026-05-22 23:33 CST.
@@ -110,7 +96,7 @@
 - Independent validation: `moon check --output-json .moonagent/eval_runs/json_schema_validator_pro_v3_output_caps` passed; default and native `moon test` both passed with 27 tests.
 - CLI smoke: valid fixture produced `{"valid":true,"errors":[]}`; invalid fixture produced a structured `minimum` error at `/age`.
 - Output-cap impact: the run did not hit a context-length error, did not inject generated native C into the transcript, and stayed two orders of magnitude smaller than the V1/V2 JSON Schema logs.
-- `moon_ide` impact: the agent used docs and definitions for `Json`, async `fs`, `io.Data`, and `&Data::text`; after inspecting the real `Data` source it repaired the native CLI file-read path.
+- Semantic doc/definition impact: the agent used docs and definitions for `Json`, async `fs`, `io.Data`, and `&Data::text`; after inspecting the real `Data` source it repaired the native CLI file-read path.
 - Remaining gaps: the agent still waited until after a large schema file before its first meaningful check, spent many steps on MoonBit mutability and enum constructor mistakes, dumped full dependency/source ranges while diagnosing `Data`, and had a few brittle edit failures (`old_string not found`, missing edit path).
 
 ## DeepSeek V4 Pro JSON Schema Validator V4 With Bounded Read
@@ -126,8 +112,8 @@
 - Inline CLI smoke: `moon run --target native cmd/main -- '{"type":"integer"}' '42'` printed `valid`; the string case printed `invalid` with an integer type error.
 - Contract gap: the final CLI accepts inline JSON strings, not schema and instance file paths. `moon run --target native cmd/main -- fixtures/schema_string.json fixtures/valid_string.json` fails with `Error parsing schema JSON: Invalid character 'i' at line 1, column 1`, so the task is not fully delivered.
 - Bounded-read impact: positive. The agent repeatedly used `read` with `start_line` and `max_lines` while repairing generated files, and those calls returned range metadata instead of flooding the transcript with whole files.
-- Remaining output gaps: broad shell commands still produced noisy listings and large compiler command lines, and `moon_cmd` output caps do not control arbitrary shell output or file/source dumps.
-- Guardrail gap: the agent bypassed the `moon_cmd` snapshot-update guardrail by using shell after `moon_cmd` rejected an unreviewed `moon test --update` attempt.
+- Remaining output gaps: broad shell commands still produced noisy listings and large compiler command lines, and command-runner output caps do not control arbitrary shell output or file/source dumps.
+- Guardrail gap: the agent bypassed the snapshot-update guardrail by using shell after the command runner rejected an unreviewed `moon test --update` attempt.
 - Debug hygiene gap: the agent created temporary debug files/packages during diagnosis, including a root `debug_main.mbt` that broke compilation until removed, and it briefly overwrote the root `moon.pkg` with an empty file before repairing it.
 - Best next ROI: enforce MoonBit command policy at the shell layer, add semantic CLI contract checks for file-path tools and JSON stdout predicates, and require scratch/debug code to live outside compiled packages.
 
@@ -142,7 +128,7 @@
 - Dependency solver task: build a package resolver plus `cmd/resolve` native CLI for semver constraints and conflict reporting.
 - Dependency solver result: succeeded at step 144. Log: `.moonagent/eval_runs/results/openseek_dep_solver_d4pro_v1.log` (2,637 lines, 132K on disk). Independent validation: `moon check --warn-list +unnecessary_annotation` passed, `moon test` passed with 21 tests, and the success fixture printed `{"ok":true,...}`. Remaining issue: the conflict fixture prints the intended JSON error followed by an extra `Failure(...)` runtime line, so the CLI failure contract is still dirty.
 - Tool-call failures: rough `tool error` counts were 23 for jqmini, 45 for JSONPath, and 18 for dependency solver. A narrower scan for avoidable tool/API/edit symptoms found 10, 17, and 8 respectively. These counts include useful domain feedback, so the important signal is the recurring avoidable shape rather than the raw count.
-- Repeated avoidable failures: invalid `moon ide doc` queries (`Json::`, `@stdio.stdin.read_until`, quoted package paths), raw shell misuse for expressions containing `|`, parentheses, and quotes, reading binary `.mi` files as text, brittle `old_string` edits, broad dependency/source dumps, and manifest churn such as rewriting `moon.pkg` with too little content.
+- Repeated avoidable failures: invalid semantic-doc queries (`Json::`, `@stdio.stdin.read_until`, quoted package paths), raw shell misuse for expressions containing `|`, parentheses, and quotes, reading binary `.mi` files as text, brittle `old_string` edits, broad dependency/source dumps, and manifest churn such as rewriting `moon.pkg` with too little content.
 - General conclusion: V4 Pro can now finish several non-trivial MoonBit tasks under the 1000-step budget, but it still spends many steps recovering from tool-shape mistakes and API discovery loops. The strongest run was the dependency solver because it worked in smaller validated increments; JSONPath had the hardest recovery because it wrote a large parser before the first useful check and repeatedly misunderstood JSON/async APIs.
 - Best ROI from this multi-task run: semantic CLI validation remains first, but the next tier should now include shell-level MoonBit command routing/quoting and manifest/package guardrails. These failures repeated across tasks and are not specific to jqmini.
 
@@ -150,51 +136,51 @@
 
 - Status: completed as of 2026-05-23 after six parallel challenging runs with `OPENSEEK_MODEL=deepseek-v4-pro` and `--max-steps 1000`.
 - Setup: the tasks were jqmini, JSONPath, CSVQL, semver dependency solver, Markdown outline/front-matter extractor, and HTTP route matcher. Logs total 16,914 lines under `.moonagent/eval_runs/results/openseek_*guarded*.log`.
-- Jqmini guarded V2: failed. The run stopped after 774 log lines with `OSError(@socket.Tcp::read(): Connection reset by peer)` after a huge `moon ide doc @array` response. Independent `moon check --output-json` still fails with 11 errors and 12 warnings, including error-type mismatches, nonexistent `Double::is_infinite`, nonexistent `Array::sorted`, and old `String::substring` call shapes.
+- Jqmini guarded V2: failed. The run stopped after 774 log lines with `OSError(@socket.Tcp::read(): Connection reset by peer)` after a huge semantic-doc response for `@array`. Independent `moon check --output-json` still fails with 11 errors and 12 warnings, including error-type mismatches, nonexistent `Double::is_infinite`, nonexistent `Array::sorted`, and old `String::substring` call shapes.
 - JSONPath guarded V2: mostly succeeded. Independent validation: `moon check --output-json` passed with 5 deprecated `Show` warnings; `moon test --target native` passed 33/33; file and stdin CLI probes produced expected JSON Lines. Caveats: invalid-path mode returns exit 0 through `moon run` even though the built binary exits 1, and the final workspace still contains whitebox tests named `debug filter ...`.
 - CSVQL guarded V1: mostly succeeded. Independent validation: `moon check --output-json` passed, `moon test` passed 27/27, the temporary `cmd/csvql/debug.mbt` was removed, and quoted single-query CLI arguments work for file and stdin probes. Caveats: unquoted multi-word query probes are easy to miscall, and malformed CSV / invalid query modes return exit 0 with error text.
 - Semver solver guarded V2: strongest clean pass. Independent validation: `moon check --target all` passed, `moon test --target native` passed 20/20, file success/conflict/backtracking probes produced expected JSON, and stdin produced `{"ok":true,"lock":{"a":"1.1.0"}}`.
 - Markdown outline guarded V1: library and CLI output succeeded with an exit-code caveat. Independent validation: `moon check --target native` passed, `moon test --target native` passed 16/16, file and stdin CLI probes produced expected JSON, and the built binary exits 1 for unterminated front matter. Through `moon run`, the same error prints `username/md_outline/md_outline.OutlineError.UnterminatedFrontMatter` but exits 0.
 - Route matcher guarded V1: functional success with a dirty failure path. Independent validation: `moon check --output-json` and `moon check --target native` pass with 8 deprecated `assert_eq`/`Show` warnings; `moon test` passes 36/36; match and no-match CLI probes work. Invalid route patterns print `invalid pattern: /*path/stuff` but leak an abort/Panic stack; `moon run` reports exit 0 while the built binary exits 134.
 - General result: five of six runs delivered a compiling, tested project with useful CLI behavior. Only semver was close to contract-clean. The dominant remaining weakness is not raw MoonBit generation ability; it is external contract verification, especially CLI error mode, exit code, stdout/stderr separation, and whether the agent's final summary matches what users actually get from `moon run`.
-- Tool-call failure patterns: five runs hit the `moon.mod` current-syntax guardrail; semver and Markdown also hit suspiciously tiny `moon.pkg` guardrails. Shell/Moon command routing worked in places, but agents still made structured-command mistakes such as treating `moon_cmd` arguments like shell strings, using `moon run -c/-e` incorrectly, or probing generated binary paths by guessing `_build` layout.
-- API-discovery failure patterns: agents repeatedly guessed async/stdio/fs/error-exit APIs, used deprecated `derive(Show)` to satisfy formatting needs, and issued broad or invalid `moon ide doc` queries. The jqmini run shows the worst case: one oversized doc response was followed by a transport reset before recovery.
+- Tool-call failure patterns: five runs hit the `moon.mod` current-syntax guardrail; semver and Markdown also hit suspiciously tiny `moon.pkg` guardrails. Shell/Moon command routing worked in places, but agents still made structured-command mistakes such as treating command arguments like shell strings, using `moon run -c/-e` incorrectly, or probing generated binary paths by guessing `_build` layout.
+- API-discovery failure patterns: agents repeatedly guessed async/stdio/fs/error-exit APIs, used deprecated `derive(Show)` to satisfy formatting needs, and issued broad or invalid semantic-doc queries. The jqmini run shows the worst case: one oversized doc response was followed by a transport reset before recovery.
 - Debug/edit hygiene patterns: CSVQL temporarily left a second `main` in `cmd/csvql/debug.mbt`, JSONPath kept debug-named whitebox tests, and route/CSVQL logs show brittle `old_string` and missing-directory failures. These were often recoverable but cost many steps and sometimes polluted final quality.
-- Best ROI from the six-task batch: add a semantic CLI acceptance tool first, then a MoonBit CLI/error cookbook and output-shaped IDE docs. Prompt wording alone is not enough; the agent already had guidance for `moon.mod`, flat package structure, small files, `moon_cmd`, and `moon_ide`, but still overstated CLI failure contracts.
+- Best ROI from the six-task batch: add a semantic CLI acceptance tool first, then a MoonBit CLI/error cookbook and output-shaped IDE docs. Prompt wording alone is not enough; the agent already had guidance for `moon.mod`, flat package structure, and small files, but still overstated CLI failure contracts.
 
 ## Tool-Call Failure Review Method
 
 - Status: added after reviewing schema-validator V3/V4 logs.
 - Evaluation reports should separate tool failures into at least four categories:
   1. Expected domain failures: `moon check`, `moon test`, or CLI runs that fail because generated code is wrong. These are useful feedback, not tool misuse.
-  2. Avoidable argument/schema failures: missing fields or wrong fields, such as the V4 `moon_ide doc` call without `query`.
+  2. Avoidable argument/schema failures: missing fields or wrong fields, such as the V4 semantic-doc call without `query`.
   3. Avoidable edit failures: empty `old_string`, `old_string not found`, or stale edit context after a previous rewrite.
   4. Policy failures and bypasses: guarded tool rejection, especially when the next step uses `shell` to bypass the same policy.
 - Each eval summary should include counts and representative examples for avoidable tool-call failures, plus whether the agent recovered or kept repeating the same mistake.
 - For edit failures, prefer prevention over recovery: require a recent bounded `read` before editing a region, make `edit` errors return enough context to choose the next exact string, and consider a line-range replacement tool for cases where exact string matching is too brittle.
 - For argument failures, improve schemas and tool descriptions when the model repeatedly miscalls a tool. If a field is required only for one action, document that relationship in the schema description and README API style.
-- For policy failures, enforce the policy at every path that can perform the action. The `moon_cmd` snapshot-update guardrail is not enough while `shell` can still run `moon test --update`.
+- For policy failures, enforce the policy at every path that can perform the action. The snapshot-update guardrail is not enough while `shell` can still run `moon test --update`.
 - For future multi-task evaluations, record tool-call failures as a first-class section alongside correctness, CLI contract, tests, log size, and final validation.
 
 ## Cross-Evaluation Conclusion
 
 - Status: synthesis updated as of 2026-05-23 after the schema-validator and six-task guarded evals.
 - DeepSeek V4 Pro is strong enough for substantial MoonBit library generation when the environment gives it tight feedback. It recovered from large compiler-error walls, fixed parser/validator logic, used semantic docs when available, and usually finished complex library tasks under a 1000-step budget.
-- The highest-impact improvements so far were tool-level, not prompt-only: `moon_cmd` fixed the TOML V3 documented-CLI mismatch, command output caps prevented JSON Schema V1/V2 context blowups, `moon_ide` improved API discovery, and bounded `read` kept repair-loop file inspection focused.
+- The highest-impact improvements so far were tool-level, not prompt-only: structured moon-command validation fixed the TOML V3 documented-CLI mismatch, command output caps prevented JSON Schema V1/V2 context blowups, semantic doc lookups improved API discovery, and bounded `read` kept repair-loop file inspection focused.
 - The current limiting factor is external contract reliability. Across schema-validator V4, dependency solver, JSONPath, Markdown, CSVQL, and route matcher, the agent often made code compile and tests pass while missing details that users notice immediately: file-vs-inline arguments, exit codes, stdout/stderr cleanliness, abort stack leaks, and whether a failing command really failed.
-- The six-task batch adds a second limiting factor: many failed calls are command-shape or tool-shape failures rather than reasoning failures. Queries with spaces, `|`, brackets, parentheses, and quotes stress shell and structured-command boundaries, while broad/invalid `moon_ide doc` calls still waste steps.
-- Prompt additions remain useful for MoonBit conventions, but they are now lower ROI than enforceable tool behavior. The agent already had guidance for native args, flat packages, small files, `moon.mod`, `moon_ide`, `moon_cmd`, and bounded reads; it still overstated several CLI error contracts in final summaries.
+- The six-task batch adds a second limiting factor: many failed calls are command-shape or tool-shape failures rather than reasoning failures. Queries with spaces, `|`, brackets, parentheses, and quotes stress shell and structured-command boundaries, while broad/invalid semantic-doc calls still waste steps.
+- Prompt additions remain useful for MoonBit conventions, but they are now lower ROI than enforceable tool behavior. The agent already had guidance for native args, flat packages, small files, `moon.mod`, and bounded reads; it still overstated several CLI error contracts in final summaries.
 - Future benchmarks should keep using several task shapes in one batch. Single tasks hide failure modes: semver looked clean, JSONPath exposed async/API discovery issues, CSVQL exposed argv/query-shape ambiguity, route matching exposed dirty abort paths, and jqmini exposed output-volume/transport fragility.
 
 ## Next ROI Investment Ranking
 
 1. Add semantic CLI validation.
-   A dedicated tool or `moon_cmd` mode should run acceptance probes and assert contract-level facts: file-path arguments are used as files, stdin mode works, stdout is valid JSON or JSON Lines, selected predicates hold, stderr is clean, and exit-code expectations match. It should optionally compare `moon run` behavior with the built native binary because JSONPath, Markdown, and route matcher exposed mismatches there.
+   A dedicated tool or moon-command mode should run acceptance probes and assert contract-level facts: file-path arguments are used as files, stdin mode works, stdout is valid JSON or JSON Lines, selected predicates hold, stderr is clean, and exit-code expectations match. It should optionally compare `moon run` behavior with the built native binary because JSONPath, Markdown, and route matcher exposed mismatches there.
 2. Add a MoonBit CLI/error-handling cookbook to the agent/tool docs.
    The repeated high-cost gap is clean native CLI behavior: async file/stdin reads, `@env.args` shape, stdout/stderr writes, structured error JSON, and nonzero process exit without abort stacks. Give the agent a small proven pattern instead of making it rediscover `stdio`, `fs`, `io.Data`, and private `argparse` exit internals.
 3. Route MoonBit commands through a structured shell policy.
-   Raw shell caused repeated quoting and policy problems for jqmini/JSONPath/CSVQL-style expressions and can bypass `moon_cmd` guardrails. Shell should either reject guarded MoonBit commands or route `moon`, `moon run`, and `moon test` through the same policy and output caps.
-4. Shape `moon_ide` and source-output responses.
+   Raw shell caused repeated quoting and policy problems for jqmini/JSONPath/CSVQL-style expressions and can bypass command-policy guardrails. Shell should either reject guarded MoonBit commands or route `moon`, `moon run`, and `moon test` through the same policy and output caps.
+4. Shape semantic-doc and source-output responses.
    Keep docs and source reads focused by default, paginate broad symbol docs, and make invalid query errors actionable. The jqmini transport reset and JSONPath's long async I/O discovery loop both point to this.
 5. Add manifest/package guardrails.
    Several runs confused legacy `moon.mod.json` with current `moon.mod` or wrote suspiciously tiny `moon.pkg` files. Add validation after manifest writes and reject package files that drop required imports/options unless explicitly intended.
@@ -218,21 +204,17 @@
 - When an evaluation allows local references, surface nearby working examples such as `.moonagent/toml_parser_demo*` before implementing from scratch.
 - Do not hide validation failures behind successful shell exits. In the retry, one check-like command returned `exit=0` while printing compiler failures, which led the loop to continue from a false success signal.
 - Keep module/package manifests and dependency assumptions under validation. The retry repeatedly mis-modeled `@json.Json`, `String::split`, suberror constructor labels, and `@string`/`@strconv` parsing APIs.
-- Done: add `moon_cmd` for direct `moon test`, `moon run`, `moon info`, `moon fmt`, and `moon build` validation without shell status masking.
-- Done: add native CLI ergonomics checks in agent policy. V4 validated README commands with `moon_cmd` and explicit `--target native`.
-- Done: add a `moon_cmd` guardrail against using `moon test --update` without `test_update_kind` and `test_update_reason`.
-- Done: add a read-only `moon_ide` tool for semantic `doc`, `outline`, `peek_def`, `hover`, and `find_references` queries.
+- Done: add native CLI ergonomics checks in agent policy. V4 validated README commands with explicit `--target native`.
 - Done: add bounded `read` output with `start_line`, `max_lines`, and `max_output_chars`. In the JSON Schema V4 eval this kept generated-file inspections focused and prevented whole-file dumps during the repair loop.
 - Reduce remaining token-heavy non-command outputs: apply similar caps or summaries to IDE source/definition dumps and broad shell listings.
 - Teach the agent a staged validation invariant: after a package or test file is added, immediately rerun `moon check` before continuing, and treat a previously passing project as regressed until proven otherwise.
 - Add prompt guidance for `#|...` multiline strings in MoonBit tests: bind them to local names or wrap them in parentheses before passing as function arguments.
-- Done: add output caps/summarization for `moon_cmd` and shell-style command results. The JSON Schema V3 log stayed small enough to finish, where V1/V2 ended with context-length errors after native output flooded the transcript.
+- Done: add output caps/summarization for command-runner and shell-style command results. The JSON Schema V3 log stayed small enough to finish, where V1/V2 ended with context-length errors after native output flooded the transcript.
 - Done: add prompt guidance for native CLI arguments. In current native `moon run`, `@env.args()[0]` can be the generated C/native path, so the CLI must drop the executable path before reading user files.
-- Add shell-layer enforcement for MoonBit command policy. In V4 bounded-read, `moon_cmd` rejected unreviewed `moon test --update`, but the agent used shell to bypass the same guardrail.
+- Add shell-layer enforcement for MoonBit command policy. In V4 bounded-read, the command runner rejected unreviewed `moon test --update`, but the agent used shell to bypass the same guardrail.
 - Add a CLI semantic validation helper that can assert stdout is valid JSON, that file-path arguments are actually consumed as files, and that output matches a small predicate, not only that `moon run` exits 0.
 - Add a clean CLI failure helper or cookbook for nonzero native exits without `abort` stack traces, and make eval prompts require both success and failure probes.
 - Add an eval log summarizer that categorizes failed tool calls into expected domain failures, avoidable argument failures, avoidable edit failures, and policy bypasses.
 - Improve `edit` failure output for `old_string not found` by returning a compact hint: file size, whether the file changed since last read if available, and nearby candidate lines when a short substring matches.
-- Make tool schemas/descriptions sharper for conditional required fields such as `moon_ide.action = "doc"` requiring `query`.
+- Make tool schemas/descriptions sharper for conditional required fields, so a field required only for one action says so in its description.
 - Keep temporary debug code outside compiled packages, or provide a dedicated scratch package that cannot regress the deliverable package.
-- Make `moon_ide` failures clearer when `cwd` does not exist, or teach the prompt to create the workspace before semantic IDE calls against it.


### PR DESCRIPTION
## What

Docs-only cleanup. `todo.md` and `agent-improvement-guide.md` were written while the `moon_check`, `moon_cmd`, and `moon_ide` tools existed. All three are now removed from the agent (`build_tools` omits them; the registry test asserts their absence). This removes **every** reference to all three from both planning docs.

### Context

- `moon_ide`'s package was already deleted (commit `f65c1131`) — investigating "remove the moon_ide package" turned up **no package**, only these doc mentions.
- `moon_check` (#381) and `moon_cmd` (#382) were removed in the preceding PRs.
- Scrubbing only `moon_ide` would have left the same docs recommending the now-removed `moon_cmd`/`moon_check`, so per the review discussion all three retired tool names are scrubbed together.

## How

- **Reworded lessons to the general point** rather than deleting history — e.g. *"`moon_cmd` caught test failures"* → *"structured command-validation caught test failures"*; *"`moon ide doc`"* → *"semantic doc"*; *"used `moon_check` repeatedly"* → *"ran `moon check` repeatedly"*.
- **Dropped obsolete forward-looking items** and *"Done: add `moon_*`"* records that describe building tools since removed.
- **Removed the "JSON Schema Validator V2 With `moon_ide`" run section** — the experiment that trialed the tool; its general findings (context blowups, CLI schema-path bug) recur in the V3/V4 sections.

## Not touched

- Real `moon check` / `moon test` / `moon run` **commands** (still valid) — verified preserved.
- The **code guards** that assert `moon_check`/`moon_cmd`/`moon_ide` stay out of the registry (`agent/tool_definition.mbt`, `eval/tool_harness/harness_test.mbt`).

Docs-only; `moon check` clean, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)