### PR TITLE
[codex] Remove unused run_turn API

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -28,14 +28,6 @@ The exported surface is small:
   system_prompt_text="You are an OpenSeek agent.",
 )
 
-let next = @agent.run_turn(
-  api_key,
-  Deepseek(V4Flash),
-  session,
-  "continue",
-  max_steps=100,
-)
-
 let persisted = @agent.run_turn_with_append(
   api_key,
   Deepseek(V4Pro),
@@ -67,14 +59,11 @@ let persisted = @agent.run_turn_with_append(
 session with id `"one-shot"`, runs one turn, logs progress, discards the final
 session value, and returns `Unit`. The caller must provide `system_prompt_text`.
 
-`run_turn` is the in-memory one-turn API. It returns the updated immutable
-session, but it owns a fresh runtime and fresh tool registry for that call. Use
-it when no background tool state needs to survive into a later turn.
-
 `run_turn_with_append` is the durable one-turn API. The `append_item` callback is
 called for every committed item and returns the new authoritative session
 snapshot. Filesystem-backed callers use this to persist progress even if a later
-model call or tool execution fails.
+model call or tool execution fails. Callers that only need an in-memory result
+can return `session.append(item)` from the callback.
 
 `run_turn_in_scope` is the long-lived engine API. The caller owns the
 `AgentRuntime`, `AgentTaskScope`, and usually a `Tools` registry built once with
@@ -176,23 +165,24 @@ abort, cancellation, failure, or exhausted steps still end the turn.
 
 ## One-Shot Turns
 
-`run_turn` appends the task as a user event, runs up to `max_steps` model/tool
-iterations, then appends a terminal event. With `max_steps=0`, no model request
-is made; this is useful for documenting the session contract without a network
-dependency:
+`run_turn_with_append` appends the task as a user event, runs up to `max_steps`
+model/tool iterations, then appends a terminal event. With `max_steps=0`, no
+model request is made; this is useful for documenting the session contract
+without a network dependency:
 
 ```mbt check
 ///|
-async test "zero step run_turn appends user then failure terminal" {
+async test "zero step run_turn_with_append appends user then failure terminal" {
   let session = @agent_session.Session(
     SessionId("readme-turn"),
     system_prompt="system",
   )
-  let result = @agent.run_turn(
+  let result = @agent.run_turn_with_append(
     api_key="unused-api-key",
     model=Deepseek(V4Flash),
     session~,
     task="hello",
+    append_item=(session, item) => session.append(item),
     max_steps=0,
   )
   debug_inspect(

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -55,9 +55,9 @@ priv struct PlanCadence {
 ///
 /// This is the highest-level convenience entry point. It creates a fresh
 /// in-memory session with id `"one-shot"`, appends `task` as the first user
-/// event through `run_turn`, runs the agent loop, logs progress through the
-/// configured process logger, and returns `Unit`. It does not persist the
-/// session and does not expose the final `Session` value to the caller.
+/// event, runs the agent loop, logs progress through the configured process
+/// logger, and returns `Unit`. It does not persist the session and does not
+/// expose the final `Session` value to the caller.
 ///
 /// `system_prompt_text` is required. Prompt selection is intentionally owned by
 /// the application layer, not by `agent`; this package does not depend on the
@@ -66,9 +66,9 @@ priv struct PlanCadence {
 /// tools resolve relative paths against that root. `api_url` is forwarded to
 /// the DeepSeek client and is mainly useful for tests or compatible endpoints.
 ///
-/// Prefer `run_turn` when the caller needs the final in-memory session, and
-/// `run_turn_with_append` when every committed event must be persisted as the
-/// turn progresses.
+/// Use `run_turn_with_append` when every committed event must be persisted as
+/// the turn progresses, or `run_turn_in_scope` when runtime/tool state must span
+/// turns.
 pub async fn run(
   api_key~ : String,
   model~ : @deepseek.Model,
@@ -84,58 +84,17 @@ pub async fn run(
     system_prompt=system_prompt_text,
   )
   ignore(
-    run_turn(
+    run_turn_with_append(
       api_key~,
       model~,
       session~,
       task~,
+      append_item=(session, item) => session.append(item),
       max_steps~,
       thinking~,
       api_url?,
       workspace_root~,
     ),
-  )
-}
-
-///|
-/// Runs one user turn against an in-memory session and returns the updated
-/// session. Callers that need durable persistence should use
-/// `run_turn_with_append`.
-///
-/// This appends `task` to `session`, owns a fresh `AgentRuntime` and
-/// `AgentTaskScope` for this single turn, builds a fresh standard tool registry,
-/// and returns the session produced by `run_turn_in_scope`. The input session is
-/// immutable; it is not changed in place.
-///
-/// Because the runtime and tools are fresh per call, registry-local tool state
-/// does not survive across separate `run_turn` calls. That is usually correct
-/// for one-shot callers. Long-lived callers should create one runtime, one task
-/// scope, and one `build_tools` registry, then call `run_turn_in_scope`
-/// repeatedly.
-///
-/// `max_steps` bounds the number of model-request iterations. If it is `0`, the
-/// turn appends the user task and then terminates with
-/// `Terminal(Failed("max steps exhausted"))` without making a model request.
-pub async fn run_turn(
-  api_key~ : String,
-  model~ : @deepseek.Model,
-  session~ : @agent_session.Session,
-  task~ : String,
-  max_steps? : Int = default_max_steps,
-  thinking? : @deepseek.ThinkingMode = Max,
-  api_url? : String,
-  workspace_root? : String = ".",
-) -> @agent_session.Session {
-  run_turn_with_append(
-    api_key~,
-    model~,
-    session~,
-    task~,
-    append_item=(session, item) => session.append(item),
-    max_steps~,
-    thinking~,
-    api_url?,
-    workspace_root~,
   )
 }
 
@@ -156,9 +115,9 @@ pub async fn run_turn(
 /// that append failure and then re-raises the original error. This means a
 /// durable store can preserve the partial turn up to the failure point.
 ///
-/// Like `run_turn`, this owns a fresh runtime, task group, and tool registry for
-/// the duration of one turn. Use `run_turn_in_scope` when the caller needs to
-/// preserve runtime state or tool state across turns.
+/// This owns a fresh runtime, task group, and tool registry for the duration of
+/// one turn. Use `run_turn_in_scope` when the caller needs to preserve runtime
+/// state or tool state across turns.
 pub async fn run_turn_with_append(
   api_key~ : String,
   model~ : @deepseek.Model,
@@ -232,9 +191,9 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// and reused across turns. When `tools` is
 /// omitted a fresh registry is built for this turn only. `scope` bounds
 /// background work the turn's tools spawn, so it must outlive every turn that
-/// may have spawned some. One-shot callers should prefer
-/// `run_turn`/`run_turn_with_append`, which own everything for the duration
-/// of a single turn.
+/// may have spawned some. One-shot callers should prefer `run` or
+/// `run_turn_with_append`, which own everything for the duration of a single
+/// turn.
 ///
 /// The loop appends `task` as a user message before the first model request.
 /// At each step boundary it first drains and applies pending non-blank steers.

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -13,8 +13,6 @@ pub fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
-pub async fn run_turn(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
-
 pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools) -> @agent_session.Session
 
 pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -372,11 +372,12 @@ async test "streaming reasoning deltas are skipped in logs" {
       SessionId("reasoning-log-test"),
       system_prompt="system",
     )
-    let result = @agent.run_turn(
+    let result = @agent.run_turn_with_append(
       api_key="test-key",
       model=Deepseek(V4Flash),
       session~,
       task="do the task",
+      append_item=(session, item) => session.append(item),
       max_steps=1,
       api_url=url,
     )


### PR DESCRIPTION
## Summary

Remove the exported `@agent.run_turn` wrapper, which was only used as a convenience in docs/tests and internally by `run`.

`run` now calls `run_turn_with_append` directly with an in-memory `session.append` callback. README examples/tests and the steering log test now use `run_turn_with_append` explicitly. The generated `agent/pkg.generated.mbti` drops the `run_turn` public API entry.

This also inlines the one-use `@agent_session.Session::apply_steer_inputs` helper into `AgentLoop::apply_steer_inputs`, keeping the steering append/log/chat-message behavior in the loop code that owns it.

## Impact

Callers should use `run_turn_with_append` for one-shot turns that need the resulting session, or `run_turn_in_scope` when runtime/tool state must span turns. The highest-level `run` entry point keeps the same behavior.

## Validation

- `moon check --warn-list +unnecessary_annotation` passes with existing warning 73 diagnostics outside this change.
- `moon test agent` passes.
- `moon info && moon fmt` passes.
- `git diff origin/main...HEAD --check` passes.
- Earlier full `moon test` failed in existing `agent_tool/shell/shell_test.mbt` output-limit tests:
  - `shell stops oversized output while the command is still running on Unix`
  - `shell does not cut multi-byte utf8 output mid-character on Unix`
  - `shell does not split four-byte utf8 characters on Unix`
  - `shell output limit wins over an unbounded producer on Unix`

Those failures reproduced when running `moon test agent_tool/shell/shell_test.mbt` and are outside the changed agent API files.