### PR TITLE
[codex] Inline steer input application

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -261,31 +261,6 @@ fn @agent_runtime.AgentRuntime::pending_steers(
 }
 
 ///|
-/// Fold steering input into the conversation: each becomes a durable user
-/// message and a model-visible chat message. Both variants emit
-/// `steer_applied`; the `kind` field distinguishes prompt steering from
-/// command context.
-async fn @agent_session.Session::apply_steer_inputs(
-  session : Self,
-  inputs : Array[@agent_runtime.SteerInput],
-  messages : Array[@deepseek.ChatMessage],
-  append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
-) -> Self {
-  for input in inputs; current = session {
-    let (kind, text) = match input {
-      Prompt(text) => ("prompt", text)
-      Command(text) => ("command", text)
-    }
-    let next = append_item(current, User(UserMessage(text)))
-    messages.push(ChatMessage(User, content=text))
-    @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
-    continue next
-  } nobreak {
-    current
-  }
-}
-
-///|
 fn print_usage(usage : @deepseek.Usage) -> Unit {
   @xlog.info() <? { "event": "usage", "usage": usage }
 }

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -98,11 +98,19 @@ async fn AgentLoop::append(
 async fn AgentLoop::apply_steer_inputs(
   self : Self,
   session : @agent_session.Session,
-  inputs : Array[@agent_runtime.SteerInput],
+  inputs : ArrayView[@agent_runtime.SteerInput],
 ) -> @agent_session.Session {
-  session.apply_steer_inputs(inputs, self.messages, append_item=(session, item) => {
-    self.append(session, item)
-  })
+  for input in inputs; current = session {
+    let (kind, text) = match input {
+      Prompt(text) => ("prompt", text)
+      Command(text) => ("command", text)
+    }
+    self.messages.push(ChatMessage(User, content=text))
+    @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
+    continue self.append(current, User(UserMessage(text)))
+  } nobreak {
+    current
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

Inline the one-use `@agent_session.Session::apply_steer_inputs` helper into `AgentLoop::apply_steer_inputs`.

The loop-level helper now owns the full steering fold directly: it appends the durable user event, pushes the model-visible chat message, and emits the `steer_applied` log event in one place. The now-unused session extension method is removed.

## Impact

No public API change. This is a package-internal refactor after `run_turn` removal.

## Validation

- `moon check --warn-list +unnecessary_annotation` passes with existing warning 73 diagnostics outside this change.
- `moon test agent` passes.
- `moon info && moon fmt` passes.
- `git diff origin/main...HEAD --check` passed on the source branch before the clean branch was cut.

Earlier full-suite `moon test` failures remain the unrelated existing `agent_tool/shell/shell_test.mbt` output-limit tests noted in PR #385.