### PR TITLE
feat: background shell tools on the execution model (2/3)

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -127,7 +127,17 @@ async test "standard tools are registered in dispatch order" {
         for tool in tools.function_tools() => tool.name
       ],
       content=(
-        #|["shell", "read", "edit", "multi_edit", "write", "plan", "finish"]
+        #|[
+        #|  "shell",
+        #|  "shell_output",
+        #|  "shell_stop",
+        #|  "read",
+        #|  "edit",
+        #|  "multi_edit",
+        #|  "write",
+        #|  "plan",
+        #|  "finish",
+        #|]
       ),
     )
   }

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -282,7 +282,12 @@ pub async fn[X] run_turn_in_scope(
 ) -> @agent_session.Session {
   let client = @client.Client(api_key~, model~, thinking~, api_url?)
   let session = session |> append_item(User(UserMessage(task)))
-  let tools = tools.unwrap_or_else(() => build_tools(runtime, scope)) catch {
+  let tools = try {
+    match tools {
+      Some(tools) => tools
+      None => build_tools(runtime, scope)
+    }
+  } catch {
     error => {
       @xlog.error() <? { "event": "agent_setup_failed", "error": "\{error}" }
       return session

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -2,6 +2,9 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/shell_output",
+  "bobzhang/openseek/agent_tool/shell_stop",
   "bobzhang/openseek/agent_tool/edit",
   "bobzhang/openseek/agent_tool/finish",
   "bobzhang/openseek/agent_tool/multi_edit",
@@ -12,6 +15,7 @@ import {
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/deepseek/client",
   "moonbitlang/async",
+  "moonbitlang/async/fs",
   "moonbitlang/core/json",
   "tonyfettes/xlog",
 }

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 }
 
 // Values
-pub fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X]) -> @agent_tool.Tools raise
+pub async fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X]) -> @agent_tool.Tools
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -24,6 +24,24 @@ pub async fn[X] build_tools(
   let spill_dir : String? = Some(@fs.tmpdir(prefix="openseek-shell-")) catch {
     _ => None
   }
+  // Remove the session spill dir (and every job's spill file in it) when the
+  // owning scope ends, so `/tmp/openseek-shell-*` cannot accumulate across turns
+  // or sessions. A task parks on a never-fed queue until group teardown cancels
+  // it, then removes the dir shielded from that cancellation (rmdir is async, so
+  // it cannot run in a `defer`).
+  if spill_dir is Some(dir) {
+    scope.group().spawn_bg(no_wait=true, allow_failure=true) <| () => {
+      let parked : @async.Queue[Unit] = Queue(kind=Unbounded)
+      try parked.get() |> ignore catch {
+        _ =>
+          @async.protect_from_cancel(() => {
+            @fs.rmdir(dir, recursive=true) catch {
+              _ => ()
+            }
+          })
+      }
+    }
+  }
   let bg_runtime = @bgjobs.BgJobRuntime::new(scope, spill_dir?)
   let workspace_root = runtime.workspace_root()
   Tools([

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Build the agent's standard tool registry bound to `runtime` and `scope`.
 ///
-/// The returned registry contains the built-in local tools: `shell`, `read`,
+/// The returned registry contains the built-in local tools: `shell`, `shell_output`, `shell_stop`, `read`,
 /// `edit`, `multi_edit`, `write`, `plan`, and `finish`. Each tool lives in its
 /// own subpackage of `agent_tool` and exposes a `definition()` constructor;
 /// this function bundles them into the `Tools` value the loop dispatches
@@ -12,17 +12,24 @@
 ///
 /// Raises if the standard tool definitions contain duplicate names. Under the
 /// checked-in registry that should be a programming error, not user input.
-pub fn[X] build_tools(
+pub async fn[X] build_tools(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[X],
-) -> @agent_tool.Tools raise {
-  // The task scope is plumbed through for stateful tools; none currently need
-  // it (moon_check — the watcher tool — was removed in favor of plain
-  // `moon check` through shell).
-  ignore(scope)
+) -> @agent_tool.Tools {
+  // One background-job runtime per session, owned by `scope.group()`, shared by
+  // the shell tools so a job started via `run_in_background` (or a command moved
+  // to the background on timeout) is visible to shell_output / shell_stop. A
+  // session temp dir makes large background-job output file-backed (full output
+  // on disk via the sink); a tmpdir failure degrades to memory-only jobs.
+  let spill_dir : String? = Some(@fs.tmpdir(prefix="openseek-shell-")) catch {
+    _ => None
+  }
+  let bg_runtime = @bgjobs.BgJobRuntime::new(scope, spill_dir?)
   let workspace_root = runtime.workspace_root()
   Tools([
-    @shell.definition(workspace_root~),
+    @shell.definition(workspace_root~, bg_runtime~),
+    @shell_output.definition(bg_runtime),
+    @shell_stop.definition(bg_runtime),
     @read.definition(workspace_root~),
     @edit.definition(workspace_root~),
     @multi_edit.definition(workspace_root~),
@@ -37,9 +44,11 @@ async test "agent registers the expected tool names" {
   @async.with_task_group() <| group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
     let function_tools = tools.function_tools()
-    assert_eq(function_tools.length(), 7)
+    assert_eq(function_tools.length(), 9)
     let names = [ for t in function_tools => t.name ]
     assert_true(names.contains("shell"))
+    assert_true(names.contains("shell_output"))
+    assert_true(names.contains("shell_stop"))
     assert_true(names.contains("read"))
     assert_true(names.contains("edit"))
     assert_true(names.contains("multi_edit"))

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -63,6 +63,10 @@ priv struct BgJob {
   command : String
   cwd : String?
   exec : @shell_exec.ShellExecution
+  // Sandbox metadata carried from the launch (opaque to bgjobs) so a reader can
+  // apply the same source-write-denial detection the foreground path does.
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
 }
 
 ///|
@@ -80,6 +84,11 @@ pub struct BgJobSnapshot {
   size : Int
   seq : Int
   exit_code : Int?
+  // Preserved so a reader can match the foreground path's error semantics: mark
+  // binary output as an error, and detect a sandboxed source-write denial.
+  had_invalid_utf8 : Bool
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
 }
 
 ///|
@@ -161,13 +170,22 @@ pub async fn BgJobRuntime::start(
   command~ : String,
   cwd? : String,
   max_output_chars? : Int = default_max_output_chars,
+  source_write_sandboxed? : Bool = false,
+  sandbox_denial_subjects? : Array[String] = [],
 ) -> String {
   // Reserve one id and use it for both the spill file and the registry entry, so
   // the job id and its `<id>.out` file never diverge.
   let id = self.next_id()
   let spill_path = self.spill_dir.map(dir => "\{dir}/\{id}.out")
   let exec = (self.spawn_exec)(program, args, cwd, max_output_chars, spill_path)
-  self.register(id, exec, command~, cwd?)
+  self.register(
+    id,
+    exec,
+    command~,
+    cwd?,
+    source_write_sandboxed~,
+    sandbox_denial_subjects~,
+  )
   id
 }
 
@@ -181,9 +199,18 @@ pub fn BgJobRuntime::adopt(
   exec : @shell_exec.ShellExecution,
   command~ : String,
   cwd? : String,
+  source_write_sandboxed? : Bool = false,
+  sandbox_denial_subjects? : Array[String] = [],
 ) -> String {
   let id = self.next_id()
-  self.register(id, exec, command~, cwd?)
+  self.register(
+    id,
+    exec,
+    command~,
+    cwd?,
+    source_write_sandboxed~,
+    sandbox_denial_subjects~,
+  )
   id
 }
 
@@ -195,8 +222,17 @@ fn BgJobRuntime::register(
   exec : @shell_exec.ShellExecution,
   command~ : String,
   cwd? : String,
+  source_write_sandboxed~ : Bool,
+  sandbox_denial_subjects~ : Array[String],
 ) -> Unit {
-  self.jobs[id] = { id, command, cwd, exec }
+  self.jobs[id] = {
+    id,
+    command,
+    cwd,
+    exec,
+    source_write_sandboxed,
+    sandbox_denial_subjects,
+  }
   // Watch for a natural exit and fire `on_job_exit` once. The job entry is set
   // above before the watcher runs (the watcher first awaits the exit, ≥ one tick
   // later), so `snapshot(id)` always resolves.
@@ -233,6 +269,9 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
     size: self.exec.size(),
     seq: self.exec.seq(),
     exit_code: self.exec.exit_code(),
+    had_invalid_utf8: self.exec.had_invalid_utf8(),
+    source_write_sandboxed: self.source_write_sandboxed,
+    sandbox_denial_subjects: self.sandbox_denial_subjects,
   }
 }
 

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -37,6 +37,11 @@ pub struct BgJobRuntime {
   // inline-preview budget, spill path) -> execution. Captured so the runtime type
   // is not generic.
   priv spawn_exec : async (String, Array[String], String?, Int, String?) -> @shell_exec.ShellExecution
+  // Spawn a *foreground* execution on the same session group: memory-only output
+  // capped at the budget and killed if it fills, so the shell tool's foreground
+  // path shares the execution model (and can be detached on timeout) without
+  // re-deriving generic spawning at each call site.
+  priv spawn_foreground_exec : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution
   // Spawn a per-job watcher task on that same group.
   priv spawn_watcher : (async () -> Unit) -> Unit
   // Directory for per-job spill files (full output beyond the inline preview).
@@ -97,6 +102,16 @@ pub fn[X] BgJobRuntime::new(
         spill_path?,
       )
     },
+    spawn_foreground_exec: (program, args, cwd, max_output_chars) => {
+      @shell_exec.ShellExecution::start(
+        scope,
+        program~,
+        args~,
+        cwd?,
+        inline_cap=max_output_chars,
+        kill_when_full=true,
+      )
+    },
     spawn_watcher: task => {
       group.spawn_bg(task, no_wait=true, allow_failure=true)
     },
@@ -112,6 +127,22 @@ fn BgJobRuntime::next_id(self : BgJobRuntime) -> String {
   let id = "bg-\{self.next_index}"
   self.next_index += 1
   id
+}
+
+///|
+/// Spawn a *foreground* execution on the session group: memory-only output
+/// capped at `max_output_chars` and killed if it fills. The shell tool's
+/// foreground path uses this so foreground and background share one execution
+/// model — and a timed-out foreground command can be `adopt`-ed (detached)
+/// rather than killed. Positional to match the shell tool's spawner type.
+pub async fn BgJobRuntime::spawn_foreground(
+  self : BgJobRuntime,
+  program : String,
+  args : Array[String],
+  cwd : String?,
+  max_output_chars : Int,
+) -> @shell_exec.ShellExecution {
+  (self.spawn_foreground_exec)(program, args, cwd, max_output_chars)
 }
 
 ///|

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -103,12 +103,17 @@ pub fn[X] BgJobRuntime::new(
       )
     },
     spawn_foreground_exec: (program, args, cwd, max_output_chars) => {
+      // Foreground output-limit semantics: cap at exactly `max_output_chars`
+      // (inline == hard) and kill on overflow, so exceeding it is reported as the
+      // output-limit error, never silently dropped. Foreground is memory-only (no
+      // spill) — full output is a background-job feature.
       @shell_exec.ShellExecution::start(
         scope,
         program~,
         args~,
         cwd?,
         inline_cap=max_output_chars,
+        hard_cap=max_output_chars,
         kill_when_full=true,
       )
     },
@@ -249,6 +254,21 @@ pub async fn BgJobRuntime::read_output(
 ) -> String? {
   match self.jobs.get(id) {
     Some(job) => Some(job.exec.read_all())
+    None => None
+  }
+}
+
+///|
+/// The last `n` characters of one job's output — a bounded window onto recent
+/// output — or `None` for an unknown id. Used by `shell_output` so a poll cannot
+/// flood the conversation with a large job's full log.
+pub async fn BgJobRuntime::read_output_tail(
+  self : BgJobRuntime,
+  id : String,
+  n : Int,
+) -> String? {
+  match self.jobs.get(id) {
+    Some(job) => Some(job.exec.read_tail(n))
     None => None
   }
 }

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -52,6 +52,10 @@ pub struct BgJobRuntime {
   priv on_job_exit : ((BgJobSnapshot) -> Unit)?
   priv jobs : Map[String, BgJob]
   priv mut next_index : Int
+  // Separate counter for the spill files of detachable foreground executions
+  // (which are not registered until adopted), so their `fg-<n>.out` files never
+  // collide with a job's `bg-<n>.out`.
+  priv mut fg_index : Int
 }
 
 ///|
@@ -133,6 +137,7 @@ pub fn[X] BgJobRuntime::new(
     on_job_exit,
     jobs: {},
     next_index: 1,
+    fg_index: 1,
   }
 }
 
@@ -157,6 +162,29 @@ pub async fn BgJobRuntime::spawn_foreground(
   max_output_chars : Int,
 ) -> @shell_exec.ShellExecution {
   (self.spawn_foreground_exec)(program, args, cwd, max_output_chars)
+}
+
+///|
+/// Spawn a foreground execution that may be *detached* (adopted) on timeout: it
+/// uses the background retention config — file-backed (spill), a large hard cap,
+/// no output-limit kill — so that if it is detached and keeps producing output,
+/// `shell_output` still sees it. The foreground output-limit (over
+/// `max_output_chars`) is enforced by the caller at display time, not by killing;
+/// the caller's `timeout_ms` bounds the wait. Reuses the background spawn with a
+/// distinct `fg-<n>.out` spill file.
+pub async fn BgJobRuntime::spawn_foreground_retained(
+  self : BgJobRuntime,
+  program : String,
+  args : Array[String],
+  cwd : String?,
+  max_output_chars : Int,
+) -> @shell_exec.ShellExecution {
+  let spill_path = self.spill_dir.map(dir => {
+    let index = self.fg_index
+    self.fg_index += 1
+    "\{dir}/fg-\{index}.out"
+  })
+  (self.spawn_exec)(program, args, cwd, max_output_chars, spill_path)
 }
 
 ///|

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -42,6 +42,18 @@ pub struct BgJobRuntime {
   // path shares the execution model (and can be detached on timeout) without
   // re-deriving generic spawning at each call site.
   priv spawn_foreground_exec : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution
+  // Spawn a *retained* foreground execution (may be detached on timeout):
+  // file-backed with a large hard cap, but still killed on exceeding the inline
+  // cap so a timed command that floods output is an immediate output-limit error;
+  // `background()` clears that kill so a detached-under-the-limit job keeps
+  // growing. The `String?` is the spill path.
+  priv spawn_foreground_retained_exec : async (
+    String,
+    Array[String],
+    String?,
+    Int,
+    String?,
+  ) -> @shell_exec.ShellExecution
   // Spawn a per-job watcher task on that same group.
   priv spawn_watcher : (async () -> Unit) -> Unit
   // Directory for per-job spill files (full output beyond the inline preview).
@@ -130,6 +142,23 @@ pub fn[X] BgJobRuntime::new(
         kill_when_full=true,
       )
     },
+    spawn_foreground_retained_exec: (
+      program,
+      args,
+      cwd,
+      max_output_chars,
+      spill_path,
+    ) => {
+      @shell_exec.ShellExecution::start(
+        scope,
+        program~,
+        args~,
+        cwd?,
+        inline_cap=max_output_chars,
+        spill_path?,
+        kill_when_full=true,
+      )
+    },
     spawn_watcher: task => {
       group.spawn_bg(task, no_wait=true, allow_failure=true)
     },
@@ -184,7 +213,9 @@ pub async fn BgJobRuntime::spawn_foreground_retained(
     self.fg_index += 1
     "\{dir}/fg-\{index}.out"
   })
-  (self.spawn_exec)(program, args, cwd, max_output_chars, spill_path)
+  (self.spawn_foreground_retained_exec)(
+    program, args, cwd, max_output_chars, spill_path,
+  )
 }
 
 ///|

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
+pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
 pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, source_write_sandboxed? : Bool, sandbox_denial_subjects? : Array[String]) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
 

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, 
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
+pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
 pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int) -> String

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -14,14 +14,14 @@ import {
 pub struct BgJobRuntime {
   // private fields
 }
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, source_write_sandboxed? : Bool, sandbox_denial_subjects? : Array[String]) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
-pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int) -> String
+pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, source_write_sandboxed? : Bool, sandbox_denial_subjects? : Array[String]) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
 
 pub struct BgJobSnapshot {
@@ -35,6 +35,9 @@ pub struct BgJobSnapshot {
   size : Int
   seq : Int
   exit_code : Int?
+  had_invalid_utf8 : Bool
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
 }
 
 pub(all) enum BgJobStatus {

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
+pub async fn BgJobRuntime::spawn_foreground(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
 pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
 

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -17,6 +17,7 @@ pub struct ShellInput {
   cwd : String?
   timeout_ms : Int?
   max_output_chars : Int
+  run_in_background : Bool
 } derive(Debug)
 
 ///|
@@ -42,11 +43,22 @@ fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
   let max_output_chars = optional_positive_int_or_default(
     fields, "max_output_chars", default_max_output_chars,
   )
+  let run_in_background = optional_bool(fields, "run_in_background")
   {
     cmd,
     cwd,
     timeout_ms,
     max_output_chars: cap_max_output_chars(max_output_chars),
+    run_in_background,
+  }
+}
+
+///|
+fn optional_bool(fields : Map[String, Json], name : String) -> Bool raise {
+  match fields.get(name) {
+    Some(True) => true
+    Some(False) | Some(Null) | None => false
+    _ => fail("arguments.\{name} to be a boolean")
   }
 }
 

--- a/agent_tool/shell/internal/decode/decode_test.mbt
+++ b/agent_tool/shell/internal/decode/decode_test.mbt
@@ -13,7 +13,9 @@ test "decode valid shell input" {
       #|  cwd: Some("/tmp"),
       #|  timeout_ms: Some(250),
       #|  max_output_chars: 50000,
+      #|  run_in_background: false,
       #|}
+
     ),
   )
 }
@@ -23,7 +25,14 @@ test "decode treats empty cwd as absent" {
   debug_inspect(
     @decode.decode({ "cmd": "pwd", "cwd": "" }),
     content=(
-      #|{ cmd: "pwd", cwd: None, timeout_ms: None, max_output_chars: 12000 }
+      #|{
+      #|  cmd: "pwd",
+      #|  cwd: None,
+      #|  timeout_ms: None,
+      #|  max_output_chars: 12000,
+      #|  run_in_background: false,
+      #|}
+
     ),
   )
 }

--- a/agent_tool/shell/internal/decode/decode_test.mbt
+++ b/agent_tool/shell/internal/decode/decode_test.mbt
@@ -15,7 +15,6 @@ test "decode valid shell input" {
       #|  max_output_chars: 50000,
       #|  run_in_background: false,
       #|}
-
     ),
   )
 }
@@ -32,7 +31,6 @@ test "decode treats empty cwd as absent" {
       #|  max_output_chars: 12000,
       #|  run_in_background: false,
       #|}
-
     ),
   )
 }

--- a/agent_tool/shell/internal/decode/pkg.generated.mbti
+++ b/agent_tool/shell/internal/decode/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub struct ShellInput {
   cwd : String?
   timeout_ms : Int?
   max_output_chars : Int
+  run_in_background : Bool
 } derive(@debug.Debug)
 
 // Type aliases

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/shell_exec",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/shell/internal/command_policy",
   "bobzhang/openseek/agent_tool/shell/internal/decode",

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -11,6 +11,10 @@ pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int
 
 pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
 
+pub fn source_write_denial_feedback() -> String
+
+pub fn source_write_denied_in_text(String, Array[String]) -> Bool
+
 // Errors
 
 // Types and methods

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -3,12 +3,13 @@ package "bobzhang/openseek/agent_tool/shell"
 
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
 }
 
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
 
-pub fn definition(workspace_root? : String, read_only? : Bool) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -66,28 +66,6 @@ priv struct AgentShellOutput {
 }
 
 ///|
-async fn collect_agent_shell_output(
-  workspace_root : String,
-  cmd : String,
-  parsed : @shell_parse.ParseResult,
-  cwd? : String,
-  max_output_chars~ : Int,
-) -> AgentShellOutput {
-  let launch = agent_shell_launch(workspace_root, cmd, parsed, cwd?)
-  let output = collect_process_output(
-    launch.program,
-    launch.args,
-    cwd?,
-    max_output_chars~,
-  )
-  {
-    output,
-    source_write_sandboxed: launch.source_write_sandboxed,
-    sandbox_denial_subjects: launch.sandbox_denial_subjects,
-  }
-}
-
-///|
 async fn agent_shell_launch(
   workspace_root : String,
   cmd : String,

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -5607,7 +5607,18 @@ fn sandbox_denied_source_write(
   output : ShellOutput,
   denial_subjects : Array[String],
 ) -> Bool {
-  output.text
+  source_write_denied_in_text(output.text, denial_subjects)
+}
+
+///|
+/// Whether `output_text` shows a sandboxed source-write denial for
+/// `denial_subjects`. Exposed so `shell_output` can apply the same detection to a
+/// background job's output that the foreground path applies inline.
+pub fn source_write_denied_in_text(
+  output_text : String,
+  denial_subjects : Array[String],
+) -> Bool {
+  output_text
   .split("\n")
   .any(line => {
     sandbox_denial_line_mentions_denial(line) &&
@@ -5616,6 +5627,13 @@ fn sandbox_denied_source_write(
       sandbox_denial_line_mentions_known_subject(line, denial_subjects)
     )
   })
+}
+
+///|
+/// The guidance appended when a shell command's output shows a sandboxed
+/// source-write denial. Exposed for `shell_output`.
+pub fn source_write_denial_feedback() -> String {
+  SandboxSourceWriteFeedback
 }
 
 ///|

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -434,6 +434,8 @@ async fn start_background(
     command=input.cmd,
     cwd?,
     max_output_chars=input.max_output_chars,
+    source_write_sandboxed=launch.source_write_sandboxed,
+    sandbox_denial_subjects=launch.sandbox_denial_subjects,
   )
   @agent_tool.ToolAction::respond(
     "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -172,10 +172,16 @@ async fn shell(
   // Detach-on-timeout: move a command that outlives its timeout to the background
   // instead of killing it — the model keeps watching it with shell_output /
   // shell_stop rather than losing it.
-  let on_timeout_detach : ((@shell_exec.ShellExecution) -> String)? = bg_runtime.map(runtime => {
-      exec => {
+  let on_timeout_detach : ((@shell_exec.ShellExecution, AgentShellLaunch) -> String)? = bg_runtime.map(runtime => {
+      (exec, launch) => {
         let _ = exec.background()
-        runtime.adopt(exec, command=input.cmd, cwd?)
+        runtime.adopt(
+          exec,
+          command=input.cmd,
+          cwd?,
+          source_write_sandboxed=launch.source_write_sandboxed,
+          sandbox_denial_subjects=launch.sandbox_denial_subjects,
+        )
       }
     },
   )
@@ -266,7 +272,7 @@ async fn run_agent_shell_with_tree_precheck(
   max_output_chars~ : Int,
   timeout_ms? : Int,
   foreground_spawn? : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution,
-  on_timeout_detach? : (@shell_exec.ShellExecution) -> String,
+  on_timeout_detach? : (@shell_exec.ShellExecution, AgentShellLaunch) -> String,
 ) -> ShellRunResult {
   match
     direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
@@ -303,7 +309,7 @@ async fn run_agent_shell_with_tree_precheck(
       match finished {
         None =>
           match on_timeout_detach {
-            Some(detach) => ShellDetached(detach(exec))
+            Some(detach) => ShellDetached(detach(exec, launch))
             None => {
               let _ = exec.stop()
               ShellTimedOut

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -332,12 +332,17 @@ async fn run_agent_shell_with_tree_precheck(
         // presented as success.
         Some(_) =>
           // `wait_or_invalid` may return with the child still running (binary
-          // output seen); stop it so binary output is an immediate error.
+          // output seen); stop it so binary output is an immediate error. Either
+          // way this execution finished in the foreground (not adopted), so free
+          // its spill file if the retained config opened one.
           if exec.had_invalid_utf8() {
             let _ = exec.stop()
+            exec.discard()
             ShellBinaryOutput
           } else {
-            ShellExecuted(agent_shell_output_from_exec(exec, launch))
+            let output = agent_shell_output_from_exec(exec, launch)
+            exec.discard()
+            ShellExecuted(output)
           }
       }
     }

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -31,6 +31,7 @@
 pub fn definition(
   workspace_root? : String = ".",
   read_only? : Bool = false,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell",
@@ -42,11 +43,12 @@ pub fn definition(
         "cwd": { "type": "string" },
         "timeout_ms": { "type": "number" },
         "max_output_chars": { "type": "number" },
+        "run_in_background": { "type": "boolean" },
       },
       "required": ["cmd"],
     }),
     execute=Async(arguments => {
-      execute_with_workspace(workspace_root, arguments, read_only~)
+      execute_with_workspace(workspace_root, arguments, read_only~, bg_runtime?)
     }),
   )
 }
@@ -68,6 +70,7 @@ async fn execute_with_workspace(
   workspace_root : String,
   arguments : Json,
   read_only~ : Bool,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -101,7 +104,7 @@ async fn execute_with_workspace(
     None => ()
   }
   let cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
-  shell(input, parsed_command, cwd, workspace_root) catch {
+  shell(input, parsed_command, cwd, workspace_root, bg_runtime?) catch {
     error =>
       @agent_tool.ToolAction::respond(
         "error running shell: \{error}",
@@ -116,6 +119,7 @@ async fn shell(
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
   workspace_root : String,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   if cwd is Some(cwd) {
     let exists = @fs.exists(cwd)
@@ -143,41 +147,71 @@ async fn shell(
       )
     None => ()
   }
-  let result = match input.timeout_ms {
-    Some(timeout_ms) =>
-      @async.with_timeout_opt(timeout_ms, () => {
-        run_agent_shell_with_tree_precheck(
-          workspace_root,
-          input.cmd,
-          parsed_command,
-          cwd?,
-          max_output_chars=input.max_output_chars,
-        )
-      })
-    None =>
-      Some(
-        run_agent_shell_with_tree_precheck(
-          workspace_root,
-          input.cmd,
-          parsed_command,
-          cwd?,
-          max_output_chars=input.max_output_chars,
-        ),
-      )
+  // Background: detach the command as a job and return its id instead of blocking
+  // for output. Runs the same source-tree guards and sandboxed launch as a
+  // foreground command, so `run_in_background` cannot bypass any guardrail.
+  if input.run_in_background {
+    return start_background(
+      input,
+      parsed_command,
+      cwd,
+      workspace_root,
+      bg_runtime?,
+    )
   }
+  // A background runtime means foreground commands run on the shared execution
+  // model (session group), which is what lets a timed-out one be detached rather
+  // than killed. Both the spawner and the detach hook come from it; without one
+  // the shell falls back to the per-call collection path (no detach).
+  let foreground_spawn : (async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution)? = bg_runtime.map(runtime => {
+      (program, args, cwd, max) => {
+        runtime.spawn_foreground(program, args, cwd, max)
+      }
+    },
+  )
+  // Detach-on-timeout: move a command that outlives its timeout to the background
+  // instead of killing it — the model keeps watching it with shell_output /
+  // shell_stop rather than losing it.
+  let on_timeout_detach : ((@shell_exec.ShellExecution) -> String)? = bg_runtime.map(runtime => {
+      exec => {
+        let _ = exec.background()
+        runtime.adopt(exec, command=input.cmd, cwd?)
+      }
+    },
+  )
+  // `run_agent_shell_with_tree_precheck` owns the timeout: with a spawner it
+  // awaits a session-group execution and, on timeout, detaches it (or stops it)
+  // so the process cannot leak; without one it wraps the per-call collection path.
+  let result = run_agent_shell_with_tree_precheck(
+    workspace_root,
+    input.cmd,
+    parsed_command,
+    cwd?,
+    max_output_chars=input.max_output_chars,
+    timeout_ms?=input.timeout_ms,
+    foreground_spawn?,
+    on_timeout_detach?,
+  )
   let agent_output = match result {
-    Some(ShellExecuted(output)) => output
-    Some(ShellPreblockedSourceTree(target)) =>
+    ShellExecuted(output) => output
+    ShellPreblockedSourceTree(target) =>
       return @agent_tool.ToolAction::respond(
         direct_source_tree_operation_blocked_content(target),
         is_error=true,
         brief=shell_brief(input.cmd, None),
       )
-    None => {
+    ShellTimedOut => {
       let timeout_ms = input.timeout_ms.unwrap_or(0)
       return @agent_tool.ToolAction::respond(
         "error: shell command timed out after \{timeout_ms}ms",
         is_error=true,
+      )
+    }
+    ShellDetached(id) => {
+      let timeout_ms = input.timeout_ms.unwrap_or(0)
+      return @agent_tool.ToolAction::respond(
+        "command still running after \{timeout_ms}ms; moved to the background as job \{id}. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
+        brief="\{@agent_tool.brief_line(input.cmd, limit=48)} → bg \{id}",
       )
     }
   }
@@ -207,6 +241,11 @@ async fn shell(
 priv enum ShellRunResult {
   ShellPreblockedSourceTree(String)
   ShellExecuted(AgentShellOutput)
+  // Still running after `timeout_ms` and stopped.
+  ShellTimedOut
+  // Still running after `timeout_ms` and detached to the background instead of
+  // stopped; carries the new job id.
+  ShellDetached(String)
 }
 
 ///|
@@ -216,29 +255,173 @@ async fn run_agent_shell_with_tree_precheck(
   parsed_command : @shell_parse.ParseResult,
   cwd? : String,
   max_output_chars~ : Int,
+  timeout_ms? : Int,
+  foreground_spawn? : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution,
+  on_timeout_detach? : (@shell_exec.ShellExecution) -> String,
 ) -> ShellRunResult {
   match
     direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
-    Some(target) => ShellPreblockedSourceTree(target)
-    None => {
-      match
-        dynamic_source_tree_operation_target(
-          parsed_command, cmd, workspace_root, cwd,
-        ) {
-        Some(target) => return ShellPreblockedSourceTree(target)
-        None => ()
+    Some(target) => return ShellPreblockedSourceTree(target)
+    None => ()
+  }
+  match
+    dynamic_source_tree_operation_target(
+      parsed_command, cmd, workspace_root, cwd,
+    ) {
+    Some(target) => return ShellPreblockedSourceTree(target)
+    None => ()
+  }
+  let launch = agent_shell_launch(workspace_root, cmd, parsed_command, cwd?)
+  match foreground_spawn {
+    // Foreground on the shared execution model: spawn on the session group and
+    // await it (up to `timeout_ms`). The session-group process outlives this
+    // await, so a timeout must stop it here — not leak it — and a turn
+    // cancellation must too (the catch stops it before re-raising).
+    Some(spawn) => {
+      let exec = spawn(launch.program, launch.args, cwd, max_output_chars)
+      let finished = try {
+        match timeout_ms {
+          Some(timeout_ms) =>
+            @async.with_timeout_opt(timeout_ms, () => exec.wait())
+          None => Some(exec.wait())
+        }
+      } catch {
+        error => {
+          exec.request_stop()
+          raise error
+        }
       }
-      ShellExecuted(
-        collect_agent_shell_output(
-          workspace_root,
-          cmd,
-          parsed_command,
-          cwd?,
-          max_output_chars~,
-        ),
-      )
+      match finished {
+        None =>
+          match on_timeout_detach {
+            Some(detach) => ShellDetached(detach(exec))
+            None => {
+              let _ = exec.stop()
+              ShellTimedOut
+            }
+          }
+        Some(_) => ShellExecuted(agent_shell_output_from_exec(exec, launch))
+      }
+    }
+    // No session scope (e.g. `collect_shell_output`, the TUI `!` command): keep
+    // the per-call collection path, with the same timeout wrapping as before.
+    None => {
+      let collected = match timeout_ms {
+        Some(timeout_ms) =>
+          @async.with_timeout_opt(timeout_ms, () => {
+            collect_process_output(
+              launch.program,
+              launch.args,
+              cwd?,
+              max_output_chars~,
+            )
+          })
+        None =>
+          Some(
+            collect_process_output(
+              launch.program,
+              launch.args,
+              cwd?,
+              max_output_chars~,
+            ),
+          )
+      }
+      match collected {
+        None => ShellTimedOut
+        Some(output) =>
+          ShellExecuted({
+            output,
+            source_write_sandboxed: launch.source_write_sandboxed,
+            sandbox_denial_subjects: launch.sandbox_denial_subjects,
+          })
+      }
     }
   }
+}
+
+///|
+/// Adapt a finished foreground execution into an `AgentShellOutput` for the
+/// shared renderer: exit code, retained output (the memory head — foreground is
+/// memory-only), and truncation, plus the launch's sandbox metadata.
+fn agent_shell_output_from_exec(
+  exec : @shell_exec.ShellExecution,
+  launch : AgentShellLaunch,
+) -> AgentShellOutput {
+  {
+    output: {
+      exit_code: exec.exit_code(),
+      text: exec.head(),
+      output_limit_reached: exec.output_truncated(),
+    },
+    source_write_sandboxed: launch.source_write_sandboxed,
+    sandbox_denial_subjects: launch.sandbox_denial_subjects,
+  }
+}
+
+///|
+/// Detach `input.cmd` as a background job through the platform shell and report
+/// its id, or a tool error when the tool was built without a job runtime.
+async fn start_background(
+  input : @decode.ShellInput,
+  parsed_command : @shell_parse.ParseResult,
+  cwd : String?,
+  workspace_root : String,
+  bg_runtime? : @bgjobs.BgJobRuntime,
+) -> @agent_tool.ToolAction {
+  guard bg_runtime is Some(runtime) else {
+    return @agent_tool.ToolAction::respond(
+      "error: run_in_background is not available in this context",
+      is_error=true,
+    )
+  }
+  if input.timeout_ms is Some(_) {
+    return @agent_tool.ToolAction::respond(
+      "error: timeout_ms is not supported with run_in_background; a background job runs until it finishes or is stopped with shell_stop",
+      is_error=true,
+    )
+  }
+  match
+    direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
+    Some(target) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_tree_operation_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
+    None => ()
+  }
+  match
+    dynamic_source_tree_operation_target(
+      parsed_command,
+      input.cmd,
+      workspace_root,
+      cwd,
+    ) {
+    Some(target) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_tree_operation_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
+    None => ()
+  }
+  let launch = agent_shell_launch(
+    workspace_root,
+    input.cmd,
+    parsed_command,
+    cwd?,
+  )
+  let id = runtime.start(
+    program=launch.program,
+    args=launch.args,
+    command=input.cmd,
+    cwd?,
+    max_output_chars=input.max_output_chars,
+  )
+  @agent_tool.ToolAction::respond(
+    "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
+    brief="\{@agent_tool.brief_line(input.cmd, limit=48)} → bg \{id}",
+  )
 }
 
 ///|

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -163,9 +163,21 @@ async fn shell(
   // model (session group), which is what lets a timed-out one be detached rather
   // than killed. Both the spawner and the detach hook come from it; without one
   // the shell falls back to the per-call collection path (no detach).
+  //
+  // A command with a `timeout_ms` may be detached on timeout, so spawn it with
+  // the *retained* (file-backed, no output-limit kill) config so it keeps a full
+  // record if it is detached and produces more output — the foreground
+  // output-limit is enforced at display via `over_inline_cap`, and the timeout
+  // bounds the wait. A command with no timeout cannot detach, so it uses the
+  // memory-only foreground config (killed at the output limit, no leak).
+  let detachable = input.timeout_ms is Some(_)
   let foreground_spawn : (async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution)? = bg_runtime.map(runtime => {
       (program, args, cwd, max) => {
-        runtime.spawn_foreground(program, args, cwd, max)
+        if detachable {
+          runtime.spawn_foreground_retained(program, args, cwd, max)
+        } else {
+          runtime.spawn_foreground(program, args, cwd, max)
+        }
       }
     },
   )
@@ -297,8 +309,8 @@ async fn run_agent_shell_with_tree_precheck(
       let finished = try {
         match timeout_ms {
           Some(timeout_ms) =>
-            @async.with_timeout_opt(timeout_ms, () => exec.wait())
-          None => Some(exec.wait())
+            @async.with_timeout_opt(timeout_ms, () => exec.wait_or_invalid())
+          None => Some(exec.wait_or_invalid())
         }
       } catch {
         error => {
@@ -319,7 +331,10 @@ async fn run_agent_shell_with_tree_precheck(
         // (binary/non-UTF-8) output is a tool error, not replacement characters
         // presented as success.
         Some(_) =>
+          // `wait_or_invalid` may return with the child still running (binary
+          // output seen); stop it so binary output is an immediate error.
           if exec.had_invalid_utf8() {
+            let _ = exec.stop()
             ShellBinaryOutput
           } else {
             ShellExecuted(agent_shell_output_from_exec(exec, launch))
@@ -374,7 +389,10 @@ fn agent_shell_output_from_exec(
     output: {
       exit_code: exec.exit_code(),
       text: exec.head(),
-      output_limit_reached: exec.output_truncated(),
+      // Foreground output-limit is the inline cap (max_output_chars): either the
+      // detachable execution grew past it (over_inline_cap, large hard cap) or the
+      // memory-only one was killed at it (truncated, hard cap == inline cap).
+      output_limit_reached: exec.over_inline_cap() || exec.output_truncated(),
     },
     source_write_sandboxed: launch.source_write_sandboxed,
     sandbox_denial_subjects: launch.sandbox_denial_subjects,

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -214,6 +214,12 @@ async fn shell(
         brief="\{@agent_tool.brief_line(input.cmd, limit=48)} → bg \{id}",
       )
     }
+    ShellBinaryOutput =>
+      return @agent_tool.ToolAction::respond(
+        "error running shell: Malformed (binary / non-UTF-8) command output",
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
   }
   let output = agent_output.output
   let response = shell_response(output, input.max_output_chars)
@@ -246,6 +252,9 @@ priv enum ShellRunResult {
   // Still running after `timeout_ms` and detached to the background instead of
   // stopped; carries the new job id.
   ShellDetached(String)
+  // The command produced invalid (non-UTF-8 / binary) output; the per-call path
+  // raises on strict decode, and the execution path reports it here.
+  ShellBinaryOutput
 }
 
 ///|
@@ -300,7 +309,15 @@ async fn run_agent_shell_with_tree_precheck(
               ShellTimedOut
             }
           }
-        Some(_) => ShellExecuted(agent_shell_output_from_exec(exec, launch))
+        // Preserve the per-call path's strict-decode behavior: invalid
+        // (binary/non-UTF-8) output is a tool error, not replacement characters
+        // presented as success.
+        Some(_) =>
+          if exec.had_invalid_utf8() {
+            ShellBinaryOutput
+          } else {
+            ShellExecuted(agent_shell_output_from_exec(exec, launch))
+          }
       }
     }
     // No session scope (e.g. `collect_shell_output`, the TUI `!` command): keep

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -36,17 +36,35 @@ pub fn definition(
   AgentToolDefinition(
     name="shell",
     description=shell_description(),
-    schema=JsonSchema({
-      "type": "object",
-      "properties": {
-        "cmd": { "type": "string" },
-        "cwd": { "type": "string" },
-        "timeout_ms": { "type": "number" },
-        "max_output_chars": { "type": "number" },
-        "run_in_background": { "type": "boolean" },
+    // Only advertise `run_in_background` when a background runtime is wired
+    // (the agent's registry); a standalone/custom definition without one cannot
+    // execute it, so exposing it would let a model make a call that only errors.
+    schema=JsonSchema(
+      if bg_runtime is Some(_) {
+        {
+          "type": "object",
+          "properties": {
+            "cmd": { "type": "string" },
+            "cwd": { "type": "string" },
+            "timeout_ms": { "type": "number" },
+            "max_output_chars": { "type": "number" },
+            "run_in_background": { "type": "boolean" },
+          },
+          "required": ["cmd"],
+        }
+      } else {
+        {
+          "type": "object",
+          "properties": {
+            "cmd": { "type": "string" },
+            "cwd": { "type": "string" },
+            "timeout_ms": { "type": "number" },
+            "max_output_chars": { "type": "number" },
+          },
+          "required": ["cmd"],
+        }
       },
-      "required": ["cmd"],
-    }),
+    ),
     execute=Async(arguments => {
       execute_with_workspace(workspace_root, arguments, read_only~, bg_runtime?)
     }),

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -96,6 +96,35 @@ async test "foreground enforces max_output_chars with an output-limit error" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "a detached foreground job retains full output past the inline cap" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    // Produces a lot of output, then keeps running past the timeout → detached.
+    let action = run_shell_wired(bg, {
+      "cmd": "seq 1 5000; sleep 5",
+      "timeout_ms": 400,
+      "max_output_chars": 100,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.content.contains("moved to the background"))
+    // The detached job is file-backed, so its full output is retained, not
+    // capped at the foreground budget. Poll until the monitor has flushed it.
+    let id = bg.list()[0].id
+    let mut seen = false
+    for _ in 0..<200 {
+      if bg.read_output(id).unwrap_or("").contains("5000") {
+        seen = true
+        break
+      }
+      @async.sleep(25)
+    }
+    assert_true(seen)
+    let _ = bg.stop(id)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "a foreground command that times out is detached to the background" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -96,13 +96,33 @@ async test "foreground enforces max_output_chars with an output-limit error" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "a timed command that floods output is an output-limit error, not detached" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    // A long timeout, but the runaway must be killed at the output limit promptly
+    // (not run to the timeout and then backgrounded).
+    let action = run_shell_wired(bg, {
+      "cmd": "yes",
+      "timeout_ms": 30000,
+      "max_output_chars": 100,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("output_limit_reached"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "a detached foreground job retains full output past the inline cap" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
-    // Produces a lot of output, then keeps running past the timeout → detached.
+    // Under the output limit at the timeout (still sleeping) → cleanly detached;
+    // then it floods output, which a detached job retains (the output-limit kill
+    // is cleared on detach).
     let action = run_shell_wired(bg, {
-      "cmd": "seq 1 5000; sleep 5",
-      "timeout_ms": 400,
+      "cmd": "sleep 0.3; seq 1 5000",
+      "timeout_ms": 150,
       "max_output_chars": 100,
     })
     guard action is Respond(output) else { fail("expected a Respond action") }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -68,6 +68,20 @@ async test "foreground runs through the execution model" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "foreground enforces max_output_chars with an output-limit error" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    // `yes` exceeds the tiny budget; the shared foreground path must report the
+    // output-limit error, not silently drop output as a success.
+    let action = run_shell_wired(bg, { "cmd": "yes", "max_output_chars": 100 })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("output_limit_reached"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "a foreground command that times out is detached to the background" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -68,6 +68,20 @@ async test "foreground runs through the execution model" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "wired foreground reports binary output as a tool error" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    // The wired path (through ShellExecution) must match the per-call path:
+    // non-UTF-8 output is a tool error, not replacement characters as success.
+    let action = run_shell_wired(bg, { "cmd": "printf '\\377'" })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("Malformed"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "foreground enforces max_output_chars with an output-limit error" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -7,6 +7,80 @@ async fn run_shell(arguments : Json) -> @agent_tool.ToolAction {
 }
 
 ///|
+/// Run the shell tool wired like the agent: a background runtime, so foreground
+/// commands run through the shared ShellExecution model and the background /
+/// detach paths are exercised.
+#cfg(not(platform="windows"))
+async fn run_shell_wired(
+  bg : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  match @shell.definition(bg_runtime=bg).execute {
+    Async(execute) => execute(arguments)
+    Sync(_) => fail("shell tool should be async")
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "run_in_background starts a job and returns its id" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, {
+      "cmd": "printf hi",
+      "run_in_background": true,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("started background job"))
+    assert_true(bg.list().length() == 1)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "run_in_background rejects timeout_ms" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, {
+      "cmd": "printf hi",
+      "run_in_background": true,
+      "timeout_ms": 1000,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("not supported with run_in_background"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "foreground runs through the execution model" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, { "cmd": "printf hi" })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("hi"))
+    assert_true(output.content.contains("exit=0"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a foreground command that times out is detached to the background" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, { "cmd": "sleep 2", "timeout_ms": 100 })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("moved to the background"))
+    assert_true(bg.list().length() == 1)
+    assert_true(bg.list()[0].status is Running)
+  })
+}
+
+///|
 async fn run_shell_in_workspace(
   workspace_root : String,
   arguments : Json,

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -98,7 +98,8 @@ async test "foreground enforces max_output_chars with an output-limit error" {
 #cfg(not(platform="windows"))
 async test "a timed command that floods output is an output-limit error, not detached" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    let dir = @fs.tmpdir(prefix="openseek-test-")
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
     // A long timeout, but the runaway must be killed at the output limit promptly
     // (not run to the timeout and then backgrounded).
     let action = run_shell_wired(bg, {
@@ -109,6 +110,9 @@ async test "a timed command that floods output is an output-limit error, not det
     guard action is Respond(output) else { fail("expected a Respond action") }
     assert_true(output.is_error)
     assert_true(output.content.contains("output_limit_reached"))
+    @fs.rmdir(dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 
@@ -116,7 +120,8 @@ async test "a timed command that floods output is an output-limit error, not det
 #cfg(not(platform="windows"))
 async test "a detached foreground job retains full output past the inline cap" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    let dir = @fs.tmpdir(prefix="openseek-test-")
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
     // Under the output limit at the timeout (still sleeping) → cleanly detached;
     // then it floods output, which a detached job retains (the output-limit kill
     // is cleared on detach).
@@ -140,6 +145,9 @@ async test "a detached foreground job retains full output past the inline cap" {
     }
     assert_true(seen)
     let _ = bg.stop(id)
+    @fs.rmdir(dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -302,6 +302,14 @@ pub fn ShellExecution::had_invalid_utf8(self : ShellExecution) -> Bool {
 }
 
 ///|
+/// Delete the spill file — for a retained execution that finished in the
+/// foreground and is not adopted as a background job, so its temp file does not
+/// leak. The in-memory head remains readable.
+pub async fn ShellExecution::discard(self : ShellExecution) -> Unit {
+  self.sink.discard()
+}
+
+///|
 /// Full-output length in characters.
 pub fn ShellExecution::size(self : ShellExecution) -> Int {
   self.sink.size()

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -214,6 +214,20 @@ pub async fn ShellExecution::wait(self : ShellExecution) -> Unit {
 }
 
 ///|
+/// Await terminal *or* the first invalid (binary / non-UTF-8) output, whichever
+/// comes first — so a foreground command that emits binary bytes and then keeps
+/// running fails immediately, matching the strict per-call path, instead of
+/// blocking until exit.
+pub async fn ShellExecution::wait_or_invalid(self : ShellExecution) -> Unit {
+  for ;; {
+    if self.status.is_terminal() || self.sink.had_invalid_utf8() {
+      return
+    }
+    @async.sleep(5)
+  }
+}
+
+///|
 /// Detach the execution: flip `Running → Backgrounded` so no call is awaiting it
 /// while the process keeps running, and clear the foreground output-limit kill (a
 /// detached job caps retention but keeps running). No-op (`false`) once terminal

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -115,12 +115,16 @@ async fn ShellExecution::monitor(
           None => break
           Some(bytes) => {
             self.sink.append_chunk(bytes)
-            // Foreground output-limit kill: once the sink fills, stop the child
-            // so an un-timed runaway cannot block forever. The monitor then
-            // reports `Killed`, and `output_truncated` marks the output-limit
-            // case.
+            // Foreground output-limit kill: stop the child as soon as output
+            // exceeds the inline cap (max_output_chars) — promptly, not only at a
+            // larger hard cap — so a chatty command is an immediate output-limit
+            // error rather than running to the timeout. `background()` clears this
+            // flag, so a job that is detached while still under the limit keeps
+            // growing afterward. `over_inline_cap` fires for a retained execution
+            // (inline < hard); `truncated` covers a memory-only one (inline ==
+            // hard, where total can never exceed inline).
             if self.kill_when_full &&
-              self.sink.truncated() &&
+              (self.sink.over_inline_cap() || self.sink.truncated()) &&
               !self.cancel_requested {
               self.cancel_requested = true
               self.process.cancel()

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -282,6 +282,12 @@ pub fn ShellExecution::output_truncated(self : ShellExecution) -> Bool {
 }
 
 ///|
+/// Whether any invalid (non-UTF-8 / binary) output was seen.
+pub fn ShellExecution::had_invalid_utf8(self : ShellExecution) -> Bool {
+  self.sink.had_invalid_utf8()
+}
+
+///|
 /// Full-output length in characters.
 pub fn ShellExecution::size(self : ShellExecution) -> Int {
   self.sink.size()

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -254,6 +254,15 @@ pub async fn ShellExecution::read_all(self : ShellExecution) -> String {
 }
 
 ///|
+/// The last `n` characters of output — a bounded window onto recent output.
+pub async fn ShellExecution::read_tail(
+  self : ShellExecution,
+  n : Int,
+) -> String {
+  self.sink.read_tail(n)
+}
+
+///|
 /// Whether output exceeded the inline cap (render a pointer; full output is in
 /// the spill file).
 pub fn ShellExecution::over_inline_cap(self : ShellExecution) -> Bool {

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -26,6 +26,7 @@ pub struct ShellExecution {
   // private fields
 }
 pub fn ShellExecution::background(Self) -> Bool
+pub async fn ShellExecution::discard(Self) -> Unit
 pub fn ShellExecution::exit_code(Self) -> Int?
 pub fn ShellExecution::had_invalid_utf8(Self) -> Bool
 pub fn ShellExecution::head(Self) -> String
@@ -49,6 +50,7 @@ pub struct ShellOutputSink {
 pub async fn ShellOutputSink::append_chunk(Self, Bytes) -> Unit
 pub async fn ShellOutputSink::append_text(Self, String) -> Unit
 pub fn ShellOutputSink::close(Self) -> Unit
+pub async fn ShellOutputSink::discard(Self) -> Unit
 pub async fn ShellOutputSink::finish(Self) -> Unit
 pub fn ShellOutputSink::had_invalid_utf8(Self) -> Bool
 pub fn ShellOutputSink::head(Self) -> String

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -27,6 +27,7 @@ pub struct ShellExecution {
 }
 pub fn ShellExecution::background(Self) -> Bool
 pub fn ShellExecution::exit_code(Self) -> Int?
+pub fn ShellExecution::had_invalid_utf8(Self) -> Bool
 pub fn ShellExecution::head(Self) -> String
 pub fn ShellExecution::output_truncated(Self) -> Bool
 pub fn ShellExecution::over_inline_cap(Self) -> Bool
@@ -48,6 +49,7 @@ pub async fn ShellOutputSink::append_chunk(Self, Bytes) -> Unit
 pub async fn ShellOutputSink::append_text(Self, String) -> Unit
 pub fn ShellOutputSink::close(Self) -> Unit
 pub async fn ShellOutputSink::finish(Self) -> Unit
+pub fn ShellOutputSink::had_invalid_utf8(Self) -> Bool
 pub fn ShellOutputSink::head(Self) -> String
 pub fn ShellOutputSink::new(inline_cap? : Int, hard_cap? : Int, spill_path? : String) -> Self
 pub fn ShellOutputSink::over_inline_cap(Self) -> Bool

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -41,6 +41,7 @@ pub async fn[X] ShellExecution::start(@agent_runtime.AgentTaskScope[X], program~
 pub fn ShellExecution::status(Self) -> ExecStatus
 pub async fn ShellExecution::stop(Self) -> Bool
 pub async fn ShellExecution::wait(Self) -> Unit
+pub async fn ShellExecution::wait_or_invalid(Self) -> Unit
 
 pub struct ShellOutputSink {
   // private fields

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -31,6 +31,7 @@ pub fn ShellExecution::head(Self) -> String
 pub fn ShellExecution::output_truncated(Self) -> Bool
 pub fn ShellExecution::over_inline_cap(Self) -> Bool
 pub async fn ShellExecution::read_all(Self) -> String
+pub async fn ShellExecution::read_tail(Self, Int) -> String
 pub fn ShellExecution::request_stop(Self) -> Unit
 pub fn ShellExecution::seq(Self) -> Int
 pub fn ShellExecution::size(Self) -> Int
@@ -51,6 +52,7 @@ pub fn ShellOutputSink::head(Self) -> String
 pub fn ShellOutputSink::new(inline_cap? : Int, hard_cap? : Int, spill_path? : String) -> Self
 pub fn ShellOutputSink::over_inline_cap(Self) -> Bool
 pub async fn ShellOutputSink::read_all(Self) -> String
+pub async fn ShellOutputSink::read_tail(Self, Int) -> String
 pub fn ShellOutputSink::seq(Self) -> Int
 pub fn ShellOutputSink::size(Self) -> Int
 pub fn ShellOutputSink::spill_path(Self) -> String?

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -204,6 +204,24 @@ pub fn ShellOutputSink::close(self : ShellOutputSink) -> Unit {
 }
 
 ///|
+/// Close and delete the spill file — for a retained execution that completed in
+/// the foreground (never adopted as a background job), so its temp file does not
+/// leak. Full output is no longer readable after this (the head remains).
+pub async fn ShellOutputSink::discard(self : ShellOutputSink) -> Unit {
+  match self.file {
+    Some(file) => {
+      file.close()
+      self.file = None
+      match self.spill_path {
+        Some(path) => @fs.remove(path) catch { _ => () }
+        None => ()
+      }
+    }
+    None => ()
+  }
+}
+
+///|
 /// Total full-output length in characters (≤ hard_cap).
 pub fn ShellOutputSink::size(self : ShellOutputSink) -> Int {
   self.total_chars

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -36,6 +36,10 @@ pub struct ShellOutputSink {
   priv mut seq : Int
   // Set once output was dropped at the hard cap.
   priv mut truncated : Bool
+  // Set once any invalid (non-UTF-8 / binary) bytes were decoded lossily, so a
+  // consumer can preserve the strict-decode "binary output" error rather than
+  // silently showing replacement characters.
+  priv mut had_invalid : Bool
   // Full-output spill file, opened lazily once output exceeds `inline_cap` and a
   // spill path is configured. None → memory-only (small output, or no path).
   priv mut file : @fs.File?
@@ -62,6 +66,7 @@ pub fn ShellOutputSink::new(
     pending: b"",
     seq: 0,
     truncated: false,
+    had_invalid: false,
     file: None,
     file_bytes: 0,
     spill_path,
@@ -88,8 +93,11 @@ pub async fn ShellOutputSink::append_chunk(
   let buffer = Buffer()
   buffer.write_bytes(self.pending)
   buffer.write_bytes(chunk)
-  let (text, rest) = split_valid_utf8(buffer.to_bytes())
+  let (text, rest, invalid) = split_valid_utf8(buffer.to_bytes())
   self.pending = rest
+  if invalid {
+    self.had_invalid = true
+  }
   self.append_text(text)
 }
 
@@ -175,6 +183,9 @@ async fn ShellOutputSink::open_spill(
 /// so a multi-byte character that never completed is surfaced rather than lost.
 pub async fn ShellOutputSink::finish(self : ShellOutputSink) -> Unit {
   guard self.pending.length() > 0 else { return }
+  // A non-empty pending buffer at end of stream is an incomplete (or invalid)
+  // sequence — strict decoding would have rejected it, so mark it binary.
+  self.had_invalid = true
   let text = @utf8.decode_lossy(self.pending)
   self.pending = b""
   self.append_text(text)
@@ -208,6 +219,13 @@ pub fn ShellOutputSink::seq(self : ShellOutputSink) -> Int {
 /// Whether full output was dropped at the hard cap.
 pub fn ShellOutputSink::truncated(self : ShellOutputSink) -> Bool {
   self.truncated
+}
+
+///|
+/// Whether any invalid (non-UTF-8 / binary) bytes were decoded — the consumer
+/// may surface this as a "binary output" error instead of showing replacements.
+pub fn ShellOutputSink::had_invalid_utf8(self : ShellOutputSink) -> Bool {
+  self.had_invalid
 }
 
 ///|
@@ -310,11 +328,17 @@ fn prefix_chars(text : String, n : Int) -> String {
 /// trailing bytes of an incomplete multi-byte sequence to carry to the next
 /// chunk. A malformed (not merely incomplete) trailing sequence is surfaced now
 /// rather than held for a completion that can never be valid.
-fn split_valid_utf8(bytes : Bytes) -> (String, Bytes) {
+fn split_valid_utf8(bytes : Bytes) -> (String, Bytes, Bool) {
   let end = bytes.length() - incomplete_suffix_len(bytes)
   let tail = Buffer()
   tail.write_bytes(bytes[end:])
-  (@utf8.decode_lossy(bytes[:end]), tail.to_bytes())
+  // Strict-decode the complete prefix; on invalid bytes fall back to lossy and
+  // report it, so the caller can preserve the "binary output" error. A valid
+  // prefix (the common case) decodes once.
+  let (text, invalid) = (@utf8.decode(bytes[:end]), false) catch {
+    _ => (@utf8.decode_lossy(bytes[:end]), true)
+  }
+  (text, tail.to_bytes(), invalid)
 }
 
 ///|

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -251,6 +251,52 @@ pub async fn ShellOutputSink::read_all(self : ShellOutputSink) -> String {
 }
 
 ///|
+/// The last `n` characters of full output — a window onto the *recent* output of
+/// a (possibly still-running) job, read from the tail of the spill file so a
+/// poller sees progress rather than the unchanging prefix. Degrades to the head
+/// on a read error or a memory-only sink.
+pub async fn ShellOutputSink::read_tail(
+  self : ShellOutputSink,
+  n : Int,
+) -> String {
+  guard n > 0 else { return "" }
+  match self.file {
+    Some(file) => {
+      // Read a byte window sized for `n` UTF-8 chars (≤ 4 bytes each) from the
+      // file tail, decode lossily (a partial lead byte at the window start
+      // becomes a replacement char, dropped when we keep the last `n`), then keep
+      // the last `n` characters.
+      let want = n.to_int64() * 4 + 4
+      let start = if self.file_bytes > want {
+        self.file_bytes - want
+      } else {
+        0
+      }
+      let len = (self.file_bytes - start).to_int()
+      let bytes = file.read_exactly_at(len, position=start) catch {
+        _ => return self.head.to_string()
+      }
+      last_chars(@utf8.decode_lossy(bytes), n)
+    }
+    None => last_chars(self.head.to_string(), n)
+  }
+}
+
+///|
+/// The last `n` characters of `text` (or all of it if shorter).
+fn last_chars(text : String, n : Int) -> String {
+  let len = text.char_length()
+  if len <= n {
+    text
+  } else {
+    match text.offset_of_nth_char(len - n) {
+      Some(start) => "\{text[start:]}"
+      None => text
+    }
+  }
+}
+
+///|
 /// First `n` characters of `text` (assumes `n < text.char_length()`).
 fn prefix_chars(text : String, n : Int) -> String {
   match text.offset_of_nth_char(n) {

--- a/agent_tool/shell_exec/sink_wbtest.mbt
+++ b/agent_tool/shell_exec/sink_wbtest.mbt
@@ -80,7 +80,7 @@ async test "finish flushes an incomplete trailing sequence lossily" {
 ///|
 test "split_valid_utf8 surfaces corrupt trailing bytes instead of hiding them" {
   let bytes : Bytes = [0x68, 0x69, 0xff]
-  let (text, rest) = split_valid_utf8(bytes)
+  let (text, rest, _) = split_valid_utf8(bytes)
   assert_true(rest.length() == 0)
   assert_true(text.has_prefix("hi"))
   assert_true(text.char_length() >= 3)
@@ -88,13 +88,13 @@ test "split_valid_utf8 surfaces corrupt trailing bytes instead of hiding them" {
 
 ///|
 test "split_valid_utf8 does not carry malformed multi-byte prefixes" {
-  let (t1, r1) = split_valid_utf8(([0x78, 0xE0, 0x80] : Bytes))
+  let (t1, r1, _) = split_valid_utf8(([0x78, 0xE0, 0x80] : Bytes))
   assert_true(r1.length() == 0)
   assert_true(t1.has_prefix("x"))
-  let (t2, r2) = split_valid_utf8(([0x78, 0xF4, 0x90] : Bytes))
+  let (t2, r2, _) = split_valid_utf8(([0x78, 0xF4, 0x90] : Bytes))
   assert_true(r2.length() == 0)
   assert_true(t2.has_prefix("x"))
-  let (t3, r3) = split_valid_utf8(([0x78, 0xE0, 0xA0] : Bytes))
+  let (t3, r3, _) = split_valid_utf8(([0x78, 0xE0, 0xA0] : Bytes))
   assert_true(t3 == "x")
   assert_true(r3.length() == 2)
 }

--- a/agent_tool/shell_output/moon.pkg
+++ b/agent_tool/shell_output/moon.pkg
@@ -8,6 +8,7 @@ import {
 import {
   "bobzhang/openseek/agent_runtime",
   "moonbitlang/async",
+  "moonbitlang/async/fs",
 } for "test"
 
 supported_targets = "+native"

--- a/agent_tool/shell_output/moon.pkg
+++ b/agent_tool/shell_output/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/shell",
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/shell_output/moon.pkg
+++ b/agent_tool/shell_output/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+} for "test"
+
+supported_targets = "+native"

--- a/agent_tool/shell_output/pkg.generated.mbti
+++ b/agent_tool/shell_output/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell_output"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+}
+
+// Values
+pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -48,9 +48,15 @@ async fn execute(
   }
   // Preserve the foreground path's error semantics for a job read later: binary
   // (non-UTF-8) output and a sandboxed source-write denial are tool errors even
-  // when the command exited 0.
-  let sandbox_denied = snapshot.source_write_sandboxed &&
-    @shell.source_write_denied_in_text(output, snapshot.sandbox_denial_subjects)
+  // when the command exited 0. Scan the *full* retained output for a denial (the
+  // denial line can be earlier than the displayed tail), but only for a sandboxed
+  // job — so a full read is done only in that rare case.
+  let sandbox_denied = if snapshot.source_write_sandboxed {
+    let full = bg_runtime.read_output(job_id).unwrap_or(output)
+    @shell.source_write_denied_in_text(full, snapshot.sandbox_denial_subjects)
+  } else {
+    false
+  }
   let is_error = exit_error || snapshot.had_invalid_utf8 || sandbox_denied
   // Truncated whenever what we show is less than what the job produced — this
   // covers the window (large output), a memory-only runtime that dropped output
@@ -73,18 +79,20 @@ async fn execute(
     ""
   }
   let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{binary}</system>"
-  let body = if output == "" {
-    footer
-  } else if output.has_suffix("\n") {
-    "\{output}\{footer}"
-  } else {
-    "\{output}\n\{footer}"
+  // Assemble: output, then the source-write denial guidance (like the foreground
+  // path), then the `<system>` footer LAST so it stays the trailing metadata line.
+  let content = StringBuilder()
+  if output != "" {
+    content.write_string(output)
+    if !output.has_suffix("\n") {
+      content.write_string("\n")
+    }
   }
-  // Append the source-write denial guidance, exactly as the foreground path does.
-  let content = if sandbox_denied {
-    "\{body}\n\n\{@shell.source_write_denial_feedback()}"
-  } else {
-    body
+  if sandbox_denied {
+    content.write_string(@shell.source_write_denial_feedback())
+    content.write_string("\n")
   }
+  content.write_string(footer)
+  let content = content.to_string()
   @agent_tool.ToolAction::respond(content, is_error~)
 }

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -36,7 +36,7 @@ async fn execute(
   }
   // Recent output, bounded to a window so a poll cannot flood the conversation
   // with a large job's full log. For output over the window, show the *tail*
-  // (recent progress) and note the total size.
+  // (recent progress).
   let window = 12000
   let output = bg_runtime
     .read_output_tail(job_id, window)
@@ -46,8 +46,18 @@ async fn execute(
     Exited(code) => ("exit=\{code}", code != 0)
     Stopped => ("stopped", true)
   }
-  let truncation = if snapshot.size > window {
-    " truncated=true total_chars=\{snapshot.size} showing_last=\{window}"
+  // Truncated whenever what we show is less than what the job produced — this
+  // covers the window (large output), a memory-only runtime that dropped output
+  // past the budget, and a hard-cap drop — so a prefix is never presented as the
+  // complete output.
+  let shown = output.char_length()
+  let truncation = if shown < snapshot.size || snapshot.output_truncated {
+    let cap = if snapshot.output_truncated {
+      " output_dropped_at_cap=true"
+    } else {
+      ""
+    }
+    " truncated=true total_chars=\{snapshot.size} shown_chars=\{shown}\{cap}"
   } else {
     ""
   }

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -41,11 +41,17 @@ async fn execute(
   let output = bg_runtime
     .read_output_tail(job_id, window)
     .unwrap_or(snapshot.output)
-  let (status_label, is_error) = match snapshot.status {
+  let (status_label, exit_error) = match snapshot.status {
     Running => ("running", false)
     Exited(code) => ("exit=\{code}", code != 0)
     Stopped => ("stopped", true)
   }
+  // Preserve the foreground path's error semantics for a job read later: binary
+  // (non-UTF-8) output and a sandboxed source-write denial are tool errors even
+  // when the command exited 0.
+  let sandbox_denied = snapshot.source_write_sandboxed &&
+    @shell.source_write_denied_in_text(output, snapshot.sandbox_denial_subjects)
+  let is_error = exit_error || snapshot.had_invalid_utf8 || sandbox_denied
   // Truncated whenever what we show is less than what the job produced — this
   // covers the window (large output), a memory-only runtime that dropped output
   // past the budget, and a hard-cap drop — so a prefix is never presented as the
@@ -61,13 +67,24 @@ async fn execute(
   } else {
     ""
   }
-  let footer = "<system>job=\{job_id} \{status_label}\{truncation}</system>"
-  let content = if output == "" {
+  let binary = if snapshot.had_invalid_utf8 {
+    " binary_output=true"
+  } else {
+    ""
+  }
+  let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{binary}</system>"
+  let body = if output == "" {
     footer
   } else if output.has_suffix("\n") {
     "\{output}\{footer}"
   } else {
     "\{output}\n\{footer}"
+  }
+  // Append the source-write denial guidance, exactly as the foreground path does.
+  let content = if sandbox_denied {
+    "\{body}\n\n\{@shell.source_write_denial_feedback()}"
+  } else {
+    body
   }
   @agent_tool.ToolAction::respond(content, is_error~)
 }

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -34,15 +34,24 @@ async fn execute(
       is_error=true,
     )
   }
-  // Full output (from the spill file for a large job); fall back to the snapshot
-  // preview if the read is unavailable.
-  let output = bg_runtime.read_output(job_id).unwrap_or(snapshot.output)
+  // Recent output, bounded to a window so a poll cannot flood the conversation
+  // with a large job's full log. For output over the window, show the *tail*
+  // (recent progress) and note the total size.
+  let window = 12000
+  let output = bg_runtime
+    .read_output_tail(job_id, window)
+    .unwrap_or(snapshot.output)
   let (status_label, is_error) = match snapshot.status {
     Running => ("running", false)
     Exited(code) => ("exit=\{code}", code != 0)
     Stopped => ("stopped", true)
   }
-  let footer = "<system>job=\{job_id} \{status_label}</system>"
+  let truncation = if snapshot.size > window {
+    " truncated=true total_chars=\{snapshot.size} showing_last=\{window}"
+  } else {
+    ""
+  }
+  let footer = "<system>job=\{job_id} \{status_label}\{truncation}</system>"
   let content = if output == "" {
     footer
   } else if output.has_suffix("\n") {

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -1,0 +1,54 @@
+///|
+/// Tool `shell_output`: read a background shell job's output and status by id.
+/// The id comes from `shell run_in_background`, or from a foreground command that
+/// was moved to the background when it exceeded its `timeout_ms`.
+pub fn definition(
+  bg_runtime : @bgjobs.BgJobRuntime,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="shell_output",
+    description="Read a background shell job's output and status by its job_id (returned by shell run_in_background, or by a command moved to the background on timeout). Returns the full output captured so far and whether the job is still running.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": { "job_id": { "type": "string" } },
+      "required": ["job_id"],
+    }),
+    execute=Async(arguments => execute(bg_runtime, arguments)),
+  )
+}
+
+///|
+async fn execute(
+  bg_runtime : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "job_id": String(job_id), .. } else {
+    return @agent_tool.ToolAction::respond(
+      "error: shell_output requires a string job_id",
+      is_error=true,
+    )
+  }
+  guard bg_runtime.snapshot(job_id) is Some(snapshot) else {
+    return @agent_tool.ToolAction::respond(
+      "error: no background job with id \{job_id}",
+      is_error=true,
+    )
+  }
+  // Full output (from the spill file for a large job); fall back to the snapshot
+  // preview if the read is unavailable.
+  let output = bg_runtime.read_output(job_id).unwrap_or(snapshot.output)
+  let (status_label, is_error) = match snapshot.status {
+    Running => ("running", false)
+    Exited(code) => ("exit=\{code}", code != 0)
+    Stopped => ("stopped", true)
+  }
+  let footer = "<system>job=\{job_id} \{status_label}</system>"
+  let content = if output == "" {
+    footer
+  } else if output.has_suffix("\n") {
+    "\{output}\{footer}"
+  } else {
+    "\{output}\n\{footer}"
+  }
+  @agent_tool.ToolAction::respond(content, is_error~)
+}

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -28,7 +28,7 @@ async fn execute(
       is_error=true,
     )
   }
-  guard bg_runtime.snapshot(job_id) is Some(snapshot) else {
+  guard bg_runtime.snapshot(job_id) is Some(_) else {
     return @agent_tool.ToolAction::respond(
       "error: no background job with id \{job_id}",
       is_error=true,
@@ -38,9 +38,17 @@ async fn execute(
   // with a large job's full log. For output over the window, show the *tail*
   // (recent progress).
   let window = 12000
-  let output = bg_runtime
-    .read_output_tail(job_id, window)
-    .unwrap_or(snapshot.output)
+  let output = bg_runtime.read_output_tail(job_id, window).unwrap_or("")
+  // Re-snapshot *after* the awaited read: the job may have appended more output
+  // or exited while the read yielded, so size/status/binary/truncation in the
+  // footer must reflect that post-read state, not a stale pre-read one — else a
+  // tail could be presented as complete or with an out-of-date status.
+  guard bg_runtime.snapshot(job_id) is Some(snapshot) else {
+    return @agent_tool.ToolAction::respond(
+      "error: no background job with id \{job_id}",
+      is_error=true,
+    )
+  }
   let (status_label, exit_error) = match snapshot.status {
     Running => ("running", false)
     Exited(code) => ("exit=\{code}", code != 0)

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -104,6 +104,34 @@ async test "shell_output flags dropped output for a memory-only job" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "shell_output marks binary background output as a tool error" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    // A background command with non-UTF-8 output that exits 0 must still be a
+    // tool error when read, matching the foreground path.
+    let id = bg.start(
+      program="sh",
+      args=["-c", "printf '\\377'"],
+      command="binary",
+    )
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("binary_output"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "shell_output errors on an unknown job id" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -1,0 +1,59 @@
+///|
+#cfg(not(platform="windows"))
+async test "shell_output returns a running job's output and status" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(
+      program="sh",
+      args=["-c", "printf hi; sleep 30"],
+      command="job",
+    )
+    @async.sleep(100)
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("hi"))
+    assert_true(output.content.contains("running"))
+    let _ = bg.stop(id)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output reports a finished job's exit code" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(program="sh", args=["-c", "exit 2"], command="job")
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("exit=2"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output errors on an unknown job id" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": "nope" })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("no background job"))
+  })
+}

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -75,6 +75,35 @@ async test "shell_output windows a large job's output and notes truncation" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "shell_output flags dropped output for a memory-only job" {
+  @async.with_task_group(group => {
+    // Memory-only runtime (no spill dir): output past the budget is dropped.
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(
+      program="sh",
+      args=["-c", "seq 1 2000"],
+      command="seq",
+      max_output_chars=100,
+    )
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    // Only ~100 chars retained but the job produced far more — must not present
+    // the prefix as complete.
+    assert_true(output.content.contains("truncated=true"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "shell_output errors on an unknown job id" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -47,7 +47,8 @@ async test "shell_output reports a finished job's exit code" {
 #cfg(not(platform="windows"))
 async test "shell_output windows a large job's output and notes truncation" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    let dir = @fs.tmpdir(prefix="openseek-test-")
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
     let id = bg.start(
       program="sh",
       args=["-c", "seq 1 20000"],
@@ -70,6 +71,9 @@ async test "shell_output windows a large job's output and notes truncation" {
     assert_true(output.content.contains("truncated=true"))
     assert_true(output.content.contains("20000"))
     assert_true(output.content.char_length() < 80000)
+    @fs.rmdir(dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -45,6 +45,36 @@ async test "shell_output reports a finished job's exit code" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "shell_output windows a large job's output and notes truncation" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    let id = bg.start(
+      program="sh",
+      args=["-c", "seq 1 20000"],
+      command="seq",
+      max_output_chars=100,
+    )
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    // Bounded to the window, with truncation metadata, but still showing the
+    // recent (tail) output — here the end of the sequence.
+    assert_true(output.content.contains("truncated=true"))
+    assert_true(output.content.contains("20000"))
+    assert_true(output.content.char_length() < 80000)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "shell_output errors on an unknown job id" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))

--- a/agent_tool/shell_stop/moon.pkg
+++ b/agent_tool/shell_stop/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+} for "test"
+
+supported_targets = "+native"

--- a/agent_tool/shell_stop/pkg.generated.mbti
+++ b/agent_tool/shell_stop/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell_stop"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+}
+
+// Values
+pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_stop/shell_stop.mbt
+++ b/agent_tool/shell_stop/shell_stop.mbt
@@ -1,0 +1,37 @@
+///|
+/// Tool `shell_stop`: cancel a running background shell job by its job_id.
+pub fn definition(
+  bg_runtime : @bgjobs.BgJobRuntime,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="shell_stop",
+    description="Stop a running background shell job by its job_id (from shell run_in_background, or a command moved to the background on timeout). Cancels the process; a job that already finished is a no-op.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": { "job_id": { "type": "string" } },
+      "required": ["job_id"],
+    }),
+    execute=Async(arguments => execute(bg_runtime, arguments)),
+  )
+}
+
+///|
+async fn execute(
+  bg_runtime : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "job_id": String(job_id), .. } else {
+    return @agent_tool.ToolAction::respond(
+      "error: shell_stop requires a string job_id",
+      is_error=true,
+    )
+  }
+  if bg_runtime.stop(job_id) {
+    @agent_tool.ToolAction::respond("stopped background job \{job_id}")
+  } else {
+    @agent_tool.ToolAction::respond(
+      "error: no background job with id \{job_id}",
+      is_error=true,
+    )
+  }
+}

--- a/agent_tool/shell_stop/shell_stop_test.mbt
+++ b/agent_tool/shell_stop/shell_stop_test.mbt
@@ -1,0 +1,33 @@
+///|
+#cfg(not(platform="windows"))
+async test "shell_stop cancels a running job" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    assert_true(bg.snapshot(id).unwrap().status is Running)
+    let action = match @shell_stop.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_stop should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("stopped"))
+    assert_true(bg.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_stop errors on an unknown job id" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = match @shell_stop.definition(bg).execute {
+      Async(execute) => execute({ "job_id": "nope" })
+      Sync(_) => fail("shell_stop should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("no background job"))
+  })
+}


### PR DESCRIPTION
Stacked on #384 (foundation). This is **2/3** of the shell execution-model series.

## Big picture

The foundation (#384) gave us one object — `ShellExecution` (a process + a single file-backed `ShellOutputSink` + a status flag) — where **"background" is a status, not a re-route**. This PR builds the tool surface on it:

```
L3   shell (run_in_background, foreground-through-execution, detach-on-timeout)
     shell_output (poll)   shell_stop (cancel)
L2   BgJobRuntime  ── session registry of executions, spill files, watchers
L1   ShellExecution ── one process, one output owner, one status   (#384)
L0   ShellOutputSink ── memory-first, file-backed full output        (#384)
```

The key idea carried through: **foreground and background are the same execution.** A foreground `shell` call now runs *through* a `ShellExecution` on the session group (not a separate per-call collector), which is exactly what lets a command that outlives its `timeout_ms` be **detached** — flipped to a background job the model keeps watching — instead of killed. Detach is a status flip + `adopt`, not a second code path.

## What's here

- **`shell` `run_in_background`**: start a command as a job, return its id immediately.
- **`shell_output` / `shell_stop`**: poll a job's output (bounded tail window + truncation metadata) and cancel it by id.
- **Foreground-through-execution**: the wired foreground path uses the shared model; a timed-out command detaches rather than dying.
- **`BgJobRuntime`**: one per session, owns the job registry, per-job spill files (removed at scope teardown), and exit watchers. It stays generic-free by capturing the session group in spawn closures.

## Full foreground/background parity (the hardening)

Background jobs read later via `shell_output` now match every foreground error semantic — each of these was found and fixed under adversarial review:

- **Output limits**: a timed runaway is killed at the inline cap *promptly* (immediate `output_limit_reached`), not run to the timeout; a job detached while still under the limit keeps growing (file-backed) afterward.
- **Binary output**: non-UTF-8 output is a `Malformed` tool error in both paths, surfaced *mid-stream* (not only at exit).
- **Sandbox denials**: a source-write denial in a background/detached job is a tool error with the same guidance the foreground path appends; detection scans the full retained output and the launch's sandbox metadata rides through detach.
- **Truncation reporting**: `shell_output` marks truncated whenever what it shows is less than what the job produced (window, memory-only drop, or hard-cap), never presenting a prefix as complete; metadata is sampled *after* the awaited read to avoid a stale-snapshot TOCTOU.
- **Lifecycle**: retained foreground spill files that finish un-detached are discarded; the session spill dir is removed when the scope ends; `run_in_background` is only advertised when a runtime is wired.

## Tests

954/954 native tests pass; `moon fmt` clean. New tests cover run_in_background, poll/stop, detach-on-timeout, detached-job retention, the prompt output-limit kill, binary output (both paths), truncation/windowing, and the memory-only drop case. Each background test uses an isolated `@fs.tmpdir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)