### PR TITLE
[codex] Make AgentLoop persistence append-first

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -250,6 +250,12 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// `finish` tool returns `Control(Finish)`, a tool returns `Control(Abort)`,
 /// `max_steps` is exhausted, the task is cancelled, or an unexpected error
 /// escapes.
+/// A model final answer is stored as `Terminal(Finished(...))`; session replay
+/// projects that terminal back into an assistant message for later turns.
+/// Long-lived callers must carry the returned or append-updated `Session`
+/// across turns, not any loop-local request buffer. Each new turn constructs a
+/// fresh `AgentLoop` whose model context starts from `Session::chat_messages`,
+/// so TUI/serve-style callers preserve final answers through the session.
 ///
 /// A steer that arrives while the model's apparent final answer or a `finish`
 /// tool call is in flight keeps the turn alive. The would-be final answer is

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -301,31 +301,6 @@ fn @agent_runtime.AgentRuntime::pending_steers(
 }
 
 ///|
-/// Fold steering input into the conversation: each becomes a durable user
-/// message and a model-visible chat message. Both variants emit
-/// `steer_applied`; the `kind` field distinguishes prompt steering from
-/// command context.
-async fn @agent_session.Session::apply_steer_inputs(
-  session : Self,
-  inputs : Array[@agent_runtime.SteerInput],
-  messages : Array[@deepseek.ChatMessage],
-  append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
-) -> Self {
-  for input in inputs; current = session {
-    let (kind, text) = match input {
-      Prompt(text) => ("prompt", text)
-      Command(text) => ("command", text)
-    }
-    let next = append_item(current, User(UserMessage(text)))
-    messages.push(ChatMessage(User, content=text))
-    @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
-    continue next
-  } nobreak {
-    current
-  }
-}
-
-///|
 fn print_usage(usage : @deepseek.Usage) -> Unit {
   @xlog.info() <? { "event": "usage", "usage": usage }
 }

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -53,9 +53,32 @@ async fn AgentLoop::run(
     for step in 0..<max_steps; session = session {
       let session = self.prepare_step(session)
       let response = self.chat(step)
-      match self.handle_response(session, response) {
-        StepContinue(next) => continue next
-        StepDone(next) => return next
+      if response.tool_calls.is_empty() {
+        let steer_inputs = self.runtime.pending_steers()
+        if steer_inputs.is_empty() {
+          @xlog.info() <?
+            { "event": "agent_finished", "answer": response.content }
+          return self.append(session, Terminal(Finished(response.content)))
+        }
+        let reasoning_content = response.optional_reasoning_content()
+        // The model considers itself done, but user-visible input arrived while the
+        // final call was in flight: user input wins over model-initiated completion.
+        // The would-be answer stays as an ordinary assistant message and the turn
+        // continues with the new input folded in.
+        self.messages.push(
+          ChatMessage(Assistant, content=response.content, reasoning_content?),
+        )
+        let session = self.append(
+          session,
+          Assistant(AssistantMessage(response.content, reasoning_content?)),
+        )
+        let session = self.apply_steer_inputs(session, steer_inputs)
+        continue session
+      } else {
+        match self.handle_tool_calls(session, response) {
+          StepContinue(next) => continue next
+          StepDone(next) => return next
+        }
       }
     } nobreak {
       @xlog.warn() <? { "event": "max_steps_exhausted" }
@@ -157,46 +180,6 @@ fn @deepseek.ChatResponse::log_and_reasoning_content(
 }
 
 ///|
-async fn AgentLoop::handle_response(
-  self : Self,
-  session : @agent_session.Session,
-  response : @deepseek.ChatResponse,
-) -> AgentStepOutcome {
-  if response.tool_calls.is_empty() {
-    self.handle_final_response(session, response)
-  } else {
-    self.handle_tool_calls(session, response)
-  }
-}
-
-///|
-async fn AgentLoop::handle_final_response(
-  self : Self,
-  session : @agent_session.Session,
-  response : @deepseek.ChatResponse,
-) -> AgentStepOutcome {
-  let steer_inputs = self.runtime.pending_steers()
-  if steer_inputs.is_empty() {
-    @xlog.info() <? { "event": "agent_finished", "answer": response.content }
-    return StepDone(self.append(session, Terminal(Finished(response.content))))
-  }
-  let reasoning_content = response.optional_reasoning_content()
-  // The model considers itself done, but user-visible input arrived while the
-  // final call was in flight: user input wins over model-initiated completion.
-  // The would-be answer stays as an ordinary assistant message and the turn
-  // continues with the new input folded in.
-  self.messages.push(
-    ChatMessage(Assistant, content=response.content, reasoning_content?),
-  )
-  let session = self.append(
-    session,
-    Assistant(AssistantMessage(response.content, reasoning_content?)),
-  )
-  let session = self.apply_steer_inputs(session, steer_inputs)
-  StepContinue(session)
-}
-
-///|
 async fn AgentLoop::handle_tool_calls(
   self : Self,
   session : @agent_session.Session,
@@ -274,79 +257,80 @@ async fn AgentLoop::execute_tool_call(
   tool_call : @agent_tool.AgentToolCall,
 ) -> ToolCallOutcome {
   let result = @agent_tool.execute_tool_call(tool_call, self.tools)
-  let mut session = session
-  let output = match result {
-    Control(Finish(answer)) =>
-      return self.finish_from_tool(
-        session, response, call_index, native_call, tool_call, answer,
+  match result {
+    Control(Finish(answer)) => {
+      let mut session = self.append(
+        session,
+        Tool(
+          ToolResult(
+            tool_call_id=native_call.id,
+            tool_name=tool_call.name,
+            content="finished: \{answer}",
+          ),
+        ),
       )
-    Control(Abort(reason)) =>
-      return self.abort_from_tool(session, native_call, tool_call, reason)
-    Respond(output) => output
+      let steer_inputs = self.runtime.pending_steers()
+      if steer_inputs.is_empty() {
+        @xlog.info() <? { "event": "agent_finished", "answer": answer }
+        return FinishAgentLoop(self.append(session, Terminal(Finished(answer))))
+      }
+      // User input wins over the finish tool as well. Continuing the turn must keep
+      // the conversation API-valid: every call in the assistant's batch needs a
+      // result message, so the finish call's result and skipped notes for the
+      // unexecuted remainder are pushed before the new input.
+      self.messages.push(
+        ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
+      )
+      let remaining_tool_calls = response.tool_calls[call_index + 1:]
+      session = self.close_skipped_tool_calls(session, remaining_tool_calls)
+      session = self.apply_steer_inputs(session, steer_inputs)
+      ContinueAgentLoop(session)
+    }
+    Control(Abort(reason)) => {
+      let session = self.append(
+        session,
+        Tool(
+          ToolResult(
+            tool_call_id=native_call.id,
+            tool_name=tool_call.name,
+            content="aborted: \{reason}",
+            is_error=true,
+          ),
+        ),
+      )
+      @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
+      return FinishAgentLoop(self.append(session, Terminal(Aborted(reason))))
+    }
+    Respond(output) => {
+      self.plan_cadence.record_plan_success(tool_call, output)
+      log_tool_result(native_call, tool_call, output)
+      self.messages.push(
+        ChatMessage(Tool(native_call.id), content=output.content),
+      )
+      let session = self.append(
+        session,
+        Tool(
+          ToolResult(
+            tool_call_id=native_call.id,
+            tool_name=tool_call.name,
+            content=output.content,
+            is_error=output.is_error,
+            brief?=output.brief,
+          ),
+        ),
+      )
+      ContinueToolBatch(session)
+    }
   }
-  self.plan_cadence.record_plan_success(tool_call, output)
-  log_tool_result(native_call, tool_call, output)
-  self.messages.push(ChatMessage(Tool(native_call.id), content=output.content))
-  session = self.append(
-    session,
-    Tool(
-      ToolResult(
-        tool_call_id=native_call.id,
-        tool_name=tool_call.name,
-        content=output.content,
-        is_error=output.is_error,
-        brief?=output.brief,
-      ),
-    ),
-  )
-  ContinueToolBatch(session)
-}
-
-///|
-async fn AgentLoop::finish_from_tool(
-  self : Self,
-  session : @agent_session.Session,
-  response : @deepseek.ChatResponse,
-  call_index : Int,
-  native_call : @deepseek.ToolCall,
-  tool_call : @agent_tool.AgentToolCall,
-  answer : String,
-) -> ToolCallOutcome {
-  let mut session = self.append(
-    session,
-    Tool(
-      ToolResult(
-        tool_call_id=native_call.id,
-        tool_name=tool_call.name,
-        content="finished: \{answer}",
-      ),
-    ),
-  )
-  let steer_inputs = self.runtime.pending_steers()
-  if steer_inputs.is_empty() {
-    @xlog.info() <? { "event": "agent_finished", "answer": answer }
-    return FinishAgentLoop(self.append(session, Terminal(Finished(answer))))
-  }
-  // User input wins over the finish tool as well. Continuing the turn must keep
-  // the conversation API-valid: every call in the assistant's batch needs a
-  // result message, so the finish call's result and skipped notes for the
-  // unexecuted remainder are pushed before the new input.
-  self.messages.push(
-    ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
-  )
-  session = self.close_skipped_tool_calls(session, response, call_index)
-  session = self.apply_steer_inputs(session, steer_inputs)
-  ContinueAgentLoop(session)
 }
 
 ///|
 async fn AgentLoop::close_skipped_tool_calls(
   self : Self,
   session : @agent_session.Session,
-  response : @deepseek.ChatResponse,
-  call_index : Int,
+  remaining_tool_calls : ArrayView[@deepseek.ToolCall],
 ) -> @agent_session.Session {
-  for skipped in response.tool_calls[call_index + 1:]; session = session {
+  for skipped in remaining_tool_calls; session = session {
     let note = "skipped: user input arrived before this call ran"
     @xlog.info() <?
       {
@@ -372,29 +356,6 @@ async fn AgentLoop::close_skipped_tool_calls(
   } nobreak {
     session
   }
-}
-
-///|
-async fn AgentLoop::abort_from_tool(
-  self : Self,
-  session : @agent_session.Session,
-  native_call : @deepseek.ToolCall,
-  tool_call : @agent_tool.AgentToolCall,
-  reason : String,
-) -> ToolCallOutcome {
-  let session = self.append(
-    session,
-    Tool(
-      ToolResult(
-        tool_call_id=native_call.id,
-        tool_name=tool_call.name,
-        content="aborted: \{reason}",
-        is_error=true,
-      ),
-    ),
-  )
-  @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
-  FinishAgentLoop(self.append(session, Terminal(Aborted(reason))))
 }
 
 ///|

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -56,21 +56,26 @@ async fn AgentLoop::run(
       if response.tool_calls.is_empty() {
         let steer_inputs = self.runtime.pending_steers()
         if steer_inputs.is_empty() {
+          let session = self.append(
+            session,
+            Terminal(Finished(response.content)),
+          )
+          self.push_finished_message(response.content)
           @xlog.info() <?
             { "event": "agent_finished", "answer": response.content }
-          return self.append(session, Terminal(Finished(response.content)))
+          return session
         }
         let reasoning_content = response.optional_reasoning_content()
         // The model considers itself done, but user-visible input arrived while the
         // final call was in flight: user input wins over model-initiated completion.
         // The would-be answer stays as an ordinary assistant message and the turn
         // continues with the new input folded in.
-        self.messages.push(
-          ChatMessage(Assistant, content=response.content, reasoning_content?),
-        )
         let session = self.append(
           session,
           Assistant(AssistantMessage(response.content, reasoning_content?)),
+        )
+        self.messages.push(
+          ChatMessage(Assistant, content=response.content, reasoning_content?),
         )
         let session = self.apply_steer_inputs(session, steer_inputs)
         continue session
@@ -81,8 +86,12 @@ async fn AgentLoop::run(
         }
       }
     } nobreak {
+      let session = self.append(
+        session,
+        Terminal(Failed("max steps exhausted")),
+      )
       @xlog.warn() <? { "event": "max_steps_exhausted" }
-      self.append(session, Terminal(Failed("max steps exhausted")))
+      session
     }
   } catch {
     error => {
@@ -114,14 +123,30 @@ async fn AgentLoop::append(
 }
 
 ///|
+fn AgentLoop::push_finished_message(self : Self, answer : String) -> Unit {
+  if !answer.trim().is_empty() {
+    self.messages.push(ChatMessage(Assistant, content=answer))
+  }
+}
+
+///|
 async fn AgentLoop::apply_steer_inputs(
   self : Self,
   session : @agent_session.Session,
-  inputs : Array[@agent_runtime.SteerInput],
+  inputs : ArrayView[@agent_runtime.SteerInput],
 ) -> @agent_session.Session {
-  session.apply_steer_inputs(inputs, self.messages, append_item=(session, item) => {
-    self.append(session, item)
-  })
+  for input in inputs; current = session {
+    let (kind, text) = match input {
+      Prompt(text) => ("prompt", text)
+      Command(text) => ("command", text)
+    }
+    let next = self.append(current, User(UserMessage(text)))
+    self.messages.push(ChatMessage(User, content=text))
+    @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
+    continue next
+  } nobreak {
+    current
+  }
 }
 
 ///|
@@ -137,9 +162,9 @@ async fn AgentLoop::prepare_step(
   )
   if self.plan_cadence.should_remind() {
     let reminder = self.plan_cadence.reminder_text()
-    @xlog.info() <? { "event": "plan_reminder", "content": reminder }
     session = self.append(session, Runtime(RuntimeNotice(reminder)))
     self.messages.push(ChatMessage(User, content=reminder))
+    @xlog.info() <? { "event": "plan_reminder", "content": reminder }
     self.plan_cadence.record_reminder()
   }
   self.plan_cadence.record_model_request()
@@ -186,15 +211,7 @@ async fn AgentLoop::handle_tool_calls(
   response : @deepseek.ChatResponse,
 ) -> AgentStepOutcome {
   let reasoning_content = response.optional_reasoning_content()
-  self.messages.push(
-    ChatMessage(
-      Assistant,
-      content=response.content,
-      tool_calls=response.tool_calls,
-      reasoning_content?,
-    ),
-  )
-  let mut session = self.append(
+  let session = self.append(
     session,
     Assistant(
       AssistantMessage(
@@ -204,9 +221,30 @@ async fn AgentLoop::handle_tool_calls(
       ),
     ),
   )
-  for call_index, native_call in response.tool_calls {
+  self.messages.push(
+    ChatMessage(
+      Assistant,
+      content=response.content,
+      tool_calls=response.tool_calls,
+      reasoning_content?,
+    ),
+  )
+  for call_index, native_call in response.tool_calls; session = session {
     let tool_call = @agent_tool.AgentToolCall(native_call) catch {
       error => {
+        let content = "error: \{error}"
+        let session = self.append(
+          session,
+          Tool(
+            ToolResult(
+              tool_call_id=native_call.id,
+              tool_name=native_call.name,
+              content~,
+              is_error=true,
+            ),
+          ),
+        )
+        self.messages.push(ChatMessage(Tool(native_call.id), content~))
         @xlog.error() <?
           {
             "event": "tool_call_decode_error",
@@ -214,31 +252,14 @@ async fn AgentLoop::handle_tool_calls(
             "tool_name": native_call.name,
             "error": "\{error}",
           }
-        self.messages.push(
-          ChatMessage(Tool(native_call.id), content="error: \{error}"),
-        )
-        session = self.append(
-          session,
-          Tool(
-            ToolResult(
-              tool_call_id=native_call.id,
-              tool_name=native_call.name,
-              content="error: \{error}",
-              is_error=true,
-            ),
-          ),
-        )
-        continue
+        continue session
       }
     }
     match
       self.execute_tool_call(
         session, response, call_index, native_call, tool_call,
       ) {
-      ContinueToolBatch(next) => {
-        session = next
-        continue
-      }
+      ContinueToolBatch(next) => continue next
       ContinueAgentLoop(next) => return StepContinue(next)
       FinishAgentLoop(next) => return StepDone(next)
     }
@@ -259,7 +280,7 @@ async fn AgentLoop::execute_tool_call(
   let result = @agent_tool.execute_tool_call(tool_call, self.tools)
   match result {
     Control(Finish(answer)) => {
-      let mut session = self.append(
+      let session = self.append(
         session,
         Tool(
           ToolResult(
@@ -269,21 +290,23 @@ async fn AgentLoop::execute_tool_call(
           ),
         ),
       )
+      self.messages.push(
+        ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
+      )
       let steer_inputs = self.runtime.pending_steers()
       if steer_inputs.is_empty() {
+        let session = self.append(session, Terminal(Finished(answer)))
+        self.push_finished_message(answer)
         @xlog.info() <? { "event": "agent_finished", "answer": answer }
-        return FinishAgentLoop(self.append(session, Terminal(Finished(answer))))
+        return FinishAgentLoop(session)
       }
       // User input wins over the finish tool as well. Continuing the turn must keep
       // the conversation API-valid: every call in the assistant's batch needs a
       // result message, so the finish call's result and skipped notes for the
       // unexecuted remainder are pushed before the new input.
-      self.messages.push(
-        ChatMessage(Tool(native_call.id), content="finished: \{answer}"),
-      )
       let remaining_tool_calls = response.tool_calls[call_index + 1:]
-      session = self.close_skipped_tool_calls(session, remaining_tool_calls)
-      session = self.apply_steer_inputs(session, steer_inputs)
+      let session = self.close_skipped_tool_calls(session, remaining_tool_calls)
+      let session = self.apply_steer_inputs(session, steer_inputs)
       ContinueAgentLoop(session)
     }
     Control(Abort(reason)) => {
@@ -298,15 +321,11 @@ async fn AgentLoop::execute_tool_call(
           ),
         ),
       )
+      let session = self.append(session, Terminal(Aborted(reason)))
       @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
-      return FinishAgentLoop(self.append(session, Terminal(Aborted(reason))))
+      return FinishAgentLoop(session)
     }
     Respond(output) => {
-      self.plan_cadence.record_plan_success(tool_call, output)
-      log_tool_result(native_call, tool_call, output)
-      self.messages.push(
-        ChatMessage(Tool(native_call.id), content=output.content),
-      )
       let session = self.append(
         session,
         Tool(
@@ -319,6 +338,11 @@ async fn AgentLoop::execute_tool_call(
           ),
         ),
       )
+      self.plan_cadence.record_plan_success(tool_call, output)
+      self.messages.push(
+        ChatMessage(Tool(native_call.id), content=output.content),
+      )
+      log_tool_result(native_call, tool_call, output)
       ContinueToolBatch(session)
     }
   }
@@ -332,15 +356,6 @@ async fn AgentLoop::close_skipped_tool_calls(
 ) -> @agent_session.Session {
   for skipped in remaining_tool_calls; session = session {
     let note = "skipped: user input arrived before this call ran"
-    @xlog.info() <?
-      {
-        "event": "tool_result",
-        "tool_call_id": skipped.id,
-        "tool_name": skipped.name,
-        "is_error": true,
-        "content": note,
-      }
-    self.messages.push(ChatMessage(Tool(skipped.id), content=note))
     let session = self.append(
       session,
       Tool(
@@ -352,6 +367,15 @@ async fn AgentLoop::close_skipped_tool_calls(
         ),
       ),
     )
+    self.messages.push(ChatMessage(Tool(skipped.id), content=note))
+    @xlog.info() <?
+      {
+        "event": "tool_result",
+        "tool_call_id": skipped.id,
+        "tool_name": skipped.name,
+        "is_error": true,
+        "content": note,
+      }
     continue session
   } nobreak {
     session

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -4,8 +4,16 @@ priv struct AgentLoop {
   client : @client.Client
   tools : @agent_tool.Tools
   append_item : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session
+  /// Turn-local DeepSeek request buffer. `AgentLoop` is private and per-run; a
+  /// later user turn gets a fresh loop seeded from `Session::chat_messages`, not
+  /// this array. Updates are append-first: whenever the loop adds a message here
+  /// for a newly appended session item, the durable append has already
+  /// succeeded.
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
+  /// Latest session returned by a successful append. The run-level error
+  /// handler uses it to persist a terminal failure/interruption even when the
+  /// local loop state is behind the last durable session.
   mut last_session : @agent_session.Session
 }
 
@@ -36,8 +44,14 @@ priv enum AgentStepOutcome {
 
 ///|
 priv enum ToolCallOutcome {
+  /// The tool returned a normal result; continue executing the remaining calls
+  /// in the current assistant tool-call batch.
   ContinueToolBatch(@agent_session.Session)
+  /// Stop the current tool batch and let the agent make another model request
+  /// with the updated session, without appending a terminal item.
   ContinueAgentLoop(@agent_session.Session)
+  /// Stop the current tool batch and finish the agent turn with a terminal
+  /// session item already appended.
   FinishAgentLoop(@agent_session.Session)
 }
 
@@ -56,6 +70,10 @@ async fn AgentLoop::run(
       if response.tool_calls.is_empty() {
         let steer_inputs = self.runtime.pending_steers()
         if steer_inputs.is_empty() {
+          // A true final answer is stored once as Terminal(Finished). Later turns
+          // rebuild model context through Session::chat_messages, which projects
+          // that terminal back into an assistant message; appending an Assistant
+          // session item here would duplicate the answer on replay.
           let session = self.append(
             session,
             Terminal(Finished(response.content)),
@@ -349,6 +367,12 @@ async fn AgentLoop::execute_tool_call(
 }
 
 ///|
+/// Append synthetic error results for tool calls left unexecuted after a finish
+/// tool loses to newly arrived user input.
+///
+/// Every call in the assistant's batch needs a result message, so the finish
+/// call's result and skipped notes for the unexecuted remainder are pushed
+/// before the new input.
 async fn AgentLoop::close_skipped_tool_calls(
   self : Self,
   session : @agent_session.Session,


### PR DESCRIPTION
## Summary
- Stack on #390 after the PlanCadence-only split.
- Inline AgentLoop response/tool control helpers and pass the remaining skipped tool calls as an ArrayView.
- Keep durable session appends before loop-local chat-buffer updates, including final answers, steer inputs, skipped tool calls, and tool results.
- Document the per-turn AgentLoop buffer and session replay invariant for TUI/serve-style multi-turn callers.

## Commits
- 7d5829c Inline AgentLoop response handling
- b54c53e Keep AgentLoop chat buffer append-first
- 7744cce Document AgentLoop replay invariants

## Validation
- `moon info && moon fmt`
- `moon check --warn-list +73` (passes; 12 existing warning-73 annotations in unrelated files)
- `moon test agent` (17/17 passing)
