### PR TITLE
docs(turn_loop): document why terminal paths skip eager tool-call closing

### DIFF
--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -313,6 +313,13 @@ async fn AgentLoop::execute_tool_call(
       )
       let steer_inputs = self.runtime.pending_steers()
       if steer_inputs.is_empty() {
+        // The turn ends here, so trailing tool calls in this batch are left
+        // without an eager result item on purpose: the loop-local `messages`
+        // buffer is discarded, and the next turn rebuilds context from
+        // `Session::chat_messages`, whose `flush_pending_tool_calls` synthesizes
+        // a result for every still-unpaired call before it emits this terminal
+        // item. Only the continue path below closes skipped calls eagerly,
+        // because it reuses `messages` for the very next model request.
         let session = self.append(session, Terminal(Finished(answer)))
         self.push_finished_message(answer)
         @xlog.info() <? { "event": "agent_finished", "answer": answer }
@@ -339,6 +346,10 @@ async fn AgentLoop::execute_tool_call(
           ),
         ),
       )
+      // Abort ends the turn, so — like the no-steer finish path above — trailing
+      // unexecuted tool calls need no eager result item here: replay's
+      // `Session::chat_messages` projection (`flush_pending_tool_calls`)
+      // synthesizes results for any calls left unpaired before this terminal.
       let session = self.append(session, Terminal(Aborted(reason)))
       @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
       return FinishAgentLoop(session)


### PR DESCRIPTION
## What

Addresses the two Copilot review comments on #391 (`turn_loop.mbt` finish/abort branches). Comment-only — **no behavior change** — because the flagged concern is a **false positive**, and this documents why.

> Stacked on #391 (base = `codex/agent-loop-persistence`), since the comments live in #391's inlined `execute_tool_call`. Merge after #391; I'll rebase onto `main` if #391 lands first.

## The review concern

Copilot flagged that the no-steer `finish` path and the `Abort` path append `Terminal(Finished)`/`Terminal(Aborted)` without appending result items for *trailing* unexecuted tool calls in the same assistant batch — suggesting that breaks tool-call/result pairing on session replay.

## Why it's already safe

Session replay does **not** read the loop-local `messages` buffer; the next turn is rebuilt from `Session::chat_messages` (`agent_session/projection.mbt`). That projection tracks pending tool calls and, before emitting any non-tool item (such as the terminal), calls `flush_pending_tool_calls`, which **synthesizes a synthetic error result** for every still-unpaired call:

```
"error: previous agent process exited before recording a result for tool <name>"
```

So a batch like `[toolA, finish, toolC]` that ends after `finish` gets a synthetic result for `toolC` during projection — the replayed conversation is API-valid.

The asymmetry with the **steer/continue** path (which *does* call `close_skipped_tool_calls`) is intentional: that path reuses the in-memory `messages` buffer for the *very next* model request in the same run, so it must be valid immediately; the terminal paths discard that buffer and rely on replay repair.

## Change

Two clarifying comments at the finish (no-steer) and abort branches recording this invariant, so the asymmetry isn't re-flagged by a future reviewer (human or bot).

`moon fmt` / `moon check` clean; `moon test agent` 17/17 (unchanged — comments only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)