### PR TITLE
[codex] Document agent_session architecture and variants

### DIFF
--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -31,6 +31,117 @@ timestamp, and one `SessionItem` payload:
 Appending never mutates the receiver. It returns a new session that shares the
 old log structure.
 
+## Architecture Diagrams
+
+The package split keeps the pure session model separate from native persistence
+and agent runtime concerns:
+
+```mermaid
+flowchart LR
+  agent["agent\nAgentLoop"] -->|"append callback"| store["agent_session/store\nSessionStore"]
+  agent -->|"in-memory append"| session["agent_session\nSession"]
+
+  store -->|"loads and appends"| session
+  store -->|"header parsing"| log["agent_session/log"]
+  compact["agent_session/compact"] -->|"chat_messages()"| session
+  compact -->|"optional durable summary"| store
+
+  session -->|"projects to"| deepseek["deepseek.ChatMessage[]"]
+```
+
+The core data model is an immutable session with an append-only event log.
+`SessionItem` and `TurnTerminal` are MoonBit enums with payloads, so the diagram
+shows them as tagged unions instead of plain UML enumerations:
+
+```mermaid
+classDiagram
+  direction LR
+
+  class Session {
+    -SessionId id
+    -String system_prompt
+    -Vector~SessionEvent~ events
+    -Int last_sequence
+    +append(SessionItem, unix_ms) Session
+    +append_event(SessionItem, unix_ms)
+    +compact(content, from_sequence, to_sequence) Session
+    +chat_messages() ChatMessage[]
+  }
+
+  class SessionId {
+    -String value
+    +value() String
+    +generated(prefix, now_ms, salt) SessionId
+  }
+
+  class SessionEvent {
+    -Int sequence
+    -Double ts
+    -SessionItem item
+    +sequence() Int
+    +item() SessionItem
+    +unix_ms() Int64
+  }
+
+  class SessionItem {
+    <<tagged union>>
+    User(UserMessage)
+    Assistant(AssistantMessage)
+    Tool(ToolResult)
+    Runtime(RuntimeNotice)
+    Summary(SessionSummary)
+    Terminal(TurnTerminal)
+  }
+
+  class UserMessage {
+    -String content
+    +content() String
+  }
+
+  class AssistantMessage {
+    -String content
+    -SessionToolCall[] tool_calls
+    -String? reasoning_content
+    +tool_calls() ToolCall[]
+  }
+
+  class ToolResult {
+    -String tool_call_id
+    -String tool_name
+    -String content
+    -Bool is_error
+    -String? brief
+  }
+
+  class RuntimeNotice {
+    -String content
+  }
+
+  class SessionSummary {
+    -String content
+    -Int from_sequence
+    -Int to_sequence
+  }
+
+  class TurnTerminal {
+    <<tagged union>>
+    Finished(String)
+    Aborted(String)
+    Interrupted(String)
+    Failed(String)
+  }
+
+  Session *-- SessionId
+  Session *-- "many" SessionEvent
+  SessionEvent *-- SessionItem
+  SessionItem --> UserMessage
+  SessionItem --> AssistantMessage
+  SessionItem --> ToolResult
+  SessionItem --> RuntimeNotice
+  SessionItem --> SessionSummary
+  SessionItem --> TurnTerminal
+```
+
 ```mbt check
 ///|
 test "append leaves the original session unchanged" {
@@ -85,6 +196,36 @@ compaction rules are applied:
   failed, aborted, and interrupted terminals become assistant-status messages.
 - A dangling assistant tool call is closed with a synthetic tool error before
   the next non-tool event, keeping the protocol-valid replay shape.
+
+```mermaid
+flowchart TD
+  start["Session::chat_messages()"] --> system["emit System(system_prompt)"]
+  system --> loop["iterate events in order"]
+
+  loop --> covered{"covered by later Summary?"}
+  covered -->|yes| loop
+  covered -->|no| kind{"SessionItem kind"}
+
+  kind -->|Assistant| flush1["flush pending tool calls"]
+  flush1 --> emitAssistant["emit Assistant message"]
+  emitAssistant --> rememberCalls["remember tool_call ids"]
+  rememberCalls --> loop
+
+  kind -->|Tool| matchTool{"tool_call_id is pending?"}
+  matchTool -->|yes| emitTool["emit Tool(call_id) message"]
+  emitTool --> removePending["remove pending call"]
+  removePending --> loop
+  matchTool -->|no| ignoreTool["ignore unmatched result"]
+  ignoreTool --> loop
+
+  kind -->|User / Runtime / Summary / Terminal| flush2["flush pending tool calls"]
+  flush2 --> emitOther["emit projected message if non-empty"]
+  emitOther --> loop
+
+  loop --> done["end"]
+  done --> finalFlush["flush remaining pending tool calls"]
+  finalFlush --> messages["DeepSeek ChatMessage[]"]
+```
 
 ```mbt check
 ///|
@@ -234,11 +375,26 @@ The store layout is:
 ```text
 <root>/sessions/<session-id>/
   openseek_session-<session-id>.jsonl
+  session.lock
 ```
 
 `openseek_session-<session-id>.jsonl` holds the whole session: a header record
 (`{"version":1,"id":...,"system_prompt":...}`) on the first line, then one
 append-only event per line. Loading replays the event lines into a `Session`.
+
+```mermaid
+flowchart TB
+  dir["root/sessions/session-id/"]
+  file["openseek_session-session-id.jsonl"]
+  lock["session.lock"]
+  header["line 1: SessionFileHeader JSON<br/>version = 1<br/>id<br/>system_prompt"]
+  events["line 2..n: SessionEvent JSONL<br/>sequence<br/>ts<br/>tagged SessionItem"]
+
+  dir --> file
+  dir --> lock
+  file --> header
+  file --> events
+```
 
 Use the store for durable callers:
 
@@ -262,6 +418,37 @@ The `agent` package appends session events as the loop progresses:
 The CLI and TUI decide whether those appends are in memory or durable. For
 durable sessions, they pass an append callback backed by `SessionStore::append`
 into the agent loop.
+
+```mermaid
+sequenceDiagram
+  participant Caller
+  participant Store as SessionStore
+  participant Lock as session.lock
+  participant File as openseek_session-id.jsonl
+  participant Session
+
+  Caller->>Store: append(session, item)
+  Store->>Store: validate session id
+  Store->>Store: ensure root/sessions/id exists
+  Store->>Lock: acquire exclusive lock
+  Store->>File: read and parse current durable session
+  Store->>Store: compare durable session with caller snapshot
+
+  alt stale snapshot
+    Store-->>Caller: raise stale session snapshot
+  else current snapshot
+    Store->>Session: append_event(item, now_ms)
+    Session-->>Store: next session + event
+    alt normal existing file
+      Store->>File: append one JSON event line
+    else missing file or torn tail
+      Store->>File: rewrite header + events atomically
+    end
+    Store->>Store: record fast-path fingerprint mark
+    Store->>Lock: release lock
+    Store-->>Caller: next Session
+  end
+```
 
 ## Public API Surface
 

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -336,9 +336,18 @@ pub fn SessionSummary::to_sequence(self : SessionSummary) -> Int {
 /// event is exactly one `Terminal`; if a session ends without one, replay is
 /// seeing a turn that was cut off mid-flight.
 pub(all) enum TurnTerminal {
+  /// The agent completed normally and produced a final assistant answer.
+  /// Non-blank text projects as an assistant message for later turns.
   Finished(String)
+  /// The agent intentionally stopped before normal completion, usually because
+  /// a control tool requested abort. The reason projects as an assistant status
+  /// message.
   Aborted(String)
+  /// The turn was externally cancelled, for example by task cancellation or
+  /// user interruption. The reason projects as an assistant status message.
   Interrupted(String)
+  /// The turn ended because an unexpected error escaped the agent loop. The
+  /// failure message projects as an assistant status message.
   Failed(String)
 } derive(Debug)
 
@@ -352,11 +361,28 @@ pub(all) enum TurnTerminal {
 /// records turn completion status and may project as a final assistant/status
 /// message.
 pub(all) enum SessionItem {
+  /// User-authored model input, including the initial task and any steering
+  /// text. JSON tag: `user`. Projection replays it as a user-role message.
   User(UserMessage)
+  /// Model output for one response. JSON tag: `assistant`. Projection preserves
+  /// visible content, optional reasoning content, and native DeepSeek tool calls;
+  /// those tool calls open pending ids that later `Tool` events may answer.
   Assistant(AssistantMessage)
+  /// Local result for one assistant tool call. JSON tag: `tool_result`.
+  /// Projection emits it only when `tool_call_id` matches a pending assistant
+  /// call; unmatched results are ignored to keep model replay protocol-valid.
   Tool(ToolResult)
+  /// Runtime-injected context, such as a plan reminder. JSON tag:
+  /// `runtime_notice`. Projection sends it as a user-role message even though it
+  /// did not originate from the user's prompt.
   Runtime(RuntimeNotice)
+  /// Append-only compaction metadata for an inclusive event sequence range.
+  /// JSON tag: `summary`. Projection skips covered earlier events when a later
+  /// summary covers their sequence and emits the summary text instead.
   Summary(SessionSummary)
+  /// Completion status for an agent turn. JSON tag: `terminal`.
+  /// `Finished(text)` can project as a final assistant message; aborted,
+  /// interrupted, and failed terminals project assistant status messages.
   Terminal(TurnTerminal)
 } derive(Debug)
 

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -464,12 +464,9 @@ pub fn Session::Session(
   system_prompt~ : String,
   events? : @vector.Vector[SessionEvent] = @vector.new(),
 ) -> Session {
-  let mut last_sequence = 0
-  for event in events {
-    if event.sequence > last_sequence {
-      last_sequence = event.sequence
-    }
-  }
+  let last_sequence = events.fold(init=0, (last_sequence, event) => {
+    last_sequence.max(event.sequence)
+  })
   { id, system_prompt, events, last_sequence }
 }
 


### PR DESCRIPTION
## What

- Add Mermaid architecture diagrams to `agent_session/README.mbt.md` covering package boundaries, the core session model, projection, store layout, and durable append flow.
- Document `TurnTerminal` and `SessionItem` constructors directly in `agent_session/types.mbt` so hover/generated docs explain each tagged-union variant.
- Refactor `Session::Session` to compute `last_sequence` with `Vector::fold` and `Int::max` instead of a mutable accumulator, preserving the existing highest-sequence contract for arbitrary event vectors.

## Why

This makes the session model easier to review and understand without changing the public API. The constructor refactor keeps the behavior explicit: `Session::Session(events=...)` still does not require contiguous or sorted events, unlike `SessionStore::load`, which validates durable logs separately.

## Validation

- `moon info && moon fmt`
- `moon test agent_session` (17/17 passed)
- `git diff --check -- agent_session/types.mbt agent_session/pkg.generated.mbti`

## Notes

`moon info` did not change `agent_session/pkg.generated.mbti`, so the code changes are API-neutral.