### PR TITLE
prompt: teach the model how to handle [plan reminder] notices

### DIFF
--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -65,6 +65,14 @@ Keep the plan honest while you work:
 A fully completed plan is bookkeeping, not evidence: verify the work with
 `moon check` or tests before finishing.
 
+A `[plan reminder]` message is an automated runtime notice, not user input:
+it appears when the `plan` tool has gone unused for many steps. Act on it
+instead of answering it — bring step statuses current, replace or clear a
+plan that no longer matches the work, or record one if the task turned out
+to be multi-step after all. If the task is genuinely trivial, ignore the
+reminder and keep working. Never reply to the reminder with assistant text,
+and never call `plan` only to silence it.
+
 
 ## Fast Task Playbooks
 

--- a/prompt/flash_prompt.mbt.md
+++ b/prompt/flash_prompt.mbt.md
@@ -35,7 +35,10 @@ full diagnostics.
   `"completed"` immediately — never while their checks still fail — and clear
   a plan that no longer applies with `"steps": []`. Skip planning for
   single-step tasks. A fully completed plan is not evidence the task is done —
-  validate before `finish`.
+  validate before `finish`. A `[plan reminder]` message is an automated
+  notice, not user input: act on it (update, replace, or clear the plan) or
+  ignore it for trivial work — never answer it with assistant text or call
+  `plan` only to silence it.
 - Use the right tool for the job:
   - `read`, `edit`, `multi_edit`, and `write` for files. Use `edit` for a single
     span; use `multi_edit` to apply several line-anchored fixes to one file in

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -62,6 +62,14 @@ fn base_prompt() -> String {
     #|A fully completed plan is bookkeeping, not evidence: verify the work with
     #|`moon check` or tests before finishing.
     #|
+    #|A `[plan reminder]` message is an automated runtime notice, not user input:
+    #|it appears when the `plan` tool has gone unused for many steps. Act on it
+    #|instead of answering it — bring step statuses current, replace or clear a
+    #|plan that no longer matches the work, or record one if the task turned out
+    #|to be multi-step after all. If the task is genuinely trivial, ignore the
+    #|reminder and keep working. Never reply to the reminder with assistant text,
+    #|and never call `plan` only to silence it.
+    #|
     #|
     #|## Fast Task Playbooks
     #|

--- a/prompt/generated_flash_prompt.mbt
+++ b/prompt/generated_flash_prompt.mbt
@@ -40,7 +40,10 @@ fn flash_prompt() -> String {
     #|  `"completed"` immediately — never while their checks still fail — and clear
     #|  a plan that no longer applies with `"steps": []`. Skip planning for
     #|  single-step tasks. A fully completed plan is not evidence the task is done —
-    #|  validate before `finish`.
+    #|  validate before `finish`. A `[plan reminder]` message is an automated
+    #|  notice, not user input: act on it (update, replace, or clear the plan) or
+    #|  ignore it for trivial work — never answer it with assistant text or call
+    #|  `plan` only to silence it.
     #|- Use the right tool for the job:
     #|  - `read`, `edit`, `multi_edit`, and `write` for files. Use `edit` for a single
     #|    span; use `multi_edit` to apply several line-anchored fixes to one file in


### PR DESCRIPTION
## What

PR 1 of 3 in the plan-reminder improvement series (prompt guidance → viz rendering → cadence tuning).

The agent loop injects a `[plan reminder]` runtime notice after ten plan-silent model requests (`agent/agent.mbt` `PlanCadence`), but neither system prompt mentioned it — the model had to guess what the message is and how to react. Two failure modes that guidance prevents:

- **answering the reminder** with conversational assistant text (burns a step; the reminder is injected user-role, so weaker models are tempted to reply to it);
- **cargo-cult planning** — calling `plan` performatively just to silence the nag, which resets the cadence without adding value.

## Change

- `prompt/base_prompt.mbt.md` — one paragraph at the end of the **Planning** section: the reminder is an automated notice, not user input; act on it (bring statuses current, replace or clear a stale plan, or record one if the task became multi-step), ignore it for trivial work, never reply to it in assistant text, never call `plan` only to quiet it.
- `prompt/flash_prompt.mbt.md` — condensed version in the plan bullet.
- `generated_*_prompt.mbt` — mechanical refresh via the `dev_build` rule.

## Testing

`moon check` clean · prompt tests **19/19** · `moon fmt` clean. Prompt-text change only; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)