### PR TITLE
viz: render plan-cadence reminders as a dedicated checklist card

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -295,13 +295,81 @@ fn event_card(
     Assistant(message) =>
       assistant_card(seq, time, message, briefs, failed, tags, step_label~)
     Tool(result) => tool_card(seq, time, result, tags)
-    Runtime(notice) =>
-      card("runtime", "Runtime notice", seq, time~, [
-        text_block(notice.content()),
-      ])
+    Runtime(notice) => runtime_card(seq, time, notice.content())
     Summary(summary) => summary_card(seq, time, summary)
     Terminal(terminal) => terminal_card(seq, time, terminal, step_label~)
   }
+}
+
+///|
+/// The label prefix the agent loop's plan cadence stamps on its staleness
+/// reminders (see `plan_reminder_text` in `agent`); the card renderer keys off
+/// it to give those notices a dedicated look.
+const PlanReminderPrefix : String = "[plan reminder]"
+
+///|
+/// Render a `RuntimeNotice` card. A plan-cadence reminder — recognized by its
+/// `[plan reminder]` prefix — gets its own label and, when it re-surfaces a
+/// recorded checklist ("Current plan:" followed by `N. [status] title` lines),
+/// the steps render as a status-classed list instead of raw text. Any other
+/// runtime notice keeps the generic card.
+fn runtime_card(seq : Int, time : String, content : String) -> @html.Html {
+  if !content.has_prefix(PlanReminderPrefix) {
+    return card("runtime", "Runtime notice", seq, time~, [text_block(content)])
+  }
+  let body : Array[@html.Html] = []
+  match split_plan_checklist(content) {
+    Some((prose, steps)) => {
+      body.push(text_block(prose))
+      body.push(
+        @html.ul(class="plan-steps") <| [
+          for step in steps => plan_step_item(step)
+        ],
+      )
+    }
+    None => body.push(text_block(content))
+  }
+  card("runtime plan-reminder", "Plan reminder", seq, time~, body)
+}
+
+///|
+/// Split a checklist-carrying reminder into its prose (through the
+/// "Current plan:" line) and the step lines after it. `None` when the notice
+/// has no checklist (the no-plan nag variant).
+fn split_plan_checklist(content : String) -> (String, Array[String])? {
+  let lines = content.split("\n").map(line => line.to_owned()).collect()
+  for index, line in lines {
+    if line.trim_end().has_suffix("Current plan:") {
+      let steps = [
+        for step in lines[index + 1:] if !step.trim().is_empty() => step
+      ]
+      if steps.is_empty() {
+        return None
+      }
+      return Some((lines[:index + 1].join("\n"), steps))
+    }
+  }
+  None
+}
+
+///|
+/// One checklist row: `N. [status] title` renders as a status chip plus the
+/// numbered title, with the status doubling as a CSS class
+/// (pending/in_progress/completed). A line that does not match the shape falls
+/// back to plain text so the card never drops content.
+fn plan_step_item(line : String) -> @html.Html {
+  guard line.find("[") is Some(open) &&
+    line.find("]") is Some(close) &&
+    open < close else {
+    return @html.li(class="plan-step") <| line
+  }
+  let status = line[open + 1:close].to_owned()
+  let number = line[:open].trim_end().to_owned()
+  let title = line[close + 1:].trim_start().to_owned()
+  @html.li(class="plan-step \{status}") <| [
+    @html.span(class="step-status") <| status,
+    @html.text(" \{number} \{title}"),
+  ]
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -824,6 +824,48 @@ test "a dangling call pairs only in the model view, where it is healed" {
 }
 
 ///|
+/// Plan-cadence reminders (the `[plan reminder]` prefix) get a dedicated card:
+/// the checklist variant renders its steps as status-classed rows, the no-plan
+/// variant keeps its prose, and an unrelated runtime notice keeps the generic
+/// card. The reminder bodies mirror `plan_reminder_text` in `agent`.
+test "plan reminder notices render a dedicated card with checklist rows" {
+  let checklist_reminder =
+    #|[plan reminder]
+    #|The plan tool has not been called in a while. If progress was made,
+    #|update step statuses; if the plan no longer matches the work,
+    #|replace it or clear it with steps: []. Current plan:
+    #|1. [completed] read the failing test
+    #|2. [in_progress] fix the parser
+    #|3. [pending] run moon test
+  let no_plan_reminder =
+    #|[plan reminder]
+    #|The plan tool has not been used in this turn. If this task takes
+    #|several distinct steps, record a plan with the plan tool and keep
+    #|step statuses current. If not, ignore this reminder.
+  let session = @agent_session.Session(SessionId("plan"), system_prompt="")
+    .append(User(UserMessage("do a long task")))
+    .append(Runtime(RuntimeNotice(checklist_reminder)))
+    .append(Runtime(RuntimeNotice(no_plan_reminder)))
+    .append(Runtime(RuntimeNotice("unrelated runtime context")))
+  let html = render(@viz.render_session(session, RawLog))
+  // Checklist variant: dedicated card, prose kept, one status-classed row per
+  // step with the status chip split from the numbered title.
+  assert_true(html.contains("class=\"card runtime plan-reminder\""))
+  assert_true(html.contains("Plan reminder"))
+  assert_true(html.contains("Current plan:"))
+  assert_true(html.contains("class=\"plan-steps\""))
+  assert_true(html.contains("class=\"plan-step completed\""))
+  assert_true(html.contains("class=\"plan-step in_progress\""))
+  assert_true(html.contains("class=\"plan-step pending\""))
+  assert_true(html.contains("2. fix the parser"))
+  // No-plan variant: the dedicated card without a checklist list.
+  assert_true(html.contains("has not been used in this turn"))
+  // Unrelated notices keep the generic runtime card.
+  assert_true(html.contains("Runtime notice"))
+  assert_true(html.contains("unrelated runtime context"))
+}
+
+///|
 /// Stamped events render relative offsets and a turn duration; unstamped
 /// events (the 0 sentinel) render no time chips at all.
 test "raw view shows total-second offsets and turn duration from ts" {

--- a/web/index.html
+++ b/web/index.html
@@ -321,6 +321,17 @@
     .card.tool { border-left-color: var(--tool); }
     .card.tool.error { border-left-color: var(--error); background: var(--notice-error-bg); }
     .card.runtime { border-left-color: var(--runtime); }
+    /* plan-cadence reminder: checklist steps as status-classed rows */
+    .plan-steps { margin: 8px 0 0; padding-left: 20px; font-size: 12.5px; list-style: none; }
+    .plan-step { margin: 3px 0; }
+    .plan-step .step-status {
+      font-family: ui-monospace, monospace; font-size: 11px;
+      color: var(--muted); border: 1px solid var(--border);
+      border-radius: 4px; padding: 0 5px; margin-right: 6px;
+    }
+    .plan-step.completed { color: var(--muted); text-decoration: line-through; }
+    .plan-step.completed .step-status { text-decoration: none; }
+    .plan-step.in_progress { font-weight: 600; }
     .card.summary { border-left-color: var(--summary); background: var(--summary-bg); }
     .card.terminal { border-left-color: var(--terminal); }
     .card.system { border-left-color: var(--muted); }


### PR DESCRIPTION
## What

PR 2 of 3 in the plan-reminder series (prompt guidance #396 → **viz rendering** → cadence tuning).

Plan staleness reminders rendered as generic **"Runtime notice"** cards: prose + re-surfaced checklist as one preformatted blob, burying the useful part (step statuses).

## Change

`viz/view.mbt` `runtime_card` now recognizes the `[plan reminder]` prefix (the literal `plan_reminder_text` stamps in `agent`):

- dedicated **"Plan reminder"** label + `plan-reminder` card class;
- when the notice carries a checklist (`Current plan:` + `N. [status] title` lines), steps render as a `plan-steps` list — one status-classed row per step, status chip split from the numbered title; **completed** struck through, **in_progress** bolded;
- the no-plan nag variant keeps its prose under the new label; unrelated runtime notices keep the generic card; a step line that doesn't match the shape falls back to plain text (the card never drops content).

Styles in `web/index.html` (the shared shell). One rendering change covers both surfaces — viz_server HTML and the viz_app bundle share `render_session`.

### Parsing edges handled
- Brackets inside a step title: status is the *first* `[...]` pair only.
- `]` before `[` or missing brackets → plain-text row fallback.
- "Current plan:" can only match the prose line (first match wins; step lines end with titles).
- Checklist header with no following steps → treated as no-checklist.

## Testing

New viz test: checklist variant (3 statuses asserted row-by-row), no-plan variant, and an unrelated notice keeping the generic card. viz **38/38** (js) · native suite **914/914** · `moon build cmd/viz_app --target js` bundle builds · `moon fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)