### PR TITLE
agent: cap the no-plan reminder at once per turn

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -5,9 +5,11 @@ let default_max_steps : Int = 1000
 /// Model requests since the last successful `plan` call — and since the last
 /// reminder — before the loop injects a plan staleness reminder. Both
 /// thresholds mirror the 10-turn / 10-turn cadence Claude Code uses for its
-/// todo reminder: long enough that short tasks never see a nag, and the
-/// second threshold caps re-nagging of a model that ignores the first at
-/// once per ten requests.
+/// todo reminder: long enough that short tasks never see a nag. Re-nagging is
+/// variant-dependent: with a recorded checklist the reminder re-surfaces real
+/// state and may repeat once per ten requests, while the no-plan nudge fires
+/// at most once per turn — a model that ignored "consider recording a plan"
+/// once gains nothing from hearing it every ten steps.
 let plan_reminder_after_steps : Int = 10
 
 ///|
@@ -41,26 +43,37 @@ fn plan_reminder_text(checklist : String?) -> String {
 /// counters advance once per model request. A successful `plan` call resets
 /// `steps_since_plan` and refreshes `checklist`; injecting a reminder resets
 /// `steps_since_reminder`, so the reminder fires only after both enough plan
-/// silence and enough reminder silence. Turn-local by design — a fresh user
-/// turn resets the cadence. `checklist` carries the last successfully recorded
-/// plan for the reminder to re-surface.
+/// silence and enough reminder silence. The no-plan nudge additionally fires
+/// at most once per turn (`nagged_without_plan`): repeats are reserved for
+/// the checklist variant, which re-surfaces real recorded state instead of
+/// repeating advice the model already declined once. Turn-local by design —
+/// a fresh user turn resets the cadence. `checklist` carries the last
+/// successfully recorded plan for the reminder to re-surface.
 priv struct PlanCadence {
   registered : Bool
   mut steps_since_plan : Int
   mut steps_since_reminder : Int
   mut checklist : String?
+  mut nagged_without_plan : Bool
 }
 
 ///|
 fn PlanCadence::PlanCadence(registered~ : Bool) -> PlanCadence {
-  { registered, steps_since_plan: 0, steps_since_reminder: 0, checklist: None }
+  {
+    registered,
+    steps_since_plan: 0,
+    steps_since_reminder: 0,
+    checklist: None,
+    nagged_without_plan: false,
+  }
 }
 
 ///|
 fn PlanCadence::should_remind(self : Self) -> Bool {
   self.registered &&
   self.steps_since_plan >= plan_reminder_after_steps &&
-  self.steps_since_reminder >= plan_reminder_after_steps
+  self.steps_since_reminder >= plan_reminder_after_steps &&
+  (self.checklist is Some(_) || !self.nagged_without_plan)
 }
 
 ///|
@@ -71,6 +84,11 @@ fn PlanCadence::reminder_text(self : Self) -> String {
 ///|
 fn PlanCadence::record_reminder(self : Self) -> Unit {
   self.steps_since_reminder = 0
+  // The once-per-turn cap applies only to the no-plan nudge; a turn that
+  // later records a plan re-nags through the checklist variant regardless.
+  if self.checklist is None {
+    self.nagged_without_plan = true
+  }
 }
 
 ///|

--- a/agent/plan_reminder_test.mbt
+++ b/agent/plan_reminder_test.mbt
@@ -1,13 +1,15 @@
 ///|
 /// A scripted DeepSeek stand-in that keeps a turn alive with `plan` calls
 /// whose arguments are invalid — each yields an error tool result, which
-/// never resets the staleness cadence. The server only records request
-/// bodies and scripts responses by request number; all assertions happen in
-/// the test body after the run, so a client retry shows up as a hard
-/// request-count mismatch instead of silently shifting the cadence.
+/// never resets the staleness cadence — for the first `plan_calls` requests,
+/// then answers. The server only records request bodies and scripts responses
+/// by request number; all assertions happen in the test body after the run,
+/// so a client retry shows up as a hard request-count mismatch instead of
+/// silently shifting the cadence.
 async fn stale_plan_test_server(
   group : @async.TaskGroup[Unit],
   bodies : Array[String],
+  plan_calls~ : Int,
 ) -> String? {
   let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
     error => {
@@ -26,7 +28,7 @@ async fn stale_plan_test_server(
         conn.send_response(200, "OK", extra_headers={
           "Content-Type": "text/event-stream",
         })
-        if bodies.length() <= 11 {
+        if bodies.length() <= plan_calls {
           conn.write(
             (
               #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
@@ -50,7 +52,9 @@ async fn stale_plan_test_server(
 async test "a plan-silent turn gets one staleness reminder after ten requests" {
   @async.with_task_group() <| group => {
     let bodies : Array[String] = []
-    guard stale_plan_test_server(group, bodies) is Some(url) else { return }
+    guard stale_plan_test_server(group, bodies, plan_calls=11) is Some(url) else {
+      return
+    }
     let runtime = @agent_runtime.AgentRuntime()
     let scope = @agent_runtime.AgentTaskScope(group)
     let session = @agent_session.Session(
@@ -99,13 +103,15 @@ async test "a plan-silent turn gets one staleness reminder after ten requests" {
 }
 
 ///|
-/// A scripted stand-in where request 1 records a valid plan. The successful
-/// write resets the cadence, so the reminder fires ten requests later — in
-/// request 12 — and re-surfaces the recorded checklist. Assertions live in
-/// the test body, as above.
+/// A scripted stand-in where request 1 records a valid plan and requests
+/// 2..plan_calls keep the turn alive with invalid `plan` calls before the
+/// answer. The successful write resets the cadence, so the first reminder
+/// fires ten requests later — in request 12 — and re-surfaces the recorded
+/// checklist. Assertions live in the test body, as above.
 async fn recorded_plan_test_server(
   group : @async.TaskGroup[Unit],
   bodies : Array[String],
+  plan_calls~ : Int,
 ) -> String? {
   let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
     error => {
@@ -131,7 +137,7 @@ async fn recorded_plan_test_server(
             ),
           )
           conn.write("\n\n")
-        } else if bodies.length() <= 12 {
+        } else if bodies.length() <= plan_calls {
           conn.write(
             (
               #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
@@ -155,7 +161,9 @@ async fn recorded_plan_test_server(
 async test "a recorded plan delays the reminder and is re-surfaced by it" {
   @async.with_task_group() <| group => {
     let bodies : Array[String] = []
-    guard recorded_plan_test_server(group, bodies) is Some(url) else { return }
+    guard recorded_plan_test_server(group, bodies, plan_calls=12) is Some(url) else {
+      return
+    }
     let runtime = @agent_runtime.AgentRuntime()
     let scope = @agent_runtime.AgentTaskScope(group)
     let session = @agent_session.Session(
@@ -192,5 +200,135 @@ async test "a recorded plan delays the reminder and is re-surfaced by it" {
     ]
     assert_eq(reminders.length(), 1)
     assert_true(reminders[0].contains("1. [in_progress] fix the parser"))
+  }
+}
+
+///|
+/// Occurrences of the reminder marker in one request body. Bodies carry the
+/// whole conversation, so a reminder injected once keeps appearing in every
+/// later request — "did it fire again" is a count on the newest body, not an
+/// absence check on it.
+fn reminder_count(body : String) -> Int {
+  body.split("[plan reminder]").collect().length() - 1
+}
+
+///|
+/// The no-plan nudge is capped at once per turn: a turn that stays plan-silent
+/// long enough for a second window (request 21 would re-fire under a pure
+/// 10/10 cadence) still gets exactly one reminder — repeating "consider
+/// recording a plan" that the model already declined once is pure noise.
+async test "the no-plan nag fires at most once per turn" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard stale_plan_test_server(group, bodies, plan_calls=23) is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("plan-nag-once"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope~,
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="do a long task",
+      append_item=(session, item) => session.append(item),
+      max_steps=30,
+      api_url=url,
+    )
+    // Exactly 24 requests: 23 tool-call steps plus the finishing answer.
+    assert_eq(bodies.length(), 24)
+    for index in 0..<10 {
+      assert_eq(
+        reminder_count(bodies[index]),
+        0,
+        msg="request \{index + 1} must not carry the reminder yet",
+      )
+    }
+    assert_eq(
+      reminder_count(bodies[10]),
+      1,
+      msg="request 11 should carry the only reminder",
+    )
+    // A pure 10/10 cadence would inject a second nag in request 21; the
+    // once-per-turn cap suppresses it, so the final request still carries
+    // exactly one reminder in its history.
+    assert_eq(
+      reminder_count(bodies[23]),
+      1,
+      msg="no later request may gain a second no-plan nag",
+    )
+    let reminders = [
+      for event in result.events() if event.item() is Runtime(notice) &&
+      notice.content().contains("[plan reminder]") => notice.content()
+    ]
+    assert_eq(reminders.length(), 1)
+    assert_true(reminders[0].contains("has not been used in this turn"))
+  }
+}
+
+///|
+/// The checklist variant is exempt from the once-per-turn cap: a recorded
+/// plan left stale keeps re-surfacing on the 10/10 cadence — request 12 and
+/// again request 22 — because it repeats real state, not declined advice.
+async test "a stale recorded plan re-nags on the ten-request cadence" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard recorded_plan_test_server(group, bodies, plan_calls=22) is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let session = @agent_session.Session(
+      SessionId("plan-renag-checklist"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope~,
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="do a long task",
+      append_item=(session, item) => session.append(item),
+      max_steps=30,
+      api_url=url,
+    )
+    // Exactly 23 requests: the plan write, 21 more tool-call steps, the
+    // finishing answer.
+    assert_eq(bodies.length(), 23)
+    assert_eq(
+      reminder_count(bodies[10]),
+      0,
+      msg="the plan write must delay the first reminder past request 11",
+    )
+    assert_eq(
+      reminder_count(bodies[11]),
+      1,
+      msg="request 12 should carry the first checklist reminder",
+    )
+    // The second re-nag lands exactly ten requests later: still one reminder
+    // in request 21's history, two from request 22 on.
+    assert_eq(
+      reminder_count(bodies[20]),
+      1,
+      msg="request 21 sits inside the ten-request window",
+    )
+    assert_eq(
+      reminder_count(bodies[21]),
+      2,
+      msg="request 22 should carry the second checklist reminder",
+    )
+    let reminders = [
+      for event in result.events() if event.item() is Runtime(notice) &&
+      notice.content().contains("[plan reminder]") => notice.content()
+    ]
+    assert_eq(reminders.length(), 2)
+    assert_true(reminders[0].contains("1. [in_progress] fix the parser"))
+    assert_true(reminders[1].contains("1. [in_progress] fix the parser"))
   }
 }


### PR DESCRIPTION
## What

PR 3 of 3 in the plan-reminder series (prompt guidance #396 → viz rendering #397 → **cadence tuning**).

The plan cadence re-nagged every ten plan-silent requests **regardless of variant**. That's right for the checklist variant — it re-surfaces recorded state that has scrolled out of recent context — but repeating the no-plan *"consider recording a plan"* nudge to a model that already declined it once is noise, and every repeat is another chance for a weak model to answer the reminder conversationally or call `plan` performatively to silence it.

## Change

`PlanCadence` gains a turn-local `nagged_without_plan` flag:

- **no-plan nudge**: fires **at most once per turn**;
- **checklist variant**: keeps the full 10/10 re-nag cadence (exempt from the cap);
- a turn that records a plan after the one nudge re-nags normally through the checklist variant (the cap keys off `checklist` at fire time).

`should_remind` / `reminder_text` / `record_reminder` all read `checklist` within one `prepare_step` with no interleaved mutation (`record_plan_success` runs later, in tool execution), so the gate, the rendered variant, and the cap always agree.

## Tests

Generalized the two scripted servers with a `plan_calls~` cutoff (no duplicated helpers) and added both cadence cases:

- **once-per-turn**: a 24-request plan-silent turn gets exactly one reminder — a pure 10/10 cadence would re-fire in request 21;
- **checklist re-nag** (also closes a pre-existing coverage gap): a stale recorded plan re-nags in requests 12 *and* 22, pinned to the exact requests.

Assertion approach worth noting: request bodies carry the whole conversation, so "didn't fire again" is asserted by **counting marker occurrences** in later bodies (`reminder_count`), not by absence checks — an absence check after the first injection can never hold. Durable-session reminder counts are asserted alongside.

`agent` tests **19/19** · full suite **916/916** · `moon fmt`/`check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)