### PR TITLE
feat: shell execution model — foundation (1/4)

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -1,0 +1,414 @@
+///|
+/// Default retained-output budget for a background job's inline preview, in
+/// characters. Matches the `shell` tool's foreground default so a command reads
+/// the same whether it runs in the foreground or the background. Full output
+/// beyond this spills to the job's file (see `ShellOutputSink`).
+let default_max_output_chars : Int = 12000
+
+///|
+/// Terminal or live state of a background job.
+///
+/// - `Running`: still executing (a detached-but-running execution also reads as
+///   `Running` — a poller has no separate "detached" state).
+/// - `Exited(code)`: exited on its own with `code`.
+/// - `Stopped`: cancelled (`stop`, a reader error, or teardown) before exit.
+pub(all) enum BgJobStatus {
+  Running
+  Exited(Int)
+  Stopped
+} derive(Eq)
+
+///|
+/// Session-scoped registry of background ("detached") jobs, each backed by one
+/// shared `@shell_exec.ShellExecution` (a process on `scope.group()`, a
+/// file-backed output sink, and a status flag). Every child is spawned on the
+/// session group, so its process is cancelled when the session's task group ends.
+///
+/// Cancellation reaches only the directly spawned process: the process library
+/// exposes no process-group kill, so a command that daemonizes its own children
+/// can leave descendants running after the job is reported terminal.
+///
+/// One `BgJobRuntime` is created per session and shared by the `shell`
+/// (`run_in_background`), `shell_output`, and `shell_stop` tools. `new` captures
+/// the session group in a spawn closure, so the runtime is not generic and can be
+/// an optional tool argument.
+pub struct BgJobRuntime {
+  // Spawn a `ShellExecution` on the captured session group: (program, args, cwd,
+  // inline-preview budget, spill path) -> execution. Captured so the runtime type
+  // is not generic.
+  priv spawn_exec : async (String, Array[String], String?, Int, String?) -> @shell_exec.ShellExecution
+  // Spawn a *foreground* execution on the same session group: memory-only output
+  // capped at the budget and killed if it fills, so the shell tool's foreground
+  // path shares the execution model (and can be detached on timeout) without
+  // re-deriving generic spawning at each call site.
+  priv spawn_foreground_exec : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution
+  // Spawn a *retained* foreground execution (may be detached on timeout):
+  // file-backed with a large hard cap, but still killed on exceeding the inline
+  // cap so a timed command that floods output is an immediate output-limit error;
+  // `background()` clears that kill so a detached-under-the-limit job keeps
+  // growing. The `String?` is the spill path.
+  priv spawn_foreground_retained_exec : async (
+    String,
+    Array[String],
+    String?,
+    Int,
+    String?,
+  ) -> @shell_exec.ShellExecution
+  // Spawn a per-job watcher task on that same group.
+  priv spawn_watcher : (async () -> Unit) -> Unit
+  // Directory for per-job spill files (full output beyond the inline preview).
+  // None → memory-only jobs (no full-output file).
+  priv spill_dir : String?
+  // Called once, with the terminal snapshot, when a job exits on its own (not on
+  // `stop`/teardown) — e.g. to push a completion notice into the agent loop.
+  priv on_job_exit : ((BgJobSnapshot) -> Unit)?
+  priv jobs : Map[String, BgJob]
+  priv mut next_index : Int
+  // Separate counter for the spill files of detachable foreground executions
+  // (which are not registered until adopted), so their `fg-<n>.out` files never
+  // collide with a job's `bg-<n>.out`.
+  priv mut fg_index : Int
+}
+
+///|
+/// One background job: session-visible metadata plus the shared execution that
+/// owns the process, output, and status. Fully private — callers see only a
+/// `BgJobSnapshot`.
+priv struct BgJob {
+  id : String
+  command : String
+  cwd : String?
+  exec : @shell_exec.ShellExecution
+  // Sandbox metadata carried from the launch (opaque to bgjobs) so a reader can
+  // apply the same source-write-denial detection the foreground path does.
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
+}
+
+///|
+/// An immutable view of a job's current state. `output` is the inline preview
+/// (the first inline-budget characters); the *full* output — when `over_inline_cap`
+/// — is read with `BgJobRuntime::read_output`.
+pub struct BgJobSnapshot {
+  id : String
+  command : String
+  cwd : String?
+  status : BgJobStatus
+  output : String
+  output_truncated : Bool
+  over_inline_cap : Bool
+  size : Int
+  seq : Int
+  exit_code : Int?
+  // Preserved so a reader can match the foreground path's error semantics: mark
+  // binary output as an error, and detect a sandboxed source-write denial.
+  had_invalid_utf8 : Bool
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
+  // The job was killed by the output-limit watchdog (flooded past the hard cap),
+  // not stopped on request — surfaced so the kill is never silent.
+  killed_by_output_limit : Bool
+}
+
+///|
+/// Create an empty runtime whose jobs are owned by `scope.group()`. Jobs spill
+/// full output into `spill_dir` (per-job files); omit it for memory-only jobs.
+/// `hard_output_cap` bounds any single job's *full* retained output (characters);
+/// the watchdog kills a job that floods past it — production uses the default,
+/// tests shrink it to exercise the watchdog cheaply.
+pub fn[X] BgJobRuntime::new(
+  scope : @agent_runtime.AgentTaskScope[X],
+  spill_dir? : String,
+  hard_output_cap? : Int = @shell_exec.default_hard_cap,
+  on_job_exit? : (BgJobSnapshot) -> Unit,
+) -> BgJobRuntime {
+  let group = scope.group()
+  {
+    spawn_exec: (program, args, cwd, max_output_chars, spill_path) => {
+      // Background retention: inline preview up to the budget, full output to
+      // the spill file, and the hard-cap watchdog so a flooding job is killed
+      // (and surfaced) rather than left burning CPU with its output dropped.
+      @shell_exec.ShellExecution::start(
+        scope,
+        program~,
+        args~,
+        cwd?,
+        inline_cap=max_output_chars,
+        hard_cap=hard_output_cap,
+        spill_path?,
+        kill_at_hard_cap=true,
+      )
+    },
+    spawn_foreground_exec: (program, args, cwd, max_output_chars) => {
+      // Foreground output-limit semantics: cap at exactly `max_output_chars`
+      // (inline == hard) and kill on overflow, so exceeding it is reported as the
+      // output-limit error, never silently dropped. Foreground is memory-only (no
+      // spill) — full output is a background-job feature.
+      @shell_exec.ShellExecution::start(
+        scope,
+        program~,
+        args~,
+        cwd?,
+        inline_cap=max_output_chars,
+        hard_cap=max_output_chars,
+        kill_when_full=true,
+      )
+    },
+    spawn_foreground_retained_exec: (
+      program,
+      args,
+      cwd,
+      max_output_chars,
+      spill_path,
+    ) => {
+      // kill_at_hard_cap so that once detached (kill_when_full cleared by
+      // `background()`), the job is still bounded in output like any other.
+      @shell_exec.ShellExecution::start(
+        scope,
+        program~,
+        args~,
+        cwd?,
+        inline_cap=max_output_chars,
+        hard_cap=hard_output_cap,
+        spill_path?,
+        kill_when_full=true,
+        kill_at_hard_cap=true,
+      )
+    },
+    spawn_watcher: task => {
+      group.spawn_bg(task, no_wait=true, allow_failure=true)
+    },
+    spill_dir,
+    on_job_exit,
+    jobs: {},
+    next_index: 1,
+    fg_index: 1,
+  }
+}
+
+///|
+fn BgJobRuntime::next_id(self : BgJobRuntime) -> String {
+  let id = "bg-\{self.next_index}"
+  self.next_index += 1
+  id
+}
+
+///|
+/// Spawn a *foreground* execution on the session group: memory-only output
+/// capped at `max_output_chars` and killed if it fills. The shell tool's
+/// foreground path uses this so foreground and background share one execution
+/// model — and a timed-out foreground command can be `adopt`-ed (detached)
+/// rather than killed. Positional to match the shell tool's spawner type.
+pub async fn BgJobRuntime::spawn_foreground(
+  self : BgJobRuntime,
+  program : String,
+  args : Array[String],
+  cwd : String?,
+  max_output_chars : Int,
+) -> @shell_exec.ShellExecution {
+  (self.spawn_foreground_exec)(program, args, cwd, max_output_chars)
+}
+
+///|
+/// Spawn a foreground execution that may be *detached* (adopted) on timeout: it
+/// uses the background retention config — file-backed (spill), a large hard cap,
+/// no output-limit kill — so that if it is detached and keeps producing output,
+/// `shell_output` still sees it. The foreground output-limit (over
+/// `max_output_chars`) is enforced by the caller at display time, not by killing;
+/// the caller's `timeout_ms` bounds the wait. Reuses the background spawn with a
+/// distinct `fg-<n>.out` spill file.
+pub async fn BgJobRuntime::spawn_foreground_retained(
+  self : BgJobRuntime,
+  program : String,
+  args : Array[String],
+  cwd : String?,
+  max_output_chars : Int,
+) -> @shell_exec.ShellExecution {
+  let spill_path = self.spill_dir.map(dir => {
+    let index = self.fg_index
+    self.fg_index += 1
+    "\{dir}/fg-\{index}.out"
+  })
+  (self.spawn_foreground_retained_exec)(
+    program, args, cwd, max_output_chars, spill_path,
+  )
+}
+
+///|
+/// Spawn `program args` as a background job on the session group and return its
+/// id. The job keeps running after this returns; `command` is the human-readable
+/// command line shown to the model.
+pub async fn BgJobRuntime::start(
+  self : BgJobRuntime,
+  program~ : String,
+  args~ : Array[String],
+  command~ : String,
+  cwd? : String,
+  max_output_chars? : Int = default_max_output_chars,
+  source_write_sandboxed? : Bool = false,
+  sandbox_denial_subjects? : Array[String] = [],
+) -> String {
+  // Reserve one id and use it for both the spill file and the registry entry, so
+  // the job id and its `<id>.out` file never diverge.
+  let id = self.next_id()
+  let spill_path = self.spill_dir.map(dir => "\{dir}/\{id}.out")
+  let exec = (self.spawn_exec)(program, args, cwd, max_output_chars, spill_path)
+  self.register(
+    id,
+    exec,
+    command~,
+    cwd?,
+    source_write_sandboxed~,
+    sandbox_denial_subjects~,
+  )
+  id
+}
+
+///|
+/// Register an already-running `ShellExecution` as a background job and return
+/// its id. Used by detach-on-timeout: a foreground command that outlived its
+/// timeout is `background()`-ed and adopted here, so `shell_output`/`shell_stop`
+/// and the completion notice see it like any explicit background job.
+pub fn BgJobRuntime::adopt(
+  self : BgJobRuntime,
+  exec : @shell_exec.ShellExecution,
+  command~ : String,
+  cwd? : String,
+  source_write_sandboxed? : Bool = false,
+  sandbox_denial_subjects? : Array[String] = [],
+) -> String {
+  let id = self.next_id()
+  self.register(
+    id,
+    exec,
+    command~,
+    cwd?,
+    source_write_sandboxed~,
+    sandbox_denial_subjects~,
+  )
+  id
+}
+
+///|
+/// Add a job to the registry under `id` and start its exit watcher.
+fn BgJobRuntime::register(
+  self : BgJobRuntime,
+  id : String,
+  exec : @shell_exec.ShellExecution,
+  command~ : String,
+  cwd? : String,
+  source_write_sandboxed~ : Bool,
+  sandbox_denial_subjects~ : Array[String],
+) -> Unit {
+  self.jobs[id] = {
+    id,
+    command,
+    cwd,
+    exec,
+    source_write_sandboxed,
+    sandbox_denial_subjects,
+  }
+  // Watch for the job ending on its own and fire `on_job_exit` once: a natural
+  // exit, or the output-limit watchdog killing a flooding job — both must be
+  // surfaced (a watchdog kill silently eating an unwatched job would look like
+  // it just never finished). A requested stop (shell_stop, session teardown) is
+  // already user-visible and fires nothing. The job entry is set above before
+  // the watcher runs (the watcher first awaits the exit, ≥ one tick later), so
+  // `snapshot(id)` always resolves.
+  (self.spawn_watcher)(() => {
+    exec.wait()
+    guard self.on_job_exit is Some(callback) else { return }
+    guard self.snapshot(id) is Some(snapshot) else { return }
+    guard snapshot.status is Exited(_) || snapshot.killed_by_output_limit else {
+      return
+    }
+    callback(snapshot)
+  })
+}
+
+///|
+/// Map an execution status onto the background-job status a poller sees. A
+/// detached-but-running execution reads as `Running`; a killed one as `Stopped`.
+fn bg_status(status : @shell_exec.ExecStatus) -> BgJobStatus {
+  match status {
+    Running | Backgrounded => Running
+    Exited(code) => Exited(code)
+    Killed => Stopped
+  }
+}
+
+///|
+fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
+  {
+    id: self.id,
+    command: self.command,
+    cwd: self.cwd,
+    status: bg_status(self.exec.status()),
+    output: self.exec.head(),
+    output_truncated: self.exec.output_truncated(),
+    over_inline_cap: self.exec.over_inline_cap(),
+    size: self.exec.size(),
+    seq: self.exec.seq(),
+    exit_code: self.exec.exit_code(),
+    had_invalid_utf8: self.exec.had_invalid_utf8(),
+    source_write_sandboxed: self.source_write_sandboxed,
+    sandbox_denial_subjects: self.sandbox_denial_subjects,
+    killed_by_output_limit: self.exec.killed_by_output_limit(),
+  }
+}
+
+///|
+/// The current state of one job (inline preview), or `None` for an unknown id.
+pub fn BgJobRuntime::snapshot(
+  self : BgJobRuntime,
+  id : String,
+) -> BgJobSnapshot? {
+  self.jobs.get(id).map(job => job.to_snapshot())
+}
+
+///|
+/// The full output of one job (reads the spill file for a large job), or `None`
+/// for an unknown id.
+pub async fn BgJobRuntime::read_output(
+  self : BgJobRuntime,
+  id : String,
+) -> String? {
+  match self.jobs.get(id) {
+    Some(job) => Some(job.exec.read_all())
+    None => None
+  }
+}
+
+///|
+/// The last `n` characters of one job's output — a bounded window onto recent
+/// output — or `None` for an unknown id. Used by `shell_output` so a poll cannot
+/// flood the conversation with a large job's full log.
+pub async fn BgJobRuntime::read_output_tail(
+  self : BgJobRuntime,
+  id : String,
+  n : Int,
+) -> String? {
+  match self.jobs.get(id) {
+    Some(job) => Some(job.exec.read_tail(n))
+    None => None
+  }
+}
+
+///|
+/// Snapshots of every job the session has started.
+pub fn BgJobRuntime::list(self : BgJobRuntime) -> Array[BgJobSnapshot] {
+  let out = []
+  for _, job in self.jobs {
+    out.push(job.to_snapshot())
+  }
+  out
+}
+
+///|
+/// Cancel a running job and return once it is terminal. Idempotent: an
+/// already-terminal known job returns `true`; an unknown id returns `false`.
+pub async fn BgJobRuntime::stop(self : BgJobRuntime, id : String) -> Bool {
+  guard self.jobs.get(id) is Some(job) else { return false }
+  let _ = job.exec.stop()
+  true
+}

--- a/agent_tool/bgjobs/bgjobs_wbtest.mbt
+++ b/agent_tool/bgjobs/bgjobs_wbtest.mbt
@@ -1,0 +1,201 @@
+///|
+/// Poll `id` until it leaves `Running`, failing after a bounded deadline so a
+/// hung child can never hang the test. Async tests run in parallel, so each test
+/// isolates its own runtime and jobs.
+#cfg(not(platform="windows"))
+async fn poll_until_terminal(
+  rt : BgJobRuntime,
+  id : String,
+  ticks? : Int = 200,
+) -> BgJobSnapshot {
+  for _ in 0..<ticks {
+    if rt.snapshot(id) is Some(snap) && !(snap.status is Running) {
+      return snap
+    }
+    @async.sleep(25)
+  }
+  fail("bg job \{id} did not reach a terminal state in time")
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "bg job runs to completion and captures output" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf hello"],
+      command="printf hello",
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(0))
+    assert_true(snap.output.contains("hello"))
+    assert_true(snap.exit_code is Some(0))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "bg job records a non-zero exit code" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(program="sh", args=["-c", "exit 3"], command="exit 3")
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(3))
+    assert_true(snap.exit_code is Some(3))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "stop terminates a running job" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let id = rt.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    assert_true(rt.snapshot(id).unwrap().status is Running)
+    assert_true(rt.stop(id))
+    assert_true(rt.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a large-output job spills; snapshot previews, read_output is full" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    let id = rt.start(
+      program="sh",
+      args=["-c", "seq 1 5000"],
+      command="seq",
+      max_output_chars=100,
+    )
+    let snap = poll_until_terminal(rt, id)
+    assert_true(snap.status is Exited(0))
+    assert_true(snap.over_inline_cap)
+    // The snapshot output is a bounded preview...
+    assert_true(snap.output.char_length() <= 100)
+    // ...while read_output returns the full output from the spill file.
+    let full = rt.read_output(id).unwrap()
+    assert_true(full.has_prefix("1\n"))
+    assert_true(full.contains("5000"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "adopt registers an already-running execution as a job" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let rt = BgJobRuntime::new(scope)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
+      "30",
+    ])
+    let id = rt.adopt(exec, command="sleep 30")
+    @async.sleep(50)
+    assert_true(rt.snapshot(id).unwrap().status is Running)
+    assert_true(rt.stop(id))
+    assert_true(rt.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "on_job_exit fires once on a natural exit, never on stop" {
+  @async.with_task_group(group => {
+    let seen : Array[BgJobSnapshot] = []
+    let rt = BgJobRuntime::new(AgentTaskScope(group), on_job_exit=snapshot => {
+      seen.push(snapshot)
+    })
+    let done = rt.start(
+      program="sh",
+      args=["-c", "printf done"],
+      command="printf done",
+    )
+    let stopped = rt.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    assert_true(rt.stop(stopped))
+    for _ in 0..<200 {
+      if seen.length() > 0 {
+        break
+      }
+      @async.sleep(25)
+    }
+    @async.sleep(50)
+    // Exactly one notice — for the natural exit, not the stopped job.
+    assert_true(seen.length() == 1)
+    assert_true(seen[0].id == done)
+    assert_true(seen[0].status is Exited(0))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "snapshot, read_output, and stop handle unknown ids" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    assert_true(rt.snapshot("nope") is None)
+    assert_true(rt.read_output("nope") is None)
+    assert_false(rt.stop("nope"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "start allocates one id per job (id matches its spill file)" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    // The first started job is bg-1 (not bg-2): start must not reserve an id for
+    // the spill path and then allocate a second one for the registry entry.
+    let a = rt.start(program="sh", args=["-c", "printf a"], command="a")
+    assert_true(a == "bg-1")
+    let b = rt.start(program="sh", args=["-c", "printf b"], command="b")
+    assert_true(b == "bg-2")
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "two jobs run independently with distinct ids" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let a = rt.start(program="sh", args=["-c", "printf aaa"], command="a")
+    let b = rt.start(program="sh", args=["-c", "printf bbb"], command="b")
+    assert_true(a != b)
+    let sa = poll_until_terminal(rt, a)
+    let sb = poll_until_terminal(rt, b)
+    assert_true(sa.output.contains("aaa"))
+    assert_true(sb.output.contains("bbb"))
+    assert_true(rt.list().length() == 2)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "the watchdog kills a background job that floods past the hard cap" {
+  @async.with_task_group(group => {
+    let notices : Array[BgJobSnapshot] = []
+    // Tiny hard cap so `yes` trips the watchdog immediately instead of running
+    // to the 20M default.
+    let rt = BgJobRuntime::new(AgentTaskScope(group), hard_output_cap=200, on_job_exit=snapshot => {
+      notices.push(snapshot)
+    })
+    let id = rt.start(program="yes", args=[], command="yes")
+    let snapshot = poll_until_terminal(rt, id)
+    // Killed by the watchdog — not left running with its output dropped — and
+    // reported as such, not as a requested stop.
+    assert_true(snapshot.status is Stopped)
+    assert_true(snapshot.killed_by_output_limit)
+    assert_true(snapshot.output_truncated)
+    // The kill is pushed like a natural exit: a silently dead job would look
+    // like it just never finished.
+    for _ in 0..<200 {
+      if notices.length() > 0 {
+        break
+      }
+      @async.sleep(25)
+    }
+    assert_true(notices.length() == 1)
+    assert_true(notices[0].killed_by_output_limit)
+  })
+}

--- a/agent_tool/bgjobs/moon.pkg
+++ b/agent_tool/bgjobs/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_tool/shell_exec",
+  "moonbitlang/async",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -1,0 +1,54 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/bgjobs"
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_tool/shell_exec",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct BgJobRuntime {
+  // private fields
+}
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, source_write_sandboxed? : Bool, sandbox_denial_subjects? : Array[String]) -> String
+pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
+pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
+pub async fn BgJobRuntime::read_output(Self, String) -> String?
+pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
+pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
+pub async fn BgJobRuntime::spawn_foreground(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
+pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
+pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, source_write_sandboxed? : Bool, sandbox_denial_subjects? : Array[String]) -> String
+pub async fn BgJobRuntime::stop(Self, String) -> Bool
+
+pub struct BgJobSnapshot {
+  id : String
+  command : String
+  cwd : String?
+  status : BgJobStatus
+  output : String
+  output_truncated : Bool
+  over_inline_cap : Bool
+  size : Int
+  seq : Int
+  exit_code : Int?
+  had_invalid_utf8 : Bool
+  source_write_sandboxed : Bool
+  sandbox_denial_subjects : Array[String]
+  killed_by_output_limit : Bool
+}
+
+pub(all) enum BgJobStatus {
+  Running
+  Exited(Int)
+  Stopped
+} derive(Eq)
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -1,0 +1,355 @@
+///|
+/// After the direct child exits, how long to let the reader keep draining the
+/// pipe before force-closing it. In the normal case the reader hits EOF almost
+/// immediately (the child closed its write end); this grace only elapses when a
+/// descendant inherited and is holding the pipe open, in which case there is no
+/// more of the job's own output to wait for.
+let reader_drain_grace_ms : Int = 200
+
+///|
+/// Terminal or live state of one execution.
+///
+/// - `Running`: the child is executing and a tool call is awaiting it.
+/// - `Backgrounded`: the child is still executing but detached — no call is
+///   awaiting it (set by detach-on-timeout; the process keeps running).
+/// - `Exited(code)`: the child exited on its own with `code`.
+/// - `Killed`: the child was cancelled (`stop`, a reader error, or session
+///   teardown) before a natural exit — no exit code is available.
+pub(all) enum ExecStatus {
+  Running
+  Backgrounded
+  Exited(Int)
+  Killed
+} derive(Eq, Debug)
+
+///|
+/// Whether a status is terminal (the child is gone).
+pub fn ExecStatus::is_terminal(self : ExecStatus) -> Bool {
+  match self {
+    Exited(_) | Killed => true
+    Running | Backgrounded => false
+  }
+}
+
+///|
+/// One shell command execution: a process spawned on the session group, its
+/// merged stdout+stderr owned by a single `ShellOutputSink`, and a status flag.
+/// This is the shared object behind both foreground `shell` and background jobs —
+/// "foreground vs background" is only whether a tool call is currently awaiting
+/// it, so detaching is a status flip (`background()`), not a re-route.
+///
+/// Cancellation reaches only the directly spawned process (like the foreground
+/// `shell` tool and `moon_check`): the process library exposes no process-group
+/// kill, so a command that daemonizes its own children can leave descendants
+/// running after the execution is terminal.
+pub struct ShellExecution {
+  priv sink : ShellOutputSink
+  priv process : @process.Process
+  priv mut status : ExecStatus
+  // Set before the child is cancelled (by `stop`, or by the output-limit kill)
+  // so the monitor reports `Killed` rather than the kill signal's exit code.
+  priv mut cancel_requested : Bool
+  // Foreground semantics: kill the child once the sink fills (output prefix hit
+  // the hard cap or the kill threshold), so an un-timed runaway cannot hang the
+  // tool call. Cleared by `background()` — a detached job keeps running.
+  priv mut kill_when_full : Bool
+  // Background watchdog: kill the child once full output hits the *hard* cap —
+  // past it every further byte is dropped, so the job is a runaway producing
+  // nothing anyone can read. Unlike `kill_when_full` this survives
+  // `background()`: a detached job keeps running but not unboundedly.
+  priv kill_at_hard_cap : Bool
+  // Set when the child was cancelled by an output-limit watchdog (either flag
+  // above), so a consumer can tell a watchdog kill from a requested stop and
+  // surface it rather than letting the job die silently.
+  priv mut killed_by_output_limit : Bool
+}
+
+///|
+/// Spawn `program args` on the session group with stdout+stderr merged into a
+/// fresh sink, start a monitor task, and return the live execution. `spill_path`,
+/// when set, is where the sink writes full output once it exceeds `inline_cap`.
+pub async fn[X] ShellExecution::start(
+  scope : @agent_runtime.AgentTaskScope[X],
+  program~ : String,
+  args~ : Array[String],
+  cwd? : String,
+  inline_cap? : Int = default_inline_cap,
+  hard_cap? : Int = default_hard_cap,
+  spill_path? : String,
+  kill_when_full? : Bool = false,
+  kill_at_hard_cap? : Bool = false,
+) -> ShellExecution {
+  let group = scope.group()
+  let sink = ShellOutputSink::new(inline_cap~, hard_cap~, spill_path?)
+  let (reader, writer) = @process.read_from_process()
+  let process = @process.spawn(
+    group,
+    program,
+    args,
+    stdout=writer,
+    stderr=writer,
+    cwd?=cwd.map(cwd => cwd.view()),
+    cancel_handler=@process.hard_cancel(),
+    no_wait=true,
+  )
+  let exec = {
+    sink,
+    process,
+    status: Running,
+    cancel_requested: false,
+    kill_when_full,
+    kill_at_hard_cap,
+    killed_by_output_limit: false,
+  }
+  group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    exec.monitor(reader, process)
+  }
+  exec
+}
+
+///|
+/// Supervise the execution: drain merged output while, *independently*, awaiting
+/// the direct child's exit. Coupling the two (read to EOF, then `wait`) would
+/// hang forever when the child exits but a descendant holds the pipe open — so a
+/// concurrent reader drains bytes and `process.wait()` is the authoritative exit
+/// signal that then closes the reader to unblock it.
+async fn ShellExecution::monitor(
+  self : ShellExecution,
+  reader : @process.ReadFromProcess,
+  process : @process.Process,
+) -> Unit {
+  let reader_done : @async.Queue[Unit] = Queue(kind=Unbounded)
+  @async.with_task_group(reads => {
+    reads.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+      defer ignore(reader_done.try_put(()) catch { _ => false })
+      for ;; {
+        match (reader.read_some(max_len=1024) catch { _ => None }) {
+          None => break
+          Some(bytes) => {
+            self.sink.append_chunk(bytes)
+            // Output-limit watchdogs, two thresholds:
+            // - Foreground (`kill_when_full`): stop the child as soon as output
+            //   exceeds the inline cap (max_output_chars) — promptly, not only at
+            //   a larger hard cap — so a chatty command is an immediate
+            //   output-limit error rather than running to the timeout.
+            //   `background()` clears this flag, so a job detached while still
+            //   under the limit keeps growing afterward. `over_inline_cap` fires
+            //   for a retained execution (inline < hard); `truncated` covers a
+            //   memory-only one (inline == hard).
+            // - Background (`kill_at_hard_cap`): stop the child once full output
+            //   hits the hard cap — past it every byte is dropped, so a flooding
+            //   job would burn CPU producing nothing readable. Survives detach.
+            let over_foreground_limit = self.kill_when_full &&
+              (self.sink.over_inline_cap() || self.sink.truncated())
+            let over_hard_cap = self.kill_at_hard_cap && self.sink.truncated()
+            if (over_foreground_limit || over_hard_cap) &&
+              !self.cancel_requested {
+              self.killed_by_output_limit = true
+              self.cancel_requested = true
+              self.process.cancel()
+            }
+          }
+        }
+      }
+    }
+    // The direct child's exit is authoritative, independent of the pipe. A
+    // concurrent `stop` cancels the process, so `wait` may raise or return a
+    // kill signal's code — every path lands on a terminal status.
+    let terminal = try {
+      let code = process.wait()
+      if self.cancel_requested {
+        Killed
+      } else {
+        Exited(code)
+      }
+    } catch {
+      error => {
+        if @async.is_being_cancelled() {
+          reader.close()
+          raise error
+        }
+        Killed
+      }
+    }
+    // The child is gone, but the pipe may still hold output it wrote before
+    // exiting. Let the reader drain to EOF; only if it is still blocked after a
+    // short grace — a descendant is holding the pipe open — force it closed.
+    match
+      @async.with_timeout_opt(reader_drain_grace_ms, () => reader_done.get()) {
+      Some(_) => ()
+      None => reader.close()
+    }
+    // Surface leftover half-decoded bytes, then publish the terminal status — in
+    // that order, so a poller can never observe a terminal execution missing the
+    // job's final output.
+    self.sink.finish()
+    self.set_terminal(terminal)
+  })
+}
+
+///|
+/// Move to a terminal status, unless already terminal (a `stop` that raced the
+/// natural exit must not clobber the recorded outcome).
+fn ShellExecution::set_terminal(
+  self : ShellExecution,
+  status : ExecStatus,
+) -> Unit {
+  guard !self.status.is_terminal() else { return }
+  self.status = status
+}
+
+///|
+/// Stop the execution: cancel the child and return once it lands terminal.
+/// Idempotent and safe under concurrent callers — each observes the status
+/// transition rather than a one-shot signal. Returns `false` for an
+/// already-terminal execution.
+pub async fn ShellExecution::stop(self : ShellExecution) -> Bool {
+  guard !self.status.is_terminal() else { return false }
+  self.request_stop()
+  for ;; {
+    if self.status.is_terminal() {
+      return true
+    }
+    @async.sleep(5)
+  }
+}
+
+///|
+/// Synchronously request cancellation of the child (mark it and fire the process
+/// cancel) without awaiting the terminal transition. `Process::cancel` is sync,
+/// so this is safe to call while a turn is being cancelled — where awaiting is
+/// not — to stop a session-group execution before it can outlive the turn as an
+/// orphan. The monitor (on the session group) then reaps it to `Killed`.
+pub fn ShellExecution::request_stop(self : ShellExecution) -> Unit {
+  self.cancel_requested = true
+  self.process.cancel()
+}
+
+///|
+/// Await the execution reaching a terminal status.
+pub async fn ShellExecution::wait(self : ShellExecution) -> Unit {
+  for ;; {
+    if self.status.is_terminal() {
+      return
+    }
+    @async.sleep(5)
+  }
+}
+
+///|
+/// Await terminal *or* the first invalid (binary / non-UTF-8) output, whichever
+/// comes first — so a foreground command that emits binary bytes and then keeps
+/// running fails immediately, matching the strict per-call path, instead of
+/// blocking until exit.
+pub async fn ShellExecution::wait_or_invalid(self : ShellExecution) -> Unit {
+  for ;; {
+    if self.status.is_terminal() || self.sink.had_invalid_utf8() {
+      return
+    }
+    @async.sleep(5)
+  }
+}
+
+///|
+/// Detach the execution: flip `Running → Backgrounded` so no call is awaiting it
+/// while the process keeps running, and clear the foreground output-limit kill —
+/// a detached job may keep producing output. The hard-cap watchdog
+/// (`kill_at_hard_cap`) is deliberately NOT cleared: detached means unbounded in
+/// time, not unbounded in output. No-op (`false`) once terminal or already
+/// backgrounded.
+pub fn ShellExecution::background(self : ShellExecution) -> Bool {
+  guard self.status is Running else { return false }
+  self.status = Backgrounded
+  self.kill_when_full = false
+  true
+}
+
+///|
+/// The current live or terminal status.
+pub fn ShellExecution::status(self : ShellExecution) -> ExecStatus {
+  self.status
+}
+
+///|
+/// The child's exit code, if it exited on its own.
+pub fn ShellExecution::exit_code(self : ShellExecution) -> Int? {
+  match self.status {
+    Exited(code) => Some(code)
+    _ => None
+  }
+}
+
+///|
+/// The in-memory head — the first `inline_cap` characters, the full output when
+/// it fits inline, otherwise a preview. Synchronous.
+pub fn ShellExecution::head(self : ShellExecution) -> String {
+  self.sink.head()
+}
+
+///|
+/// The full retained output (reads the spill file when output spilled).
+pub async fn ShellExecution::read_all(self : ShellExecution) -> String {
+  self.sink.read_all()
+}
+
+///|
+/// The last `n` characters of output — a bounded window onto recent output.
+pub async fn ShellExecution::read_tail(
+  self : ShellExecution,
+  n : Int,
+) -> String {
+  self.sink.read_tail(n)
+}
+
+///|
+/// Whether output exceeded the inline cap (render a pointer; full output is in
+/// the spill file).
+pub fn ShellExecution::over_inline_cap(self : ShellExecution) -> Bool {
+  self.sink.over_inline_cap()
+}
+
+///|
+/// The spill file's path, if output spilled to disk.
+pub fn ShellExecution::spill_path(self : ShellExecution) -> String? {
+  self.sink.spill_path()
+}
+
+///|
+/// Whether full output was dropped at the hard cap.
+pub fn ShellExecution::output_truncated(self : ShellExecution) -> Bool {
+  self.sink.truncated()
+}
+
+///|
+/// Whether any invalid (non-UTF-8 / binary) output was seen.
+pub fn ShellExecution::had_invalid_utf8(self : ShellExecution) -> Bool {
+  self.sink.had_invalid_utf8()
+}
+
+///|
+/// Whether the child was cancelled by an output-limit watchdog (rather than a
+/// requested stop) — so a consumer can surface the kill instead of letting a
+/// runaway job die silently.
+pub fn ShellExecution::killed_by_output_limit(self : ShellExecution) -> Bool {
+  self.killed_by_output_limit
+}
+
+///|
+/// Delete the spill file — for a retained execution that finished in the
+/// foreground and is not adopted as a background job, so its temp file does not
+/// leak. The in-memory head remains readable.
+pub async fn ShellExecution::discard(self : ShellExecution) -> Unit {
+  self.sink.discard()
+}
+
+///|
+/// Full-output length in characters.
+pub fn ShellExecution::size(self : ShellExecution) -> Int {
+  self.sink.size()
+}
+
+///|
+/// Output version, bumped whenever retained output grows.
+pub fn ShellExecution::seq(self : ShellExecution) -> Int {
+  self.sink.seq()
+}

--- a/agent_tool/shell_exec/execution_wbtest.mbt
+++ b/agent_tool/shell_exec/execution_wbtest.mbt
@@ -1,0 +1,128 @@
+///|
+/// Poll an execution until it reaches a terminal status, failing after a bounded
+/// deadline so a hung child can never hang the test.
+#cfg(not(platform="windows"))
+async fn poll_exec_terminal(exec : ShellExecution, ticks? : Int = 200) -> Unit {
+  for _ in 0..<ticks {
+    if exec.status().is_terminal() {
+      return
+    }
+    @async.sleep(25)
+  }
+  fail("execution did not reach a terminal state in time")
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "execution runs to completion and captures output" {
+  @async.with_task_group(group => {
+    let exec = ShellExecution::start(AgentTaskScope(group), program="sh", args=[
+      "-c", "printf hello",
+    ])
+    poll_exec_terminal(exec)
+    assert_true(exec.status() is Exited(0))
+    assert_true(exec.head().contains("hello"))
+    assert_true(exec.exit_code() is Some(0))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "execution records a non-zero exit code" {
+  @async.with_task_group(group => {
+    let exec = ShellExecution::start(AgentTaskScope(group), program="sh", args=[
+      "-c", "exit 3",
+    ])
+    poll_exec_terminal(exec)
+    assert_true(exec.status() is Exited(3))
+    assert_true(exec.exit_code() is Some(3))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "stop and request_stop terminate a running execution" {
+  @async.with_task_group(group => {
+    let exec = ShellExecution::start(AgentTaskScope(group), program="sleep", args=[
+      "30",
+    ])
+    @async.sleep(50)
+    assert_true(exec.status() is Running)
+    assert_true(exec.stop())
+    assert_true(exec.status() is Killed)
+    assert_false(exec.stop())
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "request_stop synchronously terminates a running execution" {
+  @async.with_task_group(group => {
+    let exec = ShellExecution::start(AgentTaskScope(group), program="sleep", args=[
+      "30",
+    ])
+    @async.sleep(50)
+    assert_true(exec.status() is Running)
+    exec.request_stop()
+    poll_exec_terminal(exec)
+    assert_true(exec.status() is Killed)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "background flips to Backgrounded and keeps running" {
+  @async.with_task_group(group => {
+    let exec = ShellExecution::start(AgentTaskScope(group), program="sleep", args=[
+      "30",
+    ])
+    @async.sleep(50)
+    assert_true(exec.background())
+    assert_true(exec.status() is Backgrounded)
+    assert_true(exec.stop())
+    assert_true(exec.status() is Killed)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "kill_when_full stops a runaway once the sink fills" {
+  @async.with_task_group(group => {
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      program="sh",
+      args=["-c", "yes"],
+      inline_cap=100,
+      hard_cap=100,
+      kill_when_full=true,
+    )
+    poll_exec_terminal(exec)
+    assert_true(exec.status() is Killed)
+    assert_true(exec.output_truncated())
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "large output spills and read_all returns the full output" {
+  @async.with_task_group(group => {
+    let path = "/tmp/openseek-exec-spill.out"
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      program="sh",
+      args=["-c", "seq 1 5000"],
+      inline_cap=100,
+      hard_cap=1000000,
+      spill_path=path,
+    )
+    poll_exec_terminal(exec)
+    assert_true(exec.status() is Exited(0))
+    assert_true(exec.over_inline_cap())
+    assert_true(exec.spill_path() is Some(_))
+    // head is a bounded preview; read_all is the full output.
+    assert_true(exec.head().has_prefix("1\n"))
+    let full = exec.read_all()
+    assert_true(full.has_prefix("1\n"))
+    assert_true(full.contains("5000"))
+  })
+}

--- a/agent_tool/shell_exec/moon.pkg
+++ b/agent_tool/shell_exec/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/process",
+  "moonbitlang/core/encoding/utf8",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -1,0 +1,70 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell_exec"
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub let default_hard_cap : Int
+
+pub let default_inline_cap : Int
+
+// Errors
+
+// Types and methods
+pub(all) enum ExecStatus {
+  Running
+  Backgrounded
+  Exited(Int)
+  Killed
+} derive(Eq, @debug.Debug)
+pub fn ExecStatus::is_terminal(Self) -> Bool
+
+pub struct ShellExecution {
+  // private fields
+}
+pub fn ShellExecution::background(Self) -> Bool
+pub async fn ShellExecution::discard(Self) -> Unit
+pub fn ShellExecution::exit_code(Self) -> Int?
+pub fn ShellExecution::had_invalid_utf8(Self) -> Bool
+pub fn ShellExecution::head(Self) -> String
+pub fn ShellExecution::killed_by_output_limit(Self) -> Bool
+pub fn ShellExecution::output_truncated(Self) -> Bool
+pub fn ShellExecution::over_inline_cap(Self) -> Bool
+pub async fn ShellExecution::read_all(Self) -> String
+pub async fn ShellExecution::read_tail(Self, Int) -> String
+pub fn ShellExecution::request_stop(Self) -> Unit
+pub fn ShellExecution::seq(Self) -> Int
+pub fn ShellExecution::size(Self) -> Int
+pub fn ShellExecution::spill_path(Self) -> String?
+pub async fn[X] ShellExecution::start(@agent_runtime.AgentTaskScope[X], program~ : String, args~ : Array[String], cwd? : String, inline_cap? : Int, hard_cap? : Int, spill_path? : String, kill_when_full? : Bool, kill_at_hard_cap? : Bool) -> Self
+pub fn ShellExecution::status(Self) -> ExecStatus
+pub async fn ShellExecution::stop(Self) -> Bool
+pub async fn ShellExecution::wait(Self) -> Unit
+pub async fn ShellExecution::wait_or_invalid(Self) -> Unit
+
+pub struct ShellOutputSink {
+  // private fields
+}
+pub async fn ShellOutputSink::append_chunk(Self, Bytes) -> Unit
+pub async fn ShellOutputSink::append_text(Self, String) -> Unit
+pub fn ShellOutputSink::close(Self) -> Unit
+pub async fn ShellOutputSink::discard(Self) -> Unit
+pub async fn ShellOutputSink::finish(Self) -> Unit
+pub fn ShellOutputSink::had_invalid_utf8(Self) -> Bool
+pub fn ShellOutputSink::head(Self) -> String
+pub fn ShellOutputSink::new(inline_cap? : Int, hard_cap? : Int, spill_path? : String) -> Self
+pub fn ShellOutputSink::over_inline_cap(Self) -> Bool
+pub async fn ShellOutputSink::read_all(Self) -> String
+pub async fn ShellOutputSink::read_tail(Self, Int) -> String
+pub fn ShellOutputSink::seq(Self) -> Int
+pub fn ShellOutputSink::size(Self) -> Int
+pub fn ShellOutputSink::spill_path(Self) -> String?
+pub fn ShellOutputSink::truncated(Self) -> Bool
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -1,0 +1,419 @@
+///|
+/// Default inline cap: output at or below this many characters is shown inline;
+/// larger output spills to a file and is rendered as a pointer plus a head
+/// preview. Matches the `shell` tool's foreground default so a command reads the
+/// same whether it runs in the foreground or the background.
+pub let default_inline_cap : Int = 12000
+
+///|
+/// Default hard cap: the sink retains at most this many characters of full
+/// output (across memory + the spill file), bounding disk even for a runaway
+/// producer. The size watchdog is expected to kill a job well before this.
+pub let default_hard_cap : Int = 20_000_000
+
+///|
+/// One owner for a single command's merged stdout+stderr, with a single
+/// retention story so foreground and background never disagree. **Memory-first,
+/// file-backed:** output is kept in memory up to `inline_cap`; past it the *full*
+/// output spills to a file (`spill_path`) and only a bounded in-memory *head* is
+/// kept for cheap inline rendering. The file is the source of truth for full
+/// output, so a reader can ask for any window (`read_all` now; prefix/tail/range
+/// later) without the sink pre-committing to one — that is what makes retention a
+/// read-time decision instead of a policy baked into the buffer.
+///
+/// With no `spill_path` the sink is memory-only: it keeps the head and drops the
+/// rest (bounded, never touches disk) — used by contexts that never need full
+/// large output (tests, the scope-less `collect_shell_output`).
+pub struct ShellOutputSink {
+  // The first `inline_cap` characters, for inline rendering without a file read.
+  priv head : StringBuilder
+  priv mut head_chars : Int
+  // Total decoded characters of full output (across memory + file), ≤ hard_cap.
+  priv mut total_chars : Int
+  // Trailing bytes of an incomplete UTF-8 sequence carried to the next chunk.
+  priv mut pending : Bytes
+  // Bumps whenever retained output grows, for poll change detection.
+  priv mut seq : Int
+  // Set once output was dropped at the hard cap.
+  priv mut truncated : Bool
+  // Set once any invalid (non-UTF-8 / binary) bytes were decoded lossily, so a
+  // consumer can preserve the strict-decode "binary output" error rather than
+  // silently showing replacement characters.
+  priv mut had_invalid : Bool
+  // Full-output spill file, opened lazily once output exceeds `inline_cap` and a
+  // spill path is configured. None → memory-only (small output, or no path).
+  priv mut file : @fs.File?
+  // Bytes written to the file so far (== full output byte length once spilled).
+  priv mut file_bytes : Int64
+  // Where to spill; None → never spill (memory-only, head kept, rest dropped).
+  priv spill_path : String?
+  priv inline_cap : Int
+  priv hard_cap : Int
+}
+
+///|
+/// Create an empty sink. Non-positive caps are clamped to 1. With `spill_path`
+/// set, output past `inline_cap` spills there; without it the sink is memory-only.
+pub fn ShellOutputSink::new(
+  inline_cap? : Int = default_inline_cap,
+  hard_cap? : Int = default_hard_cap,
+  spill_path? : String,
+) -> ShellOutputSink {
+  {
+    head: StringBuilder(),
+    head_chars: 0,
+    total_chars: 0,
+    pending: b"",
+    seq: 0,
+    truncated: false,
+    had_invalid: false,
+    file: None,
+    file_bytes: 0,
+    spill_path,
+    inline_cap: if inline_cap > 0 {
+      inline_cap
+    } else {
+      1
+    },
+    hard_cap: if hard_cap > 0 {
+      hard_cap
+    } else {
+      1
+    },
+  }
+}
+
+///|
+/// Feed a raw output chunk from the process reader, decoding UTF-8 across chunk
+/// boundaries — an incomplete trailing sequence is carried to the next chunk.
+pub async fn ShellOutputSink::append_chunk(
+  self : ShellOutputSink,
+  chunk : Bytes,
+) -> Unit {
+  let buffer = Buffer()
+  buffer.write_bytes(self.pending)
+  buffer.write_bytes(chunk)
+  let (text, rest, invalid) = split_valid_utf8(buffer.to_bytes())
+  self.pending = rest
+  if invalid {
+    self.had_invalid = true
+  }
+  self.append_text(text)
+}
+
+///|
+/// Feed already-decoded text. Writes the full output to the spill file (once past
+/// `inline_cap`), keeps the first `inline_cap` characters in the memory head, and
+/// drops output past `hard_cap` (setting `truncated`). `seq` bumps when retained
+/// output grows.
+pub async fn ShellOutputSink::append_text(
+  self : ShellOutputSink,
+  text : String,
+) -> Unit {
+  guard text != "" else { return }
+  guard !self.truncated else { return }
+  let room_hard = self.hard_cap - self.total_chars
+  guard room_hard > 0 else {
+    self.truncated = true
+    return
+  }
+  let text = if text.char_length() <= room_hard {
+    text
+  } else {
+    self.truncated = true
+    prefix_chars(text, room_hard)
+  }
+  // Full output → spill file. Open lazily the first time total output would pass
+  // the inline cap, seeding the file with everything buffered so far (the head,
+  // which holds all output while total ≤ inline_cap). A file-open/write failure
+  // degrades to memory-only (the head) rather than losing the run.
+  if self.spill_path is Some(path) {
+    if self.file is None &&
+      self.total_chars + text.char_length() > self.inline_cap {
+      self.open_spill(path)
+    }
+    if self.file is Some(file) {
+      let bytes = @utf8.encode(text)
+      file.write_at(bytes, position=self.file_bytes) catch {
+        _ => ()
+      }
+      self.file_bytes += bytes.length().to_int64()
+    }
+  }
+  // Head: keep the first inline_cap characters.
+  let room_head = self.inline_cap - self.head_chars
+  if room_head > 0 {
+    let piece = if text.char_length() <= room_head {
+      text
+    } else {
+      prefix_chars(text, room_head)
+    }
+    self.head.write_string(piece)
+    self.head_chars += piece.char_length()
+  }
+  self.total_chars += text.char_length()
+  self.seq += 1
+}
+
+///|
+/// Open the spill file and seed it with the output buffered so far.
+async fn ShellOutputSink::open_spill(
+  self : ShellOutputSink,
+  path : String,
+) -> Unit {
+  // ReadWrite so the same descriptor serves both the streaming writes and later
+  // `read_all` reads (a create/write-only handle cannot be read). CreateOrTruncate
+  // gives a fresh file (the path is unique per job id).
+  let file = @fs.open(path, mode=ReadWrite, create_mode=CreateOrTruncate) catch {
+    _ => return
+  }
+  let seed = @utf8.encode(self.head.to_string())
+  file.write_at(seed, position=0) catch {
+    _ => {
+      file.close()
+      return
+    }
+  }
+  self.file = Some(file)
+  self.file_bytes = seed.length().to_int64()
+}
+
+///|
+/// Flush any incomplete trailing UTF-8 bytes at end of stream (decoded lossily),
+/// so a multi-byte character that never completed is surfaced rather than lost.
+pub async fn ShellOutputSink::finish(self : ShellOutputSink) -> Unit {
+  guard self.pending.length() > 0 else { return }
+  // A non-empty pending buffer at end of stream is an incomplete (or invalid)
+  // sequence — strict decoding would have rejected it, so mark it binary.
+  self.had_invalid = true
+  let text = @utf8.decode_lossy(self.pending)
+  self.pending = b""
+  self.append_text(text)
+}
+
+///|
+/// Release the spill file descriptor. Reads after this fall back to the head.
+pub fn ShellOutputSink::close(self : ShellOutputSink) -> Unit {
+  match self.file {
+    Some(file) => {
+      file.close()
+      self.file = None
+    }
+    None => ()
+  }
+}
+
+///|
+/// Close and delete the spill file — for a retained execution that completed in
+/// the foreground (never adopted as a background job), so its temp file does not
+/// leak. Full output is no longer readable after this (the head remains).
+pub async fn ShellOutputSink::discard(self : ShellOutputSink) -> Unit {
+  match self.file {
+    Some(file) => {
+      file.close()
+      self.file = None
+      match self.spill_path {
+        Some(path) => @fs.remove(path) catch { _ => () }
+        None => ()
+      }
+    }
+    None => ()
+  }
+}
+
+///|
+/// Total full-output length in characters (≤ hard_cap).
+pub fn ShellOutputSink::size(self : ShellOutputSink) -> Int {
+  self.total_chars
+}
+
+///|
+/// Output version, bumped whenever retained output grows.
+pub fn ShellOutputSink::seq(self : ShellOutputSink) -> Int {
+  self.seq
+}
+
+///|
+/// Whether full output was dropped at the hard cap.
+pub fn ShellOutputSink::truncated(self : ShellOutputSink) -> Bool {
+  self.truncated
+}
+
+///|
+/// Whether any invalid (non-UTF-8 / binary) bytes were decoded — the consumer
+/// may surface this as a "binary output" error instead of showing replacements.
+pub fn ShellOutputSink::had_invalid_utf8(self : ShellOutputSink) -> Bool {
+  self.had_invalid
+}
+
+///|
+/// The in-memory head: the first `inline_cap` characters. This is the *full*
+/// output when it fits inline; otherwise a preview. Synchronous.
+pub fn ShellOutputSink::head(self : ShellOutputSink) -> String {
+  self.head.to_string()
+}
+
+///|
+/// Whether output exceeded the inline cap (so a consumer should render a pointer,
+/// and full output lives in the spill file).
+pub fn ShellOutputSink::over_inline_cap(self : ShellOutputSink) -> Bool {
+  self.total_chars > self.inline_cap
+}
+
+///|
+/// The spill file's path, if output spilled to disk; `None` for memory-only.
+pub fn ShellOutputSink::spill_path(self : ShellOutputSink) -> String? {
+  if self.file is Some(_) {
+    self.spill_path
+  } else {
+    None
+  }
+}
+
+///|
+/// The full retained output. Reads the spill file when output spilled; otherwise
+/// returns the in-memory head (which is the full output for a small command). On
+/// a read error it degrades to the head rather than raising.
+pub async fn ShellOutputSink::read_all(self : ShellOutputSink) -> String {
+  match self.file {
+    Some(file) => {
+      let bytes = file.read_exactly_at(self.file_bytes.to_int(), position=0) catch {
+        _ => return self.head.to_string()
+      }
+      @utf8.decode_lossy(bytes)
+    }
+    None => self.head.to_string()
+  }
+}
+
+///|
+/// The last `n` characters of full output — a window onto the *recent* output of
+/// a (possibly still-running) job, read from the tail of the spill file so a
+/// poller sees progress rather than the unchanging prefix. Degrades to the head
+/// on a read error or a memory-only sink.
+pub async fn ShellOutputSink::read_tail(
+  self : ShellOutputSink,
+  n : Int,
+) -> String {
+  guard n > 0 else { return "" }
+  match self.file {
+    Some(file) => {
+      // Read a byte window sized for `n` UTF-8 chars (≤ 4 bytes each) from the
+      // file tail, decode lossily (a partial lead byte at the window start
+      // becomes a replacement char, dropped when we keep the last `n`), then keep
+      // the last `n` characters.
+      let want = n.to_int64() * 4 + 4
+      let start = if self.file_bytes > want {
+        self.file_bytes - want
+      } else {
+        0
+      }
+      let len = (self.file_bytes - start).to_int()
+      let bytes = file.read_exactly_at(len, position=start) catch {
+        _ => return self.head.to_string()
+      }
+      last_chars(@utf8.decode_lossy(bytes), n)
+    }
+    None => last_chars(self.head.to_string(), n)
+  }
+}
+
+///|
+/// The last `n` characters of `text` (or all of it if shorter).
+fn last_chars(text : String, n : Int) -> String {
+  let len = text.char_length()
+  if len <= n {
+    text
+  } else {
+    match text.offset_of_nth_char(len - n) {
+      Some(start) => "\{text[start:]}"
+      None => text
+    }
+  }
+}
+
+///|
+/// First `n` characters of `text` (assumes `n < text.char_length()`).
+fn prefix_chars(text : String, n : Int) -> String {
+  match text.offset_of_nth_char(n) {
+    Some(end) => "\{text[:end]}"
+    None => text
+  }
+}
+
+///|
+/// Split `bytes` into the longest valid-UTF-8 prefix (decoded lossily) and the
+/// trailing bytes of an incomplete multi-byte sequence to carry to the next
+/// chunk. A malformed (not merely incomplete) trailing sequence is surfaced now
+/// rather than held for a completion that can never be valid.
+fn split_valid_utf8(bytes : Bytes) -> (String, Bytes, Bool) {
+  let end = bytes.length() - incomplete_suffix_len(bytes)
+  let tail = Buffer()
+  tail.write_bytes(bytes[end:])
+  // Strict-decode the complete prefix; on invalid bytes fall back to lossy and
+  // report it, so the caller can preserve the "binary output" error. A valid
+  // prefix (the common case) decodes once.
+  let (text, invalid) = (@utf8.decode(bytes[:end]), false) catch {
+    _ => (@utf8.decode_lossy(bytes[:end]), true)
+  }
+  (text, tail.to_bytes(), invalid)
+}
+
+///|
+fn incomplete_suffix_len(bytes : Bytes) -> Int {
+  let len = bytes.length()
+  let lookback = if len < 3 { len } else { 3 }
+  for i in 0..<lookback {
+    let pos = len - 1 - i
+    let b = bytes[pos].to_int()
+    if b < 0x80 {
+      return 0
+    }
+    if b >= 0xC0 {
+      let expected = utf8_sequence_len(b)
+      let have = len - pos
+      guard expected != 0 && expected > have else { return 0 }
+      for j in 1..<have {
+        let (lo, hi) = continuation_range(b, j)
+        let cb = bytes[pos + j].to_int()
+        if cb < lo || cb > hi {
+          return 0
+        }
+      }
+      return have
+    }
+  }
+  0
+}
+
+///|
+fn utf8_sequence_len(b : Int) -> Int {
+  if b >= 0xF0 && b <= 0xF4 {
+    4
+  } else if b >= 0xE0 && b <= 0xEF {
+    3
+  } else if b >= 0xC2 && b <= 0xDF {
+    2
+  } else {
+    0
+  }
+}
+
+///|
+fn continuation_range(lead : Int, j : Int) -> (Int, Int) {
+  if j == 1 {
+    if lead == 0xE0 {
+      (0xA0, 0xBF)
+    } else if lead == 0xED {
+      (0x80, 0x9F)
+    } else if lead == 0xF0 {
+      (0x90, 0xBF)
+    } else if lead == 0xF4 {
+      (0x80, 0x8F)
+    } else {
+      (0x80, 0xBF)
+    }
+  } else {
+    (0x80, 0xBF)
+  }
+}

--- a/agent_tool/shell_exec/sink_wbtest.mbt
+++ b/agent_tool/shell_exec/sink_wbtest.mbt
@@ -1,0 +1,100 @@
+///|
+async test "small output stays in memory, no file" {
+  let sink = ShellOutputSink::new(inline_cap=100)
+  sink.append_text("hello")
+  assert_eq(sink.head(), "hello")
+  assert_eq(sink.read_all(), "hello")
+  assert_eq(sink.size(), 5)
+  assert_false(sink.over_inline_cap())
+  assert_true(sink.spill_path() is None)
+  assert_false(sink.truncated())
+}
+
+///|
+async test "output over the inline cap spills; read_all returns everything, head previews" {
+  let path = "/tmp/openseek-sink-spill-1.out"
+  let sink = ShellOutputSink::new(inline_cap=4, hard_cap=1000, spill_path=path)
+  sink.append_text("abcdefghij")
+  assert_true(sink.over_inline_cap())
+  assert_true(sink.spill_path() is Some(_))
+  // Head is the first inline_cap chars (a preview); read_all is the full output.
+  assert_eq(sink.head(), "abcd")
+  assert_eq(sink.read_all(), "abcdefghij")
+  assert_eq(sink.size(), 10)
+  sink.close()
+}
+
+///|
+async test "the spill file is seeded with output buffered before the spill" {
+  let path = "/tmp/openseek-sink-spill-2.out"
+  let sink = ShellOutputSink::new(inline_cap=4, hard_cap=1000, spill_path=path)
+  sink.append_text("ab") // total 2, under inline cap: memory only, no file yet
+  assert_false(sink.over_inline_cap())
+  sink.append_text("cdef") // total 6 > 4: spill, seeding the file with "ab"
+  assert_eq(sink.read_all(), "abcdef") // seed + new chunk, in order
+  assert_eq(sink.head(), "abcd")
+  sink.close()
+}
+
+///|
+async test "memory-only (no spill path) keeps the head and drops the rest" {
+  let sink = ShellOutputSink::new(inline_cap=4, hard_cap=1000)
+  sink.append_text("abcdefghij")
+  assert_true(sink.over_inline_cap())
+  assert_true(sink.spill_path() is None)
+  // No file: read_all is the bounded head, not the full output.
+  assert_eq(sink.read_all(), "abcd")
+  assert_eq(sink.size(), 10) // size still reports what was produced
+}
+
+///|
+async test "output over the hard cap truncates" {
+  let sink = ShellOutputSink::new(inline_cap=2, hard_cap=5)
+  sink.append_text("abc")
+  sink.append_text("defgh") // total 8 > 5
+  assert_true(sink.truncated())
+  assert_eq(sink.size(), 5)
+  let seq_before = sink.seq()
+  sink.append_text("xyz") // dropped, no seq bump
+  assert_eq(sink.seq(), seq_before)
+}
+
+///|
+async test "append_chunk decodes utf-8 across a chunk boundary" {
+  let sink = ShellOutputSink::new(inline_cap=100)
+  // "café" = 63 61 66 C3 A9, split between é's lead and continuation byte.
+  sink.append_chunk(([0x63, 0x61, 0x66, 0xC3] : Bytes))
+  sink.append_chunk(([0xA9] : Bytes))
+  assert_eq(sink.head(), "café")
+}
+
+///|
+async test "finish flushes an incomplete trailing sequence lossily" {
+  let sink = ShellOutputSink::new(inline_cap=100)
+  sink.append_chunk(([0x68, 0x69, 0xC3] : Bytes))
+  assert_eq(sink.head(), "hi")
+  sink.finish()
+  assert_true(sink.size() >= 3)
+}
+
+///|
+test "split_valid_utf8 surfaces corrupt trailing bytes instead of hiding them" {
+  let bytes : Bytes = [0x68, 0x69, 0xff]
+  let (text, rest, _) = split_valid_utf8(bytes)
+  assert_true(rest.length() == 0)
+  assert_true(text.has_prefix("hi"))
+  assert_true(text.char_length() >= 3)
+}
+
+///|
+test "split_valid_utf8 does not carry malformed multi-byte prefixes" {
+  let (t1, r1, _) = split_valid_utf8(([0x78, 0xE0, 0x80] : Bytes))
+  assert_true(r1.length() == 0)
+  assert_true(t1.has_prefix("x"))
+  let (t2, r2, _) = split_valid_utf8(([0x78, 0xF4, 0x90] : Bytes))
+  assert_true(r2.length() == 0)
+  assert_true(t2.has_prefix("x"))
+  let (t3, r3, _) = split_valid_utf8(([0x78, 0xE0, 0xA0] : Bytes))
+  assert_true(t3 == "x")
+  assert_true(r3.length() == 2)
+}

--- a/docs/plans/shell-execution-model.md
+++ b/docs/plans/shell-execution-model.md
@@ -1,0 +1,159 @@
+# The shell execution model
+
+A single, layered model for running shell commands — foreground and background —
+in the OpenSeek agent. This document is the architecture north star; the code is
+organized to match it, foundation-first.
+
+## The one idea
+
+A shell command is **one process object with one output owner and one status
+flag.** "Foreground" vs "background" is not two code paths — it is only *whether a
+tool call is currently awaiting the object*. Detaching a command is therefore a
+**status flip**, not a re-route or a conversion.
+
+This is the lesson of the earlier attempt (a spike on `spike/detach-on-timeout`):
+routing a foreground command *through* a separate background-job runtime on
+timeout failed, because the two runtimes had opposite, lossy policies (output
+retention prefix-vs-tail, output-limit kill-vs-continue, exit notify-vs-not), and
+reconstructing a foreground result from a background snapshot discarded the
+information. The fix is not to reconcile two runtimes — it is to have **one**.
+
+## The layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ tools:  shell (run_in_background, foreground, detach)        │  L3
+│         shell_output (poll) · shell_stop (cancel)            │
+├─────────────────────────────────────────────────────────────┤
+│ integration: push-completion notice · serve-loop wake · TUI │  L3.5
+├─────────────────────────────────────────────────────────────┤
+│ registry:  BgJobRuntime — id → ShellExecution, on_exit hook │  L2
+├─────────────────────────────────────────────────────────────┤
+│ execution: ShellExecution — process + sink + status flag    │  L1
+├─────────────────────────────────────────────────────────────┤
+│ output:    ShellOutputSink — one owner, file-backed          │  L0
+└─────────────────────────────────────────────────────────────┘
+```
+
+Each layer depends only on the one below. The registry, the tools, foreground,
+and detach are all thin — the weight is in L0 and L1.
+
+### L0 — `ShellOutputSink` (the future-proof output owner)
+
+One owner for a command's merged stdout+stderr, with a single retention story so
+foreground and background never disagree. **Memory-first, file-backed:**
+
+- The parent reads the child's pipe (so output-limit and sandbox-denial checks
+  keep working in-flight), decoding UTF-8 across chunk boundaries.
+- Output is buffered in memory up to an **inline cap**. Past it, the sink
+  **spills the full output to a file** (opened lazily under a session temp dir)
+  and keeps only a bounded in-memory *head* for cheap inline rendering.
+- The **file is the source of truth for full output** — so a reader can later
+  ask for any window (prefix / tail / all / range) without the sink having to
+  pre-commit to one. That is what makes this future-proof: retention is no longer
+  a policy choice baked into the buffer; it is a read-time decision.
+- `inline_or_pointer`: small output renders inline; large output renders a
+  `<system>output_file=… size=…>` pointer plus a head preview, and the model
+  reads the rest with `shell_output`.
+- A **hard cap** bounds the file (disk), enforced by the size watchdog (L1).
+
+Why memory-first rather than always-file (Claude Code's bash mode writes straight
+to a file): the agent runs a flood of tiny commands (`ls`, `git status`); keeping
+those in memory avoids a temp file per command, and the file appears only when
+output is genuinely large — where its cost is already justified.
+
+### L1 — `ShellExecution` (the shared process object)
+
+`status : Running | Backgrounded | Exited(Int) | Killed`. Owns the process
+(spawned on the **session** task group, so it can outlive a single tool call and
+be detached), the sink, and a monitor task (concurrent pipe reader + the
+authoritative `process.wait()` + drain-to-EOF + terminal flush). Methods:
+
+- `wait()` — await terminal; `stop()` — cancel and await terminal.
+- `request_stop()` — **synchronous** cancel (uses the sync `Process::cancel`), so
+  a cancelled turn can stop a session-group execution during unwinding, where
+  awaiting is unsafe — otherwise it orphans.
+- `background()` — flip `Running → Backgrounded`, disabling the foreground
+  output-limit kill (a detached job keeps running like any background job).
+- `kill_when_full` — foreground semantics: kill an un-timed runaway once the sink
+  fills, so it cannot hang the tool call.
+- size watchdog — kill a job whose spill file passes the hard cap (disk guard).
+
+### L2 — `BgJobRuntime` (the registry)
+
+`id → { command, cwd, ShellExecution }`. Non-generic (captures the session group
+in a spawn closure) so it can be an optional tool argument. `start` spawns + adopts;
+`adopt` registers an already-running execution (this is how detach works);
+`snapshot`/`list`/`stop` delegate to the execution; a per-job watcher fires
+`on_job_exit` once on a natural exit (the push-completion hook).
+
+### L3 — tools, and L3.5 — integration
+
+- `shell`: foreground runs through a `ShellExecution` (via a spawner the agent
+  wires); `run_in_background:true` starts a job; a `timeout_ms` that elapses
+  **detaches** (background + adopt) rather than kills; turn cancellation
+  `request_stop`s the execution.
+- `shell_output` / `shell_stop`: poll and cancel — they read straight through the
+  registry, i.e. the shared sink, so they need no output logic of their own.
+- Push-completion: `on_job_exit → runtime.queue_steer(Notice(…))`, delivered to
+  the model at the next step boundary; an idle serve engine is woken by a
+  `BackgroundNotice` step and the notice rides an **untagged** event so it
+  survives the TUI's stale-run guard; the notice persists as a `Runtime` item.
+
+## Foundation-first delivery (the PRs)
+
+Re-authored from `origin/main` so the history *is* the architecture — no
+build-an-old-model-then-refactor. Each PR is one coherent layer, reviewable on
+its own, with the layer below already in place.
+
+- **PR 1 — the model (L0–L2).** `agent_tool/shell_exec` (`ShellOutputSink`
+  file-backed + `ShellExecution`) and `agent_tool/bgjobs` (registry on it). Pure
+  infrastructure, fully unit-tested against real processes, no tool wiring. This
+  PR carries the architecture overview.
+- **PR 2 — the tools (L3).** `shell` `run_in_background`, `shell_output`,
+  `shell_stop`; foreground routed through `ShellExecution`; detach-on-timeout;
+  cancellation cleanup. The user-facing surface.
+- **PR 3 — integration (L3.5).** push-completion, the serve-loop wake, the
+  untagged notice event, and TUI rendering.
+
+Commit gate for every commit: `moon fmt` → `moon check --target native <pkgs>` →
+`moon test <pkgs>` → `codex review --base <prev-sha>` (fix real findings,
+re-review clean) → regenerate `.mbti` (`moon info`).
+
+## Test plan
+
+Principles: **native target** (async spawn); **deterministic polling** (bounded
+ticks + `@async.sleep`, `fail` on a deadline, fast commands with a real sleeper
+only for stop/timeout); **isolation** (parallel async tests, per-test temp
+cwd/spill dir); **regression** (the full `agent_tool/shell` suite green; the
+scope-less `collect_shell_output` path that the TUI `!` uses stays byte-identical).
+
+Per layer:
+
+- **L0 sink** — small output inline, no file; output past the inline cap spills,
+  `read_all` returns everything (prefix intact), the head is a bounded preview,
+  `over_inline_cap` flips, UTF-8 split across a chunk *and* the spill boundary is
+  not corrupted, a non-positive budget is clamped, the hard cap truncates, a
+  file-open failure degrades to memory (never crashes).
+- **L1 execution** — exit code captured; `stop`/`request_stop` → `Killed`;
+  `background` → `Backgrounded` and keeps running; `kill_when_full` stops a
+  runaway; descendant-holds-pipe still terminates; the watchdog kills an
+  over-cap spill.
+- **L2 registry** — `start`/`snapshot`/`list`/`stop`; `adopt` an existing
+  execution; `on_job_exit` fires once on natural exit, never on stop; unknown id.
+- **L3 tools** — foreground bytes match the old path for small output; large
+  output returns the file pointer and `shell_output` reads the remainder;
+  `run_in_background` returns an id and enforces guards before spawning; a
+  timed-out foreground command detaches; a cancelled turn leaves no orphan.
+- **L3.5 integration** — notice decode; serve idle-wake untagged event; TUI `⚙`
+  render; notice persists as a `Runtime` item.
+
+## Status of the earlier stack
+
+PRs #375 / #378 / #380 delivered this feature in historical order (explicit jobs →
+push → unify-and-refactor) with a bounded *pure-memory* sink. This re-author
+supersedes them: same behavior and the same hard-won lessons (detach = flip,
+untagged idle notice, sync cancel cleanup), but foundation-first and with the
+**file-backed** output layer that makes large-output and tail-follow first-class
+instead of deferred. The superseded flawed detach attempt remains on
+`spike/detach-on-timeout` as a cautionary reference.


### PR DESCRIPTION
Slice 1/4 of the background-shell series — **see the umbrella PR #389 for the full architecture, review history, and design rationale.** The four slices merge in order and reconstruct #389's tree byte-for-byte.

New code only; nothing registers it yet (zero behavior change):

- **L0 `ShellOutputSink`** — one owner for a command's merged stdout+stderr: memory-first, **file-backed** (full output spills to a file past the inline cap, making retention a read-time decision: head / tail window / full), UTF-8-safe across chunk boundaries, hard-capped with binary-output tracking.
- **L1 `ShellExecution`** — one process + one sink + a status flag; "background" is a status, detach is a flip. Output-limit watchdogs: foreground kill at the inline cap, background kill at the hard cap (a flooding job is killed and surfaced, never a silent CPU-burning runaway).
- **L2 `BgJobRuntime`** — session-scoped job registry: per-job spill files, exit watchers, push-completion hooks, adopt (for detach-on-timeout).
- `docs/plans/shell-execution-model.md` — the architecture north star.

Tests at this tip: **940/940** (fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)