### PR TITLE
feat(shell): run_in_background + detach-on-timeout (2/4)

### DIFF
--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -17,6 +17,7 @@ pub struct ShellInput {
   cwd : String?
   timeout_ms : Int?
   max_output_chars : Int
+  run_in_background : Bool
 } derive(Debug)
 
 ///|
@@ -42,11 +43,22 @@ fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
   let max_output_chars = optional_positive_int_or_default(
     fields, "max_output_chars", default_max_output_chars,
   )
+  let run_in_background = optional_bool(fields, "run_in_background")
   {
     cmd,
     cwd,
     timeout_ms,
     max_output_chars: cap_max_output_chars(max_output_chars),
+    run_in_background,
+  }
+}
+
+///|
+fn optional_bool(fields : Map[String, Json], name : String) -> Bool raise {
+  match fields.get(name) {
+    Some(True) => true
+    Some(False) | Some(Null) | None => false
+    _ => fail("arguments.\{name} to be a boolean")
   }
 }
 

--- a/agent_tool/shell/internal/decode/decode_test.mbt
+++ b/agent_tool/shell/internal/decode/decode_test.mbt
@@ -13,6 +13,7 @@ test "decode valid shell input" {
       #|  cwd: Some("/tmp"),
       #|  timeout_ms: Some(250),
       #|  max_output_chars: 50000,
+      #|  run_in_background: false,
       #|}
     ),
   )
@@ -23,7 +24,13 @@ test "decode treats empty cwd as absent" {
   debug_inspect(
     @decode.decode({ "cmd": "pwd", "cwd": "" }),
     content=(
-      #|{ cmd: "pwd", cwd: None, timeout_ms: None, max_output_chars: 12000 }
+      #|{
+      #|  cmd: "pwd",
+      #|  cwd: None,
+      #|  timeout_ms: None,
+      #|  max_output_chars: 12000,
+      #|  run_in_background: false,
+      #|}
     ),
   )
 }

--- a/agent_tool/shell/internal/decode/pkg.generated.mbti
+++ b/agent_tool/shell/internal/decode/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub struct ShellInput {
   cwd : String?
   timeout_ms : Int?
   max_output_chars : Int
+  run_in_background : Bool
 } derive(@debug.Debug)
 
 // Type aliases

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/shell_exec",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/shell/internal/command_policy",
   "bobzhang/openseek/agent_tool/shell/internal/decode",

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -3,12 +3,17 @@ package "bobzhang/openseek/agent_tool/shell"
 
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
 }
 
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
 
-pub fn definition(workspace_root? : String, read_only? : Bool) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
+
+pub fn source_write_denial_feedback() -> String
+
+pub fn source_write_denied_in_text(String, Array[String]) -> Bool
 
 // Errors
 

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -66,28 +66,6 @@ priv struct AgentShellOutput {
 }
 
 ///|
-async fn collect_agent_shell_output(
-  workspace_root : String,
-  cmd : String,
-  parsed : @shell_parse.ParseResult,
-  cwd? : String,
-  max_output_chars~ : Int,
-) -> AgentShellOutput {
-  let launch = agent_shell_launch(workspace_root, cmd, parsed, cwd?)
-  let output = collect_process_output(
-    launch.program,
-    launch.args,
-    cwd?,
-    max_output_chars~,
-  )
-  {
-    output,
-    source_write_sandboxed: launch.source_write_sandboxed,
-    sandbox_denial_subjects: launch.sandbox_denial_subjects,
-  }
-}
-
-///|
 async fn agent_shell_launch(
   workspace_root : String,
   cmd : String,
@@ -5629,7 +5607,18 @@ fn sandbox_denied_source_write(
   output : ShellOutput,
   denial_subjects : Array[String],
 ) -> Bool {
-  output.text
+  source_write_denied_in_text(output.text, denial_subjects)
+}
+
+///|
+/// Whether `output_text` shows a sandboxed source-write denial for
+/// `denial_subjects`. Exposed so `shell_output` can apply the same detection to a
+/// background job's output that the foreground path applies inline.
+pub fn source_write_denied_in_text(
+  output_text : String,
+  denial_subjects : Array[String],
+) -> Bool {
+  output_text
   .split("\n")
   .any(line => {
     sandbox_denial_line_mentions_denial(line) &&
@@ -5638,6 +5627,13 @@ fn sandbox_denied_source_write(
       sandbox_denial_line_mentions_known_subject(line, denial_subjects)
     )
   })
+}
+
+///|
+/// The guidance appended when a shell command's output shows a sandboxed
+/// source-write denial. Exposed for `shell_output`.
+pub fn source_write_denial_feedback() -> String {
+  SandboxSourceWriteFeedback
 }
 
 ///|

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -31,24 +31,70 @@
 pub fn definition(
   workspace_root? : String = ".",
   read_only? : Bool = false,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell",
-    description=shell_description(),
-    schema=JsonSchema({
-      "type": "object",
-      "properties": {
-        "cmd": { "type": "string" },
-        "cwd": { "type": "string" },
-        "timeout_ms": { "type": "number" },
-        "max_output_chars": { "type": "number" },
+    // Only describe and advertise `run_in_background` when a background runtime
+    // is wired (the agent's registry): a standalone/custom definition without
+    // one cannot execute it, so exposing it would let a model make a call that
+    // only errors — and the timeout semantics genuinely differ (wired: detach to
+    // a background job; unwired: cancel and report a tool error), so a single
+    // static description would misstate one of the two contexts.
+    description=if bg_runtime is Some(_) {
+      shell_description() + background_description()
+    } else {
+      shell_description()
+    },
+    schema=JsonSchema(
+      if bg_runtime is Some(_) {
+        {
+          "type": "object",
+          "properties": {
+            "cmd": { "type": "string" },
+            "cwd": { "type": "string" },
+            "timeout_ms": {
+              "type": "number",
+              "description": "Max time to wait in the foreground; a command still running at the deadline is moved to the background as a job (not killed).",
+            },
+            "max_output_chars": { "type": "number" },
+            "run_in_background": {
+              "type": "boolean",
+              "description": "Run as a background job: returns a job id immediately and a completion notice arrives when it exits. Use for long-running commands instead of blocking or sleeping.",
+            },
+          },
+          "required": ["cmd"],
+        }
+      } else {
+        {
+          "type": "object",
+          "properties": {
+            "cmd": { "type": "string" },
+            "cwd": { "type": "string" },
+            "timeout_ms": {
+              "type": "number",
+              "description": "Max time to wait; a command still running at the deadline is cancelled and reported as a tool error.",
+            },
+            "max_output_chars": { "type": "number" },
+          },
+          "required": ["cmd"],
+        }
       },
-      "required": ["cmd"],
-    }),
+    ),
     execute=Async(arguments => {
-      execute_with_workspace(workspace_root, arguments, read_only~)
+      execute_with_workspace(workspace_root, arguments, read_only~, bg_runtime?)
     }),
   )
+}
+
+///|
+/// The background-jobs paragraph appended to the shell description when a
+/// background runtime is wired. Guides the model away from blocking waits:
+/// long-running work goes to a background job and its completion is *pushed* as
+/// a notice, so `sleep N && cmd` chains and shell_output polling loops are both
+/// unnecessary and wasteful.
+fn background_description() -> String {
+  " For long-running work (builds, long test suites, servers, watchers) set run_in_background=true: the call returns a job id immediately and a notice arrives automatically when the job finishes — so never block the turn waiting on time (no `sleep N && cmd` chains, no repeated polling); keep working, or finish the turn, and act on the completion notice. Read a job's recent output with shell_output and cancel it with shell_stop. A foreground command that outlives timeout_ms is moved to the background as a job (not killed)."
 }
 
 ///|
@@ -68,6 +114,7 @@ async fn execute_with_workspace(
   workspace_root : String,
   arguments : Json,
   read_only~ : Bool,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -101,7 +148,7 @@ async fn execute_with_workspace(
     None => ()
   }
   let cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
-  shell(input, parsed_command, cwd, workspace_root) catch {
+  shell(input, parsed_command, cwd, workspace_root, bg_runtime?) catch {
     error =>
       @agent_tool.ToolAction::respond(
         "error running shell: \{error}",
@@ -116,6 +163,7 @@ async fn shell(
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
   workspace_root : String,
+  bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   if cwd is Some(cwd) {
     let exists = @fs.exists(cwd)
@@ -143,43 +191,97 @@ async fn shell(
       )
     None => ()
   }
-  let result = match input.timeout_ms {
-    Some(timeout_ms) =>
-      @async.with_timeout_opt(timeout_ms, () => {
-        run_agent_shell_with_tree_precheck(
-          workspace_root,
-          input.cmd,
-          parsed_command,
-          cwd?,
-          max_output_chars=input.max_output_chars,
-        )
-      })
-    None =>
-      Some(
-        run_agent_shell_with_tree_precheck(
-          workspace_root,
-          input.cmd,
-          parsed_command,
-          cwd?,
-          max_output_chars=input.max_output_chars,
-        ),
-      )
+  // Background: detach the command as a job and return its id instead of blocking
+  // for output. Runs the same source-tree guards and sandboxed launch as a
+  // foreground command, so `run_in_background` cannot bypass any guardrail.
+  if input.run_in_background {
+    return start_background(
+      input,
+      parsed_command,
+      cwd,
+      workspace_root,
+      bg_runtime?,
+    )
   }
+  // A background runtime means foreground commands run on the shared execution
+  // model (session group), which is what lets a timed-out one be detached rather
+  // than killed. Both the spawner and the detach hook come from it; without one
+  // the shell falls back to the per-call collection path (no detach).
+  //
+  // A command with a `timeout_ms` may be detached on timeout, so spawn it with
+  // the *retained* (file-backed, no output-limit kill) config so it keeps a full
+  // record if it is detached and produces more output — the foreground
+  // output-limit is enforced at display via `over_inline_cap`, and the timeout
+  // bounds the wait. A command with no timeout cannot detach, so it uses the
+  // memory-only foreground config (killed at the output limit, no leak).
+  let detachable = input.timeout_ms is Some(_)
+  let foreground_spawn : (async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution)? = bg_runtime.map(runtime => {
+      (program, args, cwd, max) => {
+        if detachable {
+          runtime.spawn_foreground_retained(program, args, cwd, max)
+        } else {
+          runtime.spawn_foreground(program, args, cwd, max)
+        }
+      }
+    },
+  )
+  // Detach-on-timeout: move a command that outlives its timeout to the background
+  // instead of killing it — the model keeps watching it with shell_output /
+  // shell_stop rather than losing it.
+  let on_timeout_detach : ((@shell_exec.ShellExecution, AgentShellLaunch) -> String)? = bg_runtime.map(runtime => {
+      (exec, launch) => {
+        let _ = exec.background()
+        runtime.adopt(
+          exec,
+          command=input.cmd,
+          cwd?,
+          source_write_sandboxed=launch.source_write_sandboxed,
+          sandbox_denial_subjects=launch.sandbox_denial_subjects,
+        )
+      }
+    },
+  )
+  // `run_agent_shell_with_tree_precheck` owns the timeout: with a spawner it
+  // awaits a session-group execution and, on timeout, detaches it (or stops it)
+  // so the process cannot leak; without one it wraps the per-call collection path.
+  let result = run_agent_shell_with_tree_precheck(
+    workspace_root,
+    input.cmd,
+    parsed_command,
+    cwd?,
+    max_output_chars=input.max_output_chars,
+    timeout_ms?=input.timeout_ms,
+    foreground_spawn?,
+    on_timeout_detach?,
+  )
   let agent_output = match result {
-    Some(ShellExecuted(output)) => output
-    Some(ShellPreblockedSourceTree(target)) =>
+    ShellExecuted(output) => output
+    ShellPreblockedSourceTree(target) =>
       return @agent_tool.ToolAction::respond(
         direct_source_tree_operation_blocked_content(target),
         is_error=true,
         brief=shell_brief(input.cmd, None),
       )
-    None => {
+    ShellTimedOut => {
       let timeout_ms = input.timeout_ms.unwrap_or(0)
       return @agent_tool.ToolAction::respond(
         "error: shell command timed out after \{timeout_ms}ms",
         is_error=true,
       )
     }
+    ShellDetached(id) => {
+      let timeout_ms = input.timeout_ms.unwrap_or(0)
+      return @agent_tool.ToolAction::respond(
+        "command still running after \{timeout_ms}ms; moved to the background as job \{id}. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
+        brief="\{@agent_tool.brief_line(input.cmd, limit=48)} → bg \{id}",
+      )
+    }
+    ShellBinaryOutput =>
+      return @agent_tool.ToolAction::respond(
+        "error running shell: Malformed (binary / non-UTF-8) command output",
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
   }
   let output = agent_output.output
   let response = shell_response(output, input.max_output_chars)
@@ -207,6 +309,14 @@ async fn shell(
 priv enum ShellRunResult {
   ShellPreblockedSourceTree(String)
   ShellExecuted(AgentShellOutput)
+  // Still running after `timeout_ms` and stopped.
+  ShellTimedOut
+  // Still running after `timeout_ms` and detached to the background instead of
+  // stopped; carries the new job id.
+  ShellDetached(String)
+  // The command produced invalid (non-UTF-8 / binary) output; the per-call path
+  // raises on strict decode, and the execution path reports it here.
+  ShellBinaryOutput
 }
 
 ///|
@@ -216,29 +326,195 @@ async fn run_agent_shell_with_tree_precheck(
   parsed_command : @shell_parse.ParseResult,
   cwd? : String,
   max_output_chars~ : Int,
+  timeout_ms? : Int,
+  foreground_spawn? : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution,
+  on_timeout_detach? : (@shell_exec.ShellExecution, AgentShellLaunch) -> String,
 ) -> ShellRunResult {
   match
     direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
-    Some(target) => ShellPreblockedSourceTree(target)
-    None => {
-      match
-        dynamic_source_tree_operation_target(
-          parsed_command, cmd, workspace_root, cwd,
-        ) {
-        Some(target) => return ShellPreblockedSourceTree(target)
-        None => ()
+    Some(target) => return ShellPreblockedSourceTree(target)
+    None => ()
+  }
+  match
+    dynamic_source_tree_operation_target(
+      parsed_command, cmd, workspace_root, cwd,
+    ) {
+    Some(target) => return ShellPreblockedSourceTree(target)
+    None => ()
+  }
+  let launch = agent_shell_launch(workspace_root, cmd, parsed_command, cwd?)
+  match foreground_spawn {
+    // Foreground on the shared execution model: spawn on the session group and
+    // await it (up to `timeout_ms`). The session-group process outlives this
+    // await, so a timeout must stop it here — not leak it — and a turn
+    // cancellation must too (the catch stops it before re-raising).
+    Some(spawn) => {
+      let exec = spawn(launch.program, launch.args, cwd, max_output_chars)
+      let finished = try {
+        match timeout_ms {
+          Some(timeout_ms) =>
+            @async.with_timeout_opt(timeout_ms, () => exec.wait_or_invalid())
+          None => Some(exec.wait_or_invalid())
+        }
+      } catch {
+        error => {
+          exec.request_stop()
+          raise error
+        }
       }
-      ShellExecuted(
-        collect_agent_shell_output(
-          workspace_root,
-          cmd,
-          parsed_command,
-          cwd?,
-          max_output_chars~,
-        ),
-      )
+      match finished {
+        None =>
+          match on_timeout_detach {
+            Some(detach) => ShellDetached(detach(exec, launch))
+            None => {
+              let _ = exec.stop()
+              ShellTimedOut
+            }
+          }
+        // Preserve the per-call path's strict-decode behavior: invalid
+        // (binary/non-UTF-8) output is a tool error, not replacement characters
+        // presented as success.
+        Some(_) =>
+          // `wait_or_invalid` may return with the child still running (binary
+          // output seen); stop it so binary output is an immediate error. Either
+          // way this execution finished in the foreground (not adopted), so free
+          // its spill file if the retained config opened one.
+          if exec.had_invalid_utf8() {
+            let _ = exec.stop()
+            exec.discard()
+            ShellBinaryOutput
+          } else {
+            let output = agent_shell_output_from_exec(exec, launch)
+            exec.discard()
+            ShellExecuted(output)
+          }
+      }
+    }
+    // No session scope (e.g. `collect_shell_output`, the TUI `!` command): keep
+    // the per-call collection path, with the same timeout wrapping as before.
+    None => {
+      let collected = match timeout_ms {
+        Some(timeout_ms) =>
+          @async.with_timeout_opt(timeout_ms, () => {
+            collect_process_output(
+              launch.program,
+              launch.args,
+              cwd?,
+              max_output_chars~,
+            )
+          })
+        None =>
+          Some(
+            collect_process_output(
+              launch.program,
+              launch.args,
+              cwd?,
+              max_output_chars~,
+            ),
+          )
+      }
+      match collected {
+        None => ShellTimedOut
+        Some(output) =>
+          ShellExecuted({
+            output,
+            source_write_sandboxed: launch.source_write_sandboxed,
+            sandbox_denial_subjects: launch.sandbox_denial_subjects,
+          })
+      }
     }
   }
+}
+
+///|
+/// Adapt a finished foreground execution into an `AgentShellOutput` for the
+/// shared renderer: exit code, the in-memory head as the rendered output (a
+/// retained execution may also hold a spill file, but a foreground result only
+/// ever renders the head), and truncation, plus the launch's sandbox metadata.
+fn agent_shell_output_from_exec(
+  exec : @shell_exec.ShellExecution,
+  launch : AgentShellLaunch,
+) -> AgentShellOutput {
+  {
+    output: {
+      exit_code: exec.exit_code(),
+      text: exec.head(),
+      // Foreground output-limit is the inline cap (max_output_chars): either the
+      // detachable execution grew past it (over_inline_cap, large hard cap) or the
+      // memory-only one was killed at it (truncated, hard cap == inline cap).
+      output_limit_reached: exec.over_inline_cap() || exec.output_truncated(),
+    },
+    source_write_sandboxed: launch.source_write_sandboxed,
+    sandbox_denial_subjects: launch.sandbox_denial_subjects,
+  }
+}
+
+///|
+/// Detach `input.cmd` as a background job through the platform shell and report
+/// its id, or a tool error when the tool was built without a job runtime.
+async fn start_background(
+  input : @decode.ShellInput,
+  parsed_command : @shell_parse.ParseResult,
+  cwd : String?,
+  workspace_root : String,
+  bg_runtime? : @bgjobs.BgJobRuntime,
+) -> @agent_tool.ToolAction {
+  guard bg_runtime is Some(runtime) else {
+    return @agent_tool.ToolAction::respond(
+      "error: run_in_background is not available in this context",
+      is_error=true,
+    )
+  }
+  if input.timeout_ms is Some(_) {
+    return @agent_tool.ToolAction::respond(
+      "error: timeout_ms is not supported with run_in_background; a background job runs until it finishes or is stopped with shell_stop",
+      is_error=true,
+    )
+  }
+  match
+    direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
+    Some(target) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_tree_operation_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
+    None => ()
+  }
+  match
+    dynamic_source_tree_operation_target(
+      parsed_command,
+      input.cmd,
+      workspace_root,
+      cwd,
+    ) {
+    Some(target) =>
+      return @agent_tool.ToolAction::respond(
+        direct_source_tree_operation_blocked_content(target),
+        is_error=true,
+        brief=shell_brief(input.cmd, None),
+      )
+    None => ()
+  }
+  let launch = agent_shell_launch(
+    workspace_root,
+    input.cmd,
+    parsed_command,
+    cwd?,
+  )
+  let id = runtime.start(
+    program=launch.program,
+    args=launch.args,
+    command=input.cmd,
+    cwd?,
+    max_output_chars=input.max_output_chars,
+    source_write_sandboxed=launch.source_write_sandboxed,
+    sandbox_denial_subjects=launch.sandbox_denial_subjects,
+  )
+  @agent_tool.ToolAction::respond(
+    "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
+    brief="\{@agent_tool.brief_line(input.cmd, limit=48)} → bg \{id}",
+  )
 }
 
 ///|

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -7,6 +7,165 @@ async fn run_shell(arguments : Json) -> @agent_tool.ToolAction {
 }
 
 ///|
+/// Run the shell tool wired like the agent: a background runtime, so foreground
+/// commands run through the shared ShellExecution model and the background /
+/// detach paths are exercised.
+#cfg(not(platform="windows"))
+async fn run_shell_wired(
+  bg : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  match @shell.definition(bg_runtime=bg).execute {
+    Async(execute) => execute(arguments)
+    Sync(_) => fail("shell tool should be async")
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "run_in_background starts a job and returns its id" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, {
+      "cmd": "printf hi",
+      "run_in_background": true,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("started background job"))
+    assert_true(bg.list().length() == 1)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "run_in_background rejects timeout_ms" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, {
+      "cmd": "printf hi",
+      "run_in_background": true,
+      "timeout_ms": 1000,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("not supported with run_in_background"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "foreground runs through the execution model" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, { "cmd": "printf hi" })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("hi"))
+    assert_true(output.content.contains("exit=0"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "wired foreground reports binary output as a tool error" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    // The wired path (through ShellExecution) must match the per-call path:
+    // non-UTF-8 output is a tool error, not replacement characters as success.
+    let action = run_shell_wired(bg, { "cmd": "printf '\\377'" })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("Malformed"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "foreground enforces max_output_chars with an output-limit error" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    // `yes` exceeds the tiny budget; the shared foreground path must report the
+    // output-limit error, not silently drop output as a success.
+    let action = run_shell_wired(bg, { "cmd": "yes", "max_output_chars": 100 })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("output_limit_reached"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a timed command that floods output is an output-limit error, not detached" {
+  @async.with_task_group(group => {
+    let dir = @fs.tmpdir(prefix="openseek-test-")
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
+    // A long timeout, but the runaway must be killed at the output limit promptly
+    // (not run to the timeout and then backgrounded).
+    let action = run_shell_wired(bg, {
+      "cmd": "yes",
+      "timeout_ms": 30000,
+      "max_output_chars": 100,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("output_limit_reached"))
+    @fs.rmdir(dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a detached foreground job retains full output past the inline cap" {
+  @async.with_task_group(group => {
+    let dir = @fs.tmpdir(prefix="openseek-test-")
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
+    // Under the output limit at the timeout (still sleeping) → cleanly detached;
+    // then it floods output, which a detached job retains (the output-limit kill
+    // is cleared on detach).
+    let action = run_shell_wired(bg, {
+      "cmd": "sleep 0.3; seq 1 5000",
+      "timeout_ms": 150,
+      "max_output_chars": 100,
+    })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.content.contains("moved to the background"))
+    // The detached job is file-backed, so its full output is retained, not
+    // capped at the foreground budget. Poll until the monitor has flushed it.
+    let id = bg.list()[0].id
+    let mut seen = false
+    for _ in 0..<200 {
+      if bg.read_output(id).unwrap_or("").contains("5000") {
+        seen = true
+        break
+      }
+      @async.sleep(25)
+    }
+    assert_true(seen)
+    let _ = bg.stop(id)
+    @fs.rmdir(dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a foreground command that times out is detached to the background" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = run_shell_wired(bg, { "cmd": "sleep 2", "timeout_ms": 100 })
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("moved to the background"))
+    assert_true(bg.list().length() == 1)
+    assert_true(bg.list()[0].status is Running)
+  })
+}
+
+///|
 async fn run_shell_in_workspace(
   workspace_root : String,
   arguments : Json,
@@ -98,6 +257,26 @@ test "shell description tells models to use POSIX shell off Windows" {
   assert_true(description.contains("POSIX shell"))
   assert_true(description.contains("sh -c"))
   assert_true(description.contains("POSIX shell syntax"))
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell description teaches background jobs only when a runtime is wired" {
+  // Unwired: no runtime means run_in_background does not exist and a timed-out
+  // command is killed — the description must not promise otherwise.
+  let unwired = @shell.definition().description
+  assert_false(unwired.contains("run_in_background"))
+  // Wired: guide the model to background long-running work and to rely on the
+  // pushed completion notice instead of blocking on sleeps or polling.
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let wired = @shell.definition(bg_runtime=bg).description
+    assert_true(wired.contains("run_in_background"))
+    assert_true(wired.contains("notice"))
+    assert_true(wired.contains("sleep"))
+    assert_true(wired.contains("shell_output"))
+    assert_true(wired.contains("shell_stop"))
+  })
 }
 
 ///|


### PR DESCRIPTION
Slice 2/4 of the background-shell series — **architecture and review history in the umbrella PR #389.** Stacked on 1/4.

The shell tool gains an optional `bg_runtime`:

- **`run_in_background: true`** starts a job and returns its id immediately (same source-tree guards and sandboxed launch as foreground — no guardrail bypass).
- **Foreground-through-execution**: wired foreground commands run on the shared `ShellExecution`; a command that outlives `timeout_ms` is **detached to a background job instead of killed** (status flip + adopt, sandbox metadata rides along).
- **Unwired contexts unchanged** (standalone registries; Windows): per-call path, timeout cancels with a tool error, and the schema/description truthfully omit `run_in_background`.
- Foreground error semantics preserved exactly: prompt output-limit kill at `max_output_chars`, mid-stream binary-output errors, sandbox-denial detection, spill-file cleanup for runs that finish un-detached.

Nothing registers a wired runtime until slice 4/4. Tests at this tip: **949/949** (fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)