### PR TITLE
feat(shell_output,shell_stop): poll and cancel background jobs (3/4)

### DIFF
--- a/agent_tool/shell_output/moon.pkg
+++ b/agent_tool/shell_output/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/shell",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+} for "test"
+
+supported_targets = "+native"

--- a/agent_tool/shell_output/pkg.generated.mbti
+++ b/agent_tool/shell_output/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell_output"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+}
+
+// Values
+pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -1,0 +1,113 @@
+///|
+/// Tool `shell_output`: read a background shell job's output and status by id.
+/// The id comes from `shell run_in_background`, or from a foreground command that
+/// was moved to the background when it exceeded its `timeout_ms`.
+pub fn definition(
+  bg_runtime : @bgjobs.BgJobRuntime,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="shell_output",
+    description="Read a background shell job's recent output and status by its job_id (returned by shell run_in_background, or by a command moved to the background on timeout). Returns the most recent window of captured output (with truncation metadata naming the total size when output exceeds the window) and whether the job is still running.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": { "job_id": { "type": "string" } },
+      "required": ["job_id"],
+    }),
+    execute=Async(arguments => execute(bg_runtime, arguments)),
+  )
+}
+
+///|
+async fn execute(
+  bg_runtime : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "job_id": String(job_id), .. } else {
+    return @agent_tool.ToolAction::respond(
+      "error: shell_output requires a string job_id",
+      is_error=true,
+    )
+  }
+  guard bg_runtime.snapshot(job_id) is Some(_) else {
+    return @agent_tool.ToolAction::respond(
+      "error: no background job with id \{job_id}",
+      is_error=true,
+    )
+  }
+  // Recent output, bounded to a window so a poll cannot flood the conversation
+  // with a large job's full log. For output over the window, show the *tail*
+  // (recent progress).
+  let window = 12000
+  let output = bg_runtime.read_output_tail(job_id, window).unwrap_or("")
+  // Re-snapshot *after* the awaited read: the job may have appended more output
+  // or exited while the read yielded, so size/status/binary/truncation in the
+  // footer must reflect that post-read state, not a stale pre-read one — else a
+  // tail could be presented as complete or with an out-of-date status.
+  guard bg_runtime.snapshot(job_id) is Some(snapshot) else {
+    return @agent_tool.ToolAction::respond(
+      "error: no background job with id \{job_id}",
+      is_error=true,
+    )
+  }
+  let (status_label, exit_error) = match snapshot.status {
+    Running => ("running", false)
+    Exited(code) => ("exit=\{code}", code != 0)
+    // A watchdog kill (flooded past the hard cap) is named as such, so the model
+    // does not read it as a requested stop.
+    Stopped =>
+      if snapshot.killed_by_output_limit {
+        ("stopped killed_at_output_cap=true", true)
+      } else {
+        ("stopped", true)
+      }
+  }
+  // Preserve the foreground path's error semantics for a job read later: binary
+  // (non-UTF-8) output and a sandboxed source-write denial are tool errors even
+  // when the command exited 0. Scan the *full* retained output for a denial (the
+  // denial line can be earlier than the displayed tail), but only for a sandboxed
+  // job — so a full read is done only in that rare case.
+  let sandbox_denied = if snapshot.source_write_sandboxed {
+    let full = bg_runtime.read_output(job_id).unwrap_or(output)
+    @shell.source_write_denied_in_text(full, snapshot.sandbox_denial_subjects)
+  } else {
+    false
+  }
+  let is_error = exit_error || snapshot.had_invalid_utf8 || sandbox_denied
+  // Truncated whenever what we show is less than what the job produced — this
+  // covers the window (large output), a memory-only runtime that dropped output
+  // past the budget, and a hard-cap drop — so a prefix is never presented as the
+  // complete output.
+  let shown = output.char_length()
+  let truncation = if shown < snapshot.size || snapshot.output_truncated {
+    let cap = if snapshot.output_truncated {
+      " output_dropped_at_cap=true"
+    } else {
+      ""
+    }
+    " truncated=true total_chars=\{snapshot.size} shown_chars=\{shown}\{cap}"
+  } else {
+    ""
+  }
+  let binary = if snapshot.had_invalid_utf8 {
+    " binary_output=true"
+  } else {
+    ""
+  }
+  let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{binary}</system>"
+  // Assemble: output, then the source-write denial guidance (like the foreground
+  // path), then the `<system>` footer LAST so it stays the trailing metadata line.
+  let content = StringBuilder()
+  if output != "" {
+    content.write_string(output)
+    if !output.has_suffix("\n") {
+      content.write_string("\n")
+    }
+  }
+  if sandbox_denied {
+    content.write_string(@shell.source_write_denial_feedback())
+    content.write_string("\n")
+  }
+  content.write_string(footer)
+  let content = content.to_string()
+  @agent_tool.ToolAction::respond(content, is_error~)
+}

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -1,0 +1,150 @@
+///|
+#cfg(not(platform="windows"))
+async test "shell_output returns a running job's output and status" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(
+      program="sh",
+      args=["-c", "printf hi; sleep 30"],
+      command="job",
+    )
+    @async.sleep(100)
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("hi"))
+    assert_true(output.content.contains("running"))
+    let _ = bg.stop(id)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output reports a finished job's exit code" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(program="sh", args=["-c", "exit 2"], command="job")
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("exit=2"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output windows a large job's output and notes truncation" {
+  @async.with_task_group(group => {
+    let dir = @fs.tmpdir(prefix="openseek-test-")
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
+    let id = bg.start(
+      program="sh",
+      args=["-c", "seq 1 20000"],
+      command="seq",
+      max_output_chars=100,
+    )
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    // Bounded to the window, with truncation metadata, but still showing the
+    // recent (tail) output — here the end of the sequence.
+    assert_true(output.content.contains("truncated=true"))
+    assert_true(output.content.contains("20000"))
+    assert_true(output.content.char_length() < 80000)
+    @fs.rmdir(dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output flags dropped output for a memory-only job" {
+  @async.with_task_group(group => {
+    // Memory-only runtime (no spill dir): output past the budget is dropped.
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(
+      program="sh",
+      args=["-c", "seq 1 2000"],
+      command="seq",
+      max_output_chars=100,
+    )
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    // Only ~100 chars retained but the job produced far more — must not present
+    // the prefix as complete.
+    assert_true(output.content.contains("truncated=true"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output marks binary background output as a tool error" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    // A background command with non-UTF-8 output that exits 0 must still be a
+    // tool error when read, matching the foreground path.
+    let id = bg.start(
+      program="sh",
+      args=["-c", "printf '\\377'"],
+      command="binary",
+    )
+    for _ in 0..<200 {
+      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+        break
+      }
+      @async.sleep(25)
+    }
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("binary_output"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_output errors on an unknown job id" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = match @shell_output.definition(bg).execute {
+      Async(execute) => execute({ "job_id": "nope" })
+      Sync(_) => fail("shell_output should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("no background job"))
+  })
+}

--- a/agent_tool/shell_stop/moon.pkg
+++ b/agent_tool/shell_stop/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_runtime",
+  "moonbitlang/async",
+} for "test"
+
+supported_targets = "+native"

--- a/agent_tool/shell_stop/pkg.generated.mbti
+++ b/agent_tool/shell_stop/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/shell_stop"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/bgjobs",
+}
+
+// Values
+pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell_stop/shell_stop.mbt
+++ b/agent_tool/shell_stop/shell_stop.mbt
@@ -1,0 +1,37 @@
+///|
+/// Tool `shell_stop`: cancel a running background shell job by its job_id.
+pub fn definition(
+  bg_runtime : @bgjobs.BgJobRuntime,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="shell_stop",
+    description="Stop a running background shell job by its job_id (from shell run_in_background, or a command moved to the background on timeout). Cancels the process; a job that already finished is a no-op.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": { "job_id": { "type": "string" } },
+      "required": ["job_id"],
+    }),
+    execute=Async(arguments => execute(bg_runtime, arguments)),
+  )
+}
+
+///|
+async fn execute(
+  bg_runtime : @bgjobs.BgJobRuntime,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "job_id": String(job_id), .. } else {
+    return @agent_tool.ToolAction::respond(
+      "error: shell_stop requires a string job_id",
+      is_error=true,
+    )
+  }
+  if bg_runtime.stop(job_id) {
+    @agent_tool.ToolAction::respond("stopped background job \{job_id}")
+  } else {
+    @agent_tool.ToolAction::respond(
+      "error: no background job with id \{job_id}",
+      is_error=true,
+    )
+  }
+}

--- a/agent_tool/shell_stop/shell_stop_test.mbt
+++ b/agent_tool/shell_stop/shell_stop_test.mbt
@@ -1,0 +1,33 @@
+///|
+#cfg(not(platform="windows"))
+async test "shell_stop cancels a running job" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let id = bg.start(program="sleep", args=["30"], command="sleep 30")
+    @async.sleep(50)
+    assert_true(bg.snapshot(id).unwrap().status is Running)
+    let action = match @shell_stop.definition(bg).execute {
+      Async(execute) => execute({ "job_id": id })
+      Sync(_) => fail("shell_stop should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("stopped"))
+    assert_true(bg.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell_stop errors on an unknown job id" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let action = match @shell_stop.definition(bg).execute {
+      Async(execute) => execute({ "job_id": "nope" })
+      Sync(_) => fail("shell_stop should be async")
+    }
+    guard action is Respond(output) else { fail("expected a Respond action") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("no background job"))
+  })
+}


### PR DESCRIPTION
Slice 3/4 of the background-shell series — **architecture and review history in the umbrella PR #389.** Stacked on 2/4.

- **`shell_output`** — read a job's recent output by id: a bounded tail window with truncation metadata (never a flood; never a prefix presented as complete). Foreground error-semantics parity: binary output and sandboxed source-write denials are tool errors even at exit 0 (full-output denial scan, same guidance appended, `<system>` footer stays the trailing line), and footer metadata is sampled after the awaited read (no stale-snapshot TOCTOU).
- **`shell_stop`** — cancel a job by id; already-finished jobs are a no-op error.

Registered in slice 4/4. Tests at this tip: **957/957** (fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)