### PR TITLE
docs: READMEs for shell_exec, bgjobs, shell_output, shell_stop

### DIFF
--- a/agent_tool/bgjobs/README.mbt.md
+++ b/agent_tool/bgjobs/README.mbt.md
@@ -1,0 +1,66 @@
+# Background Job Registry
+
+`bobzhang/openseek/agent_tool/bgjobs` is the session-scoped registry of
+background shell jobs. Each job wraps one shared
+`@shell_exec.ShellExecution` (see `agent_tool/shell_exec`): the registry adds
+ids, session-visible metadata, spill-file placement, exit watchers, and
+push-completion hooks — it adds no second execution or output pipeline.
+
+One `BgJobRuntime` is created per session (by `@agent.build_tools`) and shared
+by the `shell` (`run_in_background`), `shell_output`, and `shell_stop` tools, so
+a job started in one turn is visible in every later turn of the session.
+
+## Lifecycle
+
+```mermaid
+flowchart LR
+  rib["shell run_in_background"] -->|"start()"| job["BgJob (id bg-N)"]
+  timeout["foreground timeout"] -->|"background() + adopt()"| job
+  job -->|"snapshot()/read_output_tail()"| out["shell_output"]
+  job -->|"stop()"| stop["shell_stop"]
+  job -->|"natural exit / watchdog kill"| watcher["exit watcher"]
+  watcher -->|"on_job_exit(snapshot)"| notice["completion notice\n(SteerInput::Notice + idle wake)"]
+```
+
+- `start` spawns a job directly (one id reserved up front, so the job id and
+  its spill file never diverge).
+- `adopt` registers an *already running* execution — this is detach-on-timeout:
+  a foreground command that outlived its `timeout_ms` is flipped to
+  `Backgrounded` and adopted, so `shell_output`/`shell_stop` and the completion
+  notice see it like any explicitly backgrounded job. The launch's sandbox
+  metadata rides along so a source-write denial is still detected when the
+  job's output is read later.
+- Every child is spawned on the session task group: session teardown cancels
+  the process. Cancellation reaches only the direct child (no process-group
+  kill), so a daemonizing command can leave descendants.
+
+## Output retention
+
+Jobs use the sink's file-backed model: an inline preview up to the budget
+(`max_output_chars`, matching the shell tool's foreground default so a command
+reads the same either way), full output in a per-job spill file under the
+session's spill directory, and the hard-cap watchdog: a job that floods past
+`hard_output_cap` (default 20M characters) is killed and reported as
+`killed_by_output_limit` — never left burning CPU with its output dropped, and
+never silently dead. Without a spill directory the runtime degrades to
+memory-only jobs (bounded preview, rest dropped).
+
+## Push-completion
+
+The per-job watcher awaits the execution and calls `on_job_exit` exactly once
+when the job ends *on its own* — a natural exit, or the output watchdog. A
+requested stop (`shell_stop`, session teardown) fires nothing: it is already
+user-visible. The `agent` package wires `on_job_exit` to queue a
+`SteerInput::Notice` (lossless) and poke the serve loop, which is what makes
+job completion *push* into the conversation instead of requiring the model to
+poll — see the `shell` tool description and the system prompts, which teach
+exactly that workflow.
+
+## Snapshots
+
+Consumers only ever see `BgJobSnapshot`, an immutable view carrying the status
+(`Running`/`Exited(code)`/`Stopped`), the inline output preview, size and
+sequence counters for change detection, and the error-semantics flags
+(`had_invalid_utf8`, sandbox metadata, `killed_by_output_limit`) that let
+`shell_output` report a background job with exactly the foreground path's error
+behavior.

--- a/agent_tool/shell_exec/README.mbt.md
+++ b/agent_tool/shell_exec/README.mbt.md
@@ -1,0 +1,95 @@
+# Shell Execution Model
+
+`bobzhang/openseek/agent_tool/shell_exec` is the shared execution model behind
+every shell command the agent runs: one process, one output owner, one status
+flag. It is the foundation the `shell`, `shell_output`, and `shell_stop` tools
+(and the `bgjobs` registry) are built on.
+
+The package deliberately contains no tool definitions and no policy about what
+commands may run — it only answers "what is a running shell command, who owns
+its output, and how does it end".
+
+## The One Idea
+
+**"Background" is a status, not a place.** A `ShellExecution` is a process
+spawned on the session task group plus a single `ShellOutputSink` plus an
+`ExecStatus`. Foreground vs background is only whether a tool call is currently
+awaiting the execution — so moving a command to the background
+(detach-on-timeout) is a status flip (`background()`), not a re-route between
+two output pipelines. An earlier design that routed timed-out foreground
+commands into a separate background system died on irreducible mismatches
+(prefix-vs-tail retention, cancel-vs-keep-running, notify-vs-not); with one
+execution object those questions cannot arise.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Running : start()
+  Running --> Backgrounded : background()  (detach)
+  Running --> Exited : child exits
+  Running --> Killed : stop() / watchdog
+  Backgrounded --> Exited : child exits
+  Backgrounded --> Killed : stop() / hard-cap watchdog
+  Exited --> [*]
+  Killed --> [*]
+```
+
+## L0 — `ShellOutputSink`: memory-first, file-backed output
+
+The sink is the single owner of a command's merged stdout+stderr, with one
+retention story so foreground and background can never disagree:
+
+- The first `inline_cap` characters are kept in memory (the *head*) for cheap
+  inline rendering.
+- Past the inline cap, the **full** output spills to a per-execution file
+  (`spill_path`), seeded with the head. The file is the source of truth, so
+  *retention is a read-time decision* — `head()`, `read_tail(n)`, or
+  `read_all()` — instead of a policy baked into the buffer at write time.
+- Past `hard_cap` (default 20M characters) further output is dropped and
+  `truncated` is set; the execution-level watchdog is expected to kill the
+  child at that point (see below).
+- Without a `spill_path` the sink is memory-only: head kept, rest dropped —
+  used by contexts that never need full large output.
+
+Byte streams are decoded incrementally and UTF-8-safely: an incomplete trailing
+sequence is carried to the next chunk, and any genuinely invalid bytes set
+`had_invalid_utf8` so a consumer can preserve the strict-decode "binary output"
+error instead of silently presenting replacement characters as success.
+
+## L1 — `ShellExecution`: process + sink + status
+
+`ShellExecution::start` spawns the child on the session task group (so session
+teardown cancels it) and starts a monitor task. The monitor's design point:
+**draining the pipe and awaiting the exit are decoupled.** Coupling them (read
+to EOF, then wait) hangs forever when the child exits but a descendant it
+spawned still holds the pipe open — so a concurrent reader drains bytes while
+`process.wait()` is the authoritative exit signal, followed by a short drain
+grace and a forced close.
+
+Two output-limit watchdogs, two thresholds:
+
+- `kill_when_full` (foreground): kill as soon as output exceeds the *inline*
+  cap, so a chatty command is an immediate output-limit error rather than
+  running to its timeout. Cleared by `background()` — a job detached while
+  still under the limit may keep growing.
+- `kill_at_hard_cap` (background): kill once full output hits the *hard* cap —
+  past it every byte is dropped, so a flooding job would burn CPU producing
+  nothing readable. Deliberately survives `background()`: detached means
+  unbounded in time, not unbounded in output. A watchdog kill records
+  `killed_by_output_limit` so it is surfaced, never silent.
+
+Cancellation notes: `request_stop()` is synchronous (safe to call while a turn
+is being cancelled, where awaiting is not), and cancellation reaches only the
+directly spawned process — the process library exposes no process-group kill,
+so a command that daemonizes children can leave descendants running.
+
+## Layering
+
+```mermaid
+flowchart TD
+  shell["agent_tool/shell\nforeground + detach-on-timeout"] --> exec
+  bgjobs["agent_tool/bgjobs\nsession job registry"] --> exec
+  exec["shell_exec.ShellExecution\n(process + status)"] --> sink["shell_exec.ShellOutputSink\n(memory head + spill file)"]
+```
+
+See `docs/plans/shell-execution-model.md` for the full architecture narrative,
+and `agent_tool/bgjobs` for the session-scoped registry built on this model.

--- a/agent_tool/shell_output/README.mbt.md
+++ b/agent_tool/shell_output/README.mbt.md
@@ -1,0 +1,47 @@
+# Shell Output Tool
+
+`shell_output` reads a background shell job's recent output and status by its
+`job_id` — the id returned by `shell` with `run_in_background=true`, or by a
+foreground command that was moved to the background when it outlived its
+`timeout_ms`.
+
+The primary consumption path for job results is the **pushed completion
+notice** (a job announces itself when it finishes); `shell_output` is for
+checking progress on a still-running job, and for reading the output once the
+notice arrives. The tool description and system prompts steer the model away
+from calling it in a polling loop.
+
+## Result Shape
+
+Output first, one `<system>` footer line last (the `read` tool convention):
+
+```text
+<recent output…>
+<system>job=bg-3 running truncated=true total_chars=48210 shown_chars=12000</system>
+```
+
+- The body is a **bounded tail window** (most recent output), never the full
+  log — a poll must not flood the conversation. `truncated=true` appears
+  whenever what is shown is less than what the job produced, with
+  `total_chars`/`shown_chars` naming the gap; `output_dropped_at_cap=true`
+  marks output lost at the hard cap, and a watchdog-killed job reports
+  `stopped killed_at_output_cap=true` so the model does not read it as a
+  requested stop.
+- Status is `running`, `exit=<code>`, or `stopped`; non-zero exits and stops
+  are tool errors, preserving the foreground shell's semantics.
+
+## Design Rationale
+
+Two invariants drove the implementation:
+
+1. **Never present a partial view as complete.** The truncation check compares
+   what is *shown* against what the job *produced* — covering the tail window,
+   a memory-only runtime that dropped output past its budget, and hard-cap
+   drops. The footer metadata is sampled *after* the awaited read, so a job
+   that appends or exits while the read yields cannot produce a stale footer.
+2. **Foreground error-semantics parity.** A background job read later behaves
+   exactly like the same command run in the foreground: binary (non-UTF-8)
+   output is a tool error even at exit 0 (`binary_output=true`), and a
+   sandboxed source-write denial is detected by scanning the *full* retained
+   output (the denial line can be earlier than the displayed tail) with the
+   same guidance appended, footer still last.

--- a/agent_tool/shell_stop/README.mbt.md
+++ b/agent_tool/shell_stop/README.mbt.md
@@ -1,0 +1,23 @@
+# Shell Stop Tool
+
+`shell_stop` cancels a running background shell job by its `job_id` — the id
+returned by `shell` with `run_in_background=true`, or by a foreground command
+that was moved to the background when it outlived its `timeout_ms`.
+
+Stopping is a request against the shared `ShellExecution`: the child process is
+cancelled and the job lands on the `Stopped` status, which `shell_output`
+reports as a tool error thereafter. Stopping an already-finished job is a
+no-op error (`no background job with id …` covers unknown ids).
+
+## Design Rationale
+
+- **A requested stop produces no completion notice.** The push-completion
+  watcher only announces jobs that end on their own (natural exit, or the
+  output-limit watchdog); the model that called `shell_stop` already has the
+  acknowledgment in the tool result, so a notice would be noise.
+- **Cancellation reaches the direct child only.** The process library exposes
+  no process-group kill, so a command that daemonized its own children can
+  leave descendants running after the job is reported stopped — the same
+  limitation as foreground cancellation, documented rather than hidden.
+- Session teardown stops all jobs the same way: every child is spawned on the
+  session task group, so nothing outlives the session.

--- a/agent_tool/shell_stop/README.mbt.md
+++ b/agent_tool/shell_stop/README.mbt.md
@@ -21,5 +21,7 @@ so `shell_stop` is idempotent; only an unknown id is a tool error
   no process-group kill, so a command that daemonized its own children can
   leave descendants running after the job is reported stopped — the same
   limitation as foreground cancellation, documented rather than hidden.
-- Session teardown stops all jobs the same way: every child is spawned on the
-  session task group, so nothing outlives the session.
+- Session teardown stops all jobs the same way: every job's direct child is
+  spawned on the session task group, so it is cancelled when the session ends —
+  with the same direct-child-only limitation as above: daemonized descendants
+  can outlive the session.

--- a/agent_tool/shell_stop/README.mbt.md
+++ b/agent_tool/shell_stop/README.mbt.md
@@ -7,7 +7,9 @@ that was moved to the background when it outlived its `timeout_ms`.
 Stopping is a request against the shared `ShellExecution`: the child process is
 cancelled and the job lands on the `Stopped` status, which `shell_output`
 reports as a tool error thereafter. Stopping an already-finished job is a
-no-op error (`no background job with id …` covers unknown ids).
+*successful* no-op — the id is known, there is just nothing left to cancel —
+so `shell_stop` is idempotent; only an unknown id is a tool error
+(`no background job with id …`).
 
 ## Design Rationale
 


### PR DESCRIPTION
Follow-up to #389: package READMEs for the background-shell series, in the house `README.mbt.md` style (behavior + design rationale, mermaid for the status machine and job lifecycle).

- **shell_exec** — the one idea ("background is a status, not a place"), the memory-first file-backed sink (retention as a read-time decision), the decoupled monitor, both output watchdogs.
- **bgjobs** — registry lifecycle (`start`/`adopt`/`stop`/watchers), retention + hard-cap watchdog, the push-completion contract (notices only for jobs that end on their own), snapshot semantics.
- **shell_output** — bounded tail window, never-present-partial-as-complete, post-await footer sampling, foreground error-parity.
- **shell_stop** — stop semantics, why a requested stop produces no notice, direct-child-only cancellation.

READMEs compile as test files (`moon check` clean); 34/34 package tests.

Also validated the merged feature end-to-end against the live engine (serve mode, real model): the model started a background job, did foreground work, received the **mid-turn completion notice** and folded the job's output into its answer without sleep-chains or polling; a job that outlived its turn produced the **idle `background_notice`** event; and a later turn read the finished job by id — **8/8 assertions passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)