### PR TITLE
refactor: share the [plan reminder] tag as one constant

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -22,7 +22,7 @@ fn plan_reminder_text(checklist : String?) -> String {
   match checklist {
     Some(lines) =>
       (
-        $|[plan reminder]
+        $|\{@agent_session.PlanReminderPrefix}
         $|The plan tool has not been called in a while. If progress was made,
         $|update step statuses; if the plan no longer matches the work,
         $|replace it or clear it with steps: []. Current plan:
@@ -30,10 +30,10 @@ fn plan_reminder_text(checklist : String?) -> String {
       )
     None =>
       (
-        #|[plan reminder]
-        #|The plan tool has not been used in this turn. If this task takes
-        #|several distinct steps, record a plan with the plan tool and keep
-        #|step statuses current. If not, ignore this reminder.
+        $|\{@agent_session.PlanReminderPrefix}
+        $|The plan tool has not been used in this turn. If this task takes
+        $|several distinct steps, record a plan with the plan tool and keep
+        $|step statuses current. If not, ignore this reminder.
       )
   }
 }

--- a/agent/plan_reminder_test.mbt
+++ b/agent/plan_reminder_test.mbt
@@ -78,19 +78,21 @@ async test "a plan-silent turn gets one staleness reminder after ten requests" {
     assert_eq(bodies.length(), 12)
     for index in 0..<10 {
       assert_false(
-        bodies[index].contains("[plan reminder]"),
+        bodies[index].contains(@agent_session.PlanReminderPrefix),
         msg="request \{index + 1} must not carry the reminder yet",
       )
     }
     assert_true(
-      bodies[10].contains("[plan reminder]"),
+      bodies[10].contains(@agent_session.PlanReminderPrefix),
       msg="request 11 should carry the reminder",
     )
     assert_true(bodies[10].contains("has not been used in this turn"))
     // The reminder is durable exactly once, in its plan-free nag variant.
     let reminders = [
       for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains("[plan reminder]") => notice.content()
+      notice.content().contains(@agent_session.PlanReminderPrefix) => {
+        notice.content()
+      }
     ]
     assert_eq(reminders.length(), 1)
     assert_true(reminders[0].contains("has not been used in this turn"))
@@ -185,18 +187,20 @@ async test "a recorded plan delays the reminder and is re-surfaced by it" {
     // finishing answer.
     assert_eq(bodies.length(), 13)
     assert_false(
-      bodies[10].contains("[plan reminder]"),
+      bodies[10].contains(@agent_session.PlanReminderPrefix),
       msg="the successful plan write must delay the reminder past request 11",
     )
     assert_true(
-      bodies[11].contains("[plan reminder]"),
+      bodies[11].contains(@agent_session.PlanReminderPrefix),
       msg="request 12 should carry the reminder",
     )
     assert_true(bodies[11].contains("Current plan:"))
     assert_true(bodies[11].contains("1. [in_progress] fix the parser"))
     let reminders = [
       for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains("[plan reminder]") => notice.content()
+      notice.content().contains(@agent_session.PlanReminderPrefix) => {
+        notice.content()
+      }
     ]
     assert_eq(reminders.length(), 1)
     assert_true(reminders[0].contains("1. [in_progress] fix the parser"))
@@ -209,7 +213,7 @@ async test "a recorded plan delays the reminder and is re-surfaced by it" {
 /// later request — "did it fire again" is a count on the newest body, not an
 /// absence check on it.
 fn reminder_count(body : String) -> Int {
-  body.split("[plan reminder]").collect().length() - 1
+  body.split(@agent_session.PlanReminderPrefix).collect().length() - 1
 }
 
 ///|
@@ -264,7 +268,9 @@ async test "the no-plan nag fires at most once per turn" {
     )
     let reminders = [
       for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains("[plan reminder]") => notice.content()
+      notice.content().contains(@agent_session.PlanReminderPrefix) => {
+        notice.content()
+      }
     ]
     assert_eq(reminders.length(), 1)
     assert_true(reminders[0].contains("has not been used in this turn"))
@@ -325,7 +331,9 @@ async test "a stale recorded plan re-nags on the ten-request cadence" {
     )
     let reminders = [
       for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains("[plan reminder]") => notice.content()
+      notice.content().contains(@agent_session.PlanReminderPrefix) => {
+        notice.content()
+      }
     ]
     assert_eq(reminders.length(), 2)
     assert_true(reminders[0].contains("1. [in_progress] fix the parser"))

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -9,6 +9,7 @@ import {
 }
 
 // Values
+pub const PlanReminderPrefix : String = "[plan reminder]"
 
 // Errors
 

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -141,7 +141,9 @@ test "session projects to DeepSeek chat messages" {
 test "session JSON round trips typed events" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("hello")))
-    .append(Runtime(RuntimeNotice("[plan reminder]\nrun tests")))
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.PlanReminderPrefix}\nrun tests")),
+    )
     .append(
       Summary(
         SessionSummary(

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -271,6 +271,13 @@ pub struct RuntimeNotice {
 } derive(Debug, ToJson, FromJson)
 
 ///|
+/// First line of the runtime notices the agent loop injects as plan-cadence
+/// reminders. The producer (`plan_reminder_text` in `agent`) stamps it and
+/// readers of the durable log (the viz card renderer, tests) key off it, so
+/// the tag lives here with `RuntimeNotice` where both sides can share it.
+pub const PlanReminderPrefix : String = "[plan reminder]"
+
+///|
 /// Wrap one runtime notice exactly as it should be replayed.
 pub fn RuntimeNotice::RuntimeNotice(content : String) -> RuntimeNotice {
   { content, }

--- a/cmd/tui/session_view_wbtest.mbt
+++ b/cmd/tui/session_view_wbtest.mbt
@@ -27,7 +27,9 @@ test "session items project to transcript items" {
   guard session_item(User(UserMessage(shell_context))) is Some(ToolCall(_)) else {
     fail("expected command user message to render as a tool")
   }
-  guard session_item(Runtime(RuntimeNotice("[plan reminder]\nrun tests")))
+  guard session_item(
+      Runtime(RuntimeNotice("\{@agent_session.PlanReminderPrefix}\nrun tests")),
+    )
     is Some(Notice(_)) else {
     fail("expected runtime notice")
   }

--- a/eval/session_analyzer/analyzer_wbtest.mbt
+++ b/eval/session_analyzer/analyzer_wbtest.mbt
@@ -18,7 +18,9 @@ fn sample_session() -> @agent_session.Session {
       ToolResult(tool_call_id="call_1", tool_name="shell", content="exit=0\nok"),
     ),
   )
-  .append(Runtime(RuntimeNotice("[plan reminder]\nrun tests")))
+  .append(
+    Runtime(RuntimeNotice("\{@agent_session.PlanReminderPrefix}\nrun tests")),
+  )
   .append(Terminal(Finished("done")))
 }
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -302,19 +302,14 @@ fn event_card(
 }
 
 ///|
-/// The label prefix the agent loop's plan cadence stamps on its staleness
-/// reminders (see `plan_reminder_text` in `agent`); the card renderer keys off
-/// it to give those notices a dedicated look.
-const PlanReminderPrefix : String = "[plan reminder]"
-
-///|
-/// Render a `RuntimeNotice` card. A plan-cadence reminder — recognized by its
-/// `[plan reminder]` prefix — gets its own label and, when it re-surfaces a
-/// recorded checklist ("Current plan:" followed by `N. [status] title` lines),
-/// the steps render as a status-classed list instead of raw text. Any other
-/// runtime notice keeps the generic card.
+/// Render a `RuntimeNotice` card. A plan-cadence reminder — recognized by the
+/// `@agent_session.PlanReminderPrefix` first line the agent loop stamps on it
+/// — gets its own label and, when it re-surfaces a recorded checklist
+/// ("Current plan:" followed by `N. [status] title` lines), the steps render
+/// as a status-classed list instead of raw text. Any other runtime notice
+/// keeps the generic card.
 fn runtime_card(seq : Int, time : String, content : String) -> @html.Html {
-  if !content.has_prefix(PlanReminderPrefix) {
+  if !content.has_prefix(@agent_session.PlanReminderPrefix) {
     return card("runtime", "Runtime notice", seq, time~, [text_block(content)])
   }
   let body : Array[@html.Html] = []

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -830,18 +830,18 @@ test "a dangling call pairs only in the model view, where it is healed" {
 /// card. The reminder bodies mirror `plan_reminder_text` in `agent`.
 test "plan reminder notices render a dedicated card with checklist rows" {
   let checklist_reminder =
-    #|[plan reminder]
-    #|The plan tool has not been called in a while. If progress was made,
-    #|update step statuses; if the plan no longer matches the work,
-    #|replace it or clear it with steps: []. Current plan:
-    #|1. [completed] read the failing test
-    #|2. [in_progress] fix the parser
-    #|3. [pending] run moon test
+    $|\{@agent_session.PlanReminderPrefix}
+    $|The plan tool has not been called in a while. If progress was made,
+    $|update step statuses; if the plan no longer matches the work,
+    $|replace it or clear it with steps: []. Current plan:
+    $|1. [completed] read the failing test
+    $|2. [in_progress] fix the parser
+    $|3. [pending] run moon test
   let no_plan_reminder =
-    #|[plan reminder]
-    #|The plan tool has not been used in this turn. If this task takes
-    #|several distinct steps, record a plan with the plan tool and keep
-    #|step statuses current. If not, ignore this reminder.
+    $|\{@agent_session.PlanReminderPrefix}
+    $|The plan tool has not been used in this turn. If this task takes
+    $|several distinct steps, record a plan with the plan tool and keep
+    $|step statuses current. If not, ignore this reminder.
   let session = @agent_session.Session(SessionId("plan"), system_prompt="")
     .append(User(UserMessage("do a long task")))
     .append(Runtime(RuntimeNotice(checklist_reminder)))


### PR DESCRIPTION
## Why

The `"[plan reminder]"` tag was duplicated as a bare literal across the producer (`plan_reminder_text` in `agent`), the consumer (`PlanReminderPrefix` in `viz/view.mbt`, which keys the dedicated checklist card off it), and five test fixtures. Nothing tied the copies together — retagging the reminder in one place would silently break the viz card and desynchronize the fixtures.

## What

- Add `pub const PlanReminderPrefix : String = "[plan reminder]"` to `agent_session`, next to the `RuntimeNotice` type it classifies (`agent_session` is the one package both the agent loop and the log readers already import; `viz` is js-only so it cannot import `agent`).
- The agent loop interpolates the constant into both reminder variants (the no-plan block switches `#|` → `$|` lines to allow interpolation and satisfy the no-mixed-prefixes lint; text unchanged).
- `viz/view.mbt` drops its private duplicate and keys off the shared constant.
- Test fixtures in `agent`, `agent_session`, `cmd/tui`, `eval/session_analyzer`, and `viz` reference the constant.
- `agent_session/pkg.generated.mbti` regenerated via `moon info`.

## Testing

- `moon check` / `moon fmt` / `moon info` clean
- `agent_session` 17/17, `viz --target js` 38/38, `eval/session_analyzer` 6/6, `cmd/tui` 78/78, `agent` 21/21
- `moon build cmd/viz_app --target js` (bundle gate) builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)