### PR TITLE
simplify(agent_tool): dedupe shell sandbox/exec boilerplate

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -397,11 +397,9 @@ pub async fn BgJobRuntime::read_output_tail(
 ///|
 /// Snapshots of every job the session has started.
 pub fn BgJobRuntime::list(self : BgJobRuntime) -> Array[BgJobSnapshot] {
-  let out = []
-  for _, job in self.jobs {
-    out.push(job.to_snapshot())
-  }
-  out
+  [
+    for _, job in self.jobs => job.to_snapshot()
+  ]
 }
 
 ///|

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -87,16 +87,18 @@ async fn agent_shell_launch(
     }
   }
   let profile_data = source_write_readonly_profile_data(real_workspace_root)
-  let args = ["-p", profile_data.profile, PlatformShellProgram]
-  for arg in platform_shell_args(cmd) {
-    args.push(arg)
-  }
   {
     program: SandboxExecPath,
-    args,
+    args: sandbox_exec_args(profile_data.profile, cmd),
     source_write_sandboxed: true,
     sandbox_denial_subjects: profile_data.denial_subjects,
   }
+}
+
+///|
+/// Argument vector for running `cmd` through `sandbox-exec` under `profile`.
+fn sandbox_exec_args(profile : String, cmd : String) -> Array[String] {
+  ["-p", profile, PlatformShellProgram, ..platform_shell_args(cmd)]
 }
 
 ///|
@@ -136,13 +138,9 @@ async fn probe_sandbox_exec_available() -> Bool {
     .normalize()
     .to_string()
   let probe_profile = sandbox_denial_probe_profile(blocked_path)
-  let args = ["-p", probe_profile, PlatformShellProgram]
-  for arg in platform_shell_args(PlatformNoopCommand) {
-    args.push(arg)
-  }
   let output = collect_process_output(
     SandboxExecPath,
-    args,
+    sandbox_exec_args(probe_profile, PlatformNoopCommand),
     max_output_chars=200,
   ) catch {
     error if @async.is_being_cancelled() => raise error
@@ -155,13 +153,12 @@ async fn probe_sandbox_exec_available() -> Bool {
     cleanup_sandbox_probe(probe_dir, blocked_path)
     return false
   }
-  let write_args = ["-p", probe_profile, PlatformShellProgram]
-  for arg in platform_shell_args("printf probe > \{shell_quote(blocked_path)}") {
-    write_args.push(arg)
-  }
   let write_output = collect_process_output(
     SandboxExecPath,
-    write_args,
+    sandbox_exec_args(
+      probe_profile,
+      "printf probe > \{shell_quote(blocked_path)}",
+    ),
     max_output_chars=400,
   ) catch {
     error if @async.is_being_cancelled() => raise error
@@ -5562,18 +5559,11 @@ fn is_protected_source_path(path : String) -> Bool {
 }
 
 ///|
-fn direct_source_write_redirect_blocked_content(target : String) -> String {
+/// Refusal content for a source-write `operation` (e.g. "source tree
+/// operation") blocked before the command is ever executed.
+fn direct_source_blocked_content(operation : String, target : String) -> String {
   (
-    $|shell sandbox: source file write redirect is blocked before execution: \{target}
-    $|\{SandboxSourceWriteFeedback}
-    $|<system>exit=blocked</system>
-  )
-}
-
-///|
-fn direct_source_tree_operation_blocked_content(target : String) -> String {
-  (
-    $|shell sandbox: source tree operation is blocked before execution: \{target}
+    $|shell sandbox: \{operation} is blocked before execution: \{target}
     $|\{SandboxSourceWriteFeedback}
     $|<system>exit=blocked</system>
   )
@@ -5663,29 +5653,10 @@ fn sandbox_denial_line_mentions_literal_subject(
 
 ///|
 fn sandbox_denial_line_mentions_source_path(line : StringView) -> Bool {
-  sandbox_denial_line_mentions_source_suffix(line, ".mbt.md") ||
-  sandbox_denial_line_mentions_source_suffix(line, ".mbt") ||
-  sandbox_denial_line_mentions_source_suffix(line, ".mbti") ||
-  sandbox_denial_line_mentions_source_suffix(line, "moon.mod.json") ||
-  sandbox_denial_line_mentions_source_suffix(line, "moon.pkg.json") ||
-  sandbox_denial_line_mentions_source_suffix(line, "moon.mod") ||
-  sandbox_denial_line_mentions_source_suffix(line, "moon.pkg") ||
-  sandbox_denial_line_mentions_source_suffix(line, "moon.work")
-}
-
-///|
-fn sandbox_denial_line_mentions_source_suffix(
-  line : StringView,
-  suffix : String,
-) -> Bool {
-  line.contains("\{suffix}:") ||
-  line.contains("\{suffix}'") ||
-  line.contains("\{suffix}\"") ||
-  line.contains("\{suffix}`") ||
-  (
-    sandbox_denial_line_has_denial_colon_before_subject(line) &&
-    line.has_suffix(suffix)
-  )
+  [
+    ".mbt.md", ".mbt", ".mbti", "moon.mod.json", "moon.pkg.json", "moon.mod", "moon.pkg",
+    "moon.work",
+  ].any(suffix => sandbox_denial_line_mentions_literal_subject(line, suffix))
 }
 
 ///|

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -185,7 +185,7 @@ async fn shell(
     direct_source_write_redirect_target(parsed_command, workspace_root, cwd) {
     Some(target) =>
       return @agent_tool.ToolAction::respond(
-        direct_source_write_redirect_blocked_content(target),
+        direct_source_blocked_content("source file write redirect", target),
         is_error=true,
         brief=shell_brief(input.cmd, None),
       )
@@ -258,7 +258,7 @@ async fn shell(
     ShellExecuted(output) => output
     ShellPreblockedSourceTree(target) =>
       return @agent_tool.ToolAction::respond(
-        direct_source_tree_operation_blocked_content(target),
+        direct_source_blocked_content("source tree operation", target),
         is_error=true,
         brief=shell_brief(input.cmd, None),
       )
@@ -475,7 +475,7 @@ async fn start_background(
     direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
     Some(target) =>
       return @agent_tool.ToolAction::respond(
-        direct_source_tree_operation_blocked_content(target),
+        direct_source_blocked_content("source tree operation", target),
         is_error=true,
         brief=shell_brief(input.cmd, None),
       )
@@ -490,7 +490,7 @@ async fn start_background(
     ) {
     Some(target) =>
       return @agent_tool.ToolAction::respond(
-        direct_source_tree_operation_blocked_content(target),
+        direct_source_blocked_content("source tree operation", target),
         is_error=true,
         brief=shell_brief(input.cmd, None),
       )

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -206,12 +206,8 @@ fn ShellExecution::set_terminal(
 pub async fn ShellExecution::stop(self : ShellExecution) -> Bool {
   guard !self.status.is_terminal() else { return false }
   self.request_stop()
-  for ;; {
-    if self.status.is_terminal() {
-      return true
-    }
-    @async.sleep(5)
-  }
+  self.wait()
+  true
 }
 
 ///|


### PR DESCRIPTION
Post-L3.5 cleanup of the new shell execution stack — five mechanical, behavior-preserving reductions (net −44 lines):

**sandbox.mbt** (commit 1)
- `sandbox_denial_line_mentions_source_suffix` was a byte-for-byte duplicate of `sandbox_denial_line_mentions_literal_subject`; dropped, and the 8-way `||` chain in `..._mentions_source_path` folded into `.any()` over the suffix list.
- The `sandbox-exec` argv (`-p <profile> <shell> <args>`) was hand-assembled at three sites (launch + both probe steps); extracted `sandbox_exec_args` using an array-literal spread.
- The two 'blocked before execution' refusal templates differed only in the operation phrase; merged into `direct_source_blocked_content(operation, target)`.

**shell_exec / bgjobs** (commit 2)
- `ShellExecution::stop` re-implemented `wait`'s poll-to-terminal loop; now `request_stop(); wait(); true`.
- `BgJobRuntime::list` manual push loop → two-variable map comprehension.

## Testing
`moon check` / `moon fmt` clean; `agent_tool/shell` 115/115, `shell_exec` 16/16, `bgjobs` 10/10, `shell_output` 6/6, `shell_stop` 2/2 (fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)