### PR TITLE
test(agent_tool): dedupe shell/sandbox/edit test boilerplate

### DIFF
--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -416,28 +416,6 @@ async test "edit replaces first repeated match only" {
 }
 
 ///|
-async test "edit rejects unbounded replace_all" {
-  @vfs.with_tmpdir(dir => {
-    let path = "\{dir}/replace-all.txt"
-    @fs.write_file(path, "alpha beta beta", create_mode=CreateOrTruncate)
-    let result = run_edit({
-      "path": path,
-      "old_string": "beta",
-      "new_string": "delta",
-      "replace_all": true,
-      "start_line": 1,
-    })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_eq(
-      output.content,
-      "error editing \{path}: replace_all=true is no longer supported; use multi_edit with explicit line-anchored edits",
-    )
-    assert_true(output.is_error)
-    assert_eq(@fs.read_file(path).text(), "alpha beta beta")
-  })
-}
-
-///|
 async test "edit rejects non-boolean replace_all" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/bad-replace-all.txt"

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -181,220 +181,176 @@ async test "sandbox profile cache invalidates when source tree changes" {
 async test "sandbox preblocks source-writing script snippets" {
   let root = "/workspace"
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import os; os.makedirs(\"_build/gen\", exist_ok=True); open(\"_build/gen/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(\"_build/gen\", \"pkg\")'",
-      ),
+    tree_target(
+      "python3 -c 'import os; os.makedirs(\"_build/gen\", exist_ok=True); open(\"_build/gen/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(\"_build/gen\", \"pkg\")'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import os; src=\"_build/gen\"; dst=\"pkg\"; os.makedirs(src, exist_ok=True); open(src + \"/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(src, dst)'",
-      ),
+    tree_target(
+      "python3 -c 'import os; src=\"_build/gen\"; dst=\"pkg\"; os.makedirs(src, exist_ok=True); open(src + \"/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(src, dst)'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "mkdir -p _build/gen && printf source > _build/gen/main.mbt && python3 -c 'import os; os.rename(\"_build/gen\", \"pkg\")'",
-      ),
+    tree_target(
+      "mkdir -p _build/gen && printf source > _build/gen/main.mbt && python3 -c 'import os; os.rename(\"_build/gen\", \"pkg\")'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import os; open(\"_build/generated.txt\", \"w\").write(\"asset\"); os.rename(\"_build/generated.txt\", \"asset.txt\")'",
-      ),
+    tree_target(
+      "python3 -c 'import os; open(\"_build/generated.txt\", \"w\").write(\"asset\"); os.rename(\"_build/generated.txt\", \"asset.txt\")'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import shutil; shutil.copyfile(\"replacement.txt\", \"main.mbt\")'",
-      ),
+    tree_target(
+      "python3 -c 'import shutil; shutil.copyfile(\"replacement.txt\", \"main.mbt\")'",
       root,
       Some(root),
     )
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "node -e 'const fs = require(\"fs\"); fs.cpSync(\"_build/gen\", \"pkg\", { recursive: true })'",
-      ),
+    tree_target(
+      "node -e 'const fs = require(\"fs\"); fs.cpSync(\"_build/gen\", \"pkg\", { recursive: true })'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'print(open(\"main.mbt\").read())'",
-      ),
+    tree_target(
+      "python3 -c 'print(open(\"main.mbt\").read())'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import sys; sys.stdout.write(open(\"main.mbt\").read())'",
-      ),
+    tree_target(
+      "python3 -c 'import sys; sys.stdout.write(open(\"main.mbt\").read())'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import sys; sys.stderr.write(open(\"main.mbt\").read())'",
-      ),
+    tree_target(
+      "python3 -c 'import sys; sys.stderr.write(open(\"main.mbt\").read())'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'print(\"w\"); print(open(\"main.mbt\").read())'",
-      ),
+    tree_target(
+      "python3 -c 'print(\"w\"); print(open(\"main.mbt\").read())'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import sys; sys.stdout.buffer.write(open(\"main.mbt\", \"rb\").read())'",
-      ),
+    tree_target(
+      "python3 -c 'import sys; sys.stdout.buffer.write(open(\"main.mbt\", \"rb\").read())'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'open(\"/tmp/probe.mbt\", \"w\").write(\"x\")'",
-      ),
+    tree_target(
+      "python3 -c 'open(\"/tmp/probe.mbt\", \"w\").write(\"x\")'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'print(\"main.mbt\".replace(\".mbt\", \".txt\"))'",
-      ),
+    tree_target(
+      "python3 -c 'print(\"main.mbt\".replace(\".mbt\", \".txt\"))'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'from pathlib import Path; Path(\"main.mbt\").write_text(\"pub fn answer() -> Int { 1 }\\\\n\")' 2>/dev/null || true",
-      ),
+    tree_target(
+      "python3 -c 'from pathlib import Path; Path(\"main.mbt\").write_text(\"pub fn answer() -> Int { 1 }\\\\n\")' 2>/dev/null || true",
       root,
       Some(root),
     )
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "awk 'BEGIN { print \"pub fn answer() -> Int { 43 }\" > \"main.mbt\" }' 2>/dev/null || true",
-      ),
+    tree_target(
+      "awk 'BEGIN { print \"pub fn answer() -> Int { 43 }\" > \"main.mbt\" }' 2>/dev/null || true",
       root,
       Some(root),
     )
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "awk -v marker=.mbt 'BEGIN { if (1 > 0) print marker }'",
-      ),
+    tree_target(
+      "awk -v marker=.mbt 'BEGIN { if (1 > 0) print marker }'",
       root,
       Some(root),
     )
     is None,
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "sh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
-      ),
+    tree_target(
+      "sh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "bash --noprofile -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
-      ),
+    tree_target(
+      "bash --noprofile -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "bash -o pipefail -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
-      ),
+    tree_target(
+      "bash -o pipefail -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "dash -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
-      ),
+    tree_target(
+      "dash -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "ksh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
-      ),
+    tree_target(
+      "ksh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
       root,
       Some(root),
     )
     is Some("/workspace/pkg"),
   )
   assert_true(
-    direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "node -e 'const fs = require(\"fs\"); fs.mkdirSync(\"_build/gen\", { recursive: true }); fs.writeFileSync(\"_build/gen/main.mbt\", \"pub fn generated() -> Int { 1 }\\\\n\"); fs.renameSync(\"_build/gen\", \"pkg\")'",
-      ),
+    tree_target(
+      "node -e 'const fs = require(\"fs\"); fs.mkdirSync(\"_build/gen\", { recursive: true }); fs.writeFileSync(\"_build/gen/main.mbt\", \"pub fn generated() -> Int { 1 }\\\\n\"); fs.renameSync(\"_build/gen\", \"pkg\")'",
       root,
       Some(root),
     )
@@ -410,10 +366,8 @@ async test "sandbox preblocks command-line created source directories" {
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
-    let target = direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "mkdir backup && cp main.mbt backup 2>/dev/null || true",
-      ),
+    let target = tree_target(
+      "mkdir backup && cp main.mbt backup 2>/dev/null || true",
       root,
       Some(root),
     )
@@ -430,10 +384,8 @@ async test "sandbox preblocks scripted existing source tree moves" {
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
-    let target = direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import os; os.rename(\"pkg\", \"pkg.bak\")' 2>/dev/null || true",
-      ),
+    let target = tree_target(
+      "python3 -c 'import os; os.rename(\"pkg\", \"pkg.bak\")' 2>/dev/null || true",
       root,
       Some(root),
     )
@@ -451,11 +403,7 @@ async test "sandbox keeps guarded cd cwd visible after semicolon" {
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
-    let target = direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy("cd ./pkg && true; rm -rf sub"),
-      root,
-      Some(root),
-    )
+    let target = tree_target("cd ./pkg && true; rm -rf sub", root, Some(root))
     assert_true(target == Some("\{root}/pkg/sub"))
   })
 }
@@ -478,18 +426,14 @@ async test "sandbox preblocks scripted external source tree imports" {
       "pub fn generated_file() -> Int { 1 }\n",
       create_mode=CreateOrTruncate,
     )
-    let target = direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import shutil; shutil.move(\"\{generated}\", \"pkg\")'",
-      ),
+    let target = tree_target(
+      "python3 -c 'import shutil; shutil.move(\"\{generated}\", \"pkg\")'",
       workspace,
       Some(workspace),
     )
     assert_true(target == Some("\{workspace}/pkg"))
-    let copy_target = direct_source_tree_operation_target_for_root(
-      @shell_parse.parse_for_policy(
-        "python3 -c 'import shutil; shutil.copy(\"\{generated_file}\", \"pkg\")'",
-      ),
+    let copy_target = tree_target(
+      "python3 -c 'import shutil; shutil.copy(\"\{generated_file}\", \"pkg\")'",
       workspace,
       Some(workspace),
     )
@@ -536,10 +480,8 @@ async test "sandbox preblocks common source-writing commands" {
     let backup_path = "\{real_root}/backup.mbt"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "cp replacement.txt main.mbt 2>/dev/null || true",
-          ),
+        tree_target(
+          "cp replacement.txt main.mbt 2>/dev/null || true",
           real_root,
           Some(real_root),
         ),
@@ -548,10 +490,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "cp replacement.txt out.log 2>/dev/null || true",
-          ),
+        tree_target(
+          "cp replacement.txt out.log 2>/dev/null || true",
           real_root,
           Some(real_root),
         ),
@@ -560,18 +500,14 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("touch main.mbt"),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target("touch main.mbt", real_root, Some(real_root)),
         main_path,
       ),
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("touch out.log 2>/dev/null || true"),
+        tree_target(
+          "touch out.log 2>/dev/null || true",
           real_root,
           Some(real_root),
         ),
@@ -579,25 +515,16 @@ async test "sandbox preblocks common source-writing commands" {
       ),
     )
     assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("touch -h out.log"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      tree_target("touch -h out.log", real_root, Some(real_root)) is None,
     )
     assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("touch --no-dereference out.log"),
-        real_root,
-        Some(real_root),
-      )
+      tree_target("touch --no-dereference out.log", real_root, Some(real_root))
       is None,
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("touch --no-dereference main.mbt"),
+        tree_target(
+          "touch --no-dereference main.mbt",
           real_root,
           Some(real_root),
         ),
@@ -606,8 +533,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("printf x | tee main.mbt >/dev/null"),
+        tree_target(
+          "printf x | tee main.mbt >/dev/null",
           real_root,
           Some(real_root),
         ),
@@ -616,8 +543,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("printf x | tee out.log >/dev/null"),
+        tree_target(
+          "printf x | tee out.log >/dev/null",
           real_root,
           Some(real_root),
         ),
@@ -626,8 +553,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("install replacement.txt out.log"),
+        tree_target(
+          "install replacement.txt out.log",
           real_root,
           Some(real_root),
         ),
@@ -636,8 +563,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("install replacement.txt main.mbt"),
+        tree_target(
+          "install replacement.txt main.mbt",
           real_root,
           Some(real_root),
         ),
@@ -646,10 +573,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "install -Dm644 replacement.txt main.mbt",
-          ),
+        tree_target(
+          "install -Dm644 replacement.txt main.mbt",
           real_root,
           Some(real_root),
         ),
@@ -658,10 +583,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "install -Dm 644 replacement.txt main.mbt",
-          ),
+        tree_target(
+          "install -Dm 644 replacement.txt main.mbt",
           real_root,
           Some(real_root),
         ),
@@ -670,8 +593,14 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("Set-Content main.mbt value"),
+        tree_target("Set-Content main.mbt value", real_root, Some(real_root)),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        tree_target(
+          "Add-Content -Path out.log -Value value",
           real_root,
           Some(real_root),
         ),
@@ -680,10 +609,20 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "Add-Content -Path out.log -Value value",
-          ),
+        tree_target("Out-File -FilePath main.mbt", real_root, Some(real_root)),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        tree_target("Tee-Object -FilePath out.log", real_root, Some(real_root)),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        tree_target(
+          "Copy-Item replacement.txt out.log",
           real_root,
           Some(real_root),
         ),
@@ -692,40 +631,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("Out-File -FilePath main.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("Tee-Object -FilePath out.log"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("Copy-Item replacement.txt out.log"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "Copy-Item _build/main.mbt src/main.mbt -ErrorAction SilentlyContinue",
-          ),
+        tree_target(
+          "Copy-Item _build/main.mbt src/main.mbt -ErrorAction SilentlyContinue",
           real_root,
           Some(real_root),
         ),
@@ -734,8 +641,20 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("Move-Item main.mbt backup"),
+        tree_target("Move-Item main.mbt backup", real_root, Some(real_root)),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        tree_target("Remove-Item main.mbt", real_root, Some(real_root)),
+        main_path,
+      ),
+    )
+    assert_true(
+      is_some_path(
+        tree_target(
+          "Rename-Item main.mbt backup.mbt",
           real_root,
           Some(real_root),
         ),
@@ -744,30 +663,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("Remove-Item main.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("Rename-Item main.mbt backup.mbt"),
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "New-Item -Path main.mbt -ItemType File",
-          ),
+        tree_target(
+          "New-Item -Path main.mbt -ItemType File",
           real_root,
           Some(real_root),
         ),
@@ -778,10 +675,8 @@ async test "sandbox preblocks common source-writing commands" {
     // not the `.` directory.
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "New-Item -Path . -Name main.mbt -ItemType File",
-          ),
+        tree_target(
+          "New-Item -Path . -Name main.mbt -ItemType File",
           real_root,
           Some(real_root),
         ),
@@ -791,12 +686,7 @@ async test "sandbox preblocks common source-writing commands" {
     let powershell_remove_glob = "Remove-Item *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(powershell_remove_glob),
-          powershell_remove_glob,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(powershell_remove_glob, real_root, Some(real_root)),
         real_root,
       ),
     )
@@ -815,11 +705,7 @@ async test "sandbox preblocks common source-writing commands" {
       ] {
       assert_true(
         is_some_path(
-          direct_source_tree_operation_target_for_root(
-            @shell_parse.parse_for_policy(blocked_git),
-            real_root,
-            Some(real_root),
-          ),
+          tree_target(blocked_git, real_root, Some(real_root)),
           real_root,
         ),
       )
@@ -828,8 +714,8 @@ async test "sandbox preblocks common source-writing commands" {
     // cwd — so it cannot slip through with a cwd outside the workspace (e.g. a
     // `git -C <workspace>` run from elsewhere).
     assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("git apply patch.diff"),
+      tree_target(
+        "git apply patch.diff",
         real_root,
         Some("\{real_root}-external"),
       )
@@ -839,12 +725,7 @@ async test "sandbox preblocks common source-writing commands" {
     let git_apply_glob = "git apply *.patch"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(git_apply_glob),
-          git_apply_glob,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(git_apply_glob, real_root, Some(real_root)),
         real_root,
       ),
     )
@@ -852,13 +733,7 @@ async test "sandbox preblocks common source-writing commands" {
     // even though the env assignment precedes the `git` word.
     let git_env_glob = "GIT_DIR=/tmp/x git checkout -- *.mbt"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(git_env_glob),
-        git_env_glob,
-        real_root,
-        Some(real_root),
-      )
-      is Some(_),
+      dyn_tree_target(git_env_glob, real_root, Some(real_root)) is Some(_),
     )
     // Recoverable git worktree subcommands (and dry-run clean) are not pre-blocked;
     // they run as trusted source writers, or harmlessly sandboxed.
@@ -869,43 +744,27 @@ async test "sandbox preblocks common source-writing commands" {
         "git clean -fdn", "git status", "git apply --check patch.diff", "git apply --stat patch.diff",
       ] {
       assert_true(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(recoverable_git),
-          real_root,
-          Some(real_root),
-        )
-        is None,
+        tree_target(recoverable_git, real_root, Some(real_root)) is None,
       )
     }
     let find_sed_source = "find \{real_root} -name '*.mbt' -exec sed -i '' 's/42/43/' {} +"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(find_sed_source),
-          find_sed_source,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(find_sed_source, real_root, Some(real_root)),
         real_root,
       ),
     )
     let find_env_sed_source = "find \{real_root} -name '*.mbt' -exec env FOO=bar sed -i '' 's/42/43/' {} + 2>/dev/null || true"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(find_env_sed_source),
-          find_env_sed_source,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(find_env_sed_source, real_root, Some(real_root)),
         real_root,
       ),
     )
     let find_sed_source_case_insensitive = "find \{real_root} -iname '*.MBT' -exec sed -i '' 's/42/43/' {} +"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(find_sed_source_case_insensitive),
+        dyn_tree_target(
           find_sed_source_case_insensitive,
           real_root,
           Some(real_root),
@@ -916,12 +775,7 @@ async test "sandbox preblocks common source-writing commands" {
     let find_sed_readme_glob = "find \{real_root} -name README.* -exec sed -i '' 's/42/43/' '{}' +"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(find_sed_readme_glob),
-          find_sed_readme_glob,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(find_sed_readme_glob, real_root, Some(real_root)),
         real_root,
       ),
     )
@@ -933,36 +787,21 @@ async test "sandbox preblocks common source-writing commands" {
     let xargs_sed_source = "echo *.mbt | xargs sed -i '' 's/42/43/g'"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(xargs_sed_source),
-          xargs_sed_source,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(xargs_sed_source, real_root, Some(real_root)),
         real_root,
       ),
     )
     let xargs_replace_sed = "echo *.mbt | xargs -I{} sed -i '' 's/42/43/g' {}"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(xargs_replace_sed),
-          xargs_replace_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(xargs_replace_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let xargs_n1_sed = "echo *.mbt | xargs -n 1 sed -i '' 's/42/43/g'"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(xargs_n1_sed),
-          xargs_n1_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(xargs_n1_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
@@ -970,12 +809,7 @@ async test "sandbox preblocks common source-writing commands" {
     let xargs_bsd_replace_sed = "echo *.mbt | xargs -J {} sed -i '' 's/42/43/g' {}"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(xargs_bsd_replace_sed),
-          xargs_bsd_replace_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(xargs_bsd_replace_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
@@ -984,12 +818,7 @@ async test "sandbox preblocks common source-writing commands" {
     let xargs_git_apply = "echo *.patch | xargs git apply"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(xargs_git_apply),
-          xargs_git_apply,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(xargs_git_apply, real_root, Some(real_root)),
         real_root,
       ),
     )
@@ -997,246 +826,133 @@ async test "sandbox preblocks common source-writing commands" {
     // must not be blocked, so analysis loops keep working.
     let xargs_grep_readonly = "echo *.mbt | xargs grep -l 'sed -i'"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(xargs_grep_readonly),
-        xargs_grep_readonly,
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      dyn_tree_target(xargs_grep_readonly, real_root, Some(real_root)) is None,
     )
     let safe_find_then_sed = "find \{real_root} -name '*.txt' -print; sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(safe_find_then_sed),
-          safe_find_then_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(safe_find_then_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let env_wrapped_sed = "env FOO=bar sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(env_wrapped_sed),
-          env_wrapped_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(env_wrapped_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let env_assignment_sed = "FOO=bar sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(env_assignment_sed),
-          env_assignment_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(env_assignment_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let env_unset_wrapped_sed = "env -u FOO sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(env_unset_wrapped_sed),
-          env_unset_wrapped_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(env_unset_wrapped_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let env_long_unset_wrapped_sed = "env --unset FOO sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(env_long_unset_wrapped_sed),
-          env_long_unset_wrapped_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(env_long_unset_wrapped_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let command_wrapped_sed = "command sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(command_wrapped_sed),
-          command_wrapped_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(command_wrapped_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let find_sed_text = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' {} +"
+    assert_true(tree_target(find_sed_text, real_root, Some(real_root)) is None)
     assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy(find_sed_text),
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
-    assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(find_sed_text),
-        find_sed_text,
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      dyn_tree_target(find_sed_text, real_root, Some(real_root)) is None,
     )
     let find_sed_text_quoted = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' '{}' +"
     assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy(find_sed_text_quoted),
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      tree_target(find_sed_text_quoted, real_root, Some(real_root)) is None,
     )
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(find_sed_text_quoted),
-        find_sed_text_quoted,
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      dyn_tree_target(find_sed_text_quoted, real_root, Some(real_root)) is None,
     )
     let find_sed_filter_after_exec = "find \{real_root} -exec sed -i '' 's/42/43/' '{}' + -name '*.txt'"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(find_sed_filter_after_exec),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(find_sed_filter_after_exec, real_root, Some(real_root)),
         real_root,
       ),
     )
     let broad_find_sed_text = "find \{real_root} -name '*' -exec sed -i '' 's/42/43/' '{}' +"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(broad_find_sed_text),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(broad_find_sed_text, real_root, Some(real_root)),
         real_root,
       ),
     )
     let find_sed_literal_source = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' main.mbt ';'"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(find_sed_literal_source),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(find_sed_literal_source, real_root, Some(real_root)),
         real_root,
       ),
     )
     let find_sed_comma_quoted = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' '{}' + , -exec sed -i '' 's/42/43/' '{}' +"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(find_sed_comma_quoted),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(find_sed_comma_quoted, real_root, Some(real_root)),
         real_root,
       ),
     )
     let readonly_sed_pipeline = "sed -n '1,5p' *.mbt | grep -i answer"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(readonly_sed_pipeline),
-        readonly_sed_pipeline,
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      dyn_tree_target(readonly_sed_pipeline, real_root, Some(real_root)) is None,
     )
     let readonly_sed_file_named_i = "while true; do sed -f -i *.mbt\ndone"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(readonly_sed_file_named_i),
-        readonly_sed_file_named_i,
-        real_root,
-        Some(real_root),
-      )
+      dyn_tree_target(readonly_sed_file_named_i, real_root, Some(real_root))
       is None,
     )
     let multiline_sed = "while true; do printf ok\nsed -i '' 's/42/43/' *.mbt\ndone"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(multiline_sed),
-          multiline_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(multiline_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let background_sed = "sleep 1 & sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(background_sed),
-          background_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(background_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let nested_shell_sed = "sh -c \"sed -i '' 's/42/43/' *.mbt\""
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(nested_shell_sed),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(nested_shell_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let quoted_sed_text = "grep 'foo|sed -i' *.mbt"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(quoted_sed_text),
-        quoted_sed_text,
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      dyn_tree_target(quoted_sed_text, real_root, Some(real_root)) is None,
     )
     let generated_script_with_sed = "cat > script.sh <<EOF\nsed -i 's/42/43/' f\nEOF"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(generated_script_with_sed),
-        generated_script_with_sed,
-        real_root,
-        Some(real_root),
-      )
+      dyn_tree_target(generated_script_with_sed, real_root, Some(real_root))
       is None,
     )
     let backslash_quoted_heredoc_then_copy = "cat <<\\EOF\nignored\nEOF\ncp main.mbt backup.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(backslash_quoted_heredoc_then_copy),
+        dyn_tree_target(
           backslash_quoted_heredoc_then_copy,
           real_root,
           Some(real_root),
@@ -1247,8 +963,7 @@ async test "sandbox preblocks common source-writing commands" {
     let generated_script_then_executed = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(generated_script_then_executed),
+        dyn_tree_target(
           generated_script_then_executed,
           real_root,
           Some(real_root),
@@ -1259,8 +974,7 @@ async test "sandbox preblocks common source-writing commands" {
     let tee_generated_script_then_executed = "tee script.sh <<EOF >/dev/null\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(tee_generated_script_then_executed),
+        dyn_tree_target(
           tee_generated_script_then_executed,
           real_root,
           Some(real_root),
@@ -1271,8 +985,7 @@ async test "sandbox preblocks common source-writing commands" {
     let pipe_tee_generated_script_then_executed = "cat <<EOF | tee script.sh >/dev/null\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(pipe_tee_generated_script_then_executed),
+        dyn_tree_target(
           pipe_tee_generated_script_then_executed,
           real_root,
           Some(real_root),
@@ -1283,8 +996,7 @@ async test "sandbox preblocks common source-writing commands" {
     let generated_script_then_bash_with_option = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nbash -o pipefail script.sh"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(generated_script_then_bash_with_option),
+        dyn_tree_target(
           generated_script_then_bash_with_option,
           real_root,
           Some(real_root),
@@ -1295,8 +1007,7 @@ async test "sandbox preblocks common source-writing commands" {
     let generated_script_then_dot_sourced = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\n. script.sh"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(generated_script_then_dot_sourced),
+        dyn_tree_target(
           generated_script_then_dot_sourced,
           real_root,
           Some(real_root),
@@ -1307,8 +1018,7 @@ async test "sandbox preblocks common source-writing commands" {
     let generated_script_then_source_sourced = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nsource script.sh"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(generated_script_then_source_sourced),
+        dyn_tree_target(
           generated_script_then_source_sourced,
           real_root,
           Some(real_root),
@@ -1319,8 +1029,7 @@ async test "sandbox preblocks common source-writing commands" {
     let generated_script_then_shell_c_sourced = "cat > script.sh <<EOF\nmkdir -p _build/gen\ncp main.mbt _build/gen/main.mbt\nmv _build/gen pkg\nEOF\nsh -c '. ./script.sh'"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(generated_script_then_shell_c_sourced),
+        dyn_tree_target(
           generated_script_then_shell_c_sourced,
           real_root,
           Some(real_root),
@@ -1331,20 +1040,14 @@ async test "sandbox preblocks common source-writing commands" {
     let shell_heredoc_with_sed = "sh <<EOF\nsed -i '' 's/42/43/' *.mbt\nEOF"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(shell_heredoc_with_sed),
-          shell_heredoc_with_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(shell_heredoc_with_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let python_heredoc_generated_move = "python3 <<EOF\nimport shutil\nshutil.move('_build/pkg', 'pkg')\nEOF"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(python_heredoc_generated_move),
+        dyn_tree_target(
           python_heredoc_generated_move,
           real_root,
           Some(real_root),
@@ -1355,20 +1058,14 @@ async test "sandbox preblocks common source-writing commands" {
     let heredoc_source_redirect = "cat 2>/dev/null > main.mbt <<'EOF' || true\npub fn answer() -> Int { 43 }\nEOF"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(heredoc_source_redirect),
-          heredoc_source_redirect,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(heredoc_source_redirect, real_root, Some(real_root)),
         real_root,
       ),
     )
     let fd_duplicate_source_redirect = "printf x >& main.mbt *.txt 2>/dev/null || true"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(fd_duplicate_source_redirect),
+        dyn_tree_target(
           fd_duplicate_source_redirect,
           real_root,
           Some(real_root),
@@ -1379,41 +1076,24 @@ async test "sandbox preblocks common source-writing commands" {
     let rm_glob_source = "rm *.mbt 2>/dev/null || true"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(rm_glob_source),
-          rm_glob_source,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(rm_glob_source, real_root, Some(real_root)),
         real_root,
       ),
     )
     let grep_mv_source = "grep mv *.mbt"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(grep_mv_source),
-        grep_mv_source,
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      dyn_tree_target(grep_mv_source, real_root, Some(real_root)) is None,
     )
     let python_heredoc_source_write = "python3 - <<'PY'\nopen('main.mbt', 'w').write('pub fn answer() -> Int { 43 }\\n')\nPY"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(python_heredoc_source_write),
-          python_heredoc_source_write,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(python_heredoc_source_write, real_root, Some(real_root)),
         main_path,
       ),
     )
     let outside_python_heredoc_source_write = "python3 - <<'PY'\nopen('/tmp/probe.mbt', 'w').write('x')\nPY"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(outside_python_heredoc_source_write),
+      dyn_tree_target(
         outside_python_heredoc_source_write,
         real_root,
         Some("/tmp"),
@@ -1422,74 +1102,46 @@ async test "sandbox preblocks common source-writing commands" {
     )
     let outside_python_c_source_write = "python3 -c 'open(\"/tmp/probe.mbt\", \"w\").write(\"x\")' *.txt"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(outside_python_c_source_write),
-        outside_python_c_source_write,
-        real_root,
-        Some(real_root),
-      )
+      dyn_tree_target(outside_python_c_source_write, real_root, Some(real_root))
       is None,
     )
     let cd_outside_glob_sed = "cd /tmp && sed -i '' 's/42/43/' *.mbt"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(cd_outside_glob_sed),
-        cd_outside_glob_sed,
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      dyn_tree_target(cd_outside_glob_sed, real_root, Some(real_root)) is None,
     )
     let cd_workspace_glob_sed = "cd \{real_root} && sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(cd_workspace_glob_sed),
-          cd_workspace_glob_sed,
-          real_root,
-          Some("/tmp"),
-        ),
+        dyn_tree_target(cd_workspace_glob_sed, real_root, Some("/tmp")),
         real_root,
       ),
     )
     let versioned_python_source_write = "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")'"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(versioned_python_source_write),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(versioned_python_source_write, real_root, Some(real_root)),
         main_path,
       ),
     )
     let python_exe_source_write = "Python.EXE -c 'open(\"main.mbt\", \"w+\").close()' 2>/dev/null || true"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(python_exe_source_write),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(python_exe_source_write, real_root, Some(real_root)),
         main_path,
       ),
     )
     let python_create_mode_source_write = "python -c 'open(\"main.mbt\", \"x\").close()' 2>/dev/null || true"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(python_create_mode_source_write),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(python_create_mode_source_write, real_root, Some(real_root)),
         main_path,
       ),
     )
     let masked_versioned_python_source_write = "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")' 2>/dev/null || true"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(masked_versioned_python_source_write),
+        tree_target(
+          masked_versioned_python_source_write,
           real_root,
           Some(real_root),
         ),
@@ -1499,139 +1151,84 @@ async test "sandbox preblocks common source-writing commands" {
     let find_sed_branch = "find \{real_root} -name '*.txt' -o -exec sed -i '' 's/42/43/' {} +"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(find_sed_branch),
-          find_sed_branch,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(find_sed_branch, real_root, Some(real_root)),
         real_root,
       ),
     )
     let find_sed_branch_quoted = "find \{real_root} -name '*.txt' -o -exec sed -i '' 's/42/43/' '{}' +"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(find_sed_branch_quoted),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(find_sed_branch_quoted, real_root, Some(real_root)),
         real_root,
       ),
     )
     let find_sed_comma = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' {} + , -exec sed -i '' 's/42/43/' {} +"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(find_sed_comma),
-          find_sed_comma,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(find_sed_comma, real_root, Some(real_root)),
         real_root,
       ),
     )
     let grouped_sed = "{ sed -i '' 's/42/43/' *.mbt; }"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(grouped_sed),
-          grouped_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(grouped_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let until_sed = "until sed -i '' 's/42/43/' *.mbt; do true; done"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(until_sed),
-          until_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(until_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let elif_sed = "if false; then true; elif sed -i '' 's/42/43/' *.mbt; then true; fi"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(elif_sed),
-          elif_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(elif_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let if_env_sed = "if env FOO=bar sed -i '' 's/42/43/' *.mbt; then true; fi"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(if_env_sed),
-          if_env_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(if_env_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let if_command_sed = "if command sed -i '' 's/42/43/' *.mbt; then true; fi"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(if_command_sed),
-          if_command_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(if_command_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let loop_sed = "while IFS= read -r f; do sed -i '' 's/42/43/' \"$f\"; done < /tmp/files.txt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(loop_sed),
-          loop_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(loop_sed, real_root, Some(real_root)),
         real_root,
       ),
     )
     let cd_glob_sed = "cd pkg && sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
-        dynamic_source_tree_operation_target(
-          @shell_parse.parse_for_policy(cd_glob_sed),
-          cd_glob_sed,
-          real_root,
-          Some(real_root),
-        ),
+        dyn_tree_target(cd_glob_sed, real_root, Some(real_root)),
         "\{real_root}/pkg",
       ),
     )
     let mkdir_or_cp_source = "mkdir gen || true; cp /tmp/generated.mbt gen 2>/dev/null || true"
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(mkdir_or_cp_source),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target(mkdir_or_cp_source, real_root, Some(real_root)),
         "\{real_root}/gen",
       ),
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "cd src && mv pkg pkg.bak 2>/dev/null || true",
-          ),
+        tree_target(
+          "cd src && mv pkg pkg.bak 2>/dev/null || true",
           real_root,
           Some(real_root),
         ),
@@ -1639,48 +1236,28 @@ async test "sandbox preblocks common source-writing commands" {
       ),
     )
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy("cp main.mbt backup.txt"),
-        "cp main.mbt backup.txt",
-        real_root,
-        Some(real_root),
-      )
+      dyn_tree_target("cp main.mbt backup.txt", real_root, Some(real_root))
       is None,
     )
     assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy("cp main.mbt backup.txt"),
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      tree_target("cp main.mbt backup.txt", real_root, Some(real_root)) is None,
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("cp main.mbt backup.mbt"),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target("cp main.mbt backup.mbt", real_root, Some(real_root)),
         backup_path,
       ),
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy("mv --force pkg pkg.bak"),
-          real_root,
-          Some(real_root),
-        ),
+        tree_target("mv --force pkg pkg.bak", real_root, Some(real_root)),
         "\{real_root}/pkg",
       ),
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "mv -b main.mbt backup 2>/dev/null || true",
-          ),
+        tree_target(
+          "mv -b main.mbt backup 2>/dev/null || true",
           real_root,
           Some(real_root),
         ),
@@ -1689,10 +1266,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "mv --no-target-directory _build/gen pkg",
-          ),
+        tree_target(
+          "mv --no-target-directory _build/gen pkg",
           real_root,
           Some(real_root),
         ),
@@ -1701,10 +1276,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "mkdir -p _build/gen.v1 && printf source > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg.v1",
-          ),
+        tree_target(
+          "mkdir -p _build/gen.v1 && printf source > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg.v1",
           real_root,
           Some(real_root),
         ),
@@ -1713,10 +1286,8 @@ async test "sandbox preblocks common source-writing commands" {
     )
     assert_true(
       is_some_path(
-        direct_source_tree_operation_target_for_root(
-          @shell_parse.parse_for_policy(
-            "mkdir -p assets _build/gen.tmp && printf source > _build/gen.tmp/main.mbt && mv _build/gen.tmp assets/pkg.tmp",
-          ),
+        tree_target(
+          "mkdir -p assets _build/gen.tmp && printf source > _build/gen.tmp/main.mbt && mv _build/gen.tmp assets/pkg.tmp",
           real_root,
           Some(real_root),
         ),
@@ -1724,10 +1295,8 @@ async test "sandbox preblocks common source-writing commands" {
       ),
     )
     assert_true(
-      direct_source_tree_operation_target_for_root(
-        @shell_parse.parse_for_policy(
-          "mkdir -p assets _build && printf data > _build/logo.txt && mv _build/logo.txt assets/logo.txt",
-        ),
+      tree_target(
+        "mkdir -p assets _build && printf data > _build/logo.txt && mv _build/logo.txt assets/logo.txt",
         real_root,
         Some(real_root),
       )
@@ -1849,146 +1418,77 @@ test "sandbox denial detection ignores masked exit code" {
 test "sandbox detects direct protected source write redirects" {
   let root = "/workspace"
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("printf x 2>/dev/null > main.mbt || true"),
-      root,
-      Some(root),
-    )
+    redirect_target("printf x 2>/dev/null > main.mbt || true", root, Some(root))
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("cd ./pkg && printf x > main.mbt"),
-      root,
-      Some(root),
-    )
+    redirect_target("cd ./pkg && printf x > main.mbt", root, Some(root))
     is Some("/workspace/pkg/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy(
-        "cd /missing 2>/dev/null || printf x 2>/dev/null > main.mbt || true",
-      ),
+    redirect_target(
+      "cd /missing 2>/dev/null || printf x 2>/dev/null > main.mbt || true",
       root,
       Some(root),
     )
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy(
-        "cd /definitely-missing && :; printf x > main.mbt",
-      ),
+    redirect_target(
+      "cd /definitely-missing && :; printf x > main.mbt",
       root,
       Some(root),
     )
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("cd /workspace; printf x > main.mbt"),
-      root,
-      Some("/tmp"),
-    )
+    redirect_target("cd /workspace; printf x > main.mbt", root, Some("/tmp"))
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy(
-        "cd /workspace; cd ./pkg && printf x > main.mbt",
-      ),
+    redirect_target(
+      "cd /workspace; cd ./pkg && printf x > main.mbt",
       root,
       Some("/tmp"),
     )
     is Some("/workspace/pkg/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("cd ./pkg && true; printf x > main.mbt"),
-      root,
-      Some(root),
-    )
+    redirect_target("cd ./pkg && true; printf x > main.mbt", root, Some(root))
     is Some("/workspace/pkg/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("cd /tmp && printf x > main.mbt"),
-      root,
-      Some(root),
-    )
-    is None,
+    redirect_target("cd /tmp && printf x > main.mbt", root, Some(root)) is None,
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("printf x > moon.work"),
-      root,
-      Some(root),
-    )
+    redirect_target("printf x > moon.work", root, Some(root))
     is Some("/workspace/moon.work"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("printf x >| main.mbt"),
-      root,
-      Some(root),
-    )
+    redirect_target("printf x >| main.mbt", root, Some(root))
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy(": <> main.mbt"),
-      root,
-      Some(root),
-    )
+    redirect_target(": <> main.mbt", root, Some(root))
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy(": 4<> main.mbt"),
-      root,
-      Some(root),
-    )
+    redirect_target(": 4<> main.mbt", root, Some(root))
     is Some("/workspace/main.mbt"),
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("printf x > _build/out"),
-      root,
-      Some(root),
-    )
-    is None,
+    redirect_target("printf x > _build/out", root, Some(root)) is None,
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("printf x > _build/main.mbt"),
-      root,
-      Some(root),
-    )
-    is None,
+    redirect_target("printf x > _build/main.mbt", root, Some(root)) is None,
   )
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("printf x > .mooncakes/pkg/main.mbt"),
-      root,
-      Some(root),
-    )
+    redirect_target("printf x > .mooncakes/pkg/main.mbt", root, Some(root))
     is None,
   )
+  assert_true(redirect_target("cat < main.mbt", root, Some(root)) is None)
   assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("cat < main.mbt"),
-      root,
-      Some(root),
-    )
-    is None,
-  )
-  assert_true(
-    direct_source_write_redirect_target_for_root(
-      @shell_parse.parse_for_policy("printf x > /tmp/main.mbt"),
-      root,
-      Some(root),
-    )
-    is None,
+    redirect_target("printf x > /tmp/main.mbt", root, Some(root)) is None,
   )
 }
 
@@ -1998,6 +1498,38 @@ fn mode_for(cmd : String) -> SourceWriteMode {
     @shell_parse.parse_for_policy(cmd),
     "/workspace",
     Some("/workspace"),
+  )
+}
+
+///|
+/// `direct_source_tree_operation_target_for_root` on `cmd` parsed for policy.
+async fn tree_target(cmd : String, root : String, cwd : String?) -> String? {
+  direct_source_tree_operation_target_for_root(
+    @shell_parse.parse_for_policy(cmd),
+    root,
+    cwd,
+  )
+}
+
+///|
+/// `dynamic_source_tree_operation_target` on `cmd` parsed for policy (the
+/// underlying detector takes the parse and the raw text separately).
+async fn dyn_tree_target(cmd : String, root : String, cwd : String?) -> String? {
+  dynamic_source_tree_operation_target(
+    @shell_parse.parse_for_policy(cmd),
+    cmd,
+    root,
+    cwd,
+  )
+}
+
+///|
+/// `direct_source_write_redirect_target_for_root` on `cmd` parsed for policy.
+fn redirect_target(cmd : String, root : String, cwd : String?) -> String? {
+  direct_source_write_redirect_target_for_root(
+    @shell_parse.parse_for_policy(cmd),
+    root,
+    cwd,
   )
 }
 
@@ -2056,23 +1588,13 @@ async test "sandbox scans source writes after CRLF here-documents" {
     // in-place source edit.
     let crlf_heredoc_then_sed = "cat <<EOF\r\nnote\r\nEOF\r\nsed -i 's/42/43/' main.mbt\r\n"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(crlf_heredoc_then_sed),
-        crlf_heredoc_then_sed,
-        real_root,
-        Some(real_root),
-      )
+      dyn_tree_target(crlf_heredoc_then_sed, real_root, Some(real_root))
       is Some(_),
     )
     // The LF form already worked; keep it as a control for the same shape.
     let lf_heredoc_then_sed = "cat <<EOF\nnote\nEOF\nsed -i 's/42/43/' main.mbt\n"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(lf_heredoc_then_sed),
-        lf_heredoc_then_sed,
-        real_root,
-        Some(real_root),
-      )
+      dyn_tree_target(lf_heredoc_then_sed, real_root, Some(real_root))
       is Some(_),
     )
   })
@@ -2092,24 +1614,10 @@ async test "sandbox scans source writes after arithmetic left shifts" {
     // following in-place source edit.
     let arith_then_sed = "SHIFT=$((1 << 8))\nsed -i 's/42/43/' main.mbt\n"
     assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(arith_then_sed),
-        arith_then_sed,
-        real_root,
-        Some(real_root),
-      )
-      is Some(_),
+      dyn_tree_target(arith_then_sed, real_root, Some(real_root)) is Some(_),
     )
     // A bare arithmetic command with no source write stays allowed.
     let arith_only = "echo $((1 << 8))\n"
-    assert_true(
-      dynamic_source_tree_operation_target(
-        @shell_parse.parse_for_policy(arith_only),
-        arith_only,
-        real_root,
-        Some(real_root),
-      )
-      is None,
-    )
+    assert_true(dyn_tree_target(arith_only, real_root, Some(real_root)) is None)
   })
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -177,6 +177,48 @@ async fn run_shell_in_workspace(
 }
 
 ///|
+/// The canonical protected source fixture for the masked-write catalog below.
+let answer_source : String = "pub fn answer() -> Int { 42 }\n"
+
+///|
+/// Write the protected `main.mbt` fixture into `dir`.
+async fn write_answer_main(
+  dir : String,
+  content? : String = answer_source,
+) -> Unit {
+  @fs.write_file("\{dir}/main.mbt", content, create_mode=CreateOrTruncate)
+}
+
+///|
+/// Assert the protected `main.mbt` fixture survived untouched.
+async fn assert_answer_main_unchanged(
+  dir : String,
+  content? : String = answer_source,
+) -> Unit {
+  assert_eq(@fs.read_file("\{dir}/main.mbt").text(), content)
+}
+
+///|
+/// Assert `result` is the pre-execution source-write refusal: an error
+/// Respond carrying the `marker` phrase plus the shared feedback line (and,
+/// when `line_anchored`, the edit-tool redirection hint).
+fn expect_source_write_blocked(
+  result : @agent_tool.ToolAction,
+  marker? : String = "source tree operation is blocked",
+  line_anchored? : Bool = false,
+) -> Unit raise {
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains(marker))
+  assert_true(
+    output.content.contains("source file writes from shell are blocked"),
+  )
+  if line_anchored {
+    assert_true(output.content.contains("line-anchored"))
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async fn sandbox_exec_usable_for_test() -> Bool {
   if !@fs.exists("/usr/bin/sandbox-exec") {
@@ -663,11 +705,7 @@ async test "shell sandbox blocks source writes and points to edit tools" {
     return
   }
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     // The redirect target hides behind a variable, so the static preblock cannot
     // see it. The write only fails because the kernel source-write sandbox denies
     // it at runtime, which is exactly the enforcement this test must cover.
@@ -687,10 +725,7 @@ async test "shell sandbox blocks source writes and points to edit tools" {
     assert_true(output.content.contains("edit"))
     assert_true(output.content.contains("line-anchored"))
     assert_false(output.content.contains("`write`"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -724,11 +759,7 @@ async test "shell sandbox allows generated source writes under _build" {
 #cfg(not(platform="windows"))
 async test "shell sandbox reports masked source write denials as errors" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-masked-denial-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "printf %s changed 2>/dev/null > main.mbt || true",
       "cwd": dir,
@@ -742,10 +773,7 @@ async test "shell sandbox reports masked source write denials as errors" {
     )
     assert_true(output.content.contains("line-anchored"))
     assert_false(output.content.contains("`write`"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -753,11 +781,7 @@ async test "shell sandbox reports masked source write denials as errors" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks source write through symlink redirect" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-symlink-redirect-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     @fs.symlink(target="main.mbt", "\{dir}/out.log")
     let result = run_shell_in_workspace(dir, {
       "cmd": "moon fmt > out.log",
@@ -771,10 +795,7 @@ async test "shell sandbox preblocks source write through symlink redirect" {
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
     )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -782,11 +803,7 @@ async test "shell sandbox preblocks source write through symlink redirect" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks copy through symlinked source destination" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-symlink-copy-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     @fs.write_file(
       "\{dir}/replacement.txt",
       "pub fn answer() -> Int { 43 }\n",
@@ -797,17 +814,8 @@ async test "shell sandbox preblocks copy through symlinked source destination" {
       "cmd": "cp replacement.txt out.log 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(output.content.contains("line-anchored"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result, line_anchored=true)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -815,26 +823,14 @@ async test "shell sandbox preblocks copy through symlinked source destination" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks tee through symlinked source destination" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-symlink-tee-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     @fs.symlink(target="main.mbt", "\{dir}/out.log")
     let result = run_shell_in_workspace(dir, {
       "cmd": "printf changed | tee out.log >/dev/null",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -859,11 +855,7 @@ async test "shell sandbox does not treat unrelated output as source denial" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks source write after uncertain cd chain" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cd-chain-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "cd /definitely-missing-openseek 2>/dev/null && :; printf changed > main.mbt",
       "cwd": dir,
@@ -874,10 +866,7 @@ async test "shell sandbox preblocks source write after uncertain cd chain" {
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
     )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -885,11 +874,7 @@ async test "shell sandbox preblocks source write after uncertain cd chain" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks source write after entering workspace from external cwd" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-external-cwd-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "cd \{dir}; printf changed 2>/dev/null > main.mbt || true",
       "cwd": "/tmp",
@@ -897,10 +882,7 @@ async test "shell sandbox preblocks source write after entering workspace from e
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("blocked before execution"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -942,12 +924,7 @@ async test "shell sandbox tracks static relative cd before source directory move
       "cmd": "cd src && mv pkg pkg.bak 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
+    expect_source_write_blocked(result)
     assert_true(@fs.exists("\{dir}/src/pkg/main.mbt"))
     assert_false(@fs.exists("\{dir}/src/pkg.bak"))
   })
@@ -957,11 +934,7 @@ async test "shell sandbox tracks static relative cd before source directory move
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked cp source writes" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cp-masked-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     @fs.write_file(
       "\{dir}/replacement.txt",
       "pub fn answer() -> Int { 43 }\n",
@@ -971,17 +944,8 @@ async test "shell sandbox preblocks masked cp source writes" {
       "cmd": "cp replacement.txt main.mbt 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(output.content.contains("line-anchored"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result, line_anchored=true)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -989,21 +953,12 @@ async test "shell sandbox preblocks masked cp source writes" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked mv backup source moves" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-backup-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "mv -b main.mbt backup 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
+    expect_source_write_blocked(result)
     assert_true(@fs.exists("\{dir}/main.mbt"))
     assert_false(@fs.exists("\{dir}/backup"))
   })
@@ -1013,11 +968,7 @@ async test "shell sandbox preblocks masked mv backup source moves" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked git apply" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-git-apply-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     // `git apply` applies an EXTERNAL patch — arbitrary content — so it stays
     // pre-blocked before execution even when the failure is masked. Recoverable
     // git worktree subcommands (checkout/restore/reset/rm/mv/...) are no longer
@@ -1026,16 +977,8 @@ async test "shell sandbox preblocks masked git apply" {
       "cmd": "git apply change.patch 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1043,26 +986,13 @@ async test "shell sandbox preblocks masked git apply" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked awk source writes" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-awk-masked-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "awk 'BEGIN { print \"pub fn answer() -> Int { 43 }\" > \"main.mbt\" }' 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(output.content.contains("line-anchored"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result, line_anchored=true)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1074,13 +1004,7 @@ async test "shell sandbox preblocks masked dynamic source tree renames" {
       "cmd": "src=_build/gen; mkdir -p \"$src\"; printf 'pub fn generated() -> Int { 1 }\\n' > \"$src/main.mbt\"; mv \"$src\" pkg 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(output.content.contains("line-anchored"))
+    expect_source_write_blocked(result, line_anchored=true)
     assert_false(@fs.exists("\{dir}/pkg"))
     assert_false(@fs.exists("\{dir}/_build"))
   })
@@ -1098,26 +1022,13 @@ async test "shell sandbox preblocks masked pathlib source writes" {
     return
   }
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-pathlib-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "python3 -c 'from pathlib import Path; Path(\"main.mbt\").write_text(\"pub fn answer() -> Int { 43 }\\\\n\")' 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(output.content.contains("line-anchored"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result, line_anchored=true)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1125,25 +1036,13 @@ async test "shell sandbox preblocks masked pathlib source writes" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked heredoc source redirects" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-heredoc-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "cat 2>/dev/null > main.mbt <<'EOF' || true\npub fn answer() -> Int { 43 }\nEOF",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1151,25 +1050,13 @@ async test "shell sandbox preblocks masked heredoc source redirects" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked python heredoc source writes" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-python-heredoc-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "python3 - <<'PY' 2>/dev/null || true\nopen('main.mbt', 'w').write('pub fn answer() -> Int { 43 }\\n')\nPY",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1177,25 +1064,13 @@ async test "shell sandbox preblocks masked python heredoc source writes" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked versioned python source writes" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-python-versioned-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")' 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1203,25 +1078,13 @@ async test "shell sandbox preblocks masked versioned python source writes" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks python exe source write modes" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-python-exe-mode-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "python.exe -c 'open(\"main.mbt\", \"w+\").close()' 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    expect_source_write_blocked(result)
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1229,22 +1092,12 @@ async test "shell sandbox preblocks python exe source write modes" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks masked cp into created source directory" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cp-created-dir-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "mkdir backup && cp main.mbt backup 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(output.content.contains("line-anchored"))
+    expect_source_write_blocked(result, line_anchored=true)
     assert_true(@fs.exists("\{dir}/main.mbt"))
     assert_false(@fs.exists("\{dir}/backup/main.mbt"))
   })
@@ -1255,11 +1108,7 @@ async test "shell sandbox preblocks masked cp into created source directory" {
 async test "shell sandbox preserves mkdir predictions across fallback branches" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cp-or-created-dir-", dir => {
     @vfs.with_tmpdir(prefix="openseek-shell-sandbox-external-source-", external => {
-      @fs.write_file(
-        "\{dir}/main.mbt",
-        "pub fn answer() -> Int { 42 }\n",
-        create_mode=CreateOrTruncate,
-      )
+      write_answer_main(dir)
       @fs.write_file(
         "\{external}/generated.mbt",
         "pub fn generated() -> Int { 1 }\n",
@@ -1269,13 +1118,7 @@ async test "shell sandbox preserves mkdir predictions across fallback branches" 
         "cmd": "mkdir gen || true; cp \{external}/generated.mbt gen 2>/dev/null || true",
         "cwd": dir,
       })
-      guard result is Respond(output) else { fail("expected Respond") }
-      assert_true(output.is_error)
-      assert_true(output.content.contains("source tree operation is blocked"))
-      assert_true(
-        output.content.contains("source file writes from shell are blocked"),
-      )
-      assert_true(output.content.contains("line-anchored"))
+      expect_source_write_blocked(result, line_anchored=true)
       assert_false(@fs.exists("\{dir}/gen/generated.mbt"))
     })
   })
@@ -1312,13 +1155,7 @@ async test "shell sandbox preblocks scripted source directory renames" {
       "cmd": "python3 -c 'import os; os.rename(\"pkg\", \"pkg.bak\")' 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("source tree operation is blocked"))
-    assert_true(
-      output.content.contains("source file writes from shell are blocked"),
-    )
-    assert_true(output.content.contains("line-anchored"))
+    expect_source_write_blocked(result, line_anchored=true)
     assert_true(@fs.exists("\{dir}/pkg/main.mbt"))
     assert_false(@fs.exists("\{dir}/pkg.bak/main.mbt"))
   })
@@ -1349,13 +1186,7 @@ async test "shell sandbox preblocks scripted external source directory imports" 
         "cmd": "python3 -c 'import shutil; shutil.move(\"\{generated}\", \"pkg\")'",
         "cwd": workspace,
       })
-      guard result is Respond(output) else { fail("expected Respond") }
-      assert_true(output.is_error)
-      assert_true(output.content.contains("source tree operation is blocked"))
-      assert_true(
-        output.content.contains("source file writes from shell are blocked"),
-      )
-      assert_true(output.content.contains("line-anchored"))
+      expect_source_write_blocked(result, line_anchored=true)
       assert_true(@fs.exists("\{generated}/main.mbt"))
       assert_false(@fs.exists("\{workspace}/pkg/main.mbt"))
       let copy_result = run_shell_in_workspace(workspace, {
@@ -1701,11 +1532,7 @@ async test "shell sandbox still permits moon check build outputs" {
       "name = \"tmp/shell_sandbox_moon_check\"\n",
       create_mode=CreateOrTruncate,
     )
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
@@ -1738,11 +1565,7 @@ async test "shell allows moon check pre-build source outputs" {
       ),
       create_mode=CreateOrTruncate,
     )
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { generated() }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir, content="pub fn answer() -> Int { generated() }\n")
     let result = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
@@ -1814,11 +1637,7 @@ async test "shell sandbox blocks too-complex sed source rewrites" {
     return
   }
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-sed-glob-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { old }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
     let result = run_shell_in_workspace(dir, {
       "cmd": "sed -i '' 's/old/new/' *.mbt",
       "cwd": dir,
@@ -1830,9 +1649,9 @@ async test "shell sandbox blocks too-complex sed source rewrites" {
     )
     assert_true(output.content.contains("line-anchored"))
     assert_false(output.content.contains("`write`"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { old }\n",
+    assert_answer_main_unchanged(
+      dir,
+      content="pub fn answer() -> Int { old }\n",
     )
   })
 }
@@ -1841,11 +1660,7 @@ async test "shell sandbox blocks too-complex sed source rewrites" {
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks too-complex fd duplicate source redirect" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-fd-dup-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     let result = run_shell_in_workspace(dir, {
       "cmd": "printf changed >& main.mbt *.txt 2>/dev/null || true",
       "cwd": dir,
@@ -1853,10 +1668,7 @@ async test "shell sandbox preblocks too-complex fd duplicate source redirect" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    assert_answer_main_unchanged(dir)
   })
 }
 
@@ -1884,11 +1696,7 @@ async test "shell sandbox allows read-only grep of source text" {
 #cfg(not(platform="windows"))
 async test "shell preblocks env unset sed source rewrites" {
   @vfs.with_tmpdir(prefix="openseek-shell-env-sed-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { old }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
     let result = run_shell_in_workspace(dir, {
       "cmd": "env -u FOO sed -i '' 's/old/new/' *.mbt 2>/dev/null || true",
       "cwd": dir,
@@ -1900,9 +1708,9 @@ async test "shell preblocks env unset sed source rewrites" {
     )
     assert_true(output.content.contains("line-anchored"))
     assert_false(output.content.contains("`write`"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { old }\n",
+    assert_answer_main_unchanged(
+      dir,
+      content="pub fn answer() -> Int { old }\n",
     )
   })
 }
@@ -1911,11 +1719,7 @@ async test "shell preblocks env unset sed source rewrites" {
 #cfg(not(platform="windows"))
 async test "shell preblocks env assignment sed source rewrites" {
   @vfs.with_tmpdir(prefix="openseek-shell-env-assign-sed-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { old }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
     let result = run_shell_in_workspace(dir, {
       "cmd": "FOO=bar sed -i '' 's/old/new/' *.mbt 2>/dev/null || true",
       "cwd": dir,
@@ -1927,9 +1731,9 @@ async test "shell preblocks env assignment sed source rewrites" {
     )
     assert_true(output.content.contains("line-anchored"))
     assert_false(output.content.contains("`write`"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { old }\n",
+    assert_answer_main_unchanged(
+      dir,
+      content="pub fn answer() -> Int { old }\n",
     )
   })
 }
@@ -1938,11 +1742,7 @@ async test "shell preblocks env assignment sed source rewrites" {
 #cfg(not(platform="windows"))
 async test "shell preblocks find exec sed source rewrites" {
   @vfs.with_tmpdir(prefix="openseek-shell-find-sed-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { old }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
     let result = run_shell_in_workspace(dir, {
       "cmd": "find \{dir} -name '*.mbt' -exec env FOO=bar sed -i '' 's/old/new/' {} + 2>/dev/null || true",
       "cwd": dir,
@@ -1954,9 +1754,9 @@ async test "shell preblocks find exec sed source rewrites" {
     )
     assert_true(output.content.contains("line-anchored"))
     assert_false(output.content.contains("`write`"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { old }\n",
+    assert_answer_main_unchanged(
+      dir,
+      content="pub fn answer() -> Int { old }\n",
     )
   })
 }
@@ -1965,11 +1765,7 @@ async test "shell preblocks find exec sed source rewrites" {
 #cfg(not(platform="windows"))
 async test "shell preblocks looped sed source rewrites through path list" {
   @vfs.with_tmpdir(prefix="openseek-shell-loop-sed-source-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { old }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
     @fs.write_file(
       "\{dir}/files.txt",
       "\{dir}/main.mbt\n",
@@ -1986,9 +1782,9 @@ async test "shell preblocks looped sed source rewrites through path list" {
     )
     assert_true(output.content.contains("line-anchored"))
     assert_false(output.content.contains("`write`"))
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { old }\n",
+    assert_answer_main_unchanged(
+      dir,
+      content="pub fn answer() -> Int { old }\n",
     )
   })
 }
@@ -1997,11 +1793,7 @@ async test "shell preblocks looped sed source rewrites through path list" {
 #cfg(not(platform="windows"))
 async test "shell allows recoverable git worktree rollback" {
   @vfs.with_tmpdir(prefix="openseek-shell-git-rollback-", dir => {
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 42 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir)
     // Build a tiny repo with a committed main.mbt. init/config/add/commit only
     // touch `.git`, so they run (sandboxed) without being blocked.
     let setup = run_shell_in_workspace(dir, {
@@ -2014,11 +1806,7 @@ async test "shell allows recoverable git worktree rollback" {
     )
     // Dirty the tracked source, then discard the change with `git checkout` — a
     // trusted, recoverable worktree write that now runs unsandboxed and succeeds.
-    @fs.write_file(
-      "\{dir}/main.mbt",
-      "pub fn answer() -> Int { 999 }\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_answer_main(dir, content="pub fn answer() -> Int { 999 }\n")
     let result = run_shell_in_workspace(dir, {
       "cmd": "git checkout -- main.mbt",
       "cwd": dir,
@@ -2028,10 +1816,7 @@ async test "shell allows recoverable git worktree rollback" {
     assert_false(
       output.content.contains("source file writes from shell are blocked"),
     )
-    assert_eq(
-      @fs.read_file("\{dir}/main.mbt").text(),
-      "pub fn answer() -> Int { 42 }\n",
-    )
+    assert_answer_main_unchanged(dir)
   })
 }
 

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -1,4 +1,32 @@
 ///|
+/// Execute the shell_output tool for `job_id` and unwrap its Respond output.
+#cfg(not(platform="windows"))
+async fn run_shell_output(
+  bg : @bgjobs.BgJobRuntime,
+  job_id : String,
+) -> @agent_tool.ToolOutput {
+  let action = match @shell_output.definition(bg).execute {
+    Async(execute) => execute({ "job_id": job_id })
+    Sync(_) => fail("shell_output should be async")
+  }
+  guard action is Respond(output) else { fail("expected a Respond action") }
+  output
+}
+
+///|
+/// Poll until `id` leaves Running, on the same 200 x 25ms budget every test
+/// used inline (timing-sensitive: keep in lockstep with the old loops).
+#cfg(not(platform="windows"))
+async fn poll_bg_terminal(bg : @bgjobs.BgJobRuntime, id : String) -> Unit {
+  for _ in 0..<200 {
+    if bg.snapshot(id) is Some(s) && !(s.status is Running) {
+      break
+    }
+    @async.sleep(25)
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "shell_output returns a running job's output and status" {
   @async.with_task_group(group => {
@@ -9,11 +37,7 @@ async test "shell_output returns a running job's output and status" {
       command="job",
     )
     @async.sleep(100)
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_output(bg, id)
     assert_false(output.is_error)
     assert_true(output.content.contains("hi"))
     assert_true(output.content.contains("running"))
@@ -27,17 +51,8 @@ async test "shell_output reports a finished job's exit code" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "exit 2"], command="job")
-    for _ in 0..<200 {
-      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
-        break
-      }
-      @async.sleep(25)
-    }
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    poll_bg_terminal(bg, id)
+    let output = run_shell_output(bg, id)
     assert_true(output.is_error)
     assert_true(output.content.contains("exit=2"))
   })
@@ -55,17 +70,8 @@ async test "shell_output windows a large job's output and notes truncation" {
       command="seq",
       max_output_chars=100,
     )
-    for _ in 0..<200 {
-      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
-        break
-      }
-      @async.sleep(25)
-    }
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    poll_bg_terminal(bg, id)
+    let output = run_shell_output(bg, id)
     // Bounded to the window, with truncation metadata, but still showing the
     // recent (tail) output — here the end of the sequence.
     assert_true(output.content.contains("truncated=true"))
@@ -89,17 +95,8 @@ async test "shell_output flags dropped output for a memory-only job" {
       command="seq",
       max_output_chars=100,
     )
-    for _ in 0..<200 {
-      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
-        break
-      }
-      @async.sleep(25)
-    }
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    poll_bg_terminal(bg, id)
+    let output = run_shell_output(bg, id)
     // Only ~100 chars retained but the job produced far more — must not present
     // the prefix as complete.
     assert_true(output.content.contains("truncated=true"))
@@ -118,17 +115,8 @@ async test "shell_output marks binary background output as a tool error" {
       args=["-c", "printf '\\377'"],
       command="binary",
     )
-    for _ in 0..<200 {
-      if bg.snapshot(id) is Some(s) && !(s.status is Running) {
-        break
-      }
-      @async.sleep(25)
-    }
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    poll_bg_terminal(bg, id)
+    let output = run_shell_output(bg, id)
     assert_true(output.is_error)
     assert_true(output.content.contains("binary_output"))
   })
@@ -139,11 +127,7 @@ async test "shell_output marks binary background output as a tool error" {
 async test "shell_output errors on an unknown job id" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": "nope" })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_output(bg, "nope")
     assert_true(output.is_error)
     assert_true(output.content.contains("no background job"))
   })


### PR DESCRIPTION
Test-suite cleanup of `agent_tool` — assertions and expected values unchanged throughout, net **−730 lines**:

**Commit 1 — sandbox_wbtest.mbt (−492)**: the three preblock mega-tests repeated the same 7–10-line `parse_for_policy` → `*_target_for_root` nesting at **153 sites** (76 tree / 60 dynamic — which also passed the command text twice / 17 redirect). Added `tree_target`/`dyn_tree_target`/`redirect_target` beside the existing `mode_for` helper and folded every site to a short assert.

**Commit 2 — shell_test.mbt (−215)**: the masked-source-write catalog repeated the `main.mbt` fixture write (28×), the fixture-unchanged assert (22×), and the pre-execution refusal chain (17×). Extracted `write_answer_main` / `assert_answer_main_unchanged` / `expect_source_write_blocked`; tests with extra side-path assertions keep them inline.

**Commit 3 — shell_output_test.mbt / edit_test.mbt (−23)**: extracted the 6× dispatch-and-unwrap and 4× poll-until-terminal loops (poll keeps the exact 200×25ms budget — timing-sensitive); deleted `edit rejects unbounded replace_all`, a strict subset of `edit rejects replace_all even with a range` (same error string, same untouched-file assert; the guard fires before range handling).

## Testing
`moon check`/`fmt` clean; `agent_tool/shell` 115/115, `shell_output` 6/6, `edit` 30/30 (fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)