### PR TITLE
test(agent_session,agent,deepseek): dedupe test scaffolding

### DIFF
--- a/agent/mock_server_test.mbt
+++ b/agent/mock_server_test.mbt
@@ -1,0 +1,16 @@
+///|
+/// Bind a localhost mock server for one test, or report the skip and return
+/// None where the sandbox forbids TCP binds.
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}

--- a/agent/plan_reminder_test.mbt
+++ b/agent/plan_reminder_test.mbt
@@ -1,4 +1,15 @@
 ///|
+/// The durable plan-reminder notices recorded in `result`, in order.
+fn plan_reminders(result : @agent_session.Session) -> Array[String] {
+  [
+    for event in result.events() if event.item() is Runtime(notice) &&
+    notice.content().contains(@agent_session.PlanReminderPrefix) => {
+      notice.content()
+    }
+  ]
+}
+
+///|
 /// A scripted DeepSeek stand-in that keeps a turn alive with `plan` calls
 /// whose arguments are invalid — each yields an error tool result, which
 /// never resets the staleness cadence — for the first `plan_calls` requests,
@@ -11,15 +22,11 @@ async fn stale_plan_test_server(
   bodies : Array[String],
   plan_calls~ : Int,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping plan reminder test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server(
+      "local TCP bind unavailable; skipping plan reminder test",
+    )
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -88,12 +95,7 @@ async test "a plan-silent turn gets one staleness reminder after ten requests" {
     )
     assert_true(bodies[10].contains("has not been used in this turn"))
     // The reminder is durable exactly once, in its plan-free nag variant.
-    let reminders = [
-      for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains(@agent_session.PlanReminderPrefix) => {
-        notice.content()
-      }
-    ]
+    let reminders = plan_reminders(result)
     assert_eq(reminders.length(), 1)
     assert_true(reminders[0].contains("has not been used in this turn"))
     guard result.events().peek() is Some(last) &&
@@ -115,15 +117,11 @@ async fn recorded_plan_test_server(
   bodies : Array[String],
   plan_calls~ : Int,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping plan reminder test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server(
+      "local TCP bind unavailable; skipping plan reminder test",
+    )
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -196,12 +194,7 @@ async test "a recorded plan delays the reminder and is re-surfaced by it" {
     )
     assert_true(bodies[11].contains("Current plan:"))
     assert_true(bodies[11].contains("1. [in_progress] fix the parser"))
-    let reminders = [
-      for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains(@agent_session.PlanReminderPrefix) => {
-        notice.content()
-      }
-    ]
+    let reminders = plan_reminders(result)
     assert_eq(reminders.length(), 1)
     assert_true(reminders[0].contains("1. [in_progress] fix the parser"))
   }
@@ -266,12 +259,7 @@ async test "the no-plan nag fires at most once per turn" {
       1,
       msg="no later request may gain a second no-plan nag",
     )
-    let reminders = [
-      for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains(@agent_session.PlanReminderPrefix) => {
-        notice.content()
-      }
-    ]
+    let reminders = plan_reminders(result)
     assert_eq(reminders.length(), 1)
     assert_true(reminders[0].contains("has not been used in this turn"))
   }
@@ -329,12 +317,7 @@ async test "a stale recorded plan re-nags on the ten-request cadence" {
       2,
       msg="request 22 should carry the second checklist reminder",
     )
-    let reminders = [
-      for event in result.events() if event.item() is Runtime(notice) &&
-      notice.content().contains(@agent_session.PlanReminderPrefix) => {
-        notice.content()
-      }
-    ]
+    let reminders = plan_reminders(result)
     assert_eq(reminders.length(), 2)
     assert_true(reminders[0].contains("1. [in_progress] fix the parser"))
     assert_true(reminders[1].contains("1. [in_progress] fix the parser"))

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -3,15 +3,9 @@
 /// carries both the original task and the steered text as user messages, then
 /// streams a plain content answer so the turn finishes without tool calls.
 async fn steer_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping steer test: \{message}")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server("local TCP bind unavailable; skipping steer test")
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -88,15 +82,9 @@ async fn override_test_server(
   group : @async.TaskGroup[Unit],
   runtime : @agent_runtime.AgentRuntime,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping override test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server("local TCP bind unavailable; skipping override test")
+    is Some(server) else {
+    return None
   }
   let mut requests = 0
   group.spawn_bg(no_wait=true) <| () => {
@@ -174,15 +162,9 @@ async fn inject_override_test_server(
   runtime : @agent_runtime.AgentRuntime,
   context : String,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping inject test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server("local TCP bind unavailable; skipping inject test")
+    is Some(server) else {
+    return None
   }
   let mut requests = 0
   group.spawn_bg(no_wait=true) <| () => {
@@ -322,15 +304,11 @@ fn log_event(entry : Json) -> String {
 
 ///|
 async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping reasoning log test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server(
+      "local TCP bind unavailable; skipping reasoning log test",
+    )
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -401,15 +379,9 @@ async fn notice_test_server(
   runtime : @agent_runtime.AgentRuntime,
   notice : String,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping notice test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server("local TCP bind unavailable; skipping notice test")
+    is Some(server) else {
+    return None
   }
   let mut requests = 0
   group.spawn_bg(no_wait=true) <| () => {

--- a/agent/tool_batch_test.mbt
+++ b/agent/tool_batch_test.mbt
@@ -1,14 +1,8 @@
 ///|
 async fn tool_batch_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping tool batch test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server("local TCP bind unavailable; skipping tool batch test")
+    is Some(server) else {
+    return None
   }
   let mut requests = 0
   group.spawn_bg(no_wait=true) <| () => {
@@ -115,15 +109,11 @@ async test "agent executes each normal tool call in a response batch" {
 async fn max_step_exhaustion_test_server(
   group : @async.TaskGroup[Unit],
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping max-step exhaustion test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server(
+      "local TCP bind unavailable; skipping max-step exhaustion test",
+    )
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -195,15 +185,11 @@ async test "max-step exhaustion preserves continued session state" {
 
 ///|
 async fn append_failure_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping append failure test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server(
+      "local TCP bind unavailable; skipping append failure test",
+    )
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -79,16 +79,15 @@ async test "store validates invalid ids before creating directories" {
   let parent = @fs.tmpdir(prefix="openseek-session-store-invalid-")
   let root = "\{parent}/missing-root"
   let store : @store.SessionStore = SessionStore(root)
-  let _ = store.create(Session(SessionId("../bad"), system_prompt="system")) catch {
+  try store.create(Session(SessionId("../bad"), system_prompt="system")) catch {
     error => {
       assert_true("\{error}".contains("path separators"))
       assert_true(!@fs.exists("\{root}/sessions"))
-      @fs.rmdir(parent, recursive=true)
-      return
     }
+  } noraise {
+    _ => fail("invalid session id accepted")
   }
   @fs.rmdir(parent, recursive=true)
-  fail("invalid session id accepted")
 }
 
 ///|
@@ -174,15 +173,12 @@ async test "store propagates non-missing list errors" {
     "not a directory",
     create_mode=CreateOrTruncate,
   )
-  let _ = store.list() catch {
-    error => {
-      assert_true("\{error}" != "")
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  try store.list() catch {
+    error => assert_true("\{error}" != "")
+  } noraise {
+    _ => fail("list error was silently treated as empty")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("list error was silently treated as empty")
 }
 
 ///|
@@ -302,17 +298,16 @@ async test "another store instance's write defeats the fingerprint fast path" {
   let from_a = store_a.append(session, User(UserMessage("from a")))
   let loaded_by_b = store_b.load(SessionId("s1"))
   ignore(store_b.append(loaded_by_b, Runtime(RuntimeNotice("from b"))))
-  let _ = store_a.append(from_a, Runtime(RuntimeNotice("stale from a"))) catch {
+  try store_a.append(from_a, Runtime(RuntimeNotice("stale from a"))) catch {
     error => {
       assert_true("\{error}".contains("stale session snapshot"))
       let loaded = store_a.load(SessionId("s1"))
       assert_eq(loaded.events().length(), 2)
-      @fs.rmdir(store_a.root(), recursive=true)
-      return
     }
+  } noraise {
+    _ => fail("stale append past the fast path was accepted")
   }
   @fs.rmdir(store_a.root(), recursive=true)
-  fail("stale append past the fast path was accepted")
 }
 
 ///|
@@ -330,16 +325,15 @@ async test "a same-size rewrite by another store is still detected" {
   // beat between writes to order reliably.
   @async.sleep(50)
   store_b.create(Session(SessionId("s1"), system_prompt="prompt B"))
-  let _ = store_a.append(session, User(UserMessage("stale"))) catch {
+  try store_a.append(session, User(UserMessage("stale"))) catch {
     error => {
       assert_true("\{error}".contains("stale session snapshot"))
       assert_eq(store_a.load(SessionId("s1")).system_prompt(), "prompt B")
-      @fs.rmdir(store_a.root(), recursive=true)
-      return
     }
+  } noraise {
+    _ => fail("same-size rewrite slipped past the fingerprint fast path")
   }
   @fs.rmdir(store_a.root(), recursive=true)
-  fail("same-size rewrite slipped past the fingerprint fast path")
 }
 
 ///|
@@ -348,17 +342,16 @@ async test "store rejects stale snapshots before appending" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   store.create(session)
   ignore(store.append(session, User(UserMessage("first"))))
-  let _ = store.append(session, Runtime(RuntimeNotice("stale"))) catch {
+  try store.append(session, Runtime(RuntimeNotice("stale"))) catch {
     error => {
       assert_true("\{error}".contains("stale session snapshot"))
       let loaded = store.load(SessionId("s1"))
       assert_eq(loaded.events().length(), 1)
-      @fs.rmdir(store.root(), recursive=true)
-      return
     }
+  } noraise {
+    _ => fail("stale append was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("stale append was accepted")
 }
 
 ///|
@@ -373,18 +366,17 @@ async test "store rejects divergent snapshots with the same sequence" {
     events=session.events(),
   )
   store.create(session)
-  let _ = store.append(divergent, Runtime(RuntimeNotice("stale"))) catch {
+  try store.append(divergent, Runtime(RuntimeNotice("stale"))) catch {
     error => {
       assert_true("\{error}".contains("stale session snapshot"))
       let loaded = store.load(SessionId("s1"))
       assert_eq(loaded.system_prompt(), "system")
       assert_eq(loaded.events().length(), 1)
-      @fs.rmdir(store.root(), recursive=true)
-      return
     }
+  } noraise {
+    _ => fail("divergent same-sequence append was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("divergent same-sequence append was accepted")
 }
 
 ///|
@@ -395,15 +387,12 @@ async test "store rejects non-empty snapshots when the session file is missing" 
   )
   store.create(session)
   @fs.remove(session_file(store, "s1"))
-  let _ = store.append(session, Runtime(RuntimeNotice("more"))) catch {
-    error => {
-      assert_true("\{error}".contains("stale session snapshot"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  try store.append(session, Runtime(RuntimeNotice("more"))) catch {
+    error => assert_true("\{error}".contains("stale session snapshot"))
+  } noraise {
+    _ => fail("append onto a missing session file was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("append onto a missing session file was accepted")
 }
 
 ///|
@@ -434,18 +423,9 @@ async test "store serializes concurrent appends from the same snapshot" {
       }
     }
   }
-  let mut ok = 0
-  let mut stale = 0
-  for result in results {
-    if result == "ok" {
-      ok += 1
-    } else if result == "stale" {
-      stale += 1
-    }
-  }
+  assert_eq(results.filter(r => r == "ok").length(), 1)
+  assert_eq(results.filter(r => r == "stale").length(), 1)
   let loaded = store.load(SessionId("s1"))
-  assert_eq(ok, 1)
-  assert_eq(stale, 1)
   assert_eq(loaded.events().length(), 1)
   assert_eq(loaded.last_sequence(), 1)
   @fs.rmdir(store.root(), recursive=true)
@@ -459,22 +439,23 @@ async test "store rejects stale snapshots before compacting" {
     .append(Assistant(AssistantMessage("second")))
   store.create(session)
   ignore(store.append(session, Runtime(RuntimeNotice("new durable tail"))))
-  let _ = store.compact(
-    session,
-    content="first two events",
-    from_sequence=1,
-    to_sequence=2,
-  ) catch {
+  try
+    store.compact(
+      session,
+      content="first two events",
+      from_sequence=1,
+      to_sequence=2,
+    )
+  catch {
     error => {
       assert_true("\{error}".contains("stale session snapshot"))
       let loaded = store.load(SessionId("s1"))
       assert_eq(loaded.events().length(), 3)
-      @fs.rmdir(store.root(), recursive=true)
-      return
     }
+  } noraise {
+    _ => fail("stale compact was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("stale compact was accepted")
 }
 
 ///|
@@ -482,15 +463,12 @@ async test "store fails load when the session file is missing" {
   let store = new_store()
   store.create(Session(SessionId("s1"), system_prompt="system"))
   @fs.remove(session_file(store, "s1"))
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
-      assert_true("\{error}" != "")
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  try store.load(SessionId("s1")) catch {
+    error => assert_true("\{error}" != "")
+  } noraise {
+    _ => fail("missing session file was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("missing session file was accepted")
 }
 
 ///|
@@ -506,15 +484,13 @@ async test "store rejects a session file without a header record" {
     "\{event.to_json().stringify()}\n",
     create_mode=CreateOrTruncate,
   )
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
+  try store.load(SessionId("s1")) catch {
+    error =>
       assert_true("\{error}".contains("does not start with a header record"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  } noraise {
+    _ => fail("header-less session file was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("header-less session file was accepted")
 }
 
 ///|
@@ -526,15 +502,13 @@ async test "store rejects a malformed header line" {
     "not json at all\n",
     create_mode=CreateOrTruncate,
   )
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
+  try store.load(SessionId("s1")) catch {
+    error =>
       assert_true("\{error}".contains("does not start with a header line"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  } noraise {
+    _ => fail("malformed header line was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("malformed header line was accepted")
 }
 
 ///|
@@ -547,15 +521,12 @@ async test "store rejects a header whose id does not match the directory" {
     @fs.read_file(session_file(store, "other")).text(),
     create_mode=CreateOrTruncate,
   )
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
-      assert_true("\{error}".contains("session header id mismatch"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  try store.load(SessionId("s1")) catch {
+    error => assert_true("\{error}".contains("session header id mismatch"))
+  } noraise {
+    _ => fail("mismatched header id was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("mismatched header id was accepted")
 }
 
 ///|
@@ -672,7 +643,7 @@ async test "append rejects a stale snapshot against an unterminated durable even
     create_mode=OpenOrCreate,
     append=true,
   )
-  let _ = store.append(session, Runtime(RuntimeNotice("stale"))) catch {
+  try store.append(session, Runtime(RuntimeNotice("stale"))) catch {
     error => {
       assert_true("\{error}".contains("stale session snapshot"))
       let loaded = store.load(SessionId("s1"))
@@ -681,12 +652,11 @@ async test "append rejects a stale snapshot against an unterminated durable even
         fail("expected the durable user event to survive")
       }
       assert_eq(message.content(), "first")
-      @fs.rmdir(store.root(), recursive=true)
-      return
     }
+  } noraise {
+    _ => fail("stale append onto an unterminated durable event was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("stale append onto an unterminated durable event was accepted")
 }
 
 ///|
@@ -813,7 +783,7 @@ async test "load still fails on corruption that is not a torn tail" {
     create_mode=OpenOrCreate,
     append=true,
   )
-  let _ = store.load(SessionId("s1")) catch {
+  try store.load(SessionId("s1")) catch {
     error => {
       assert_true("\{error}" != "")
       // A bad line with valid lines after it fails the same way.
@@ -824,19 +794,16 @@ async test "load still fails on corruption that is not a torn tail" {
         create_mode=OpenOrCreate,
         append=true,
       )
-      let _ = store.load(SessionId("s1")) catch {
-        error => {
-          assert_true("\{error}" != "")
-          @fs.rmdir(store.root(), recursive=true)
-          return
-        }
+      try store.load(SessionId("s1")) catch {
+        error => assert_true("\{error}" != "")
+      } noraise {
+        _ => fail("interior corruption was accepted")
       }
-      @fs.rmdir(store.root(), recursive=true)
-      fail("interior corruption was accepted")
     }
+  } noraise {
+    _ => fail("terminated garbage line was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("terminated garbage line was accepted")
 }
 
 ///|
@@ -849,15 +816,12 @@ async test "store propagates unreadable session files instead of dropping histor
   let path = session_file(store, "s1")
   @fs.remove(path)
   @fs.mkdir(path)
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
-      assert_true("\{error}" != "")
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  try store.load(SessionId("s1")) catch {
+    error => assert_true("\{error}" != "")
+  } noraise {
+    _ => fail("unreadable session file was silently accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("unreadable session file was silently accepted")
 }
 
 ///|
@@ -869,42 +833,35 @@ async test "store names an unsupported session file version on load" {
     "{\"version\":2,\"id\":\"s1\",\"system_prompt\":\"system\"}\n",
     create_mode=CreateOrTruncate,
   )
-  let _ = store.load(SessionId("s1")) catch {
-    error => {
+  try store.load(SessionId("s1")) catch {
+    error =>
       assert_true("\{error}".contains("unsupported session file version 2"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  } noraise {
+    _ => fail("version-2 session file was accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("version-2 session file was accepted")
 }
 
 ///|
 async test "store rejects session ids containing NUL" {
   let store = new_store()
-  let _ = store.exists(SessionId("bad\u{0}id")) catch {
-    error => {
-      assert_true("\{error}".contains("NUL"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  try store.exists(SessionId("bad\u{0}id")) catch {
+    error => assert_true("\{error}".contains("NUL"))
+  } noraise {
+    _ => fail("NUL in session id accepted")
   }
   @fs.rmdir(store.root(), recursive=true)
-  fail("NUL in session id accepted")
 }
 
 ///|
 async test "store rejects path-like session ids" {
   let store = new_store()
-  let _ = store.exists(SessionId("../bad")) catch {
-    error => {
-      assert_true("\{error}".contains("path separators"))
-      @fs.rmdir(store.root(), recursive=true)
-      return
-    }
+  try store.exists(SessionId("../bad")) catch {
+    error => assert_true("\{error}".contains("path separators"))
+  } noraise {
+    _ => fail("invalid session id accepted")
   }
-  fail("invalid session id accepted")
+  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -8,15 +8,9 @@ async fn flaky_server(
   status~ : Int,
   sse? : Bool = false,
 ) -> (String, Ref[Int])? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping retry test: \{message}")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server("local TCP bind unavailable; skipping retry test")
+    is Some(server) else {
+    return None
   }
   let hits : Ref[Int] = { val: 0 }
   group.spawn_bg(no_wait=true) <| () => {
@@ -171,15 +165,9 @@ async test "streaming Kimi chat retries a pre-stream 502 and then streams" {
 /// serves the full stream.
 async test "streaming chat retries a pre-delta stream drop" {
   @async.with_task_group() <| group => {
-    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-      error => {
-        let message = "\{error}"
-        if message.contains("Operation not permitted") {
-          println("local TCP bind unavailable; skipping retry test")
-          return
-        }
-        raise error
-      }
+    guard bind_test_server("local TCP bind unavailable; skipping retry test")
+      is Some(server) else {
+      return
     }
     let hits : Ref[Int] = { val: 0 }
     group.spawn_bg(no_wait=true) <| () => {
@@ -224,15 +212,9 @@ async test "streaming chat retries a pre-delta stream drop" {
 /// second hit.
 async test "streaming chat never retries after the first delta" {
   @async.with_task_group() <| group => {
-    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-      error => {
-        let message = "\{error}"
-        if message.contains("Operation not permitted") {
-          println("local TCP bind unavailable; skipping retry test")
-          return
-        }
-        raise error
-      }
+    guard bind_test_server("local TCP bind unavailable; skipping retry test")
+      is Some(server) else {
+      return
     }
     let hits : Ref[Int] = { val: 0 }
     group.spawn_bg(no_wait=true) <| () => {
@@ -281,15 +263,9 @@ async test "streaming chat never retries after the first delta" {
 /// review: the bail flag used to track callback-delivered text only.)
 async test "streaming chat never retries after a tool-call-only delta" {
   @async.with_task_group() <| group => {
-    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-      error => {
-        let message = "\{error}"
-        if message.contains("Operation not permitted") {
-          println("local TCP bind unavailable; skipping retry test")
-          return
-        }
-        raise error
-      }
+    guard bind_test_server("local TCP bind unavailable; skipping retry test")
+      is Some(server) else {
+      return
     }
     let hits : Ref[Int] = { val: 0 }
     group.spawn_bg(no_wait=true) <| () => {

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -4,15 +4,9 @@ async fn stream_test_server(
   finish? : Bool = true,
   kimi_usage? : Bool = false,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping stream test: \{message}")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server("local TCP bind unavailable; skipping stream test")
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -117,15 +111,11 @@ async test "chat stream handler accumulates Kimi stream_options usage" {
 /// bound this `read_until` blocks indefinitely (the observed production hang).
 async test "streaming chat retries an idle stall before any event" {
   @async.with_task_group() <| group => {
-    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-      error => {
-        let message = "\{error}"
-        if message.contains("Operation not permitted") {
-          println("local TCP bind unavailable; skipping idle-stall test")
-          return
-        }
-        raise error
-      }
+    guard bind_test_server(
+        "local TCP bind unavailable; skipping idle-stall test",
+      )
+      is Some(server) else {
+      return
     }
     let hits : Ref[Int] = { val: 0 }
     group.spawn_bg(no_wait=true) <| () => {
@@ -176,15 +166,11 @@ async test "streaming chat retries an idle stall before any event" {
 /// is no second hit.
 async test "streaming chat fails an idle stall after a delta without retrying" {
   @async.with_task_group() <| group => {
-    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-      error => {
-        let message = "\{error}"
-        if message.contains("Operation not permitted") {
-          println("local TCP bind unavailable; skipping idle-stall test")
-          return
-        }
-        raise error
-      }
+    guard bind_test_server(
+        "local TCP bind unavailable; skipping idle-stall test",
+      )
+      is Some(server) else {
+      return
     }
     let hits : Ref[Int] = { val: 0 }
     group.spawn_bg(no_wait=true) <| () => {
@@ -237,15 +223,11 @@ async test "streaming chat fails an idle stall after a delta without retrying" {
 /// replaying a half-consumed completion. Exactly one hit; the delta is seen.
 async test "streaming chat does not retry an idle stall after an unterminated data line" {
   @async.with_task_group() <| group => {
-    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-      error => {
-        let message = "\{error}"
-        if message.contains("Operation not permitted") {
-          println("local TCP bind unavailable; skipping idle-stall test")
-          return
-        }
-        raise error
-      }
+    guard bind_test_server(
+        "local TCP bind unavailable; skipping idle-stall test",
+      )
+      is Some(server) else {
+      return
     }
     let hits : Ref[Int] = { val: 0 }
     group.spawn_bg(no_wait=true) <| () => {

--- a/deepseek/client/mock_server_test.mbt
+++ b/deepseek/client/mock_server_test.mbt
@@ -1,0 +1,16 @@
+///|
+/// Bind a localhost mock server for one test, or report the skip and return
+/// None where the sandbox forbids TCP binds.
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -202,18 +202,6 @@ test "kimi highspeed uses the same code-model request policy" {
 }
 
 ///|
-test "tools and thinking are omitted when absent" {
-  let body = @deepseek.encode_chat_request(model=Deepseek(V4Flash)) <| [
-    ChatMessage(User, content="hi"),
-  ]
-  json_inspect(body, content={
-    "model": "deepseek-v4-flash",
-    "messages": [{ "role": "user", "content": "hi" }],
-    "stream": false,
-  })
-}
-
-///|
 test "assistant tool-call echo and tool result round-trip" {
   let call = @deepseek.ToolCall(
     id="call_42",


### PR DESCRIPTION
Test-suite cleanup across the session/agent/deepseek packages — net −186 lines, one true duplicate removed:

**Commit 1 — agent_session/store (−43)**: eighteen expected-error tests used the same catch \{ asserts; rmdir; return \} + trailing rmdir + fail() shape, duplicating cleanup in every catch arm (one test skipped cleanup on a path entirely). Rewritten as `try … catch { asserts } noraise { fail }` — the form the decode tests already use — with a single trailing rmdir on every path. (`defer` was tried first; MoonBit forbids async/raising calls in `defer`.) Also normalized one manual ok/stale counting loop to the `filter().length()` form its sibling uses.

**Commit 2 — agent/ + deepseek/client (−121)**: the ten-line localhost bind-or-skip block was copy-pasted into all **18** mock-server builders; extracted a per-package `bind_test_server(skip_message)` helper. Three sites that interpolated the raw bind error into the skip println now print the plain message like the other fifteen (skip-path diagnostics only). Also `plan_reminders(result)` names the durable-notices comprehension repeated at 4 sites in plan_reminder_test.

**Commit 3 — deepseek (−13)**: deleted `tools and thinking are omitted when absent` — it snapshotted the identical option set as the file's opening `minimal request` test (same encoder call, same full-body json_inspect). Zero coverage lost.

## Testing
`moon check`/`fmt` clean (0 warnings); `agent_session/store` 45/45, `agent` 21/21, `deepseek/client` 25/25, `deepseek` 39/39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)