### PR TITLE
feat: /goal — a durable long-horizon objective

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -139,6 +139,7 @@ async test "standard tools are registered in dispatch order" {
         #|  "multi_edit",
         #|  "write",
         #|  "plan",
+        #|  "goal",
         #|  "finish",
         #|]
       ),

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -173,6 +173,12 @@ async fn AgentLoop::yield_at_context_ceiling(
   session : @agent_session.Session,
   steers : ArrayView[@agent_runtime.SteerInput],
 ) -> @agent_session.Session {
+  // A goal(met) recorded in the turn's final batch defers its durable
+  // [goal cleared] tombstone to a batch-safe boundary; every yield site
+  // has the batch closed, and without this flush the tombstone would be
+  // lost — current_goal() would resurrect a goal the model already met,
+  // and auto-continue would keep chaining toward it.
+  let session = self.flush_goal_tombstone(session)
   let to_sequence = session.last_sequence()
   let (session, compacted) = self.checkpoint_at_ceiling(session, steers)
   // The summary request takes seconds; steers submitted while it was in

--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -1,0 +1,307 @@
+///|
+/// The turn-start reminder is a DECISION POINT, not just an alignment
+/// note: each turn — under auto-continue, each context-window cycle —
+/// opens with a brief three-way assessment. Catching "already met" or
+/// "cannot proceed" here saves a whole window of work; the finish check
+/// still gates the exit so a completion cannot slip out unverified.
+fn goal_reminder_text(goal : String, tool_registered~ : Bool) -> String {
+  let met_action = if tool_registered {
+    "record that by calling the goal tool with status \"met\", then finish"
+  } else {
+    "finish and say so"
+  }
+  (
+    $|\{@agent_session.GoalReminderPrefix}
+    $|The standing goal for this session:
+    $|\{goal}
+    $|Assess it briefly at this turn boundary:
+    $|- Fully met? Verify per the goal's own criteria first, then
+    $|  \{met_action}.
+    $|- Unable to proceed (blocked, impossible, or superseded)? Record that
+    $|  — call the goal tool with status "blocked" and a reason if it is
+    $|  available, otherwise say why — then finish; the user decides what
+    $|  is next.
+    $|- Otherwise continue working toward it. If the current task conflicts
+    $|  with the goal, the current task wins; note the conflict briefly.
+  )
+}
+
+///|
+fn goal_check_text(goal : String, tool_registered~ : Bool) -> String {
+  if tool_registered {
+    (
+      $|\{@agent_session.GoalCheckPrefix}
+      $|The standing goal for this session:
+      $|\{goal}
+      $|You attempted to finish. If the goal is fully met, record that by
+      $|calling the goal tool with status "met", then finish. If this task
+      $|is complete but the goal is not, call the goal tool with status
+      $|"continuing" and what remains, then finish. If the goal cannot
+      $|proceed (blocked, impossible, or superseded), call the goal tool
+      $|with status "blocked" and a reason, then finish — the user decides
+      $|what is next. Otherwise continue working toward the goal.
+    )
+  } else {
+    (
+      $|\{@agent_session.GoalCheckPrefix}
+      $|The standing goal for this session:
+      $|\{goal}
+      $|You attempted to finish. If the goal is fully met, finish again and
+      $|say so. If this task is complete but the goal is not, finish with a
+      $|one-line status of what remains. Otherwise continue working toward
+      $|the goal.
+    )
+  }
+}
+
+///|
+/// Standing-goal tracking for one turn, parallel to `PlanCadence`. Seeded
+/// from the durable log at loop construction; a mid-turn goal set/clear
+/// steer updates it live through `observe_notice`. Turn-local by design — a
+/// fresh loop re-derives the goal from the session.
+///
+/// `remind_now` starts true only when the model has already answered since
+/// the goal was set: a fresh set marker still rides the next request, so a
+/// turn-start reminder would only duplicate it. `finish_checked` caps the
+/// finish-time goal check at one per turn — the model may end the turn
+/// immediately after answering the check, so a turn is never held hostage.
+priv struct GoalCadence {
+  /// Whether the goal status tool is in this turn's registry: selects the
+  /// tool-aware finish-check text and enables the structured met/continuing
+  /// protocol.
+  tool_registered : Bool
+  mut goal : String?
+  mut remind_now : Bool
+  mut finish_checked : Bool
+  /// A blocked verdict awaiting its durable marker at a batch-safe
+  /// boundary, exactly like the met tombstone.
+  mut pending_blocked_reason : String?
+  /// A goal(met) call was recorded mid-batch; the durable [goal cleared]
+  /// tombstone must land only at a batch-safe boundary (next step start or
+  /// turn finish) — a mid-batch runtime notice would make replay synthesize
+  /// exited-errors for the batch's remaining tool calls.
+  mut pending_tombstone : Bool
+}
+
+///|
+fn GoalCadence::GoalCadence(
+  session : @agent_session.Session,
+  tool_registered~ : Bool,
+) -> GoalCadence {
+  match session.current_goal() {
+    Some(goal) =>
+      {
+        tool_registered,
+        goal: Some(goal.text()),
+        remind_now: goal.answered_since_set(),
+        finish_checked: false,
+        pending_blocked_reason: None,
+        pending_tombstone: false,
+      }
+    None =>
+      {
+        tool_registered,
+        goal: None,
+        remind_now: false,
+        finish_checked: false,
+        pending_blocked_reason: None,
+        pending_tombstone: false,
+      }
+  }
+}
+
+///|
+/// The goal text when a finish attempt should be answered with a goal check
+/// instead of ending the turn.
+fn GoalCadence::due_finish_check(self : GoalCadence) -> String? {
+  if self.finish_checked {
+    return None
+  }
+  self.goal
+}
+
+///|
+/// A structured goal(met) call: the goal stops standing immediately (the
+/// finish check disarms) and the durable tombstone is deferred to the next
+/// batch-safe boundary.
+fn GoalCadence::record_goal_met(self : GoalCadence) -> Unit {
+  self.goal = None
+  self.pending_tombstone = true
+}
+
+///|
+/// A structured goal(continuing) call answers exactly what the finish check
+/// would ask, so the check disarms for the rest of the turn.
+fn GoalCadence::record_goal_continuing(self : GoalCadence) -> Unit {
+  self.finish_checked = true
+}
+
+///|
+fn GoalCadence::record_finish_check(self : GoalCadence) -> Unit {
+  self.finish_checked = true
+  // The check restates the goal, so it counts as the turn's reminder:
+  // without the reset, a pending turn-start reminder could fire right
+  // after the check, burying the confirmation ask it just injected.
+  self.remind_now = false
+}
+
+///|
+/// The goal text when a reminder is due: once per turn, at the start. No
+/// mid-turn re-reminders — since turns became context-bounded, nothing
+/// ever leaves the model's context within a turn, so the turn-start
+/// reminder (or the goal marker itself) stays visible throughout; the
+/// finish check is the enforcement point, and under auto-continue each
+/// context-window cycle starts a fresh turn that re-surfaces the goal
+/// right after the checkpoint.
+fn GoalCadence::due_reminder(self : GoalCadence) -> String? {
+  guard self.goal is Some(goal) else { return None }
+  if self.remind_now {
+    Some(goal)
+  } else {
+    None
+  }
+}
+
+///|
+fn GoalCadence::record_reminder(self : GoalCadence) -> Unit {
+  self.remind_now = false
+}
+
+///|
+/// Track a durably applied notice steer. A goal set/clear marker updates the
+/// live cadence and reports the new state as a `goal_updated` event. The
+/// event is emitted here — after the durable append, never at queue time —
+/// so a controller can only learn a goal that was actually persisted.
+fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
+  match @agent_session.goal_marker(content) {
+    Some(GoalSet(text)) => {
+      self.goal = Some(text)
+      self.remind_now = false
+      // A NEW goal deserves its own finish check: without this reset, a
+      // goal set after an earlier check in the same turn would let the
+      // next finish attempt end the turn unconfirmed.
+      self.finish_checked = false
+      // A deferred tombstone belonged to the goal this set supersedes;
+      // flushing it after the new marker would wipe the new goal (last
+      // marker wins in the scan).
+      self.pending_tombstone = false
+      // Same for a deferred blocked verdict: flushing it after the new
+      // marker would mark the REPLACEMENT goal blocked.
+      self.pending_blocked_reason = None
+      @xlog.info() <? { "event": "goal_updated", "goal": text }
+    }
+    Some(GoalCleared) => {
+      self.goal = None
+      // A durable clear just landed; a second tombstone would be noise.
+      self.pending_tombstone = false
+      self.pending_blocked_reason = None
+      @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
+    }
+    // A blocked marker changes auto-continuation policy (serve reads it
+    // from the standing goal), not the cadence: the goal still stands.
+    Some(GoalBlocked(_)) => ()
+    None => ()
+  }
+}
+
+///|
+/// Flush a deferred goal tombstone at a batch-safe boundary: the durable
+/// `[goal cleared]` clear for a goal(met) recorded mid-batch, appended
+/// through the loop's persistence seam and reported as `goal_updated` only
+/// after that append succeeds.
+async fn AgentLoop::flush_goal_tombstone(
+  self : Self,
+  session : @agent_session.Session,
+) -> @agent_session.Session {
+  let session = if self.goal_cadence.pending_blocked_reason is Some(reason) {
+    let marker = "\{@agent_session.GoalBlockedPrefix}\n\{reason}"
+    let next = self.append(session, Runtime(RuntimeNotice(marker)))
+    self.messages.push(ChatMessage(User, content=marker))
+    // Cleared only AFTER the durable append, like the tombstone.
+    self.goal_cadence.pending_blocked_reason = None
+    @xlog.info() <? { "event": "goal_blocked", "reason": reason }
+    next
+  } else {
+    session
+  }
+  if !self.goal_cadence.pending_tombstone {
+    return session
+  }
+  let next = self.append(
+    session,
+    Runtime(RuntimeNotice(@agent_session.GoalClearedNotice)),
+  )
+  // Cleared only AFTER the durable append: a failed append must leave the
+  // flag set so the error-path retry still lands the tombstone — otherwise
+  // a durable goal(met) result coexists with a resurrected goal on resume.
+  self.goal_cadence.pending_tombstone = false
+  self.messages.push(
+    ChatMessage(User, content=@agent_session.GoalClearedNotice),
+  )
+  @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
+  next
+}
+
+///|
+/// Handle a `goal` status tool call in place of executing the registry
+/// entry: only the loop knows whether a goal currently stands, and the
+/// durable clear must be sequenced at a batch-safe boundary. `met` clears
+/// the standing goal (tombstone deferred via `record_goal_met`);
+/// `continuing` records the structured remainder and stands in for the
+/// finish check. Either with no standing goal is an error result — a
+/// semantic assertion against missing state should read as model confusion
+/// in the transcript, not success.
+async fn AgentLoop::handle_goal_tool_call(
+  self : Self,
+  session : @agent_session.Session,
+  native_call : @deepseek.ToolCall,
+  tool_call : @agent_tool.AgentToolCall,
+) -> ToolCallOutcome {
+  let verdict = (
+    @goal.decode_status(tool_call.arguments),
+    self.goal_cadence.goal,
+  )
+  let (content, is_error) = match verdict {
+    (Err(message), _) => ("error: \{message}", true)
+    (Ok(_), None) => ("error: no standing goal is set", true)
+    (Ok(Met), Some(_)) =>
+      ("goal recorded as met; the standing goal is now cleared", false)
+    (Ok(Continuing(remaining)), Some(_)) =>
+      ("goal status recorded as continuing: \{remaining}", false)
+    (Ok(Blocked(reason)), Some(_)) =>
+      (
+        "goal recorded as blocked: \{reason}. The goal still stands; auto-continuation is paused for the user",
+        false,
+      )
+  }
+  let session = self.record_tool_result(
+    session,
+    tool_call_id=native_call.id,
+    tool_name=tool_call.name,
+    content~,
+    is_error~,
+  )
+  // Cadence updates only after the result append succeeded: a rejected
+  // append must not leave a pending tombstone (the error-path flush would
+  // then durably clear a goal whose met verdict was never persisted).
+  match verdict {
+    (Ok(Met), Some(_)) => self.goal_cadence.record_goal_met()
+    (Ok(Continuing(_)), Some(_)) => self.goal_cadence.record_goal_continuing()
+    // Blocked answers the check like continuing, and lands a durable
+    // marker so serve pauses auto-continuation while the goal stands.
+    (Ok(Blocked(reason)), Some(_)) => {
+      self.goal_cadence.record_goal_continuing()
+      self.goal_cadence.pending_blocked_reason = Some(reason)
+    }
+    _ => ()
+  }
+  @xlog.info() <?
+    {
+      "event": "tool_result",
+      "tool_call_id": native_call.id,
+      "tool_name": tool_call.name,
+      "is_error": is_error,
+      "content": content,
+    }
+  ContinueToolBatch(session)
+}

--- a/agent/goal_check_test.mbt
+++ b/agent/goal_check_test.mbt
@@ -1,0 +1,412 @@
+///|
+/// Scripted stand-in for goal-check tests: responses come from a queue of
+/// SSE payload lines, bodies are recorded, assertions happen after the run.
+async fn goal_check_test_server(
+  group : @async.TaskGroup[Unit],
+  bodies : Array[String],
+  responses : Array[String],
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping goal check test")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        bodies.push(body.read_all().text())
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write("data: \{responses[bodies.length() - 1]}\n\n")
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=2,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+/// Ceiling-aware variant: streaming responses (with fabricated usage) come
+/// from the queue; the checkpoint summary call — the only non-streaming
+/// request, recognizable by its prompt — gets a plain JSON body.
+async fn goal_ceiling_test_server(
+  group : @async.TaskGroup[Unit],
+  bodies : Array[String],
+  checkpoint_bodies : Array[String],
+  responses : Array[String],
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping goal check test")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        let text = body.read_all().text()
+        if text.contains("CONTEXT CHECKPOINT COMPACTION") {
+          checkpoint_bodies.push(text)
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "application/json",
+          })
+          conn.write(
+            "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"GOAL-CEILING-SUMMARY\"}}]}",
+          )
+        } else {
+          bodies.push(text)
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write("data: \{responses[bodies.length() - 1]}\n\n")
+          conn.write("data: [DONE]\n\n")
+        }
+      },
+      max_connections=4,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+fn pressured_final_payload(content : String, total_tokens : Int) -> String {
+  "{\"choices\":[{\"delta\":{\"content\":\"\{content}\"}}],\"usage\":{\"prompt_tokens\":\{total_tokens - 1000},\"completion_tokens\":1000,\"total_tokens\":\{total_tokens}}}"
+}
+
+///|
+fn final_answer_payload(content : String) -> String {
+  "{\"choices\":[{\"delta\":{\"content\":\"\{content}\"}}]}"
+}
+
+///|
+/// A session with an answered standing goal, so the turn-start reminder and
+/// the finish check are both armed.
+fn answered_goal_session(id : String) -> @agent_session.Session {
+  @agent_session.Session(SessionId(id), system_prompt="system")
+  .append(
+    Runtime(
+      RuntimeNotice("\{@agent_session.GoalPrefix}\nGOAL-MARKER big objective"),
+    ),
+  )
+  .append(Terminal(Finished("earlier answer")))
+}
+
+///|
+async test "a finish attempt with a standing goal gets one goal check" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        final_answer_payload("premature answer"),
+        final_answer_payload("really done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-check-final"),
+      task="do the next chunk",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    // Exactly two model rounds: the premature finish, then the post-check
+    // finish. The check itself never re-fires (once per turn).
+    assert_eq(bodies.length(), 2)
+    assert_false(bodies[0].contains(@agent_session.GoalCheckPrefix))
+    assert_true(bodies[1].contains(@agent_session.GoalCheckPrefix))
+    assert_true(bodies[1].contains("premature answer"))
+    let events = result.events()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "really done")
+    let checks = [
+      for event in events if event.item() is Runtime(notice) &&
+      notice.content().has_prefix(@agent_session.GoalCheckPrefix) => notice
+    ]
+    assert_eq(checks.length(), 1)
+    // The premature answer is preserved as an ordinary assistant message.
+    let held = [
+      for event in events if event.item() is Assistant(message) &&
+      message.content() == "premature answer" => message
+    ]
+    assert_eq(held.length(), 1)
+  }
+}
+
+///|
+async test "a finish tool call mid-batch closes the batch before the check" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let finish_then_probe =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_finish","function":{"name":"finish_test","arguments":"{}"}},{"index":1,"id":"call_probe","function":{"name":"probe","arguments":"{}"}}]}}]}
+    guard goal_check_test_server(group, bodies, [
+        finish_then_probe,
+        final_answer_payload("confirmed done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let mut probe_ran = false
+    let tools = @agent_tool.Tools([
+      AgentToolDefinition(
+        name="finish_test",
+        description="Finish stand-in.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => @agent_tool.ToolAction::finish("early answer")),
+      ),
+      AgentToolDefinition(
+        name="probe",
+        description="Probe tool.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => {
+          probe_ran = true
+          @agent_tool.ToolAction::respond("probe-result")
+        }),
+      ),
+    ])
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-check-batch"),
+      task="do the next chunk",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools~,
+    )
+    assert_eq(bodies.length(), 2)
+    assert_false(probe_ran)
+    // The second request stays API-valid: both batch calls carry results —
+    // the finish result and the skipped note — before the goal check.
+    assert_true(bodies[1].contains("call_finish"))
+    assert_true(bodies[1].contains("finished: early answer"))
+    assert_true(bodies[1].contains("call_probe"))
+    // The remainder is closed by the finish call's own unconditional
+    // close (in call order) before the goal check converts the completion
+    // into a check round.
+    assert_true(
+      bodies[1].contains("an earlier finish tool call ended the batch"),
+    )
+    assert_true(bodies[1].contains(@agent_session.GoalCheckPrefix))
+    let events = result.events()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "confirmed done")
+    let skipped = [
+      for event in events if event.item() is Tool(tool_result) &&
+      tool_result.tool_call_id() == "call_probe" => tool_result
+    ]
+    assert_eq(skipped.length(), 1)
+    assert_true(skipped[0].is_error())
+  }
+}
+
+///|
+async test "a check on the reminder boundary is not buried by a reminder" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    // 29 probe rounds put the finish attempt (request 30) exactly on the
+    // 30-request reminder boundary; the check resets the cadence, so the
+    // post-check request carries the check as the tail instruction with no
+    // fresh reminder after it.
+    let responses = []
+    for _ in 0..<29 {
+      responses.push(
+        (
+          #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_probe","function":{"name":"probe","arguments":"{}"}}]}}]}
+        ),
+      )
+    }
+    responses.push(final_answer_payload("premature answer"))
+    responses.push(final_answer_payload("really done"))
+    guard goal_check_test_server(group, bodies, responses) is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-check-boundary"),
+      task="grind through it",
+      append_item=(session, item) => session.append(item),
+      max_steps=40,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    assert_eq(bodies.length(), 31)
+    let last = bodies[30]
+    assert_true(last.contains(@agent_session.GoalCheckPrefix))
+    // Only the turn-start reminder — the boundary reminder was absorbed by
+    // the check.
+    assert_eq(count_reminders(last), 1)
+    guard result.events().peek() is Some(event) &&
+      event.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "really done")
+  }
+}
+
+///|
+async test "no goal or a cleared goal never triggers the check" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        final_answer_payload("done"),
+        final_answer_payload("done again"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let cleared = answered_goal_session("goal-check-cleared").append(
+      Runtime(RuntimeNotice(@agent_session.GoalClearedNotice)),
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=cleared,
+      task="just answer",
+      append_item=(session, item) => session.append(item),
+      max_steps=2,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    assert_eq(bodies.length(), 1)
+    assert_false(bodies[0].contains(@agent_session.GoalCheckPrefix))
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "done")
+  }
+}
+
+///|
+async test "a goal check at the ceiling checkpoints first" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let checkpoint_bodies : Array[String] = []
+    guard goal_ceiling_test_server(group, bodies, checkpoint_bodies, [
+        pressured_final_payload("premature answer", 750_000),
+        final_answer_payload("really done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let session = answered_goal_session("goal-check-ceiling")
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="do the big task",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+    )
+    // The pressured completion with an unchecked goal checkpoints FIRST,
+    // then runs the check round from the compacted projection — never from
+    // the pressured history plus a check notice.
+    assert_eq(bodies.length(), 2)
+    assert_eq(checkpoint_bodies.length(), 1)
+    // The checkpoint request precedes the kept answer and the check.
+    assert_false(checkpoint_bodies[0].contains("premature answer"))
+    assert_false(checkpoint_bodies[0].contains(@agent_session.GoalCheckPrefix))
+    // The check round is compacted: summary in, original task folded away,
+    // kept answer and check notice verbatim.
+    assert_true(bodies[1].contains("GOAL-CEILING-SUMMARY"))
+    assert_true(bodies[1].contains("premature answer"))
+    assert_true(bodies[1].contains(@agent_session.GoalCheckPrefix))
+    assert_false(bodies[1].contains("do the big task"))
+    // The confirmation seals the turn normally below the ceiling.
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "really done")
+    // Durable order: Summary before the check notice.
+    let mut summary_sequence = 0
+    let mut check_sequence = 0
+    for event in result.events() {
+      match event.item() {
+        Summary(_) => summary_sequence = event.sequence()
+        Runtime(notice) if notice
+          .content()
+          .contains(@agent_session.GoalCheckPrefix) =>
+          check_sequence = event.sequence()
+        _ => ()
+      }
+    }
+    assert_true(summary_sequence > 0)
+    assert_true(check_sequence > summary_sequence)
+  }
+}
+
+///|
+async test "a pressured goal-met-then-finish batch salvages both" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let checkpoint_bodies : Array[String] = []
+    guard goal_ceiling_test_server(group, bodies, checkpoint_bodies, [
+        (
+          #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}},{"index":1,"id":"c2","function":{"name":"finish","arguments":"{\"answer\":\"all done\"}"}}]}}],"usage":{"prompt_tokens":899000,"completion_tokens":1000,"total_tokens":900000}}
+        ),
+      ])
+      is Some(url) else {
+      return
+    }
+    let session = answered_goal_session("goal-met-salvage")
+    let tools : @agent_tool.Tools = Tools([
+      @goal.definition(),
+      @finish.definition(),
+    ])
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="wrap it all up",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools~,
+    )
+    // The check text asks for goal(met) BEFORE finish: at the hard ceiling
+    // BOTH control calls execute — skip-closing the goal verdict would
+    // resurrect a completed goal for auto-continue.
+    assert_eq(bodies.length(), 1)
+    assert_eq(checkpoint_bodies.length(), 1)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "all done")
+    // The met verdict landed durably: the goal no longer stands.
+    assert_true(result.current_goal() is None)
+  }
+}

--- a/agent/goal_reminder_test.mbt
+++ b/agent/goal_reminder_test.mbt
@@ -1,0 +1,260 @@
+///|
+/// A scripted DeepSeek stand-in for goal-reminder cadence tests: the first
+/// `probe_calls` requests answer with a `probe` tool call (keeping the turn
+/// alive), the next request answers. Bodies are recorded; all assertions
+/// happen in the test after the run, so a client retry shows up as a hard
+/// request-count mismatch instead of silently shifting the cadence.
+async fn goal_test_server(
+  group : @async.TaskGroup[Unit],
+  bodies : Array[String],
+  probe_calls~ : Int,
+) -> String? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println("local TCP bind unavailable; skipping goal reminder test")
+        return None
+      }
+      raise error
+    }
+  }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (_request, body, conn) => {
+        bodies.push(body.read_all().text())
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        if bodies.length() <= probe_calls {
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_\{bodies.length()}\",\"function\":{\"name\":\"probe\",\"arguments\":\"{}\"}}]}}]}\n\n",
+          )
+        } else {
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
+          )
+        }
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=2,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+fn goal_probe_tools() -> @agent_tool.Tools raise {
+  Tools([
+    AgentToolDefinition(
+      name="probe",
+      description="Probe tool.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::respond("probe-result")),
+    ),
+  ])
+}
+
+///|
+fn goal_set_marker(text : String) -> @agent_session.SessionItem {
+  Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\n\{text}"))
+}
+
+///|
+fn count_reminders(body : String) -> Int {
+  let mut count = 0
+  let mut view = body[:]
+  while view.find("[goal reminder]") is Some(offset) {
+    count += 1
+    view = view[offset + 1:]
+  }
+  count
+}
+
+///|
+async test "a standing goal from a prior turn is re-surfaced at turn start" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_test_server(group, bodies, probe_calls=0) is Some(url) else {
+      return
+    }
+    let session = @agent_session.Session(
+        SessionId("goal-turn-start"),
+        system_prompt="system",
+      )
+      .append(goal_set_marker("GOAL-MARKER port the decoder"))
+      .append(User(UserMessage("earlier task")))
+      .append(Terminal(Finished("earlier answer")))
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="next chunk",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    // Two rounds: the answer, then the once-per-turn goal check's follow-up.
+    assert_eq(bodies.length(), 2)
+    assert_true(bodies[0].contains(@agent_session.GoalReminderPrefix))
+    assert_true(bodies[0].contains("GOAL-MARKER port the decoder"))
+    assert_true(bodies[1].contains(@agent_session.GoalCheckPrefix))
+    // Durable exactly once, after the task.
+    let reminders = [
+      for event in result.events() if event.item() is Runtime(notice) &&
+      notice.content().has_prefix(@agent_session.GoalReminderPrefix) => notice
+    ]
+    assert_eq(reminders.length(), 1)
+  }
+}
+
+///|
+async test "a freshly set goal is not double-announced" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_test_server(group, bodies, probe_calls=0) is Some(url) else {
+      return
+    }
+    // The idle /goal set appends the marker, then the prompt appends the
+    // task: the marker is not the last event, but no model response follows
+    // it, so the marker itself still rides the first request.
+    let session = @agent_session.Session(
+        SessionId("goal-fresh-set"),
+        system_prompt="system",
+      )
+      .append(User(UserMessage("earlier task")))
+      .append(Terminal(Finished("earlier answer")))
+      .append(goal_set_marker("GOAL-MARKER fresh objective"))
+    let _ = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="get started",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    // Two rounds: the goal check still fires for a fresh goal; only the
+    // duplicate turn-start reminder is suppressed.
+    assert_eq(bodies.length(), 2)
+    assert_true(bodies[0].contains("GOAL-MARKER fresh objective"))
+    assert_false(bodies[0].contains(@agent_session.GoalReminderPrefix))
+    assert_false(bodies[1].contains(@agent_session.GoalReminderPrefix))
+  }
+}
+
+///|
+async test "a long turn is reminded exactly once, at the start" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_test_server(group, bodies, probe_calls=31) is Some(url) else {
+      return
+    }
+    let session = @agent_session.Session(
+        SessionId("goal-cadence"),
+        system_prompt="system",
+      )
+      .append(goal_set_marker("GOAL-MARKER long objective"))
+      .append(Terminal(Finished("earlier answer")))
+    let _ = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep going",
+      append_item=(session, item) => session.append(item),
+      max_steps=40,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    // 31 probe rounds, the first final answer, then the goal check's
+    // follow-up round.
+    assert_eq(bodies.length(), 33)
+    // Once per turn: the turn-start reminder in request 1 and NO mid-turn
+    // re-reminders — turns are context-bounded now, so the reminder never
+    // leaves the model's context, and the finish check (visible in the
+    // final round) is the enforcement point.
+    assert_eq(count_reminders(bodies[0]), 1)
+    assert_eq(count_reminders(bodies[29]), 1)
+    assert_eq(count_reminders(bodies[30]), 1)
+    assert_eq(count_reminders(bodies[32]), 1)
+  }
+}
+
+///|
+async test "a goal steered in mid-turn is announced once, not reminded" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_test_server(group, bodies, probe_calls=1) is Some(url) else {
+      return
+    }
+    let runtime = @agent_runtime.AgentRuntime()
+    runtime.queue_steer(
+      Notice("\{@agent_session.GoalPrefix}\nGOAL-MARKER steered"),
+    )
+    let session = @agent_session.Session(
+      SessionId("goal-steered"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="start",
+      append_item=(session, item) => session.append(item),
+      max_steps=4,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    // Probe round, first final answer, goal-check follow-up.
+    assert_eq(bodies.length(), 3)
+    assert_true(bodies[0].contains("GOAL-MARKER steered"))
+    for body in bodies {
+      assert_false(body.contains(@agent_session.GoalReminderPrefix))
+    }
+    guard result.current_goal() is Some(goal) else {
+      fail("expected the steered goal to be durable")
+    }
+    assert_eq(goal.text(), "GOAL-MARKER steered")
+  }
+}
+
+///|
+async test "a cleared goal produces no reminders" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_test_server(group, bodies, probe_calls=0) is Some(url) else {
+      return
+    }
+    let session = @agent_session.Session(
+        SessionId("goal-cleared"),
+        system_prompt="system",
+      )
+      .append(goal_set_marker("GOAL-MARKER stale"))
+      .append(Terminal(Finished("earlier answer")))
+      .append(Runtime(RuntimeNotice(@agent_session.GoalClearedNotice)))
+    let _ = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="just answer",
+      append_item=(session, item) => session.append(item),
+      max_steps=2,
+      api_url=url,
+      tools=goal_probe_tools(),
+    )
+    assert_eq(bodies.length(), 1)
+    assert_false(bodies[0].contains(@agent_session.GoalReminderPrefix))
+  }
+}

--- a/agent/goal_tool_test.mbt
+++ b/agent/goal_tool_test.mbt
@@ -1,0 +1,274 @@
+///|
+fn goal_tool_call_payload(arguments : String) -> String {
+  (
+    {
+      "choices": [
+        {
+          "delta": {
+            "tool_calls": [
+              {
+                "index": 0,
+                "id": "call_goal",
+                "type": "function",
+                "function": { "name": "goal", "arguments": arguments },
+              },
+            ],
+          },
+        },
+      ],
+    } : Json).stringify()
+}
+
+///|
+fn goal_tools_with_probe() -> @agent_tool.Tools raise {
+  Tools([
+    @goal.definition(),
+    AgentToolDefinition(
+      name="probe",
+      description="Probe tool.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::respond("probe-result")),
+    ),
+  ])
+}
+
+///|
+async test "goal met defers the tombstone to a batch-safe boundary" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    // One batch: goal(met) followed by probe — the tombstone must not split
+    // the batch on replay.
+    let met_and_probe =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_goal","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}},{"index":1,"id":"call_probe","function":{"name":"probe","arguments":"{}"}}]}}]}
+    guard goal_check_test_server(group, bodies, [
+        met_and_probe,
+        final_answer_payload("wrapped up"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-tool-met"),
+      task="finish the objective",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools=goal_tools_with_probe(),
+    )
+    // No finish check (met disarmed it) and no third round.
+    assert_eq(bodies.length(), 2)
+    assert_false(bodies[1].contains(@agent_session.GoalCheckPrefix))
+    // Durable order: both batch results precede the tombstone, which
+    // precedes the terminal — replay stays protocol-valid.
+    let mut goal_seq = 0
+    let mut probe_seq = 0
+    let mut tombstone_seq = 0
+    let mut terminal_seq = 0
+    for event in result.events() {
+      match event.item() {
+        Tool(tool_result) if tool_result.tool_call_id() == "call_goal" => {
+          assert_false(tool_result.is_error())
+          assert_true(tool_result.content().contains("met"))
+          goal_seq = event.sequence()
+        }
+        Tool(tool_result) if tool_result.tool_call_id() == "call_probe" => {
+          assert_eq(tool_result.content(), "probe-result")
+          probe_seq = event.sequence()
+        }
+        Runtime(notice) if notice.content() == @agent_session.GoalClearedNotice =>
+          tombstone_seq = event.sequence()
+        Terminal(Finished(_)) => terminal_seq = event.sequence()
+        _ => ()
+      }
+    }
+    assert_true(0 < goal_seq)
+    assert_true(goal_seq < probe_seq)
+    assert_true(probe_seq < tombstone_seq)
+    assert_true(tombstone_seq < terminal_seq)
+    // The goal is durably gone and replay synthesizes nothing.
+    assert_true(result.current_goal() is None)
+    for message in result.chat_messages() {
+      assert_false(message.content.contains("previous agent process exited"))
+    }
+  }
+}
+
+///|
+async test "goal met in the final batch flushes before the terminal" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        goal_tool_call_payload("{\"status\":\"met\"}"),
+        final_answer_payload("all done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-tool-met-final"),
+      task="finish the objective",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools=goal_tools_with_probe(),
+    )
+    assert_eq(bodies.length(), 2)
+    let events = result.events()
+    guard events.peek() is Some(last) && last.item() is Terminal(Finished(_)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(result.current_goal() is None)
+  }
+}
+
+///|
+async test "goal continuing stands in for the finish check" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        goal_tool_call_payload(
+          "{\"status\":\"continuing\",\"remaining\":\"the parser is half done\"}",
+        ),
+        final_answer_payload("pausing here"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-tool-continuing"),
+      task="do a slice",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools=goal_tools_with_probe(),
+    )
+    // The structured continuing answer replaces the goal check: the final
+    // answer ends the turn in two rounds, and the goal still stands.
+    assert_eq(bodies.length(), 2)
+    assert_false(bodies[1].contains(@agent_session.GoalCheckPrefix))
+    guard result.current_goal() is Some(goal) else {
+      fail("expected the goal to keep standing")
+    }
+    assert_true(goal.text().contains("GOAL-MARKER"))
+  }
+}
+
+///|
+async test "goal calls without a standing goal or remaining are errors" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        goal_tool_call_payload("{\"status\":\"met\"}"),
+        goal_tool_call_payload("{\"status\":\"continuing\"}"),
+        final_answer_payload("ok"),
+      ])
+      is Some(url) else {
+      return
+    }
+    // No goal marker anywhere in this session.
+    let session = @agent_session.Session(
+      SessionId("goal-tool-errors"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="try the goal tool",
+      append_item=(session, item) => session.append(item),
+      max_steps=4,
+      api_url=url,
+      tools=goal_tools_with_probe(),
+    )
+    let errors = [
+      for event in result.events() if event.item() is Tool(tool_result) &&
+      tool_result.is_error() => tool_result
+    ]
+    assert_eq(errors.length(), 2)
+    assert_true(errors[0].content().contains("no standing goal"))
+    assert_true(errors[1].content().contains("remaining"))
+    // No tombstone was ever appended.
+    for event in result.events() {
+      if event.item() is Runtime(notice) {
+        assert_false(notice.content() == @agent_session.GoalClearedNotice)
+      }
+    }
+  }
+}
+
+///|
+async test "goal met flushes its tombstone on non-finish terminals" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    // The turn's only step calls goal(met); max_steps=1 exhausts without
+    // ever reaching finish_turn.
+    guard goal_check_test_server(group, bodies, [
+        goal_tool_call_payload("{\"status\":\"met\"}"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-tool-max-steps"),
+      task="finish the objective",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      api_url=url,
+      tools=goal_tools_with_probe(),
+    )
+    let events = result.events()
+    guard events.peek() is Some(last) && last.item() is Terminal(Failed(_)) else {
+      fail("expected max-steps failure terminal")
+    }
+    // The durable clear landed before the terminal: the next turn must not
+    // resurrect a goal the tool result says was met.
+    assert_true(result.current_goal() is None)
+  }
+}
+
+///|
+async test "the goal check names the goal tool when registered" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        final_answer_payload("premature"),
+        final_answer_payload("done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let _ = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=answered_goal_session("goal-tool-check-text"),
+      task="do the next chunk",
+      append_item=(session, item) => session.append(item),
+      max_steps=3,
+      api_url=url,
+      tools=goal_tools_with_probe(),
+    )
+    assert_eq(bodies.length(), 2)
+    assert_true(bodies[1].contains(@agent_session.GoalCheckPrefix))
+    assert_true(bodies[1].contains("calling the goal tool"))
+  }
+}

--- a/agent/goal_wbtest.mbt
+++ b/agent/goal_wbtest.mbt
@@ -1,0 +1,35 @@
+///|
+test "a new goal observed after met drops the stale tombstone" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nold objective")),
+  )
+  let cadence = GoalCadence(session, tool_registered=true)
+  cadence.record_goal_met()
+  assert_true(cadence.pending_tombstone)
+  // A steered-in set supersedes the met verdict: flushing the old
+  // tombstone after the new marker would wipe the new goal.
+  cadence.observe_notice("\{@agent_session.GoalPrefix}\nnew objective")
+  assert_false(cadence.pending_tombstone)
+  assert_true(cadence.goal is Some("new objective"))
+  // A durable clear also settles a pending tombstone.
+  cadence.record_goal_met() |> ignore
+  cadence.observe_notice(@agent_session.GoalClearedNotice)
+  assert_false(cadence.pending_tombstone)
+  assert_true(cadence.goal is None)
+}
+
+///|
+test "a goal set after an earlier check re-arms the finish check" {
+  let session = @agent_session.Session(
+    SessionId("goal-recheck"),
+    system_prompt="sys",
+  )
+  let cadence = GoalCadence(session, tool_registered=false)
+  cadence.observe_notice("\{@agent_session.GoalPrefix}\nfirst objective")
+  cadence.record_finish_check()
+  assert_true(cadence.due_finish_check() is None)
+  // A NEW goal deserves its own check — the earlier one confirmed a
+  // different objective.
+  cadence.observe_notice("\{@agent_session.GoalPrefix}\nsecond objective")
+  assert_true(cadence.due_finish_check() is Some("second objective"))
+}

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -8,6 +8,7 @@ import {
   "bobzhang/openseek/agent_tool/shell_stop",
   "bobzhang/openseek/agent_tool/edit",
   "bobzhang/openseek/agent_tool/finish",
+  "bobzhang/openseek/agent_tool/goal",
   "bobzhang/openseek/agent_tool/multi_edit",
   "bobzhang/openseek/agent_tool/plan",
   "bobzhang/openseek/agent_tool/read",

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -129,6 +129,7 @@ pub async fn[X] build_tools(
       @multi_edit.definition(workspace_root~),
       @write.definition(workspace_root~),
       @plan.definition(),
+      @goal.definition(),
       @finish.definition(),
     ],
   )
@@ -140,7 +141,7 @@ async test "agent registers the expected tool names" {
   @async.with_task_group() <| group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
     let function_tools = tools.function_tools()
-    assert_eq(function_tools.length(), 9)
+    assert_eq(function_tools.length(), 10)
     let names = [ for t in function_tools => t.name ]
     assert_true(names.contains("shell"))
     assert_true(names.contains("shell_output"))
@@ -150,6 +151,7 @@ async test "agent registers the expected tool names" {
     assert_true(names.contains("multi_edit"))
     assert_true(names.contains("write"))
     assert_true(names.contains("plan"))
+    assert_true(names.contains("goal"))
     assert_true(names.contains("finish"))
     assert_false(names.contains("moon_check"))
     assert_false(names.contains("moon_cmd"))
@@ -166,7 +168,7 @@ async test "agent registers the expected tool names on windows" {
   @async.with_task_group() <| group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
     let function_tools = tools.function_tools()
-    assert_eq(function_tools.length(), 7)
+    assert_eq(function_tools.length(), 8)
     let names = [ for t in function_tools => t.name ]
     assert_true(names.contains("shell"))
     assert_false(names.contains("shell_output"))
@@ -176,6 +178,7 @@ async test "agent registers the expected tool names on windows" {
     assert_true(names.contains("multi_edit"))
     assert_true(names.contains("write"))
     assert_true(names.contains("plan"))
+    assert_true(names.contains("goal"))
     assert_true(names.contains("finish"))
     guard tools.find("shell") is Some(shell) else { fail("shell tool missing") }
     assert_false(shell.description.contains("run_in_background"))

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -14,6 +14,7 @@ priv struct AgentLoop {
   /// succeeded.
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
+  goal_cadence : GoalCadence
   /// Latest session returned by a successful append. The run-level error
   /// handler uses it to persist a terminal failure/interruption even when the
   /// local loop state is behind the last durable session.
@@ -37,6 +38,15 @@ fn AgentLoop::AgentLoop(
     append_item,
     messages: session.chat_messages(),
     plan_cadence: PlanCadence(registered=tools.find("plan") is Some(_)),
+    goal_cadence: GoalCadence(
+      session,
+      // Control-gated like the finish salvage: a custom non-control tool
+      // that happens to be named "goal" keeps its own schema and executor —
+      // the loop protocol only claims the name when the registered
+      // definition declares itself a control tool (the built-in does).
+      tool_registered=tools.find("goal") is Some(definition) &&
+        definition.is_control(),
+    ),
     last_session: session,
   }
 }
@@ -101,6 +111,27 @@ async fn AgentLoop::run(
       if response.tool_calls.is_empty() {
         let steer_inputs = self.runtime.pending_steers()
         if steer_inputs.is_empty() {
+          if step + 1 < max_steps &&
+            self.goal_cadence.due_finish_check() is Some(_) {
+            // The model considers itself done, but the standing goal is
+            // unconfirmed: keep the would-be answer as an ordinary assistant
+            // message and ask once whether the goal is met. The model may
+            // finish again immediately, so the turn is never held hostage.
+            // At the ceiling the history is checkpointed first, so the
+            // check round cannot overflow the pressured context.
+            match
+              self.continue_into_goal_check(
+                session,
+                response.usage,
+                spent_result_chars=0,
+                kept_answer=response.content,
+                keep_only_when_compacted=false,
+                reasoning_content?=response.optional_reasoning_content(),
+              ) {
+              Sealed(next) => return next
+              ContinueTurn(next) => continue next
+            }
+          }
           // A true final answer is stored once as Terminal(Finished). Later turns
           // rebuild model context through Session::chat_messages, which projects
           // that terminal back into an assistant message; appending an Assistant
@@ -139,7 +170,12 @@ async fn AgentLoop::run(
           response,
           tool_calls=response.tool_calls,
         )
-        match self.salvage_finish_at_ceiling(session, response) {
+        match
+          self.salvage_finish_at_ceiling(
+            session,
+            response,
+            last_step=step + 1 >= max_steps,
+          ) {
           Some(StepDone(next)) => return next
           // A steer arrived during the salvaged finish's checkpoint: the
           // turn continues from the compacted projection.
@@ -161,7 +197,12 @@ async fn AgentLoop::run(
           self.runtime.pending_steers(),
         )
       } else {
-        match self.handle_tool_calls(session, response) {
+        match
+          self.handle_tool_calls(
+            session,
+            response,
+            last_step=step + 1 >= max_steps,
+          ) {
           // Plain continuation — including after a checkpoint whose late
           // steer converted a finish into a continue: the soft decision
           // lives in handle_tool_calls, which knows the batch's real
@@ -180,6 +221,8 @@ async fn AgentLoop::run(
         }
       }
     } nobreak {
+      // A goal met in the last step's batch still needs its durable clear.
+      let session = self.flush_goal_tombstone(session)
       let session = self.append(
         session,
         Terminal(Failed("max steps exhausted")),
@@ -195,11 +238,12 @@ async fn AgentLoop::run(
       } else {
         Terminal(Failed("agent failed: \{error}"))
       }
-      ignore(
-        self.append(self.last_session, terminal) catch {
-          _ => self.last_session
-        },
-      )
+      // Best-effort: a goal met in the dying batch keeps its durable clear
+      // when the store still accepts appends.
+      let session = self.flush_goal_tombstone(self.last_session) catch {
+        _ => self.last_session
+      }
+      ignore(self.append(session, terminal) catch { _ => session })
       raise error
     }
   }
@@ -271,6 +315,9 @@ async fn AgentLoop::apply_steer_inputs(
     let next = self.append(current, item)
     self.messages.push(ChatMessage(User, content=text))
     @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
+    if input is Notice(text) {
+      self.goal_cadence.observe_notice(text)
+    }
     continue next
   } nobreak {
     current
@@ -282,12 +329,25 @@ async fn AgentLoop::prepare_step(
   self : Self,
   session : @agent_session.Session,
 ) -> @agent_session.Session {
+  // A goal(met) recorded in the previous batch lands its durable tombstone
+  // here, at a batch-safe boundary.
+  let session = self.flush_goal_tombstone(session)
   // Steering first: user-visible mid-turn input should be applied before plan
   // reminders or the next model request.
   let mut session = self.apply_steer_inputs(
     session,
     self.runtime.pending_steers(),
   )
+  if self.goal_cadence.due_reminder() is Some(goal) {
+    let reminder = goal_reminder_text(
+      goal,
+      tool_registered=self.goal_cadence.tool_registered,
+    )
+    session = self.append(session, Runtime(RuntimeNotice(reminder)))
+    self.messages.push(ChatMessage(User, content=reminder))
+    @xlog.info() <? { "event": "goal_reminder", "content": reminder }
+    self.goal_cadence.record_reminder()
+  }
   if self.plan_cadence.should_remind() {
     let reminder = self.plan_cadence.reminder_text()
     session = self.append(session, Runtime(RuntimeNotice(reminder)))
@@ -337,6 +397,7 @@ async fn AgentLoop::handle_tool_calls(
   self : Self,
   session : @agent_session.Session,
   response : @deepseek.ChatResponse,
+  last_step~ : Bool,
 ) -> AgentStepOutcome {
   let session = self.record_assistant(
     session,
@@ -362,6 +423,7 @@ async fn AgentLoop::handle_tool_calls(
           response,
           from=call_index,
           spent_result_chars~,
+          last_step~,
         ) {
         Some(outcome) => return outcome
         None => ()
@@ -401,6 +463,7 @@ async fn AgentLoop::handle_tool_calls(
         native_call,
         tool_call,
         spent_result_chars~,
+        last_step~,
       ) {
       ContinueToolBatch(next) => {
         // Account the result actually recorded for this call (the loop
@@ -438,7 +501,16 @@ async fn AgentLoop::execute_tool_call(
   native_call : @deepseek.ToolCall,
   tool_call : @agent_tool.AgentToolCall,
   spent_result_chars~ : Int64,
+  last_step~ : Bool,
 ) -> ToolCallOutcome {
+  // The goal status tool is loop-intercepted: only the loop knows whether a
+  // goal currently stands, and the durable clear must be sequenced by the
+  // loop, so the registry entry never executes here. Gated on registration:
+  // a hallucinated `goal` call against a registry that never advertised the
+  // tool must get the normal unknown-tool error, not clear a standing goal.
+  if tool_call.name == "goal" && self.goal_cadence.tool_registered {
+    return self.handle_goal_tool_call(session, native_call, tool_call)
+  }
   let result = @agent_tool.execute_tool_call(tool_call, self.tools)
   match result {
     Control(Finish(answer)) => {
@@ -465,6 +537,26 @@ async fn AgentLoop::execute_tool_call(
       )
       let steer_inputs = self.runtime.pending_steers()
       if steer_inputs.is_empty() {
+        // An unchecked standing goal converts the completion into a check
+        // round BEFORE steer/ceiling routing: the batch remainder is
+        // already closed above, so the check is the only insertion. At the
+        // ceiling the history is checkpointed first (see the helper).
+        // On the final bounded step there is no request budget left for a
+        // check round: injecting one would exit into "max steps exhausted"
+        // and turn a successful bounded turn into a failure. Finish.
+        if !last_step && self.goal_cadence.due_finish_check() is Some(_) {
+          return match
+            self.continue_into_goal_check(
+              session,
+              response.usage,
+              spent_result_chars~,
+              kept_answer=answer,
+              keep_only_when_compacted=true,
+            ) {
+            Sealed(next) => FinishAgentLoop(next)
+            ContinueTurn(next) => ContinueAgentLoop(next)
+          }
+        }
         return match
           self.finish_turn(
             session,
@@ -502,6 +594,9 @@ async fn AgentLoop::execute_tool_call(
           ),
         ),
       )
+      // The abort closes the batch; a goal met earlier in it still needs
+      // its durable clear before the terminal.
+      let session = self.flush_goal_tombstone(session)
       let session = self.append(session, Terminal(Aborted(reason)))
       @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
       return FinishAgentLoop(session)
@@ -535,7 +630,7 @@ async fn AgentLoop::execute_tool_call(
 
 ///|
 /// Append synthetic error results for tool calls left unexecuted after a finish
-/// tool loses to newly arrived user input.
+/// tool loses to newly arrived user input or to a goal check.
 ///
 /// Every call in the assistant's batch needs a result message, so the finish
 /// call's result and skipped notes for the unexecuted remainder are pushed
@@ -601,6 +696,7 @@ async fn AgentLoop::salvage_finish_at_ceiling(
   response : @deepseek.ChatResponse,
   from? : Int = 0,
   spent_result_chars? : Int64 = 0,
+  last_step~ : Bool,
 ) -> AgentStepOutcome? {
   // The registry must declare the finish tool a CONTROL tool: that is how
   // the loop knows — without executing — that honoring the call appends a
@@ -618,11 +714,54 @@ async fn AgentLoop::salvage_finish_at_ceiling(
   let tool_call = @agent_tool.AgentToolCall(native_call) catch {
     _ => return None
   }
-  let session = self.close_skipped_tool_calls(
-    session,
-    response.tool_calls[from:finish_index],
-    note=ceiling_skip_note,
-  )
+  // Control-registered calls in the prefix are bounded by contract and can
+  // carry the completion's substance — the goal check text asks for
+  // goal(met) BEFORE finish, and skip-closing it would resurrect a
+  // completed goal for auto-continue. Execute them; skip everything else.
+  let session = for index = from, session = session {
+    if index >= finish_index {
+      break session
+    }
+    let call = response.tool_calls[index]
+    let is_control_call = self.tools.find(call.name) is Some(definition) &&
+      definition.is_control()
+    if is_control_call {
+      let decoded : @agent_tool.AgentToolCall? = Some(AgentToolCall(call)) catch {
+        _ => None
+      }
+      match decoded {
+        Some(tool_call) =>
+          match
+            self.execute_tool_call(
+              session,
+              response,
+              index,
+              call,
+              tool_call,
+              spent_result_chars~,
+              last_step~,
+            ) {
+            ContinueToolBatch(next) => continue index + 1, next
+            // The control already closed the batch remainder and prepared a
+            // continuation (e.g. a control finish converted into a goal
+            // check): re-scanning the same calls would duplicate results
+            // and bypass the injected check.
+            ContinueAgentLoop(next) => return Some(StepContinue(next))
+            // A prefix control that SEALED the turn (e.g. an abort) owns
+            // the terminal: executing the finish after it would append
+            // past a terminal and override the intended outcome.
+            FinishAgentLoop(next) => return Some(StepDone(next))
+          }
+        None => ()
+      }
+    }
+    continue index + 1,
+      self.close_skipped_tool_calls(
+        session,
+        response.tool_calls[index:index + 1],
+        note=ceiling_skip_note,
+      )
+  }
   match
     self.execute_tool_call(
       session,
@@ -631,6 +770,7 @@ async fn AgentLoop::salvage_finish_at_ceiling(
       native_call,
       tool_call,
       spent_result_chars~,
+      last_step~,
     ) {
     FinishAgentLoop(next) => Some(StepDone(next))
     // The finish ran but a steer converted it into a continuation: its
@@ -715,6 +855,125 @@ async fn AgentLoop::record_tool_result(
 }
 
 ///|
+/// Convert a completion attempt into a goal-check round. At the soft
+/// ceiling the history is checkpointed FIRST, so the check round runs from
+/// a compacted context — continuing with the uncheckpointed pressured
+/// history plus the check notice could overflow the next request. A failed
+/// checkpoint yields fail-open instead: the goal survives in the raw log
+/// and the next turn's start re-surfaces it. `kept_answer` (with its
+/// reasoning) becomes an ordinary assistant message — appended after any
+/// summary, so it stays verbatim — BOTH arms pass it: without it a ceiling
+/// checkpoint covers the finish result and the check round would see only
+/// the lossy summary instead of the verbatim answer non-ceiling checks
+/// get. Only the no-tool arm passes reasoning: the finish tool's answer is
+/// synthetic (its reasoning lives on the batch's covered assistant
+/// message; re-attaching it would duplicate what Kimi preserves there).
+async fn AgentLoop::continue_into_goal_check(
+  self : Self,
+  session : @agent_session.Session,
+  usage : @deepseek.Usage,
+  spent_result_chars~ : Int64,
+  kept_answer~ : String,
+  keep_only_when_compacted~ : Bool,
+  reasoning_content? : String,
+) -> FinishOutcome {
+  let at_ceiling = self.at_soft_context_ceiling(
+    usage,
+    extra_result_chars=spent_result_chars,
+  )
+  let (session, compacted) = if at_ceiling {
+    self.checkpoint_at_ceiling(session, [])
+  } else {
+    (session, false)
+  }
+  if at_ceiling && !compacted {
+    let to_sequence = session.last_sequence()
+    // A no-tool answer exists nowhere else: persist it before sealing, or
+    // the completion attempt is lost with the failed checkpoint. The
+    // finish-tool variant is already durable as the batch's tool result.
+    let session = if keep_only_when_compacted {
+      session
+    } else {
+      self.append(
+        session,
+        Assistant(AssistantMessage(kept_answer, reasoning_content?)),
+      )
+    }
+    // Same lossless-steering rule as the yield path: input queued during
+    // the failed checkpoint request persists (uncovered) instead of being
+    // boundary-dropped at TurnDone.
+    let session = self.apply_steer_inputs(
+      session,
+      self.runtime.pending_steers(),
+    )
+    return Sealed(
+      self.finish_context_yield(session, to_sequence, compacted=false),
+    )
+  }
+  // The finish-tool arm's answer is already durable as the batch's tool
+  // result, so it is re-kept only when a checkpoint just covered it; the
+  // no-tool arm's answer exists nowhere else and is always kept.
+  let session = if !keep_only_when_compacted || at_ceiling {
+    let session = self.append(
+      session,
+      Assistant(AssistantMessage(kept_answer, reasoning_content?)),
+    )
+    self.messages.push(
+      ChatMessage(Assistant, content=kept_answer, reasoning_content?),
+    )
+    session
+  } else {
+    session
+  }
+  // Steers queued during the checkpoint await land NOW, before the check:
+  // otherwise the next prepare_step would append them after it, the model
+  // would answer the newer instruction, and — finish_checked being spent —
+  // finish without ever addressing the standing-goal check.
+  let session = self.apply_steer_inputs(session, self.runtime.pending_steers())
+  // Those steers may themselves have SET or CLEARED the goal: check the
+  // cadence's CURRENT goal, never the text captured before the checkpoint —
+  // a goal set during the await deserves its own check, and a cleared one
+  // needs none (finish_checked stays unspent).
+  let session = match self.goal_cadence.due_finish_check() {
+    Some(current) => self.inject_goal_check(session, current)
+    None => session
+  }
+  if at_ceiling {
+    // Re-seed the in-flight buffer from the compacted projection: the
+    // whole point of the checkpoint is that the check round is small.
+    self.messages.clear()
+    for message in session.chat_messages() {
+      self.messages.push(message)
+    }
+  }
+  ContinueTurn(session)
+}
+
+///|
+/// Answer a finish attempt with the once-per-turn goal check: a durable
+/// runtime notice plus the mirrored model message, so the next request asks
+/// the model to confirm the standing goal before the turn may end.
+async fn AgentLoop::inject_goal_check(
+  self : Self,
+  session : @agent_session.Session,
+  goal : String,
+) -> @agent_session.Session {
+  let check = goal_check_text(
+    goal,
+    tool_registered=self.goal_cadence.tool_registered,
+  )
+  let session = self.append(session, Runtime(RuntimeNotice(check)))
+  self.messages.push(ChatMessage(User, content=check))
+  @xlog.info() <? { "event": "goal_check", "content": check }
+  self.goal_cadence.record_finish_check()
+  // The check must stay the newest instruction: a plan reminder landing at
+  // the same cadence boundary would bury it — the model would answer the
+  // plan nag, and finish_checked is already spent, bypassing the gate.
+  self.plan_cadence.record_reminder()
+  session
+}
+
+///|
 /// Durably record the turn's final answer and mirror it for the still-live
 /// loop state.
 ///
@@ -739,6 +998,10 @@ async fn AgentLoop::finish_turn(
   spent_result_chars? : Int64 = 0,
   reasoning_content? : String,
 ) -> FinishOutcome {
+  // A goal met in the turn's final batch still needs its durable clear
+  // before the terminal seals the turn — and before any compact-on-finish
+  // checkpoint, so the tombstone is covered like the rest of the history.
+  let session = self.flush_goal_tombstone(session)
   let session = if self.at_soft_context_ceiling(
       usage,
       extra_result_chars=spent_result_chars,

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -1,0 +1,152 @@
+///|
+/// First line of the runtime notice that sets a standing goal. The full
+/// marker content is `[goal]\n<text>`; `Session::current_goal` keys off the
+/// exact prefix line, so it lives here with `RuntimeNotice` alongside
+/// `PlanReminderPrefix` where producers (the serve engine, the agent loop)
+/// and readers (the scan, viz, tests) share it. The bracket tags below are
+/// reserved: only the goal command paths write notices with these first
+/// lines.
+pub const GoalPrefix : String = "[goal]"
+
+///|
+/// Exact content of the tombstone notice that clears a standing goal.
+pub const GoalClearedNotice : String = "[goal cleared]"
+
+///|
+/// Marker prefix recording that the model declared the standing goal
+/// BLOCKED: the goal keeps standing (the user decides what is next), but
+/// auto-continuation must pause instead of relaunching declared-impossible
+/// work.
+pub const GoalBlockedPrefix : String = "[goal blocked]"
+
+///|
+/// First line of the reminder notice the agent loop re-injects so a
+/// long-running conversation keeps the standing goal near the context tail.
+pub const GoalReminderPrefix : String = "[goal reminder]"
+
+///|
+/// First line of the notice the agent loop injects when the model tries to
+/// end a turn while a standing goal is set.
+pub const GoalCheckPrefix : String = "[goal check]"
+
+///|
+/// A standing goal derived from the durable event log.
+pub struct StandingGoal {
+  priv text : String
+  priv answered_since_set : Bool
+  priv set_sequence : Int
+  priv blocked : Bool
+} derive(Debug)
+
+///|
+/// The goal text as it was set (may span lines when set over the wire).
+pub fn StandingGoal::text(self : StandingGoal) -> String {
+  self.text
+}
+
+///|
+/// Sequence of the set marker event that established this goal. Marker
+/// identity for consumers that must distinguish "this exact set persisted"
+/// from "an identical-text goal was already standing" — text alone cannot.
+pub fn StandingGoal::set_sequence(self : StandingGoal) -> Int {
+  self.set_sequence
+}
+
+///|
+/// Whether any model response (assistant message or turn terminal) was
+/// appended after the goal was set. When false the set marker itself is
+/// still ahead of the model's next request, so injecting a turn-start
+/// reminder would only duplicate it.
+pub fn StandingGoal::answered_since_set(self : StandingGoal) -> Bool {
+  self.answered_since_set
+}
+
+///|
+/// Whether the model durably declared this goal blocked since it was set:
+/// the goal still stands for the user, but auto-continuation must pause.
+pub fn StandingGoal::blocked(self : StandingGoal) -> Bool {
+  self.blocked
+}
+
+///|
+/// A goal marker recognized in a runtime notice.
+pub(all) enum GoalMarker {
+  GoalSet(String)
+  GoalCleared
+  GoalBlocked(String)
+} derive(Debug)
+
+///|
+/// Parse a runtime-notice content as a goal marker, if it is one. The set
+/// marker requires the exact `[goal]` first line and the tombstone requires
+/// exact content, so other notices (plan reminders, goal reminders, goal
+/// checks) never match.
+pub fn goal_marker(content : String) -> GoalMarker? {
+  if content == GoalClearedNotice {
+    Some(GoalCleared)
+  } else if content.has_prefix("\{GoalBlockedPrefix}\n") {
+    Some(
+      GoalBlocked(
+        "\{content.view(start_offset=GoalBlockedPrefix.length() + 1)}",
+      ),
+    )
+  } else if content.has_prefix("\{GoalPrefix}\n") {
+    Some(GoalSet(content[GoalPrefix.length() + 1:].to_owned()))
+  } else {
+    None
+  }
+}
+
+///|
+/// Standing goal state: the last goal marker in the log wins — a
+/// `[goal]\n<text>` notice yields that goal, a `[goal cleared]` tombstone
+/// yields none.
+///
+/// The scan reads raw events, not the compacted projection, so a goal whose
+/// set marker is covered by a later compaction summary is still recovered
+/// verbatim from the append-only log.
+pub fn Session::current_goal(self : Session) -> StandingGoal? {
+  let events = self.events()
+  let mut answered = false
+  let mut blocked = false
+  let covered : Array[(Int, Int)] = []
+  for index = events.length() - 1; index >= 0; index = index - 1 {
+    match events[index].item() {
+      Assistant(_) | Terminal(_) => answered = true
+      // A summary whose range CONTAINS the set marker removes its verbatim
+      // text from the projection: treat the goal as "answered" so the
+      // cadence re-surfaces it — the next request must not see only the
+      // lossy summary where the standing goal used to be. A summary of
+      // later events leaves the marker verbatim and must not re-remind.
+      Summary(summary) =>
+        covered.push((summary.from_sequence(), summary.to_sequence()))
+      Runtime(notice) =>
+        match goal_marker(notice.content()) {
+          Some(GoalCleared) => return None
+          // Newest-first: a blocked marker precedes the set it follows
+          // temporally; a NEWER set is found first and naturally resets it.
+          Some(GoalBlocked(_)) => blocked = true
+          Some(GoalSet(text)) => {
+            let sequence = events[index].sequence()
+            let mut is_covered = false
+            for range in covered {
+              let (from, to) = range
+              if from <= sequence && sequence <= to {
+                is_covered = true
+                break
+              }
+            }
+            return Some({
+              text,
+              answered_since_set: answered || is_covered,
+              set_sequence: sequence,
+              blocked,
+            })
+          }
+          None => ()
+        }
+      _ => ()
+    }
+  }
+  None
+}

--- a/agent_session/goal_test.mbt
+++ b/agent_session/goal_test.mbt
@@ -1,0 +1,98 @@
+///|
+fn goal_set_notice(text : String) -> @agent_session.SessionItem {
+  Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\n\{text}"))
+}
+
+///|
+test "current_goal is none without markers" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("hello")))
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.PlanReminderPrefix}\nplan")),
+    )
+  assert_true(session.current_goal() is None)
+}
+
+///|
+test "current_goal returns the last set marker" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(goal_set_notice("port the decoder"))
+    .append(User(UserMessage("start with the parser")))
+  guard session.current_goal() is Some(goal) else { fail("expected a goal") }
+  assert_eq(goal.text(), "port the decoder")
+  assert_false(goal.answered_since_set())
+}
+
+///|
+test "current_goal marks goals the model has answered since" {
+  let assistant_first = @agent_session.Session(
+      SessionId("s1"),
+      system_prompt="system",
+    )
+    .append(goal_set_notice("port the decoder"))
+    .append(Assistant(AssistantMessage("on it")))
+  guard assistant_first.current_goal() is Some(goal) else {
+    fail("expected a goal")
+  }
+  assert_true(goal.answered_since_set())
+  let terminal_only = @agent_session.Session(
+      SessionId("s2"),
+      system_prompt="system",
+    )
+    .append(goal_set_notice("port the decoder"))
+    .append(Terminal(Finished("done for now")))
+  guard terminal_only.current_goal() is Some(goal) else {
+    fail("expected a goal")
+  }
+  assert_true(goal.answered_since_set())
+}
+
+///|
+test "cleared tombstone hides earlier goals and a later set revives" {
+  let cleared = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(goal_set_notice("first objective"))
+    .append(Runtime(RuntimeNotice(@agent_session.GoalClearedNotice)))
+  assert_true(cleared.current_goal() is None)
+  let revived = cleared.append(goal_set_notice("second objective"))
+  guard revived.current_goal() is Some(goal) else { fail("expected a goal") }
+  assert_eq(goal.text(), "second objective")
+}
+
+///|
+test "reminder and check notices are not set markers" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(goal_set_notice("real goal"))
+    .append(Runtime(RuntimeNotice(@agent_session.GoalClearedNotice)))
+    .append(
+      Runtime(
+        RuntimeNotice("\{@agent_session.GoalReminderPrefix}\nstale reminder"),
+      ),
+    )
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalCheckPrefix}\nstale check")),
+    )
+  // The cleared tombstone stays authoritative: reminder/check tags after it
+  // must not resurrect the goal.
+  assert_true(session.current_goal() is None)
+}
+
+///|
+test "multiline goal text survives the scan" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
+    goal_set_notice("line one\nline two"),
+  )
+  guard session.current_goal() is Some(goal) else { fail("expected a goal") }
+  assert_eq(goal.text(), "line one\nline two")
+}
+
+///|
+test "a compaction summary covering the set marker does not hide the goal" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(goal_set_notice("long objective"))
+    .append(User(UserMessage("work on it")))
+    .append(Assistant(AssistantMessage("progress")))
+    .compact(content="summary of the work", from_sequence=1, to_sequence=3)
+  guard session.current_goal() is Some(goal) else { fail("expected a goal") }
+  assert_eq(goal.text(), "long objective")
+  assert_true(goal.answered_since_set())
+}

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -11,7 +11,19 @@ import {
 // Values
 pub const ContextYieldAnswerPrefix : String = "[context ceiling]"
 
+pub const GoalBlockedPrefix : String = "[goal blocked]"
+
+pub const GoalCheckPrefix : String = "[goal check]"
+
+pub const GoalClearedNotice : String = "[goal cleared]"
+
+pub const GoalPrefix : String = "[goal]"
+
+pub const GoalReminderPrefix : String = "[goal reminder]"
+
 pub const PlanReminderPrefix : String = "[plan reminder]"
+
+pub fn goal_marker(String) -> GoalMarker?
 
 // Errors
 
@@ -23,6 +35,12 @@ pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.
 pub fn AssistantMessage::content(Self) -> String
 pub fn AssistantMessage::reasoning_content(Self) -> String?
 pub fn AssistantMessage::tool_calls(Self) -> Array[@deepseek.ToolCall]
+
+pub(all) enum GoalMarker {
+  GoalSet(String)
+  GoalCleared
+  GoalBlocked(String)
+} derive(@debug.Debug)
 
 pub struct RuntimeNotice {
   // private fields
@@ -38,6 +56,7 @@ pub fn Session::append(Self, SessionItem, unix_ms? : Int64) -> Self
 pub fn Session::append_event(Self, SessionItem, unix_ms? : Int64) -> (Self, SessionEvent)
 pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
 pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int, unix_ms? : Int64) -> Self raise
+pub fn Session::current_goal(Self) -> StandingGoal?
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int
@@ -80,6 +99,14 @@ pub fn SessionSummary::SessionSummary(content~ : String, from_sequence~ : Int, t
 pub fn SessionSummary::content(Self) -> String
 pub fn SessionSummary::from_sequence(Self) -> Int
 pub fn SessionSummary::to_sequence(Self) -> Int
+
+pub struct StandingGoal {
+  // private fields
+} derive(@debug.Debug)
+pub fn StandingGoal::answered_since_set(Self) -> Bool
+pub fn StandingGoal::blocked(Self) -> Bool
+pub fn StandingGoal::set_sequence(Self) -> Int
+pub fn StandingGoal::text(Self) -> String
 
 pub struct ToolResult {
   // private fields

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -383,3 +383,58 @@ test "generated session ids stamp the launcher prefix and UTC wall clock" {
     "cli-20260611-081500-042-1a2b3c4d",
   )
 }
+
+///|
+test "a compacted-over set marker re-arms the turn-start reminder" {
+  // A fresh set normally rides the next request verbatim, so no reminder —
+  // but a summary covering the marker removes that verbatim text from the
+  // projection, and the cadence must re-surface the goal instead of
+  // trusting the lossy summary.
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="sys")
+    .append(User(UserMessage("task")))
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nbig objective")),
+    )
+    .append(
+      Summary(SessionSummary(content="folded", from_sequence=1, to_sequence=2)),
+    )
+  guard session.current_goal() is Some(goal) else { fail("goal must stand") }
+  assert_true(goal.answered_since_set())
+}
+
+///|
+test "a summary of later events leaves a fresh set marker verbatim" {
+  // The marker stays in the projection (the summary's range starts after
+  // it), so the fresh-set suppression still applies: no extra reminder.
+  let session = @agent_session.Session(SessionId("s2"), system_prompt="sys")
+    .append(User(UserMessage("task one")))
+    .append(User(UserMessage("task two")))
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nbig objective")),
+    )
+    .append(
+      Summary(SessionSummary(content="folded", from_sequence=1, to_sequence=2)),
+    )
+  guard session.current_goal() is Some(goal) else { fail("goal must stand") }
+  assert_false(goal.answered_since_set())
+}
+
+///|
+test "a blocked marker pauses the standing goal without clearing it" {
+  let session = @agent_session.Session(SessionId("s3"), system_prompt="sys")
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nbig objective")),
+    )
+    .append(Terminal(Finished("earlier")))
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalBlockedPrefix}\nneeds a key")),
+    )
+  guard session.current_goal() is Some(goal) else { fail("goal must stand") }
+  assert_true(goal.blocked())
+  // A NEWER set resets the pause.
+  let session = session.append(
+    Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nnew objective")),
+  )
+  guard session.current_goal() is Some(goal) else { fail("goal must stand") }
+  assert_false(goal.blocked())
+}

--- a/agent_tool/goal/README.mbt.md
+++ b/agent_tool/goal/README.mbt.md
@@ -1,0 +1,47 @@
+# `goal` — the structured goal-status tool
+
+The `goal` tool is how the model reports where the **standing session goal**
+stands, as data instead of prose. It exists so the engine can stop, chain, or
+keep working on a durable signal — never on parsing the model's phrasing.
+
+## Arguments
+
+- `status` (string, required): `"met"` or `"continuing"`.
+- `remaining` (string, required when `status` is `"continuing"`): what is
+  still left to do — must be non-blank, because this text is the durable
+  record whoever (or whatever turn) resumes the goal will read.
+
+## Result
+
+This package only **decodes**; the action is the agent loop's. The loop
+intercepts a `goal` call instead of dispatching it like an ordinary tool:
+
+- `goal(met)` — the standing goal stops standing immediately (the finish
+  check disarms) and a durable `[goal cleared]` tombstone lands at the next
+  batch-safe boundary. Under auto-continue this is the **structural stop**:
+  the chain ends on the tombstone, not on trusting an answer's wording.
+- `goal(continuing)` — answers exactly what the finish check asks, so the
+  check disarms for the rest of the turn and the turn may end with the goal
+  still standing; `remaining` is recorded for the next turn.
+- Invalid arguments come back as an error tool result naming the exact
+  problem, so the model can re-issue the call without guessing.
+
+The tool is registered only while a goal stands; `GoalCadence` selects the
+tool-aware finish-check wording when it is (see `agent/goal.mbt`).
+
+## Example
+
+```moonbit check
+///|
+test "goal arguments decode to structured verdicts" {
+  assert_true(@goal.decode_status({ "status": "met" }) is Ok(Met))
+  assert_true(
+    @goal.decode_status({ "status": "continuing", "remaining": "wire the CLI" })
+    is Ok(Continuing("wire the CLI")),
+  )
+  // A blank `remaining` is rejected: the durable record must be actionable.
+  assert_true(
+    @goal.decode_status({ "status": "continuing", "remaining": "  " }) is Err(_),
+  )
+}
+```

--- a/agent_tool/goal/goal.mbt
+++ b/agent_tool/goal/goal.mbt
@@ -1,0 +1,90 @@
+///|
+/// Decoded `goal` tool arguments: the model's structured verdict on the
+/// standing session goal.
+pub(all) enum GoalStatus {
+  Met
+  Continuing(String)
+  /// The goal cannot proceed (impossible, blocked, or superseded): it
+  /// keeps standing for the user, but auto-continuation pauses.
+  Blocked(String)
+} derive(Debug)
+
+///|
+/// Decode and validate `goal` tool-call arguments. `met` needs nothing else;
+/// `continuing` requires a non-blank `remaining` — the durable record must be
+/// actionable for whoever (or whatever turn) resumes the goal.
+pub fn decode_status(arguments : Json) -> Result[GoalStatus, String] {
+  match arguments {
+    { "status": "met", .. } => Ok(Met)
+    { "status": "continuing", "remaining": String(remaining), .. } =>
+      if remaining.trim().is_empty() {
+        Err(
+          "goal requires a non-blank \"remaining\" when status is \"continuing\"",
+        )
+      } else {
+        Ok(Continuing(remaining))
+      }
+    { "status": "continuing", .. } =>
+      Err("goal requires a string \"remaining\" when status is \"continuing\"")
+    { "status": "blocked", "reason": String(reason), .. } =>
+      if reason.trim().is_empty() {
+        Err("goal requires a non-blank \"reason\" when status is \"blocked\"")
+      } else {
+        Ok(Blocked(reason))
+      }
+    { "status": "blocked", .. } =>
+      Err("goal requires a string \"reason\" when status is \"blocked\"")
+    { "status": String(other), .. } =>
+      Err(
+        "goal status must be \"met\", \"continuing\", or \"blocked\", got \"\{other}\"",
+      )
+    _ => Err("goal requires a string \"status\" field")
+  }
+}
+
+///|
+/// Tool definition for `goal`: record the standing goal's status as
+/// structured state instead of prose, so the engine can act on it — `met`
+/// durably clears the goal (the auto-continue termination signal) and
+/// `continuing` records what remains.
+///
+/// The agent loop intercepts calls to this tool before execution: only the
+/// loop knows whether a goal currently stands and owns the durable log, and
+/// the clear must land at a batch-safe boundary. This stateless execute is
+/// the fallback for registries dispatched outside the loop; it validates the
+/// arguments and acknowledges without touching any state.
+pub fn definition() -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="goal",
+    description=(
+      #|Record the status of the standing session goal. Call with status "met" only when the goal is fully achieved and verified — this durably clears it. Call with status "continuing" plus a short "remaining" summary when you finish a task while goal work remains. Call with status "blocked" plus a "reason" when the goal cannot proceed (impossible, blocked, or superseded) — the goal keeps standing for the user, but autonomous continuation pauses. Only meaningful when a standing goal is set.
+    ),
+    schema=JsonSchema({
+      "type": "object",
+      "properties": {
+        "status": { "type": "string", "enum": ["met", "continuing", "blocked"] },
+        "remaining": {
+          "type": "string",
+          "description": "Required when status is \"continuing\": one or two lines on what is left to reach the goal.",
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why the goal cannot proceed; required with status \"blocked\".",
+        },
+      },
+      "required": ["status"],
+      "additionalProperties": false,
+    }),
+    execute=Sync(execute),
+    control=true,
+  )
+}
+
+///|
+fn execute(arguments : Json) -> @agent_tool.ToolAction {
+  match decode_status(arguments) {
+    Ok(_) => @agent_tool.ToolAction::respond("goal status recorded")
+    Err(message) =>
+      @agent_tool.ToolAction::respond("error: \{message}", is_error=true)
+  }
+}

--- a/agent_tool/goal/goal_test.mbt
+++ b/agent_tool/goal/goal_test.mbt
@@ -1,0 +1,35 @@
+///|
+test "goal status decodes met and continuing" {
+  assert_true(@goal.decode_status({ "status": "met" }) is Ok(Met))
+  assert_true(
+    @goal.decode_status({ "status": "continuing", "remaining": "parser left" })
+    is Ok(Continuing("parser left")),
+  )
+}
+
+///|
+test "goal status rejects malformed arguments" {
+  guard @goal.decode_status({ "status": "continuing" }) is Err(message) else {
+    fail("continuing without remaining accepted")
+  }
+  assert_true(message.contains("remaining"))
+  guard @goal.decode_status({ "status": "continuing", "remaining": "  " })
+    is Err(message) else {
+    fail("blank remaining accepted")
+  }
+  assert_true(message.contains("non-blank"))
+  guard @goal.decode_status({ "status": "done" }) is Err(message) else {
+    fail("unknown status accepted")
+  }
+  assert_true(message.contains("met"))
+  guard @goal.decode_status({ "remaining": "x" }) is Err(message) else {
+    fail("missing status accepted")
+  }
+  assert_true(message.contains("status"))
+}
+
+///|
+test "goal definition validates through its fallback execute" {
+  let definition = @goal.definition()
+  assert_eq(definition.name, "goal")
+}

--- a/agent_tool/goal/moon.pkg
+++ b/agent_tool/goal/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "moonbitlang/core/json",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/goal/pkg.generated.mbti
+++ b/agent_tool/goal/pkg.generated.mbti
@@ -1,0 +1,26 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/goal"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn decode_status(Json) -> Result[GoalStatus, String]
+
+pub fn definition() -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+pub(all) enum GoalStatus {
+  Met
+  Continuing(String)
+  Blocked(String)
+} derive(@debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -6,6 +6,77 @@ priv enum ServeCommand {
   Steer(@agent_runtime.SteerInput)
   Compact
   Cancel
+  Goal(GoalAction)
+}
+
+///|
+/// A goal command's payload: set/replace the standing goal or clear it.
+/// `auto` opts the engine into continuing toward the goal on its own after
+/// each finished turn (headless controllers; the TUI composes /loop instead).
+/// Arming never self-starts work: continuation fires only off a finishing
+/// turn, so the controller still sends the first prompt.
+priv enum GoalAction {
+  SetGoal(String, auto~ : Bool)
+  ClearGoal
+}
+
+///|
+/// Turns the engine will start on its own toward one standing goal before
+/// pausing for input — the same order as /loop's default fire budget. Reset
+/// whenever a goal is set with auto continuation.
+const GoalAutoContinueMaxTurns : Int = 20
+
+///|
+const GoalContinuePrompt : String =
+  #|Continue working toward the standing goal. When it is fully met, record
+  #|that by calling the goal tool with status "met".
+
+///|
+/// Whether a pending auto intent may be promoted to armed: the persisted
+/// standing goal must carry the intent's exact text AND a set marker newer
+/// than the sequence baseline recorded when the command arrived. Text alone
+/// cannot distinguish "this exact set persisted" from "an identical-text
+/// goal was already standing when the new set's append failed" (codex
+/// review), so promotion keys on marker identity.
+fn goal_auto_promotable(
+  current : @agent_session.StandingGoal?,
+  text : String,
+  baseline : Int,
+) -> Bool {
+  current is Some(goal) && goal.text() == text && goal.set_sequence() > baseline
+}
+
+///|
+/// Whether auto-continue is armed for the persisted standing goal. `target`
+/// is only ever set by promotion (goal_auto_promotable), so this is the
+/// cheap per-decision recheck that the armed goal still stands unchanged.
+fn goal_auto_armed(
+  current : @agent_session.StandingGoal?,
+  target : String?,
+) -> Bool {
+  current is Some(goal) && target is Some(text) && goal.text() == text
+}
+
+///|
+/// Whether the engine should start another turn toward the standing goal.
+/// Pure so the policy is unit-testable: only a cleanly finished turn on a
+/// fully idle, still-serving engine with a standing goal and budget left
+/// continues — failures, aborts, interruptions, queued work, and shutdown
+/// all pause for the controller.
+fn should_auto_continue(
+  auto~ : Bool,
+  finished~ : Bool,
+  idle~ : Bool,
+  shutting_down~ : Bool,
+  goal_standing~ : Bool,
+  turns_remaining~ : Int,
+) -> Bool {
+  auto &&
+  finished &&
+  idle &&
+  !shutting_down &&
+  goal_standing &&
+  turns_remaining > 0
 }
 
 ///|
@@ -13,6 +84,19 @@ priv enum ServeCommand {
 priv enum PendingWork {
   PendingPrompt(String)
   PendingCompact
+  // A goal marker holding its wire-order position behind a compaction: a
+  // pending compaction must not cover a goal that arrived after the compact
+  // command.
+  // The marker plus the command context that PRECEDED it at arrival: the
+  // drain replays true wire order — context arriving later stays in the
+  // runtime queue and lands after the goal.
+  // marker, arrival-context snapshot, and whether THIS command carried
+  // auto: promotion fires only on the auto entry's own durable append.
+  PendingGoal(String, Array[@agent_runtime.SteerInput], Bool, Int)
+  // Context that arrived AFTER a queued goal: fenced into the ordered
+  // queue so it cannot overtake the goal via the runtime steer queue (an
+  // earlier pending prompt would otherwise drain it first).
+  PendingContext(@agent_runtime.SteerInput)
 }
 
 ///|
@@ -30,7 +114,7 @@ priv enum ActiveWork {
 /// command handling race-free against turn lifecycle.
 priv enum ServeStep {
   Wire(ServeCommand)
-  TurnDone
+  TurnDone(finished~ : Bool)
   CompactDone(@agent_session.Session)
   // A background job finished; wake the loop to drain and surface its notice
   // even when no turn is active.
@@ -57,6 +141,17 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
     { "command": "prompt", .. } => Err("expected a string \"text\" field")
     { "command": "compact", .. } => Ok(Compact)
     { "command": "cancel", .. } => Ok(Cancel)
+    { "command": "goal", "action": "set", "text": String(text), .. } =>
+      if text.trim().is_empty() {
+        Err("goal text must not be blank")
+      } else {
+        Ok(Goal(SetGoal(text, auto=json is { "auto": True, .. })))
+      }
+    { "command": "goal", "action": "clear", .. } => Ok(Goal(ClearGoal))
+    { "command": "goal", .. } =>
+      Err(
+        "expected {\"action\": \"set\", \"text\": ...} or {\"action\": \"clear\"}",
+      )
     { "command": String(other), .. } => Err("unknown command: \{other}")
     _ => Err("expected a {\"command\": ...} object")
   }
@@ -132,6 +227,55 @@ test "serve commands decode and reject with actionable errors" {
     fail("non-object accepted")
   }
   assert_true(message.contains("command"))
+  assert_true(
+    decode_serve_command({
+      "command": "goal",
+      "action": "set",
+      "text": "port the decoder",
+    })
+    is Ok(Goal(SetGoal("port the decoder", auto=false))),
+  )
+  assert_true(
+    decode_serve_command({
+      "command": "goal",
+      "action": "set",
+      "text": "grind it out",
+      "auto": true,
+    })
+    is Ok(Goal(SetGoal("grind it out", auto=true))),
+  )
+  assert_true(
+    decode_serve_command({
+      "command": "goal",
+      "action": "set",
+      "text": "grind it out",
+      "auto": "yes",
+    })
+    is Ok(Goal(SetGoal("grind it out", auto=false))),
+  )
+  assert_true(
+    decode_serve_command({ "command": "goal", "action": "clear" })
+    is Ok(Goal(ClearGoal)),
+  )
+  guard decode_serve_command({
+      "command": "goal",
+      "action": "set",
+      "text": "  ",
+    })
+    is Err(message) else {
+    fail("blank goal accepted")
+  }
+  assert_true(message.contains("blank"))
+  guard decode_serve_command({ "command": "goal", "action": "set" })
+    is Err(message) else {
+    fail("textless goal set accepted")
+  }
+  assert_true(message.contains("action"))
+  guard decode_serve_command({ "command": "goal", "action": "toggle" })
+    is Err(message) else {
+    fail("unknown goal action accepted")
+  }
+  assert_true(message.contains("action"))
 }
 
 ///|
@@ -147,17 +291,191 @@ fn has_pending_prompt(pending : Array[PendingWork]) -> Bool {
 }
 
 ///|
-test "pending prompt helpers ignore queued compactions" {
+fn has_pending_goal(pending : Array[PendingWork]) -> Bool {
+  pending.any(work => work is PendingGoal(_, _, _, _))
+}
+
+///|
+fn has_pending_compact(pending : Array[PendingWork]) -> Bool {
+  for work in pending {
+    if work is PendingCompact {
+      return true
+    }
+  }
+  false
+}
+
+///|
+test "pending prompt helpers ignore queued compactions and goals" {
   let pending : Array[PendingWork] = []
   assert_false(has_pending_prompt(pending))
+  assert_false(has_pending_compact(pending))
   pending.push(PendingCompact)
+  pending.push(PendingGoal("[goal]\nship it", [], false, 1))
   assert_false(has_pending_prompt(pending))
+  assert_true(has_pending_compact(pending))
   pending.push(PendingPrompt("next"))
   assert_true(has_pending_prompt(pending))
+  // Cancel targets the next prompt, never a queued goal update.
   remove_next_pending_prompt(pending)
   assert_false(has_pending_prompt(pending))
-  assert_eq(pending.length(), 1)
+  assert_eq(pending.length(), 2)
   assert_true(pending[0] is PendingCompact)
+  assert_true(pending[1] is PendingGoal(_, _, _, _))
+}
+
+///|
+test "auto arms only for the exact persisted goal" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="p").append(
+    Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nship the feature")),
+  )
+  let standing = session.current_goal()
+  assert_true(goal_auto_armed(standing, Some("ship the feature")))
+  // A set whose append failed (or was superseded) never arms.
+  assert_false(goal_auto_armed(standing, Some("a different goal")))
+  assert_false(goal_auto_armed(standing, None))
+  assert_false(goal_auto_armed(None, Some("ship the feature")))
+}
+
+///|
+test "promotion requires a marker newer than the command baseline" {
+  // The goal marker is event 1.
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="p").append(
+    Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nship the feature")),
+  )
+  let standing = session.current_goal()
+  // A set command that arrived when last_sequence was 0 promotes: the
+  // marker (sequence 1) is newer than its baseline.
+  assert_true(goal_auto_promotable(standing, "ship the feature", 0))
+  // The same-text regression: a re-set arriving AFTER that marker existed
+  // (baseline 1) whose own append failed must NOT promote off the old
+  // marker, even though the text matches.
+  assert_false(goal_auto_promotable(standing, "ship the feature", 1))
+  assert_false(goal_auto_promotable(standing, "different text", 0))
+  assert_false(goal_auto_promotable(None, "ship the feature", 0))
+}
+
+///|
+test "a context-yield turn chains: finished derivation and standing goal" {
+  // The whole PR-B contract in one place: a turn that ended at the context
+  // ceiling is durably Terminal(Finished(...)), so serve derives
+  // finished=true from the last event exactly as for a real completion —
+  // and the goal marker, covered by the checkpoint summary or not, still
+  // stands in the raw log. Auto-continue therefore chains one turn per
+  // context window with no yield-specific code.
+  let session = @agent_session.Session(
+      SessionId("yield-chains"),
+      system_prompt="system",
+    )
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nbig objective")),
+    )
+    .append(Terminal(Finished("turn one answer")))
+    .append(User(UserMessage("continue")))
+    .append(
+      Summary(
+        SessionSummary(content="checkpoint", from_sequence=1, to_sequence=3),
+      ),
+    )
+    .append(
+      Terminal(
+        Finished(
+          "\{@agent_session.ContextYieldAnswerPrefix} continue in a new turn",
+        ),
+      ),
+    )
+  let finished = session.events().peek() is Some(event) &&
+    event.item() is Terminal(Finished(_))
+  assert_true(finished)
+  guard session.current_goal() is Some(goal) else {
+    fail("the goal must survive the checkpoint")
+  }
+  assert_eq(goal.text(), "big objective")
+  assert_true(
+    should_auto_continue(
+      auto=true,
+      finished~,
+      idle=true,
+      shutting_down=false,
+      goal_standing=true,
+      turns_remaining=1,
+    ),
+  )
+}
+
+///|
+test "auto-continue requires a finished idle serving turn with budget" {
+  assert_true(
+    should_auto_continue(
+      auto=true,
+      finished=true,
+      idle=true,
+      shutting_down=false,
+      goal_standing=true,
+      turns_remaining=1,
+    ),
+  )
+  // Any single condition failing pauses for the controller.
+  assert_false(
+    should_auto_continue(
+      auto=false,
+      finished=true,
+      idle=true,
+      shutting_down=false,
+      goal_standing=true,
+      turns_remaining=1,
+    ),
+  )
+  assert_false(
+    should_auto_continue(
+      auto=true,
+      finished=false,
+      idle=true,
+      shutting_down=false,
+      goal_standing=true,
+      turns_remaining=1,
+    ),
+  )
+  assert_false(
+    should_auto_continue(
+      auto=true,
+      finished=true,
+      idle=false,
+      shutting_down=false,
+      goal_standing=true,
+      turns_remaining=1,
+    ),
+  )
+  assert_false(
+    should_auto_continue(
+      auto=true,
+      finished=true,
+      idle=true,
+      shutting_down=true,
+      goal_standing=true,
+      turns_remaining=1,
+    ),
+  )
+  assert_false(
+    should_auto_continue(
+      auto=true,
+      finished=true,
+      idle=true,
+      shutting_down=false,
+      goal_standing=false,
+      turns_remaining=1,
+    ),
+  )
+  assert_false(
+    should_auto_continue(
+      auto=true,
+      finished=true,
+      idle=true,
+      shutting_down=false,
+      goal_standing=true,
+      turns_remaining=0,
+    ),
+  )
 }
 
 ///|
@@ -250,6 +568,37 @@ async fn run_serve(
     let pending : Array[PendingWork] = []
     let mut active_work : ActiveWork? = None
     let mut shutting_down = false
+    // Auto-continue bookkeeping. A set with "auto": true records a PENDING
+    // intent (text + the last_sequence baseline at command receipt); the
+    // intent is promoted to the armed target — and the budget granted — only
+    // once a matching set marker NEWER than the baseline is durably standing
+    // (goal_auto_promotable), so neither a failed append nor an
+    // identical-text goal that was already standing can arm the loop.
+    let mut goal_auto_pending : (String, Int)? = None
+    let mut goal_auto_target : String? = None
+    let mut goal_turns_remaining = 0
+    let mut goal_promoted_this_boundary = false
+    // Monotonic serial over goal-affecting commands (set/clear/cancel): a
+    // queued auto entry arms only if NO later command superseded it.
+    let mut goal_command_serial = 0
+    // Local closures cannot take labelled args: the Bool is
+    // defer_continue — true only when the marker landed AFTER the turn
+    // ended (the PendingGoal drain).
+    fn maybe_promote_goal_auto(defer_continue : Bool) -> Unit {
+      if goal_auto_pending is Some((text, baseline)) &&
+        goal_auto_promotable(session.current_goal(), text, baseline) {
+        goal_auto_target = Some(text)
+        goal_turns_remaining = GoalAutoContinueMaxTurns
+        goal_auto_pending = None
+        // Deferred only when the marker landed AFTER the turn ended (the
+        // PendingGoal drain): that turn never saw the goal, so its first
+        // turn belongs to the controller. A goal steered INTO the
+        // finishing turn was already worked under — continue it.
+        if defer_continue {
+          goal_promoted_this_boundary = true
+        }
+      }
+    }
     async fn compact_and_report(
       current : @agent_session.Session,
     ) -> @agent_session.Session {
@@ -297,6 +646,24 @@ async fn run_serve(
       }
     }
 
+    // Report a durably appended goal marker to the controller. Called only
+    // after the append succeeded — never at queue time, when the marker could
+    // still be lost with a dying turn — so the TUI can only learn a goal that
+    // was actually persisted.
+    fn report_goal_update(content : String) -> Unit {
+      match @agent_session.goal_marker(content) {
+        Some(GoalSet(text)) =>
+          @xlog.info() <? { "event": "goal_updated", "goal": text }
+        Some(GoalCleared) =>
+          @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
+        // A blocked marker pauses auto-continuation but the goal stands:
+        // it is reported by the loop's own goal_blocked event, not as a
+        // goal_updated (the goal did not change).
+        Some(GoalBlocked(_)) => ()
+        None => ()
+      }
+    }
+
     // Surface a background-job completion notice while the engine is idle
     // (between turns). Persist it as a `Runtime` item — on resume it renders as a
     // notice, not user input — and log it untagged: the TUI drops run-tagged
@@ -313,15 +680,58 @@ async fn run_serve(
     // the session's current boundary. Called whenever the loop returns to idle
     // (turn or compaction done), so a `!` delivered mid-work is never left
     // orphaned in the steer queue to be lost or applied to an unrelated prompt.
+    async fn apply_idle_context_input(
+      input : @agent_runtime.SteerInput,
+    ) -> Unit {
+      match input {
+        Prompt(text) =>
+          @xlog.warn() <? { "event": "steer_dropped", "content": text }
+        Command(text) => append_command_context(text, "command")
+        Notice(text) =>
+          match @agent_session.goal_marker(text) {
+            // A goal marker deferred behind a live turn lands here when the
+            // turn ends before its next step boundary. Its notice leg is
+            // transport: persist and report it as a goal update, so no
+            // controller ever sees it dressed as a background notice.
+            Some(_) =>
+              if append_idle_item(Runtime(RuntimeNotice(text)), "goal update") {
+                report_goal_update(text)
+                // Drained at idle: the finished turn never saw this marker,
+                // so its first turn belongs to the controller.
+                maybe_promote_goal_auto(true)
+              }
+            None => append_background_notice(text)
+          }
+      }
+    }
+
     async fn drain_command_context() -> Unit {
       for input in runtime.drain_steers() {
-        match input {
-          Prompt(text) =>
-            @xlog.warn() <? { "event": "steer_dropped", "content": text }
-          Command(text) => append_command_context(text, "command")
-          Notice(text) => append_background_notice(text)
+        apply_idle_context_input(input)
+      }
+    }
+
+    // Snapshot the command context PRECEDING a goal at its ARRIVAL:
+    // everything from the first Prompt onward belongs to a pending prompt
+    // turn and is re-queued in order, never dropped. The snapshot rides the
+    // PendingGoal entry so the eventual drain replays true wire order.
+    fn take_context_before_goal() -> Array[@agent_runtime.SteerInput] {
+      let inputs = runtime.drain_steers()
+      let mut boundary = inputs.length()
+      for index, input in inputs {
+        if input is Prompt(_) {
+          boundary = index
+          break
         }
       }
+      let context : Array[@agent_runtime.SteerInput] = []
+      for index in 0..<boundary {
+        context.push(inputs[index])
+      }
+      for index in boundary..<inputs.length() {
+        runtime.queue_steer(inputs[index])
+      }
+      context
     }
 
     fn start_turn(task_text : String) -> @async.Task[Unit] {
@@ -358,11 +768,15 @@ async fn run_serve(
             } else {
               @xlog.error() <? { "event": "turn_failed", "error": "\{error}" }
             }
-            ignore(steps.try_put(TurnDone) catch { _ => false })
+            ignore(steps.try_put(TurnDone(finished=false)) catch { _ => false })
             return
           }
         }
-        ignore(steps.try_put(TurnDone) catch { _ => false })
+        // The auto-continue policy keys off a cleanly finished turn; the live
+        // `session` var already holds every append this turn made.
+        let finished = session.events().peek() is Some(event) &&
+          event.item() is Terminal(Finished(_))
+        ignore(steps.try_put(TurnDone(finished~)) catch { _ => false })
       }
     }
 
@@ -385,12 +799,46 @@ async fn run_serve(
       }
     }
 
-    fn start_next_pending() -> Unit {
-      guard active_work is None && pending.length() > 0 else { return }
-      match pending.remove(0) {
-        PendingPrompt(text) => active_work = Some(ActiveTurn(start_turn(text)))
-        PendingCompact =>
-          active_work = Some(ActiveCompact(start_compaction(session)))
+    async fn start_next_pending() -> Unit {
+      pending_loop~: for ;; {
+        if active_work is Some(_) || pending.length() == 0 {
+          break pending_loop~
+        }
+        match pending.remove(0) {
+          PendingPrompt(text) => {
+            active_work = Some(ActiveTurn(start_turn(text)))
+            break pending_loop~
+          }
+          PendingCompact => {
+            active_work = Some(ActiveCompact(start_compaction(session)))
+            break pending_loop~
+          }
+          // Instant work: append the goal at its ordered position and keep
+          // draining the queue. A command context produced BEFORE the goal
+          // was queued lands first — the goal may depend on that output,
+          // and durable order must match arrival order.
+          // Fenced context: apply at its ordered position and keep draining.
+          PendingContext(input) => apply_idle_context_input(input)
+          PendingGoal(marker, context, is_auto, serial) => {
+            for input in context {
+              apply_idle_context_input(input)
+            }
+            if append_idle_item(Runtime(RuntimeNotice(marker)), "goal update") {
+              report_goal_update(marker)
+              // Promotion tied to THIS entry's durable append: with two
+              // same-text goals queued, an earlier append must not arm an
+              // auto command whose own marker is not durable yet.
+              if is_auto &&
+                serial == goal_command_serial &&
+                @agent_session.goal_marker(marker) is Some(GoalSet(text)) {
+                goal_auto_target = Some(text)
+                goal_turns_remaining = GoalAutoContinueMaxTurns
+                goal_auto_pending = None
+                goal_promoted_this_boundary = true
+              }
+            }
+          }
+        }
       }
     }
 
@@ -433,16 +881,31 @@ async fn run_serve(
               // appended at the next turn's drain — never written straight into
               // a session a running compaction is about to replace. Only a fully
               // idle engine appends it immediately.
-              if active_work is Some(_) || has_pending_prompt(pending) {
+              if has_pending_goal(pending) {
+                // Fenced behind the queued goal: wire order must stay
+                // goal-then-context for context sent after the goal.
+                pending.push(PendingContext(Command(text)))
+              } else if active_work is Some(_) || has_pending_prompt(pending) {
                 runtime.queue_steer(Command(text))
               } else {
                 append_command_context(text, "command")
               }
             // A notice is engine-internal and never actually arrives over the
             // wire; queue it losslessly for completeness.
-            Notice(text) => runtime.queue_steer(Notice(text))
+            Notice(text) =>
+              if has_pending_goal(pending) {
+                pending.push(PendingContext(Notice(text)))
+              } else {
+                runtime.queue_steer(Notice(text))
+              }
           }
-        Wire(Cancel) =>
+        Wire(Cancel) => {
+          // A user interrupt stops the autonomous loop, not just one turn —
+          // including any auto intent still queued behind pending work.
+          goal_command_serial += 1
+          goal_auto_pending = None
+          goal_auto_target = None
+          goal_turns_remaining = 0
           match active_work {
             Some(ActiveTurn(task)) => task.cancel()
             Some(ActiveCompact(task)) => task.cancel()
@@ -451,20 +914,125 @@ async fn run_serve(
               // submitted prompt, so withdraw it before it starts.
               remove_next_pending_prompt(pending)
           }
+        }
         Wire(Compact) =>
           if active_work is Some(_) {
             pending.push(PendingCompact)
           } else {
             active_work = Some(ActiveCompact(start_compaction(session)))
           }
+        Wire(Goal(action)) => {
+          // Any new goal command supersedes the previous auto state; a set
+          // with auto only records a PENDING intent against the current
+          // sequence baseline — arming happens at promotion, after the
+          // marker durably lands.
+          match action {
+            SetGoal(text, auto~) => {
+              // For a QUEUED goal the promotion is tied to its own append
+              // (see the PendingGoal drain); the baseline mechanism covers
+              // the steer/idle paths where the append happens elsewhere.
+              goal_auto_pending = if auto {
+                Some((text, session.last_sequence()))
+              } else {
+                None
+              }
+              goal_auto_target = None
+              goal_turns_remaining = 0
+            }
+            ClearGoal => {
+              goal_auto_pending = None
+              goal_auto_target = None
+              goal_turns_remaining = 0
+            }
+          }
+          let marker = match action {
+            SetGoal(text, ..) => "\{@agent_session.GoalPrefix}\n\{text}"
+            ClearGoal => @agent_session.GoalClearedNotice
+          }
+          if pending.length() > 0 || active_work is Some(ActiveCompact(_)) {
+            // ANY queued work ahead in wire order — a pipelined prompt as
+            // much as a compaction — must precede this goal, or a pending
+            // prompt would start under a goal sent after it. A running
+            // compaction's session snapshot must also not be invalidated by
+            // a mid-flight append: hold the ordered queue position.
+            let is_auto = action is SetGoal(_, auto=true)
+            goal_command_serial += 1
+            // The entry OWNS the auto intent: promotion happens only on
+            // its own successful append (drain arm), never via the
+            // baseline path — an earlier same-text marker must not arm it.
+            goal_auto_pending = None
+            // Snapshot the preceding context ONLY when nothing else owns
+            // the runtime queue: with a live turn or a prompt queued ahead,
+            // those steers belong to the earlier consumer — stealing them
+            // into this entry would drag earlier wire items behind it.
+            let context = if active_work is Some(ActiveTurn(_)) ||
+              has_pending_prompt(pending) {
+              []
+            } else {
+              take_context_before_goal()
+            }
+            pending.push(
+              PendingGoal(marker, context, is_auto, goal_command_serial),
+            )
+          } else if active_work is Some(ActiveTurn(_)) {
+            // A live turn: the lossless steer queue makes the marker
+            // model-visible at the next step boundary (reporting after the
+            // durable append); if the turn ends first, the TurnDone drain
+            // persists it before any queued prompt starts, so the next turn
+            // still sees it.
+            runtime.queue_steer(Notice(marker))
+          } else if append_idle_item(
+              Runtime(RuntimeNotice(marker)),
+              "goal update",
+            ) {
+            report_goal_update(marker)
+            maybe_promote_goal_auto(false)
+          }
+        }
         // A background job finished. If a turn is active, its next step boundary
         // drains and applies the queued notice live; only drain here when idle,
         // so an idle engine still surfaces the completion.
         BackgroundNotice => if active_work is None { drain_command_context() }
-        TurnDone => {
+        TurnDone(finished~) => {
+          goal_promoted_this_boundary = false
           drain_command_context()
           active_work = None
           start_next_pending()
+          // Promotion here covers the steer path: a goal set applied inside
+          // a live turn is only observable to serve through the session.
+          maybe_promote_goal_auto(false)
+          let standing = session.current_goal()
+          let armed = goal_auto_armed(standing, goal_auto_target) &&
+            !goal_promoted_this_boundary
+          if should_auto_continue(
+              auto=armed,
+              finished~,
+              idle=active_work is None && pending.length() == 0,
+              shutting_down~,
+              // A durably blocked goal stands for the user but must not
+              // relaunch declared-impossible work.
+              goal_standing=standing is Some(goal) && !goal.blocked(),
+              turns_remaining=goal_turns_remaining,
+            ) {
+            goal_turns_remaining -= 1
+            @xlog.info() <?
+              { "event": "goal_continue", "remaining": goal_turns_remaining }
+            active_work = Some(ActiveTurn(start_turn(GoalContinuePrompt)))
+          } else if armed &&
+            finished &&
+            !shutting_down &&
+            active_work is None &&
+            pending.length() == 0 &&
+            goal_turns_remaining == 0 {
+            // The loop ran its full budget without the goal being met:
+            // disarm and tell the controller, once.
+            goal_auto_target = None
+            @xlog.warn() <?
+              {
+                "event": "goal_budget_exhausted",
+                "turns": GoalAutoContinueMaxTurns,
+              }
+          }
           if active_work is None && pending.length() == 0 && shutting_down {
             break serve~
           }

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -12,6 +12,12 @@ priv struct EngineProcess {
   // The stdout reader task for this engine, so a graceful shutdown can wait for
   // the engine to drain its stdin and exit before teardown kills it.
   mut reader : @async.Task[Unit]?
+  // Goal set/clear lines written to THIS engine but not yet answered by a
+  // matching durable goal_updated (Some(text)=set, None=clear; unrelated
+  // updates must not consume an ack). Owned by the process like run
+  // bookkeeping: a replaced engine's EOF must not clear — or falsely warn
+  // about — a successor's outstanding ack.
+  pending_goal_acks : Array[String?]
 }
 
 ///|
@@ -78,6 +84,7 @@ async fn[G] EngineClient::start(
     latest_run: 0,
     run_open: false,
     reader: None,
+    pending_goal_acks: [],
   }
   self.live = Some(engine)
   let reader_task = group.spawn(no_wait=true) <| () => {
@@ -94,19 +101,74 @@ async fn[G] EngineClient::start(
           // always reaches the user.
           SteerDropped(text) =>
             self.messages.try_put(EngineSteerDropped(text)) |> ignore
+          // A rejection can answer an idle command (e.g. /goal sent to an
+          // engine that does not implement it), where no run owns it and a
+          // tagged message would be eaten by the stale-run guard. Rejections
+          // are never run-terminal, so untagged is safe in-run too.
+          CommandRejected(message) => {
+            // A rejection cannot be correlated to a specific pending goal
+            // ack; settle them all — the rejection itself is surfaced, and
+            // stale entries would otherwise mis-warn at EOF or consume a
+            // later matching ack.
+            engine.pending_goal_acks.clear()
+            self.messages.try_put(
+              EngineBackgroundNotice("engine rejected command: \{message}"),
+            )
+            |> ignore
+          }
           // A background job finished between turns: the engine already emitted
           // this untagged, so post it untagged too — a run-tagged message would
           // be swept by the stale-run guard once the turn closed.
           BackgroundNotice(text) =>
             self.messages.try_put(EngineBackgroundNotice(text)) |> ignore
+          // A durable goal update. Posted untagged: an idle set/clear (or one
+          // landing after its turn closed) must survive the stale-run guard.
+          GoalUpdated(goal) => {
+            match engine.pending_goal_acks.search(goal) {
+              Some(index) => engine.pending_goal_acks.remove(index) |> ignore
+              None => ()
+            }
+            self.messages.try_put(EngineGoalUpdated(goal)) |> ignore
+          }
+          // Auto-continue lifecycle from a headless-armed goal: surfaced as
+          // plain notices — the TUI never arms auto itself, and engine-
+          // initiated turns are invisible to run tracking by design.
+          GoalContinue(remaining) =>
+            self.messages.try_put(
+              EngineBackgroundNotice(
+                "goal: engine continuing (\{remaining} auto turns left)",
+              ),
+            )
+            |> ignore
+          GoalBudgetExhausted =>
+            self.messages.try_put(
+              EngineBackgroundNotice(
+                "goal: auto-continue budget exhausted; goal still standing",
+              ),
+            )
+            |> ignore
           // A command context's delivery ack. The output is already rendered as
           // a local card and the engine appended it synchronously, so there is
           // nothing to do — in particular, do not echo it like a prompt steer.
           SteerApplied(Command(_)) => ()
           // The engine reports this when a command-context append failed; surface
           // it so the lost output is not silent.
-          SessionError(error) =>
+          AgentError(_) as failure => {
+            // A failed turn can swallow a goal notice drained into it (its
+            // store append died with the turn): settle pending acks so a
+            // retry is not mis-correlated and EOF does not mis-warn.
+            engine.pending_goal_acks.clear()
+            self.messages.try_put(
+              AgentProgress(run_id=engine.latest_run, failure),
+            )
+            |> ignore
+          }
+          SessionError(error) => {
+            // Persistence failed: any pending goal ack may never be
+            // answered — settle rather than mis-warn or mis-consume later.
+            engine.pending_goal_acks.clear()
             self.messages.try_put(EngineSessionError(error)) |> ignore
+          }
           _ => {
             if is_terminal_event(event) {
               engine.run_open = false
@@ -146,6 +208,20 @@ async fn[G] EngineClient::start(
           engine_exit_without_result(code, diagnostics),
         ),
       )
+    }
+    // An idle goal update the engine never confirmed died with it: say so —
+    // silence here reads as success.
+    if engine.pending_goal_acks.length() > 0 {
+      engine.pending_goal_acks.clear()
+      // EngineSessionError, not a background notice: the quit path's
+      // post-shutdown drain renders only errors, and quit-before-confirm
+      // is exactly the case this warning exists for.
+      self.messages.try_put(
+        EngineSessionError(
+          "goal update may not have been recorded: the engine exited before confirming it — check /goal and resend if needed",
+        ),
+      )
+      |> ignore
     }
     // The watchers this engine owned died with it: let the loop observe the
     // engine boundary, whatever the exit reason.
@@ -303,6 +379,61 @@ async fn[G] EngineClient::steer(
           )
         }
       }
+    }
+  }
+}
+
+///|
+/// Send a standing-goal update to the serve engine: `Some(text)` sets or
+/// replaces the goal, `None` clears it. Like command context, this is an
+/// explicit user operation on the durable session, so it may start the
+/// long-lived engine to record the goal without opening a model turn. The
+/// engine answers every persisted update with `goal_updated`, which is the
+/// only signal that mutates the TUI's mirrored goal state.
+async fn[G] EngineClient::goal(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+  goal : String?,
+) -> Unit {
+  if self.live is None {
+    self.start(group) catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      error => {
+        self.messages.put(
+          EngineSessionError("failed to start engine for goal update: \{error}"),
+        )
+        return
+      }
+    }
+  }
+  guard self.live is Some(live) else {
+    self.messages.put(
+      EngineSessionError("failed to send goal update: engine is not running"),
+    )
+    return
+  }
+  let command : Json = match goal {
+    Some(text) => { "command": "goal", "action": "set", "text": text }
+    None => { "command": "goal", "action": "clear" }
+  }
+  // Registered BEFORE the write: a fast engine can append the marker and
+  // emit goal_updated while the write call is still yielding, and the
+  // reader must find the expected ack already present. Rolled back if the
+  // write itself fails.
+  live.pending_goal_acks.push(goal)
+  live.writer.write("\{command.stringify()}\n") catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    error => {
+      match live.pending_goal_acks.search(goal) {
+        Some(index) => live.pending_goal_acks.remove(index) |> ignore
+        None => ()
+      }
+      self.live = None
+      self.messages.put(
+        EngineSessionError("failed to send goal update: \{error}"),
+      )
     }
   }
 }

--- a/cmd/tui/goal.mbt
+++ b/cmd/tui/goal.mbt
@@ -1,0 +1,55 @@
+///|
+/// `/goal` — show, set, or clear the session's standing goal.
+///
+/// Bare `/goal` shows the mirrored state locally. `set <text>` and `clear`
+/// go to the serve engine as a wire command; the transcript confirmation
+/// arrives with the engine's `goal_updated` event, after the durable append,
+/// so the TUI never claims a goal that was not persisted. The explicit `set`
+/// keyword keeps a goal whose text starts with "clear" expressible.
+fn handle_goal_command(
+  state : State,
+  arguments : String,
+  cmds : Array[Cmd],
+) -> Unit {
+  let trimmed = arguments.trim().to_owned()
+  if trimmed.is_empty() {
+    match state.goal {
+      Some(goal) => cmds.push(AppendItem(command_notice("goal: \{goal}")))
+      None =>
+        cmds.push(
+          AppendItem(
+            command_notice("no standing goal — set one with /goal set <text>"),
+          ),
+        )
+    }
+    return
+  }
+  // The goal is durable session state on the persistent serve engine; a
+  // oneshot engine is spawned per prompt and keeps no session to anchor it.
+  if state.config.engine_mode is OneShot {
+    cmds.push(
+      AppendItem(
+        Error("The goal command is not supported by a oneshot engine."),
+      ),
+    )
+    return
+  }
+  if trimmed == "clear" {
+    // Always send the clear: the mirror lags the engine by one ack, so a
+    // clear typed while a set is still in flight must not be dropped on the
+    // mirror's say-so. A tombstone on a goalless session is a harmless
+    // no-op the engine still confirms.
+    cmds.push(UpdateGoal(None))
+    return
+  }
+  if trimmed == "set" || trimmed.has_prefix("set ") {
+    let text = trimmed["set".length():].trim().to_owned()
+    if text.is_empty() {
+      cmds.push(AppendItem(Error("usage: /goal set <text>")))
+    } else {
+      cmds.push(UpdateGoal(Some(text)))
+    }
+    return
+  }
+  cmds.push(AppendItem(Error("usage: /goal | /goal set <text> | /goal clear")))
+}

--- a/cmd/tui/goal_wbtest.mbt
+++ b/cmd/tui/goal_wbtest.mbt
@@ -1,0 +1,151 @@
+///|
+fn goal_test_state() -> State {
+  State::new({
+    api_key: "k",
+    api_url: Some("https://proxy.example/v1/chat/completions"),
+    model: Deepseek(V4Pro),
+    cwd: ".",
+    max_steps: Some(10),
+    thinking: Max,
+    session_id: SessionId("goal-test"),
+    session_root: ".openseek",
+    engine: "openseek",
+    engine_args_prefix: [],
+    engine_mode: Serve,
+  })
+}
+
+///|
+fn update_goal_cmds(cmds : Array[Cmd]) -> Array[String?] {
+  [
+    for cmd in cmds if cmd is UpdateGoal(goal) => goal
+  ]
+}
+
+///|
+/// Local copies of the scheduler_wbtest counters: whitebox test files do not
+/// reliably share definitions across files on release toolchains.
+fn goal_notice_count(cmds : Array[Cmd]) -> Int {
+  [ for cmd in cmds if cmd is AppendItem(Notice(_)) => cmd ].length()
+}
+
+///|
+fn goal_error_count(cmds : Array[Cmd]) -> Int {
+  [ for cmd in cmds if cmd is AppendItem(Error(_)) => cmd ].length()
+}
+
+///|
+test "goal set and clear go to the engine; state stays untouched locally" {
+  let state = goal_test_state()
+  let set = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="set ship the feature")),
+  )
+  assert_true(update_goal_cmds(set) is [Some("ship the feature")])
+  assert_eq(goal_error_count(set), 0)
+  // Only the engine's goal_updated confirmation mutates the mirror.
+  assert_true(state.goal is None)
+  state.goal = Some("ship the feature")
+  let cleared = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="clear")),
+  )
+  assert_true(update_goal_cmds(cleared) is [None])
+  assert_eq(goal_error_count(cleared), 0)
+}
+
+///|
+test "bare goal shows the mirrored state" {
+  let state = goal_test_state()
+  let empty = update(state, UiInput(SlashCommand(name="goal", arguments="")))
+  assert_eq(goal_notice_count(empty), 1)
+  assert_eq(update_goal_cmds(empty).length(), 0)
+  state.goal = Some("ship the feature")
+  let shown = update(state, UiInput(SlashCommand(name="goal", arguments="")))
+  assert_eq(goal_notice_count(shown), 1)
+  assert_eq(update_goal_cmds(shown).length(), 0)
+}
+
+///|
+test "goal grammar rejects blanks, bare set, and unknown subcommands" {
+  let state = goal_test_state()
+  let bare_set = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="set")),
+  )
+  assert_eq(goal_error_count(bare_set), 1)
+  assert_eq(update_goal_cmds(bare_set).length(), 0)
+  let padded_set = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="set    ")),
+  )
+  assert_eq(goal_error_count(padded_set), 1)
+  // No implicit set: a goal must be introduced by the keyword, so a goal
+  // literally starting with "clear" stays expressible via `set clear ...`.
+  let implicit = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="just do it")),
+  )
+  assert_eq(goal_error_count(implicit), 1)
+  assert_eq(update_goal_cmds(implicit).length(), 0)
+  let keyword_goal = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="set clear the backlog")),
+  )
+  assert_true(update_goal_cmds(keyword_goal) is [Some("clear the backlog")])
+}
+
+///|
+test "clearing without a mirrored goal still goes to the engine" {
+  // The mirror lags the engine by one ack: a clear typed while a set is
+  // still in flight must reach the engine, not be dropped locally.
+  let state = goal_test_state()
+  let cmds = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="clear")),
+  )
+  assert_true(update_goal_cmds(cmds) is [None])
+  assert_eq(goal_error_count(cmds), 0)
+}
+
+///|
+test "goal set is rejected on a oneshot engine" {
+  let state = State::new({
+    api_key: "k",
+    api_url: None,
+    model: Deepseek(V4Pro),
+    cwd: ".",
+    max_steps: Some(10),
+    thinking: Max,
+    session_id: SessionId("goal-oneshot"),
+    session_root: ".openseek",
+    engine: "replay-engine",
+    engine_args_prefix: [],
+    engine_mode: OneShot,
+  })
+  let cmds = update(
+    state,
+    UiInput(SlashCommand(name="goal", arguments="set ship it")),
+  )
+  assert_eq(goal_error_count(cmds), 1)
+  assert_eq(update_goal_cmds(cmds).length(), 0)
+  // Show still works locally.
+  let shown = update(state, UiInput(SlashCommand(name="goal", arguments="")))
+  assert_eq(goal_notice_count(shown), 1)
+}
+
+///|
+test "goal_updated events write the mirror and confirm in the transcript" {
+  let state = goal_test_state()
+  let set = update(state, EngineGoalUpdated(Some("ship the feature")))
+  assert_true(state.goal is Some("ship the feature"))
+  assert_eq(goal_notice_count(set) + goal_input_notice_count(set), 1)
+  let cleared = update(state, EngineGoalUpdated(None))
+  assert_true(state.goal is None)
+  assert_eq(goal_notice_count(cleared) + goal_input_notice_count(cleared), 1)
+}
+
+///|
+fn goal_input_notice_count(cmds : Array[Cmd]) -> Int {
+  [ for cmd in cmds if cmd is AppendItem(Input(Notice(_))) => cmd ].length()
+}

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -80,6 +80,15 @@ pub fn decode_event(object : Json) -> AgentEvent? {
       Some(CompactionFinished(@jsonx.string(object, "summary")))
     "compaction_failed" =>
       Some(AgentError("compaction failed: \{@jsonx.string(object, "error")}"))
+    // A durably recorded goal update. Decoded null-aware — a cleared goal is
+    // {"goal": null}, which must not collapse into an empty-string set.
+    "goal_updated" =>
+      match object {
+        { "goal": String(goal), .. } => Some(GoalUpdated(Some(goal)))
+        _ => Some(GoalUpdated(None))
+      }
+    "goal_continue" => Some(GoalContinue(@jsonx.int(object, "remaining")))
+    "goal_budget_exhausted" => Some(GoalBudgetExhausted)
     // A turn that ended at the context ceiling: run-terminal, not success.
     "context_yield" => Some(ContextYield(@jsonx.string(object, "answer")))
     _ => None

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -168,6 +168,35 @@ test "usage total is derived from prompt and completion tokens" {
 }
 
 ///|
+test "goal updates decode null-aware" {
+  assert_true(
+    @event.decode_event({ "event": "goal_updated", "goal": "ship it" })
+    is Some(GoalUpdated(Some("ship it"))),
+  )
+  // A cleared goal is {"goal": null}: it must decode to None, not collapse
+  // into an empty-string set.
+  assert_true(
+    @event.decode_event({ "event": "goal_updated", "goal": Json::null() })
+    is Some(GoalUpdated(None)),
+  )
+  assert_true(
+    @event.decode_event({ "event": "goal_updated" }) is Some(GoalUpdated(None)),
+  )
+}
+
+///|
+test "goal auto-continue lifecycle decodes" {
+  assert_true(
+    @event.decode_event({ "event": "goal_continue", "remaining": 19 })
+    is Some(GoalContinue(19)),
+  )
+  assert_true(
+    @event.decode_event({ "event": "goal_budget_exhausted", "turns": 20 })
+    is Some(GoalBudgetExhausted),
+  )
+}
+
+///|
 test "a context yield decodes as its own run terminal" {
   assert_true(
     @event.decode_event({

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -60,6 +60,18 @@ pub(all) enum AgentEvent {
   // the durable session — now the conversation's context — so the controller can
   // preview it.
   CompactionFinished(String)
+  // The engine durably recorded a standing-goal update: `Some(text)` for a
+  // set, `None` for a clear. Non-terminal, and posted untagged by the client —
+  // an idle set/clear (or one landing after its turn closed) must survive the
+  // stale-run guard.
+  GoalUpdated(String?)
+  // The engine is starting an auto-continuation turn toward the standing
+  // goal (headless auto mode); carries the remaining turn budget. Posted
+  // untagged: it always lands between runs.
+  GoalContinue(Int)
+  // The auto-continue budget ran out with the goal still standing; the
+  // engine paused for input. Posted untagged for the same reason.
+  GoalBudgetExhausted
   // The turn ended at the model's context ceiling: checkpointed and
   // terminal for the run, but NOT task success — the work continues in a
   // new turn the user (or a controller) starts.

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -29,6 +29,9 @@ pub(all) enum AgentEvent {
   AgentError(String)
   CommandRejected(String)
   CompactionFinished(String)
+  GoalUpdated(String?)
+  GoalContinue(Int)
+  GoalBudgetExhausted
   ContextYield(String)
 }
 

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -412,12 +412,16 @@ fn handle_agent_event(
     // event is only a delivery acknowledgment.
     SteerApplied(Command(_)) => ()
     // A notice (e.g. a background job finishing) originates in the engine, not
-    // from a pending local steer, so just render it in the transcript. Idle
-    // background notices arrive untagged (as EngineBackgroundNotice), making
-    // the tagged BackgroundNotice path unreachable — but render it the same
-    // way for completeness.
+    // from a pending local steer, so just render it in the transcript — except
+    // goal markers, whose steer path is transport: the user-facing
+    // confirmation is the goal_updated event that follows the durable append.
+    // Idle background notices arrive untagged (as EngineBackgroundNotice),
+    // making the tagged BackgroundNotice path unreachable — but render it
+    // the same way for completeness.
     SteerApplied(Notice(text)) | BackgroundNotice(text) =>
-      cmds.push(AppendItem(Input(Notice(text))))
+      if @agent_session.goal_marker(text) is None {
+        cmds.push(AppendItem(Input(Notice(text))))
+      }
     // Normally unreachable from the wire: the engine client routes
     // steer_dropped events to the untagged message (they always trail the
     // racing turn's terminal, so a run-tagged copy would be stale-filtered).
@@ -483,6 +487,21 @@ fn handle_agent_event(
       cmds.push(AppendItem(compaction_item(summary)))
       state.finish_run()
     }
+    // The serve client posts goal updates untagged (EngineGoalUpdated) so
+    // idle confirmations survive the stale-run guard — but ONESHOT mode
+    // forwards engine events run-tagged, so this path is live there: the
+    // mirror must follow (a goal(met) mid-run would otherwise leave /goal
+    // reporting a cleared goal until restart).
+    GoalUpdated(goal) => {
+      state.goal = goal
+      let title = match goal {
+        Some(text) => "goal set: \{text}"
+        None => "goal cleared"
+      }
+      cmds.push(AppendItem(Input(Notice(title))))
+    }
+    // Likewise routed untagged by the client (as background notices).
+    GoalContinue(_) | GoalBudgetExhausted => ()
     // Terminal for the run but not task success: surface the continuation
     // guidance the yield answer carries. For a scheduled /loop run the next
     // fire IS the continuation, so a ceiling yield settles the schedule as
@@ -572,6 +591,7 @@ fn handle_slash_command(
       }
     "compact" => handle_compact_command(state, arguments, cmds)
     "loop" => handle_loop_command(state, arguments, cmds)
+    "goal" => handle_goal_command(state, arguments, cmds)
     other => cmds.push(AppendItem(Error("Unknown slash command: /\{other}")))
   }
 }
@@ -751,7 +771,23 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // fresh identical-text steer's entry from the next turn.
     EngineSteerDropped(text) => cmds.push(AppendItem(steer_dropped_item(text)))
     EngineSessionError(error) => cmds.push(AppendItem(Error(error)))
-    EngineBackgroundNotice(text) => cmds.push(AppendItem(Input(Notice(text))))
+    // Goal markers are filtered for the same reason as on the steer path:
+    // their notice leg is transport, and goal_updated carries the
+    // confirmation (defense in depth against engine version skew).
+    EngineBackgroundNotice(text) =>
+      if @agent_session.goal_marker(text) is None {
+        cmds.push(AppendItem(Input(Notice(text))))
+      }
+    // The engine's durable-append confirmation is the only writer of the
+    // mirrored goal state.
+    EngineGoalUpdated(goal) => {
+      state.goal = goal
+      let title = match goal {
+        Some(text) => "goal set: \{text}"
+        None => "goal cleared"
+      }
+      cmds.push(AppendItem(Input(Notice(title))))
+    }
     EngineExited => ()
     // Tick is a 1s heartbeat: it keeps the message loop turning so the trailing
     // refresh_ui re-runs (the elapsed-time activity line keeps advancing during
@@ -861,6 +897,7 @@ async fn[G] run_message_loop(
             }
           }
         SteerAgent(input) => engine.steer(group, input)
+        UpdateGoal(goal) => engine.goal(group, goal)
         // Compaction is an engine operation with no local task. Clear any stale
         // command handle (as a queued prompt would) so a Ctrl-C cancels this
         // compaction turn rather than a finished command task.

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -306,6 +306,10 @@ async fn run_tui(config : AppConfig, initial : String?) -> Unit {
         name="loop",
         description="recurring prompt: /loop [--max <n>] <interval> <prompt> | off | status | pause | resume",
       ),
+      @ui.SlashCommandSpec::new(
+        name="goal",
+        description="standing goal: /goal | /goal set <text> | /goal clear",
+      ),
     ]),
     ui => run_app(config, initial, ui),
   )
@@ -315,7 +319,7 @@ async fn run_tui(config : AppConfig, initial : String?) -> Unit {
 async fn run_app(config : AppConfig, initial : String?, ui : @ui.Ui) -> Unit {
   let state = State::new(config)
   let messages = @async.Queue(kind=Unbounded)
-  append_session_history(state.config, ui)
+  append_session_history(state, ui)
   // Name the session so the conversation is resumable later with
   // `--session <id>` — for generated ids this line is the only place the user
   // ever sees one.

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -48,7 +48,15 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
         Some(Response(message.content()))
       }
     Tool(result) => Some(session_tool_item(result))
-    Runtime(notice) => Some(runtime_notice_item(notice.content()))
+    // Goal markers are transport, not display — the resume path seeds a
+    // single "goal: ..." notice from current_goal(), matching the live
+    // path where markers are filtered and goal_updated is what renders.
+    Runtime(notice) =>
+      if @agent_session.goal_marker(notice.content()) is Some(_) {
+        None
+      } else {
+        Some(runtime_notice_item(notice.content()))
+      }
     Summary(summary) => Some(summary_item(summary))
     Terminal(terminal) => terminal_item(terminal)
   }
@@ -66,7 +74,8 @@ fn session_transcript_items(
 }
 
 ///|
-async fn append_session_history(config : AppConfig, ui : @ui.Ui) -> Unit {
+async fn append_session_history(state : State, ui : @ui.Ui) -> Unit {
+  let config = state.config
   let session_id = config.session_id
   let store = @store.SessionStore(config.session_root)
   let exists = store.exists(session_id) catch {
@@ -84,5 +93,11 @@ async fn append_session_history(config : AppConfig, ui : @ui.Ui) -> Unit {
   }
   for item in session_transcript_items(session) {
     ui.append_item(item)
+  }
+  // Seed the mirrored goal from the durable log so `/goal` shows a resumed
+  // session's standing goal before any engine is spawned or event arrives.
+  if session.current_goal() is Some(goal) {
+    state.goal = Some(goal.text())
+    ui.append_item(Notice(ToolCall(@doc.Text::plain("goal: \{goal.text()}"))))
   }
 }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -117,6 +117,10 @@ priv struct State {
   // point `scheduler_maybe_fire`, which also needs the composer state that
   // `update` cannot see.
   mut schedule : Schedule?
+  /// The standing goal mirrored from the engine: seeded from the loaded
+  /// session at startup and updated only by `goal_updated` events, so it
+  /// only ever reflects durably persisted state.
+  mut goal : String?
   // Outstanding fire-and-forget background `!` commands (run alongside a live
   // turn, `run_id=None`). Their completion hands command context to the engine,
   // so a scheduled fire must wait for them or that context would leak into the
@@ -139,6 +143,7 @@ fn State::new(config : AppConfig) -> State {
     streaming_reasoning: None,
     usage: None,
     schedule: None,
+    goal: None,
     background_commands: 0,
   }
 }
@@ -224,6 +229,9 @@ priv enum Msg {
   // id (like a session error) so it is never swept by the stale-run guard, and
   // rendered as a notice line in the transcript.
   EngineBackgroundNotice(String)
+  // The engine durably recorded a goal update. Untagged like a background
+  // notice, so an idle confirmation is never swept by the stale-run guard.
+  EngineGoalUpdated(String?)
   // The persistent engine process exited (for any reason): its background
   // watchers died with it, so the loop can observe the engine boundary.
   EngineExited
@@ -242,6 +250,7 @@ fn Msg::run_id(self : Msg) -> Int? {
     CommandCancelled(run_id~, ..) => Some(run_id)
     UiInput(_)
     | SteerDropped(_)
+    | EngineGoalUpdated(_)
     | EngineSteerDropped(_)
     | EngineSessionError(_)
     | EngineBackgroundNotice(_)
@@ -269,6 +278,9 @@ priv enum Cmd {
   // run id so the compaction's wire events are tagged to the run that requested
   // it, exactly like a prompt.
   CompactSession(run_id~ : Int)
+  // Set (Some) or clear (None) the standing goal on the serve engine. The
+  // engine's goal_updated event — not this command — mutates local state.
+  UpdateGoal(String?)
   CancelAgent
   // Second Ctrl-C while already interrupting: the cancel command was not
   // enough, so kill the engine process outright.


### PR DESCRIPTION
Adds `/goal` — a durable long-horizon objective the agent stays oriented toward across turns, restarts, and compactions. It completes the existing trio: the **plan tool** orients within a turn, **`/loop`** re-fires prompts across idle gaps, and **`/goal`** is the standing objective both serve. For fully autonomous long tasks the two compose: `/goal set <objective>` + `/loop 60 continue the goal`.

## Usage

- `/goal set <text>` — set or replace the standing goal (explicit `set` keyword, so a goal starting with "clear" stays expressible)
- `/goal` — show it
- `/goal clear` — clear it

Serve engines only (oneshot rejects, like `/compact`).

## Design

- **No session-schema change.** The goal rides `Runtime(RuntimeNotice)` markers — `[goal]\n<text>` / the `[goal cleared]` tombstone — because the session decoder is strict about unknown kinds: old binaries keep loading new logs. `Session::current_goal` scans the raw append-only log backward (last marker wins), so a goal whose set marker was covered by a compaction summary is still recovered verbatim.
- **Model visibility**: `GoalCadence` (parallel to `PlanCadence`, seeded from the session per turn) injects a `[goal reminder]` at turn start — suppressed while no model response follows the set marker, which still rides the next request anyway — and every 30 requests within a long turn.
- **The long-horizon teeth**: a finish attempt (final answer or `finish` tool) with an unconfirmed standing goal draws **one `[goal check]` per turn**: confirm the goal is met, finish with a one-line status of what remains, or keep working. The model may finish again immediately — a turn is never held hostage; a sub-task answer costs at most one extra round. The finish-tool path closes the remaining batch calls first (API-validity preserved; finish-not-last-in-batch tested), and the check counts as a reminder so a boundary-timed reminder can't bury it.
- **Wire + TUI**: `{"command":"goal","action":"set"|"clear"}` on the serve engine. Idle sets append directly; a live turn takes them through the lossless steer queue (model-visible at the next boundary); a pending or running **compaction holds them in the ordered work queue** so the summary never covers a goal that arrived after the compact command. Every durable path — and no queue-time path — emits `goal_updated`, so the TUI's mirrored state only ever reflects persisted goals. The TUI seeds the mirror from the store-loaded session at startup (resume shows the goal before any engine spawns) and routes `goal_updated` untagged so idle confirmations survive the stale-run guard, decoding `goal: null` (clear) distinctly from an empty string.

## Tests

Layered like the rest of the repo, no live API: marker/scan unit tests (set, clear, revive, multiline, compaction-covered markers); mock-HTTP agent-loop tests for turn-start reminder, fresh-set suppression, the 30-request cadence, mid-turn steered sets, the goal check on both finish seams, its once-per-turn cap, and the reminder-boundary interaction; serve decode tests (blank/unknown rejections) and pending-queue helpers; TUI wbtests driving `update()` for the grammar, oneshot rejection, mirror discipline, and null-aware `goal_updated` decode.

Plan and every commit reviewed with codex CLI; its findings shaped the grammar (`set` keyword), the suppression rule, the wire-order handling around compactions, the reminder/check interaction, and the untagged event routing. `moon check --deny-warn`, `moon info && moon fmt`, full `moon test` (989/989) + cram + the JS viz bundle all clean.

## Out of scope (possible follow-ups)

- Auto-continue on goal (compose with `/loop` instead)
- `--goal` CLI flag; goal in the TUI status line; multiline goals via the TUI composer (wire supports them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: structured goal status + engine auto-continue (follow-up commits)

The original "out of scope: auto-continue" is now shipped, redesigned around a structured completion signal (both Claude Code and Codex make harness-actionable transitions tool calls, never prose):

- **`goal` status tool** (`agent_tool/goal`): the model records `met` (durably clears the goal — the loop defers the `[goal cleared]` tombstone to a batch-safe boundary so replay never splits a tool batch) or `continuing` with a required `remaining` summary (which stands in for the finish check). The loop intercepts these calls — only it knows whether a goal stands — so `met` with no goal is an honest tool error. Cadence mutates only after the result append persists.
- **Engine auto-continue** (opt-in `"auto": true` on the goal set wire command): after a cleanly finished turn (`TurnDone` now threads `finished~` from the turn's terminal), a fully idle, still-serving engine with the goal standing starts a continuation turn — 20-turn budget per armed goal, `goal_continue`/`goal_budget_exhausted` events, stopped by the met tombstone, `/goal clear`, any `Cancel` (zeroes the budget), queued user work, or shutdown. Headless-first by design: the TUI never arms auto (engine-initiated turns are invisible to its run-id tracking; interactive users compose `/loop`) and surfaces the lifecycle as notices.

## Live validation

Dogfooded on a real long-horizon goal before the auto-continue commits: a goal-branch engine built a **5,048-line C compiler in MoonBit (95 tests green) in 3 turns / ~100 min / 478 requests**, with every goal mechanism observed working in production — fresh-set suppression, 30-step reminders, turn-start re-surfacing, three goal checks each catching a premature finish (the last forcing a verify-before-declare), mid-turn steer recovery from a 24-minute toolchain hang, and set/clear confirmations. The run's turn-3 "goal is fully met" existed only as prose — exactly the gap the goal tool closes. Findings filed as #419–#423.
