### PR TITLE
test(agent_tool): unwrap Respond inside the run_* tool helpers

### DIFF
--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -1,20 +1,24 @@
 ///|
-async fn run_edit(arguments : Json) -> @agent_tool.ToolAction {
-  match @edit.definition().execute {
+async fn run_edit(arguments : Json) -> @agent_tool.ToolOutput {
+  let action = match @edit.definition().execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("edit tool should be async")
   }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
 }
 
 ///|
 async fn run_edit_in_workspace(
   workspace_root : String,
   arguments : Json,
-) -> @agent_tool.ToolAction {
-  match @edit.definition(workspace_root~).execute {
+) -> @agent_tool.ToolOutput {
+  let action = match @edit.definition(workspace_root~).execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("edit tool should be async")
   }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
 }
 
 ///|
@@ -22,13 +26,12 @@ async test "a failed edit names the file in its brief" {
   @vfs.with_tmpdir(dir => {
     // Editing a missing file fails; the error still briefs the target file so
     // the viz shows `→ edit · edit ghost.mbt 🚩`.
-    let result = run_edit({
+    let output = run_edit({
       "path": "\{dir}/ghost.mbt",
       "old_string": "a",
       "new_string": "b",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     guard output.brief is Some(brief) else { fail("expected a brief") }
     assert_eq(brief, "edit ghost.mbt")
@@ -40,13 +43,12 @@ async test "edit replaces a unique exact match" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/unique.txt"
     @fs.write_file(path, "alpha\nbeta\ngamma\n", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "beta",
       "new_string": "delta",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "ok: replaced 1 occurrence(s) at line 2 in \{path}",
@@ -63,14 +65,13 @@ async test "edit range limits a unique replacement" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/range.txt"
     @fs.write_file(path, "target\nkeep\ntarget\n", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "target",
       "new_string": "changed",
       "start_line": 3,
       "end_line": 3,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "ok: replaced 1 occurrence(s) at line 3 in \{path}",
@@ -89,7 +90,7 @@ async test "edit rejects replace_all even with a range" {
       "token\ninside token\ninside token\noutside token\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "token",
       "new_string": "value",
@@ -97,7 +98,6 @@ async test "edit rejects replace_all even with a range" {
       "start_line": 2,
       "end_line": 3,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "error editing \{path}: replace_all=true is no longer supported; use multi_edit with explicit line-anchored edits",
@@ -115,13 +115,12 @@ async test "edit resolves relative paths under the workspace root" {
   @vfs.with_tmpdir(prefix="openseek-edit-workspace-", dir => {
     let path = "\{dir}/note.txt"
     @fs.write_file(path, "before", create_mode=CreateOrTruncate)
-    let result = run_edit_in_workspace(dir, {
+    let output = run_edit_in_workspace(dir, {
       "path": "note.txt",
       "old_string": "before",
       "new_string": "after",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(
       output.content,
@@ -140,13 +139,12 @@ async test "edit preserves surrounding multiline content" {
       "fn main {\n  println(\"old\")\n}\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "  println(\"old\")",
       "new_string": "  println(\"new\")",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(@fs.read_file(path).text(), "fn main {\n  println(\"new\")\n}\n")
   })
@@ -155,8 +153,7 @@ async test "edit preserves surrounding multiline content" {
 ///|
 async test "edit rejects missing old_string" {
   @vfs.with_tmpdir(dir => {
-    let result = run_edit({ "path": "\{dir}/noop.txt" })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_edit({ "path": "\{dir}/noop.txt" })
     assert_eq(output.content, "error: edit requires arguments.old_string")
     assert_true(output.is_error)
   })
@@ -165,8 +162,7 @@ async test "edit rejects missing old_string" {
 ///|
 async test "edit rejects missing new_string" {
   @vfs.with_tmpdir(dir => {
-    let result = run_edit({ "path": "\{dir}/noop.txt", "old_string": "x" })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_edit({ "path": "\{dir}/noop.txt", "old_string": "x" })
     assert_eq(output.content, "error: edit requires arguments.new_string")
     assert_true(output.is_error)
   })
@@ -174,8 +170,7 @@ async test "edit rejects missing new_string" {
 
 ///|
 async test "edit rejects non-object arguments" {
-  let result = run_edit(Json::null())
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_edit(Json::null())
   assert_eq(output.content, "error: edit requires object arguments")
   assert_true(output.is_error)
 }
@@ -186,13 +181,12 @@ async test "edit inserts when old_string is empty" {
     let path = "\{dir}/insert.txt"
     @fs.write_file(path, "line1\nline2\n", create_mode=CreateOrTruncate)
     // insert before line 2
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "",
       "new_string": "inserted\n",
       "start_line": 2,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("ok: inserted at line 2"))
     let updated = @fs.read_file(path).text()
@@ -205,13 +199,12 @@ async test "edit can append at end of file via start_line past the last line" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/append.txt"
     @fs.write_file(path, "a\nb\n", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "",
       "new_string": "c\n",
       "start_line": 99,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(@fs.read_file(path).text(), "a\nb\nc\n")
   })
@@ -222,13 +215,12 @@ async test "edit rejects empty old_string and new_string" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/empty-both.txt"
     @fs.write_file(path, "content", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "",
       "new_string": "",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "error editing \{path}: old_string and new_string are both empty",
@@ -242,13 +234,12 @@ async test "edit rejects identical replacement" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/identical.txt"
     @fs.write_file(path, "content", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "content",
       "new_string": "content",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "error editing \{path}: old_string and new_string are identical",
@@ -266,14 +257,13 @@ async test "edit rejects invalid moon.pkg comment rewrite" {
       "warnings = \"+unnecessary_annotation\"",
       create_mode=CreateOrTruncate,
     )
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "warnings = \"+unnecessary_annotation\"",
       "new_string": "# comment",
       "start_line": 1,
     })
     let read_back = @fs.read_file(path).text()
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("moon.pkg use // for comment syntax, not #"),
@@ -287,14 +277,13 @@ async test "edit rejects generated mbti files" {
   @vfs.with_tmpdir(prefix="openseek-edit-generated-", dir => {
     let path = "\{dir}/pkg.generated.mbti"
     @fs.write_file(path, "package old\n", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "old",
       "new_string": "new",
       "start_line": 1,
     })
     let read_back = @fs.read_file(path).text()
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("run moon info"))
     assert_eq(read_back, "package old\n")
@@ -306,13 +295,12 @@ async test "edit rejects missing match" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/missing.txt"
     @fs.write_file(path, "alpha", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "beta",
       "new_string": "gamma",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "error editing \{path}: old_string not found from line 1",
@@ -326,14 +314,13 @@ async test "edit reports range for missing match" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/range-missing.txt"
     @fs.write_file(path, "alpha\nbeta\nalpha\n", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "alpha",
       "new_string": "gamma",
       "start_line": 2,
       "end_line": 2,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "error editing \{path}: old_string not found in line range 2-2",
@@ -352,13 +339,12 @@ async test "edit replaces first match from start line" {
       "alpha beta\nmiddle\nbeta",
       create_mode=CreateOrTruncate,
     )
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "beta",
       "new_string": "delta",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "ok: replaced 1 occurrence(s) at line 1 in \{path}",
@@ -377,14 +363,13 @@ async test "edit replaces first match inside range" {
       "beta\nbeta\nmiddle\nbeta\nbeta\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "beta",
       "new_string": "delta",
       "start_line": 2,
       "end_line": 4,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "ok: replaced 1 occurrence(s) at line 2 in \{path}",
@@ -399,13 +384,12 @@ async test "edit replaces first repeated match only" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/many-matches.txt"
     @fs.write_file(path, "x\nx\nx\nx\nx\nx\n", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "x",
       "new_string": "y",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "ok: replaced 1 occurrence(s) at line 1 in \{path}",
@@ -420,14 +404,13 @@ async test "edit rejects non-boolean replace_all" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/bad-replace-all.txt"
     @fs.write_file(path, "alpha", create_mode=CreateOrTruncate)
-    let result = run_edit({
+    let output = run_edit({
       "path": path,
       "old_string": "alpha",
       "new_string": "beta",
       "replace_all": "yes",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "error: edit requires arguments.replace_all to be a boolean",
@@ -439,13 +422,12 @@ async test "edit rejects non-boolean replace_all" {
 ///|
 async test "edit surfaces read errors" {
   @vfs.with_tmpdir(dir => {
-    let result = run_edit({
+    let output = run_edit({
       "path": "\{dir}/does-not-exist.txt",
       "old_string": "x",
       "new_string": "y",
       "start_line": 1,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("error editing"))
     assert_true(output.content.contains("error reading file"))
     assert_true(output.is_error)
@@ -462,48 +444,44 @@ async test "edit gates .mbt results through moonc before writing" {
     let path = "\{dir}/a.mbt"
     @fs.write_file(path, original, create_mode=CreateOrTruncate)
     // A breaking edit is rejected and the file is untouched.
-    let broken = run_edit({
+    let out = run_edit({
       "path": path,
       "old_string": "  42",
       "new_string": "  match 42 {",
       "start_line": 3,
     })
-    guard broken is Respond(out) else { fail("expected Respond") }
     assert_true(out.is_error)
     assert_true(out.content.contains("rejected: the edit would introduce"))
     assert_eq(@fs.read_file(path).text(), original)
     // A clean edit is applied.
-    let clean = run_edit({
+    let ok = run_edit({
       "path": path,
       "old_string": "  42",
       "new_string": "  43",
       "start_line": 3,
     })
-    guard clean is Respond(ok) else { fail("expected Respond") }
     assert_false(ok.is_error)
     assert_true(@fs.read_file(path).text().contains("  43"))
     // A file with a pre-existing parse error still accepts an unrelated edit.
     let pre_broken = "///|\npub fn g() -> Int {\n  1 +\n}\n// tail\n"
     let path2 = "\{dir}/b.mbt"
     @fs.write_file(path2, pre_broken, create_mode=CreateOrTruncate)
-    let unrelated = run_edit({
+    let kept = run_edit({
       "path": path2,
       "old_string": "// tail",
       "new_string": "// tail (edited)",
       "start_line": 5,
     })
-    guard unrelated is Respond(kept) else { fail("expected Respond") }
     assert_false(kept.is_error)
     assert_true(@fs.read_file(path2).text().contains("(edited)"))
     // Opt-out: the breaking edit lands.
-    let fixture = run_edit({
+    let fx = run_edit({
       "path": path,
       "old_string": "  43",
       "new_string": "  match 43 {",
       "start_line": 3,
       "revert_on_parse_errors": false,
     })
-    guard fixture is Respond(fx) else { fail("expected Respond") }
     assert_false(fx.is_error)
     assert_true(@fs.read_file(path).text().contains("match 43 {"))
   })
@@ -519,13 +497,12 @@ async test "edit gates a breaking edit made through a non-mbt symlink" {
     // past the parse gate — the write lands in the .mbt target.
     let link = "\{dir}/alias.txt"
     @fs.symlink(target="lib.mbt", link)
-    let broken = run_edit({
+    let out = run_edit({
       "path": link,
       "old_string": "  42",
       "new_string": "  match 42 {",
       "start_line": 3,
     })
-    guard broken is Respond(out) else { fail("expected Respond") }
     assert_true(out.is_error)
     assert_true(out.content.contains("rejected: the edit would introduce"))
     assert_eq(@fs.read_file(src).text(), original)
@@ -544,13 +521,12 @@ async test "edit gates by the target kind through a .mbt.md-named symlink" {
     @fs.write_file(src, original, create_mode=CreateOrTruncate)
     let link = "\{dir}/doc.mbt.md"
     @fs.symlink(target="lib.mbt", link)
-    let broken = run_edit({
+    let out = run_edit({
       "path": link,
       "old_string": "  42",
       "new_string": "  match 42 {",
       "start_line": 3,
     })
-    guard broken is Respond(out) else { fail("expected Respond") }
     assert_true(out.is_error)
     assert_true(out.content.contains("rejected: the edit would introduce"))
     assert_eq(@fs.read_file(src).text(), original)
@@ -571,13 +547,12 @@ async test "edit gates by the link kind through a .mbt-named symlink" {
     @fs.write_file(target, original, create_mode=CreateOrTruncate)
     let link = "\{dir}/link.mbt"
     @fs.symlink(target="notes.mbt.md", link)
-    let broken = run_edit({
+    let out = run_edit({
       "path": link,
       "old_string": "  42",
       "new_string": "  match 42 {",
       "start_line": 3,
     })
-    guard broken is Respond(out) else { fail("expected Respond") }
     assert_true(out.is_error)
     assert_true(out.content.contains("rejected: the edit would introduce"))
     assert_eq(@fs.read_file(target).text(), original)

--- a/agent_tool/multi_edit/multi_edit_gate_test.mbt
+++ b/agent_tool/multi_edit/multi_edit_gate_test.mbt
@@ -11,7 +11,7 @@ async test "multi_edit gates the whole batch through moonc before writing" {
     @fs.write_file("\{dir}/b.mbt", b_original, create_mode=CreateOrTruncate)
     // One clean edit (a.mbt) plus one that would break b.mbt: the WHOLE batch
     // is rejected and neither file changes.
-    let broken = run_multi_edit({
+    let out = run_multi_edit({
       "edits": [
         {
           "file": "\{dir}/a.mbt",
@@ -27,7 +27,6 @@ async test "multi_edit gates the whole batch through moonc before writing" {
         },
       ],
     })
-    guard broken is Respond(out) else { fail("expected Respond") }
     assert_true(out.is_error)
     assert_true(out.content.contains("rejected: the batch would introduce"))
     assert_true(out.content.contains("NO files were changed"))
@@ -35,7 +34,7 @@ async test "multi_edit gates the whole batch through moonc before writing" {
     assert_eq(@fs.read_file("\{dir}/a.mbt").text(), a_original)
     assert_eq(@fs.read_file("\{dir}/b.mbt").text(), b_original)
     // A clean batch applies to both files.
-    let clean = run_multi_edit({
+    let ok = run_multi_edit({
       "edits": [
         {
           "file": "\{dir}/a.mbt",
@@ -51,12 +50,11 @@ async test "multi_edit gates the whole batch through moonc before writing" {
         },
       ],
     })
-    guard clean is Respond(ok) else { fail("expected Respond") }
     assert_false(ok.is_error)
     assert_true(@fs.read_file("\{dir}/a.mbt").text().contains("  43"))
     assert_true(@fs.read_file("\{dir}/b.mbt").text().contains("  8"))
     // Opt-out: the breaking batch lands.
-    let fixture = run_multi_edit({
+    let fx = run_multi_edit({
       "edits": [
         {
           "file": "\{dir}/b.mbt",
@@ -67,7 +65,6 @@ async test "multi_edit gates the whole batch through moonc before writing" {
       ],
       "revert_on_parse_errors": false,
     })
-    guard fixture is Respond(fx) else { fail("expected Respond") }
     assert_false(fx.is_error)
     assert_true(@fs.read_file("\{dir}/b.mbt").text().contains("match 8 {"))
   })

--- a/agent_tool/multi_edit/multi_edit_test.mbt
+++ b/agent_tool/multi_edit/multi_edit_test.mbt
@@ -1,20 +1,24 @@
 ///|
-async fn run_multi_edit(arguments : Json) -> @agent_tool.ToolAction {
-  match @multi_edit.definition().execute {
+async fn run_multi_edit(arguments : Json) -> @agent_tool.ToolOutput {
+  let action = match @multi_edit.definition().execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("multi_edit tool should be async")
   }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
 }
 
 ///|
 async fn run_multi_edit_in_workspace(
   workspace_root : String,
   arguments : Json,
-) -> @agent_tool.ToolAction {
-  match @multi_edit.definition(workspace_root~).execute {
+) -> @agent_tool.ToolOutput {
+  let action = match @multi_edit.definition(workspace_root~).execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("multi_edit tool should be async")
   }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
 }
 
 ///|
@@ -26,7 +30,7 @@ async test "multi_edit applies multiple line-anchored replacements" {
       "let a = old_a\nlet b = keep\nlet c = old_c\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -43,7 +47,6 @@ async test "multi_edit applies multiple line-anchored replacements" {
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(
       output.content,
       "ok: applied 2 edit(s) across 1 file(s)\n\{path}: 2 edit(s)",
@@ -67,7 +70,7 @@ async test "multi_edit applies a batch spanning several files" {
       "let b = old_b\nlet c = old_c\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": first,
@@ -89,7 +92,6 @@ async test "multi_edit applies a batch spanning several files" {
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(
       output.content,
@@ -108,7 +110,7 @@ async test "multi_edit collapses aliased spellings of one file into a single gro
     // `note.txt` and `./note.txt` resolve to the same file. They must form one
     // group so both edits land; otherwise the second write would clobber the
     // first and silently drop an edit.
-    let result = run_multi_edit_in_workspace(dir, {
+    let output = run_multi_edit_in_workspace(dir, {
       "edits": [
         {
           "file": "note.txt",
@@ -124,7 +126,6 @@ async test "multi_edit collapses aliased spellings of one file into a single gro
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(
       output.content,
@@ -144,7 +145,7 @@ async test "multi_edit rejects a file whose edits are not contiguous" {
     @fs.write_file(first, original_first, create_mode=CreateOrTruncate)
     @fs.write_file(second, original_second, create_mode=CreateOrTruncate)
     // first reappears at edit[2] after second's block — rejected before any write.
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": first,
@@ -166,7 +167,6 @@ async test "multi_edit rejects a file whose edits are not contiguous" {
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("must be contiguous"))
     assert_true(output.content.contains("edit[2]"))
@@ -184,7 +184,7 @@ async test "multi_edit inserts when old_string is empty, alongside a replacement
       "let a = old_a\nlet b = keep\nlet c = old_c\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -200,7 +200,6 @@ async test "multi_edit inserts when old_string is empty, alongside a replacement
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(
       @fs.read_file(path).text(),
@@ -214,12 +213,11 @@ async test "multi_edit rejects an edit with empty old_string and new_string" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/empty.mbt"
     @fs.write_file(path, "let a = 1\n", create_mode=CreateOrTruncate)
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         { "file": path, "old_string": "", "new_string": "", "start_line": 1 },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("both empty"))
   })
@@ -237,7 +235,7 @@ async test "multi_edit applies edits against original offsets despite length cha
     // edit[0] grows line 1 and edit[1] shrinks line 3. A naive left-to-right
     // apply would shift the later span; planning against the original keeps both
     // anchored.
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -255,7 +253,6 @@ async test "multi_edit applies edits against original offsets despite length cha
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(
       @fs.read_file(path).text(),
@@ -272,7 +269,7 @@ async test "multi_edit matches the original file, not text introduced by earlier
     // edit[0] rewrites line 1 to "beta"; a sequential rewrite could then let
     // edit[1] match that introduced text. Validating against the original keeps
     // edit[1] anchored to line 2's real "beta".
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -290,7 +287,6 @@ async test "multi_edit matches the original file, not text introduced by earlier
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(@fs.read_file(path).text(), "beta\ngamma\n")
   })
@@ -307,7 +303,7 @@ async test "multi_edit uses line anchors to disambiguate duplicate spans" {
     )
     // The same span appears on three lines; each edit's anchor selects exactly
     // one, leaving the unanchored line 2 untouched.
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -325,7 +321,6 @@ async test "multi_edit uses line anchors to disambiguate duplicate spans" {
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(@fs.read_file(path).text(), "x = one\ny = dup\nz = three\n")
   })
@@ -336,7 +331,7 @@ async test "multi_edit resolves relative paths under the workspace root" {
   @vfs.with_tmpdir(prefix="openseek-multi-edit-workspace-", dir => {
     let path = "\{dir}/note.txt"
     @fs.write_file(path, "alpha\nbeta\n", create_mode=CreateOrTruncate)
-    let result = run_multi_edit_in_workspace(dir, {
+    let output = run_multi_edit_in_workspace(dir, {
       "edits": [
         {
           "file": "note.txt",
@@ -346,7 +341,6 @@ async test "multi_edit resolves relative paths under the workspace root" {
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(
       output.content,
@@ -362,7 +356,7 @@ async test "multi_edit reports all failed edits and leaves file unchanged" {
     let path = "\{dir}/failures.txt"
     let original = "alpha\nbeta\nsame\nsame\n"
     @fs.write_file(path, original, create_mode=CreateOrTruncate)
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -387,7 +381,6 @@ async test "multi_edit reports all failed edits and leaves file unchanged" {
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_eq(
       output.content,
@@ -403,7 +396,7 @@ async test "multi_edit rejects overlapping replacements and leaves file unchange
     let path = "\{dir}/overlap.txt"
     let original = "abcdef\n"
     @fs.write_file(path, original, create_mode=CreateOrTruncate)
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -421,7 +414,6 @@ async test "multi_edit rejects overlapping replacements and leaves file unchange
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_eq(
       output.content,
@@ -437,7 +429,7 @@ async test "multi_edit rejects generated mbti files before writing" {
     let path = "\{dir}/pkg.generated.mbti"
     let original = "package old\n"
     @fs.write_file(path, original, create_mode=CreateOrTruncate)
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -448,7 +440,6 @@ async test "multi_edit rejects generated mbti files before writing" {
         },
       ],
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("run moon info"))
     assert_eq(@fs.read_file(path).text(), original)
@@ -457,7 +448,7 @@ async test "multi_edit rejects generated mbti files before writing" {
 
 ///|
 async test "multi_edit rejects invalid arguments" {
-  let result = run_multi_edit({
+  let output = run_multi_edit({
     "edits": [
       {
         "file": "file.mbt",
@@ -468,7 +459,6 @@ async test "multi_edit rejects invalid arguments" {
       },
     ],
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_eq(
     output.content,
     "error: multi_edit requires arguments.edits[0].start_line to be an integer",
@@ -478,10 +468,9 @@ async test "multi_edit rejects invalid arguments" {
 
 ///|
 async test "multi_edit rejects an edit that omits its file" {
-  let result = run_multi_edit({
+  let output = run_multi_edit({
     "edits": [{ "old_string": "old", "new_string": "new", "start_line": 1 }],
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_eq(
     output.content,
     "error: multi_edit requires arguments.edits[0] to include file (present keys: new_string, old_string, start_line)",
@@ -514,8 +503,7 @@ async test "multi_edit applies a batch from a response file (edits_file)" {
       },
     ]
     @fs.write_file(spec_path, spec.stringify(), create_mode=CreateOrTruncate)
-    let result = run_multi_edit({ "edits_file": spec_path })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_multi_edit({ "edits_file": spec_path })
     assert_false(output.is_error)
     assert_eq(
       output.content,
@@ -545,7 +533,7 @@ async test "multi_edit concatenates inline edits with an edits_file" {
     ]
     @fs.write_file(spec_path, spec.stringify(), create_mode=CreateOrTruncate)
     // Inline edits and the file's edits are both applied (concatenated).
-    let result = run_multi_edit({
+    let output = run_multi_edit({
       "edits": [
         {
           "file": path,
@@ -556,7 +544,6 @@ async test "multi_edit concatenates inline edits with an edits_file" {
       ],
       "edits_file": spec_path,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_eq(
       output.content,
@@ -568,13 +555,11 @@ async test "multi_edit concatenates inline edits with an edits_file" {
 
 ///|
 async test "multi_edit rejects a call with no edits at all" {
-  let result = run_multi_edit({})
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_multi_edit({})
   assert_true(output.is_error)
   assert_true(output.content.contains("edits and/or edits_file"))
   // An explicit empty array is the same combined-empty case.
-  let empty = run_multi_edit({ "edits": [] })
-  guard empty is Respond(empty_out) else { fail("expected Respond") }
+  let empty_out = run_multi_edit({ "edits": [] })
   assert_true(empty_out.is_error)
   assert_true(empty_out.content.contains("edits and/or edits_file"))
 }
@@ -582,8 +567,7 @@ async test "multi_edit rejects a call with no edits at all" {
 ///|
 async test "multi_edit reports an unreadable response file" {
   @vfs.with_tmpdir(dir => {
-    let result = run_multi_edit({ "edits_file": "\{dir}/missing.json" })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_multi_edit({ "edits_file": "\{dir}/missing.json" })
     assert_true(output.is_error)
     assert_true(output.content.contains("could not read edits file"))
   })
@@ -594,8 +578,7 @@ async test "multi_edit reports a response file that is not valid JSON" {
   @vfs.with_tmpdir(dir => {
     let spec_path = "\{dir}/broken.json"
     @fs.write_file(spec_path, "{ not json", create_mode=CreateOrTruncate)
-    let result = run_multi_edit({ "edits_file": spec_path })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_multi_edit({ "edits_file": spec_path })
     assert_true(output.is_error)
     assert_true(output.content.contains("is not valid JSON"))
   })
@@ -610,8 +593,7 @@ async test "multi_edit reports a malformed response file entry" {
       { "old_string": "a", "new_string": "b", "start_line": 1 },
     ]
     @fs.write_file(spec_path, spec.stringify(), create_mode=CreateOrTruncate)
-    let result = run_multi_edit({ "edits_file": spec_path })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_multi_edit({ "edits_file": spec_path })
     assert_true(output.is_error)
     assert_true(output.content.contains("arguments.edits[0] to include file"))
     assert_true(output.content.contains("in edits file"))

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -1,9 +1,11 @@
 ///|
-async fn run_shell(arguments : Json) -> @agent_tool.ToolAction {
-  match @shell.definition().execute {
+async fn run_shell(arguments : Json) -> @agent_tool.ToolOutput {
+  let action = match @shell.definition().execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("shell tool should be async")
   }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
 }
 
 ///|
@@ -14,11 +16,13 @@ async fn run_shell(arguments : Json) -> @agent_tool.ToolAction {
 async fn run_shell_wired(
   bg : @bgjobs.BgJobRuntime,
   arguments : Json,
-) -> @agent_tool.ToolAction {
-  match @shell.definition(bg_runtime=bg).execute {
+) -> @agent_tool.ToolOutput {
+  let action = match @shell.definition(bg_runtime=bg).execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("shell tool should be async")
   }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
 }
 
 ///|
@@ -26,11 +30,10 @@ async fn run_shell_wired(
 async test "run_in_background starts a job and returns its id" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let action = run_shell_wired(bg, {
+    let output = run_shell_wired(bg, {
       "cmd": "printf hi",
       "run_in_background": true,
     })
-    guard action is Respond(output) else { fail("expected a Respond action") }
     assert_false(output.is_error)
     assert_true(output.content.contains("started background job"))
     assert_true(bg.list().length() == 1)
@@ -42,12 +45,11 @@ async test "run_in_background starts a job and returns its id" {
 async test "run_in_background rejects timeout_ms" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let action = run_shell_wired(bg, {
+    let output = run_shell_wired(bg, {
       "cmd": "printf hi",
       "run_in_background": true,
       "timeout_ms": 1000,
     })
-    guard action is Respond(output) else { fail("expected a Respond action") }
     assert_true(output.is_error)
     assert_true(output.content.contains("not supported with run_in_background"))
   })
@@ -58,8 +60,7 @@ async test "run_in_background rejects timeout_ms" {
 async test "foreground runs through the execution model" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let action = run_shell_wired(bg, { "cmd": "printf hi" })
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_wired(bg, { "cmd": "printf hi" })
     assert_false(output.is_error)
     assert_true(output.content.contains("hi"))
     assert_true(output.content.contains("exit=0"))
@@ -73,8 +74,7 @@ async test "wired foreground reports binary output as a tool error" {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
     // The wired path (through ShellExecution) must match the per-call path:
     // non-UTF-8 output is a tool error, not replacement characters as success.
-    let action = run_shell_wired(bg, { "cmd": "printf '\\377'" })
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_wired(bg, { "cmd": "printf '\\377'" })
     assert_true(output.is_error)
     assert_true(output.content.contains("Malformed"))
   })
@@ -87,8 +87,7 @@ async test "foreground enforces max_output_chars with an output-limit error" {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
     // `yes` exceeds the tiny budget; the shared foreground path must report the
     // output-limit error, not silently drop output as a success.
-    let action = run_shell_wired(bg, { "cmd": "yes", "max_output_chars": 100 })
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_wired(bg, { "cmd": "yes", "max_output_chars": 100 })
     assert_true(output.is_error)
     assert_true(output.content.contains("output_limit_reached"))
   })
@@ -102,12 +101,11 @@ async test "a timed command that floods output is an output-limit error, not det
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
     // A long timeout, but the runaway must be killed at the output limit promptly
     // (not run to the timeout and then backgrounded).
-    let action = run_shell_wired(bg, {
+    let output = run_shell_wired(bg, {
       "cmd": "yes",
       "timeout_ms": 30000,
       "max_output_chars": 100,
     })
-    guard action is Respond(output) else { fail("expected a Respond action") }
     assert_true(output.is_error)
     assert_true(output.content.contains("output_limit_reached"))
     @fs.rmdir(dir, recursive=true) catch {
@@ -125,12 +123,11 @@ async test "a detached foreground job retains full output past the inline cap" {
     // Under the output limit at the timeout (still sleeping) → cleanly detached;
     // then it floods output, which a detached job retains (the output-limit kill
     // is cleared on detach).
-    let action = run_shell_wired(bg, {
+    let output = run_shell_wired(bg, {
       "cmd": "sleep 0.3; seq 1 5000",
       "timeout_ms": 150,
       "max_output_chars": 100,
     })
-    guard action is Respond(output) else { fail("expected a Respond action") }
     assert_true(output.content.contains("moved to the background"))
     // The detached job is file-backed, so its full output is retained, not
     // capped at the foreground budget. Poll until the monitor has flushed it.
@@ -156,8 +153,7 @@ async test "a detached foreground job retains full output past the inline cap" {
 async test "a foreground command that times out is detached to the background" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let action = run_shell_wired(bg, { "cmd": "sleep 2", "timeout_ms": 100 })
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_wired(bg, { "cmd": "sleep 2", "timeout_ms": 100 })
     assert_false(output.is_error)
     assert_true(output.content.contains("moved to the background"))
     assert_true(bg.list().length() == 1)
@@ -169,11 +165,13 @@ async test "a foreground command that times out is detached to the background" {
 async fn run_shell_in_workspace(
   workspace_root : String,
   arguments : Json,
-) -> @agent_tool.ToolAction {
-  match @shell.definition(workspace_root~).execute {
+) -> @agent_tool.ToolOutput {
+  let action = match @shell.definition(workspace_root~).execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("shell tool should be async")
   }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
 }
 
 ///|
@@ -203,11 +201,10 @@ async fn assert_answer_main_unchanged(
 /// Respond carrying the `marker` phrase plus the shared feedback line (and,
 /// when `line_anchored`, the edit-tool redirection hint).
 fn expect_source_write_blocked(
-  result : @agent_tool.ToolAction,
+  output : @agent_tool.ToolOutput,
   marker? : String = "source tree operation is blocked",
   line_anchored? : Bool = false,
 ) -> Unit raise {
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains(marker))
   assert_true(
@@ -323,8 +320,7 @@ async test "shell description teaches background jobs only when a runtime is wir
 
 ///|
 async test "shell runs cmd and returns exit code plus output" {
-  let result = run_shell({ "cmd": "echo hello" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "echo hello" })
   assert_false(output.is_error)
   assert_true(output.content.contains("exit=0"))
   assert_true(output.content.contains("hello"))
@@ -332,8 +328,7 @@ async test "shell runs cmd and returns exit code plus output" {
 
 ///|
 async test "shell propagates non-zero exit codes" {
-  let result = run_shell({ "cmd": "exit 7" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "exit 7" })
   assert_true(output.is_error)
   assert_true(output.content.contains("exit=7"))
 }
@@ -341,8 +336,7 @@ async test "shell propagates non-zero exit codes" {
 ///|
 #cfg(platform="windows")
 async test "shell follows PowerShell native Windows exit semantics" {
-  let result = run_shell({ "cmd": "cmd /c exit 7" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "cmd /c exit 7" })
   assert_true(output.is_error)
   assert_true(output.content.contains("exit=1"))
 }
@@ -350,8 +344,7 @@ async test "shell follows PowerShell native Windows exit semantics" {
 ///|
 #cfg(platform="windows")
 async test "shell follows final successful PowerShell command on Windows" {
-  let result = run_shell({ "cmd": "cmd /c exit 7; Write-Output 'ok'" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "cmd /c exit 7; Write-Output 'ok'" })
   assert_false(output.is_error)
   assert_true(output.content.contains("exit=0"))
   assert_true(output.content.contains("ok"))
@@ -360,11 +353,10 @@ async test "shell follows final successful PowerShell command on Windows" {
 ///|
 async test "shell honors cwd when non-empty" {
   @vfs.with_tmpdir(prefix="openseek-shell-cwd-", dir => {
-    let result = run_shell({ "cmd": "echo cwd-ok > marker.txt", "cwd": dir })
+    let output = run_shell({ "cmd": "echo cwd-ok > marker.txt", "cwd": dir })
     let dir_path : @path.Path = dir
     let marker_path = dir_path.join("marker.txt").normalize().to_string()
     let marker = @fs.read_file(marker_path).text() catch { _ => "" }
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("exit=0"))
     assert_eq(marker.trim(), "cwd-ok")
@@ -379,8 +371,7 @@ async test "shell uses the workspace root when cwd is omitted" {
       "root-ok\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, { "cmd": "cat marker.txt" })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell_in_workspace(dir, { "cmd": "cat marker.txt" })
     assert_false(output.is_error)
     assert_true(output.content.contains("exit=0"))
     assert_true(output.content.contains("root-ok"))
@@ -396,8 +387,7 @@ async test "shell reads a virtual filesystem fixture from cwd" {
         #|
       ),
     }).write_to(project)
-    let result = run_shell({ "cmd": "cat data/input.txt", "cwd": project })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell({ "cmd": "cat data/input.txt", "cwd": project })
     assert_false(output.is_error)
     inspect(
       output.content.trim(),
@@ -411,8 +401,7 @@ async test "shell reads a virtual filesystem fixture from cwd" {
 
 ///|
 async test "shell treats empty cwd as missing" {
-  let result = run_shell({ "cmd": "echo cwdless", "cwd": "" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "echo cwdless", "cwd": "" })
   assert_false(output.is_error)
   assert_true(output.content.contains("exit=0"))
   assert_true(output.content.contains("cwdless"))
@@ -421,11 +410,10 @@ async test "shell treats empty cwd as missing" {
 ///|
 #cfg(platform="windows")
 async test "shell leaves output at exact limit as a normal result on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "[Console]::Out.Write('abc')",
     "max_output_chars": 3,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_eq(output.content, "abc\n<system>exit=0</system>")
 }
@@ -433,8 +421,7 @@ async test "shell leaves output at exact limit as a normal result on Windows" {
 ///|
 #cfg(not(platform="windows"))
 async test "shell leaves output at exact limit as a normal result on Unix" {
-  let result = run_shell({ "cmd": "printf %s 'abc'", "max_output_chars": 3 })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "printf %s 'abc'", "max_output_chars": 3 })
   assert_false(output.is_error)
   assert_eq(output.content, "abc\n<system>exit=0</system>")
 }
@@ -442,11 +429,10 @@ async test "shell leaves output at exact limit as a normal result on Unix" {
 ///|
 #cfg(platform="windows")
 async test "shell counts output limits in characters for non-ascii text on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "[Console]::Out.Write('中中')",
     "max_output_chars": 2,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_eq(output.content, "中中\n<system>exit=0</system>")
 }
@@ -454,8 +440,7 @@ async test "shell counts output limits in characters for non-ascii text on Windo
 ///|
 #cfg(not(platform="windows"))
 async test "shell counts output limits in characters for non-ascii text on Unix" {
-  let result = run_shell({ "cmd": "printf %s '中中'", "max_output_chars": 2 })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "printf %s '中中'", "max_output_chars": 2 })
   assert_false(output.is_error)
   assert_eq(output.content, "中中\n<system>exit=0</system>")
 }
@@ -463,11 +448,10 @@ async test "shell counts output limits in characters for non-ascii text on Unix"
 ///|
 #cfg(platform="windows")
 async test "shell leaves four-byte utf8 output at exact character limit on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "[Console]::Out.Write('😀')",
     "max_output_chars": 1,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_eq(output.content, "😀\n<system>exit=0</system>")
 }
@@ -475,8 +459,7 @@ async test "shell leaves four-byte utf8 output at exact character limit on Windo
 ///|
 #cfg(not(platform="windows"))
 async test "shell leaves four-byte utf8 output at exact character limit on Unix" {
-  let result = run_shell({ "cmd": "printf %s '😀'", "max_output_chars": 1 })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "printf %s '😀'", "max_output_chars": 1 })
   assert_false(output.is_error)
   assert_eq(output.content, "😀\n<system>exit=0</system>")
 }
@@ -484,12 +467,11 @@ async test "shell leaves four-byte utf8 output at exact character limit on Unix"
 ///|
 #cfg(platform="windows")
 async test "shell stops oversized output while the command is still running on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "[Console]::Out.Write('abcdef'); Start-Sleep -Seconds 2",
     "max_output_chars": 3,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^abc\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=3 max_output_chars=3</system>$",
@@ -501,12 +483,11 @@ async test "shell stops oversized output while the command is still running on W
 ///|
 #cfg(not(platform="windows"))
 async test "shell stops oversized output while the command is still running on Unix" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "printf %s 'abcdef'; sleep 2",
     "max_output_chars": 3,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^abc\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=3 max_output_chars=3</system>$",
@@ -518,12 +499,11 @@ async test "shell stops oversized output while the command is still running on U
 ///|
 #cfg(platform="windows")
 async test "shell does not cut multi-byte utf8 output mid-character on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "[Console]::Out.Write('中中中'); Start-Sleep -Seconds 2",
     "max_output_chars": 2,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^中中\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=2 max_output_chars=2</system>$",
@@ -535,12 +515,11 @@ async test "shell does not cut multi-byte utf8 output mid-character on Windows" 
 ///|
 #cfg(not(platform="windows"))
 async test "shell does not cut multi-byte utf8 output mid-character on Unix" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "printf %s '中中中'; sleep 2",
     "max_output_chars": 2,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^中中\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=2 max_output_chars=2</system>$",
@@ -552,12 +531,11 @@ async test "shell does not cut multi-byte utf8 output mid-character on Unix" {
 ///|
 #cfg(platform="windows")
 async test "shell does not split four-byte utf8 characters on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "[Console]::Out.Write('😀😀'); Start-Sleep -Seconds 2",
     "max_output_chars": 1,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^😀\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=1 max_output_chars=1</system>$",
@@ -569,12 +547,11 @@ async test "shell does not split four-byte utf8 characters on Windows" {
 ///|
 #cfg(not(platform="windows"))
 async test "shell does not split four-byte utf8 characters on Unix" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "printf %s '😀😀'; sleep 2",
     "max_output_chars": 1,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^😀\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=1 max_output_chars=1</system>$",
@@ -586,10 +563,9 @@ async test "shell does not split four-byte utf8 characters on Unix" {
 ///|
 #cfg(platform="windows")
 async test "shell reports binary output as a tool error on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "[Console]::OpenStandardOutput().WriteByte(255)",
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(output.content.contains("error running shell:"))
   assert_true(output.content.contains("Malformed"))
@@ -598,8 +574,7 @@ async test "shell reports binary output as a tool error on Windows" {
 ///|
 #cfg(not(platform="windows"))
 async test "shell reports binary output as a tool error on Unix" {
-  let result = run_shell({ "cmd": "printf '\\377'" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "printf '\\377'" })
   assert_true(output.is_error)
   assert_true(output.content.contains("error running shell:"))
   assert_true(output.content.contains("Malformed"))
@@ -608,12 +583,11 @@ async test "shell reports binary output as a tool error on Unix" {
 ///|
 #cfg(platform="windows")
 async test "shell output limit wins over an unbounded producer on Windows" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "while ($true) { [Console]::Out.Write('yyyyyyyyyy') }",
     "max_output_chars": 5,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^yyyyy\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=5 max_output_chars=5</system>$",
@@ -624,12 +598,11 @@ async test "shell output limit wins over an unbounded producer on Windows" {
 ///|
 #cfg(not(platform="windows"))
 async test "shell output limit wins over an unbounded producer on Unix" {
-  let result = run_shell({
+  let output = run_shell({
     "cmd": "while :; do printf %s 'yyyyyyyyyy'; done",
     "max_output_chars": 5,
     "timeout_ms": 1000,
   })
-  guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
   assert_true(
     output.content =~ re"^yyyyy\n<system>exit=cancelled truncated=true output_limit_reached=true shown_chars=5 max_output_chars=5</system>$",
@@ -640,8 +613,7 @@ async test "shell output limit wins over an unbounded producer on Unix" {
 ///|
 #cfg(platform="windows")
 async test "shell merges stderr into the captured output on Windows" {
-  let result = run_shell({ "cmd": "[Console]::Error.WriteLine('oops')" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "[Console]::Error.WriteLine('oops')" })
   assert_false(output.is_error)
   assert_true(output.content.contains("oops"))
 }
@@ -649,8 +621,7 @@ async test "shell merges stderr into the captured output on Windows" {
 ///|
 #cfg(not(platform="windows"))
 async test "shell merges stderr into the captured output on Unix" {
-  let result = run_shell({ "cmd": "printf '%s\\n' 'oops' 1>&2" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "printf '%s\\n' 'oops' 1>&2" })
   assert_false(output.is_error)
   assert_true(output.content.contains("oops"))
 }
@@ -658,8 +629,7 @@ async test "shell merges stderr into the captured output on Unix" {
 ///|
 #cfg(platform="windows")
 async test "shell times out long running commands on Windows" {
-  let result = run_shell({ "cmd": "Start-Sleep -Seconds 2", "timeout_ms": 50 })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "Start-Sleep -Seconds 2", "timeout_ms": 50 })
   assert_true(output.is_error)
   assert_eq(output.content, "error: shell command timed out after 50ms")
 }
@@ -667,8 +637,7 @@ async test "shell times out long running commands on Windows" {
 ///|
 #cfg(not(platform="windows"))
 async test "shell times out long running commands on Unix" {
-  let result = run_shell({ "cmd": "sleep 2", "timeout_ms": 50 })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "sleep 2", "timeout_ms": 50 })
   assert_true(output.is_error)
   assert_eq(output.content, "error: shell command timed out after 50ms")
 }
@@ -679,8 +648,7 @@ async test "shell rejects moon_cmd as a shell command" {
   // is the bare `moon_cmd` tool name, blocked before execution. We do not
   // exercise `moon check` here: the shell tool would run a nested `moon` under
   // `moon test` and deadlock on the build lock.
-  let result = run_shell({ "cmd": "moon_cmd run cmd/main" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "moon_cmd run cmd/main" })
   assert_true(output.is_error)
   assert_true(output.content.contains("moon_cmd is not a shell command"))
 }
@@ -689,8 +657,7 @@ async test "shell rejects moon_cmd as a shell command" {
 async test "shell rejects sed -i in-place editing" {
   // Blocked by policy before execution, so no file is touched; the model is
   // redirected to the edit tool.
-  let result = run_shell({ "cmd": "sed -i 's/old/new/' main.mbt" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cmd": "sed -i 's/old/new/' main.mbt" })
   assert_true(output.is_error)
   assert_true(output.content.contains("sed -i"))
   assert_true(output.content.contains("edit"))
@@ -709,11 +676,10 @@ async test "shell sandbox blocks source writes and points to edit tools" {
     // The redirect target hides behind a variable, so the static preblock cannot
     // see it. The write only fails because the kernel source-write sandbox denies
     // it at runtime, which is exactly the enforcement this test must cover.
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "dest=main.mbt; printf 'pub fn answer() -> Int { 43 }\\n' > \"$dest\"",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("Operation not permitted") ||
@@ -739,11 +705,10 @@ async test "shell sandbox allows generated source writes under _build" {
     @fs.mkdir("\{dir}/_build")
     // `_build/main.mbt` matches the source-file shape but lives under a
     // Moon-managed build tree, so the SBPL carve-out must keep it writable.
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "awk 'BEGIN { print \"pub fn generated() -> Int { 1 }\" > \"_build/main.mbt\" }'",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_false(
       output.content.contains("source file writes from shell are blocked"),
@@ -760,11 +725,10 @@ async test "shell sandbox allows generated source writes under _build" {
 async test "shell sandbox reports masked source write denials as errors" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-masked-denial-", dir => {
     write_answer_main(dir)
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "printf %s changed 2>/dev/null > main.mbt || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("<system>exit=blocked</system>"))
     assert_true(output.content.contains("blocked before execution"))
@@ -783,11 +747,10 @@ async test "shell sandbox preblocks source write through symlink redirect" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-symlink-redirect-", dir => {
     write_answer_main(dir)
     @fs.symlink(target="main.mbt", "\{dir}/out.log")
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "moon fmt > out.log",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("source file write redirect is blocked"),
@@ -838,11 +801,10 @@ async test "shell sandbox preblocks tee through symlinked source destination" {
 #cfg(not(platform="windows"))
 async test "shell sandbox does not treat unrelated output as source denial" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-unrelated-denial-", dir => {
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "printf '%s\\n' 'foo: Operation not permitted'",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("foo: Operation not permitted"))
     assert_false(
@@ -856,11 +818,10 @@ async test "shell sandbox does not treat unrelated output as source denial" {
 async test "shell sandbox preblocks source write after uncertain cd chain" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-cd-chain-", dir => {
     write_answer_main(dir)
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "cd /definitely-missing-openseek 2>/dev/null && :; printf changed > main.mbt",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("blocked before execution"))
     assert_true(
@@ -875,11 +836,10 @@ async test "shell sandbox preblocks source write after uncertain cd chain" {
 async test "shell sandbox preblocks source write after entering workspace from external cwd" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-external-cwd-", dir => {
     write_answer_main(dir)
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "cd \{dir}; printf changed 2>/dev/null > main.mbt || true",
       "cwd": "/tmp",
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("blocked before execution"))
     assert_answer_main_unchanged(dir)
@@ -896,11 +856,10 @@ async test "shell sandbox preblocks source directory moves" {
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "mv pkg pkg.bak",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(output.content.contains("line-anchored"))
@@ -1128,11 +1087,10 @@ async test "shell sandbox preserves mkdir predictions across fallback branches" 
 #cfg(not(platform="windows"))
 async test "shell sandbox preblocks nested shell source generation" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-nested-sh-source-", dir => {
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "sh -c 'mkdir -p _build/gen; printf source > _build/gen/main.mbt; mv _build/gen pkg'",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(output.content.contains("line-anchored"))
@@ -1189,13 +1147,10 @@ async test "shell sandbox preblocks scripted external source directory imports" 
       expect_source_write_blocked(result, line_anchored=true)
       assert_true(@fs.exists("\{generated}/main.mbt"))
       assert_false(@fs.exists("\{workspace}/pkg/main.mbt"))
-      let copy_result = run_shell_in_workspace(workspace, {
+      let copy_output = run_shell_in_workspace(workspace, {
         "cmd": "python3 -c 'import shutil; shutil.copy(\"\{generated_file}\", \"pkg\")'",
         "cwd": workspace,
       })
-      guard copy_result is Respond(copy_output) else {
-        fail("expected Respond")
-      }
       assert_true(copy_output.is_error)
       assert_true(
         copy_output.content.contains("source tree operation is blocked"),
@@ -1218,11 +1173,10 @@ async test "shell sandbox blocks unrecognized incoming source directory renames"
     prefix="openseek-shell-sandbox-python-incoming-source-dir-",
     dir => {
       @fs.mkdir("\{dir}/_build")
-      let result = run_shell_in_workspace(dir, {
+      let output = run_shell_in_workspace(dir, {
         "cmd": "python3 -c 'import os; os.makedirs(\"_build/gen\", exist_ok=True); open(\"_build/gen/main.mbt\", \"w\").write(\"pub fn generated() -> Int { 1 }\\\\n\"); os.rename(\"_build/gen\", \"pkg\")'",
         "cwd": dir,
       })
-      guard result is Respond(output) else { fail("expected Respond") }
       assert_true(output.is_error)
       assert_true(output.content.contains("source tree operation is blocked"))
       assert_true(output.content.contains("line-anchored"))
@@ -1238,11 +1192,10 @@ async test "shell sandbox preblocks script rename of generated source directory"
   @vfs.with_tmpdir(
     prefix="openseek-shell-sandbox-python-generated-dir-rename-",
     dir => {
-      let result = run_shell_in_workspace(dir, {
+      let output = run_shell_in_workspace(dir, {
         "cmd": "mkdir -p _build/gen && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen/main.mbt && python3 -c 'import os; os.rename(\"_build/gen\", \"pkg\")'",
         "cwd": dir,
       })
-      guard result is Respond(output) else { fail("expected Respond") }
       assert_true(output.is_error)
       assert_true(output.content.contains("source tree operation is blocked"))
       assert_true(output.content.contains("line-anchored"))
@@ -1262,11 +1215,10 @@ async test "shell sandbox allows non-source directory moves" {
       "not MoonBit source\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "mv assets pkg",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_false(output.content.contains("source tree operation is blocked"))
     assert_true(@fs.exists("\{dir}/pkg/logo.txt"))
@@ -1284,11 +1236,10 @@ async test "shell sandbox preblocks source directory move after uncertain cd cha
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "cd /definitely-missing-openseek 2>/dev/null && :; mv pkg pkg.bak",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(@fs.exists("\{dir}/pkg/main.mbt"))
@@ -1306,11 +1257,10 @@ async test "shell sandbox preblocks source directory move after entering workspa
       "pub fn answer() -> Int { 42 }\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "cd \{dir}; mv pkg pkg.bak",
       "cwd": "/tmp",
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(@fs.exists("\{dir}/pkg/main.mbt"))
@@ -1328,8 +1278,7 @@ async test "shell sandbox preblocks source directory removals" {
       "warnings = \"\"\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, { "cmd": "rm -rf pkg", "cwd": dir })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell_in_workspace(dir, { "cmd": "rm -rf pkg", "cwd": dir })
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(@fs.exists("\{dir}/pkg/moon.pkg"))
@@ -1349,11 +1298,10 @@ async test "shell sandbox preblocks incoming source directory moves" {
       "pub fn generated() -> Int { 1 }\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(workspace, {
+    let output = run_shell_in_workspace(workspace, {
       "cmd": "mv \{generated} pkg",
       "cwd": workspace,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(output.content.contains("line-anchored"))
@@ -1367,11 +1315,10 @@ async test "shell sandbox preblocks incoming source directory moves" {
 async test "shell sandbox preblocks generated source directory moves from build output" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-dir-", workspace => {
     @fs.mkdir("\{workspace}/_build")
-    let result = run_shell_in_workspace(workspace, {
+    let output = run_shell_in_workspace(workspace, {
       "cmd": "mkdir -p _build/gen && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen/main.mbt && mv _build/gen pkg",
       "cwd": workspace,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_false(@fs.exists("\{workspace}/_build/gen/main.mbt"))
@@ -1384,11 +1331,10 @@ async test "shell sandbox preblocks generated source directory moves from build 
 async test "shell sandbox preblocks generated dotted source directory moves from build output" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-dot-dir-", workspace => {
     @fs.mkdir("\{workspace}/_build")
-    let result = run_shell_in_workspace(workspace, {
+    let output = run_shell_in_workspace(workspace, {
       "cmd": "mkdir -p _build/gen.v1 && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg",
       "cwd": workspace,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_false(@fs.exists("\{workspace}/_build/gen.v1/main.mbt"))
@@ -1404,11 +1350,10 @@ async test "shell sandbox preblocks generated dotted source directory moves into
     workspace => {
       @fs.mkdir("\{workspace}/_build")
       @fs.mkdir("\{workspace}/pkg")
-      let result = run_shell_in_workspace(workspace, {
+      let output = run_shell_in_workspace(workspace, {
         "cmd": "mkdir -p _build/gen.v1 && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg",
         "cwd": workspace,
       })
-      guard result is Respond(output) else { fail("expected Respond") }
       assert_true(output.is_error)
       assert_true(output.content.contains("source tree operation is blocked"))
       assert_false(@fs.exists("\{workspace}/_build/gen.v1/main.mbt"))
@@ -1422,11 +1367,10 @@ async test "shell sandbox preblocks generated dotted source directory moves into
 async test "shell sandbox preblocks generated source directory moves to dotted destinations" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-dir-dot-dest-", workspace => {
     @fs.mkdir("\{workspace}/_build")
-    let result = run_shell_in_workspace(workspace, {
+    let output = run_shell_in_workspace(workspace, {
       "cmd": "mkdir -p _build/gen && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen/main.mbt && mv _build/gen pkg.v1",
       "cwd": workspace,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_false(@fs.exists("\{workspace}/_build/gen/main.mbt"))
@@ -1441,11 +1385,10 @@ async test "shell sandbox preblocks generated file-like source directory moves t
     prefix="openseek-shell-sandbox-mv-generated-file-like-dir-",
     workspace => {
       @fs.mkdir("\{workspace}/_build")
-      let result = run_shell_in_workspace(workspace, {
+      let output = run_shell_in_workspace(workspace, {
         "cmd": "mkdir -p assets _build/gen.tmp && printf 'pub fn generated() -> Int { 1 }\\n' > _build/gen.tmp/main.mbt && mv _build/gen.tmp assets/pkg.tmp",
         "cwd": workspace,
       })
-      guard result is Respond(output) else { fail("expected Respond") }
       assert_true(output.is_error)
       assert_true(output.content.contains("source tree operation is blocked"))
       assert_false(@fs.exists("\{workspace}/_build/gen.tmp/main.mbt"))
@@ -1458,11 +1401,10 @@ async test "shell sandbox preblocks generated file-like source directory moves t
 #cfg(not(platform="windows"))
 async test "shell sandbox allows generated non-source file moves from build output" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-mv-generated-file-", workspace => {
-    let result = run_shell_in_workspace(workspace, {
+    let output = run_shell_in_workspace(workspace, {
       "cmd": "mkdir -p assets _build && printf data > _build/logo.txt && mv _build/logo.txt assets/logo.txt",
       "cwd": workspace,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_false(output.content.contains("source tree operation is blocked"))
     assert_eq(@fs.read_file("\{workspace}/assets/logo.txt").text(), "data")
@@ -1483,11 +1425,10 @@ async test "shell sandbox preblocks incoming source files moved into workspace d
       "pub fn generated() -> Int { 1 }\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(workspace, {
+    let output = run_shell_in_workspace(workspace, {
       "cmd": "mv -t pkg \{generated}",
       "cwd": workspace,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_true(@fs.exists(generated))
@@ -1507,11 +1448,10 @@ async test "shell sandbox blocks moon work writes" {
       "members = []\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "printf 'members = [\".\"]' > moon.work",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
@@ -1533,8 +1473,7 @@ async test "shell sandbox still permits moon check build outputs" {
       create_mode=CreateOrTruncate,
     )
     write_answer_main(dir)
-    let result = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
     assert_false(output.is_error)
     assert_true(output.content.contains("<system>exit=0</system>"))
     assert_false(output.content.contains("source file writes from shell"))
@@ -1566,8 +1505,7 @@ async test "shell allows moon check pre-build source outputs" {
       create_mode=CreateOrTruncate,
     )
     write_answer_main(dir, content="pub fn answer() -> Int { generated() }\n")
-    let result = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell_in_workspace(dir, { "cmd": "moon check", "cwd": dir })
     assert_false(output.is_error)
     assert_true(output.content.contains("<system>exit=0</system>"))
     assert_true(@fs.exists("\{dir}/generated.mbt"))
@@ -1611,11 +1549,10 @@ async test "shell trusts guarded package cd before moon check pre-build output" 
       "pub fn answer() -> Int { generated() }\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "cd pkg && moon check",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     // `cd pkg && moon check` is a trusted source-write command, so the sandbox
     // must run it unsandboxed and let moon's pre-build write source. We assert
     // only that our guard did not interpose; whether moon's pre-build itself
@@ -1638,11 +1575,10 @@ async test "shell sandbox blocks too-complex sed source rewrites" {
   }
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-sed-glob-", dir => {
     write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "sed -i '' 's/old/new/' *.mbt",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
@@ -1661,11 +1597,10 @@ async test "shell sandbox blocks too-complex sed source rewrites" {
 async test "shell sandbox preblocks too-complex fd duplicate source redirect" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-fd-dup-source-", dir => {
     write_answer_main(dir)
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "printf changed >& main.mbt *.txt 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("source tree operation is blocked"))
     assert_answer_main_unchanged(dir)
@@ -1681,11 +1616,10 @@ async test "shell sandbox allows read-only grep of source text" {
       "let mv_marker = 1\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "grep mv *.mbt",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("mv_marker"))
     assert_false(output.content.contains("source tree operation is blocked"))
@@ -1697,11 +1631,10 @@ async test "shell sandbox allows read-only grep of source text" {
 async test "shell preblocks env unset sed source rewrites" {
   @vfs.with_tmpdir(prefix="openseek-shell-env-sed-source-", dir => {
     write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "env -u FOO sed -i '' 's/old/new/' *.mbt 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
@@ -1720,11 +1653,10 @@ async test "shell preblocks env unset sed source rewrites" {
 async test "shell preblocks env assignment sed source rewrites" {
   @vfs.with_tmpdir(prefix="openseek-shell-env-assign-sed-source-", dir => {
     write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "FOO=bar sed -i '' 's/old/new/' *.mbt 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
@@ -1743,11 +1675,10 @@ async test "shell preblocks env assignment sed source rewrites" {
 async test "shell preblocks find exec sed source rewrites" {
   @vfs.with_tmpdir(prefix="openseek-shell-find-sed-source-", dir => {
     write_answer_main(dir, content="pub fn answer() -> Int { old }\n")
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "find \{dir} -name '*.mbt' -exec env FOO=bar sed -i '' 's/old/new/' {} + 2>/dev/null || true",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
@@ -1771,11 +1702,10 @@ async test "shell preblocks looped sed source rewrites through path list" {
       "\{dir}/main.mbt\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "while IFS= read -r f; do sed -i '' 's/old/new/' \"$f\"; done < files.txt",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("source file writes from shell are blocked"),
@@ -1796,22 +1726,20 @@ async test "shell allows recoverable git worktree rollback" {
     write_answer_main(dir)
     // Build a tiny repo with a committed main.mbt. init/config/add/commit only
     // touch `.git`, so they run (sandboxed) without being blocked.
-    let setup = run_shell_in_workspace(dir, {
+    let setup_output = run_shell_in_workspace(dir, {
       "cmd": "git init -q && git config user.email a@b.c && git config user.name t && git add main.mbt && git commit -q -m init",
       "cwd": dir,
     })
-    guard setup is Respond(setup_output) else { fail("expected Respond") }
     assert_false(
       setup_output.content.contains("source file writes from shell are blocked"),
     )
     // Dirty the tracked source, then discard the change with `git checkout` — a
     // trusted, recoverable worktree write that now runs unsandboxed and succeeds.
     write_answer_main(dir, content="pub fn answer() -> Int { 999 }\n")
-    let result = run_shell_in_workspace(dir, {
+    let output = run_shell_in_workspace(dir, {
       "cmd": "git checkout -- main.mbt",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_false(
       output.content.contains("source file writes from shell are blocked"),
@@ -1837,8 +1765,7 @@ async test "shell allows trusted moon fmt command" {
       "pub fn answer()->Int{42}\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell_in_workspace(dir, { "cmd": "moon fmt", "cwd": dir })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell_in_workspace(dir, { "cmd": "moon fmt", "cwd": dir })
     assert_false(output.is_error)
     assert_true(output.content.contains("<system>exit=0</system>"))
     assert_false(output.content.contains("source file writes from shell"))
@@ -1870,11 +1797,10 @@ async test "shell appends moon check after applied moon ide rename" {
       ),
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell({
+    let output = run_shell({
       "cmd": "moon ide rename old_name new_name --loc main.mbt:1:8 --apply",
       "cwd": dir,
     })
-    guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("<system>exit=0</system>"))
     assert_true(output.content.contains("Applied 2 edit(s)"))
@@ -1914,8 +1840,7 @@ async test "shell appends moon check from moon.work workspace root" {
       "pub fn broken()->Int{missing_from_workspace}\n",
       create_mode=CreateOrTruncate,
     )
-    let result = run_shell({ "cmd": "moon fmt", "cwd": dir })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell({ "cmd": "moon fmt", "cwd": dir })
     assert_false(output.is_error)
     assert_true(output.content.contains("<system>exit=0</system>"))
     assert_true(output.content.contains("\nmoon check:\nexit=255"))
@@ -1945,12 +1870,14 @@ async test "shell does not append moon check for non-mutating moon shapes" {
       create_mode=CreateOrTruncate,
     )
     for cmd in ["echo moon add", "true || moon fmt", "moon fmt --check"] {
-      let result = run_shell({ "cmd": cmd, "cwd": dir })
-      guard result is Respond(output) else { fail("expected Respond") }
+      let output = run_shell({ "cmd": cmd, "cwd": dir })
       assert_false(output.content.contains("moon check:"))
     }
-    let timed = run_shell({ "cmd": "moon fmt", "cwd": dir, "timeout_ms": 30000 })
-    guard timed is Respond(output) else { fail("expected Respond") }
+    let output = run_shell({
+      "cmd": "moon fmt",
+      "cwd": dir,
+      "timeout_ms": 30000,
+    })
     assert_false(output.is_error)
     assert_false(output.content.contains("moon check:"))
   })
@@ -1984,8 +1911,7 @@ async test "shell appends moon check from moon command target cwd" {
       cmd in [
         "moon -C project fmt", "moon -Cproject fmt", "moon -C=project fmt", "cd ./project && moon fmt",
       ] {
-      let result = run_shell({ "cmd": cmd, "cwd": dir })
-      guard result is Respond(output) else { fail("expected Respond") }
+      let output = run_shell({ "cmd": cmd, "cwd": dir })
       assert_false(output.is_error)
       assert_true(output.content.contains("<system>exit=0</system>"))
       assert_true(output.content.contains("\nmoon check:\nexit="))
@@ -1996,8 +1922,7 @@ async test "shell appends moon check from moon command target cwd" {
 
 ///|
 async test "shell rejects missing cmd" {
-  let result = run_shell({ "cwd": "unused" })
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell({ "cwd": "unused" })
   assert_true(output.is_error)
   assert_true(output.content.contains("error: shell requires"))
   assert_true(output.content.contains("arguments.cmd"))
@@ -2005,8 +1930,7 @@ async test "shell rejects missing cmd" {
 
 ///|
 async test "shell rejects non-object arguments" {
-  let result = run_shell(Json::null())
-  guard result is Respond(output) else { fail("expected Respond") }
+  let output = run_shell(Json::null())
   assert_true(output.is_error)
   assert_eq(output.content, "error: shell requires object arguments")
 }
@@ -2016,8 +1940,7 @@ async test "shell rejects non-existent cwd" {
   @vfs.with_tmpdir(prefix="openseek-shell-cwd-", dir => {
     let dir_path : @path.Path = dir
     let path = dir_path.join("does-not-exist").normalize().to_string()
-    let result = run_shell({ "cmd": "echo hello", "cwd": path })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell({ "cmd": "echo hello", "cwd": path })
     assert_true(output.is_error)
     assert_true(output.content.contains("cwd does not exist"))
   })
@@ -2029,8 +1952,7 @@ async test "shell rejects cwd that is a file not a directory" {
     let dir_path : @path.Path = dir
     let path = dir_path.join("file.txt").normalize().to_string()
     @fs.write_file(path, "not a directory", create_mode=CreateOrTruncate)
-    let result = run_shell({ "cmd": "echo hello", "cwd": path })
-    guard result is Respond(output) else { fail("expected Respond") }
+    let output = run_shell({ "cmd": "echo hello", "cwd": path })
     assert_true(output.is_error)
     assert_true(output.content.contains("cwd is not a directory"))
   })


### PR DESCRIPTION
Follow-up to #413, found while sweeping the one thing the previous rounds never measured: **all 131 call sites** of the seven `run_*` tool-dispatch helpers (`run_shell`/`run_shell_wired`/`run_shell_in_workspace`/`run_edit`/`run_edit_in_workspace`/`run_multi_edit`/`run_multi_edit_in_workspace`) immediately follow the call with the identical `guard … is Respond(output) else fail` unwrap — no test anywhere consumes the raw `ToolAction`.

Move the unwrap into the helpers (return `ToolOutput`), delete the per-site guard lines (110 single-line + multi-line variants across `shell_test`, `edit_test`, `multi_edit_test`, `multi_edit_gate_test`), and let `expect_source_write_blocked` take the output directly. Every assertion and expected value is unchanged. Net **−124 lines**.

## Testing
`moon check`/`fmt` clean; `agent_tool/shell` 115/115, `edit` 30/30, `multi_edit` 30/30 (fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)