### PR TITLE
feat(agent): optional max_steps — turns bounded by context, not steps

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -1,5 +1,9 @@
 ///|
-let default_max_steps : Int = 1000
+/// Default step bound: effectively unbounded (Int max). Turns are bounded
+/// by the context window instead — a response at the ceiling yields the
+/// turn with a checkpoint summary — so a step count only binds when a
+/// caller passes one explicitly.
+pub let unbounded_max_steps : Int = 2147483647
 
 ///|
 /// Model requests since the last plan activity — a successful `plan` call or
@@ -126,7 +130,7 @@ pub async fn run(
   model~ : @deepseek.Model,
   task~ : String,
   system_prompt_text~ : String,
-  max_steps? : Int = default_max_steps,
+  max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
@@ -176,7 +180,7 @@ pub async fn run_turn_with_append(
   session~ : @agent_session.Session,
   task~ : String,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
-  max_steps? : Int = default_max_steps,
+  max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
@@ -289,7 +293,7 @@ pub async fn[X] run_turn_in_scope(
   session~ : @agent_session.Session,
   task~ : String,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
-  max_steps? : Int = default_max_steps,
+  max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   tools? : @agent_tool.Tools,

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -35,16 +35,17 @@ fn at_context_share(
 ///|
 /// The turn must end at this step's boundary. `total_tokens` — last prompt
 /// plus completion — is the closest available proxy for the next request's
-/// prompt size.
+/// prompt size; `extra_result_chars` adds the current batch's recorded
+/// results (measured AFTER usage was), so a below-threshold response whose
+/// batch grew the context into the soft band still ends compacted.
 fn AgentLoop::at_soft_context_ceiling(
   self : Self,
   usage : @deepseek.Usage,
+  extra_result_chars? : Int64 = 0,
 ) -> Bool {
-  at_context_share(
-    usage,
-    self.client.model.context_window(),
-    soft_context_ceiling_percent,
-  )
+  let window = self.client.model.context_window().to_int64()
+  (usage.total_tokens.to_int64() + extra_result_chars) * 100 >=
+  window * soft_context_ceiling_percent.to_int64()
 }
 
 ///|

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -1,105 +1,150 @@
 ///|
-/// Share of the model context window, in percent, at which the loop
-/// compacts. Auto-compaction is a context-ceiling guard, not a cost
-/// optimization: appending a summary rewrites the model-facing prefix and
-/// busts DeepSeek prefix-cache pricing, so it must fire only where the
-/// alternative is request failure (improvement.md). The headroom left below
-/// the ceiling must still fit the summary-generation request, which resends
-/// the projected history plus the checkpoint prompt.
-let auto_compact_threshold_percent = 80
+/// Soft context ceiling, percent of the model window: at or past it the
+/// turn ENDS at the current step's boundary — gracefully. A tool batch
+/// measured in the soft band still executes (aggregate-budgeted, see
+/// `soft_batch_fits`), the checkpoint covers its real results, and nothing
+/// is discarded or re-issued. Crossings land in the soft band whenever one
+/// round grows the context by less than the tier gap, which makes graceful
+/// exits the common case. The guard is a ceiling guard, not a cost
+/// optimization: rewriting the model-facing prefix busts DeepSeek
+/// prefix-cache pricing, so it must fire only where the alternative is
+/// request failure.
+let soft_context_ceiling_percent = 70
 
 ///|
-/// Compact the session when the last response reports token usage near the
-/// model's context window.
+/// Hard context ceiling: at or past it no tool batch STARTS — every call
+/// is skip-closed (completion salvage aside) so the checkpoint request
+/// stays bounded by the measured usage plus a few bytes of notes. Only
+/// reachable when a single round jumped the entire soft band, i.e. the
+/// previous batch returned enormous results — exactly when more unmeasured
+/// execution is dangerous. The headroom above must still fit the
+/// summary-generation request, which resends the projected history plus
+/// the checkpoint prompt.
+let hard_context_ceiling_percent = 80
+
+///|
+fn at_context_share(
+  usage : @deepseek.Usage,
+  context_window : Int,
+  percent : Int,
+) -> Bool {
+  usage.total_tokens.to_int64() * 100 >=
+  context_window.to_int64() * percent.to_int64()
+}
+
+///|
+/// The turn must end at this step's boundary. `total_tokens` — last prompt
+/// plus completion — is the closest available proxy for the next request's
+/// prompt size.
+fn AgentLoop::at_soft_context_ceiling(
+  self : Self,
+  usage : @deepseek.Usage,
+) -> Bool {
+  at_context_share(
+    usage,
+    self.client.model.context_window(),
+    soft_context_ceiling_percent,
+  )
+}
+
+///|
+/// No tool batch may start; skip-close and yield.
+fn AgentLoop::at_hard_context_ceiling(
+  self : Self,
+  usage : @deepseek.Usage,
+) -> Bool {
+  at_context_share(
+    usage,
+    self.client.model.context_window(),
+    hard_context_ceiling_percent,
+  )
+}
+
+///|
+/// Token allowance the checkpoint request needs beyond the projected
+/// history: the checkpoint prompt and message wrappers on the prompt side,
+/// PLUS the completion budget the summary itself is generated into — a
+/// budget that lets a batch push the projection to the window edge would
+/// leave the summary no room to be written and strand the session via
+/// fail-open. Consumed by the running batch budget in
+/// `AgentLoop::handle_tool_calls`.
+let checkpoint_reserve_tokens : Int = 16_384
+
+///|
+/// Whether the NEXT tool call in an executing batch provably fits:
+/// measured usage, plus the batch's results recorded so far (actual
+/// sizes, 1 char >= 1 token for mostly-ASCII tool output), plus one
+/// worst-case result for the call about to run, plus the checkpoint
+/// reserve, stays under the window. Checked before EVERY call at EVERY
+/// usage level — this, not a pre-execution estimate, is what makes batch
+/// execution safe: a pre-execution worst case over the whole batch would
+/// false-positive constantly (any 4-call batch would trip it on a 256K
+/// window at any usage), while the running check uses real sizes and only
+/// pessimizes one call ahead.
+fn AgentLoop::next_call_fits(
+  self : Self,
+  usage : @deepseek.Usage,
+  spent_result_chars : Int64,
+) -> Bool {
+  let window = self.client.model.context_window().to_int64()
+  usage.total_tokens.to_int64() +
+  spent_result_chars +
+  max_tool_result_chars.to_int64() +
+  checkpoint_reserve_tokens.to_int64() <
+  window
+}
+
+///|
+/// Append the ceiling checkpoint: still-queued steers first, then the
+/// Summary covering everything before them. Shared by both pressured
+/// terminal shapes — the context yield and compact-on-finish.
 ///
-/// The trigger reads `usage.total_tokens` — last prompt plus completion, the
-/// closest available proxy for the next request's prompt — right after every
-/// response, so a final-answer step still compacts and the next turn starts
-/// from the checkpoint instead of creeping past the ceiling turn by turn.
+/// The steers were already drained from the runtime queue, so they must be
+/// persisted BEFORE the cancellable summary request — a cancellation mid-
+/// request must find them durable, not lost (serve's turn-end drain would
+/// see an empty queue and report nothing). The summary is generated from
+/// the pre-steer snapshot (sessions are immutable values), so their content
+/// cannot be folded into the checkpoint text; they stay verbatim past it,
+/// projecting right after the summary to head the next turn.
 ///
-/// Two stages, bounded per turn. The first folds only events before this
-/// turn's task (`1..turn_start_sequence - 1`): the active task, steers, and
-/// tool results stay verbatim in context. If pressure persists — or there is
-/// no prior history — the second checkpoints everything so far, the same
-/// lossy-but-designed semantic as the manual compact flow, whose prompt
-/// carries current goal and intent forward. After that (or after a failed
-/// summary) the guard disarms for the rest of the turn; the next turn's
-/// fresh loop re-arms it.
-///
-/// Fail-open: a failed summary logs `auto_compaction_failed` and the turn
-/// continues uncompacted — a guardrail must not kill a turn that might still
-/// fit, and one that no longer fits fails visibly on the next main request.
-/// Known limit: the guard reacts to reported usage, so a single oversized
-/// tool result appended between responses can still overflow before the next
-/// check; tool-output capping (todo.md) is the fix for that, not compaction.
-///
-/// The `auto_compaction_*` event names are deliberately distinct from the
-/// manual flow's `compaction_*`: the TUI treats `compaction_finished` and
-/// `compaction_failed` as terminal for the active run, which a mid-turn
-/// auto-compaction is not.
-async fn AgentLoop::maybe_auto_compact(
+/// Only summary GENERATION is fail-open: on a model/endpoint error the
+/// session is returned uncompacted — a guardrail must not strand the turn —
+/// and the next pressured step retries. The summary APPEND stays outside
+/// the catch so a durability failure propagates like every other append.
+/// Cancellation re-raises. The Bool reports whether a Summary was actually
+/// appended, so callers never claim a checkpoint that does not exist.
+async fn AgentLoop::checkpoint_at_ceiling(
   self : Self,
   session : @agent_session.Session,
-  usage : @deepseek.Usage,
-) -> @agent_session.Session {
-  if self.auto_compact_disarmed {
-    return session
-  }
-  let context_window = self.client.model.context_window()
-  if usage.total_tokens.to_int64() * 100 <
-    context_window.to_int64() * auto_compact_threshold_percent.to_int64() {
-    return session
-  }
-  let prior_prefix_end = self.turn_start_sequence - 1
-  let to_sequence = if prior_prefix_end >= 1 &&
-    self.auto_compacted_to < prior_prefix_end {
-    prior_prefix_end
-  } else {
-    self.auto_compact_disarmed = true
-    session.last_sequence()
-  }
+  steers : ArrayView[@agent_runtime.SteerInput],
+) -> (@agent_session.Session, Bool) {
+  let to_sequence = session.last_sequence()
+  let covered = session
+  let session = self.apply_steer_inputs(session, steers)
   @xlog.info() <?
     {
       "event": "auto_compaction_started",
       "from_sequence": 1,
       "to_sequence": to_sequence,
-      "total_tokens": usage.total_tokens,
-      "context_window": context_window,
     }
-  let summary_source = if to_sequence == session.last_sequence() {
-    session
-  } else {
-    session_prefix(session, to_sequence)
-  }
   let summary = @compact.generate_compaction_summary(
     client=self.summary_client,
-    summary_source,
+    covered,
   ) catch {
     error => {
       if @async.is_being_cancelled() || @async.is_cancellation_error(error) {
         raise error
       }
-      self.auto_compact_disarmed = true
       @xlog.warn() <? { "event": "auto_compaction_failed", "error": "\{error}" }
-      return session
+      return (session, false)
     }
   }
-  // The preconditions hold by construction (the generator rejects empty
-  // summaries; 1 <= to_sequence <= last_sequence), and persistence must go
-  // through the loop's append seam, so `Session::compact`'s direct append is
-  // not usable here. A raise from either half propagates like any other
-  // append failure and closes the turn through the run-level handler.
   let item = session.summary_item(
     content=summary,
     from_sequence=1,
     to_sequence~,
   )
-  let next = self.append(session, item)
-  self.auto_compacted_to = to_sequence
-  self.messages.clear()
-  for message in next.chat_messages() {
-    self.messages.push(message)
-  }
+  let compacted = self.append(session, item)
   @xlog.info() <?
     {
       "event": "auto_compaction_finished",
@@ -107,30 +152,67 @@ async fn AgentLoop::maybe_auto_compact(
       "to_sequence": to_sequence,
       "summary": summary,
     }
-  next
+  (compacted, true)
 }
 
 ///|
-/// Rebuild events `1..to_sequence` as a standalone session so the checkpoint
-/// request summarizes exactly the range the summary event will cover — not
-/// the active turn it leaves verbatim. Re-appending a contiguous prefix
-/// preserves its sequence numbers, so ranges inside earlier summary events
-/// stay valid for the projection.
-fn session_prefix(
+/// End the turn at the context ceiling: the checkpoint, then the yield
+/// terminal, in that order, so the turn's last event stays a terminal (the
+/// session invariant every consumer of the raw log relies on) and the next
+/// turn — chained by a controller, an armed goal, or the user — seeds from
+/// the compacted projection.
+///
+/// The terminal is `Finished`: a distinct terminal kind would break old
+/// readers (the session decoder is strict), and continuation machinery
+/// chains finished turns. The `context_yield` event is the discriminator
+/// for consumers that must not read a yield as task success.
+async fn AgentLoop::yield_at_context_ceiling(
+  self : Self,
+  session : @agent_session.Session,
+  steers : ArrayView[@agent_runtime.SteerInput],
+) -> @agent_session.Session {
+  let to_sequence = session.last_sequence()
+  let (session, compacted) = self.checkpoint_at_ceiling(session, steers)
+  // The summary request takes seconds; steers submitted while it was in
+  // flight are still preservable — drain again so they persist (uncovered,
+  // after the summary) instead of being boundary-dropped at TurnDone.
+  // (Compact-on-finish handles its own late steers by CONTINUING the turn
+  // from the compacted projection — see finish_turn.)
+  let session = self.apply_steer_inputs(session, self.runtime.pending_steers())
+  self.finish_context_yield(session, to_sequence, compacted~)
+}
+
+///|
+/// Seal a context yield: the `Finished` terminal for replay and chaining,
+/// but `context_yield` — not `agent_finished` — on the wire, so live
+/// consumers never read a mid-task ceiling yield as task success.
+async fn AgentLoop::finish_context_yield(
+  self : Self,
   session : @agent_session.Session,
   to_sequence : Int,
+  compacted~ : Bool,
 ) -> @agent_session.Session {
-  for
-    event in session.events()
-    prefix = @agent_session.Session(
-      session.id(),
-      system_prompt=session.system_prompt(),
-    ) {
-    if event.sequence() <= to_sequence {
-      continue prefix.append(event.item())
-    }
-    continue prefix
-  } nobreak {
-    prefix
+  // Built FROM the shared prefix so the durable-log contract
+  // (@agent_session.ContextYieldAnswerPrefix) can never drift from the
+  // answer actually persisted — and honest about whether a checkpoint
+  // actually exists (fail-open must not promise a summary that was never
+  // appended).
+  let answer = if compacted {
+    @agent_session.ContextYieldAnswerPrefix +
+    " This turn reached the model's context window and was checkpointed. " +
+    "The work is not necessarily complete — continue it in a new turn, " +
+    "which starts from the checkpoint summary."
+  } else {
+    @agent_session.ContextYieldAnswerPrefix +
+    " This turn reached the model's context window; the checkpoint " +
+    "attempt failed, so the turn ended uncompacted. Continue in a new " +
+    "turn — its pressure retries the checkpoint."
   }
+  let session = self.append(session, Terminal(Finished(answer)))
+  // No push_finished_message: the yield status is not an assistant message
+  // — the model-facing projection skips it too (the loop ends here, but the
+  // buffer must never disagree with Session::chat_messages).
+  @xlog.info() <?
+    { "event": "context_yield", "to_sequence": to_sequence, "answer": answer }
+  session
 }

--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -81,6 +81,28 @@ fn sse_tool_call(id : String, name : String, total_tokens : Int) -> String {
 }
 
 ///|
+fn sse_tool_calls(
+  calls : Array[(String, String)],
+  total_tokens : Int,
+) -> String {
+  let entries : Array[Json] = []
+  for index, call in calls {
+    let (id, name) = call
+    entries.push({
+      "index": index,
+      "id": id,
+      "type": "function",
+      "function": { "name": name, "arguments": "{}" },
+    })
+  }
+  (
+    {
+      "choices": [{ "delta": { "tool_calls": entries.to_json() } }],
+      "usage": usage_json(total_tokens),
+    } : Json).stringify()
+}
+
+///|
 fn sse_final(content : String, total_tokens : Int) -> String {
   (
     {
@@ -100,14 +122,6 @@ fn request_messages(request : Json) -> Array[Json] raise {
     fail("request without messages: \{request.stringify()}")
   }
   messages
-}
-
-///|
-fn message_role(message : Json) -> String raise {
-  guard message is { "role": String(role), .. } else {
-    fail("message without role: \{message.stringify()}")
-  }
-  role
 }
 
 ///|
@@ -148,120 +162,40 @@ fn probe_tools(results : Array[String]) -> @agent_tool.Tools raise {
 }
 
 ///|
-async test "auto-compaction stage one folds prior turns and keeps the task" {
-  @async.with_task_group() <| group => {
-    let checkpoint_requests : Array[Json] = []
-    let mut main_step = 0
-    let mut compacted_request : Json? = None
-    let handle = request => {
-      if is_checkpoint_request(request) {
-        checkpoint_requests.push(request)
-        Body(checkpoint_body("PRIOR-SUMMARY"))
-      } else {
-        main_step += 1
-        if main_step == 1 {
-          Sse(sse_tool_call("call_probe", "probe", 900_000))
-        } else {
-          compacted_request = Some(request)
-          Sse(sse_final("done", 5_000))
-        }
-      }
-    }
-    guard auto_compact_test_server(group, handle) is Some(url) else { return }
-    let session = @agent_session.Session(
-        SessionId("auto-compact-stage-one"),
-        system_prompt="system",
-      )
-      .append(User(UserMessage("prior question about llamas")))
-      .append(Terminal(Finished("prior answer about llamas")))
-    let result = @agent.run_turn_in_scope(
-      runtime=AgentRuntime(),
-      scope=AgentTaskScope(group),
-      api_key="test-key",
-      model=Deepseek(V4Flash),
-      session~,
-      task="TASK-MARKER count the llamas",
-      append_item=(session, item) => session.append(item),
-      max_steps=3,
-      api_url=url,
-      tools=probe_tools(["probe-result"]),
-    )
-
-    // Durable log: the summary covers exactly the prior turn, and the
-    // current turn's events land after it untouched.
-    let events = result.events()
-    assert_eq(events.length(), 7)
-    guard events[3].item() is Summary(summary) else {
-      fail("expected summary event")
-    }
-    assert_eq(summary.from_sequence(), 1)
-    assert_eq(summary.to_sequence(), 2)
-    assert_eq(summary.content(), "PRIOR-SUMMARY")
-    guard events[6].item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_eq(answer, "done")
-
-    // The checkpoint request summarized only the covered prefix: the prior
-    // turn is there, the active task is not.
-    assert_eq(checkpoint_requests.length(), 1)
-    let checkpoint_messages = request_messages(checkpoint_requests[0])
-    assert_eq(checkpoint_messages.length(), 4)
-    assert_eq(message_role(checkpoint_messages[0]), "system")
-    assert_true(message_content(checkpoint_messages[1]).contains("llamas"))
-    for message in checkpoint_messages {
-      assert_false(message_content(message).contains("TASK-MARKER"))
-    }
-
-    // The next main request was re-seeded from the compacted projection:
-    // the summary stands where the prior turn stood — before the active
-    // task, which stays verbatim — and the tool batch is intact.
-    guard compacted_request is Some(request) else {
-      fail("expected a post-compaction main request")
-    }
-    let messages = request_messages(request)
-    assert_eq(messages.length(), 5)
-    assert_eq(message_role(messages[0]), "system")
-    assert_eq(message_role(messages[1]), "user")
-    assert_true(message_content(messages[1]).contains("[conversation summary]"))
-    assert_true(message_content(messages[1]).contains("PRIOR-SUMMARY"))
-    assert_eq(message_role(messages[2]), "user")
-    assert_true(message_content(messages[2]).contains("TASK-MARKER"))
-    assert_eq(message_role(messages[3]), "assistant")
-    assert_true(messages[3] is { "tool_calls": Array(_), .. })
-    assert_eq(message_role(messages[4]), "tool")
-    assert_true(message_content(messages[4]).contains("probe-result"))
-    for message in messages {
-      assert_false(message_content(message).contains("prior question"))
-    }
-  }
+fn finish_and_probe_tools() -> @agent_tool.Tools raise {
+  Tools([
+    AgentToolDefinition(
+      name="finish",
+      description="Finish tool.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::finish("wrapped: all done")),
+    ),
+    AgentToolDefinition(
+      name="probe",
+      description="Probe tool.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+    ),
+  ])
 }
 
 ///|
-async test "auto-compaction escalates to a full checkpoint once then disarms" {
+async test "pressure on a tool-call response yields immediately" {
   @async.with_task_group() <| group => {
     let checkpoint_requests : Array[Json] = []
     let mut main_step = 0
-    let mut final_request : Json? = None
     let handle = request => {
       if is_checkpoint_request(request) {
         checkpoint_requests.push(request)
-        Body(checkpoint_body("S\{checkpoint_requests.length()}"))
+        Body(checkpoint_body("CEILING-SUMMARY"))
       } else {
         main_step += 1
-        match main_step {
-          1 => Sse(sse_tool_call("call_1", "probe", 900_000))
-          2 => Sse(sse_tool_call("call_2", "probe", 900_000))
-          _ => {
-            final_request = Some(request)
-            Sse(sse_final("done", 900_000))
-          }
-        }
+        Sse(sse_tool_call("call_1", "probe", 900_000))
       }
     }
     guard auto_compact_test_server(group, handle) is Some(url) else { return }
     let session = @agent_session.Session(
-        SessionId("auto-compact-escalation"),
+        SessionId("yield-tool-batch"),
         system_prompt="system",
       )
       .append(User(UserMessage("prior question")))
@@ -272,71 +206,58 @@ async test "auto-compaction escalates to a full checkpoint once then disarms" {
       api_key="test-key",
       model=Deepseek(V4Flash),
       session~,
-      task="TASK-MARKER keep working",
+      task="keep grinding",
       append_item=(session, item) => session.append(item),
-      max_steps=4,
       api_url=url,
-      tools=probe_tools(["result-1", "result-2"]),
+      tools=probe_tools(["result-1"]),
     )
-
-    // Stage one folded the prior turn; the persisting pressure escalated to
-    // one full-range checkpoint; the third high-usage response triggered
-    // nothing more.
-    assert_eq(checkpoint_requests.length(), 2)
+    // One model round plus the checkpoint call: the arming batch is closed
+    // WITHOUT executing (its results could fill the remaining headroom),
+    // then the turn ends Summary-then-Terminal so the last event stays a
+    // terminal.
+    assert_eq(main_step, 1)
+    assert_eq(checkpoint_requests.length(), 1)
     let events = result.events()
-    assert_eq(events.length(), 10)
-    guard events[3].item() is Summary(first) else {
-      fail("expected stage-one summary")
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal last")
     }
-    assert_eq(first.from_sequence(), 1)
-    assert_eq(first.to_sequence(), 2)
-    assert_eq(first.content(), "S1")
-    guard events[6].item() is Summary(second) else {
-      fail("expected full-range summary")
+    assert_true(answer.contains("[context ceiling]"))
+    let count = events.length()
+    guard events[count - 2].item() is Summary(summary) else {
+      fail("expected the checkpoint summary before the terminal")
     }
-    assert_eq(second.from_sequence(), 1)
-    assert_eq(second.to_sequence(), 6)
-    assert_eq(second.content(), "S2")
-    guard events[9].item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
+    assert_eq(summary.content(), "CEILING-SUMMARY")
+    assert_eq(summary.from_sequence(), 1)
+    // The summary covers everything before it, including the closed batch.
+    assert_eq(summary.to_sequence(), count - 2)
+    guard events[count - 3].item() is Tool(tool_result) else {
+      fail("expected the batch closed before the summary")
     }
-    assert_eq(answer, "done")
-
-    // After the full checkpoint the model context is just the summary plus
-    // the still-open tool batch; even the task folded.
-    guard final_request is Some(request) else {
-      fail("expected a post-escalation main request")
-    }
-    let messages = request_messages(request)
-    assert_eq(messages.length(), 4)
-    assert_eq(message_role(messages[0]), "system")
-    assert_eq(message_role(messages[1]), "user")
-    assert_true(message_content(messages[1]).contains("S2"))
-    assert_eq(message_role(messages[2]), "assistant")
-    assert_eq(message_role(messages[3]), "tool")
-    assert_true(message_content(messages[3]).contains("result-2"))
-    for message in messages {
-      assert_false(message_content(message).contains("TASK-MARKER"))
-    }
+    assert_true(tool_result.is_error())
+    assert_true(
+      tool_result.content().contains("yielding at the context ceiling"),
+    )
   }
 }
 
 ///|
-async test "auto-compaction guards the final answer at the exact threshold" {
+async test "a final answer at pressure checkpoints then finishes normally" {
   @async.with_task_group() <| group => {
     let checkpoint_requests : Array[Json] = []
-    // 80% of the 1M deepseek-v4-flash window: >= must trigger.
+    let mut main_requests = 0
     let handle = request => {
       if is_checkpoint_request(request) {
         checkpoint_requests.push(request)
-        Body(checkpoint_body("MONO-SUMMARY"))
+        Body(checkpoint_body("FINISH-SUMMARY"))
       } else {
-        Sse(sse_final("boundary done", 800_000))
+        main_requests += 1
+        Sse(sse_final("really done", 900_000))
       }
     }
     guard auto_compact_test_server(group, handle) is Some(url) else { return }
     let session = @agent_session.Session(
-      SessionId("auto-compact-boundary"),
+      SessionId("compact-on-finish"),
       system_prompt="system",
     )
     let result = @agent.run_turn_in_scope(
@@ -347,92 +268,129 @@ async test "auto-compaction guards the final answer at the exact threshold" {
       session~,
       task="answer briefly",
       append_item=(session, item) => session.append(item),
-      max_steps=1,
       api_url=url,
     )
-
-    // No prior history: the first trigger goes straight to a full
-    // checkpoint, appended before the terminal so the next turn starts
-    // compacted instead of creeping past the ceiling.
+    // Compact-on-finish: the completed turn still leaves a checkpoint, but
+    // stays a normal success — the terminal carries the REAL answer.
+    assert_eq(main_requests, 1)
     assert_eq(checkpoint_requests.length(), 1)
-    let checkpoint_messages = request_messages(checkpoint_requests[0])
-    assert_eq(checkpoint_messages.length(), 3)
-    assert_true(
-      message_content(checkpoint_messages[1]).contains("answer briefly"),
-    )
+    // The answer is not durable when the summary generates: it must not be
+    // foldable into the checkpoint text (it projects verbatim after it).
+    assert_false(checkpoint_requests[0].stringify().contains("really done"))
     let events = result.events()
-    assert_eq(events.length(), 3)
-    assert_true(events[0].item() is User(_))
-    guard events[1].item() is Summary(summary) else {
-      fail("expected summary event")
-    }
-    assert_eq(summary.from_sequence(), 1)
-    assert_eq(summary.to_sequence(), 1)
-    assert_eq(summary.content(), "MONO-SUMMARY")
-    guard events[2].item() is Terminal(Finished(answer)) else {
+    let count = events.length()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
       fail("expected finished terminal")
     }
-    assert_eq(answer, "boundary done")
-  }
-}
-
-///|
-async test "auto-compaction stays quiet below the threshold" {
-  @async.with_task_group() <| group => {
-    let mut requests = 0
-    let handle = request => {
-      requests += 1
-      assert_false(is_checkpoint_request(request))
-      Sse(sse_final("done", 799_999))
+    assert_eq(answer, "really done")
+    guard events[count - 2].item() is Summary(summary) else {
+      fail("expected the checkpoint summary before the terminal")
     }
-    guard auto_compact_test_server(group, handle) is Some(url) else { return }
-    let session = @agent_session.Session(
-      SessionId("auto-compact-quiet"),
-      system_prompt="system",
-    )
-    let result = @agent.run_turn_in_scope(
-      runtime=AgentRuntime(),
-      scope=AgentTaskScope(group),
-      api_key="test-key",
-      model=Deepseek(V4Flash),
-      session~,
-      task="answer briefly",
-      append_item=(session, item) => session.append(item),
-      max_steps=1,
-      api_url=url,
-    )
-    assert_eq(requests, 1)
-    let events = result.events()
-    assert_eq(events.length(), 2)
-    assert_true(events[0].item() is User(_))
-    assert_true(events[1].item() is Terminal(Finished(_)))
+    assert_eq(summary.content(), "FINISH-SUMMARY")
+    assert_eq(summary.from_sequence(), 1)
+    assert_eq(summary.to_sequence(), count - 2)
   }
 }
 
 ///|
-async test "auto-compaction fails open and stops retrying for the turn" {
+async test "a steer during compact-on-finish continues the turn compacted" {
   @async.with_task_group() <| group => {
-    let mut checkpoint_requests = 0
-    let mut main_step = 0
-    let mut after_failure_request : Json? = None
+    let runtime = @agent_runtime.AgentRuntime()
+    let main_requests : Array[Json] = []
+    let checkpoint_requests : Array[Json] = []
     let handle = request => {
       if is_checkpoint_request(request) {
-        checkpoint_requests += 1
-        // An empty summary fails generation client-side without HTTP retries.
-        Body(checkpoint_body(""))
+        checkpoint_requests.push(request)
+        // The steer lands while the compact-on-finish summary is in flight.
+        runtime.queue_steer(Prompt("late steer"))
+        Body(checkpoint_body("FINISH-SUMMARY"))
       } else {
-        main_step += 1
-        if main_step == 1 {
-          Sse(sse_tool_call("call_probe", "probe", 900_000))
+        main_requests.push(request)
+        if main_requests.length() == 1 {
+          Sse(sse_final("really done", 750_000))
         } else {
-          after_failure_request = Some(request)
-          Sse(sse_final("done", 900_000))
+          Sse(sse_final("done", 100_000))
         }
       }
     }
     guard auto_compact_test_server(group, handle) is Some(url) else { return }
     let session = @agent_session.Session(
-      SessionId("auto-compact-fail-open"),
+      SessionId("compact-finish-late-steer"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="answer briefly",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+    )
+    // Steer beats finish once more: the turn CONTINUES instead of sealing,
+    // and the continuation request is built from the compacted projection —
+    // summary in, covered history out.
+    assert_eq(main_requests.length(), 2)
+    assert_eq(checkpoint_requests.length(), 1)
+    let continuation = main_requests[1].stringify()
+    assert_true(continuation.contains("FINISH-SUMMARY"))
+    assert_true(continuation.contains("late steer"))
+    assert_true(continuation.contains("really done"))
+    // The original task is covered by the checkpoint — not resent verbatim.
+    assert_false(continuation.contains("answer briefly"))
+    // Durable shape: the decided answer became an ordinary assistant
+    // message, the steer follows it, and the real terminal is the second
+    // answer.
+    let mut summary_sequence = 0
+    let mut answer_sequence = 0
+    let mut steer_sequence = 0
+    for event in result.events() {
+      match event.item() {
+        Summary(_) => summary_sequence = event.sequence()
+        Assistant(message) if message.content() == "really done" =>
+          answer_sequence = event.sequence()
+        User(message) if message.content() == "late steer" =>
+          steer_sequence = event.sequence()
+        _ => ()
+      }
+    }
+    // Strict order: Summary, then the kept answer (uncovered — it projects
+    // right after the checkpoint), then the steer heading the continuation.
+    assert_true(summary_sequence > 0)
+    assert_true(answer_sequence > summary_sequence)
+    assert_true(steer_sequence > answer_sequence)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "done")
+  }
+}
+
+///|
+async test "a pressured finish batch salvages the completion" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("FINISH-SUMMARY"))
+      } else {
+        main_requests += 1
+        Sse(
+          sse_tool_calls(
+            [("call_1", "probe"), ("call_2", "finish"), ("call_3", "probe")],
+            900_000,
+          ),
+        )
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("finish-tool-pressure"),
       system_prompt="system",
     )
     let result = @agent.run_turn_in_scope(
@@ -441,31 +399,912 @@ async test "auto-compaction fails open and stops retrying for the turn" {
       api_key="test-key",
       model=Deepseek(V4Flash),
       session~,
-      task="TASK-MARKER keep going",
+      task="wrap it up",
       append_item=(session, item) => session.append(item),
-      max_steps=3,
       api_url=url,
-      tools=probe_tools(["probe-result"]),
+      tools=finish_and_probe_tools(),
     )
-
-    // One failed attempt disarms the guard: the turn continues on the full
-    // history and the second high-usage response asks for no new summary.
-    assert_eq(checkpoint_requests, 1)
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
     let events = result.events()
-    assert_eq(events.length(), 4)
-    assert_true(events[0].item() is User(_))
-    assert_true(events[1].item() is Assistant(_))
-    assert_true(events[2].item() is Tool(_))
-    guard events[3].item() is Terminal(Finished(answer)) else {
+    let count = events.length()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    // A completed task, not a yield: the finish tool's answer verbatim.
+    assert_eq(answer, "wrapped: all done")
+    guard events[count - 2].item() is Summary(summary) else {
+      fail("expected the checkpoint summary before the terminal")
+    }
+    // The leftover call was closed BEFORE the checkpoint, so the summary
+    // range covers it — no projection repair text can leak into summaries.
+    assert_eq(summary.to_sequence(), count - 2)
+    let mut finish_result = false
+    let mut prefix_skipped = false
+    let mut leftover_closed = false
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        // Neither probe may execute: their results could grow the
+        // checkpoint request and cannot change the decided answer.
+        assert_true(tool_result.content() != "result-1")
+        if tool_result.content().contains("finished: wrapped: all done") {
+          finish_result = true
+        }
+        if tool_result.is_error() &&
+          tool_result.content().contains("yielding at the context ceiling") {
+          prefix_skipped = true
+        }
+        if tool_result.is_error() &&
+          tool_result.content().contains("finish tool call ended the batch") {
+          leftover_closed = true
+        }
+      }
+    }
+    assert_true(finish_result)
+    assert_true(prefix_skipped)
+    assert_true(leftover_closed)
+  }
+}
+
+///|
+async test "a pressured finish tool losing to a steer yields instead" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("CEILING-SUMMARY"))
+      } else {
+        main_requests += 1
+        // The steer lands while the pressured finish response is in flight.
+        runtime.queue_steer(Prompt("user redirection"))
+        Sse(sse_tool_calls([("call_1", "finish")], 900_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("finish-steer-pressure"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="wrap it up",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=finish_and_probe_tools(),
+    )
+    // Steer beats finish, but is never answered in a starved context: the
+    // turn yields and the steer survives the checkpoint verbatim.
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    assert_false(
+      checkpoint_requests[0].stringify().contains("user redirection"),
+    )
+    let mut steer_sequence = 0
+    let mut summary_to = -1
+    for event in result.events() {
+      match event.item() {
+        User(message) if message.content() == "user redirection" =>
+          steer_sequence = event.sequence()
+        Summary(summary) => summary_to = summary.to_sequence()
+        _ => ()
+      }
+    }
+    assert_true(steer_sequence > 0)
+    assert_true(summary_to > 0)
+    assert_true(summary_to < steer_sequence)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+  }
+}
+
+///|
+async test "a failing checkpoint on a pressured finish keeps the real answer" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        // Empty summary fails generation client-side without HTTP retries.
+        Body(checkpoint_body(""))
+      } else {
+        Sse(sse_final("really done", 900_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("compact-on-finish-fail-open"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="answer briefly",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+    )
+    // Fail-open: the turn still finishes as a normal success, uncompacted.
+    assert_eq(checkpoint_requests.length(), 1)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "really done")
+    for event in result.events() {
+      assert_false(event.item() is Summary(_))
+    }
+  }
+}
+
+///|
+async test "below the soft ceiling nothing yields" {
+  @async.with_task_group() <| group => {
+    let mut requests = 0
+    let handle = request => {
+      requests += 1
+      assert_false(is_checkpoint_request(request))
+      if requests == 1 {
+        // One token below 70% of the 1M window: the boundary is exclusive
+        // from below — the turn continues normally.
+        Sse(sse_tool_call("call_1", "probe", 699_999))
+      } else {
+        Sse(sse_final("done", 699_999))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("yield-quiet"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="do a thing",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    assert_eq(requests, 2)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
       fail("expected finished terminal")
     }
     assert_eq(answer, "done")
-    guard after_failure_request is Some(request) else {
-      fail("expected a post-failure main request")
+  }
+}
+
+///|
+async test "a failed checkpoint still yields fail-open" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let checkpoint_requests : Array[Json] = []
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        // Empty summary fails generation client-side without HTTP retries.
+        Body(checkpoint_body(""))
+      } else {
+        runtime.queue_steer(Prompt("user redirection"))
+        Sse(sse_tool_call("call_1", "probe", 900_000))
+      }
     }
-    let messages = request_messages(request)
-    assert_eq(messages.length(), 4)
-    assert_true(message_content(messages[1]).contains("TASK-MARKER"))
-    assert_true(message_content(messages[3]).contains("probe-result"))
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("yield-fail-open"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    // The turn still ends at the ceiling — uncompacted — so the next turn's
+    // pressure retries the checkpoint instead of stranding this one.
+    assert_eq(checkpoint_requests.length(), 1)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+    // Honest fail-open: the terminal must not claim a checkpoint exists.
+    assert_true(answer.contains("checkpoint attempt failed"))
+    // No summary — but the drained steer is durable regardless of the
+    // checkpoint request's fate.
+    let mut steer_persisted = false
+    for event in result.events() {
+      assert_false(event.item() is Summary(_))
+      if event.item() is User(message) &&
+        message.content() == "user redirection" {
+        steer_persisted = true
+      }
+    }
+    assert_true(steer_persisted)
+  }
+}
+
+///|
+async test "a steer arriving under pressure survives the checkpoint verbatim" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let checkpoint_requests : Array[Json] = []
+    let mut main_step = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("CEILING-SUMMARY"))
+      } else {
+        main_step += 1
+        // The steer lands while the pressured response is in flight.
+        runtime.queue_steer(Prompt("user redirection"))
+        Sse(sse_tool_call("call_1", "probe", 900_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("yield-steer-preserved"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    // The yield proceeds regardless of the steer: one model round plus the
+    // checkpoint. The steer is appended AFTER the summary range is captured,
+    // so it survives verbatim — uncovered — and heads the next turn.
+    assert_eq(main_step, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    // The summary is generated from the pre-steer session: the checkpoint
+    // request must not see the steer, or its content would be folded into
+    // the summary AND replayed verbatim — duplicated next turn.
+    assert_false(
+      checkpoint_requests[0].stringify().contains("user redirection"),
+    )
+    let mut steer_sequence = 0
+    let mut summary_sequence = 0
+    let mut summary_to = -1
+    for event in result.events() {
+      match event.item() {
+        User(message) if message.content() == "user redirection" =>
+          steer_sequence = event.sequence()
+        Summary(summary) => {
+          summary_sequence = event.sequence()
+          summary_to = summary.to_sequence()
+        }
+        _ => ()
+      }
+    }
+    assert_true(steer_sequence > 0)
+    assert_true(summary_to > 0)
+    // Uncovered: the checkpoint folds everything BEFORE the steer only.
+    assert_true(summary_to < steer_sequence)
+    // Durable order: the steer persists BEFORE the summary is appended (and
+    // before the summary request is even sent — a cancellation mid-request
+    // must not lose already-drained input).
+    assert_true(steer_sequence < summary_sequence)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+  }
+}
+
+///|
+async test "pressure on the last allowed step yields at the ceiling not as exhaustion" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("LAST-STEP-SUMMARY"))
+      } else {
+        Sse(sse_tool_call("call_1", "probe", 900_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("yield-exhaustion"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="one pressured step",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    // Context beats steps: the pressured response yields in its own
+    // iteration, so the step bound is never the one to end the turn.
+    assert_eq(checkpoint_requests.length(), 1)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+  }
+}
+
+///|
+async test "an explicit single-step bound still exhausts without pressure" {
+  @async.with_task_group() <| group => {
+    let mut main_step = 0
+    let handle = request => {
+      assert_false(is_checkpoint_request(request))
+      main_step += 1
+      Sse(sse_tool_call("call_1", "probe", 5_000))
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("bounded-one"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="one step only",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    assert_eq(main_step, 1)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Failed(message)) else {
+      fail("expected exhaustion terminal")
+    }
+    assert_true(message.contains("max steps exhausted"))
+  }
+}
+
+///|
+async test "a soft-ceiling batch executes then yields gracefully" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("SOFT-SUMMARY"))
+      } else {
+        main_requests += 1
+        // 70% of the 1M window exactly: the soft boundary is inclusive.
+        Sse(sse_tool_call("call_1", "probe", 700_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("soft-graceful"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    // The batch EXECUTED — its real result is durable, nothing was skipped —
+    // and the turn still ended at the boundary with a checkpoint.
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let events = result.events()
+    let count = events.length()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+    guard events[count - 2].item() is Summary(summary) else {
+      fail("expected the checkpoint summary before the terminal")
+    }
+    assert_eq(summary.content(), "SOFT-SUMMARY")
+    // The executed result is inside the covered range.
+    assert_eq(summary.to_sequence(), count - 2)
+    let mut executed = false
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        assert_false(tool_result.is_error())
+        if tool_result.content() == "result-1" {
+          executed = true
+        }
+      }
+    }
+    assert_true(executed)
+  }
+}
+
+///|
+fn flood_tools(chars : Int) -> @agent_tool.Tools raise {
+  let flood = StringBuilder()
+  for _i in 0..<chars {
+    flood.write_char('y')
+  }
+  let content = flood.to_string()
+  Tools([
+    AgentToolDefinition(
+      name="flood",
+      description="Flood tool.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::respond(content)),
+    ),
+  ])
+}
+
+///|
+fn flood_batch(count : Int) -> Array[(String, String)] {
+  let calls : Array[(String, String)] = []
+  for index in 0..<count {
+    calls.push(("call_\{index + 1}", "flood"))
+  }
+  calls
+}
+
+///|
+fn flood_and_finish_tools(chars : Int) -> @agent_tool.Tools raise {
+  let flood = StringBuilder()
+  for _i in 0..<chars {
+    flood.write_char('y')
+  }
+  let content = flood.to_string()
+  Tools([
+    AgentToolDefinition(
+      name="flood",
+      description="Flood tool.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::respond(content)),
+    ),
+    AgentToolDefinition(
+      name="finish",
+      description="Finish tool.",
+      schema=JsonSchema({ "type": "object" }),
+      execute=Sync(_args => @agent_tool.ToolAction::finish("wrapped: all done")),
+    ),
+  ])
+}
+
+///|
+async test "a budget trip salvages a finish in the remainder" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("BUDGET-SUMMARY"))
+      } else {
+        main_requests += 1
+        // Four floods then a finish at 750K: the budget trips before the
+        // fourth flood, but the finish is a completion — a few bytes — and
+        // must be honored, not skip-closed into a context yield.
+        Sse(
+          sse_tool_calls(
+            [
+              ("call_1", "flood"),
+              ("call_2", "flood"),
+              ("call_3", "flood"),
+              ("call_4", "flood"),
+              ("call_5", "finish"),
+            ],
+            750_000,
+          ),
+        )
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("budget-salvage"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=flood_and_finish_tools(59_000),
+    )
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let events = result.events()
+    let count = events.length()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    // A completed task, not a yield: the salvaged finish's answer.
+    assert_eq(answer, "wrapped: all done")
+    guard events[count - 2].item() is Summary(_) else {
+      fail("expected the checkpoint summary before the terminal")
+    }
+    let mut executed_floods = 0
+    let mut skipped = 0
+    let mut finish_result = false
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        if tool_result.content().length() == 59_000 {
+          executed_floods += 1
+        }
+        if tool_result.is_error() &&
+          tool_result.content().contains("yielding at the context ceiling") {
+          skipped += 1
+        }
+        if tool_result.content().contains("finished: wrapped: all done") {
+          finish_result = true
+        }
+      }
+    }
+    // Three floods fit the budget, the fourth was skip-closed, the finish ran.
+    assert_eq(executed_floods, 3)
+    assert_eq(skipped, 1)
+    assert_true(finish_result)
+  }
+}
+
+///|
+async test "the running budget stops an overflowing batch mid-way" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("BUDGET-SUMMARY"))
+      } else {
+        main_requests += 1
+        // Six calls at 750K whose ACTUAL results are ~59K chars each: after
+        // three, the next call's worst case (60K cap + checkpoint reserve)
+        // no longer fits under the 1M window — execution stops there.
+        Sse(sse_tool_calls(flood_batch(6), 750_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("budget-midway"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=flood_tools(59_000),
+    )
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let mut executed = 0
+    let mut skipped = 0
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        if tool_result.is_error() &&
+          tool_result.content().contains("yielding at the context ceiling") {
+          skipped += 1
+        } else {
+          assert_eq(tool_result.content().length(), 59_000)
+          executed += 1
+        }
+      }
+    }
+    // The executed prefix is covered by the checkpoint; the rest waits.
+    assert_eq(executed, 3)
+    assert_eq(skipped, 3)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+  }
+}
+
+///|
+async test "a below-soft batch with huge results yields instead of overflowing" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("BUDGET-SUMMARY"))
+      } else {
+        main_requests += 1
+        // One token BELOW the soft ceiling: no tier fires on the response,
+        // yet six ~59K results would push the next request past the window.
+        // The running budget is what saves it — at every usage level.
+        Sse(sse_tool_calls(flood_batch(6), 699_999))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("budget-below-soft"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=flood_tools(59_000),
+    )
+    // The turn yields at the checkpoint instead of sending a doomed second
+    // request: one model round only.
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let mut executed = 0
+    let mut skipped = 0
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        if tool_result.is_error() &&
+          tool_result.content().contains("yielding at the context ceiling") {
+          skipped += 1
+        } else {
+          executed += 1
+        }
+      }
+    }
+    assert_eq(executed, 4)
+    assert_eq(skipped, 2)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+  }
+}
+
+///|
+async test "a finish tool in the soft band compacts and finishes normally" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("SOFT-SUMMARY"))
+      } else {
+        main_requests += 1
+        Sse(sse_tool_calls([("call_1", "finish")], 750_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("soft-finish"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="wrap it up",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=finish_and_probe_tools(),
+    )
+    // The finish ran through the NORMAL path (no salvage needed in the
+    // soft band) and compact-on-finish still checkpointed the session.
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let events = result.events()
+    let count = events.length()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "wrapped: all done")
+    guard events[count - 2].item() is Summary(_) else {
+      fail("expected the checkpoint summary before the terminal")
+    }
+  }
+}
+
+///|
+async test "a failing checkpoint after a soft batch keeps its results" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        // Empty summary fails generation client-side without HTTP retries.
+        Body(checkpoint_body(""))
+      } else {
+        Sse(sse_tool_call("call_1", "probe", 750_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("soft-fail-open"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    // Fail-open: the executed result stays durable, the turn still yields.
+    assert_eq(checkpoint_requests.length(), 1)
+    let mut executed = false
+    for event in result.events() {
+      assert_false(event.item() is Summary(_))
+      if event.item() is Tool(tool_result) &&
+        tool_result.content() == "result-1" {
+        executed = true
+      }
+    }
+    assert_true(executed)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+    assert_true(answer.contains("checkpoint attempt failed"))
+  }
+}
+
+///|
+async test "a steer arriving during the checkpoint request is preserved" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let checkpoint_requests : Array[Json] = []
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        // The steer lands while the summary request is being served — after
+        // the one-time drain, seconds before the terminal.
+        runtime.queue_steer(Prompt("late steer"))
+        Body(checkpoint_body("CEILING-SUMMARY"))
+      } else {
+        Sse(sse_tool_call("call_1", "probe", 900_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("late-steer"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    // The second drain persists it — uncovered, after the summary — instead
+    // of letting the turn-end drain drop it.
+    let mut steer_sequence = 0
+    let mut summary_sequence = 0
+    for event in result.events() {
+      match event.item() {
+        User(message) if message.content() == "late steer" =>
+          steer_sequence = event.sequence()
+        Summary(_) => summary_sequence = event.sequence()
+        _ => ()
+      }
+    }
+    assert_true(summary_sequence > 0)
+    assert_true(steer_sequence > summary_sequence)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+  }
+}
+
+///|
+async test "an oversized tool result is clamped at the loop" {
+  @async.with_task_group() <| group => {
+    let mut requests = 0
+    let handle = request => {
+      requests += 1
+      assert_false(is_checkpoint_request(request))
+      if requests == 1 {
+        Sse(sse_tool_call("call_1", "flood", 100_000))
+      } else {
+        Sse(sse_final("done", 100_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let flood = StringBuilder()
+    for _i in 0..<70_000 {
+      flood.write_char('x')
+    }
+    let tools : @agent_tool.Tools = Tools([
+      AgentToolDefinition(
+        name="flood",
+        description="Flood tool.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => @agent_tool.ToolAction::respond(flood.to_string())),
+      ),
+    ])
+    let session = @agent_session.Session(
+      SessionId("clamp"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="flood me",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools~,
+    )
+    ignore(result)
+    let mut clamped = false
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        // The 70K result was clamped to AT MOST the 60K cap — marker
+        // included — so the bound the soft-tier batch budget relies on is
+        // exact for EVERY tool, not just the self-clamping in-tree ones.
+        assert_true(tool_result.content().length() <= 60_000)
+        assert_true(tool_result.content().contains("[truncated:"))
+        clamped = true
+      }
+    }
+    assert_true(clamped)
   }
 }

--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -112,6 +112,21 @@ fn sse_final(content : String, total_tokens : Int) -> String {
 }
 
 ///|
+fn sse_final_with_reasoning(
+  content : String,
+  reasoning : String,
+  total_tokens : Int,
+) -> String {
+  (
+    {
+      "choices": [
+        { "delta": { "content": content, "reasoning_content": reasoning } },
+      ],
+      "usage": usage_json(total_tokens),
+    } : Json).stringify()
+}
+
+///|
 fn checkpoint_body(summary : String) -> Json {
   { "choices": [{ "message": { "role": "assistant", "content": summary } }] }
 }
@@ -169,6 +184,7 @@ fn finish_and_probe_tools() -> @agent_tool.Tools raise {
       description="Finish tool.",
       schema=JsonSchema({ "type": "object" }),
       execute=Sync(_args => @agent_tool.ToolAction::finish("wrapped: all done")),
+      control=true,
     ),
     AgentToolDefinition(
       name="probe",
@@ -308,7 +324,11 @@ async test "a steer during compact-on-finish continues the turn compacted" {
       } else {
         main_requests.push(request)
         if main_requests.length() == 1 {
-          Sse(sse_final("really done", 750_000))
+          Sse(
+            sse_final_with_reasoning(
+              "really done", "ceiling reasoning trace", 750_000,
+            ),
+          )
         } else {
           Sse(sse_final("done", 100_000))
         }
@@ -338,6 +358,7 @@ async test "a steer during compact-on-finish continues the turn compacted" {
     assert_true(continuation.contains("FINISH-SUMMARY"))
     assert_true(continuation.contains("late steer"))
     assert_true(continuation.contains("really done"))
+
     // The original task is covered by the checkpoint — not resent verbatim.
     assert_false(continuation.contains("answer briefly"))
     // Durable shape: the decided answer became an ordinary assistant
@@ -349,8 +370,16 @@ async test "a steer during compact-on-finish continues the turn compacted" {
     for event in result.events() {
       match event.item() {
         Summary(_) => summary_sequence = event.sequence()
-        Assistant(message) if message.content() == "really done" =>
+        Assistant(message) if message.content() == "really done" => {
           answer_sequence = event.sequence()
+          // The converted answer keeps its reasoning: Kimi requires
+          // preserved reasoning_content on historical assistant messages
+          // (the encoder sends it for Kimi models only — that per-provider
+          // wire behavior is pinned by the deepseek encoder tests).
+          assert_true(
+            message.reasoning_content() is Some("ceiling reasoning trace"),
+          )
+        }
         User(message) if message.content() == "late steer" =>
           steer_sequence = event.sequence()
         _ => ()
@@ -366,6 +395,129 @@ async test "a steer during compact-on-finish continues the turn compacted" {
       fail("expected finished terminal")
     }
     assert_eq(answer, "done")
+  }
+}
+
+///|
+async test "a failed checkpoint with a late steer yields instead of continuing" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        // The steer lands during the summary request — which then FAILS.
+        runtime.queue_steer(Prompt("late steer"))
+        // Empty summary fails generation client-side without HTTP retries.
+        Body(checkpoint_body(""))
+      } else {
+        main_requests += 1
+        Sse(sse_final("really done", 750_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("failed-checkpoint-late-steer"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="answer briefly",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+    )
+    // Continuing would rebuild the next request from the same pressured,
+    // uncheckpointed history — so the turn yields fail-open instead. The
+    // answer and the steer are durable and head the next turn.
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let mut answer_kept = false
+    let mut steer_kept = false
+    for event in result.events() {
+      assert_false(event.item() is Summary(_))
+      match event.item() {
+        Assistant(message) if message.content() == "really done" =>
+          answer_kept = true
+        User(message) if message.content() == "late steer" => steer_kept = true
+        _ => ()
+      }
+    }
+    assert_true(answer_kept)
+    assert_true(steer_kept)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
+    assert_true(answer.contains("checkpoint attempt failed"))
+  }
+}
+
+///|
+async test "a non-control finish shadow is skip-closed at the ceiling" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("CEILING-SUMMARY"))
+      } else {
+        main_requests += 1
+        Sse(sse_tool_calls([("call_1", "finish")], 900_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    // A custom registry shadowing the built-in name WITHOUT declaring
+    // control: salvage must not execute it — running arbitrary tool work
+    // at the ceiling is exactly what the guard prevents.
+    let tools : @agent_tool.Tools = Tools([
+      AgentToolDefinition(
+        name="finish",
+        description="Not a completion.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => {
+          @agent_tool.ToolAction::respond("shadow ran anyway")
+        }),
+      ),
+    ])
+    let session = @agent_session.Session(
+      SessionId("finish-shadow"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools~,
+    )
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        // Never executed: the only result is the ceiling skip note.
+        assert_true(tool_result.content() != "shadow ran anyway")
+        assert_true(tool_result.is_error())
+        assert_true(
+          tool_result.content().contains("yielding at the context ceiling"),
+        )
+      }
+    }
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_true(answer.contains("[context ceiling]"))
   }
 }
 
@@ -557,11 +709,12 @@ async test "below the soft ceiling nothing yields" {
       requests += 1
       assert_false(is_checkpoint_request(request))
       if requests == 1 {
-        // One token below 70% of the 1M window: the boundary is exclusive
-        // from below — the turn continues normally.
-        Sse(sse_tool_call("call_1", "probe", 699_999))
+        // Below 70% of the 1M window with enough margin that the batch's
+        // own small result cannot cross the boundary (post-batch growth
+        // counts): the turn continues normally.
+        Sse(sse_tool_call("call_1", "probe", 699_900))
       } else {
-        Sse(sse_final("done", 699_999))
+        Sse(sse_final("done", 699_900))
       }
     }
     guard auto_compact_test_server(group, handle) is Some(url) else { return }
@@ -899,6 +1052,7 @@ fn flood_and_finish_tools(chars : Int) -> @agent_tool.Tools raise {
       description="Finish tool.",
       schema=JsonSchema({ "type": "object" }),
       execute=Sync(_args => @agent_tool.ToolAction::finish("wrapped: all done")),
+      control=true,
     ),
   ])
 }
@@ -1249,6 +1403,146 @@ async test "a steer arriving during the checkpoint request is preserved" {
       fail("expected finished terminal")
     }
     assert_true(answer.contains("[context ceiling]"))
+  }
+}
+
+///|
+fn flood_then_finish_calls() -> Array[(String, String)] {
+  let calls = flood_batch(6)
+  calls.push(("call_7", "finish"))
+  calls
+}
+
+///|
+async test "a budget-tripped salvaged finish still checkpoints" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("SALVAGE-SUMMARY"))
+      } else {
+        main_requests += 1
+        // Below the soft ceiling, but the executed prefix's growth (4 x ~59K)
+        // trips the running budget before the finish call; the salvage must
+        // carry that growth so the sealed turn is still checkpointed.
+        Sse(sse_tool_calls(flood_then_finish_calls(), 699_900))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("salvage-budget-checkpoint"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="wrap it up",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=flood_and_finish_tools(59_000),
+    )
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let events = result.events()
+    let count = events.length()
+    guard events.peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    // A real completion — with the checkpoint the fat prefix demands.
+    assert_eq(answer, "wrapped: all done")
+    guard events[count - 2].item() is Summary(summary) else {
+      fail("expected the checkpoint summary before the terminal")
+    }
+    assert_eq(summary.content(), "SALVAGE-SUMMARY")
+    let mut executed = 0
+    let mut skipped = 0
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        if tool_result.is_error() {
+          skipped += 1
+        } else if tool_result.content().length() == 59_000 {
+          executed += 1
+        }
+      }
+    }
+    assert_eq(executed, 4)
+    assert_eq(skipped, 2)
+  }
+}
+
+///|
+async test "a steer during a salvaged finish's checkpoint continues once" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        // The steer lands while the salvaged finish's checkpoint is in
+        // flight: the finish converts into a continuation — the remainder is
+        // already closed, so it must NOT be closed again or summarized twice.
+        runtime.queue_steer(Prompt("late steer"))
+        Body(checkpoint_body("SALVAGE-SUMMARY"))
+      } else {
+        main_requests += 1
+        if main_requests == 1 {
+          Sse(sse_tool_calls(flood_then_finish_calls(), 699_900))
+        } else {
+          Sse(sse_final("done", 100_000))
+        }
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("salvage-late-steer"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="wrap it up",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=flood_and_finish_tools(59_000),
+    )
+    assert_eq(main_requests, 2)
+    assert_eq(checkpoint_requests.length(), 1)
+    let mut summaries = 0
+    let mut skip_notes = 0
+    let mut steer_present = false
+    for event in result.events() {
+      match event.item() {
+        Summary(_) => summaries += 1
+        Tool(tool_result) =>
+          if tool_result.is_error() &&
+            tool_result.content().contains("yielding at the context ceiling") {
+            skip_notes += 1
+          }
+        User(message) if message.content() == "late steer" =>
+          steer_present = true
+        _ => ()
+      }
+    }
+    // Exactly one checkpoint, the two budget-skipped calls closed exactly
+    // once, and the steer survives as the continuation's input.
+    assert_eq(summaries, 1)
+    assert_eq(skip_notes, 2)
+    assert_true(steer_present)
+    guard result.events().peek() is Some(last) &&
+      last.item() is Terminal(Finished(answer)) else {
+      fail("expected finished terminal")
+    }
+    assert_eq(answer, "done")
   }
 }
 

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -17,6 +17,8 @@ pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~
 
 pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
 
+pub let unbounded_max_steps : Int
+
 // Errors
 
 // Types and methods

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -106,7 +106,12 @@ async fn AgentLoop::run(
           // that terminal back into an assistant message; appending an Assistant
           // session item here would duplicate the answer on replay.
           match
-            self.finish_turn(session, response.content, usage=response.usage) {
+            self.finish_turn(
+              session,
+              response.content,
+              usage=response.usage,
+              reasoning_content?=response.optional_reasoning_content(),
+            ) {
             Sealed(next) => return next
             ContinueTurn(next) => continue next
           }
@@ -156,7 +161,15 @@ async fn AgentLoop::run(
           ),
         )
         match self.salvage_finish_at_ceiling(session, response) {
-          Some(next) => return next
+          Some(StepDone(next)) => return next
+          // A steer arrived during the salvaged finish's checkpoint: the
+          // turn continues from the compacted projection.
+          Some(StepContinue(next)) => continue next
+          Some(StepYield(next)) =>
+            return self.yield_at_context_ceiling(
+              next,
+              self.runtime.pending_steers(),
+            )
           None => ()
         }
         let session = self.close_skipped_tool_calls(
@@ -170,19 +183,11 @@ async fn AgentLoop::run(
         )
       } else {
         match self.handle_tool_calls(session, response) {
-          StepContinue(next) => {
-            if self.at_soft_context_ceiling(response.usage) {
-              // The soft ceiling ends the turn at this step's boundary: the
-              // batch above executed (under the running budget), so the
-              // checkpoint covers its real results and nothing is
-              // discarded or re-issued.
-              return self.yield_at_context_ceiling(
-                next,
-                self.runtime.pending_steers(),
-              )
-            }
-            continue next
-          }
+          // Plain continuation — including after a checkpoint whose late
+          // steer converted a finish into a continue: the soft decision
+          // lives in handle_tool_calls, which knows the batch's real
+          // growth and must not re-fire on stale pre-checkpoint usage.
+          StepContinue(next) => continue next
           StepDone(next) => return next
           // The running budget stopped the batch mid-way — at ANY usage
           // level, including below the soft ceiling: a below-threshold
@@ -357,9 +362,16 @@ async fn AgentLoop::handle_tool_calls(
       // A finish call in the unexecuted remainder is a completion, not
       // more output — on small-window models the budget can trip well
       // below the hard ceiling, and skip-closing the finish would turn an
-      // already-completed task into a context yield.
-      match self.salvage_finish_at_ceiling(session, response, from=call_index) {
-        Some(next) => return StepDone(next)
+      // already-completed task into a context yield. The executed prefix's
+      // growth rides along so the salvaged finish still checkpoints.
+      match
+        self.salvage_finish_at_ceiling(
+          session,
+          response,
+          from=call_index,
+          spent_result_chars~,
+        ) {
+        Some(outcome) => return outcome
         None => ()
       }
       let session = self.close_skipped_tool_calls(
@@ -391,7 +403,12 @@ async fn AgentLoop::handle_tool_calls(
     }
     match
       self.execute_tool_call(
-        session, response, call_index, native_call, tool_call,
+        session,
+        response,
+        call_index,
+        native_call,
+        tool_call,
+        spent_result_chars~,
       ) {
       ContinueToolBatch(next) => {
         // Account the result actually recorded for this call (the loop
@@ -405,7 +422,18 @@ async fn AgentLoop::handle_tool_calls(
       FinishAgentLoop(next) => return StepDone(next)
     }
   } nobreak {
-    StepContinue(session)
+    // The batch ran to completion. The soft decision includes the batch's
+    // own growth: a below-threshold response whose results carried the
+    // context into the soft band still ends here, gracefully, instead of
+    // sending one more oversized request to find out.
+    if self.at_soft_context_ceiling(
+        response.usage,
+        extra_result_chars=spent_result_chars,
+      ) {
+      StepYield(session)
+    } else {
+      StepContinue(session)
+    }
   }
 }
 
@@ -417,6 +445,7 @@ async fn AgentLoop::execute_tool_call(
   call_index : Int,
   native_call : @deepseek.ToolCall,
   tool_call : @agent_tool.AgentToolCall,
+  spent_result_chars~ : Int64,
 ) -> ToolCallOutcome {
   let result = @agent_tool.execute_tool_call(tool_call, self.tools)
   match result {
@@ -444,7 +473,13 @@ async fn AgentLoop::execute_tool_call(
       )
       let steer_inputs = self.runtime.pending_steers()
       if steer_inputs.is_empty() {
-        return match self.finish_turn(session, answer, usage=response.usage) {
+        return match
+          self.finish_turn(
+            session,
+            answer,
+            usage=response.usage,
+            spent_result_chars~,
+          ) {
           Sealed(next) => FinishAgentLoop(next)
           ContinueTurn(next) => ContinueAgentLoop(next)
         }
@@ -452,7 +487,10 @@ async fn AgentLoop::execute_tool_call(
       // User input wins over the finish tool as well — but never answered in
       // a starved context: at the ceiling the turn yields and the steers
       // survive the checkpoint verbatim.
-      if self.at_soft_context_ceiling(response.usage) {
+      if self.at_soft_context_ceiling(
+          response.usage,
+          extra_result_chars=spent_result_chars,
+        ) {
         return FinishAgentLoop(
           self.yield_at_context_ceiling(session, steer_inputs),
         )
@@ -551,19 +589,34 @@ async fn AgentLoop::close_skipped_tool_calls(
 /// whenever its batch executes; it just cannot be salvaged at the ceiling.
 ///
 /// Returns None when the batch carries no decodable finish call — nothing
-/// was appended and the caller proceeds with the plain yield.
+/// was appended and the caller proceeds with the plain yield. Otherwise
+/// the outcome distinguishes a sealed turn (StepDone: finished or yielded)
+/// from a continuation (StepContinue: a steer arriving during the salvaged
+/// finish's checkpoint converted it into ContinueTurn — treating that as a
+/// failed salvage would close already-closed calls again and fold the
+/// steer into a second summary).
 ///
 /// `from` is where the unexecuted remainder starts: 0 when the whole batch
 /// is being skipped (hard ceiling), or the tripping call's index when the
 /// running budget stopped execution mid-batch — calls before it already
-/// executed and have results. The finish call itself is exempt from the
-/// budget: its result is a few bytes of completion, not tool output.
+/// executed and have results (their growth arrives as
+/// `spent_result_chars`, so the salvaged finish still checkpoints). The
+/// finish call itself is exempt from the budget: its result is a few bytes
+/// of completion, not tool output.
 async fn AgentLoop::salvage_finish_at_ceiling(
   self : Self,
   session : @agent_session.Session,
   response : @deepseek.ChatResponse,
   from? : Int = 0,
-) -> @agent_session.Session? {
+  spent_result_chars? : Int64 = 0,
+) -> AgentStepOutcome? {
+  // The registry must declare the finish tool a CONTROL tool: that is how
+  // the loop knows — without executing — that honoring the call appends a
+  // few bytes, not tool output. A custom non-control tool shadowing the
+  // name is skip-closed like any other call at the ceiling.
+  guard self.tools.find("finish") is Some(definition) && definition.is_control() else {
+    return None
+  }
   let mut finish_index = -1
   for index, call in response.tool_calls {
     if index >= from && call.name == "finish" {
@@ -585,18 +638,30 @@ async fn AgentLoop::salvage_finish_at_ceiling(
   )
   match
     self.execute_tool_call(
-      session, response, finish_index, native_call, tool_call,
+      session,
+      response,
+      finish_index,
+      native_call,
+      tool_call,
+      spent_result_chars~,
     ) {
-    FinishAgentLoop(next) => Some(next)
+    FinishAgentLoop(next) => Some(StepDone(next))
+    // The finish ran but a steer converted it into a continuation: its
+    // remainder is already closed and the checkpoint appended.
+    ContinueAgentLoop(next) => Some(StepContinue(next))
     // A tool named `finish` that did not finish (custom override returning
     // Respond): close the remainder and fall back to the ceiling yield.
-    ContinueToolBatch(next) | ContinueAgentLoop(next) => {
+    ContinueToolBatch(next) => {
       let next = self.close_skipped_tool_calls(
         next,
         response.tool_calls[finish_index + 1:],
         note=ceiling_skip_note,
       )
-      Some(self.yield_at_context_ceiling(next, self.runtime.pending_steers()))
+      Some(
+        StepDone(
+          self.yield_at_context_ceiling(next, self.runtime.pending_steers()),
+        ),
+      )
     }
   }
 }
@@ -684,9 +749,14 @@ async fn AgentLoop::finish_turn(
   session : @agent_session.Session,
   answer : String,
   usage~ : @deepseek.Usage,
+  spent_result_chars? : Int64 = 0,
+  reasoning_content? : String,
 ) -> FinishOutcome {
-  let session = if self.at_soft_context_ceiling(usage) {
-    let (session, _compacted) = self.checkpoint_at_ceiling(session, [])
+  let session = if self.at_soft_context_ceiling(
+      usage,
+      extra_result_chars=spent_result_chars,
+    ) {
+    let (session, compacted) = self.checkpoint_at_ceiling(session, [])
     // The checkpoint request takes seconds; user input may have queued
     // while it was in flight. Appending it before the terminal would make
     // the decided answer read as its reply, and leaving it queued gets it
@@ -695,8 +765,26 @@ async fn AgentLoop::finish_turn(
     // and the turn continues, from the compacted projection.
     let steers = self.runtime.pending_steers()
     if !steers.is_empty() {
-      let session = self.append(session, Assistant(AssistantMessage(answer)))
+      let to_sequence = session.last_sequence()
+      // Keep the response's reasoning on the converted message: Kimi
+      // requires preserved reasoning_content on historical assistant
+      // messages, and this answer is history now.
+      let session = self.append(
+        session,
+        Assistant(AssistantMessage(answer, reasoning_content?)),
+      )
       let session = self.apply_steer_inputs(session, steers)
+      if !compacted {
+        // The checkpoint FAILED: continuing would build the next request
+        // from the same pressured, uncheckpointed history plus two more
+        // messages — the exact overflow the guard exists to prevent.
+        // Yield fail-open instead: the answer and steers are durable
+        // (uncovered, heading the next turn) and the next turn's pressure
+        // retries the checkpoint.
+        return Sealed(
+          self.finish_context_yield(session, to_sequence, compacted=false),
+        )
+      }
       // Re-seed the in-flight buffer from the projection: the whole point
       // of the checkpoint is that the continuation request is small, and
       // the buffer must never disagree with Session::chat_messages.

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -14,20 +14,10 @@ priv struct AgentLoop {
   /// succeeded.
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
-  /// Sequence of this turn's user task. Auto-compaction's first stage folds
-  /// only events before it, keeping the active turn verbatim.
-  turn_start_sequence : Int
   /// Latest session returned by a successful append. The run-level error
   /// handler uses it to persist a terminal failure/interruption even when the
   /// local loop state is behind the last durable session.
   mut last_session : @agent_session.Session
-  /// Highest `to_sequence` an auto-compaction has covered this turn; once it
-  /// reaches the pre-turn prefix the next trigger escalates to a full range.
-  mut auto_compacted_to : Int
-  /// Set after a full-range auto-compaction or a failed summary: further
-  /// triggers this turn could only churn, so the guard disarms until the
-  /// next turn's fresh loop re-arms it.
-  mut auto_compact_disarmed : Bool
 }
 
 ///|
@@ -47,17 +37,27 @@ fn AgentLoop::AgentLoop(
     append_item,
     messages: session.chat_messages(),
     plan_cadence: PlanCadence(registered=tools.find("plan") is Some(_)),
-    turn_start_sequence: session.last_sequence(),
     last_session: session,
-    auto_compacted_to: 0,
-    auto_compact_disarmed: false,
   }
+}
+
+///|
+priv enum FinishOutcome {
+  /// The terminal is appended; the turn is over.
+  Sealed(@agent_session.Session)
+  /// User input arrived during the compact-on-finish checkpoint: the
+  /// answer stayed an ordinary assistant message, the steers are applied,
+  /// and the turn continues from the compacted projection.
+  ContinueTurn(@agent_session.Session)
 }
 
 ///|
 priv enum AgentStepOutcome {
   StepContinue(@agent_session.Session)
   StepDone(@agent_session.Session)
+  /// The running batch budget stopped execution: the remainder is already
+  /// skip-closed and the turn must yield at the ceiling checkpoint.
+  StepYield(@agent_session.Session)
 }
 
 ///|
@@ -74,18 +74,30 @@ priv enum ToolCallOutcome {
 }
 
 ///|
+/// Result note for tool calls discarded because the turn is ending at the
+/// context ceiling.
+let ceiling_skip_note : String = "skipped: the turn is yielding at the context ceiling; re-issue after the checkpoint if still needed"
+
+///|
 async fn AgentLoop::run(
   self : Self,
   session : @agent_session.Session,
   max_steps : Int,
 ) -> @agent_session.Session {
   self.last_session = session
-
   try {
     for step in 0..<max_steps; session = session {
       let session = self.prepare_step(session)
       let response = self.chat(step)
-      let session = self.maybe_auto_compact(session, response.usage)
+      // Usage only exists per response, so ceiling pressure is detected at
+      // each exit point below by consulting this response's usage — no
+      // pressure state exists anywhere, not even across lines: a pressured
+      // step always ends the turn within its own iteration. Two tiers: at
+      // the SOFT ceiling the turn ends gracefully at this step's boundary
+      // (batches still execute, aggregate-budgeted); at the HARD ceiling —
+      // or when a soft batch cannot be proven to fit — no batch starts.
+      // Abort and error exits stay exempt by policy: failure paths never
+      // wait on a checkpoint request.
       if response.tool_calls.is_empty() {
         let steer_inputs = self.runtime.pending_steers()
         if steer_inputs.is_empty() {
@@ -93,7 +105,11 @@ async fn AgentLoop::run(
           // rebuild model context through Session::chat_messages, which projects
           // that terminal back into an assistant message; appending an Assistant
           // session item here would duplicate the answer on replay.
-          return self.finish_turn(session, response.content)
+          match
+            self.finish_turn(session, response.content, usage=response.usage) {
+            Sealed(next) => return next
+            ContinueTurn(next) => continue next
+          }
         }
         let reasoning_content = response.optional_reasoning_content()
         // The model considers itself done, but user-visible input arrived while the
@@ -107,12 +123,76 @@ async fn AgentLoop::run(
         self.messages.push(
           ChatMessage(Assistant, content=response.content, reasoning_content?),
         )
+        if self.at_soft_context_ceiling(response.usage) {
+          // Yield now rather than answering the steer in a starved context;
+          // the steers survive the checkpoint verbatim.
+          return self.yield_at_context_ceiling(session, steer_inputs)
+        }
         let session = self.apply_steer_inputs(session, steer_inputs)
         continue session
+      } else if self.at_hard_context_ceiling(response.usage) {
+        // Past the hard ceiling the batch never executes: its results
+        // could fill the remaining headroom, overflowing the checkpoint
+        // request itself. Close every call with a skip note — API-valid, a
+        // few bytes — and yield; the checkpoint summary carries the state
+        // and the model re-issues the calls next turn if needed.
+        let reasoning_content = response.optional_reasoning_content()
+        let session = self.append(
+          session,
+          Assistant(
+            AssistantMessage(
+              response.content,
+              tool_calls=response.tool_calls,
+              reasoning_content?,
+            ),
+          ),
+        )
+        self.messages.push(
+          ChatMessage(
+            Assistant,
+            content=response.content,
+            tool_calls=response.tool_calls,
+            reasoning_content?,
+          ),
+        )
+        match self.salvage_finish_at_ceiling(session, response) {
+          Some(next) => return next
+          None => ()
+        }
+        let session = self.close_skipped_tool_calls(
+          session,
+          response.tool_calls,
+          note=ceiling_skip_note,
+        )
+        return self.yield_at_context_ceiling(
+          session,
+          self.runtime.pending_steers(),
+        )
       } else {
         match self.handle_tool_calls(session, response) {
-          StepContinue(next) => continue next
+          StepContinue(next) => {
+            if self.at_soft_context_ceiling(response.usage) {
+              // The soft ceiling ends the turn at this step's boundary: the
+              // batch above executed (under the running budget), so the
+              // checkpoint covers its real results and nothing is
+              // discarded or re-issued.
+              return self.yield_at_context_ceiling(
+                next,
+                self.runtime.pending_steers(),
+              )
+            }
+            continue next
+          }
           StepDone(next) => return next
+          // The running budget stopped the batch mid-way — at ANY usage
+          // level, including below the soft ceiling: a below-threshold
+          // response with several large results could otherwise push the
+          // next request past the window before any ceiling check runs.
+          StepYield(next) =>
+            return self.yield_at_context_ceiling(
+              next,
+              self.runtime.pending_steers(),
+            )
         }
       }
     } nobreak {
@@ -266,7 +346,29 @@ async fn AgentLoop::handle_tool_calls(
       reasoning_content?,
     ),
   )
+  let mut spent_result_chars : Int64 = 0
   for call_index, native_call in response.tool_calls; session = session {
+    // Running batch budget: stop BEFORE a call whose worst case could push
+    // the projection past what the checkpoint request needs. Uses actual
+    // recorded sizes for everything already executed, so it only ever
+    // pessimizes one call ahead — no pre-execution estimate over the whole
+    // batch, no false positives at low usage.
+    if !self.next_call_fits(response.usage, spent_result_chars) {
+      // A finish call in the unexecuted remainder is a completion, not
+      // more output — on small-window models the budget can trip well
+      // below the hard ceiling, and skip-closing the finish would turn an
+      // already-completed task into a context yield.
+      match self.salvage_finish_at_ceiling(session, response, from=call_index) {
+        Some(next) => return StepDone(next)
+        None => ()
+      }
+      let session = self.close_skipped_tool_calls(
+        session,
+        response.tool_calls[call_index:],
+        note=ceiling_skip_note,
+      )
+      return StepYield(session)
+    }
     let tool_call = @agent_tool.AgentToolCall(native_call) catch {
       error => {
         let content = "error: \{error}"
@@ -291,7 +393,14 @@ async fn AgentLoop::handle_tool_calls(
       self.execute_tool_call(
         session, response, call_index, native_call, tool_call,
       ) {
-      ContinueToolBatch(next) => continue next
+      ContinueToolBatch(next) => {
+        // Account the result actually recorded for this call (the loop
+        // clamp bounds it at max_tool_result_chars).
+        if next.events().peek() is Some(event) && event.item() is Tool(result) {
+          spent_result_chars += result.content().length().to_int64()
+        }
+        continue next
+      }
       ContinueAgentLoop(next) => return StepContinue(next)
       FinishAgentLoop(next) => return StepDone(next)
     }
@@ -318,16 +427,36 @@ async fn AgentLoop::execute_tool_call(
         tool_name=tool_call.name,
         content="finished: \{answer}",
       )
+      // Close the batch's unexecuted remainder, whatever comes next: every
+      // call in the assistant's batch needs a result message — in CALL
+      // order, matching the assistant's tool_calls echo sequence — so the
+      // durable log and any checkpoint request generated from it stay
+      // API-valid without projection repair text leaking into summaries.
+      // Step attribution downstream does not need the finish result last:
+      // analyzers treat "a finish result seen since the last assistant
+      // message" as finish-completion, because everything recorded after
+      // it in the same batch is by construction a skip note.
+      let remaining_tool_calls = response.tool_calls[call_index + 1:]
+      let session = self.close_skipped_tool_calls(
+        session,
+        remaining_tool_calls,
+        note="skipped: an earlier finish tool call ended the batch before this call ran",
+      )
       let steer_inputs = self.runtime.pending_steers()
       if steer_inputs.is_empty() {
-        return FinishAgentLoop(self.finish_turn(session, answer))
+        return match self.finish_turn(session, answer, usage=response.usage) {
+          Sealed(next) => FinishAgentLoop(next)
+          ContinueTurn(next) => ContinueAgentLoop(next)
+        }
       }
-      // User input wins over the finish tool as well. Continuing the turn must keep
-      // the conversation API-valid: every call in the assistant's batch needs a
-      // result message, so the finish call's result and skipped notes for the
-      // unexecuted remainder are pushed before the new input.
-      let remaining_tool_calls = response.tool_calls[call_index + 1:]
-      let session = self.close_skipped_tool_calls(session, remaining_tool_calls)
+      // User input wins over the finish tool as well — but never answered in
+      // a starved context: at the ceiling the turn yields and the steers
+      // survive the checkpoint verbatim.
+      if self.at_soft_context_ceiling(response.usage) {
+        return FinishAgentLoop(
+          self.yield_at_context_ceiling(session, steer_inputs),
+        )
+      }
       let session = self.apply_steer_inputs(session, steer_inputs)
       ContinueAgentLoop(session)
     }
@@ -348,16 +477,27 @@ async fn AgentLoop::execute_tool_call(
       return FinishAgentLoop(session)
     }
     Respond(output) => {
+      // Clamp once, here, so the durable item, the in-flight model message
+      // (via record_tool_result), and the live JSONL/TUI event all carry
+      // the SAME bounded content — a log that disagrees with what the
+      // model saw defeats the cap for live consumers.
+      let content = clamp_tool_result_content(output.content)
       let session = self.record_tool_result(
         session,
         tool_call_id=native_call.id,
         tool_name=tool_call.name,
-        content=output.content,
+        content~,
         is_error=output.is_error,
         brief?=output.brief,
       )
       self.plan_cadence.record_plan_success(tool_call, output)
-      log_tool_result(native_call, tool_call, output)
+      log_tool_result(
+        native_call,
+        tool_call,
+        is_error=output.is_error,
+        content~,
+        brief=output.brief,
+      )
       ContinueToolBatch(session)
     }
   }
@@ -374,9 +514,9 @@ async fn AgentLoop::close_skipped_tool_calls(
   self : Self,
   session : @agent_session.Session,
   remaining_tool_calls : ArrayView[@deepseek.ToolCall],
+  note~ : String,
 ) -> @agent_session.Session {
   for skipped in remaining_tool_calls; session = session {
-    let note = "skipped: user input arrived before this call ran"
     let session = self.record_tool_result(
       session,
       tool_call_id=skipped.id,
@@ -399,6 +539,107 @@ async fn AgentLoop::close_skipped_tool_calls(
 }
 
 ///|
+/// At the context ceiling, a batch carrying the built-in `finish` call is a
+/// completion, not more work — honor it instead of discarding it. Calls
+/// before the finish are skip-closed (their results cannot change the
+/// already-decided answer, and executing them would grow the checkpoint
+/// request); the finish call itself executes — a few bytes of result — and
+/// its Control(Finish) path closes the remainder, checkpoints, and seals
+/// the real answer. `finish` is matched by name: it is the loop's
+/// documented structured-completion contract (see agent_tool/finish). A
+/// custom tool returning Control(Finish) under another name still works
+/// whenever its batch executes; it just cannot be salvaged at the ceiling.
+///
+/// Returns None when the batch carries no decodable finish call — nothing
+/// was appended and the caller proceeds with the plain yield.
+///
+/// `from` is where the unexecuted remainder starts: 0 when the whole batch
+/// is being skipped (hard ceiling), or the tripping call's index when the
+/// running budget stopped execution mid-batch — calls before it already
+/// executed and have results. The finish call itself is exempt from the
+/// budget: its result is a few bytes of completion, not tool output.
+async fn AgentLoop::salvage_finish_at_ceiling(
+  self : Self,
+  session : @agent_session.Session,
+  response : @deepseek.ChatResponse,
+  from? : Int = 0,
+) -> @agent_session.Session? {
+  let mut finish_index = -1
+  for index, call in response.tool_calls {
+    if index >= from && call.name == "finish" {
+      finish_index = index
+      break
+    }
+  }
+  if finish_index < 0 {
+    return None
+  }
+  let native_call = response.tool_calls[finish_index]
+  let tool_call = @agent_tool.AgentToolCall(native_call) catch {
+    _ => return None
+  }
+  let session = self.close_skipped_tool_calls(
+    session,
+    response.tool_calls[from:finish_index],
+    note=ceiling_skip_note,
+  )
+  match
+    self.execute_tool_call(
+      session, response, finish_index, native_call, tool_call,
+    ) {
+    FinishAgentLoop(next) => Some(next)
+    // A tool named `finish` that did not finish (custom override returning
+    // Respond): close the remainder and fall back to the ceiling yield.
+    ContinueToolBatch(next) | ContinueAgentLoop(next) => {
+      let next = self.close_skipped_tool_calls(
+        next,
+        response.tool_calls[finish_index + 1:],
+        note=ceiling_skip_note,
+      )
+      Some(self.yield_at_context_ceiling(next, self.runtime.pending_steers()))
+    }
+  }
+}
+
+///|
+/// Ceiling for one recorded tool result, in UTF-16 units. It MUST sit
+/// above every in-tree tool's self-cap PLUS its metadata footer (shell
+/// inline output caps at 12K; read caps its body budget at 50K and then
+/// appends a `<system>…</system>` footer), so in-tree results always pass
+/// through untouched — a loop-level cut would strip exactly the
+/// truncation/line/exit metadata the model needs to know a result is
+/// incomplete. The clamp therefore only ever fires on custom tool
+/// registrations, which is what gives the soft-tier batch budget a real
+/// per-call bound.
+let max_tool_result_chars : Int = 60_000
+
+///|
+/// Clamp an oversized tool result to `max_tool_result_chars`, never
+/// splitting a surrogate pair.
+fn clamp_tool_result_content(content : String) -> String {
+  if content.length() <= max_tool_result_chars {
+    return content
+  }
+  // The marker fits INSIDE the cap: the recorded result must never exceed
+  // the per-call figure soft_batch_fits budgets with.
+  let marker = "\n[truncated: result exceeded the \{max_tool_result_chars}-char cap]"
+  let body_budget = max_tool_result_chars - marker.length()
+  let kept = StringBuilder()
+  for ch in content; units = 0 {
+    let width : Int = if ch.to_int() > 0xFFFF { 2 } else { 1 }
+    if units + width > body_budget {
+      break
+    }
+    kept.write_char(ch)
+    continue units + width
+  } nobreak {
+
+  }
+  kept.write_string(marker)
+  kept.to_string()
+}
+
+///|
 /// Record one tool result: append it durably and mirror it into the in-flight
 /// chat messages. The two must stay in lockstep — every tool call in an
 /// assistant batch needs a matching result message for the conversation to
@@ -412,6 +653,7 @@ async fn AgentLoop::record_tool_result(
   is_error? : Bool = false,
   brief? : String,
 ) -> @agent_session.Session {
+  let content = clamp_tool_result_content(content)
   let session = self.append(
     session,
     Tool(ToolResult(tool_call_id~, tool_name~, content~, is_error~, brief?)),
@@ -423,31 +665,73 @@ async fn AgentLoop::record_tool_result(
 ///|
 /// Durably record the turn's final answer and mirror it for the still-live
 /// loop state.
+///
+/// Compact-on-finish: a turn that completes at the context ceiling still
+/// leaves a checkpoint, so the next turn seeds from the compacted
+/// projection instead of landing its first request on a pressured one. The
+/// answer is not yet durable when the summary generates, so it cannot fold
+/// into the checkpoint text — it projects verbatim after the summary, and
+/// the turn stays a normal success (`agent_finished`, real answer) on both
+/// the wire and the durable log. Fail-open: a failed checkpoint finishes
+/// uncompacted.
+///
+/// EXCEPT when user input queued during the checkpoint request: then the
+/// steer-beats-finish rule applies once more and the turn CONTINUES from
+/// the compacted projection (`ContinueTurn`) — the answer becomes ordinary
+/// history and the model addresses the steer with fresh headroom.
 async fn AgentLoop::finish_turn(
   self : Self,
   session : @agent_session.Session,
   answer : String,
-) -> @agent_session.Session {
+  usage~ : @deepseek.Usage,
+) -> FinishOutcome {
+  let session = if self.at_soft_context_ceiling(usage) {
+    let (session, _compacted) = self.checkpoint_at_ceiling(session, [])
+    // The checkpoint request takes seconds; user input may have queued
+    // while it was in flight. Appending it before the terminal would make
+    // the decided answer read as its reply, and leaving it queued gets it
+    // boundary-dropped at TurnDone — so the steer-beats-finish rule
+    // applies once more: the answer stays an ordinary assistant message
+    // and the turn continues, from the compacted projection.
+    let steers = self.runtime.pending_steers()
+    if !steers.is_empty() {
+      let session = self.append(session, Assistant(AssistantMessage(answer)))
+      let session = self.apply_steer_inputs(session, steers)
+      // Re-seed the in-flight buffer from the projection: the whole point
+      // of the checkpoint is that the continuation request is small, and
+      // the buffer must never disagree with Session::chat_messages.
+      self.messages.clear()
+      for message in session.chat_messages() {
+        self.messages.push(message)
+      }
+      return ContinueTurn(session)
+    }
+    session
+  } else {
+    session
+  }
   let session = self.append(session, Terminal(Finished(answer)))
   self.push_finished_message(answer)
   @xlog.info() <? { "event": "agent_finished", "answer": answer }
-  session
+  Sealed(session)
 }
 
 ///|
 fn log_tool_result(
   native_call : @deepseek.ToolCall,
   tool_call : @agent_tool.AgentToolCall,
-  output : @agent_tool.ToolOutput,
+  is_error~ : Bool,
+  content~ : String,
+  brief~ : String?,
 ) -> Unit {
   @xlog.info() <?
     {
       "event": "tool_result",
       "tool_call_id": native_call.id,
       "tool_name": tool_call.name,
-      "is_error": output.is_error,
-      "content": output.content,
-      "brief": if output.brief is Some(brief) {
+      "is_error": is_error,
+      "content": content,
+      "brief": if brief is Some(brief) {
         Json::string(brief)
       } else {
         Json::null()

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -9,6 +9,8 @@ import {
 }
 
 // Values
+pub const ContextYieldAnswerPrefix : String = "[context ceiling]"
+
 pub const PlanReminderPrefix : String = "[plan reminder]"
 
 // Errors

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -22,7 +22,14 @@ fn agent_status_message(label : String, reason : String) -> String? {
 fn terminal_model_message(terminal : TurnTerminal) -> String? {
   match terminal {
     Finished(answer) =>
-      if answer.trim().is_empty() {
+      // A context-yield terminal is synthetic run status, not something the
+      // assistant said: replaying it would make the model read its own
+      // ceiling notice as a prior answer — and, worse, as the "reply" to a
+      // steer preserved past the checkpoint, so the steer looks handled.
+      // The resumed turn starts from the checkpoint summary and any
+      // preserved user input alone. (Raw-log consumers still see the
+      // terminal; only the model-facing projection skips it.)
+      if answer.trim().is_empty() || answer.has_prefix(ContextYieldAnswerPrefix) {
         None
       } else {
         Some(answer)
@@ -130,7 +137,8 @@ fn is_covered_by_later_summary(
 /// - pending tool calls are closed with synthetic tool-error messages before a
 ///   non-tool event or at the end of projection;
 /// - `Terminal(Finished(text))` becomes a final assistant message when `text`
-///   is non-blank;
+///   is non-blank and is not a context-yield status (see
+///   `ContextYieldAnswerPrefix`);
 /// - `Terminal(Aborted|Interrupted|Failed)` becomes an assistant status
 ///   message, preserving any non-blank reason.
 ///

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -184,6 +184,34 @@ test "projection closes unresolved historical tool calls" {
 }
 
 ///|
+test "projection skips context-yield terminals" {
+  // The full ceiling-yield shape: work, preserved steer, checkpoint
+  // summary, synthetic yield terminal. The resumed model context must be
+  // [system, summary, steer] — the yield status is run metadata, not an
+  // assistant answer, and must never read as the reply to the steer.
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("build everything")))
+    .append(User(UserMessage("preserved steer")))
+    .append(
+      Summary(
+        SessionSummary(content="checkpoint", from_sequence=1, to_sequence=1),
+      ),
+    )
+    .append(
+      Terminal(
+        Finished(
+          "\{@agent_session.ContextYieldAnswerPrefix} continue in a new turn",
+        ),
+      ),
+    )
+  let messages = session.chat_messages()
+  assert_eq(messages.length(), 3)
+  assert_true(messages[1].content.contains("checkpoint"))
+  assert_true(messages[2].role is User)
+  assert_eq(messages[2].content, "preserved steer")
+}
+
+///|
 test "projection skips compacted assistant tool results" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("inspect")))

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -1,4 +1,21 @@
 ///|
+/// The answer prefix every context-yield terminal carries. A turn that ends
+/// at the model's context ceiling is persisted as `Terminal(Finished(...))`
+/// — a distinct terminal kind would break old readers (the decoder is
+/// strict) and continuation machinery chains finished turns — so this
+/// prefix is how durable-log consumers distinguish a ceiling yield from
+/// task success. Lives here, next to the session model, because it is a
+/// raw-log contract: analyzers, fleet classification, and replay tooling
+/// all match on it.
+///
+/// Known, accepted limitation: a real answer that happens to START with
+/// this text (e.g. a task asking the model to echo it) classifies as a
+/// yield. The collision fails toward NOT-success — never false success —
+/// and the durable format has no terminal-metadata side channel, so a
+/// spoof-proof sentinel is not worth the format change.
+pub const ContextYieldAnswerPrefix : String = "[context ceiling]"
+
+///|
 /// Stable identifier for one OpenSeek conversation.
 ///
 /// `SessionId` is stored in every `Session` and is also used by

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -42,6 +42,12 @@ pub struct AgentToolDefinition {
   description : String
   schema : JsonSchema
   execute : ToolExecutor
+  /// A control tool's action is loop flow (`Control(Finish/Abort)`), not
+  /// tool output — its "result" is a few bytes. The loop uses this to know,
+  /// WITHOUT executing, that a call is safe to honor at the context
+  /// ceiling: the built-in `finish` declares it, and a custom completion
+  /// override must too or it is skip-closed like any other call there.
+  control : Bool
 } derive(Debug(ignore=ToolExecutor))
 
 ///|
@@ -52,8 +58,15 @@ pub fn AgentToolDefinition::AgentToolDefinition(
   description~ : String,
   schema~ : JsonSchema,
   execute~ : ToolExecutor,
+  control? : Bool = false,
 ) -> AgentToolDefinition {
-  { name, description, schema, execute }
+  { name, description, schema, execute, control }
+}
+
+///|
+/// Whether this tool declared itself a control tool (see the field doc).
+pub fn AgentToolDefinition::is_control(self : AgentToolDefinition) -> Bool {
+  self.control
 }
 
 ///|
@@ -288,6 +301,7 @@ test "Tools::function_tools converts the registry to deepseek tool definitions" 
       description: "Echo the input.",
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("ok")),
+      control: false,
     },
   ])
   let function_tools = tools.function_tools()
@@ -303,6 +317,7 @@ test "Tools::find returns the registered definition by name" {
       description: "Echo.",
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("ok")),
+      control: false,
     },
   ])
   guard tools.find("echo") is Some(definition) else { fail("missing echo") }
@@ -318,12 +333,14 @@ test "Tools::Tools raises on duplicate tool names" {
       description: "First.",
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("first")),
+      control: false,
     },
     {
       name: "echo",
       description: "Second.",
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("second")),
+      control: false,
     },
   ]) catch {
     error => {
@@ -358,6 +375,7 @@ async test "execute_tool_call dispatches to registered executor" {
           _ => ToolAction::respond("no value", is_error=true)
         }
       }),
+      control: false,
     },
   ])
   let call = AgentToolCall(
@@ -386,6 +404,7 @@ async test "execute_tool_call dispatches to async executor" {
       description: "Async echo.",
       schema: JsonSchema({ "type": "object" }),
       execute: Async(async_echo),
+      control: false,
     },
   ])
   let call = AgentToolCall(
@@ -405,6 +424,7 @@ test "Tools::function_tools preserves description and schema" {
       description: "Echo what comes in.",
       schema: JsonSchema({ "type": "object", "properties": {} }),
       execute: Sync(_args => ToolAction::respond("ok")),
+      control: false,
     },
   ])
   let function_tools = tools.function_tools()
@@ -430,18 +450,21 @@ test "Tools::function_tools yields one entry per definition" {
       description: "First.",
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("1")),
+      control: false,
     },
     {
       name: "second",
       description: "Second.",
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("2")),
+      control: false,
     },
     {
       name: "third",
       description: "Third.",
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("3")),
+      control: false,
     },
   ])
   let function_tools = tools.function_tools()

--- a/agent_tool/finish/finish.mbt
+++ b/agent_tool/finish/finish.mbt
@@ -21,6 +21,7 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
       "required": ["answer"],
     }),
     execute=Sync(execute),
+    control=true,
   )
 }
 

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -32,8 +32,10 @@ pub struct AgentToolDefinition {
   description : String
   schema : JsonSchema
   execute : ToolExecutor
+  control : Bool
 } derive(@debug.Debug)
-pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor) -> Self
+pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool) -> Self
+pub fn AgentToolDefinition::is_control(Self) -> Bool
 
 pub(all) struct JsonSchema(Json) derive(@debug.Debug)
 

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -124,6 +124,7 @@ test "read tool advertises the expected schema" {
       #|    ),
       #|  ),
       #|  execute: ...,
+      #|  control: false,
       #|}
     ),
   )

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -188,7 +188,10 @@ async fn run_one_attempt(
       session: id.value(),
       status,
       detail,
-      ok: status == "finished",
+      // A context-ceiling yield is durably Finished (replay/chaining) but is
+      // not task success for a one-shot fleet run.
+      ok: status == "finished" &&
+      !detail.has_prefix(@agent_session.ContextYieldAnswerPrefix),
     }
   } catch {
     error =>

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -80,6 +80,8 @@ pub fn decode_event(object : Json) -> AgentEvent? {
       Some(CompactionFinished(@jsonx.string(object, "summary")))
     "compaction_failed" =>
       Some(AgentError("compaction failed: \{@jsonx.string(object, "error")}"))
+    // A turn that ended at the context ceiling: run-terminal, not success.
+    "context_yield" => Some(ContextYield(@jsonx.string(object, "answer")))
     _ => None
   }
 }

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -166,3 +166,15 @@ test "usage total is derived from prompt and completion tokens" {
     _ => fail("expected Usage")
   }
 }
+
+///|
+test "a context yield decodes as its own run terminal" {
+  assert_true(
+    @event.decode_event({
+      "event": "context_yield",
+      "to_sequence": 41,
+      "answer": "[context ceiling] checkpointed",
+    })
+    is Some(ContextYield("[context ceiling] checkpointed")),
+  )
+}

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -60,4 +60,8 @@ pub(all) enum AgentEvent {
   // the durable session — now the conversation's context — so the controller can
   // preview it.
   CompactionFinished(String)
+  // The turn ended at the model's context ceiling: checkpointed and
+  // terminal for the run, but NOT task success — the work continues in a
+  // new turn the user (or a controller) starts.
+  ContextYield(String)
 }

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -29,6 +29,7 @@ pub(all) enum AgentEvent {
   AgentError(String)
   CommandRejected(String)
   CompactionFinished(String)
+  ContextYield(String)
 }
 
 pub(all) struct ToolResultEvent {

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -128,7 +128,8 @@ fn is_terminal_event(event : @event.AgentEvent) -> Bool {
     | AgentAborted(_)
     | MaxStepsExhausted
     | AgentError(_)
-    | CompactionFinished(_) => true
+    | CompactionFinished(_)
+    | ContextYield(_) => true
     _ => false
   }
 }
@@ -485,6 +486,26 @@ fn handle_agent_event(
     // now standing in for the prior turns, and close the run.
     CompactionFinished(summary) => {
       cmds.push(AppendItem(compaction_item(summary)))
+      state.finish_run()
+    }
+    // Terminal for the run but not task success: surface the continuation
+    // guidance the yield answer carries. For a scheduled /loop run the next
+    // fire IS the continuation, so a ceiling yield settles the schedule as
+    // a completed fire rather than wedging it (codex review).
+    ContextYield(answer) => {
+      scheduler_on_run_end(state, LoopRunFinished, cmds)
+      cmds.push(AppendItem(Response(answer)))
+      cmds.push(
+        AppendItem(
+          Notice(
+            ToolCall(
+              @doc.Text::plain(
+                "context ceiling reached — send a prompt to continue in a new turn",
+              ),
+            ),
+          ),
+        ),
+      )
       state.finish_run()
     }
   }

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1044,11 +1044,25 @@ fn session_metadata(
 fn agent_step_count(parsed : @session_log.ParsedLog) -> Int {
   let mut count = 0
   let mut previous : @agent_session.SessionEvent? = None
+  let mut finish_in_batch = false
   for event in parsed.events {
-    if event_represents_agent_step(event, previous) {
+    if event_represents_agent_step(event, previous, finish_in_batch) {
       count += 1
     }
-    previous = Some(event)
+    // A checkpoint Summary can sit between a finish-tool result and its
+    // terminal (compact-on-finish); skip it when looking backward so the
+    // terminal is still attributed to the finish call.
+    match event.item() {
+      Tool(result) =>
+        if result.tool_name() == "finish" {
+          finish_in_batch = true
+        }
+      Summary(_) => ()
+      _ => finish_in_batch = false
+    }
+    if !(event.item() is Summary(_)) {
+      previous = Some(event)
+    }
   }
   count
 }
@@ -1057,23 +1071,34 @@ fn agent_step_count(parsed : @session_log.ParsedLog) -> Int {
 fn event_represents_agent_step(
   event : @agent_session.SessionEvent,
   previous : @agent_session.SessionEvent?,
+  finish_in_batch : Bool,
 ) -> Bool {
   match event.item() {
     Assistant(_) => true
-    Terminal(Finished(_)) => terminal_finished_represents_agent_step(previous)
+    Terminal(Finished(message)) =>
+      // A context-ceiling yield's terminal is synthetic, not a model step.
+      !message.has_prefix(@agent_session.ContextYieldAnswerPrefix) &&
+      terminal_finished_represents_agent_step(previous, finish_in_batch)
     _ => false
   }
 }
 
 ///|
+/// Tool results are recorded in CALL order, so a finish result may be
+/// followed by same-batch skip notes; `finish_in_batch` — a finish result
+/// seen since the last assistant message — is the completion signal, not
+/// "the finish result came last".
 fn terminal_finished_represents_agent_step(
   previous : @agent_session.SessionEvent?,
+  finish_in_batch : Bool,
 ) -> Bool {
+  if finish_in_batch {
+    return false
+  }
   match previous {
     Some(event) =>
       match event.item() {
         Assistant(_) => false
-        Tool(result) => result.tool_name() != "finish"
         _ => true
       }
     None => true

--- a/eval/session_analyzer/analyzer.mbt
+++ b/eval/session_analyzer/analyzer.mbt
@@ -126,22 +126,37 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
         if result.is_error() {
           tool_errors += 1
         }
-        previous_finish_tool = result.tool_name() == "finish"
+        // Sticky within the batch: results recorded after a finish call
+        // are by construction skip notes, and results are in CALL order —
+        // so "a finish result seen since the last assistant message" is
+        // the completion signal, not "the finish result came last".
+        if result.tool_name() == "finish" {
+          previous_finish_tool = true
+        }
       }
       Runtime(_) => {
         runtime_notices += 1
         previous_finish_tool = false
       }
-      Terminal(Finished(message)) => {
-        if !previous_finish_tool {
-          steps += 1
+      Terminal(Finished(message)) =>
+        if message.has_prefix(@agent_session.ContextYieldAnswerPrefix) {
+          // A context-ceiling yield is durably Finished (replay/chaining)
+          // but NOT task success: the work was checkpointed mid-flight. The
+          // synthetic terminal is not a model step either.
+          finished = false
+          terminal_status = "context_yield"
+          terminal_message = message
+          previous_finish_tool = false
+        } else {
+          if !previous_finish_tool {
+            steps += 1
+          }
+          finished = true
+          finish_message = message
+          terminal_status = "finished"
+          terminal_message = message
+          previous_finish_tool = false
         }
-        finished = true
-        finish_message = message
-        terminal_status = "finished"
-        terminal_message = message
-        previous_finish_tool = false
-      }
       Terminal(Aborted(message)) => {
         finished = false
         terminal_status = "aborted"
@@ -160,7 +175,10 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
         terminal_message = message
         previous_finish_tool = false
       }
-      _ => previous_finish_tool = false
+      // A compact-on-finish checkpoint sits between the finish result and
+      // its terminal; it must not break the attribution.
+      Summary(_) => ()
+      User(_) => previous_finish_tool = false
     }
   }
   {

--- a/eval/session_analyzer/analyzer_wbtest.mbt
+++ b/eval/session_analyzer/analyzer_wbtest.mbt
@@ -25,6 +25,91 @@ fn sample_session() -> @agent_session.Session {
 }
 
 ///|
+test "a checkpoint between finish result and terminal keeps step attribution" {
+  let session = @agent_session.Session(
+      SessionId("compact-on-finish"),
+      system_prompt="",
+    )
+    .append(User(UserMessage("wrap it up")))
+    .append(
+      Assistant(
+        AssistantMessage("finishing", tool_calls=[
+          ToolCall(id="call_1", name="finish", arguments="{}"),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="call_1",
+          tool_name="finish",
+          content="finished: done",
+        ),
+      ),
+    )
+    .append(
+      // Results are recorded in CALL order: a skip note for a call after
+      // the finish sits between the finish result and the terminal. The
+      // attribution must survive it.
+      Tool(
+        ToolResult(
+          tool_call_id="call_2",
+          tool_name="probe",
+          content="skipped: an earlier finish tool call ended the batch before this call ran",
+          is_error=true,
+        ),
+      ),
+    )
+    .append(
+      Summary(
+        SessionSummary(content="checkpoint", from_sequence=1, to_sequence=4),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let result = analyze_session(session)
+  // The terminal belongs to the finish call: one model step, not two.
+  assert_eq(result.steps, 1)
+  assert_true(result.finished)
+}
+
+///|
+test "a context-yield terminal is not task success" {
+  let session = @agent_session.Session(
+      SessionId("ceiling-yield"),
+      system_prompt="",
+    )
+    .append(User(UserMessage("build everything")))
+    .append(
+      Assistant(
+        AssistantMessage("working", tool_calls=[
+          ToolCall(id="call_1", name="shell", arguments="{}"),
+        ]),
+      ),
+    )
+    .append(
+      Tool(ToolResult(tool_call_id="call_1", tool_name="shell", content="ok")),
+    )
+    .append(
+      Summary(
+        SessionSummary(content="checkpoint", from_sequence=1, to_sequence=3),
+      ),
+    )
+    .append(
+      Terminal(
+        Finished(
+          "\{@agent_session.ContextYieldAnswerPrefix} continue in a new turn",
+        ),
+      ),
+    )
+  let result = analyze_session(session)
+  assert_false(result.finished)
+  assert_false(result.success)
+  assert_eq(result.terminal_status, "context_yield")
+  // The synthetic yield terminal is not a model step.
+  assert_eq(result.steps, 1)
+}
+
+///|
 test "session analyzer counts typed events" {
   let result = analyze_session(sample_session())
   assert_true(result.success)

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -108,12 +108,26 @@ fn agent_step_labels(session : @agent_session.Session) -> Map[Int, String] {
   let labels : Map[Int, String] = Map([])
   let mut step = 0
   let mut previous : @agent_session.SessionEvent? = None
+  let mut finish_in_batch = false
   for event in session.events() {
-    if event_represents_agent_step(event, previous) {
+    if event_represents_agent_step(event, previous, finish_in_batch) {
       step += 1
       labels.set(event.sequence(), "Step \{step}/\{total}")
     }
-    previous = Some(event)
+    // A checkpoint Summary can sit between a finish-tool result and its
+    // terminal (compact-on-finish); skip it when looking backward so the
+    // terminal is still attributed to the finish call.
+    match event.item() {
+      Tool(result) =>
+        if result.tool_name() == "finish" {
+          finish_in_batch = true
+        }
+      Summary(_) => ()
+      _ => finish_in_batch = false
+    }
+    if !(event.item() is Summary(_)) {
+      previous = Some(event)
+    }
   }
   labels
 }
@@ -122,11 +136,25 @@ fn agent_step_labels(session : @agent_session.Session) -> Map[Int, String] {
 fn agent_step_count(session : @agent_session.Session) -> Int {
   let mut count = 0
   let mut previous : @agent_session.SessionEvent? = None
+  let mut finish_in_batch = false
   for event in session.events() {
-    if event_represents_agent_step(event, previous) {
+    if event_represents_agent_step(event, previous, finish_in_batch) {
       count += 1
     }
-    previous = Some(event)
+    // A checkpoint Summary can sit between a finish-tool result and its
+    // terminal (compact-on-finish); skip it when looking backward so the
+    // terminal is still attributed to the finish call.
+    match event.item() {
+      Tool(result) =>
+        if result.tool_name() == "finish" {
+          finish_in_batch = true
+        }
+      Summary(_) => ()
+      _ => finish_in_batch = false
+    }
+    if !(event.item() is Summary(_)) {
+      previous = Some(event)
+    }
   }
   count
 }
@@ -135,23 +163,34 @@ fn agent_step_count(session : @agent_session.Session) -> Int {
 fn event_represents_agent_step(
   event : @agent_session.SessionEvent,
   previous : @agent_session.SessionEvent?,
+  finish_in_batch : Bool,
 ) -> Bool {
   match event.item() {
     Assistant(_) => true
-    Terminal(Finished(_)) => terminal_finished_represents_agent_step(previous)
+    Terminal(Finished(message)) =>
+      // A context-ceiling yield's terminal is synthetic, not a model step.
+      !message.has_prefix(@agent_session.ContextYieldAnswerPrefix) &&
+      terminal_finished_represents_agent_step(previous, finish_in_batch)
     _ => false
   }
 }
 
 ///|
+/// Tool results are recorded in CALL order, so a finish result may be
+/// followed by same-batch skip notes; `finish_in_batch` — a finish result
+/// seen since the last assistant message — is the completion signal, not
+/// "the finish result came last".
 fn terminal_finished_represents_agent_step(
   previous : @agent_session.SessionEvent?,
+  finish_in_batch : Bool,
 ) -> Bool {
+  if finish_in_batch {
+    return false
+  }
   match previous {
     Some(event) =>
       match event.item() {
         Assistant(_) => false
-        Tool(result) => result.tool_name() != "finish"
         _ => true
       }
     None => true
@@ -904,7 +943,13 @@ fn terminal_projects_model_message(
   terminal : @agent_session.TurnTerminal,
 ) -> Bool {
   match terminal {
-    Finished(answer) => !answer.trim().is_empty()
+    // Mirrors Session::chat_messages exactly: blank answers and synthetic
+    // context-yield terminals never reach the model, so they must not
+    // consume a model-view label either — one extra label here shifts
+    // every later timestamp/step chip after a continued yield.
+    Finished(answer) =>
+      !answer.trim().is_empty() &&
+      !answer.has_prefix(@agent_session.ContextYieldAnswerPrefix)
     Aborted(_) | Interrupted(_) | Failed(_) => true
   }
 }


### PR DESCRIPTION
Turns are bounded by the model's context window, not by a step count.

## Design (simplified per review — supersedes the earlier in-loop re-arm approach)

- `max_steps` defaults to Int-max (`unbounded_max_steps`): a step bound only exists when a caller passes one explicitly. The loop structure, cancellation, and exhaustion semantics for explicit bounds are unchanged (`max_steps=0`/`=1` still exhaust exactly as before).
- **Two-tier ceiling** (usage only exists per response, so this is the earliest possible boundary; no pressure state survives an iteration): at the **soft ceiling (70%)** the turn ends gracefully at that step's boundary — the tool batch executes in full, the checkpoint covers its real results, nothing is discarded or re-issued. At the **hard ceiling (80%)** — or when a soft batch's aggregate worst case can't be proven to fit — no batch starts: skip-close + yield. Crossings land in the soft band whenever one round grows the context <10% of the window, so graceful exits are the overwhelming common case; the hard tier is the provably-bounded fallback for single-round jumps. The turn ends `Summary` then `Terminal(Finished("[context ceiling] …"))`, in that order so the session's last event stays a terminal (the invariant serve's turn-outcome derivation, raw log viewers, and the docs rely on).
- **Running batch budget, at every usage level**: before each call in an executing batch, `usage + results-so-far (actual sizes) + one worst-case result + checkpoint reserve < window` — otherwise the remainder is skip-closed and the turn yields with the executed prefix checkpointed. This also protects batches that start *below* the soft ceiling but whose results would push the next request past the window; a whole-batch pre-estimate would false-positive constantly (any 4-call batch trips it on a 256K window), while the running check pessimizes only one call ahead. The per-call bound is real because the loop clamps every recorded result to 60K units (marker included, surrogate-safe) — above every in-tree tool's self-cap plus its metadata footer, so in-tree results pass through untouched — and the same clamped content feeds the durable log, the model buffer, and the live JSONL/TUI event.
- **Detection happens at every exit point** (settled by an explicit codex A/B design judgment): each normal exit consults `need_compaction(response.usage)` at its own call site — no precomputed flag, no cross-iteration state. Exhaustion/error/abort are exempt (a pressured step exits within its own iteration; failure paths never wait on a network call).
- **Compact-on-finish**: a final answer or finish tool at pressure appends the checkpoint `Summary` before `Terminal(Finished(real answer))` — a normal success on wire and log, but the next turn seeds from the compacted projection instead of landing its first request on a pressured one. Fail-open: a failed checkpoint finishes uncompacted.
- The tool batch that ARMS the yield never executes (the codex A/B vet confirmed why this must stay: 50K-char per-result caps × unbounded call count can push the projection past the window, and a failed checkpoint then strands the session — fail-open would leave the same oversized projection for every future call). Every call is closed with an API-valid skip note; the checkpoint summary carries the state. One exception — **completion salvage**: a pressured batch carrying the built-in `finish` call is a completion, not more work; everything else is skip-closed but the finish executes (bounded, bytes), checkpoints, and seals the real answer instead of bouncing the user with a yield.
- The finish tool closes its batch remainder unconditionally before finishing, so checkpoint requests never rely on projection-repair text; viz/viz_app step counters skip `Summary` when looking backward (a checkpoint can sit between `Tool(finish)` and the terminal).
- **When the ceiling is hit, the yield happens regardless of steers.** Queued steers are preserved verbatim PAST the checkpoint instead of being answered in the starved turn: they persist durably BEFORE the cancellable summary request (already drained from the queue, so a mid-request cancellation must find them saved), the summary is generated from the pre-steer snapshot (so their content cannot be folded into the checkpoint text and then replayed — no duplication), and they sit after the covered range, projecting right after the summary to head the next turn with fresh headroom. The earlier steer-cancels-yield rule is gone — it relied on the next response re-arming, and answering in a starved context risks the very overflow the guard prevents.
- Remaining rules, each pinned by a test: a genuine final answer with no queued steers beats the yield (a completed task is never reported as a ceiling yield); pressure on the last allowed step yields at the ceiling, never as exhaustion (context beats steps); a failed summary yields uncompacted, fail-open — with any queued steers still durable — and the next turn's pressure retries.
- A new `context_yield` event replaces `agent_finished` on the wire for ceiling yields, so live consumers (TUI terminal handling, fleet ok-classification) never read a mid-task yield as task success; the durable terminal stays `Finished` because the session decoder is strict about unknown kinds and continuation machinery chains finished turns. Durable-log consumers discriminate via the exported `ContextYieldAnswerPrefix`.
- Net deletion: the mid-turn two-stage compaction policy, prefix-session rebuilding, hysteresis/backoff state, steer-cancellation, and in-flight buffer re-seeding are all removed — after a yield nothing continues, so none of it has a job. A fresh turn re-arms everything by construction, which is the whole point.

CLI/TUI defaults are deliberately untouched in this PR (absent still means 1000 there): flipping the user-facing default belongs with the goal-branch integration, where armed goals auto-continue across yield boundaries and "unspecified = a new turn per context window" is actually true end to end.

Every commit codex-reviewed; the rework itself was design-vetted by codex before implementation. Full suite 982/982, deny-warn clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



