### PR TITLE
chore: bump moonbitlang/async to v0.20.1, moonbit-community/tty to v0.3.0

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -348,7 +348,7 @@ fn BgJobRuntime::register(
   // against the same deadline. The trip marks the reason before cancelling,
   // and the exit watcher above surfaces it like an output-limit kill.
   let remaining = self.hard_timeout_ms.to_int64() -
-    (@async.now() - exec.started_at_ms())
+    (@env.now().reinterpret_as_int64() - exec.started_at_ms())
   (self.spawn_watcher)(() => {
     if remaining > 0L {
       @async.sleep(remaining.to_int())

--- a/agent_tool/bgjobs/moon.pkg
+++ b/agent_tool/bgjobs/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool/shell_exec",
   "moonbitlang/async",
+  "moonbitlang/core/env",
 }
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -107,7 +107,7 @@ pub async fn[X] ShellExecution::start(
     kill_when_full,
     kill_at_hard_cap,
     killed_by_output_limit: false,
-    started_at_ms: @async.now(),
+    started_at_ms: @env.now().reinterpret_as_int64(),
     killed_by_time_limit: false,
   }
   group.spawn_bg(no_wait=true, allow_failure=true) <| () => {

--- a/agent_tool/shell_exec/moon.pkg
+++ b/agent_tool/shell_exec/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
 }
 
 warnings = "+unnecessary_annotation"

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -533,7 +533,7 @@ fn handle_compact_command(
   // for many seconds, and a slash command never echoes itself into the
   // transcript, so the notice is the only sign work has begun until it lands.
   cmds.push(AppendItem(command_notice("compacting context…")))
-  let run_id = state.start_run(@async.now())
+  let run_id = state.start_run(@env.now().reinterpret_as_int64())
   // Mark the run non-steerable: a prompt typed while this is in flight must be
   // queued, not steered into a compaction the engine will refuse it from.
   state.run_is_compaction = true
@@ -751,7 +751,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
   // reach "idle with a non-empty queue", so this never fires spuriously.
   if state.run is Idle && state.queued.length() > 0 {
     let input = state.queued.remove(0)
-    let run_id = state.start_run(@async.now())
+    let run_id = state.start_run(@env.now().reinterpret_as_int64())
     match input {
       Prompt(text) => {
         cmds.push(AppendItem(Input(Prompt(text))))

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -175,7 +175,7 @@ fn scheduler_maybe_fire(
       return
     }
   }
-  let run_id = state.start_run(@async.now())
+  let run_id = state.start_run(@env.now().reinterpret_as_int64())
   schedule.fired_run_id = Some(run_id)
   // Attribution lives in the notice; the prompt itself is echoed — and reaches
   // the engine — verbatim, so the model sees exactly what the user stored and

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -212,7 +212,7 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
     return Some(Text(spans + steer_segment))
   }
   let elapsed = format_elapsed_compact(
-    elapsed_seconds(started_ms, @async.now()),
+    elapsed_seconds(started_ms, @env.now().reinterpret_as_int64()),
   )
   let spans : Array[@doc.Span] = [
     @doc.Span::plain("Working"),

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -35,7 +35,7 @@ async fn main {
 /// measurement: does it background the slow command and overlap the quick work?
 async fn scenario_overlap(engine : Engine) -> Unit {
   println("== S1 overlap: slow command + quick questions, efficiency hint ==")
-  let started_ms = @async.now()
+  let started_ms = @env.now().reinterpret_as_int64()
   engine.prompt(
     (
       #|Please do all of the following, and be efficient with wall-clock time:
@@ -49,7 +49,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
   let finished = engine.wait_for(360_000, seen, event => {
     event is { "event": String("agent_finished"), .. }
   })
-  let wall_s = (@async.now() - started_ms) / 1000
+  let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
   let backgrounded = first_index(seen, event => {
     event is { "event": String("tool_result"), "content": String(content), .. } &&
     content.contains("started background job")
@@ -114,7 +114,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
 /// fire the job and end the turn — do not hold the turn hostage for 45s.
 async fn scenario_fire_and_forget(engine : Engine) -> Unit {
   println("== S2 fire-and-forget: user says do not wait ==")
-  let started_ms = @async.now()
+  let started_ms = @env.now().reinterpret_as_int64()
   engine.prompt(
     (
       #|Kick off the long soak check: sh -c 'sleep 45; echo SOAK-DONE-555'.
@@ -127,7 +127,7 @@ async fn scenario_fire_and_forget(engine : Engine) -> Unit {
   let finished = engine.wait_for(240_000, seen, event => {
     event is { "event": String("agent_finished"), .. }
   })
-  let wall_s = (@async.now() - started_ms) / 1000
+  let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
   let backgrounded = seen
     .iter()
     .any(event => {

--- a/moon.mod
+++ b/moon.mod
@@ -3,8 +3,8 @@ name = "bobzhang/openseek"
 version = "0.2.2"
 
 import {
-  "moonbit-community/tty@0.2.4",
-  "moonbitlang/async@0.19.4",
+  "moonbit-community/tty@0.3.0",
+  "moonbitlang/async@0.20.1",
   "moonbitlang/x@0.4.45",
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",

--- a/tui/internal/viewport/viewport.mbt
+++ b/tui/internal/viewport/viewport.mbt
@@ -294,7 +294,7 @@ async fn apply_style(tty : @tty.Tty, style : @style.Style) -> Unit {
     tty.set_background(style.background)
   }
   if style.underline {
-    tty.underline()
+    tty.set_underline()
   }
 }
 


### PR DESCRIPTION
This PR bumps:

- `moonbitlang/async` to `0.20.1`, and
- `moonbit-community/tty` to `0.3.0`.

And fixes the deprecation warnings introduced by these two bumps.

The `0.20.1` release of `moonbitlang/async`:

- fixes the missing `@fs.chmod` on Windows,
- deprecated `@async.now()` and suggested migration to `@env.now()`, and
- is not compatible with `moonbit-community/tty@0.2.4`, which means we need to bump `moonbit-community/tty` to `0.3.0` as well.

This PR is a pre-requisite for PR #167.