### PR TITLE
feat(agent): emit "brief" in tool_result

### DIFF
--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -447,6 +447,11 @@ fn log_tool_result(
       "tool_name": tool_call.name,
       "is_error": output.is_error,
       "content": output.content,
+      "brief": if output.brief is Some(brief) {
+        Json::string(brief)
+      } else {
+        Json::null()
+      },
     }
 }
 


### PR DESCRIPTION
This PR add "brief" to `tool_result` log entry, so that UI (desktop app, TUI, etc.) can support collapsing contiguous tool calls into briefs.

This PR is a pre-requisite of PR #167