### PR TITLE
refactor(shell): local simplification + dedupe sweep

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -43,11 +43,6 @@ pub struct BgJobRuntime {
   // inline-preview budget, spill path) -> execution. Captured so the runtime type
   // is not generic.
   priv spawn_exec : async (String, Array[String], String?, Int, String?) -> @shell_exec.ShellExecution
-  // Spawn a *foreground* execution on the same session group: memory-only output
-  // capped at the budget and killed if it fills, so the shell tool's foreground
-  // path shares the execution model (and can be detached on timeout) without
-  // re-deriving generic spawning at each call site.
-  priv spawn_foreground_exec : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution
   // Spawn a *retained* foreground execution (may be detached on timeout):
   // file-backed with a large hard cap, but still killed on exceeding the inline
   // cap so a timed command that floods output is an immediate output-limit error;
@@ -155,21 +150,6 @@ pub fn[X] BgJobRuntime::new(
         kill_at_hard_cap=true,
       )
     },
-    spawn_foreground_exec: (program, args, cwd, max_output_chars) => {
-      // Foreground output-limit semantics: cap at exactly `max_output_chars`
-      // (inline == hard) and kill on overflow, so exceeding it is reported as the
-      // output-limit error, never silently dropped. Foreground is memory-only (no
-      // spill) — full output is a background-job feature.
-      @shell_exec.ShellExecution::start(
-        scope,
-        program~,
-        args~,
-        cwd?,
-        inline_cap=max_output_chars,
-        hard_cap=max_output_chars,
-        kill_when_full=true,
-      )
-    },
     spawn_foreground_retained_exec: (
       program,
       args,
@@ -208,22 +188,6 @@ fn BgJobRuntime::next_id(self : BgJobRuntime) -> String {
   let id = "bg-\{self.next_index}"
   self.next_index += 1
   id
-}
-
-///|
-/// Spawn a *foreground* execution on the session group: memory-only output
-/// capped at `max_output_chars` and killed if it fills. The shell tool's
-/// foreground path uses this so foreground and background share one execution
-/// model — and a timed-out foreground command can be `adopt`-ed (detached)
-/// rather than killed. Positional to match the shell tool's spawner type.
-pub async fn BgJobRuntime::spawn_foreground(
-  self : BgJobRuntime,
-  program : String,
-  args : Array[String],
-  cwd : String?,
-  max_output_chars : Int,
-) -> @shell_exec.ShellExecution {
-  (self.spawn_foreground_exec)(program, args, cwd, max_output_chars)
 }
 
 ///|

--- a/agent_tool/bgjobs/bgjobs_wbtest.mbt
+++ b/agent_tool/bgjobs/bgjobs_wbtest.mbt
@@ -18,6 +18,19 @@ async fn poll_until_terminal(
 }
 
 ///|
+/// Await the first pushed exit notice, on the same 200 x 25ms budget as
+/// `poll_until_terminal`.
+#cfg(not(platform="windows"))
+async fn wait_for_first(notices : Array[BgJobSnapshot]) -> Unit {
+  for _ in 0..<200 {
+    if notices.length() > 0 {
+      return
+    }
+    @async.sleep(25)
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "bg job runs to completion and captures output" {
   @async.with_task_group(group => {
@@ -115,12 +128,7 @@ async test "on_job_exit fires once on a natural exit, never on stop" {
     let stopped = rt.start(program="sleep", args=["30"], command="sleep 30")
     @async.sleep(50)
     assert_true(rt.stop(stopped))
-    for _ in 0..<200 {
-      if seen.length() > 0 {
-        break
-      }
-      @async.sleep(25)
-    }
+    wait_for_first(seen)
     @async.sleep(50)
     // Exactly one notice — for the natural exit, not the stopped job.
     assert_true(seen.length() == 1)
@@ -189,12 +197,7 @@ async test "the watchdog kills a background job that floods past the hard cap" {
     assert_true(snapshot.output_truncated)
     // The kill is pushed like a natural exit: a silently dead job would look
     // like it just never finished.
-    for _ in 0..<200 {
-      if notices.length() > 0 {
-        break
-      }
-      @async.sleep(25)
-    }
+    wait_for_first(notices)
     assert_true(notices.length() == 1)
     assert_true(notices[0].killed_by_output_limit)
   })
@@ -214,12 +217,7 @@ async test "the reaper kills a background job that outlives the time cap" {
     assert_true(snapshot.killed_by_time_limit)
     assert_false(snapshot.killed_by_output_limit)
     // The kill is surfaced exactly once, like an output-cap kill.
-    for _ in 0..<200 {
-      if notices.length() > 0 {
-        break
-      }
-      @async.sleep(25)
-    }
+    wait_for_first(notices)
     assert_true(notices.length() == 1)
     assert_true(notices[0].killed_by_time_limit)
   })

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -21,7 +21,6 @@ pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : Strin
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
-pub async fn BgJobRuntime::spawn_foreground(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
 pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
 pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, source_write_sandboxed? : Bool, sandbox_denial_subjects? : Array[String]) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -101,19 +101,17 @@ fn sed_option_consumes_next(arg : String) -> Bool {
   if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
     return false
   }
-  let chars = [ for ch in arg => ch ]
-  let mut idx = 1
-  while idx < chars.length() {
-    match chars[idx] {
+  for view = arg[1:] {
+    match view {
       // `e`/`f` consume the remainder of the token; if they are the last char,
       // the value is the next word.
-      'e' | 'f' => return idx == chars.length() - 1
+      ['e' | 'f', .. rest] => break rest is []
       // `i` consumes the remainder as its in-place suffix, not the next word.
-      'i' => return false
-      _ => idx += 1
+      ['i', ..] => break false
+      [_, .. rest] => continue rest
+      [] => break false
     }
   }
-  false
 }
 
 ///|

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -40,8 +40,8 @@ fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
   let cmd = required_string(fields, "cmd")
   let cwd = optional_string(fields, "cwd")
   let timeout_ms = optional_positive_int(fields, "timeout_ms")
-  let max_output_chars = optional_positive_int_or_default(
-    fields, "max_output_chars", default_max_output_chars,
+  let max_output_chars = optional_positive_int(fields, "max_output_chars").unwrap_or(
+    default_max_output_chars,
   )
   let run_in_background = optional_bool(fields, "run_in_background")
   {
@@ -96,15 +96,6 @@ fn optional_positive_int(
     Some(Null) | None => None
     _ => fail("arguments.\{name} to be a number")
   }
-}
-
-///|
-fn optional_positive_int_or_default(
-  fields : Map[String, Json],
-  name : String,
-  default : Int,
-) -> Int raise {
-  optional_positive_int(fields, name).unwrap_or(default)
 }
 
 ///|

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -170,14 +170,12 @@ async fn execute_with_workspace(
       is_error=true,
     )
   }
-  match
-    @command_policy.moonbit_command_policy_error_for_parse(
+  if @command_policy.moonbit_command_policy_error_for_parse(
       input.cmd,
       parsed_command,
-    ) {
-    Some(message) =>
-      return @agent_tool.ToolAction::respond(message, is_error=true)
-    None => ()
+    )
+    is Some(message) {
+    return @agent_tool.ToolAction::respond(message, is_error=true)
   }
   let cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
   shell(
@@ -229,15 +227,13 @@ async fn shell(
       )
     }
   }
-  match
-    direct_source_write_redirect_target(parsed_command, workspace_root, cwd) {
-    Some(target) =>
-      return @agent_tool.ToolAction::respond(
-        direct_source_blocked_content("source file write redirect", target),
-        is_error=true,
-        brief=shell_brief(input.cmd, None),
-      )
-    None => ()
+  if direct_source_write_redirect_target(parsed_command, workspace_root, cwd)
+    is Some(target) {
+    return @agent_tool.ToolAction::respond(
+      direct_source_blocked_content("source file write redirect", target),
+      is_error=true,
+      brief=shell_brief(input.cmd, None),
+    )
   }
   // Background: detach the command as a job and return its id instead of blocking
   // for output. Runs the same source-tree guards and sandboxed launch as a
@@ -280,14 +276,9 @@ async fn shell(
   // keeps a full record if detached — the foreground output-limit is still
   // enforced at display via `over_inline_cap` and the spill is discarded
   // when the command finishes in the foreground.
-  let detachable = bg_runtime is Some(_)
   let foreground_spawn : (async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution)? = bg_runtime.map(runtime => {
       (program, args, cwd, max) => {
-        if detachable {
-          runtime.spawn_foreground_retained(program, args, cwd, max)
-        } else {
-          runtime.spawn_foreground(program, args, cwd, max)
-        }
+        runtime.spawn_foreground_retained(program, args, cwd, max)
       }
     },
   )
@@ -394,6 +385,26 @@ priv enum ShellRunResult {
 }
 
 ///|
+/// The protected target of a source-tree operation in `cmd`, or `None` when the
+/// command is allowed: the direct (parse-based) detection first, then the
+/// dynamic (text-based) one for too-complex commands.
+async fn source_tree_operation_target(
+  parsed_command : @shell_parse.ParseResult,
+  cmd : String,
+  workspace_root : String,
+  cwd : String?,
+) -> String? {
+  match
+    direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
+    Some(target) => Some(target)
+    None =>
+      dynamic_source_tree_operation_target(
+        parsed_command, cmd, workspace_root, cwd,
+      )
+  }
+}
+
+///|
 async fn run_agent_shell_with_tree_precheck(
   workspace_root : String,
   cmd : String,
@@ -404,17 +415,9 @@ async fn run_agent_shell_with_tree_precheck(
   foreground_spawn? : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution,
   on_timeout_detach? : (@shell_exec.ShellExecution, AgentShellLaunch) -> String,
 ) -> ShellRunResult {
-  match
-    direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
-    Some(target) => return ShellPreblockedSourceTree(target)
-    None => ()
-  }
-  match
-    dynamic_source_tree_operation_target(
-      parsed_command, cmd, workspace_root, cwd,
-    ) {
-    Some(target) => return ShellPreblockedSourceTree(target)
-    None => ()
+  if source_tree_operation_target(parsed_command, cmd, workspace_root, cwd)
+    is Some(target) {
+    return ShellPreblockedSourceTree(target)
   }
   let launch = agent_shell_launch(workspace_root, cmd, parsed_command, cwd?)
   match foreground_spawn {
@@ -529,30 +532,18 @@ async fn start_background(
       is_error=true,
     )
   }
-  match
-    direct_source_tree_operation_target(parsed_command, workspace_root, cwd) {
-    Some(target) =>
-      return @agent_tool.ToolAction::respond(
-        direct_source_blocked_content("source tree operation", target),
-        is_error=true,
-        brief=shell_brief(input.cmd, None),
-      )
-    None => ()
-  }
-  match
-    dynamic_source_tree_operation_target(
+  if source_tree_operation_target(
       parsed_command,
       input.cmd,
       workspace_root,
       cwd,
-    ) {
-    Some(target) =>
-      return @agent_tool.ToolAction::respond(
-        direct_source_blocked_content("source tree operation", target),
-        is_error=true,
-        brief=shell_brief(input.cmd, None),
-      )
-    None => ()
+    )
+    is Some(target) {
+    return @agent_tool.ToolAction::respond(
+      direct_source_blocked_content("source tree operation", target),
+      is_error=true,
+      brief=shell_brief(input.cmd, None),
+    )
   }
   let launch = agent_shell_launch(
     workspace_root,

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -1,11 +1,20 @@
 ///|
-async fn run_shell(arguments : Json) -> @agent_tool.ToolOutput {
-  let action = match @shell.definition().execute {
+/// Execute a shell tool definition and unwrap its Respond output.
+async fn exec_shell(
+  definition : @agent_tool.AgentToolDefinition,
+  arguments : Json,
+) -> @agent_tool.ToolOutput {
+  let action = match definition.execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("shell tool should be async")
   }
   guard action is Respond(output) else { fail("expected Respond") }
   output
+}
+
+///|
+async fn run_shell(arguments : Json) -> @agent_tool.ToolOutput {
+  exec_shell(@shell.definition(), arguments)
 }
 
 ///|
@@ -17,12 +26,7 @@ async fn run_shell_wired(
   bg : @bgjobs.BgJobRuntime,
   arguments : Json,
 ) -> @agent_tool.ToolOutput {
-  let action = match @shell.definition(bg_runtime=bg).execute {
-    Async(execute) => execute(arguments)
-    Sync(_) => fail("shell tool should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
-  output
+  exec_shell(@shell.definition(bg_runtime=bg), arguments)
 }
 
 ///|
@@ -166,12 +170,7 @@ async fn run_shell_in_workspace(
   workspace_root : String,
   arguments : Json,
 ) -> @agent_tool.ToolOutput {
-  let action = match @shell.definition(workspace_root~).execute {
-    Async(execute) => execute(arguments)
-    Sync(_) => fail("shell tool should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
-  output
+  exec_shell(@shell.definition(workspace_root~), arguments)
 }
 
 ///|
@@ -1965,12 +1964,7 @@ async fn run_shell_default(
   arguments : Json,
   default_timeout_ms~ : Int,
 ) -> @agent_tool.ToolOutput {
-  let action = match @shell.definition(default_timeout_ms~).execute {
-    Async(execute) => execute(arguments)
-    Sync(_) => fail("shell tool should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
-  output
+  exec_shell(@shell.definition(default_timeout_ms~), arguments)
 }
 
 ///|
@@ -1988,12 +1982,10 @@ async test "an omitted timeout gets a default that kills on the unwired path" {
 async test "an omitted timeout detaches at the default on the wired path" {
   @async.with_task_group() <| group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let action = match
-      @shell.definition(bg_runtime=bg, default_timeout_ms=50).execute {
-      Async(execute) => execute({ "cmd": "sleep 2" })
-      Sync(_) => fail("shell tool should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = exec_shell(
+      @shell.definition(bg_runtime=bg, default_timeout_ms=50),
+      { "cmd": "sleep 2" },
+    )
     assert_false(output.is_error)
     assert_true(output.content.contains("moved to the background as job"))
     assert_true(output.content.contains("default foreground budget"))
@@ -2018,12 +2010,10 @@ async test "an explicit timeout above the ceiling is an error, not a clamp" {
 async test "run_in_background without timeout_ms is unaffected by defaults" {
   @async.with_task_group() <| group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let action = match
-      @shell.definition(bg_runtime=bg, default_timeout_ms=50).execute {
-      Async(execute) => execute({ "cmd": "sleep 1", "run_in_background": true })
-      Sync(_) => fail("shell tool should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = exec_shell(
+      @shell.definition(bg_runtime=bg, default_timeout_ms=50),
+      { "cmd": "sleep 1", "run_in_background": true },
+    )
     assert_false(output.is_error)
     assert_true(output.content.contains("started background job"))
     let jobs = bg.list()

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -154,8 +154,7 @@ async fn ShellExecution::monitor(
             if (over_foreground_limit || over_hard_cap) &&
               !self.cancel_requested {
               self.killed_by_output_limit = true
-              self.cancel_requested = true
-              self.process.cancel()
+              self.request_stop()
             }
           }
         }
@@ -357,12 +356,9 @@ pub fn ShellExecution::killed_by_time_limit(self : ShellExecution) -> Bool {
 /// monitor reports `Killed` and consumers can name the reaper rather than
 /// reading it as a requested stop. No-op once terminal.
 pub fn ShellExecution::kill_for_time_limit(self : ShellExecution) -> Unit {
-  if self.status.is_terminal() {
-    return
-  }
+  guard !self.status.is_terminal() else { return }
   self.killed_by_time_limit = true
-  self.cancel_requested = true
-  self.process.cancel()
+  self.request_stop()
 }
 
 ///|

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -194,12 +194,9 @@ pub async fn ShellOutputSink::finish(self : ShellOutputSink) -> Unit {
 ///|
 /// Release the spill file descriptor. Reads after this fall back to the head.
 pub fn ShellOutputSink::close(self : ShellOutputSink) -> Unit {
-  match self.file {
-    Some(file) => {
-      file.close()
-      self.file = None
-    }
-    None => ()
+  if self.file is Some(file) {
+    file.close()
+    self.file = None
   }
 }
 
@@ -208,16 +205,12 @@ pub fn ShellOutputSink::close(self : ShellOutputSink) -> Unit {
 /// the foreground (never adopted as a background job), so its temp file does not
 /// leak. Full output is no longer readable after this (the head remains).
 pub async fn ShellOutputSink::discard(self : ShellOutputSink) -> Unit {
-  match self.file {
-    Some(file) => {
-      file.close()
-      self.file = None
-      match self.spill_path {
-        Some(path) => @fs.remove(path) catch { _ => () }
-        None => ()
-      }
+  guard self.file is Some(_) else { return }
+  self.close()
+  if self.spill_path is Some(path) {
+    @fs.remove(path) catch {
+      _ => ()
     }
-    None => ()
   }
 }
 
@@ -388,32 +381,21 @@ fn incomplete_suffix_len(bytes : Bytes) -> Int {
 
 ///|
 fn utf8_sequence_len(b : Int) -> Int {
-  if b >= 0xF0 && b <= 0xF4 {
-    4
-  } else if b >= 0xE0 && b <= 0xEF {
-    3
-  } else if b >= 0xC2 && b <= 0xDF {
-    2
-  } else {
-    0
+  match b {
+    0xF0..=0xF4 => 4
+    0xE0..=0xEF => 3
+    0xC2..=0xDF => 2
+    _ => 0
   }
 }
 
 ///|
 fn continuation_range(lead : Int, j : Int) -> (Int, Int) {
-  if j == 1 {
-    if lead == 0xE0 {
-      (0xA0, 0xBF)
-    } else if lead == 0xED {
-      (0x80, 0x9F)
-    } else if lead == 0xF0 {
-      (0x90, 0xBF)
-    } else if lead == 0xF4 {
-      (0x80, 0x8F)
-    } else {
-      (0x80, 0xBF)
-    }
-  } else {
-    (0x80, 0xBF)
+  match (j, lead) {
+    (1, 0xE0) => (0xA0, 0xBF)
+    (1, 0xED) => (0x80, 0x9F)
+    (1, 0xF0) => (0x90, 0xBF)
+    (1, 0xF4) => (0x80, 0x8F)
+    _ => (0x80, 0xBF)
   }
 }

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -73,14 +73,11 @@ async fn execute(
     Exited(code) => ("exit=\{code}", code != 0)
     // A watchdog kill (flooded past the hard cap) is named as such, so the model
     // does not read it as a requested stop.
-    Stopped =>
-      if snapshot.killed_by_output_limit {
-        ("stopped killed_at_output_cap=true", true)
-      } else if snapshot.killed_by_time_limit {
-        ("stopped killed_at_time_cap=true", true)
-      } else {
-        ("stopped", true)
-      }
+    Stopped if snapshot.killed_by_output_limit =>
+      ("stopped killed_at_output_cap=true", true)
+    Stopped if snapshot.killed_by_time_limit =>
+      ("stopped killed_at_time_cap=true", true)
+    Stopped => ("stopped", true)
   }
   // Preserve the foreground path's error semantics for a job read later: binary
   // (non-UTF-8) output and a sandboxed source-write denial are tool errors even

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -1,12 +1,12 @@
 ///|
-/// Execute the shell_output tool for `job_id` and unwrap its Respond output.
+/// Execute the shell_output tool and unwrap its Respond output.
 #cfg(not(platform="windows"))
 async fn run_shell_output(
   bg : @bgjobs.BgJobRuntime,
-  job_id : String,
+  arguments : Json,
 ) -> @agent_tool.ToolOutput {
   let action = match @shell_output.definition(bg).execute {
-    Async(execute) => execute({ "job_id": job_id })
+    Async(execute) => execute(arguments)
     Sync(_) => fail("shell_output should be async")
   }
   guard action is Respond(output) else { fail("expected a Respond action") }
@@ -37,7 +37,7 @@ async test "shell_output returns a running job's output and status" {
       command="job",
     )
     @async.sleep(100)
-    let output = run_shell_output(bg, id)
+    let output = run_shell_output(bg, { "job_id": id })
     assert_false(output.is_error)
     assert_true(output.content.contains("hi"))
     assert_true(output.content.contains("running"))
@@ -52,7 +52,7 @@ async test "shell_output reports a finished job's exit code" {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "exit 2"], command="job")
     poll_bg_terminal(bg, id)
-    let output = run_shell_output(bg, id)
+    let output = run_shell_output(bg, { "job_id": id })
     assert_true(output.is_error)
     assert_true(output.content.contains("exit=2"))
   })
@@ -71,7 +71,7 @@ async test "shell_output windows a large job's output and notes truncation" {
       max_output_chars=100,
     )
     poll_bg_terminal(bg, id)
-    let output = run_shell_output(bg, id)
+    let output = run_shell_output(bg, { "job_id": id })
     // Bounded to the window, with truncation metadata, but still showing the
     // recent (tail) output — here the end of the sequence.
     assert_true(output.content.contains("truncated=true"))
@@ -96,7 +96,7 @@ async test "shell_output flags dropped output for a memory-only job" {
       max_output_chars=100,
     )
     poll_bg_terminal(bg, id)
-    let output = run_shell_output(bg, id)
+    let output = run_shell_output(bg, { "job_id": id })
     // Only ~100 chars retained but the job produced far more — must not present
     // the prefix as complete.
     assert_true(output.content.contains("truncated=true"))
@@ -116,7 +116,7 @@ async test "shell_output marks binary background output as a tool error" {
       command="binary",
     )
     poll_bg_terminal(bg, id)
-    let output = run_shell_output(bg, id)
+    let output = run_shell_output(bg, { "job_id": id })
     assert_true(output.is_error)
     assert_true(output.content.contains("binary_output"))
   })
@@ -127,7 +127,7 @@ async test "shell_output marks binary background output as a tool error" {
 async test "shell_output errors on an unknown job id" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
-    let output = run_shell_output(bg, "nope")
+    let output = run_shell_output(bg, { "job_id": "nope" })
     assert_true(output.is_error)
     assert_true(output.content.contains("no background job"))
   })
@@ -144,11 +144,7 @@ async test "wait_ms blocks until the job finishes and returns its output" {
       command="waited",
     )
     // No polling loop: a single call awaits the exit and returns the result.
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id, "wait_ms": 30000 })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_output(bg, { "job_id": id, "wait_ms": 30000 })
     assert_false(output.is_error)
     assert_true(output.content.contains("WAITED-OK"))
     assert_true(output.content.contains("exit=0"))
@@ -161,11 +157,7 @@ async test "a wait_ms deadline on a still-running job is not an error" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "sleep 30"], command="slow")
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id, "wait_ms": 200 })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_output(bg, { "job_id": id, "wait_ms": 200 })
     // Deadline expiry just reports the live status; the model can call again.
     assert_false(output.is_error)
     assert_true(output.content.contains("running"))
@@ -179,11 +171,7 @@ async test "a non-positive wait_ms is a tool error" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "true"], command="noop")
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id, "wait_ms": -5 })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_output(bg, { "job_id": id, "wait_ms": -5 })
     assert_true(output.is_error)
     assert_true(output.content.contains("wait_ms"))
   })
@@ -195,11 +183,7 @@ async test "a non-numeric wait_ms is a tool error, not silently ignored" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "true"], command="noop")
-    let action = match @shell_output.definition(bg).execute {
-      Async(execute) => execute({ "job_id": id, "wait_ms": "30000" })
-      Sync(_) => fail("shell_output should be async")
-    }
-    guard action is Respond(output) else { fail("expected a Respond action") }
+    let output = run_shell_output(bg, { "job_id": id, "wait_ms": "30000" })
     assert_true(output.is_error)
     assert_true(output.content.contains("wait_ms must be a number"))
   })


### PR DESCRIPTION
Applies all 13 findings of the shell-family simplification sweep (agent_tool/shell, shell_exec, shell_output, bgjobs, and shell internals). Behavior-identical: error messages, output ordering, and timing budgets are preserved. `moon check --deny-warn` clean, full `moon test` green (1001/1001).

## Dead code
- **shell.mbt**: fold the `detachable` dead branch — the foreground spawner closure only exists inside `bg_runtime.map`, where `detachable` is definitionally true (#424 changed the condition without folding), so it always spawns retained.
- **bgjobs.mbt**: delete the now-unused `BgJobRuntime::spawn_foreground`, its `spawn_foreground_exec` field, and the closure in `new` (same commit as the fold above — the dead else-arm was its only caller; tree re-grepped to confirm). Pub API shrinks by one method; `pkg.generated.mbti` regenerated.

## Dedupe
- **shell.mbt**: one `source_tree_operation_target` helper (direct-then-dynamic short-circuit preserved) replaces four near-identical match blocks in `run_agent_shell_with_tree_precheck` and `start_background`.
- **shell_exec/execution.mbt**: `kill_for_time_limit` and the monitor's output-limit watchdog reuse `request_stop()` instead of hand-inlining `cancel_requested = true; process.cancel()`.
- **shell_exec/sink.mbt**: `discard()` reuses `close()` instead of re-inlining its body.

## Pattern-match idioms
- **shell.mbt**: if-is-Some early returns for the command-policy error and the source-write redirect (drops empty `None => ()` arms; matches the file's own style).
- **shell_output.mbt**: guarded `Stopped if ...` arms replace the nested if/else chain for the status label.
- **command_policy.mbt**: view-pattern scanner for sed flag clusters replaces the chars array + mutable index loop.
- **shell_exec/sink.mbt**: declarative range/tuple match tables for `utf8_sequence_len` and `continuation_range`.
- **decode.mbt**: single-use `optional_positive_int_or_default` wrapper inlined into its one caller.

## Test-helper dedupe
- **shell/shell_test.mbt**: one `exec_shell` helper behind the four `run_shell*` wrappers (which become one-liners) and the two inline Async/Respond unwrap blocks.
- **shell_output/shell_output_test.mbt**: `run_shell_output` generalized to take Json arguments, absorbing the four re-inlined `wait_ms` unwrap blocks.
- **bgjobs/bgjobs_wbtest.mbt**: `wait_for_first` helper for the three notice poll loops (identical 200 x 25ms budget; the on_job_exit test keeps its trailing sleep).

## Skips
None — all 13 findings applied. The reviewer's verified non-findings (wait/wait_or_invalid merge, effective_timeout_ms nested match, dual JSON schema literals, git_policy mirrors, lexer state machine, sandbox predicate catalogs) were deliberately not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)