### PR TITLE
refactor(cmd/tui): local simplification + core-API sweep

### DIFF
--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -27,59 +27,29 @@ fn drain_oneshot_test_state() -> State {
 
 ///|
 fn start_agent_count(cmds : Array[Cmd]) -> Int {
-  for cmd in cmds; count = 0 {
-    if cmd is StartAgent(_, ..) {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  cmds.count_if(cmd => cmd is StartAgent(_, ..))
 }
 
 ///|
 fn error_item_count(cmds : Array[Cmd]) -> Int {
-  for cmd in cmds; count = 0 {
-    if cmd is AppendItem(Error(_)) {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  cmds.count_if(cmd => cmd is AppendItem(Error(_)))
 }
 
 ///|
 /// Foreground `!` commands: those that own a run slot (run_id present).
 fn run_command_count(cmds : Array[Cmd]) -> Int {
-  for cmd in cmds; count = 0 {
-    if cmd is RunCommand(run_id=Some(_), _) {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  cmds.count_if(cmd => cmd is RunCommand(run_id=Some(_), _))
 }
 
 ///|
 /// Background `!` commands launched alongside a live turn (run_id absent).
 fn run_background_command_count(cmds : Array[Cmd]) -> Int {
-  for cmd in cmds; count = 0 {
-    if cmd is RunCommand(run_id=None, _) {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  cmds.count_if(cmd => cmd is RunCommand(run_id=None, _))
 }
 
 ///|
 fn compact_session_count(cmds : Array[Cmd]) -> Int {
-  for cmd in cmds; count = 0 {
-    if cmd is CompactSession(_) {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  cmds.count_if(cmd => cmd is CompactSession(_))
 }
 
 ///|
@@ -376,13 +346,7 @@ test "a stale terminal event from a superseded run is ignored" {
 
 ///|
 fn quit_count(cmds : Array[Cmd]) -> Int {
-  for cmd in cmds; count = 0 {
-    if cmd is Quit {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  cmds.count_if(cmd => cmd is Quit)
 }
 
 ///|

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -182,6 +182,27 @@ async fn EngineClient::send(
 }
 
 ///|
+/// Open `run_id` on the live engine and write its opening `command` — the
+/// shared tail of `prompt` and `compact`. Stamps the run bookkeeping the
+/// stdout reader relies on to attribute events and an EOF-without-terminal
+/// failure to the right run.
+async fn EngineClient::open_run(
+  self : EngineClient,
+  run_id : Int,
+  command : Json,
+) -> Unit {
+  guard self.live is Some(live) else {
+    self.messages.put(
+      AgentFailed(run_id~, Failure::Failure("engine is not running")),
+    )
+    return
+  }
+  live.latest_run = run_id
+  live.run_open = true
+  self.send(run_id, command)
+}
+
+///|
 async fn[G] EngineClient::prompt(
   self : EngineClient,
   group : @async.TaskGroup[G],
@@ -198,15 +219,7 @@ async fn[G] EngineClient::prompt(
       }
     }
   }
-  guard self.live is Some(live) else {
-    self.messages.put(
-      AgentFailed(run_id~, Failure::Failure("engine is not running")),
-    )
-    return
-  }
-  live.latest_run = run_id
-  live.run_open = true
-  self.send(run_id, { "command": "prompt", "text": text })
+  self.open_run(run_id, { "command": "prompt", "text": text })
 }
 
 ///|
@@ -312,15 +325,7 @@ async fn[G] EngineClient::compact(
       }
     }
   }
-  guard self.live is Some(live) else {
-    self.messages.put(
-      AgentFailed(run_id~, Failure::Failure("engine is not running")),
-    )
-    return
-  }
-  live.latest_run = run_id
-  live.run_open = true
-  self.send(run_id, { "command": "compact" })
+  self.open_run(run_id, { "command": "compact" })
 }
 
 ///|

--- a/cmd/tui/jsonl_wbtest.mbt
+++ b/cmd/tui/jsonl_wbtest.mbt
@@ -7,14 +7,11 @@ fn append_items(
   value : Json,
   items : Array[@ui.TranscriptItem],
 ) -> Unit {
-  match @event.decode_event(value) {
-    Some(event) =>
-      for cmd in update(state, AgentProgress(run_id=state.run_id, event)) {
-        if cmd is AppendItem(item) {
-          items.push(item)
-        }
-      }
-    None => ()
+  guard @event.decode_event(value) is Some(event) else { return }
+  for cmd in update(state, AgentProgress(run_id=state.run_id, event)) {
+    if cmd is AppendItem(item) {
+      items.push(item)
+    }
   }
 }
 

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -113,11 +113,8 @@ fn steer_dropped_item(text : String) -> @ui.TranscriptItem {
 /// fresh steer it has nothing to do with. No match (the old turn's list
 /// was already swept) is a no-op.
 fn confirm_pending_steer(state : State, text : String) -> Unit {
-  for index, pending in state.pending_steers {
-    if pending == text {
-      let _ = state.pending_steers.remove(index)
-      return
-    }
+  if state.pending_steers.search(text) is Some(index) {
+    state.pending_steers.remove(index) |> ignore
   }
 }
 
@@ -174,14 +171,6 @@ fn engine_env(
 }
 
 ///|
-/// One-shot engine invocation: `<engine> ... run -- <task>`. The `run`
-/// subcommand is the headless one-shot mode; `--` stops option parsing so a task
-/// starting with `-` is taken literally.
-fn oneshot_engine_args(task : String) -> Array[String] {
-  ["run", "--", task]
-}
-
-///|
 /// Spawn the agent engine for one input and stream its JSONL stdout into the
 /// message loop.
 ///
@@ -206,14 +195,15 @@ async fn run_agent_task(
     let proc = @process.spawn(
       group,
       config.engine,
-      // The queued task is already prompt text here. Forward it after a `--`
-      // delimiter so the engine's argparse treats any leading `-`/`--` as the
-      // task positional rather than parsing it as one of its own options (which
+      // The queued task is already prompt text here; `run` is the engine's
+      // headless one-shot subcommand. Forward the task after a `--` delimiter
+      // so the engine's argparse treats any leading `-`/`--` as the task
+      // positional rather than parsing it as one of its own options (which
       // would exit/print help and never emit a terminal JSONL event). Session
       // settings go through a fully materialized environment so custom replay
       // engines do not need to accept OpenSeek-specific flags, and inherited
       // session vars cannot shadow explicit TUI config.
-      config.engine_args(oneshot_engine_args(task)),
+      config.engine_args(["run", "--", task]),
       inherit_env=false,
       extra_env=child_env,
       stdout=child_stdout,
@@ -418,11 +408,12 @@ fn handle_agent_event(
     // event is only a delivery acknowledgment.
     SteerApplied(Command(_)) => ()
     // A notice (e.g. a background job finishing) originates in the engine, not
-    // from a pending local steer, so just render it in the transcript.
-    SteerApplied(Notice(text)) => cmds.push(AppendItem(Input(Notice(text))))
-    // Idle background notices arrive untagged (as EngineBackgroundNotice); this
-    // tagged path is unreachable, but render it the same way for completeness.
-    BackgroundNotice(text) => cmds.push(AppendItem(Input(Notice(text))))
+    // from a pending local steer, so just render it in the transcript. Idle
+    // background notices arrive untagged (as EngineBackgroundNotice), making
+    // the tagged BackgroundNotice path unreachable — but render it the same
+    // way for completeness.
+    SteerApplied(Notice(text)) | BackgroundNotice(text) =>
+      cmds.push(AppendItem(Input(Notice(text))))
     // Normally unreachable from the wire: the engine client routes
     // steer_dropped events to the untagged message (they always trail the
     // racing turn's terminal, so a run-tagged copy would be stale-filtered).
@@ -560,8 +551,6 @@ fn handle_compact_command(
   state.run_is_compaction = true
   cmds.push(CompactSession(run_id~))
 }
-
-///|
 
 ///|
 fn handle_slash_command(
@@ -815,12 +804,11 @@ async fn[G] run_message_loop(
     // new can arrive mid-drain — so after the drain the queue is provably
     // empty and the composer check cannot contradict pending input.
     let cmds : Array[Cmd] = []
-    let mut message = messages.get()
-    drain_updates~: for ;; {
+    for message = messages.get() {
       cmds.append(update(state, message))
       match messages.try_get() {
-        Some(next) => message = next
-        None => break drain_updates~
+        Some(next) => continue next
+        None => break
       }
     }
     // The `/loop` dispatch choke point: runs once per drained batch, after
@@ -904,13 +892,9 @@ async fn[G] run_message_loop(
           // never had its card rendered (shell output is carded on completion,
           // not streamed), so dropping it is consistent with resume and a
           // deliberate quit has no next turn that needs the output.
-          drain~: for ;; {
-            if messages.try_get() is Some(pending) {
-              if pending is EngineSessionError(error) {
-                ui.append_item(Error(error))
-              }
-            } else {
-              break drain~
+          while messages.try_get() is Some(pending) {
+            if pending is EngineSessionError(error) {
+              ui.append_item(Error(error))
             }
           }
           break outer~

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -275,12 +275,9 @@ fn default_engine(args : ArrayView[String]) -> (String, Array[String]) {
 
 ///|
 fn moon_native_tcc_run_args(argv0 : String) -> Array[String]? {
-  if argv0.has_suffix(".c") &&
+  if argv0.strip_suffix(".c") is Some(stem) &&
     (argv0.contains("/_build/native/") || argv0.contains("\\_build\\native\\")) {
-    match argv0.strip_suffix(".c") {
-      Some(stem) => Some(["@\{stem}.rspfile"])
-      None => None
-    }
+    Some(["@\{stem}.rspfile"])
   } else {
     None
   }
@@ -371,11 +368,6 @@ async fn engine_command_launchable(
 }
 
 ///|
-async fn engine_launchable(config : AppConfig) -> Bool {
-  engine_command_launchable(config.engine, config.engine_args_prefix)
-}
-
-///|
 /// Run the interactive UI from already-parsed argparse `matches` — the top-level
 /// `openseek` command (in `cmd/openseek`) owns parsing and dispatches here for
 /// both the default (no subcommand) and the explicit `tui` subcommand.
@@ -386,7 +378,7 @@ pub async fn run(matches : @argparse.Matches) -> Unit {
   }
   // Fail before the terminal UI takes over the screen if the engine is unusable,
   // rather than dropping the user into a UI that dies on the first task.
-  if !engine_launchable(config) {
+  if !engine_command_launchable(config.engine, config.engine_args_prefix) {
     println(
       "error: engine '\{config.engine_display()}' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.",
     )
@@ -433,7 +425,7 @@ test "cli accepts no initial task" {
   // (`default_engine` of the process args), not a hardcoded string.
   let (expected_engine, expected_prefix) = default_engine(@sys.get_cli_args())
   assert_eq(config.engine, expected_engine)
-  assert_string_array_eq(config.engine_args_prefix, expected_prefix)
+  @debug.assert_eq(config.engine_args_prefix, expected_prefix)
   // No --session still converses in a session: a generated per-launch id, so
   // consecutive prompts share context instead of running amnesiac one-shots.
   assert_true(config.session_id.value().has_prefix("tui-"))
@@ -576,66 +568,45 @@ test "cli accepts --continue and rejects combining it with --session" {
 }
 
 ///|
-fn assert_string_array_eq(
-  actual : Array[String],
-  expected : Array[String],
-) -> Unit raise {
-  assert_eq(actual.length(), expected.length())
-  for i in 0..<actual.length() {
-    assert_eq(actual[i], expected[i])
-  }
-}
-
-///|
-fn assert_default_engine(
-  actual : (String, Array[String]),
-  engine : String,
-  args_prefix : Array[String],
-) -> Unit raise {
-  let (actual_engine, actual_prefix) = actual
-  assert_eq(actual_engine, engine)
-  assert_string_array_eq(actual_prefix, args_prefix)
-}
-
-///|
 test "default_engine re-launches a path argv0 and falls back to PATH otherwise" {
-  assert_default_engine(
+  @debug.assert_eq(
     default_engine(["/usr/local/bin/openseek"]),
-    "/usr/local/bin/openseek",
-    [],
+    ("/usr/local/bin/openseek", []),
   )
-  assert_default_engine(default_engine(["./openseek"]), "./openseek", [])
-  assert_default_engine(default_engine(["src/openseek.c"]), "src/openseek.c", [])
-  assert_default_engine(
+  @debug.assert_eq(default_engine(["./openseek"]), ("./openseek", []))
+  @debug.assert_eq(default_engine(["src/openseek.c"]), ("src/openseek.c", []))
+  @debug.assert_eq(
     default_engine(["target/native/openseek"]),
-    "target/native/openseek",
-    [],
+    ("target/native/openseek", []),
   )
-  assert_default_engine(
+  @debug.assert_eq(
     default_engine(["target\\native\\openseek.exe"]),
-    "target\\native\\openseek.exe",
-    [],
+    ("target\\native\\openseek.exe", []),
   )
-  assert_default_engine(
+  @debug.assert_eq(
     default_engine([
       "/repo/_build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.c",
     ]),
-    "tcc",
-    [
-      "@/repo/_build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.rspfile",
-    ],
+    (
+      "tcc",
+      [
+        "@/repo/_build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.rspfile",
+      ],
+    ),
   )
-  assert_default_engine(
+  @debug.assert_eq(
     default_engine([
       "C:\\repo\\_build\\native\\debug\\build\\bobzhang\\openseek\\cmd\\openseek\\openseek.c",
     ]),
-    "tcc",
-    [
-      "@C:\\repo\\_build\\native\\debug\\build\\bobzhang\\openseek\\cmd\\openseek\\openseek.rspfile",
-    ],
+    (
+      "tcc",
+      [
+        "@C:\\repo\\_build\\native\\debug\\build\\bobzhang\\openseek\\cmd\\openseek\\openseek.rspfile",
+      ],
+    ),
   )
-  assert_default_engine(default_engine(["openseek"]), "openseek", [])
-  assert_default_engine(default_engine([]), "openseek", [])
+  @debug.assert_eq(default_engine(["openseek"]), ("openseek", []))
+  @debug.assert_eq(default_engine([]), ("openseek", []))
 }
 
 ///|
@@ -646,7 +617,7 @@ async test "engine defaults to this binary; --engine/OPENSEEK_ENGINE override it
   )
   let (expected_engine, expected_prefix) = default_engine(@sys.get_cli_args())
   assert_eq(default_cfg.engine, expected_engine)
-  assert_string_array_eq(default_cfg.engine_args_prefix, expected_prefix)
+  @debug.assert_eq(default_cfg.engine_args_prefix, expected_prefix)
   // OPENSEEK_ENGINE is treated as an explicit engine.
   let env_cfg = parse_config(
     cli_command().parse(argv=[], env={
@@ -655,7 +626,7 @@ async test "engine defaults to this binary; --engine/OPENSEEK_ENGINE override it
     }),
   )
   assert_eq(env_cfg.engine, "./fake-engine")
-  assert_string_array_eq(env_cfg.engine_args_prefix, [])
+  @debug.assert_eq(env_cfg.engine_args_prefix, [])
 }
 
 ///|
@@ -683,7 +654,7 @@ async test "oneshot with an explicit engine (flag or env) is accepted" {
   )
   assert_true(flag_cfg.engine_mode is OneShot)
   assert_eq(flag_cfg.engine, "./fake-engine")
-  assert_string_array_eq(flag_cfg.engine_args_prefix, [])
+  @debug.assert_eq(flag_cfg.engine_args_prefix, [])
   let env_cfg = parse_config(
     cli_command().parse(argv=[], env={
       "DEEPSEEK": "k",
@@ -701,7 +672,7 @@ test "cli overrides the engine binary" {
   })
   let config = parse_config(parsed)
   assert_eq(config.engine, "./fake-engine")
-  assert_string_array_eq(config.engine_args_prefix, [])
+  @debug.assert_eq(config.engine_args_prefix, [])
 }
 
 ///|

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -19,6 +19,7 @@ import {
   "moonbitlang/async/process",
   "moonbitlang/async/stdio",
   "moonbitlang/core/argparse",
+  "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
   "moonbitlang/x/sys",

--- a/cmd/tui/scheduler.mbt
+++ b/cmd/tui/scheduler.mbt
@@ -319,7 +319,7 @@ fn parse_loop_number(digits : StringView) -> Int? {
   guard !digits.is_empty() else { return None }
   let mut value = 0
   for ch in digits {
-    guard ch >= '0' && ch <= '9' else { return None }
+    guard ch is ('0'..='9') else { return None }
     value = value * 10 + (ch.to_int() - '0'.to_int())
     if value > MaxLoopIntervalSecs {
       return None
@@ -338,14 +338,11 @@ fn parse_loop_number(digits : StringView) -> Int? {
 /// `MaxLoopIntervalSecs`. The `MinLoopIntervalSecs` floor is enforced by the
 /// caller so it can name the limit in its error message.
 fn parse_loop_interval(text : StringView) -> Int? {
-  let (digits, unit) = if text.strip_suffix("s") is Some(digits) {
-    (digits, 1)
-  } else if text.strip_suffix("m") is Some(digits) {
-    (digits, 60)
-  } else if text.strip_suffix("h") is Some(digits) {
-    (digits, 3600)
-  } else {
-    (text, 1)
+  let (digits, unit) = match text {
+    [.. digits, 's'] => (digits, 1)
+    [.. digits, 'm'] => (digits, 60)
+    [.. digits, 'h'] => (digits, 3600)
+    _ => (text, 1)
   }
   guard parse_loop_number(digits) is Some(value) else { return None }
   // Bound before multiplying: `604800h * 3600` would overflow Int and wrap

--- a/cmd/tui/scheduler_wbtest.mbt
+++ b/cmd/tui/scheduler_wbtest.mbt
@@ -69,7 +69,7 @@ fn armed_state(arguments : String) -> State {
 
 ///|
 fn notice_count(cmds : Array[Cmd]) -> Int {
-  [ for cmd in cmds if cmd is AppendItem(Notice(_)) => cmd ].length()
+  cmds.count_if(cmd => cmd is AppendItem(Notice(_)))
 }
 
 ///|
@@ -302,18 +302,10 @@ test "each busy source individually holds a due fire" {
   )
   scheduler_maybe_fire(waiting, input_idle=true, after)
   assert_eq(start_agent_count(after), 1)
-  let steer_index = for index, cmd in after {
-    if cmd is SteerAgent(_) {
-      break index
-    }
-  } nobreak {
+  guard after.search_by(cmd => cmd is SteerAgent(_)) is Some(steer_index) else {
     fail("expected the command-context steer")
   }
-  let start_index = for index, cmd in after {
-    if cmd is StartAgent(_, ..) {
-      break index
-    }
-  } nobreak {
+  guard after.search_by(cmd => cmd is StartAgent(_, ..)) is Some(start_index) else {
     fail("expected the fire's StartAgent")
   }
   assert_true(steer_index < start_index)
@@ -402,18 +394,12 @@ test "loop segment precedes the clippable variable-length fields" {
   // countdown must sit ahead of a long cwd so it cannot be pushed off-screen.
   let state = armed_state("5m do x")
   let segments = status_segments(state)
-  let loop_index = for index, segment in segments {
-    if segment.text.has_prefix("⟳") {
-      break index
-    }
-  } nobreak {
+  guard segments.search_by(segment => segment.text.has_prefix("⟳"))
+    is Some(loop_index) else {
     fail("expected the loop segment")
   }
-  let cwd_index = for index, segment in segments {
-    if segment.text == state.config.cwd {
-      break index
-    }
-  } nobreak {
+  guard segments.search_by(segment => segment.text == state.config.cwd)
+    is Some(cwd_index) else {
     fail("expected the cwd segment")
   }
   assert_true(loop_index < cwd_index)

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -58,13 +58,11 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
 fn session_transcript_items(
   session : @agent_session.Session,
 ) -> Array[@ui.TranscriptItem] {
-  let items : Array[@ui.TranscriptItem] = []
-  for event in session.events() {
-    if session_item(event.item()) is Some(item) {
-      items.push(item)
-    }
-  }
-  items
+  session
+  .events()
+  .iter()
+  .filter_map(event => session_item(event.item()))
+  .collect()
 }
 
 ///|

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -73,11 +73,6 @@ fn loop_segment_text(schedule : Schedule?) -> String {
 }
 
 ///|
-fn format_status_bar_text(state : State) -> @doc.Text {
-  format_status_segments(status_segments(state))
-}
-
-///|
 fn format_two_digits(value : Int64) -> String {
   if value < 10L {
     "0\{value}"
@@ -137,10 +132,7 @@ fn pending_steer_segment(steers : Array[String]) -> Array[@doc.Span] {
   let budget = SteerSegmentMaxColumns - @displaytext.DisplayText(label).width()
   [
     Span(DisplayText(label), style=@style.dim),
-    Span(
-      DisplayText(tail_columns(latest, if budget < 8 { 8 } else { budget })),
-      style=@style.dim,
-    ),
+    Span(DisplayText(tail_columns(latest, budget.max(8))), style=@style.dim),
   ]
 }
 
@@ -161,7 +153,7 @@ fn streaming_activity_spans(
     ActivityChromeColumns -
     reserved -
     @displaytext.DisplayText(label).width()
-  let preview = tail_columns(text, if budget < 16 { 16 } else { budget })
+  let preview = tail_columns(text, budget.max(16))
   [
     Span(DisplayText(label), style=@style.dim),
     if dim_preview {
@@ -224,7 +216,7 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
 ///|
 async fn refresh_ui(ui : @ui.Ui, state : State) -> Unit {
   ui.set_live_view(
-    status=format_status_bar_text(state),
+    status=format_status_segments(status_segments(state)),
     activity=format_activity_text(state, cols=ui.columns()),
     queued_inputs=state.queued,
   )

--- a/cmd/tui/tool_view.mbt
+++ b/cmd/tui/tool_view.mbt
@@ -157,14 +157,11 @@ fn command_text_item(content : String) -> @ui.TranscriptItem? {
   if parsed.output_limit_reached {
     output.push("… output truncated")
   }
-  let title = if exit == "failed" {
-    "$ \{parsed.command} (failed)"
-  } else if exit == "cancelled" {
-    "$ \{parsed.command} (cancelled)"
-  } else if exit == "0" {
-    "$ \{parsed.command}"
-  } else {
-    "$ \{parsed.command} (exit \{exit})"
+  let title = match exit {
+    "failed" => "$ \{parsed.command} (failed)"
+    "cancelled" => "$ \{parsed.command} (cancelled)"
+    "0" => "$ \{parsed.command}"
+    code => "$ \{parsed.command} (exit \{code})"
   }
   Some(
     ToolCall(


### PR DESCRIPTION
Applies 19 behavior-identical findings from a read-only simplification review of `cmd/tui` (and confirms its internals — `internal/event`, `internal/command_context`, `internal/jsonx` — already idiomatic, untouched).

## Core search/count_if adoption (first uses of these core APIs in the repo)
- `confirm_pending_steer` (loop.mbt): manual `for index, pending` scan + remove → `Array::search` + remove; settlement-by-text semantics and doc comment unchanged.
- `drain_wbtest.mbt` / `scheduler_wbtest.mbt`: seven 6–9-line accumulator count loops (`start_agent_count`, `error_item_count`, `run_command_count`, `run_background_command_count`, `compact_session_count`, `quit_count`, `notice_count`) → `Array::count_if` one-liners; names and docs kept, `notice_count` also drops its intermediate array.
- `scheduler_wbtest.mbt`: four index-hunting `for`/`break index`/`nobreak fail(...)` loops (`steer_index`, `start_index`, `loop_index`, `cwd_index`) → `Array::search_by` guards with the exact same fail messages and first-match semantics.
- `session_transcript_items` (session_view.mbt): build-by-push → `session.events().iter().filter_map(...).collect()`.

## Functional-for / while-is / pattern-match rewrites
- `run_message_loop` (loop.mbt): `mut message` + labeled `drain_updates~` drain → functional `for message = messages.get() { ... continue next }`; identical drain semantics, no mut, no label.
- Quit drain (loop.mbt): labeled `drain~: for ;;` + else-break → `while messages.try_get() is Some(pending)`; drops the label and one nesting level.
- `handle_agent_event` (loop.mbt): adjacent `SteerApplied(Notice(text))` / `BackgroundNotice(text)` arms with identical bodies → one or-pattern arm, comments merged.
- `command_text_item` (tool_view.mbt): `if exit == "failed" / "cancelled" / "0" / else` chain → `match` aligning the protocol tokens, with a named `code` fall-through binder.
- `parse_loop_number` (scheduler.mbt): `ch >= '0' && ch <= '9'` → `ch is ('0'..='9')` range pattern.
- `parse_loop_interval` (scheduler.mbt): `strip_suffix` if-chain for `s`/`m`/`h` → suffix view-pattern `match` (`[.. digits, 's'] => ...`); single ASCII code units, byte-identical.
- `moon_native_tcc_run_args` (main.mbt): `has_suffix(".c")` + inner `strip_suffix` match with unreachable `None` → single `strip_suffix(".c") is Some(stem)` condition; dead branch gone.
- `append_items` (jsonl_wbtest.mbt): `match decode_event { Some => ...; None => () }` → `guard ... is Some(event) else { return }`, the package's dominant decode-or-bail style.

## Dedupe
- `EngineClient::open_run` (engine_client.mbt) names the identical 9-line guard + `latest_run`/`run_open` + send tail shared by `prompt` and `compact`. Both ensure-start prologs are untouched and byte-identical in behavior (`compact`'s catch not re-raising cancellation is a separately flagged behavioral question, deliberately out of scope here).

## Dead code / inlining
- Deleted the hand-rolled `assert_string_array_eq` / `assert_default_engine` test helpers (~20 lines); call sites use `assert_eq` directly. Note: arrays/tuples had to go through `@debug.assert_eq` (Debug-based) — the unqualified `assert_eq` resolves the deprecated `Show for Array` / `Show for (A, B)` impls and fails `--deny-warn`; scalar call sites keep unqualified `assert_eq`. Adds the `moonbitlang/core/debug` import.
- Inlined single-use `oneshot_engine_args` (doc folded into the call-site comment), `format_status_bar_text`, and `engine_launchable` at their only callers.
- Removed a stray empty `///|` doc marker left from a removed function (loop.mbt).
- `status_view.mbt`: `if budget < 8 { 8 } else { budget }` clamps → `budget.max(8)` / `budget.max(16)`, matching the existing clamp idiom.

## Skips / adaptations
- None skipped; one adapted: the "assert_eq on arrays/tuples directly" finding needed `@debug.assert_eq` for the container-typed sites (deprecation detailed above).

## Validation
- `moon fmt` clean, `moon check --deny-warn` clean, `moon test` 1001/1001 passed, `moon info` produced no `.mbti` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)