### PR TITLE
refactor(agent): local simplification + dedupe sweep

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -22,17 +22,17 @@ The exported surface is small:
 
 ```mbt nocheck
 @agent.run(
-  api_key,
-  Deepseek(V4Pro),
-  "fix the tests",
+  api_key~,
+  model=Deepseek(V4Pro),
+  task="fix the tests",
   system_prompt_text="You are an OpenSeek agent.",
 )
 
 let persisted = @agent.run_turn_with_append(
-  api_key,
-  Deepseek(V4Pro),
-  session,
-  "continue",
+  api_key~,
+  model=Deepseek(V4Pro),
+  session~,
+  task="continue",
   append_item=(session, item) => store.append(session, item),
 )
 
@@ -41,18 +41,18 @@ let persisted = @agent.run_turn_with_append(
   let scope = @agent_runtime.AgentTaskScope(group)
   let tools = @agent.build_tools(runtime, scope)
   let next = @agent.run_turn_in_scope(
-    runtime,
-    scope,
-    api_key,
-    Deepseek(V4Pro),
-    session,
-    "continue",
+    runtime~,
+    scope~,
+    api_key~,
+    model=Deepseek(V4Pro),
+    session~,
+    task="continue",
     append_item=(session, item) => session.append(item),
     tools~,
   )
 }
 
-@agent.steer(runtime, "also update README")
+runtime.queue_steer(Prompt("also update README"))
 ```
 
 `run` is the highest-level one-shot entry point. It creates a fresh in-memory
@@ -70,8 +70,9 @@ can return `session.append(item)` from the callback.
 `build_tools`. This is the API used by serve mode so stateful tools and queued
 steering can span turns.
 
-`steer` queues raw user steering text on an `AgentRuntime`. It does not trim or
-filter. The loop drops blank strings when it drains steering at a step boundary.
+`runtime.queue_steer(Prompt(text))` queues raw user steering text on an
+`AgentRuntime`. It does not trim or filter. The loop drops blank strings when it
+drains steering at a step boundary.
 
 ## Prompt Ownership
 
@@ -112,8 +113,10 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `finish`: end the task with a final answer.
 
 File-oriented tools capture `runtime.workspace_root()` when the registry is
-built. The registry still receives the runtime and task scope for stateful
-tools, though none currently use them.
+built. The registry also receives the runtime and task scope for stateful
+tools: the shell tools use both — background-job completion notices are pushed
+through `runtime.queue_steer`, and the background-job runtime plus its spill-dir
+cleanup are owned by the task scope's group.
 
 ```mbt check
 ///|

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -332,8 +332,3 @@ fn @agent_runtime.AgentRuntime::pending_steers(
     !text.trim().is_empty() => input
   ]
 }
-
-///|
-fn print_usage(usage : @deepseek.Usage) -> Unit {
-  @xlog.info() <? { "event": "usage", "usage": usage }
-}

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -23,13 +23,14 @@ let soft_context_ceiling_percent = 70
 let hard_context_ceiling_percent = 80
 
 ///|
-fn at_context_share(
-  usage : @deepseek.Usage,
-  context_window : Int,
+/// Whether `tokens` reaches `percent` of the model's context window.
+fn AgentLoop::at_context_share(
+  self : Self,
+  tokens : Int64,
   percent : Int,
 ) -> Bool {
-  usage.total_tokens.to_int64() * 100 >=
-  context_window.to_int64() * percent.to_int64()
+  tokens * 100 >=
+  self.client.model.context_window().to_int64() * percent.to_int64()
 }
 
 ///|
@@ -43,9 +44,10 @@ fn AgentLoop::at_soft_context_ceiling(
   usage : @deepseek.Usage,
   extra_result_chars? : Int64 = 0,
 ) -> Bool {
-  let window = self.client.model.context_window().to_int64()
-  (usage.total_tokens.to_int64() + extra_result_chars) * 100 >=
-  window * soft_context_ceiling_percent.to_int64()
+  self.at_context_share(
+    usage.total_tokens.to_int64() + extra_result_chars,
+    soft_context_ceiling_percent,
+  )
 }
 
 ///|
@@ -54,9 +56,8 @@ fn AgentLoop::at_hard_context_ceiling(
   self : Self,
   usage : @deepseek.Usage,
 ) -> Bool {
-  at_context_share(
-    usage,
-    self.client.model.context_window(),
+  self.at_context_share(
+    usage.total_tokens.to_int64(),
     hard_context_ceiling_percent,
   )
 }

--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -13,15 +13,11 @@ async fn auto_compact_test_server(
   group : @async.TaskGroup[Unit],
   handle : (Json) -> MockReply raise,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error => {
-      let message = "\{error}"
-      if message.contains("Operation not permitted") {
-        println("local TCP bind unavailable; skipping auto-compaction test")
-        return None
-      }
-      raise error
-    }
+  guard bind_test_server(
+      "local TCP bind unavailable; skipping auto-compaction test",
+    )
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -60,24 +56,7 @@ fn usage_json(total_tokens : Int) -> Json {
 
 ///|
 fn sse_tool_call(id : String, name : String, total_tokens : Int) -> String {
-  (
-    {
-      "choices": [
-        {
-          "delta": {
-            "tool_calls": [
-              {
-                "index": 0,
-                "id": id,
-                "type": "function",
-                "function": { "name": name, "arguments": "{}" },
-              },
-            ],
-          },
-        },
-      ],
-      "usage": usage_json(total_tokens),
-    } : Json).stringify()
+  sse_tool_calls([(id, name)], total_tokens)
 }
 
 ///|
@@ -85,16 +64,18 @@ fn sse_tool_calls(
   calls : Array[(String, String)],
   total_tokens : Int,
 ) -> String {
-  let entries : Array[Json] = []
-  for index, call in calls {
-    let (id, name) = call
-    entries.push({
-      "index": index,
-      "id": id,
-      "type": "function",
-      "function": { "name": name, "arguments": "{}" },
-    })
-  }
+  let entries : Array[Json] = [
+    for index, call in calls => {
+      let (id, name) = call
+      (
+        {
+          "index": index,
+          "id": id,
+          "type": "function",
+          "function": { "name": name, "arguments": "{}" },
+        } : Json)
+    }
+  ]
   (
     {
       "choices": [{ "delta": { "tool_calls": entries.to_json() } }],
@@ -161,6 +142,36 @@ fn is_checkpoint_request(request : Json) -> Bool raise {
 }
 
 ///|
+/// The turn's final answer, failing the test unless the last event is a
+/// finished terminal.
+#callsite(autofill(loc))
+fn finished_answer(
+  result : @agent_session.Session,
+  loc~ : SourceLoc,
+) -> String raise {
+  guard result.events().peek() is Some(last) &&
+    last.item() is Terminal(Finished(answer)) else {
+    fail("expected finished terminal", loc~)
+  }
+  answer
+}
+
+///|
+/// The checkpoint summary appended right before the terminal, failing the
+/// test when it is missing.
+#callsite(autofill(loc))
+fn summary_before_terminal(
+  result : @agent_session.Session,
+  loc~ : SourceLoc,
+) -> @agent_session.SessionSummary raise {
+  let events = result.events()
+  guard events[events.length() - 2].item() is Summary(summary) else {
+    fail("expected the checkpoint summary before the terminal", loc~)
+  }
+  summary
+}
+
+///|
 fn probe_tools(results : Array[String]) -> @agent_tool.Tools raise {
   let mut calls = 0
   Tools([
@@ -177,15 +188,20 @@ fn probe_tools(results : Array[String]) -> @agent_tool.Tools raise {
 }
 
 ///|
+fn finish_definition() -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="finish",
+    description="Finish tool.",
+    schema=JsonSchema({ "type": "object" }),
+    execute=Sync(_args => @agent_tool.ToolAction::finish("wrapped: all done")),
+    control=true,
+  )
+}
+
+///|
 fn finish_and_probe_tools() -> @agent_tool.Tools raise {
   Tools([
-    AgentToolDefinition(
-      name="finish",
-      description="Finish tool.",
-      schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.ToolAction::finish("wrapped: all done")),
-      control=true,
-    ),
+    finish_definition(),
     AgentToolDefinition(
       name="probe",
       description="Probe tool.",
@@ -233,16 +249,10 @@ async test "pressure on a tool-call response yields immediately" {
     // terminal.
     assert_eq(main_step, 1)
     assert_eq(checkpoint_requests.length(), 1)
+    assert_true(finished_answer(result).contains("[context ceiling]"))
     let events = result.events()
-    guard events.peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal last")
-    }
-    assert_true(answer.contains("[context ceiling]"))
     let count = events.length()
-    guard events[count - 2].item() is Summary(summary) else {
-      fail("expected the checkpoint summary before the terminal")
-    }
+    let summary = summary_before_terminal(result)
     assert_eq(summary.content(), "CEILING-SUMMARY")
     assert_eq(summary.from_sequence(), 1)
     // The summary covers everything before it, including the closed batch.
@@ -293,16 +303,9 @@ async test "a final answer at pressure checkpoints then finishes normally" {
     // The answer is not durable when the summary generates: it must not be
     // foldable into the checkpoint text (it projects verbatim after it).
     assert_false(checkpoint_requests[0].stringify().contains("really done"))
-    let events = result.events()
-    let count = events.length()
-    guard events.peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_eq(answer, "really done")
-    guard events[count - 2].item() is Summary(summary) else {
-      fail("expected the checkpoint summary before the terminal")
-    }
+    assert_eq(finished_answer(result), "really done")
+    let count = result.events().length()
+    let summary = summary_before_terminal(result)
     assert_eq(summary.content(), "FINISH-SUMMARY")
     assert_eq(summary.from_sequence(), 1)
     assert_eq(summary.to_sequence(), count - 2)
@@ -390,11 +393,7 @@ async test "a steer during compact-on-finish continues the turn compacted" {
     assert_true(summary_sequence > 0)
     assert_true(answer_sequence > summary_sequence)
     assert_true(steer_sequence > answer_sequence)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_eq(answer, "done")
+    assert_eq(finished_answer(result), "done")
   }
 }
 
@@ -449,10 +448,7 @@ async test "a failed checkpoint with a late steer yields instead of continuing" 
     }
     assert_true(answer_kept)
     assert_true(steer_kept)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
+    let answer = finished_answer(result)
     assert_true(answer.contains("[context ceiling]"))
     assert_true(answer.contains("checkpoint attempt failed"))
   }
@@ -513,11 +509,7 @@ async test "a non-control finish shadow is skip-closed at the ceiling" {
         )
       }
     }
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
+    assert_true(finished_answer(result).contains("[context ceiling]"))
   }
 }
 
@@ -558,20 +550,14 @@ async test "a pressured finish batch salvages the completion" {
     )
     assert_eq(main_requests, 1)
     assert_eq(checkpoint_requests.length(), 1)
-    let events = result.events()
-    let count = events.length()
-    guard events.peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
     // A completed task, not a yield: the finish tool's answer verbatim.
-    assert_eq(answer, "wrapped: all done")
-    guard events[count - 2].item() is Summary(summary) else {
-      fail("expected the checkpoint summary before the terminal")
-    }
+    assert_eq(finished_answer(result), "wrapped: all done")
     // The leftover call was closed BEFORE the checkpoint, so the summary
     // range covers it — no projection repair text can leak into summaries.
-    assert_eq(summary.to_sequence(), count - 2)
+    assert_eq(
+      summary_before_terminal(result).to_sequence(),
+      result.events().length() - 2,
+    )
     let mut finish_result = false
     let mut prefix_skipped = false
     let mut leftover_closed = false
@@ -652,11 +638,7 @@ async test "a pressured finish tool losing to a steer yields instead" {
     assert_true(steer_sequence > 0)
     assert_true(summary_to > 0)
     assert_true(summary_to < steer_sequence)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
+    assert_true(finished_answer(result).contains("[context ceiling]"))
   }
 }
 
@@ -690,11 +672,7 @@ async test "a failing checkpoint on a pressured finish keeps the real answer" {
     )
     // Fail-open: the turn still finishes as a normal success, uncompacted.
     assert_eq(checkpoint_requests.length(), 1)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_eq(answer, "really done")
+    assert_eq(finished_answer(result), "really done")
     for event in result.events() {
       assert_false(event.item() is Summary(_))
     }
@@ -734,11 +712,7 @@ async test "below the soft ceiling nothing yields" {
       tools=probe_tools(["result-1"]),
     )
     assert_eq(requests, 2)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_eq(answer, "done")
+    assert_eq(finished_answer(result), "done")
   }
 }
 
@@ -776,10 +750,7 @@ async test "a failed checkpoint still yields fail-open" {
     // The turn still ends at the ceiling — uncompacted — so the next turn's
     // pressure retries the checkpoint instead of stranding this one.
     assert_eq(checkpoint_requests.length(), 1)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
+    let answer = finished_answer(result)
     assert_true(answer.contains("[context ceiling]"))
     // Honest fail-open: the terminal must not claim a checkpoint exists.
     assert_true(answer.contains("checkpoint attempt failed"))
@@ -863,11 +834,7 @@ async test "a steer arriving under pressure survives the checkpoint verbatim" {
     // before the summary request is even sent — a cancellation mid-request
     // must not lose already-drained input).
     assert_true(steer_sequence < summary_sequence)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
+    assert_true(finished_answer(result).contains("[context ceiling]"))
   }
 }
 
@@ -903,11 +870,7 @@ async test "pressure on the last allowed step yields at the ceiling not as exhau
     // Context beats steps: the pressured response yields in its own
     // iteration, so the step bound is never the one to end the turn.
     assert_eq(checkpoint_requests.length(), 1)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
+    assert_true(finished_answer(result).contains("[context ceiling]"))
   }
 }
 
@@ -981,19 +944,11 @@ async test "a soft-ceiling batch executes then yields gracefully" {
     // and the turn still ended at the boundary with a checkpoint.
     assert_eq(main_requests, 1)
     assert_eq(checkpoint_requests.length(), 1)
-    let events = result.events()
-    let count = events.length()
-    guard events.peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
-    guard events[count - 2].item() is Summary(summary) else {
-      fail("expected the checkpoint summary before the terminal")
-    }
+    assert_true(finished_answer(result).contains("[context ceiling]"))
+    let summary = summary_before_terminal(result)
     assert_eq(summary.content(), "SOFT-SUMMARY")
     // The executed result is inside the covered range.
-    assert_eq(summary.to_sequence(), count - 2)
+    assert_eq(summary.to_sequence(), result.events().length() - 2)
     let mut executed = false
     for event in result.events() {
       if event.item() is Tool(tool_result) {
@@ -1008,53 +963,31 @@ async test "a soft-ceiling batch executes then yields gracefully" {
 }
 
 ///|
+fn flood_definition(chars : Int) -> @agent_tool.AgentToolDefinition {
+  let content = "y".repeat(chars)
+  AgentToolDefinition(
+    name="flood",
+    description="Flood tool.",
+    schema=JsonSchema({ "type": "object" }),
+    execute=Sync(_args => @agent_tool.ToolAction::respond(content)),
+  )
+}
+
+///|
 fn flood_tools(chars : Int) -> @agent_tool.Tools raise {
-  let flood = StringBuilder()
-  for _i in 0..<chars {
-    flood.write_char('y')
-  }
-  let content = flood.to_string()
-  Tools([
-    AgentToolDefinition(
-      name="flood",
-      description="Flood tool.",
-      schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.ToolAction::respond(content)),
-    ),
-  ])
+  Tools([flood_definition(chars)])
 }
 
 ///|
 fn flood_batch(count : Int) -> Array[(String, String)] {
-  let calls : Array[(String, String)] = []
-  for index in 0..<count {
-    calls.push(("call_\{index + 1}", "flood"))
-  }
-  calls
+  [
+    for index in 0..<count => ("call_\{index + 1}", "flood")
+  ]
 }
 
 ///|
 fn flood_and_finish_tools(chars : Int) -> @agent_tool.Tools raise {
-  let flood = StringBuilder()
-  for _i in 0..<chars {
-    flood.write_char('y')
-  }
-  let content = flood.to_string()
-  Tools([
-    AgentToolDefinition(
-      name="flood",
-      description="Flood tool.",
-      schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.ToolAction::respond(content)),
-    ),
-    AgentToolDefinition(
-      name="finish",
-      description="Finish tool.",
-      schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.ToolAction::finish("wrapped: all done")),
-      control=true,
-    ),
-  ])
+  Tools([flood_definition(chars), finish_definition()])
 }
 
 ///|
@@ -1103,17 +1036,9 @@ async test "a budget trip salvages a finish in the remainder" {
     )
     assert_eq(main_requests, 1)
     assert_eq(checkpoint_requests.length(), 1)
-    let events = result.events()
-    let count = events.length()
-    guard events.peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
     // A completed task, not a yield: the salvaged finish's answer.
-    assert_eq(answer, "wrapped: all done")
-    guard events[count - 2].item() is Summary(_) else {
-      fail("expected the checkpoint summary before the terminal")
-    }
+    assert_eq(finished_answer(result), "wrapped: all done")
+    ignore(summary_before_terminal(result))
     let mut executed_floods = 0
     let mut skipped = 0
     let mut finish_result = false
@@ -1189,11 +1114,7 @@ async test "the running budget stops an overflowing batch mid-way" {
     // The executed prefix is covered by the checkpoint; the rest waits.
     assert_eq(executed, 3)
     assert_eq(skipped, 3)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
+    assert_true(finished_answer(result).contains("[context ceiling]"))
   }
 }
 
@@ -1248,11 +1169,7 @@ async test "a below-soft batch with huge results yields instead of overflowing" 
     }
     assert_eq(executed, 4)
     assert_eq(skipped, 2)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
+    assert_true(finished_answer(result).contains("[context ceiling]"))
   }
 }
 
@@ -1290,16 +1207,8 @@ async test "a finish tool in the soft band compacts and finishes normally" {
     // soft band) and compact-on-finish still checkpointed the session.
     assert_eq(main_requests, 1)
     assert_eq(checkpoint_requests.length(), 1)
-    let events = result.events()
-    let count = events.length()
-    guard events.peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_eq(answer, "wrapped: all done")
-    guard events[count - 2].item() is Summary(_) else {
-      fail("expected the checkpoint summary before the terminal")
-    }
+    assert_eq(finished_answer(result), "wrapped: all done")
+    ignore(summary_before_terminal(result))
   }
 }
 
@@ -1343,10 +1252,7 @@ async test "a failing checkpoint after a soft batch keeps its results" {
       }
     }
     assert_true(executed)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
+    let answer = finished_answer(result)
     assert_true(answer.contains("[context ceiling]"))
     assert_true(answer.contains("checkpoint attempt failed"))
   }
@@ -1398,11 +1304,7 @@ async test "a steer arriving during the checkpoint request is preserved" {
     }
     assert_true(summary_sequence > 0)
     assert_true(steer_sequence > summary_sequence)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_true(answer.contains("[context ceiling]"))
+    assert_true(finished_answer(result).contains("[context ceiling]"))
   }
 }
 
@@ -1448,18 +1350,9 @@ async test "a budget-tripped salvaged finish still checkpoints" {
     )
     assert_eq(main_requests, 1)
     assert_eq(checkpoint_requests.length(), 1)
-    let events = result.events()
-    let count = events.length()
-    guard events.peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
     // A real completion — with the checkpoint the fat prefix demands.
-    assert_eq(answer, "wrapped: all done")
-    guard events[count - 2].item() is Summary(summary) else {
-      fail("expected the checkpoint summary before the terminal")
-    }
-    assert_eq(summary.content(), "SALVAGE-SUMMARY")
+    assert_eq(finished_answer(result), "wrapped: all done")
+    assert_eq(summary_before_terminal(result).content(), "SALVAGE-SUMMARY")
     let mut executed = 0
     let mut skipped = 0
     for event in result.events() {
@@ -1538,11 +1431,7 @@ async test "a steer during a salvaged finish's checkpoint continues once" {
     assert_eq(summaries, 1)
     assert_eq(skip_notes, 2)
     assert_true(steer_present)
-    guard result.events().peek() is Some(last) &&
-      last.item() is Terminal(Finished(answer)) else {
-      fail("expected finished terminal")
-    }
-    assert_eq(answer, "done")
+    assert_eq(finished_answer(result), "done")
   }
 }
 
@@ -1560,18 +1449,6 @@ async test "an oversized tool result is clamped at the loop" {
       }
     }
     guard auto_compact_test_server(group, handle) is Some(url) else { return }
-    let flood = StringBuilder()
-    for _i in 0..<70_000 {
-      flood.write_char('x')
-    }
-    let tools : @agent_tool.Tools = Tools([
-      AgentToolDefinition(
-        name="flood",
-        description="Flood tool.",
-        schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => @agent_tool.ToolAction::respond(flood.to_string())),
-      ),
-    ])
     let session = @agent_session.Session(
       SessionId("clamp"),
       system_prompt="system",
@@ -1585,9 +1462,8 @@ async test "an oversized tool result is clamped at the loop" {
       task="flood me",
       append_item=(session, item) => session.append(item),
       api_url=url,
-      tools~,
+      tools=flood_tools(70_000),
     )
-    ignore(result)
     let mut clamped = false
     for event in result.events() {
       if event.item() is Tool(tool_result) {

--- a/agent/plan_reminder_test.mbt
+++ b/agent/plan_reminder_test.mbt
@@ -13,14 +13,18 @@ fn plan_reminders(result : @agent_session.Session) -> Array[String] {
 /// A scripted DeepSeek stand-in that keeps a turn alive with `plan` calls
 /// whose arguments are invalid — each yields an error tool result, which
 /// never resets the staleness cadence — for the first `plan_calls` requests,
-/// then answers. The server only records request bodies and scripts responses
-/// by request number; all assertions happen in the test body after the run,
-/// so a client retry shows up as a hard request-count mismatch instead of
-/// silently shifting the cadence.
-async fn stale_plan_test_server(
+/// then answers. With `record_first=true`, request 1 instead records a VALID
+/// plan: the successful write resets the cadence, so the first reminder
+/// fires a full cadence window later and re-surfaces the recorded checklist.
+/// The server only records request bodies and scripts responses by request
+/// number; all assertions happen in the test body after the run, so a client
+/// retry shows up as a hard request-count mismatch instead of silently
+/// shifting the cadence.
+async fn plan_test_server(
   group : @async.TaskGroup[Unit],
   bodies : Array[String],
   plan_calls~ : Int,
+  record_first~ : Bool,
 ) -> String? {
   guard bind_test_server(
       "local TCP bind unavailable; skipping plan reminder test",
@@ -35,7 +39,14 @@ async fn stale_plan_test_server(
         conn.send_response(200, "OK", extra_headers={
           "Content-Type": "text/event-stream",
         })
-        if bodies.length() <= plan_calls {
+        if record_first && bodies.length() == 1 {
+          conn.write(
+            (
+              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"}]}"}}]}}]}
+            ),
+          )
+          conn.write("\n\n")
+        } else if bodies.length() <= plan_calls {
           conn.write(
             (
               #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
@@ -60,7 +71,12 @@ async test "a plan-silent turn gets one staleness reminder after the cadence" {
   @async.with_task_group() <| group => {
     let cadence = @agent.plan_reminder_after_steps
     let bodies : Array[String] = []
-    guard stale_plan_test_server(group, bodies, plan_calls=cadence + 1)
+    guard plan_test_server(
+        group,
+        bodies,
+        plan_calls=cadence + 1,
+        record_first=false,
+      )
       is Some(url) else {
       return
     }
@@ -109,62 +125,16 @@ async test "a plan-silent turn gets one staleness reminder after the cadence" {
 }
 
 ///|
-/// A scripted stand-in where request 1 records a valid plan and requests
-/// 2..plan_calls keep the turn alive with invalid `plan` calls before the
-/// answer. The successful write resets the cadence, so the first reminder
-/// fires a full cadence window later and re-surfaces the recorded
-/// checklist. Assertions live in the test body, as above.
-async fn recorded_plan_test_server(
-  group : @async.TaskGroup[Unit],
-  bodies : Array[String],
-  plan_calls~ : Int,
-) -> String? {
-  guard bind_test_server(
-      "local TCP bind unavailable; skipping plan reminder test",
-    )
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        bodies.push(body.read_all().text())
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if bodies.length() == 1 {
-          conn.write(
-            (
-              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"}]}"}}]}}]}
-            ),
-          )
-          conn.write("\n\n")
-        } else if bodies.length() <= plan_calls {
-          conn.write(
-            (
-              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
-            ),
-          )
-          conn.write("\n\n")
-        } else {
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
-          )
-        }
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
-}
-
-///|
 async test "a recorded plan delays the reminder and is re-surfaced by it" {
   @async.with_task_group() <| group => {
     let cadence = @agent.plan_reminder_after_steps
     let bodies : Array[String] = []
-    guard recorded_plan_test_server(group, bodies, plan_calls=cadence + 2)
+    guard plan_test_server(
+        group,
+        bodies,
+        plan_calls=cadence + 2,
+        record_first=true,
+      )
       is Some(url) else {
       return
     }
@@ -210,7 +180,7 @@ async test "a recorded plan delays the reminder and is re-surfaced by it" {
 /// later request — "did it fire again" is a count on the newest body, not an
 /// absence check on it.
 fn reminder_count(body : String) -> Int {
-  body.split(@agent_session.PlanReminderPrefix).collect().length() - 1
+  body.split(@agent_session.PlanReminderPrefix).count() - 1
 }
 
 ///|
@@ -222,7 +192,12 @@ async test "the no-plan nag fires at most once per turn" {
   @async.with_task_group() <| group => {
     let cadence = @agent.plan_reminder_after_steps
     let bodies : Array[String] = []
-    guard stale_plan_test_server(group, bodies, plan_calls=2 * cadence + 3)
+    guard plan_test_server(
+        group,
+        bodies,
+        plan_calls=2 * cadence + 3,
+        record_first=false,
+      )
       is Some(url) else {
       return
     }
@@ -280,7 +255,12 @@ async test "a stale recorded plan re-nags on the request cadence" {
   @async.with_task_group() <| group => {
     let cadence = @agent.plan_reminder_after_steps
     let bodies : Array[String] = []
-    guard recorded_plan_test_server(group, bodies, plan_calls=2 * cadence + 2)
+    guard plan_test_server(
+        group,
+        bodies,
+        plan_calls=2 * cadence + 2,
+        record_first=true,
+      )
       is Some(url) else {
       return
     }

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -116,18 +116,11 @@ async fn AgentLoop::run(
             ContinueTurn(next) => continue next
           }
         }
-        let reasoning_content = response.optional_reasoning_content()
         // The model considers itself done, but user-visible input arrived while the
         // final call was in flight: user input wins over model-initiated completion.
         // The would-be answer stays as an ordinary assistant message and the turn
         // continues with the new input folded in.
-        let session = self.append(
-          session,
-          Assistant(AssistantMessage(response.content, reasoning_content?)),
-        )
-        self.messages.push(
-          ChatMessage(Assistant, content=response.content, reasoning_content?),
-        )
+        let session = self.record_assistant(session, response)
         if self.at_soft_context_ceiling(response.usage) {
           // Yield now rather than answering the steer in a starved context;
           // the steers survive the checkpoint verbatim.
@@ -141,24 +134,10 @@ async fn AgentLoop::run(
         // request itself. Close every call with a skip note — API-valid, a
         // few bytes — and yield; the checkpoint summary carries the state
         // and the model re-issues the calls next turn if needed.
-        let reasoning_content = response.optional_reasoning_content()
-        let session = self.append(
+        let session = self.record_assistant(
           session,
-          Assistant(
-            AssistantMessage(
-              response.content,
-              tool_calls=response.tool_calls,
-              reasoning_content?,
-            ),
-          ),
-        )
-        self.messages.push(
-          ChatMessage(
-            Assistant,
-            content=response.content,
-            tool_calls=response.tool_calls,
-            reasoning_content?,
-          ),
+          response,
+          tool_calls=response.tool_calls,
         )
         match self.salvage_finish_at_ceiling(session, response) {
           Some(StepDone(next)) => return next
@@ -235,6 +214,33 @@ async fn AgentLoop::append(
   let next = (self.append_item)(session, item)
   self.last_session = next
   next
+}
+
+///|
+/// Durably append the response's assistant message and mirror it into the
+/// in-flight chat buffer — the two must stay in lockstep (see `messages`).
+async fn AgentLoop::record_assistant(
+  self : Self,
+  session : @agent_session.Session,
+  response : @deepseek.ChatResponse,
+  tool_calls? : Array[@deepseek.ToolCall],
+) -> @agent_session.Session {
+  let reasoning_content = response.optional_reasoning_content()
+  let session = self.append(
+    session,
+    Assistant(
+      AssistantMessage(response.content, tool_calls?, reasoning_content?),
+    ),
+  )
+  self.messages.push(
+    ChatMessage(
+      Assistant,
+      content=response.content,
+      tool_calls?,
+      reasoning_content?,
+    ),
+  )
+  session
 }
 
 ///|
@@ -322,7 +328,7 @@ fn @deepseek.ChatResponse::log_and_reasoning_content(
     @xlog.info() <?
       { "event": "assistant_message", "content": response.content }
   }
-  print_usage(response.usage)
+  @xlog.info() <? { "event": "usage", "usage": response.usage }
   response
 }
 
@@ -332,24 +338,10 @@ async fn AgentLoop::handle_tool_calls(
   session : @agent_session.Session,
   response : @deepseek.ChatResponse,
 ) -> AgentStepOutcome {
-  let reasoning_content = response.optional_reasoning_content()
-  let session = self.append(
+  let session = self.record_assistant(
     session,
-    Assistant(
-      AssistantMessage(
-        response.content,
-        tool_calls=response.tool_calls,
-        reasoning_content?,
-      ),
-    ),
-  )
-  self.messages.push(
-    ChatMessage(
-      Assistant,
-      content=response.content,
-      tool_calls=response.tool_calls,
-      reasoning_content?,
-    ),
+    response,
+    tool_calls=response.tool_calls,
   )
   let mut spent_result_chars : Int64 = 0
   for call_index, native_call in response.tool_calls; session = session {
@@ -617,16 +609,11 @@ async fn AgentLoop::salvage_finish_at_ceiling(
   guard self.tools.find("finish") is Some(definition) && definition.is_control() else {
     return None
   }
-  let mut finish_index = -1
-  for index, call in response.tool_calls {
-    if index >= from && call.name == "finish" {
-      finish_index = index
-      break
-    }
-  }
-  if finish_index < 0 {
+  guard response.tool_calls[from:].search_by(call => call.name == "finish")
+    is Some(offset) else {
     return None
   }
+  let finish_index = from + offset
   let native_call = response.tool_calls[finish_index]
   let tool_call = @agent_tool.AgentToolCall(native_call) catch {
     _ => return None
@@ -789,9 +776,7 @@ async fn AgentLoop::finish_turn(
       // of the checkpoint is that the continuation request is small, and
       // the buffer must never disagree with Session::chat_messages.
       self.messages.clear()
-      for message in session.chat_messages() {
-        self.messages.push(message)
-      }
+      self.messages.append(session.chat_messages())
       return ContinueTurn(session)
     }
     session

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -39,7 +39,8 @@ pub async fn run_review(
     system_prompt=review_system_prompt(),
   )
   let task = review_task(base)
-  let final_session : @agent_session.Session = @async.with_task_group() <| group => {
+  // Review is read-only and ephemeral; the final session is not persisted.
+  let _ : @agent_session.Session = @async.with_task_group() <| group => {
     @agent.run_turn_in_scope(
       runtime=@agent_runtime.AgentRuntime(workspace_root~),
       scope=@agent_runtime.AgentTaskScope(group),
@@ -54,8 +55,6 @@ pub async fn run_review(
       tools~,
     )
   }
-  // Review is read-only and ephemeral; the final session is not persisted.
-  ignore(final_session)
   match captured.val {
     Some(report) => report
     None =>

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -42,7 +42,7 @@ pub fn Skill::path(self : Skill) -> String {
 fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) {
   let mut name = fallback_name
   let mut description = ""
-  let lines = text.split("\n").map(line => line.to_owned()).collect()
+  let lines = text.split("\n").collect()
   guard lines is [first, .. rest] && first.trim() == "---" else {
     return (name, description)
   }


### PR DESCRIPTION
One PR of the repo-wide simplification sweep, covering `agent`, `agent_review`, and `agent_skill`. All 19 reviewer findings applied; behavior-identical by construction (no public API change — `pkg.generated.mbti` files are untouched by `moon info`).

## turn_loop dedupe
- Fold the 3 copy-pasted append-Assistant + mirror-push blocks (steer-beats-answer, hard ceiling, `handle_tool_calls`) into a file-local `AgentLoop::record_assistant`; the optional `tool_calls` forwards verbatim.
- `salvage_finish_at_ceiling`: replace the `-1`-sentinel index loop with `response.tool_calls[from:].search_by(...)` on a zero-copy slice.
- `finish_turn` buffer re-seed: `messages.append(session.chat_messages())` instead of a push loop.
- `auto_compact`: `at_context_share` becomes a token-based `AgentLoop` method shared by both ceiling tiers — bit-for-bit the same comparisons, removing the soft tier's inline re-implementation.
- Inline the single-use, cross-file `print_usage` at its one call site.

## auto_compact test dedupe
- Reuse the shared `bind_test_server` bind-or-skip helper (the file postdated it and missed it).
- `sse_tool_call` delegates to `sse_tool_calls` (byte-identical singleton payload).
- `flood_definition(chars)` / `finish_definition()` shared across the 3 flood registries and 2 finish registries; registration order unchanged; the clamp test reuses `flood_tools(70_000)` (its assertions never reference the fill char).
- `finished_answer` / `summary_before_terminal` helpers replace the ~20 repeated 5-line terminal/summary guard blocks; `loc~` autofill keeps failures pointing at the test line.
- Drop a dead `ignore(result)` two lines before `result` is used.

## idiom rewrites
- Comprehensions for `sse_tool_calls` entries and `flood_batch`; `String::repeat` for flood strings.
- `plan_reminder_test`: merge `stale_plan_test_server` / `recorded_plan_test_server` into one `plan_test_server(record_first~)` — the scripted responses stay byte-identical per request number; `reminder_count` uses `Iter::count` instead of materializing the split.
- `agent_skill/parse_frontmatter`: drop the per-line `to_owned` copy; trim/`split_once`/interpolation already operate on views.
- `agent_review/engine`: `let _ : @agent_session.Session = ...` instead of bind-then-`ignore`.

## README fixes
- The `mbt nocheck` API fence used positional arguments that would not compile and an `@agent.steer` function that does not exist: now uses the labeled arguments verified against `agent/pkg.generated.mbti` and `runtime.queue_steer(Prompt(...))`; the steering prose updated to match.
- Corrected the stale claim that no tools use the runtime/scope — the shell tools use both since the background-jobs series (steer notices via `queue_steer`; `BgJobRuntime` + spill-dir cleanup owned by the scope's group).

## Skips
None — all 19 findings applied. The known trap was honored: `log_tool_result`'s brief `if/else Json::string/null` encoding is untouched (core encodes `Option` ToJson as `Some(v) => [v]`, so `brief.to_json()` would change the wire format).

## Validation
- `moon fmt` (clean; it normalized `loc~ : SourceLoc = _` to the `#callsite(autofill(loc))` form)
- `moon check --deny-warn`: 0 warnings, 0 errors
- `moon test`: 1001/1001 passed
- `moon info`: no `.mbti` changes (public surface unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)