### PR TITLE
refactor(tui): local simplification sweep (spread splice, min/max methods, append)

### DIFF
--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -210,9 +210,7 @@ pub fn Text::first_line(self : Text, width~ : Int) -> @surface.Line {
 pub fn Doc::layout(self : Doc, width~ : Int) -> Array[@surface.Line] {
   let rows : Array[@surface.Line] = []
   for text in self.texts {
-    for row in text.wrap(width~) {
-      rows.push(row)
-    }
+    rows.append(text.wrap(width~))
   }
   rows
 }

--- a/tui/internal/composer/composer_test.mbt
+++ b/tui/internal/composer/composer_test.mbt
@@ -1,12 +1,7 @@
 ///|
-fn display_text_string(line : @displaytext.DisplayText) -> String {
-  line.text()
-}
-
-///|
 fn visible_row_text(model : @composer.Model, row : Int) -> String {
   if model.visible_line(row) is Some(line) {
-    display_text_string(line)
+    line.text()
   } else {
     ""
   }

--- a/tui/internal/composer/composer_wbtest.mbt
+++ b/tui/internal/composer/composer_wbtest.mbt
@@ -12,14 +12,9 @@ fn cursor_column(model : Model) -> Int {
 }
 
 ///|
-fn display_text_string(line : @displaytext.DisplayText) -> String {
-  line.text()
-}
-
-///|
 fn visible_row_text(model : Model, row : Int) -> String {
   if model.visible_line(row) is Some(line) {
-    display_text_string(line)
+    line.text()
   } else {
     ""
   }

--- a/tui/internal/composer/logical_line.mbt
+++ b/tui/internal/composer/logical_line.mbt
@@ -91,15 +91,5 @@ fn splice_logical_lines(
   let start = start.clamp(min=0, max=lines.length())
   let delete_count = delete_count.max(0)
   let tail_start = (start + delete_count).clamp(min=start, max=lines.length())
-  let result : Array[LogicLine] = []
-  for index in 0..<start {
-    result.push(lines[index])
-  }
-  for line in inserted {
-    result.push(line)
-  }
-  for index in tail_start..<lines.length() {
-    result.push(lines[index])
-  }
-  result
+  [..lines[:start], ..inserted, ..lines[tail_start:]]
 }

--- a/tui/internal/geometry/geometry.mbt
+++ b/tui/internal/geometry/geometry.mbt
@@ -83,12 +83,7 @@ pub fn calculate_max_top(
   size : @terminal_size.TerminalSize,
   height : Int,
 ) -> Int {
-  let top = size.rows() - height + 1
-  if top < 1 {
-    1
-  } else {
-    top
-  }
+  (size.rows() - height + 1).max(1)
 }
 
 ///|

--- a/tui/internal/render/queued.mbt
+++ b/tui/internal/render/queued.mbt
@@ -68,16 +68,13 @@ fn queued_input_rows(
     indented_dim_line(DisplayText("Queued follow-up inputs:"), cols~, indent~),
   )
   let item_budget = max_rows - 1
-  if count <= item_budget {
-    for index, input in inputs {
-      rows.push(queued_input_line(input, index~, cols~, indent~))
-    }
-  } else {
-    // Reserve the last row for the summary of everything that did not fit.
-    let shown = item_budget - 1
-    for index, input in inputs[:shown] {
-      rows.push(queued_input_line(input, index~, cols~, indent~))
-    }
+  // When the inputs overflow the budget, reserve the last row for the summary
+  // of everything that did not fit.
+  let shown = if count <= item_budget { count } else { item_budget - 1 }
+  for index, input in inputs[:shown] {
+    rows.push(queued_input_line(input, index~, cols~, indent~))
+  }
+  if shown < count {
     rows.push(
       indented_dim_line(
         DisplayText("… \{count - shown} more"),

--- a/tui/internal/render/render.mbt
+++ b/tui/internal/render/render.mbt
@@ -256,24 +256,20 @@ pub fn composer_surface(
   if show_activity && has_queue {
     rows.push(@surface.Line::new([]))
   }
-  for row in queued {
-    rows.push(row)
-  }
+  rows.append(queued)
   // Set the live-status group off from the composer border with a blank.
   if show_activity || has_queue {
     rows.push(@surface.Line::new([]))
   }
   let composer_top = rows.length()
   rows.push(separator_line(cols~))
-  for row in 0..<composer.visible_text_rows() {
+  for row in 0..<composer_rows {
     if composer.visible_line(row) is Some(line) {
       rows.push(prompt_line(prefix=composer.input_prefix(row), line~, cols~))
     }
   }
   rows.push(separator_line(cols~))
-  for row in completion_rows {
-    rows.push(row)
-  }
+  rows.append(completion_rows)
   rows.push(
     indent_line(status_line(status, notice, cols=cols - indent), indent~),
   )

--- a/tui/internal/surface/surface.mbt
+++ b/tui/internal/surface/surface.mbt
@@ -108,30 +108,14 @@ pub fn Cursor::col(self : Cursor) -> Int {
 }
 
 ///|
-fn normalize_surface_width(width : Int) -> Int {
-  if width < 1 {
-    1
-  } else {
-    width
-  }
-}
-
-///|
-fn normalize_surface_index(value : Int, max_value : Int) -> Int {
-  value.clamp(min=0, max=max_value)
-}
-
-///|
 fn normalize_surface_cursor(
   rows : Array[Line],
   width : Int,
   cursor : Cursor,
 ) -> Cursor {
-  let max_row = if rows.length() == 0 { 0 } else { rows.length() - 1 }
-  let max_col = if width <= 1 { 0 } else { width - 1 }
   {
-    row: normalize_surface_index(cursor.row, max_row),
-    col: normalize_surface_index(cursor.col, max_col),
+    row: cursor.row.clamp(min=0, max=(rows.length() - 1).max(0)),
+    col: cursor.col.clamp(min=0, max=(width - 1).max(0)),
   }
 }
 
@@ -144,7 +128,7 @@ pub fn Surface::new(
   rows~ : Array[Line],
   cursor~ : Cursor,
 ) -> Surface {
-  let width = normalize_surface_width(width)
+  let width = width.max(1)
   let cursor = normalize_surface_cursor(rows, width, cursor)
   { width, rows, cursor }
 }

--- a/tui/internal/viewport/moon.pkg
+++ b/tui/internal/viewport/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "moonbitlang/core/cmp",
   "bobzhang/openseek/tui/internal/geometry",
   "bobzhang/openseek/tui/internal/terminal_size",
   "bobzhang/openseek/tui/internal/surface",

--- a/tui/internal/viewport/viewport.mbt
+++ b/tui/internal/viewport/viewport.mbt
@@ -479,13 +479,10 @@ async fn Viewport::redraw_placed_surface_rows(
   old_frame : PlacedSurface,
   new_frame : PlacedSurface,
 ) -> Unit {
-  let draw_top = @cmp.maximum(@cmp.minimum(old_frame.top, new_frame.top), 1)
+  let draw_top = old_frame.top.min(new_frame.top).max(1)
   let old_bottom = old_frame.top + old_frame.surface.height() - 1
   let new_bottom = new_frame.top + new_frame.surface.height() - 1
-  let draw_bottom = @cmp.minimum(
-    @cmp.maximum(old_bottom, new_bottom),
-    self.size.rows(),
-  )
+  let draw_bottom = old_bottom.max(new_bottom).min(self.size.rows())
   guard draw_top <= draw_bottom else { return }
   let mut rows_changed = false
   without_auto_wrap(tty, () => {
@@ -521,7 +518,7 @@ async fn Viewport::redraw_uncached_placed_surface_rows(
   old : @geometry.Geometry,
   new_frame : PlacedSurface,
 ) -> Unit {
-  let draw_top = @cmp.maximum(@cmp.minimum(old.top(), new_frame.top), 1)
+  let draw_top = old.top().min(new_frame.top).max(1)
   let draw_bottom = self.size.rows()
   guard draw_top <= draw_bottom else { return }
   tty.hide_cursor()
@@ -695,8 +692,8 @@ async fn Viewport::shift_down_for_insert(
 ) -> Int {
   let top = self.top()
   let space = self.size.rows() - self.bottom()
-  let available = @cmp.maximum(space, 0)
-  let shift = @cmp.minimum(lines, available)
+  let available = space.max(0)
+  let shift = lines.min(available)
   if shift > 0 {
     with_scroll_region(tty, top, self.size.rows(), () => {
       tty.set_cursor_position(top, 1)

--- a/tui/terminal.mbt
+++ b/tui/terminal.mbt
@@ -55,9 +55,7 @@ fn item_rows(doc : @doc.Doc, cols~ : Int) -> Array[@surface.Line] {
 fn Ui::transcript_rows(self : Self, cols~ : Int) -> Array[@surface.Line] {
   let rows : Array[@surface.Line] = []
   for doc in self.transcript {
-    for row in item_rows(doc, cols~) {
-      rows.push(row)
-    }
+    rows.append(item_rows(doc, cols~))
   }
   rows
 }


### PR DESCRIPTION
Applies 10 behavior-identical simplifications under `tui/` from a strict read-only review pass ("clearly clearer" bar; rendering code is perf-sensitive, so each change is exactly what the finding specified).

## Applied findings (10/10)

1. **composer/logical_line.mbt** — `splice_logical_lines`: three index/push loops collapse to one spread literal `[..lines[:start], ..inserted, ..lines[tail_start:]]` (house idiom, cf. `cmd/tui/tool_view.mbt`).
2. **viewport/viewport.mbt** — replace the package's only `@cmp.maximum/minimum` uses (5 sites: redraw tops/bottoms, shift-down space/shift) with `Int::min/max` methods, matching geometry/composer/render; drop the now-unused `moonbitlang/core/cmp` import from `moon.pkg`.
3. **geometry/geometry.mbt** — `calculate_max_top`: `if top < 1 { 1 } else { top }` becomes `(size.rows() - height + 1).max(1)`.
4. **surface/surface.mbt** — inline single-use `normalize_surface_width` (== `.max(1)`) and `normalize_surface_index` (bare clamp alias) into `Surface::new` / `normalize_surface_cursor`; `normalize_surface_cursor` stays as the named seam.
5. **terminal.mbt** — transcript row collection: nested push loop becomes `rows.append(item_rows(doc, cols~))`.
6. **doc/doc.mbt** — `Doc::layout`: same `Array::append` pattern over `text.wrap(width~)`.
7. **render/render.mbt** — `rows.append(queued)` and `rows.append(completion_rows)` replace element-wise copies (once per frame, not a hot inner loop).
8. **render/render.mbt** — reuse the existing `composer_rows` local instead of recomputing `composer.visible_text_rows()`; nothing mutates the composer in between, and it makes the row-budget relation explicit.
9. **render/queued.mbt** — merge the two duplicated queued-input render branches into one `inputs[:shown]` loop plus a conditional `… N more` overflow row; identical output in both cases.
10. **composer tests** — delete the one-line `display_text_string` wrapper duplicated verbatim in `composer_test.mbt` and `composer_wbtest.mbt`; call `line.text()` directly.

## Skipped

None. Items rejected by the reviewer's notes were not implemented (map+join rewrites over `<+` interpolations, `unwrap_or` rewrites in per-row redraw paths, the viewport bottom guard that trips `ambiguous_range_direction` under deny-warn, cosmetic `Stale(..)`).

## Validation

- `moon fmt` — clean
- `moon check --deny-warn` — clean
- `moon test` — 1001 passed, 0 failed
- `moon info` — no `.mbti` changes (all edits private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)