### PR TITLE
refactor(agent_session): local simplification + dedupe sweep

### DIFF
--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -66,32 +66,18 @@ pub impl FromJson for SessionId with fn from_json(
 }
 
 ///|
-fn terminal_kind(terminal : TurnTerminal) -> String {
-  match terminal {
-    Finished(_) => "finished"
-    Aborted(_) => "aborted"
-    Interrupted(_) => "interrupted"
-    Failed(_) => "failed"
-  }
-}
-
-///|
-fn terminal_message(terminal : TurnTerminal) -> String {
-  match terminal {
-    Finished(message)
-    | Aborted(message)
-    | Interrupted(message)
-    | Failed(message) => message
-  }
-}
-
-///|
 /// Encode a terminal status as `{ "kind": ..., "message": ... }`.
 ///
 /// `kind` is one of `finished`, `aborted`, `interrupted`, or `failed`. The
 /// variant payload is stored in `message`.
 pub impl ToJson for TurnTerminal with fn to_json(terminal : TurnTerminal) -> Json {
-  { "kind": terminal_kind(terminal), "message": terminal_message(terminal) }
+  let (kind, message) = match terminal {
+    Finished(message) => ("finished", message)
+    Aborted(message) => ("aborted", message)
+    Interrupted(message) => ("interrupted", message)
+    Failed(message) => ("failed", message)
+  }
+  { "kind": kind, "message": message }
 }
 
 ///|
@@ -117,8 +103,13 @@ pub impl FromJson for TurnTerminal with fn from_json(
 }
 
 ///|
-fn item_payload(item : SessionItem) -> (String, Json) {
-  match item {
+/// Encode a `SessionItem` as a tagged payload object.
+///
+/// The JSON shape is `{ "kind": <tag>, "payload": <variant-json> }`. Tags are
+/// stable storage strings such as `user`, `assistant`, `tool_result`,
+/// `runtime_notice`, `summary`, and `terminal`.
+pub impl ToJson for SessionItem with fn to_json(item : SessionItem) -> Json {
+  let (kind, payload) = match item {
     User(message) => ("user", message.to_json())
     Assistant(message) => ("assistant", message.to_json())
     Tool(result) => ("tool_result", result.to_json())
@@ -126,16 +117,6 @@ fn item_payload(item : SessionItem) -> (String, Json) {
     Summary(summary) => ("summary", summary.to_json())
     Terminal(terminal) => ("terminal", terminal.to_json())
   }
-}
-
-///|
-/// Encode a `SessionItem` as a tagged payload object.
-///
-/// The JSON shape is `{ "kind": <tag>, "payload": <variant-json> }`. Tags are
-/// stable storage strings such as `user`, `assistant`, `tool_result`,
-/// `runtime_notice`, `summary`, and `terminal`.
-pub impl ToJson for SessionItem with fn to_json(item : SessionItem) -> Json {
-  let (kind, payload) = item_payload(item)
   { "kind": kind, "payload": payload }
 }
 

--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -109,6 +109,21 @@ pub fn parse_events(text : String) -> ParsedLog {
   let ends_with_newline = text.has_suffix("\n")
   let lines = text.split("\n").map(line => line.to_owned()).collect()
   let mut partial_tail = false
+  // The one policy for a line that does not decode: an unterminated final
+  // line is a torn tail; anything else is a recorded per-line error.
+  fn note_bad_line(
+    line_number : Int,
+    line : String,
+    torn : Bool,
+    message : String,
+  ) -> Unit {
+    if torn {
+      partial_tail = true
+    } else {
+      errors.push({ line_number, content: line, message })
+    }
+  }
+
   let mut first_content_line = true
   for index, line in lines {
     let line_number = index + 1
@@ -117,14 +132,10 @@ pub fn parse_events(text : String) -> ParsedLog {
     }
     let may_be_header = first_content_line
     first_content_line = false
-    let is_last_segment = index == lines.length() - 1
+    let torn = index == lines.length() - 1 && !ends_with_newline
     let json = @json.parse(line) catch {
       error => {
-        if is_last_segment && !ends_with_newline {
-          partial_tail = true
-        } else {
-          errors.push({ line_number, content: line, message: "\{error}" })
-        }
+        note_bad_line(line_number, line, torn, "\{error}")
         continue
       }
     }
@@ -134,11 +145,7 @@ pub fn parse_events(text : String) -> ParsedLog {
     }
     let event : @agent_session.SessionEvent = @json.from_json(json) catch {
       error => {
-        if is_last_segment && !ends_with_newline {
-          partial_tail = true
-        } else {
-          errors.push({ line_number, content: line, message: "\{error}" })
-        }
+        note_bad_line(line_number, line, torn, "\{error}")
         continue
       }
     }

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -72,20 +72,6 @@ fn append_item_message(
 }
 
 ///|
-fn remove_pending_tool_call(
-  pending : Array[@deepseek.ToolCall],
-  tool_call_id : String,
-) -> Bool {
-  for index, call in pending {
-    if call.id == tool_call_id {
-      ignore(pending.remove(index))
-      return true
-    }
-  }
-  false
-}
-
-///|
 fn flush_pending_tool_calls(
   pending : Array[@deepseek.ToolCall],
   messages : Array[@deepseek.ChatMessage],
@@ -173,12 +159,12 @@ pub fn Session::chat_messages(self : Session) -> Array[@deepseek.ChatMessage] {
       Assistant(message) => {
         flush_pending_tool_calls(pending_tool_calls, messages)
         append_item_message(Assistant(message), messages)
-        for call in message.tool_calls() {
-          pending_tool_calls.push(call)
-        }
+        pending_tool_calls.append(message.tool_calls())
       }
       Tool(result) =>
-        if remove_pending_tool_call(pending_tool_calls, result.tool_call_id()) {
+        if pending_tool_calls.search_by(call => call.id == result.tool_call_id())
+          is Some(index) {
+          ignore(pending_tool_calls.remove(index))
           append_item_message(Tool(result), messages)
         }
       item => {

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -336,13 +336,11 @@ test "compact validates and appends summary event" {
   assert_eq(summary.content(), "first two events")
   assert_eq(summary.from_sequence(), 1)
   assert_eq(summary.to_sequence(), 2)
-  let _ = session.compact(content="", from_sequence=1, to_sequence=2) catch {
-    error => {
-      assert_true("\{error}".contains("content must not be empty"))
-      return
-    }
+  try session.compact(content="", from_sequence=1, to_sequence=2) catch {
+    error => assert_true("\{error}".contains("content must not be empty"))
+  } noraise {
+    _ => fail("empty summary accepted")
   }
-  fail("empty summary accepted")
 }
 
 ///|
@@ -357,13 +355,11 @@ test "summary_item validates without appending" {
   )
   assert_true(item is Summary(_))
   assert_eq(session.events().length(), 2)
-  let _ = session.summary_item(content="x", from_sequence=1, to_sequence=3) catch {
-    error => {
-      assert_true("\{error}".contains("exceeds last sequence"))
-      return
-    }
+  try session.summary_item(content="x", from_sequence=1, to_sequence=3) catch {
+    error => assert_true("\{error}".contains("exceeds last sequence"))
+  } noraise {
+    _ => fail("out-of-range summary accepted")
   }
-  fail("out-of-range summary accepted")
 }
 
 ///|

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -151,19 +151,16 @@ fn session_file_text(session : @agent_session.Session) -> String {
 }
 
 ///|
-fn checked_last_sequence_in_events(
+fn check_contiguous_sequences(
   events : @vector.Vector[@agent_session.SessionEvent],
-) -> Int raise {
-  let mut expected = 1
-  for event in events {
-    if event.sequence() != expected {
+) -> Unit raise {
+  events.eachi((index, event) => {
+    if event.sequence() != index + 1 {
       fail(
-        "session event log sequence mismatch: expected \{expected}, found \{event.sequence()}",
+        "session event log sequence mismatch: expected \{index + 1}, found \{event.sequence()}",
       )
     }
-    expected += 1
-  }
-  expected - 1
+  })
 }
 
 ///|
@@ -235,7 +232,7 @@ fn parse_session_file(
     decoded.push(event)
   }
   let events = @vector.from_array(decoded)
-  ignore(checked_last_sequence_in_events(events))
+  check_contiguous_sequences(events)
   {
     session: Session(
       SessionId(header.id),
@@ -428,18 +425,13 @@ async fn sync_dir_best_effort(dir : String) -> Unit {
 }
 
 ///|
-async fn ensure_dir_exists(dir : String) -> Unit {
-  ensure_dir_exists_with_retry(dir, attempts=4)
-}
-
-///|
-async fn ensure_dir_exists_with_retry(dir : String, attempts~ : Int) -> Unit {
+async fn ensure_dir_exists(dir : String, attempts? : Int = 4) -> Unit {
   if @fs.exists(dir) {
     return
   }
   @fs.mkdir(dir, recursive=true) catch {
     @os_error.OSError(_) as error if error.is_EEXIST() && attempts > 0 =>
-      ensure_dir_exists_with_retry(dir, attempts=attempts - 1)
+      ensure_dir_exists(dir, attempts=attempts - 1)
     error => if @fs.exists(dir) { () } else { raise error }
   }
 }
@@ -449,8 +441,7 @@ async fn ensure_session_dir(
   store : SessionStore,
   id : @agent_session.SessionId,
 ) -> Unit {
-  let dir = store.session_dir(id)
-  ensure_dir_exists(dir)
+  ensure_dir_exists(store.session_dir(id))
 }
 
 ///|
@@ -661,11 +652,7 @@ pub async fn SessionStore::listings(
   }
   // Most recently active first.
   stamped.sort_by(stamped_newest_first)
-  let listings = [ for entry in stamped => entry.0 ]
-  for listing in unreadable {
-    listings.push(listing)
-  }
-  listings
+  [ for entry in stamped => entry.0 ]..append(unreadable)
 }
 
 ///|
@@ -803,7 +790,7 @@ pub async fn SessionStore::append(
 /// Append a validated summary event to a durable session.
 ///
 /// This has the same stale-snapshot and locking behavior as `append`, but the
-/// item is created by `Session::compact`. `content` must be non-blank,
+/// item is created by `Session::summary_item`. `content` must be non-blank,
 /// `from_sequence` must be positive, `to_sequence` must be at least
 /// `from_sequence`, and the range must already exist in the supplied session.
 ///
@@ -821,16 +808,10 @@ pub async fn SessionStore::compact(
   ensure_session_dir(self, session.id())
   with_session_lock(self, session.id(), Exclusive, () => {
     let repair_tail = ensure_session_is_current(self, session)
-    let next = session.compact(
-      content~,
-      from_sequence~,
-      to_sequence~,
+    let (next, event) = session.append_event(
+      session.summary_item(content~, from_sequence~, to_sequence~),
       unix_ms=@env.now().reinterpret_as_int64(),
     )
-    let event = match next.events().peek() {
-      Some(event) => event
-      None => fail("compacted session did not append a summary event")
-    }
     persist_event(self, next, event, repair_tail~)
     record_mark(self, next)
     next

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -256,37 +256,43 @@ async test "first append creates the session file with its header" {
 }
 
 ///|
-async test "store serializes concurrent first appends from empty snapshots" {
-  let store = new_store()
-  // Two writers race to be the first durable write for the same id. The
-  // exclusive lock serializes them; the loser sees the winner's file and gets
-  // a stale-snapshot error instead of clobbering the first event.
-  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+/// Race two appends of the same in-memory snapshot. The exclusive lock
+/// serializes them, so exactly one lands and the other must see a
+/// stale-snapshot error.
+async fn race_two_appends(
+  store : @store.SessionStore,
+  session : @agent_session.Session,
+) -> Unit {
+  let items : Array[@agent_session.SessionItem] = [
+    User(UserMessage("first")),
+    Runtime(RuntimeNotice("second")),
+  ]
   let results : Array[String] = []
   @async.with_task_group() <| group => {
-    group.spawn_bg() <| () => {
-      try store.append(session, User(UserMessage("first"))) catch {
-        error => {
-          assert_true("\{error}".contains("stale session snapshot"))
-          results.push("stale")
+    for item in items {
+      group.spawn_bg() <| () => {
+        try store.append(session, item) catch {
+          error => {
+            assert_true("\{error}".contains("stale session snapshot"))
+            results.push("stale")
+          }
+        } noraise {
+          _ => results.push("ok")
         }
-      } noraise {
-        _ => results.push("ok")
-      }
-    }
-    group.spawn_bg() <| () => {
-      try store.append(session, Runtime(RuntimeNotice("second"))) catch {
-        error => {
-          assert_true("\{error}".contains("stale session snapshot"))
-          results.push("stale")
-        }
-      } noraise {
-        _ => results.push("ok")
       }
     }
   }
   assert_eq(results.filter(r => r == "ok").length(), 1)
   assert_eq(results.filter(r => r == "stale").length(), 1)
+}
+
+///|
+async test "store serializes concurrent first appends from empty snapshots" {
+  let store = new_store()
+  // Two writers race to be the first durable write for the same id. The loser
+  // sees the winner's file and must not clobber the first event.
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+  race_two_appends(store, session)
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 1)
   assert_eq(loaded.last_sequence(), 1)
@@ -431,32 +437,8 @@ async test "store rejects non-empty snapshots when the session file is missing" 
 async test "store serializes concurrent appends from the same snapshot" {
   let store = new_store()
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
-  let results : Array[String] = []
   store.create(session)
-  @async.with_task_group() <| group => {
-    group.spawn_bg() <| () => {
-      try store.append(session, User(UserMessage("first"))) catch {
-        error => {
-          assert_true("\{error}".contains("stale session snapshot"))
-          results.push("stale")
-        }
-      } noraise {
-        _ => results.push("ok")
-      }
-    }
-    group.spawn_bg() <| () => {
-      try store.append(session, Runtime(RuntimeNotice("second"))) catch {
-        error => {
-          assert_true("\{error}".contains("stale session snapshot"))
-          results.push("stale")
-        }
-      } noraise {
-        _ => results.push("ok")
-      }
-    }
-  }
-  assert_eq(results.filter(r => r == "ok").length(), 1)
-  assert_eq(results.filter(r => r == "stale").length(), 1)
+  race_two_appends(store, session)
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 1)
   assert_eq(loaded.last_sequence(), 1)


### PR DESCRIPTION
Behavior-identical simplification sweep over `agent_session`, `agent_session/compact`, `agent_session/log`, and `agent_session/store`, applying all 11 findings from a read-only reviewer pass. No public API changes (`moon info` produced no `.mbti` diffs).

## Applied findings (11/11)

**agent_session/store/store.mbt**
1. `SessionStore::compact` now uses `session.append_event(session.summary_item(...))` directly — `Session::compact` is exactly `append(summary_item(...))`, and `append_event` hands back the event, so the `events().peek()` + impossible-`None` `fail` disappear and the body mirrors `SessionStore::append`. Validation errors, the appended event, and the persist/`record_mark` flow are identical (equivalence verified against `Session::compact`/`append`/`append_event` in `types.mbt`). The doc phrase "created by `Session::compact`" was updated to `Session::summary_item`.
2. `checked_last_sequence_in_events` (mutable-counter loop returning an `Int` the only caller ignored) → `check_contiguous_sequences` returning `Unit` via `Vector::eachi`; failure message byte-identical.
3. `ensure_dir_exists` + `ensure_dir_exists_with_retry` folded into one `ensure_dir_exists(dir, attempts? : Int = 4)` with self-recursion; `ensure_session_dir` becomes a one-liner.
4. `listings` tail: sorted-comprehension-then-push-loop → `[ for entry in stamped => entry.0 ]..append(unreadable)` (ordered-then-unreadable in one expression).

**agent_session/json.mbt**

5. `terminal_kind` + `terminal_message` (two single-use matches over `TurnTerminal`) → one tuple-producing match inside `ToJson for TurnTerminal`; one traversal, pairing visible in place.
6. `item_payload` inlined into `ToJson for SessionItem`, keeping the two `ToJson` impls symmetric.

**agent_session/projection.mbt**

7. `remove_pending_tool_call` bool-mutation helper → `Array::search_by` + `remove` at the call site; same first-match semantics.
8. Push-loop of assistant tool calls → `pending_tool_calls.append(message.tool_calls())` (implicit view coercion accepted; no `[:]` needed).

**agent_session/log/log.mbt**

9. The two byte-identical bad-line catch policies in `parse_events` dedupe into a local `note_bad_line(line_number, line, torn, message)`. Two small deviations from the finding as written, both required for correctness: local functions cannot take labelled arguments (`torn` is positional), and the helper takes the already-formatted `message : String` rather than the error value — `@json.ParseError` has a custom `Show` impl, so formatting through an `Error`-typed parameter would have changed the recorded message text.

**agent_session/session_test.mbt**

10. The two remaining catch-then-`return`-then-trailing-`fail` expected-error blocks (`compact` empty content, `summary_item` out-of-range) converted to the blessed `try ... catch ... noraise` form.

**agent_session/store/store_test.mbt**

11. The two copies of the two-writer append race (4 duplicate `spawn_bg` try/catch/noraise blocks + filter assertions) collapse into an async `race_two_appends(store, session)` helper; each test keeps its distinct setup and post-race load assertions. The `for`-in binder is per-iteration, so each spawned closure captures its own item.

## Skips

None — all 11 findings applied. Do-not-touch items from the findings notes (projection nested summary loop, `summary_covers_event`, compact wbtest seams, `pad2`/`pad3`, store_test rmdir cleanups) were left untouched.

## Validation

- `moon fmt` clean
- `moon check --deny-warn` clean (0 warnings, 0 errors)
- `moon test`: 1001/1001 pass (native)
- `moon info`: no `.mbti` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)