### PR TITLE
refactor(agent_tool): edit/multi_edit/write dedupe + find() efficiency sweep

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -79,35 +79,28 @@ async fn edit_file(
   // Every failure names the file it tried to edit so the viz can show
   // `→ edit · edit <file> 🚩` on the folded call line.
   let fail_brief = "edit \{@agent_tool.brief_basename(path)}"
-  if input.replace_all {
-    return @agent_tool.ToolAction::respond(
-      "error editing \{path}: replace_all=true is no longer supported; use multi_edit with explicit line-anchored edits",
+  fn err(message : String) -> @agent_tool.ToolAction {
+    @agent_tool.ToolAction::respond(
+      "error editing \{path}: \{message}",
       is_error=true,
       brief=fail_brief,
+    )
+  }
+
+  if input.replace_all {
+    return err(
+      "replace_all=true is no longer supported; use multi_edit with explicit line-anchored edits",
     )
   }
   if input.old_string == "" && input.new_string == "" {
-    return @agent_tool.ToolAction::respond(
-      "error editing \{path}: old_string and new_string are both empty",
-      is_error=true,
-      brief=fail_brief,
-    )
+    return err("old_string and new_string are both empty")
   }
   if input.old_string == input.new_string {
-    return @agent_tool.ToolAction::respond(
-      "error editing \{path}: old_string and new_string are identical",
-      is_error=true,
-      brief=fail_brief,
-    )
+    return err("old_string and new_string are identical")
   }
   let content = @fs.read_file(path).text() catch {
     error if @async.is_being_cancelled() => raise error
-    error =>
-      return @agent_tool.ToolAction::respond(
-        "error editing \{path}: error reading file: \{error}",
-        is_error=true,
-        brief=fail_brief,
-      )
+    error => return err("error reading file: \{error}")
   }
   if input.old_string == "" {
     // Insertion: insert new_string at the start of start_line (a zero-width
@@ -128,25 +121,15 @@ async fn edit_file(
     )
   }
   let region = select_edit_region(content, input)
-  let parts = region.body
-    .split(input.old_string)
-    .map(part => part.to_owned())
-    .collect()
-  if parts.length() <= 1 {
-    return @agent_tool.ToolAction::respond(
-      "error editing \{path}: old_string not found\{range_detail(input)}",
-      is_error=true,
-      brief=fail_brief,
-    )
+  guard region.body.find(input.old_string) is Some(match_start) else {
+    return err("old_string not found\{range_detail(input)}")
   }
-  let replacement_count = 1
-  let match_start = parts[0].length()
   let match_end = match_start + input.old_string.length()
   let match_line = line_number_at_offset(
     content,
     region.prefix.length() + match_start,
   )
-  let new_body = "\{parts[0]}\{input.new_string}\{region.body.unsafe_substring(start=match_end, end=region.body.length())}"
+  let new_body = "\{region.body.unsafe_substring(start=0, end=match_start)}\{input.new_string}\{region.body.unsafe_substring(start=match_end, end=region.body.length())}"
   let new_content = "\{region.prefix}\{new_body}\{region.suffix}"
   commit_edit(
     path,
@@ -154,8 +137,8 @@ async fn edit_file(
     new_content~,
     revert_on_parse_errors=input.revert_on_parse_errors,
     fail_brief~,
-    summary="ok: replaced \{replacement_count} occurrence(s) at line \{match_line} in \{path}",
-    ok_brief="edited \{@agent_tool.brief_basename(path)}:\{match_line} (\{replacement_count}×)",
+    summary="ok: replaced 1 occurrence(s) at line \{match_line} in \{path}",
+    ok_brief="edited \{@agent_tool.brief_basename(path)}:\{match_line} (1×)",
   )
 }
 
@@ -362,21 +345,12 @@ fn select_edit_region(
 
 ///|
 fn line_start_offset(content : String, line : Int) -> Int {
+  // Line `line` starts right after line `line - 1` ends (nobreak: both scans
+  // land on content.length() for a line past EOF).
   if line <= 1 {
     0
   } else {
-    let len = content.length()
-    let mut current_line = 1
-    for cursor = 0; cursor < len; cursor = cursor + 1 {
-      if content[cursor] == '\n' {
-        current_line = current_line + 1
-        if current_line == line {
-          break cursor + 1
-        }
-      }
-    } nobreak {
-      len
-    }
+    line_end_offset(content, line - 1)
   }
 }
 

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -1,11 +1,7 @@
 ///|
 async fn run_edit(arguments : Json) -> @agent_tool.ToolOutput {
-  let action = match @edit.definition().execute {
-    Async(execute) => execute(arguments)
-    Sync(_) => fail("edit tool should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
-  output
+  // definition() defaults workspace_root to ".", so this is the same tool.
+  run_edit_in_workspace(".", arguments)
 }
 
 ///|

--- a/agent_tool/edit/internal/decode/decode_test.mbt
+++ b/agent_tool/edit/internal/decode/decode_test.mbt
@@ -70,118 +70,94 @@ test "decode line range" {
 }
 
 ///|
+/// Asserts that decoding `arguments` fails and the error message names the
+/// offending field.
+fn assert_decode_error(arguments : Json, expected : String) -> Unit raise {
+  let _ = @decode.decode(arguments) catch {
+    error => {
+      let message = "\{error}"
+      assert_true(
+        message.contains(expected),
+        msg="\{message} should contain \{expected}",
+      )
+      return
+    }
+  }
+  fail("expected decode error")
+}
+
+///|
 test "decode rejects invalid replace_all" {
-  try
-    @decode.decode({
+  assert_decode_error(
+    {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
       "replace_all": "yes",
       "start_line": 1,
-    })
-  catch {
-    error => assert_true("\{error}".contains("arguments.replace_all"))
-  } noraise {
-    _ => fail("invalid replace_all decoded")
-  }
+    },
+    "arguments.replace_all",
+  )
 }
 
 ///|
 test "decode rejects invalid line range" {
-  try
-    @decode.decode({
+  assert_decode_error(
+    {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
       "start_line": 0,
-    })
-  catch {
-    error =>
-      assert_true(
-        "\{error}".contains("arguments.start_line to be a positive integer"),
-      )
-  } noraise {
-    _ => fail("invalid start_line decoded")
-  }
-  try
-    @decode.decode({
+    },
+    "arguments.start_line to be a positive integer",
+  )
+  assert_decode_error(
+    {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
       "start_line": 1,
       "end_line": "4",
-    })
-  catch {
-    error =>
-      assert_true("\{error}".contains("arguments.end_line to be an integer"))
-  } noraise {
-    _ => fail("invalid end_line decoded")
-  }
-  try
-    @decode.decode({
+    },
+    "arguments.end_line to be an integer",
+  )
+  assert_decode_error(
+    {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
       "start_line": 1.9,
-    })
-  catch {
-    error =>
-      assert_true("\{error}".contains("arguments.start_line to be an integer"))
-  } noraise {
-    _ => fail("fractional start_line decoded")
-  }
-  try
-    @decode.decode({
+    },
+    "arguments.start_line to be an integer",
+  )
+  assert_decode_error(
+    {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
       "start_line": 4,
       "end_line": 2,
-    })
-  catch {
-    error =>
-      assert_true(
-        "\{error}".contains(
-          "arguments.end_line to be greater than or equal to arguments.start_line",
-        ),
-      )
-  } noraise {
-    _ => fail("inverted line range decoded")
-  }
+    },
+    "arguments.end_line to be greater than or equal to arguments.start_line",
+  )
 }
 
 ///|
 test "decode rejects missing required fields" {
-  try @decode.decode({ "path": "file.mbt" }) catch {
-    error => assert_true("\{error}".contains("arguments.old_string"))
-  } noraise {
-    _ => fail("missing old_string decoded")
-  }
-  try @decode.decode({ "path": "file.mbt", "old_string": "old" }) catch {
-    error => assert_true("\{error}".contains("arguments.new_string"))
-  } noraise {
-    _ => fail("missing new_string decoded")
-  }
-  try
-    @decode.decode({
-      "path": "file.mbt",
-      "old_string": "old",
-      "new_string": "new",
-    })
-  catch {
-    error => assert_true("\{error}".contains("arguments.start_line"))
-  } noraise {
-    _ => fail("missing start_line decoded")
-  }
+  assert_decode_error({ "path": "file.mbt" }, "arguments.old_string")
+  assert_decode_error(
+    { "path": "file.mbt", "old_string": "old" },
+    "arguments.new_string",
+  )
+  assert_decode_error(
+    { "path": "file.mbt", "old_string": "old", "new_string": "new" },
+    "arguments.start_line",
+  )
 }
 
 ///|
 test "decode rejects non-object arguments" {
-  try @decode.decode(Json::null()) catch {
-    error => assert_true("\{error}".contains("object arguments"))
-  } noraise {
-    _ => fail("non-object decoded")
-  }
+  assert_decode_error(Json::null(), "object arguments")
 }
 
 ///|
@@ -201,18 +177,14 @@ test "decode reads revert_on_parse_errors" {
     "start_line": 1,
   })
   assert_true(default_on.revert_on_parse_errors)
-  try
-    @decode.decode({
+  assert_decode_error(
+    {
       "path": "file.mbt",
       "old_string": "old",
       "new_string": "new",
       "start_line": 1,
       "revert_on_parse_errors": "yes",
-    })
-  catch {
-    error =>
-      assert_true("\{error}".contains("arguments.revert_on_parse_errors"))
-  } noraise {
-    _ => fail("non-boolean flag decoded")
-  }
+    },
+    "arguments.revert_on_parse_errors",
+  )
 }

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -136,7 +136,7 @@ fn missing_field(
   name : String,
   prefix : String,
 ) -> String {
-  let keys = [ for key in fields.keys() => key ]
+  let keys = fields.keys().collect()
   keys.sort()
   "\{prefix} to include \{name} (present keys: \{keys.join(", ")})"
 }

--- a/agent_tool/multi_edit/internal/decode/decode_test.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode_test.mbt
@@ -62,23 +62,32 @@ test "decode_args allows absent or empty edits (combined-empty is the tool's che
 }
 
 ///|
+/// Asserts that decoding `arguments` fails and the error message names the
+/// offending field.
+fn assert_decode_args_error(arguments : Json, expected : String) -> Unit raise {
+  let _ = @decode.decode_args(arguments) catch {
+    error => {
+      let message = "\{error}"
+      assert_true(
+        message.contains(expected),
+        msg="\{message} should contain \{expected}",
+      )
+      return
+    }
+  }
+  fail("expected decode error")
+}
+
+///|
 test "decode_args rejects wrong field types" {
-  try @decode.decode_args({ "edits": 5 }) catch {
-    error =>
-      assert_true(
-        "\{error}".contains("arguments.edits to be an array of edit objects"),
-      )
-  } noraise {
-    _ => fail("numeric edits decoded")
-  }
-  try @decode.decode_args({ "edits_file": 5 }) catch {
-    error =>
-      assert_true(
-        "\{error}".contains("arguments.edits_file to be a string path"),
-      )
-  } noraise {
-    _ => fail("numeric edits_file decoded")
-  }
+  assert_decode_args_error(
+    { "edits": 5 },
+    "arguments.edits to be an array of edit objects",
+  )
+  assert_decode_args_error(
+    { "edits_file": 5 },
+    "arguments.edits_file to be a string path",
+  )
 }
 
 ///|
@@ -97,26 +106,14 @@ test "decode_args reads revert_when_errors_above and defaults to None" {
 
 ///|
 test "decode_args rejects a non-integer revert_when_errors_above" {
-  try @decode.decode_args({ "revert_when_errors_above": 1.5 }) catch {
-    error =>
-      assert_true(
-        "\{error}".contains(
-          "arguments.revert_when_errors_above to be an integer",
-        ),
-      )
-  } noraise {
-    _ => fail("fractional threshold decoded")
-  }
-  try @decode.decode_args({ "revert_when_errors_above": "5" }) catch {
-    error =>
-      assert_true(
-        "\{error}".contains(
-          "arguments.revert_when_errors_above to be an integer",
-        ),
-      )
-  } noraise {
-    _ => fail("string threshold decoded")
-  }
+  assert_decode_args_error(
+    { "revert_when_errors_above": 1.5 },
+    "arguments.revert_when_errors_above to be an integer",
+  )
+  assert_decode_args_error(
+    { "revert_when_errors_above": "5" },
+    "arguments.revert_when_errors_above to be an integer",
+  )
 }
 
 ///|
@@ -146,8 +143,8 @@ test "decode_edits_json rejects a non-array document" {
 
 ///|
 test "decode rejects malformed edit entries with indexes" {
-  try
-    @decode.decode_args({
+  assert_decode_args_error(
+    {
       "edits": [
         {
           "file": "file.mbt",
@@ -157,19 +154,11 @@ test "decode rejects malformed edit entries with indexes" {
           "end_line": 1,
         },
       ],
-    })
-  catch {
-    error =>
-      assert_true(
-        "\{error}".contains(
-          "arguments.edits[0].start_line to be a positive integer",
-        ),
-      )
-  } noraise {
-    _ => fail("invalid start_line decoded")
-  }
-  try
-    @decode.decode_args({
+    },
+    "arguments.edits[0].start_line to be a positive integer",
+  )
+  assert_decode_args_error(
+    {
       "edits": [
         {
           "file": "file.mbt",
@@ -179,57 +168,29 @@ test "decode rejects malformed edit entries with indexes" {
           "end_line": 2,
         },
       ],
-    })
-  catch {
-    error =>
-      assert_true(
-        "\{error}".contains(
-          "arguments.edits[0].end_line to be greater than or equal to arguments.edits[0].start_line",
-        ),
-      )
-  } noraise {
-    _ => fail("inverted range decoded")
-  }
+    },
+    "arguments.edits[0].end_line to be greater than or equal to arguments.edits[0].start_line",
+  )
 }
 
 ///|
 test "decode rejects missing required fields" {
-  try
-    @decode.decode_args({
-      "edits": [{ "old_string": "old", "new_string": "new", "start_line": 1 }],
-    })
-  catch {
-    error =>
-      assert_true("\{error}".contains("arguments.edits[0] to include file"))
-  } noraise {
-    _ => fail("missing file decoded")
-  }
-  try
-    @decode.decode_args({
-      "edits": [{ "file": "file.mbt", "old_string": "old", "start_line": 1 }],
-    })
-  catch {
-    error =>
-      assert_true(
-        "\{error}".contains("arguments.edits[0] to include new_string"),
-      )
-  } noraise {
-    _ => fail("missing new_string decoded")
-  }
-  try
-    @decode.decode_args({
+  assert_decode_args_error(
+    { "edits": [{ "old_string": "old", "new_string": "new", "start_line": 1 }] },
+    "arguments.edits[0] to include file",
+  )
+  assert_decode_args_error(
+    { "edits": [{ "file": "file.mbt", "old_string": "old", "start_line": 1 }] },
+    "arguments.edits[0] to include new_string",
+  )
+  assert_decode_args_error(
+    {
       "edits": [
         { "file": "file.mbt", "old_string": "old", "new_string": "new" },
       ],
-    })
-  catch {
-    error =>
-      assert_true(
-        "\{error}".contains("arguments.edits[0] to include start_line"),
-      )
-  } noraise {
-    _ => fail("missing start_line decoded")
-  }
+    },
+    "arguments.edits[0] to include start_line",
+  )
 }
 
 ///|
@@ -263,11 +224,7 @@ test "decode lists present keys when a required field is misnamed" {
 
 ///|
 test "decode rejects non-object arguments" {
-  try @decode.decode_args(Json::null()) catch {
-    error => assert_true("\{error}".contains("object arguments"))
-  } noraise {
-    _ => fail("non-object decoded")
-  }
+  assert_decode_args_error(Json::null(), "object arguments")
 }
 
 ///|
@@ -281,10 +238,8 @@ test "decode reads revert_on_parse_errors" {
   assert_false(off.revert_on_parse_errors)
   let default_on = @decode.decode_args({ "edits": [] })
   assert_true(default_on.revert_on_parse_errors)
-  try @decode.decode_args({ "edits": [], "revert_on_parse_errors": 1 }) catch {
-    error =>
-      assert_true("\{error}".contains("arguments.revert_on_parse_errors"))
-  } noraise {
-    _ => fail("non-boolean flag decoded")
-  }
+  assert_decode_args_error(
+    { "edits": [], "revert_on_parse_errors": 1 },
+    "arguments.revert_on_parse_errors",
+  )
 }

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -179,15 +179,17 @@ async fn multi_edit_files(
   // Resolve every edit's path up front and key contiguity and grouping on the
   // resolved path, so two spellings of one file (e.g. `a.mbt` and `./a.mbt`)
   // collapse into a single group rather than racing each other's writes.
-  let resolved : Array[ResolvedEdit] = []
-  for index, item in edits {
-    resolved.push({
-      index,
-      file: item.file,
-      path: @workspace_path.resolve(workspace_root, item.file),
-      item,
-    })
-  }
+  let resolved = [
+    for index, item in edits => {
+      (
+        {
+          index,
+          file: item.file,
+          path: @workspace_path.resolve(workspace_root, item.file),
+          item,
+        } : ResolvedEdit)
+    }
+  ]
   // A file's edits must form one contiguous block so each file is read,
   // validated, and written exactly once.
   if check_contiguity(resolved) is Some(message) {
@@ -377,14 +379,10 @@ async fn parse_gate_batch_rejection(
   if rejections.is_empty() {
     return None
   }
-  let mut total = 0
-  let mut any_truncated = false
-  for rejection in rejections {
-    total += rejection.introduced
-    if rejection.truncated {
-      any_truncated = true
-    }
-  }
+  let total = rejections.fold(init=0, (total, rejection) => {
+    total + rejection.introduced
+  })
+  let any_truncated = rejections.iter().any(rejection => rejection.truncated)
   let bound = if any_truncated { "≥" } else { "" }
   Some(
     @agent_tool.ToolAction::respond(
@@ -405,11 +403,7 @@ fn batch_reject_report(
 ) -> String {
   let total_label = if any_truncated { "at least \{total}" } else { "\{total}" }
   let head = "rejected: the batch would introduce \{total_label} new parse error(s) across \{rejections.length()} file(s), so NO files were changed."
-  let shown = if rejections.length() < RejectedFileDisplayLimit {
-    rejections.length()
-  } else {
-    RejectedFileDisplayLimit
-  }
+  let shown = rejections.length().min(RejectedFileDisplayLimit)
   let sections = [ for rejection in rejections[0:shown] => rejection.section ]
   let overflow = if rejections.length() > shown {
     let hidden = [ for rejection in rejections[shown:] => rejection.path ]
@@ -605,12 +599,9 @@ fn check_contiguity(edits : Array[ResolvedEdit]) -> String? {
   let ended : Map[String, Unit] = {}
   let mut current : String? = None
   for edit in edits {
-    let same = match current {
-      Some(path) => path == edit.path
-      None => false
-    }
+    let same = current is Some(path) && path == edit.path
     if !same {
-      if ended.get(edit.path) is Some(_) {
+      if ended.contains(edit.path) {
         return Some(
           "error multi_editing: edits for \{edit.file} must be contiguous; it reappears at edit[\{edit.index}] after another file's edits; list all edits for a file together",
         )
@@ -663,11 +654,7 @@ fn group_contiguous(edits : Array[ResolvedEdit]) -> Array[FileGroup] {
 ///|
 /// Total number of edits applied across a batch's writes.
 fn total_edit_count(writes : Array[PreparedWrite]) -> Int {
-  let mut total = 0
-  for write in writes {
-    total = total + write.edit_count
-  }
-  total
+  writes.fold(init=0, (total, write) => total + write.edit_count)
 }
 
 ///|
@@ -755,12 +742,7 @@ fn validate_edit(
     })
   }
   let region = select_edit_region(content, item.start_line, item.end_line)
-  let parts = region.body
-    .split(item.old_string)
-    .map(part => part.to_owned())
-    .collect()
-  let occurrences = parts.length() - 1
-  if occurrences == 0 {
+  guard region.body.find(item.old_string) is Some(offset) else {
     return Invalid({
       file,
       index: Some(index),
@@ -768,7 +750,7 @@ fn validate_edit(
       message: "old_string not found",
     })
   }
-  let start = region.start_offset + parts[0].length()
+  let start = region.start_offset + offset
   Valid({
     index,
     start,
@@ -806,17 +788,7 @@ fn collect_overlap_failures(
 
 ///|
 fn compare_plan_ascending(a : PlannedEdit, b : PlannedEdit) -> Int {
-  if a.start < b.start {
-    -1
-  } else if a.start > b.start {
-    1
-  } else if a.end < b.end {
-    -1
-  } else if a.end > b.end {
-    1
-  } else {
-    a.index.compare(b.index)
-  }
+  (a.start, a.end, a.index).compare((b.start, b.end, b.index))
 }
 
 ///|
@@ -874,21 +846,12 @@ fn select_edit_region(
 
 ///|
 fn line_start_offset(content : String, line : Int) -> Int {
+  // Line `line` starts right after line `line - 1` ends (nobreak: both scans
+  // land on content.length() for a line past EOF).
   if line <= 1 {
     0
   } else {
-    let len = content.length()
-    let mut current_line = 1
-    for cursor = 0; cursor < len; cursor = cursor + 1 {
-      if content[cursor] == '\n' {
-        current_line = current_line + 1
-        if current_line == line {
-          break cursor + 1
-        }
-      }
-    } nobreak {
-      len
-    }
+    line_end_offset(content, line - 1)
   }
 }
 

--- a/agent_tool/multi_edit/multi_edit_test.mbt
+++ b/agent_tool/multi_edit/multi_edit_test.mbt
@@ -1,11 +1,7 @@
 ///|
 async fn run_multi_edit(arguments : Json) -> @agent_tool.ToolOutput {
-  let action = match @multi_edit.definition().execute {
-    Async(execute) => execute(arguments)
-    Sync(_) => fail("multi_edit tool should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
-  output
+  // definition() defaults workspace_root to ".", so this is the same tool.
+  run_multi_edit_in_workspace(".", arguments)
 }
 
 ///|

--- a/agent_tool/write/moon.pkg
+++ b/agent_tool/write/moon.pkg
@@ -2,7 +2,7 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
-  "bobzhang/openseek/agent_tool/internal/manifest_path",
+  "bobzhang/openseek/agent_tool/internal/manifest_error",
   "bobzhang/openseek/agent_tool/write/internal/decode",
   "bobzhang/openseek/internal/workspace_path",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -79,7 +79,7 @@ async fn write_file(
   path~ : String,
 ) -> @agent_tool.ToolAction {
   try {
-    if manifest_write_error(path, input.content) is Some(message) {
+    if @manifest_error.write_error(path, input.content) is Some(message) {
       return @agent_tool.ToolAction::respond(
         "error writing \{path}: \{message}",
         is_error=true,
@@ -265,47 +265,6 @@ fn parent_dir(path : String) -> String {
 }
 
 ///|
-async fn manifest_write_error(path : String, content : String) -> String? {
-  let trimmed = content.trim()
-  if @manifest_path.is_generated_mbti_path(path) {
-    return Some(
-      "*.generated.mbti files are generated; run moon info instead of editing them",
-    )
-  }
-  if @manifest_path.is_moon_mod_json_path(path) && !@fs.exists(path) {
-    return Some(
-      "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
-    )
-  }
-  if @manifest_path.is_moon_mod_path(path) {
-    if trimmed == "" {
-      return Some("moon.mod must not be empty")
-    }
-    if trimmed.has_prefix("{") || trimmed.contains("\"name\"") {
-      return Some("moon.mod uses current text syntax, not JSON")
-    }
-    if !trimmed.contains("name =") {
-      return Some("moon.mod should include a module `name = ...` entry")
-    }
-  }
-  if @manifest_path.is_moon_pkg_path(path) {
-    // This is normal when we create a moon.pkg dummy file
-    // another mistake is AI is trying to write 
-    // # as a comment
-    // if trimmed.length() < 8 {    
-    //   return Some("moon.pkg content is suspiciously small")
-    // }
-    if trimmed.has_prefix("#") {
-      return Some("moon.pkg use // for comment syntax, not #")
-    }
-    if trimmed.has_prefix("{") {
-      return Some("moon.pkg uses current text syntax, not JSON")
-    }
-  }
-  None
-}
-
-///|
 async test "write creates missing parent directories" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/pkg/sub/moon.pkg"
@@ -352,31 +311,6 @@ async test "write resolves relative paths under the workspace root" {
     assert_eq(output.content, "ok: wrote 9 chars to \{path}")
     assert_eq(@fs.read_file(path).text(), "workspace")
   })
-}
-
-///|
-async test "write manifest guards accept Windows path separators" {
-  guard manifest_write_error("C:\\workspace\\pkg.generated.mbti", "package x")
-    is Some(generated_mbti) else {
-    fail("expected generated mbti guard")
-  }
-  assert_true(generated_mbti.contains("run moon info"))
-  guard manifest_write_error("C:\\workspace\\moon.mod", "{\"name\":\"bad\"}")
-    is Some(moon_mod) else {
-    fail("expected moon.mod guard")
-  }
-  assert_eq(moon_mod, "moon.mod uses current text syntax, not JSON")
-  // guard manifest_write_error("C:\\workspace\\moon.pkg", "x") is Some(moon_pkg) else {
-  //   fail("expected moon.pkg guard")
-  // }
-  // assert_eq(moon_pkg, "moon.pkg content is suspiciously small")
-  guard manifest_write_error("C:\\workspace\\moon.mod.json", "{}")
-    is Some(moon_mod_json) else {
-    fail("expected moon.mod.json guard")
-  }
-  assert_eq(
-    moon_mod_json, "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
-  )
 }
 
 ///|


### PR DESCRIPTION
Behavior-identical simplification sweep over the file-editing tools (`edit`, `multi_edit`, `write`), applying the file-tools subset of the agent-tool-core findings. A sibling PR handles the rest of that findings group.

## Applied findings

**Dedupe**
- `write/write.mbt`: deleted `manifest_write_error` — a 39-line verbatim copy of `@manifest_error.write_error` — and call the internal package instead (one import line added to `write/moon.pkg`; the now-unused `manifest_path` import removed). Also deleted the duplicated Windows-path test — `manifest_error_test.mbt` covers it verbatim; the execute-level manifest tests remain.
- `edit.mbt` / `multi_edit.mbt`: collapsed the duplicated `line_start_offset` scanner into `line_end_offset(content, line - 1)` for `line >= 2`. Verified identical on both loop pairs, including the `nobreak => length` past-EOF case.
- `edit.mbt`: the five identical 5-line respond-error scaffolds in `edit_file` now go through a local `err(message)` helper; messages are byte-identical.
- `edit_test.mbt` / `multi_edit_test.mbt`: `run_edit` / `run_multi_edit` now delegate to their `run_*_in_workspace(".", ...)` twins (`definition()` defaults `workspace_root` to `"."`).
- `edit/internal/decode/decode_test.mbt` / `multi_edit/internal/decode/decode_test.mbt`: adopted plan decode_test's `assert_decode_error(arguments, expected)` helper pattern (`assert_decode_args_error` in multi_edit) for the repeated `try/catch/noraise` scaffolds.

**Efficiency**
- `edit.mbt` / `multi_edit.mbt`: the first-occurrence scan no longer materializes every fragment via `split(...).map(to_owned).collect()` — `region.body.find(old_string)` gives the same first-occurrence offset. Error messages and offsets are unchanged; `old_string` is guaranteed non-empty at both sites (the insertion path returns earlier). The `replacement_count = 1` constant is gone (interpolated literal `1`).

**Idiom / simplify (multi_edit.mbt)**
- `compare_plan_ascending`: 10-line if-chain → tuple `Compare` (`(a.start, a.end, a.index).compare(...)`); the ascending/descending pair stays symmetric.
- resolved-edit build loop → two-var comprehension.
- `check_contiguity`: `match`-to-Bool → `current is Some(path) && path == edit.path`; `ended.get(...) is Some(_)` → `ended.contains(...)`.
- `total_edit_count` and the rejection total → `fold(init=0, ...)`; the truncated flag → `iter().any(...)`.
- shown-rejections cap → `rejections.length().min(RejectedFileDisplayLimit)`.
- `multi_edit/internal/decode`: identity comprehension over `fields.keys()` → `fields.keys().collect()`.

## Skips (within the multi_edit decode_test scope)
- The "decode lists present keys when a required field is misnamed" scaffold kept its explicit `try/catch`: it makes four compound assertions (including an `assert_false`) that the single-expectation helper cannot express.
- The single `decode_edits_json` reject scaffold kept as-is: one use, different entry point — a dedicated helper would be a net add.

Cross-package dedupes flagged in the findings notes (edit vs multi_edit gate cores, shared line helpers, decode field helpers) are intentionally NOT done — they grow pub API surface and are left for a deliberate decision.

## Validation
- `moon fmt` — clean
- `moon check --deny-warn` — clean
- `moon test` — 1000/1000 passed
- `moon info` — no `.mbti` changes (public API untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)