### PR TITLE
refactor(viz): dedupe label walkers + local simplification sweep

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -342,10 +342,7 @@ fn apply_dropped_file(
   text : String,
 ) -> Model {
   let parsed = @viz.parse_events(text)
-  let (system_prompt, header_present) = match parsed.header {
-    Some(header) => (header.system_prompt, true)
-    None => ("", false)
-  }
+  let (system_prompt, header_present) = header_info(parsed)
   {
     ..model,
     selected: None,
@@ -717,8 +714,7 @@ fn sidebar_groups(rows : Array[SessionRow]) -> Array[String] {
 fn last_separator(p : String) -> Int {
   match (p.rev_find("/"), p.rev_find("\\")) {
     (Some(a), Some(b)) => if a > b { a } else { b }
-    (Some(a), None) => a
-    (None, Some(b)) => b
+    (Some(a), None) | (None, Some(a)) => a
     (None, None) => -1
   }
 }
@@ -1115,6 +1111,17 @@ fn runtime_label(parsed : @session_log.ParsedLog) -> String {
 
 ///|
 fn running_ms(parsed : @session_log.ParsedLog) -> Int64? {
+  match stamp_range(parsed) {
+    // A torn log can stamp backwards; show no span rather than a negative one.
+    Some((first, last)) if last >= first => Some(last - first)
+    _ => None
+  }
+}
+
+///|
+/// The first and last positive wall-clock stamps in the log (unix ms), in file
+/// order, or `None` when no event carries one.
+fn stamp_range(parsed : @session_log.ParsedLog) -> (Int64, Int64)? {
   let mut first = 0L
   let mut last = 0L
   for event in parsed.events {
@@ -1126,8 +1133,8 @@ fn running_ms(parsed : @session_log.ParsedLog) -> Int64? {
       last = stamp
     }
   }
-  if first > 0L && last >= first {
-    Some(last - first)
+  if first > 0L {
+    Some((first, last))
   } else {
     None
   }
@@ -1143,18 +1150,7 @@ fn end_time_label(parsed : @session_log.ParsedLog) -> String {
 
 ///|
 fn last_event_ms(parsed : @session_log.ParsedLog) -> Int64? {
-  let mut last = 0L
-  for event in parsed.events {
-    let stamp = event.unix_ms()
-    if stamp > 0 {
-      last = stamp
-    }
-  }
-  if last > 0L {
-    Some(last)
-  } else {
-    None
-  }
+  stamp_range(parsed).map(range => range.1)
 }
 
 ///|
@@ -1312,13 +1308,7 @@ fn plural_s(n : Int) -> String {
 fn parse_session_rows(text : String) -> Array[SessionRow]? {
   let json = @json.parse(text) catch { _ => return None }
   guard json is Array(items) else { return None }
-  let rows : Array[SessionRow] = []
-  for item in items {
-    if session_row_of(item) is Some(row) {
-      rows.push(row)
-    }
-  }
-  Some(rows)
+  Some(items.filter_map(session_row_of))
 }
 
 ///|
@@ -1370,13 +1360,21 @@ fn parse_load(text : String) -> LoadOutcome {
     _ => return Malformed
   }
   let parsed = @viz.parse_events(events_text)
-  let (system_prompt, header_present) = match parsed.header {
-    Some(header) => (header.system_prompt, true)
-    None => ("", false)
-  }
+  let (system_prompt, header_present) = header_info(parsed)
   let log_bytes = match fields.get("events_bytes") {
     Some(Number(value, ..)) => value.to_int64()
     _ => events_text.length().to_int64()
   }
   Loaded(parsed, system_prompt, header_present, log_bytes)
+}
+
+///|
+/// Lift the header line's identity out of a parsed log:
+/// `(system_prompt, header_present)`. Shared by the served and dropped-file
+/// paths so both label the header strip and seed the model view the same way.
+fn header_info(parsed : @session_log.ParsedLog) -> (String, Bool) {
+  match parsed.header {
+    Some(header) => (header.system_prompt, true)
+    None => ("", false)
+  }
 }

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -340,12 +340,23 @@ async fn read_first_existing(
   candidates : Array[String],
   what : String,
 ) -> String {
+  match first_existing(candidates) {
+    Some(path) => read_text_lossy(path)
+    None => fail("could not locate \{what}")
+  }
+}
+
+///|
+/// The first non-empty candidate path that names an existing file, or `None`.
+/// Shared by the live asset route and the exporter so they resolve candidates
+/// identically.
+async fn first_existing(candidates : Array[String]) -> String? {
   for candidate in candidates {
     if candidate != "" && @fs.exists(candidate) {
-      return read_text_lossy(candidate)
+      return Some(candidate)
     }
   }
-  fail("could not locate \{what}")
+  None
 }
 
 ///|
@@ -463,20 +474,20 @@ fn SessionListRow::to_json(self : SessionListRow) -> Json {
 ///|
 fn compare_session_list_rows(a : SessionListRow, b : SessionListRow) -> Int {
   match (a.last_active, b.last_active) {
-    (Some(a_time), Some(b_time)) =>
-      if a_time == b_time {
-        if a.last_active_nanoseconds == b.last_active_nanoseconds {
-          compare_session_list_row_labels(a, b)
-        } else if a.last_active_nanoseconds > b.last_active_nanoseconds {
-          -1
-        } else {
-          1
-        }
-      } else if a_time > b_time {
-        -1
-      } else {
-        1
+    (Some(a_time), Some(b_time)) => {
+      // Most recently active first: compare b to a for a descending order.
+      let by_time = b_time.compare(a_time)
+      if by_time != 0 {
+        return by_time
       }
+      let by_nanoseconds = b.last_active_nanoseconds.compare(
+        a.last_active_nanoseconds,
+      )
+      if by_nanoseconds != 0 {
+        return by_nanoseconds
+      }
+      compare_session_list_row_labels(a, b)
+    }
     (Some(_), None) => -1
     (None, Some(_)) => 1
     (None, None) => compare_session_list_row_labels(a, b)
@@ -502,25 +513,24 @@ async fn session_catalog(
   search_dirs : Array[String],
   session_root_name : String,
 ) -> SessionCatalog {
-  let roots : Array[SessionRoot] = []
-  // Serve the explicit --session-root directly when it is a store, a directory
-  // of copied `openseek_session-*.jsonl` files, or a single matching file.
-  for root in session_root_sources(session_root, session_root_name) {
-    roots.push(root)
-  }
   // Scan the --session-root only when it is a container, so nested stores under
   // a container root and standalone copied-log directories are surfaced the same
-  // way search-dir trees are. A direct store root is already served above; do
-  // not recurse into its `sessions/<id>` directories as copied-log roots.
+  // way search-dir trees are. A direct store root is already served via
+  // `session_root_sources`; do not recurse into its `sessions/<id>` directories
+  // as copied-log roots.
   let scan_dirs = if is_session_store(session_root, session_root_name) {
     search_dirs
   } else {
     [session_root, ..search_dirs]
   }
-  for root in discover_session_roots(scan_dirs, session_root_name) {
-    roots.push(root)
-  }
-  let roots = unique_roots(roots)
+  let roots = unique_roots(
+    [
+      // Serve the explicit --session-root directly when it is a store, a directory
+      // of copied `openseek_session-*.jsonl` files, or a single matching file.
+      ..session_root_sources(session_root, session_root_name),
+      ..discover_session_roots(scan_dirs, session_root_name),
+    ],
+  )
   { roots, }
 }
 
@@ -656,19 +666,12 @@ async fn contains_direct_session_file(dir : String) -> Bool {
 
 ///|
 fn should_skip_scan_dir(name : String, session_root_name : String) -> Bool {
-  name == session_root_name ||
-  name == ".git" ||
-  name == "node_modules" ||
-  name == ".mooncakes" ||
-  name == "_build"
+  name == session_root_name || should_skip_session_file_scan_dir(name)
 }
 
 ///|
 fn should_skip_session_file_scan_dir(name : String) -> Bool {
-  name == ".git" ||
-  name == "node_modules" ||
-  name == ".mooncakes" ||
-  name == "_build"
+  name is (".git" | "node_modules" | ".mooncakes" | "_build")
 }
 
 ///|
@@ -800,12 +803,11 @@ fn stable_session_key(path : String) -> String {
 
 ///|
 fn session_id_from_file_name(name : String) -> String? {
-  guard name.has_prefix(session_file_prefix) &&
-    name.has_suffix(session_file_suffix) else {
+  guard name.strip_prefix(session_file_prefix) is Some(rest) &&
+    rest.strip_suffix(session_file_suffix) is Some(id) else {
     return None
   }
-  let id = name[session_file_prefix.length():name.length() -
-  session_file_suffix.length()].to_owned()
+  let id = id.to_owned()
   if valid_session_id(id) {
     Some(id)
   } else {
@@ -862,20 +864,25 @@ fn path_tail(path : String) -> String {
 fn last_path_separator(path : String) -> Int? {
   match (path.rev_find("/"), path.rev_find("\\")) {
     (Some(a), Some(b)) => Some(if a > b { a } else { b })
-    (Some(a), None) => Some(a)
-    (None, Some(b)) => Some(b)
+    (Some(a), None) | (None, Some(a)) => Some(a)
     (None, None) => None
   }
 }
 
 ///|
 fn trim_trailing_path_separators(path : String) -> String {
-  let mut result = path
-  while result.length() > 1 &&
-        (result.has_suffix("/") || result.has_suffix("\\")) {
-    result = result[:result.length() - 1].to_owned()
+  let trimmed = for view = path[:] {
+    match view {
+      // Always keep at least one character, so "/" stays "/".
+      [.. rest, '/' | '\\'] if !rest.is_empty() => continue rest
+      _ => break view
+    }
   }
-  result
+  if trimmed.length() == path.length() {
+    path
+  } else {
+    trimmed.to_owned()
+  }
 }
 
 ///|
@@ -935,24 +942,16 @@ fn bundle_candidates(
   web_dir : String,
   module_root : String?,
 ) -> Array[String] {
-  let candidates = [
-    bundle,
-    "\{web_dir}/viz_app.js",
-    "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-    "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-    "_build/js/release/build/cmd/viz_app/viz_app.js",
-    "_build/js/debug/build/cmd/viz_app/viz_app.js",
+  let build_outputs = [
+    "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js", "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
+    "_build/js/release/build/cmd/viz_app/viz_app.js", "_build/js/debug/build/cmd/viz_app/viz_app.js",
   ]
+  let candidates = [bundle, "\{web_dir}/viz_app.js", ..build_outputs]
   if module_root is Some(root) {
     candidates.push("\{root}/web/viz_app.js")
-    candidates.push(
-      "\{root}/_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-    )
-    candidates.push(
-      "\{root}/_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-    )
-    candidates.push("\{root}/_build/js/release/build/cmd/viz_app/viz_app.js")
-    candidates.push("\{root}/_build/js/debug/build/cmd/viz_app/viz_app.js")
+    for path in build_outputs {
+      candidates.push("\{root}/\{path}")
+    }
   }
   candidates
 }
@@ -965,12 +964,10 @@ async fn search_reply(
   content_type : String,
   missing : String,
 ) -> Reply {
-  for candidate in candidates {
-    if candidate != "" && @fs.exists(candidate) {
-      return asset_reply(candidate, content_type)
-    }
+  match first_existing(candidates) {
+    Some(path) => asset_reply(path, content_type)
+    None => text_reply(404, "Not Found", missing)
   }
-  text_reply(404, "Not Found", missing)
 }
 
 ///|

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -104,42 +104,23 @@ fn group_turns(
 /// but the common final-answer path stores the no-tool response only as
 /// `Terminal(Finished(_))`, so derive stable human-facing labels from both.
 fn agent_step_labels(session : @agent_session.Session) -> Map[Int, String] {
-  let total = agent_step_count(session)
+  let sequences = agent_step_sequences(session)
   let labels : Map[Int, String] = Map([])
-  let mut step = 0
-  let mut previous : @agent_session.SessionEvent? = None
-  let mut finish_in_batch = false
-  for event in session.events() {
-    if event_represents_agent_step(event, previous, finish_in_batch) {
-      step += 1
-      labels.set(event.sequence(), "Step \{step}/\{total}")
-    }
-    // A checkpoint Summary can sit between a finish-tool result and its
-    // terminal (compact-on-finish); skip it when looking backward so the
-    // terminal is still attributed to the finish call.
-    match event.item() {
-      Tool(result) =>
-        if result.tool_name() == "finish" {
-          finish_in_batch = true
-        }
-      Summary(_) => ()
-      _ => finish_in_batch = false
-    }
-    if !(event.item() is Summary(_)) {
-      previous = Some(event)
-    }
+  for index, sequence in sequences {
+    labels.set(sequence, "Step \{index + 1}/\{sequences.length()}")
   }
   labels
 }
 
 ///|
-fn agent_step_count(session : @agent_session.Session) -> Int {
-  let mut count = 0
+/// Sequence numbers of the events that represent agent steps, in log order.
+fn agent_step_sequences(session : @agent_session.Session) -> Array[Int] {
+  let sequences : Array[Int] = []
   let mut previous : @agent_session.SessionEvent? = None
   let mut finish_in_batch = false
   for event in session.events() {
     if event_represents_agent_step(event, previous, finish_in_batch) {
-      count += 1
+      sequences.push(event.sequence())
     }
     // A checkpoint Summary can sit between a finish-tool result and its
     // terminal (compact-on-finish); skip it when looking backward so the
@@ -156,7 +137,7 @@ fn agent_step_count(session : @agent_session.Session) -> Int {
       previous = Some(event)
     }
   }
-  count
+  sequences
 }
 
 ///|
@@ -371,7 +352,7 @@ fn runtime_card(seq : Int, time : String, content : String) -> @html.Html {
 /// "Current plan:" line) and the step lines after it. `None` when the notice
 /// has no checklist (the no-plan nag variant).
 fn split_plan_checklist(content : String) -> (String, Array[String])? {
-  let lines = content.split("\n").map(line => line.to_owned()).collect()
+  let lines = string_lines(content)
   for index, line in lines {
     if line.trim_end().has_suffix("Current plan:") {
       let steps = [
@@ -609,20 +590,20 @@ fn generate_diff(old : String, new : String) -> String {
         old_lines[n - 1 - suf] == new_lines[m - 1 - suf] {
     suf += 1
   }
-  let out : Array[String] = []
-  for i in 0..<pre {
-    out.push("  " + old_lines[i])
-  }
-  for i in pre..<(n - suf) {
-    out.push("- " + old_lines[i])
-  }
-  for i in pre..<(m - suf) {
-    out.push("+ " + new_lines[i])
-  }
-  for i in (n - suf)..<n {
-    out.push("  " + old_lines[i])
-  }
-  out.join("\n")
+  [
+    ..[
+      for line in old_lines[:pre] => "  " + line
+    ],
+    ..[
+      for line in old_lines[pre:n - suf] => "- " + line
+    ],
+    ..[
+      for line in new_lines[pre:m - suf] => "+ " + line
+    ],
+    ..[
+      for line in old_lines[n - suf:] => "  " + line
+    ],
+  ].join("\n")
 }
 
 ///|
@@ -762,22 +743,10 @@ fn tool_card(
   } else {
     "Tool result · \{result.tool_name()}"
   }
-  let flag = if is_error {
-    @html.span(class="tool-flag") <| "🚩 failed"
-  } else {
-    @html.nothing
-  }
+  let flag = failed_flag(is_error)
   // Pair this result back to the call that produced it (same `call N` tag).
   let pair = tags.get(result.tool_call_id())
-  let link = match pair {
-    Some(n) =>
-      pair_link(
-        n,
-        href="#\{tool_call_anchor(n)}",
-        title="Jump to the originating call (call \{n})",
-      )
-    None => @html.nothing
-  }
+  let link = result_back_link(pair)
   let anchor = pair.map(n => tool_result_anchor(n))
   @html.details(id?=anchor, class="card \{kind}") <| [
     @html.summary(class="card-label") <| card_head(
@@ -791,6 +760,32 @@ fn tool_card(
       text_block(result.content()),
     ],
   ]
+}
+
+///|
+/// The red flag a failed tool result shows while its card is still collapsed;
+/// nothing for a success.
+fn failed_flag(is_error : Bool) -> @html.Html {
+  if is_error {
+    @html.span(class="tool-flag") <| "🚩 failed"
+  } else {
+    @html.nothing
+  }
+}
+
+///|
+/// The `call N` chip on a result card, linking back to the originating call;
+/// nothing for an unpaired result.
+fn result_back_link(pair : Int?) -> @html.Html {
+  match pair {
+    Some(n) =>
+      pair_link(
+        n,
+        href="#\{tool_call_anchor(n)}",
+        title="Jump to the originating call (call \{n})",
+      )
+    None => @html.nothing
+  }
 }
 
 ///|
@@ -845,16 +840,8 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
   let tags = model_pair_tags(messages)
   let cards : Array[@html.Html] = [
     for index, message in messages => {
-      let time = if index < time_labels.length() {
-        time_labels[index]
-      } else {
-        ""
-      }
-      let step_label = if index < step_labels.length() {
-        step_labels[index]
-      } else {
-        ""
-      }
+      let time = time_labels.get(index).unwrap_or("")
+      let step_label = step_labels.get(index).unwrap_or("")
       message_card(
         message,
         tool_results,
@@ -976,47 +963,10 @@ fn event_label(
 /// that event's relative turn offset.
 fn model_message_time_labels(session : @agent_session.Session) -> Array[String] {
   let labels = event_time_labels(session)
-  let times : Array[String] = [""]
-  let pending_tool_calls : Array[String] = []
-  let events = session.events()
-  for event in events {
-    // Mirror `Session::chat_messages`: a surviving summary projects at the
-    // start of its covered range, so its label lands there too.
-    for candidate in events {
-      if candidate.item() is Summary(summary) &&
-        summary.from_sequence() == event.sequence() &&
-        !model_event_covered_by_later_summary(candidate, events) {
-        flush_pending_tool_labels(pending_tool_calls, times)
-        times.push(event_label(labels, candidate))
-      }
-    }
-    if model_event_covered_by_later_summary(event, events) {
-      continue
-    }
-    match event.item() {
-      // Labeled above at the start of its covered range.
-      Summary(_) => ()
-      Assistant(message) => {
-        flush_pending_tool_labels(pending_tool_calls, times)
-        times.push(event_label(labels, event))
-        for call in message.tool_calls() {
-          pending_tool_calls.push(call.id)
-        }
-      }
-      Tool(result) =>
-        if remove_pending_tool_id(pending_tool_calls, result.tool_call_id()) {
-          times.push(event_label(labels, event))
-        }
-      item => {
-        flush_pending_tool_labels(pending_tool_calls, times)
-        if item_projects_model_message(item) {
-          times.push(event_label(labels, event))
-        }
-      }
-    }
+  let label_of = (event : @agent_session.SessionEvent) => {
+    event_label(labels, event)
   }
-  flush_pending_tool_labels(pending_tool_calls, times)
-  times
+  model_message_labels(session, label_of~, tool_label_of=label_of)
 }
 
 ///|
@@ -1024,8 +974,26 @@ fn model_message_time_labels(session : @agent_session.Session) -> Array[String] 
 /// assistant events get a label; terminal answers and synthetic healed tool
 /// results may project as model messages, but they are not agent-loop steps.
 fn model_message_step_labels(session : @agent_session.Session) -> Array[String] {
-  let event_labels = agent_step_labels(session)
-  let labels : Array[String] = [""]
+  let steps = agent_step_labels(session)
+  model_message_labels(session, label_of=event => event_label(steps, event), tool_label_of=_ => {
+    ""
+  })
+}
+
+///|
+/// One label per projected model message, parallel to
+/// `Session::chat_messages()`: the first system prompt has no backing event and
+/// gets `""`, each event-backed message gets `label_of` for its event —
+/// `tool_label_of` for a tool result — and each synthetic repair message gets
+/// `""` (see `flush_pending_tool_labels`). This walker must mirror the
+/// projection's message order exactly; one extra or missing label shifts every
+/// later chip.
+fn model_message_labels(
+  session : @agent_session.Session,
+  label_of~ : (@agent_session.SessionEvent) -> String,
+  tool_label_of~ : (@agent_session.SessionEvent) -> String,
+) -> Array[String] {
+  let out : Array[String] = [""]
   let pending_tool_calls : Array[String] = []
   let events = session.events()
   for event in events {
@@ -1035,8 +1003,8 @@ fn model_message_step_labels(session : @agent_session.Session) -> Array[String] 
       if candidate.item() is Summary(summary) &&
         summary.from_sequence() == event.sequence() &&
         !model_event_covered_by_later_summary(candidate, events) {
-        flush_pending_tool_labels(pending_tool_calls, labels)
-        labels.push(event_labels.get(candidate.sequence()).unwrap_or(""))
+        flush_pending_tool_labels(pending_tool_calls, out)
+        out.push(label_of(candidate))
       }
     }
     if model_event_covered_by_later_summary(event, events) {
@@ -1046,26 +1014,26 @@ fn model_message_step_labels(session : @agent_session.Session) -> Array[String] 
       // Labeled above at the start of its covered range.
       Summary(_) => ()
       Assistant(message) => {
-        flush_pending_tool_labels(pending_tool_calls, labels)
-        labels.push(event_labels.get(event.sequence()).unwrap_or(""))
+        flush_pending_tool_labels(pending_tool_calls, out)
+        out.push(label_of(event))
         for call in message.tool_calls() {
           pending_tool_calls.push(call.id)
         }
       }
       Tool(result) =>
         if remove_pending_tool_id(pending_tool_calls, result.tool_call_id()) {
-          labels.push("")
+          out.push(tool_label_of(event))
         }
       item => {
-        flush_pending_tool_labels(pending_tool_calls, labels)
+        flush_pending_tool_labels(pending_tool_calls, out)
         if item_projects_model_message(item) {
-          labels.push(event_labels.get(event.sequence()).unwrap_or(""))
+          out.push(label_of(event))
         }
       }
     }
   }
-  flush_pending_tool_labels(pending_tool_calls, labels)
-  labels
+  flush_pending_tool_labels(pending_tool_calls, out)
+  out
 }
 
 ///|
@@ -1136,14 +1104,8 @@ fn assign_pair_tags(
   call_ids : Array[String],
   result_ids : Array[String],
 ) -> Map[String, Int] {
-  let call_counts : Map[String, Int] = Map([])
-  for id in call_ids {
-    call_counts.set(id, call_counts.get(id).unwrap_or(0) + 1)
-  }
-  let result_counts : Map[String, Int] = Map([])
-  for id in result_ids {
-    result_counts.set(id, result_counts.get(id).unwrap_or(0) + 1)
-  }
+  let call_counts = occurrence_counts(call_ids)
+  let result_counts = occurrence_counts(result_ids)
   let tags : Map[String, Int] = Map([])
   let mut next = 1
   // A call_count of 1 means the id occurs exactly once in `call_ids`, so the loop
@@ -1157,6 +1119,16 @@ fn assign_pair_tags(
     }
   }
   tags
+}
+
+///|
+/// How many times each id occurs in `ids`.
+fn occurrence_counts(ids : Array[String]) -> Map[String, Int] {
+  let counts : Map[String, Int] = Map([])
+  for id in ids {
+    counts.set(id, counts.get(id).unwrap_or(0) + 1)
+  }
+  counts
 }
 
 ///|
@@ -1375,25 +1347,13 @@ fn model_tool_card(
     Tool(id) => tags.get(id)
     _ => None
   }
-  let link = match pair {
-    Some(n) =>
-      pair_link(
-        n,
-        href="#\{tool_call_anchor(n)}",
-        title="Jump to the originating call (call \{n})",
-      )
-    None => @html.nothing
-  }
+  let link = result_back_link(pair)
   let anchor = pair.map(n => tool_result_anchor(n))
   @html.details(id?=anchor, class="card \{kind}") <| [
     @html.summary(class="card-label") <| model_card_head(
       label,
       time~,
-      flag=if is_error {
-        @html.span(class="tool-flag") <| "🚩 failed"
-      } else {
-        @html.nothing
-      },
+      flag=failed_flag(is_error),
       link~,
     ),
     @html.div(class="card-body") <| [
@@ -1488,19 +1448,10 @@ fn card_head(
   link? : @html.Html = @html.nothing,
   step_label? : String = "",
 ) -> Array[@html.Html] {
-  let head : Array[@html.Html] = [
+  [
     @html.span(class="card-seq") <| "#\{seq}",
-    flag,
-    @html.text(label),
-    link,
+    ..model_card_head(label, time~, flag~, link~, step_label~),
   ]
-  if !step_label.is_empty() {
-    head.push(@html.span(class="card-step") <| step_label)
-  }
-  if !time.is_empty() {
-    head.push(@html.span(class="card-ts") <| time)
-  }
-  head
 }
 
 ///|


### PR DESCRIPTION
Simplification-sweep PR for the viz stack (`viz`, `cmd/viz_app`, `cmd/viz_server`). All changes are behavior-identical, package-private refactors from a read-only review pass; no `.mbti` interface changes.

## Applied findings (20)

### viz/view.mbt
1. **agent_step_sequences** — `agent_step_count` copy-pasted `agent_step_labels`' 25-line stateful walk; replaced with one pass collecting step sequences, labels derived as `Step i+1/len`. `agent_step_count` deleted (single caller).
2. **model_message_labels** — `model_message_time_labels` and `model_message_step_labels` were ~45-line character-identical walkers differing only in three push expressions; now one shared walker taking `label_of~`/`tool_label_of~`, so the projection-mirroring invariant lives in one place. Applied after finding 1 since step labels feed it.
3. `time_labels.get(index).unwrap_or("")` instead of manual bounds checks (x2).
4. `split_plan_checklist` reuses the existing `string_lines` helper as-is (helper itself untouched).
5. `generate_diff` builds its four sections with slice comprehensions + spread instead of index-arithmetic push loops.
6. **failed_flag / result_back_link** — verbatim 🚩-flag and pair-link blocks deduped between `tool_card` and `model_tool_card`.
7. **occurrence_counts** — the two identical count-building blocks in `assign_pair_tags`.
8. `card_head` = seq chip + spread of `model_card_head(...)` — one source of truth for the step/time chip logic (byte-identical head order).

### cmd/viz_app/app.mbt
9. **header_info** — header-lift match shared by `apply_dropped_file` and `parse_load` (served vs dropped-file contract in one place).
10. Or-pattern collapse in `last_separator`: `(Some(a), None) | (None, Some(a)) => a`.
11. `parse_session_rows` uses `Array::filter_map(session_row_of)`.
12. **stamp_range** — one first/last stamp scan behind `running_ms` and `last_event_ms`. Deviation from the reviewer's sketch: `running_ms` keeps its original `last >= first` guard instead of a bare `.map(r => r.1 - r.0)`, because a non-monotonic log previously yielded `None`, not a negative span — kept exactly identical.

### cmd/viz_server/main.mbt
13. `should_skip_scan_dir` delegates to `should_skip_session_file_scan_dir`, itself a string or-pattern (`".git" | "node_modules" | ".mooncakes" | "_build"`).
14. `bundle_candidates` spells the four `_build` outputs once and reuses them root-prefixed — candidate strings and order unchanged (`main_wbtest.mbt` pins them; test green unchanged).
15. `session_id_from_file_name` via `strip_prefix`/`strip_suffix` instead of `has_prefix`/`has_suffix` + length-arithmetic slicing.
16. Or-pattern collapse in `last_path_separator` — applied **in place**; the near-copy in viz_app stays deliberately duplicated per the sweep's cross-package exclusion.
17. `trim_trailing_path_separators` — view-pattern scanner replaces the per-iteration `.to_owned()` rebuild (O(n²) → O(n)); keeps the keep-one-char rule and the no-copy fast path.
18. **first_existing** — the skip-empty-exists candidate scan shared by `read_first_existing` (exporter) and `search_reply` (live route), so the two stay in lockstep.
19. `session_catalog` builds roots with `unique_roots([..sources, ..discovered])` instead of two element-copy loops (same order, same dedupe; comments kept).
20. `compare_session_list_rows` — reversed `.compare` chain with early returns replaces the hand-rolled three-level -1/1 nesting (sign-driven sort, identical order).

## Skipped
None — all 20 findings applied. Respected exclusions: `escape_json_for_html` / `escape_script_close` untouched (security-load-bearing), `string_lines` not view-converted, cross-package helper copies (`agent_step` family, `plural` vs `plural_s`, `last_separator` vs `last_path_separator`, `format_span_total_seconds`) left duplicated by design.

## Validation
- `moon fmt` — clean
- `moon check --deny-warn` — clean
- `moon test` — 1001/1001 passed (native)
- `moon test --target js` — 215/215 passed (covers the js-only viz stack, incl. `viz_test` 'Step 1/2' / card-step expectations and `main_wbtest` bundle-candidate order)
- `moon info` — no `.mbti` changes (all edits package-private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)