### PR TITLE
refactor(agent_tool): plan/read/finish/internal idiom sweep

### DIFF
--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -170,12 +170,10 @@ pub fn brief_line(text : String, limit? : Int = 72) -> String {
 /// name a file without its directory. Returns `path` unchanged when it has no
 /// separator.
 pub fn brief_basename(path : String) -> String {
-  let cut = match (path.rev_find("/"), path.rev_find("\\")) {
-    (Some(a), Some(b)) => if a > b { a } else { b }
-    (Some(a), None) => a
-    (None, Some(b)) => b
-    (None, None) => -1
-  }
+  let cut = path
+    .rev_find("/")
+    .unwrap_or(-1)
+    .max(path.rev_find("\\").unwrap_or(-1))
   if cut < 0 {
     path
   } else {

--- a/agent_tool/finish/finish.mbt
+++ b/agent_tool/finish/finish.mbt
@@ -27,12 +27,7 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
 
 ///|
 fn execute(arguments : Json) -> @agent_tool.ToolAction {
-  finish(@decode.decode(arguments))
-}
-
-///|
-fn finish(input : @decode.FinishInput) -> @agent_tool.ToolAction {
-  @agent_tool.ToolAction::finish(input.answer)
+  @agent_tool.ToolAction::finish(@decode.decode(arguments).answer)
 }
 
 ///|

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -90,13 +90,9 @@ pub async fn count_errors(path : String) -> CheckErrors? {
     error if @async.is_being_cancelled() => raise error
     _ => return None
   }
-  match result {
-    Some(output) =>
-      Some(
-        tally_diagnostics(output.text, truncated=output.output_limit_reached),
-      )
-    None => None
-  }
+  result.map(output => {
+    tally_diagnostics(output.text, truncated=output.output_limit_reached)
+  })
 }
 
 ///|
@@ -207,7 +203,6 @@ fn is_relevant_moonbit_path(path : String) -> Bool {
 
 ///|
 fn is_moonbit_source_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
   path.has_suffix(".mbt") || path.has_suffix(".mbt.md")
 }
 
@@ -258,10 +253,11 @@ fn is_windows_drive_root(path : String) -> Bool {
 
 ///|
 fn strip_trailing_slash(path : String) -> String {
-  if path.length() > 1 && path.has_suffix("/") {
-    strip_trailing_slash(path[:path.length() - 1].to_owned())
-  } else {
-    path
+  for v = path[:] {
+    match v {
+      [.. rest, '/'] if rest.length() > 0 => continue rest
+      _ => break if v.length() == path.length() { path } else { v.to_owned() }
+    }
   }
 }
 

--- a/agent_tool/internal/auto_check/auto_check_test.mbt
+++ b/agent_tool/internal/auto_check/auto_check_test.mbt
@@ -1,16 +1,23 @@
 ///|
+/// Writes the `moon.mod` + `moon.pkg` fixture pair a checkable module needs;
+/// tests whose manifest is itself under test keep explicit writes.
+async fn write_module(dir : String, name : String) -> Unit {
+  @fs.write_file(
+    "\{dir}/moon.mod",
+    "name = \"\{name}\"\n",
+    create_mode=CreateOrTruncate,
+  )
+  @fs.write_file(
+    "\{dir}/moon.pkg",
+    "warnings = \"+unnecessary_annotation\"\n",
+    create_mode=CreateOrTruncate,
+  )
+}
+
+///|
 async test "append_summary runs compact check for MoonBit source" {
   @vfs.with_tmpdir(prefix="openseek-auto-check-", dir => {
-    @fs.write_file(
-      "\{dir}/moon.mod",
-      "name = \"tmp/auto_check\"\n",
-      create_mode=CreateOrTruncate,
-    )
-    @fs.write_file(
-      "\{dir}/moon.pkg",
-      "warnings = \"+unnecessary_annotation\"\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_module(dir, "tmp/auto_check")
     let path = "\{dir}/main.mbt"
     @fs.write_file(
       path,
@@ -33,16 +40,7 @@ async test "append_summary runs compact check for MoonBit source" {
 ///|
 async test "append_summary checks from module root for nested source" {
   @vfs.with_tmpdir(prefix="openseek-auto-check-root-", dir => {
-    @fs.write_file(
-      "\{dir}/moon.mod",
-      "name = \"tmp/auto_check_root\"\n",
-      create_mode=CreateOrTruncate,
-    )
-    @fs.write_file(
-      "\{dir}/moon.pkg",
-      "warnings = \"+unnecessary_annotation\"\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_module(dir, "tmp/auto_check_root")
     @fs.write_file(
       "\{dir}/root_bad.mbt",
       "pub fn root_bad() -> Int { missing_from_root }\n",
@@ -67,16 +65,7 @@ async test "append_summary checks from module root for nested source" {
 ///|
 async test "append_summary runs compact check for MoonBit markdown source" {
   @vfs.with_tmpdir(prefix="openseek-auto-check-md-", dir => {
-    @fs.write_file(
-      "\{dir}/moon.mod",
-      "name = \"tmp/auto_check_md\"\n",
-      create_mode=CreateOrTruncate,
-    )
-    @fs.write_file(
-      "\{dir}/moon.pkg",
-      "warnings = \"+unnecessary_annotation\"\n",
-      create_mode=CreateOrTruncate,
-    )
+    write_module(dir, "tmp/auto_check_md")
     let path = "\{dir}/README.mbt.md"
     @fs.write_file(
       path,

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -251,11 +251,7 @@ pub fn format_parse_gate_errors(
   errors : Array[ParseGateError],
 ) -> Array[String] {
   let lines = split_owned(content, "\n")
-  let shown = if errors.length() < ParseErrorDisplayLimit {
-    errors.length()
-  } else {
-    ParseErrorDisplayLimit
-  }
+  let shown = errors.length().min(ParseErrorDisplayLimit)
   [
     for error in errors[0:shown] => {
       let header = if error.loc == "" {
@@ -301,18 +297,9 @@ fn excerpt_for_loc(lines : Array[String], loc : String) -> String {
     return ""
   }
   // Cap the span so a single error covering a huge region cannot flood the
-  // report; the error line itself always shows.
-  let mut last = if end_line > start_line + 3 {
-    start_line + 3
-  } else {
-    end_line
-  }
-  if last > lines.length() {
-    last = lines.length()
-  }
-  if last < first {
-    last = first
-  }
+  // report; the error line itself always shows. The early return above
+  // guarantees `first <= lines.length()`, so the clamp bounds are ordered.
+  let last = end_line.min(start_line + 3).clamp(min=first, max=lines.length())
   let width = "\{last}".length()
   let rendered = [
     for number in first..<=last => {

--- a/agent_tool/internal/error/error.mbt
+++ b/agent_tool/internal/error/error.mbt
@@ -4,19 +4,12 @@
 /// an internal package and the raw error string includes source locations.
 pub fn failure_message(error_text : String) -> String {
   let marker = " FAILED: "
-  let pieces : Array[String] = error_text
-    .split(marker)
-    .map(piece => piece.to_owned())
-    .collect()
-  if pieces.length() < 2 {
-    return error_text
+  guard error_text.rev_find(marker) is Some(cut) else { return error_text }
+  let message = error_text[cut + marker.length():]
+  match message.strip_suffix(")") {
+    Some(trimmed) => trimmed.to_owned()
+    None => message.to_owned()
   }
-  let message = pieces[pieces.length() - 1]
-  let message = match message.strip_suffix(")") {
-    Some(trimmed) => trimmed
-    None => message
-  }
-  "\{message}"
 }
 
 ///|

--- a/agent_tool/plan/internal/decode/decode.mbt
+++ b/agent_tool/plan/internal/decode/decode.mbt
@@ -127,14 +127,7 @@ fn normalize_title(index : Int, raw_title : String) -> String raise {
   if title.contains("\n") || title.contains("\r") {
     fail("arguments.steps[\{index}].title to be a single line")
   }
-  let mut visible = false
-  for ch in title {
-    if !ch.is_whitespace() {
-      visible = true
-      break
-    }
-  }
-  if !visible {
+  if title.iter().all(ch => ch.is_whitespace()) {
     fail("arguments.steps[\{index}].title to be non-blank")
   }
   let chars = title.char_length()

--- a/agent_tool/plan/plan.mbt
+++ b/agent_tool/plan/plan.mbt
@@ -76,22 +76,21 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
 /// grows its own copy of the plan argument syntax.
 pub fn reminder_checklist(arguments : Json) -> String? {
   let input = @decode.decode(arguments) catch { _ => return None }
-  if input.steps.length() == 0 {
+  if input.steps.is_empty() {
     return None
   }
-  let lines = StringBuilder::new()
-  for index, step in input.steps {
-    let status = match step.status {
-      Pending => "pending"
-      InProgress => "in_progress"
-      Completed => "completed"
-    }
-    if index > 0 {
-      lines.write_char('\n')
-    }
-    lines.write_string("\{index + 1}. [\{status}] \{step.title}")
-  }
-  Some(lines.to_string())
+  Some(
+    [
+      for index, step in input.steps => {
+        let status = match step.status {
+          Pending => "pending"
+          InProgress => "in_progress"
+          Completed => "completed"
+        }
+        "\{index + 1}. [\{status}] \{step.title}"
+      }
+    ].join("\n"),
+  )
 }
 
 ///|
@@ -158,19 +157,16 @@ fn render(input : @decode.PlanInput) -> @agent_tool.ToolAction {
       brief="plan cleared",
     )
   }
-  let mut completed = 0
-  let mut in_progress : String? = None
-  let mut has_verification = false
-  for step in input.steps {
-    match step.status {
-      Completed => completed += 1
-      InProgress => in_progress = Some(step.title)
-      Pending => ()
-    }
-    if is_verification_title(step.title) {
-      has_verification = true
-    }
-  }
+  let completed = input.steps.iter().count_if(step => step.status is Completed)
+  // The decoder rejects plans with more than one in_progress step, so the
+  // first match is the only one.
+  let in_progress = input.steps
+    .iter()
+    .find_first(step => step.status is InProgress)
+    .map(step => step.title)
+  let has_verification = input.steps
+    .iter()
+    .any(step => is_verification_title(step.title))
   let mut content = match in_progress {
     Some(title) =>
       "Plan updated: \{completed}/\{total} done · in progress: \{title}."

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -108,7 +108,7 @@ async fn read_file(
       brief~,
     )
   }
-  let lines = [ for line in content.split("\n") => line ]
+  let lines = content.split("\n").collect()
   let total_lines = lines.length()
   // Clamp both bounds into [0, total_lines] so the render loop only visits
   // valid lines — a start past the last line selects nothing.


### PR DESCRIPTION
Behavior-identical, clearly-clearer cleanups in `agent_tool` (plan/read/finish/internal scope) from the agent-tool-core simplification findings. A sibling PR handles the edit/multi_edit/write packages.

## Applied findings

- **agent_tool.mbt (`brief_basename`)**: 4-arm match on `(rev_find("/"), rev_find("\\"))` → `rev_find(...).unwrap_or(-1).max(...)`, the exact idiom the sibling `parent_dir` in write.mbt already uses.
- **plan/plan.mbt (`reminder_checklist`)**: StringBuilder with manual first-element separator → two-var comprehension + `join("\n")`; `is_empty()` for the cleared-plan guard.
- **plan/plan.mbt (`render`)**: three `mut` accumulators in one loop → `count_if(status is Completed)`, `find_first(status is InProgress).map(title)`, `any(is_verification_title)`. The decoder rejects plans with more than one `in_progress` step, so first == last.
- **plan/internal/decode (`normalize_title`)**: mut-flag-with-break blank scan → `title.iter().all(ch => ch.is_whitespace())`. Kept `Char::is_whitespace` (Unicode White_Space) and its rationale comment — `String::is_blank` is ASCII-only and would change behavior.
- **finish/finish.mbt**: inlined the single-use one-line `finish()` helper into `execute`.
- **read/read.mbt**: identity comprehension `[for line in content.split("\n") => line]` → `content.split("\n").collect()`. The budgeted, code-unit-sensitive render loop below is untouched.
- **internal/auto_check (`is_moonbit_source_path`)**: dropped the dead `replace_all("\\" -> "/")` — the suffixes contain no separators and the only caller already normalizes.
- **internal/auto_check (`count_errors`)**: identity `Some`/`None` match → `result.map(...)`.
- **internal/auto_check (`strip_trailing_slash`)**: per-character recursive re-allocation → view-pattern functional `for` loop, allocating at most one owned string; the keep-one-char (`"/"` stays `"/"`) behavior is preserved.
- **internal/auto_check/parse_gate**: if-expression min for the error display cap → `errors.length().min(ParseErrorDisplayLimit)`; `excerpt_for_loc`'s `mut last` + three sequential adjustments → `end_line.min(start_line + 3).clamp(min=first, max=lines.length())`. Verified the early return guarantees `first <= lines.length()`, so the clamp bounds are ordered and the sequential/clamp forms agree case-by-case.
- **internal/error (`failure_message`)**: `split(marker)` materializing every piece owned just to take the last → `rev_find(marker)` + slice. The no-marker (return input unchanged) and no-`)` cases are preserved exactly, including the multi-marker last-occurrence behavior.
- **internal/auto_check tests**: the `moon.mod` + `moon.pkg` fixture preamble repeated verbatim across three tests (differing only in module name) → shared `write_module(dir, name)` helper. Tests whose manifest is itself under test keep their explicit writes.

## Skips

None — all 13 assigned findings applied.

## Validation

- `moon fmt` — clean
- `moon check --deny-warn` — clean
- `moon test` — 1001 passed, 0 failed
- `moon info` — no `.mbti` changes (no public API surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)