### PR TITLE
refactor(eval): core-API adoption + local simplification sweep

### DIFF
--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -50,7 +50,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
     event is { "event": String("agent_finished"), .. }
   })
   let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
-  let backgrounded = first_index(seen, event => {
+  let backgrounded = seen.search_by(event => {
     event is { "event": String("tool_result"), "content": String(content), .. } &&
     content.contains("started background job")
   })
@@ -71,7 +71,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
     })
   // Any tool activity strictly between the job start and the marker retrieval
   // shows the wait was actually used for work.
-  let retrieved_at = first_index(seen, event => {
+  let retrieved_at = seen.search_by(event => {
     event
     is {
       "event": String("tool_result"),
@@ -82,21 +82,21 @@ async fn scenario_overlap(engine : Engine) -> Unit {
     content.contains("INTEG-OK-31337")
   })
   let overlapped = match (backgrounded, retrieved_at) {
-    (Some(started), Some(retrieved)) => {
-      let mut found = false
-      for index in (started + 1)..<retrieved {
-        if seen[index]
-          is { "event": String("tool_result"), "tool_name": String(name), .. } &&
-          name != "shell_output" {
-          found = true
-          break
-        }
-      }
-      found
-    }
+    (Some(started), Some(retrieved)) if started < retrieved =>
+      seen[started + 1:retrieved]
+      .iter()
+      .any(event => {
+        event
+        is { "event": String("tool_result"), "tool_name": String(name), .. } &&
+        name != "shell_output"
+      })
     _ => false
   }
-  let answer = finished_answer(finished)
+  let answer = match finished {
+    Some({ "event": String("agent_finished"), "answer": String(answer), .. }) =>
+      answer
+    _ => ""
+  }
   report("S1 used background job (the core judgment)", backgrounded is Some(_))
   report("S1 did not block the turn on the slow command", !blocked_foreground)
   report("S1 overlapped quick work with the running job", overlapped)
@@ -222,11 +222,10 @@ async fn Engine::wait_for(
   matches : (Json) -> Bool,
 ) -> Json? {
   let result = @async.with_timeout_opt(timeout_ms, () => {
-    let mut found : Json? = None
     for ;; {
       let event = self.events.get()
       if event is { "event": String("__engine_eof"), .. } {
-        break
+        break None
       }
       seen.push(event)
       // A failed or aborted turn is terminal for whatever we were waiting on:
@@ -240,36 +239,12 @@ async fn Engine::wait_for(
           ),
           ..
         } {
-        break
+        break None
       }
       if matches(event) {
-        found = Some(event)
-        break
+        break Some(event)
       }
     }
-    found
   })
-  match result {
-    Some(found) => found
-    None => None
-  }
-}
-
-///|
-fn first_index(seen : Array[Json], matches : (Json) -> Bool) -> Int? {
-  for index, event in seen {
-    if matches(event) {
-      return Some(index)
-    }
-  }
-  None
-}
-
-///|
-fn finished_answer(event : Json?) -> String {
-  match event {
-    Some({ "event": String("agent_finished"), "answer": String(answer), .. }) =>
-      answer
-    _ => ""
-  }
+  result.unwrap_or(None)
 }

--- a/eval/file_edit/cmd/main/config.mbt
+++ b/eval/file_edit/cmd/main/config.mbt
@@ -27,8 +27,7 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
 ///|
 fn value(matches : @argparse.Matches, name : String) -> String raise {
   match matches.values.get(name) {
-    Some([value]) => value
-    Some(values) if values.length() > 0 => values[0]
+    Some([first, ..]) => first
     _ => fail("missing parsed argument: \{name}")
   }
 }

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -71,7 +71,7 @@ pub async fn run_suite(config : Config) -> EvalReport {
     runs: config.runs,
     concurrency: config.concurrency,
     min_successes: config.min_successes,
-    successes: count_successes(results),
+    successes: results.iter().count_if(result => result.success),
     out_dir: config.out_dir,
     results,
   }
@@ -113,7 +113,7 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
   let case = @cases.case_for_trial(index)
   let workspace = "\{config.out_dir}/workspaces/\{padded_index(index + 1)}-\{case.id}"
   @fs.mkdir(workspace, recursive=true)
-  write_fixture(workspace, case)
+  case.initial.write_to(workspace)
   let real_workspace = @fs.realpath(workspace)
   let task = case.task(real_workspace)
   // Run the engine in the trial workspace so environment grounding names it
@@ -187,11 +187,6 @@ fn api_key_env_for_model(model : @deepseek.Model) -> String {
     Kimi(_) => "KIMI"
     Deepseek(_) => "DEEPSEEK"
   }
-}
-
-///|
-async fn write_fixture(workspace : String, case : @cases.EvalCase) -> Unit {
-  case.initial.write_to(workspace)
 }
 
 ///|
@@ -301,9 +296,8 @@ fn summarize_agent_log(log_text : String) -> AgentLogSummary {
         if tool_name == "shell" {
           shell_uses += 1
         }
-        match is_error {
-          True => tool_errors += 1
-          _ => ()
+        if is_error is True {
+          tool_errors += 1
         }
       }
       { "event": String(_), .. } => has_json_events = true
@@ -341,9 +335,8 @@ async fn check_expected_state(
     let initial = case.initial.get(unchanged) catch {
       error => return "invalid initial file system: \{error}"
     }
-    let expected = match initial {
-      Some(content) => content
-      None => return "no initial fixture for unchanged file \{unchanged}"
+    guard initial is Some(expected) else {
+      return "no initial fixture for unchanged file \{unchanged}"
     }
     let path = "\{workspace}/\{unchanged}"
     let content = @fs.read_file(path).text() catch {
@@ -361,31 +354,16 @@ async fn run_validation(
   workspace : String,
   validation : Array[String],
 ) -> String {
-  if validation.length() == 0 {
-    return ""
-  }
-  let command = validation[0]
-  let args = [ for i in 1..<validation.length() => validation[i] ]
+  guard validation is [command, .. rest] else { return "" }
   let (code, output) = @process.collect_output_merged(
     command,
-    args,
+    rest.to_owned(),
     cwd=workspace,
   )
   if code == 0 {
     ""
   } else {
     "validation failed: \{validation.join(" ")} exited \{code}: \{output.text()}"
-  }
-}
-
-///|
-fn count_successes(results : Array[TrialResult]) -> Int {
-  for result in results; count = 0 {
-    if result.success {
-      continue count + 1
-    }
-  } nobreak {
-    count
   }
 }
 

--- a/eval/file_edit/harness/harness_wbtest.mbt
+++ b/eval/file_edit/harness/harness_wbtest.mbt
@@ -15,7 +15,7 @@ async test "dry run exact replacement oracle" {
     let workspace = root + "/workspace"
     let log_path = root + "/trial.log"
     @fs.mkdir(workspace, recursive=true)
-    write_fixture(workspace, case)
+    case.initial.write_to(workspace)
     @vfs.FileSystem({ "src/note.txt": "alpha\ndelta\ngamma\n" }).write_to(
       workspace,
     )
@@ -53,7 +53,7 @@ async test "dry run exact replacement oracle with jsonl agent log" {
     let workspace = root + "/workspace"
     let log_path = root + "/trial.log"
     @fs.mkdir(workspace, recursive=true)
-    write_fixture(workspace, case)
+    case.initial.write_to(workspace)
     @vfs.FileSystem({ "src/note.txt": "alpha\ndelta\ngamma\n" }).write_to(
       workspace,
     )

--- a/eval/internal/metrics/metrics.mbt
+++ b/eval/internal/metrics/metrics.mbt
@@ -5,8 +5,7 @@ pub fn count_occurrences(content : String, needle : String) -> Int {
   if needle == "" {
     return 0
   }
-  let pieces = content.split(needle).collect()
-  pieces.length() - 1
+  content.split(needle).count() - 1
 }
 
 ///|
@@ -16,15 +15,7 @@ pub fn count_lines_containing_all(
   content : String,
   needles : Array[String],
 ) -> Int {
-  for line in content.split("\n"); count = 0 {
-    for needle in needles {
-      if !line.contains(needle) {
-        break
-      }
-    } nobreak {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  content
+  .split("\n")
+  .count_if(line => needles.iter().all(needle => line.contains(needle)))
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -71,13 +71,7 @@ pub fn Report::Report(
 ///|
 /// How many rows passed.
 pub fn Report::successes(self : Report) -> Int {
-  for row in self.rows; count = 0 {
-    if row.success {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  self.rows.iter().count_if(row => row.success)
 }
 
 ///|
@@ -108,18 +102,14 @@ pub fn Report::markdown(self : Report) -> String {
     lines.push("")
     lines.push("## Trial Details")
     lines.push("")
-    for line in detail_lines {
-      lines.push(line)
-    }
+    lines.append(detail_lines)
   }
   let log_lines = log_section_lines(self.rows)
   if log_lines.length() > 0 {
     lines.push("")
     lines.push("## Logs")
     lines.push("")
-    for line in log_lines {
-      lines.push(line)
-    }
+    lines.append(log_lines)
   }
   "\{lines.join("\n")}\n"
 }
@@ -167,12 +157,14 @@ pub fn Report::html(self : Report) -> String {
     out.write_string("</div>")
   }
   out.write_string("<div class=\"table-wrap\"><table><thead><tr>")
-  let columns : Array[String] = ["#", "Case", "Result"]
-  for column in self.metric_columns {
-    columns.push(column)
-  }
-  columns.push("Reason")
-  columns.push("Warnings")
+  let columns : Array[String] = [
+    "#",
+    "Case",
+    "Result",
+    ..self.metric_columns,
+    "Reason",
+    "Warnings",
+  ]
   for column in columns {
     out.write_string("<th>")
     out.write_string(escape_html(column))
@@ -303,24 +295,15 @@ fn ReportRow::to_json(self : ReportRow) -> Json {
 
 ///|
 fn table_header(metric_columns : Array[String]) -> String {
-  let cells : Array[String] = ["#", "Case", "Result"]
-  for column in metric_columns {
-    cells.push(column)
-  }
-  cells.push("Reason")
-  cells.push("Warnings")
+  let cells : Array[String] = [
+    "#", "Case", "Result", ..metric_columns, "Reason", "Warnings",
+  ]
   "| \{cells.join(" | ")} |"
 }
 
 ///|
 fn table_divider(metric_columns : Array[String]) -> String {
-  let cells : Array[String] = ["---", "---", "---"]
-  for _ in metric_columns {
-    cells.push("---")
-  }
-  cells.push("---")
-  cells.push("---")
-  "| \{cells.join(" | ")} |"
+  "| \{Array::make(metric_columns.length() + 5, "---").join(" | ")} |"
 }
 
 ///|

--- a/eval/session_analyzer/analyzer.mbt
+++ b/eval/session_analyzer/analyzer.mbt
@@ -39,35 +39,26 @@ priv struct SessionMetrics {
 /// Analyze one already-loaded session.
 pub fn analyze_session(session : @agent_session.Session) -> EvalResult {
   let metrics = summarize_session(session)
-  let reasons : Array[String] = []
-  if !metrics.finished && metrics.terminal_status != "" {
-    reasons.push(
-      "agent terminal " +
-      metrics.terminal_status +
-      ": " +
-      metrics.terminal_message,
-    )
-  } else if !metrics.finished {
-    reasons.push("finish marker missing")
+  let reason = if metrics.finished {
+    "ok"
+  } else if metrics.terminal_status != "" {
+    "agent terminal " +
+    metrics.terminal_status +
+    ": " +
+    metrics.terminal_message
+  } else {
+    "finish marker missing"
   }
-  let warnings : Array[String] = []
-  if metrics.shell_uses > 0 {
-    warnings.push("shell output observed \{metrics.shell_uses} time(s)")
+  let warnings = if metrics.shell_uses > 0 {
+    "shell output observed \{metrics.shell_uses} time(s)"
+  } else {
+    ""
   }
-  let success = reasons.length() == 0
   {
     session_id: session.id().value(),
-    success,
-    reason: if success {
-      "ok"
-    } else {
-      reasons.join("; ")
-    },
-    warnings: if warnings.length() == 0 {
-      ""
-    } else {
-      warnings.join("; ")
-    },
+    success: metrics.finished,
+    reason,
+    warnings,
     steps: metrics.steps,
     tool_results: metrics.tool_results,
     tool_errors: metrics.tool_errors,

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -338,7 +338,7 @@ fn expect_finish(action : @agent_tool.ToolAction, expected : String) -> String {
 
 ///|
 fn build_report(rows : Array[@report.ReportRow]) -> @report.Report {
-  let successes = count_successes(rows)
+  let successes = rows.iter().count_if(row => row.success)
   Report(
     title="Tool Harness",
     summary=[
@@ -348,17 +348,6 @@ fn build_report(rows : Array[@report.ReportRow]) -> @report.Report {
     metric_columns=["Mode", "Action"],
     rows~,
   )
-}
-
-///|
-fn count_successes(rows : Array[@report.ReportRow]) -> Int {
-  for item in rows; count = 0 {
-    if item.success {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
 }
 
 ///|


### PR DESCRIPTION
Part of the eval simplification sweep (the `eval/prompt_task` harness is handled in a sibling PR). All changes are behavior-identical; validated with `moon fmt`, `moon check --deny-warn`, and the full `moon test` suite (1001/1001 pass). `moon info` produced no `.mbti` diffs — no public API changes.

## Applied findings

**eval/bgjobs_capability/main.mbt**
- Deleted the hand-rolled `first_index` helper; both call sites now use `Array::search_by`.
- Rewrote the S1 overlap-window scan (mut flag + index range loop) as `seen[started + 1:retrieved].iter().any(...)` with a `started < retrieved` guard, preserving the reversed-index case the old range loop tolerated.
- `Engine::wait_for`: replaced the `mut found` accumulator with a break-with-value loop (`break Some(event)` / `break None`) and collapsed the trailing Option-of-Option match into `result.unwrap_or(None)`.
- Inlined the single-use `finished_answer` helper as a match at its only call site.

**eval/session_analyzer/analyzer.mbt**
- `analyze_session`: collapsed the ≤1-element `reasons`/`warnings` arrays plus joins into direct string expressions; `success` is now `metrics.finished` directly. Output is byte-identical (the arrays could never hold more than one element, and non-empty `reasons` ⇔ `!metrics.finished`). The Terminal-arm repetition in `summarize_session` is deliberately untouched (load-bearing for step attribution).

**eval/file_edit/cmd/main/config.mbt**
- `value`: folded the `Some([value])` and `Some(values) if values.length() > 0` arms into one rest-pattern arm `Some([first, ..]) => first`.

**eval/file_edit/harness/harness.mbt (+ wbtest)**
- `summarize_agent_log`: one-arm `match is_error { True => ...; _ => () }` → `if is_error is True { ... }`.
- `check_expected_state`: match-with-early-return on the initial fixture → `guard initial is Some(expected) else { return ... }`.
- `run_validation`: length check + `[0]` + index-comprehension rebuild → `guard validation is [command, .. rest] else { return "" }` with `rest.to_owned()` (same copy the comprehension made).
- Deleted `count_successes`; `run_suite` uses `results.iter().count_if(result => result.success)`.
- Inlined the pass-through `write_fixture` (`case.initial.write_to(workspace)`) at its three call sites.

**eval/internal/metrics/metrics.mbt**
- `count_occurrences`: `split().collect()` + `length() - 1` → `split().count() - 1` (drops the intermediate array).
- `count_lines_containing_all`: nested for/nobreak/nobreak → `split("\n").count_if(line => needles.iter().all(...))`. Identical semantics including the vacuous-true empty-needles case, pinned by the existing `debug_inspect` `[3, 1, 1, 0, 3]` test.

**eval/report/report.mbt**
- `Report::successes`: for/nobreak count → `count_if` (pub signature unchanged).
- `Report::markdown`: element-wise push loops → `lines.append(detail_lines)` / `lines.append(log_lines)`.
- Header columns built with spread literals `["#", "Case", "Result", ..metric_columns, "Reason", "Warnings"]` in both the markdown (`table_header`) and HTML paths, dissolving the duplicated push-building.
- `table_divider`: three push shapes → `Array::make(metric_columns.length() + 5, "---")`.
- Rendered report output is byte-identical.

**eval/tool_harness/harness.mbt**
- Deleted the `count_successes` helper; `build_report` uses `rows.iter().count_if(row => row.success)`.

## Skips / notes
- `Option::flatten` and `ArrayView::to_array` are deprecated in the pinned core (deny-warn rejects them); used the non-deprecated equivalents `unwrap_or(None)` and `to_owned()` instead.
- Excluded by design (per the sweep findings): `eval/swe_agi/tasks/csv` (snapshot independence is deliberate), cross-package dedupe between the file_edit and prompt_task harnesses, and everything under `eval/prompt_task` (sibling PR).

## Validation
- `moon fmt` — clean
- `moon check --deny-warn` — clean
- `moon test` — 1001 passed, 0 failed
- `moon info` — no `.mbti` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)