### PR TITLE
refactor(cli,deepseek): dead decoder arms + local simplification sweep

### DIFF
--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -69,13 +69,9 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
     }
   })
   print_fleet_summary(task, outcomes, session_root_value)
-  let mut any_ok = false
-  for outcome in outcomes {
-    if outcome is Some(result) && result.ok {
-      any_ok = true
-    }
+  guard outcomes.any(outcome => outcome is Some(result) && result.ok) else {
+    fail("all \{concurrency} run(s) failed")
   }
-  guard any_ok else { fail("all \{concurrency} run(s) failed") }
 }
 
 ///|
@@ -359,12 +355,9 @@ async fn print_fleet_summary(
   session_root_value : String,
 ) -> Unit {
   let total = outcomes.length()
-  let mut finished = 0
-  for outcome in outcomes {
-    if outcome is Some(result) && result.ok {
-      finished += 1
-    }
-  }
+  let finished = outcomes
+    .iter()
+    .count_if(outcome => outcome is Some(result) && result.ok)
   let lines : Array[String] = [
     "",
     "openseek: \{total} run(s) of \"\{one_line_brief(task, 60)}\" — \{finished} finished, \{total - finished} not",
@@ -395,12 +388,8 @@ fn one_line_brief(text : String, max : Int) -> String {
     "\{one}"
   } else {
     let kept = StringBuilder()
-    for ch in one; count = 0 {
-      if count >= max {
-        break
-      }
+    for ch in one.iter().take(max) {
       kept.write_char(ch)
-      continue count + 1
     }
     kept.write_char('…')
     kept.to_string()

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -95,15 +95,22 @@ async fn with_jsonl_stdout(body : async () -> Unit) -> Unit {
 }
 
 ///|
+/// `--no-session` combined with an explicit `--session` is a contradiction
+/// every mode rejects up front, before any workspace or session work.
+fn reject_session_contradiction(matches : @argparse.Matches) -> Unit raise {
+  if @cli.flag(matches, "no-session") &&
+    @agentcli.session_id(matches) is Some(_) {
+    fail("--no-session contradicts --session; pick one behavior")
+  }
+}
+
+///|
 /// `openseek run [TASK…]` — a headless one-shot agent run (best-of-N under
 /// `--concurrency`), streaming JSONL events on stdout.
 async fn run_task_command(matches : @argparse.Matches) -> Unit {
   with_jsonl_stdout(() => {
     // --no-session contradicts an explicit --session; reject up front.
-    if @cli.flag(matches, "no-session") &&
-      @agentcli.session_id(matches) is Some(_) {
-      fail("--no-session contradicts --session; pick one behavior")
-    }
+    reject_session_contradiction(matches)
     // Best-of-N fleet mode owns its own workspace materialization and session
     // creation, so it branches before prepare_workspace_root (which would
     // create a single --dir).
@@ -185,10 +192,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
 async fn run_serve_command(matches : @argparse.Matches) -> Unit {
   // Serve is ephemeral by default (durable only with --session); --no-session
   // makes that explicit and, as in every mode, contradicts an explicit --session.
-  if @cli.flag(matches, "no-session") &&
-    @agentcli.session_id(matches) is Some(_) {
-    fail("--no-session contradicts --session; pick one behavior")
-  }
+  reject_session_contradiction(matches)
   with_jsonl_stdout(() => {
     let workspace_root = prepare_workspace_root(matches, log_created=true)
     run_serve(matches, workspace_root~)
@@ -252,10 +256,9 @@ async fn sessions_compact(matches : @argparse.Matches) -> Unit {
   let workspace_root = prepare_workspace_root(matches, log_created=false)
   let store = @store.SessionStore(session_root(matches, workspace_root~))
   let id = sessions_target_id(matches)
-  let compact_file = @cli.value(matches, "file").trim().to_owned()
-  if compact_file.is_empty() {
-    fail("`openseek sessions compact` requires --file")
-  }
+  let compact_file = @cli.require_non_empty(
+    matches, "file", "`openseek sessions compact` requires --file",
+  )
   let from_sequence = required_positive_int(
     @cli.value(matches, "from"),
     "--from",
@@ -811,24 +814,22 @@ async fn load_or_new_session(
   model : @deepseek.Model,
   workspace_root? : String = ".",
 ) -> @agent_session.Session {
-  if store.exists(id) {
-    store.load(id) catch {
-      @os_error.OSError(_) as error if error.is_ENOENT() =>
-        Session(
-          id,
-          system_prompt=configured_system_prompt(
-            matches,
-            model,
-            workspace_root~,
-          ),
-        )
-      error => raise error
-    }
-  } else {
+  // The prompt is built only when actually creating a fresh session: a
+  // re-load must not read prompt files again.
+  async fn fresh() -> @agent_session.Session {
     Session(
       id,
       system_prompt=configured_system_prompt(matches, model, workspace_root~),
     )
+  }
+
+  if store.exists(id) {
+    store.load(id) catch {
+      @os_error.OSError(_) as error if error.is_ENOENT() => fresh()
+      error => raise error
+    }
+  } else {
+    fresh()
   }
 }
 
@@ -888,13 +889,12 @@ async fn configured_system_prompt(
 
 ///|
 fn global_skills_dir_for_home(value : String?) -> String? {
-  if value is Some(value) {
-    let home = value.trim()
-    if !home.is_empty() {
-      return Some("\{home}/.openseek/skills")
-    }
+  let home = value.unwrap_or("").trim()
+  if home.is_empty() {
+    None
+  } else {
+    Some("\{home}/.openseek/skills")
   }
-  None
 }
 
 ///|
@@ -960,15 +960,8 @@ async fn skills_prompt_section_for_cwd(
 /// the recorded directory is where the session was started — resume it from
 /// the same project root.
 async fn environment_prompt_section(workspace_root? : String = ".") -> String {
-  let cwd = if workspace_root == "." || workspace_root == "" {
-    @fs.realpath(".") catch {
-      _ => "."
-    }
-  } else {
-    @fs.realpath(workspace_root) catch {
-      _ => workspace_root
-    }
-  }
+  let target = if workspace_root == "" { "." } else { workspace_root }
+  let cwd = @fs.realpath(target) catch { _ => target }
   // FIXME(upstream)
   // " \{sb => f(sb)}"
   // `f` is not allowed to be async, either fix it or better error message (macro expansion should work)

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -51,8 +51,7 @@ async fn run_review_cli(
     }
   }
   @stdio.stdout.write(report.to_json_string() + "\n")
-  let blockers = report.findings.filter(f => f.severity == "blocker").length()
-  if blockers > 0 {
+  if report.findings.any(f => f.severity == "blocker") {
     @sys.exit(2)
   }
 }

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -53,10 +53,7 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
   match json {
     { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text))
     { "command": "steer", .. } =>
-      match decode_steer_input(json) {
-        Ok(input) => Ok(Steer(input))
-        Err(message) => Err(message)
-      }
+      decode_steer_input(json).map(input => Steer(input))
     { "command": "prompt", .. } => Err("expected a string \"text\" field")
     { "command": "compact", .. } => Ok(Compact)
     { "command": "cancel", .. } => Ok(Cancel)
@@ -139,22 +136,14 @@ test "serve commands decode and reject with actionable errors" {
 
 ///|
 fn remove_next_pending_prompt(pending : Array[PendingWork]) -> Unit {
-  for index, work in pending {
-    if work is PendingPrompt(_) {
-      ignore(pending.remove(index))
-      return
-    }
+  if pending.search_by(work => work is PendingPrompt(_)) is Some(index) {
+    ignore(pending.remove(index))
   }
 }
 
 ///|
 fn has_pending_prompt(pending : Array[PendingWork]) -> Bool {
-  for work in pending {
-    if work is PendingPrompt(_) {
-      return true
-    }
-  }
-  false
+  pending.any(work => work is PendingPrompt(_))
 }
 
 ///|
@@ -397,20 +386,11 @@ async fn run_serve(
     }
 
     fn start_next_pending() -> Unit {
-      pending_loop~: for ;; {
-        if active_work is Some(_) || pending.length() == 0 {
-          break pending_loop~
-        }
-        match pending.remove(0) {
-          PendingPrompt(text) => {
-            active_work = Some(ActiveTurn(start_turn(text)))
-            break pending_loop~
-          }
-          PendingCompact => {
-            active_work = Some(ActiveCompact(start_compaction(session)))
-            break pending_loop~
-          }
-        }
+      guard active_work is None && pending.length() > 0 else { return }
+      match pending.remove(0) {
+        PendingPrompt(text) => active_work = Some(ActiveTurn(start_turn(text)))
+        PendingCompact =>
+          active_work = Some(ActiveCompact(start_compaction(session)))
       }
     }
 
@@ -469,9 +449,7 @@ async fn run_serve(
             None =>
               // No active work: in wire order the cancel targets the next
               // submitted prompt, so withdraw it before it starts.
-              if pending.length() > 0 {
-                remove_next_pending_prompt(pending)
-              }
+              remove_next_pending_prompt(pending)
           }
         Wire(Compact) =>
           if active_work is Some(_) {

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -189,7 +189,25 @@ pub async fn Client::chat(
   ) <| messages
   match stream {
     None => self.with_retries(() => self.chat_attempt(body), () => false)
-    Some(stream) => self.chat_stream_body(body, stream)
+    Some(stream) => {
+      // Once the server has produced any complete SSE event the completion is
+      // running and billed — text deltas, tool-call deltas, and usage alike,
+      // even though only text reaches the callbacks. A retry past that point
+      // could duplicate content or generate a different tool call, so the
+      // first event (not just the first text delta) bails the retry loop and
+      // failures surface instead (Codex review).
+      let mut streamed = false
+      self.with_retries(
+        () => {
+          self.chat_stream_attempt(
+            body,
+            on_stream_event=() => streamed = true,
+            stream,
+          )
+        },
+        () => streamed,
+      )
+    }
   }
 }
 
@@ -220,31 +238,6 @@ async fn Client::chat_attempt(
   ) catch {
     error => fail("DeepSeek response decode error: \{error}; body: \{text}")
   }
-}
-
-///|
-async fn Client::chat_stream_body(
-  self : Client,
-  body : Json,
-  stream : StreamHandler,
-) -> @deepseek.ChatResponse {
-  // Once the server has produced any complete SSE event the completion is
-  // running and billed — text deltas, tool-call deltas, and usage alike,
-  // even though only text reaches the callbacks. A retry past that point
-  // could duplicate content or generate a different tool call, so the
-  // first event (not just the first text delta) bails the retry loop and
-  // failures surface instead (Codex review).
-  let mut streamed = false
-  self.with_retries(
-    () => {
-      self.chat_stream_attempt(
-        body,
-        on_stream_event=() => streamed = true,
-        stream,
-      )
-    },
-    () => streamed,
-  )
 }
 
 ///|

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -154,10 +154,7 @@ async fn apply_stream_json(
 ///|
 fn sse_data_fragment(raw : String) -> String? {
   let line = raw.strip_suffix("\r").unwrap_or(raw)
-  match line.strip_prefix("data:") {
-    Some(data) => Some("\{data.trim()}")
-    None => None
-  }
+  line.strip_prefix("data:").map(data => "\{data.trim()}")
 }
 
 ///|

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -61,42 +61,21 @@ impl FromJson for ToolCall with fn from_json(json : Json, path : @json.JsonPath)
       "function": { "name": String(name), "arguments": String(arguments), .. },
       ..
     } => ToolCall(id~, name~, arguments~)
-    {
-      "id": String(_),
-      "function": { "name": String(_), "arguments": _, .. },
-      ..
-    } =>
-      json_decode_error(
-        path.add_key("function").add_key("arguments"),
-        "ToolCall::from_json: expected function.arguments",
-      )
     { "id": String(_), "function": { "name": String(_), .. }, .. } =>
       json_decode_error(
         path.add_key("function").add_key("arguments"),
         "ToolCall::from_json: expected function.arguments",
-      )
-    { "id": String(_), "function": { "name": _, .. }, .. } =>
-      json_decode_error(
-        path.add_key("function").add_key("name"),
-        "ToolCall::from_json: expected function.name",
       )
     Object({ "id": String(_), "function": Object(_), .. }) =>
       json_decode_error(
         path.add_key("function").add_key("name"),
         "ToolCall::from_json: expected function.name",
       )
-    Object({ "id": String(_), "function": _, .. }) =>
-      json_decode_error(
-        path.add_key("function"),
-        "ToolCall::from_json: expected function object",
-      )
     Object({ "id": String(_), .. }) =>
       json_decode_error(
         path.add_key("function"),
         "ToolCall::from_json: expected function object",
       )
-    Object({ "id": _, .. }) =>
-      json_decode_error(path.add_key("id"), "ToolCall::from_json: expected id")
     Object(_) =>
       json_decode_error(path.add_key("id"), "ToolCall::from_json: expected id")
     _ => json_decode_error(path, "ToolCall::from_json: expected object")
@@ -125,10 +104,6 @@ pub impl FromJson for ChatResponse with fn from_json(
         path.add_key("choices"),
         "ChatResponse::from_json: empty choices",
       )
-    { "choices": [Object({ "message": _, .. }), ..], .. } =>
-      json_decode_error(
-        message_path, "ChatResponse::from_json: expected message object",
-      )
     { "choices": [Object(_), ..], .. } =>
       json_decode_error(
         message_path, "ChatResponse::from_json: expected message object",
@@ -137,11 +112,6 @@ pub impl FromJson for ChatResponse with fn from_json(
       json_decode_error(
         path.add_key("choices").add_index(0),
         "ChatResponse::from_json: expected choice object",
-      )
-    { "choices": _, .. } =>
-      json_decode_error(
-        path.add_key("choices"),
-        "ChatResponse::from_json: expected choices array",
       )
     Object(_) =>
       json_decode_error(

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -10,13 +10,10 @@ fn ChatMessage::reasoning_json_fields(
   message : ChatMessage,
   model : Model,
 ) -> Array[(String, Json)] {
-  if !(model is Kimi(_)) {
-    return []
-  }
-  if message.role is Assistant && message.reasoning_content is Some(reasoning) {
-    [("reasoning_content", Json::string(reasoning))]
-  } else {
-    []
+  match (model, message.role, message.reasoning_content) {
+    (Kimi(_), Assistant, Some(reasoning)) =>
+      [("reasoning_content", Json::string(reasoning))]
+    _ => []
   }
 }
 

--- a/testkit/filesystem/filesystem.mbt
+++ b/testkit/filesystem/filesystem.mbt
@@ -208,12 +208,8 @@ fn validate_relative_path(path : String) -> Unit raise {
 
 ///|
 async fn ensure_parent_dir(root : String, path : String) -> Unit {
-  let parts = path.split("/").collect()
-  if parts.length() <= 1 {
-    return
-  }
-  let dirs = parts[:parts.length() - 1]
-  let _ = @fs.mkdir("\{root}/\{dirs.join("/")}", recursive=true) catch {
+  guard path.rev_split_once("/") is Some((dirs, _)) else { return }
+  @fs.mkdir("\{root}/\{dirs}", recursive=true) catch {
     _ => ()
   }
 }

--- a/testkit/filesystem/outline.mbt
+++ b/testkit/filesystem/outline.mbt
@@ -56,18 +56,13 @@ async fn collect_dirs(
 fn sanitize_name(name : String) -> String {
   let limit = 64
   let sb = StringBuilder()
-  let mut count = 0
-  for ch in name {
+  for ch in name; count = 0 {
     if count >= limit {
       sb.write_string("…")
       break
     }
-    if ch is ('\u{00}'..='\u{1F}' | '\u{7F}') {
-      sb.write_char('?')
-    } else {
-      sb.write_char(ch)
-    }
-    count += 1
+    sb.write_char(if ch is ('\u{00}'..='\u{1F}' | '\u{7F}') { '?' } else { ch })
+    continue count + 1
   }
   sb.to_string()
 }


### PR DESCRIPTION
One PR of the simplification sweep, covering `cmd/openseek`, `deepseek`, `deepseek/client`, and `testkit/filesystem`. All changes are behavior-identical (including exact error messages and wire formats); net −93 lines.

## Applied findings (20/20)

### deepseek
1. **`json_decode.mbt` — `ToolCall::from_json`**: deleted four error arms, each a strict subset of the immediately following arm with a byte-identical `JsonPath` + message (10 → 6 arms; surviving order unchanged; decode tests untouched).
2. **`json_decode.mbt` — `ChatResponse::from_json`**: deleted two dead arms the same way (`[Object({"message": _, ..}), ..]` ⊂ `[Object(_), ..]`; `{"choices": _, ..}` ⊂ `Object(_)`); the `[]` and `[_, ..]` arms are unaffected.
3. **`json_encode.mbt` — `reasoning_json_fields`**: one `match (model, message.role, message.reasoning_content)` with a `(Kimi(_), Assistant, Some(reasoning))` arm — all three preconditions visible in one pattern.
4. **`client/stream.mbt` — `sse_data_fragment`**: `strip_prefix("data:").map(...)` instead of a match that rebuilds the Option.
5. **`client/client.mbt`**: inlined the single-use `chat_stream_body` passthrough into `Client::chat`'s `Some(stream)` arm; the bail-once-streamed comment moved with it, and the two arms are now parallel `with_retries` calls with the `() => false` vs `() => streamed` bail policies side by side.

### cmd/openseek
6. **`serve.mbt` — `decode_serve_command`**: `decode_steer_input(json).map(input => Steer(input))`.
7. **`serve.mbt` — `start_next_pending`**: replaced the labeled `for ;;` that never iterates (every path breaks) with `guard` + `match`.
8. **`serve.mbt` — `has_pending_prompt`**: `pending.any(...)` (same short-circuit).
9. **`serve.mbt` — `remove_next_pending_prompt`**: `search_by` + `remove`, removing the mutate-while-iterating question; the `Cancel` call site drops its now-redundant length guard (comment kept).
10. **`main.mbt` — `sessions_compact`**: `@cli.require_non_empty(matches, "file", ...)`, the helper already used elsewhere in the file (identical trim/fail/own semantics).
11. **`main.mbt` — `reject_session_contradiction`**: dedupes the byte-identical `--no-session`/`--session` check in `run_task_command` and `run_serve_command`; mode-specific comments stay at the call sites, and the documented defense-in-depth copy in `resolved_session_id` is left alone.
12. **`main.mbt` — `load_or_new_session`**: local `async fn fresh()` used by both the ENOENT arm and the else branch. The prompt is deliberately **not** hoisted — it is only built when actually creating a fresh session (a test deletes the prompt file before a re-load).
13. **`main.mbt` — `global_skills_dir_for_home`**: `value.unwrap_or("").trim()` merges the `None` and whitespace-only cases.
14. **`main.mbt` — `environment_prompt_section`**: the `"."` special case is the general realpath-with-fallback branch applied to `"."`; one branch now handles both (`""` still maps to `"."` first).
15. **`concurrent.mbt` — `run_fleet`**: `guard outcomes.any(...)` replaces the mutable `any_ok` flag + full scan.
16. **`concurrent.mbt` — `print_fleet_summary`**: `iter().count_if(...)` replaces the mutable counter loop.
17. **`concurrent.mbt` — `one_line_brief`**: `for ch in one.iter().take(max)` replaces the manual counter; still per-`Char`, so still surrogate-safe.
18. **`review.mbt`**: `report.findings.any(f => f.severity == "blocker")` — existence check, no intermediate array.

### testkit/filesystem
19. **`filesystem.mbt` — `ensure_parent_dir`**: `rev_split_once("/")` replaces split/collect/length-guard/slice/join (same behavior for no-slash, trailing-slash, and leading-slash inputs).
20. **`outline.mbt` — `sanitize_name`**: loop binder for the counter and a single `write_char` call with the sanitizing choice inlined.

## Skipped
None — all 20 findings applied.

Deliberately untouched per the findings notes: `apply_stream_json`'s `{"choices": [], ..}` arm, `Usage::from_json`, the duplicated `DeepSeek API error` guard, `random_salt`, `trim_trailing_path_separators`, the `markdown_comments` scanners, and `prompt/*.mbt.md` fences.

## Validation
- `moon fmt` — clean
- `moon check --deny-warn` — clean
- `moon test` — 1001/1001 passed
- `moon cram test tests/cram` — 23/23 passed
- `moon info` — no `.mbti` changes (all edits are to package-private code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)