### PR TITLE
refactor(eval/prompt_task): struct-update spreads + core-API sweep

### DIFF
--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -52,17 +52,13 @@ async fn suite_config_from_matches(
 
 ///|
 fn flag(matches : @argparse.Matches, name : String) -> Bool {
-  match matches.flags.get(name) {
-    Some(value) => value
-    None => false
-  }
+  matches.flags.get(name).unwrap_or(false)
 }
 
 ///|
 fn value(matches : @argparse.Matches, name : String) -> String raise {
   match matches.values.get(name) {
-    Some([value]) => value
-    Some(values) if values.length() > 0 => values[0]
+    Some([first, ..]) => first
     _ => fail("missing parsed argument: \{name}")
   }
 }

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -181,7 +181,7 @@ fn combine_results(
     runs: manifest.runs,
     concurrency: manifest.concurrency,
     min_successes: manifest.min_successes,
-    successes: count_successes(results),
+    successes: results.count_if(result => result.success),
     out_dir: manifest.out_dir,
     results,
   }
@@ -192,24 +192,15 @@ fn manifest_for_output_dir(
   manifest : RunManifest,
   out_dir : String,
 ) -> RunManifest {
-  let original_out_dir = manifest.out_dir
-  RunManifest(
-    model=manifest.model,
-    problem_id=manifest.problem_id,
-    prompt_label=manifest.prompt_label,
-    task_file=manifest.task_file,
-    runs=manifest.runs,
-    concurrency=manifest.concurrency,
-    min_successes=manifest.min_successes,
-    max_steps=manifest.max_steps,
-    out_dir~,
-    validation_probes=manifest.validation_probes,
-    trials=[
+  {
+    ..manifest,
+    out_dir,
+    trials: [
       for trial in manifest.trials => {
-        relocate_trial_artifacts(trial, original_out_dir, out_dir)
+        relocate_trial_artifacts(trial, manifest.out_dir, out_dir)
       }
     ],
-  )
+  }
 }
 
 ///|
@@ -218,18 +209,16 @@ fn relocate_trial_artifacts(
   old_out_dir : String,
   new_out_dir : String,
 ) -> TrialArtifact {
-  TrialArtifact(
-    index=trial.index,
-    workspace=relocate_workspace_path(trial, old_out_dir, new_out_dir),
-    log_path=relocate_output_path(trial.log_path, old_out_dir, new_out_dir),
-    session_id=trial.session_id,
-    events_path=relocate_output_path(
+  {
+    ..trial,
+    workspace: relocate_workspace_path(trial, old_out_dir, new_out_dir),
+    log_path: relocate_output_path(trial.log_path, old_out_dir, new_out_dir),
+    events_path: relocate_output_path(
       trial.events_path,
       old_out_dir,
       new_out_dir,
     ),
-    exit_code=trial.exit_code,
-  )
+  }
 }
 
 ///|
@@ -325,20 +314,14 @@ fn eval_session_with_context(
   context : EvalContext,
 ) -> EvalResult {
   let base = @session_analyzer.analyze_session(session)
-  let reasons : Array[String] = []
-  for reason in context.extra_reasons {
-    reasons.push(reason)
-  }
+  let reasons = context.extra_reasons.copy()
   if !base.success {
     reasons.push(base.reason)
   }
   if context.validation.ran && !context.validation.passed {
     reasons.push(context.validation.reason)
   }
-  let warnings : Array[String] = []
-  for warning in context.extra_warnings {
-    warnings.push(warning)
-  }
+  let warnings = context.extra_warnings.copy()
   if base.warnings != "" {
     warnings.push(base.warnings)
   }
@@ -461,12 +444,11 @@ async fn validate_workspace(
   for probe in probes {
     results.push(run_validation_probe(workspace, probe))
   }
-  let failures : Array[String] = []
-  for result in results {
-    if !result.passed {
-      failures.push(result.name + ": " + result.reason)
+  let failures = [
+    for result in results if !result.passed => {
+      result.name + ": " + result.reason
     }
-  }
+  ]
   {
     ran: true,
     passed: failures.length() == 0,
@@ -489,7 +471,7 @@ async fn run_validation_probe(
   workspace : String,
   spec : ValidationProbeSpec,
 ) -> ProbeResult {
-  if spec.command.length() == 0 {
+  guard spec.command is [head, .. rest] else {
     return ProbeResult(name=spec.name, passed=false, reason="command is empty")
   }
   if spec.write_file != "" {
@@ -499,17 +481,10 @@ async fn run_validation_probe(
       create_mode=CreateOrTruncate,
     )
   }
-  let args = [
-    for i in 1..<spec.command.length() => {
-      replace_workspace(spec.command[i], workspace)
-    }
-  ]
-  let (code, stdout, stderr) = if spec.stdin == "" {
-    @process.collect_output(
-      replace_workspace(spec.command[0], workspace),
-      args,
-      cwd=workspace,
-    )
+  let command = replace_workspace(head, workspace)
+  let args = [ for arg in rest => replace_workspace(arg, workspace) ]
+  let stdin_redirect : &@process.ProcessInput? = if spec.stdin == "" {
+    None
   } else {
     let stdin_path = workspace +
       "/.openseek-" +
@@ -520,13 +495,14 @@ async fn run_validation_probe(
       replace_workspace(spec.stdin, workspace),
       create_mode=CreateOrTruncate,
     )
-    @process.collect_output(
-      replace_workspace(spec.command[0], workspace),
-      args,
-      stdin=@process.redirect_from_file(stdin_path),
-      cwd=workspace,
-    )
+    Some(@process.redirect_from_file(stdin_path))
   }
+  let (code, stdout, stderr) = @process.collect_output(
+    command,
+    args,
+    stdin?=stdin_redirect,
+    cwd=workspace,
+  )
   probe_output_result(spec, code, stdout.text(), stderr.text())
 }
 
@@ -634,17 +610,6 @@ fn sanitize_artifact_name(name : String) -> String {
   .replace_all(old="\\", new="_")
   .replace_all(old=":", new="_")
   .replace_all(old=" ", new="_")
-}
-
-///|
-fn count_successes(results : Array[EvalResult]) -> Int {
-  for result in results; count = 0 {
-    if result.success {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
 }
 
 ///|

--- a/eval/prompt_task/harness/report.mbt
+++ b/eval/prompt_task/harness/report.mbt
@@ -323,11 +323,7 @@ fn eval_result_name(result : EvalResult) -> String {
 
 ///|
 fn eval_result_artifact_name(result : EvalResult) -> String {
-  eval_result_name(result)
-  .replace_all(old="/", new="_")
-  .replace_all(old="\\", new="_")
-  .replace_all(old=":", new="_")
-  .replace_all(old=" ", new="_")
+  sanitize_artifact_name(eval_result_name(result))
 }
 
 ///|
@@ -353,12 +349,11 @@ fn validation_probe_summary(validation : ValidationResult) -> String {
   if validation.probes.length() == 0 {
     return "-"
   }
-  let cells : Array[String] = []
-  for probe in validation.probes {
-    let status = if probe.passed { "pass" } else { "fail" }
-    cells.push(probe.name + "=" + status)
-  }
-  cells.join(", ")
+  [
+    for probe in validation.probes => {
+      probe.name + "=" + (if probe.passed { "pass" } else { "fail" })
+    }
+  ].join(", ")
 }
 
 ///|

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -357,7 +357,7 @@ async fn prepare_suite_output_dir(out_dir : String) -> Unit {
 async fn prepare_combo_output_dirs(jobs : Array[SuiteJob]) -> Unit {
   let seen : Array[String] = []
   for job in jobs {
-    if !string_array_contains(seen, job.out_dir) {
+    if !seen.contains(job.out_dir) {
       seen.push(job.out_dir)
       prepare_output_dir(job.out_dir)
     }
@@ -495,22 +495,15 @@ fn suite_manifest_for_output_dir(
   manifest : SuiteManifest,
   out_dir : String,
 ) -> SuiteManifest {
-  let original_out_dir = manifest.out_dir
-  SuiteManifest(
-    name=manifest.name,
-    out_dir~,
-    runs_per_combo=manifest.runs_per_combo,
-    concurrency=manifest.concurrency,
-    min_successes=manifest.min_successes,
-    max_steps=manifest.max_steps,
-    models=manifest.models,
-    problems=manifest.problems,
-    combos=[
+  {
+    ..manifest,
+    out_dir,
+    combos: [
       for combo in manifest.combos => {
-        relocate_suite_combo(combo, original_out_dir, out_dir)
+        relocate_suite_combo(combo, manifest.out_dir, out_dir)
       }
     ],
-  )
+  }
 }
 
 ///|
@@ -519,18 +512,15 @@ fn relocate_suite_combo(
   old_out_dir : String,
   new_out_dir : String,
 ) -> ComboRun {
-  ComboRun(
-    model=combo.model,
-    problem_id=combo.problem_id,
-    prompt_label=combo.prompt_label,
-    task_file=combo.task_file,
-    out_dir=relocate_output_path(combo.out_dir, old_out_dir, new_out_dir),
-    manifest_path=relocate_output_path(
+  {
+    ..combo,
+    out_dir: relocate_output_path(combo.out_dir, old_out_dir, new_out_dir),
+    manifest_path: relocate_output_path(
       combo.manifest_path,
       old_out_dir,
       new_out_dir,
     ),
-  )
+  }
 }
 
 ///|
@@ -705,24 +695,13 @@ fn SuiteReport::to_json(self : SuiteReport) -> Json {
 ///|
 /// Whether every combo report met its configured threshold.
 pub fn SuiteReport::passed(self : SuiteReport) -> Bool {
-  for report in self.reports {
-    if !report.passed() {
-      return false
-    }
-  }
-  true
+  self.reports.all(report => report.passed())
 }
 
 ///|
 /// One-line failure summary for CLIs that exit non-zero on missed thresholds.
 pub fn SuiteReport::failure_message(self : SuiteReport) -> String {
-  let failed = for report in self.reports; count = 0 {
-    if !report.passed() {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
+  let failed = self.reports.count_if(report => !report.passed())
   "prompt task suite failed: \{failed}/\{self.reports.length()} combos below threshold"
 }
 
@@ -755,12 +734,8 @@ fn SuiteReport::as_report(self : SuiteReport) -> @report.Report {
       "Finished", "Validation",
     ],
     rows=[
-      for index in 0..<self.reports.length() => {
-        suite_report_row(
-          self.reports[index],
-          suite_out_dir=self.out_dir,
-          index~,
-        )
+      for index, report in self.reports => {
+        suite_report_row(report, suite_out_dir=self.out_dir, index~)
       }
     ],
   )
@@ -849,14 +824,9 @@ fn average_result_metric(
   report : EvalReport,
   metric : (EvalResult) -> Int,
 ) -> String {
-  if report.results.length() == 0 {
-    return "0.0"
-  }
-  let total = for result in report.results; total = 0 {
-    continue total + metric(result)
-  } nobreak {
-    total
-  }
+  let total = report.results.fold(init=0, (total, result) => {
+    total + metric(result)
+  })
   format_average(total, report.results.length())
 }
 
@@ -871,26 +841,12 @@ fn format_average(total : Int, count : Int) -> String {
 
 ///|
 fn finished_summary(report : EvalReport) -> String {
-  let count = for result in report.results; count = 0 {
-    if result.finished {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
-  "\{count}/\{report.results.length()}"
+  "\{report.results.count_if(result => result.finished)}/\{report.results.length()}"
 }
 
 ///|
 fn validation_summary(report : EvalReport) -> String {
-  let count = for result in report.results; count = 0 {
-    if result.validation.passed {
-      continue count + 1
-    }
-  } nobreak {
-    count
-  }
-  "\{count}/\{report.results.length()}"
+  "\{report.results.count_if(result => result.validation.passed)}/\{report.results.length()}"
 }
 
 ///|
@@ -927,16 +883,6 @@ fn combo_out_dir(
 }
 
 ///|
-fn string_array_contains(items : Array[String], value : String) -> Bool {
-  for item in items {
-    if item == value {
-      return true
-    }
-  }
-  false
-}
-
-///|
 fn resolve_relative_path(base_dir : String, path : String) -> String {
   if path.has_prefix("/") || base_dir == "." {
     path
@@ -951,11 +897,7 @@ fn dirname(path : String) -> String {
   if pieces.length() <= 1 {
     return "."
   }
-  let cells : Array[String] = []
-  for index in 0..<(pieces.length() - 1) {
-    cells.push(pieces[index].to_owned())
-  }
-  let joined = cells.join("/")
+  let joined = pieces[:pieces.length() - 1].join("/")
   if joined == "" {
     if path.has_prefix("/") {
       "/"


### PR DESCRIPTION
Behavior-identical simplification sweep over `eval/prompt_task` (sibling PR covers the rest of `eval`). Net -102 lines; no public API changes (`moon info` produced no `.mbti` diff); report/summary strings byte-identical.

## Applied findings (17)

**harness/analyzer.mbt**
- `manifest_for_output_dir`: 11-field `RunManifest` rebuild -> struct-update spread (`{ ..manifest, out_dir, trials: ... }`; `manifest.out_dir` still reads the old value since the new struct is built after evaluation)
- `relocate_trial_artifacts`: 6-field `TrialArtifact` rebuild -> spread with the 3 changed fields
- `eval_session_with_context`: element-clone push loops -> `context.extra_reasons.copy()` / `context.extra_warnings.copy()`
- `validate_workspace`: failures push loop -> filtered comprehension
- `run_validation_probe`: length check + `[0]` + index comprehension -> `guard spec.command is [head, .. rest]` view pattern, with the duplicated `replace_workspace(spec.command[0], ...)` hoisted once
- `run_validation_probe`: two near-identical `collect_output` calls -> one call with optional `stdin?=` forwarding (`&@process.ProcessInput?` annotation typechecks cleanly)
- `count_successes` helper deleted -> `results.count_if(result => result.success)`

**harness/report.mbt**
- `eval_result_artifact_name`: inline 4-step replace chain -> reuse `sanitize_artifact_name` (same package)
- `validation_probe_summary`: cells push loop -> comprehension + `join(", ")` (empty `"-"` return kept)

**harness/suite.mbt**
- `suite_manifest_for_output_dir`: 9-field `SuiteManifest` rebuild -> spread
- `relocate_suite_combo`: 6-field `ComboRun` rebuild -> spread
- `SuiteReport::as_report`: index-range row loop -> two-var comprehension
- `SuiteReport::passed`: early-return loop -> `self.reports.all(...)` (same short-circuit + vacuous-true)
- `SuiteReport::failure_message`: for/nobreak count -> `count_if`
- `finished_summary` / `validation_summary`: 9-line for/nobreak twins -> one-liner `count_if` interpolations
- `average_result_metric`: dead empty-guard dropped (`format_average` already returns `"0.0"` for count 0) + for/nobreak sum -> `fold`
- `string_array_contains` helper deleted -> `Array::contains`
- `dirname`: per-piece `to_owned` rebuild loop -> `pieces[:pieces.length() - 1].join("/")`

**cmd/main/config.mbt**
- `value()`: `Some([value])` + length-guarded twin arms -> single `Some([first, ..])` rest-pattern arm
- `flag()`: hand-rolled match -> `.unwrap_or(false)`

## Skips

None within the assigned subset — all 17 findings typechecked and passed the full suite. (Cross-package dedupe between `file_edit` and `prompt_task` and the other `eval` packages are explicitly out of scope per the findings notes.)

Note: the direct `Array::count_if` / `Array::all` methods are used instead of the findings' `iter().count_if` / `iter().all` spelling — same core APIs, one fewer hop.

## Validation

- `moon fmt` — clean
- `moon check --deny-warn` — clean
- `moon test` — 1001/1001 passed (native)
- `moon info` — no `.mbti` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)