### PR TITLE
refactor: drop .iter() hop where container methods exist

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -208,6 +208,6 @@ async test "a finished background job queues a notice and wakes the controller" 
     }
     assert_true(woke)
     let steers = runtime.drain_steers()
-    assert_true(steers.iter().any(s => s is Notice(_)))
+    assert_true(steers.any(s => s is Notice(_)))
   })
 }

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -382,7 +382,7 @@ async fn parse_gate_batch_rejection(
   let total = rejections.fold(init=0, (total, rejection) => {
     total + rejection.introduced
   })
-  let any_truncated = rejections.iter().any(rejection => rejection.truncated)
+  let any_truncated = rejections.any(rejection => rejection.truncated)
   let bound = if any_truncated { "≥" } else { "" }
   Some(
     @agent_tool.ToolAction::respond(

--- a/agent_tool/plan/internal/decode/decode.mbt
+++ b/agent_tool/plan/internal/decode/decode.mbt
@@ -127,7 +127,7 @@ fn normalize_title(index : Int, raw_title : String) -> String raise {
   if title.contains("\n") || title.contains("\r") {
     fail("arguments.steps[\{index}].title to be a single line")
   }
-  if title.iter().all(ch => ch.is_whitespace()) {
+  if title.all(ch => ch.is_whitespace()) {
     fail("arguments.steps[\{index}].title to be non-blank")
   }
   let chars = title.char_length()

--- a/agent_tool/plan/plan.mbt
+++ b/agent_tool/plan/plan.mbt
@@ -157,7 +157,7 @@ fn render(input : @decode.PlanInput) -> @agent_tool.ToolAction {
       brief="plan cleared",
     )
   }
-  let completed = input.steps.iter().count_if(step => step.status is Completed)
+  let completed = input.steps.count_if(step => step.status is Completed)
   // The decoder rejects plans with more than one in_progress step, so the
   // first match is the only one.
   let in_progress = input.steps

--- a/cmd/tui/drain_wbtest.mbt
+++ b/cmd/tui/drain_wbtest.mbt
@@ -171,7 +171,7 @@ test "a prompt during compaction is rejected locally, not steered" {
   // compaction); it is rejected locally so the text is not lost.
   let steered = update(state, UiInput(Steer(Prompt("hello"))))
   assert_eq(error_item_count(steered), 1)
-  assert_true(steered.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(steered.all(cmd => !(cmd is SteerAgent(_))))
   assert_eq(state.pending_steers.length(), 0)
 
   // Tab queues it instead, to run once compaction lands.
@@ -364,13 +364,13 @@ test "Ctrl+C quits when idle and interrupts when a task is running" {
   assert_true(state.run is Running(_))
   let cmds = update(state, UiInput(Interrupt))
   assert_eq(quit_count(cmds), 0)
-  assert_true(cmds.iter().any(cmd => cmd is CancelAgent))
+  assert_true(cmds.any(cmd => cmd is CancelAgent))
   assert_true(state.run is Interrupting(_))
 
   // A second interrupt escalates from the polite cancel command to killing
   // the engine process.
   let cmds = update(state, UiInput(Interrupt))
-  assert_true(cmds.iter().any(cmd => cmd is KillEngine))
+  assert_true(cmds.any(cmd => cmd is KillEngine))
   assert_eq(quit_count(cmds), 0)
 
   // Steering a turn that is being cancelled is refused: the text could
@@ -378,7 +378,7 @@ test "Ctrl+C quits when idle and interrupts when a task is running" {
   // prompt.
   let cmds = update(state, UiInput(Steer(Prompt("late idea"))))
   assert_eq(error_item_count(cmds), 1)
-  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(cmds.all(cmd => !(cmd is SteerAgent(_))))
 }
 
 ///|
@@ -417,7 +417,7 @@ test "steering a running agent sends a steer command" {
   assert_eq(error_item_count(cmds), 0)
   assert_eq(run_background_command_count(cmds), 1)
   assert_eq(run_command_count(cmds), 0)
-  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(cmds.all(cmd => !(cmd is SteerAgent(_))))
   assert_true(state.run is Running(_))
 
   // Queue while running still queues without error.
@@ -455,7 +455,7 @@ test "oneshot engines reject steering" {
   // emitting a steer command.
   let cmds = update(state, UiInput(Steer(Prompt("b"))))
   assert_eq(error_item_count(cmds), 1)
-  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(cmds.all(cmd => !(cmd is SteerAgent(_))))
   let _ = update(
     state,
     AgentProgress(run_id=state.run_id, AgentFinished("done")),
@@ -472,15 +472,15 @@ test "a running shell command is never steered and never kills the engine" {
   // Steering a local command run errors instead of poking the idle engine.
   let cmds = update(state, UiInput(Steer(Prompt("change of plan"))))
   assert_eq(error_item_count(cmds), 1)
-  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(cmds.all(cmd => !(cmd is SteerAgent(_))))
 
   // Interrupt escalation stays on the local task: a second Ctrl-C cancels
   // again rather than killing the bystander engine process.
   let _ = update(state, UiInput(Interrupt))
   assert_true(state.run is Interrupting(_))
   let cmds = update(state, UiInput(Interrupt))
-  assert_true(cmds.iter().any(cmd => cmd is CancelAgent))
-  assert_true(cmds.iter().all(cmd => !(cmd is KillEngine)))
+  assert_true(cmds.any(cmd => cmd is CancelAgent))
+  assert_true(cmds.all(cmd => !(cmd is KillEngine)))
 
   // Finishing the command clears the flag.
   let _ = update(
@@ -515,7 +515,7 @@ test "a cancelled foreground shell command survives as a card, not a lost line" 
   guard cmds is [AppendItem(ToolCall(_))] else {
     fail("expected exactly one cancelled command card, not a lost line")
   }
-  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(cmds.all(cmd => !(cmd is SteerAgent(_))))
   assert_true(state.run is Idle)
   assert_false(state.run_is_command)
 }
@@ -543,7 +543,7 @@ test "a completed shell command is persisted as an idle user message" {
   assert_true(text.contains("<command>\nls\n</command>"))
   assert_true(text.contains("error running shell:"))
   assert_true(state.run is Idle)
-  assert_true(cmds.iter().all(cmd => !(cmd is StartAgent(_, ..))))
+  assert_true(cmds.all(cmd => !(cmd is StartAgent(_, ..))))
   assert_false(state.run_is_command)
 
   let cmds = update(state, UiInput(Steer(Prompt("what changed?"))))
@@ -602,7 +602,7 @@ test "oneshot shell commands run locally but hand nothing to the model" {
   guard cmds is [AppendItem(_)] else {
     fail("expected only the command transcript item")
   }
-  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(cmds.all(cmd => !(cmd is SteerAgent(_))))
   assert_true(state.run is Idle)
 
   let cmds = update(state, UiInput(Steer(Prompt("summarize"))))
@@ -683,7 +683,7 @@ test "blank steers are neither sent nor acknowledged" {
   // The engine would filter it without any settling event, so the TUI must
   // not create an acknowledgment that can never clear.
   assert_eq(state.pending_steers.length(), 0)
-  assert_true(cmds.iter().all(cmd => !(cmd is SteerAgent(_))))
+  assert_true(cmds.all(cmd => !(cmd is SteerAgent(_))))
 }
 
 ///|

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -71,7 +71,7 @@ pub async fn run_suite(config : Config) -> EvalReport {
     runs: config.runs,
     concurrency: config.concurrency,
     min_successes: config.min_successes,
-    successes: results.iter().count_if(result => result.success),
+    successes: results.count_if(result => result.success),
     out_dir: config.out_dir,
     results,
   }

--- a/eval/internal/metrics/metrics.mbt
+++ b/eval/internal/metrics/metrics.mbt
@@ -17,5 +17,5 @@ pub fn count_lines_containing_all(
 ) -> Int {
   content
   .split("\n")
-  .count_if(line => needles.iter().all(needle => line.contains(needle)))
+  .count_if(line => needles.all(needle => line.contains(needle)))
 }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -71,7 +71,7 @@ pub fn Report::Report(
 ///|
 /// How many rows passed.
 pub fn Report::successes(self : Report) -> Int {
-  self.rows.iter().count_if(row => row.success)
+  self.rows.count_if(row => row.success)
 }
 
 ///|

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -338,7 +338,7 @@ fn expect_finish(action : @agent_tool.ToolAction, expected : String) -> String {
 
 ///|
 fn build_report(rows : Array[@report.ReportRow]) -> @report.Report {
-  let successes = rows.iter().count_if(row => row.success)
+  let successes = rows.count_if(row => row.success)
   Report(
     title="Tool Harness",
     summary=[


### PR DESCRIPTION
Follow-up to the simplification sweep: `xs.iter().method(...)` → `xs.method(...)` wherever the receiver is a container that has the method directly with identical semantics. Every receiver type was verified with `moon ide hover`, and every direct method signature against the core `.mbti` (`Array::all/any/count_if`, `String::all` — all take the same predicate, none deprecated).

## Rewritten (21 sites)

**`Array` receivers (hover: `Array[...]`)** — direct `all`/`any`/`count_if` exist in `moonbitlang/core/builtin`:

- `agent/tool_definition.mbt:211` — `steers.any(...)` (was `steers.iter().any`)
- `agent_tool/multi_edit/multi_edit.mbt:385` — `rejections.any(...)`
- `agent_tool/plan/plan.mbt:160` — `input.steps.count_if(...)`
- `cmd/tui/drain_wbtest.mbt` — 13 sites (`cmds`/`steered`, all hover `Array[Cmd]`): lines 174, 367, 373, 381, 420, 458, 475, 482, 483, 518, 546, 605, 686 — `all`/`any` direct
- `eval/file_edit/harness/harness.mbt:74` — `results.count_if(...)`
- `eval/internal/metrics/metrics.mbt:20` — inner `needles.all(...)` (hover: `Array[String]`); the **outer** `.count_if` is on the `Iter` from `content.split("\n")` and stays
- `eval/report/report.mbt:74` — `self.rows.count_if(...)`
- `eval/tool_harness/harness.mbt:341` — `rows.count_if(...)`

**String receiver:**

- `agent_tool/plan/internal/decode/decode.mbt:130` — `title.all(ch => ch.is_whitespace())`. Hover: `title : String`. `String::all(self, (Char) -> Bool raise?)` exists (core `builtin/string.mbt:280`, not deprecated) and iterates `for c in self` — the same Char (code-point) iteration as `String::iter()`, so semantics are identical.

## Verified keeps

- `cmd/openseek/concurrent.mbt:391` — `for ch in one.iter().take(max)`. Hover: `one : StringView`. There is **no** `StringView::take` (or `String::take`) in core — only `Iter::take` — so the `.iter()` hop is required here to cap by character count without splitting surrogate pairs.
- `eval/internal/metrics/metrics.mbt:19` — the outer `.count_if` chains off `content.split("\n")`, which is already an `Iter[StringView]`; nothing to drop.

## Validation

- `moon fmt` — no changes
- `moon check --deny-warn` — clean
- `moon test` — 1000/1000 passed (native)
- `moon info` — zero `.mbti` diffs


## Follow-up commit: count directly instead of building throwaway collections

A second scan for the same shape (intermediate collection built only to be counted) found two leftovers missed by the count_if adoption in #429–#439:

- `agent_session/store/store_test.mbt:285-286` — `results.filter(r => ...).length()` → `results.count_if(r => ...)` (hover: `Array[String]`; drops the filtered-copy allocation)
- `viz/viz_test.mbt:106` — `text.split(needle).collect().length() - 1` → `text.split(needle).count() - 1` (`Iter::count` exists in core builtin; drops the collected array)

Also re-checked and deliberately left: the `for x in xs.iter()` loops in `scripts/internal/markdown_comments` (scripts/ was verified idiomatic in the 2026-07-08 sweep round; not re-sweeping).

Same validation matrix after the commit: `moon fmt` clean, `moon check --deny-warn` clean, `moon test` 1000/1000 (native), zero `.mbti` diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
