### PR TITLE
refactor: simplification + dedupe sweep over the goal-era code

### DIFF
--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -88,25 +88,14 @@ fn GoalCadence::GoalCadence(
   session : @agent_session.Session,
   tool_registered~ : Bool,
 ) -> GoalCadence {
-  match session.current_goal() {
-    Some(goal) =>
-      {
-        tool_registered,
-        goal: Some(goal.text()),
-        remind_now: goal.answered_since_set(),
-        finish_checked: false,
-        pending_blocked_reason: None,
-        pending_tombstone: false,
-      }
-    None =>
-      {
-        tool_registered,
-        goal: None,
-        remind_now: false,
-        finish_checked: false,
-        pending_blocked_reason: None,
-        pending_tombstone: false,
-      }
+  let standing = session.current_goal()
+  {
+    tool_registered,
+    goal: standing.map(goal => goal.text()),
+    remind_now: standing.map(goal => goal.answered_since_set()).unwrap_or(false),
+    finish_checked: false,
+    pending_blocked_reason: None,
+    pending_tombstone: false,
   }
 }
 
@@ -115,9 +104,10 @@ fn GoalCadence::GoalCadence(
 /// instead of ending the turn.
 fn GoalCadence::due_finish_check(self : GoalCadence) -> String? {
   if self.finish_checked {
-    return None
+    None
+  } else {
+    self.goal
   }
-  self.goal
 }
 
 ///|
@@ -154,9 +144,8 @@ fn GoalCadence::record_finish_check(self : GoalCadence) -> Unit {
 /// context-window cycle starts a fresh turn that re-surfaces the goal
 /// right after the checkpoint.
 fn GoalCadence::due_reminder(self : GoalCadence) -> String? {
-  guard self.goal is Some(goal) else { return None }
   if self.remind_now {
-    Some(goal)
+    self.goal
   } else {
     None
   }
@@ -214,9 +203,10 @@ async fn AgentLoop::flush_goal_tombstone(
   session : @agent_session.Session,
 ) -> @agent_session.Session {
   let session = if self.goal_cadence.pending_blocked_reason is Some(reason) {
-    let marker = "\{@agent_session.GoalBlockedPrefix}\n\{reason}"
-    let next = self.append(session, Runtime(RuntimeNotice(marker)))
-    self.messages.push(ChatMessage(User, content=marker))
+    let next = self.append_runtime_notice(
+      session,
+      "\{@agent_session.GoalBlockedPrefix}\n\{reason}",
+    )
     // Cleared only AFTER the durable append, like the tombstone.
     self.goal_cadence.pending_blocked_reason = None
     @xlog.info() <? { "event": "goal_blocked", "reason": reason }
@@ -227,17 +217,14 @@ async fn AgentLoop::flush_goal_tombstone(
   if !self.goal_cadence.pending_tombstone {
     return session
   }
-  let next = self.append(
+  let next = self.append_runtime_notice(
     session,
-    Runtime(RuntimeNotice(@agent_session.GoalClearedNotice)),
+    @agent_session.GoalClearedNotice,
   )
   // Cleared only AFTER the durable append: a failed append must leave the
   // flag set so the error-path retry still lands the tombstone — otherwise
   // a durable goal(met) result coexists with a resurrected goal on resume.
   self.goal_cadence.pending_tombstone = false
-  self.messages.push(
-    ChatMessage(User, content=@agent_session.GoalClearedNotice),
-  )
   @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
   next
 }

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -84,6 +84,16 @@ priv enum ToolCallOutcome {
 }
 
 ///|
+/// A finish attempt's verdict, seen from inside a tool batch: a sealed turn
+/// stops the loop, a compact-on-finish continuation goes back to the model.
+fn ToolCallOutcome::of_finish(outcome : FinishOutcome) -> ToolCallOutcome {
+  match outcome {
+    Sealed(session) => FinishAgentLoop(session)
+    ContinueTurn(session) => ContinueAgentLoop(session)
+  }
+}
+
+///|
 /// Result note for tool calls discarded because the turn is ending at the
 /// context ceiling.
 let ceiling_skip_note : String = "skipped: the turn is yielding at the context ceiling; re-issue after the checkpoint if still needed"
@@ -261,6 +271,20 @@ async fn AgentLoop::append(
 }
 
 ///|
+/// Durably append a runtime notice and mirror it into the in-flight chat
+/// buffer — the notice becomes model-visible only after the durable append
+/// succeeds, so a failed append never leaves the buffer ahead of the log.
+async fn AgentLoop::append_runtime_notice(
+  self : Self,
+  session : @agent_session.Session,
+  content : String,
+) -> @agent_session.Session {
+  let next = self.append(session, Runtime(RuntimeNotice(content)))
+  self.messages.push(ChatMessage(User, content~))
+  next
+}
+
+///|
 /// Durably append the response's assistant message and mirror it into the
 /// in-flight chat buffer — the two must stay in lockstep (see `messages`).
 async fn AgentLoop::record_assistant(
@@ -343,15 +367,13 @@ async fn AgentLoop::prepare_step(
       goal,
       tool_registered=self.goal_cadence.tool_registered,
     )
-    session = self.append(session, Runtime(RuntimeNotice(reminder)))
-    self.messages.push(ChatMessage(User, content=reminder))
+    session = self.append_runtime_notice(session, reminder)
     @xlog.info() <? { "event": "goal_reminder", "content": reminder }
     self.goal_cadence.record_reminder()
   }
   if self.plan_cadence.should_remind() {
     let reminder = self.plan_cadence.reminder_text()
-    session = self.append(session, Runtime(RuntimeNotice(reminder)))
-    self.messages.push(ChatMessage(User, content=reminder))
+    session = self.append_runtime_notice(session, reminder)
     @xlog.info() <? { "event": "plan_reminder", "content": reminder }
     self.plan_cadence.record_reminder()
   }
@@ -545,28 +567,24 @@ async fn AgentLoop::execute_tool_call(
         // check round: injecting one would exit into "max steps exhausted"
         // and turn a successful bounded turn into a failure. Finish.
         if !last_step && self.goal_cadence.due_finish_check() is Some(_) {
-          return match
+          return ToolCallOutcome::of_finish(
             self.continue_into_goal_check(
               session,
               response.usage,
               spent_result_chars~,
               kept_answer=answer,
               keep_only_when_compacted=true,
-            ) {
-            Sealed(next) => FinishAgentLoop(next)
-            ContinueTurn(next) => ContinueAgentLoop(next)
-          }
+            ),
+          )
         }
-        return match
+        return ToolCallOutcome::of_finish(
           self.finish_turn(
             session,
             answer,
             usage=response.usage,
             spent_result_chars~,
-          ) {
-          Sealed(next) => FinishAgentLoop(next)
-          ContinueTurn(next) => ContinueAgentLoop(next)
-        }
+          ),
+        )
       }
       // User input wins over the finish tool as well — but never answered in
       // a starved context: at the ceiling the turn yields and the steers
@@ -942,9 +960,7 @@ async fn AgentLoop::continue_into_goal_check(
     // Re-seed the in-flight buffer from the compacted projection: the
     // whole point of the checkpoint is that the check round is small.
     self.messages.clear()
-    for message in session.chat_messages() {
-      self.messages.push(message)
-    }
+    self.messages.append(session.chat_messages())
   }
   ContinueTurn(session)
 }
@@ -962,8 +978,7 @@ async fn AgentLoop::inject_goal_check(
     goal,
     tool_registered=self.goal_cadence.tool_registered,
   )
-  let session = self.append(session, Runtime(RuntimeNotice(check)))
-  self.messages.push(ChatMessage(User, content=check))
+  let session = self.append_runtime_notice(session, check)
   @xlog.info() <? { "event": "goal_check", "content": check }
   self.goal_cadence.record_finish_check()
   // The check must stay the newest instruction: a plan reminder landing at

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -85,11 +85,7 @@ pub fn goal_marker(content : String) -> GoalMarker? {
   if content == GoalClearedNotice {
     Some(GoalCleared)
   } else if content.has_prefix("\{GoalBlockedPrefix}\n") {
-    Some(
-      GoalBlocked(
-        "\{content.view(start_offset=GoalBlockedPrefix.length() + 1)}",
-      ),
-    )
+    Some(GoalBlocked(content[GoalBlockedPrefix.length() + 1:].to_owned()))
   } else if content.has_prefix("\{GoalPrefix}\n") {
     Some(GoalSet(content[GoalPrefix.length() + 1:].to_owned()))
   } else {
@@ -111,7 +107,8 @@ pub fn Session::current_goal(self : Session) -> StandingGoal? {
   let mut blocked = false
   let covered : Array[(Int, Int)] = []
   for index = events.length() - 1; index >= 0; index = index - 1 {
-    match events[index].item() {
+    let event = events[index]
+    match event.item() {
       Assistant(_) | Terminal(_) => answered = true
       // A summary whose range CONTAINS the set marker removes its verbatim
       // text from the projection: treat the goal as "answered" so the
@@ -127,15 +124,11 @@ pub fn Session::current_goal(self : Session) -> StandingGoal? {
           // temporally; a NEWER set is found first and naturally resets it.
           Some(GoalBlocked(_)) => blocked = true
           Some(GoalSet(text)) => {
-            let sequence = events[index].sequence()
-            let mut is_covered = false
-            for range in covered {
+            let sequence = event.sequence()
+            let is_covered = covered.any(range => {
               let (from, to) = range
-              if from <= sequence && sequence <= to {
-                is_covered = true
-                break
-              }
-            }
+              from <= sequence && sequence <= to
+            })
             return Some({
               text,
               answered_since_set: answered || is_covered,

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -64,7 +64,7 @@ priv struct FileFingerprint {
 /// treat a missing `root/sessions` directory as an empty store where that makes
 /// sense.
 pub fn SessionStore::SessionStore(root : String) -> SessionStore {
-  { root, marks: {} }
+  { root, marks: Map([]) }
 }
 
 ///|

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -206,7 +206,7 @@ pub struct Tools {
 /// since the model dispatches by name and a silent override would mask one
 /// of the tools.
 pub fn Tools::Tools(definitions : Array[AgentToolDefinition]) -> Tools raise {
-  let by_name : Map[String, AgentToolDefinition] = {}
+  let by_name : Map[String, AgentToolDefinition] = Map([])
   for definition in definitions {
     if by_name.contains(definition.name) {
       fail("duplicate tool name: \{definition.name}")
@@ -420,7 +420,10 @@ test "Tools::function_tools preserves description and schema" {
     {
       name: "echo",
       description: "Echo what comes in.",
-      schema: JsonSchema({ "type": "object", "properties": {} }),
+      schema: JsonSchema({
+        "type": "object",
+        "properties": Json::object(Map([])),
+      }),
       execute: Sync(_args => ToolAction::respond("ok")),
       control: false,
     },

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -177,7 +177,7 @@ pub fn[X] BgJobRuntime::new(
     spill_dir,
     hard_timeout_ms,
     on_job_exit,
-    jobs: {},
+    jobs: Map([]),
     next_index: 1,
     fg_index: 1,
   }

--- a/agent_tool/finish/finish.mbt
+++ b/agent_tool/finish/finish.mbt
@@ -56,7 +56,7 @@ test "finish ignores extra fields on the payload" {
 
 ///|
 test "finish returns empty Finish when answer is missing" {
-  assert_finish({}, "")
+  assert_finish(Json::object(Map([])), "")
 }
 
 ///|

--- a/agent_tool/finish/internal/decode/decode_test.mbt
+++ b/agent_tool/finish/internal/decode/decode_test.mbt
@@ -31,7 +31,7 @@ test "decode ignores extra fields" {
 ///|
 test "decode falls back to empty answer" {
   debug_inspect(
-    @decode.decode({}),
+    @decode.decode(Json::object(Map([]))),
     content=(
       #|{ answer: "" }
     ),

--- a/agent_tool/multi_edit/internal/decode/decode_test.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode_test.mbt
@@ -54,7 +54,7 @@ test "decode_args accepts inline edits and an edits_file together" {
 
 ///|
 test "decode_args allows absent or empty edits (combined-empty is the tool's check)" {
-  let nothing = @decode.decode_args({})
+  let nothing = @decode.decode_args(Json::object(Map([])))
   assert_eq(nothing.inline.length(), 0)
   assert_true(nothing.edits_file is None)
   let empty_array = @decode.decode_args({ "edits": [] })

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -596,7 +596,7 @@ fn error_count_label(after : @auto_check.CheckErrors) -> String {
 fn check_contiguity(edits : Array[ResolvedEdit]) -> String? {
   // Set of paths whose contiguous block has already ended, so the membership
   // test stays O(1) even for a large batch touching many files.
-  let ended : Map[String, Unit] = {}
+  let ended : Map[String, Unit] = Map([])
   let mut current : String? = None
   for edit in edits {
     let same = current is Some(path) && path == edit.path

--- a/agent_tool/multi_edit/multi_edit_test.mbt
+++ b/agent_tool/multi_edit/multi_edit_test.mbt
@@ -551,7 +551,7 @@ async test "multi_edit concatenates inline edits with an edits_file" {
 
 ///|
 async test "multi_edit rejects a call with no edits at all" {
-  let output = run_multi_edit({})
+  let output = run_multi_edit(Json::object(Map([])))
   assert_true(output.is_error)
   assert_true(output.content.contains("edits and/or edits_file"))
   // An explicit empty array is the same combined-empty case.

--- a/agent_tool/plan/internal/decode/decode_test.mbt
+++ b/agent_tool/plan/internal/decode/decode_test.mbt
@@ -71,7 +71,7 @@ fn assert_decode_error(arguments : Json, expected : String) -> Unit raise {
 
 ///|
 test "decode rejects missing steps" {
-  assert_decode_error({}, "arguments.steps to be an array")
+  assert_decode_error(Json::object(Map([])), "arguments.steps to be an array")
 }
 
 ///|

--- a/agent_tool/plan/plan.mbt
+++ b/agent_tool/plan/plan.mbt
@@ -305,7 +305,10 @@ test "plan clears with an empty step list" {
 
 ///|
 test "plan rejects malformed arguments with a field-naming error" {
-  assert_plan_error({}, "error: plan requires arguments.steps to be an array")
+  assert_plan_error(
+    Json::object(Map([])),
+    "error: plan requires arguments.steps to be an array",
+  )
   assert_plan_error(
     { "steps": [{ "title": "one", "status": "doing" }] },
     "arguments.steps[0].status to be one of pending|in_progress|completed",

--- a/agent_tool/read/internal/decode/decode_test.mbt
+++ b/agent_tool/read/internal/decode/decode_test.mbt
@@ -35,7 +35,7 @@ test "decode defaults optional limits" {
 
 ///|
 test "decode rejects missing path" {
-  try @decode.decode({}) catch {
+  try @decode.decode(Json::object(Map([]))) catch {
     error => assert_true("\{error}".contains("arguments.path"))
   } noraise {
     _ => fail("missing path decoded")

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -482,7 +482,7 @@ async test "read reports directories with an actionable hint" {
 
 ///|
 async test "read rejects missing path" {
-  let result = execute({})
+  let result = execute(Json::object(Map([])))
   guard result is Respond(output) else { fail("expected Respond") }
   assert_true(output.content.contains("error: read requires"))
   assert_true(output.content.contains("arguments.path"))

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -5,7 +5,7 @@ const SandboxExecPath : String = "/usr/bin/sandbox-exec"
 const SandboxSourceWriteFeedback : String = "shell sandbox: source file writes from shell are blocked. Editing source through the shell is not how this project works — it is discouraged, not a temporary obstacle to route around. Our practice is to make source changes with line-anchored `edit` (or `multi_edit` for several fixes in one file) so each change stays small and reviewable. For compiler-feedback or mechanical fixes, use `edit`, not shell-generated rewrites. Do NOT try to work around this block (redirects, `sed`/`awk`/scripts, `git apply`, or stage-then-checkout tricks) — apply the change with `edit`. Keep `shell` for read-only analysis and validation commands."
 
 ///|
-let source_write_profile_cache : Map[String, CachedSourceWriteProfile] = {}
+let source_write_profile_cache : Map[String, CachedSourceWriteProfile] = Map([])
 
 ///|
 let sandbox_exec_available_cache : Ref[Bool?] = { val: None }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -369,7 +369,7 @@ test "root command rejects an unknown subcommand" {
   // argparse owns this now (no hand-rolled dispatch): a bare non-subcommand word
   // is refused rather than silently opening the UI as a free-form prompt.
   let outcome = try {
-    root_command().parse(argv=["serv"], env={}) |> ignore
+    root_command().parse(argv=["serv"], env=Map([])) |> ignore
     "parsed"
   } catch {
     e => "\{e}"
@@ -1152,13 +1152,16 @@ test "cli uses KIMI only for Kimi models" {
 ///|
 test "explicit --concurrency selects fleet mode even at 1" {
   // Any explicit --concurrency copies --dir; 1 is not an in-place special case.
-  let explicit_one = run_matches(argv=["--concurrency", "1", "task"], env={})
+  let explicit_one = run_matches(
+    argv=["--concurrency", "1", "task"],
+    env=Map([]),
+  )
   assert_true(fleet_mode(explicit_one, 1))
   // The env var counts as explicit too.
   let via_env = run_matches(argv=["task"], env={ "OPENSEEK_CONCURRENCY": "1" })
   assert_true(fleet_mode(via_env, 1))
   // Only the flagless default runs in place.
-  let default_run = run_matches(argv=["task"], env={})
+  let default_run = run_matches(argv=["task"], env=Map([]))
   assert_false(fleet_mode(default_run, 1))
   // N >= 2 is fleet mode regardless of how it was set.
   assert_true(fleet_mode(default_run, 2))
@@ -1166,7 +1169,7 @@ test "explicit --concurrency selects fleet mode even at 1" {
 
 ///|
 test "cli rejects unknown options before task text" {
-  let _ = run_matches(argv=["--xxy", "he"], env={}) catch {
+  let _ = run_matches(argv=["--xxy", "he"], env=Map([])) catch {
     error => {
       assert_true("\{error}".contains("unexpected argument '--xxy' found"))
       return
@@ -1177,7 +1180,7 @@ test "cli rejects unknown options before task text" {
 
 ///|
 test "cli accepts hyphen-leading task text after option delimiter" {
-  let parsed = run_matches(argv=["--", "--xxy", "he"], env={})
+  let parsed = run_matches(argv=["--", "--xxy", "he"], env=Map([]))
   assert_eq(task_text(parsed), "--xxy he")
 }
 
@@ -1185,7 +1188,7 @@ test "cli accepts hyphen-leading task text after option delimiter" {
 test "sessions list needs no api key or task" {
   // The `sessions` subcommands do not declare api-key/task at all, so listing
   // works with no DeepSeek setup.
-  let parsed = sessions_leaf_matches(sub="list", argv=[], env={})
+  let parsed = sessions_leaf_matches(sub="list", argv=[], env=Map([]))
   assert_eq(@cli.value(parsed, "format"), "text")
   assert_eq(@cli.value(parsed, "session-root"), ".openseek")
 }
@@ -1286,7 +1289,11 @@ test "session root resolves relative to workspace root" {
 
 ///|
 async test "session commands reject empty session root" {
-  let parsed = sessions_leaf_matches(sub="list", argv=["--session-root", ""], env={})
+  let parsed = sessions_leaf_matches(
+    sub="list",
+    argv=["--session-root", ""],
+    env=Map([]),
+  )
   let _ = sessions_list(parsed) catch {
     error => {
       assert_true("\{error}".contains("--session-root"))
@@ -1298,7 +1305,7 @@ async test "session commands reject empty session root" {
 
 ///|
 test "agent runs require api key" {
-  let parsed = run_matches(argv=["write", "MoonBit"], env={})
+  let parsed = run_matches(argv=["write", "MoonBit"], env=Map([]))
   let _ = @agentcli.api_key(parsed, Deepseek(V4Pro)) catch {
     error => {
       assert_true("\{error}".contains("DEEPSEEK"))
@@ -1633,7 +1640,7 @@ async test "session list command does not require deepseek setup" {
     let parsed = sessions_leaf_matches(
       sub="list",
       argv=["--session-root", root],
-      env={},
+      env=Map([]),
     )
     // Prints the listing and succeeds with no DeepSeek setup.
     sessions_list(parsed)
@@ -1642,15 +1649,19 @@ async test "session list command does not require deepseek setup" {
 
 ///|
 test "session list format defaults to text and rejects unknown values" {
-  let default_format = sessions_leaf_matches(sub="list", argv=[], env={})
+  let default_format = sessions_leaf_matches(sub="list", argv=[], env=Map([]))
   assert_true(session_list_format(default_format) is Text)
   let json_format = sessions_leaf_matches(
     sub="list",
     argv=["--format", "json"],
-    env={},
+    env=Map([]),
   )
   assert_true(session_list_format(json_format) is Json)
-  let bogus = sessions_leaf_matches(sub="list", argv=["--format", "yaml"], env={})
+  let bogus = sessions_leaf_matches(
+    sub="list",
+    argv=["--format", "yaml"],
+    env=Map([]),
+  )
   let _ = session_list_format(bogus) catch {
     error => {
       assert_true("\{error}".contains("--format must be text or json"))
@@ -1739,7 +1750,7 @@ async test "session compact command appends summary without api key" {
         "cli-test", "--session-root", root, "--file", summary_path, "--from", "1",
         "--to", "2",
       ],
-      env={},
+      env=Map([]),
     )
     sessions_compact(parsed)
     let loaded = store.load(SessionId("cli-test"))
@@ -1774,7 +1785,7 @@ async test "session compact file resolves relative to workspace root" {
         "cli-test", "--dir", workspace, "--file", "summary.txt", "--from", "1", "--to",
         "2",
       ],
-      env={},
+      env=Map([]),
     )
     sessions_compact(parsed)
     let loaded = store.load(SessionId("cli-test"))
@@ -1790,7 +1801,7 @@ async test "session compaction rejects missing summary file" {
   let parsed = sessions_leaf_matches(
     sub="compact",
     argv=["cli-test", "--from", "1", "--to", "2"],
-    env={},
+    env=Map([]),
   )
   let _ = sessions_compact(parsed) catch {
     error => {

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -296,24 +296,12 @@ fn has_pending_goal(pending : Array[PendingWork]) -> Bool {
 }
 
 ///|
-fn has_pending_compact(pending : Array[PendingWork]) -> Bool {
-  for work in pending {
-    if work is PendingCompact {
-      return true
-    }
-  }
-  false
-}
-
-///|
 test "pending prompt helpers ignore queued compactions and goals" {
   let pending : Array[PendingWork] = []
   assert_false(has_pending_prompt(pending))
-  assert_false(has_pending_compact(pending))
   pending.push(PendingCompact)
   pending.push(PendingGoal("[goal]\nship it", [], false, 1))
   assert_false(has_pending_prompt(pending))
-  assert_true(has_pending_compact(pending))
   pending.push(PendingPrompt("next"))
   assert_true(has_pending_prompt(pending))
   // Cancel targets the next prompt, never a queued goal update.
@@ -581,22 +569,25 @@ async fn run_serve(
     // Monotonic serial over goal-affecting commands (set/clear/cancel): a
     // queued auto entry arms only if NO later command superseded it.
     let mut goal_command_serial = 0
-    // Local closures cannot take labelled args: the Bool is
-    // defer_continue — true only when the marker landed AFTER the turn
-    // ended (the PendingGoal drain).
+    // Arm the autonomous loop for a durably standing goal. Local closures
+    // cannot take labelled args: the Bool is defer_continue — true only
+    // when the marker landed AFTER the turn ended (the PendingGoal drain
+    // and the idle drain): that turn never saw the goal, so its first turn
+    // belongs to the controller. A goal steered INTO the finishing turn
+    // was already worked under — continue it.
+    fn arm_goal_auto(text : String, defer_continue : Bool) -> Unit {
+      goal_auto_target = Some(text)
+      goal_turns_remaining = GoalAutoContinueMaxTurns
+      goal_auto_pending = None
+      if defer_continue {
+        goal_promoted_this_boundary = true
+      }
+    }
+
     fn maybe_promote_goal_auto(defer_continue : Bool) -> Unit {
       if goal_auto_pending is Some((text, baseline)) &&
         goal_auto_promotable(session.current_goal(), text, baseline) {
-        goal_auto_target = Some(text)
-        goal_turns_remaining = GoalAutoContinueMaxTurns
-        goal_auto_pending = None
-        // Deferred only when the marker landed AFTER the turn ended (the
-        // PendingGoal drain): that turn never saw the goal, so its first
-        // turn belongs to the controller. A goal steered INTO the
-        // finishing turn was already worked under — continue it.
-        if defer_continue {
-          goal_promoted_this_boundary = true
-        }
+        arm_goal_auto(text, defer_continue)
       }
     }
     async fn compact_and_report(
@@ -659,8 +650,21 @@ async fn run_serve(
         // A blocked marker pauses auto-continuation but the goal stands:
         // it is reported by the loop's own goal_blocked event, not as a
         // goal_updated (the goal did not change).
-        Some(GoalBlocked(_)) => ()
-        None => ()
+        Some(GoalBlocked(_)) | None => ()
+      }
+    }
+
+    // Persist a goal marker at the session's current boundary and report it.
+    // The report happens only after the durable append succeeded — never at
+    // queue time — so a controller can only learn a goal that was actually
+    // persisted; callers gate their promotion tails on the returned Bool for
+    // the same reason.
+    async fn append_goal_marker(marker : String) -> Bool {
+      if append_idle_item(Runtime(RuntimeNotice(marker)), "goal update") {
+        report_goal_update(marker)
+        true
+      } else {
+        false
       }
     }
 
@@ -694,8 +698,7 @@ async fn run_serve(
             // transport: persist and report it as a goal update, so no
             // controller ever sees it dressed as a background notice.
             Some(_) =>
-              if append_idle_item(Runtime(RuntimeNotice(text)), "goal update") {
-                report_goal_update(text)
+              if append_goal_marker(text) {
                 // Drained at idle: the finished turn never saw this marker,
                 // so its first turn belongs to the controller.
                 maybe_promote_goal_auto(true)
@@ -717,21 +720,13 @@ async fn run_serve(
     // PendingGoal entry so the eventual drain replays true wire order.
     fn take_context_before_goal() -> Array[@agent_runtime.SteerInput] {
       let inputs = runtime.drain_steers()
-      let mut boundary = inputs.length()
-      for index, input in inputs {
-        if input is Prompt(_) {
-          boundary = index
-          break
-        }
+      let boundary = inputs
+        .search_by(input => input is Prompt(_))
+        .unwrap_or(inputs.length())
+      for input in inputs[boundary:] {
+        runtime.queue_steer(input)
       }
-      let context : Array[@agent_runtime.SteerInput] = []
-      for index in 0..<boundary {
-        context.push(inputs[index])
-      }
-      for index in boundary..<inputs.length() {
-        runtime.queue_steer(inputs[index])
-      }
-      context
+      [..inputs[:boundary]]
     }
 
     fn start_turn(task_text : String) -> @async.Task[Unit] {
@@ -800,19 +795,14 @@ async fn run_serve(
     }
 
     async fn start_next_pending() -> Unit {
-      pending_loop~: for ;; {
-        if active_work is Some(_) || pending.length() == 0 {
-          break pending_loop~
-        }
+      // Starting work makes the condition false on the recheck; instant-work
+      // arms (context, goal markers) keep draining in arrival order.
+      while active_work is None && pending.length() > 0 {
         match pending.remove(0) {
-          PendingPrompt(text) => {
+          PendingPrompt(text) =>
             active_work = Some(ActiveTurn(start_turn(text)))
-            break pending_loop~
-          }
-          PendingCompact => {
+          PendingCompact =>
             active_work = Some(ActiveCompact(start_compaction(session)))
-            break pending_loop~
-          }
           // Instant work: append the goal at its ordered position and keep
           // draining the queue. A command context produced BEFORE the goal
           // was queued lands first — the goal may depend on that output,
@@ -823,19 +813,14 @@ async fn run_serve(
             for input in context {
               apply_idle_context_input(input)
             }
-            if append_idle_item(Runtime(RuntimeNotice(marker)), "goal update") {
-              report_goal_update(marker)
-              // Promotion tied to THIS entry's durable append: with two
-              // same-text goals queued, an earlier append must not arm an
-              // auto command whose own marker is not durable yet.
-              if is_auto &&
-                serial == goal_command_serial &&
-                @agent_session.goal_marker(marker) is Some(GoalSet(text)) {
-                goal_auto_target = Some(text)
-                goal_turns_remaining = GoalAutoContinueMaxTurns
-                goal_auto_pending = None
-                goal_promoted_this_boundary = true
-              }
+            // Promotion tied to THIS entry's durable append: with two
+            // same-text goals queued, an earlier append must not arm an
+            // auto command whose own marker is not durable yet.
+            if append_goal_marker(marker) &&
+              is_auto &&
+              serial == goal_command_serial &&
+              @agent_session.goal_marker(marker) is Some(GoalSet(text)) {
+              arm_goal_auto(text, true)
             }
           }
         }
@@ -926,25 +911,15 @@ async fn run_serve(
           // with auto only records a PENDING intent against the current
           // sequence baseline — arming happens at promotion, after the
           // marker durably lands.
-          match action {
-            SetGoal(text, auto~) => {
-              // For a QUEUED goal the promotion is tied to its own append
-              // (see the PendingGoal drain); the baseline mechanism covers
-              // the steer/idle paths where the append happens elsewhere.
-              goal_auto_pending = if auto {
-                Some((text, session.last_sequence()))
-              } else {
-                None
-              }
-              goal_auto_target = None
-              goal_turns_remaining = 0
-            }
-            ClearGoal => {
-              goal_auto_pending = None
-              goal_auto_target = None
-              goal_turns_remaining = 0
-            }
+          // For a QUEUED goal the promotion is tied to its own append (see
+          // the PendingGoal drain); the baseline mechanism covers the
+          // steer/idle paths where the append happens elsewhere.
+          goal_auto_pending = match action {
+            SetGoal(text, auto=true) => Some((text, session.last_sequence()))
+            SetGoal(_, ..) | ClearGoal => None
           }
+          goal_auto_target = None
+          goal_turns_remaining = 0
           let marker = match action {
             SetGoal(text, ..) => "\{@agent_session.GoalPrefix}\n\{text}"
             ClearGoal => @agent_session.GoalClearedNotice
@@ -981,11 +956,7 @@ async fn run_serve(
             // persists it before any queued prompt starts, so the next turn
             // still sees it.
             runtime.queue_steer(Notice(marker))
-          } else if append_idle_item(
-              Runtime(RuntimeNotice(marker)),
-              "goal update",
-            ) {
-            report_goal_update(marker)
+          } else if append_goal_marker(marker) {
             maybe_promote_goal_auto(false)
           }
         }

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -124,9 +124,8 @@ async fn[G] EngineClient::start(
           // A durable goal update. Posted untagged: an idle set/clear (or one
           // landing after its turn closed) must survive the stale-run guard.
           GoalUpdated(goal) => {
-            match engine.pending_goal_acks.search(goal) {
-              Some(index) => engine.pending_goal_acks.remove(index) |> ignore
-              None => ()
+            if engine.pending_goal_acks.search(goal) is Some(index) {
+              engine.pending_goal_acks.remove(index) |> ignore
             }
             self.messages.try_put(EngineGoalUpdated(goal)) |> ignore
           }
@@ -299,6 +298,39 @@ async fn[G] EngineClient::prompt(
 }
 
 ///|
+/// Ensure the long-lived engine is running for an explicit user operation
+/// on the durable session (command context, goal update), starting it if
+/// idle. Returns the live process, or None after posting an
+/// EngineSessionError naming `what`.
+async fn[G] EngineClient::live_for(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+  what : String,
+) -> EngineProcess? {
+  if self.live is None {
+    self.start(group) catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      error => {
+        self.messages.put(
+          EngineSessionError("failed to start engine for \{what}: \{error}"),
+        )
+        return None
+      }
+    }
+  }
+  match self.live {
+    Some(live) => Some(live)
+    None => {
+      self.messages.put(
+        EngineSessionError("failed to send \{what}: engine is not running"),
+      )
+      None
+    }
+  }
+}
+
+///|
 /// Send typed model-visible input to the serve engine. Prompt steering is only
 /// deliverable to an open run; command context may start the long-lived engine
 /// so an idle session can append it without opening a model turn.
@@ -321,26 +353,7 @@ async fn[G] EngineClient::steer(
         _ => self.messages.put(SteerDropped(text))
       }
     Command(text) => {
-      if self.live is None {
-        self.start(group) catch {
-          error if @async.is_being_cancelled() ||
-            @async.is_cancellation_error(error) => raise error
-          error => {
-            self.messages.put(
-              EngineSessionError(
-                "failed to start engine for command context: \{error}",
-              ),
-            )
-            return
-          }
-        }
-      }
-      guard self.live is Some(live) else {
-        self.messages.put(
-          EngineSessionError(
-            "failed to send command context: engine is not running",
-          ),
-        )
+      guard self.live_for(group, "command context") is Some(live) else {
         return
       }
       let command : Json = {
@@ -395,24 +408,7 @@ async fn[G] EngineClient::goal(
   group : @async.TaskGroup[G],
   goal : String?,
 ) -> Unit {
-  if self.live is None {
-    self.start(group) catch {
-      error if @async.is_being_cancelled() ||
-        @async.is_cancellation_error(error) => raise error
-      error => {
-        self.messages.put(
-          EngineSessionError("failed to start engine for goal update: \{error}"),
-        )
-        return
-      }
-    }
-  }
-  guard self.live is Some(live) else {
-    self.messages.put(
-      EngineSessionError("failed to send goal update: engine is not running"),
-    )
-    return
-  }
+  guard self.live_for(group, "goal update") is Some(live) else { return }
   let command : Json = match goal {
     Some(text) => { "command": "goal", "action": "set", "text": text }
     None => { "command": "goal", "action": "clear" }
@@ -426,9 +422,8 @@ async fn[G] EngineClient::goal(
     error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
       raise error
     error => {
-      match live.pending_goal_acks.search(goal) {
-        Some(index) => live.pending_goal_acks.remove(index) |> ignore
-        None => ()
+      if live.pending_goal_acks.search(goal) is Some(index) {
+        live.pending_goal_acks.remove(index) |> ignore
       }
       self.live = None
       self.messages.put(

--- a/cmd/tui/goal.mbt
+++ b/cmd/tui/goal.mbt
@@ -13,15 +13,11 @@ fn handle_goal_command(
 ) -> Unit {
   let trimmed = arguments.trim().to_owned()
   if trimmed.is_empty() {
-    match state.goal {
-      Some(goal) => cmds.push(AppendItem(command_notice("goal: \{goal}")))
-      None =>
-        cmds.push(
-          AppendItem(
-            command_notice("no standing goal — set one with /goal set <text>"),
-          ),
-        )
+    let text = match state.goal {
+      Some(goal) => "goal: \{goal}"
+      None => "no standing goal — set one with /goal set <text>"
     }
+    cmds.push(AppendItem(command_notice(text)))
     return
   }
   // The goal is durable session state on the persistent serve engine; a
@@ -52,4 +48,18 @@ fn handle_goal_command(
     return
   }
   cmds.push(AppendItem(Error("usage: /goal | /goal set <text> | /goal clear")))
+}
+
+///|
+/// Mirror an engine-confirmed goal update into local state and the
+/// transcript. The engine's durable-append confirmation is the only writer
+/// of the mirror — both the serve path (`EngineGoalUpdated`) and the
+/// oneshot path (`GoalUpdated`) land here.
+fn apply_goal_update(state : State, goal : String?, cmds : Array[Cmd]) -> Unit {
+  state.goal = goal
+  let title = match goal {
+    Some(text) => "goal set: \{text}"
+    None => "goal cleared"
+  }
+  cmds.push(AppendItem(Input(Notice(title))))
 }

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -492,14 +492,7 @@ fn handle_agent_event(
     // forwards engine events run-tagged, so this path is live there: the
     // mirror must follow (a goal(met) mid-run would otherwise leave /goal
     // reporting a cleared goal until restart).
-    GoalUpdated(goal) => {
-      state.goal = goal
-      let title = match goal {
-        Some(text) => "goal set: \{text}"
-        None => "goal cleared"
-      }
-      cmds.push(AppendItem(Input(Notice(title))))
-    }
+    GoalUpdated(goal) => apply_goal_update(state, goal, cmds)
     // Likewise routed untagged by the client (as background notices).
     GoalContinue(_) | GoalBudgetExhausted => ()
     // Terminal for the run but not task success: surface the continuation
@@ -780,14 +773,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
       }
     // The engine's durable-append confirmation is the only writer of the
     // mirrored goal state.
-    EngineGoalUpdated(goal) => {
-      state.goal = goal
-      let title = match goal {
-        Some(text) => "goal set: \{text}"
-        None => "goal cleared"
-      }
-      cmds.push(AppendItem(Input(Notice(title))))
-    }
+    EngineGoalUpdated(goal) => apply_goal_update(state, goal, cmds)
     EngineExited => ()
     // Tick is a 1s heartbeat: it keeps the message loop turning so the trailing
     // refresh_ui re-runs (the elapsed-time activity line keeps advancing during

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -51,12 +51,9 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
     // Goal markers are transport, not display — the resume path seeds a
     // single "goal: ..." notice from current_goal(), matching the live
     // path where markers are filtered and goal_updated is what renders.
-    Runtime(notice) =>
-      if @agent_session.goal_marker(notice.content()) is Some(_) {
-        None
-      } else {
-        Some(runtime_notice_item(notice.content()))
-      }
+    Runtime(notice) if @agent_session.goal_marker(notice.content()) is Some(_) =>
+      None
+    Runtime(notice) => Some(runtime_notice_item(notice.content()))
     Summary(summary) => Some(summary_item(summary))
     Terminal(terminal) => terminal_item(terminal)
   }

--- a/cmd/viz_server/main_wbtest.mbt
+++ b/cmd/viz_server/main_wbtest.mbt
@@ -154,7 +154,7 @@ test "valid_session_id mirrors the store's id rules" {
 ///|
 test "explicit --session-root drops the default cwd scan" {
   // Default invocation keeps the `.` scan so nearby stores are discovered.
-  let default_run = cli_command().parse(argv=[], env={})
+  let default_run = cli_command().parse(argv=[], env=Map([]))
   @debug.debug_inspect(
     effective_search_dirs(default_run),
     content=(
@@ -164,7 +164,7 @@ test "explicit --session-root drops the default cwd scan" {
   // An explicit root means "serve this", not "this plus wherever I'm standing".
   let flag_root = cli_command().parse(
     argv=["--session-root", "/srv/app/.openseek"],
-    env={},
+    env=Map([]),
   )
   @debug.debug_inspect(effective_search_dirs(flag_root), content="[]")
   // The env var counts as explicit too.
@@ -175,7 +175,7 @@ test "explicit --session-root drops the default cwd scan" {
   // An explicit --search-dir always wins: both flags means root plus scans.
   let both = cli_command().parse(
     argv=["--session-root", "/srv/app/.openseek", "--search-dir", "/srv/lib"],
-    env={},
+    env=Map([]),
   )
   @debug.debug_inspect(
     effective_search_dirs(both),

--- a/desktop/frontend/fileeditor/tabs_wbtest.mbt
+++ b/desktop/frontend/fileeditor/tabs_wbtest.mbt
@@ -407,7 +407,7 @@ test "a deleted tab whose file reappears reloads on the next stats" {
 ///|
 test "FsChanged re-lists the root and expanded, already-listed directories" {
   let emit = test_emit()
-  let children : Map[@pathx.Relative, Array[FileEntry]] = {}
+  let children : Map[@pathx.Relative, Array[FileEntry]] = Map([])
   children[Relative("")] = []
   children[Relative("src")] = []
   let state = {

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -415,7 +415,7 @@ pub async fn run_engine_pump(
   guard manager.pump is Stopped else {
     raise EngineError("engine host is already connected")
   }
-  let sessions : Map[String, SessionSlot] = {}
+  let sessions : Map[String, SessionSlot] = Map([])
   fn reset() -> Unit {
     manager.pump = Stopped
   }

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -69,7 +69,7 @@ pub async fn apply_login_shell_env(
     ["-i", "-l", "-c", command]
   }
   log.info() <? { "message": "shell env probe", "shell": shell }
-  let probe_env : Map[String, String] = {}
+  let probe_env : Map[String, String] = Map([])
   probe_env[ResolvingGuardVar] = "1"
   let result = @async.with_timeout_opt(ProbeTimeoutMs, () => {
     @process.collect_stdout(shell, args, extra_env=probe_env)
@@ -121,7 +121,7 @@ fn parse_probe_output(text : String, mark : String) -> Map[String, String]? {
   guard text.rev_find(mark) is Some(last) && last >= start else { return None }
   let json = @json.parse(text[start:last]) catch { _ => return None }
   guard json is Object(entries) else { return None }
-  let env : Map[String, String] = {}
+  let env : Map[String, String] = Map([])
   for key, value in entries {
     if value is String(value) {
       env[key] = value

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -173,7 +173,7 @@ async fn[G] Engine::spawn(group : @async.TaskGroup[G]) -> Engine {
   let (reader, child_stdout) = @process.read_from_process()
   let (stderr_reader, child_stderr) = @process.read_from_process()
   let parent = @env.get_env_vars()
-  let child_env : Map[String, String] = {}
+  let child_env : Map[String, String] = Map([])
   for name in ["PATH", "HOME", "TMPDIR", "DEEPSEEK"] {
     if parent.get(name) is Some(value) {
       child_env[name] = value

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -272,7 +272,7 @@ import {
 }
 
 async fn main {
-  let seen = {}
+  let seen = Map([])
   while @stdio.stdin.read_until("\n") is Some(line) {
     try @json.parse(line.trim()) catch {
       _ => ()
@@ -1038,7 +1038,7 @@ test "multi-line string literals" {
 test "map literals and common operations" {
   // Map literal syntax
   let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
-  let empty : Map[String, Int] = {} // Empty map, preferred
+  let empty : Map[String, Int] = Map([]) // Empty map, preferred
   let also_empty : Map[String, Int] = Map([])
   // From array of pairs
   let from_pairs : Map[String, Int] = Map::from_array([("x", 1), ("y", 2)])

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -269,7 +269,7 @@ fn base_prompt() -> String {
     #|}
     #|
     #|async fn main {
-    #|  let seen = {}
+    #|  let seen = Map([])
     #|  while @stdio.stdin.read_until("\n") is Some(line) {
     #|    try @json.parse(line.trim()) catch {
     #|      _ => ()
@@ -1035,7 +1035,7 @@ fn base_prompt() -> String {
     #|test "map literals and common operations" {
     #|  // Map literal syntax
     #|  let map : Map[String, Int] = { "a": 1, "b": 2, "c": 3 }
-    #|  let empty : Map[String, Int] = {} // Empty map, preferred
+    #|  let empty : Map[String, Int] = Map([]) // Empty map, preferred
     #|  let also_empty : Map[String, Int] = Map([])
     #|  // From array of pairs
     #|  let from_pairs : Map[String, Int] = Map::from_array([("x", 1), ("y", 2)])

--- a/testkit/filesystem/filesystem.mbt
+++ b/testkit/filesystem/filesystem.mbt
@@ -29,7 +29,7 @@ pub fn FileSystem::from_json(json : Json) -> FileSystem raise {
 pub fn FileSystem::from_pairs(
   files : Array[(String, String)],
 ) -> FileSystem raise {
-  let object : Map[String, Json] = {}
+  let object : Map[String, Json] = Map([])
   for file in files {
     let (path, content) = file
     validate_relative_path(path)


### PR DESCRIPTION
A local simplification and deduplication round over the code merged since the last repo-wide sweep — the /goal machinery (#416), the CLI flip (#440), and the context-ceiling era additions. Behavior-preserving rewrites only; every ordering/durability invariant stays where the review rounds put it, now in fewer places:

**agent**
- `append_runtime_notice` — one seam for "durable append, then mirror into the model buffer" (goal/plan reminders, goal check, blocked marker, tombstone — 5 sites).
- `ToolCallOutcome::of_finish` replaces the twin `Sealed/ContinueTurn` matches in the finish arm.
- `GoalCadence` constructor folded over one `Option`; `due_reminder`/`due_finish_check` flattened; the check-round buffer reseed uses `messages.append` like the finish path.

**agent_session**
- `goal_marker` payload extraction unified on the slice form (was slice in one arm, view-interpolation in the other).
- `current_goal` binds the indexed event once; summary coverage via `.any()`.

**serve**
- `arm_goal_auto` shared by baseline promotion and the entry-owned PendingGoal drain — the arm sequence can no longer drift between the two.
- `append_goal_marker` centralizes report-only-after-durable-append (idle drain, PendingGoal drain, idle Wire(Goal) path).
- `Wire(Goal)` auto-state reset collapsed to a single assignment over the action.
- `take_context_before_goal` via `search_by` + view slices; `start_next_pending` as a plain `while`; dead `has_pending_compact` removed.

**tui**
- `apply_goal_update` shared by the serve (`EngineGoalUpdated`) and oneshot (`GoalUpdated`) mirror arms — the engine confirmation stays the only writer of mirrored goal state, in one place.
- `EngineClient::live_for` dedupes the start-if-idle prologue shared by goal updates and command context (messages byte-identical).
- Ack settling on the `is Some` idiom; `/goal` show branch and the session-view marker filter flattened.

Considered and not taken: hoisting the TurnDone `idle` condition (the shutdown re-check must not reuse it — trap for future edits); removing the EOF-path `pending_goal_acks.clear()` (cheap belt-and-braces); a `goal_updated` decoder inline (pure style); `(..)` constructor patterns (this toolchain rejects eliding all-positional args).

Net −46 lines. Gates: `moon check --deny-warn`, `moon test` (1045/1045), `moon cram test tests/cram`, `moon fmt`, `moon info`, viz JS bundle.

Stacked on #444 (its commit rides along so local checks pass under the 20260709 toolchain; rebases to nothing once #444 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
