### PR TITLE
chore: migrate executable package manifests to pkgtype

### DIFF
--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -32,6 +32,4 @@ warnings = "+unnecessary_annotation"
 
 supported_targets = "+native"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/cmd/viz_app/moon.pkg
+++ b/cmd/viz_app/moon.pkg
@@ -15,6 +15,4 @@ warnings = "+unnecessary_annotation"
 
 supported_targets = "js"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/cmd/viz_server/moon.pkg
+++ b/cmd/viz_server/moon.pkg
@@ -20,6 +20,4 @@ import {
 
 supported_targets = "native"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/eval/bgjobs_capability/moon.pkg
+++ b/eval/bgjobs_capability/moon.pkg
@@ -8,6 +8,4 @@ import {
 
 supported_targets = "+native"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/eval/file_edit/cmd/main/moon.pkg
+++ b/eval/file_edit/cmd/main/moon.pkg
@@ -10,6 +10,4 @@ warnings = "+unnecessary_annotation"
 
 supported_targets = "+native"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/eval/prompt_task/cmd/main/moon.pkg
+++ b/eval/prompt_task/cmd/main/moon.pkg
@@ -10,6 +10,4 @@ warnings = "+unnecessary_annotation"
 
 supported_targets = "+native"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")


### PR DESCRIPTION
## Summary

- replace legacy `options("is-main": true)` declarations in the root module's six executable packages
- use the first-class `pkgtype(kind: "executable")` manifest form

## Why

The current MoonBit formatter migrates executable package declarations to `pkgtype`. Committing the normalized manifests keeps `moon fmt --check` clean on the current toolchain while preserving package behavior.

## Impact

Manifest-only change. The same six packages remain executable; no MoonBit source or public interface changes.

## Validation

- `moon fmt --check`
- `moon check --deny-warn`
- `moon test` (1,069 tests passed across JS and native)
- `moon cram test tests/cram` (23 tests passed)
- `moon info` (no `.mbti` changes)