### PR TITLE
refactor: share Moon auto-check plumbing

### DIFF
--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -1,13 +1,4 @@
 ///|
-const MoonCheckTimeoutMs : Int = 30000
-
-///|
-const MoonCheckMaxOutputChars : Int = 12000
-
-///|
-const MoonCheckCommand : String = "moon check --diagnostic-limit 1"
-
-///|
 /// Append bounded raw `moon check` feedback after successful writes to MoonBit
 /// source or manifest files. The check runs from the containing MoonBit module
 /// or workspace root. Non-MoonBit paths and paths outside a MoonBit project are
@@ -26,18 +17,25 @@ pub async fn append_summary(path : String, content : String) -> String {
 ///|
 async fn auto_check_summary(path : String) -> String? {
   guard moon_check_cwd(path) is Some(cwd) else { return None }
-  let result = @async.with_timeout_opt(MoonCheckTimeoutMs, () => {
+  let result = @async.with_timeout_opt(@moon_check.TimeoutMs, () => {
     @shell.collect_shell_output(
-      MoonCheckCommand,
+      @moon_check.Command,
       cwd~,
-      max_output_chars=MoonCheckMaxOutputChars,
+      max_output_chars=@moon_check.MaxOutputChars,
     )
   }) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return Some("moon check: failed to run")
   }
   match result {
-    Some(output) => Some(format_moon_check_output(output))
+    Some(output) =>
+      Some(
+        @moon_check.format_output(
+          output.exit_code,
+          output.text,
+          output.output_limit_reached,
+        ),
+      )
     None => Some("moon check: timed out")
   }
 }
@@ -80,7 +78,7 @@ pub(all) struct CheckErrors {
 /// batch unguarded, matching `append_summary`'s fail-open behavior.
 pub async fn count_errors(path : String) -> CheckErrors? {
   guard moon_check_cwd(path) is Some(cwd) else { return None }
-  let result = @async.with_timeout_opt(MoonCheckTimeoutMs, () => {
+  let result = @async.with_timeout_opt(@moon_check.TimeoutMs, () => {
     @shell.collect_shell_output(
       MoonCheckJsonCommand,
       cwd~,
@@ -154,39 +152,7 @@ async fn moon_check_cwd(path : String) -> String? {
   if !is_relevant_moonbit_path(path) {
     return None
   }
-  nearest_moon_project_dir(containing_dir(path))
-}
-
-///|
-fn format_moon_check_output(output : @shell.ShellOutput) -> String {
-  format_moon_check_output_parts(
-    output.exit_code,
-    output.text,
-    output.output_limit_reached,
-  )
-}
-
-///|
-fn format_moon_check_output_parts(
-  exit_code : Int?,
-  output : String,
-  output_limit_reached : Bool,
-) -> String {
-  let header = match exit_code {
-    Some(0) => "moon check:"
-    Some(code) => "moon check:\nexit=\{code}"
-    None => "moon check:\nexit=cancelled"
-  }
-  let header = if output_limit_reached {
-    "\{header}\noutput_limit_reached=true"
-  } else {
-    header
-  }
-  if output == "" {
-    header
-  } else {
-    "\{header}\n\{output}"
-  }
+  @moon_check.nearest_project_dir(containing_dir(path))
 }
 
 ///|
@@ -217,62 +183,6 @@ fn containing_dir(path : String) -> String {
 }
 
 ///|
-async fn nearest_moon_project_dir(start : String) -> String? {
-  for dir = start {
-    if @fs.exists(join_path(dir, "moon.mod")) ||
-      @fs.exists(join_path(dir, "moon.work")) {
-      return Some(dir)
-    }
-    match parent_dir(dir) {
-      Some(parent) => continue parent
-      None => return None
-    }
-  }
-}
-
-///|
-fn parent_dir(dir : String) -> String? {
-  let normalized = strip_trailing_slash(dir.replace_all(old="\\", new="/"))
-  if normalized == "" ||
-    normalized == "." ||
-    normalized == "/" ||
-    is_windows_drive_root(normalized) {
-    return None
-  }
-  match normalized.rev_find("/") {
-    Some(0) => Some("/")
-    Some(cut) => Some(normalized[:cut].to_owned())
-    None => Some(".")
-  }
-}
-
-///|
-fn is_windows_drive_root(path : String) -> Bool {
-  path.length() == 2 && path[1] == ':'
-}
-
-///|
-fn strip_trailing_slash(path : String) -> String {
-  for v = path[:] {
-    match v {
-      [.. rest, '/'] if rest.length() > 0 => continue rest
-      _ => break if v.length() == path.length() { path } else { v.to_owned() }
-    }
-  }
-}
-
-///|
-fn join_path(dir : String, base : String) -> String {
-  if dir == "" || dir == "." {
-    base
-  } else if dir.has_suffix("/") {
-    "\{dir}\{base}"
-  } else {
-    "\{dir}/\{base}"
-  }
-}
-
-///|
 test "relevant path detection covers MoonBit source and manifests" {
   assert_true(is_relevant_moonbit_path("moon.mod"))
   assert_true(is_relevant_moonbit_path("lib/moon.pkg"))
@@ -281,67 +191,6 @@ test "relevant path detection covers MoonBit source and manifests" {
   assert_true(is_relevant_moonbit_path("lib/README.mbt.md"))
   assert_false(is_relevant_moonbit_path("lib/parser.mbti"))
   assert_false(is_relevant_moonbit_path("README.md"))
-}
-
-///|
-test "parent dir stops at filesystem roots" {
-  assert_true(parent_dir("/") is None)
-  assert_true(parent_dir("C:") is None)
-  assert_true(parent_dir("C:/") is None)
-  assert_true(parent_dir("C:/work") is Some("C:"))
-  assert_true(parent_dir("C:/work/lib") is Some("C:/work"))
-}
-
-///|
-test "formats raw moon check output with exit code" {
-  assert_eq(
-    format_moon_check_output_parts(
-      Some(255),
-      (
-        #|Error: Failed to calculate build plan
-        #|
-        #|Caused by:
-        #|    0: Failed to resolve the module dependency graph
-      ),
-      false,
-    ),
-    (
-      #|moon check:
-      #|exit=255
-      #|Error: Failed to calculate build plan
-      #|
-      #|Caused by:
-      #|    0: Failed to resolve the module dependency graph
-    ),
-  )
-}
-
-///|
-test "formats successful moon check output without exit code" {
-  assert_eq(
-    format_moon_check_output_parts(
-      Some(0),
-      "Finished. moon: ran 2 tasks, now up to date",
-      false,
-    ),
-    (
-      #|moon check:
-      #|Finished. moon: ran 2 tasks, now up to date
-    ),
-  )
-}
-
-///|
-test "formats truncated moon check output with metadata" {
-  assert_eq(
-    format_moon_check_output_parts(None, "long output", true),
-    (
-      #|moon check:
-      #|exit=cancelled
-      #|output_limit_reached=true
-      #|long output
-    ),
-  )
 }
 
 ///|

--- a/agent_tool/internal/auto_check/moon.pkg
+++ b/agent_tool/internal/auto_check/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_tool/internal/manifest_path",
+  "bobzhang/openseek/agent_tool/internal/moon_check",
   "bobzhang/openseek/agent_tool/shell",
   "moonbitlang/async",
   "moonbitlang/async/fs",

--- a/agent_tool/internal/moon_check/moon.pkg
+++ b/agent_tool/internal/moon_check/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "bobzhang/openseek/internal/workspace_path",
+  "moonbitlang/async/fs",
+}
+
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+  "moonbitlang/async",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/internal/moon_check/moon_check.mbt
+++ b/agent_tool/internal/moon_check/moon_check.mbt
@@ -1,0 +1,50 @@
+///|
+/// The bounded follow-up command shared by edit and shell auto-checks.
+pub const Command : String = "moon check --diagnostic-limit 1"
+
+///|
+/// Maximum time a follow-up `moon check` may run.
+pub const TimeoutMs : Int = 30000
+
+///|
+/// Maximum number of characters captured from a follow-up `moon check`.
+pub const MaxOutputChars : Int = 12000
+
+///|
+/// Render a captured `moon check` result for inclusion in tool output.
+pub fn format_output(
+  exit_code : Int?,
+  output : String,
+  output_limit_reached : Bool,
+) -> String {
+  let header = match exit_code {
+    Some(0) => "moon check:"
+    Some(code) => "moon check:\nexit=\{code}"
+    None => "moon check:\nexit=cancelled"
+  }
+  let header = if output_limit_reached {
+    "\{header}\noutput_limit_reached=true"
+  } else {
+    header
+  }
+  if output == "" {
+    header
+  } else {
+    "\{header}\n\{output}"
+  }
+}
+
+///|
+/// Find the nearest ancestor containing a `moon.mod` or `moon.work` marker.
+pub async fn nearest_project_dir(start : String) -> String? {
+  for dir = start {
+    if @fs.exists(@workspace_path.join_child(dir, "moon.mod")) ||
+      @fs.exists(@workspace_path.join_child(dir, "moon.work")) {
+      return Some(dir)
+    }
+    match @workspace_path.parent_dir(dir) {
+      Some(parent) => continue parent
+      None => return None
+    }
+  }
+}

--- a/agent_tool/internal/moon_check/moon_check_test.mbt
+++ b/agent_tool/internal/moon_check/moon_check_test.mbt
@@ -1,0 +1,73 @@
+///|
+test "format output includes failures and captured text" {
+  assert_eq(
+    @moon_check.format_output(
+      Some(255),
+      (
+        #|Error: Failed to calculate build plan
+        #|
+        #|Caused by:
+        #|    0: Failed to resolve the module dependency graph
+      ),
+      false,
+    ),
+    (
+      #|moon check:
+      #|exit=255
+      #|Error: Failed to calculate build plan
+      #|
+      #|Caused by:
+      #|    0: Failed to resolve the module dependency graph
+    ),
+  )
+}
+
+///|
+test "format output keeps successful and truncated metadata" {
+  assert_eq(
+    @moon_check.format_output(
+      Some(0),
+      "Finished. moon: ran 2 tasks, now up to date",
+      false,
+    ),
+    (
+      #|moon check:
+      #|Finished. moon: ran 2 tasks, now up to date
+    ),
+  )
+  assert_eq(
+    @moon_check.format_output(None, "long output", true),
+    (
+      #|moon check:
+      #|exit=cancelled
+      #|output_limit_reached=true
+      #|long output
+    ),
+  )
+}
+
+///|
+async test "nearest project dir prefers the closest module or workspace" {
+  @vfs.with_tmpdir(prefix="openseek-moon-check-root-", dir => {
+    let module_dir = "\{dir}/packages/demo"
+    let source = "\{module_dir}/src"
+    @fs.mkdir(source, recursive=true)
+    @fs.write_file(
+      "\{dir}/moon.work",
+      "members = []\n",
+      create_mode=CreateOrTruncate,
+    )
+    assert_true(
+      @moon_check.nearest_project_dir(source) is Some(root) && root == dir,
+    )
+    @fs.write_file(
+      "\{module_dir}/moon.mod",
+      "name = \"example/demo\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    assert_true(
+      @moon_check.nearest_project_dir(source) is Some(root) &&
+      root == module_dir,
+    )
+  })
+}

--- a/agent_tool/internal/moon_check/pkg.generated.mbti
+++ b/agent_tool/internal/moon_check/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/moon_check"
+
+// Values
+pub const Command : String = "moon check --diagnostic-limit 1"
+
+pub const MaxOutputChars : Int = 12000
+
+pub const TimeoutMs : Int = 30000
+
+pub fn format_output(Int?, String, Bool) -> String
+
+pub async fn nearest_project_dir(String) -> String?
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/shell/moon.pkg
+++ b/agent_tool/shell/moon.pkg
@@ -3,6 +3,7 @@ import {
   "bobzhang/openseek/agent_tool/bgjobs",
   "bobzhang/openseek/agent_tool/shell_exec",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/moon_check",
   "bobzhang/openseek/agent_tool/shell/internal/command_policy",
   "bobzhang/openseek/agent_tool/shell/internal/decode",
   "bobzhang/openseek/agent_tool/shell/internal/git_policy",

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -1,13 +1,4 @@
 ///|
-const MoonCheckTimeoutMs : Int = 30000
-
-///|
-const MoonCheckMaxOutputChars : Int = 12000
-
-///|
-const MoonCheckCommand : String = "moon check --diagnostic-limit 1"
-
-///|
 async fn append_moon_command_check_summary(
   parsed : @shell_parse.ParseResult,
   cwd : String?,
@@ -59,10 +50,10 @@ fn moon_check_output_budget(content : String, max_output_chars : Int) -> Int {
   let remaining = max_output_chars - content.char_length() - 1
   if remaining <= 0 {
     0
-  } else if remaining < MoonCheckMaxOutputChars {
+  } else if remaining < @moon_check.MaxOutputChars {
     remaining
   } else {
-    MoonCheckMaxOutputChars
+    @moon_check.MaxOutputChars
   }
 }
 
@@ -71,38 +62,26 @@ async fn moon_check_summary_for_cwd(
   cwd : String,
   max_output_chars : Int,
 ) -> String? {
-  let check_cwd = match nearest_moon_project_dir(cwd) {
+  let check_cwd = match @moon_check.nearest_project_dir(cwd) {
     Some(check_cwd) => check_cwd
     None => return None
   }
-  let result = @async.with_timeout_opt(MoonCheckTimeoutMs, () => {
-    collect_shell_output(MoonCheckCommand, cwd=check_cwd, max_output_chars~)
+  let result = @async.with_timeout_opt(@moon_check.TimeoutMs, () => {
+    collect_shell_output(@moon_check.Command, cwd=check_cwd, max_output_chars~)
   }) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return Some("moon check: failed to run")
   }
   match result {
-    Some(output) => Some(format_moon_check_output(output))
+    Some(output) =>
+      Some(
+        @moon_check.format_output(
+          output.exit_code,
+          output.text,
+          output.output_limit_reached,
+        ),
+      )
     None => Some("moon check: timed out")
-  }
-}
-
-///|
-fn format_moon_check_output(output : ShellOutput) -> String {
-  let header = match output.exit_code {
-    Some(0) => "moon check:"
-    Some(code) => "moon check:\nexit=\{code}"
-    None => "moon check:\nexit=cancelled"
-  }
-  let header = if output.output_limit_reached {
-    "\{header}\noutput_limit_reached=true"
-  } else {
-    header
-  }
-  if output.text == "" {
-    header
-  } else {
-    "\{header}\n\{output.text}"
   }
 }
 
@@ -508,58 +487,13 @@ fn resolve_command_cwd(base : String, target : String) -> String {
 }
 
 ///|
-async fn nearest_moon_project_dir(start : String) -> String? {
-  for dir = start {
-    if @fs.exists(join_path(dir, "moon.mod")) ||
-      @fs.exists(join_path(dir, "moon.work")) {
-      return Some(dir)
-    }
-    match parent_dir(dir) {
-      Some(parent) => continue parent
-      None => return None
-    }
-  }
-}
-
-///|
-fn parent_dir(dir : String) -> String? {
-  let normalized = strip_trailing_slash(dir.replace_all(old="\\", new="/"))
-  if normalized == "" ||
-    normalized == "." ||
-    normalized == "/" ||
-    is_windows_drive_root(normalized) {
-    return None
-  }
-  match normalized.rev_find("/") {
-    Some(0) => Some("/")
-    Some(cut) => Some(normalized[:cut].to_owned())
-    None => Some(".")
-  }
-}
-
-///|
-fn is_windows_drive_root(path : String) -> Bool {
-  path.length() == 2 && path[1] == ':'
+fn parent_dir(path : String) -> String? {
+  @workspace_path.parent_dir(path)
 }
 
 ///|
 fn strip_trailing_slash(path : String) -> String {
-  if path.length() > 1 && path.has_suffix("/") {
-    strip_trailing_slash(path[:path.length() - 1].to_owned())
-  } else {
-    path
-  }
-}
-
-///|
-fn join_path(dir : String, base : String) -> String {
-  if dir == "" || dir == "." {
-    base
-  } else if dir.has_suffix("/") {
-    "\{dir}\{base}"
-  } else {
-    "\{dir}/\{base}"
-  }
+  @workspace_path.strip_trailing_slash(path)
 }
 
 ///|
@@ -598,7 +532,7 @@ test "bound follow-up check output by remaining shell output budget" {
   assert_eq(moon_check_output_budget("exit=0\nabc", 10), 0)
   assert_eq(
     moon_check_output_budget("exit=0\n", 20000),
-    MoonCheckMaxOutputChars,
+    @moon_check.MaxOutputChars,
   )
   assert_eq(moon_check_output_budget("exit=0\nabcdef", 20), 6)
 }

--- a/internal/workspace_path/pkg.generated.mbti
+++ b/internal/workspace_path/pkg.generated.mbti
@@ -2,9 +2,15 @@
 package "bobzhang/openseek/internal/workspace_path"
 
 // Values
+pub fn join_child(String, String) -> String
+
+pub fn parent_dir(String) -> String?
+
 pub fn resolve(String, String) -> String
 
 pub fn resolve_cwd(String, String?) -> String?
+
+pub fn strip_trailing_slash(String) -> String
 
 // Errors
 

--- a/internal/workspace_path/workspace_path.mbt
+++ b/internal/workspace_path/workspace_path.mbt
@@ -6,6 +6,51 @@ fn is_default_root(workspace_root : String) -> Bool {
 }
 
 ///|
+/// Remove trailing `/` separators without collapsing a filesystem root.
+pub fn strip_trailing_slash(path : String) -> String {
+  for view = path[:] {
+    match view {
+      [.. rest, '/'] if rest.length() > 0 => continue rest
+      _ =>
+        break if view.length() == path.length() {
+          path
+        } else {
+          view.to_owned()
+        }
+    }
+  }
+}
+
+///|
+/// Return the lexical parent of a POSIX or Windows-style path.
+pub fn parent_dir(path : String) -> String? {
+  let normalized = strip_trailing_slash(path.replace_all(old="\\", new="/"))
+  if normalized == "" ||
+    normalized == "." ||
+    normalized == "/" ||
+    (normalized.length() == 2 && normalized[1] == ':') {
+    return None
+  }
+  match normalized.rev_find("/") {
+    Some(0) => Some("/")
+    Some(cut) => Some(normalized[:cut].to_owned())
+    None => Some(".")
+  }
+}
+
+///|
+/// Append one basename to a lexical directory path.
+pub fn join_child(dir : String, base : String) -> String {
+  if dir == "" || dir == "." {
+    base
+  } else if dir.has_suffix("/") {
+    "\{dir}\{base}"
+  } else {
+    "\{dir}/\{base}"
+  }
+}
+
+///|
 /// Resolve a tool path against the agent workspace root. Absolute paths are
 /// already explicit, and the default root "." intentionally preserves the
 /// pre-workspace behavior and output text.
@@ -44,4 +89,17 @@ test "workspace path resolves relative paths under a non-default root" {
   assert_true(
     resolve_cwd("/tmp/work", Some("subdir")) is Some("/tmp/work/subdir"),
   )
+}
+
+///|
+test "lexical path helpers preserve roots and normalize separators" {
+  assert_eq(strip_trailing_slash("/work///"), "/work")
+  assert_eq(strip_trailing_slash("/"), "/")
+  assert_true(parent_dir("/") is None)
+  assert_true(parent_dir("C:") is None)
+  assert_true(parent_dir("C:/") is None)
+  assert_true(parent_dir("C:/work") is Some("C:"))
+  assert_true(parent_dir("C:\\work\\lib\\") is Some("C:/work"))
+  assert_eq(join_child(".", "moon.mod"), "moon.mod")
+  assert_eq(join_child("/work/", "moon.mod"), "/work/moon.mod")
 }


### PR DESCRIPTION
## Summary
- centralize the Moon auto-check command, limits, result formatting, and nearest project-root discovery
- move shared lexical path helpers into `internal/workspace_path`
- retain thin shell-local delegates so security-sensitive sandbox call sites remain unchanged
- add focused tests for the extracted behavior

## Why
The edit auto-check and shell auto-check paths had independently copied implementations. Keeping one implementation prevents drift while preserving both callers' public behavior.

## Validation
- `moon fmt --check`
- `moon check --deny-warn`
- `moon test` (1,069 tests)
- `moon cram test tests/cram` (23 tests)
- targeted tests for `moon_check`, `workspace_path`, `auto_check`, and `shell`
- `moon info` with only the expected internal interface additions
- fresh ephemeral Codex CLI review: no findings