### PR TITLE
refactor: prefer patterns for JSON and CLI decoding

### DIFF
--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -131,9 +131,9 @@ pub impl FromJson for SessionItem with fn from_json(
   path : @json.JsonPath,
 ) -> SessionItem {
   let fields = expect_object(json, path)
-  let payload = match fields.get("payload") {
-    Some(payload) => payload
-    None => json_decode_error(path.add_key("payload"), "expected payload")
+  let payload = match fields {
+    { "payload": payload, .. } => payload
+    _ => json_decode_error(path.add_key("payload"), "expected payload")
   }
   match string_field(fields, path, "kind") {
     "user" => User(@json.from_json(payload, path=path.add_key("payload")))
@@ -189,12 +189,12 @@ pub impl FromJson for Session with fn from_json(
         "unsupported session version: \{other}",
       )
   }
-  let id : SessionId = match fields.get("id") {
-    Some(id) => @json.from_json(id, path=path.add_key("id"))
-    None => json_decode_error(path.add_key("id"), "expected id")
+  let id : SessionId = match fields {
+    { "id": id, .. } => @json.from_json(id, path=path.add_key("id"))
+    _ => json_decode_error(path.add_key("id"), "expected id")
   }
-  let events = match fields.get("events") {
-    Some(Array(values)) => {
+  let events = match fields {
+    { "events": Array(values), .. } => {
       let decoded : Array[SessionEvent] = [
         for index, value in values => {
           @json.from_json(value, path=path.add_key("events").add_index(index))
@@ -202,9 +202,9 @@ pub impl FromJson for Session with fn from_json(
       ]
       @vector.from_array(decoded)
     }
-    Some(_) =>
+    { "events": _, .. } =>
       json_decode_error(path.add_key("events"), "expected events array")
-    None => @vector.new()
+    _ => @vector.new()
   }
   Session(
     id,

--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -46,18 +46,17 @@ pub(all) enum HeaderParse {
 /// header from a format this build does not read — `UnsupportedVersion` —
 /// even though its remaining fields cannot be interpreted.
 pub fn classify_header(json : Json) -> HeaderParse {
-  guard json is Object(fields) else { return NotHeader }
-  guard fields.get("version") is Some(Number(version, ..)) else {
-    return NotHeader
+  match json {
+    { "version": Number(version, ..), .. } if version.to_int() !=
+      session_file_version => UnsupportedVersion(version.to_int())
+    {
+      "version": Number(_, ..),
+      "id": String(id),
+      "system_prompt": String(system_prompt),
+      ..
+    } => Header({ id, system_prompt })
+    _ => NotHeader
   }
-  if version.to_int() != session_file_version {
-    return UnsupportedVersion(version.to_int())
-  }
-  guard fields.get("id") is Some(String(id)) else { return NotHeader }
-  guard fields.get("system_prompt") is Some(String(system_prompt)) else {
-    return NotHeader
-  }
-  Header({ id, system_prompt })
 }
 
 ///|

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -142,8 +142,7 @@ fn format_diagnostic_line(fields : Map[String, Json]) -> String {
 ///|
 fn json_string_field(fields : Map[String, Json], name : String) -> String {
   match fields.get(name) {
-    Some(String(value)) => value
-    _ => ""
+    Some(String(value)) | _ with value = "" => value
   }
 }
 

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -108,15 +108,23 @@ pub fn tally_diagnostics(text : String, truncated~ : Bool) -> CheckErrors {
       continue
     }
     let json = @json.parse(raw.to_owned()) catch { _ => continue }
-    guard json is Object(fields) else { continue }
-    match fields.get("level") {
-      Some(String("error")) => {
+    match json {
+      {
+        "level": String("error"),
+        "path"? : Some(String(path))
+        | _ with path = "",
+        "loc"? : Some(String(loc))
+        | _ with loc = "",
+        "message"? : Some(String(message))
+        | _ with message = "",
+        ..
+      } => {
         error_count = error_count + 1
         if first_errors.length() < RevertErrorDisplayLimit {
-          first_errors.push(format_diagnostic_line(fields))
+          first_errors.push(format_diagnostic_line(path, loc, message))
         }
       }
-      Some(String("warning")) => warning_count = warning_count + 1
+      { "level": String("warning"), .. } => warning_count = warning_count + 1
       _ => ()
     }
   }
@@ -127,22 +135,16 @@ pub fn tally_diagnostics(text : String, truncated~ : Bool) -> CheckErrors {
 /// Render one diagnostic object as `path:loc: message`, the same shape the
 /// human `moon check` output uses, so a reverted batch points the model
 /// straight at the offending sites.
-fn format_diagnostic_line(fields : Map[String, Json]) -> String {
-  let path = json_string_field(fields, "path")
-  let loc = json_string_field(fields, "loc")
-  let message = json_string_field(fields, "message")
+fn format_diagnostic_line(
+  path : String,
+  loc : String,
+  message : String,
+) -> String {
   let where_ = if loc == "" { path } else { "\{path}:\{loc}" }
   if message == "" {
     where_
   } else {
     "\{where_}: \{message}"
-  }
-}
-
-///|
-fn json_string_field(fields : Map[String, Json], name : String) -> String {
-  match fields.get(name) {
-    Some(String(value)) | _ with value = "" => value
   }
 }
 

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -34,14 +34,9 @@ const ParseErrorCodeMin : Int = 3000
 const ParseErrorCodeMax : Int = 3999
 
 ///|
-fn is_parse_error_code(fields : Map[String, Json]) -> Bool {
-  match fields.get("error_code") {
-    Some(Number(code, ..)) => {
-      let code = code.to_int()
-      code >= ParseErrorCodeMin && code <= ParseErrorCodeMax
-    }
-    _ => false
-  }
+fn is_parse_error_code(code : Double) -> Bool {
+  let code = code.to_int()
+  code >= ParseErrorCodeMin && code <= ParseErrorCodeMax
 }
 
 ///|
@@ -209,14 +204,19 @@ fn decide_parse_gate(
       continue
     }
     let json = @json.parse(raw.to_owned()) catch { _ => continue }
-    guard json is Object(fields) else { continue }
-    if fields.get("level") is Some(String("error")) &&
-      is_parse_error_code(fields) {
-      errors.push({
-        loc: json_string_field(fields, "loc"),
-        message: json_string_field(fields, "message"),
-        context: json_string_field(fields, "context"),
-      })
+    match json {
+      {
+        "level": String("error"),
+        "error_code": Number(code, ..),
+        "loc"? : Some(String(loc))
+        | _ with loc = "",
+        "message"? : Some(String(message))
+        | _ with message = "",
+        "context"? : Some(String(context))
+        | _ with context = "",
+        ..
+      } if is_parse_error_code(code) => errors.push({ loc, message, context })
+      _ => ()
     }
   }
   if errors.length() > 0 {

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -41,32 +41,32 @@ pub struct MultiEditArgs {
 pub fn decode_args(arguments : Json) -> MultiEditArgs raise {
   match arguments {
     Object(fields) => {
-      let inline = match fields.get("edits") {
-        Some(Array(items)) => decode_edit_array(items)
-        Some(Null) | None => []
-        Some(_) => fail("arguments.edits to be an array of edit objects")
+      let inline = match fields {
+        { "edits": Array(items), .. } => decode_edit_array(items)
+        { "edits"? : Some(Null) | None, .. } => []
+        _ => fail("arguments.edits to be an array of edit objects")
       }
-      let edits_file = match fields.get("edits_file") {
-        Some(String(path)) => Some(path)
-        Some(Null) | None => None
-        Some(_) => fail("arguments.edits_file to be a string path")
+      let edits_file = match fields {
+        { "edits_file": String(path), .. } => Some(path)
+        { "edits_file"? : Some(Null) | None, .. } => None
+        _ => fail("arguments.edits_file to be a string path")
       }
-      let revert_when_errors_above = match
-        fields.get("revert_when_errors_above") {
-        Some(Number(value, ..)) => {
+      let revert_when_errors_above = match fields {
+        { "revert_when_errors_above": Number(value, ..), .. } => {
           let int_value = value.to_int()
           if int_value.to_double() != value {
             fail("arguments.revert_when_errors_above to be an integer")
           }
           Some(int_value)
         }
-        Some(Null) | None => None
-        Some(_) => fail("arguments.revert_when_errors_above to be an integer")
+        { "revert_when_errors_above"? : Some(Null) | None, .. } => None
+        _ => fail("arguments.revert_when_errors_above to be an integer")
       }
-      let revert_on_parse_errors = match fields.get("revert_on_parse_errors") {
-        Some(True) | Some(Null) | None => true
-        Some(False) => false
-        Some(_) => fail("arguments.revert_on_parse_errors to be a boolean")
+      let revert_on_parse_errors = match fields {
+        { "revert_on_parse_errors"? : Some(True) | Some(Null) | None, .. } =>
+          true
+        { "revert_on_parse_errors": False, .. } => false
+        _ => fail("arguments.revert_on_parse_errors to be a boolean")
       }
       { inline, edits_file, revert_when_errors_above, revert_on_parse_errors }
     }

--- a/agent_tool/plan/internal/decode/decode.mbt
+++ b/agent_tool/plan/internal/decode/decode.mbt
@@ -60,7 +60,7 @@ pub fn decode(arguments : Json) -> PlanInput raise {
       fail("arguments to have only the steps field")
     }
   }
-  guard fields.get("steps") is Some(Array(items)) else {
+  guard fields is { "steps": Array(items), .. } else {
     fail("arguments.steps to be an array of steps")
   }
   if items.length() > MAX_STEPS {
@@ -93,22 +93,23 @@ fn decode_step(index : Int, item : Json) -> PlanStep raise {
       fail("arguments.steps[\{index}] to have only title and status fields")
     }
   }
-  let raw_title = match fields.get("title") {
-    Some(String(value)) => value
-    Some(_) => fail("arguments.steps[\{index}].title to be a string")
-    None => fail("arguments.steps[\{index}].title to be present")
+  let raw_title = match fields {
+    { "title": String(value), .. } => value
+    { "title": _, .. } => fail("arguments.steps[\{index}].title to be a string")
+    _ => fail("arguments.steps[\{index}].title to be present")
   }
   let title = normalize_title(index, raw_title)
-  let status = match fields.get("status") {
-    Some(String("pending")) => PlanStatus::Pending
-    Some(String("in_progress")) => InProgress
-    Some(String("completed")) => Completed
-    Some(String(_)) =>
+  let status = match fields {
+    { "status": String("pending"), .. } => PlanStatus::Pending
+    { "status": String("in_progress"), .. } => InProgress
+    { "status": String("completed"), .. } => Completed
+    { "status": String(_), .. } =>
       fail(
         "arguments.steps[\{index}].status to be one of pending|in_progress|completed",
       )
-    Some(_) => fail("arguments.steps[\{index}].status to be a string")
-    None => fail("arguments.steps[\{index}].status to be present")
+    { "status": _, .. } =>
+      fail("arguments.steps[\{index}].status to be a string")
+    _ => fail("arguments.steps[\{index}].status to be present")
   }
   { title, status }
 }

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -68,8 +68,8 @@ fn optional_string(fields : Map[String, Json], name : String) -> String? raise {
 
 ///|
 fn reject_paths(fields : Map[String, Json]) -> Unit raise {
-  match fields.get("paths") {
-    Some(Null) | None => ()
+  match fields {
+    { "paths"? : Some(Null) | None, .. } => ()
     _ =>
       fail(
         "arguments.paths is not supported; batch separate read calls in one assistant response",

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -33,7 +33,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
       let usage : @deepseek.Usage = @json.from_json(
         @jsonx.field(object, "usage").unwrap_or_default(),
       ) catch {
-        // Unreachable with the lenient Usage impl; drop rather than crash.
+        // Drop malformed usage events rather than crashing the UI.
         _ => return None
       }
       Some(

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1313,27 +1313,29 @@ fn parse_session_rows(text : String) -> Array[SessionRow]? {
 
 ///|
 fn session_row_of(json : Json) -> SessionRow? {
-  guard json is Object(fields) else { return None }
-  guard fields.get("id") is Some(String(id)) else { return None }
-  let key = match fields.get("key") {
-    Some(String(value)) => value
+  guard json
+    is {
+      "id": String(id),
+      "first_prompt"? : Some(String(first_prompt))
+      | _ with first_prompt = "",
+      ..
+    } else {
+    return None
+  }
+  let key = match json {
+    { "key": String(value), .. } => value
     _ => id
   }
-  let root_label = match fields.get("root_label") {
-    Some(String(value)) => value
-    _ =>
-      match fields.get("root") {
-        Some(String(value)) | _ with value = "" => value
-      }
+  let root_label = match json {
+    { "root_label": String(value), .. } => value
+    { "root"? : Some(String(value)) | _ with value = "", .. } => value
+    _ => ""
   }
-  let first_prompt = match fields.get("first_prompt") {
-    Some(String(value)) | _ with value = "" => value
-  }
-  let last_active = match fields.get("last_active") {
-    Some(Number(value, ..)) => Some(value.to_int64())
+  let last_active = match json {
+    { "last_active": Number(value, ..), .. } => Some(value.to_int64())
     _ => None
   }
-  let is_marker = fields.get("is_marker") is Some(True)
+  let is_marker = json is { "is_marker": True, .. }
   Some({ key, id, root_label, last_active, is_marker, first_prompt })
 }
 
@@ -1344,26 +1346,19 @@ fn session_row_of(json : Json) -> SessionRow? {
 /// the model view.
 fn parse_load(text : String) -> LoadOutcome {
   let json = @json.parse(text) catch { _ => return Malformed }
-  guard json is Object(fields) else { return Malformed }
-  let found = match fields.get("found") {
-    Some(True) => true
-    Some(False) => false
-    _ => return Malformed
+  match json {
+    { "found": False, .. } => NotFound
+    { "found": True, "events": String(events_text), .. } => {
+      let parsed = @viz.parse_events(events_text)
+      let (system_prompt, header_present) = header_info(parsed)
+      let log_bytes = match json {
+        { "events_bytes": Number(value, ..), .. } => value.to_int64()
+        _ => events_text.length().to_int64()
+      }
+      Loaded(parsed, system_prompt, header_present, log_bytes)
+    }
+    _ => Malformed
   }
-  if !found {
-    return NotFound
-  }
-  let events_text = match fields.get("events") {
-    Some(String(value)) => value
-    _ => return Malformed
-  }
-  let parsed = @viz.parse_events(events_text)
-  let (system_prompt, header_present) = header_info(parsed)
-  let log_bytes = match fields.get("events_bytes") {
-    Some(Number(value, ..)) => value.to_int64()
-    _ => events_text.length().to_int64()
-  }
-  Loaded(parsed, system_prompt, header_present, log_bytes)
 }
 
 ///|

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1323,13 +1323,11 @@ fn session_row_of(json : Json) -> SessionRow? {
     Some(String(value)) => value
     _ =>
       match fields.get("root") {
-        Some(String(value)) => value
-        _ => ""
+        Some(String(value)) | _ with value = "" => value
       }
   }
   let first_prompt = match fields.get("first_prompt") {
-    Some(String(value)) => value
-    _ => ""
+    Some(String(value)) | _ with value = "" => value
   }
   let last_active = match fields.get("last_active") {
     Some(Number(value, ..)) => Some(value.to_int64())

--- a/deepseek/chatresponse_decode_test.mbt
+++ b/deepseek/chatresponse_decode_test.mbt
@@ -56,6 +56,32 @@ test "chat response decode allows tool call without content or usage" {
 }
 
 ///|
+test "chat response decode rejects present null usage" {
+  try
+    decode_chat_response(
+      (
+        #|{"choices":[{"message":{"content":"ok"}}],"usage":null}
+      ),
+    )
+  catch {
+    e =>
+      debug_inspect(
+        e,
+        content=(
+          #|JsonDecodeError(
+          #|  (
+          #|    Key(Root, key="usage"),
+          #|    "Usage::from_json: expected object with numeric fields",
+          #|  ),
+          #|)
+        ),
+      )
+  } noraise {
+    _ => fail("expected present null usage to fail")
+  }
+}
+
+///|
 test "chat response decode keeps multiple tool calls in order" {
   let response = decode_chat_response(
     (

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -1,25 +1,33 @@
 ///|
-/// Reads an integer-valued field from a JSON object, returning 0 when the field
-/// is absent or is not a number.
-fn json_object_int(json : Json, key : String) -> Int {
+fn Usage::from_json(
+  json : Json,
+  path : @json.JsonPath,
+) -> Usage raise @json.JsonDecodeError {
   match json {
-    Object(fields) =>
-      match fields.get(key) {
-        Some(Number(n, ..)) => n.to_int()
-        _ => 0
+    {
+      "prompt_tokens"? : Some(Number(prompt_tokens, ..))
+      | None with prompt_tokens = 0,
+      "completion_tokens"? : Some(Number(completion_tokens, ..))
+      | None with completion_tokens = 0,
+      "total_tokens"? : Some(Number(total_tokens, ..))
+      | None with total_tokens = 0,
+      "prompt_cache_hit_tokens"? : Some(Number(prompt_cache_hit_tokens, ..))
+      | None with prompt_cache_hit_tokens = 0,
+      "prompt_cache_miss_tokens"? : Some(Number(prompt_cache_miss_tokens, ..))
+      | None with prompt_cache_miss_tokens = 0,
+      ..
+    } =>
+      {
+        prompt_tokens: prompt_tokens.to_int(),
+        completion_tokens: completion_tokens.to_int(),
+        total_tokens: total_tokens.to_int(),
+        prompt_cache_hit_tokens: prompt_cache_hit_tokens.to_int(),
+        prompt_cache_miss_tokens: prompt_cache_miss_tokens.to_int(),
       }
-    _ => 0
-  }
-}
-
-///|
-fn Usage::from_json(json : Json) -> Usage {
-  {
-    prompt_tokens: json_object_int(json, "prompt_tokens"),
-    completion_tokens: json_object_int(json, "completion_tokens"),
-    total_tokens: json_object_int(json, "total_tokens"),
-    prompt_cache_hit_tokens: json_object_int(json, "prompt_cache_hit_tokens"),
-    prompt_cache_miss_tokens: json_object_int(json, "prompt_cache_miss_tokens"),
+    _ =>
+      json_decode_error(
+        path, "Usage::from_json: expected object with numeric fields",
+      )
   }
 }
 
@@ -44,13 +52,13 @@ fn[T] json_decode_error(
 
 ///|
 /// Public so wire consumers (the TUI decodes the engine's `usage` log event)
-/// can round-trip the same schema `ToJson` emits. Lenient by design: absent
-/// or malformed fields decode as 0, and no shape ever raises.
+/// can round-trip the same schema `ToJson` emits. Absent counters decode as 0;
+/// malformed counters or a non-object value raise `JsonDecodeError`.
 pub impl FromJson for Usage with fn from_json(
   json : Json,
-  _path : @json.JsonPath,
+  path : @json.JsonPath,
 ) -> Usage {
-  Usage::from_json(json)
+  Usage::from_json(json, path)
 }
 
 ///|
@@ -94,11 +102,9 @@ pub impl FromJson for ChatResponse with fn from_json(
   let (message_fields, usage_json) : (Map[String, Json], Json?) = match json {
     {
       "choices": [{ "message": Object(message_fields), .. }, ..],
-      "usage": usage_json,
+      "usage"? : usage_json,
       ..
-    } => (message_fields, Some(usage_json))
-    { "choices": [{ "message": Object(message_fields), .. }, ..], .. } =>
-      (message_fields, None)
+    } => (message_fields, usage_json)
     { "choices": [], .. } =>
       json_decode_error(
         path.add_key("choices"),
@@ -142,14 +148,14 @@ pub impl FromJson for ChatResponse with fn from_json(
     _ => []
   }
   let content = match message_fields {
-    { "content": String(content), .. } => content
-    { "content": Null, .. } => ""
-    { "content": _, .. } =>
+    { "content"? : Some(String(content)) | Some(Null) with content = "", .. } =>
+      content
+    { "content"? : None, .. } if tool_calls.length() > 0 => ""
+    { "content"? : None, .. } =>
       json_decode_error(
         message_path.add_key("content"),
         "ChatResponse::from_json: expected message content",
       )
-    _ if tool_calls.length() > 0 => ""
     _ =>
       json_decode_error(
         message_path.add_key("content"),
@@ -157,14 +163,17 @@ pub impl FromJson for ChatResponse with fn from_json(
       )
   }
   let reasoning_content = match message_fields {
-    { "reasoning_content": String(reasoning_content), .. } => reasoning_content
-    { "reasoning_content": Null, .. } => ""
-    { "reasoning_content": _, .. } =>
+    {
+      "reasoning_content"? : Some(String(reasoning_content))
+      | (Some(Null)
+      | None) with reasoning_content = "",
+      ..
+    } => reasoning_content
+    _ =>
       json_decode_error(
         message_path.add_key("reasoning_content"),
         "ChatResponse::from_json: expected reasoning_content string",
       )
-    _ => ""
   }
   let usage = match usage_json {
     Some(usage) => FromJson::from_json(usage, path.add_key("usage"))

--- a/deepseek/usage_decode_test.mbt
+++ b/deepseek/usage_decode_test.mbt
@@ -1,0 +1,46 @@
+///|
+fn decode_usage(text : String) -> @deepseek.Usage raise {
+  @json.from_json(@json.parse(text))
+}
+
+///|
+test "usage decode rejects malformed fields" {
+  try
+    decode_usage(
+      (
+        #|{"prompt_tokens":"2","completion_tokens":3}
+      ),
+    )
+  catch {
+    e =>
+      debug_inspect(
+        e,
+        content=(
+          #|JsonDecodeError((Root, "Usage::from_json: expected object with numeric fields"))
+        ),
+      )
+  } noraise {
+    _ => fail("expected malformed usage to fail")
+  }
+}
+
+///|
+test "usage decode rejects non-object input" {
+  try
+    decode_usage(
+      (
+        #|null
+      ),
+    )
+  catch {
+    e =>
+      debug_inspect(
+        e,
+        content=(
+          #|JsonDecodeError((Root, "Usage::from_json: expected object with numeric fields"))
+        ),
+      )
+  } noraise {
+    _ => fail("expected non-object usage to fail")
+  }
+}

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -535,18 +535,14 @@ fn arg_field(key : String, value : Json) -> @html.Html {
 fn augment_with_diffs(tool_name : String, json : Json) -> Json {
   match tool_name {
     "edit" => add_edit_diff(json)
-    "multi_edit" =>
-      match json {
-        Object(fields) => {
-          if fields.get("edits") is Some(Array(items)) {
-            for item in items {
-              add_edit_diff(item) |> ignore
-            }
-          }
-          json
+    "multi_edit" => {
+      if json is { "edits": Array(items), .. } {
+        for item in items {
+          add_edit_diff(item) |> ignore
         }
-        _ => json
       }
+      json
+    }
     _ => json
   }
 }
@@ -557,8 +553,9 @@ fn augment_with_diffs(tool_name : String, json : Json) -> Json {
 /// are absent, not strings, or equal (a no-op the tool would reject anyway).
 fn add_edit_diff(json : Json) -> Json {
   guard json is Object(fields) else { return json }
-  guard fields.get("old_string") is Some(String(old)) else { return json }
-  guard fields.get("new_string") is Some(String(new)) else { return json }
+  guard json is { "old_string": String(old), "new_string": String(new), .. } else {
+    return json
+  }
   if old != new {
     fields["generated_diff"] = Json::string(generate_diff(old, new))
   }


### PR DESCRIPTION
## Summary
- refactor `Usage::from_json` into one optional-field object pattern
- default only absent counters to zero; reject malformed counters, `null`, and non-object values with `JsonDecodeError`
- prefer direct, nested, and multi-field map patterns for fixed JSON keys across DeepSeek, session persistence, auto-check, multi-edit, plan, read, and visualization packages
- decode fixed `@argparse.Matches` values, flags, and sources with record/map patterns in `openseek`, TUI, visualizer, and shared agent CLI configuration
- retain `.get(name)` and shared accessors only for genuinely dynamic keys
- add focused tests for malformed Usage fields, non-object input, and present-null response usage

## CLI pattern scope
- TUI configuration matches required defaults and optional engine/session fields together
- visualizer startup converts one `Matches` value into a typed `VizConfig`
- session compaction matches `file`, `from`, and `to` in one branch
- model/thinking decoding is shared across run, fleet, and serve modes
- visualizer search behavior matches `values` and `sources` together, preserving explicit flag/env precedence

`with` is used for scalar defaults. Constructed collection defaults and read-only external enum constructors cannot be used as `with` defaults, so those cases remain ordered pattern arms.

## Scope
This completes the root production-code sweep for fixed literal JSON and CLI keys outside the desktop, eval, and test-heavy trees. The refactor changes no public interfaces.

## Pattern reachability
A `moon run --deny-warn -e` probe confirmed that a direct `Map` pattern followed by a redundant wildcard reports `unreachable_code`. The corresponding `Json` pattern does not warn because its wildcard still handles non-object variants, so no core issue was filed.

## GitHub review feedback
The streaming decoder intentionally discards wire-level `"usage": null` placeholders before assembling a `ChatResponse`. Direct `ChatResponse` decoding rejects a present null value, consistent with the contract that only an absent field defaults; a regression test documents this distinction and the review thread is resolved.

## Validation
- `moon info` (no public interface changes)
- `moon fmt --check`
- `moon check --deny-warn`
- affected CLI packages: 168 tests
- `moon test` (1,048 native tests)
- `moon test --target js` (228 tests)
- `moon cram test tests/cram` (23 tests)
- fresh ephemeral, read-only Codex CLI review of the complete final PR: no actionable regressions
