### PR TITLE
refactor: decode argparse matches with patterns

### DIFF
--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -9,21 +9,29 @@
 async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
   // Fleet mode owns session creation and is a one-shot batch, so it conflicts
   // with the single-session and no-session modes of `openseek run`.
-  guard @agentcli.session_id(matches) is None else {
-    fail("--concurrency runs independent sessions; remove --session")
-  }
   guard !(matches is { flags: { "no-session": true, .. }, .. }) else {
     fail("--concurrency records each run; remove --no-session")
   }
   let task = task_text(matches)
-  let api_url = @agentcli.api_url(matches)
-  let (model, thinking) = model_and_thinking(matches)
+  let (model, thinking, api_url) = agent_settings(matches)
   let api_key = @agentcli.api_key(matches, model)
   let max_steps = max_steps(matches)
-  let (dir_input, session_root_input) = match matches {
-    { values: { "dir": [dir, ..], "session-root": [session_root, ..], .. }, .. } =>
-      (dir, session_root)
+  let (session, dir_input, session_root_input) = match matches {
+    {
+      values: {
+        "session"? : Some([session, ..])
+        | (Some([])
+        | None) with session = "",
+        "dir": [dir, ..],
+        "session-root": [session_root, ..],
+        ..
+      },
+      ..,
+    } => (session.trim(), dir, session_root)
     _ => fail("missing parsed fleet defaults")
+  }
+  guard session.is_empty() else {
+    fail("--concurrency runs independent sessions; remove --session")
   }
   let dir = trim_trailing_path_separators("\{dir_input.trim()}")
   let (run_dirs, source) = resolve_run_dirs(dir, concurrency)

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -12,20 +12,22 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
   guard @agentcli.session_id(matches) is None else {
     fail("--concurrency runs independent sessions; remove --session")
   }
-  guard !@cli.flag(matches, "no-session") else {
+  guard !(matches is { flags: { "no-session": true, .. }, .. }) else {
     fail("--concurrency records each run; remove --no-session")
   }
   let task = task_text(matches)
   let api_url = @agentcli.api_url(matches)
-  let model = @deepseek.Model::parse(@cli.value(matches, "model"))
+  let (model, thinking) = model_and_thinking(matches)
   let api_key = @agentcli.api_key(matches, model)
   let max_steps = max_steps(matches)
-  let thinking = @deepseek.ThinkingMode::parse(@cli.value(matches, "thinking"))
-  let dir = trim_trailing_path_separators(
-    "\{@cli.value(matches, "dir").trim()}",
-  )
+  let (dir_input, session_root_input) = match matches {
+    { values: { "dir": [dir, ..], "session-root": [session_root, ..], .. }, .. } =>
+      (dir, session_root)
+    _ => fail("missing parsed fleet defaults")
+  }
+  let dir = trim_trailing_path_separators("\{dir_input.trim()}")
   let (run_dirs, source) = resolve_run_dirs(dir, concurrency)
-  let session_root_value = "\{@cli.value(matches, "session-root").trim()}"
+  let session_root_value = "\{session_root_input.trim()}"
   // Skip the configured session store (not just the default) so a custom
   // --session-root does not copy stale source sessions into every trial.
   let sessions_rel = workspace_sessions_rel(session_root_value)

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -98,8 +98,13 @@ async fn with_jsonl_stdout(body : async () -> Unit) -> Unit {
 /// `--no-session` combined with an explicit `--session` is a contradiction
 /// every mode rejects up front, before any workspace or session work.
 fn reject_session_contradiction(matches : @argparse.Matches) -> Unit raise {
-  if @cli.flag(matches, "no-session") &&
-    @agentcli.session_id(matches) is Some(_) {
+  if matches
+    is {
+      flags: { "no-session": true, .. },
+      values: { "session": [session, ..], .. },
+      ..,
+    } &&
+    !session.trim().is_empty() {
     fail("--no-session contradicts --session; pick one behavior")
   }
 }
@@ -114,9 +119,12 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
     // Best-of-N fleet mode owns its own workspace materialization and session
     // creation, so it branches before prepare_workspace_root (which would
     // create a single --dir).
+    let concurrency_input = match matches {
+      { values: { "concurrency": [input, ..], .. }, .. } => input
+      _ => fail("missing parsed argument: concurrency")
+    }
     let concurrency = @cli.parse_positive_int(
-      @cli.value(matches, "concurrency"),
-      "--concurrency",
+      concurrency_input, "--concurrency",
     )
     if fleet_mode(matches, concurrency) {
       run_fleet(matches, concurrency~)
@@ -124,12 +132,9 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
     }
     let workspace_root = prepare_workspace_root(matches, log_created=true)
     let api_url = @agentcli.api_url(matches)
-    let model = @deepseek.Model::parse(@cli.value(matches, "model"))
+    let (model, thinking) = model_and_thinking(matches)
     let api_key = @agentcli.api_key(matches, model)
     let max_steps = max_steps(matches)
-    let thinking = @deepseek.ThinkingMode::parse(
-      @cli.value(matches, "thinking"),
-    )
     let task = task_text(matches)
     match resolved_session_id(matches) {
       None => {
@@ -225,8 +230,9 @@ async fn run_sessions_command(matches : @argparse.Matches) -> Unit {
 fn sessions_target_id(
   matches : @argparse.Matches,
 ) -> @agent_session.SessionId raise {
-  match @cli.values(matches, "id") {
-    [id, ..] if !id.trim().is_empty() => SessionId(id.trim().to_owned())
+  match matches {
+    { values: { "id": [id, ..], .. }, .. } if !id.trim().is_empty() =>
+      SessionId(id.trim().to_owned())
     _ => fail("a session id is required (e.g. `openseek sessions show <id>`)")
   }
 }
@@ -256,14 +262,23 @@ async fn sessions_compact(matches : @argparse.Matches) -> Unit {
   let workspace_root = prepare_workspace_root(matches, log_created=false)
   let store = @store.SessionStore(session_root(matches, workspace_root~))
   let id = sessions_target_id(matches)
-  let compact_file = @cli.require_non_empty(
-    matches, "file", "`openseek sessions compact` requires --file",
-  )
-  let from_sequence = required_positive_int(
-    @cli.value(matches, "from"),
-    "--from",
-  )
-  let to_sequence = required_positive_int(@cli.value(matches, "to"), "--to")
+  let (compact_file, from_input, to_input) = match matches {
+    {
+      values: {
+        "file": [compact_file, ..],
+        "from": [from_input, ..],
+        "to": [to_input, ..],
+        ..
+      },
+      ..,
+    } => (compact_file.trim().to_owned(), from_input, to_input)
+    _ => fail("missing parsed session compaction arguments")
+  }
+  guard !compact_file.is_empty() else {
+    fail("`openseek sessions compact` requires --file")
+  }
+  let from_sequence = required_positive_int(from_input, "--from")
+  let to_sequence = required_positive_int(to_input, "--to")
   let summary_path = @workspace_path.resolve(workspace_root, compact_file)
   let summary = @fs.read_file(summary_path).text()
   let compacted = store.compact(
@@ -297,7 +312,17 @@ async fn sessions_compact(matches : @argparse.Matches) -> Unit {
 async fn resolved_session_id(
   matches : @argparse.Matches,
 ) -> @agent_session.SessionId? {
-  match (@agentcli.session_id(matches), @cli.flag(matches, "no-session")) {
+  let no_session = match matches {
+    {
+      flags: {
+        "no-session"? : Some(no_session)
+        | None with no_session = false,
+        ..
+      },
+      ..,
+    } => no_session
+  }
+  match (@agentcli.session_id(matches), no_session) {
     (Some(_), true) =>
       fail("--no-session contradicts --session; pick one behavior")
     (Some(id), false) => Some(id)
@@ -589,15 +614,33 @@ fn explicitly_provided(matches : @argparse.Matches, name : String) -> Bool {
 }
 
 ///|
+fn model_and_thinking(
+  matches : @argparse.Matches,
+) -> (@deepseek.Model, @deepseek.ThinkingMode) raise {
+  match matches {
+    { values: { "model": [model, ..], "thinking": [thinking, ..], .. }, .. } =>
+      (@deepseek.Model::parse(model), @deepseek.ThinkingMode::parse(thinking))
+    _ => fail("missing parsed model or thinking default")
+  }
+}
+
+///|
 /// `None` — no flag, no env — means turns bounded by the model's context
 /// window (the engine's own default), not by a step count.
 fn max_steps(matches : @argparse.Matches) -> Int? raise {
-  @cli.parse_optional_positive_int(matches, "max-steps", "--max-steps")
+  match matches {
+    { values: { "max-steps": [input, ..], .. }, .. } =>
+      Some(@cli.parse_positive_int(input, "--max-steps"))
+    _ => None
+  }
 }
 
 ///|
 fn task_text(matches : @argparse.Matches) -> String raise {
-  let task = @cli.values(matches, "task").join(" ").trim()
+  let task = match matches {
+    { values: { "task": words, .. }, .. } => words.join(" ").trim()
+    _ => ""
+  }
   if task.is_empty() {
     fail("task description is required for agent runs")
   }
@@ -609,9 +652,11 @@ async fn prepare_workspace_root(
   matches : @argparse.Matches,
   log_created? : Bool = true,
 ) -> String {
-  let dir = trim_trailing_path_separators(
-    "\{@cli.value(matches, "dir").trim()}",
-  )
+  let dir_input = match matches {
+    { values: { "dir": [dir, ..], .. }, .. } => dir
+    _ => fail("missing parsed argument: dir")
+  }
+  let dir = trim_trailing_path_separators("\{dir_input.trim()}")
   if dir.is_empty() {
     fail("--dir or OPENSEEK_DIR must not be empty")
   }
@@ -668,9 +713,13 @@ fn session_root(
   matches : @argparse.Matches,
   workspace_root? : String = ".",
 ) -> String raise {
-  let root = @cli.require_non_empty(
-    matches, "session-root", "--session-root or OPENSEEK_SESSION_ROOT must not be empty",
-  )
+  let root = match matches {
+    { values: { "session-root": [root, ..], .. }, .. } => root.trim().to_owned()
+    _ => fail("missing parsed argument: session-root")
+  }
+  guard !root.is_empty() else {
+    fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
+  }
   @workspace_path.resolve(workspace_root, root)
 }
 
@@ -748,10 +797,12 @@ priv enum SessionListFormat {
 
 ///|
 fn session_list_format(matches : @argparse.Matches) -> SessionListFormat raise {
-  match @cli.value(matches, "format") {
-    "text" => Text
-    "json" => Json
-    other => fail("--format must be text or json, got: \{other}")
+  match matches {
+    { values: { "format": ["text", ..], .. }, .. } => Text
+    { values: { "format": ["json", ..], .. }, .. } => Json
+    { values: { "format": [other, ..], .. }, .. } =>
+      fail("--format must be text or json, got: \{other}")
+    _ => fail("missing parsed argument: format")
   }
 }
 
@@ -841,8 +892,18 @@ async fn configured_system_prompt(
   model : @deepseek.Model,
   workspace_root? : String = ".",
 ) -> String {
-  let base_path = @cli.value(matches, "system-prompt-file")
-  let addendum_path = @cli.value(matches, "system-prompt-addendum-file")
+  let (base_path, addendum_path, global_skills_dir) = match matches {
+    {
+      values: {
+        "system-prompt-file": [base_path, ..],
+        "system-prompt-addendum-file": [addendum_path, ..],
+        "global-skills-dir": [global_skills_dir, ..],
+        ..
+      },
+      ..,
+    } => (base_path, addendum_path, global_skills_dir)
+    _ => fail("missing parsed system-prompt defaults")
+  }
   let base = if base_path == "" {
     @prompt.system_prompt_for_model(model)
   } else {
@@ -875,10 +936,7 @@ async fn configured_system_prompt(
   // edited), so they must sit after all globally shared text to keep it
   // prefix-cache hittable.
   match
-    skills_prompt_section_for_cwd(
-      global_dir=@cli.value(matches, "global-skills-dir"),
-      workspace_root~,
-    ) {
+    skills_prompt_section_for_cwd(global_dir=global_skills_dir, workspace_root~) {
     Some(section) =>
       (
         $|\{tail}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -131,8 +131,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
       return
     }
     let workspace_root = prepare_workspace_root(matches, log_created=true)
-    let api_url = @agentcli.api_url(matches)
-    let (model, thinking) = model_and_thinking(matches)
+    let (model, thinking, api_url) = agent_settings(matches)
     let api_key = @agentcli.api_key(matches, model)
     let max_steps = max_steps(matches)
     let task = task_text(matches)
@@ -312,17 +311,27 @@ async fn sessions_compact(matches : @argparse.Matches) -> Unit {
 async fn resolved_session_id(
   matches : @argparse.Matches,
 ) -> @agent_session.SessionId? {
-  let no_session = match matches {
+  let (session, no_session) = match matches {
     {
+      values: {
+        "session"? : Some([session, ..])
+        | (Some([])
+        | None) with session = "",
+        ..
+      },
       flags: {
         "no-session"? : Some(no_session)
         | None with no_session = false,
         ..
       },
       ..,
-    } => no_session
+    } => (session.trim(), no_session)
   }
-  match (@agentcli.session_id(matches), no_session) {
+  let session_id = match session {
+    "" => None
+    session => Some(@agent_session.SessionId("\{session}"))
+  }
+  match (session_id, no_session) {
     (Some(_), true) =>
       fail("--no-session contradicts --session; pick one behavior")
     (Some(id), false) => Some(id)
@@ -614,13 +623,28 @@ fn explicitly_provided(matches : @argparse.Matches, name : String) -> Bool {
 }
 
 ///|
-fn model_and_thinking(
+fn agent_settings(
   matches : @argparse.Matches,
-) -> (@deepseek.Model, @deepseek.ThinkingMode) raise {
+) -> (@deepseek.Model, @deepseek.ThinkingMode, String?) raise {
   match matches {
-    { values: { "model": [model, ..], "thinking": [thinking, ..], .. }, .. } =>
-      (@deepseek.Model::parse(model), @deepseek.ThinkingMode::parse(thinking))
-    _ => fail("missing parsed model or thinking default")
+    {
+      values: {
+        "model": [model, ..],
+        "thinking": [thinking, ..],
+        "api-url": [api_url, ..],
+        ..
+      },
+      ..,
+    } =>
+      (
+        @deepseek.Model::parse(model),
+        @deepseek.ThinkingMode::parse(thinking),
+        match api_url.trim() {
+          "" => None
+          url => Some("\{url}")
+        },
+      )
+    _ => fail("missing parsed agent defaults")
   }
 }
 
@@ -1156,8 +1180,9 @@ test "cli parses env backed options and task" {
     "OPENSEEK_SESSION_ROOT": "/tmp/openseek-sessions",
   })
   assert_eq(@agentcli.api_key(parsed, Deepseek(V4Pro)), "test-key")
-  assert_eq(@cli.value(parsed, "model"), "deepseek-v4-pro")
-  guard @agentcli.api_url(parsed) is Some(url) else { fail("expected api url") }
+  let (model, _, api_url) = agent_settings(parsed)
+  assert_true(model is Deepseek(V4Pro))
+  guard api_url is Some(url) else { fail("expected api url") }
   assert_eq(url, "https://proxy.example/v1/chat/completions")
   assert_eq(@cli.value(parsed, "dir"), "/tmp/openseek-workspace")
   assert_true(max_steps(parsed) is Some(120))
@@ -1166,10 +1191,7 @@ test "cli parses env backed options and task" {
     @cli.value(parsed, "system-prompt-addendum-file"),
     "/tmp/prompt-b.md",
   )
-  guard @agentcli.session_id(parsed) is Some(id) else {
-    fail("expected session id")
-  }
-  assert_eq(id.value(), "demo")
+  assert_true(parsed is { values: { "session": ["demo", ..], .. }, .. })
   assert_eq(session_root(parsed), "/tmp/openseek-sessions")
   assert_eq(task_text(parsed), "write MoonBit")
 }
@@ -1180,11 +1202,12 @@ test "cli defaults model and max steps" {
     "DEEPSEEK": "test-key",
   })
   assert_eq(@agentcli.api_key(parsed, Deepseek(V4Pro)), "test-key")
-  assert_eq(@cli.value(parsed, "model"), "deepseek-v4-pro")
-  assert_true(@agentcli.api_url(parsed) is None)
+  let (model, _, api_url) = agent_settings(parsed)
+  assert_true(model is Deepseek(V4Pro))
+  assert_true(api_url is None)
   assert_eq(@cli.value(parsed, "dir"), ".")
   assert_true(max_steps(parsed) is None)
-  assert_true(@agentcli.session_id(parsed) is None)
+  assert_true(parsed is { values: { "session"? : None, .. }, .. })
   assert_eq(session_root(parsed), ".openseek")
 }
 

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -20,15 +20,29 @@ async fn run_review_cli(
   matches : @argparse.Matches,
   workspace_root~ : String,
 ) -> Unit {
-  let api_url = @agentcli.api_url(matches)
   // Reviews always run on the strongest model; flash is too shallow for the
   // judgement a code review needs, so --model is not consulted here.
   let model = @deepseek.Deepseek(V4Pro)
   let api_key = @agentcli.api_key(matches, model)
   let max_steps = max_steps(matches)
-  let (thinking, base) = match matches {
-    { values: { "thinking": [thinking, ..], "base": [base, ..], .. }, .. } =>
-      (@deepseek.ThinkingMode::parse(thinking), base)
+  let (thinking, base, api_url) = match matches {
+    {
+      values: {
+        "thinking": [thinking, ..],
+        "base": [base, ..],
+        "api-url": [api_url, ..],
+        ..
+      },
+      ..,
+    } =>
+      (
+        @deepseek.ThinkingMode::parse(thinking),
+        base,
+        match api_url.trim() {
+          "" => None
+          url => Some("\{url}")
+        },
+      )
     _ => fail("missing parsed review defaults")
   }
   if base.trim() == "" {

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -26,8 +26,11 @@ async fn run_review_cli(
   let model = @deepseek.Deepseek(V4Pro)
   let api_key = @agentcli.api_key(matches, model)
   let max_steps = max_steps(matches)
-  let thinking = @deepseek.ThinkingMode::parse(@cli.value(matches, "thinking"))
-  let base = @cli.value(matches, "base")
+  let (thinking, base) = match matches {
+    { values: { "thinking": [thinking, ..], "base": [base, ..], .. }, .. } =>
+      (@deepseek.ThinkingMode::parse(thinking), base)
+    _ => fail("missing parsed review defaults")
+  }
   if base.trim() == "" {
     @stdio.stderr.write("review failed: --base must be a non-empty git ref\n")
     @sys.exit(1)

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -486,11 +486,25 @@ async fn run_serve(
   matches : @argparse.Matches,
   workspace_root~ : String,
 ) -> Unit {
-  let api_url = @agentcli.api_url(matches)
-  let (model, thinking) = model_and_thinking(matches)
+  let (model, thinking, api_url) = agent_settings(matches)
   let api_key = @agentcli.api_key(matches, model)
   let max_steps = max_steps(matches)
-  let (store, initial_session) = match @agentcli.session_id(matches) {
+  let session_id = match matches {
+    {
+      values: {
+        "session"? : Some([session, ..])
+        | (Some([])
+        | None) with session = "",
+        ..
+      },
+      ..,
+    } =>
+      match session.trim() {
+        "" => None
+        session => Some(@agent_session.SessionId("\{session}"))
+      }
+  }
+  let (store, initial_session) = match session_id {
     Some(id) => {
       let store = @store.SessionStore(session_root(matches, workspace_root~))
       (

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -487,10 +487,9 @@ async fn run_serve(
   workspace_root~ : String,
 ) -> Unit {
   let api_url = @agentcli.api_url(matches)
-  let model = @deepseek.Model::parse(@cli.value(matches, "model"))
+  let (model, thinking) = model_and_thinking(matches)
   let api_key = @agentcli.api_key(matches, model)
   let max_steps = max_steps(matches)
-  let thinking = @deepseek.ThinkingMode::parse(@cli.value(matches, "thinking"))
   let (store, initial_session) = match @agentcli.session_id(matches) {
     Some(id) => {
       let store = @store.SessionStore(session_root(matches, workspace_root~))

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -158,7 +158,11 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   if config.max_steps is Some(max_steps) {
     env["OPENSEEK_MAX_STEPS"] = max_steps.to_string()
   }
-  env[@agentcli.api_key_env_for_model(config.model)] = config.api_key
+  let api_key_env = match config.model {
+    Kimi(_) => "KIMI"
+    Deepseek(_) => "DEEPSEEK"
+  }
+  env[api_key_env] = config.api_key
   env
 }
 

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -143,8 +143,23 @@ pub fn cli_command() -> @argparse.Command {
 /// answers to "which conversation", and silently preferring either would
 /// surprise whoever typed the other.
 fn continue_requested(matches : @argparse.Matches) -> Bool raise {
-  let continue_flag = @cli.flag(matches, "continue")
-  if continue_flag && @agentcli.session_id(matches) is Some(_) {
+  let (continue_flag, session) = match matches {
+    {
+      flags: {
+        "continue"? : Some(continue_flag)
+        | None with continue_flag = false,
+        ..
+      },
+      values: {
+        "session"? : Some([session, ..])
+        | (Some([])
+        | None) with session = "",
+        ..
+      },
+      ..,
+    } => (continue_flag, session.trim())
+  }
+  if continue_flag && !session.is_empty() {
     fail(
       "--continue resumes the latest session; it cannot be combined with --session",
     )
@@ -164,13 +179,6 @@ async fn with_latest_session(config : AppConfig) -> AppConfig {
 }
 
 ///|
-fn session_root(matches : @argparse.Matches) -> String raise {
-  @cli.require_non_empty(
-    matches, "session-root", "--session-root or OPENSEEK_SESSION_ROOT must not be empty",
-  )
-}
-
-///|
 /// Session id for a TUI launch that did not pick one.
 ///
 /// Conversation continuity is the TUI's default. The engine runs once per
@@ -185,15 +193,43 @@ fn generated_session_id(now_ms : Int64) -> @agent_session.SessionId {
 
 ///|
 fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
+  let (
+    session_root_input,
+    engine_input,
+    engine_mode_input,
+    model_input,
+    thinking_input,
+  ) = match matches {
+    {
+      values: {
+        "session-root": [session_root, ..],
+        "engine"? : Some([engine, ..])
+        | (Some([])
+        | None) with engine = "",
+        "engine-mode"? : Some([engine_mode, ..])
+        | (Some([])
+        | None) with engine_mode = "serve",
+        "model": [model, ..],
+        "thinking": [thinking, ..],
+        ..
+      },
+      ..,
+    } => (session_root, engine, engine_mode, model, thinking)
+    _ => fail("missing parsed TUI defaults")
+  }
   let cwd = match @env.current_dir() {
     Some(cwd) => cwd
     None => "."
   }
   let explicit_session = @agentcli.session_id(matches)
   let session_root_value = if explicit_session is Some(_) {
-    session_root(matches)
+    let root = session_root_input.trim()
+    guard !root.is_empty() else {
+      fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
+    }
+    "\{root}"
   } else {
-    let root = @cli.value(matches, "session-root").trim().to_owned()
+    let root = session_root_input.trim().to_owned()
     if root.is_empty() {
       ".openseek"
     } else {
@@ -204,18 +240,14 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   // command as the engine (see `default_engine`). Presence of a non-blank value,
   // not a magic default string, decides — which also gates oneshot below. A
   // blank `--engine ""` counts as unset rather than an empty command.
-  let explicit_engine : String? = match @cli.values(matches, "engine") {
-    [engine, ..] if !engine.trim().is_empty() => Some(engine)
-    _ => None
+  let explicit_engine : String? = if engine_input.trim().is_empty() {
+    None
+  } else {
+    Some(engine_input)
   }
   // `--engine-mode` is a UI-only option on the `tui` subcommand; a bare
   // `openseek` (no subcommand) never has it, so read it gracefully.
-  let engine_mode = EngineMode::parse(
-    match @cli.values(matches, "engine-mode") {
-      [mode, ..] => mode
-      [] => "serve"
-    },
-  )
+  let engine_mode = EngineMode::parse(engine_mode_input)
   // `oneshot` only makes sense for a custom/replay engine that cannot speak the
   // persistent `serve` protocol; re-launching ourselves in oneshot buys nothing
   // and loses steering/compaction, so require an explicit engine.
@@ -225,7 +257,7 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     )
   }
   // Enforced here rather than via argparse `required`: see `tui_shared_options`.
-  let model = @deepseek.Model::parse(@cli.value(matches, "model"))
+  let model = @deepseek.Model::parse(model_input)
   let api_key = @agentcli.api_key(matches, model)
   let (engine, engine_args_prefix) = match explicit_engine {
     Some(engine) => (engine, [])
@@ -236,12 +268,14 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
     api_url: @agentcli.api_url(matches),
     model,
     cwd,
-    max_steps: @cli.parse_optional_positive_int(
-      matches, "max-steps", "--max-steps",
-    ),
+    max_steps: match matches {
+      { values: { "max-steps": [input, ..], .. }, .. } =>
+        Some(@cli.parse_positive_int(input, "--max-steps"))
+      _ => None
+    },
     // Parsed eagerly so a typo fails at launch with a CLI error instead of
     // inside the first turn's engine run.
-    thinking: @deepseek.ThinkingMode::parse(@cli.value(matches, "thinking")),
+    thinking: @deepseek.ThinkingMode::parse(thinking_input),
     session_id: match explicit_session {
       Some(id) => id
       None => generated_session_id(@env.now().reinterpret_as_int64())
@@ -286,9 +320,20 @@ fn moon_native_tcc_run_args(argv0 : String) -> Array[String]? {
 /// There is no free-form positional: a bare non-subcommand token is a typo the
 /// top-level dispatcher rejects rather than silently treats as a prompt.
 fn initial_task(matches : @argparse.Matches) -> String? {
-  match @cli.values(matches, "prompt") {
-    [prompt, ..] if !prompt.trim().is_empty() => Some(prompt.trim().to_owned())
-    _ => None
+  match matches {
+    {
+      values: {
+        "prompt"? : Some([prompt, ..])
+        | (Some([])
+        | None) with prompt = "",
+        ..
+      },
+      ..,
+    } =>
+      match prompt.trim() {
+        "" => None
+        prompt => Some("\{prompt}")
+      }
   }
 }
 

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -194,6 +194,8 @@ fn generated_session_id(now_ms : Int64) -> @agent_session.SessionId {
 ///|
 fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   let (
+    api_url_input,
+    session_input,
     session_root_input,
     engine_input,
     engine_mode_input,
@@ -202,6 +204,10 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   ) = match matches {
     {
       values: {
+        "api-url": [api_url, ..],
+        "session"? : Some([session, ..])
+        | (Some([])
+        | None) with session = "",
         "session-root": [session_root, ..],
         "engine"? : Some([engine, ..])
         | (Some([])
@@ -214,14 +220,17 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
         ..
       },
       ..,
-    } => (session_root, engine, engine_mode, model, thinking)
+    } => (api_url, session, session_root, engine, engine_mode, model, thinking)
     _ => fail("missing parsed TUI defaults")
   }
   let cwd = match @env.current_dir() {
     Some(cwd) => cwd
     None => "."
   }
-  let explicit_session = @agentcli.session_id(matches)
+  let explicit_session = match session_input.trim() {
+    "" => None
+    session => Some(@agent_session.SessionId("\{session}"))
+  }
   let session_root_value = if explicit_session is Some(_) {
     let root = session_root_input.trim()
     guard !root.is_empty() else {
@@ -265,7 +274,10 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   }
   {
     api_key,
-    api_url: @agentcli.api_url(matches),
+    api_url: match api_url_input.trim() {
+      "" => None
+      url => Some("\{url}")
+    },
     model,
     cwd,
     max_steps: match matches {

--- a/cmd/viz_server/main.mbt
+++ b/cmd/viz_server/main.mbt
@@ -13,53 +13,108 @@
 /// Session discovery is intentionally file-oriented: only
 /// `openseek_session-*.jsonl` files are listed, so `.DS_Store`, lock files, and
 /// malformed/husk directories do not show up as sessions.
+priv struct VizConfig {
+  port : Int
+  host : String
+  session_root : String
+  session_root_name : String
+  search_dirs : Array[String]
+  web_dir : String
+  bundle : String
+  export_path : String
+}
+
+///|
+fn viz_config_from_matches(matches : @argparse.Matches) -> VizConfig raise {
+  let (port, host, session_root, session_root_name, web_dir, bundle, export_path
+  ) = match matches {
+    {
+      values: {
+        "port": [port, ..],
+        "host": [host, ..],
+        "session-root": [session_root, ..],
+        "session-root-name": [session_root_name, ..],
+        "web-dir": [web_dir, ..],
+        "bundle": [bundle, ..],
+        "export": [export_path, ..],
+        ..
+      },
+      ..,
+    } =>
+      (
+        port, host, session_root, session_root_name, web_dir, bundle, export_path,
+      )
+    _ => fail("missing parsed visualizer defaults")
+  }
+  let host = host.trim()
+  guard !host.is_empty() else {
+    fail("--host or OPENSEEK_VIZ_HOST must not be empty")
+  }
+  let session_root = session_root.trim()
+  guard !session_root.is_empty() else {
+    fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
+  }
+  let session_root_name = session_root_name.trim()
+  guard !session_root_name.is_empty() else {
+    fail(
+      "--session-root-name or OPENSEEK_VIZ_SESSION_ROOT_NAME must not be empty",
+    )
+  }
+  {
+    port: parse_port(port),
+    host: "\{host}",
+    session_root: "\{session_root}",
+    session_root_name: "\{session_root_name}",
+    search_dirs: effective_search_dirs(matches),
+    web_dir,
+    bundle,
+    export_path,
+  }
+}
+
+///|
 async fn main {
   let matches = cli_command().parse(env=@env.get_env_vars())
-  let port = parse_port(@cli.value(matches, "port"))
-  let host = @cli.require_non_empty(
-    matches, "host", "--host or OPENSEEK_VIZ_HOST must not be empty",
-  )
-  let session_root = @cli.require_non_empty(
-    matches, "session-root", "--session-root or OPENSEEK_SESSION_ROOT must not be empty",
-  )
-  let session_root_name = @cli.require_non_empty(
-    matches, "session-root-name", "--session-root-name or OPENSEEK_VIZ_SESSION_ROOT_NAME must not be empty",
-  )
+  let config = viz_config_from_matches(matches)
   // Keep main's fix (f26def11): an explicit --session-root drops the default
   // cwd scan. effective_search_dirs encodes that; do not revert to a bare
   // non_empty_values(matches, "search-dir").
-  let search_dirs = effective_search_dirs(matches)
-  let web_dir = @cli.value(matches, "web-dir")
-  let bundle = @cli.value(matches, "bundle")
   let module_root = match @env.args() {
     [exe, ..] => module_root_from_exe(exe)
     [] => None
   }
-  let shell = shell_candidates(web_dir, module_root)
-  let bundle_paths = bundle_candidates(bundle, web_dir, module_root)
-  let catalog = session_catalog(session_root, search_dirs, session_root_name)
+  let shell = shell_candidates(config.web_dir, module_root)
+  let bundle_paths = bundle_candidates(
+    config.bundle,
+    config.web_dir,
+    module_root,
+  )
+  let catalog = session_catalog(
+    config.session_root,
+    config.search_dirs,
+    config.session_root_name,
+  )
   // Export mode: freeze the sessions the server would serve into one standalone
   // HTML and exit, rather than run_forever. The exported file is decoupled from
   // this server and from the current parser — it carries its own bundle + data.
-  let export_path = @cli.value(matches, "export")
-  if export_path != "" {
+  if config.export_path != "" {
     let rows = catalog.rows()
     let html = build_export_html(rows, shell, bundle_paths)
-    @fs.write_file(export_path, html, create_mode=CreateOrTruncate)
+    @fs.write_file(config.export_path, html, create_mode=CreateOrTruncate)
     println(
-      "openseek viz: wrote standalone export '\{export_path}' (\{rows.length()} session(s), \{html.length()} chars)",
+      "openseek viz: wrote standalone export '\{config.export_path}' (\{rows.length()} session(s), \{html.length()} chars)",
     )
     return
   }
-  let addr = @socket.Addr::parse("\{host}:\{port}") catch {
-    _ => fail("invalid --host/--port: \{host}:\{port}")
+  let addr = @socket.Addr::parse("\{config.host}:\{config.port}") catch {
+    _ => fail("invalid --host/--port: \{config.host}:\{config.port}")
   }
   println("openseek viz: serving \{catalog.roots.length()} session root(s)")
   for root in catalog.roots {
     println("openseek viz: sessions under '\{root.path}'")
   }
   println("openseek viz: shell from '\{shell[0]}'")
-  print_open_urls(host, port)
+  print_open_urls(config.host, config.port)
   let server = @http.Server(addr)
   server.run_forever((request, _body, conn) => {
     handle(request, conn, catalog, shell, bundle_paths)
@@ -1141,34 +1196,19 @@ fn cli_command() -> @argparse.Command {
 /// explicit `--search-dir` always wins: giving both flags means "that root,
 /// plus these scans".
 fn effective_search_dirs(matches : @argparse.Matches) -> Array[String] {
-  if explicitly_provided(matches, "session-root") &&
-    !explicitly_provided(matches, "search-dir") {
-    []
-  } else {
-    non_empty_values(matches, "search-dir")
-  }
-}
-
-///|
-/// Whether the user supplied `name` on the command line or via its
-/// environment variable, rather than the built-in default filling it in.
-fn explicitly_provided(matches : @argparse.Matches, name : String) -> Bool {
-  matches.sources.get(name) is (Some(Argv) | Some(Env))
-}
-
-///|
-fn non_empty_values(
-  matches : @argparse.Matches,
-  name : String,
-) -> Array[String] {
-  match matches.values.get(name) {
-    Some(values) =>
+  match matches {
+    {
+      values: { "search-dir": _, .. },
+      sources: { "session-root": Argv | Env, "search-dir": Default, .. },
+      ..,
+    } => []
+    { values: { "search-dir": values, .. }, .. } =>
       [
         for value in values if !value.trim().is_empty() => {
           value.trim().to_owned()
         }
       ]
-    None => []
+    _ => []
   }
 }
 

--- a/cmd/viz_server/moon.pkg
+++ b/cmd/viz_server/moon.pkg
@@ -5,7 +5,6 @@ import {
 
 import {
   "bobzhang/openseek/agent_session",
-  "bobzhang/openseek/internal/cli",
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/async/socket",

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -16,9 +16,8 @@
 ///
 ///   moon run --target native eval/bgjobs_capability
 async fn main {
-  // `DEEPSEEK` is the engine's API-key env var (see
-  // @agentcli.api_key_env_for_model); blank means the engine would reject it
-  // at startup, so both count as unset.
+  // `DEEPSEEK` is the engine's API-key env var; blank means the engine would
+  // reject it at startup, so both count as unset.
   guard @env.get_env_var("DEEPSEEK") is Some(key) && !key.trim().is_empty() else {
     println("SKIP: DEEPSEEK is not set; this eval drives the live engine")
     return

--- a/internal/agentcli/agentcli.mbt
+++ b/internal/agentcli/agentcli.mbt
@@ -7,15 +7,6 @@
 /// package removes.
 
 ///|
-/// CLI option that carries the provider-specific API key for `model`.
-fn api_key_arg_for_model(model : @deepseek.Model) -> String {
-  match model {
-    Kimi(_) => "kimi-api-key"
-    Deepseek(_) => "deepseek-api-key"
-  }
-}
-
-///|
 /// Environment variable that carries the API key for `model`'s provider.
 /// Spawned engine processes inherit their key through this variable, so it
 /// must stay in lockstep with `api_key`'s lookup order.
@@ -44,11 +35,32 @@ pub fn api_key(
   matches : @argparse.Matches,
   model : @deepseek.Model,
 ) -> String raise {
-  if @cli.non_empty_value(matches, "api-key") is Some(key) {
-    return key
+  let (generic_key, deepseek_key, kimi_key) = match matches {
+    {
+      values: {
+        "api-key"? : Some([generic_key, ..])
+        | (Some([])
+        | None) with generic_key = "",
+        "deepseek-api-key"? : Some([deepseek_key, ..])
+        | (Some([])
+        | None) with deepseek_key = "",
+        "kimi-api-key"? : Some([kimi_key, ..])
+        | (Some([])
+        | None) with kimi_key = "",
+        ..
+      },
+      ..,
+    } => (generic_key.trim(), deepseek_key.trim(), kimi_key.trim())
   }
-  if @cli.non_empty_value(matches, api_key_arg_for_model(model)) is Some(key) {
-    return key
+  if !generic_key.is_empty() {
+    return "\{generic_key}"
+  }
+  let provider_key = match model {
+    Kimi(_) => kimi_key
+    Deepseek(_) => deepseek_key
+  }
+  if !provider_key.is_empty() {
+    return "\{provider_key}"
   }
   fail(
     "an API key is required for \{api_key_provider_for_model(model)} models: pass --api-key or set \{api_key_env_for_model(model)}",
@@ -59,7 +71,15 @@ pub fn api_key(
 /// `--api-url` as an override: unset or whitespace-only means "use the
 /// provider default".
 pub fn api_url(matches : @argparse.Matches) -> String? raise {
-  @cli.non_empty_value(matches, "api-url")
+  let url = match matches {
+    { values: { "api-url": [url, ..], .. }, .. } => url.trim()
+    _ => fail("missing parsed argument: api-url")
+  }
+  if url.is_empty() {
+    None
+  } else {
+    Some("\{url}")
+  }
 }
 
 ///|
@@ -67,9 +87,16 @@ pub fn api_url(matches : @argparse.Matches) -> String? raise {
 /// a default, so read it gracefully: it is absent (not empty) in a
 /// subcommand's matches when unset.
 pub fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? {
-  let id = match @cli.values(matches, "session") {
-    [session, ..] => session.trim()
-    [] => ""
+  let id = match matches {
+    {
+      values: {
+        "session"? : Some([session, ..])
+        | (Some([])
+        | None) with session = "",
+        ..
+      },
+      ..,
+    } => session.trim()
   }
   if id.is_empty() {
     None

--- a/internal/agentcli/agentcli.mbt
+++ b/internal/agentcli/agentcli.mbt
@@ -7,26 +7,6 @@
 /// package removes.
 
 ///|
-/// Environment variable that carries the API key for `model`'s provider.
-/// Spawned engine processes inherit their key through this variable, so it
-/// must stay in lockstep with `api_key`'s lookup order.
-pub fn api_key_env_for_model(model : @deepseek.Model) -> String {
-  match model {
-    Kimi(_) => "KIMI"
-    Deepseek(_) => "DEEPSEEK"
-  }
-}
-
-///|
-/// Human-readable provider name for `model`, used in error guidance.
-fn api_key_provider_for_model(model : @deepseek.Model) -> String {
-  match model {
-    Kimi(_) => "Kimi"
-    Deepseek(_) => "DeepSeek"
-  }
-}
-
-///|
 /// Resolve the API key for `model`: an explicit `--api-key` wins, then the
 /// provider-specific option (which each command table backs with the
 /// provider's environment variable). Fails with provider-specific guidance
@@ -55,52 +35,14 @@ pub fn api_key(
   if !generic_key.is_empty() {
     return "\{generic_key}"
   }
-  let provider_key = match model {
-    Kimi(_) => kimi_key
-    Deepseek(_) => deepseek_key
+  let (provider_key, provider, env_var) = match model {
+    Kimi(_) => (kimi_key, "Kimi", "KIMI")
+    Deepseek(_) => (deepseek_key, "DeepSeek", "DEEPSEEK")
   }
   if !provider_key.is_empty() {
     return "\{provider_key}"
   }
   fail(
-    "an API key is required for \{api_key_provider_for_model(model)} models: pass --api-key or set \{api_key_env_for_model(model)}",
+    "an API key is required for \{provider} models: pass --api-key or set \{env_var}",
   )
-}
-
-///|
-/// `--api-url` as an override: unset or whitespace-only means "use the
-/// provider default".
-pub fn api_url(matches : @argparse.Matches) -> String? raise {
-  let url = match matches {
-    { values: { "api-url": [url, ..], .. }, .. } => url.trim()
-    _ => fail("missing parsed argument: api-url")
-  }
-  if url.is_empty() {
-    None
-  } else {
-    Some("\{url}")
-  }
-}
-
-///|
-/// `--session` as a durable session id. `--session` is a root global without
-/// a default, so read it gracefully: it is absent (not empty) in a
-/// subcommand's matches when unset.
-pub fn session_id(matches : @argparse.Matches) -> @agent_session.SessionId? {
-  let id = match matches {
-    {
-      values: {
-        "session"? : Some([session, ..])
-        | (Some([])
-        | None) with session = "",
-        ..
-      },
-      ..,
-    } => session.trim()
-  }
-  if id.is_empty() {
-    None
-  } else {
-    Some(SessionId("\{id}"))
-  }
 }

--- a/internal/agentcli/moon.pkg
+++ b/internal/agentcli/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/deepseek",
   "moonbitlang/core/argparse",
 }

--- a/internal/agentcli/moon.pkg
+++ b/internal/agentcli/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/deepseek",
-  "bobzhang/openseek/internal/cli",
   "moonbitlang/core/argparse",
 }
 

--- a/internal/agentcli/pkg.generated.mbti
+++ b/internal/agentcli/pkg.generated.mbti
@@ -2,19 +2,12 @@
 package "bobzhang/openseek/internal/agentcli"
 
 import {
-  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/deepseek",
   "moonbitlang/core/argparse",
 }
 
 // Values
 pub fn api_key(@argparse.Matches, @deepseek.Model) -> String raise
-
-pub fn api_key_env_for_model(@deepseek.Model) -> String
-
-pub fn api_url(@argparse.Matches) -> String? raise
-
-pub fn session_id(@argparse.Matches) -> @agent_session.SessionId?
 
 // Errors
 


### PR DESCRIPTION
## Summary
- decode fixed `@argparse.Matches` values, flags, and sources with record and map patterns
- match related CLI fields together at configuration boundaries instead of repeating dynamic accessors
- use scalar `with` defaults for optional flags and values
- keep URL, session, and provider environment decoding local so readers do not have to chase one-use helpers
- retain the shared `agentcli.api_key` helper because it owns nontrivial provider precedence and error policy
- retain `.get(name)` only where the key is genuinely dynamic

## Scope
- TUI configuration matches required defaults plus optional engine, URL, and session fields together
- visualizer startup converts one `Matches` value into a typed `VizConfig`
- session compaction matches `file`, `from`, and `to` in one branch
- model, thinking, and API URL decoding is shared across run, fleet, and serve modes
- visualizer search behavior matches `values` and `sources` together, preserving explicit flag and environment precedence
- remove the one-use `agentcli` URL, session, and provider-name wrappers and their unused dependencies

This is behavior-preserving. There are no public interface changes; the internal `agentcli` interface intentionally shrinks to its substantive API-key policy. Constructed collection defaults and read-only external enum constructors cannot be used as `with` defaults, so those cases use ordered pattern arms.

## Validation
- `moon info && moon fmt`
- `moon fmt --check`
- `moon check --deny-warn`
- affected CLI packages: 147 tests
- `moon test`: 1,048 native tests
- `moon test --target js`: 228 tests
- `moon cram test tests/cram`: 23 tests
- fresh ephemeral, read-only Codex CLI review against current `origin/main`: no actionable defects
