### PR TITLE
fix(viz): open standalone exports on raw log

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -97,6 +97,18 @@ enum LoadOutcome {
 }
 
 ///|
+/// A standalone archive is primarily a complete durable trace, so open it on
+/// the append-only raw log. The live viewer keeps its established model-view
+/// default for inspecting the context sent to the next request.
+fn initial_view_mode(standalone : Bool) -> @viz.ViewMode {
+  if standalone {
+    RawLog
+  } else {
+    ModelView
+  }
+}
+
+///|
 fn init_model() -> Model {
   {
     sessions: [],
@@ -107,7 +119,7 @@ fn init_model() -> Model {
     system_prompt: "",
     header_present: false,
     log_bytes: 0L,
-    view_mode: ModelView,
+    view_mode: initial_view_mode(embedded_has("/api/sessions")),
     theme: Light,
     sidebar_visible: true,
     collapsed_roots: [],

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -378,6 +378,8 @@ test "theme values map to the data-theme attribute" {
 }
 
 ///|
-test "visualizer defaults to model view" {
+test "standalone exports default raw while the live viewer defaults model" {
+  assert_true(initial_view_mode(true) == RawLog)
+  assert_true(initial_view_mode(false) == ModelView)
   assert_true(init_model().view_mode == ModelView)
 }

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -10,6 +10,10 @@ toggle:
   summaries replace the events they cover, and tool calls left dangling by a
   crashed process show the synthesized "previous agent process exited…" marker.
 
+A standalone export opens on **Raw log** so loading an archived trace never
+appears to discard history. The live viewer retains its **Model view** default;
+either view remains available from the toggle.
+
 A Light / Dark / System theme toggle sits in the sidebar (default Light;
 System follows the OS via `prefers-color-scheme`).
 


### PR DESCRIPTION
## Summary

- open self-contained, embedded-data exports on the append-only Raw log
- preserve the established Model view default for the live server viewer
- document and test the mode selection while leaving both toggle choices available

## Root cause

Standalone HTML archives contain the complete JSONL trace, but the app initialized them in Model view. That projection correctly substitutes a later checkpoint summary for every event it covers. In the captured C-compiler run, summary event 895 covers events 1–894, so opening the archive appeared to drop the first turn even though all raw events were embedded.

The app now recognizes the embedded `/api/sessions` response that only a standalone export carries and selects Raw log for that startup path. Live/server-backed sessions still initialize in Model view.

## Validation

- `moon test cmd/viz_app --target js` (24/24)
- `moon test viz --target js` (38/38)
- `moon test cmd/viz_server --target native` (21/21)
- `moon build cmd/viz_app --target js`
- `moon info`
- `moon fmt`
- regenerated `openseek-ccomp-run6.html` from the original JSONL and verified the header plus all 1,818 sequenced events remain embedded
- fresh independent review of the final export-only diff: no findings
