### PR TITLE
feat(compact): cap summary completion and measure post-checkpoint fit

### DIFF
--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -156,13 +156,15 @@ async fn AgentLoop::checkpoint_at_ceiling(
     to_sequence~,
   )
   let compacted = self.append(session, item)
-  // The checkpoint's fit postcondition, as telemetry: the compacted
-  // projection is what seeds every following request, so its measured size
-  // belongs next to the checkpoint that produced it. The pressure warning
-  // uses the loop's conservative 1 char >= 1 token accounting — a
-  // projection this size could not fit a next request even under the
-  // charitable reading, meaning the summary did not actually relieve the
-  // ceiling it was generated for.
+  // Checkpoint output telemetry: the compacted projection measured at
+  // checkpoint time. The surrounding shapes append suffixes afterwards
+  // (late steers, kept answers, goal-check notices), so this is a LOWER
+  // bound on the next request's seed — which keeps the warning's trigger
+  // direction sound: a bound the suffixes only grow. The char proxy
+  // itself overestimates tokens (a mostly-ASCII token spans several
+  // chars), so crossing the window is NOT proven overflow — it means the
+  // conservative accounting can no longer prove the next request fits,
+  // and the event name says exactly that.
   let projection_chars = projected_chars(compacted)
   @xlog.info() <?
     {
@@ -172,14 +174,14 @@ async fn AgentLoop::checkpoint_at_ceiling(
       "summary": summary.content,
       "usage": summary.usage,
       "duration_ms": summary.duration_ms,
-      "post_projection_chars": projection_chars,
+      "compacted_projection_chars": projection_chars,
     }
   let window = self.client.model.context_window().to_int64()
   if projection_chars >= window {
     @xlog.warn() <?
       {
-        "event": "auto_compaction_still_pressured",
-        "post_projection_chars": projection_chars,
+        "event": "auto_compaction_fit_unproven",
+        "compacted_projection_chars": projection_chars,
         "context_window": window,
       }
   }
@@ -188,9 +190,10 @@ async fn AgentLoop::checkpoint_at_ceiling(
 
 ///|
 /// Every model-visible character of the session's projection: content,
-/// reasoning, and tool-call names and arguments. The conservative proxy
-/// (1 char >= 1 token for mostly-ASCII histories) for what the next
-/// request resends.
+/// reasoning, and tool-call names and arguments. A char proxy for what
+/// the next request resends: tokens never exceed chars for mostly-ASCII
+/// histories, so a projection whose chars fit provably fits, while one
+/// whose chars do not fit is merely unproven.
 fn projected_chars(session : @agent_session.Session) -> Int64 {
   let mut total : Int64 = 0
   for message in session.chat_messages() {

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -156,6 +156,14 @@ async fn AgentLoop::checkpoint_at_ceiling(
     to_sequence~,
   )
   let compacted = self.append(session, item)
+  // The checkpoint's fit postcondition, as telemetry: the compacted
+  // projection is what seeds every following request, so its measured size
+  // belongs next to the checkpoint that produced it. The pressure warning
+  // uses the loop's conservative 1 char >= 1 token accounting — a
+  // projection this size could not fit a next request even under the
+  // charitable reading, meaning the summary did not actually relieve the
+  // ceiling it was generated for.
+  let projection_chars = projected_chars(compacted)
   @xlog.info() <?
     {
       "event": "auto_compaction_finished",
@@ -164,8 +172,38 @@ async fn AgentLoop::checkpoint_at_ceiling(
       "summary": summary.content,
       "usage": summary.usage,
       "duration_ms": summary.duration_ms,
+      "post_projection_chars": projection_chars,
     }
+  let window = self.client.model.context_window().to_int64()
+  if projection_chars >= window {
+    @xlog.warn() <?
+      {
+        "event": "auto_compaction_still_pressured",
+        "post_projection_chars": projection_chars,
+        "context_window": window,
+      }
+  }
   (compacted, true)
+}
+
+///|
+/// Every model-visible character of the session's projection: content,
+/// reasoning, and tool-call names and arguments. The conservative proxy
+/// (1 char >= 1 token for mostly-ASCII histories) for what the next
+/// request resends.
+fn projected_chars(session : @agent_session.Session) -> Int64 {
+  let mut total : Int64 = 0
+  for message in session.chat_messages() {
+    total += message.content.length().to_int64()
+    if message.reasoning_content is Some(reasoning) {
+      total += reasoning.length().to_int64()
+    }
+    for call in message.tool_calls {
+      total += call.name.length().to_int64() +
+        call.arguments.length().to_int64()
+    }
+  }
+  total
 }
 
 ///|

--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -1564,3 +1564,102 @@ async test "ceiling checkpoint logs summary usage and duration" {
     assert_true(duration_ms >= 0)
   }
 }
+
+///|
+/// The checkpoint request must cap its completion inside the loop's
+/// checkpoint reserve; the main streaming request must stay uncapped.
+async test "only the checkpoint request caps its completion" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let main_requests : Array[Json] = []
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("CEILING-SUMMARY"))
+      } else {
+        main_requests.push(request)
+        Sse(sse_tool_call("call_1", "probe", 900_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("checkpoint-max-tokens"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools=probe_tools(["result-1"]),
+    )
+    assert_eq(summary_before_terminal(result).content(), "CEILING-SUMMARY")
+    guard checkpoint_requests is [{ "max_tokens": Number(max_tokens, ..), .. }] else {
+      fail("expected one capped checkpoint request")
+    }
+    assert_eq(max_tokens.to_int(), @compact.CompactionSummaryMaxTokens)
+    guard main_requests is [main_request] else {
+      fail("expected one main request")
+    }
+    assert_false(main_request.stringify().contains("max_tokens"))
+  }
+}
+
+///|
+/// A summarizer that answers with a native tool call produced no usable
+/// summary: generation fails exactly like an empty summary, and this
+/// compact-on-finish shape finishes fail-open — the real answer seals the
+/// turn and no summary event is appended.
+async test "a checkpoint answering with tool calls fails fail-open" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body({
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "I will inspect the repository first.",
+                "tool_calls": [
+                  {
+                    "id": "call_x",
+                    "type": "function",
+                    "function": { "name": "read", "arguments": "{}" },
+                  },
+                ],
+              },
+            },
+          ],
+        })
+      } else {
+        Sse(sse_final("really done", 750_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let session = @agent_session.Session(
+      SessionId("checkpoint-tool-call-reply"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="answer briefly",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+    )
+    assert_eq(checkpoint_requests.length(), 1)
+    for event in result.events() {
+      assert_false(event.item() is Summary(_))
+    }
+    assert_eq(finished_answer(result), "really done")
+  }
+}

--- a/agent/auto_compact_wbtest.mbt
+++ b/agent/auto_compact_wbtest.mbt
@@ -1,0 +1,9 @@
+///|
+/// The checkpoint reserve's documented contract: it must hold the capped
+/// summary completion PLUS the checkpoint request's prompt overhead.
+/// Equality would leave the prompt side no headroom, so the relation is
+/// strict — a change to either constant that breaks it silently re-opens
+/// the fail-open stranding this reserve exists to prevent.
+test "checkpoint reserve holds the capped summary completion" {
+  assert_true(checkpoint_reserve_tokens > @compact.CompactionSummaryMaxTokens)
+}

--- a/agent_session/compact/compact.mbt
+++ b/agent_session/compact/compact.mbt
@@ -40,6 +40,15 @@ fn compaction_messages(
 }
 
 ///|
+/// Completion budget for the checkpoint summary request. A summary that
+/// rambles past this is not a better checkpoint — it is a bigger seed for
+/// every later request and a hole in the agent loop's checkpoint reserve,
+/// which must hold BOTH this completion and the request's prompt overhead
+/// (the loop pins that relation in its tests). Sized generously: real
+/// checkpoint summaries measure well under 1K tokens.
+pub const CompactionSummaryMaxTokens : Int = 8_192
+
+///|
 /// A checkpoint summary plus the telemetry of the request that generated it.
 /// The summary request resends the whole projected history, making it the
 /// most expensive single request an agent issues: `usage` carries the
@@ -55,19 +64,38 @@ pub struct CompactionSummary {
 
 ///|
 /// Generate a handoff summary of the session's projected history through one
-/// model call, failing when the endpoint returns an empty summary. Pass a
-/// `thinking=No` client where the model honors the control (Kimi models
-/// ignore it): a checkpoint summary needs no reasoning budget.
+/// model call, failing when the endpoint returns an empty summary or answers
+/// with native tool calls instead of one (the isolated system prompt makes
+/// that rare, not impossible). A completion that spent the entire
+/// `CompactionSummaryMaxTokens` budget was length-truncated by the cap; the
+/// summary is still returned — a truncated checkpoint beats none at the
+/// ceiling — with a warning for the log. Pass a `thinking=No` client where
+/// the model honors the control (Kimi models ignore it): a checkpoint
+/// summary needs no reasoning budget.
 pub async fn generate_compaction_summary(
   client~ : @client.Client,
   session : @agent_session.Session,
 ) -> CompactionSummary {
   let started_ms = @env.now()
-  let response = client.chat(compaction_messages(session))
+  let response = client.chat(
+    compaction_messages(session),
+    max_tokens=CompactionSummaryMaxTokens,
+  )
   let duration_ms = (@env.now() - started_ms).reinterpret_as_int64().to_int()
+  if !response.tool_calls.is_empty() {
+    fail("compaction summary answered with tool calls instead of a summary")
+  }
   let content = response.content.trim().to_owned()
   if content.is_empty() {
     fail("compaction summary was empty")
+  }
+  if response.usage.completion_tokens >= CompactionSummaryMaxTokens {
+    @xlog.warn() <?
+      {
+        "event": "compaction_summary_truncated",
+        "completion_tokens": response.usage.completion_tokens,
+        "max_tokens": CompactionSummaryMaxTokens,
+      }
   }
   { content, usage: response.usage, duration_ms }
 }

--- a/agent_session/compact/pkg.generated.mbti
+++ b/agent_session/compact/pkg.generated.mbti
@@ -9,6 +9,8 @@ import {
 }
 
 // Values
+pub const CompactionSummaryMaxTokens : Int = 8_192
+
 pub async fn compact_session(store? : @store.SessionStore, @agent_session.Session, api_key~ : String, model~ : @deepseek.Model, api_url? : String) -> @agent_session.Session
 
 pub async fn generate_compaction_summary(client~ : @client.Client, @agent_session.Session) -> CompactionSummary

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -171,12 +171,14 @@ async fn[T] Client::with_retries(
 /// `response_format=JsonObject` only when the assistant content itself should
 /// be constrained to a JSON object. Pass `stream=StreamHandler(...)` to send
 /// the request in SSE streaming mode while still receiving the accumulated
-/// response as the return value.
+/// response as the return value. Pass `max_tokens` to cap the completion;
+/// omitted means the provider default.
 pub async fn Client::chat(
   self : Client,
   messages : Array[@deepseek.ChatMessage],
   tools? : Array[@deepseek.ToolDefinition] = [],
   response_format? : @deepseek.ResponseFormat,
+  max_tokens? : Int,
   stream? : StreamHandler,
 ) -> @deepseek.ChatResponse {
   let is_streaming = stream is Some(_)
@@ -186,6 +188,7 @@ pub async fn Client::chat(
     thinking=self.thinking,
     stream=is_streaming,
     response_format?,
+    max_tokens?,
   ) <| messages
   match stream {
     None => self.with_retries(() => self.chat_attempt(body), () => false)

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -21,7 +21,7 @@ pub struct Client {
   // private fields
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int, idle_timeout_ms? : Int) -> Self
-pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
+pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, max_tokens? : Int, stream? : StreamHandler) -> @deepseek.ChatResponse
 
 pub struct StreamHandler {
   // private fields

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -289,3 +289,23 @@ test "multiple tool definitions are all encoded" {
     ],
   })
 }
+
+///|
+test "max_tokens caps the completion only when passed" {
+  let capped = @deepseek.encode_chat_request(
+    model=Deepseek(V4Flash),
+    max_tokens=8192,
+  ) <| [
+    ChatMessage(User, content="ping"),
+  ]
+  json_inspect(capped, content={
+    "model": "deepseek-v4-flash",
+    "messages": [{ "role": "user", "content": "ping" }],
+    "stream": false,
+    "max_tokens": 8192,
+  })
+  let uncapped = @deepseek.encode_chat_request(model=Deepseek(V4Flash)) <| [
+    ChatMessage(User, content="ping"),
+  ]
+  assert_false(uncapped.stringify().contains("max_tokens"))
+}

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -309,3 +309,23 @@ test "max_tokens caps the completion only when passed" {
   ]
   assert_false(uncapped.stringify().contains("max_tokens"))
 }
+
+///|
+/// Kimi's legacy `max_tokens` budget is shared with reasoning_content (and
+/// Kimi ignores `thinking=No`), so a cap there can starve the visible
+/// completion to empty; the cap must go out as `max_completion_tokens`.
+test "kimi caps encode as max_completion_tokens" {
+  let capped = @deepseek.encode_chat_request(
+    model=Kimi(K27Code),
+    max_tokens=8192,
+  ) <| [
+    ChatMessage(User, content="ping"),
+  ]
+  json_inspect(capped, content={
+    "model": "kimi-k2.7-code",
+    "messages": [{ "role": "user", "content": "ping" }],
+    "stream": false,
+    "max_completion_tokens": 8192,
+  })
+  assert_false(capped.stringify().contains("\"max_tokens\""))
+}

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -84,6 +84,7 @@ pub fn encode_chat_request(
   thinking? : ThinkingMode,
   stream? : Bool = false,
   response_format? : ResponseFormat,
+  max_tokens? : Int,
   model? : Model = Deepseek(V4Pro),
   messages : Array[ChatMessage],
 ) -> Json {
@@ -98,6 +99,9 @@ pub fn encode_chat_request(
           ],
         ),
         ("stream", Json::boolean(stream)),
+        ..if max_tokens is Some(limit) {
+          [("max_tokens", Json::number(limit.to_double()))]
+        },
         ..if response_format is Some(format) {
           [("response_format", ({ "type": format.to_string() } : Json))]
         },

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -100,7 +100,16 @@ pub fn encode_chat_request(
         ),
         ("stream", Json::boolean(stream)),
         ..if max_tokens is Some(limit) {
-          [("max_tokens", Json::number(limit.to_double()))]
+          match model {
+            // Kimi cannot honor `thinking=No`, and its legacy `max_tokens`
+            // budget is shared with reasoning_content — reasoning could
+            // spend the whole cap and hand back empty visible content.
+            // `max_completion_tokens` caps the completion without starving
+            // it (subal review).
+            Kimi(_) =>
+              [("max_completion_tokens", Json::number(limit.to_double()))]
+            Deepseek(_) => [("max_tokens", Json::number(limit.to_double()))]
+          }
         },
         ..if response_format is Some(format) {
           [("response_format", ({ "type": format.to_string() } : Json))]

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn encode_chat_request(tools? : Array[ToolDefinition], thinking? : ThinkingMode, stream? : Bool, response_format? : ResponseFormat, model? : Model, Array[ChatMessage]) -> Json
+pub fn encode_chat_request(tools? : Array[ToolDefinition], thinking? : ThinkingMode, stream? : Bool, response_format? : ResponseFormat, max_tokens? : Int, model? : Model, Array[ChatMessage]) -> Json
 
 // Errors
 


### PR DESCRIPTION
## Summary

Fourth slice of the compaction production-hardening plan (R2: enforce the reserve's contract). Stacked on #455.

- `Client::chat` gains optional `max_tokens`, encoded per provider: `max_tokens` for DeepSeek, `max_completion_tokens` for Kimi — Kimi ignores `thinking=No` and its legacy field shares the budget with `reasoning_content`, so a legacy cap could be spent entirely on reasoning and hand back an empty summary, failing every ceiling checkpoint (subal P1).
- The checkpoint summary request caps itself at `CompactionSummaryMaxTokens` (8,192); a whitebox test enforces `checkpoint_reserve_tokens > cap`, the reserve's documented-but-previously-unenforced contract.
- Generation rejects a summarizer response that answers with native tool calls (fails fail-open exactly like an empty summary — test pins that the compact-on-finish shape keeps the real answer and appends no summary), and warns `compaction_summary_truncated` when the completion spends the whole cap (summary kept: truncated beats none at the ceiling).
- `auto_compaction_finished` gains `compacted_projection_chars` — the checkpoint's output size at checkpoint time, a lower bound later suffixes only grow — plus an `auto_compaction_fit_unproven` warning when conservative char accounting can no longer prove the next request fits (explicitly not proven overflow: chars overestimate tokens).

## Testing

- Encode snapshot tests for capped/uncapped DeepSeek and Kimi request bodies.
- Mock-server tests: the checkpoint request carries the cap while the main streaming request stays uncapped; a tool-call summarizer reply fails fail-open.
- Reserve-relation whitebox test.
- `moon check --deny-warn` clean; deepseek+agent+compact 115/115.
- Two subal (codex) rounds: P1 Kimi cap starvation + two telemetry-semantics findings fixed; final round clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)