### PR TITLE
feat(viz): dedicated cards for goal markers, reminders, and checks

### DIFF
--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -364,11 +364,23 @@ fn runtime_card(seq : Int, time : String, content : String) -> @html.Html {
   }
   if content.has_prefix(@agent_session.GoalReminderPrefix) {
     return goal_notice_card(
-      "goal-reminder", "Goal reminder", seq, time, content,
+      "goal-reminder",
+      "Goal reminder",
+      seq,
+      time,
+      content,
+      boilerplate="Assess it briefly at this turn boundary:",
     )
   }
   if content.has_prefix(@agent_session.GoalCheckPrefix) {
-    return goal_notice_card("goal-check", "Goal check", seq, time, content)
+    return goal_notice_card(
+      "goal-check",
+      "Goal check",
+      seq,
+      time,
+      content,
+      boilerplate="You attempted to finish.",
+    )
   }
   card("runtime", "Runtime notice", seq, time~, [text_block(content)])
 }
@@ -410,8 +422,10 @@ fn goal_notice_card(
   seq : Int,
   time : String,
   content : String,
+  boilerplate~ : String,
 ) -> @html.Html {
-  let body : Array[@html.Html] = match split_goal_notice(content) {
+  let body : Array[@html.Html] = match
+    split_goal_notice(content, boilerplate~) {
     Some(goal) =>
       [
         goal_text_block(goal),
@@ -427,25 +441,22 @@ fn goal_notice_card(
 
 ///|
 /// The goal text inside a reminder/check notice: the lines between the
-/// "The standing goal for this session:" header and the first boilerplate
-/// line ("Assess it briefly…" for reminders, "You attempted to finish…" for
-/// checks — mirroring `goal_reminder_text` / `goal_check_text` in `agent`).
-/// `None` when the shape is not recognized.
-fn split_goal_notice(content : String) -> String? {
+/// "The standing goal for this session:" header and this notice kind's own
+/// boilerplate delimiter (mirroring `goal_reminder_text` / `goal_check_text`
+/// in `agent`). The goal is arbitrary user input and may itself contain
+/// delimiter-looking lines, so only the caller's delimiter is recognized and
+/// its LAST occurrence wins — the loop appends the instructions after the
+/// goal, so everything above that line is goal text. `None` when the shape
+/// is not recognized.
+fn split_goal_notice(content : String, boilerplate~ : String) -> String? {
   let lines = string_lines(content)
   guard lines.length() >= 3 && lines[1] == "The standing goal for this session:" else {
     return None
   }
-  let goal : Array[String] = []
-  for line in lines[2:] {
-    if line.has_prefix("Assess it briefly") ||
-      line.has_prefix("You attempted to finish") {
-      if goal.is_empty() {
-        return None
-      }
-      return Some(goal.join("\n").trim().to_owned())
+  for index = lines.length() - 1; index > 2; index = index - 1 {
+    if lines[index].has_prefix(boilerplate) {
+      return Some(lines[2:index].join("\n").trim().to_owned())
     }
-    goal.push(line)
   }
   None
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -335,16 +335,48 @@ fn event_card(
 }
 
 ///|
-/// Render a `RuntimeNotice` card. A plan-cadence reminder — recognized by the
-/// `@agent_session.PlanReminderPrefix` first line the agent loop stamps on it
-/// — gets its own label and, when it re-surfaces a recorded checklist
-/// ("Current plan:" followed by `N. [status] title` lines), the steps render
-/// as a status-classed list instead of raw text. Any other runtime notice
-/// keeps the generic card.
+/// Render a `RuntimeNotice` card. Notices the agent loop stamps with a known
+/// first line get dedicated cards: plan-cadence reminders render their
+/// checklist, and the goal-command family — set/cleared/blocked markers
+/// (recognized by the shared `@agent_session.goal_marker` decoder, so the
+/// view can never disagree with the engine about what a marker means) plus
+/// goal reminders and finish-time goal checks — surfaces the goal text
+/// itself instead of a wall of boilerplate. Any other runtime notice keeps
+/// the generic card.
 fn runtime_card(seq : Int, time : String, content : String) -> @html.Html {
-  if !content.has_prefix(@agent_session.PlanReminderPrefix) {
-    return card("runtime", "Runtime notice", seq, time~, [text_block(content)])
+  if content.has_prefix(@agent_session.PlanReminderPrefix) {
+    return plan_reminder_card(seq, time, content)
   }
+  match @agent_session.goal_marker(content) {
+    Some(GoalSet(text)) =>
+      return card("runtime goal-set", "Goal set", seq, time~, [
+        goal_text_block(text),
+      ])
+    Some(GoalCleared) =>
+      return card("runtime goal-cleared", "Goal cleared", seq, time~, [
+        @html.span(class="goal-cleared-note") <| "standing goal cleared",
+      ])
+    Some(GoalBlocked(reason)) =>
+      return card("runtime goal-blocked", "Goal blocked", seq, time~, [
+        text_block(reason),
+      ])
+    None => ()
+  }
+  if content.has_prefix(@agent_session.GoalReminderPrefix) {
+    return goal_notice_card(
+      "goal-reminder", "Goal reminder", seq, time, content,
+    )
+  }
+  if content.has_prefix(@agent_session.GoalCheckPrefix) {
+    return goal_notice_card("goal-check", "Goal check", seq, time, content)
+  }
+  card("runtime", "Runtime notice", seq, time~, [text_block(content)])
+}
+
+///|
+/// A plan-cadence reminder card: prose kept verbatim, the re-surfaced
+/// checklist (when present) as a progress meter plus status-classed rows.
+fn plan_reminder_card(seq : Int, time : String, content : String) -> @html.Html {
   let body : Array[@html.Html] = []
   match split_plan_checklist(content) {
     Some((prose, steps)) => {
@@ -364,6 +396,68 @@ fn runtime_card(seq : Int, time : String, content : String) -> @html.Html {
     None => body.push(text_block(content))
   }
   card("runtime plan-reminder", "Plan reminder", seq, time~, body)
+}
+
+///|
+/// A goal reminder / goal check card. The goal text is the only part that
+/// varies — the surrounding assessment instructions are identical on every
+/// card — so the goal renders prominently and the verbatim notice folds away
+/// beneath it. An unrecognized shape falls back to the plain text block so
+/// the card never drops content.
+fn goal_notice_card(
+  kind : String,
+  label : String,
+  seq : Int,
+  time : String,
+  content : String,
+) -> @html.Html {
+  let body : Array[@html.Html] = match split_goal_notice(content) {
+    Some(goal) =>
+      [
+        goal_text_block(goal),
+        @html.details(class="goal-boilerplate") <| [
+          @html.summary("full notice"),
+          text_block(content),
+        ],
+      ]
+    None => [text_block(content)]
+  }
+  card("runtime \{kind}", label, seq, time~, body)
+}
+
+///|
+/// The goal text inside a reminder/check notice: the lines between the
+/// "The standing goal for this session:" header and the first boilerplate
+/// line ("Assess it briefly…" for reminders, "You attempted to finish…" for
+/// checks — mirroring `goal_reminder_text` / `goal_check_text` in `agent`).
+/// `None` when the shape is not recognized.
+fn split_goal_notice(content : String) -> String? {
+  let lines = string_lines(content)
+  guard lines.length() >= 3 && lines[1] == "The standing goal for this session:" else {
+    return None
+  }
+  let goal : Array[String] = []
+  for line in lines[2:] {
+    if line.has_prefix("Assess it briefly") ||
+      line.has_prefix("You attempted to finish") {
+      if goal.is_empty() {
+        return None
+      }
+      return Some(goal.join("\n").trim().to_owned())
+    }
+    goal.push(line)
+  }
+  None
+}
+
+///|
+/// The standing goal, rendered as the card's payload: a marked block that
+/// stands out from boilerplate prose.
+fn goal_text_block(text : String) -> @html.Html {
+  @html.div(class="goal-text") <| [
+    @html.span(class="goal-icon", title="standing goal") <| "🎯",
+    @html.pre(class="goal-text-body") <| text,
+  ]
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1144,6 +1144,80 @@ test "duplicate and empty plan-call ids render without delta chips" {
 }
 
 ///|
+/// Goal set/cleared/blocked markers — parsed by the shared
+/// `@agent_session.goal_marker` decoder — get dedicated cards with the goal
+/// text (or reason) as the payload instead of a generic runtime notice.
+test "goal markers render dedicated set, cleared, and blocked cards" {
+  let session = @agent_session.Session(SessionId("goal"), system_prompt="")
+    .append(
+      Runtime(
+        RuntimeNotice(
+          "\{@agent_session.GoalPrefix}\nShip the parser rewrite\nwith tests passing",
+        ),
+      ),
+    )
+    .append(
+      Runtime(
+        RuntimeNotice(
+          "\{@agent_session.GoalBlockedPrefix}\nupstream API is down",
+        ),
+      ),
+    )
+    .append(Runtime(RuntimeNotice(@agent_session.GoalClearedNotice)))
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("class=\"card runtime goal-set\""))
+  assert_true(html.contains("Goal set"))
+  assert_true(html.contains("class=\"goal-text\""))
+  // Multi-line goal text survives inside the marked block.
+  assert_true(html.contains("Ship the parser rewrite\nwith tests passing"))
+  assert_true(html.contains("class=\"card runtime goal-blocked\""))
+  assert_true(html.contains("upstream API is down"))
+  assert_true(html.contains("class=\"card runtime goal-cleared\""))
+  assert_true(html.contains("standing goal cleared"))
+}
+
+///|
+/// Goal reminders and finish-time goal checks surface the goal text as the
+/// card's payload and fold the fixed assessment boilerplate away; a notice
+/// whose shape is not recognized keeps its verbatim text. The bodies mirror
+/// `goal_reminder_text` / `goal_check_text` in `agent`.
+test "goal reminders and checks show the goal and fold the boilerplate" {
+  let reminder =
+    $|\{@agent_session.GoalReminderPrefix}
+    $|The standing goal for this session:
+    $|Ship the parser rewrite with tests passing
+    $|Assess it briefly at this turn boundary:
+    $|- Fully met? Verify per the goal's own criteria first, then
+    $|  record that by calling the goal tool with status "met", then finish.
+    $|- Otherwise continue working toward it.
+  let check =
+    $|\{@agent_session.GoalCheckPrefix}
+    $|The standing goal for this session:
+    $|Ship the parser rewrite with tests passing
+    $|You attempted to finish. If the goal is fully met, record that by
+    $|calling the goal tool with status "met", then finish.
+  let odd =
+    $|\{@agent_session.GoalReminderPrefix}
+    $|some future body this build does not know
+  let session = @agent_session.Session(SessionId("remind"), system_prompt="")
+    .append(Runtime(RuntimeNotice(reminder)))
+    .append(Runtime(RuntimeNotice(check)))
+    .append(Runtime(RuntimeNotice(odd)))
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("class=\"card runtime goal-reminder\""))
+  assert_true(html.contains("Goal reminder"))
+  assert_true(html.contains("class=\"card runtime goal-check\""))
+  assert_true(html.contains("Goal check"))
+  // Both recognized notices surface the goal in the marked block and keep
+  // the verbatim notice one fold away.
+  assert_eq(occurrences(html, "class=\"goal-text\""), 2)
+  assert_eq(occurrences(html, "class=\"goal-boilerplate\""), 2)
+  assert_true(html.contains("Ship the parser rewrite with tests passing"))
+  // The unrecognized shape falls back to verbatim text, no goal block.
+  assert_true(html.contains("some future body this build does not know"))
+}
+
+///|
 /// The reminder meter parses each line's leading status bracket, so a title
 /// that mentions "[completed]" is not miscounted, and an unknown status word
 /// renders literally instead of being disguised as a pending ring.

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1218,6 +1218,34 @@ test "goal reminders and checks show the goal and fold the boilerplate" {
 }
 
 ///|
+/// The goal is arbitrary user input: a goal line that looks like the OTHER
+/// notice's delimiter — or like this notice's own — must not truncate the
+/// marked payload. Only the notice kind's delimiter counts, and its last
+/// occurrence wins.
+test "delimiter-looking goal lines are not mistaken for boilerplate" {
+  let reminder =
+    $|\{@agent_session.GoalReminderPrefix}
+    $|The standing goal for this session:
+    $|Review the migration
+    $|You attempted to finish the old path; now recover it
+    $|Assess it briefly at this turn boundary: for each module
+    $|Assess it briefly at this turn boundary:
+    $|- Fully met? Verify per the goal's own criteria first, then finish.
+  let session = @agent_session.Session(SessionId("tricky"), system_prompt="").append(
+    Runtime(RuntimeNotice(reminder)),
+  )
+  let html = render(@viz.render_session(session, RawLog))
+  // The full three-line goal survives in the marked block: the check
+  // sentinel inside it is goal text (wrong notice kind), and the goal's own
+  // delimiter-prefixed line loses to the LAST (real) delimiter.
+  assert_true(
+    html.contains(
+      "Review the migration\nYou attempted to finish the old path; now recover it\nAssess it briefly at this turn boundary: for each module",
+    ),
+  )
+}
+
+///|
 /// The reminder meter parses each line's leading status bracket, so a title
 /// that mentions "[completed]" is not miscounted, and an unknown status word
 /// renders literally instead of being disguised as a pending ring.

--- a/web/index.html
+++ b/web/index.html
@@ -390,6 +390,26 @@
     .plan-ribbon-seg.in_progress { background: var(--accent); border-color: var(--accent); }
     .plan-args { margin: 2px 0 0; }
     .plan-cleared { color: var(--muted); font-style: italic; font-size: 12px; }
+
+    /* goal notices: the standing goal is the payload — shown as a marked
+       block — while the fixed assessment boilerplate folds away beneath it */
+    .goal-text {
+      display: flex; gap: 8px; align-items: baseline;
+      margin: 2px 0; padding: 8px 10px;
+      background: var(--panel-2); border: 1px solid var(--border);
+      border-left: 3px solid var(--runtime); border-radius: 6px;
+    }
+    .goal-icon { flex: 0 0 auto; }
+    .goal-text-body {
+      margin: 0; white-space: pre-wrap; word-break: break-word;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12.5px; font-weight: 600; min-width: 0;
+    }
+    .goal-boilerplate { margin-top: 6px; }
+    .goal-boilerplate > summary { cursor: pointer; color: var(--muted); font-size: 12px; }
+    .goal-boilerplate .content { color: var(--muted); }
+    .card.goal-blocked { border-left-color: var(--error); background: var(--notice-error-bg); }
+    .goal-cleared-note { color: var(--muted); font-style: italic; font-size: 12px; }
     .card.summary { border-left-color: var(--summary); background: var(--summary-bg); }
     .card.terminal { border-left-color: var(--terminal); }
     .card.system { border-left-color: var(--muted); }


### PR DESCRIPTION
## What

Follow-up to #457: the goal-command notice family gets the same treatment plans got.

- **`[goal]` / `[goal cleared]` / `[goal blocked]` markers** are decoded with the shared `@agent_session.goal_marker` parser (same no-drift principle as the shared plan decoder) and render as dedicated cards: *Goal set* shows the goal text in a 🎯-marked block, *Goal cleared* a tombstone note, *Goal blocked* the reason on an error-tinted card.
- **`[goal reminder]` and `[goal check]` notices** surface the goal text as the card's payload — the only part that varies — while the fixed assessment boilerplate folds behind a "full notice" toggle. Unrecognized shapes keep the verbatim text, so the card never drops content.
- `runtime_card` is now a plan/goal/generic dispatch with the plan branch extracted to `plan_reminder_card`.

## Goal reminder cadence (verified while building this)

The reminder is **at most once per turn, at the turn start**: `GoalCadence` is turn-local, `remind_now` is armed only at construction (from `StandingGoal::answered_since_set`) and every path after that clears it — `record_reminder` right after the append in `prepare_step`, `record_finish_check`, and a mid-turn `[goal]` set. A goal set in the current turn gets no same-turn reminder (its marker still rides the next request); the finish-time `[goal check]` is separately capped at one per turn via `finish_checked`.

## Verification

241 js + 1049 native tests pass (new tests mirror the `goal_reminder_text`/`goal_check_text` bodies); `moon check --deny-warn` clean on both targets. Re-exported the ccomp-run6 goal-dogfood session and drove it headless: its 5 goal notices (2 sets, 1 reminder, 1 finish check, 1 cleared) all render dedicated cards, screenshots eyeballed in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)