### PR TITLE
feat(viz): step anchors, refresh restore, and a click-to-jump step scrubber

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -471,10 +471,15 @@ extern "js" fn restore_scroll_to_hash_seq() -> Unit =
 extern "js" fn install_position_tracker() -> Unit =
   #|() => {
   #|  if (typeof document === 'undefined') return;
-  #|  const anchors = () => Array.from(document.querySelectorAll('[id^="seq-"]'));
+  #|  // Hidden cards (errors-only filter, collapsed turns) report zeroed
+  #|  // rects, which would let the scan pick an anchor no scroll can reveal —
+  #|  // only visible anchors count.
+  #|  const visible = (el) => el && el.getClientRects().length > 0;
+  #|  const anchors = () =>
+  #|    Array.from(document.querySelectorAll('[id^="seq-"]')).filter(visible);
   #|  window.__openseekNearestSeq = (want) => {
   #|    const exact = document.getElementById('seq-' + want);
-  #|    if (exact) return exact;
+  #|    if (visible(exact)) return exact;
   #|    const all = anchors();
   #|    return all.find((el) => parseInt(el.id.slice(4), 10) >= want) || all[all.length - 1] || null;
   #|  };
@@ -494,10 +499,13 @@ extern "js" fn install_position_tracker() -> Unit =
   #|      ticking = false;
   #|      const all = anchors();
   #|      if (!all.length) return;
-  #|      // The current card: the last anchor at or above the sticky toolbar.
+  #|      // The current card: the last anchor at or above the reading line.
+  #|      // The cutoff must sit BELOW the anchors' scroll-margin-top (105px in
+  #|      // the stylesheet): a jump parks its target exactly at the margin,
+  #|      // and a tighter cutoff would record the preceding card instead.
   #|      let best = null;
   #|      for (const el of all) {
-  #|        if (el.getBoundingClientRect().top <= 100) best = el;
+  #|        if (el.getBoundingClientRect().top <= 110) best = el;
   #|        else break;
   #|      }
   #|      const seq = (best || all[0]).id.slice(4);

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -551,6 +551,10 @@ extern "js" fn install_position_tracker() -> Unit =
   #|    tip.style.top = (rect.bottom + 6) + 'px';
   #|  });
   #|  document.addEventListener('scroll', hideTip, { capture: true, passive: true });
+  #|  // The scrubber sits near the top edge, so the pointer can exit straight
+  #|  // into browser chrome — no further mouseover ever fires to hide the tip.
+  #|  document.addEventListener('mouseleave', hideTip);
+  #|  window.addEventListener('blur', hideTip);
   #|}
 
 ///|

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -22,6 +22,10 @@ struct SessionRow {
 struct Model {
   sessions : Array[SessionRow]
   selected : String?
+  // Session key parsed from the URL hash at startup, waiting for the first
+  // session listing so a refresh can land back on the same session. Consumed
+  // (set to None) by the first `SessionsFetched`.
+  pending_restore_key : String?
   // Name of a locally dropped session file being viewed instead of a server
   // session. Mutually exclusive with `selected`.
   dropped : String?
@@ -122,17 +126,44 @@ fn should_auto_open(
 }
 
 ///|
+/// The view mode to start in: an explicit `v=` in the URL hash (a restored
+/// refresh) wins over the standalone/live defaults.
+fn restored_view_mode(hash_view : String, standalone : Bool) -> @viz.ViewMode {
+  match hash_view {
+    "raw" => RawLog
+    "model" => ModelView
+    _ => initial_view_mode(standalone)
+  }
+}
+
+///|
+/// The hash spelling of a view mode (the `v=` value the scrollspy state keeps).
+fn view_mode_value(mode : @viz.ViewMode) -> String {
+  match mode {
+    RawLog => "raw"
+    ModelView => "model"
+  }
+}
+
+///|
 fn init_model() -> Model {
   {
     sessions: [],
     selected: None,
+    pending_restore_key: match hash_param("s") {
+      "" => None
+      key => Some(key)
+    },
     dropped: None,
     drop_ticket: 0,
     parsed: None,
     system_prompt: "",
     header_present: false,
     log_bytes: 0L,
-    view_mode: initial_view_mode(embedded_has("/api/sessions")),
+    view_mode: restored_view_mode(
+      hash_param("v"),
+      embedded_has("/api/sessions"),
+    ),
     theme: System,
     sidebar_visible: true,
     collapsed_roots: [],
@@ -154,25 +185,33 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
           let listed = {
             ..model,
             sessions,
+            pending_restore_key: None,
             collapsed_roots: prune_collapsed_roots(
               model.collapsed_roots,
               sessions,
             ),
             status: list_status(model, "\{sessions.length()} session(s)"),
           }
-          // A standalone export is a frozen archive; when it holds exactly one
-          // session, open it immediately so the reader lands on the log
-          // instead of an empty pane. Live servers keep the explicit click —
-          // their list refreshes must never yank the user off a session.
-          if should_auto_open(
-              embedded_has("/api/sessions"),
-              sessions,
-              selected=model.selected,
-              dropped=model.dropped,
-            ) {
-            update(emit, Select(sessions[0].key), listed)
-          } else {
-            (@cmd.none, listed)
+          // A refresh restores the session named in the URL hash — in the
+          // live viewer and in exports alike. Otherwise a standalone export
+          // holding exactly one session opens it immediately; live servers
+          // keep the explicit click, since their list refreshes must never
+          // yank the user off a session.
+          let untouched = model.selected is None && model.dropped is None
+          match model.pending_restore_key {
+            Some(key) if untouched && sessions.iter().any(row => row.key == key) =>
+              update(emit, Select(key), listed)
+            _ =>
+              if should_auto_open(
+                  embedded_has("/api/sessions"),
+                  sessions,
+                  selected=model.selected,
+                  dropped=model.dropped,
+                ) {
+                update(emit, Select(sessions[0].key), listed)
+              } else {
+                (@cmd.none, listed)
+              }
           }
         }
         None =>
@@ -197,8 +236,12 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
       let command = fetch_text(emit, session_url(key), result => {
         SessionFetched(key, result)
       })
+      // Record the selection in the URL hash so a refresh lands back here.
+      // Selecting a different session drops the stale seq= position (the
+      // extern compares keys); re-selecting the same one keeps it.
+      let mode = view_mode_value(model.view_mode)
       (
-        command,
+        @cmd.batch([command, @cmd.effect(() => set_hash_session(key, mode))]),
         {
           ..model,
           selected: Some(key),
@@ -230,7 +273,9 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
             match parse_load(text) {
               Loaded(parsed, system_prompt, header_present, log_bytes) =>
                 (
-                  @cmd.none,
+                  // The log renders in this same cycle; once it is in the
+                  // DOM, scroll back to the seq= position saved in the hash.
+                  @cmd.effect(() => restore_scroll_to_hash_seq()),
                   {
                     ..model,
                     parsed: Some(parsed),
@@ -298,7 +343,19 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
             )
         }
       }
-    SetMode(mode) => (@cmd.none, { ..model, view_mode: mode })
+    SetMode(mode) => {
+      // Keep the hash's v= current, and re-anchor the scroll position: the
+      // seq= anchors are shared across views where the event projects, so
+      // switching modes stays on (or near) the same event.
+      let value = view_mode_value(mode)
+      (
+        @cmd.batch([
+          @cmd.effect(() => set_hash_view(value)),
+          @cmd.effect(() => restore_scroll_to_hash_seq()),
+        ]),
+        { ..model, view_mode: mode },
+      )
+    }
     SetArgsView(show_original) =>
       (@cmd.none, { ..model, show_original_args: show_original })
     ToggleErrorsOnly =>
@@ -336,6 +393,134 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
 /// Set `data-theme` on the document root. `light`/`dark` pick a fixed palette;
 /// `system` defers to the OS via the stylesheet's `prefers-color-scheme` query.
 extern "js" fn set_document_theme(theme : String) -> Unit = "(t) => document.documentElement.setAttribute('data-theme', t)"
+
+// ---- URL-hash position state -------------------------------------------------
+// The hash carries `s=<session key>&v=<raw|model>&seq=<n>` so a refresh (or a
+// shared link) lands back on the same session, view, and step. `seq` is a
+// durable event sequence — the `seq-N` card anchors — so it survives log
+// growth; all writes use replaceState so scrolling never spams history.
+
+///|
+/// One decoded parameter from the location hash, `""` when absent (or when
+/// running without a browser, e.g. under tests).
+extern "js" fn hash_param(name : String) -> String =
+  #|(name) => {
+  #|  if (typeof location === 'undefined') return '';
+  #|  try {
+  #|    return new URLSearchParams(location.hash.slice(1)).get(name) || '';
+  #|  } catch (e) {
+  #|    return '';
+  #|  }
+  #|}
+
+///|
+/// Record the selected session (and current view) in the hash. Switching from
+/// one session to a DIFFERENT one drops the stale `seq=` position;
+/// re-selecting the same one keeps it, and so does the first selection of the
+/// page (no `s=` yet — an auto-opened export restoring `#seq=` relies on it).
+extern "js" fn set_hash_session(key : String, view : String) -> Unit =
+  #|(key, view) => {
+  #|  if (typeof location === 'undefined') return;
+  #|  const params = new URLSearchParams(location.hash.slice(1));
+  #|  const previous = params.get('s');
+  #|  if (previous !== null && previous !== key) params.delete('seq');
+  #|  params.set('s', key);
+  #|  params.set('v', view);
+  #|  history.replaceState(null, '', '#' + params.toString());
+  #|}
+
+///|
+/// Record the active view mode in the hash, keeping session and position.
+extern "js" fn set_hash_view(view : String) -> Unit =
+  #|(view) => {
+  #|  if (typeof location === 'undefined') return;
+  #|  const params = new URLSearchParams(location.hash.slice(1));
+  #|  params.set('v', view);
+  #|  history.replaceState(null, '', '#' + params.toString());
+  #|}
+
+///|
+/// Scroll the log back to the hash's `seq=` position. A large log may take
+/// several frames to commit, so this polls briefly until the `seq-` anchors
+/// exist. The exact anchor may be absent in the current view (compacted away
+/// in the model projection, or a result card that carries a pair id
+/// instead), so the lookup falls back to the nearest following anchor.
+extern "js" fn restore_scroll_to_hash_seq() -> Unit =
+  #|() => {
+  #|  if (typeof location === 'undefined') return;
+  #|  const attempt = (tries) => {
+  #|    const params = new URLSearchParams(location.hash.slice(1));
+  #|    const want = parseInt(params.get('seq') || '', 10);
+  #|    if (!Number.isFinite(want)) return;
+  #|    const el = window.__openseekNearestSeq && window.__openseekNearestSeq(want);
+  #|    if (el) {
+  #|      el.scrollIntoView({ block: 'start' });
+  #|      return;
+  #|    }
+  #|    if (tries > 0) setTimeout(() => attempt(tries - 1), 100);
+  #|  };
+  #|  requestAnimationFrame(() => requestAnimationFrame(() => attempt(50)));
+  #|}
+
+///|
+/// Install the position tracker: a rAF-throttled scroll listener that writes
+/// the topmost visible `seq-` anchor into the hash's `seq=` (replaceState, no
+/// history spam) and moves the scrubber's `current` mark, plus a delegated
+/// click handler that makes `.step-seg` segments jump to their step. Also
+/// defines the shared nearest-anchor lookup `restore_scroll_to_hash_seq` uses.
+extern "js" fn install_position_tracker() -> Unit =
+  #|() => {
+  #|  if (typeof document === 'undefined') return;
+  #|  const anchors = () => Array.from(document.querySelectorAll('[id^="seq-"]'));
+  #|  window.__openseekNearestSeq = (want) => {
+  #|    const exact = document.getElementById('seq-' + want);
+  #|    if (exact) return exact;
+  #|    const all = anchors();
+  #|    return all.find((el) => parseInt(el.id.slice(4), 10) >= want) || all[all.length - 1] || null;
+  #|  };
+  #|  const markScrubber = (seq) => {
+  #|    let current = null;
+  #|    for (const seg of document.querySelectorAll('.step-seg')) {
+  #|      seg.classList.remove('current');
+  #|      if (+seg.dataset.seq <= seq) current = seg;
+  #|    }
+  #|    if (current) current.classList.add('current');
+  #|  };
+  #|  let ticking = false;
+  #|  document.addEventListener('scroll', () => {
+  #|    if (ticking) return;
+  #|    ticking = true;
+  #|    requestAnimationFrame(() => {
+  #|      ticking = false;
+  #|      const all = anchors();
+  #|      if (!all.length) return;
+  #|      // The current card: the last anchor at or above the sticky toolbar.
+  #|      let best = null;
+  #|      for (const el of all) {
+  #|        if (el.getBoundingClientRect().top <= 100) best = el;
+  #|        else break;
+  #|      }
+  #|      const seq = (best || all[0]).id.slice(4);
+  #|      const params = new URLSearchParams(location.hash.slice(1));
+  #|      if (params.get('seq') !== seq) {
+  #|        params.set('seq', seq);
+  #|        history.replaceState(null, '', '#' + params.toString());
+  #|      }
+  #|      markScrubber(+seq);
+  #|    });
+  #|  }, { capture: true, passive: true });
+  #|  document.addEventListener('click', (event) => {
+  #|    if (!(event.target instanceof Element)) return;
+  #|    const seg = event.target.closest('.step-seg');
+  #|    if (!seg || !seg.dataset.seq) return;
+  #|    const el = window.__openseekNearestSeq(+seg.dataset.seq);
+  #|    if (!el) return;
+  #|    const params = new URLSearchParams(location.hash.slice(1));
+  #|    params.set('seq', el.id.slice(4));
+  #|    history.replaceState(null, '', '#' + params.toString());
+  #|    el.scrollIntoView({ block: 'start' });
+  #|  });
+  #|}
 
 ///|
 fn apply_theme(theme : Theme) -> @cmd.Cmd {
@@ -969,7 +1154,7 @@ fn session_pane(
     // Pin the view/args toggles and the error bar to the top of the
     // scroll area so they stay reachable while reading a long log.
     @html.div(class="sticky-toolbar") <| [
-      mode_row(emit, model, parsed),
+      mode_row(emit, model, parsed, @viz.step_scrubber(session)),
       error_bar(emit, model, error_count),
     ],
     @viz.render_notices(parsed),
@@ -1007,12 +1192,14 @@ fn mode_row(
   emit : @cmd.Emit[Msg],
   model : Model,
   parsed : @session_log.ParsedLog,
+  scrubber : @html.Html,
 ) -> @html.Html {
   @html.div(class="mode-row") <| [
     @html.div(class="mode-cluster") <| [
       mode_toggle(emit, model),
       args_toggle(emit, model),
     ],
+    scrubber,
     session_metadata(model, parsed),
   ]
 }

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -528,6 +528,29 @@ extern "js" fn install_position_tracker() -> Unit =
   #|    history.replaceState(null, '', '#' + params.toString());
   #|    el.scrollIntoView({ block: 'start' });
   #|  });
+  #|  // Instant scrubber tooltip: shows each segment's data-label ("Step
+  #|  // N/M[ · has failures]") the moment the pointer touches it — a native
+  #|  // title tooltip would lag behind the OS hover delay while sweeping.
+  #|  const tip = document.createElement('div');
+  #|  tip.className = 'scrubber-tip';
+  #|  tip.style.display = 'none';
+  #|  document.body.appendChild(tip);
+  #|  const hideTip = () => { tip.style.display = 'none'; };
+  #|  document.addEventListener('mouseover', (event) => {
+  #|    if (!(event.target instanceof Element)) return hideTip();
+  #|    const seg = event.target.closest('.step-seg');
+  #|    if (!seg || !seg.dataset.label) return hideTip();
+  #|    tip.textContent = seg.dataset.label;
+  #|    tip.style.display = 'block';
+  #|    const rect = seg.getBoundingClientRect();
+  #|    const x = Math.min(
+  #|      Math.max(rect.left + rect.width / 2 - tip.offsetWidth / 2, 8),
+  #|      window.innerWidth - tip.offsetWidth - 8,
+  #|    );
+  #|    tip.style.left = x + 'px';
+  #|    tip.style.top = (rect.bottom + 6) + 'px';
+  #|  });
+  #|  document.addEventListener('scroll', hideTip, { capture: true, passive: true });
   #|}
 
 ///|

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -387,6 +387,47 @@ test "standalone exports default raw while the live viewer defaults model" {
 }
 
 ///|
+/// An `s=` session key parsed from the URL hash is honored by the first
+/// session listing — in the live viewer and exports alike — and consumed
+/// whether or not it matches, so a stale key cannot re-fire on refreshes of
+/// the list.
+test "the hash session key restores the selection on the first listing" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let listing =
+    #|[{"key":"k1","id":"s1"},{"key":"k2","id":"s2"}]
+  let pending = { ..init_model(), pending_restore_key: Some("k2") }
+  let (_, restored) = update(emit, SessionsFetched(Ok(listing)), pending)
+  debug_inspect(restored.selected, content="Some(\"k2\")")
+  debug_inspect(restored.pending_restore_key, content="None")
+  // An unknown key is consumed without selecting anything.
+  let stale = { ..init_model(), pending_restore_key: Some("gone") }
+  let (_, ignored) = update(emit, SessionsFetched(Ok(listing)), stale)
+  debug_inspect(ignored.selected, content="None")
+  debug_inspect(ignored.pending_restore_key, content="None")
+  // An existing selection is never yanked by a late restore key.
+  let busy = {
+    ..init_model(),
+    pending_restore_key: Some("k2"),
+    selected: Some("k1"),
+  }
+  let (_, kept) = update(emit, SessionsFetched(Ok(listing)), busy)
+  debug_inspect(kept.selected, content="Some(\"k1\")")
+}
+
+///|
+/// The hash's `v=` overrides the standalone/live view-mode defaults on
+/// restore; anything else falls through to them.
+test "the hash view mode wins over the defaults" {
+  assert_true(restored_view_mode("raw", false) == RawLog)
+  assert_true(restored_view_mode("model", true) == ModelView)
+  assert_true(restored_view_mode("", true) == RawLog)
+  assert_true(restored_view_mode("", false) == ModelView)
+  assert_true(restored_view_mode("nonsense", false) == ModelView)
+  inspect(view_mode_value(RawLog), content="raw")
+  inspect(view_mode_value(ModelView), content="model")
+}
+
+///|
 /// Only a standalone export with exactly one session and an untouched pane
 /// auto-opens; a live server list, several sessions, an existing selection,
 /// or a dropped file all keep the explicit click.

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -15,6 +15,9 @@ fn main {
     @cmd.batch([
       fetch_text(emit, "/api/sessions", result => SessionsFetched(result)),
       install_shortcuts(emit),
+      // Position tracking: keep `seq=` in the URL hash while scrolling and
+      // make step-scrubber segments jump, so a refresh restores the spot.
+      @cmd.effect(() => install_position_tracker()),
     ]),
   )
   app.mount("app")

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -19,6 +19,8 @@ pub fn rendered_error_count(@agent_session.Session, ViewMode) -> Int
 
 pub fn session_from_parse(@log.ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
 
+pub fn step_scrubber(@agent_session.Session) -> @html.Html
+
 // Errors
 
 // Types and methods
@@ -30,3 +32,4 @@ pub(all) enum ViewMode {
 // Type aliases
 
 // Traits
+

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1293,17 +1293,22 @@ pub fn step_scrubber(session : @agent_session.Session) -> @html.Html {
     return @html.nothing
   }
   let flagged = steps_with_errors(session, seqs)
-  @html.div(class="step-scrubber", title="Steps — click to jump") <| [
+  // Labels ride a data attribute, not `title`: the shell shows them in an
+  // instant tooltip that follows the pointer across the bar, where a native
+  // title tooltip only appears after the OS hover delay (and would double up
+  // with the custom one).
+  @html.div(class="step-scrubber") <| [
     for index, seq in seqs => {
-      let cls = if flagged.contains(index) {
-        "step-seg has-error"
+      let (cls, label) = if flagged.contains(index) {
+        ("step-seg has-error", "Step \{index + 1}/\{total} · has failures")
       } else {
-        "step-seg"
+        ("step-seg", "Step \{index + 1}/\{total}")
       }
       @html.span(
         class=cls,
-        title="Step \{index + 1}/\{total}",
-        attrs=@html.Attrs::build().data_set("seq", "\{seq}"),
+        attrs=@html.Attrs::build()
+          .data_set("seq", "\{seq}")
+          .data_set("label", label),
       ) <| ""
     }
   ]

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1196,10 +1196,16 @@ fn tool_card(
   }
   let flag = failed_flag(is_error)
   // Pair this result back to the call that produced it (same `call N` tag).
+  // The pair anchor wins the element's single id (the cross-link targets
+  // it); an unpaired result anchors at its sequence like every other card —
+  // scroll restore only needs a nearby anchor, not one on every card.
   let pair = tags.get(result.tool_call_id())
   let link = result_back_link(pair)
-  let anchor = pair.map(n => tool_result_anchor(n))
-  @html.details(id?=anchor, class="card \{kind}") <| [
+  let anchor = match pair {
+    Some(n) => tool_result_anchor(n)
+    None => seq_anchor(seq)
+  }
+  @html.details(id=anchor, class="card \{kind}") <| [
     @html.summary(class="card-label") <| card_head(
       label,
       seq,
@@ -1271,6 +1277,60 @@ fn terminal_card(
   card("terminal", "Turn ended", seq, time~, body, step_label~)
 }
 
+// ---- step scrubber -----------------------------------------------------------
+
+///|
+/// A click-to-jump scrubber over the session's agent steps: one segment per
+/// step in log order, each carrying `data-seq` (the step event's durable
+/// sequence) so the shell can scroll to — or near — its card via the `seq-N`
+/// anchors. A segment is error-tinted when a failed tool result lands in
+/// that step's range, so failure clusters are visible on the bar itself.
+/// Renders nothing for sessions with fewer than two steps.
+pub fn step_scrubber(session : @agent_session.Session) -> @html.Html {
+  let seqs = agent_step_sequences(session)
+  let total = seqs.length()
+  if total < 2 {
+    return @html.nothing
+  }
+  let flagged = steps_with_errors(session, seqs)
+  @html.div(class="step-scrubber", title="Steps — click to jump") <| [
+    for index, seq in seqs => {
+      let cls = if flagged.contains(index) {
+        "step-seg has-error"
+      } else {
+        "step-seg"
+      }
+      @html.span(
+        class=cls,
+        title="Step \{index + 1}/\{total}",
+        attrs=@html.Attrs::build().data_set("seq", "\{seq}"),
+      ) <| ""
+    }
+  ]
+}
+
+///|
+/// Indices of steps whose range — from the step's own event up to (but not
+/// including) the next step's — contains a failed tool result. Results are
+/// appended after the assistant step that called them, so the owning step is
+/// the last one at or before the error.
+fn steps_with_errors(
+  session : @agent_session.Session,
+  seqs : Array[Int],
+) -> Map[Int, Unit] {
+  let flagged : Map[Int, Unit] = Map([])
+  for event in session.events() {
+    guard event.item() is Tool(result) && result.is_error() else { continue }
+    for index = seqs.length() - 1; index >= 0; index = index - 1 {
+      if seqs[index] <= event.sequence() {
+        flagged.set(index, ())
+        break
+      }
+    }
+  }
+  flagged
+}
+
 // ---- model projection view -------------------------------------------------
 
 ///|
@@ -1290,10 +1350,15 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
   let briefs = model_tool_call_briefs(messages, tool_results)
   let tags = model_pair_tags(messages)
   let plans = model_plan_baselines(messages, failed)
+  let anchor_seqs = model_message_anchor_seqs(session)
   let cards : Array[@html.Html] = [
     for index, message in messages => {
       let time = time_labels.get(index).unwrap_or("")
       let step_label = step_labels.get(index).unwrap_or("")
+      let anchor = match anchor_seqs.get(index) {
+        Some(seq) if !seq.is_empty() => Some("seq-\{seq}")
+        _ => None
+      }
       message_card(
         message,
         tool_results,
@@ -1303,6 +1368,7 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
         plans,
         time~,
         step_label~,
+        anchor~,
       )
     }
   ]
@@ -1431,6 +1497,16 @@ fn model_message_step_labels(session : @agent_session.Session) -> Array[String] 
   model_message_labels(session, label_of=event => event_label(steps, event), tool_label_of=_ => {
     ""
   })
+}
+
+///|
+/// Durable sequence numbers parallel to `Session::chat_messages()`, as anchor
+/// strings: every event-backed message gets its event's sequence, while the
+/// system prompt and synthetic repair messages (which have no durable event
+/// to anchor at) get `""`.
+fn model_message_anchor_seqs(session : @agent_session.Session) -> Array[String] {
+  let seq_of = (event : @agent_session.SessionEvent) => "\{event.sequence()}"
+  model_message_labels(session, label_of=seq_of, tool_label_of=seq_of)
 }
 
 ///|
@@ -1671,6 +1747,7 @@ fn message_card(
   plans : Map[String, Array[@steps.PlanStep]],
   time~ : String,
   step_label~ : String,
+  anchor~ : String?,
 ) -> @html.Html {
   match message.role {
     System =>
@@ -1694,6 +1771,7 @@ fn message_card(
         plans,
         time~,
         step_label~,
+        anchor~,
       )
     Assistant =>
       model_card(
@@ -1706,6 +1784,7 @@ fn message_card(
         plans,
         time~,
         step_label~,
+        anchor~,
       )
     Tool(_) =>
       model_tool_card(
@@ -1713,6 +1792,7 @@ fn message_card(
         model_shown_result(message, tool_results),
         tags,
         time~,
+        anchor~,
       )
   }
 }
@@ -1785,6 +1865,7 @@ fn model_tool_card(
   shown : @agent_session.ToolResult?,
   tags : Map[String, Int],
   time~ : String,
+  anchor~ : String?,
 ) -> @html.Html {
   let is_error = shown is Some(r) && r.is_error()
   let name = match shown {
@@ -1799,12 +1880,17 @@ fn model_tool_card(
   }
   // The pair tag comes from the message's own id (structural), independent of
   // whether `model_shown_result` trusts the durable result for enrichment.
+  // Like the raw view, the pair anchor wins the element's single id; the
+  // sequence anchor is the fallback for unpaired results.
   let pair = match message.role {
     Tool(id) => tags.get(id)
     _ => None
   }
   let link = result_back_link(pair)
-  let anchor = pair.map(n => tool_result_anchor(n))
+  let anchor = match pair {
+    Some(n) => Some(tool_result_anchor(n))
+    None => anchor
+  }
   @html.details(id?=anchor, class="card \{kind}") <| [
     @html.summary(class="card-label") <| model_card_head(
       label,
@@ -1829,6 +1915,7 @@ fn model_card(
   plans : Map[String, Array[@steps.PlanStep]],
   time~ : String,
   step_label~ : String,
+  anchor~ : String?,
 ) -> @html.Html {
   let body : Array[@html.Html] = []
   if message.reasoning_content is Some(reasoning) &&
@@ -1851,7 +1938,7 @@ fn model_card(
     ]
     body.push(@html.div(class="tool-calls") <| call_views)
   }
-  @html.section(class="card \{kind}") <| [
+  @html.section(id?=anchor, class="card \{kind}") <| [
     @html.div(class="card-label") <| model_card_head(label, time~, step_label~),
     @html.div(class="card-body") <| body,
   ]
@@ -1886,10 +1973,20 @@ fn card(
   body : Array[@html.Html],
   step_label? : String = "",
 ) -> @html.Html {
-  @html.section(class="card \{kind}") <| [
+  // Every raw-view card anchors at its durable sequence: the id is what the
+  // shell's scrollspy/restore and the step scrubber navigate by, and the
+  // sequence is stable across refreshes because it comes from the
+  // append-only log.
+  @html.section(id=seq_anchor(seq), class="card \{kind}") <| [
     @html.div(class="card-label") <| card_head(label, seq, time~, step_label~),
     @html.div(class="card-body") <| body,
   ]
+}
+
+///|
+/// DOM anchor id for the card of the event with durable sequence `seq`.
+fn seq_anchor(seq : Int) -> String {
+  "seq-\{seq}"
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1364,7 +1364,11 @@ test "step scrubber marks steps and their failures" {
   assert_eq(occurrences(html, "data-seq="), 2)
   assert_true(html.contains("data-seq=\"2\""))
   assert_true(html.contains("data-seq=\"4\""))
-  assert_true(html.contains("title=\"Step 1/2\""))
+  // Hover labels ride data-label (instant shell tooltip, not native title);
+  // the failing step's label names the failure.
+  assert_true(html.contains("data-label=\"Step 1/2 · has failures\""))
+  assert_true(html.contains("data-label=\"Step 2/2\""))
+  assert_false(html.contains("title="))
   // Only the first step's range contains the failed result.
   assert_eq(occurrences(html, "step-seg has-error"), 1)
   // A one-step session has nothing to scrub.

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1298,6 +1298,81 @@ test "cleared and malformed plans degrade gracefully" {
 }
 
 ///|
+/// Every raw-view card anchors at its durable sequence (`seq-N`), the ids the
+/// scrollspy, refresh restore, and step scrubber navigate by. A paired tool
+/// result keeps its pair anchor (the call↔result cross-link targets it);
+/// unpaired results fall back to the sequence anchor.
+test "raw cards carry stable seq anchors" {
+  let html = render(@viz.render_session(multi_step_session(), RawLog))
+  assert_true(html.contains("id=\"seq-1\"")) // user
+  assert_true(html.contains("id=\"seq-2\"")) // assistant
+  assert_true(html.contains("id=\"seq-4\"")) // terminal
+  // The tool result at seq 3 is paired: pair anchor wins, no seq id.
+  assert_true(html.contains("id=\"tool-result-1\""))
+  assert_false(html.contains("id=\"seq-3\""))
+  // An unpaired (orphan) result anchors at its sequence instead.
+  let orphan = render(@viz.render_session(unpairable_session(), RawLog))
+  assert_true(orphan.contains("id=\"seq-2\""))
+}
+
+///|
+/// Model-view cards anchor at the sequence of the event backing them; the
+/// system prompt and synthetic repair messages have no durable event, so
+/// they carry no seq anchor.
+test "model cards anchor event-backed messages only" {
+  let html = render(@viz.render_session(multi_step_session(), ModelView))
+  assert_true(html.contains("id=\"seq-1\""))
+  assert_true(html.contains("id=\"seq-2\""))
+  assert_true(html.contains("id=\"seq-4\""))
+  // The healed synthetic result of a dangling call gets no seq anchor (it
+  // pairs, so it carries the pair id instead).
+  let healed = render(@viz.render_session(dangling_call_session(), ModelView))
+  assert_true(healed.contains("id=\"tool-result-1\""))
+}
+
+///|
+/// The step scrubber renders one `data-seq` segment per agent step, tints
+/// segments whose range contains a failed tool result, and disappears for
+/// sessions with fewer than two steps.
+test "step scrubber marks steps and their failures" {
+  // Two steps: the assistant at seq 2 (whose shell call fails at seq 3) and
+  // the assistant at seq 4. The terminal right after an assistant message is
+  // that step's own answer, not a new step.
+  let session = @agent_session.Session(SessionId("scrub"), system_prompt="")
+    .append(User(UserMessage("go")))
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(id="c1", name="shell", arguments="{\"cmd\":\"boom\"}"),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="shell",
+          content="exit 1",
+          is_error=true,
+        ),
+      ),
+    )
+    .append(Assistant(AssistantMessage("recovered")))
+    .append(Terminal(Finished("done")))
+  let html = render(@viz.step_scrubber(session))
+  assert_true(html.contains("class=\"step-scrubber\""))
+  assert_eq(occurrences(html, "data-seq="), 2)
+  assert_true(html.contains("data-seq=\"2\""))
+  assert_true(html.contains("data-seq=\"4\""))
+  assert_true(html.contains("title=\"Step 1/2\""))
+  // Only the first step's range contains the failed result.
+  assert_eq(occurrences(html, "step-seg has-error"), 1)
+  // A one-step session has nothing to scrub.
+  let single = render(@viz.step_scrubber(error_tool_session()))
+  assert_false(single.contains("step-scrubber"))
+}
+
+///|
 /// Stamped events render relative offsets and a turn duration; unstamped
 /// events (the 0 sentinel) render no time chips at all.
 test "raw view shows total-second offsets and turn duration from ts" {

--- a/web/index.html
+++ b/web/index.html
@@ -257,6 +257,31 @@
     }
     .mode-button:hover { border-color: var(--accent); }
     .mode-button.active { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
+    /* step scrubber: one segment per agent step; click jumps to that step's
+       card (via the seq-N anchors), red segments carry failed tool results,
+       and the scrollspy marks the segment you are reading */
+    .step-scrubber {
+      display: flex;
+      align-items: stretch;
+      flex: 1 1 180px;
+      min-width: 120px;
+      max-width: 420px;
+      height: 14px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: var(--panel);
+      overflow: hidden;
+      cursor: pointer;
+    }
+    .step-seg { flex: 1 1 auto; min-width: 1px; }
+    .step-seg:hover { background: var(--accent); }
+    .step-seg.has-error { background: var(--error); opacity: .45; }
+    .step-seg.has-error:hover { background: var(--error); opacity: 1; }
+    .step-seg.current { background: var(--accent); }
+
+    /* anchored cards scroll to just below the sticky toolbar */
+    [id^="seq-"] { scroll-margin-top: 105px; }
+
     .session-metadata {
       display: flex;
       align-items: center;

--- a/web/index.html
+++ b/web/index.html
@@ -278,6 +278,21 @@
     .step-seg.has-error { background: var(--error); opacity: .45; }
     .step-seg.has-error:hover { background: var(--error); opacity: 1; }
     .step-seg.current { background: var(--accent); }
+    /* instant hover tooltip (positioned by the shell): "Step N/M" */
+    .scrubber-tip {
+      position: fixed;
+      z-index: 20;
+      pointer-events: none;
+      padding: 3px 9px;
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, .18);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      white-space: nowrap;
+    }
 
     /* anchored cards scroll to just below the sticky toolbar */
     [id^="seq-"] { scroll-margin-top: 105px; }

--- a/web/index.html
+++ b/web/index.html
@@ -519,8 +519,11 @@
       text-transform: none; letter-spacing: 0; opacity: .85; white-space: nowrap;
     }
     .tool-link:hover { text-decoration: underline; opacity: 1; }
-    /* highlight the call/result you jumped to via a pairing chip */
-    .tool-call:target, .card:target {
+    /* highlight the call/result you jumped to via a pairing chip (the class
+       form is what the click handler sets — it cannot use location.hash,
+       which carries the viewer's s/v/seq position state) */
+    .tool-call:target, .card:target,
+    .tool-call.jump-target, .card.jump-target {
       outline: 2px solid var(--accent); outline-offset: 2px;
     }
 
@@ -552,9 +555,12 @@
     // A pairing chip (`.tool-link`) lives inside a <summary>, so a bare click on
     // it would both navigate AND toggle the enclosing <details>. Cancel the
     // default (which suppresses the fold toggle and the native jump) when the
-    // target anchor exists, then drive :target + scroll ourselves. Delegated on
-    // document, so it survives the app's virtual-DOM re-renders. Missing targets
-    // fall through to native navigation.
+    // target anchor exists, then highlight + scroll ourselves. The highlight is
+    // a `jump-target` class rather than `location.hash` — the hash carries the
+    // viewer's s/v/seq position state, which a bare `#tool-result-N` assignment
+    // would wipe (the scrollspy re-records seq= right after the jump scrolls).
+    // Delegated on document, so it survives the app's virtual-DOM re-renders.
+    // Missing targets fall through to native navigation.
     document.addEventListener("click", function (e) {
       // Leave modified / non-primary clicks to the browser (open-in-new-tab etc.).
       if (e.defaultPrevented || e.button !== 0) return;
@@ -567,7 +573,10 @@
       var el = document.getElementById(href.slice(1));
       if (!el) return;
       e.preventDefault();
-      if (location.hash !== href) location.hash = href;
+      document.querySelectorAll(".jump-target").forEach(function (old) {
+        old.classList.remove("jump-target");
+      });
+      el.classList.add("jump-target");
       el.scrollIntoView({ block: "center" });
     });
   </script>


### PR DESCRIPTION
## What

Refreshing the viewer used to lose the selected session, the view mode, and the scroll position. The URL hash now carries `s=<session>&v=<raw|model>&seq=<n>` and the viewer restores all three — live viewer and standalone exports alike. A shared link like `…#v=raw&seq=915` opens straight at that step.

- **Stable anchors**: every raw-view card gets `id="seq-<n>"` from its durable sequence (stable across refreshes and log growth); model-view cards anchor where a durable event backs them; paired tool results keep their `tool-result-N` pair anchor (cross-links target it) with unpaired ones falling back to seq.
- **Scrollspy**: a rAF-throttled listener keeps `seq=` pointing at the topmost visible anchor via `replaceState` — the back button is never spammed. Session select writes `s=`/`v=`; mode switches rewrite `v=` and re-anchor the scroll position on the shared seq; loads poll briefly for anchors (large logs take a few frames to commit) then scroll back with a nearest-anchor fallback for events the model projection compacted away.
- **Restore precedence**: the first session listing honors a hash `s=` before the single-session auto-open, so live-viewer refreshes land back on the same session. The first selection of the page preserves a bare `#seq=` link (a subtle bug caught during verification: the auto-open used to wipe it).
- **Step scrubber** in the sticky toolbar: one `data-seq` segment per agent step, hover shows *Step N/M*, segments whose range carries a failed tool result are error-tinted, click jumps to the step's card.

## Verification

247 js + 1049 native tests pass; `moon check --deny-warn` clean on both targets. End-to-end on the 894-step ccomp-run6 export in headless Chrome: 912 seq anchors, 894 scrubber segments (76 error-tinted), and opening the file at `#v=raw&seq=915` screenshots directly at "Step 450/894" pinned under the sticky toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)