### PR TITLE
docs(prompt): moon run -e cannot test local packages; bless #skip/#cfg(false)

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -112,7 +112,7 @@ Common `moon` subcommands:
   module fails with `module not found`, and if the module IS published the
   import silently binds the STALE published snapshot instead of your working
   tree. To exercise local package code, write a black-box test and run
-  `moon test <pkg> --filter` instead.
+  `moon test <pkg> --filter '<name glob>'` instead.
   `moon run -e` defaults to native on current MoonBit nightlies, but `moon run -`
   can still default to wasm-gc; pass `--target native` when stdin snippets need
   native or async support.

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -92,13 +92,27 @@ Common `moon` subcommands:
   `--target` and `--diagnostic-limit <N>`.
 - shell `moon test`: targeted or full tests; run plain `moon test` before
   `moon test --update`. Example: `moon test parser --filter "Parser::*"
-  --diagnostic-limit 5`. Filters support glob syntax.
+  --diagnostic-limit 5`. Filters support glob syntax. This is THE way to
+  exercise local package code: write a black-box `_test.mbt` test and run it
+  with `--filter` — never probe local packages through `moon run -e` (see
+  below). To keep a test but not run it, annotate it `#skip("reason")`: still
+  type-checked, but run only with `--include-skipped` (or `-i <index>`, which
+  implies it) — plain `moon test --filter` will not run it. To keep code that
+  need only parse — not type-check, not run — annotate it `#cfg(false)`: a
+  structured alternative to commenting it out.
 - shell `moon run`: executable package and CLI probes; package path goes before
   `--`, program arguments go after `--`. Example:
   `moon run --target native cmd/tomljson -- /tmp/input.toml`.
 - shell `moon run -e` or `moon run -`: quick language/API snippets.
   Verified examples: `moon run -e 'fn main { println("ok") }'`
   and `moon run - <<'EOF'`.
+  Snippets may open with a multi-line `import { ... }` block, but those
+  imports resolve ONLY from the mooncakes.io registry — never from the local
+  workspace. Probing local packages this way is always wrong: an unpublished
+  module fails with `module not found`, and if the module IS published the
+  import silently binds the STALE published snapshot instead of your working
+  tree. To exercise local package code, write a black-box test and run
+  `moon test <pkg> --filter` instead.
   `moon run -e` defaults to native on current MoonBit nightlies, but `moon run -`
   can still default to wasm-gc; pass `--target native` when stdin snippets need
   native or async support.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -117,7 +117,7 @@ fn default_prompt() -> String {
     #|  module fails with `module not found`, and if the module IS published the
     #|  import silently binds the STALE published snapshot instead of your working
     #|  tree. To exercise local package code, write a black-box test and run
-    #|  `moon test <pkg> --filter` instead.
+    #|  `moon test <pkg> --filter '<name glob>'` instead.
     #|  `moon run -e` defaults to native on current MoonBit nightlies, but `moon run -`
     #|  can still default to wasm-gc; pass `--target native` when stdin snippets need
     #|  native or async support.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -97,13 +97,27 @@ fn default_prompt() -> String {
     #|  `--target` and `--diagnostic-limit <N>`.
     #|- shell `moon test`: targeted or full tests; run plain `moon test` before
     #|  `moon test --update`. Example: `moon test parser --filter "Parser::*"
-    #|  --diagnostic-limit 5`. Filters support glob syntax.
+    #|  --diagnostic-limit 5`. Filters support glob syntax. This is THE way to
+    #|  exercise local package code: write a black-box `_test.mbt` test and run it
+    #|  with `--filter` — never probe local packages through `moon run -e` (see
+    #|  below). To keep a test but not run it, annotate it `#skip("reason")`: still
+    #|  type-checked, but run only with `--include-skipped` (or `-i <index>`, which
+    #|  implies it) — plain `moon test --filter` will not run it. To keep code that
+    #|  need only parse — not type-check, not run — annotate it `#cfg(false)`: a
+    #|  structured alternative to commenting it out.
     #|- shell `moon run`: executable package and CLI probes; package path goes before
     #|  `--`, program arguments go after `--`. Example:
     #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
     #|- shell `moon run -e` or `moon run -`: quick language/API snippets.
     #|  Verified examples: `moon run -e 'fn main { println("ok") }'`
     #|  and `moon run - <<'EOF'`.
+    #|  Snippets may open with a multi-line `import { ... }` block, but those
+    #|  imports resolve ONLY from the mooncakes.io registry — never from the local
+    #|  workspace. Probing local packages this way is always wrong: an unpublished
+    #|  module fails with `module not found`, and if the module IS published the
+    #|  import silently binds the STALE published snapshot instead of your working
+    #|  tree. To exercise local package code, write a black-box test and run
+    #|  `moon test <pkg> --filter` instead.
     #|  `moon run -e` defaults to native on current MoonBit nightlies, but `moon run -`
     #|  can still default to wasm-gc; pass `--target native` when stdin snippets need
     #|  native or async support.


### PR DESCRIPTION
## Verified behavior (all claims tested against the current toolchain)

**`moon run -e` imports are registry-only.** Snippets may open with a multi-line `import { ... }` block, but resolution goes through the mooncakes.io registry index — never the local workspace:

- An unpublished local module fails outright: `module 'scratch/localtest' not found ... must be resolvable from local registry index`.
- The insidious case: if the module **is** published (as `bobzhang/openseek` is), the import **silently binds the published snapshot**, not the working tree. Proven: the cached published 0.2.2 contains zero occurrences of a symbol added locally the same day (7 occurrences in the working tree). An agent "testing" local code via `-e` runs stale code with no error.

**`#skip("reason")`** — body **is** type-checked (a type error under it fails `moon check`); not run by plain `moon test`; **not run by `--filter` alone** ("no test entry found"); runs only with `--include-skipped` (or `-i/--index`, which implies it).

**`#cfg(false)`** — body must still **parse** (a parse error under it fails `moon check`) but is **not type-checked** (a type error under it passes) and never runs: a structured alternative to commenting code out.

## Prompt changes

- `moon test` bullet: black-box `_test.mbt` + `--filter` is THE way to exercise local package code; documents `#skip` (with the `--include-skipped` caveat) and `#cfg(false)`.
- `moon run -e` bullet: imports resolve only from the registry; names both failure modes (module-not-found, stale published snapshot) and routes to `moon test --filter`.

## Verification

- `moon check --deny-warn` clean; `moon test prompt` 19/19; generated prompt regenerated via the `md_to_mbt_string` rule.
- Branch rebased onto current main (includes the merged #460 append bullet; sections are disjoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)