### PR TITLE
refactor(viz_app): share class/row/emit helpers and fold a lookup loop

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -802,12 +802,7 @@ fn session_label(model : Model, key : String) -> String {
 
 ///|
 fn session_row(model : Model, key : String) -> SessionRow? {
-  for row in model.sessions {
-    if row.key == key {
-      return Some(row)
-    }
-  }
-  None
+  model.sessions.iter().find_first(row => row.key == key)
 }
 
 ///|
@@ -834,12 +829,20 @@ fn view(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
 }
 
 ///|
-fn app_class(model : Model) -> String {
-  if model.sidebar_visible {
-    "app"
+/// A base class with `modifier` appended when `on` — the conditional-class
+/// idiom shared by the theme/mode/args buttons, the session rows, the app
+/// shell, and the error toggle.
+fn class_with(base : String, modifier : String, on : Bool) -> String {
+  if on {
+    "\{base} \{modifier}"
   } else {
-    "app sidebar-hidden"
+    base
   }
+}
+
+///|
+fn app_class(model : Model) -> String {
+  class_with("app", "sidebar-hidden", !model.sidebar_visible)
 }
 
 ///|
@@ -894,11 +897,7 @@ fn theme_button(
   theme : Theme,
   label : String,
 ) -> @html.Html {
-  let classes = if model.theme == theme {
-    "theme-button active"
-  } else {
-    "theme-button"
-  }
+  let classes = class_with("theme-button", "active", model.theme == theme)
   @html.button(class=classes, on_click=emit(SetTheme(theme))) <| label
 }
 
@@ -915,7 +914,7 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
     let collapsed = root_collapsed(model, group)
     let display = group_display(group)
     sections.push(
-      @html.div(class=session_root_class(collapsed)) <| [
+      @html.div(class=class_with("session-root", "collapsed", collapsed)) <| [
         @html.button(
           class="session-root-toggle",
           title=if collapsed {
@@ -942,15 +941,6 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
     )
   }
   @html.div(class="session-list") <| sections
-}
-
-///|
-fn session_root_class(collapsed : Bool) -> String {
-  if collapsed {
-    "session-root collapsed"
-  } else {
-    "session-root"
-  }
 }
 
 ///|
@@ -1107,7 +1097,7 @@ fn sidebar_row(
   } else {
     row.first_prompt
   }
-  let classes = if selected { "session-item selected" } else { "session-item" }
+  let classes = class_with("session-item", "selected", selected)
   @html.li(class=classes, on_click=emit(Select(row.key))) <| [
     @html.div(class="session-item-label") <| label,
     @html.div(class="session-item-meta") <| [
@@ -1258,11 +1248,11 @@ fn args_button(
   show_original : Bool,
   label : String,
 ) -> @html.Html {
-  let classes = if model.show_original_args == show_original {
-    "mode-button active"
-  } else {
-    "mode-button"
-  }
+  let classes = class_with(
+    "mode-button",
+    "active",
+    model.show_original_args == show_original,
+  )
   @html.button(class=classes, on_click=emit(SetArgsView(show_original))) <| label
 }
 
@@ -1273,11 +1263,7 @@ fn mode_button(
   mode : @viz.ViewMode,
   label : String,
 ) -> @html.Html {
-  let classes = if model.view_mode == mode {
-    "mode-button active"
-  } else {
-    "mode-button"
-  }
+  let classes = class_with("mode-button", "active", model.view_mode == mode)
   @html.button(class=classes, on_click=emit(SetMode(mode))) <| label
 }
 
@@ -1481,11 +1467,7 @@ fn error_bar(emit : @cmd.Emit[Msg], model : Model, count : Int) -> @html.Html {
   if count == 0 && !model.errors_only {
     return @html.nothing
   }
-  let toggle_class = if model.errors_only {
-    "error-toggle active"
-  } else {
-    "error-toggle"
-  }
+  let toggle_class = class_with("error-toggle", "active", model.errors_only)
   let children : Array[@html.Html] = []
   if count > 0 {
     children.push(

--- a/cmd/viz_app/app_wbtest.mbt
+++ b/cmd/viz_app/app_wbtest.mbt
@@ -2,29 +2,26 @@
 test "parse_load lifts the system prompt from the header line" {
   let text =
     #|{"found":true,"events":"{\"version\":1,\"id\":\"demo\",\"system_prompt\":\"SYS\"}\n{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n","events_bytes":77}
-  match parse_load(text) {
-    Loaded(parsed, system_prompt, header_present, log_bytes) => {
-      inspect(parsed.events.length(), content="1")
-      inspect(system_prompt, content="SYS")
-      inspect(header_present, content="true")
-      inspect(log_bytes, content="77")
-    }
-    _ => fail("expected Loaded")
+  guard parse_load(text)
+    is Loaded(parsed, system_prompt, header_present, log_bytes) else {
+    fail("expected Loaded")
   }
+  inspect(parsed.events.length(), content="1")
+  inspect(system_prompt, content="SYS")
+  inspect(header_present, content="true")
+  inspect(log_bytes, content="77")
 }
 
 ///|
 test "parse_load treats a header-less file as events-only" {
   let text =
     #|{"found":true,"events":""}
-  match parse_load(text) {
-    Loaded(_, system_prompt, header_present, log_bytes) => {
-      inspect(system_prompt, content="")
-      inspect(header_present, content="false")
-      inspect(log_bytes, content="0")
-    }
-    _ => fail("expected Loaded")
+  guard parse_load(text) is Loaded(_, system_prompt, header_present, log_bytes) else {
+    fail("expected Loaded")
   }
+  inspect(system_prompt, content="")
+  inspect(header_present, content="false")
+  inspect(log_bytes, content="0")
 }
 
 ///|
@@ -43,15 +40,13 @@ fn parsed_log(session : @agent_session.Session) -> @session_log.ParsedLog {
 test "session metadata counts steps and total runtime" {
   let text =
     #|{"found":true,"events":"{\"sequence\":1,\"ts\":100000,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"hi\"}}}\n{\"sequence\":2,\"ts\":101500,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"\",\"tool_calls\":[]}}}\n{\"sequence\":3,\"ts\":170300,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"finished\",\"message\":\"done\"}}}\n","events_bytes":307}
-  match parse_load(text) {
-    Loaded(parsed, _, _, log_bytes) => {
-      inspect(format_log_size(log_bytes), content="307 B")
-      inspect(agent_step_count(parsed), content="1")
-      inspect(runtime_label(parsed), content="70.3s")
-      inspect(end_time_label(parsed), content="1970-01-01 00:02 UTC")
-    }
-    _ => fail("expected Loaded")
+  guard parse_load(text) is Loaded(parsed, _, _, log_bytes) else {
+    fail("expected Loaded")
   }
+  inspect(format_log_size(log_bytes), content="307 B")
+  inspect(agent_step_count(parsed), content="1")
+  inspect(runtime_label(parsed), content="70.3s")
+  inspect(end_time_label(parsed), content="1970-01-01 00:02 UTC")
 }
 
 ///|
@@ -142,7 +137,7 @@ test "dropped display id prefers the header identity over the file name" {
 
 ///|
 test "stale dropped-file reads are discarded" {
-  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let emit = stub_emit()
   let model = { ..init_model(), drop_ticket: 2 }
   // A read issued before the user moved on carries an old ticket: ignored.
   let (_, unchanged) = update(
@@ -162,7 +157,7 @@ test "stale dropped-file reads are discarded" {
 
 ///|
 test "a late session list does not clobber the dropped-file status" {
-  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let emit = stub_emit()
   let dropped = apply_dropped_file(
     init_model(),
     "run.jsonl",
@@ -183,7 +178,7 @@ test "a late session list does not clobber the dropped-file status" {
 
 ///|
 test "selecting a session invalidates an in-flight dropped-file read" {
-  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let emit = stub_emit()
   let model = { ..init_model(), drop_ticket: 5 }
   let (_, selected) = update(emit, Select("0|remote"), model)
   inspect(selected.drop_ticket, content="6")
@@ -270,6 +265,17 @@ fn marker_row(key : String, id : String, root_label : String) -> SessionRow {
 }
 
 ///|
+fn direct_row(key : String, id : String, root_label : String) -> SessionRow {
+  { key, id, root_label, last_active: None, is_marker: false, first_prompt: "" }
+}
+
+///|
+/// A no-op `Emit` for `update` tests that ignore the emitted commands.
+fn stub_emit() -> @cmd.Emit[Msg] {
+  Emit(_ => @cmd.none)
+}
+
+///|
 test "session grouping derives container, row label, and heading" {
   // A nested run workspace (marker store): grouped by container, labelled by
   // workspace name.
@@ -321,22 +327,8 @@ test "session grouping derives container, row label, and heading" {
 ///|
 test "sidebar_groups keeps unrelated direct stores separate" {
   let rows = [
-    {
-      key: "0|a",
-      id: "a",
-      root_label: "/srv/store-a",
-      last_active: None,
-      is_marker: false,
-      first_prompt: "",
-    },
-    {
-      key: "1|b",
-      id: "b",
-      root_label: "/srv/store-b",
-      last_active: None,
-      is_marker: false,
-      first_prompt: "",
-    },
+    direct_row("0|a", "a", "/srv/store-a"),
+    direct_row("1|b", "b", "/srv/store-b"),
   ]
   @debug.debug_inspect(
     sidebar_groups(rows),
@@ -392,7 +384,7 @@ test "standalone exports default raw while the live viewer defaults model" {
 /// whether or not it matches, so a stale key cannot re-fire on refreshes of
 /// the list.
 test "the hash session key restores the selection on the first listing" {
-  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let emit = stub_emit()
   let listing =
     #|[{"key":"k1","id":"s1"},{"key":"k2","id":"s2"}]
   let pending = { ..init_model(), pending_restore_key: Some("k2") }
@@ -432,14 +424,7 @@ test "the hash view mode wins over the defaults" {
 /// auto-opens; a live server list, several sessions, an existing selection,
 /// or a dropped file all keep the explicit click.
 test "single-session standalone exports auto-open their session" {
-  let row : SessionRow = {
-    key: "k1",
-    id: "s1",
-    root_label: "",
-    last_active: None,
-    is_marker: false,
-    first_prompt: "",
-  }
+  let row = direct_row("k1", "s1", "")
   let other = { ..row, key: "k2", id: "s2" }
   assert_true(should_auto_open(true, [row], selected=None, dropped=None))
   assert_false(should_auto_open(false, [row], selected=None, dropped=None))


### PR DESCRIPTION
Scoped simplification/dedup of `cmd/viz_app`, touched by the step-scrubber work (#459). Private helpers only — **no public API change** (`pkg.generated.mbti` unchanged). Net **−33 lines**.

## Product code (app.mbt)
- **`class_with(base, modifier, on)`** — the conditional modifier-class idiom `if flag { "base mod" } else { "base" }` was copied across the theme / mode / args buttons, the session-item row, the app shell, and the error toggle. `app_class` keeps its dedicated unit test and now delegates to `class_with`; the single-use `session_root_class` folds into its one call site.
- **`session_row`** — the linear key-lookup loop → `model.sessions.iter().find_first(...)` (Array has no `find_first`, so the `.iter()` hop is load-bearing and stays).

## Tests (app_wbtest.mbt)
- **`direct_row(key, id, root_label)`** — sibling of the existing `marker_row`, replacing three full `is_marker: false` `SessionRow` literals.
- **`stub_emit()`** — the no-op `Emit(_ => @cmd.none)` repeated across four `update` tests.
- The three `parse_load` tests drop their `match`/catch-all arm for the file's own `guard … is Loaded(…) else { fail(…) }` idiom (already used elsewhere in the file).

## Verification
- `moon check cmd/viz_app --target js --deny-warn` clean; `moon test cmd/viz_app --target js` **27/27**.
- `moon info` → `pkg.generated.mbti` unchanged.
- `moon build cmd/viz_app --target js` (shipped bundle) builds.
- `moon fmt` applied.
- `subal review` sign-off posted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)