### PR TITLE
feat(goal): let goal(continuing) clear a prior blocked state

### DIFF
--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -17,10 +17,12 @@ fn goal_reminder_text(goal : String, tool_registered~ : Bool) -> String {
     $|Assess it briefly at this turn boundary:
     $|- Fully met? Verify per the goal's own criteria first, then
     $|  \{met_action}.
-    $|- Unable to proceed (blocked, impossible, or superseded)? Record that
-    $|  — call the goal tool with status "blocked" and a reason if it is
-    $|  available, otherwise say why — then finish; the user decides what
-    $|  is next.
+    $|- Truly cannot proceed — progress needs user action or an external
+    $|  change (access, a decision only the user can make, an unrecoverable
+    $|  dependency), or the goal is superseded? Record that with status
+    $|  "blocked" and a reason, then finish; the user decides what is next.
+    $|  Do NOT block for a problem you can work around yourself (a failed
+    $|  command, a tool error, a file you can rewrite).
     $|- Otherwise continue working toward it. If the current task conflicts
     $|  with the goal, the current task wins; note the conflict briefly.
   )
@@ -36,10 +38,13 @@ fn goal_check_text(goal : String, tool_registered~ : Bool) -> String {
       $|You attempted to finish. If the goal is fully met, record that by
       $|calling the goal tool with status "met", then finish. If this task
       $|is complete but the goal is not, call the goal tool with status
-      $|"continuing" and what remains, then finish. If the goal cannot
-      $|proceed (blocked, impossible, or superseded), call the goal tool
-      $|with status "blocked" and a reason, then finish — the user decides
-      $|what is next. Otherwise continue working toward the goal.
+      $|"continuing" and what remains, then finish (this also clears a prior
+      $|"blocked" status and resumes autonomous continuation). Only if real
+      $|progress is impossible without user action or an external change, or
+      $|the goal is superseded, call the goal tool with status "blocked" and
+      $|a reason, then finish — the user decides what is next; do not block
+      $|for a problem you can work around yourself. Otherwise continue
+      $|working toward the goal.
     )
   } else {
     (
@@ -52,6 +57,20 @@ fn goal_check_text(goal : String, tool_registered~ : Bool) -> String {
       $|the goal.
     )
   }
+}
+
+///|
+/// The block/unblock marker a batch will land at its next batch-safe
+/// boundary. At most one such transition is pending per batch, so this is a
+/// single field rather than two independent flags: `continuing` after a block
+/// in the same batch rewrites it, never leaving a stale half-state.
+priv enum PendingBlockTransition {
+  NoBlockTransition
+  /// A goal(blocked) verdict awaiting its durable `[goal blocked]` marker.
+  PendingBlock(String)
+  /// A goal(continuing) that resumes a durably blocked goal, awaiting its
+  /// durable `[goal unblocked]` marker.
+  PendingUnblock
 }
 
 ///|
@@ -73,9 +92,15 @@ priv struct GoalCadence {
   mut goal : String?
   mut remind_now : Bool
   mut finish_checked : Bool
-  /// A blocked verdict awaiting its durable marker at a batch-safe
-  /// boundary, exactly like the met tombstone.
-  mut pending_blocked_reason : String?
+  /// Cache of the DURABLE blocked state (whether a live `[goal blocked]`
+  /// stands in the log). Seeded from the standing goal and updated only after
+  /// a marker durably lands (flush) or a durable notice is observed — never
+  /// optimistically from an unflushed batch verdict, so `continuing` can tell
+  /// a prior-batch block (which needs an unblock marker) from a same-batch one
+  /// (which just cancels).
+  mut durably_blocked : Bool
+  /// The block/unblock marker awaiting the next batch-safe boundary.
+  mut pending_block : PendingBlockTransition
   /// A goal(met) call was recorded mid-batch; the durable [goal cleared]
   /// tombstone must land only at a batch-safe boundary (next step start or
   /// turn finish) — a mid-batch runtime notice would make replay synthesize
@@ -94,7 +119,8 @@ fn GoalCadence::GoalCadence(
     goal: standing.map(goal => goal.text()),
     remind_now: standing.map(goal => goal.answered_since_set()).unwrap_or(false),
     finish_checked: false,
-    pending_blocked_reason: None,
+    durably_blocked: standing.map(goal => goal.blocked()).unwrap_or(false),
+    pending_block: NoBlockTransition,
     pending_tombstone: false,
   }
 }
@@ -113,17 +139,40 @@ fn GoalCadence::due_finish_check(self : GoalCadence) -> String? {
 ///|
 /// A structured goal(met) call: the goal stops standing immediately (the
 /// finish check disarms) and the durable tombstone is deferred to the next
-/// batch-safe boundary.
+/// batch-safe boundary. Any pending block/unblock is abandoned — the goal is
+/// going away, so its blocked state is moot.
 fn GoalCadence::record_goal_met(self : GoalCadence) -> Unit {
   self.goal = None
+  self.pending_block = NoBlockTransition
   self.pending_tombstone = true
 }
 
 ///|
-/// A structured goal(continuing) call answers exactly what the finish check
-/// would ask, so the check disarms for the rest of the turn.
+/// A structured goal(continuing) call answers the finish check (disarming it
+/// for the rest of the turn) and, if the goal is durably blocked, resumes
+/// auto-continuation by scheduling a `[goal unblocked]` marker. Keying off
+/// `durably_blocked` (not the pending field) is what makes a continue after a
+/// PRIOR-batch block emit the marker, while a block+continue within one batch
+/// simply cancels to nothing durable.
 fn GoalCadence::record_goal_continuing(self : GoalCadence) -> Unit {
   self.finish_checked = true
+  if self.durably_blocked {
+    self.pending_block = PendingUnblock
+  } else if self.pending_block is PendingBlock(_) {
+    self.pending_block = NoBlockTransition
+  }
+}
+
+///|
+/// A structured goal(blocked) call: pauses auto-continuation. Like a finish
+/// check answer it disarms the turn's finish check, and it schedules a durable
+/// `[goal blocked]` marker (superseding any same-batch pending unblock).
+fn GoalCadence::record_goal_blocked(
+  self : GoalCadence,
+  reason : String,
+) -> Unit {
+  self.finish_checked = true
+  self.pending_block = PendingBlock(reason)
 }
 
 ///|
@@ -174,45 +223,71 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       // flushing it after the new marker would wipe the new goal (last
       // marker wins in the scan).
       self.pending_tombstone = false
-      // Same for a deferred blocked verdict: flushing it after the new
-      // marker would mark the REPLACEMENT goal blocked.
-      self.pending_blocked_reason = None
+      // Same for a deferred block/unblock verdict: it belonged to the goal
+      // this set supersedes; a new goal starts unblocked.
+      self.pending_block = NoBlockTransition
+      self.durably_blocked = false
       @xlog.info() <? { "event": "goal_updated", "goal": text }
     }
     Some(GoalCleared) => {
       self.goal = None
       // A durable clear just landed; a second tombstone would be noise.
       self.pending_tombstone = false
-      self.pending_blocked_reason = None
+      self.pending_block = NoBlockTransition
+      self.durably_blocked = false
       @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
     }
-    // A blocked marker changes auto-continuation policy (serve reads it
-    // from the standing goal), not the cadence: the goal still stands.
-    Some(GoalBlocked(_)) => ()
+    // A block/unblock marker landing durably (this loop's own flush, or a
+    // steer observed after its append) toggles the cached durable state; the
+    // goal still stands, so the rest of the cadence is untouched.
+    Some(GoalBlocked(_)) => self.durably_blocked = true
+    Some(GoalUnblocked) => self.durably_blocked = false
     None => ()
   }
 }
 
 ///|
-/// Flush a deferred goal tombstone at a batch-safe boundary: the durable
-/// `[goal cleared]` clear for a goal(met) recorded mid-batch, appended
-/// through the loop's persistence seam and reported as `goal_updated` only
-/// after that append succeeds.
+/// Flush the goal markers a batch deferred, at a batch-safe boundary: the
+/// `[goal blocked]` / `[goal unblocked]` transition, then the `[goal cleared]`
+/// tombstone. Each is appended through the loop's persistence seam and its
+/// pending flag cleared only AFTER the append succeeds — a failed append must
+/// leave the flag set so the error-path retry re-lands the marker, otherwise
+/// a durable goal-tool result would coexist with a stale standing state on
+/// resume. The two markers cannot both be pending (met abandons a pending
+/// block, and a set/clear supersedes it), so their order does not conflict.
 async fn AgentLoop::flush_goal_tombstone(
   self : Self,
   session : @agent_session.Session,
 ) -> @agent_session.Session {
-  let session = if self.goal_cadence.pending_blocked_reason is Some(reason) {
-    let next = self.append_runtime_notice(
-      session,
-      "\{@agent_session.GoalBlockedPrefix}\n\{reason}",
-    )
-    // Cleared only AFTER the durable append, like the tombstone.
-    self.goal_cadence.pending_blocked_reason = None
-    @xlog.info() <? { "event": "goal_blocked", "reason": reason }
-    next
-  } else {
-    session
+  let session = match self.goal_cadence.pending_block {
+    PendingBlock(reason) => {
+      let next = self.append_runtime_notice(
+        session,
+        "\{@agent_session.GoalBlockedPrefix}\n\{reason}",
+      )
+      self.goal_cadence.pending_block = NoBlockTransition
+      self.goal_cadence.durably_blocked = true
+      @xlog.info() <? { "event": "goal_blocked", "reason": reason }
+      next
+    }
+    // A continue that resumes a durably blocked goal: land the unblock marker
+    // so serve's next auto-continue check reads the goal as no longer blocked.
+    PendingUnblock if self.goal_cadence.durably_blocked => {
+      let next = self.append_runtime_notice(
+        session,
+        @agent_session.GoalUnblockedNotice,
+      )
+      self.goal_cadence.pending_block = NoBlockTransition
+      self.goal_cadence.durably_blocked = false
+      @xlog.info() <? { "event": "goal_unblocked" }
+      next
+    }
+    // A no-op unblock (the goal was not durably blocked): nothing to rescind.
+    PendingUnblock => {
+      self.goal_cadence.pending_block = NoBlockTransition
+      session
+    }
+    NoBlockTransition => session
   }
   if !self.goal_cadence.pending_tombstone {
     return session
@@ -221,9 +296,6 @@ async fn AgentLoop::flush_goal_tombstone(
     session,
     @agent_session.GoalClearedNotice,
   )
-  // Cleared only AFTER the durable append: a failed append must leave the
-  // flag set so the error-path retry still lands the tombstone — otherwise
-  // a durable goal(met) result coexists with a resurrected goal on resume.
   self.goal_cadence.pending_tombstone = false
   @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
   next
@@ -248,13 +320,23 @@ async fn AgentLoop::handle_goal_tool_call(
     @goal.decode_status(tool_call.arguments),
     self.goal_cadence.goal,
   )
+  // A continue that resumes a durably blocked goal reports the resume, so the
+  // transcript shows auto-continuation coming back rather than silently.
+  let resumes_block = self.goal_cadence.durably_blocked
   let (content, is_error) = match verdict {
     (Err(message), _) => ("error: \{message}", true)
     (Ok(_), None) => ("error: no standing goal is set", true)
     (Ok(Met), Some(_)) =>
       ("goal recorded as met; the standing goal is now cleared", false)
     (Ok(Continuing(remaining)), Some(_)) =>
-      ("goal status recorded as continuing: \{remaining}", false)
+      if resumes_block {
+        (
+          "goal status recorded as continuing: \{remaining}. The goal is no longer blocked; auto-continuation resumes",
+          false,
+        )
+      } else {
+        ("goal status recorded as continuing: \{remaining}", false)
+      }
     (Ok(Blocked(reason)), Some(_)) =>
       (
         "goal recorded as blocked: \{reason}. The goal still stands; auto-continuation is paused for the user",
@@ -273,13 +355,13 @@ async fn AgentLoop::handle_goal_tool_call(
   // then durably clear a goal whose met verdict was never persisted).
   match verdict {
     (Ok(Met), Some(_)) => self.goal_cadence.record_goal_met()
+    // Continuing answers the finish check and, if the goal is durably
+    // blocked, schedules a `[goal unblocked]` marker so serve resumes.
     (Ok(Continuing(_)), Some(_)) => self.goal_cadence.record_goal_continuing()
-    // Blocked answers the check like continuing, and lands a durable
+    // Blocked answers the check and schedules a durable `[goal blocked]`
     // marker so serve pauses auto-continuation while the goal stands.
-    (Ok(Blocked(reason)), Some(_)) => {
-      self.goal_cadence.record_goal_continuing()
-      self.goal_cadence.pending_blocked_reason = Some(reason)
-    }
+    (Ok(Blocked(reason)), Some(_)) =>
+      self.goal_cadence.record_goal_blocked(reason)
     _ => ()
   }
   @xlog.info() <?

--- a/agent/goal_wbtest.mbt
+++ b/agent/goal_wbtest.mbt
@@ -19,6 +19,103 @@ test "a new goal observed after met drops the stale tombstone" {
 }
 
 ///|
+/// A session whose standing goal is durably blocked: `[goal]` then a
+/// `[goal blocked]` marker, so `current_goal().blocked()` is true and a fresh
+/// cadence seeds `durably_blocked = true`.
+fn blocked_goal_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("blocked"), system_prompt="sys")
+  .append(Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nship it")))
+  .append(User(UserMessage("work")))
+  .append(Runtime(RuntimeNotice("\{@agent_session.GoalBlockedPrefix}\nstuck")))
+}
+
+///|
+/// A session with a plain standing goal (never blocked).
+fn open_goal_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("open"), system_prompt="sys").append(
+    Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nship it")),
+  )
+}
+
+///|
+/// goal(blocked) disarms the turn's finish check (like continuing) and
+/// schedules a `[goal blocked]` marker.
+test "blocked answers the finish check and schedules a block marker" {
+  let cadence = GoalCadence(open_goal_session(), tool_registered=true)
+  assert_true(cadence.due_finish_check() is Some(_))
+  cadence.record_goal_blocked("stuck")
+  assert_true(cadence.due_finish_check() is None)
+  assert_true(cadence.pending_block is PendingBlock("stuck"))
+}
+
+///|
+/// continue after a PRIOR-batch (durable) block schedules the unblock marker
+/// that resumes auto-continuation — the case the naive design missed.
+test "continue after a durable block schedules an unblock marker" {
+  let cadence = GoalCadence(blocked_goal_session(), tool_registered=true)
+  assert_true(cadence.durably_blocked)
+  cadence.record_goal_continuing()
+  assert_true(cadence.pending_block is PendingUnblock)
+}
+
+///|
+/// Batch orderings, both starting durable states. `continue` keys off the
+/// durable state, so a same-batch block+continue cancels when the goal was
+/// open but resolves to an unblock when it was already blocked.
+test "block/continue batch orderings resolve to the right pending marker" {
+  // open + block -> continue  ==> nothing durable (block cancelled)
+  let a = GoalCadence(open_goal_session(), tool_registered=true)
+  a.record_goal_blocked("x")
+  a.record_goal_continuing()
+  assert_true(a.pending_block is NoBlockTransition)
+
+  // blocked + block -> continue  ==> unblock (the durable block is rescinded)
+  let b = GoalCadence(blocked_goal_session(), tool_registered=true)
+  b.record_goal_blocked("x")
+  b.record_goal_continuing()
+  assert_true(b.pending_block is PendingUnblock)
+
+  // blocked + block -> continue -> block  ==> block wins (stays blocked)
+  let c = GoalCadence(blocked_goal_session(), tool_registered=true)
+  c.record_goal_blocked("x")
+  c.record_goal_continuing()
+  c.record_goal_blocked("y")
+  assert_true(c.pending_block is PendingBlock("y"))
+
+  // blocked + continue -> block -> continue  ==> unblock
+  let d = GoalCadence(blocked_goal_session(), tool_registered=true)
+  d.record_goal_continuing()
+  d.record_goal_blocked("x")
+  d.record_goal_continuing()
+  assert_true(d.pending_block is PendingUnblock)
+
+  // open + continue -> block -> continue  ==> nothing durable
+  let e = GoalCadence(open_goal_session(), tool_registered=true)
+  e.record_goal_continuing()
+  e.record_goal_blocked("x")
+  e.record_goal_continuing()
+  assert_true(e.pending_block is NoBlockTransition)
+}
+
+///|
+/// met abandons a pending block/unblock (the goal is going away) and a new
+/// goal or clear resets the durable-blocked cache.
+test "met and a superseding set/clear reset the block state" {
+  let cadence = GoalCadence(blocked_goal_session(), tool_registered=true)
+  cadence.record_goal_continuing()
+  assert_true(cadence.pending_block is PendingUnblock)
+  cadence.record_goal_met()
+  assert_true(cadence.pending_block is NoBlockTransition)
+  assert_true(cadence.pending_tombstone)
+  // A superseding set clears the durable-blocked cache for the new goal.
+  let other = GoalCadence(blocked_goal_session(), tool_registered=true)
+  assert_true(other.durably_blocked)
+  other.observe_notice("\{@agent_session.GoalPrefix}\nnew objective")
+  assert_false(other.durably_blocked)
+  assert_true(other.pending_block is NoBlockTransition)
+}
+
+///|
 test "a goal set after an earlier check re-arms the finish check" {
   let session = @agent_session.Session(
     SessionId("goal-recheck"),

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -20,6 +20,13 @@ pub const GoalClearedNotice : String = "[goal cleared]"
 pub const GoalBlockedPrefix : String = "[goal blocked]"
 
 ///|
+/// Exact content of the marker that RESCINDS a prior `[goal blocked]`: the
+/// model resumed work on the still-standing goal (via `goal(continuing)`), so
+/// auto-continuation must resume too. A pure state transition, so it carries
+/// no reason payload — exact content, like `[goal cleared]`.
+pub const GoalUnblockedNotice : String = "[goal unblocked]"
+
+///|
 /// First line of the reminder notice the agent loop re-injects so a
 /// long-running conversation keeps the standing goal near the context tail.
 pub const GoalReminderPrefix : String = "[goal reminder]"
@@ -74,16 +81,21 @@ pub(all) enum GoalMarker {
   GoalSet(String)
   GoalCleared
   GoalBlocked(String)
+  GoalUnblocked
 } derive(Debug)
 
 ///|
 /// Parse a runtime-notice content as a goal marker, if it is one. The set
-/// marker requires the exact `[goal]` first line and the tombstone requires
-/// exact content, so other notices (plan reminders, goal reminders, goal
-/// checks) never match.
+/// marker requires the exact `[goal]` first line and the tombstone/unblock
+/// markers require exact content, so other notices (plan reminders, goal
+/// reminders, goal checks) never match. Unknown content is not a marker
+/// (`None`), so a reader from an older build treats `[goal unblocked]` as a
+/// plain notice and keeps the goal blocked — a safe degradation.
 pub fn goal_marker(content : String) -> GoalMarker? {
   if content == GoalClearedNotice {
     Some(GoalCleared)
+  } else if content == GoalUnblockedNotice {
+    Some(GoalUnblocked)
   } else if content.has_prefix("\{GoalBlockedPrefix}\n") {
     Some(GoalBlocked(content[GoalBlockedPrefix.length() + 1:].to_owned()))
   } else if content.has_prefix("\{GoalPrefix}\n") {
@@ -105,6 +117,10 @@ pub fn Session::current_goal(self : Session) -> StandingGoal? {
   let events = self.events()
   let mut answered = false
   let mut blocked = false
+  // The newest of the block/unblock pair wins: scanning newest-first, the
+  // first one encountered before the set marker decides `blocked`, and
+  // `blocked_decided` freezes it so an older transition cannot override it.
+  let mut blocked_decided = false
   let covered : Array[(Int, Int)] = []
   for index = events.length() - 1; index >= 0; index = index - 1 {
     let event = events[index]
@@ -120,9 +136,19 @@ pub fn Session::current_goal(self : Session) -> StandingGoal? {
       Runtime(notice) =>
         match goal_marker(notice.content()) {
           Some(GoalCleared) => return None
-          // Newest-first: a blocked marker precedes the set it follows
-          // temporally; a NEWER set is found first and naturally resets it.
-          Some(GoalBlocked(_)) => blocked = true
+          // Newest-first: a blocked/unblocked marker precedes the set it
+          // follows temporally; a NEWER set is found first and naturally
+          // resets both. Between them, whichever is newer wins.
+          Some(GoalBlocked(_)) =>
+            if !blocked_decided {
+              blocked = true
+              blocked_decided = true
+            }
+          Some(GoalUnblocked) =>
+            if !blocked_decided {
+              blocked = false
+              blocked_decided = true
+            }
           Some(GoalSet(text)) => {
             let sequence = event.sequence()
             let is_covered = covered.any(range => {

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -21,6 +21,8 @@ pub const GoalPrefix : String = "[goal]"
 
 pub const GoalReminderPrefix : String = "[goal reminder]"
 
+pub const GoalUnblockedNotice : String = "[goal unblocked]"
+
 pub const PlanReminderPrefix : String = "[plan reminder]"
 
 pub fn goal_marker(String) -> GoalMarker?
@@ -40,6 +42,7 @@ pub(all) enum GoalMarker {
   GoalSet(String)
   GoalCleared
   GoalBlocked(String)
+  GoalUnblocked
 } derive(@debug.Debug)
 
 pub struct RuntimeNotice {

--- a/agent_tool/goal/goal.mbt
+++ b/agent_tool/goal/goal.mbt
@@ -57,7 +57,7 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="goal",
     description=(
-      #|Record the status of the standing session goal. Call with status "met" only when the goal is fully achieved and verified — this durably clears it. Call with status "continuing" plus a short "remaining" summary when you finish a task while goal work remains. Call with status "blocked" plus a "reason" when the goal cannot proceed (impossible, blocked, or superseded) — the goal keeps standing for the user, but autonomous continuation pauses. Only meaningful when a standing goal is set.
+      #|Record the status of the standing session goal. Call with status "met" only when the goal is fully achieved and verified — this durably clears it. Call with status "continuing" plus a short "remaining" summary when you finish a task while goal work remains; if the goal was previously marked "blocked" and you have resumed work, "continuing" clears that blocked status and resumes autonomous continuation. Call with status "blocked" plus a "reason" ONLY when real progress is impossible without user action or an external-state change (e.g. missing credentials or access, a required decision only the user can make, a genuinely unrecoverable dependency), or the goal has been superseded — NOT for a transient or recoverable problem you can work around yourself (a failed command, a tool error, a corrupted file you can rewrite). Blocking keeps the goal standing for the user but pauses autonomous continuation, so reserve it for when you truly cannot proceed. Only meaningful when a standing goal is set.
     ),
     schema=JsonSchema({
       "type": "object",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -392,6 +392,51 @@ test "a context-yield turn chains: finished derivation and standing goal" {
 }
 
 ///|
+test "an unblocked goal resumes auto-continuation at the boundary" {
+  // serve gates auto-continue on `goal_standing = standing is Some && !blocked`
+  // read fresh from current_goal() each TurnDone. A goal blocked then unblocked
+  // reads as standing-and-not-blocked, so continuation resumes with no serve
+  // change — the whole point of the [goal unblocked] marker.
+  let base = @agent_session.Session(SessionId("resume"), system_prompt="system")
+    .append(Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nobjective")))
+    .append(User(UserMessage("work")))
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalBlockedPrefix}\nstuck")),
+    )
+    .append(Terminal(Finished("turn answer")))
+  let goal_standing = fn(session : @agent_session.Session) -> Bool {
+    session.current_goal() is Some(goal) && !goal.blocked()
+  }
+  // While blocked, the boundary does NOT auto-continue.
+  assert_false(goal_standing(base))
+  assert_false(
+    should_auto_continue(
+      auto=true,
+      finished=true,
+      idle=true,
+      shutting_down=false,
+      goal_standing=goal_standing(base),
+      turns_remaining=1,
+    ),
+  )
+  // After the unblock marker lands, the same boundary resumes.
+  let resumed = base.append(
+    Runtime(RuntimeNotice(@agent_session.GoalUnblockedNotice)),
+  )
+  assert_true(goal_standing(resumed))
+  assert_true(
+    should_auto_continue(
+      auto=true,
+      finished=true,
+      idle=true,
+      shutting_down=false,
+      goal_standing=goal_standing(resumed),
+      turns_remaining=1,
+    ),
+  )
+}
+
+///|
 test "auto-continue requires a finished idle serving turn with budget" {
   assert_true(
     should_auto_continue(
@@ -660,10 +705,10 @@ async fn run_serve(
           @xlog.info() <? { "event": "goal_updated", "goal": text }
         Some(GoalCleared) =>
           @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
-        // A blocked marker pauses auto-continuation but the goal stands:
-        // it is reported by the loop's own goal_blocked event, not as a
-        // goal_updated (the goal did not change).
-        Some(GoalBlocked(_)) | None => ()
+        // Block/unblock markers change auto-continuation policy but not the
+        // goal itself; they are reported by the loop's own goal_blocked /
+        // goal_unblocked events, not as goal_updated.
+        Some(GoalBlocked(_)) | Some(GoalUnblocked) | None => ()
       }
     }
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -354,6 +354,10 @@ fn runtime_card(seq : Int, time : String, content : String) -> @html.Html {
       return card("runtime goal-blocked", "Goal blocked", seq, time~, [
         text_block(reason),
       ])
+    Some(GoalUnblocked) =>
+      return card("runtime goal-unblocked", "Goal unblocked", seq, time~, [
+        @html.span(class="goal-cleared-note") <| "goal resumed; auto-continuation re-enabled",
+      ])
     None => ()
   }
   if content.has_prefix(@agent_session.GoalReminderPrefix) {

--- a/web/index.html
+++ b/web/index.html
@@ -449,6 +449,7 @@
     .goal-boilerplate > summary { cursor: pointer; color: var(--muted); font-size: 12px; }
     .goal-boilerplate .content { color: var(--muted); }
     .card.goal-blocked { border-left-color: var(--error); background: var(--notice-error-bg); }
+    .card.goal-unblocked { border-left-color: var(--added); }
     .goal-cleared-note { color: var(--muted); font-style: italic; font-size: 12px; }
     .card.summary { border-left-color: var(--summary); background: var(--summary-bg); }
     .card.terminal { border-left-color: var(--terminal); }


### PR DESCRIPTION
## Motivation

Found while re-running the C-compiler goal experiment (run7) on the latest engine: the model hit recoverable edit-tool corruption at 26 min, reached for `goal(blocked)`, kept working, called `goal(continuing)` — but the goal stayed **durably blocked**, so when its single turn finished, auto-continue did not fire and the run stopped at ~10K lines instead of using its 20-turn budget.

`goal(blocked)` writes a durable `[goal blocked]` marker and serve gates auto-continue on `!goal.blocked()`. `goal(continuing)` wrote no durable marker, so it could not rescind the block. This makes `continuing` clear it.

## Change

- **New durable `[goal unblocked]` marker** + `GoalMarker::GoalUnblocked`. `current_goal` scans newest-first with a decided-latch so the newest of the block/unblock pair wins (survives reload; unknown to older binaries, which degrade to a plain notice and stay blocked — safe).
- **No serve scheduling change:** serve keeps the auto-continue armed *through* a block (only Cancel/new-goal disarm it) and re-reads `blocked()` fresh each `TurnDone`, so the marker alone rearms continuation.
- **Cadence:** a `durably_blocked` cache (updated only after a marker lands or a durable notice is observed) is kept separate from a single pending block/unblock transition. `continuing` keys off the durable state, so a continue after a *prior-batch* block emits the unblock marker while a block+continue *within one batch* cancels to nothing. `record_goal_blocked` still disarms the finish check.
- **Prompt hardening (the deeper fix):** the goal tool description, turn-start reminder, and finish check now reserve `blocked` for problems needing user action / an external change — not recoverable tool failures the model can work around — and state that `continuing` clears a block. Aims to prevent the premature block that started this.

## Review

Designed and implemented against a codex design review (which caught a real bug in the first cadence design — a `block→continue` batch starting from a durable block would wrongly stay blocked) and a codex implementation review (clean: "no actionable regressions"). Tests cover the batch orderings (block/continue interleavings, both initial durable states), `current_goal` newest-transition-wins + reload, and a serve-boundary test proving an armed blocked goal resumes after its unblock marker. 1058 native + 247 js tests pass; `moon check --deny-warn` clean on both targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)