### PR TITLE
feat(agent_tool): record per-session file provenance in a FileStateMap

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -121,13 +121,18 @@ pub async fn[X] build_tools(
   on_background_wake? : () -> Unit,
 ) -> @agent_tool.Tools {
   let workspace_root = runtime.workspace_root()
+  // One session-scoped file-state map, shared by the file-writing tools so they
+  // record which paths the agent created vs. modified this session — the record
+  // a future `remove` reads to tell an agent-created file (safe to delete) from
+  // a pre-existing one.
+  let file_state = @agent_tool.FileStateMap::new()
   Tools(
     shell_tools(runtime, scope, on_background_wake?) +
     [
       @read.definition(workspace_root~),
-      @edit.definition(workspace_root~),
-      @multi_edit.definition(workspace_root~),
-      @write.definition(workspace_root~),
+      @edit.definition(workspace_root~, file_state~),
+      @multi_edit.definition(workspace_root~, file_state~),
+      @write.definition(workspace_root~, file_state~),
       @plan.definition(),
       @goal.definition(),
       @finish.definition(),

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -33,6 +33,7 @@
 ///   invalid arguments.
 pub fn definition(
   workspace_root? : String = ".",
+  file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
@@ -53,13 +54,16 @@ pub fn definition(
       },
       "required": ["path", "old_string", "new_string", "start_line"],
     }),
-    execute=Async(arguments => execute_with_workspace(workspace_root, arguments)),
+    execute=Async(arguments => {
+      execute_with_workspace(workspace_root, file_state, arguments)
+    }),
   )
 }
 
 ///|
 async fn execute_with_workspace(
   workspace_root : String,
+  file_state : @agent_tool.FileStateMap,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
@@ -72,13 +76,14 @@ async fn execute_with_workspace(
     }
   }
   let path = @workspace_path.resolve(workspace_root, input.path)
-  edit_file(input, path~)
+  edit_file(input, path~, file_state~)
 }
 
 ///|
 async fn edit_file(
   input : @decode.EditInput,
   path~ : String,
+  file_state~ : @agent_tool.FileStateMap,
 ) -> @agent_tool.ToolAction {
   // Every failure names the file it tried to edit so the viz can show
   // `→ edit · edit <file> 🚩` on the folded call line.
@@ -149,6 +154,7 @@ async fn edit_file(
       fail_brief~,
       summary~,
       ok_brief~,
+      file_state~,
     )
   }
   let region = select_edit_region(content, input)
@@ -170,6 +176,7 @@ async fn edit_file(
     fail_brief~,
     summary="ok: replaced 1 occurrence(s) at line \{match_line} in \{path}",
     ok_brief="edited \{@agent_tool.brief_basename(path)}:\{match_line} (1×)",
+    file_state~,
   )
 }
 
@@ -187,6 +194,7 @@ async fn commit_edit(
   fail_brief~ : String,
   summary~ : String,
   ok_brief~ : String,
+  file_state~ : @agent_tool.FileStateMap,
 ) -> @agent_tool.ToolAction {
   if @manifest_error.write_error(path, new_content) is Some(message) {
     return @agent_tool.ToolAction::respond(
@@ -206,6 +214,10 @@ async fn commit_edit(
   }
   try {
     @fs.write_file(path, new_content, create_mode=CreateOrTruncate)
+    // An edit always changes a file that already existed (its content was read
+    // above), so record it as modified — record_modified preserves a stronger
+    // `Created` state if the agent created this file earlier this session.
+    file_state.record_modified(path)
     let response = @auto_check.append_summary(path, summary)
     @agent_tool.ToolAction::respond(response, brief=ok_brief)
   } catch {

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -18,6 +18,30 @@ async fn run_edit_in_workspace(
 }
 
 ///|
+async test "edit records the file it changed as Modified" {
+  @vfs.with_tmpdir(dir => {
+    let state = @agent_tool.FileStateMap::new()
+    let path = "\{dir}/lib.mbt"
+    @fs.write_file(
+      path,
+      "pub fn f() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let run = match @edit.definition(file_state=state).execute {
+      Async(execute) => execute
+      Sync(_) => fail("edit tool should be async")
+    }
+    let _ = run({
+      "path": path,
+      "old_string": "1",
+      "new_string": "2",
+      "start_line": 1,
+    })
+    assert_true(state.get(path) is Some(Modified))
+  })
+}
+
+///|
 async test "a failed edit names the file in its brief" {
   @vfs.with_tmpdir(dir => {
     // Editing a missing file fails; the error still briefs the target file so

--- a/agent_tool/edit/pkg.generated.mbti
+++ b/agent_tool/edit/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn definition(workspace_root? : String) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -1,9 +1,17 @@
 ///|
 /// How the agent has touched a file during this session, as recorded by the
-/// file-writing tools (`write`, `edit`, `multi_edit`). `remove` reads this to
-/// decide whether deleting a path is low-risk: a file the agent created this
-/// session can be removed with confidence, since doing so only undoes the
-/// agent's own work.
+/// file-writing tools (`write`, `edit`, `multi_edit`).
+///
+/// This is an ADVISORY provenance signal, keyed by path, not a capability. A
+/// consumer that gates deletion on `Created` must NOT treat it as sole
+/// authority: a path can be rebound after it is recorded (the sandboxed shell
+/// still permits `mv`/`rm` on non-source files, and a session spans many
+/// turns), so `Created` proves only that the agent once created *a* file at
+/// this path — not that the file there now is still that file. A safe consumer
+/// revalidates at delete time (the path still refers to the agent's file) and
+/// combines this with independent guards (e.g. only deleting git-tracked or
+/// recoverable/soft-deleted files), treating `Created` as necessary, not
+/// sufficient.
 pub(all) enum FileState {
   /// The agent created this file this session — a `write` to a path that did
   /// not exist. Editing it afterward keeps this state; it is still the agent's
@@ -22,6 +30,13 @@ pub(all) enum FileState {
 /// `remove`, which reads it. `Map` is a reference type, so the shared handle
 /// observes every tool's updates without a `Ref`.
 ///
+/// Keys are lexically normalized (`./a`, `a//b`, `x/../y` collapse) so a file
+/// recorded under one spelling is found under an equivalent one — the tools'
+/// `workspace_path.resolve` leaves paths unnormalized under the default `.`
+/// root, so `note.txt` and `./note.txt` would otherwise be distinct keys.
+/// Normalization is lexical only: symlink aliases still map to distinct keys, a
+/// gap a consumer closes by canonicalizing (realpath) at delete time.
+///
 /// In-memory only: it reflects what THIS process did this session, not history
 /// restored from a durable log. A file created in an earlier process (before a
 /// resume) is absent, so consumers must read "absent" as "unknown provenance",
@@ -37,10 +52,18 @@ pub fn FileStateMap::new() -> FileStateMap {
 }
 
 ///|
+/// The lexically normalized key for `path`, so equivalent spellings of one file
+/// (`a`, `./a`, `dir/../a`) share an entry. Lexical only — it does not touch the
+/// filesystem, so it does not resolve symlink aliases.
+fn normalize_key(path : String) -> String {
+  @path.Path(path).normalize().to_string()
+}
+
+///|
 /// Record that the agent created `path` this session. Creation always wins: a
 /// later `record_modified` will not downgrade a `Created` entry.
 pub fn FileStateMap::record_created(self : FileStateMap, path : String) -> Unit {
-  self.entries[path] = Created
+  self.entries[normalize_key(path)] = Created
 }
 
 ///|
@@ -51,10 +74,11 @@ pub fn FileStateMap::record_modified(
   self : FileStateMap,
   path : String,
 ) -> Unit {
-  if self.entries.get(path) is Some(Created) {
+  let key = normalize_key(path)
+  if self.entries.get(key) is Some(Created) {
     return
   }
-  self.entries[path] = Modified
+  self.entries[key] = Modified
 }
 
 ///|
@@ -62,7 +86,7 @@ pub fn FileStateMap::record_modified(
 /// tool has touched it (which a consumer must treat as "unknown", not
 /// "pre-existing").
 pub fn FileStateMap::get(self : FileStateMap, path : String) -> FileState? {
-  self.entries.get(path)
+  self.entries.get(normalize_key(path))
 }
 
 ///|
@@ -104,4 +128,16 @@ test "handles share one underlying map (no Ref needed)" {
   let b = a
   b.record_created("lib/shared.mbt")
   assert_true(a.get("lib/shared.mbt") is Some(Created))
+}
+
+///|
+test "equivalent path spellings resolve to the same entry" {
+  // resolve() leaves paths verbatim under the default `.` root, so without
+  // normalization these would be distinct keys for the same file.
+  let state = FileStateMap::new()
+  state.record_created("./lib/x.mbt")
+  assert_true(state.get("lib/x.mbt") is Some(Created))
+  // A later modify through a third spelling must still find the Created entry.
+  state.record_modified("lib/./x.mbt")
+  assert_true(state.get("lib/x.mbt") is Some(Created))
 }

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -1,0 +1,107 @@
+///|
+/// How the agent has touched a file during this session, as recorded by the
+/// file-writing tools (`write`, `edit`, `multi_edit`). `remove` reads this to
+/// decide whether deleting a path is low-risk: a file the agent created this
+/// session can be removed with confidence, since doing so only undoes the
+/// agent's own work.
+pub(all) enum FileState {
+  /// The agent created this file this session — a `write` to a path that did
+  /// not exist. Editing it afterward keeps this state; it is still the agent's
+  /// own file.
+  Created
+  /// The agent modified a file that already existed when it first touched it
+  /// this session — an `edit`/`multi_edit`, or a `write` overwriting a
+  /// pre-existing non-source file.
+  Modified
+} derive(Eq, Debug)
+
+///|
+/// Per-session record of how the agent has touched files, keyed by the resolved
+/// path the tools write to. One map is created per session (in `build_tools`)
+/// and shared with every file-writing tool, which records into it, plus
+/// `remove`, which reads it. `Map` is a reference type, so the shared handle
+/// observes every tool's updates without a `Ref`.
+///
+/// In-memory only: it reflects what THIS process did this session, not history
+/// restored from a durable log. A file created in an earlier process (before a
+/// resume) is absent, so consumers must read "absent" as "unknown provenance",
+/// never as "not created".
+pub struct FileStateMap {
+  priv entries : Map[String, FileState]
+}
+
+///|
+/// A fresh, empty session file-state map.
+pub fn FileStateMap::new() -> FileStateMap {
+  { entries: Map([]) }
+}
+
+///|
+/// Record that the agent created `path` this session. Creation always wins: a
+/// later `record_modified` will not downgrade a `Created` entry.
+pub fn FileStateMap::record_created(self : FileStateMap, path : String) -> Unit {
+  self.entries[path] = Created
+}
+
+///|
+/// Record that the agent modified `path` this session — unless it is already
+/// `Created`, since editing a file the agent itself created keeps the stronger
+/// creation provenance.
+pub fn FileStateMap::record_modified(
+  self : FileStateMap,
+  path : String,
+) -> Unit {
+  if self.entries.get(path) is Some(Created) {
+    return
+  }
+  self.entries[path] = Modified
+}
+
+///|
+/// The recorded state of `path` this session, or `None` when no file-writing
+/// tool has touched it (which a consumer must treat as "unknown", not
+/// "pre-existing").
+pub fn FileStateMap::get(self : FileStateMap, path : String) -> FileState? {
+  self.entries.get(path)
+}
+
+///|
+test "record_created marks a path and survives a later modify" {
+  let state = FileStateMap::new()
+  state.record_created("lib/new.mbt")
+  assert_true(state.get("lib/new.mbt") is Some(Created))
+  // Editing a file the agent created keeps the creation provenance.
+  state.record_modified("lib/new.mbt")
+  assert_true(state.get("lib/new.mbt") is Some(Created))
+}
+
+///|
+test "record_modified marks a pre-existing file" {
+  let state = FileStateMap::new()
+  state.record_modified("lib/old.mbt")
+  assert_true(state.get("lib/old.mbt") is Some(Modified))
+}
+
+///|
+test "an untouched path has no recorded state" {
+  let state = FileStateMap::new()
+  assert_true(state.get("lib/absent.mbt") is None)
+}
+
+///|
+test "record_created overrides a prior modified" {
+  // A path first seen as modified then created (e.g. removed and rewritten)
+  // becomes Created — creation is the stronger signal.
+  let state = FileStateMap::new()
+  state.record_modified("lib/x.mbt")
+  state.record_created("lib/x.mbt")
+  assert_true(state.get("lib/x.mbt") is Some(Created))
+}
+
+///|
+test "handles share one underlying map (no Ref needed)" {
+  let a = FileStateMap::new()
+  let b = a
+  b.record_created("lib/shared.mbt")
+  assert_true(a.get("lib/shared.mbt") is Some(Created))
+}

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -54,17 +54,30 @@ pub fn FileStateMap::new() -> FileStateMap {
 }
 
 ///|
-/// The lexical key for `path`, so equivalent spellings of one file (`a`, `./a`,
-/// `a//b`) share an entry. A `..` is NOT resolved: lexically dropping it is
-/// unsound when a preceding component is a symlink (`link/../x` and `x` are
-/// different files), which would let one path's provenance mask another's — so
-/// a path containing `..` is keyed verbatim, and full symlink-aware
-/// canonicalization is left to the deletion consumer (realpath at delete time).
+/// The lexical key for `path`: drop `.` and empty (`//`, trailing `/`)
+/// components so equivalent spellings of one file (`a`, `./a`, `a//b`) share an
+/// entry, while keeping every other component. A component that is exactly `..`
+/// is kept too, because lexically dropping it is unsound across symlinks
+/// (`link/../x` and `x` are different files) — only a real parent-directory
+/// segment is preserved this way, so an ordinary dotted name like `snap..bak`
+/// normalizes like any other. Full symlink-aware canonicalization is the
+/// deletion consumer's job (realpath at delete time).
 fn normalize_key(path : String) -> String {
-  if path.contains("..") {
-    path
+  let absolute = path.has_prefix("/")
+  let components = []
+  for component in path.split("/") {
+    match component {
+      "" | "." => ()
+      _ => components.push(component.to_owned())
+    }
+  }
+  let joined = components.join("/")
+  if absolute {
+    "/\{joined}"
+  } else if joined == "" {
+    "."
   } else {
-    @path.Path(path).normalize().to_string()
+    joined
   }
 }
 
@@ -159,4 +172,13 @@ test "a `..` segment is kept verbatim, never resolved lexically" {
   state.record_created("link/../victim")
   assert_true(state.get("victim") is None)
   assert_true(state.get("link/../victim") is Some(Created))
+}
+
+///|
+test "an ordinary dotted filename normalizes; only a `..` component is kept" {
+  // `snap..bak` has consecutive dots but no parent-directory segment, so it
+  // must normalize like any other name rather than being keyed verbatim.
+  let state = FileStateMap::new()
+  state.record_created("./snap..bak")
+  assert_true(state.get("snap..bak") is Some(Created))
 }

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -30,14 +30,18 @@ pub(all) enum FileState {
 /// `remove`, which reads it. `Map` is a reference type, so the shared handle
 /// observes every tool's updates without a `Ref`.
 ///
-/// Keys drop `.` segments and redundant separators (`./a`, `a//b`) so a file
-/// recorded under one spelling is found under an equivalent one — the tools'
-/// `workspace_path.resolve` leaves paths unnormalized under the default `.`
-/// root, so `note.txt` and `./note.txt` would otherwise be distinct keys. A
-/// `..` is deliberately left unresolved: collapsing it lexically is unsound
-/// when a preceding component is a symlink (`link/../x` and `x` are different
-/// files), so it stays part of the key. Full symlink-aware canonicalization
-/// (realpath) is the deletion consumer's job at delete time.
+/// Keys are the exact resolved path each tool wrote to — deliberately NOT
+/// normalized or canonicalized. Unifying equivalent spellings (`note.txt` vs
+/// `./note.txt`) or symlink aliases correctly needs OS-level canonicalization
+/// (realpath); lexical normalization instead MISattributes provenance — it
+/// mishandles `..` across symlinks, native path separators, and the POSIX `//`
+/// root, any of which could report `Created` for a DIFFERENT file, strictly
+/// worse than failing to recognize an equivalent spelling. So this map
+/// under-approximates on purpose: an unrecognized spelling reads as `None`
+/// ("unknown"), which a consumer already treats conservatively. The deletion
+/// consumer canonicalizes with realpath at delete time — where the file is
+/// live — and pairs it with an identity revalidation, which is also where the
+/// map's provenance is confirmed rather than trusted.
 ///
 /// In-memory only: it reflects what THIS process did this session, not history
 /// restored from a durable log. A file created in an earlier process (before a
@@ -54,38 +58,10 @@ pub fn FileStateMap::new() -> FileStateMap {
 }
 
 ///|
-/// The lexical key for `path`: drop `.` and empty (`//`, trailing `/`)
-/// components so equivalent spellings of one file (`a`, `./a`, `a//b`) share an
-/// entry, while keeping every other component. A component that is exactly `..`
-/// is kept too, because lexically dropping it is unsound across symlinks
-/// (`link/../x` and `x` are different files) — only a real parent-directory
-/// segment is preserved this way, so an ordinary dotted name like `snap..bak`
-/// normalizes like any other. Full symlink-aware canonicalization is the
-/// deletion consumer's job (realpath at delete time).
-fn normalize_key(path : String) -> String {
-  let absolute = path.has_prefix("/")
-  let components = []
-  for component in path.split("/") {
-    match component {
-      "" | "." => ()
-      _ => components.push(component.to_owned())
-    }
-  }
-  let joined = components.join("/")
-  if absolute {
-    "/\{joined}"
-  } else if joined == "" {
-    "."
-  } else {
-    joined
-  }
-}
-
-///|
 /// Record that the agent created `path` this session. Creation always wins: a
 /// later `record_modified` will not downgrade a `Created` entry.
 pub fn FileStateMap::record_created(self : FileStateMap, path : String) -> Unit {
-  self.entries[normalize_key(path)] = Created
+  self.entries[path] = Created
 }
 
 ///|
@@ -96,11 +72,10 @@ pub fn FileStateMap::record_modified(
   self : FileStateMap,
   path : String,
 ) -> Unit {
-  let key = normalize_key(path)
-  if self.entries.get(key) is Some(Created) {
+  if self.entries.get(path) is Some(Created) {
     return
   }
-  self.entries[key] = Modified
+  self.entries[path] = Modified
 }
 
 ///|
@@ -108,7 +83,7 @@ pub fn FileStateMap::record_modified(
 /// tool has touched it (which a consumer must treat as "unknown", not
 /// "pre-existing").
 pub fn FileStateMap::get(self : FileStateMap, path : String) -> FileState? {
-  self.entries.get(normalize_key(path))
+  self.entries.get(path)
 }
 
 ///|
@@ -153,32 +128,14 @@ test "handles share one underlying map (no Ref needed)" {
 }
 
 ///|
-test "equivalent path spellings resolve to the same entry" {
-  // resolve() leaves paths verbatim under the default `.` root, so without
-  // normalization these would be distinct keys for the same file.
+test "distinct path spellings are distinct keys (a safe under-approximation)" {
+  // The map keys verbatim — it never canonicalizes — so an equivalent spelling
+  // reads as unknown rather than risk reporting a different file as
+  // agent-created. A miss is safe (the consumer falls back to its other
+  // guards); a false `Created` would not be. Canonicalization (realpath) is
+  // the deletion consumer's job at delete time.
   let state = FileStateMap::new()
-  state.record_created("./lib/x.mbt")
-  assert_true(state.get("lib/x.mbt") is Some(Created))
-  // A later modify through a third spelling must still find the Created entry.
-  state.record_modified("lib/./x.mbt")
-  assert_true(state.get("lib/x.mbt") is Some(Created))
-}
-
-///|
-test "a `..` segment is kept verbatim, never resolved lexically" {
-  // `link/../victim` may traverse a symlink to a different directory, so its
-  // provenance must not leak onto a plain `victim` entry.
-  let state = FileStateMap::new()
-  state.record_created("link/../victim")
-  assert_true(state.get("victim") is None)
-  assert_true(state.get("link/../victim") is Some(Created))
-}
-
-///|
-test "an ordinary dotted filename normalizes; only a `..` component is kept" {
-  // `snap..bak` has consecutive dots but no parent-directory segment, so it
-  // must normalize like any other name rather than being keyed verbatim.
-  let state = FileStateMap::new()
-  state.record_created("./snap..bak")
-  assert_true(state.get("snap..bak") is Some(Created))
+  state.record_created("./note.txt")
+  assert_true(state.get("./note.txt") is Some(Created))
+  assert_true(state.get("note.txt") is None)
 }

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -30,12 +30,14 @@ pub(all) enum FileState {
 /// `remove`, which reads it. `Map` is a reference type, so the shared handle
 /// observes every tool's updates without a `Ref`.
 ///
-/// Keys are lexically normalized (`./a`, `a//b`, `x/../y` collapse) so a file
+/// Keys drop `.` segments and redundant separators (`./a`, `a//b`) so a file
 /// recorded under one spelling is found under an equivalent one — the tools'
 /// `workspace_path.resolve` leaves paths unnormalized under the default `.`
-/// root, so `note.txt` and `./note.txt` would otherwise be distinct keys.
-/// Normalization is lexical only: symlink aliases still map to distinct keys, a
-/// gap a consumer closes by canonicalizing (realpath) at delete time.
+/// root, so `note.txt` and `./note.txt` would otherwise be distinct keys. A
+/// `..` is deliberately left unresolved: collapsing it lexically is unsound
+/// when a preceding component is a symlink (`link/../x` and `x` are different
+/// files), so it stays part of the key. Full symlink-aware canonicalization
+/// (realpath) is the deletion consumer's job at delete time.
 ///
 /// In-memory only: it reflects what THIS process did this session, not history
 /// restored from a durable log. A file created in an earlier process (before a
@@ -52,11 +54,18 @@ pub fn FileStateMap::new() -> FileStateMap {
 }
 
 ///|
-/// The lexically normalized key for `path`, so equivalent spellings of one file
-/// (`a`, `./a`, `dir/../a`) share an entry. Lexical only — it does not touch the
-/// filesystem, so it does not resolve symlink aliases.
+/// The lexical key for `path`, so equivalent spellings of one file (`a`, `./a`,
+/// `a//b`) share an entry. A `..` is NOT resolved: lexically dropping it is
+/// unsound when a preceding component is a symlink (`link/../x` and `x` are
+/// different files), which would let one path's provenance mask another's — so
+/// a path containing `..` is keyed verbatim, and full symlink-aware
+/// canonicalization is left to the deletion consumer (realpath at delete time).
 fn normalize_key(path : String) -> String {
-  @path.Path(path).normalize().to_string()
+  if path.contains("..") {
+    path
+  } else {
+    @path.Path(path).normalize().to_string()
+  }
 }
 
 ///|
@@ -140,4 +149,14 @@ test "equivalent path spellings resolve to the same entry" {
   // A later modify through a third spelling must still find the Created entry.
   state.record_modified("lib/./x.mbt")
   assert_true(state.get("lib/x.mbt") is Some(Created))
+}
+
+///|
+test "a `..` segment is kept verbatim, never resolved lexically" {
+  // `link/../victim` may traverse a symlink to a different directory, so its
+  // provenance must not leak onto a plain `victim` entry.
+  let state = FileStateMap::new()
+  state.record_created("link/../victim")
+  assert_true(state.get("victim") is None)
+  assert_true(state.get("link/../victim") is Some(Created))
 }

--- a/agent_tool/moon.pkg
+++ b/agent_tool/moon.pkg
@@ -2,7 +2,6 @@ import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/async",
   "moonbitlang/core/json",
-  "moonbitlang/x/path",
 }
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/moon.pkg
+++ b/agent_tool/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/async",
   "moonbitlang/core/json",
+  "moonbitlang/x/path",
 }
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -10,6 +10,7 @@
 /// listed contiguously.
 pub fn definition(
   workspace_root? : String = ".",
+  file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="multi_edit",
@@ -59,13 +60,16 @@ pub fn definition(
         },
       },
     }),
-    execute=Async(arguments => execute_with_workspace(workspace_root, arguments)),
+    execute=Async(arguments => {
+      execute_with_workspace(workspace_root, file_state, arguments)
+    }),
   )
 }
 
 ///|
 async fn execute_with_workspace(
   workspace_root : String,
+  file_state : @agent_tool.FileStateMap,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   let args = @decode.decode_args(arguments) catch {
@@ -94,6 +98,7 @@ async fn execute_with_workspace(
     edits,
     args.revert_when_errors_above,
     revert_on_parse_errors=args.revert_on_parse_errors,
+    file_state~,
   )
 }
 
@@ -174,6 +179,7 @@ async fn multi_edit_files(
   edits : Array[@decode.MultiEditItem],
   revert_when_errors_above : Int?,
   revert_on_parse_errors~ : Bool,
+  file_state~ : @agent_tool.FileStateMap,
 ) -> @agent_tool.ToolAction {
   let brief = "multi_edit"
   // Resolve every edit's path up front and key contiguity and grouping on the
@@ -276,6 +282,11 @@ async fn multi_edit_files(
           brief~,
         )
     }
+    // multi_edit only rewrites files it read, so each is a modification (never
+    // a create). record_modified preserves a stronger `Created` state if the
+    // agent created this file earlier this session. A later auto-revert may
+    // restore the content, but the tool did write the path this session.
+    file_state.record_modified(write.path)
   }
   // The batch is on disk. Run the auto-revert guard from the first written
   // file's module: it appends `moon check` feedback and, if this batch

--- a/agent_tool/multi_edit/pkg.generated.mbti
+++ b/agent_tool/multi_edit/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn definition(workspace_root? : String) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -37,6 +37,19 @@ pub struct AgentToolDefinition {
 pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool) -> Self
 pub fn AgentToolDefinition::is_control(Self) -> Bool
 
+pub(all) enum FileState {
+  Created
+  Modified
+} derive(Eq, @debug.Debug)
+
+pub struct FileStateMap {
+  // private fields
+}
+pub fn FileStateMap::get(Self, String) -> FileState?
+pub fn FileStateMap::new() -> Self
+pub fn FileStateMap::record_created(Self, String) -> Unit
+pub fn FileStateMap::record_modified(Self, String) -> Unit
+
 pub(all) struct JsonSchema(Json) derive(@debug.Debug)
 
 pub(all) enum ToolAction {

--- a/agent_tool/write/pkg.generated.mbti
+++ b/agent_tool/write/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn definition(workspace_root? : String) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -29,6 +29,7 @@
 ///   invalid arguments.
 pub fn definition(
   workspace_root? : String = ".",
+  file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="write",
@@ -46,18 +47,21 @@ pub fn definition(
       },
       "required": ["path", "content"],
     }),
-    execute=Async(arguments => execute_with_workspace(workspace_root, arguments)),
+    execute=Async(arguments => {
+      execute_with_workspace(workspace_root, file_state, arguments)
+    }),
   )
 }
 
 ///|
 async fn execute(arguments : Json) -> @agent_tool.ToolAction {
-  execute_with_workspace(".", arguments)
+  execute_with_workspace(".", @agent_tool.FileStateMap::new(), arguments)
 }
 
 ///|
 async fn execute_with_workspace(
   workspace_root : String,
+  file_state : @agent_tool.FileStateMap,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
@@ -70,13 +74,14 @@ async fn execute_with_workspace(
     }
   }
   let path = @workspace_path.resolve(workspace_root, input.path)
-  write_file(input, path~)
+  write_file(input, path~, file_state~)
 }
 
 ///|
 async fn write_file(
   input : @decode.WriteInput,
   path~ : String,
+  file_state~ : @agent_tool.FileStateMap,
 ) -> @agent_tool.ToolAction {
   try {
     if @manifest_error.write_error(path, input.content) is Some(message) {
@@ -157,6 +162,13 @@ async fn write_file(
         CreateNew
       },
     )
+    // Record this write's provenance for the session so `remove` can later tell
+    // a file the agent created from one it merely overwrote.
+    if existed {
+      file_state.record_modified(path)
+    } else {
+      file_state.record_created(path)
+    }
     let chars = input.content.length()
     let summary = if existed {
       "ok: wrote \{chars} chars to \{path} (overwrote existing file)"
@@ -669,4 +681,38 @@ async test "write rejects non-object arguments" {
   guard result is Respond(output) else { fail("expected Respond") }
   assert_eq(output.content, "error: write requires object arguments")
   assert_true(output.is_error)
+}
+
+///|
+async test "write records a new file as Created and keeps it on overwrite" {
+  @vfs.with_tmpdir(dir => {
+    let state = @agent_tool.FileStateMap::new()
+    let run = match definition(file_state=state).execute {
+      Async(run) => run
+      Sync(_) => fail("write tool should be async")
+    }
+    let path = "\{dir}/note.txt"
+    // A brand-new file the agent wrote is recorded as its own creation.
+    let _ = run({ "path": path, "content": "v1" })
+    assert_true(state.get(path) is Some(Created))
+    // Overwriting that same non-source file keeps the stronger Created state.
+    let _ = run({ "path": path, "content": "v2" })
+    assert_true(state.get(path) is Some(Created))
+  })
+}
+
+///|
+async test "write records an overwrite of a pre-existing file as Modified" {
+  @vfs.with_tmpdir(dir => {
+    let state = @agent_tool.FileStateMap::new()
+    let path = "\{dir}/pre.txt"
+    // The file exists before the agent touches it this session.
+    @fs.write_file(path, "old", create_mode=CreateOrTruncate)
+    let run = match definition(file_state=state).execute {
+      Async(run) => run
+      Sync(_) => fail("write tool should be async")
+    }
+    let _ = run({ "path": path, "content": "new" })
+    assert_true(state.get(path) is Some(Modified))
+  })
 }


### PR DESCRIPTION
**PR 1 of 2.** Foundational state layer for a future `remove` tool: a per-session record of how the agent has touched files, so `remove` can later tell a file the agent **created this session** (safe to delete — removing it only undoes the agent's own work) from a pre-existing one. No behavior change — pure instrumentation.

## What

- **`FileState` (`Created` | `Modified`)** and **`FileStateMap`**, a thin handle over a shared mutable `Map[path, FileState]`. `Map` is a reference type, so the shared handle observes every tool's updates with **no `Ref`**. `record_created` always wins; `record_modified` never downgrades a `Created` entry (editing a file the agent itself created keeps that provenance). It lives in `agent_tool`, which the file tools already import — zero new package deps.
- **`write` / `edit` / `multi_edit`** gain an optional `file_state?` parameter (defaulting to a fresh empty map, so **every existing call site and test is unchanged**) and record on a successful write: `write` marks `Created` for a new file / `Modified` for an overwrite; `edit`/`multi_edit` mark `Modified`.
- **`build_tools`** constructs one map per session and shares it across those three tools — the same per-session wiring `bg_runtime` already uses, **not a global**: `serve.mbt` and `concurrent.mbt` run multiple sessions per process, and async tests run in parallel, so a global would cross-contaminate provenance (a correctness bug for a delete gate, not just test flakiness).

## Design notes

- **In-memory only**: it reflects this process's session, not history restored from a durable log. Consumers must read "absent" as **"unknown"**, never "not created" — the PR-2 `remove` gate will pair this with a git-tracked fallback so a resumed session still deletes safely.
- `multi_edit` records `Modified` per written path even if a later auto-revert restores content: the map tracks tool writes, and only the `Created`-preservation behavior is load-bearing (the gate keys on `Created`, which `multi_edit` never produces).

## Verification

- `moon check --deny-warn --target native` clean across the whole workspace (no downstream breakage).
- `moon test` green: agent_tool + write + edit + multi_edit **111/111**, agent (build_tools) **67/67**. New tests cover the map merge logic (unit) and end-to-end recording through `write` (Created on create, preserved on overwrite, Modified on pre-existing) and `edit` (Modified).
- `moon info` regenerated the 4 `.mbti` files; the diff is purely additive (`FileState`, `FileStateMap`, and the `file_state?` param).
- subal sign-off posted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)