### PR TITLE
feat(agent_tool): add the remove tool for agent-created source files

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -138,6 +138,7 @@ async test "standard tools are registered in dispatch order" {
         #|  "edit",
         #|  "multi_edit",
         #|  "write",
+        #|  "remove",
         #|  "plan",
         #|  "goal",
         #|  "finish",

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -12,6 +12,7 @@ import {
   "bobzhang/openseek/agent_tool/multi_edit",
   "bobzhang/openseek/agent_tool/plan",
   "bobzhang/openseek/agent_tool/read",
+  "bobzhang/openseek/agent_tool/remove",
   "bobzhang/openseek/agent_tool/shell",
   "bobzhang/openseek/agent_tool/write",
   "bobzhang/openseek/deepseek",

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -102,7 +102,8 @@ async fn[X] shell_tools(
 ///
 /// The returned registry contains the built-in local tools: `shell` (plus
 /// `shell_output` and `shell_stop` where background jobs are supported — see
-/// `shell_tools`), `read`, `edit`, `multi_edit`, `write`, `plan`, and `finish`.
+/// `shell_tools`), `read`, `edit`, `multi_edit`, `write`, `remove`, `plan`, and
+/// `finish`.
 /// Each tool lives in its own subpackage of `agent_tool` and exposes a
 /// `definition()` constructor; this function bundles them into the `Tools`
 /// value the loop dispatches against. File-oriented tools capture
@@ -123,8 +124,8 @@ pub async fn[X] build_tools(
   let workspace_root = runtime.workspace_root()
   // One session-scoped file-state map, shared by the file-writing tools so they
   // record which paths the agent created vs. modified this session — the record
-  // a future `remove` reads to tell an agent-created file (safe to delete) from
-  // a pre-existing one.
+  // `remove` reads to tell an agent-created file (safe to delete) from a
+  // pre-existing one.
   let file_state = @agent_tool.FileStateMap::new()
   Tools(
     shell_tools(runtime, scope, on_background_wake?) +
@@ -133,6 +134,7 @@ pub async fn[X] build_tools(
       @edit.definition(workspace_root~, file_state~),
       @multi_edit.definition(workspace_root~, file_state~),
       @write.definition(workspace_root~, file_state~),
+      @remove.definition(workspace_root~, file_state~),
       @plan.definition(),
       @goal.definition(),
       @finish.definition(),
@@ -146,7 +148,7 @@ async test "agent registers the expected tool names" {
   @async.with_task_group() <| group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
     let function_tools = tools.function_tools()
-    assert_eq(function_tools.length(), 10)
+    assert_eq(function_tools.length(), 11)
     let names = [ for t in function_tools => t.name ]
     assert_true(names.contains("shell"))
     assert_true(names.contains("shell_output"))
@@ -155,6 +157,7 @@ async test "agent registers the expected tool names" {
     assert_true(names.contains("edit"))
     assert_true(names.contains("multi_edit"))
     assert_true(names.contains("write"))
+    assert_true(names.contains("remove"))
     assert_true(names.contains("plan"))
     assert_true(names.contains("goal"))
     assert_true(names.contains("finish"))
@@ -173,7 +176,7 @@ async test "agent registers the expected tool names on windows" {
   @async.with_task_group() <| group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
     let function_tools = tools.function_tools()
-    assert_eq(function_tools.length(), 8)
+    assert_eq(function_tools.length(), 9)
     let names = [ for t in function_tools => t.name ]
     assert_true(names.contains("shell"))
     assert_false(names.contains("shell_output"))
@@ -182,6 +185,7 @@ async test "agent registers the expected tool names on windows" {
     assert_true(names.contains("edit"))
     assert_true(names.contains("multi_edit"))
     assert_true(names.contains("write"))
+    assert_true(names.contains("remove"))
     assert_true(names.contains("plan"))
     assert_true(names.contains("goal"))
     assert_true(names.contains("finish"))

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -87,6 +87,15 @@ pub fn FileStateMap::get(self : FileStateMap, path : String) -> FileState? {
 }
 
 ///|
+/// Drop any recorded state for `path`. `remove` calls this after deleting a file
+/// so the `Created` provenance does not outlive the file: if the same path is
+/// later recreated by something other than the agent's tools, it reads as
+/// unknown again rather than as still-agent-created.
+pub fn FileStateMap::forget(self : FileStateMap, path : String) -> Unit {
+  self.entries.remove(path)
+}
+
+///|
 test "record_created marks a path and survives a later modify" {
   let state = FileStateMap::new()
   state.record_created("lib/new.mbt")
@@ -125,6 +134,15 @@ test "handles share one underlying map (no Ref needed)" {
   let b = a
   b.record_created("lib/shared.mbt")
   assert_true(a.get("lib/shared.mbt") is Some(Created))
+}
+
+///|
+test "forget drops a path's provenance" {
+  let state = FileStateMap::new()
+  state.record_created("lib/gone.mbt")
+  state.forget("lib/gone.mbt")
+  // A path recreated after being forgotten reads as unknown, not Created.
+  assert_true(state.get("lib/gone.mbt") is None)
 }
 
 ///|

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -45,6 +45,7 @@ pub(all) enum FileState {
 pub struct FileStateMap {
   // private fields
 }
+pub fn FileStateMap::forget(Self, String) -> Unit
 pub fn FileStateMap::get(Self, String) -> FileState?
 pub fn FileStateMap::new() -> Self
 pub fn FileStateMap::record_created(Self, String) -> Unit

--- a/agent_tool/remove/README.mbt.md
+++ b/agent_tool/remove/README.mbt.md
@@ -43,15 +43,17 @@ honest on top of the `Created` check:
   has since been replaced by a symlink is refused rather than followed to its
   target.
 
-For **source** files the `Created` signal is strong: the sandbox blocks the
-shell from writing or moving onto a source path, so a recorded source path
-cannot be rebound to a different file while it sits un-removed. For **non-source**
-files that protection does not apply — a permitted `shell mv` could replace an
-un-removed created path in place — so the residual case (an external process
-replacing an un-removed `Created` file) is left to a later hardening (stored
-file identity, or recoverable/soft delete). Keys are the exact resolved path
-`write` used, so an unrecognized spelling reads as unknown and is
-conservatively refused rather than risking a wrong-file deletion.
+The residual the guards do not cover is a path replaced *in place* while it sits
+un-removed, without going through the agent's tools — so `FileStateMap` keeps the
+stale `Created`. This is possible for any file type, source included: the sandbox
+blocks a direct shell write or move onto a source path, but a permitted operation
+can still rebind a created path without updating the map — a `git checkout --
+x.mbt` restoring a tracked file the agent had recreated, or a `shell mv` onto a
+non-source path. Closing it needs stored file identity (revalidate the file at
+delete time) or recoverable/soft deletion; that hardening is deferred. Keys are
+the exact resolved path `write` used, so an unrecognized spelling reads as
+unknown and is conservatively refused rather than risking a wrong-file
+deletion.
 
 ## Arguments
 
@@ -110,7 +112,10 @@ async test "remove deletes an agent-created file through the registry" {
     let tools = @agent_tool.Tools([@remove.definition(file_state~)])
     // Build the arguments as JSON and stringify: a Windows temp path would
     // otherwise form an invalid escape inside a JSON string literal.
-    let arguments : Json = { "path": path, "reason": "scratch no longer needed" }
+    let arguments : Json = {
+      "path": path,
+      "reason": "scratch no longer needed",
+    }
     let call = @agent_tool.AgentToolCall(
       ToolCall(id="call_remove", name="remove", arguments=arguments.stringify()),
     )
@@ -149,7 +154,9 @@ async test "remove refuses a file the agent did not create" {
     let result = @agent_tool.execute_tool_call(call, tools)
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
-    assert_true(output.content.contains("not created by the agent this session"))
+    assert_true(
+      output.content.contains("not created by the agent this session"),
+    )
     // The file is untouched.
     assert_true(@fs.exists(path))
   })

--- a/agent_tool/remove/README.mbt.md
+++ b/agent_tool/remove/README.mbt.md
@@ -1,0 +1,157 @@
+# Remove Tool
+
+`remove` deletes a file the agent created earlier this session, gated on that
+provenance and carrying a required rationale for the audit trail. It is the
+delete verb of the tool-mediated file API: `read`, `write`, and
+`edit`/`multi_edit` already exist, but there was no in-workflow way to delete a
+file — the shell sandbox blocks `rm` on source paths, and routing other
+deletions through `shell` bypasses provenance entirely.
+
+`remove` deletes a path **only** when the session's
+[`FileStateMap`](../file_state.mbt) records it as `Created` — one the agent
+itself created this session — so removing it merely undoes the agent's own
+work. A pre-existing file (one the agent never created, or only modified) is
+refused.
+
+## Design Rationale
+
+The gate is provenance, not file type. `remove` handles any file the agent
+created: for a source file it is the *only* way to delete it (the sandbox
+blocks `rm` on `.mbt`/`.mbt.md`/manifest paths), and for any other file it is
+the *provenance-checked* path where a bare `shell rm` is not. Deleting a
+`.mbt`/`.mbt.md` file runs module `moon check` and appends the feedback, so a
+break the deletion causes surfaces in the result exactly as it does after
+`write`/`edit`.
+
+Because deletion is irreversible, every call carries a `reason`. The rationale
+is recorded in the (durable) success message — `ok: removed <path> (reason:
+…)` — so a destructive action can be audited after the fact.
+
+## Safety Model
+
+`Created` is treated as an **advisory** signal, not a bare delete capability
+(see the [`FileStateMap`](../file_state.mbt) docs). Two guards keep the gate
+honest on top of the `Created` check:
+
+- **Forget on delete.** After a successful removal the provenance is dropped
+  (`FileStateMap::forget`), so if the same path is later recreated by something
+  other than the agent's tools, a second `remove` sees it as unknown and
+  refuses — it never deletes a different file that happens to land at a path the
+  agent once created.
+- **No symlink following.** The regular-file check uses
+  `follow_symlink=false`, so a path that was a file when `write` recorded it but
+  has since been replaced by a symlink is refused rather than followed to its
+  target.
+
+For **source** files the `Created` signal is strong: the sandbox blocks the
+shell from writing or moving onto a source path, so a recorded source path
+cannot be rebound to a different file while it sits un-removed. For **non-source**
+files that protection does not apply — a permitted `shell mv` could replace an
+un-removed created path in place — so the residual case (an external process
+replacing an un-removed `Created` file) is left to a later hardening (stored
+file identity, or recoverable/soft delete). Keys are the exact resolved path
+`write` used, so an unrecognized spelling reads as unknown and is
+conservatively refused rather than risking a wrong-file deletion.
+
+## Arguments
+
+| Name     | Type   | Required | Notes |
+| -------- | ------ | -------- | ----- |
+| `path`   | string | yes | Filesystem path. Relative paths resolve against the workspace root. Must name an existing regular file the agent created this session. |
+| `reason` | string | yes | A short explanation of why the file is being deleted, recorded with the result for auditing. |
+
+## Action
+
+The action is always `Respond(ToolOutput(...))`; the agent loop forwards
+`ToolOutput.content` to the model. `is_error` is `false` on success and `true`
+otherwise. The body has one of these shapes:
+
+- `"ok: removed <path> (reason: <reason>)"` — the file was deleted. When the
+  target is a `.mbt`/`.mbt.md` file inside a MoonBit module, bounded module-root
+  `moon check` feedback is appended after the success line, starting with
+  `"moon check:"`.
+- `"error removing <path>: not created by the agent this session — ..."` — the
+  gate refused: the file is pre-existing, or the agent only modified it.
+- `"error removing <path>: no such file"` / `"... not a regular file; remove
+  deletes regular files"` — the path is missing, a directory, or a symlink.
+- `"error removing <path>: <error>"` — the unlink itself failed (e.g. permission
+  denied).
+- `"error: remove requires arguments.path"` / `"... arguments.reason"` /
+  `"... object arguments"` — invalid payload.
+
+## Examples
+
+```moonbit check
+///|
+test "remove tool advertises the expected schema" {
+  let tool = @remove.definition()
+  assert_eq(tool.name, "remove")
+  let JsonSchema(schema) = tool.schema
+  let text = schema.stringify()
+  assert_true(text.contains("\"path\""))
+  assert_true(text.contains("\"reason\""))
+  assert_true(text.contains("\"required\""))
+}
+```
+
+```moonbit check
+///|
+async test "remove deletes an agent-created file through the registry" {
+  @vfs.with_tmpdir(prefix="openseek-remove-readme-", dir => {
+    let path = "\{dir}/scratch.mbt"
+    @fs.write_file(
+      path,
+      "pub fn f() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // The session recorded that the agent created this file, as `write` would.
+    let file_state = @agent_tool.FileStateMap::new()
+    file_state.record_created(path)
+    let tools = @agent_tool.Tools([@remove.definition(file_state~)])
+    // Build the arguments as JSON and stringify: a Windows temp path would
+    // otherwise form an invalid escape inside a JSON string literal.
+    let arguments : Json = { "path": path, "reason": "scratch no longer needed" }
+    let call = @agent_tool.AgentToolCall(
+      ToolCall(id="call_remove", name="remove", arguments=arguments.stringify()),
+    )
+    let result = @agent_tool.execute_tool_call(call, tools)
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_eq(
+      output.content,
+      "ok: removed \{path} (reason: scratch no longer needed)",
+    )
+    assert_false(@fs.exists(path))
+  })
+}
+```
+
+```moonbit check
+///|
+async test "remove refuses a file the agent did not create" {
+  @vfs.with_tmpdir(prefix="openseek-remove-readme-refuse-", dir => {
+    let path = "\{dir}/lib.mbt"
+    @fs.write_file(
+      path,
+      "pub fn g() -> Int { 0 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // An empty file-state map: the agent never created this file this session.
+    let tools = @agent_tool.Tools([@remove.definition()])
+    let arguments : Json = { "path": path, "reason": "cleanup" }
+    let call = @agent_tool.AgentToolCall(
+      ToolCall(
+        id="call_remove_refuse",
+        name="remove",
+        arguments=arguments.stringify(),
+      ),
+    )
+    let result = @agent_tool.execute_tool_call(call, tools)
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("not created by the agent this session"))
+    // The file is untouched.
+    assert_true(@fs.exists(path))
+  })
+}
+```

--- a/agent_tool/remove/internal/decode/decode.mbt
+++ b/agent_tool/remove/internal/decode/decode.mbt
@@ -1,0 +1,22 @@
+///|
+/// Decoded arguments of the `remove` tool: delete the file at `path`, with a
+/// `reason` recorded for auditing this destructive action.
+pub struct RemoveInput {
+  path : String
+  reason : String
+} derive(Debug)
+
+///|
+/// Decode `remove` tool-call arguments.
+///
+/// `path` and `reason` are required strings. Failures name the first offending
+/// field (`arguments.reason` / `arguments.path` / `object arguments`) so the
+/// error fed back to the model says exactly which argument to fix.
+pub fn decode(arguments : Json) -> RemoveInput raise {
+  match arguments {
+    { "path": String(path), "reason": String(reason), .. } => { path, reason }
+    { "path": String(_), .. } => fail("arguments.reason")
+    Object(_) => fail("arguments.path")
+    _ => fail("object arguments")
+  }
+}

--- a/agent_tool/remove/internal/decode/moon.pkg
+++ b/agent_tool/remove/internal/decode/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/core/json",
+}
+
+warnings = "+unnecessary_annotation"

--- a/agent_tool/remove/internal/decode/pkg.generated.mbti
+++ b/agent_tool/remove/internal/decode/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/remove/internal/decode"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn decode(Json) -> RemoveInput raise
+
+// Errors
+
+// Types and methods
+pub struct RemoveInput {
+  path : String
+  reason : String
+} derive(@debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/remove/moon.pkg
+++ b/agent_tool/remove/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/remove/internal/decode",
   "bobzhang/openseek/internal/workspace_path",
   "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",

--- a/agent_tool/remove/moon.pkg
+++ b/agent_tool/remove/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/internal/workspace_path",
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/json",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/remove/pkg.generated.mbti
+++ b/agent_tool/remove/pkg.generated.mbti
@@ -1,0 +1,18 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/remove"
+
+import {
+  "bobzhang/openseek/agent_tool",
+}
+
+// Values
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -1,0 +1,294 @@
+///|
+/// Tool definition for `remove`: delete a `.mbt`/`.mbt.md` source file that the
+/// agent created earlier this session.
+///
+/// This fills the one gap in the tool-mediated file API — `read`/`write`/`edit`
+/// exist, but there was no in-workflow way to delete a source file, because the
+/// shell sandbox blocks `rm` on source paths. `remove` is intentionally narrow:
+/// it deletes ONLY a source file the session's `FileStateMap` records as
+/// `Created`, i.e. one the agent itself created this session, so removing it
+/// merely undoes the agent's own work. A pre-existing source file (one the agent
+/// did not create this session) is refused — change it with `edit`, or delete it
+/// outside the agent.
+///
+/// The `Created` gate is sound for source files without a soft-delete: the
+/// sandbox blocks the shell from writing or moving onto a source path, so a
+/// recorded source path cannot be rebound to a different file after `write`
+/// recorded it. The map is keyed by the same resolved path `write` used, so the
+/// lookup matches the recording spelling-for-spelling (an equivalent spelling
+/// reads as unknown and is conservatively refused).
+///
+/// ## Result
+/// - `Respond(ToolOutput("ok: removed <path>"))` when the file is deleted.
+/// - `Respond(ToolOutput("error removing <path>: <reason>", is_error=true))` for
+///   a non-source path, a missing file, a directory, a file the agent did not
+///   create this session, or a filesystem failure.
+/// - `Respond(ToolOutput("error: remove requires ...", is_error=true))` for
+///   invalid arguments.
+pub fn definition(
+  workspace_root? : String = ".",
+  file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="remove",
+    description="Delete a .mbt or .mbt.md source file that the agent created earlier THIS session (tracked in the session's file-state record). Only a source file the agent itself created this session can be removed — a pre-existing one is refused, since deleting it could lose work the agent never made; change existing source with edit/multi_edit, and delete non-source files with shell. The path must name an existing regular .mbt/.mbt.md file. This is the only in-workflow way to delete a source file: the shell sandbox blocks rm on source paths.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": { "path": { "type": "string" } },
+      "required": ["path"],
+    }),
+    execute=Async(arguments => {
+      execute_with_workspace(workspace_root, file_state, arguments)
+    }),
+  )
+}
+
+///|
+async fn execute_with_workspace(
+  workspace_root : String,
+  file_state : @agent_tool.FileStateMap,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  let requested = decode_path(arguments) catch {
+    error => {
+      let message = @tool_error.failure_message("\{error}")
+      return @agent_tool.ToolAction::respond(
+        "error: remove requires \{message}",
+        is_error=true,
+      )
+    }
+  }
+  let path = @workspace_path.resolve(workspace_root, requested)
+  remove_file(path, requested, file_state)
+}
+
+///|
+/// Decode the `remove` arguments: a single required `path` string. Names the
+/// offending field (`arguments.path` / `object arguments`) so the model is told
+/// exactly what to fix.
+fn decode_path(arguments : Json) -> String raise {
+  match arguments {
+    Object(fields) =>
+      match fields.get("path") {
+        Some(String(path)) => path
+        _ => fail("arguments.path")
+      }
+    _ => fail("object arguments")
+  }
+}
+
+///|
+async fn remove_file(
+  path : String,
+  requested : String,
+  file_state : @agent_tool.FileStateMap,
+) -> @agent_tool.ToolAction {
+  let fail_brief = "remove \{@agent_tool.brief_basename(path)}"
+  fn err(message : String) -> @agent_tool.ToolAction {
+    @agent_tool.ToolAction::respond(
+      "error removing \{path}: \{message}",
+      is_error=true,
+      brief=fail_brief,
+    )
+  }
+
+  // Scope: source files only. The shell sandbox does not block `rm` on
+  // non-source files, so those are deleted with shell; this tool exists for the
+  // source gap alone.
+  if !is_mbt_source(path) {
+    return err(
+      "remove handles .mbt/.mbt.md source files; delete other files with shell",
+    )
+  }
+  let exists = @fs.exists(path) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => return err("\{error}")
+  }
+  if !exists {
+    return err("no such file")
+  }
+  // `kind` does not follow the final symlink, so a symlink named `x.mbt` reports
+  // `SymLink` (not a source file to delete through) and, were it removed, only
+  // the link would be unlinked — its target untouched.
+  let kind = @fs.kind(path) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => return err("\{error}")
+  }
+  guard kind is Regular else {
+    return err("not a regular file; remove deletes regular files")
+  }
+  // The gate: only a source file the agent CREATED this session may be removed.
+  // `record_modified` never downgrades `Created`, so a file the agent created
+  // and then edited still qualifies; a file it only modified, or never touched,
+  // does not.
+  guard file_state.get(path) is Some(Created) else {
+    return err(
+      "not created by the agent this session — only a .mbt/.mbt.md file the agent itself created this session can be removed; change existing source with edit/multi_edit, or delete it outside the agent",
+    )
+  }
+  @fs.remove(path) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => return err("\{error}")
+  }
+  @agent_tool.ToolAction::respond(
+    "ok: removed \{path}",
+    brief=@agent_tool.brief_line("removed \{requested}"),
+  )
+}
+
+///|
+/// Whether `path` is a hand-written MoonBit source file (`.mbt` or `.mbt.md`) —
+/// the same set `write` refuses to overwrite and the shell sandbox blocks `rm`
+/// on. `.mbti` and manifests are intentionally out of scope for now.
+fn is_mbt_source(path : String) -> Bool {
+  path.has_suffix(".mbt") || path.has_suffix(".mbt.md")
+}
+
+///|
+/// Run the `remove` tool bound to a shared file-state map — the shape every test
+/// drives.
+async fn run_remove(
+  file_state : @agent_tool.FileStateMap,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  match definition(file_state~).execute {
+    Async(run) => run(arguments)
+    Sync(_) => fail("remove tool should be async")
+  }
+}
+
+///|
+async test "remove deletes a source file the agent created this session" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/scratch.mbt"
+    @fs.write_file(
+      path,
+      "pub fn f() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // The map records the create, as `write` would have.
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_eq(output.content, "ok: removed \{path}")
+    assert_false(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove keeps deleting a created file it later edited" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/grown.mbt"
+    @fs.write_file(
+      path,
+      "pub fn f() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let state = @agent_tool.FileStateMap::new()
+    // Created then modified this session: record_modified must not downgrade it.
+    state.record_created(path)
+    state.record_modified(path)
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_false(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove refuses a pre-existing source file it did not create" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/lib.mbt"
+    @fs.write_file(
+      path,
+      "pub fn g() -> Int { 0 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // Empty state: the agent did not create this file this session.
+    let state = @agent_tool.FileStateMap::new()
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("not created by the agent this session"),
+    )
+    // The file is untouched.
+    assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove refuses a source file the agent only modified" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/edited.mbt"
+    @fs.write_file(
+      path,
+      "pub fn h() -> Int { 2 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let state = @agent_tool.FileStateMap::new()
+    state.record_modified(path)
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("not created by the agent this session"),
+    )
+    assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove rejects a non-source path" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/notes.txt"
+    @fs.write_file(path, "scratch", create_mode=CreateOrTruncate)
+    // Even a Created non-source file is out of scope: shell can rm those.
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("delete other files with shell"))
+    assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove reports a missing file" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/ghost.mbt"
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("no such file"))
+  })
+}
+
+///|
+async test "remove refuses a directory" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/pkg.mbt"
+    @fs.mkdir(path, recursive=true)
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("not a regular file"))
+    assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove rejects missing path" {
+  let state = @agent_tool.FileStateMap::new()
+  let result = run_remove(state, { "note": "no path here" })
+  guard result is Respond(output) else { fail("expected Respond") }
+  assert_eq(output.content, "error: remove requires arguments.path")
+  assert_true(output.is_error)
+}

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -1,33 +1,37 @@
 ///|
-/// Tool definition for `remove`: delete a `.mbt`/`.mbt.md` source file that the
-/// agent created earlier this session.
+/// Tool definition for `remove`: delete a file the agent created earlier this
+/// session, with a required rationale recorded for auditing.
 ///
 /// This fills the one gap in the tool-mediated file API — `read`/`write`/`edit`
-/// exist, but there was no in-workflow way to delete a source file, because the
-/// shell sandbox blocks `rm` on source paths. `remove` is intentionally narrow:
-/// it deletes ONLY a source file the session's `FileStateMap` records as
-/// `Created`, i.e. one the agent itself created this session, so removing it
-/// merely undoes the agent's own work. A pre-existing source file (one the agent
-/// did not create this session) is refused — change it with `edit`, or delete it
-/// outside the agent.
+/// exist, but there was no in-workflow way to delete a file. `remove` is
+/// intentionally narrow: it deletes ONLY a file the session's `FileStateMap`
+/// records as `Created` — one the agent itself created this session — so removing
+/// it merely undoes the agent's own work. A pre-existing file (one the agent did
+/// not create this session) is refused. It handles any file type: it is the only
+/// way to delete a source file (the shell sandbox blocks `rm` on source paths),
+/// and the gated path for other files too — a deletion here is provenance-checked
+/// where a `shell` `rm` is not. Deleting a `.mbt`/`.mbt.md` file runs `moon
+/// check`, so a break it causes shows up in the result as after `write`/`edit`.
+/// Each removal carries a required `reason`, recorded in the (durable) result so
+/// a destructive action can be audited later.
 ///
-/// `Created` is advisory, not a bare delete capability (see `FileStateMap`).
-/// Three things keep the gate honest: this tool drops the provenance when it
-/// removes a file (`forget`), so a path recreated after a removal is no longer
-/// seen as agent-created; the kind check does not follow symlinks, so a source
-/// path replaced by a link is refused rather than followed; and the shell
-/// sandbox blocks writing or moving onto a source path, so an un-removed
-/// `Created` source file cannot be rebound through the shell. The narrow
-/// residual — an external process replacing an un-removed `Created` file in
-/// place — is left to a later hardening (stored file identity, or soft-delete).
-/// The map is keyed by the same resolved path `write` used, so an unrecognized
-/// spelling reads as unknown and is conservatively refused.
+/// `Created` is advisory, not a bare delete capability (see `FileStateMap`). Two
+/// guards keep the gate honest: this tool drops the provenance when it removes a
+/// file (`forget`), so a path recreated after a removal is no longer seen as
+/// agent-created; and the kind check does not follow symlinks, so a path replaced
+/// by a link is refused rather than followed. The map is keyed by the same
+/// resolved path `write` used, so an unrecognized spelling reads as unknown and
+/// is conservatively refused. The narrow residual — an external process replacing
+/// an un-removed `Created` file in place — is left to a later hardening (stored
+/// file identity, or soft-delete).
 ///
 /// ## Result
-/// - `Respond(ToolOutput("ok: removed <path>"))` when the file is deleted.
+/// - `Respond(ToolOutput("ok: removed <path> (reason: <reason>)"))` when the file
+///   is deleted; a `.mbt`/`.mbt.md` removal also appends module `moon check`
+///   feedback.
 /// - `Respond(ToolOutput("error removing <path>: <reason>", is_error=true))` for
-///   a non-source path, a missing file, a directory, a file the agent did not
-///   create this session, or a filesystem failure.
+///   a missing file, a non-regular file, a file the agent did not create this
+///   session, or a filesystem failure.
 /// - `Respond(ToolOutput("error: remove requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition(
@@ -36,11 +40,17 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="remove",
-    description="Delete a .mbt or .mbt.md source file that the agent created earlier THIS session (tracked in the session's file-state record). Only a source file the agent itself created this session can be removed — a pre-existing one is refused, since deleting it could lose work the agent never made; change existing source with edit/multi_edit, and delete non-source files with shell. The path must name an existing regular .mbt/.mbt.md file. This is the only in-workflow way to delete a source file: the shell sandbox blocks rm on source paths.",
+    description="Delete a file the agent created earlier THIS session (tracked in the session's file-state record). Only a file the agent itself created this session can be removed — a pre-existing file is refused, since deleting it could lose work the agent never made; change existing source with edit/multi_edit. Handles any file type: the only in-workflow way to delete a source file (the shell sandbox blocks rm on source paths), and the provenance-gated path for other files too. Deleting a .mbt/.mbt.md file runs moon check so any break it causes is reported. Requires a short `reason` explaining why the file is deleted — it is recorded with the result for auditing this destructive action. The path must name an existing regular file.",
     schema=JsonSchema({
       "type": "object",
-      "properties": { "path": { "type": "string" } },
-      "required": ["path"],
+      "properties": {
+        "path": { "type": "string" },
+        "reason": {
+          "type": "string",
+          "description": "A short explanation of why this file is being deleted, recorded in the result so a destructive action can be audited later.",
+        },
+      },
+      "required": ["path", "reason"],
     }),
     execute=Async(arguments => {
       execute_with_workspace(workspace_root, file_state, arguments)
@@ -54,7 +64,7 @@ async fn execute_with_workspace(
   file_state : @agent_tool.FileStateMap,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
-  let requested = decode_path(arguments) catch {
+  let input = @decode.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
       return @agent_tool.ToolAction::respond(
@@ -63,29 +73,14 @@ async fn execute_with_workspace(
       )
     }
   }
-  let path = @workspace_path.resolve(workspace_root, requested)
-  remove_file(path, requested, file_state)
-}
-
-///|
-/// Decode the `remove` arguments: a single required `path` string. Names the
-/// offending field (`arguments.path` / `object arguments`) so the model is told
-/// exactly what to fix.
-fn decode_path(arguments : Json) -> String raise {
-  match arguments {
-    Object(fields) =>
-      match fields.get("path") {
-        Some(String(path)) => path
-        _ => fail("arguments.path")
-      }
-    _ => fail("object arguments")
-  }
+  let path = @workspace_path.resolve(workspace_root, input.path)
+  remove_file(path, input, file_state)
 }
 
 ///|
 async fn remove_file(
   path : String,
-  requested : String,
+  input : @decode.RemoveInput,
   file_state : @agent_tool.FileStateMap,
 ) -> @agent_tool.ToolAction {
   let fail_brief = "remove \{@agent_tool.brief_basename(path)}"
@@ -97,14 +92,6 @@ async fn remove_file(
     )
   }
 
-  // Scope: source files only. The shell sandbox does not block `rm` on
-  // non-source files, so those are deleted with shell; this tool exists for the
-  // source gap alone.
-  if !is_mbt_source(path) {
-    return err(
-      "remove handles .mbt/.mbt.md source files; delete other files with shell",
-    )
-  }
   let exists = @fs.exists(path) catch {
     error if @async.is_being_cancelled() => raise error
     error => return err("\{error}")
@@ -112,9 +99,9 @@ async fn remove_file(
   if !exists {
     return err("no such file")
   }
-  // Classify the final component WITHOUT following a symlink: a path that was a
-  // source file when `write` recorded it but has since been replaced by a
-  // symlink must be refused, not followed to whatever it now points at.
+  // Classify the final component WITHOUT following a symlink: a path replaced by
+  // a symlink since `write` recorded it must be refused, not followed to whatever
+  // it now points at.
   let kind = @fs.kind(path, follow_symlink=false) catch {
     error if @async.is_being_cancelled() => raise error
     error => return err("\{error}")
@@ -122,35 +109,32 @@ async fn remove_file(
   guard kind is Regular else {
     return err("not a regular file; remove deletes regular files")
   }
-  // The gate: only a source file the agent CREATED this session may be removed.
-  // `record_modified` never downgrades `Created`, so a file the agent created
-  // and then edited still qualifies; a file it only modified, or never touched,
-  // does not.
+  // The gate: only a file the agent CREATED this session may be removed.
+  // `record_modified` never downgrades `Created`, so a file the agent created and
+  // then edited still qualifies; a file it only modified, or never touched, does
+  // not.
   guard file_state.get(path) is Some(Created) else {
     return err(
-      "not created by the agent this session — only a .mbt/.mbt.md file the agent itself created this session can be removed; change existing source with edit/multi_edit, or delete it outside the agent",
+      "not created by the agent this session — only a file the agent itself created this session can be removed; change existing source with edit/multi_edit",
     )
   }
   @fs.remove(path) catch {
     error if @async.is_being_cancelled() => raise error
     error => return err("\{error}")
   }
-  // Drop the provenance so a path recreated after this removal is not treated
-  // as still agent-created — otherwise a later remove could delete a different
-  // file that happens to land at the same path.
+  // Drop the provenance so a path recreated after this removal is not treated as
+  // still agent-created — otherwise a later remove could delete a different file
+  // that happens to land at the same path.
   file_state.forget(path)
+  // Record the rationale in the (durable) result for auditing, and append module
+  // `moon check` feedback when a source file was removed — a deletion can break
+  // the build just as an edit can.
+  let summary = "ok: removed \{path} (reason: \{input.reason})"
+  let content = @auto_check.append_summary(path, summary)
   @agent_tool.ToolAction::respond(
-    "ok: removed \{path}",
-    brief=@agent_tool.brief_line("removed \{requested}"),
+    content,
+    brief=@agent_tool.brief_line("removed \{input.path}"),
   )
-}
-
-///|
-/// Whether `path` is a hand-written MoonBit source file (`.mbt` or `.mbt.md`) —
-/// the same set `write` refuses to overwrite and the shell sandbox blocks `rm`
-/// on. `.mbti` and manifests are intentionally out of scope for now.
-fn is_mbt_source(path : String) -> Bool {
-  path.has_suffix(".mbt") || path.has_suffix(".mbt.md")
 }
 
 ///|
@@ -167,7 +151,7 @@ async fn run_remove(
 }
 
 ///|
-async test "remove deletes a source file the agent created this session" {
+async test "remove deletes a file the agent created this session, recording why" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/scratch.mbt"
     @fs.write_file(
@@ -178,10 +162,17 @@ async test "remove deletes a source file the agent created this session" {
     // The map records the create, as `write` would have.
     let state = @agent_tool.FileStateMap::new()
     state.record_created(path)
-    let result = run_remove(state, { "path": path })
+    let result = run_remove(state, {
+      "path": path,
+      "reason": "scratch no longer needed",
+    })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    assert_eq(output.content, "ok: removed \{path}")
+    // The rationale is recorded in the durable result for auditing.
+    assert_eq(
+      output.content,
+      "ok: removed \{path} (reason: scratch no longer needed)",
+    )
     assert_false(@fs.exists(path))
   })
 }
@@ -199,7 +190,7 @@ async test "remove keeps deleting a created file it later edited" {
     // Created then modified this session: record_modified must not downgrade it.
     state.record_created(path)
     state.record_modified(path)
-    let result = run_remove(state, { "path": path })
+    let result = run_remove(state, { "path": path, "reason": "undo" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_false(@fs.exists(path))
@@ -207,7 +198,23 @@ async test "remove keeps deleting a created file it later edited" {
 }
 
 ///|
-async test "remove refuses a pre-existing source file it did not create" {
+async test "remove deletes a non-source file the agent created" {
+  @vfs.with_tmpdir(dir => {
+    // The gate is provenance, not file type: a created .txt is deletable too
+    // (and this path is gated, unlike a bare shell `rm`).
+    let path = "\{dir}/notes.txt"
+    @fs.write_file(path, "scratch", create_mode=CreateOrTruncate)
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    let result = run_remove(state, { "path": path, "reason": "temp file" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_false(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove refuses a pre-existing file it did not create" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/lib.mbt"
     @fs.write_file(
@@ -217,19 +224,18 @@ async test "remove refuses a pre-existing source file it did not create" {
     )
     // Empty state: the agent did not create this file this session.
     let state = @agent_tool.FileStateMap::new()
-    let result = run_remove(state, { "path": path })
+    let result = run_remove(state, { "path": path, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("not created by the agent this session"),
     )
-    // The file is untouched.
     assert_true(@fs.exists(path))
   })
 }
 
 ///|
-async test "remove refuses a source file the agent only modified" {
+async test "remove refuses a file the agent only modified" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/edited.mbt"
     @fs.write_file(
@@ -239,28 +245,12 @@ async test "remove refuses a source file the agent only modified" {
     )
     let state = @agent_tool.FileStateMap::new()
     state.record_modified(path)
-    let result = run_remove(state, { "path": path })
+    let result = run_remove(state, { "path": path, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
       output.content.contains("not created by the agent this session"),
     )
-    assert_true(@fs.exists(path))
-  })
-}
-
-///|
-async test "remove rejects a non-source path" {
-  @vfs.with_tmpdir(dir => {
-    let path = "\{dir}/notes.txt"
-    @fs.write_file(path, "scratch", create_mode=CreateOrTruncate)
-    // Even a Created non-source file is out of scope: shell can rm those.
-    let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
-    let result = run_remove(state, { "path": path })
-    guard result is Respond(output) else { fail("expected Respond") }
-    assert_true(output.is_error)
-    assert_true(output.content.contains("delete other files with shell"))
     assert_true(@fs.exists(path))
   })
 }
@@ -271,7 +261,7 @@ async test "remove reports a missing file" {
     let path = "\{dir}/ghost.mbt"
     let state = @agent_tool.FileStateMap::new()
     state.record_created(path)
-    let result = run_remove(state, { "path": path })
+    let result = run_remove(state, { "path": path, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("no such file"))
@@ -285,7 +275,7 @@ async test "remove refuses a directory" {
     @fs.mkdir(path, recursive=true)
     let state = @agent_tool.FileStateMap::new()
     state.record_created(path)
-    let result = run_remove(state, { "path": path })
+    let result = run_remove(state, { "path": path, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("not a regular file"))
@@ -305,7 +295,7 @@ async test "remove refuses a path recreated after an earlier removal" {
     let state = @agent_tool.FileStateMap::new()
     state.record_created(path)
     // The first removal succeeds and drops the provenance.
-    let first = run_remove(state, { "path": path })
+    let first = run_remove(state, { "path": path, "reason": "undo" })
     guard first is Respond(ok) else { fail("expected Respond") }
     assert_false(ok.is_error)
     assert_false(@fs.exists(path))
@@ -316,7 +306,7 @@ async test "remove refuses a path recreated after an earlier removal" {
       create_mode=CreateOrTruncate,
     )
     // The stale Created must not authorize deleting this different file.
-    let second = run_remove(state, { "path": path })
+    let second = run_remove(state, { "path": path, "reason": "undo again" })
     guard second is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(
@@ -327,7 +317,7 @@ async test "remove refuses a path recreated after an earlier removal" {
 }
 
 ///|
-async test "remove refuses a source path replaced by a symlink" {
+async test "remove refuses a path replaced by a symlink" {
   @vfs.with_tmpdir(dir => {
     let target = "\{dir}/target.mbt"
     @fs.write_file(
@@ -335,12 +325,12 @@ async test "remove refuses a source path replaced by a symlink" {
       "pub fn t() -> Int { 0 }\n",
       create_mode=CreateOrTruncate,
     )
-    // The .mbt path the agent created is now a symlink to another file.
+    // The path the agent created is now a symlink to another file.
     let link = "\{dir}/alias.mbt"
     @fs.symlink(target~, link)
     let state = @agent_tool.FileStateMap::new()
     state.record_created(link)
-    let result = run_remove(state, { "path": link })
+    let result = run_remove(state, { "path": link, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("not a regular file"))
@@ -354,8 +344,28 @@ async test "remove refuses a source path replaced by a symlink" {
 ///|
 async test "remove rejects missing path" {
   let state = @agent_tool.FileStateMap::new()
-  let result = run_remove(state, { "note": "no path here" })
+  let result = run_remove(state, { "reason": "cleanup" })
   guard result is Respond(output) else { fail("expected Respond") }
   assert_eq(output.content, "error: remove requires arguments.path")
   assert_true(output.is_error)
+}
+
+///|
+async test "remove rejects a missing reason" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/x.mbt"
+    @fs.write_file(
+      path,
+      "pub fn x() -> Int { 0 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    // A destructive action must carry a rationale — no delete without one.
+    let result = run_remove(state, { "path": path })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(output.content, "error: remove requires arguments.reason")
+    assert_true(output.is_error)
+    assert_true(@fs.exists(path))
+  })
 }

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -11,12 +11,17 @@
 /// did not create this session) is refused — change it with `edit`, or delete it
 /// outside the agent.
 ///
-/// The `Created` gate is sound for source files without a soft-delete: the
-/// sandbox blocks the shell from writing or moving onto a source path, so a
-/// recorded source path cannot be rebound to a different file after `write`
-/// recorded it. The map is keyed by the same resolved path `write` used, so the
-/// lookup matches the recording spelling-for-spelling (an equivalent spelling
-/// reads as unknown and is conservatively refused).
+/// `Created` is advisory, not a bare delete capability (see `FileStateMap`).
+/// Three things keep the gate honest: this tool drops the provenance when it
+/// removes a file (`forget`), so a path recreated after a removal is no longer
+/// seen as agent-created; the kind check does not follow symlinks, so a source
+/// path replaced by a link is refused rather than followed; and the shell
+/// sandbox blocks writing or moving onto a source path, so an un-removed
+/// `Created` source file cannot be rebound through the shell. The narrow
+/// residual — an external process replacing an un-removed `Created` file in
+/// place — is left to a later hardening (stored file identity, or soft-delete).
+/// The map is keyed by the same resolved path `write` used, so an unrecognized
+/// spelling reads as unknown and is conservatively refused.
 ///
 /// ## Result
 /// - `Respond(ToolOutput("ok: removed <path>"))` when the file is deleted.
@@ -107,10 +112,10 @@ async fn remove_file(
   if !exists {
     return err("no such file")
   }
-  // `kind` does not follow the final symlink, so a symlink named `x.mbt` reports
-  // `SymLink` (not a source file to delete through) and, were it removed, only
-  // the link would be unlinked — its target untouched.
-  let kind = @fs.kind(path) catch {
+  // Classify the final component WITHOUT following a symlink: a path that was a
+  // source file when `write` recorded it but has since been replaced by a
+  // symlink must be refused, not followed to whatever it now points at.
+  let kind = @fs.kind(path, follow_symlink=false) catch {
     error if @async.is_being_cancelled() => raise error
     error => return err("\{error}")
   }
@@ -130,6 +135,10 @@ async fn remove_file(
     error if @async.is_being_cancelled() => raise error
     error => return err("\{error}")
   }
+  // Drop the provenance so a path recreated after this removal is not treated
+  // as still agent-created — otherwise a later remove could delete a different
+  // file that happens to land at the same path.
+  file_state.forget(path)
   @agent_tool.ToolAction::respond(
     "ok: removed \{path}",
     brief=@agent_tool.brief_line("removed \{requested}"),
@@ -281,6 +290,64 @@ async test "remove refuses a directory" {
     assert_true(output.is_error)
     assert_true(output.content.contains("not a regular file"))
     assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove refuses a path recreated after an earlier removal" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/redo.mbt"
+    @fs.write_file(
+      path,
+      "pub fn a() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    // The first removal succeeds and drops the provenance.
+    let first = run_remove(state, { "path": path })
+    guard first is Respond(ok) else { fail("expected Respond") }
+    assert_false(ok.is_error)
+    assert_false(@fs.exists(path))
+    // Something OTHER than the agent's tools recreates the same path.
+    @fs.write_file(
+      path,
+      "pub fn b() -> Int { 2 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // The stale Created must not authorize deleting this different file.
+    let second = run_remove(state, { "path": path })
+    guard second is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(
+      output.content.contains("not created by the agent this session"),
+    )
+    assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove refuses a source path replaced by a symlink" {
+  @vfs.with_tmpdir(dir => {
+    let target = "\{dir}/target.mbt"
+    @fs.write_file(
+      target,
+      "pub fn t() -> Int { 0 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // The .mbt path the agent created is now a symlink to another file.
+    let link = "\{dir}/alias.mbt"
+    @fs.symlink(target~, link)
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(link)
+    let result = run_remove(state, { "path": link })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("not a regular file"))
+    // The kind check does not follow the link, so neither it nor its target is
+    // removed.
+    assert_true(@fs.exists(link))
+    assert_true(@fs.exists(target))
   })
 }
 

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -48,11 +48,14 @@ full diagnostics.
     changes fall on the same line (or in one tight span), combine them into a
     single edit whose `old_string` covers the whole span — adjacent edits
     collide and the batch is rejected.
-  - `remove` deletes a `.mbt`/`.mbt.md` source file you created earlier this
-    session (shell cannot `rm` source files). It refuses a pre-existing source
-    file — one you did not create this session — so it only ever undoes your own
-    work; change existing source with `edit`, and delete non-source files with
-    `shell`.
+  - `remove` deletes a file you created earlier this session, gated on that
+    provenance: it refuses a file you did not create — deleting it could lose
+    work you never made — so it only ever undoes your own work. It is the only
+    way to delete a source file (shell cannot `rm` source) and the
+    provenance-checked path for any other file too; a `.mbt`/`.mbt.md` removal
+    runs `moon check` so a break it causes is reported. Pass a short `reason` —
+    it is recorded with the result for auditing. Change existing source with
+    `edit`, not by removing and rewriting.
   - To add NEW top-level code (functions, tests, types) to an existing file,
     append at end of file: `edit` with an empty `old_string` and any
     `start_line` past the last line (e.g. 999999) — top-level order does not

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -40,14 +40,19 @@ full diagnostics.
   ignore it for trivial work — never answer it with assistant text or call
   `plan` only to silence it.
 - Use the right tool for the job:
-  - `read`, `edit`, `multi_edit`, and `write` for files. Use `edit` for a single
-    span; use `multi_edit` to apply several line-anchored fixes to one file in
-    one call. To fix several files at once, issue one `multi_edit` per file in
-    the same step rather than editing files one turn at a time. Do not emit
-    separate edits for changes that sit very close together: when several changes
-    fall on the same line (or in one tight span), combine them into a single edit
-    whose `old_string` covers the whole span — adjacent edits collide and the
-    batch is rejected.
+  - `read`, `edit`, `multi_edit`, `write`, and `remove` for files. Use `edit` for
+    a single span; use `multi_edit` to apply several line-anchored fixes to one
+    file in one call. To fix several files at once, issue one `multi_edit` per
+    file in the same step rather than editing files one turn at a time. Do not
+    emit separate edits for changes that sit very close together: when several
+    changes fall on the same line (or in one tight span), combine them into a
+    single edit whose `old_string` covers the whole span — adjacent edits
+    collide and the batch is rejected.
+  - `remove` deletes a `.mbt`/`.mbt.md` source file you created earlier this
+    session (shell cannot `rm` source files). It refuses a pre-existing source
+    file — one you did not create this session — so it only ever undoes your own
+    work; change existing source with `edit`, and delete non-source files with
+    `shell`.
   - To add NEW top-level code (functions, tests, types) to an existing file,
     append at end of file: `edit` with an empty `old_string` and any
     `start_line` past the last line (e.g. 999999) — top-level order does not

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -53,11 +53,14 @@ fn default_prompt() -> String {
     #|    changes fall on the same line (or in one tight span), combine them into a
     #|    single edit whose `old_string` covers the whole span — adjacent edits
     #|    collide and the batch is rejected.
-    #|  - `remove` deletes a `.mbt`/`.mbt.md` source file you created earlier this
-    #|    session (shell cannot `rm` source files). It refuses a pre-existing source
-    #|    file — one you did not create this session — so it only ever undoes your own
-    #|    work; change existing source with `edit`, and delete non-source files with
-    #|    `shell`.
+    #|  - `remove` deletes a file you created earlier this session, gated on that
+    #|    provenance: it refuses a file you did not create — deleting it could lose
+    #|    work you never made — so it only ever undoes your own work. It is the only
+    #|    way to delete a source file (shell cannot `rm` source) and the
+    #|    provenance-checked path for any other file too; a `.mbt`/`.mbt.md` removal
+    #|    runs `moon check` so a break it causes is reported. Pass a short `reason` —
+    #|    it is recorded with the result for auditing. Change existing source with
+    #|    `edit`, not by removing and rewriting.
     #|  - To add NEW top-level code (functions, tests, types) to an existing file,
     #|    append at end of file: `edit` with an empty `old_string` and any
     #|    `start_line` past the last line (e.g. 999999) — top-level order does not

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -45,14 +45,19 @@ fn default_prompt() -> String {
     #|  ignore it for trivial work — never answer it with assistant text or call
     #|  `plan` only to silence it.
     #|- Use the right tool for the job:
-    #|  - `read`, `edit`, `multi_edit`, and `write` for files. Use `edit` for a single
-    #|    span; use `multi_edit` to apply several line-anchored fixes to one file in
-    #|    one call. To fix several files at once, issue one `multi_edit` per file in
-    #|    the same step rather than editing files one turn at a time. Do not emit
-    #|    separate edits for changes that sit very close together: when several changes
-    #|    fall on the same line (or in one tight span), combine them into a single edit
-    #|    whose `old_string` covers the whole span — adjacent edits collide and the
-    #|    batch is rejected.
+    #|  - `read`, `edit`, `multi_edit`, `write`, and `remove` for files. Use `edit` for
+    #|    a single span; use `multi_edit` to apply several line-anchored fixes to one
+    #|    file in one call. To fix several files at once, issue one `multi_edit` per
+    #|    file in the same step rather than editing files one turn at a time. Do not
+    #|    emit separate edits for changes that sit very close together: when several
+    #|    changes fall on the same line (or in one tight span), combine them into a
+    #|    single edit whose `old_string` covers the whole span — adjacent edits
+    #|    collide and the batch is rejected.
+    #|  - `remove` deletes a `.mbt`/`.mbt.md` source file you created earlier this
+    #|    session (shell cannot `rm` source files). It refuses a pre-existing source
+    #|    file — one you did not create this session — so it only ever undoes your own
+    #|    work; change existing source with `edit`, and delete non-source files with
+    #|    `shell`.
     #|  - To add NEW top-level code (functions, tests, types) to an existing file,
     #|    append at end of file: `edit` with an empty `old_string` and any
     #|    `start_line` past the last line (e.g. 999999) — top-level order does not


### PR DESCRIPTION
**PR 2 of 2** (builds on the `FileStateMap` from #465). Completes the tool-mediated file API: `read`/`write`/`edit` existed, but **delete did not** — the shell sandbox blocks `rm` on source paths, so there was no in-workflow way to delete a source file.

## What

`remove` deletes a `.mbt`/`.mbt.md` file **only** when the session's `FileStateMap` records it as `Created` — i.e. one the agent itself created this session, so removing it merely undoes the agent's own work. It refuses:
- a pre-existing source file (never created, or only `Modified`),
- a non-source path (→ delete with `shell`),
- a missing file or a directory.

## Why the `Created` gate is sound without soft-delete

The sandbox **blocks the shell from writing or moving onto a source path** (`SandboxSourceWriteFeedback`, `source_tree_mv_target`), so a source path recorded `Created` **cannot be rebound** to a different file after `write` recorded it — the rebind attack that would otherwise defeat a path-keyed provenance signal is closed for source files specifically. The map is keyed by the same resolved path `write` used, so an unrecognized spelling reads as unknown and is conservatively refused (never a false delete).

## Integration

- Wired into `build_tools`, sharing the session `file_state` with `write`/`edit`/`multi_edit`.
- Registered in the dispatch registry (registry tests + the ordered README doc-test updated).
- Taught in the default prompt's tool-routing section.
- 8 tests: create→remove, created-then-edited still removable, refuse pre-existing / modified-only / non-source / missing / directory, and arg validation.

## Deferred (noted for follow-up)

A git-tracked fallback (to allow removing pre-existing *tracked* files during refactors — recoverable via git), soft-delete into a session trash, and manifest/`.mbti` scope.

## Verification

`moon check --deny-warn --target native` clean across the workspace; `moon test` green (remove **8/8**, agent registry + prompt included, **94/94** in that set); `moon info` mbti is additive-only; `moon fmt` applied; prompt regenerated via the build rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)