### PR TITLE
Use strip_prefix for prefix parsing

### DIFF
--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -96,10 +96,10 @@ pub fn goal_marker(content : String) -> GoalMarker? {
     Some(GoalCleared)
   } else if content == GoalUnblockedNotice {
     Some(GoalUnblocked)
-  } else if content.has_prefix("\{GoalBlockedPrefix}\n") {
-    Some(GoalBlocked(content[GoalBlockedPrefix.length() + 1:].to_owned()))
-  } else if content.has_prefix("\{GoalPrefix}\n") {
-    Some(GoalSet(content[GoalPrefix.length() + 1:].to_owned()))
+  } else if content.strip_prefix("\{GoalBlockedPrefix}\n") is Some(content) {
+    Some(GoalBlocked(content.to_owned()))
+  } else if content.strip_prefix("\{GoalPrefix}\n") is Some(content) {
+    Some(GoalSet(content.to_owned()))
   } else {
     None
   }

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -98,10 +98,12 @@ fn sed_option_consumes_next(arg : String) -> Bool {
   if arg == "--expression" || arg == "--file" {
     return true
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    !options.is_empty() else {
     return false
   }
-  for view = arg[1:] {
+  for view = options {
     match view {
       // `e`/`f` consume the remainder of the token; if they are the last char,
       // the value is the next word.
@@ -134,10 +136,12 @@ fn is_sed_in_place_flag(arg : String) -> Bool {
   if arg == "--in-place" || arg.has_prefix("--in-place=") {
     return true
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    !options.is_empty() else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'i' => return true
       'e' | 'f' => return false

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -346,8 +346,8 @@ fn global_no_arg_option(arg : String) -> Bool {
 
 ///|
 fn attached_cwd_option(arg : String) -> String? {
-  if arg.has_prefix("-C") && arg != "-C" {
-    Some(arg[2:].to_owned())
+  if arg.strip_prefix("-C") is Some(value) && !value.is_empty() {
+    Some(value.to_owned())
   } else {
     None
   }
@@ -355,8 +355,8 @@ fn attached_cwd_option(arg : String) -> String? {
 
 ///|
 fn attached_work_tree_option(arg : String) -> String? {
-  if arg.has_prefix("--work-tree=") {
-    Some(arg["--work-tree=".length():].to_owned())
+  if arg.strip_prefix("--work-tree=") is Some(value) {
+    Some(value.to_owned())
   } else {
     None
   }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -2138,8 +2138,8 @@ fn command_word_matches_one_heredoc_target(
 ///|
 fn strip_leading_dot_slash(path : String) -> String {
   let mut result = path
-  while result.has_prefix("./") {
-    result = result[2:].to_owned()
+  while result.strip_prefix("./") is Some(rest) {
+    result = rest.to_owned()
   }
   result
 }
@@ -2879,21 +2879,27 @@ fn parse_powershell_path_operands(
 
 ///|
 fn powershell_attached_parameter(arg : String) -> (String, String)? {
-  guard arg.has_prefix("-") && arg != "-" else { return None }
-  match arg.find(":") {
-    Some(colon) if colon > 1 =>
-      Some((arg[1:colon].to_owned().to_lower(), arg[colon + 1:].to_owned()))
+  guard arg.strip_prefix("-") is Some(parameter) && !parameter.is_empty() else {
+    return None
+  }
+  match parameter.find(":") {
+    Some(colon) if colon > 0 =>
+      Some(
+        (
+          parameter[:colon].to_owned().to_lower(),
+          parameter[colon + 1:].to_owned(),
+        ),
+      )
     _ => None
   }
 }
 
 ///|
 fn powershell_parameter_name(arg : String) -> String? {
-  if !arg.has_prefix("-") || arg == "-" {
-    None
-  } else {
-    Some(arg[1:].to_owned().to_lower())
+  guard arg.strip_prefix("-") is Some(name) && !name.is_empty() else {
+    return None
   }
+  Some(name.to_owned().to_lower())
 }
 
 ///|
@@ -3104,10 +3110,12 @@ fn shell_attached_value_option(arg : String) -> Bool {
 
 ///|
 fn shell_short_option_cluster_has_c(arg : String) -> Bool {
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg.length() <= 2 {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    options.length() > 1 else {
     return false
   }
-  arg[1:].contains("c")
+  options.contains("c")
 }
 
 ///|
@@ -3612,10 +3620,12 @@ fn sed_option_supplies_script(arg : String) -> Bool {
     arg.has_prefix("--file=") {
     return true
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    !options.is_empty() else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'e' | 'f' => return true
       'i' => return false
@@ -3627,10 +3637,12 @@ fn sed_option_supplies_script(arg : String) -> Bool {
 
 ///|
 fn sed_readonly_option(arg : String) -> Bool {
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    !options.is_empty() else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'n' | 'E' | 'r' | 's' | 'u' | 'l' => ()
       _ => return false
@@ -3730,8 +3742,8 @@ fn awk_option_is_inline_program(arg : String) -> Bool {
 
 ///|
 fn awk_attached_inline_program(arg : String) -> String? {
-  if arg.has_prefix("--source=") {
-    Some(arg["--source=".length():].to_owned())
+  if arg.strip_prefix("--source=") is Some(program) {
+    Some(program.to_owned())
   } else {
     None
   }
@@ -4512,12 +4524,14 @@ fn mkdir_attached_value_option(arg : String) -> Bool {
   if arg.has_prefix("--mode=") || arg.has_prefix("--context=") {
     return true
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg.length() <= 2 {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    options.length() > 1 else {
     return false
   }
-  for index, ch in arg[1:] {
+  for index, ch in options {
     if ch == 'm' || ch == 'Z' {
-      return index + 2 < arg.length()
+      return index + 1 < options.length()
     }
   }
   false
@@ -4532,10 +4546,10 @@ fn mkdir_supported_no_arg_option(arg : String) -> Bool {
     "--parents" | "--verbose" => return true
     _ => ()
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") {
+  guard arg.strip_prefix("-") is Some(options) && !options.has_prefix("-") else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'p' | 'v' => ()
       _ => return false
@@ -4597,10 +4611,10 @@ fn mv_option_consumes_next(arg : String) -> Bool {
 
 ///|
 fn mv_attached_target_directory_option(arg : String) -> String? {
-  if arg.has_prefix("-t") && arg.length() > 2 {
-    Some(arg[2:].to_owned())
-  } else if arg.has_prefix("--target-directory=") {
-    Some(arg["--target-directory=".length():].to_owned())
+  if arg.strip_prefix("-t") is Some(target) && !target.is_empty() {
+    Some(target.to_owned())
+  } else if arg.strip_prefix("--target-directory=") is Some(target) {
+    Some(target.to_owned())
   } else {
     None
   }
@@ -4627,10 +4641,10 @@ fn mv_supported_no_arg_option(arg : String) -> Bool {
     | "--verbose" => return true
     _ => ()
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") {
+  guard arg.strip_prefix("-") is Some(options) && !options.has_prefix("-") else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'b' | 'f' | 'i' | 'n' | 'v' | 'T' | 'u' | 'Z' => ()
       _ => return false
@@ -4760,10 +4774,10 @@ fn cp_option_consumes_next(arg : String) -> Bool {
 
 ///|
 fn cp_attached_target_directory_option(arg : String) -> String? {
-  if arg.has_prefix("-t") && arg.length() > 2 {
-    Some(arg[2:].to_owned())
-  } else if arg.has_prefix("--target-directory=") {
-    Some(arg["--target-directory=".length():].to_owned())
+  if arg.strip_prefix("-t") is Some(target) && !target.is_empty() {
+    Some(target.to_owned())
+  } else if arg.strip_prefix("--target-directory=") is Some(target) {
+    Some(target.to_owned())
   } else {
     None
   }
@@ -4800,10 +4814,10 @@ fn cp_supported_no_arg_option(arg : String) -> Bool {
     | "--one-file-system" => return true
     _ => ()
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") {
+  guard arg.strip_prefix("-") is Some(options) && !options.has_prefix("-") else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'R'
       | 'r'
@@ -4956,10 +4970,10 @@ fn install_option_consumes_next(arg : String) -> Bool {
 
 ///|
 fn install_attached_target_directory_option(arg : String) -> String? {
-  if arg.has_prefix("-t") && arg.length() > 2 {
-    Some(arg[2:].to_owned())
-  } else if arg.has_prefix("--target-directory=") {
-    Some(arg["--target-directory=".length():].to_owned())
+  if arg.strip_prefix("-t") is Some(target) && !target.is_empty() {
+    Some(target.to_owned())
+  } else if arg.strip_prefix("--target-directory=") is Some(target) {
+    Some(target.to_owned())
   } else {
     None
   }
@@ -4997,11 +5011,13 @@ fn install_short_cluster_ends_with_consuming_option(arg : String) -> Bool {
 
 ///|
 fn install_short_cluster_consuming_option_index(arg : String) -> Int? {
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg.length() <= 2 {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    options.length() > 1 else {
     return None
   }
   let mut index = 1
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'g' | 'm' | 'o' | 'S' => return Some(index)
       'C' | 'D' | 'd' | 'p' | 's' | 'v' => ()
@@ -5014,10 +5030,10 @@ fn install_short_cluster_consuming_option_index(arg : String) -> Int? {
 
 ///|
 fn install_short_option_cluster_has(arg : String, needle : Char) -> Bool {
-  if !arg.has_prefix("-") || arg.has_prefix("--") {
+  guard arg.strip_prefix("-") is Some(options) && !options.has_prefix("-") else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     if ch == needle {
       return true
     }
@@ -5041,10 +5057,10 @@ fn install_supported_no_arg_option(arg : String) -> Bool {
     | "--verbose" => return true
     _ => ()
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") {
+  guard arg.strip_prefix("-") is Some(options) && !options.has_prefix("-") else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'C' | 'D' | 'd' | 'p' | 's' | 'v' => ()
       _ => return false
@@ -5154,10 +5170,12 @@ fn touch_supported_no_arg_option(arg : String) -> Bool {
     "--no-create" | "--no-dereference" | "--help" | "--version" => return true
     _ => ()
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") || arg == "-" {
+  guard arg.strip_prefix("-") is Some(options) &&
+    !options.has_prefix("-") &&
+    !options.is_empty() else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'a' | 'c' | 'm' | 'h' | 'f' => ()
       _ => return false
@@ -5225,10 +5243,10 @@ fn tee_supported_no_arg_option(arg : String) -> Bool {
     "--append" | "--ignore-interrupts" | "--help" | "--version" => return true
     _ => ()
   }
-  if !arg.has_prefix("-") || arg.has_prefix("--") {
+  guard arg.strip_prefix("-") is Some(options) && !options.has_prefix("-") else {
     return false
   }
-  for ch in arg[1:] {
+  for ch in options {
     match ch {
       'a' | 'i' | 'p' => ()
       _ => return false

--- a/cmd/tui/goal.mbt
+++ b/cmd/tui/goal.mbt
@@ -38,8 +38,9 @@ fn handle_goal_command(
     cmds.push(UpdateGoal(None))
     return
   }
-  if trimmed == "set" || trimmed.has_prefix("set ") {
-    let text = trimmed["set".length():].trim().to_owned()
+  if trimmed.strip_prefix("set") is Some(text) &&
+    (text.is_empty() || text.has_prefix(" ")) {
+    let text = text.trim().to_owned()
     if text.is_empty() {
       cmds.push(AppendItem(Error("usage: /goal set <text>")))
     } else {

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -995,8 +995,8 @@ fn path_basename(p : String) -> String {
 /// `./app` workspace is `.`, which would merge every direct workspace under one
 /// `.` heading.
 fn strip_dot_prefix(p : String) -> String {
-  if p.has_prefix("./") {
-    p[2:].to_owned()
+  if p.strip_prefix("./") is Some(p) {
+    p.to_owned()
   } else {
     p
   }

--- a/desktop/internal/lsp/framing.mbt
+++ b/desktop/internal/lsp/framing.mbt
@@ -20,8 +20,10 @@ fn frame_message(body : String) -> String {
 fn parse_content_length(line : String) -> Int? {
   let trimmed = line.trim(char_set="\r\n ")
   let prefix = "content-length:"
-  guard trimmed.to_lower().has_prefix(prefix) else { return None }
-  Some(@string.parse_int(trimmed[prefix.length():].trim(), base=10)) catch {
+  guard trimmed.to_lower().strip_prefix(prefix) is Some(length) else {
+    return None
+  }
+  Some(@string.parse_int(length.trim(), base=10)) catch {
     _ => None
   }
 }

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -70,18 +70,15 @@ async fn fake_registry(group : @async.TaskGroup[Unit]) -> String? {
         if path == "/api/v0/skills" {
           conn.send_response(200, "OK", extra_headers=json_headers)
           conn.write_string(catalog_body())
-        } else if path.has_prefix(SkillsPrefix) &&
-          skills.contains(path[SkillsPrefix.length():].to_owned()) {
+        } else if path.strip_prefix(SkillsPrefix) is Some(skill) &&
+          skills.contains(skill.to_owned()) {
           // The per-skill API only confirms the entry is a skill; the install
           // ignores the body.
           conn.send_response(200, "OK", extra_headers=json_headers)
           conn.write_string("{}")
-        } else if path.has_prefix(AssetsPrefix) &&
-          path.has_suffix(SkillMdSuffix) &&
-          skills.get(
-            path[AssetsPrefix.length():path.length() - SkillMdSuffix.length()].to_owned(),
-          )
-          is Some(true) {
+        } else if path.strip_prefix(AssetsPrefix) is Some(asset) &&
+          asset.strip_suffix(SkillMdSuffix) is Some(skill) &&
+          skills.get(skill.to_owned()) is Some(true) {
           conn.send_response(200, "OK")
           conn.write(skill_body)
         } else {

--- a/desktop/package/internal/moonbit/toolchain.mbt
+++ b/desktop/package/internal/moonbit/toolchain.mbt
@@ -261,8 +261,8 @@ async fn compiler_version(
     )
   }
   let version = output.text().trim().split(" ").collect()[0].to_owned()
-  if version.has_prefix("v") {
-    version[1:].to_owned()
+  if version.strip_prefix("v") is Some(version) {
+    version.to_owned()
   } else {
     version
   }


### PR DESCRIPTION
## Summary

- replace `has_prefix` plus manual string slicing with `strip_prefix` across goal parsing, command option parsing, path/version helpers, and LSP framing
- preserve owned-string boundaries by converting returned `StringView` values only where the receiving API requires `String`
- simplify compound skill-registry prefix/suffix extraction without duplicating length arithmetic

## Why

The original `agent_session` change correctly aimed to couple prefix validation with prefix removal, but `String::strip_prefix` returns `StringView?`; passing that view directly to `GoalSet` or `GoalBlocked` did not type-check. The same validation-then-slice pattern appeared elsewhere in the repository and could drift if a prefix changed without its matching index arithmetic.

This refactor makes successful matching produce the exact suffix consumed by each parser while preserving existing behavior.

## Impact

There is no public API or `.mbti` change. `agent_session` documentation is unchanged because goal marker syntax and behavior are unchanged.

## Validation

- `moon check --warn-list +73`
- `moon info && moon fmt` in the root, `cmd/viz_app`, and `desktop` modules
- root `moon test`
- desktop `moon test` (719 JS tests and 212 native tests passed)
- targeted affected-package tests for `agent_session`, shell policy, TUI, viz app, LSP, and skill market
