### PR TITLE
perf(shell): drop needless .to_owned() in command/git policy parsing

### DIFF
--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -155,7 +155,7 @@ fn is_sed_in_place_flag(arg : String) -> Bool {
 fn shell_words(cmd : String) -> Array[String] {
   let words : Array[String] = []
   for piece in cmd.split(" ") {
-    let word = clean_shell_word(piece.to_owned())
+    let word = clean_shell_word(piece)
     if word != "" {
       words.push(word)
     }
@@ -164,7 +164,7 @@ fn shell_words(cmd : String) -> Array[String] {
 }
 
 ///|
-fn clean_shell_word(word : String) -> String {
+fn clean_shell_word(word : StringView) -> String {
   "\{word.trim(chars="\t\r\n ").trim(chars=";&|()")}"
 }
 

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -345,18 +345,20 @@ fn global_no_arg_option(arg : String) -> Bool {
 }
 
 ///|
-fn attached_cwd_option(arg : String) -> String? {
+/// Returns a view into `arg` (not an owned copy): every caller only tests
+/// `is Some(_)`, so materializing the value would allocate for nothing.
+fn attached_cwd_option(arg : String) -> StringView? {
   if arg.strip_prefix("-C") is Some(value) && !value.is_empty() {
-    Some(value.to_owned())
+    Some(value)
   } else {
     None
   }
 }
 
 ///|
-fn attached_work_tree_option(arg : String) -> String? {
+fn attached_work_tree_option(arg : String) -> StringView? {
   if arg.strip_prefix("--work-tree=") is Some(value) {
-    Some(value.to_owned())
+    Some(value)
   } else {
     None
   }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1589,12 +1589,12 @@ fn command_text_env_assignment_word(word : String) -> Bool {
   if parts.length() < 2 {
     return false
   }
-  command_text_valid_env_name(parts[0].to_owned())
+  command_text_valid_env_name(parts[0])
 }
 
 ///|
-fn command_text_valid_env_name(name : String) -> Bool {
-  if name == "" {
+fn command_text_valid_env_name(name : StringView) -> Bool {
+  if name.is_empty() {
     return false
   }
   let mut index = 0


### PR DESCRIPTION
## What

On the per-command shell-policy parse path, several leaf helpers took an owned `String` only to inspect or trim it, forcing callers to copy a `StringView` they already held. Type the leaves by `StringView` instead:

- `command_text_valid_env_name` / `clean_shell_word` take `StringView` (they only iterate/trim), so callers pass the split view directly.
- `attached_cwd_option` / `attached_work_tree_option` return `StringView?` — every caller only tests `is Some(_)`, so materializing the value allocated for nothing.

## Why it's safe

Behavior is unchanged: `String` coerces to `StringView` at the remaining call sites, and in every case the value is iterated or discarded — never stored — so no view pins a backing string (no retention). 119 shell-policy tests and the full 1082-test native suite pass; codex review clean.

## Scope

Deliberately limited to the clearly-correct, self-contained cases. Converting the heredoc/redirect parser families rippled through String-returning chains (`StringView`→`String` doesn't auto-coerce) — not worth the churn/risk in security-critical code for a per-line gain, so left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)