### PR TITLE
fix(remove): reject a blank reason (stranded from #472)

### DIFF
--- a/agent_tool/remove/README.mbt.md
+++ b/agent_tool/remove/README.mbt.md
@@ -60,7 +60,7 @@ deletion.
 | Name     | Type   | Required | Notes |
 | -------- | ------ | -------- | ----- |
 | `path`   | string | yes | Filesystem path. Relative paths resolve against the workspace root. Must name an existing regular file the agent created this session. |
-| `reason` | string | yes | A short explanation of why the file is being deleted, recorded with the result for auditing. |
+| `reason` | string | yes | A short, **non-empty** explanation of why the file is being deleted, recorded with the result for auditing. A blank (whitespace-only) reason is rejected. |
 
 ## Action
 
@@ -79,7 +79,8 @@ otherwise. The body has one of these shapes:
 - `"error removing <path>: <error>"` — the unlink itself failed (e.g. permission
   denied).
 - `"error: remove requires arguments.path"` / `"... arguments.reason"` /
-  `"... object arguments"` — invalid payload.
+  `"... arguments.reason to be a non-empty explanation"` / `"... object
+  arguments"` — invalid payload.
 
 ## Examples
 

--- a/agent_tool/remove/internal/decode/decode.mbt
+++ b/agent_tool/remove/internal/decode/decode.mbt
@@ -9,12 +9,23 @@ pub struct RemoveInput {
 ///|
 /// Decode `remove` tool-call arguments.
 ///
-/// `path` and `reason` are required strings. Failures name the first offending
-/// field (`arguments.reason` / `arguments.path` / `object arguments`) so the
-/// error fed back to the model says exactly which argument to fix.
+/// `path` and `reason` are required strings, and `reason` must not be blank — a
+/// destructive action must carry a real explanation, so a whitespace-only reason
+/// is rejected rather than recorded as an empty audit entry. Failures name the
+/// first offending field (`arguments.reason` / `arguments.path` /
+/// `object arguments`) so the error fed back to the model says exactly which
+/// argument to fix.
 pub fn decode(arguments : Json) -> RemoveInput raise {
   match arguments {
-    { "path": String(path), "reason": String(reason), .. } => { path, reason }
+    { "path": String(path), "reason": String(reason), .. } => {
+      // Unicode-correct blank check: `String::trim` strips only ASCII
+      // whitespace, so a reason of only non-breaking or ideographic spaces would
+      // slip through and record a visually blank audit entry.
+      guard !reason.all(ch => ch.is_whitespace()) else {
+        fail("arguments.reason to be a non-empty explanation")
+      }
+      { path, reason }
+    }
     { "path": String(_), .. } => fail("arguments.reason")
     Object(_) => fail("arguments.path")
     _ => fail("object arguments")

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -40,14 +40,14 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="remove",
-    description="Delete a file the agent created earlier THIS session (tracked in the session's file-state record). Only a file the agent itself created this session can be removed — a pre-existing file is refused, since deleting it could lose work the agent never made; change existing source with edit/multi_edit. Handles any file type: the only in-workflow way to delete a source file (the shell sandbox blocks rm on source paths), and the provenance-gated path for other files too. Deleting a .mbt/.mbt.md file runs moon check so any break it causes is reported. Requires a short `reason` explaining why the file is deleted — it is recorded with the result for auditing this destructive action. The path must name an existing regular file.",
+    description="Delete a file the agent created earlier THIS session (tracked in the session's file-state record). Only a file the agent itself created this session can be removed — a pre-existing file is refused, since deleting it could lose work the agent never made; change existing source with edit/multi_edit. Handles any file type: the only in-workflow way to delete a source file (the shell sandbox blocks rm on source paths), and the provenance-gated path for other files too. Deleting a .mbt/.mbt.md file runs moon check so any break it causes is reported. Requires a `reason` — a short, non-empty explanation of why the file is deleted — recorded with the result for auditing this destructive action; a blank reason is rejected. The path must name an existing regular file.",
     schema=JsonSchema({
       "type": "object",
       "properties": {
         "path": { "type": "string" },
         "reason": {
           "type": "string",
-          "description": "A short explanation of why this file is being deleted, recorded in the result so a destructive action can be audited later.",
+          "description": "A short, non-empty explanation of why this file is being deleted, recorded in the result so a destructive action can be audited later. A blank reason is rejected.",
         },
       },
       "required": ["path", "reason"],
@@ -365,6 +365,34 @@ async test "remove rejects a missing reason" {
     let result = run_remove(state, { "path": path })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_eq(output.content, "error: remove requires arguments.reason")
+    assert_true(output.is_error)
+    assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "remove rejects a blank reason" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/y.mbt"
+    @fs.write_file(
+      path,
+      "pub fn y() -> Int { 0 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(path)
+    // A whitespace-only rationale would produce an empty audit entry, so it is
+    // rejected just like a missing one. Includes Unicode whitespace (a
+    // non-breaking and an ideographic space) that ASCII `trim` would miss.
+    let result = run_remove(state, {
+      "path": path,
+      "reason": "\u{00a0} \u{3000}",
+    })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_eq(
+      output.content,
+      "error: remove requires arguments.reason to be a non-empty explanation",
+    )
     assert_true(output.is_error)
     assert_true(@fs.exists(path))
   })


### PR DESCRIPTION
## Why

#472 (the remove tool) was **squash-merged mid-review**, so the follow-up commit that rejected a blank `reason` never reached `main` — pushing to an already-squash-merged branch is a no-op. Right now `main`'s remove tool accepts an empty/whitespace `reason`, recording a blank audit entry. This lands the rejection off current `main`.

## What

- **Reject a blank `reason`.** `decode` now rejects a reason that is empty or only whitespace, using the Unicode-correct `reason.all(ch => ch.is_whitespace())` (`String::trim` is ASCII-only and would miss U+00A0/U+3000, as the plan decoder already handles). Documented in the tool description and schema; covered by a test.

## Dropped from the earlier stranded branch

The stranded branch also carried a **pre-build-output detection** step. It's dropped here as **dead code**: a pre-build output is written by the build's pre-build step, not the agent's `write` tool, so it is never recorded as `Created` — the `Created` gate already refuses to remove it, and the post-delete regeneration check could never be reached in practice. (`moon check` still runs on a `.mbt`/`.mbt.md` removal, since a real source deletion can break the build.)

## Verification

`moon check --deny-warn --target native` clean; `moon test agent_tool/remove` **16/16** (incl. README doc-tests and blank/Unicode-reason tests); `moon fmt --check` clean; no mbti drift — all against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)