### PR TITLE
refactor(agent_tool): idiomatic for-loops (range + two-var)

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -401,7 +401,7 @@ fn line_start_offset(content : String, line : Int) -> Int {
 fn line_end_offset(content : String, line : Int) -> Int {
   let len = content.length()
   let mut current_line = 1
-  for cursor = 0; cursor < len; cursor = cursor + 1 {
+  for cursor in 0..<len {
     if content[cursor] == '\n' {
       if current_line == line {
         break cursor + 1
@@ -436,7 +436,7 @@ fn inserted_line_span(new_string : String) -> Int {
 fn line_number_at_offset(content : String, offset : Int) -> Int {
   let bounded_offset = offset.clamp(min=0, max=content.length())
   let mut line = 1
-  for cursor = 0; cursor < bounded_offset; cursor = cursor + 1 {
+  for cursor in 0..<bounded_offset {
     if content[cursor] == '\n' {
       line = line + 1
     }

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -871,7 +871,7 @@ fn line_start_offset(content : String, line : Int) -> Int {
 fn line_end_offset(content : String, line : Int) -> Int {
   let len = content.length()
   let mut current_line = 1
-  for cursor = 0; cursor < len; cursor = cursor + 1 {
+  for cursor in 0..<len {
     if content[cursor] == '\n' {
       if current_line == line {
         break cursor + 1

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1147,8 +1147,8 @@ fn command_text_redirects_to_source_path(text : String) -> Bool {
 ///|
 fn command_text_mentions_unsafe_in_place_sed(text : String) -> Bool {
   let words = command_text_words(text)
-  for index in 0..<words.length() {
-    if command_token_basename_is(words[index], "sed") &&
+  for index, word in words {
+    if command_token_basename_is(word, "sed") &&
       command_text_word_runs_as_command(words, index) {
       if command_text_sed_segment_has_in_place(words, index) {
         if !command_text_sed_is_safe_non_source_find_exec(words, index) {
@@ -1254,8 +1254,8 @@ fn command_text_xargs_option_consumes_next(arg : String) -> Bool {
 ///|
 fn command_text_mentions_unsafe_git_source_operation(text : String) -> Bool {
   let words = command_text_words(text)
-  for index in 0..<words.length() {
-    if command_token_basename_is(words[index], "git") &&
+  for index, word in words {
+    if command_token_basename_is(word, "git") &&
       command_text_word_runs_as_command(words, index) {
       let segment_end = command_text_segment_end(words, index)
       if @git_policy.text_should_preblock(words, index + 1, segment_end) {


### PR DESCRIPTION
Sweep converting imperative `for` loops to idiomatic range / iterator forms. No behavior change.

- `agent_tool/edit/edit.mbt` (×2) & `agent_tool/multi_edit/multi_edit.mbt`: C-style line/offset scanners `for cursor = 0; cursor < n; cursor = cursor + 1` → `for cursor in 0..<n` (still uses `break cursor + 1` / `nobreak`, which range loops support).
- `agent_tool/shell/sandbox.mbt` (×2): sed/git command scanners `for index in 0..<words.length() { … words[index] … }` → `for index, word in words { … word … }`, keeping `index` for the helper calls that need it.

`moon check --deny-warn` clean; edit 35/35, multi_edit 30/30, shell 119/119 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)