### PR TITLE
refactor(markdown_comments): idiomatic range for-loops

### DIFF
--- a/scripts/internal/markdown_comments/markdown_comments.mbt
+++ b/scripts/internal/markdown_comments/markdown_comments.mbt
@@ -167,7 +167,7 @@ fn push_html_comment_ranges(
 fn find_html_comment_open(markdown : String, start~ : Int, stop~ : Int) -> Int? {
   let stop = stop.clamp(min=0, max=markdown.length())
   let start = start.clamp(min=0, max=stop)
-  for cursor = start; cursor + 3 < stop; cursor = cursor + 1 {
+  for cursor in start..<(stop - 3) {
     if markdown[cursor] == '<' &&
       markdown[cursor + 1] == '!' &&
       markdown[cursor + 2] == '-' &&
@@ -187,7 +187,7 @@ fn find_html_comment_close(
 ) -> Int? {
   let stop = stop.clamp(min=0, max=markdown.length())
   let start = start.clamp(min=0, max=stop)
-  for cursor = start; cursor + 2 < stop; cursor = cursor + 1 {
+  for cursor in start..<(stop - 2) {
     if markdown[cursor] == '-' &&
       markdown[cursor + 1] == '-' &&
       markdown[cursor + 2] == '>' {
@@ -200,13 +200,12 @@ fn find_html_comment_close(
 
 ///|
 fn line_start(markdown : String, offset : Int) -> Int {
-  for cursor = offset; cursor > 0; {
+  for cursor in offset>=..1 {
     if markdown[cursor - 1] == '\n' || markdown[cursor - 1] == '\r' {
       break cursor
     }
-    continue cursor - 1
   } nobreak {
-    cursor
+    0
   }
 }
 


### PR DESCRIPTION
Sweep converting imperative `for` loops to idiomatic range form in `scripts/internal/markdown_comments`. No behavior change.

- `find_html_comment_open`: `for cursor = start; cursor + 3 < stop; cursor = cursor + 1` → `for cursor in start..<(stop - 3)` (condition `cursor + 3 < stop` ≡ `cursor < stop - 3`).
- `find_html_comment_close`: same shape → `for cursor in start..<(stop - 2)`.
- `line_start`: descending `for cursor = offset; cursor > 0; { … continue cursor - 1 }` → `for cursor in offset>=..1 { … }`. Endpoint semantics: `N>=..M` = N,N-1,…,M inclusive. The no-match `nobreak` returns `0` instead of the old post-loop `cursor` — equivalent because the sole caller passes `offset = …clamp(min=0…)`, so the loop always ran down to `cursor = 0`.

Verified `N>=..M` / `N>..M` semantics empirically before converting. `moon check --deny-warn` clean; markdown_comments 18/18 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)