### PR TITLE
refactor(agent_session,viz): explicit descending range for-loops

### DIFF
--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -122,7 +122,7 @@ pub fn Session::current_goal(self : Session) -> StandingGoal? {
   // `blocked_decided` freezes it so an older transition cannot override it.
   let mut blocked_decided = false
   let covered : Array[(Int, Int)] = []
-  for index = events.length() - 1; index >= 0; index = index - 1 {
+  for index in (events.length() - 1)>=..0 {
     let event = events[index]
     match event.item() {
       Assistant(_) | Terminal(_) => answered = true

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -483,7 +483,7 @@ fn split_goal_notice(content : String, boilerplate~ : String) -> String? {
   guard lines.length() >= 3 && lines[1] == "The standing goal for this session:" else {
     return None
   }
-  for index = lines.length() - 1; index > 2; index = index - 1 {
+  for index in (lines.length() - 1)>=..3 {
     if lines[index].has_prefix(boilerplate) {
       return Some(lines[2:index].join("\n").trim().to_owned())
     }


### PR DESCRIPTION
Sweep converting newest-first / bottom-up C-style scans to explicit descending range syntax. No behavior change.

- `agent_session/goal.mbt` `Session::current_goal` (scans the log newest-first): `for index = events.length() - 1; index >= 0; index = index - 1` → `for index in (events.length() - 1)>=..0`.
- `viz/view.mbt` `split_goal_notice` (scans lines bottom-up): `for index = lines.length() - 1; index > 2; index = index - 1` → `for index in (lines.length() - 1)>=..3` — `index > 2` means it descends to 3 inclusive, and `N>=..M` is end-inclusive, so the endpoint moves to 3.

`N>=..M` = N,N-1,…,M (both endpoints inclusive) — verified empirically before converting. `moon check --deny-warn` clean; agent_session 30/30, viz (js) 53/53 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)