### PR TITLE
refactor(harness): array comprehensions for single-loop accumulators

### DIFF
--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -159,10 +159,9 @@ pub async fn analyze_run(out_dir : String) -> EvalReport {
 ///|
 /// Analyze a prompt-task run manifest and write report artifacts.
 async fn analyze_manifest(manifest : RunManifest) -> EvalReport {
-  let results : Array[EvalResult] = []
-  for trial in manifest.trials {
-    results.push(analyze_trial(manifest, trial))
-  }
+  let results = [
+    for trial in manifest.trials => analyze_trial(manifest, trial)
+  ]
   let report = combine_results(manifest, results)
   write_report_files(report)
   report
@@ -440,10 +439,9 @@ async fn validate_workspace(
       probes: [],
     }
   }
-  let results : Array[ProbeResult] = []
-  for probe in probes {
-    results.push(run_validation_probe(workspace, probe))
-  }
+  let results = [
+    for probe in probes => run_validation_probe(workspace, probe)
+  ]
   let failures = [
     for result in results if !result.passed => {
       result.name + ": " + result.reason

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -475,10 +475,7 @@ pub async fn analyze_suite(out_dir : String) -> SuiteReport {
     read_suite_manifest(out_dir),
     out_dir,
   )
-  let reports : Array[EvalReport] = []
-  for combo in manifest.combos {
-    reports.push(analyze_run(combo.out_dir))
-  }
+  let reports = [ for combo in manifest.combos => analyze_run(combo.out_dir) ]
   let report = SuiteReport(
     name=manifest.name,
     out_dir~,


### PR DESCRIPTION
Sweep applying MoonBit array comprehensions to `fresh array + single push-loop` accumulators in `eval/prompt_task/harness`, matching the idiom already used in that package (`parse_models`, `parse_problems`, `manifest_for_output_dir`, …). No behavior change.

- `analyze_manifest`: `let results = []; for trial in manifest.trials { results.push(analyze_trial(…)) }` → `let results = [for trial in manifest.trials => analyze_trial(…)]`
- `validate_workspace`: same shape over `probes` → `run_validation_probe`
- `analyze_suite`: same shape over `manifest.combos` → `analyze_run`

Only converted the *clean* cases — a fresh array populated by exactly one loop. Multi-step accumulators (a comprehension plus extra conditional pushes) were left as-is. Async calls inside comprehensions work (verified). `moon check --deny-warn` clean; harness 19/19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)