### PR TITLE
refactor(sandbox): array comprehensions for two slice-copy loops

### DIFF
--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1085,10 +1085,7 @@ fn command_text_static_cwd_before_dynamic_source_write(
         None => ()
       }
     } else {
-      let segment : Array[String] = []
-      for segment_index in index..<end {
-        segment.push(words[segment_index])
-      }
+      let segment = [ for segment_index in index..<end => words[segment_index] ]
       if command_text_mentions_dynamic_source_tree_write(segment.join(" ")) {
         return cwd
       }
@@ -5264,10 +5261,9 @@ fn operands_with_optional_dest(
     Some(dest) => Some({ sources: operands, dest: Some(dest) })
     None =>
       if operands.length() >= 2 {
-        let sources : Array[String] = []
-        for index in 0..<(operands.length() - 1) {
-          sources.push(operands[index])
-        }
+        let sources = [
+          for index in 0..<(operands.length() - 1) => operands[index]
+        ]
         Some({ sources, dest: Some(operands[operands.length() - 1]) })
       } else {
         Some({ sources: [], dest: None })


### PR DESCRIPTION
Follow-up to the for-loop idiom sweep, applying array comprehensions to the remaining *clean* single-loop accumulators in `agent_tool/shell/sandbox.mbt`. No behavior change.

- `segment`: `let segment = []; for segment_index in index..<end { segment.push(words[segment_index]) }` → `let segment = [for segment_index in index..<end => words[segment_index]]`
- `sources`: same shape over `0..<(operands.length() - 1)` → `operands[index]`

Note: I checked the other multi-step accumulators (report/parser/other sandbox sites) and left them — they interleave conditional/multi-branch pushes, and MoonBit does not allow two `for … =>` generators in one array literal (so e.g. `viz` plan-rows stays a comprehension + append). `moon check --deny-warn` clean; shell 119/119 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)