### PR TITLE
feat(agent_tool): revalidate file identity before remove deletes

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -214,10 +214,15 @@ async fn commit_edit(
   }
   try {
     @fs.write_file(path, new_content, create_mode=CreateOrTruncate)
-    // An edit always changes a file that already existed (its content was read
-    // above), so record it as modified — record_modified preserves a stronger
-    // `Created` state if the agent created this file earlier this session.
-    file_state.record_modified(path)
+    // A targeted edit preserves most of the file, so provenance depends on
+    // whether the content it read (original_content) is still what the agent last
+    // wrote: record_edited keeps a stronger `Created` only then, and otherwise
+    // downgrades (the file was rebound to different content before this edit).
+    file_state.record_edited(
+      path,
+      @agent_tool.content_digest(original_content),
+      @agent_tool.content_digest(new_content),
+    )
     let response = @auto_check.append_summary(path, summary)
     @agent_tool.ToolAction::respond(response, brief=ok_brief)
   } catch {

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -42,6 +42,38 @@ async test "edit records the file it changed as Modified" {
 }
 
 ///|
+async test "edit downgrades a Created file that was rebound before the edit" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/lib.mbt"
+    // The agent created this path with content A (recorded), but the file on disk
+    // is now different content B — as if a `git checkout` rebound it. Editing B
+    // must NOT keep `Created`: the result is mostly B, not the agent's file.
+    @fs.write_file(
+      path,
+      "pub fn b() -> Int { 2 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(
+      path,
+      @agent_tool.content_digest("pub fn a() -> Int { 1 }\n"),
+    )
+    let run = match @edit.definition(file_state=state).execute {
+      Async(execute) => execute
+      Sync(_) => fail("edit tool should be async")
+    }
+    let _ = run({
+      "path": path,
+      "old_string": "2",
+      "new_string": "3",
+      "start_line": 1,
+    })
+    // The edit read content B, not the agent's recorded A, so Created is dropped.
+    assert_true(state.get(path) is Some(Modified))
+  })
+}
+
+///|
 async test "a failed edit names the file in its brief" {
   @vfs.with_tmpdir(dir => {
     // Editing a missing file fails; the error still briefs the target file so

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -1,17 +1,15 @@
 ///|
 /// How the agent has touched a file during this session, as recorded by the
-/// file-writing tools (`write`, `edit`, `multi_edit`).
+/// file-writing tools (`write`, `edit`, `multi_edit`). This is the public
+/// *provenance* projection; the map stores a richer per-path record internally
+/// (see `Entry`).
 ///
-/// This is an ADVISORY provenance signal, keyed by path, not a capability. A
-/// consumer that gates deletion on `Created` must NOT treat it as sole
-/// authority: a path can be rebound after it is recorded (the sandboxed shell
-/// still permits `mv`/`rm` on non-source files, and a session spans many
-/// turns), so `Created` proves only that the agent once created *a* file at
-/// this path — not that the file there now is still that file. A safe consumer
-/// revalidates at delete time (the path still refers to the agent's file) and
-/// combines this with independent guards (e.g. only deleting git-tracked or
-/// recoverable/soft-deleted files), treating `Created` as necessary, not
-/// sufficient.
+/// A consumer that gates deletion on `Created` must still confirm the file is
+/// unchanged: a path can be rebound after it is recorded (a `git checkout` that
+/// restores a tracked file the agent recreated, a `mv` onto a non-source path),
+/// so `Created` alone proves only that the agent once created *a* file at this
+/// path. Use `created_and_unchanged`, which pairs the provenance with a content
+/// check, rather than `get(...) is Some(Created)`.
 pub(all) enum FileState {
   /// The agent created this file this session — a `write` to a path that did
   /// not exist. Editing it afterward keeps this state; it is still the agent's
@@ -24,6 +22,23 @@ pub(all) enum FileState {
 } derive(Eq, Debug)
 
 ///|
+/// The internal per-path record: provenance plus the file's identity — a
+/// content digest of what the agent last wrote there.
+///
+/// Identity is a content DIGEST, not an `mtime`: the file-writing tools already
+/// hold the content in memory, so the digest is computed synchronously (no stat,
+/// no cancellation window) and cannot collide the way coarse-resolution or
+/// `mv`-preserved mtimes can. It is a content *version*, not a filesystem object
+/// id — a different file with byte-identical content passes, which is harmless
+/// (deleting identical bytes is deleting the agent's own content). The digest
+/// also lets an edit detect that the file was rebound before it ran (its
+/// pre-edit content no longer matches what the agent last wrote).
+priv struct Entry {
+  provenance : FileState
+  digest : String
+}
+
+///|
 /// Per-session record of how the agent has touched files, keyed by the resolved
 /// path the tools write to. One map is created per session (in `build_tools`)
 /// and shared with every file-writing tool, which records into it, plus
@@ -31,24 +46,18 @@ pub(all) enum FileState {
 /// observes every tool's updates without a `Ref`.
 ///
 /// Keys are the exact resolved path each tool wrote to — deliberately NOT
-/// normalized or canonicalized. Unifying equivalent spellings (`note.txt` vs
-/// `./note.txt`) or symlink aliases correctly needs OS-level canonicalization
-/// (realpath); lexical normalization instead MISattributes provenance — it
-/// mishandles `..` across symlinks, native path separators, and the POSIX `//`
-/// root, any of which could report `Created` for a DIFFERENT file, strictly
-/// worse than failing to recognize an equivalent spelling. So this map
-/// under-approximates on purpose: an unrecognized spelling reads as `None`
-/// ("unknown"), which a consumer already treats conservatively. The deletion
-/// consumer canonicalizes with realpath at delete time — where the file is
-/// live — and pairs it with an identity revalidation, which is also where the
-/// map's provenance is confirmed rather than trusted.
+/// normalized or canonicalized. Unifying equivalent spellings or symlink aliases
+/// correctly needs OS-level canonicalization (realpath); lexical normalization
+/// instead MISattributes provenance. So this map under-approximates on purpose:
+/// an unrecognized spelling reads as unknown, which a consumer treats
+/// conservatively.
 ///
 /// In-memory only: it reflects what THIS process did this session, not history
 /// restored from a durable log. A file created in an earlier process (before a
 /// resume) is absent, so consumers must read "absent" as "unknown provenance",
 /// never as "not created".
 pub struct FileStateMap {
-  priv entries : Map[String, FileState]
+  priv entries : Map[String, Entry]
 }
 
 ///|
@@ -58,57 +67,120 @@ pub fn FileStateMap::new() -> FileStateMap {
 }
 
 ///|
-/// Record that the agent created `path` this session. Creation always wins: a
-/// later `record_modified` will not downgrade a `Created` entry.
-pub fn FileStateMap::record_created(self : FileStateMap, path : String) -> Unit {
-  self.entries[path] = Created
+/// The content digest a file-writing tool records and `remove` revalidates — the
+/// hex SHA-256 of `content`. Computed from the in-memory content the tool wrote
+/// (or, for `remove`, the bytes it read back), so identity capture never stats
+/// the filesystem and never races cancellation.
+pub fn content_digest(content : String) -> String {
+  @crypto.bytes_to_hex_string(@crypto.sha256(@utf8.encode(content)))
 }
 
 ///|
-/// Record that the agent modified `path` this session — unless it is already
-/// `Created`, since editing a file the agent itself created keeps the stronger
-/// creation provenance.
+/// Record that the agent created `path` this session with content whose digest
+/// is `digest`. Creation always wins over a later modify.
+pub fn FileStateMap::record_created(
+  self : FileStateMap,
+  path : String,
+  digest : String,
+) -> Unit {
+  self.entries[path] = { provenance: Created, digest }
+}
+
+///|
+/// Record that the agent OVERWROTE `path` wholesale this session (a `write` over
+/// an existing file), with the new content's `digest`. The whole file is now the
+/// agent's content, so a path already recorded `Created` keeps that stronger
+/// provenance; anything else becomes `Modified`. No continuity check is needed —
+/// the overwrite replaced whatever was there.
 pub fn FileStateMap::record_modified(
   self : FileStateMap,
   path : String,
+  digest : String,
 ) -> Unit {
-  if self.entries.get(path) is Some(Created) {
-    return
+  let provenance = if self.entries.get(path)
+    is Some({ provenance: Created, .. }) {
+    Created
+  } else {
+    Modified
   }
-  self.entries[path] = Modified
+  self.entries[path] = { provenance, digest }
 }
 
 ///|
-/// The recorded state of `path` this session, or `None` when no file-writing
-/// tool has touched it (which a consumer must treat as "unknown", not
-/// "pre-existing").
+/// Record that the agent made a TARGETED edit to `path` (an `edit`/`multi_edit`
+/// that preserved most of the file), where `seen_digest` is the digest of the
+/// content the tool read just before editing and `result_digest` is the digest
+/// of what it wrote. A `Created` path keeps that provenance only if `seen_digest`
+/// still matches what the agent last wrote — otherwise the file was rebound to
+/// different content before this edit, so most of the result is not the agent's
+/// and it is downgraded to `Modified`.
+pub fn FileStateMap::record_edited(
+  self : FileStateMap,
+  path : String,
+  seen_digest : String,
+  result_digest : String,
+) -> Unit {
+  let provenance = if self.entries.get(path)
+    is Some({ provenance: Created, digest: stored }) &&
+    stored == seen_digest {
+    Created
+  } else {
+    Modified
+  }
+  self.entries[path] = { provenance, digest: result_digest }
+}
+
+///|
+/// The recorded provenance of `path` this session, or `None` when no
+/// file-writing tool has touched it (which a consumer must treat as "unknown",
+/// not "pre-existing"). This is provenance only — it does NOT confirm the file
+/// is still the one the agent wrote; use `created_and_unchanged` to gate a
+/// destructive action.
 pub fn FileStateMap::get(self : FileStateMap, path : String) -> FileState? {
-  self.entries.get(path)
+  self.entries.get(path).map(entry => entry.provenance)
+}
+
+///|
+/// Whether the agent created `path` this session AND the file there now still has
+/// the content the agent last wrote — `current_digest` matches the recorded
+/// digest. This is the gate `remove` uses (it hashes the bytes it reads back and
+/// passes them here): it refuses when the path was never created by the agent or
+/// when its content differs from what the agent wrote (rebound since).
+pub fn FileStateMap::created_and_unchanged(
+  self : FileStateMap,
+  path : String,
+  current_digest : String,
+) -> Bool {
+  self.entries.get(path) is Some({ provenance: Created, digest: stored }) &&
+  stored == current_digest
 }
 
 ///|
 /// Drop any recorded state for `path`. `remove` calls this after deleting a file
-/// so the `Created` provenance does not outlive the file: if the same path is
-/// later recreated by something other than the agent's tools, it reads as
-/// unknown again rather than as still-agent-created.
+/// so the provenance does not outlive the file: if the same path is later
+/// recreated by something other than the agent's tools, it reads as unknown
+/// again rather than as still-agent-created.
 pub fn FileStateMap::forget(self : FileStateMap, path : String) -> Unit {
   self.entries.remove(path)
 }
 
 ///|
-test "record_created marks a path and survives a later modify" {
+test "record_created marks a path and survives a later overwrite" {
+  let a = content_digest("fn a\n")
+  let b = content_digest("fn b\n")
   let state = FileStateMap::new()
-  state.record_created("lib/new.mbt")
+  state.record_created("lib/new.mbt", a)
   assert_true(state.get("lib/new.mbt") is Some(Created))
-  // Editing a file the agent created keeps the creation provenance.
-  state.record_modified("lib/new.mbt")
+  // Overwriting a file the agent created keeps the creation provenance.
+  state.record_modified("lib/new.mbt", b)
   assert_true(state.get("lib/new.mbt") is Some(Created))
+  assert_true(state.created_and_unchanged("lib/new.mbt", b))
 }
 
 ///|
 test "record_modified marks a pre-existing file" {
   let state = FileStateMap::new()
-  state.record_modified("lib/old.mbt")
+  state.record_modified("lib/old.mbt", content_digest("x\n"))
   assert_true(state.get("lib/old.mbt") is Some(Modified))
 }
 
@@ -119,41 +191,69 @@ test "an untouched path has no recorded state" {
 }
 
 ///|
-test "record_created overrides a prior modified" {
-  // A path first seen as modified then created (e.g. removed and rewritten)
-  // becomes Created — creation is the stronger signal.
+test "created_and_unchanged holds only for a Created path with a matching digest" {
+  let created = content_digest("v1\n")
+  let other = content_digest("v2\n")
   let state = FileStateMap::new()
-  state.record_modified("lib/x.mbt")
-  state.record_created("lib/x.mbt")
-  assert_true(state.get("lib/x.mbt") is Some(Created))
+  state.record_created("lib/x.mbt", created)
+  assert_true(state.created_and_unchanged("lib/x.mbt", created))
+  // Different content means the file was rebound since the agent wrote it.
+  assert_false(state.created_and_unchanged("lib/x.mbt", other))
+}
+
+///|
+test "an edit keeps Created only when it saw the agent's own content" {
+  let created = content_digest("original\n")
+  let edited = content_digest("edited\n")
+  let foreign = content_digest("someone else\n")
+  let after_foreign = content_digest("someone else + edit\n")
+  // Normal edit: the tool read back the agent's own content, so Created holds.
+  let ok = FileStateMap::new()
+  ok.record_created("a.mbt", created)
+  ok.record_edited("a.mbt", created, edited)
+  assert_true(ok.get("a.mbt") is Some(Created))
+  assert_true(ok.created_and_unchanged("a.mbt", edited))
+  // Rebound-then-edited: the tool read foreign content (not what the agent
+  // wrote), so Created is downgraded and the file is no longer deletable.
+  let rebound = FileStateMap::new()
+  rebound.record_created("a.mbt", created)
+  rebound.record_edited("a.mbt", foreign, after_foreign)
+  assert_true(rebound.get("a.mbt") is Some(Modified))
+  assert_false(rebound.created_and_unchanged("a.mbt", after_foreign))
+}
+
+///|
+test "created_and_unchanged is false for a modified or untouched path" {
+  let d = content_digest("x\n")
+  let state = FileStateMap::new()
+  state.record_modified("lib/pre.mbt", d)
+  assert_false(state.created_and_unchanged("lib/pre.mbt", d))
+  assert_false(state.created_and_unchanged("lib/absent.mbt", d))
+}
+
+///|
+test "forget drops a path's provenance" {
+  let state = FileStateMap::new()
+  state.record_created("lib/gone.mbt", content_digest("x\n"))
+  state.forget("lib/gone.mbt")
+  assert_true(state.get("lib/gone.mbt") is None)
 }
 
 ///|
 test "handles share one underlying map (no Ref needed)" {
   let a = FileStateMap::new()
   let b = a
-  b.record_created("lib/shared.mbt")
+  b.record_created("lib/shared.mbt", content_digest("x\n"))
   assert_true(a.get("lib/shared.mbt") is Some(Created))
-}
-
-///|
-test "forget drops a path's provenance" {
-  let state = FileStateMap::new()
-  state.record_created("lib/gone.mbt")
-  state.forget("lib/gone.mbt")
-  // A path recreated after being forgotten reads as unknown, not Created.
-  assert_true(state.get("lib/gone.mbt") is None)
 }
 
 ///|
 test "distinct path spellings are distinct keys (a safe under-approximation)" {
   // The map keys verbatim — it never canonicalizes — so an equivalent spelling
   // reads as unknown rather than risk reporting a different file as
-  // agent-created. A miss is safe (the consumer falls back to its other
-  // guards); a false `Created` would not be. Canonicalization (realpath) is
-  // the deletion consumer's job at delete time.
+  // agent-created. Canonicalization (realpath) is the deletion consumer's job.
   let state = FileStateMap::new()
-  state.record_created("./note.txt")
+  state.record_created("./note.txt", content_digest("x\n"))
   assert_true(state.get("./note.txt") is Some(Created))
   assert_true(state.get("note.txt") is None)
 }

--- a/agent_tool/moon.pkg
+++ b/agent_tool/moon.pkg
@@ -1,7 +1,9 @@
 import {
   "bobzhang/openseek/deepseek",
   "moonbitlang/async",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
+  "moonbitlang/x/crypto",
 }
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -282,11 +282,6 @@ async fn multi_edit_files(
           brief~,
         )
     }
-    // multi_edit only rewrites files it read, so each is a modification (never
-    // a create). record_modified preserves a stronger `Created` state if the
-    // agent created this file earlier this session. A later auto-revert may
-    // restore the content, but the tool did write the path this session.
-    file_state.record_modified(write.path)
   }
   // The batch is on disk. Run the auto-revert guard from the first written
   // file's module: it appends `moon check` feedback and, if this batch
@@ -295,7 +290,7 @@ async fn multi_edit_files(
   // is acceptable for the in-project repair case. `writes` is non-empty here (a
   // non-empty batch with no failures always renders at least one write), but
   // match defensively rather than index blindly.
-  match writes.get(0) {
+  let response = match writes.get(0) {
     Some(first) =>
       revert_guarded_response(
         first.path,
@@ -308,6 +303,34 @@ async fn multi_edit_files(
         brief=success_brief(writes),
       )
   }
+  // Record each file's provenance and content digest AFTER the auto-revert guard
+  // above, which may have rewritten some files back to their pre-batch content —
+  // so read each file's FINAL content rather than assuming the new content stuck.
+  // A targeted edit's continuity turns on the PRE-batch content (original_content
+  // = what the tool read): a `Created` file keeps that provenance only if the tool
+  // saw the agent's own content, so a file rebound before the batch is downgraded
+  // and not deletable. (A write that fails mid-batch returns earlier, before this
+  // loop, leaving the already-written files unrecorded — a safe under-record for
+  // that error case.)
+  for write in writes {
+    let seen_digest = @agent_tool.content_digest(write.original_content)
+    let new_digest = @agent_tool.content_digest(write.new_content)
+    let final_content = @fs.read_file(write.path).text() catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => write.new_content
+    }
+    let final_digest = @agent_tool.content_digest(final_content)
+    // Only record when the file's final content is one the tool itself left: the
+    // applied `new_content` (kept), or the `original_content` (rolled back by the
+    // revert guard). If it is neither, an external writer changed the file during
+    // the guard's `moon check` window — leave any prior entry untouched (its
+    // recorded digest will not match the replacement, so `remove` refuses) rather
+    // than bless the external content as the agent's.
+    if final_digest == new_digest || final_digest == seen_digest {
+      file_state.record_edited(write.path, seen_digest, final_digest)
+    }
+  }
+  response
 }
 
 ///|

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -11,6 +11,8 @@ pub fn brief_basename(String) -> String
 
 pub fn brief_line(String, limit? : Int) -> String
 
+pub fn content_digest(String) -> String
+
 pub async fn execute_tool_call(AgentToolCall, Tools) -> ToolAction
 
 // Errors
@@ -45,11 +47,13 @@ pub(all) enum FileState {
 pub struct FileStateMap {
   // private fields
 }
+pub fn FileStateMap::created_and_unchanged(Self, String, String) -> Bool
 pub fn FileStateMap::forget(Self, String) -> Unit
 pub fn FileStateMap::get(Self, String) -> FileState?
 pub fn FileStateMap::new() -> Self
-pub fn FileStateMap::record_created(Self, String) -> Unit
-pub fn FileStateMap::record_modified(Self, String) -> Unit
+pub fn FileStateMap::record_created(Self, String, String) -> Unit
+pub fn FileStateMap::record_edited(Self, String, String, String) -> Unit
+pub fn FileStateMap::record_modified(Self, String, String) -> Unit
 
 pub(all) struct JsonSchema(Json) derive(@debug.Debug)
 

--- a/agent_tool/remove/README.mbt.md
+++ b/agent_tool/remove/README.mbt.md
@@ -29,30 +29,30 @@ is recorded in the (durable) success message — `ok: removed <path> (reason:
 
 ## Safety Model
 
-`Created` is treated as an **advisory** signal, not a bare delete capability
-(see the [`FileStateMap`](../file_state.mbt) docs). Two guards keep the gate
-honest on top of the `Created` check:
+`Created` alone is not a delete capability (see the
+[`FileStateMap`](../file_state.mbt) docs). Three guards gate a removal:
 
+- **Content revalidation.** The gate is `created_and_unchanged`, which pairs the
+  `Created` provenance with a content digest (SHA-256) of what the agent last
+  wrote. `remove` reads the file back at delete time, hashes it, and refuses on a
+  mismatch, so a path *rebound to different content* since the agent wrote it — a
+  `git checkout -- x.mbt` restoring a tracked file the agent had recreated, or a
+  `mv` onto the path — is not deleted. And a targeted `edit` cannot launder a
+  rebind: `record_edited` downgrades a `Created` file whose pre-edit content is
+  not what the agent last wrote. A read failure at delete time also refuses.
 - **Forget on delete.** After a successful removal the provenance is dropped
-  (`FileStateMap::forget`), so if the same path is later recreated by something
-  other than the agent's tools, a second `remove` sees it as unknown and
-  refuses — it never deletes a different file that happens to land at a path the
-  agent once created.
-- **No symlink following.** The regular-file check uses
-  `follow_symlink=false`, so a path that was a file when `write` recorded it but
-  has since been replaced by a symlink is refused rather than followed to its
-  target.
+  (`FileStateMap::forget`), so a path recreated after a removal reads as unknown
+  and a second `remove` refuses it.
+- **No symlink following.** The regular-file check uses `follow_symlink=false`,
+  so a path replaced by a symlink is refused rather than followed to its target.
 
-The residual the guards do not cover is a path replaced *in place* while it sits
-un-removed, without going through the agent's tools — so `FileStateMap` keeps the
-stale `Created`. This is possible for any file type, source included: the sandbox
-blocks a direct shell write or move onto a source path, but a permitted operation
-can still rebind a created path without updating the map — a `git checkout --
-x.mbt` restoring a tracked file the agent had recreated, or a `shell mv` onto a
-non-source path. Closing it needs stored file identity (revalidate the file at
-delete time) or recoverable/soft deletion; that hardening is deferred. Keys are
-the exact resolved path `write` used, so an unrecognized spelling reads as
-unknown and is conservatively refused rather than risking a wrong-file
+The digest is captured from the content the tools already hold in memory — so
+identity capture never stats the filesystem and never races cancellation — and,
+being a content *version*, it cannot collide the way coarse-resolution or
+`mv`-preserved mtimes can. A different file with byte-identical content passes,
+which is harmless (deleting identical bytes deletes the agent's own content).
+Keys are the exact resolved path `write` used, so an unrecognized spelling reads
+as unknown and is conservatively refused rather than risking a wrong-file
 deletion.
 
 ## Arguments
@@ -107,9 +107,13 @@ async test "remove deletes an agent-created file through the registry" {
       "pub fn f() -> Int { 1 }\n",
       create_mode=CreateOrTruncate,
     )
-    // The session recorded that the agent created this file, as `write` would.
+    // The session recorded that the agent created this file, as `write` would,
+    // capturing its content digest so the delete gate can revalidate it.
     let file_state = @agent_tool.FileStateMap::new()
-    file_state.record_created(path)
+    file_state.record_created(
+      path,
+      @agent_tool.content_digest(@fs.read_file(path).text()),
+    )
     let tools = @agent_tool.Tools([@remove.definition(file_state~)])
     // Build the arguments as JSON and stringify: a Windows temp path would
     // otherwise form an invalid escape inside a JSON string literal.

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -15,15 +15,17 @@
 /// Each removal carries a required `reason`, recorded in the (durable) result so
 /// a destructive action can be audited later.
 ///
-/// `Created` is advisory, not a bare delete capability (see `FileStateMap`). Two
-/// guards keep the gate honest: this tool drops the provenance when it removes a
-/// file (`forget`), so a path recreated after a removal is no longer seen as
-/// agent-created; and the kind check does not follow symlinks, so a path replaced
-/// by a link is refused rather than followed. The map is keyed by the same
-/// resolved path `write` used, so an unrecognized spelling reads as unknown and
-/// is conservatively refused. The narrow residual — an external process replacing
-/// an un-removed `Created` file in place — is left to a later hardening (stored
-/// file identity, or soft-delete).
+/// `Created` alone is not a delete capability (see `FileStateMap`). Three guards
+/// keep the gate honest: the gate is `created_and_unchanged`, which pairs the
+/// `Created` provenance with a content digest — `remove` reads the file back and
+/// hashes it, so a path rebound to different content since the agent wrote it (a
+/// `git checkout` restoring a tracked file, a `mv` onto the path) is refused, and
+/// an `edit` cannot launder a rebind into a deletable `Created` (`record_edited`
+/// downgrades it); this tool drops the provenance when it removes a file
+/// (`forget`), so a path recreated after a removal reads as unknown; and the kind
+/// check does not follow symlinks, so a path replaced by a link is refused rather
+/// than followed. The digest is a content version — a byte-identical different
+/// file passes, which is harmless — suited to the cooperative environment.
 ///
 /// ## Result
 /// - `Respond(ToolOutput("ok: removed <path> (reason: <reason>)"))` when the file
@@ -31,7 +33,8 @@
 ///   feedback.
 /// - `Respond(ToolOutput("error removing <path>: <reason>", is_error=true))` for
 ///   a missing file, a non-regular file, a file the agent did not create this
-///   session, or a filesystem failure.
+///   session (or created but whose content has changed since), or a filesystem
+///   failure.
 /// - `Respond(ToolOutput("error: remove requires ...", is_error=true))` for
 ///   invalid arguments.
 pub fn definition(
@@ -109,13 +112,31 @@ async fn remove_file(
   guard kind is Regular else {
     return err("not a regular file; remove deletes regular files")
   }
-  // The gate: only a file the agent CREATED this session may be removed.
-  // `record_modified` never downgrades `Created`, so a file the agent created and
-  // then edited still qualifies; a file it only modified, or never touched, does
-  // not.
+  // The gate is two steps. First the CHEAP provenance check: a path the agent
+  // never created (or only modified) is rejected without reading the file — so a
+  // mistaken call against a large or binary pre-existing asset does not load and
+  // decode it just to reject it.
   guard file_state.get(path) is Some(Created) else {
     return err(
       "not created by the agent this session — only a file the agent itself created this session can be removed; change existing source with edit/multi_edit",
+    )
+  }
+  // It IS recorded `Created`. Now confirm its CONTENT is still what the agent
+  // wrote: read the file back and digest it. A path rebound to different content
+  // since the agent wrote it (a `git checkout` restoring a tracked file, a `mv`)
+  // fails this and is refused. `record_edited` already downgrades a `Created`
+  // file rebound before an edit, so an edit cannot launder a rebind either.
+  let current_text = @fs.read_file(path).text() catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      return err("could not read the file to verify its identity: \{error}")
+  }
+  guard file_state.created_and_unchanged(
+    path,
+    @agent_tool.content_digest(current_text),
+  ) else {
+    return err(
+      "the agent created this file this session but its content has changed since (rebound or externally modified) — refusing to remove what may no longer be the file it created",
     )
   }
   @fs.remove(path) catch {
@@ -135,6 +156,18 @@ async fn remove_file(
     content,
     brief=@agent_tool.brief_line("removed \{input.path}"),
   )
+}
+
+///|
+/// The digest `remove` will compute for the file at `path` — read it back and
+/// hash it — so a test records the same identity the delete gate revalidates
+/// against. Returns `""` for a path that cannot be read (e.g. a missing-file
+/// test, where the gate is never reached).
+async fn recorded_digest(path : String) -> String {
+  @agent_tool.content_digest(@fs.read_file(path).text()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ""
+  }
 }
 
 ///|
@@ -161,7 +194,7 @@ async test "remove deletes a file the agent created this session, recording why"
     )
     // The map records the create, as `write` would have.
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
+    state.record_created(path, recorded_digest(path))
     let result = run_remove(state, {
       "path": path,
       "reason": "scratch no longer needed",
@@ -188,8 +221,8 @@ async test "remove keeps deleting a created file it later edited" {
     )
     let state = @agent_tool.FileStateMap::new()
     // Created then modified this session: record_modified must not downgrade it.
-    state.record_created(path)
-    state.record_modified(path)
+    state.record_created(path, recorded_digest(path))
+    state.record_modified(path, recorded_digest(path))
     let result = run_remove(state, { "path": path, "reason": "undo" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
@@ -205,7 +238,7 @@ async test "remove deletes a non-source file the agent created" {
     let path = "\{dir}/notes.txt"
     @fs.write_file(path, "scratch", create_mode=CreateOrTruncate)
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
+    state.record_created(path, recorded_digest(path))
     let result = run_remove(state, { "path": path, "reason": "temp file" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
@@ -244,7 +277,7 @@ async test "remove refuses a file the agent only modified" {
       create_mode=CreateOrTruncate,
     )
     let state = @agent_tool.FileStateMap::new()
-    state.record_modified(path)
+    state.record_modified(path, recorded_digest(path))
     let result = run_remove(state, { "path": path, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
@@ -256,11 +289,37 @@ async test "remove refuses a file the agent only modified" {
 }
 
 ///|
+async test "remove refuses a created file whose identity no longer matches" {
+  @vfs.with_tmpdir(dir => {
+    let path = "\{dir}/lib.mbt"
+    @fs.write_file(
+      path,
+      "pub fn f() -> Int { 1 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let state = @agent_tool.FileStateMap::new()
+    // Record a digest that cannot match the file's actual content, standing in
+    // for a path rebound to a DIFFERENT file since the agent wrote it (e.g. a
+    // `git checkout` restoring a tracked file). The gate must refuse rather than
+    // delete what may no longer be the agent's file.
+    state.record_created(
+      path,
+      @agent_tool.content_digest("different content\n"),
+    )
+    let result = run_remove(state, { "path": path, "reason": "cleanup" })
+    guard result is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("content has changed since"))
+    assert_true(@fs.exists(path))
+  })
+}
+
+///|
 async test "remove reports a missing file" {
   @vfs.with_tmpdir(dir => {
     let path = "\{dir}/ghost.mbt"
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
+    state.record_created(path, recorded_digest(path))
     let result = run_remove(state, { "path": path, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
@@ -274,7 +333,7 @@ async test "remove refuses a directory" {
     let path = "\{dir}/pkg.mbt"
     @fs.mkdir(path, recursive=true)
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
+    state.record_created(path, recorded_digest(path))
     let result = run_remove(state, { "path": path, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
@@ -293,7 +352,7 @@ async test "remove refuses a path recreated after an earlier removal" {
       create_mode=CreateOrTruncate,
     )
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
+    state.record_created(path, recorded_digest(path))
     // The first removal succeeds and drops the provenance.
     let first = run_remove(state, { "path": path, "reason": "undo" })
     guard first is Respond(ok) else { fail("expected Respond") }
@@ -329,7 +388,7 @@ async test "remove refuses a path replaced by a symlink" {
     let link = "\{dir}/alias.mbt"
     @fs.symlink(target~, link)
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(link)
+    state.record_created(link, recorded_digest(link))
     let result = run_remove(state, { "path": link, "reason": "cleanup" })
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
@@ -360,7 +419,7 @@ async test "remove rejects a missing reason" {
       create_mode=CreateOrTruncate,
     )
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
+    state.record_created(path, recorded_digest(path))
     // A destructive action must carry a rationale — no delete without one.
     let result = run_remove(state, { "path": path })
     guard result is Respond(output) else { fail("expected Respond") }
@@ -380,7 +439,7 @@ async test "remove rejects a blank reason" {
       create_mode=CreateOrTruncate,
     )
     let state = @agent_tool.FileStateMap::new()
-    state.record_created(path)
+    state.record_created(path, recorded_digest(path))
     // A whitespace-only rationale would produce an empty audit entry, so it is
     // rejected just like a missing one. Includes Unicode whitespace (a
     // non-breaking and an ideographic space) that ASCII `trim` would miss.

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -162,12 +162,16 @@ async fn write_file(
         CreateNew
       },
     )
-    // Record this write's provenance for the session so `remove` can later tell
-    // a file the agent created from one it merely overwrote.
+    // Record this write's provenance and content digest for the session so
+    // `remove` can later tell a file the agent created from one it merely
+    // overwrote, and confirm its content has not been rebound since. A write is
+    // a wholesale replacement, so the file now holds the agent's content
+    // regardless of what was there — no continuity check is needed.
+    let digest = @agent_tool.content_digest(input.content)
     if existed {
-      file_state.record_modified(path)
+      file_state.record_modified(path, digest)
     } else {
-      file_state.record_created(path)
+      file_state.record_created(path, digest)
     }
     let chars = input.content.length()
     let summary = if existed {


### PR DESCRIPTION
**PR 1 of 2** of the unified `FileState` work (design note reviewed by the Codex CLI, then this implementation per-commit reviewed). Closes the "path rebound to a different file" residual that earlier reviews flagged in `remove`.

## Problem

`remove`'s gate was `Created` provenance keyed by path — which proves only that the agent once created *a* file at a path, not that the file there *now* is still that file. A permitted operation can rebind the path: `git checkout -- x.mbt` restoring a tracked file the agent recreated, or a `mv`. `remove` would then delete the wrong file.

## Fix — content revalidation

`remove` gates on **`created_and_unchanged`**, pairing the provenance with a **content digest** (hex SHA-256) of what the agent last wrote, and re-checks it by reading + hashing the file at delete time.

**Why a content digest, not mtime** (the plan review + the first per-commit review pushed on this): the file-writing tools already hold the content in memory, so the digest is computed **synchronously** — no stat, no cancellation window — and, being a content *version*, cannot collide the way coarse-resolution or `mv`-preserved mtimes can. A byte-identical different file passes, which is harmless. Only `remove` reads the file, at delete time. This is *simpler* than mtime here, not heavier.

- **`FileStateMap` reshape** (public enum kept, richer record private): `FileState { Created | Modified }` stays as the projection returned by `get`; a private `Entry` stores the digest — no public break.
- `record_created`/`record_modified` (wholesale write) take the new content's digest; **`record_edited` (targeted edit)** also takes the digest of the content the tool *read* and keeps `Created` only if that still matches what the agent last wrote — so **an edit of a rebound file is downgraded** and cannot launder a rebind into a deletable `Created` (the serious hole the first review found).
- **Tool wiring:** `write` records the content it wrote; `edit` records `(seen=old, result=new)`; **`multi_edit` records each file's provenance + final on-disk content *after* the auto-revert guard**, keyed for continuity on the pre-batch content; `remove` reads + hashes at delete, distinguishing "never created" from "content changed since".

## Verification

`moon check --deny-warn --target native` clean; `moon test` **199/199** in the touched set (new `FileStateMap` continuity unit tests, an `edit` rebound-downgrade test, a `remove` rebind-refusal test, README doc-tests); `moon info` mbti additive; `moon fmt` clean.

Next: PR 2 — read tracking + the unread-modify policy (block unread `write` / flag unread `edit`), superseding #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)