### PR TITLE
feat(jsonrpc): JSON-RPC 2.0 client core (MCP support, 1/6)

### DIFF
--- a/jsonrpc/client.mbt
+++ b/jsonrpc/client.mbt
@@ -1,0 +1,282 @@
+// A JSON-RPC 2.0 client over an arbitrary message Transport.
+//
+// The client runs two standing tasks, spawned once per connection by the
+// caller: a reader (`run_message_pump`) that owns `transport.recv` and routes
+// each inbound reply to the waiting request's inbox, and a writer (`run_writer`)
+// that owns `transport.send`, draining an outbox queue. Every outgoing
+// message — a `request`, a `notify`, or the pump's answer to a peer request —
+// is enqueued on the outbox, so the reader never blocks on a write (which would
+// otherwise deadlock all routing under a backpressured duplex transport) and the
+// transport only ever sees one sender.
+//
+// A `request` allocates a numeric id, registers a one-shot inbox under it,
+// enqueues the request, and blocks on that inbox until the reader delivers its
+// reply (or the client closes). Because the reader is the only reader, requests
+// are fully concurrent and order-independent with no read lock.
+//
+// Both tasks are REQUIRED: spawn `run_message_pump` and `run_writer` on tasks
+// that outlive the requests (e.g. `group.spawn_bg(no_wait=true, ...)`). Closing
+// the transport — end of stream, a failed send, or either task being
+// cancelled — closes the client, ending both tasks and failing every
+// outstanding and future request with `Closed`. This client advertises no
+// capabilities; it answers a peer `ping` with an empty result and any other
+// peer request with "method not found", and does not otherwise act on
+// peer-initiated requests. `request` has no built-in deadline — a caller that
+// needs one wraps the call in `@async.with_timeout`.
+
+///|
+/// The message transport a `Client` speaks over. It owns framing and delivery,
+/// exchanging whole JSON-RPC messages. `recv` yields `None` at end of stream.
+/// `send` is called only by the writer task (a single sender). `close` unblocks
+/// any in-progress `recv`/`send` and is idempotent.
+pub(open) trait Transport {
+  /// Send one whole JSON-RPC message to the peer.
+  async fn send(Self, Json) -> Unit
+  /// Receive the next whole JSON-RPC message, or `None` once the stream ends.
+  async fn recv(Self) -> Json?
+  /// Close the transport, unblocking any in-progress `recv`/`send` so the
+  /// client's reader and writer tasks return. Must be idempotent.
+  fn close(Self) -> Unit
+}
+
+///|
+/// Cap on the outbox so a peer flooding requests (each answered by the reader)
+/// cannot grow it without bound while the writer is backpressured. Generous
+/// enough that ordinary request/notify traffic never approaches it.
+const OutboxCapacity : Int = 1024
+
+///|
+/// A JSON-RPC client. Build it with `Client::new`, spawn `run_message_pump` and
+/// `run_writer`, then issue `request`/`notify`. Requests may be concurrent;
+/// replies are matched by id.
+struct Client {
+  transport : &Transport
+  // One-shot inbox per outstanding request, keyed by its id. The reader delivers
+  // each reply's outcome here; the owning request wakes and takes it. Because
+  // the reader is the sole reader and MoonBit's async is cooperative, the plain
+  // map and counter mutation below never race.
+  pending : Map[Int, @async.Queue[Result[Json, ResponseError]]]
+  // Outgoing messages awaiting the writer, bounded (see OutboxCapacity) so a
+  // flooding peer cannot grow it without bound. request/notify block when it is
+  // full (natural backpressure); the reader's peer-request auto-replies are
+  // dropped when full (see try_enqueue) so routing never blocks. The writer is
+  // the only task that touches the wire.
+  outbox : @async.Queue[Json]
+  mut next_id : Int
+  // Set once the client is closing (EOF, a failed send, or a cancelled task);
+  // later requests fail fast with `Closed`, and both tasks return.
+  mut closed : Bool
+  // Called for each peer-initiated notification, on the reader task. The default
+  // drops them; a caller that cares installs its own via
+  // `set_notification_handler`. It must not block (it runs on the reader, so
+  // blocking stalls routing) and must not abort (an abort is uncatchable and
+  // takes down the process — the reader cannot contain it).
+  mut on_notification : (String, Json) -> Unit
+}
+
+///|
+/// Build a client over `transport`. Pure setup — no I/O and no background task.
+/// The caller must spawn `run_message_pump` and `run_writer` before issuing
+/// requests (see the module comment). Closing the transport makes in-flight and
+/// later requests fail with `Closed`.
+pub fn[T : Transport] Client::new(transport : T) -> Client {
+  {
+    transport: transport as &Transport,
+    pending: Map([]),
+    outbox: Queue(kind=Blocking(OutboxCapacity)),
+    next_id: 1,
+    closed: false,
+    on_notification: (_, _) => (),
+  }
+}
+
+///|
+/// Install the handler run for each peer-initiated notification (`method`,
+/// `params`). Replaces any previous handler; it runs on the reader task, so it
+/// must not block on I/O.
+pub fn Client::set_notification_handler(
+  self : Client,
+  handler : (String, Json) -> Unit,
+) -> Unit {
+  self.on_notification = handler
+}
+
+///|
+/// Whether the client has closed. A closed client never answers again — every
+/// later request fails fast with `Closed` — so a pool holding one should discard
+/// it and connect afresh.
+pub fn Client::is_closed(self : Client) -> Bool {
+  self.closed
+}
+
+///|
+/// Issue a request and await its result. Concurrency-safe and order-independent:
+/// many requests may be outstanding at once, and each reply is routed to its
+/// request by id by the reader. Requires running `run_message_pump` and
+/// `run_writer`. Raises `ResponseError::Failed` on a JSON-RPC error reply, or
+/// `ResponseError::Closed` if the client closes before the reply arrives.
+pub async fn Client::request(
+  self : Client,
+  method_~ : String,
+  params~ : Json,
+) -> Json {
+  guard !self.closed else { raise Closed }
+  let id = self.next_id
+  self.next_id = self.next_id + 1
+  let inbox : @async.Queue[Result[Json, ResponseError]] = Queue(kind=Unbounded)
+  self.pending.set(id, inbox)
+  defer self.pending.remove(id)
+  // Register the inbox before enqueuing so a concurrent close still delivers
+  // `Closed` here rather than leaving us to block forever.
+  self.enqueue(build_request(id, method_, params))
+  match inbox.get() {
+    Ok(json) => json
+    Err(error) => raise error
+  }
+}
+
+///|
+/// Send a notification (no reply expected). Like `request`, it enqueues on the
+/// outbox and so may block if the outbox is full (the writer is backpressured).
+pub async fn Client::notify(
+  self : Client,
+  method_~ : String,
+  params~ : Json,
+) -> Unit {
+  guard !self.closed else { return }
+  self.enqueue(build_notification(method_, params))
+}
+
+///|
+/// Enqueue one outgoing request/notification for the writer. Blocks only if the
+/// outbox is full (the writer is backpressured); a closed outbox (the client is
+/// shutting down) drops the message, since the owning request already fails via
+/// its inbox.
+async fn Client::enqueue(self : Client, message : Json) -> Unit {
+  self.outbox.put(message) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+}
+
+///|
+/// Enqueue a reader-generated reply (a peer-request answer) without ever
+/// blocking the reader: if the outbox is full (a flooding peer) or closed, drop
+/// it. This keeps routing live and the outbox bounded.
+fn Client::try_enqueue(self : Client, message : Json) -> Unit {
+  (self.outbox.try_put(message) catch { _ => false }) |> ignore
+}
+
+///|
+/// The writer task: the sole caller of `transport.send`, draining the outbox
+/// until the client closes. A failed send closes the client (so a request never
+/// waits on a reply to a message that could not be sent). Spawn exactly one.
+pub async fn Client::run_writer(self : Client) -> Unit {
+  while !self.closed {
+    let message = self.outbox.get() catch {
+      error if @async.is_being_cancelled() => {
+        self.close()
+        raise error
+      }
+      // Outbox closed: the client is shutting down.
+      _ => break
+    }
+    self.transport.send(message) catch {
+      error if @async.is_being_cancelled() => {
+        self.close()
+        raise error
+      }
+      _ => break
+    }
+  }
+  self.close()
+}
+
+///|
+/// The reader task: owns `transport.recv` and routes each inbound message until
+/// the stream ends or the client closes. Spawn exactly one, on a task that
+/// outlives the requests. Closes the client on every exit — end of stream, a
+/// transport error, or cancellation — so `is_closed` is always truthful and no
+/// request is left hanging.
+pub async fn Client::run_message_pump(self : Client) -> Unit {
+  for ;; {
+    if self.closed {
+      break
+    }
+    let ended = self.route_next() catch {
+      error => {
+        self.close()
+        raise error
+      }
+    }
+    if ended {
+      break
+    }
+  }
+  self.close()
+}
+
+///|
+/// Read and route one inbound message (or, for a batch, each element). Returns
+/// `true` once the transport has ended. Cancellation propagates.
+async fn Client::route_next(self : Client) -> Bool {
+  let message = self.transport.recv() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return true
+  }
+  guard message is Some(message) else { return true }
+  // A non-conformant peer may batch replies in a top-level array; route each so
+  // the correlated requests are not left hanging.
+  match message {
+    Array(items) =>
+      for item in items {
+        self.dispatch(item)
+      }
+    _ => self.dispatch(message)
+  }
+  false
+}
+
+///|
+/// Act on one classified message: deliver a reply to its request, answer a peer
+/// request (via the outbox, never inline on the read path), or run the
+/// notification handler.
+async fn Client::dispatch(self : Client, message : Json) -> Unit {
+  match classify_incoming(message) {
+    // Deliver to whichever request owns this id, if any (a stale or unknown id
+    // is dropped).
+    Reply(reply_id, outcome) =>
+      if self.pending.get(reply_id) is Some(target) {
+        target.put(outcome)
+      }
+    PeerRequest(peer_id, method_) => {
+      let reply = if method_ == "ping" {
+        build_success_reply(peer_id, Json::empty_object())
+      } else {
+        build_error_reply(peer_id)
+      }
+      // Non-blocking: never let answering a peer stall the read loop or grow the
+      // outbox without bound.
+      self.try_enqueue(reply)
+    }
+    Notification(method_, params) => (self.on_notification)(method_, params)
+    Unknown => ()
+  }
+}
+
+///|
+/// Mark the client closed, close the transport (unblocking a parked reader/
+/// writer) and the outbox, and fail every outstanding request with `Closed`.
+/// Idempotent, and never suspends (unbounded `put`, synchronous transport
+/// `close`), so it is safe to run during cancellation unwind.
+async fn Client::close(self : Client) -> Unit {
+  if self.closed {
+    return
+  }
+  self.closed = true
+  self.transport.close()
+  self.outbox.close()
+  for _, inbox in self.pending {
+    inbox.put(Err(Closed))
+  }
+}

--- a/jsonrpc/client_wbtest.mbt
+++ b/jsonrpc/client_wbtest.mbt
@@ -1,0 +1,426 @@
+// Round-trip tests over in-memory transports (queues), so the client is
+// exercised with no framing and no process. Every test that issues a request
+// spawns both standing tasks — `run_message_pump` (reader) and `run_writer`
+// (writer) — the client requires.
+
+///|
+/// A `Transport` backed by two queues: `inbound` carries peer->client messages
+/// the client reads, `outbound` collects client->peer messages the fake peer
+/// reads. `close` closes both, ending the stream and unblocking a parked reader.
+struct FakeTransport {
+  inbound : @async.Queue[Json]
+  outbound : @async.Queue[Json]
+}
+
+///|
+impl Transport for FakeTransport with fn send(self, message) {
+  self.outbound.put(message)
+}
+
+///|
+impl Transport for FakeTransport with fn recv(self) {
+  Some(self.inbound.get()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+}
+
+///|
+impl Transport for FakeTransport with fn close(self) {
+  self.inbound.close()
+  self.outbound.close()
+}
+
+///|
+fn new_transport() -> FakeTransport {
+  { inbound: Queue(kind=Unbounded), outbound: Queue(kind=Unbounded) }
+}
+
+///|
+/// A `Transport` whose `send` always fails and whose `recv` blocks until closed,
+/// to exercise the close-on-send path and reader wake-up.
+struct SendFailTransport {
+  inbound : @async.Queue[Json]
+}
+
+///|
+impl Transport for SendFailTransport with fn send(self, _message) {
+  ignore(self.inbound)
+  fail("send failed")
+}
+
+///|
+impl Transport for SendFailTransport with fn recv(self) {
+  Some(self.inbound.get()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+}
+
+///|
+impl Transport for SendFailTransport with fn close(self) {
+  self.inbound.close()
+}
+
+///|
+/// Spawn the two standing tasks the client needs: reader and writer.
+fn[X] spawn_client(group : @async.TaskGroup[X], client : Client) -> Unit {
+  group.spawn_bg(no_wait=true, allow_failure=true, () => {
+    client.run_message_pump()
+  })
+  group.spawn_bg(no_wait=true, allow_failure=true, () => client.run_writer())
+}
+
+///|
+/// The raw id of a request, or `Null` if it somehow has none.
+fn id_of(request : Json) -> Json {
+  match request {
+    { "id": id, .. } => id
+    _ => Json::null()
+  }
+}
+
+///|
+/// Build a success reply echoing a request's id, tagging the result with the
+/// request's method so a test can tell replies apart regardless of order.
+fn reply_for(request : Json) -> Json {
+  let method_ = match request {
+    { "method": String(method_), .. } => method_
+    _ => ""
+  }
+  { "jsonrpc": "2.0", "id": id_of(request), "result": { "method": method_ } }
+}
+
+///|
+/// Build a JSON-RPC error reply echoing a request's id.
+fn error_for(request : Json, code : Int, message : String) -> Json {
+  {
+    "jsonrpc": "2.0",
+    "id": id_of(request),
+    "error": { "code": Json::number(code.to_double()), "message": message },
+  }
+}
+
+///|
+async test "concurrent requests each get their own reply even when answered out of order" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    // Fake peer: take both requests, then answer them in reverse arrival order.
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      let first_seen = transport.outbound.get()
+      let second_seen = transport.outbound.get()
+      transport.inbound.put(reply_for(second_seen))
+      transport.inbound.put(reply_for(first_seen))
+    })
+    let first = group.spawn(() => {
+      client.request(method_="first", params=Json::empty_object())
+    })
+    let second = group.spawn(() => {
+      client.request(method_="second", params=Json::empty_object())
+    })
+    assert_true(first.wait() is { "method": String("first"), .. })
+    assert_true(second.wait() is { "method": String("second"), .. })
+  })
+}
+
+///|
+/// Regression guard: with several requests outstanding and only one answered,
+/// the answered request's reply must come back promptly (no read-lock starving).
+async test "a delivered reply never waits behind other outstanding requests" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      client.request(method_="first", params=Json::null()) |> ignore
+    })
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      client.request(method_="second", params=Json::null()) |> ignore
+    })
+    let third = group.spawn(() => {
+      client.request(method_="third", params=Json::null())
+    })
+    let mut third_request = Json::null()
+    for _ in 0..<3 {
+      let sent = transport.outbound.get()
+      if sent is { "method": String("third"), .. } {
+        third_request = sent
+      }
+    }
+    transport.inbound.put(reply_for(third_request))
+    assert_true(third.wait() is { "method": String("third"), .. })
+  })
+}
+
+///|
+async test "a request raises Failed on a JSON-RPC error reply" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      transport.inbound.put(error_for(transport.outbound.get(), -32601, "nope"))
+    })
+    let outcome = try {
+      client.request(method_="tools/call", params=Json::empty_object())
+      |> ignore
+      "no error raised"
+    } catch {
+      Failed(code~, message~) => "failed \{code} \{message}"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "failed -32601 nope")
+  })
+}
+
+///|
+/// A malformed peer that puts both `result` and `error` in one reply: the error
+/// must win so a failure is never masked as success.
+async test "a reply with both result and error surfaces the error" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      let request = transport.outbound.get()
+      transport.inbound.put({
+        "jsonrpc": "2.0",
+        "id": id_of(request),
+        "result": { "ignored": true },
+        "error": { "code": -32000, "message": "both" },
+      })
+    })
+    let outcome = try {
+      client.request(method_="x", params=Json::empty_object()) |> ignore
+      "no error raised"
+    } catch {
+      Failed(code~, message~) => "failed \{code} \{message}"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "failed -32000 both")
+  })
+}
+
+///|
+/// A reply carrying `error: null` next to a result is a success, not a failure.
+async test "a reply with a null error alongside a result succeeds" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      let request = transport.outbound.get()
+      transport.inbound.put({
+        "jsonrpc": "2.0",
+        "id": id_of(request),
+        "result": { "value": 7 },
+        "error": Json::null(),
+      })
+    })
+    let result = client.request(method_="probe", params=Json::empty_object())
+    assert_true(result is { "value": Number(7, ..), .. })
+  })
+}
+
+///|
+/// A non-conformant peer batching two replies in one array must not wedge the
+/// correlated requests.
+async test "a batched array reply routes each element" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      let first = transport.outbound.get()
+      let second = transport.outbound.get()
+      transport.inbound.put([reply_for(first), reply_for(second)])
+    })
+    let a = group.spawn(() => {
+      client.request(method_="a", params=Json::empty_object())
+    })
+    let b = group.spawn(() => {
+      client.request(method_="b", params=Json::empty_object())
+    })
+    assert_true(a.wait() is { "method": String("a"), .. })
+    assert_true(b.wait() is { "method": String("b"), .. })
+  })
+}
+
+///|
+async test "peer notifications reach the installed handler" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    let seen : Ref[String] = { val: "" }
+    client.set_notification_handler((method_, _params) => seen.val = method_)
+    spawn_client(group, client)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      let request = transport.outbound.get()
+      transport.inbound.put({
+        "jsonrpc": "2.0",
+        "method": "notifications/message",
+        "params": Json::empty_object(),
+      })
+      transport.inbound.put(reply_for(request))
+    })
+    client.request(method_="ping", params=Json::empty_object()) |> ignore
+    assert_eq(seen.val, "notifications/message")
+  })
+}
+
+///|
+/// A stray reply for an id we never issued is dropped, and the client stays
+/// usable for the real request.
+async test "a reply for an unknown id is dropped and the client stays usable" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      let request = transport.outbound.get()
+      transport.inbound.put({
+        "jsonrpc": "2.0",
+        "id": 9999,
+        "result": Json::empty_object(),
+      })
+      transport.inbound.put(reply_for(request))
+    })
+    let result = client.request(method_="real", params=Json::empty_object())
+    assert_true(result is { "method": String("real"), .. })
+  })
+}
+
+///|
+/// A peer `ping` request is answered with an empty success (this client serves
+/// no other method).
+async test "a peer ping is answered with an empty success" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    transport.inbound.put({ "jsonrpc": "2.0", "id": 42, "method": "ping" })
+    let reply = transport.outbound.get()
+    assert_true(reply is { "id": Number(42, ..), "result": _, .. })
+    assert_true(!(reply is { "error": _, .. }))
+  })
+}
+
+///|
+async test "a request fails with Closed when the transport ends without a reply" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    // The peer consumes the request but ends the stream without answering.
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      transport.outbound.get() |> ignore
+      transport.inbound.close()
+    })
+    let outcome = try {
+      client.request(method_="ping", params=Json::empty_object()) |> ignore
+      "no error raised"
+    } catch {
+      Closed => "closed"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "closed")
+    assert_true(client.is_closed())
+  })
+}
+
+///|
+/// A failed send closes the client and unblocks the parked reader, so both
+/// standing tasks return and the in-flight request fails with `Closed`.
+async test "a failed send closes the client and stops both tasks" {
+  @async.with_task_group(group => {
+    let client = Client::new(SendFailTransport::{
+      inbound: Queue(kind=Unbounded),
+    })
+    let pump = group.spawn(() => client.run_message_pump())
+    let writer = group.spawn(() => client.run_writer())
+    let outcome = try {
+      client.request(method_="ping", params=Json::empty_object()) |> ignore
+      "no error raised"
+    } catch {
+      Closed => "closed"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "closed")
+    assert_true(client.is_closed())
+    pump.wait()
+    writer.wait()
+  })
+}
+
+///|
+/// Regression guard: cancelling the reader must close the client (not leave a
+/// zombie whose `is_closed` lies) and fail every in-flight request with `Closed`.
+async test "cancelling the reader closes the client and fails in-flight requests" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    // Reader with nothing to read (peer never answers); writer drains sends.
+    let pump = group.spawn(() => client.run_message_pump())
+    group.spawn_bg(no_wait=true, allow_failure=true, () => client.run_writer())
+    let request = group.spawn(() => {
+      try {
+        client.request(method_="ping", params=Json::empty_object()) |> ignore
+        "returned"
+      } catch {
+        Closed => "closed"
+        error if @async.is_being_cancelled() => raise error
+        _ => "other error"
+      }
+    })
+    pump.cancel()
+    assert_eq(request.wait(), "closed")
+    assert_true(client.is_closed())
+  })
+}
+
+///|
+async test "a request after close raises Closed and notify is a no-op" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    client.close()
+    assert_true(client.is_closed())
+    let outcome = try {
+      client.request(method_="ping", params=Json::empty_object()) |> ignore
+      "returned"
+    } catch {
+      Closed => "closed"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "closed")
+    // notify after close must not raise.
+    client.notify(
+      method_="notifications/initialized",
+      params=Json::empty_object(),
+    )
+    ignore(group)
+  })
+}
+
+///|
+async test "notify enqueues an id-less message the writer sends" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    client.notify(
+      method_="notifications/initialized",
+      params=Json::empty_object(),
+    )
+    let sent = transport.outbound.get()
+    assert_true(sent is { "method": String("notifications/initialized"), .. })
+    assert_true(!(sent is { "id": _, .. }))
+  })
+}

--- a/jsonrpc/moon.pkg
+++ b/jsonrpc/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/async",
+}
+
+supported_targets = "+native"

--- a/jsonrpc/pkg.generated.mbti
+++ b/jsonrpc/pkg.generated.mbti
@@ -1,0 +1,31 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/jsonrpc"
+
+// Values
+
+// Errors
+pub(all) suberror ResponseError {
+  Failed(code~ : Int, message~ : String)
+  Closed
+}
+pub impl Show for ResponseError
+
+// Types and methods
+type Client
+pub fn Client::is_closed(Self) -> Bool
+pub fn[T : Transport] Client::new(T) -> Self
+pub async fn Client::notify(Self, method_~ : String, params~ : Json) -> Unit
+pub async fn Client::request(Self, method_~ : String, params~ : Json) -> Json
+pub async fn Client::run_message_pump(Self) -> Unit
+pub async fn Client::run_writer(Self) -> Unit
+pub fn Client::set_notification_handler(Self, (String, Json) -> Unit) -> Unit
+
+// Type aliases
+
+// Traits
+pub(open) trait Transport {
+  async fn send(Self, Json) -> Unit
+  async fn recv(Self) -> Json?
+  fn close(Self) -> Unit
+}
+

--- a/jsonrpc/protocol.mbt
+++ b/jsonrpc/protocol.mbt
@@ -1,0 +1,156 @@
+// The JSON-RPC 2.0 message layer: the error a request can fail with, the
+// envelope builders, and the classification the client routes inbound messages
+// on. All pure (no transport), so it is unit-testable without a transport.
+
+///|
+/// Why a request did not yield a result: the peer answered with a JSON-RPC error
+/// object, or the transport ended before any reply arrived.
+pub(all) suberror ResponseError {
+  /// The peer answered with a JSON-RPC error object, carrying its `code` and
+  /// `message`.
+  Failed(code~ : Int, message~ : String)
+  /// The transport ended before a reply to the request arrived.
+  Closed
+}
+
+///|
+pub impl Show for ResponseError with fn output(self, logger) {
+  match self {
+    Failed(code~, message~) =>
+      logger.write_string("JSON-RPC error \{code}: \{message}")
+    Closed => logger.write_string("transport closed before a reply")
+  }
+}
+
+///|
+/// Build a request envelope with a numeric id. Numeric ids let the client
+/// correlate replies by `Int` rather than carrying arbitrary id shapes.
+fn build_request(id : Int, method_ : String, params : Json) -> Json {
+  {
+    "jsonrpc": "2.0",
+    "id": Json::number(id.to_double()),
+    "method": method_,
+    "params": params,
+  }
+}
+
+///|
+/// Build a notification envelope — a request with no id, which the peer never
+/// answers.
+fn build_notification(method_ : String, params : Json) -> Json {
+  { "jsonrpc": "2.0", "method": method_, "params": params }
+}
+
+///|
+/// Build a success reply echoing a peer request's id (used to answer `ping`).
+fn build_success_reply(id : Json, result : Json) -> Json {
+  { "jsonrpc": "2.0", "id": id, "result": result }
+}
+
+///|
+/// The JSON-RPC reserved code for an unimplemented method.
+const MethodNotFound : Int = -32601
+
+///|
+/// Build a "method not found" error reply echoing a peer request's id. This
+/// client advertises no capabilities, so any request the peer sends us (other
+/// than `ping`) gets this — a proper JSON-RPC error rather than a misleading
+/// empty success, while still answering so the peer does not block.
+fn build_error_reply(id : Json) -> Json {
+  {
+    "jsonrpc": "2.0",
+    "id": id,
+    "error": {
+      "code": Json::number(MethodNotFound.to_double()),
+      "message": "Method not found",
+    },
+  }
+}
+
+///|
+/// What an inbound message is, so the client can route it: a reply to one of our
+/// requests (carrying the outcome to deliver), a request *from* the peer we must
+/// answer, or a notification we hand to the notification handler.
+priv enum Incoming {
+  Reply(Int, Result[Json, ResponseError])
+  // A peer-initiated request; carries the raw id to echo back and the method so
+  // the client can answer `ping` with a success and everything else with an
+  // error.
+  PeerRequest(Json, String)
+  // A peer-initiated notification: its method and params.
+  Notification(String, Json)
+  // Neither — malformed, or a reply with a non-numeric/non-integer id we never
+  // issue.
+  Unknown
+}
+
+///|
+/// Classify an inbound message. A `method` field marks a request (with id) or a
+/// notification (without); otherwise an `id` marks a reply.
+fn classify_incoming(message : Json) -> Incoming {
+  if message is { "method": String(method_), .. } {
+    // JSON-RPC 2.0 defines a notification by the *omission* of `id`; a present
+    // `id` — even the discouraged `null` — is a request whose reply must echo
+    // that id. So any message that carries an `id` member is a peer request.
+    match message {
+      { "id": id, .. } => PeerRequest(id, method_)
+      { "params": params, .. } => Notification(method_, params)
+      _ => Notification(method_, Json::null())
+    }
+  } else {
+    match message {
+      { "id": Number(id, ..), .. } =>
+        // JSON-RPC correlation requires the server to echo our exact id, and we
+        // only ever issue integer ids. Accept a numeric id only when it is an
+        // exact, in-range integer — `Double::to_int` truncates (1.5 -> 1) and
+        // saturates out-of-range, which would misroute a reply to a real
+        // pending id. A non-integer id is classified `Unknown` and dropped.
+        if int_reply_id(id) is Some(reply_id) {
+          Reply(reply_id, parse_outcome(message))
+        } else {
+          Unknown
+        }
+      _ => Unknown
+    }
+  }
+}
+
+///|
+/// A numeric reply id as an `Int`, but only when it round-trips exactly (no
+/// fractional part, in `Int` range). Otherwise `None`.
+fn int_reply_id(id : Double) -> Int? {
+  let as_int = id.to_int()
+  if as_int.to_double() == id {
+    Some(as_int)
+  } else {
+    None
+  }
+}
+
+///|
+/// Read the outcome of a reply. A present, non-null `error` wins (so a failure
+/// is never masked as success even when a peer sends both), but an explicit
+/// `error: null` alongside a result — which many hand-rolled servers emit — is
+/// not a failure; a reply with neither is a successful empty result.
+fn parse_outcome(message : Json) -> Result[Json, ResponseError] {
+  match message {
+    { "error": error, .. } if !(error is Null) => Err(parse_error(error))
+    { "result": value, .. } => Ok(value)
+    _ => Ok(Json::null())
+  }
+}
+
+///|
+/// Pull `code`/`message` out of a JSON-RPC error object, defaulting each when
+/// the peer omits it.
+fn parse_error(error : Json) -> ResponseError {
+  let code = match error {
+    { "code": Number(code, ..), .. } => code.to_int()
+    _ => 0
+  }
+  let message = match error {
+    { "message": String(message), .. } => message
+    _ => ""
+  }
+  Failed(code~, message~)
+}

--- a/jsonrpc/protocol_wbtest.mbt
+++ b/jsonrpc/protocol_wbtest.mbt
@@ -1,0 +1,220 @@
+///|
+test "build_request carries jsonrpc, numeric id, method and params" {
+  let params : Json = { "name": "list", "cursor": "abc" }
+  let request = build_request(7, "tools/list", params)
+  assert_true(
+    request
+    is {
+      "jsonrpc": String("2.0"),
+      "id": Number(7, ..),
+      "method": String("tools/list"),
+      "params": { "name": String("list"), "cursor": String("abc"), .. },
+      ..
+    },
+  )
+}
+
+///|
+test "build_notification omits the id" {
+  let note = build_notification(
+    "notifications/initialized",
+    Json::empty_object(),
+  )
+  assert_true(note is { "method": String("notifications/initialized"), .. })
+  assert_true(!(note is { "id": _, .. }))
+}
+
+///|
+test "build_error_reply answers a peer request with a method-not-found error" {
+  let reply = build_error_reply(Json::number(5))
+  assert_true(
+    reply
+    is {
+      "id": Number(5, ..),
+      "error": {
+        "code": Number(-32601, ..),
+        "message": String("Method not found"),
+        ..
+      },
+      ..
+    },
+  )
+  // An error reply, not a misleading empty success.
+  assert_true(!(reply is { "result": _, .. }))
+}
+
+///|
+test "classify_incoming routes a successful reply by id" {
+  let message : Json = { "jsonrpc": "2.0", "id": 3, "result": { "tools": [] } }
+  match classify_incoming(message) {
+    Reply(id, Ok(value)) => {
+      assert_eq(id, 3)
+      assert_true(value is { "tools": Array([]), .. })
+    }
+    _ => fail("expected a successful Reply")
+  }
+}
+
+///|
+test "classify_incoming parses an error reply into a typed failure" {
+  let message : Json = {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "error": { "code": -32601, "message": "method not found" },
+  }
+  match classify_incoming(message) {
+    Reply(id, Err(Failed(code~, message~))) => {
+      assert_eq(id, 4)
+      assert_eq(code, -32601)
+      assert_eq(message, "method not found")
+    }
+    _ => fail("expected a failed Reply")
+  }
+}
+
+///|
+test "parse_error defaults code and message when the peer omits them" {
+  match
+    classify_incoming({
+      "jsonrpc": "2.0",
+      "id": 8,
+      "error": Json::empty_object(),
+    }) {
+    Reply(_, Err(Failed(code~, message~))) => {
+      assert_eq(code, 0)
+      assert_eq(message, "")
+    }
+    _ => fail("expected a failed Reply")
+  }
+}
+
+///|
+test "classify_incoming distinguishes peer requests from notifications" {
+  let peer_request : Json = {
+    "jsonrpc": "2.0",
+    "id": 9,
+    "method": "roots/list",
+  }
+  match classify_incoming(peer_request) {
+    PeerRequest(id, method_) => {
+      assert_true(id is Number(9, ..))
+      assert_eq(method_, "roots/list")
+    }
+    _ => fail("expected a PeerRequest")
+  }
+  let notification : Json = {
+    "jsonrpc": "2.0",
+    "method": "notifications/tools/list_changed",
+  }
+  match classify_incoming(notification) {
+    Notification(method_, _) =>
+      assert_eq(method_, "notifications/tools/list_changed")
+    _ => fail("expected a Notification")
+  }
+}
+
+///|
+test "classify_incoming prefers error over result when a reply has both" {
+  match
+    classify_incoming({
+      "jsonrpc": "2.0",
+      "id": 5,
+      "result": Json::null(),
+      "error": { "code": -1, "message": "boom" },
+    }) {
+    Reply(5, Err(Failed(code~, message~))) => {
+      assert_eq(code, -1)
+      assert_eq(message, "boom")
+    }
+    _ => fail("expected the error to win over the result")
+  }
+}
+
+///|
+test "classify_incoming ignores an explicit null error and returns the result" {
+  match
+    classify_incoming({
+      "jsonrpc": "2.0",
+      "id": 6,
+      "result": { "ok": true },
+      "error": Json::null(),
+    }) {
+    Reply(6, Ok(value)) => assert_true(value is { "ok": True, .. })
+    _ => fail("expected the null error to be ignored and the result returned")
+  }
+}
+
+///|
+test "classify_incoming treats a present null id as a peer request" {
+  // JSON-RPC 2.0: a notification omits `id`; a present `id: null` is a request
+  // that must be answered (echoing the null id).
+  match
+    classify_incoming({ "jsonrpc": "2.0", "id": Json::null(), "method": "ping" }) {
+    PeerRequest(id, method_) => {
+      assert_true(id is Null)
+      assert_eq(method_, "ping")
+    }
+    _ => fail("expected a present null id to be a peer request")
+  }
+}
+
+///|
+test "classify_incoming treats an id-less, method-less message as unknown" {
+  match classify_incoming({ "jsonrpc": "2.0" }) {
+    Unknown => ()
+    _ => fail("expected Unknown")
+  }
+}
+
+///|
+test "a reply with neither result nor error is a successful empty result" {
+  match classify_incoming({ "jsonrpc": "2.0", "id": 2 }) {
+    Reply(id, Ok(value)) => {
+      assert_eq(id, 2)
+      assert_true(value is Null)
+    }
+    _ => fail("expected a successful empty Reply")
+  }
+}
+
+///|
+test "classify_incoming accepts an exact integer reply id" {
+  match
+    classify_incoming({
+      "jsonrpc": "2.0",
+      "id": Json::number(3.0),
+      "result": Json::null(),
+    }) {
+    Reply(3, Ok(_)) => ()
+    _ => fail("expected an exact integer id to route")
+  }
+}
+
+///|
+test "classify_incoming rejects a fractional reply id as unknown" {
+  // 1.5 truncates to 1 under `to_int`; accepting it would misroute the reply to
+  // pending request 1.
+  match
+    classify_incoming({
+      "jsonrpc": "2.0",
+      "id": Json::number(1.5),
+      "result": Json::null(),
+    }) {
+    Unknown => ()
+    _ => fail("expected a fractional id to be Unknown")
+  }
+}
+
+///|
+test "classify_incoming rejects an out-of-range reply id as unknown" {
+  // Beyond Int range `to_int` saturates, so the id would not round-trip; drop it.
+  match
+    classify_incoming({
+      "jsonrpc": "2.0",
+      "id": Json::number(4294967297.0),
+      "result": Json::null(),
+    }) {
+    Unknown => ()
+    _ => fail("expected an out-of-range id to be Unknown")
+  }
+}


### PR DESCRIPTION
## What

First PR in a series adding **MCP (Model Context Protocol) client support** to openseek. This one lands the foundation: a transport-agnostic **JSON-RPC 2.0 client** in a new main-module `jsonrpc/` package, built as a **duplex reader + writer** so it is safe for the long-lived, bidirectional MCP setting. No wiring, no behavior change to the agent yet.

- `Transport` trait — `send`/`recv`/`close`, exchanging whole JSON-RPC messages; framing lives in transport impls.
- Reader task (`run_message_pump`) — owns `recv`, routes each reply to the waiting request's inbox by numeric id (concurrent, out-of-order-safe), answers a peer `ping` (rejects other peer requests), and dispatches batched array replies.
- Writer task (`run_writer`) — the sole caller of `send`, draining a **bounded** outbox, so the reader never blocks on a write (no backpressure deadlock) and a flooding peer can't grow the outbox without bound.
- `request`/`notify` with id correlation; pure envelope/classification layer; a queue-backed `FakeTransport`.

## Why this shape

Modeled on the proven JSON-RPC client already in the repo at `openseek_desktop/internal/jsonrpc` (used for LSP), reimplemented here because that code lives in a **separate MoonBit module**. The single-reader-plus-writer design and the hardening below came out of codex review plus three rounds of adversarial self-review, which caught a real deadlock, teardown zombies, and duplex-liveness bugs in the initial port.

## Robustness (review-driven)

- Both tasks `close()` the client on **every** exit — EOF, failed send, or cancellation — so `is_closed()` is truthful and no request is left hanging; `close()` unblocks a parked reader/writer via `Transport::close`.
- Reply ids accepted only as **exact in-range integers** (no truncation misrouting).
- A real (non-null) `error` surfaces as a failure; an explicit `error: null` alongside a result does **not**.
- Per JSON-RPC 2.0, a present `id` (even `null`) marks a peer request to answer; a notification is the *omission* of `id`.

## Tests

29 tests, fully hermetic (no process, no network): out-of-order concurrency, the deadlock regression, batched replies, error/`error:null`/both-present, peer ping, pump-cancel → clean close, failed-send close, request/notify after close, unknown-id drop, id-integer rejection. `moon check --deny-warn`, `moon test`, `moon info`, `moon fmt` clean; native-only.

## Series
1. **jsonrpc core (this PR)**
2. mcp/ protocol layer (initialize / tools/list / tools/call, content + structuredContent)
3. stdio transport + subprocess connect
4. config (`--mcp-config`) + tool bridging + wiring
5. Streamable HTTP transport
6. docs, `openseek mcp` diagnostic subcommand, resources/prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)