### PR TITLE
feat(mcp): MCP protocol layer over the JSON-RPC client (MCP support, 2/6)

### DIFF
--- a/mcp/client.mbt
+++ b/mcp/client.mbt
@@ -1,0 +1,105 @@
+// The MCP client: typed `initialize` / `tools/list` / `tools/call` over a
+// `@jsonrpc.Client`. The caller owns the transport and must have a running
+// message pump (the connect layer spawns it) before issuing these calls.
+
+///|
+/// The MCP protocol version this client prefers and advertises in `initialize`
+/// (the current revision as of this writing).
+pub const ProtocolVersion : String = "2025-11-25"
+
+///|
+/// Whether this client can speak `version`. The server echoes our preferred
+/// version when it supports it, otherwise names another; if that one is not in
+/// this set the connection is incompatible and the handshake must not proceed.
+/// The tool surface (`tools/list`, `tools/call`) is stable across these
+/// revisions.
+fn is_supported_version(version : String) -> Bool {
+  version == "2025-11-25" ||
+  version == "2025-06-18" ||
+  version == "2025-03-26" ||
+  version == "2024-11-05"
+}
+
+///|
+/// An MCP client bound to a connected `@jsonrpc.Client`.
+struct McpClient {
+  rpc : @jsonrpc.Client
+}
+
+///|
+/// Wrap a connected JSON-RPC client. Its message pump must already be running
+/// (spawned by the transport/connect layer) so replies are routed.
+pub fn McpClient::new(rpc : @jsonrpc.Client) -> McpClient {
+  { rpc, }
+}
+
+///|
+/// Run the MCP handshake: send `initialize` with our client identity, then the
+/// `notifications/initialized` notification once the server has answered.
+/// Returns the server's negotiated protocol version and identity. Raises on
+/// transport failure (`@jsonrpc.ResponseError`) or a malformed result
+/// (`McpError`).
+pub async fn McpClient::initialize(
+  self : McpClient,
+  client_name~ : String,
+  client_version~ : String,
+) -> InitializeResult {
+  let params : Json = {
+    "protocolVersion": ProtocolVersion,
+    "capabilities": Json::empty_object(),
+    "clientInfo": { "name": client_name, "version": client_version },
+  }
+  let result = self.rpc.request(method_="initialize", params~)
+  let init = decode_initialize_result(result)
+  // The server may negotiate down to a version it supports; if we cannot speak
+  // it, do not send `initialized` — the connection is incompatible.
+  guard is_supported_version(init.protocol_version) else {
+    raise Protocol(
+      "server negotiated unsupported protocol version \{init.protocol_version}",
+    )
+  }
+  self.rpc.notify(
+    method_="notifications/initialized",
+    params=Json::empty_object(),
+  )
+  init
+}
+
+///|
+/// List every tool the server offers, following `nextCursor` pagination until
+/// the server stops returning one. Raises on transport failure or a malformed
+/// result.
+pub async fn McpClient::list_tools(self : McpClient) -> Array[McpTool] {
+  let tools = []
+  let mut cursor : String? = None
+  for ;; {
+    let params : Json = match cursor {
+      Some(cursor) => { "cursor": cursor }
+      None => Json::empty_object()
+    }
+    let result = self.rpc.request(method_="tools/list", params~)
+    let (page, next) = decode_tools_page(result)
+    for tool in page {
+      tools.push(tool)
+    }
+    match next {
+      Some(next) => cursor = Some(next)
+      None => break
+    }
+  }
+  tools
+}
+
+///|
+/// Invoke a tool by its server-side name. A JSON-RPC error reply (e.g. unknown
+/// tool, invalid params) raises `@jsonrpc.ResponseError`; a tool-level failure
+/// comes back as a normal result with `is_error = true`.
+pub async fn McpClient::call_tool(
+  self : McpClient,
+  name~ : String,
+  arguments~ : Json,
+) -> CallToolResult {
+  let params : Json = { "name": name, "arguments": arguments }
+  let result = self.rpc.request(method_="tools/call", params~)
+  decode_call_result(result)
+}

--- a/mcp/client_test.mbt
+++ b/mcp/client_test.mbt
@@ -1,0 +1,358 @@
+// End-to-end tests of the MCP client over an in-memory jsonrpc transport driven
+// by a scripted server — no process, no network. Every test spawns the jsonrpc
+// message pump (the single reader the client requires) and a server task.
+
+///|
+struct FakeTransport {
+  inbound : @async.Queue[Json]
+  outbound : @async.Queue[Json]
+}
+
+///|
+impl @jsonrpc.Transport for FakeTransport with fn send(self, message) {
+  self.outbound.put(message)
+}
+
+///|
+impl @jsonrpc.Transport for FakeTransport with fn recv(self) {
+  Some(self.inbound.get()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+}
+
+///|
+impl @jsonrpc.Transport for FakeTransport with fn close(self) {
+  self.inbound.close()
+  self.outbound.close()
+}
+
+///|
+fn new_transport() -> FakeTransport {
+  { inbound: Queue(kind=Unbounded), outbound: Queue(kind=Unbounded) }
+}
+
+///|
+fn id_of(request : Json) -> Json {
+  match request {
+    { "id": id, .. } => id
+    _ => Json::null()
+  }
+}
+
+///|
+fn method_of(request : Json) -> String {
+  match request {
+    { "method": String(method_), .. } => method_
+    _ => ""
+  }
+}
+
+///|
+/// A JSON-RPC success reply echoing the request's id.
+fn success(request : Json, result : Json) -> Json {
+  { "jsonrpc": "2.0", "id": id_of(request), "result": result }
+}
+
+///|
+/// A JSON-RPC error reply echoing the request's id.
+fn failure(request : Json, code : Int, message : String) -> Json {
+  {
+    "jsonrpc": "2.0",
+    "id": id_of(request),
+    "error": { "code": Json::number(code.to_double()), "message": message },
+  }
+}
+
+///|
+/// The `initialize` result a stock fake server returns.
+fn stock_initialize_result() -> Json {
+  {
+    "protocolVersion": "2025-11-25",
+    "serverInfo": { "name": "fake", "version": "1.0" },
+  }
+}
+
+///|
+/// A stock server responder: answers `initialize`/`tools/list`/`tools/call`
+/// with the given fixtures and ignores everything else (notifications).
+fn stock_reply(tools_result : Json, call_result : Json) -> (Json) -> Json? {
+  fn(request : Json) -> Json? {
+    match method_of(request) {
+      "initialize" => Some(success(request, stock_initialize_result()))
+      "tools/list" => Some(success(request, tools_result))
+      "tools/call" => Some(success(request, call_result))
+      _ => None
+    }
+  }
+}
+
+///|
+fn[X] spawn_client(group : @async.TaskGroup[X], rpc : @jsonrpc.Client) -> Unit {
+  group.spawn_bg(no_wait=true, allow_failure=true, () => rpc.run_message_pump())
+  group.spawn_bg(no_wait=true, allow_failure=true, () => rpc.run_writer())
+}
+
+///|
+async fn serve_loop(transport : FakeTransport, reply : (Json) -> Json?) -> Unit {
+  for ;; {
+    let request = transport.outbound.get()
+    if reply(request) is Some(response) {
+      transport.inbound.put(response)
+    }
+  }
+}
+
+///|
+fn[X] spawn_server(
+  group : @async.TaskGroup[X],
+  transport : FakeTransport,
+  reply : (Json) -> Json?,
+) -> Unit {
+  group.spawn_bg(no_wait=true, allow_failure=true, () => {
+    serve_loop(transport, reply)
+  })
+}
+
+///|
+async test "initialize completes the handshake and returns server identity" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    spawn_server(
+      group,
+      transport,
+      stock_reply({ "tools": [] }, { "content": [] }),
+    )
+    let init = @mcp.McpClient::new(rpc).initialize(
+      client_name="openseek",
+      client_version="0.1",
+    )
+    assert_eq(init.protocol_version, "2025-11-25")
+    assert_eq(init.server_name, "fake")
+    assert_eq(init.server_version, "1.0")
+  })
+}
+
+///|
+async test "initialize accepts a supported older protocol version" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let reply = fn(request : Json) -> Json? {
+      match method_of(request) {
+        "initialize" =>
+          Some(
+            success(request, {
+              "protocolVersion": "2024-11-05",
+              "serverInfo": { "name": "old", "version": "0.1" },
+            }),
+          )
+        _ => None
+      }
+    }
+    spawn_server(group, transport, reply)
+    let init = @mcp.McpClient::new(rpc).initialize(
+      client_name="openseek",
+      client_version="0.1",
+    )
+    assert_eq(init.protocol_version, "2024-11-05")
+  })
+}
+
+///|
+async test "initialize rejects an unsupported negotiated protocol version" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let reply = fn(request : Json) -> Json? {
+      match method_of(request) {
+        "initialize" =>
+          Some(
+            success(request, {
+              "protocolVersion": "1999-01-01",
+              "serverInfo": { "name": "future", "version": "9.9" },
+            }),
+          )
+        _ => None
+      }
+    }
+    spawn_server(group, transport, reply)
+    let outcome = try {
+      @mcp.McpClient::new(rpc).initialize(
+        client_name="openseek",
+        client_version="0.1",
+      )
+      |> ignore
+      "no error raised"
+    } catch {
+      @mcp.Protocol(_) => "protocol"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "protocol")
+  })
+}
+
+///|
+async test "list_tools returns tools with pass-through schemas" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let tools_result : Json = {
+      "tools": [
+        {
+          "name": "echo",
+          "description": "Echo text",
+          "inputSchema": {
+            "type": "object",
+            "properties": { "text": { "type": "string" } },
+          },
+        },
+      ],
+    }
+    spawn_server(group, transport, stock_reply(tools_result, { "content": [] }))
+    let tools = @mcp.McpClient::new(rpc).list_tools()
+    assert_eq(tools.length(), 1)
+    assert_eq(tools[0].name, "echo")
+    assert_eq(tools[0].description, "Echo text")
+    assert_true(
+      tools[0].input_schema
+      is {
+        "type": String("object"),
+        "properties": { "text": { "type": String("string"), .. }, .. },
+        ..
+      },
+    )
+  })
+}
+
+///|
+async test "list_tools follows nextCursor pagination" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let calls : Ref[Int] = { val: 0 }
+    let reply = fn(request : Json) -> Json? {
+      match method_of(request) {
+        "tools/list" => {
+          calls.val = calls.val + 1
+          if calls.val == 1 {
+            Some(
+              success(request, {
+                "tools": [{ "name": "a" }],
+                "nextCursor": "page-2",
+              }),
+            )
+          } else {
+            Some(success(request, { "tools": [{ "name": "b" }] }))
+          }
+        }
+        _ => None
+      }
+    }
+    spawn_server(group, transport, reply)
+    let tools = @mcp.McpClient::new(rpc).list_tools()
+    assert_eq(tools.length(), 2)
+    assert_eq(tools[0].name, "a")
+    assert_eq(tools[1].name, "b")
+  })
+}
+
+///|
+async test "call_tool returns text content and renders it" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let call_result : Json = {
+      "content": [{ "type": "text", "text": "hello world" }],
+      "isError": false,
+    }
+    spawn_server(group, transport, stock_reply({ "tools": [] }, call_result))
+    let result = @mcp.McpClient::new(rpc).call_tool(name="echo", arguments={
+      "text": "hi",
+    })
+    assert_false(result.is_error)
+    assert_eq(result.render_text(), "hello world")
+  })
+}
+
+///|
+async test "call_tool surfaces a tool-level error as is_error" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let call_result : Json = {
+      "content": [{ "type": "text", "text": "boom" }],
+      "isError": true,
+    }
+    spawn_server(group, transport, stock_reply({ "tools": [] }, call_result))
+    let result = @mcp.McpClient::new(rpc).call_tool(
+      name="explode",
+      arguments=Json::empty_object(),
+    )
+    assert_true(result.is_error)
+    assert_eq(result.render_text(), "boom")
+  })
+}
+
+///|
+async test "call_tool raises on a JSON-RPC error reply" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let reply = fn(request : Json) -> Json? {
+      match method_of(request) {
+        "tools/call" => Some(failure(request, -32602, "unknown tool"))
+        _ => None
+      }
+    }
+    spawn_server(group, transport, reply)
+    let outcome = try {
+      @mcp.McpClient::new(rpc).call_tool(
+        name="ghost",
+        arguments=Json::empty_object(),
+      )
+      |> ignore
+      "no error raised"
+    } catch {
+      @jsonrpc.Failed(code~, message~) => "failed \{code} \{message}"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "failed -32602 unknown tool")
+  })
+}
+
+///|
+async test "list_tools raises Protocol on a malformed result" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let rpc = @jsonrpc.Client::new(transport)
+    spawn_client(group, rpc)
+    let reply = fn(request : Json) -> Json? {
+      match method_of(request) {
+        "tools/list" => Some(success(request, Json::empty_object()))
+        _ => None
+      }
+    }
+    spawn_server(group, transport, reply)
+    let outcome = try {
+      @mcp.McpClient::new(rpc).list_tools() |> ignore
+      "no error raised"
+    } catch {
+      @mcp.Protocol(_) => "protocol"
+      error if @async.is_being_cancelled() => raise error
+      _ => "other error"
+    }
+    assert_eq(outcome, "protocol")
+  })
+}

--- a/mcp/moon.pkg
+++ b/mcp/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "bobzhang/openseek/jsonrpc",
+}
+
+import {
+  "bobzhang/openseek/jsonrpc",
+  "moonbitlang/async",
+} for "test"
+
+supported_targets = "+native"

--- a/mcp/pkg.generated.mbti
+++ b/mcp/pkg.generated.mbti
@@ -1,0 +1,54 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/mcp"
+
+import {
+  "bobzhang/openseek/jsonrpc",
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub const ProtocolVersion : String = "2025-11-25"
+
+// Errors
+pub(all) suberror McpError {
+  Protocol(String)
+}
+
+// Types and methods
+pub struct CallToolResult {
+  content : Array[ContentBlock]
+  structured_content : Json?
+  is_error : Bool
+} derive(Eq, @debug.Debug)
+pub fn CallToolResult::render_text(Self) -> String
+
+pub(all) enum ContentBlock {
+  Text(String)
+  Image(mime_type~ : String)
+  Resource(uri~ : String, text~ : String?)
+  Other(kind~ : String)
+} derive(Eq, @debug.Debug)
+
+pub struct InitializeResult {
+  protocol_version : String
+  server_name : String
+  server_version : String
+  instructions : String?
+} derive(Eq, @debug.Debug)
+
+type McpClient
+pub async fn McpClient::call_tool(Self, name~ : String, arguments~ : Json) -> CallToolResult
+pub async fn McpClient::initialize(Self, client_name~ : String, client_version~ : String) -> InitializeResult
+pub async fn McpClient::list_tools(Self) -> Array[McpTool]
+pub fn McpClient::new(@jsonrpc.Client) -> Self
+
+pub struct McpTool {
+  name : String
+  description : String
+  input_schema : Json
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -1,0 +1,232 @@
+// MCP protocol value types and their decoders, plus rendering a `tools/call`
+// result into the plain text openseek surfaces to the model.
+
+///|
+/// An MCP-layer failure: the server sent a response that could not be read as
+/// the expected MCP shape. A JSON-RPC *error* reply surfaces separately as
+/// `@jsonrpc.ResponseError`.
+pub(all) suberror McpError {
+  /// The server's response did not match the expected MCP shape; the string
+  /// says what was wrong.
+  Protocol(String)
+}
+
+///|
+impl Show for McpError with fn output(self, logger) {
+  match self {
+    Protocol(message) => logger.write_string("mcp protocol error: \{message}")
+  }
+}
+
+///|
+/// A tool advertised by an MCP server via `tools/list`.
+pub struct McpTool {
+  /// The tool's name as the server exposes it (before openseek namespaces it).
+  name : String
+  /// Human-readable description, or "" when the server omits one.
+  description : String
+  /// The tool's JSON Schema for arguments, forwarded to the model unchanged.
+  /// Defaults to an open object schema when the server omits `inputSchema`.
+  input_schema : Json
+} derive(Eq, Debug)
+
+///|
+/// One block of a `tools/call` result's `content` array. openseek's model view
+/// is text, so non-text blocks are kept as compact descriptors — image/audio
+/// bytes are noted, not forwarded.
+pub(all) enum ContentBlock {
+  /// A text block and its text.
+  Text(String)
+  /// An image block; only its MIME type is surfaced (the base64 payload is not
+  /// sent to a text model).
+  Image(mime_type~ : String)
+  /// An embedded resource: its uri and, when the server inlines it, its text.
+  Resource(uri~ : String, text~ : String?)
+  /// Any other block type (audio, resource_link, unknown): its `type` tag.
+  Other(kind~ : String)
+} derive(Eq, Debug)
+
+///|
+/// The result of a `tools/call`: its content blocks, any structured output, and
+/// whether the server flagged the call as a tool-level error (distinct from a
+/// JSON-RPC error). Since 2025-06-18 a server may return the real result in
+/// `structuredContent` and leave `content` empty (or a generic status), so the
+/// structured value is kept rather than dropped.
+pub struct CallToolResult {
+  content : Array[ContentBlock]
+  structured_content : Json?
+  is_error : Bool
+} derive(Eq, Debug)
+
+///|
+/// What the server reported from `initialize`: its negotiated protocol version
+/// and identity. `server_name`/`server_version` are "" when the server omits
+/// `serverInfo`.
+pub struct InitializeResult {
+  protocol_version : String
+  server_name : String
+  server_version : String
+  instructions : String?
+} derive(Eq, Debug)
+
+///|
+/// The open object schema used when a tool omits its `inputSchema`.
+fn default_object_schema() -> Json {
+  { "type": "object" }
+}
+
+///|
+/// Decode an `initialize` result. Raises `Protocol` when `protocolVersion` is
+/// missing (the one field the handshake cannot proceed without).
+fn decode_initialize_result(result : Json) -> InitializeResult raise {
+  guard result is { "protocolVersion": String(protocol_version), .. } else {
+    raise Protocol("initialize result is missing a string `protocolVersion`")
+  }
+  let server_name = match result {
+    { "serverInfo": { "name": String(name), .. }, .. } => name
+    _ => ""
+  }
+  let server_version = match result {
+    { "serverInfo": { "version": String(version), .. }, .. } => version
+    _ => ""
+  }
+  let instructions = match result {
+    { "instructions": String(text), .. } => Some(text)
+    _ => None
+  }
+  { protocol_version, server_name, server_version, instructions }
+}
+
+///|
+/// Decode one page of a `tools/list` result: its tools and the `nextCursor`
+/// (when the server paginates). Raises `Protocol` when the `tools` array is
+/// absent.
+fn decode_tools_page(result : Json) -> (Array[McpTool], String?) raise {
+  guard result is { "tools": Array(entries), .. } else {
+    raise Protocol("tools/list result is missing a `tools` array")
+  }
+  let tools = []
+  for entry in entries {
+    tools.push(decode_tool(entry))
+  }
+  let cursor = match result {
+    { "nextCursor": String(cursor), .. } => Some(cursor)
+    _ => None
+  }
+  (tools, cursor)
+}
+
+///|
+/// Decode one tool entry. Raises `Protocol` when it has no string `name`.
+fn decode_tool(entry : Json) -> McpTool raise {
+  guard entry is { "name": String(name), .. } else {
+    raise Protocol("tool entry is missing a string `name`")
+  }
+  let description = match entry {
+    { "description": String(description), .. } => description
+    _ => ""
+  }
+  let input_schema = match entry {
+    { "inputSchema": schema, .. } => schema
+    _ => default_object_schema()
+  }
+  { name, description, input_schema }
+}
+
+///|
+/// Decode a `tools/call` result. A missing `content` array yields empty content;
+/// `isError` defaults to false.
+fn decode_call_result(result : Json) -> CallToolResult raise {
+  let content = match result {
+    { "content": Array(blocks), .. } => {
+      let decoded = []
+      for block in blocks {
+        decoded.push(decode_content_block(block))
+      }
+      decoded
+    }
+    _ => []
+  }
+  let structured_content = match result {
+    { "structuredContent": value, .. } => Some(value)
+    _ => None
+  }
+  let is_error = match result {
+    { "isError": True, .. } => true
+    _ => false
+  }
+  { content, structured_content, is_error }
+}
+
+///|
+/// Decode one content block. Raises `Protocol` when the block has no string
+/// `type`.
+fn decode_content_block(block : Json) -> ContentBlock raise {
+  match block {
+    { "type": String("text"), "text": String(text), .. } => Text(text)
+    { "type": String("image"), .. } => {
+      let mime_type = match block {
+        { "mimeType": String(mime_type), .. } => mime_type
+        _ => ""
+      }
+      Image(mime_type~)
+    }
+    { "type": String("resource"), "resource": resource, .. } => {
+      let uri = match resource {
+        { "uri": String(uri), .. } => uri
+        _ => ""
+      }
+      let text = match resource {
+        { "text": String(text), .. } => Some(text)
+        _ => None
+      }
+      Resource(uri~, text~)
+    }
+    { "type": String(kind), .. } => Other(kind~)
+    _ => raise Protocol("content block is missing a string `type`")
+  }
+}
+
+///|
+/// Render the result into a single string for the model: text blocks verbatim,
+/// non-text blocks as compact placeholders, joined by newlines, plus any
+/// `structuredContent` the content array does not already carry (so structured
+/// output is never lost). The caller applies any size budget and metadata
+/// footer. Empty content and no structured output yields "".
+pub fn CallToolResult::render_text(self : CallToolResult) -> String {
+  let out = StringBuilder()
+  let mut first = true
+  for block in self.content {
+    if !first {
+      out.write_string("\n")
+    }
+    first = false
+    match block {
+      Text(text) => out.write_string(text)
+      Image(mime_type~) => out.write_string("[image: \{mime_type}]")
+      Resource(uri~, text~) =>
+        match text {
+          Some(text) => out.write_string("[resource \{uri}]\n\{text}")
+          None => out.write_string("[resource: \{uri}]")
+        }
+      Other(kind~) => out.write_string("[unsupported content: \{kind}]")
+    }
+  }
+  let text = out.to_string()
+  // Preserve structured output. A conformant server mirrors it into a text
+  // block (then `text` already contains it — don't duplicate); when it does not
+  // (empty content, or a bare status) append the serialized structure.
+  match self.structured_content {
+    Some(structured) => {
+      let serialized = structured.stringify()
+      if text == "" {
+        serialized
+      } else if text.contains(serialized) {
+        text
+      } else {
+        "\{text}\n\{serialized}"
+      }
+    }
+    None => text
+  }
+}

--- a/mcp/types_wbtest.mbt
+++ b/mcp/types_wbtest.mbt
@@ -1,0 +1,184 @@
+// Pure decoder and rendering tests — no transport.
+
+///|
+test "decode_tool reads all fields" {
+  let tool = decode_tool({
+    "name": "search",
+    "description": "Search the web",
+    "inputSchema": { "type": "object", "required": ["q"] },
+  })
+  assert_eq(tool.name, "search")
+  assert_eq(tool.description, "Search the web")
+  assert_true(tool.input_schema is { "type": String("object"), .. })
+}
+
+///|
+test "decode_tool defaults a missing description and schema" {
+  let tool = decode_tool({ "name": "bare" })
+  assert_eq(tool.name, "bare")
+  assert_eq(tool.description, "")
+  assert_true(tool.input_schema is { "type": String("object"), .. })
+}
+
+///|
+test "decode_tool raises Protocol when name is missing" {
+  let outcome = try {
+    decode_tool({ "description": "no name" }) |> ignore
+    "no error"
+  } catch {
+    Protocol(_) => "protocol"
+    _ => "other"
+  }
+  assert_eq(outcome, "protocol")
+}
+
+///|
+test "decode_content_block reads each block kind" {
+  assert_eq(decode_content_block({ "type": "text", "text": "hi" }), Text("hi"))
+  assert_eq(
+    decode_content_block({
+      "type": "image",
+      "data": "AAAA",
+      "mimeType": "image/png",
+    }),
+    Image(mime_type="image/png"),
+  )
+  assert_eq(
+    decode_content_block({ "type": "image", "data": "AAAA" }),
+    Image(mime_type=""),
+  )
+  assert_eq(
+    decode_content_block({
+      "type": "resource",
+      "resource": { "uri": "file:///a", "text": "body" },
+    }),
+    Resource(uri="file:///a", text=Some("body")),
+  )
+  assert_eq(
+    decode_content_block({
+      "type": "resource",
+      "resource": { "uri": "file:///a" },
+    }),
+    Resource(uri="file:///a", text=None),
+  )
+  assert_eq(decode_content_block({ "type": "audio" }), Other(kind="audio"))
+}
+
+///|
+test "decode_content_block raises Protocol without a type" {
+  let outcome = try {
+    decode_content_block({ "text": "orphan" }) |> ignore
+    "no error"
+  } catch {
+    Protocol(_) => "protocol"
+    _ => "other"
+  }
+  assert_eq(outcome, "protocol")
+}
+
+///|
+test "decode_call_result defaults content and isError" {
+  let empty = decode_call_result(Json::empty_object())
+  assert_eq(empty.content.length(), 0)
+  assert_false(empty.is_error)
+  let flagged = decode_call_result({ "content": [], "isError": true })
+  assert_true(flagged.is_error)
+}
+
+///|
+test "decode_initialize_result reads identity and defaults" {
+  let full = decode_initialize_result({
+    "protocolVersion": "2025-06-18",
+    "serverInfo": { "name": "srv", "version": "2.0" },
+    "instructions": "be nice",
+  })
+  assert_eq(full.protocol_version, "2025-06-18")
+  assert_eq(full.server_name, "srv")
+  assert_eq(full.server_version, "2.0")
+  assert_eq(full.instructions, Some("be nice"))
+  let minimal = decode_initialize_result({ "protocolVersion": "2025-06-18" })
+  assert_eq(minimal.server_name, "")
+  assert_eq(minimal.server_version, "")
+  assert_eq(minimal.instructions, None)
+}
+
+///|
+test "decode_initialize_result raises without a protocol version" {
+  let outcome = try {
+    decode_initialize_result({ "serverInfo": { "name": "srv" } }) |> ignore
+    "no error"
+  } catch {
+    Protocol(_) => "protocol"
+    _ => "other"
+  }
+  assert_eq(outcome, "protocol")
+}
+
+///|
+test "render_text joins text and placeholders" {
+  let result : CallToolResult = {
+    content: [
+      Text("see"),
+      Image(mime_type="image/png"),
+      Resource(uri="file:///x", text=Some("body")),
+      Resource(uri="file:///y", text=None),
+      Other(kind="audio"),
+    ],
+    structured_content: None,
+    is_error: false,
+  }
+  assert_eq(
+    result.render_text(),
+    "see\n[image: image/png]\n[resource file:///x]\nbody\n[resource: file:///y]\n[unsupported content: audio]",
+  )
+}
+
+///|
+test "render_text is empty for empty content" {
+  let result : CallToolResult = {
+    content: [],
+    structured_content: None,
+    is_error: false,
+  }
+  assert_eq(result.render_text(), "")
+}
+
+///|
+test "decode_call_result keeps structuredContent" {
+  let result = decode_call_result({
+    "content": [],
+    "structuredContent": { "value": 42 },
+  })
+  assert_eq(result.structured_content, Some({ "value": 42 }))
+}
+
+///|
+test "render_text renders structuredContent when content is empty" {
+  let result : CallToolResult = {
+    content: [],
+    structured_content: Some({ "value": 42 }),
+    is_error: false,
+  }
+  assert_eq(result.render_text(), "{\"value\":42}")
+}
+
+///|
+test "render_text does not duplicate structuredContent already in content" {
+  let serialized = ({ "value": 42 } : Json).stringify()
+  let result : CallToolResult = {
+    content: [Text(serialized)],
+    structured_content: Some({ "value": 42 }),
+    is_error: false,
+  }
+  assert_eq(result.render_text(), serialized)
+}
+
+///|
+test "render_text appends structuredContent distinct from a status message" {
+  let result : CallToolResult = {
+    content: [Text("done")],
+    structured_content: Some({ "value": 42 }),
+    is_error: false,
+  }
+  assert_eq(result.render_text(), "done\n{\"value\":42}")
+}


### PR DESCRIPTION
## What

Second PR in the **MCP client support** series (on top of the `jsonrpc/` core from #489). Adds the `mcp/` package: the typed MCP protocol layer over `@jsonrpc.Client` — `initialize`, `tools/list`, `tools/call`. Still no agent wiring; the stdio transport and tool bridging come next.

- **Types + decoders**: `McpTool` (name / description / pass-through `inputSchema`), `ContentBlock` (text / image / resource / other), `CallToolResult` (content + `structuredContent` + `isError`), `InitializeResult`. Decoders are lenient with sensible defaults and raise `McpError::Protocol` on a malformed shape.
- **`McpClient`**:
  - `initialize` runs the handshake (`initialize` request + `notifications/initialized`) and **negotiates a supported protocol version** — `2025-11-25` preferred; `2025-06-18` / `2025-03-26` / `2024-11-05` accepted — refusing to complete on an unsupported one.
  - `list_tools` follows `nextCursor` pagination.
  - `call_tool` returns the tool result, raising `@jsonrpc.ResponseError` on a JSON-RPC error and surfacing a tool-level failure as `is_error`.
- **`CallToolResult::render_text`** flattens content blocks into one string (text verbatim, non-text as compact placeholders) and **preserves `structuredContent`** (rendering it when the content array doesn't already carry it), so structured output is never lost. The bridge layer (PR 4) applies openseek's size budget and system footer.

## Review

codex (xhigh) caught three interop issues, all fixed here: accepting an unsupported negotiated protocol version, dropping `structuredContent`, and not advertising the current `2025-11-25` version.

## Tests

23 tests: end-to-end over an in-memory scripted server (blackbox) — handshake, version accept/reject, pagination, text / error / mixed / structured content, JSON-RPC error, malformed-result — plus pure decoder/render unit tests (whitebox). `moon check --deny-warn`, `moon test`, `moon info`, `moon fmt` clean; native-only.

## Series
1. jsonrpc core (#489, merged)
2. **mcp/ protocol layer (this PR)**
3. stdio transport + subprocess connect
4. config (`--mcp-config`) + tool bridging + wiring
5. Streamable HTTP transport
6. docs, `openseek mcp` diagnostic subcommand, resources/prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)