### PR TITLE
feat(mcp): stdio transport + subprocess connect (MCP support, 3/6)

### DIFF
--- a/mcp/stdio/connect.mbt
+++ b/mcp/stdio/connect.mbt
@@ -1,0 +1,172 @@
+// Launch an MCP server as a subprocess and speak MCP to it over stdio.
+
+///|
+/// The default handshake deadline: a server that does not answer `initialize`
+/// within this many milliseconds is abandoned (so a non-MCP or wedged child
+/// cannot hang the caller).
+pub const DefaultHandshakeTimeoutMs : Int = 30000
+
+///|
+/// A live stdio MCP connection: the initialized client plus an idempotent
+/// teardown. Its reader/writer tasks run on the task group passed to `connect`;
+/// the connection is torn down when that group ends, or eagerly via `shutdown`.
+struct StdioConnection {
+  client : @mcp.McpClient
+  init : @mcp.InitializeResult
+  teardown : () -> Unit
+}
+
+///|
+/// The initialized MCP client to issue `list_tools` / `call_tool` against.
+pub fn StdioConnection::client(self : StdioConnection) -> @mcp.McpClient {
+  self.client
+}
+
+///|
+/// What the server reported from `initialize`.
+pub fn StdioConnection::init(self : StdioConnection) -> @mcp.InitializeResult {
+  self.init
+}
+
+///|
+/// Tear the connection down eagerly: cancel the reader/writer tasks, close the
+/// pipes (the child sees stdin EOF), and terminate the process. Idempotent.
+pub fn StdioConnection::shutdown(self : StdioConnection) -> Unit {
+  (self.teardown)()
+}
+
+///|
+/// Spawn `command args...` as an MCP server, wire an NDJSON transport to a
+/// JSON-RPC client (with its reader and writer tasks on `group`), run the MCP
+/// handshake under `handshake_timeout_ms`, and return the initialized
+/// connection. Returns `None` if the process cannot start, the handshake fails,
+/// or the handshake times out — terminating the process and closing the pipes in
+/// every failure case so nothing leaks. The server inherits openseek's
+/// environment (so it always has `PATH`, `HOME`, etc.); `env` adds to and
+/// overrides it.
+pub async fn[X] connect(
+  group : @async.TaskGroup[X],
+  command~ : String,
+  args~ : Array[String],
+  env? : Map[String, String],
+  cwd? : String,
+  client_name~ : String,
+  client_version~ : String,
+  handshake_timeout_ms? : Int = DefaultHandshakeTimeoutMs,
+) -> StdioConnection? {
+  // The child's stdin/stdout pipes via the process helpers, which create the
+  // synchronous, non-overlapped child endpoints a subprocess needs on every
+  // platform (including Windows). They hand the child ends back as un-closable
+  // trait objects and clean them up in `spawn`'s own teardown, so the only
+  // unreachable-in-practice leak is one fd if `read_from_process` raises (fd
+  // exhaustion) after `write_to_process` succeeded — accepted, since that end
+  // cannot be closed here.
+  let (child_stdin, stdin_writer) = @process.write_to_process() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return None
+  }
+  let (stdout_reader, child_stdout) = @process.read_from_process() catch {
+    error if @async.is_being_cancelled() => {
+      stdin_writer.close()
+      raise error
+    }
+    _ => {
+      stdin_writer.close()
+      return None
+    }
+  }
+  // `no_wait`: the group terminates the server at teardown rather than waiting
+  // for an exit that only comes once its stdin is closed.
+  let process = @process.spawn(
+    group,
+    command,
+    args,
+    extra_env?=env,
+    inherit_env=true,
+    stdin=child_stdin,
+    stdout=child_stdout,
+    cwd?=cwd.map(dir => dir.view()),
+    no_wait=true,
+  ) catch {
+    error if @async.is_being_cancelled() => {
+      stdout_reader.close()
+      stdin_writer.close()
+      raise error
+    }
+    // Spawn failed: close our parent ends (spawn's own cleanup releases the
+    // child ends).
+    _ => {
+      stdout_reader.close()
+      stdin_writer.close()
+      return None
+    }
+  }
+  // Idempotent teardown, wired once the reader/writer tasks exist. Cancelling the
+  // tasks is what unblocks a reader/writer parked in the pipe — closing an fd
+  // does not wake a coroutine suspended on it. Closing stdin lets a well-behaved
+  // server exit on EOF; `process.cancel()` is the backstop. Caveat: cancel signals
+  // only the direct child, so a launcher that forks (e.g. `npx`) and ignores
+  // stdin EOF may leave descendants running — an upstream group-kill gap.
+  let torn_down : Ref[Bool] = { val: false }
+  // Seeded with pipe + process cleanup so teardown is complete even if it fires
+  // before the task handles exist; once they exist it is upgraded to also cancel
+  // the tasks (which is what unblocks a parked reader/writer).
+  let teardown_action : Ref[() -> Unit] = {
+    val: () => {
+      stdout_reader.close()
+      stdin_writer.close()
+      process.cancel()
+    },
+  }
+  let teardown = () => {
+    if !torn_down.val {
+      torn_down.val = true
+      (teardown_action.val)()
+    }
+  }
+  let transport = NdjsonTransport::new(
+    stdout_reader,
+    stdin_writer,
+    on_close=teardown,
+  )
+  let client = @jsonrpc.Client::new(transport)
+  // Cancellable (so teardown stops them) and `no_wait` (so they do not hold the
+  // group open); a failed send / EOF still closes the client via the transport.
+  let pump = group.spawn(
+    () => client.run_message_pump(),
+    no_wait=true,
+    allow_failure=true,
+  )
+  let writer = group.spawn(
+    () => client.run_writer(),
+    no_wait=true,
+    allow_failure=true,
+  )
+  teardown_action.val = () => {
+    pump.cancel()
+    writer.cancel()
+    stdout_reader.close()
+    stdin_writer.close()
+    process.cancel()
+  }
+  let mcp_client = @mcp.McpClient::new(client)
+  let init = @async.with_timeout_opt(handshake_timeout_ms, () => {
+    mcp_client.initialize(client_name~, client_version~)
+  }) catch {
+    error if @async.is_being_cancelled() => {
+      teardown()
+      raise error
+    }
+    // Handshake raised (transport closed, unsupported protocol version, ...).
+    _ => {
+      teardown()
+      return None
+    }
+  }
+  guard init is Some(init) else {
+    // Handshake exceeded the deadline.
+    teardown()
+    return None
+  }
+  Some({ client: mcp_client, init, teardown })
+}

--- a/mcp/stdio/moon.pkg
+++ b/mcp/stdio/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "bobzhang/openseek/jsonrpc",
+  "bobzhang/openseek/mcp",
+  "moonbitlang/async",
+  "moonbitlang/async/process",
+  "moonbitlang/async/io",
+  "moonbitlang/core/json",
+}
+
+supported_targets = "+native"

--- a/mcp/stdio/ndjson.mbt
+++ b/mcp/stdio/ndjson.mbt
@@ -1,0 +1,64 @@
+// An NDJSON `@jsonrpc.Transport`: newline-delimited JSON-RPC over a byte
+// reader/writer pair — an MCP server subprocess's stdout/stdin. MCP stdio frames
+// each message as one line of UTF-8 JSON with no embedded newlines.
+
+///|
+/// A `@jsonrpc.Transport` that frames messages as newline-delimited JSON over a
+/// reader/writer pair. `on_close` is the synchronous teardown (e.g. terminate
+/// the subprocess and close its pipes) run when the client closes.
+struct NdjsonTransport {
+  reader : &@io.Reader
+  writer : &@io.Writer
+  on_close : () -> Unit
+}
+
+///|
+/// Build an NDJSON transport over `reader`/`writer`. `on_close` is the required,
+/// synchronous, idempotent teardown the client runs when it closes the
+/// transport. It MUST actually unblock a reader/writer parked on this pair —
+/// closing the underlying fd does not wake a coroutine suspended on it, so a
+/// subprocess transport cancels its reader/writer tasks — and should close the
+/// endpoints (and terminate any process). There is deliberately no default: a
+/// no-op `on_close` would leave the client's tasks and fds alive.
+pub fn NdjsonTransport::new(
+  reader : &@io.Reader,
+  writer : &@io.Writer,
+  on_close~ : () -> Unit,
+) -> NdjsonTransport {
+  { reader, writer, on_close }
+}
+
+///|
+pub impl @jsonrpc.Transport for NdjsonTransport with fn send(self, message) {
+  // One line per message; JSON stringify never emits a newline, so the frame is
+  // unambiguous.
+  self.writer.write("\{message.stringify()}\n")
+}
+
+///|
+pub impl @jsonrpc.Transport for NdjsonTransport with fn recv(self) {
+  // Read whole lines until one parses as JSON or the stream ends. A valid-UTF-8
+  // line that is not JSON (e.g. a stray log line the server leaked to stdout) is
+  // skipped; end of stream, a read error, or invalid UTF-8 (a server violating
+  // the "stdout carries only UTF-8 MCP messages" contract) returns `None`, which
+  // closes the connection.
+  for ;; {
+    let line = self.reader.read_until("\n") catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => None
+    }
+    guard line is Some(line) else { return None }
+    let trimmed = line.trim(chars="\r\n").to_owned()
+    if trimmed == "" {
+      continue
+    }
+    if (Some(@json.parse(trimmed)) catch { _ => None }) is Some(message) {
+      return Some(message)
+    }
+  }
+}
+
+///|
+pub impl @jsonrpc.Transport for NdjsonTransport with fn close(self) {
+  (self.on_close)()
+}

--- a/mcp/stdio/pkg.generated.mbti
+++ b/mcp/stdio/pkg.generated.mbti
@@ -1,0 +1,31 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/mcp/stdio"
+
+import {
+  "bobzhang/openseek/jsonrpc",
+  "bobzhang/openseek/mcp",
+  "moonbitlang/async",
+  "moonbitlang/async/io",
+}
+
+// Values
+pub const DefaultHandshakeTimeoutMs : Int = 30000
+
+pub async fn[X] connect(@async.TaskGroup[X], command~ : String, args~ : Array[String], env? : Map[String, String], cwd? : String, client_name~ : String, client_version~ : String, handshake_timeout_ms? : Int) -> StdioConnection?
+
+// Errors
+
+// Types and methods
+type NdjsonTransport
+pub fn NdjsonTransport::new(&@io.Reader, &@io.Writer, on_close~ : () -> Unit) -> Self
+pub impl @jsonrpc.Transport for NdjsonTransport
+
+type StdioConnection
+pub fn StdioConnection::client(Self) -> @mcp.McpClient
+pub fn StdioConnection::init(Self) -> @mcp.InitializeResult
+pub fn StdioConnection::shutdown(Self) -> Unit
+
+// Type aliases
+
+// Traits
+

--- a/mcp/stdio/stdio_wbtest.mbt
+++ b/mcp/stdio/stdio_wbtest.mbt
@@ -1,0 +1,149 @@
+// Integration tests: NDJSON framing end to end over an in-process pipe (the full
+// jsonrpc + mcp stack) and over a real subprocess, plus connect's failure path.
+
+///|
+/// A minimal in-process MCP server speaking over a jsonrpc transport, for the
+/// pipe test: answer initialize/tools-list/tools-call, ignore notifications.
+async fn pipe_mcp_server(transport : &@jsonrpc.Transport) -> Unit {
+  for ;; {
+    guard transport.recv() is Some(request) else { return }
+    guard request is { "method": String(method_), "id": id, .. } else {
+      // A notification (e.g. notifications/initialized): nothing to answer.
+      continue
+    }
+    let result : Json = match method_ {
+      "initialize" =>
+        {
+          "protocolVersion": "2025-11-25",
+          "serverInfo": { "name": "pipe", "version": "1.0" },
+        }
+      "tools/list" =>
+        {
+          "tools": [
+            {
+              "name": "echo",
+              "description": "Echo",
+              "inputSchema": { "type": "object" },
+            },
+          ],
+        }
+      "tools/call" => { "content": [{ "type": "text", "text": "called" }] }
+      _ => Json::empty_object()
+    }
+    transport.send({ "jsonrpc": "2.0", "id": id, "result": result })
+  }
+}
+
+///|
+async test "the MCP stack runs a handshake, list, and call over an ndjson pipe" {
+  @async.with_task_group(group => {
+    // client -> server and server -> client byte pipes.
+    let (server_reads, client_writes) = @io.pipe()
+    let (client_reads, server_writes) = @io.pipe()
+    let client_transport = NdjsonTransport::new(client_reads, client_writes, on_close=() => {
+      client_reads.close()
+      client_writes.close()
+    })
+    let server_transport : &@jsonrpc.Transport = NdjsonTransport::new(
+      server_reads,
+      server_writes,
+      on_close=() => {
+        server_reads.close()
+        server_writes.close()
+      },
+    )
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      pipe_mcp_server(server_transport)
+    })
+    let rpc = @jsonrpc.Client::new(client_transport)
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      rpc.run_message_pump()
+    })
+    group.spawn_bg(no_wait=true, allow_failure=true, () => rpc.run_writer())
+    let client = @mcp.McpClient::new(rpc)
+    let init = client.initialize(client_name="openseek", client_version="0.1")
+    assert_eq(init.server_name, "pipe")
+    assert_eq(init.protocol_version, "2025-11-25")
+    let tools = client.list_tools()
+    assert_eq(tools.length(), 1)
+    assert_eq(tools[0].name, "echo")
+    let result = client.call_tool(name="echo", arguments=Json::empty_object())
+    assert_eq(result.render_text(), "called")
+  })
+}
+
+///|
+async test "recv reads a JSON-RPC line from a real subprocess" {
+  @async.with_task_group(group => {
+    let (child_stdin, stdin_writer) = @process.write_to_process()
+    let (stdout_reader, child_stdout) = @process.read_from_process()
+    let line = "{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"ok\":true}}"
+    // `sh -c "echo '<line>'"` prints the JSON-RPC line and exits.
+    let process = @process.spawn(
+      group,
+      "sh",
+      ["-c", "echo '\{line}'"],
+      stdin=child_stdin,
+      stdout=child_stdout,
+      no_wait=true,
+    ) catch {
+      // Spawning is forbidden in this sandbox: skip (close our pipe ends; the
+      // child ends are released by spawn's own cleanup).
+      _ => {
+        stdout_reader.close()
+        stdin_writer.close()
+        return
+      }
+    }
+    let transport : &@jsonrpc.Transport = NdjsonTransport::new(
+      stdout_reader,
+      stdin_writer,
+      on_close=() => {
+        stdout_reader.close()
+        stdin_writer.close()
+        process.cancel()
+      },
+    )
+    guard transport.recv() is Some(json) else {
+      fail("expected a JSON-RPC line from the subprocess")
+    }
+    assert_true(
+      json is { "id": Number(7, ..), "result": { "ok": True, .. }, .. },
+    )
+    transport.close()
+  })
+}
+
+///|
+async test "connect returns None when the command cannot start" {
+  @async.with_task_group(group => {
+    let conn = connect(
+      group,
+      command="openseek-no-such-mcp-server-xyz",
+      args=[],
+      client_name="openseek",
+      client_version="0.1",
+    )
+    assert_true(conn is None)
+  })
+}
+
+///|
+/// A child that starts but never answers `initialize` must not hang connect: it
+/// returns None at the deadline (and tears the process down).
+async test "connect times out a server that never handshakes" {
+  @async.with_task_group(group => {
+    let conn = connect(
+      group,
+      command="sh",
+      args=["-c", "sleep 30"],
+      client_name="openseek",
+      client_version="0.1",
+      handshake_timeout_ms=500,
+    ) catch {
+      // Spawning is forbidden in this sandbox: skip.
+      _ => return
+    }
+    assert_true(conn is None)
+  })
+}


### PR DESCRIPTION
## What

Third PR in the **MCP client support** series (on top of #489 jsonrpc core and #490 mcp protocol layer). Adds the **stdio transport** and the **subprocess connect** in a new `mcp/stdio` package — enough to launch a local MCP server and speak MCP to it. No agent wiring yet (that's PR 4).

- **`NdjsonTransport`** — a `@jsonrpc.Transport` framing each JSON-RPC message as one newline-delimited line of UTF-8 JSON over an `@io` reader/writer pair (a server subprocess's stdout/stdin). A valid non-JSON line (a stray stdout log) is skipped; EOF, a read error, or invalid UTF-8 ends the stream. `close()` runs a required, synchronous, idempotent teardown.
- **`connect()`** — spawns `command args…` with stdin/stdout pipes (via the process helpers, whose child ends are Windows-correct synchronous endpoints), wires the transport to a `@jsonrpc.Client` (reader + writer tasks on the caller's group), runs the MCP handshake under a **timeout** (default 30s), and returns an initialized `StdioConnection` — or `None` on spawn failure, handshake failure, or timeout. The server **inherits openseek's environment** (`PATH`, `HOME`, …); config `env` adds/overrides.
- **Teardown** (`shutdown()` / every failure path / transport close): cancels the reader/writer **tasks** (closing an fd does not wake a coroutine parked on it), closes the pipes (the child sees stdin EOF), and terminates the process. Idempotent; seeded before the tasks exist so an early-exiting child can't consume a no-op.

## Review-driven hardening

Six rounds of codex (xhigh) + adversarial self-review, each finding empirically verified: handshake timeout (a non-answering child can't hang the caller), spawn-failure fd cleanup (checked under `MOONBIT_ASYNC_CHECK_FD_LEAK`), task-cancelling teardown, early-teardown seeding, Windows-correct child pipe ends (reverted a `@pipe.pipe()` refactor that would have broken blocking-stdio servers on Windows), and environment inheritance (an empty env made real servers fail to start).

## Accepted limitation (documented in code)

`Process::cancel()` signals only the direct child; the async process library has no process-group kill (same upstream gap as openseek's shell watchdog). A launcher that forks (e.g. `npx`) **and** ignores stdin-EOF can leave descendants running. Mitigated: teardown closes the server's stdin, so conformant MCP servers exit on EOF. Revisit when upstream grows group-kill.

## Tests

4 hermetic tests: full jsonrpc+mcp stack over `@io.pipe()` (handshake/list/call through real NDJSON framing), real-subprocess line read (skip-guarded), handshake-timeout, spawn-failure. All clean under fd-leak checking. **Dogfooded against a real MCP server** (`codex mcp-server`): negotiated protocol `2025-11-25`, listed its tools, clean shutdown — and the PR 4 bridge built real `mcp__codex__*` agent tools from it end-to-end.

## Series
1. jsonrpc core (#489, merged)
2. mcp/ protocol layer (#490, merged)
3. **stdio transport + subprocess connect (this PR)**
4. config (`--mcp-config`) + tool bridging + wiring
5. Streamable HTTP transport
6. docs, `openseek mcp` diagnostic subcommand, resources/prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)