### PR TITLE
feat(mcp): Streamable HTTP transport + http server config (MCP support, 5/6)

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -535,7 +535,7 @@ fn agent_options() -> Array[@argparse.OptionArg] {
       long="mcp-config",
       env="OPENSEEK_MCP_CONFIG",
       default_values=[""],
-      about="Path to a JSON file of MCP servers ({\"mcpServers\": {\"<name>\": {\"command\", \"args\", \"env\"}}}); each stdio server's tools are exposed to the agent, namespaced mcp__<server>__<tool>. Empty disables MCP.",
+      about="Path to a JSON file of MCP servers ({\"mcpServers\": {\"<name>\": {\"command\", \"args\", \"env\"} | {\"url\", \"headers\"}}}); each server's tools (stdio subprocess or Streamable HTTP) are exposed to the agent, namespaced mcp__<server>__<tool>. Empty disables MCP.",
     ),
   ]
 }

--- a/mcp/config/config.mbt
+++ b/mcp/config/config.mbt
@@ -1,12 +1,13 @@
 // Decode openseek's MCP server configuration — the de-facto standard
-// `{ "mcpServers": { "<name>": { "command", "args"?, "env"? } } }` shape, so an
-// existing Claude/Cursor-style `mcp.json` can be pointed at directly. File
-// reading and JSON parsing are the caller's; this layer is pure and decodes a
-// parsed `Json`.
+// `{ "mcpServers": { "<name>": { … } } }` shape, so an existing
+// Claude/Cursor-style `mcp.json` can be pointed at directly. A server entry is
+// either a stdio server (`"command"` + optional `"args"`/`"env"`) or a
+// Streamable HTTP server (`"url"` + optional `"headers"`). File reading and
+// JSON parsing are the caller's; this layer is pure and decodes a parsed `Json`.
 
 ///|
-/// A configured MCP server. Only stdio servers exist today (launched as a
-/// subprocess); an HTTP variant is added when that transport lands.
+/// A configured MCP server: launched as a subprocess (stdio) or reached at a
+/// Streamable HTTP endpoint.
 pub(all) enum McpServer {
   Stdio(
     name~ : String,
@@ -14,13 +15,14 @@ pub(all) enum McpServer {
     args~ : Array[String],
     env~ : Map[String, String]
   )
+  Http(name~ : String, url~ : String, headers~ : Map[String, String])
 } derive(Eq, Debug)
 
 ///|
 /// The configured server's name (the key under `mcpServers`).
 pub fn McpServer::name(self : McpServer) -> String {
   match self {
-    Stdio(name~, ..) => name
+    Stdio(name~, ..) | Http(name~, ..) => name
   }
 }
 
@@ -53,10 +55,16 @@ pub fn decode(json : Json) -> Array[McpServer] raise {
 }
 
 ///|
-/// Decode one server entry keyed by `name`.
+/// Decode one server entry keyed by `name`: `"url"` marks a Streamable HTTP
+/// server, `"command"` a stdio one; exactly one of the two must be present.
 fn decode_server(name : String, entry : Json) -> McpServer raise {
+  if entry is { "url": _, .. } {
+    return decode_http_server(name, entry)
+  }
   guard entry is { "command": String(command), .. } else {
-    raise Invalid("server `\{name}` is missing a string `command`")
+    raise Invalid(
+      "server `\{name}` needs a string `command` (stdio) or `url` (http)",
+    )
   }
   // A present-but-mistyped optional field is a config mistake, not an omission:
   // silently treating `"args": "--flag"` as no args would launch the server
@@ -86,4 +94,33 @@ fn decode_server(name : String, entry : Json) -> McpServer raise {
     }
   }
   Stdio(name~, command~, args~, env~)
+}
+
+///|
+/// Decode a Streamable HTTP server entry (its `url` key is already known to be
+/// present).
+fn decode_http_server(name : String, entry : Json) -> McpServer raise {
+  guard entry is { "url": String(url), .. } else {
+    raise Invalid("server `\{name}`: `url` must be a string")
+  }
+  if entry is { "command": _, .. } {
+    raise Invalid(
+      "server `\{name}`: give `command` (stdio) or `url` (http), not both",
+    )
+  }
+  let headers : Map[String, String] = Map([])
+  if entry is { "headers": headers_value, .. } {
+    guard headers_value is Object(vars) else {
+      raise Invalid("server `\{name}`: `headers` must be an object of strings")
+    }
+    for key, value in vars {
+      guard value is String(text) else {
+        raise Invalid(
+          "server `\{name}`: every `headers` value must be a string",
+        )
+      }
+      headers[key] = text
+    }
+  }
+  Http(name~, url~, headers~)
 }

--- a/mcp/config/config_wbtest.mbt
+++ b/mcp/config/config_wbtest.mbt
@@ -101,3 +101,69 @@ test "McpServer::name returns the configured key" {
   let servers = decode({ "mcpServers": { "srv": { "command": "run" } } })
   assert_eq(servers[0].name(), "srv")
 }
+
+///|
+test "decode parses an http server with headers" {
+  let servers = decode({
+    "mcpServers": {
+      "remote": {
+        "url": "https://example.com/mcp",
+        "headers": { "Authorization": "Bearer tok" },
+      },
+    },
+  })
+  guard servers[0] is Http(name~, url~, headers~) else {
+    fail("expected an http server")
+  }
+  assert_eq(name, "remote")
+  assert_eq(url, "https://example.com/mcp")
+  assert_eq(headers.get("Authorization"), Some("Bearer tok"))
+  assert_eq(servers[0].name(), "remote")
+}
+
+///|
+test "decode defaults missing http headers" {
+  let servers = decode({
+    "mcpServers": { "r": { "url": "http://127.0.0.1:9/mcp" } },
+  })
+  guard servers[0] is Http(headers~, ..) else {
+    fail("expected an http server")
+  }
+  assert_eq(headers.length(), 0)
+}
+
+///|
+test "decode rejects a server with both command and url" {
+  let outcome = try {
+    decode({
+      "mcpServers": { "x": { "command": "run", "url": "http://h/mcp" } },
+    })
+    |> ignore
+    "no error"
+  } catch {
+    Invalid(_) => "invalid"
+    _ => "other"
+  }
+  assert_eq(outcome, "invalid")
+}
+
+///|
+test "decode rejects mistyped http fields" {
+  let bad_url = try {
+    decode({ "mcpServers": { "x": { "url": 7 } } }) |> ignore
+    "no error"
+  } catch {
+    Invalid(_) => "invalid"
+    _ => "other"
+  }
+  assert_eq(bad_url, "invalid")
+  let bad_headers = try {
+    decode({ "mcpServers": { "x": { "url": "http://h/mcp", "headers": [] } } })
+    |> ignore
+    "no error"
+  } catch {
+    Invalid(_) => "invalid"
+    _ => "other"
+  }
+  assert_eq(bad_headers, "invalid")
+}

--- a/mcp/config/pkg.generated.mbti
+++ b/mcp/config/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub(all) suberror ConfigError {
 // Types and methods
 pub(all) enum McpServer {
   Stdio(name~ : String, command~ : String, args~ : Array[String], env~ : Map[String, String])
+  Http(name~ : String, url~ : String, headers~ : Map[String, String])
 } derive(Eq, @debug.Debug)
 pub fn McpServer::name(Self) -> String
 

--- a/mcp/streamhttp/connect.mbt
+++ b/mcp/streamhttp/connect.mbt
@@ -1,0 +1,97 @@
+// Connect to a remote MCP server over Streamable HTTP.
+
+///|
+/// The default handshake deadline, matching the stdio transport's.
+pub const DefaultHandshakeTimeoutMs : Int = 30000
+
+///|
+/// A live Streamable HTTP MCP connection: the initialized client plus an
+/// idempotent teardown. Its reader/writer tasks run on the task group passed to
+/// `connect`; the connection is torn down when that group ends, or eagerly via
+/// `shutdown`.
+struct HttpConnection {
+  client : @mcp.McpClient
+  init : @mcp.InitializeResult
+  teardown : () -> Unit
+}
+
+///|
+/// The initialized MCP client to issue `list_tools` / `call_tool` against.
+pub fn HttpConnection::client(self : HttpConnection) -> @mcp.McpClient {
+  self.client
+}
+
+///|
+/// What the server reported from `initialize`.
+pub fn HttpConnection::init(self : HttpConnection) -> @mcp.InitializeResult {
+  self.init
+}
+
+///|
+/// Tear the connection down eagerly: cancel the reader/writer tasks and close
+/// the transport. Idempotent.
+pub fn HttpConnection::shutdown(self : HttpConnection) -> Unit {
+  (self.teardown)()
+}
+
+///|
+/// Wire a Streamable HTTP transport for the MCP endpoint at `url` to a JSON-RPC
+/// client (reader and writer tasks on `group`), run the MCP handshake under
+/// `handshake_timeout_ms`, and return the initialized connection — or `None`
+/// when the endpoint is unreachable, answers with an error, or the handshake
+/// fails or times out. `headers` (e.g. `Authorization`) go on every request.
+pub async fn[X] connect(
+  group : @async.TaskGroup[X],
+  url~ : String,
+  headers? : Map[String, String] = Map([]),
+  client_name~ : String,
+  client_version~ : String,
+  handshake_timeout_ms? : Int = DefaultHandshakeTimeoutMs,
+) -> HttpConnection? {
+  // Each POST exchange runs as its own cancellable task on the connection's
+  // group, so the jsonrpc writer is never blocked by a long or stalled response
+  // stream — and teardown can cancel an in-flight exchange.
+  let transport = HttpTransport::new(
+    url,
+    spawn=exchange => group.spawn(exchange, no_wait=true, allow_failure=true),
+    extra_headers=headers,
+  )
+  let client = @jsonrpc.Client::new(transport)
+  let pump = group.spawn(
+    () => client.run_message_pump(),
+    no_wait=true,
+    allow_failure=true,
+  )
+  let writer = group.spawn(
+    () => client.run_writer(),
+    no_wait=true,
+    allow_failure=true,
+  )
+  let torn_down : Ref[Bool] = { val: false }
+  let teardown = () => {
+    if !torn_down.val {
+      torn_down.val = true
+      pump.cancel()
+      writer.cancel()
+      transport.close()
+    }
+  }
+  let mcp_client = @mcp.McpClient::new(client)
+  let init = @async.with_timeout_opt(handshake_timeout_ms, () => {
+    mcp_client.initialize(client_name~, client_version~)
+  }) catch {
+    error if @async.is_being_cancelled() => {
+      teardown()
+      raise error
+    }
+    _ => {
+      teardown()
+      return None
+    }
+  }
+  guard init is Some(init) else {
+    teardown()
+    return None
+  }
+  Some({ client: mcp_client, init, teardown })
+}

--- a/mcp/streamhttp/moon.pkg
+++ b/mcp/streamhttp/moon.pkg
@@ -1,0 +1,17 @@
+import {
+  "bobzhang/openseek/jsonrpc",
+  "bobzhang/openseek/mcp",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/core/json",
+  "moonbitlang/core/encoding/utf8",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/json",
+} for "test"
+
+supported_targets = "+native"

--- a/mcp/streamhttp/pkg.generated.mbti
+++ b/mcp/streamhttp/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/mcp/streamhttp"
+
+import {
+  "bobzhang/openseek/jsonrpc",
+  "bobzhang/openseek/mcp",
+  "moonbitlang/async",
+}
+
+// Values
+pub const DefaultHandshakeTimeoutMs : Int = 30000
+
+pub async fn[X] connect(@async.TaskGroup[X], url~ : String, headers? : Map[String, String], client_name~ : String, client_version~ : String, handshake_timeout_ms? : Int) -> HttpConnection?
+
+// Errors
+
+// Types and methods
+type HttpConnection
+pub fn HttpConnection::client(Self) -> @mcp.McpClient
+pub fn HttpConnection::init(Self) -> @mcp.InitializeResult
+pub fn HttpConnection::shutdown(Self) -> Unit
+
+type HttpTransport
+pub fn HttpTransport::new(String, spawn~ : (async () -> Unit) -> @async.Task[Unit], extra_headers? : Map[String, String]) -> Self
+pub impl @jsonrpc.Transport for HttpTransport
+
+// Type aliases
+
+// Traits
+

--- a/mcp/streamhttp/streamhttp_test.mbt
+++ b/mcp/streamhttp/streamhttp_test.mbt
@@ -1,0 +1,404 @@
+// End-to-end tests against a local mock MCP endpoint served by @http.Server:
+// the full jsonrpc + mcp stack over real HTTP, exercising both response modes
+// (single application/json body and an SSE event stream), session-id echoing,
+// and the negotiated-protocol-version header.
+
+///|
+/// Bind a localhost mock server for one test, or report the skip and return
+/// None where the sandbox forbids TCP binds.
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}
+
+///|
+/// Headers seen on the requests after initialization, for asserting that the
+/// session id and protocol version are echoed.
+struct SeenHeaders {
+  mut session_id : String
+  mut protocol_version : String
+  mut accept : String
+  mut deleted_session : String
+}
+
+///|
+/// A mock MCP endpoint: `initialize` answered as a single JSON body carrying an
+/// `Mcp-Session-Id` header; notifications answered 202; `tools/list` answered as
+/// an SSE stream (one notification event, then the reply). Returns the endpoint
+/// URL and the headers seen on the `tools/list` request.
+async fn mock_mcp_endpoint(
+  group : @async.TaskGroup[Unit],
+) -> (String, SeenHeaders)? {
+  guard bind_test_server("local TCP bind unavailable; skipping http mcp test")
+    is Some(server) else {
+    return None
+  }
+  let seen : SeenHeaders = {
+    session_id: "",
+    protocol_version: "",
+    accept: "",
+    deleted_session: "",
+  }
+  group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        let text = body.read_all().text()
+        if request.meth is Delete {
+          for key, value in request.headers {
+            if key.to_lower() == "mcp-session-id" {
+              seen.deleted_session = value
+            }
+          }
+          conn.send_response(200, "OK")
+          return
+        }
+        let message = @json.parse(text) catch { _ => Json::null() }
+        match message {
+          { "method": String("initialize"), "id": id, .. } => {
+            let reply : Json = {
+              "jsonrpc": "2.0",
+              "id": id,
+              "result": {
+                "protocolVersion": "2025-11-25",
+                "serverInfo": { "name": "http-mock", "version": "1.0" },
+              },
+            }
+            conn.send_response(200, "OK", extra_headers={
+              "Content-Type": "application/json",
+              "Mcp-Session-Id": "session-123",
+            })
+            conn.write(reply.stringify())
+          }
+          { "method": String("tools/list"), "id": id, .. } => {
+            for key, value in request.headers {
+              match key.to_lower() {
+                "mcp-session-id" => seen.session_id = value
+                "mcp-protocol-version" => seen.protocol_version = value
+                "accept" => seen.accept = value
+                _ => ()
+              }
+            }
+            let reply : Json = {
+              "jsonrpc": "2.0",
+              "id": id,
+              "result": {
+                "tools": [
+                  {
+                    "name": "fetch",
+                    "description": "Fetch a URL",
+                    "inputSchema": { "type": "object" },
+                  },
+                ],
+              },
+            }
+            conn.send_response(200, "OK", extra_headers={
+              "Content-Type": "text/event-stream",
+            })
+            // A notification event before the reply, framed with lone CRs (the
+            // third terminator SSE permits), then the reply as a CRLF-framed
+            // multi-line data event.
+            conn.write(
+              "event: message\rdata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{}}\r\r",
+            )
+            conn.flush()
+            // Split at a token boundary: SSE joins the lines with a newline,
+            // which JSON tolerates only between tokens.
+            ignore(reply)
+            conn.write(
+              "data: {\"jsonrpc\":\"2.0\",\"id\":\{id.stringify()},\r\ndata: \"result\":{\"tools\":[{\"name\":\"fetch\",\"description\":\"Fetch a URL\",\"inputSchema\":{\"type\":\"object\"}}]}}\r\n\r\n",
+            )
+            conn.flush()
+            // Hold the stream open past the reply: the client must release the
+            // exchange (and answer promptly) instead of reading to EOF.
+            @async.sleep(3000)
+          }
+          // A notification (e.g. notifications/initialized): accepted, no body.
+          _ => conn.send_response(202, "Accepted")
+        }
+      },
+      max_connections=8,
+    )
+  }
+  Some(("http://127.0.0.1:\{server.addr.port()}/mcp", seen))
+}
+
+///|
+async test "http connect handshakes, lists tools over SSE, and echoes session headers" {
+  @async.with_task_group() <| group => {
+    guard mock_mcp_endpoint(group) is Some((url, seen)) else { return }
+    guard @streamhttp.connect(
+        group,
+        url~,
+        client_name="openseek",
+        client_version="0.1",
+        handshake_timeout_ms=10000,
+      )
+      is Some(conn) else {
+      fail("expected the http connect to succeed")
+    }
+    assert_eq(conn.init().server_name, "http-mock")
+    assert_eq(conn.init().protocol_version, "2025-11-25")
+    let tools = conn.client().list_tools()
+    assert_eq(tools.length(), 1)
+    assert_eq(tools[0].name, "fetch")
+    // The post-initialize request carried the session and version headers.
+    assert_eq(seen.session_id, "session-123")
+    assert_eq(seen.protocol_version, "2025-11-25")
+    assert_true(seen.accept.contains("text/event-stream"))
+    conn.shutdown()
+    // Shutdown releases the server session with a best-effort DELETE.
+    for _ in 0..<100 {
+      if seen.deleted_session != "" {
+        break
+      }
+      @async.sleep(20)
+    }
+    assert_eq(seen.deleted_session, "session-123")
+  }
+}
+
+///|
+async test "http connect returns None for an unreachable endpoint" {
+  @async.with_task_group() <| group => {
+    let conn = @streamhttp.connect(
+      group,
+      // A localhost port from the dynamic range with nothing listening.
+      url="http://127.0.0.1:1/mcp",
+      client_name="openseek",
+      client_version="0.1",
+      handshake_timeout_ms=3000,
+    )
+    assert_true(conn is None)
+  }
+}
+
+///|
+/// Regression guard for the send-serialization deadlock: a server-initiated
+/// `ping` arriving mid-SSE-stream must be answerable while that stream is still
+/// open (each POST runs on its own task), and the original request completes
+/// after the server sees the pong.
+async test "a server ping mid-stream is answered while the stream is open" {
+  @async.with_task_group() <| group => {
+    guard bind_test_server("local TCP bind unavailable; skipping ping test")
+      is Some(server) else {
+      return
+    }
+    // The pong POST arrives on a separate connection; hand it to the stream
+    // handler through a queue.
+    let pongs : @async.Queue[Json] = Queue(kind=Unbounded)
+    group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let message = @json.parse(body.read_all().text()) catch {
+            _ => Json::null()
+          }
+          match message {
+            { "method": String("initialize"), "id": id, .. } => {
+              let reply : Json = {
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "protocolVersion": "2025-11-25" },
+              }
+              conn.send_response(200, "OK", extra_headers={
+                "Content-Type": "application/json",
+              })
+              conn.write(reply.stringify())
+            }
+            { "method": String("tools/list"), "id": id, .. } => {
+              conn.send_response(200, "OK", extra_headers={
+                "Content-Type": "text/event-stream",
+              })
+              // Ask the client for a ping mid-stream and WAIT for its pong
+              // before answering the request — the old inline-SSE design
+              // deadlocked exactly here.
+              conn.write(
+                "data: {\"jsonrpc\":\"2.0\",\"id\":\"srv-ping\",\"method\":\"ping\"}\n\n",
+              )
+              conn.flush()
+              let pong = pongs.get()
+              assert_true(pong is { "id": String("srv-ping"), "result": _, .. })
+              let reply : Json = {
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "tools": [{ "name": "late" }] },
+              }
+              conn.write("data: \{reply.stringify()}\n\n")
+            }
+            // The pong (a response, no method) — route it to the stream handler.
+            { "id": String("srv-ping"), .. } => {
+              pongs.put(message)
+              conn.send_response(202, "Accepted")
+            }
+            _ => conn.send_response(202, "Accepted")
+          }
+        },
+        max_connections=8,
+      )
+    }
+    guard @streamhttp.connect(
+        group,
+        url="http://127.0.0.1:\{server.addr.port()}/mcp",
+        client_name="openseek",
+        client_version="0.1",
+        handshake_timeout_ms=10000,
+      )
+      is Some(conn) else {
+      fail("expected the http connect to succeed")
+    }
+    let tools = @async.with_timeout_opt(10000, () => conn.client().list_tools())
+    guard tools is Some(tools) else {
+      fail("tools/list deadlocked behind the mid-stream ping")
+    }
+    assert_eq(tools[0].name, "late")
+    conn.shutdown()
+  }
+}
+
+///|
+/// A failed POST (HTTP 500) fails the pending request fast via a synthesized
+/// JSON-RPC error instead of leaving it to an outer timeout.
+async test "an http error fails the request fast" {
+  @async.with_task_group() <| group => {
+    guard bind_test_server("local TCP bind unavailable; skipping error test")
+      is Some(server) else {
+      return
+    }
+    group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let message = @json.parse(body.read_all().text()) catch {
+            _ => Json::null()
+          }
+          match message {
+            { "method": String("initialize"), "id": id, .. } => {
+              let reply : Json = {
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "protocolVersion": "2025-11-25" },
+              }
+              conn.send_response(200, "OK", extra_headers={
+                "Content-Type": "application/json",
+              })
+              conn.write(reply.stringify())
+            }
+            { "method": String("tools/list"), .. } => {
+              conn.send_response(500, "Internal Server Error", extra_headers={
+                "Content-Type": "text/plain",
+              })
+              conn.write("boom")
+            }
+            _ => conn.send_response(202, "Accepted")
+          }
+        },
+        max_connections=8,
+      )
+    }
+    guard @streamhttp.connect(
+        group,
+        url="http://127.0.0.1:\{server.addr.port()}/mcp",
+        client_name="openseek",
+        client_version="0.1",
+        handshake_timeout_ms=10000,
+      )
+      is Some(conn) else {
+      fail("expected the http connect to succeed")
+    }
+    // Bounded well below any outer timeout: the failure must arrive promptly.
+    let outcome = @async.with_timeout_opt(5000, () => {
+      try {
+        conn.client().list_tools() |> ignore
+        "no error raised"
+      } catch {
+        @jsonrpc.Failed(code~, message~) => "failed \{code}: \{message}"
+        error if @async.is_being_cancelled() => raise error
+        _ => "other error"
+      }
+    })
+    guard outcome is Some(outcome) else { fail("request did not fail fast") }
+    assert_true(outcome.contains("failed -32000"))
+    assert_true(outcome.contains("HTTP 500"))
+    conn.shutdown()
+  }
+}
+
+///|
+/// Regression guard for the lifecycle ordering race: with detached per-POST
+/// tasks, `tools/list` must still reach the server only after the
+/// `notifications/initialized` POST has completed — even when the server is
+/// slow to process that notification.
+async test "tools/list waits for the initialized notification to complete" {
+  @async.with_task_group() <| group => {
+    guard bind_test_server("local TCP bind unavailable; skipping ordering test")
+      is Some(server) else {
+      return
+    }
+    let initialized_done : Ref[Bool] = { val: false }
+    let list_saw_initialized : Ref[Bool] = { val: false }
+    group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let message = @json.parse(body.read_all().text()) catch {
+            _ => Json::null()
+          }
+          match message {
+            { "method": String("initialize"), "id": id, .. } => {
+              let reply : Json = {
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "protocolVersion": "2025-11-25" },
+              }
+              conn.send_response(200, "OK", extra_headers={
+                "Content-Type": "application/json",
+              })
+              conn.write(reply.stringify())
+            }
+            { "method": String("notifications/initialized"), .. } => {
+              // A slow lifecycle handler: without the transport's gate, the
+              // detached tools/list POST overtakes this notification.
+              @async.sleep(150)
+              initialized_done.val = true
+              conn.send_response(202, "Accepted")
+            }
+            { "method": String("tools/list"), "id": id, .. } => {
+              list_saw_initialized.val = initialized_done.val
+              let reply : Json = {
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": { "tools": [{ "name": "ordered" }] },
+              }
+              conn.send_response(200, "OK", extra_headers={
+                "Content-Type": "application/json",
+              })
+              conn.write(reply.stringify())
+            }
+            _ => conn.send_response(202, "Accepted")
+          }
+        },
+        max_connections=8,
+      )
+    }
+    guard @streamhttp.connect(
+        group,
+        url="http://127.0.0.1:\{server.addr.port()}/mcp",
+        client_name="openseek",
+        client_version="0.1",
+        handshake_timeout_ms=10000,
+      )
+      is Some(conn) else {
+      fail("expected the http connect to succeed")
+    }
+    let tools = conn.client().list_tools()
+    assert_eq(tools[0].name, "ordered")
+    assert_true(list_saw_initialized.val)
+    conn.shutdown()
+  }
+}

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -1,0 +1,599 @@
+// The MCP Streamable HTTP transport: every outgoing JSON-RPC message is an HTTP
+// POST to the server's single MCP endpoint; inbound messages arrive in the POST
+// responses — either one `application/json` body or a `text/event-stream` whose
+// events each carry a JSON-RPC message — and are queued for the reader.
+//
+// Each POST runs on its own spawned task, so `send` returns as soon as the POST
+// is dispatched. That keeps the jsonrpc writer free: concurrent requests POST
+// concurrently, a reply to a server-initiated request (e.g. a `ping` arriving
+// mid-stream) can be sent while its stream is still open, and a stalled stream
+// wedges only its own request — which is failed fast by a synthesized JSON-RPC
+// error reply whenever its POST errors, so callers never wait out an outer
+// timeout on a dead exchange.
+//
+// Scope: the POST flow of the Streamable HTTP spec, including session ids
+// (`Mcp-Session-Id`) and the negotiated `MCP-Protocol-Version` header. The
+// optional standing GET stream (server-initiated messages between requests) and
+// SSE resumability are not implemented: openseek only issues requests and reads
+// their (possibly streamed) replies. A server that expires the session answers
+// 404; that fails the in-flight call with a clear error (reinitialization is
+// not attempted — reconnect by restarting the engine).
+
+///|
+/// Cap on concurrently running POST exchanges. A legitimate agent workload
+/// stays in single digits; the cap exists so a server flooding peer requests
+/// (each answered by a POST) or stalling response streams cannot grow tasks and
+/// connections without bound. At the cap, a client request fails fast with a
+/// synthesized error and a server-bound reply/notification is dropped.
+const MaxInFlightExchanges : Int = 32
+
+///|
+/// Deadline for one whole POST exchange, with margin over the bridge's 120s
+/// per-call timeout: when a caller has long since timed out, the exchange must
+/// not keep holding a socket and a cap slot on an endpoint that never closes
+/// its response.
+const ExchangeTimeoutMs : Int = 150000
+
+///|
+/// Deadline for the best-effort session DELETE sent at close.
+const SessionDeleteTimeoutMs : Int = 5000
+
+///|
+/// A `@jsonrpc.Transport` speaking MCP Streamable HTTP against `url`.
+struct HttpTransport {
+  url : String
+  // User-supplied headers (e.g. Authorization), sent on every request.
+  extra_headers : Map[String, String]
+  // Runs one POST's request/response exchange as a cancellable task on the
+  // owning task group.
+  spawn : (async () -> Unit) -> @async.Task[Unit]
+  // In-flight POST tasks by ticket, so `close` can cancel a connecting or
+  // streaming exchange instead of leaving its socket alive on the agent scope.
+  // Each task removes itself on exit, keeping the map bounded.
+  pending_posts : Map[Int, @async.Task[Unit]]
+  mut next_post : Int
+  // Messages parsed out of POST responses, awaiting the reader.
+  inbound : @async.Queue[Json]
+  // Fed exactly once, when the `notifications/initialized` POST completes.
+  // MCP's lifecycle requires that notification to reach the server before any
+  // normal request, but detached POSTs use separate connections and order only
+  // task creation — so later POSTs first await this gate.
+  mut initialized_gate : @async.Queue[Unit]?
+  // The server's session id, captured from the `initialize` response and echoed
+  // on every later request.
+  mut session_id : String?
+  // The id of the in-flight `initialize` request, so its reply (which fixes the
+  // negotiated protocol version) can be recognized.
+  mut initialize_id : Json?
+  // The negotiated protocol version, sent as `MCP-Protocol-Version` on every
+  // request after initialization.
+  mut protocol_version : String?
+  mut closed : Bool
+}
+
+///|
+/// Build a Streamable HTTP transport for the MCP endpoint at `url`. `spawn`
+/// runs one POST exchange as a cancellable task on the connection's group
+/// (`connect` wires it); `extra_headers` (e.g. `Authorization`) are added to
+/// every request.
+pub fn HttpTransport::new(
+  url : String,
+  spawn~ : (async () -> Unit) -> @async.Task[Unit],
+  extra_headers? : Map[String, String] = Map([]),
+) -> HttpTransport {
+  {
+    url,
+    extra_headers,
+    spawn,
+    pending_posts: Map([]),
+    next_post: 0,
+    inbound: Queue(kind=Unbounded),
+    initialized_gate: None,
+    session_id: None,
+    initialize_id: None,
+    protocol_version: None,
+    closed: false,
+  }
+}
+
+///|
+/// The headers for one POST: the MCP-required set, the session/version state,
+/// and the user's extras. `Accept-Encoding: identity` keeps an intermediary from
+/// re-buffering the event stream (same pitfall the DeepSeek client pins).
+fn HttpTransport::request_headers(self : HttpTransport) -> Map[String, String] {
+  let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+    "Accept-Encoding": "identity",
+  }
+  if self.session_id is Some(session_id) {
+    headers["Mcp-Session-Id"] = session_id
+  }
+  if self.protocol_version is Some(version) {
+    headers["MCP-Protocol-Version"] = version
+  }
+  for key, value in self.extra_headers {
+    if !reserved_header(key) {
+      headers[key] = value
+    }
+  }
+  headers
+}
+
+///|
+/// Whether `name` is a transport-owned header a configured extra must not
+/// replace: the protocol-managed set plus the message-framing headers the HTTP
+/// layer computes. Case-insensitive (differently cased user keys would
+/// otherwise emit conflicting duplicates on the wire).
+fn reserved_header(name : String) -> Bool {
+  match name.to_lower() {
+    "content-type"
+    | "accept"
+    | "accept-encoding"
+    | "mcp-session-id"
+    | "mcp-protocol-version"
+    | "content-length"
+    | "transfer-encoding"
+    | "host" => true
+    _ => false
+  }
+}
+
+///|
+/// Feed a lifecycle gate, if any: synchronous (a defer cannot await) and total
+/// on the unbounded queue unless the transport already closed it.
+fn feed_gate(completion : @async.Queue[Unit]?) -> Unit {
+  if completion is Some(completion) {
+    (completion.try_put(()) catch { _ => false }) |> ignore
+  }
+}
+
+///|
+/// Case-insensitive response-header lookup (header names are case-insensitive
+/// on the wire and servers vary).
+fn header_value(headers : Map[String, String], name : String) -> String? {
+  let wanted = name.to_lower()
+  for key, value in headers {
+    if key.to_lower() == wanted {
+      return Some(value)
+    }
+  }
+  None
+}
+
+///|
+pub impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
+  guard !self.closed else { fail("transport closed") }
+  // The id this POST must answer (None for a notification or a reply): if the
+  // exchange fails before delivering that reply, a synthesized error fails the
+  // pending request fast instead of leaving it to an outer timeout.
+  let request_id : Json? = match message {
+    { "method": _, "id": id, .. } => Some(id)
+    _ => None
+  }
+  // Bounded concurrency, checked before any lifecycle bookkeeping: at the cap,
+  // fail a client request fast and drop a flood-driven reply/notification
+  // rather than growing tasks and connections without bound.
+  if self.pending_posts.length() >= MaxInFlightExchanges {
+    if request_id is Some(id) {
+      self.deliver({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+          "code": -32000,
+          "message": "too many in-flight MCP exchanges (server flooding or stalling)",
+        },
+      })
+    }
+    return
+  }
+  // Remember the initialize request's id so its reply can fix the negotiated
+  // protocol version for later headers.
+  if message is { "method": String("initialize"), "id": id, .. } {
+    self.initialize_id = Some(id)
+  }
+  // The lifecycle notification opens the ordering gate; every later POST must
+  // wait behind it (see `initialized_gate`). Which gate (if any) this POST
+  // awaits is decided HERE, at dispatch order, not when the task first runs.
+  let gate = self.initialized_gate
+  let opens_gate = message
+    is { "method": String("notifications/initialized"), .. }
+  let completion : @async.Queue[Unit]? = if opens_gate {
+    let completion : @async.Queue[Unit] = Queue(kind=Unbounded)
+    self.initialized_gate = Some(completion)
+    Some(completion)
+  } else {
+    None
+  }
+  let ticket = self.next_post
+  self.next_post = self.next_post + 1
+  // Whether the exchange task already ran to completion: TaskGroup::spawn's
+  // start timing is undefined, so registration below must not resurrect a
+  // ticket whose task finished before `spawn` returned.
+  let done : Ref[Bool] = { val: false }
+  let task = (self.spawn)(() => {
+    // All defers sit at the task-body scope (a defer inside an `if` block
+    // would fire at that block's end — i.e. immediately), so they run when the
+    // task exits: feeding the gate however this exchange ends means a failed
+    // lifecycle notification cannot wedge every later request.
+    defer {
+      done.val = true
+    }
+    defer self.pending_posts.remove(ticket)
+    defer feed_gate(completion)
+    if gate is Some(gate) {
+      gate.get() catch {
+        error if @async.is_being_cancelled() => raise error
+        // Gate closed with the transport: proceed to fail normally below.
+        _ => ()
+      }
+      (gate.try_put(()) catch { _ => false }) |> ignore
+    }
+    self.run_post(message, request_id)
+  })
+  // Register only if the task has not already finished (spawn's start timing is
+  // undefined): inserting a completed task would strand its ticket and consume
+  // the exchange cap forever.
+  if !done.val {
+    self.pending_posts[ticket] = task
+  }
+}
+
+///|
+pub impl @jsonrpc.Transport for HttpTransport with fn recv(self) {
+  Some(self.inbound.get()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+}
+
+///|
+pub impl @jsonrpc.Transport for HttpTransport with fn close(self) {
+  let already_closed = self.closed
+  self.closed = true
+  self.inbound.close()
+  // Cancel a connecting or streaming exchange rather than leaving its socket
+  // alive on the agent scope. Idempotent: completed tasks removed themselves,
+  // and cancelling twice is a no-op.
+  for _, task in self.pending_posts {
+    task.cancel()
+  }
+  self.pending_posts.clear()
+  // Release the server-assigned session (spec: DELETE with the session header;
+  // 405 means the server declines). Best-effort and bounded, on a detached
+  // task — close() itself must never suspend. When close comes from the owning
+  // group's own termination, the spawned task is cancelled before it can do
+  // I/O; the session then ends by server-side expiry, which the spec requires
+  // servers to handle anyway (clients can vanish at any time).
+  if !already_closed && self.session_id is Some(session_id) {
+    let url = self.url
+    let headers = { "Mcp-Session-Id": session_id }
+    // A strict server enforces the negotiated version on every
+    // post-initialization request, the DELETE included.
+    if self.protocol_version is Some(version) {
+      headers["MCP-Protocol-Version"] = version
+    }
+    for key, value in self.extra_headers {
+      if !reserved_header(key) {
+        headers[key] = value
+      }
+    }
+    (self.spawn)(() => {
+      @async.with_timeout_opt(SessionDeleteTimeoutMs, () => {
+        delete_session(url, headers)
+      })
+      |> ignore
+    })
+    |> ignore
+  }
+}
+
+///|
+/// Best-effort `DELETE <endpoint>` with the session (and negotiated-version)
+/// headers; every failure — including 405 from a server that declines
+/// client-initiated termination — is swallowed.
+async fn delete_session(url : String, headers : Map[String, String]) -> Unit {
+  // Split the MCP URL into origin (scheme + host[:port]) and path.
+  guard url.find("://") is Some(scheme_end) else { return }
+  let host_start = scheme_end + 3
+  let (origin, path) = match url[host_start:].find("/") {
+    Some(slash) => {
+      let cut = host_start + slash
+      (url[:cut].to_owned(), url[cut:].to_owned())
+    }
+    None => (url, "/")
+  }
+  let client = @http.Client::Client(origin) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return
+  }
+  defer client.close()
+  client.request(Delete, path, extra_headers=headers) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return
+  }
+  let _ = client.end_request() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return
+  }
+  client.skip_response_body() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+}
+
+///|
+/// One POST exchange: send `message`, parse the response (single JSON body or
+/// SSE stream), and deliver each inbound message. Any failure before
+/// `request_id`'s reply has been delivered fails that request via a synthesized
+/// JSON-RPC error reply. Runs on its own task; cancellation propagates.
+async fn HttpTransport::run_post(
+  self : HttpTransport,
+  message : Json,
+  request_id : Json?,
+) -> Unit {
+  let mut answered = false
+  let deliver = (inbound : Json) => {
+    // Only a reply (result/error) counts as the answer — a server-initiated
+    // request whose id happens to collide (both sides number from 1) must not
+    // suppress the fail-fast synthesized error.
+    if request_id is Some(expected) &&
+      inbound is ({ "id": id, "result": _, .. } | { "id": id, "error": _, .. }) &&
+      id == expected {
+      answered = true
+    }
+    self.deliver(inbound)
+  }
+  let bounded = @async.with_timeout_opt(ExchangeTimeoutMs, () => {
+    self.exchange(message, deliver, answered=() => answered)
+  }) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      // Fail the pending request fast (the exchange is dead); a notification
+      // has nothing to answer.
+      if request_id is Some(id) && !answered {
+        answered = true
+        self.deliver({
+          "jsonrpc": "2.0",
+          "id": id,
+          "error": {
+            "code": -32000,
+            "message": "MCP endpoint exchange failed: \{error}",
+          },
+        })
+      }
+      return
+    }
+  }
+  // Deadline expiry: the endpoint held the exchange open past any useful
+  // lifetime; fail the request and release this slot.
+  if bounded is None && request_id is Some(id) && !answered {
+    answered = true
+    self.deliver({
+      "jsonrpc": "2.0",
+      "id": id,
+      "error": {
+        "code": -32000,
+        "message": "MCP endpoint exchange exceeded \{ExchangeTimeoutMs / 1000}s",
+      },
+    })
+  }
+  // The response ended without answering the request (e.g. an SSE stream closed
+  // early): fail it rather than leaving the caller to an outer timeout.
+  if request_id is Some(id) && !answered {
+    self.deliver({
+      "jsonrpc": "2.0",
+      "id": id,
+      "error": {
+        "code": -32000,
+        "message": "MCP endpoint response ended without answering the request",
+      },
+    })
+  }
+}
+
+///|
+/// POST `message` and deliver every inbound message in the response. Raises on
+/// an HTTP error status or a transport failure.
+async fn HttpTransport::exchange(
+  self : HttpTransport,
+  message : Json,
+  deliver : (Json) -> Unit,
+  answered~ : () -> Bool,
+) -> Unit {
+  let client = @http.post_stream(self.url, headers=self.request_headers())
+  defer client.close()
+  client.write(message.stringify())
+  let response = client.end_request()
+  // The spec assigns the session id on the initialize response only; capturing
+  // it elsewhere would let a later (or misbehaving) response rebind the session.
+  if message is { "method": String("initialize"), .. } &&
+    header_value(response.headers, "Mcp-Session-Id") is Some(session_id) {
+    self.session_id = Some(session_id)
+  }
+  // < 300: @http follows no redirects, so a 3xx answer is also a dead exchange —
+  // name its status rather than reporting a generic unanswered response.
+  guard response.code < 300 else {
+    // 404 with a session marks an expired session per the spec; name it.
+    if response.code == 404 && self.session_id is Some(_) {
+      fail("MCP session expired (HTTP 404); reconnect to reinitialize")
+    }
+    fail("MCP endpoint answered HTTP \{response.code}")
+  }
+  // Media types are case-insensitive on the wire.
+  let content_type = header_value(response.headers, "Content-Type")
+    .unwrap_or("")
+    .to_lower()
+  if content_type.contains("text/event-stream") {
+    self.read_sse_stream(client, deliver, answered~)
+  } else if content_type.contains("application/json") {
+    let text = client.read_all().text()
+    deliver(@json.parse(text))
+  } else {
+    // 202 Accepted (a notification/response was consumed) or an empty body.
+    client.skip_response_body()
+  }
+}
+
+///|
+/// Read one SSE response stream to its end, delivering each event's JSON-RPC
+/// message. Multi-line `data:` fields are joined with newlines per the SSE spec;
+/// `event:`/`id:`/comment lines are ignored. Raises on a read failure (which
+/// fails the owning request) rather than masking it as a clean end of stream.
+async fn HttpTransport::read_sse_stream(
+  self : HttpTransport,
+  client : @http.Client,
+  deliver : (Json) -> Unit,
+  answered~ : () -> Bool,
+) -> Unit {
+  ignore(self)
+  let data = StringBuilder()
+  let mut has_data = false
+  let lines = SseLineReader::new(client)
+  for ;; {
+    guard lines.next_line() is Some(line) else { break }
+    if line == "" {
+      // Event boundary: dispatch the accumulated data, if any.
+      if has_data {
+        let text = data.to_string()
+        data.reset()
+        has_data = false
+        if (Some(@json.parse(text)) catch { _ => None }) is Some(message) {
+          deliver(message)
+          // The spec has the server close the stream after the reply; a server
+          // that keeps it open instead would pin this exchange's cap slot, so
+          // once our request is answered we close from this side (allowed at
+          // any time) rather than read to EOF.
+          if answered() {
+            break
+          }
+        }
+      }
+      continue
+    }
+    if line.has_prefix("data:") {
+      let payload = line[5:].trim(chars=" ").to_owned()
+      if has_data {
+        data.write_string("\n")
+      }
+      data.write_string(payload)
+      has_data = true
+    }
+    // event:/id:/retry:/comments are irrelevant to the message layer.
+  }
+  // A final event unterminated by a blank line still counts.
+  if has_data &&
+    (Some(@json.parse(data.to_string())) catch { _ => None }) is Some(message) {
+    deliver(message)
+  }
+}
+
+///|
+/// Incremental SSE line reader over `read_some`, recognizing all three
+/// terminators the SSE grammar allows — LF, CRLF, and lone CR — without
+/// waiting for an LF (a `read_until("\n")` on a held-open CR-only stream
+/// would stall until EOF). The buffer grows with unterminated input, matching
+/// `read_until`; the exchange deadline bounds a hostile stream.
+priv struct SseLineReader {
+  client : @http.Client
+  buf : Array[Byte]
+  mut start : Int
+  // Bytes in [start, scan) are known terminator-free, so a line spanning many
+  // network chunks is scanned once, not re-scanned per chunk.
+  mut scan : Int
+  mut eof : Bool
+}
+
+///|
+/// Compaction threshold: once this many consumed bytes accumulate, shift the
+/// live tail down so a long-lived stream retains only the current line.
+const SseCompactAt : Int = 4096
+
+///|
+fn SseLineReader::new(client : @http.Client) -> SseLineReader {
+  { client, buf: [], start: 0, scan: 0, eof: false }
+}
+
+///|
+/// The next logical line (terminator excluded), the final unterminated line at
+/// end of stream, then `None`. Raises on a read failure or invalid UTF-8 (which
+/// fails the owning request) rather than masking either as a clean end.
+async fn SseLineReader::next_line(self : SseLineReader) -> String? {
+  // Drop consumed bytes so memory tracks the current line, not the stream.
+  if self.start >= SseCompactAt {
+    let remaining = self.buf.length() - self.start
+    for j in 0..<remaining {
+      self.buf[j] = self.buf[self.start + j]
+    }
+    self.buf.truncate(remaining)
+    self.scan = self.scan - self.start
+    self.start = 0
+  }
+  for ;; {
+    let mut i = if self.scan > self.start { self.scan } else { self.start }
+    while i < self.buf.length() {
+      let byte = self.buf[i]
+      if byte == b'\n' {
+        return Some(self.take(i, i + 1))
+      }
+      if byte == b'\r' {
+        if i + 1 < self.buf.length() {
+          // Coalesce CRLF into one terminator.
+          let after = if self.buf[i + 1] == b'\n' { i + 2 } else { i + 1 }
+          return Some(self.take(i, after))
+        }
+        if self.eof {
+          return Some(self.take(i, i + 1))
+        }
+        // A CR at the buffer's edge may be half of a CRLF: read on before
+        // deciding, then resume from this position.
+        break
+      }
+      i = i + 1
+    }
+    self.scan = i
+    if self.eof {
+      if self.start < self.buf.length() {
+        return Some(self.take(self.buf.length(), self.buf.length()))
+      }
+      return None
+    }
+    match self.client.read_some() {
+      None => self.eof = true
+      Some(chunk) =>
+        for byte in chunk {
+          self.buf.push(byte)
+        }
+    }
+  }
+}
+
+///|
+/// Decode `[start, until)` as the line, consume through `consumed`, and return
+/// it. Terminator bytes are ASCII, so the cut never splits a UTF-8 sequence;
+/// decoding is strict (malformed UTF-8 raises, failing the exchange).
+fn SseLineReader::take(
+  self : SseLineReader,
+  until : Int,
+  consumed : Int,
+) -> String raise {
+  let bytes = Bytes::makei(until - self.start, i => self.buf[self.start + i])
+  self.start = consumed
+  self.scan = consumed
+  @utf8.decode(bytes)
+}
+
+///|
+/// Queue one inbound message for the reader, noting the initialize reply's
+/// negotiated protocol version on the way past.
+fn HttpTransport::deliver(self : HttpTransport, message : Json) -> Unit {
+  if self.initialize_id is Some(expected) &&
+    message is { "id": id, "result": result, .. } &&
+    id == expected {
+    self.initialize_id = None
+    if result is { "protocolVersion": String(version), .. } {
+      self.protocol_version = Some(version)
+    }
+  }
+  (self.inbound.try_put(message) catch { _ => false }) |> ignore
+}

--- a/mcp/tools/moon.pkg
+++ b/mcp/tools/moon.pkg
@@ -3,6 +3,7 @@ import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/mcp",
   "bobzhang/openseek/mcp/stdio",
+  "bobzhang/openseek/mcp/streamhttp",
   "bobzhang/openseek/mcp/config",
   "moonbitlang/async",
   "tonyfettes/xlog",
@@ -15,6 +16,9 @@ import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/mcp/config",
   "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/json",
 } for "test"
 
 supported_targets = "+native"

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -198,19 +198,34 @@ async fn[X] connect_server(
   workspace_root? : String,
   discovery_timeout_ms~ : Int,
 ) -> Array[@agent_tool.AgentToolDefinition] {
-  let @config.Stdio(name~, command~, args~, env~) = server
-  // The server runs in the agent's workspace, not openseek's invocation
-  // directory, so cwd-sensitive servers and relative args target the same tree
-  // the built-in tools do.
-  let connection = @stdio.connect(
-    scope.group(),
-    command~,
-    args~,
-    env~,
-    cwd?=workspace_root,
-    client_name~,
-    client_version~,
-  ) catch {
+  let name = server.name()
+  // A connected server, normalized across transports: the initialized client
+  // plus its idempotent teardown.
+  let connection : (@mcp.McpClient, () -> Unit)? = try {
+    match server {
+      // A stdio server runs in the agent's workspace, not openseek's invocation
+      // directory, so cwd-sensitive servers and relative args target the same
+      // tree the built-in tools do.
+      @config.Stdio(command~, args~, env~, ..) =>
+        @stdio.connect(
+          scope.group(),
+          command~,
+          args~,
+          env~,
+          cwd?=workspace_root,
+          client_name~,
+          client_version~,
+        ).map(conn => (conn.client(), () => conn.shutdown()))
+      @config.Http(url~, headers~, ..) =>
+        @streamhttp.connect(
+          scope.group(),
+          url~,
+          headers~,
+          client_name~,
+          client_version~,
+        ).map(conn => (conn.client(), () => conn.shutdown()))
+    }
+  } catch {
     error if @async.is_being_cancelled() => raise error
     error => {
       @xlog.warn() <?
@@ -218,12 +233,12 @@ async fn[X] connect_server(
       return []
     }
   }
-  guard connection is Some(connection) else {
+  guard connection is Some((client, shutdown)) else {
     @xlog.warn() <? { "event": "mcp_connect_failed", "server": name }
     return []
   }
   let discovered = @async.with_timeout_opt(discovery_timeout_ms, () => {
-    tools_for_client(name, connection.client())
+    tools_for_client(name, client)
   }) catch {
     error if @async.is_being_cancelled() => raise error
     error => {
@@ -233,20 +248,20 @@ async fn[X] connect_server(
           "server": name,
           "error": "\{error}",
         }
-      connection.shutdown()
+      shutdown()
       return []
     }
   }
   guard discovered is Some(discovered) else {
     @xlog.warn() <? { "event": "mcp_list_tools_timeout", "server": name }
-    connection.shutdown()
+    shutdown()
     return []
   }
   // A server with nothing to offer is useless for the rest of the session:
   // release its process and tasks instead of holding them on the scope.
   if discovered.is_empty() {
     @xlog.warn() <? { "event": "mcp_no_tools", "server": name }
-    connection.shutdown()
+    shutdown()
   }
   discovered
 }

--- a/mcp/tools/tools_test.mbt
+++ b/mcp/tools/tools_test.mbt
@@ -234,3 +234,93 @@ async test "build skips a server that cannot start" {
     assert_eq(tools.length(), 0)
   })
 }
+
+///|
+/// Answer one mock-endpoint request with a JSON-RPC success body.
+async fn respond_json(
+  conn : @http.ServerConnection,
+  id : Json,
+  result : Json,
+) -> Unit {
+  let reply : Json = { "jsonrpc": "2.0", "id": id, "result": result }
+  conn.send_response(200, "OK", extra_headers={
+    "Content-Type": "application/json",
+  })
+  conn.write(reply.stringify())
+}
+
+///|
+/// End-to-end over HTTP: `build` connects a configured Http server (a local
+/// mock MCP endpoint), discovers its tool, and the bridged executor proxies a
+/// live tools/call through the Streamable HTTP transport.
+async test "build bridges and dispatches tools from an http server" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+      error => {
+        let message = "\{error}"
+        if message.contains("Operation not permitted") {
+          println("local TCP bind unavailable; skipping http bridge test")
+          return
+        }
+        raise error
+      }
+    }
+    group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let message = @json.parse(body.read_all().text()) catch {
+            _ => Json::null()
+          }
+          let id = match message {
+            { "id": id, .. } => id
+            _ => Json::null()
+          }
+          match message {
+            { "method": String("initialize"), .. } =>
+              respond_json(conn, id, { "protocolVersion": "2025-11-25" })
+            { "method": String("tools/list"), .. } =>
+              respond_json(conn, id, {
+                "tools": [
+                  {
+                    "name": "ping",
+                    "description": "Ping",
+                    "inputSchema": { "type": "object" },
+                  },
+                ],
+              })
+            { "method": String("tools/call"), .. } =>
+              respond_json(conn, id, {
+                "content": [{ "type": "text", "text": "pong" }],
+              })
+            _ => conn.send_response(202, "Accepted")
+          }
+        },
+        max_connections=8,
+      )
+    }
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let servers = [
+      @config.Http(
+        name="remote",
+        url="http://127.0.0.1:\{server.addr.port()}/mcp",
+        headers=Map([]),
+      ),
+    ]
+    let tools = @tools.build(
+      scope,
+      servers,
+      client_name="openseek",
+      client_version="0.1",
+    )
+    assert_eq(tools.length(), 1)
+    assert_eq(tools[0].name, "mcp__remote__ping")
+    guard tools[0].execute is @agent_tool.Async(exec) else {
+      fail("expected an async executor")
+    }
+    guard exec(Json::empty_object()) is @agent_tool.Respond(output) else {
+      fail("expected a respond action")
+    }
+    assert_false(output.is_error)
+    assert_eq(output.content, "pong")
+  }
+}

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -140,7 +140,7 @@ Options:
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
   --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
-  --mcp-config <mcp-config>                                    Path to a JSON file of MCP servers ({"mcpServers": {"<name>": {"command", "args", "env"}}}); each stdio server's tools are exposed to the agent, namespaced mcp__<server>__<tool>. Empty disables MCP. [env: OPENSEEK_MCP_CONFIG] [default: ]
+  --mcp-config <mcp-config>                                    Path to a JSON file of MCP servers ({"mcpServers": {"<name>": {"command", "args", "env"} | {"url", "headers"}}}); each server's tools (stdio subprocess or Streamable HTTP) are exposed to the agent, namespaced mcp__<server>__<tool>. Empty disables MCP. [env: OPENSEEK_MCP_CONFIG] [default: ]
   --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N). Any explicit value, including 1, copies --dir into <dir>_run_<i> and never writes to --dir itself; omit the flag for a single in-place run. [env: OPENSEEK_CONCURRENCY] [default: 1]
 ```
 


### PR DESCRIPTION
## What

Fifth PR in the **MCP client support** series: remote MCP servers over the **Streamable HTTP** transport. A config entry `{"url": "https://…/mcp", "headers": {…}}` now works beside stdio's `{"command", …}`.

- **`mcp/streamhttp`** — `HttpTransport`, a `@jsonrpc.Transport` where every outgoing message is a POST to the MCP endpoint. **Each POST runs as its own cancellable task**, so the jsonrpc writer never blocks: concurrent requests POST concurrently, a reply to a server request (`ping` mid-SSE-stream) posts while that stream is open, and a stalled stream wedges only its own request. Responses (single JSON body or SSE stream) are parsed and queued for the reader; a failed/expired/unanswered exchange **fails its request fast** via a synthesized JSON-RPC error.
- **Lifecycle & robustness:** an ordering gate holds post-`initialized` requests until that notification's POST completes (strict-lifecycle servers); `Mcp-Session-Id` captured only from the initialize response and echoed with the negotiated `MCP-Protocol-Version`; in-flight exchange cap (32) against flooding servers; per-exchange deadline (150s) so wedged endpoints can't pin cap slots; SSE exchanges released as soon as their reply arrives; best-effort **session `DELETE`** on shutdown; reserved header names protected from config extras; a terminator-agnostic incremental SSE line reader (LF/CRLF/lone-CR, single-scan, compacting).
- **`mcp/config`** — `Http` variant; exactly one of `command`/`url`; same mistyped-field strictness. **`mcp/tools`** — dispatches on the variant; all PR-4 bounds apply to HTTP servers unchanged. Docs + cram updated.
- Scope non-goals (documented): the standing GET stream, SSE resumability, and 404-session auto-reinitialize.

## Review

Ten codex (xhigh) rounds + an adversarial subagent with runnable PoCs. Caught and fixed along the way: the send-serialization deadlock (server `ping` mid-stream), writer wedged after caller timeouts, the initialized/tools-list ordering race (plus a block-scoped-`defer` bug my regression test exposed), untracked exchange tasks at shutdown, session-id hijack via later responses, exchange/DELETE header gaps, CRLF/CR-only SSE framing, and quadratic scan/unbounded buffering. Final round: **"No actionable correctness defects were found."**

## Tests

25 tests: mock-endpoint integration (JSON-body + SSE handshakes, **CR-only and CRLF multi-line events**, session-id echo asserted server-side, **mid-stream ping answered while the stream is open**, held-open stream released at the reply, HTTP 500 failing fast, **session DELETE observed on shutdown**, initialized-ordering under a slow server, unreachable endpoint) plus an end-to-end bridge test dispatching a live `tools/call` over HTTP. `moon check --deny-warn` / `moon info` / `moon fmt` / cram clean; native-only.

## Series
1. #489 · 2. #490 · 3. #491 · 4. #492 — all merged · 5. **this PR** · 6. docs + diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)