### PR TITLE
feat(mcp): docs, openseek mcp diagnostic, and TUI notices (MCP support, 6/6)

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -91,6 +91,40 @@ another workspace while still launching from the current shell. The default is
 `.`; if the final directory component is missing and its parent exists,
 OpenSeek creates it and logs `workspace_created`.
 
+## MCP Servers
+
+OpenSeek can use tools from [MCP](https://modelcontextprotocol.io) servers.
+Point `--mcp-config` (or `OPENSEEK_MCP_CONFIG`) at a JSON file in the de-facto
+standard shape — an existing Claude/Cursor-style `mcp.json` works as-is:
+
+```json
+{
+  "mcpServers": {
+    "codex": { "command": "codex", "args": ["mcp-server"] },
+    "remote": { "url": "https://example.com/mcp", "headers": { "Authorization": "Bearer …" } }
+  }
+}
+```
+
+A `command` entry is launched as a stdio subprocess (in the agent's workspace,
+inheriting the environment plus any `env` overrides); a `url` entry speaks the
+Streamable HTTP transport. Each server's tools join the agent's registry as
+`mcp__<server>__<tool>` for `run`, `serve`, and the TUI (which forwards
+`OPENSEEK_MCP_CONFIG` to its engine). A server that fails to start, handshake,
+or list its tools is logged and skipped — MCP never breaks a session. Tool
+results are size-capped, calls are bounded by a timeout, and tool names are
+sanitized to the provider's function-name rules.
+
+Validate a configuration without starting a session:
+
+```bash
+moon run cmd/openseek -- mcp --mcp-config mcp.json
+```
+
+Resources and prompts (the other MCP capabilities) are not consumed: openseek's
+agent is tool-driven, and a server that wants to feed it context can expose a
+tool. This keeps the surface small; revisit if a concrete need appears.
+
 ## Terminal UI
 
 The terminal UI is the **default** mode of the single `openseek` binary (the

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -30,6 +30,7 @@ async fn dispatch() -> Unit {
     Some(("run", m)) => run_task_command(m)
     Some(("serve", m)) => run_serve_command(m)
     Some(("review", m)) => run_review_command(m)
+    Some(("mcp", m)) => run_mcp_command(m)
     Some(("sessions", m)) => run_sessions_command(m)
     // argparse rejects unknown subcommands during parse, so this is unreachable.
     Some((name, _)) => fail("unhandled subcommand: \{name}")
@@ -608,6 +609,11 @@ fn root_command() -> @argparse.Command {
             about="Run ephemerally: do not record this server's conversation to a durable session.",
           ),
         ],
+      ),
+      Command(
+        "mcp",
+        about="List configured MCP servers and the tools they expose.",
+        options=agent_options(),
       ),
       Command(
         "review",

--- a/cmd/openseek/mcp.mbt
+++ b/cmd/openseek/mcp.mbt
@@ -63,3 +63,166 @@ async fn[X] resolve_mcp_tools(
     }
   tools
 }
+
+///|
+/// `openseek mcp` — build the MCP tool registry exactly as a session would
+/// (one combined build, so cross-server renames and the global tool budget
+/// match a real run) and print it grouped by server, so a user can validate an
+/// mcp.json without starting a session. A missing, unreadable, or invalid
+/// configuration raises, exiting nonzero — the command is usable as a
+/// validation gate. Logs are discarded: stdout carries only the summary.
+async fn run_mcp_command(matches : @argparse.Matches) -> Unit {
+  @xlog.global().set_handler(DiscardLog::{  })
+  let path = mcp_config_path(matches)
+  if path == "" {
+    fail(
+      "no MCP configuration: pass --mcp-config <file> (or OPENSEEK_MCP_CONFIG)",
+    )
+  }
+  let workspace_root = prepare_workspace_root(matches, log_created=false)
+  // Failure text reaches the terminal via stderr, and both the path and the
+  // decoder's error can embed configuration strings: keep them terminal-safe.
+  let text = @fs.read_file(path).text() catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      fail(
+        "cannot read \{terminal_safe_line(path, limit=200)}: \{terminal_safe_line("\{error}", limit=200)}",
+      )
+  }
+  let servers = @mcpconfig.decode(@json.parse(text)) catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      fail(
+        "invalid MCP configuration in \{terminal_safe_line(path, limit=200)}: \{terminal_safe_line("\{error}", limit=200)}",
+      )
+  }
+  // The path is CLI input: guard it like every other displayed string (a
+  // longer cap than the metadata's, so real paths stay identifiable).
+  let shown_path = terminal_safe_line(path, limit=200)
+  if servers.is_empty() {
+    println("\{shown_path}: no servers configured")
+    return
+  }
+  println("\{shown_path}: \{servers.length()} server(s)")
+  @async.with_task_group() <| group => {
+    let scope = @agent_runtime.AgentTaskScope(group)
+    // One combined, grouped build, exactly as serve/run register tools:
+    // cross-server renames and the global tool budget behave as in a real
+    // session, and ownership comes from the build itself.
+    let labels : Map[String, String] = Map([])
+    for server in servers {
+      labels[server.name()] = server_label(server)
+    }
+    for
+      entry in @mcptools.build_grouped(
+        scope,
+        servers,
+        client_name="openseek",
+        client_version=McpClientVersion,
+        workspace_root~,
+      ) {
+      let (name, tools) = entry
+      let label = labels.get(name).unwrap_or("")
+      // The name is a config key — arbitrary JSON text — so guard it like the
+      // rest of the displayed metadata.
+      let name = terminal_safe_line(name)
+      if tools.is_empty() {
+        // Neutral: an empty group can be a failed connection, a tools-less
+        // (e.g. resources-only) server, or one skipped over the tool budget.
+        println("- \{name} (\{label}): no tools registered")
+      } else {
+        println("- \{name} (\{label}): \{tools.length()} tool(s)")
+        for tool in tools {
+          // Descriptions are server-controlled: strip control characters so a
+          // hostile server cannot inject terminal escape sequences (tool names
+          // are already sanitized to the provider alphabet by the bridge).
+          println(
+            "    \{tool.name} — \{terminal_safe_line(tool.description)}",
+          )
+        }
+      }
+    }
+    // The servers spawned above live on this group; returning tears them down.
+    group.return_immediately(())
+  }
+}
+
+///|
+/// Collapse untrusted text to one terminal-safe line: whitespace runs become a
+/// single space, C0/C1 controls and DEL are dropped (ESC, CSI, OSC and friends
+/// render as terminal commands, not text — same rule as the sessions listing's
+/// prompt labels), and anything past 72 characters is elided with `…`.
+fn terminal_safe_line(text : String, limit? : Int = 72) -> String {
+  let out = StringBuilder()
+  for ch in text.trim(); last_was_space = false, count = 0 {
+    if count >= limit {
+      out.write_char('…')
+      break
+    }
+    if ch is (' ' | '\t' | '\n' | '\r') {
+      if !last_was_space {
+        out.write_char(' ')
+        continue true, count + 1
+      }
+      continue true, count
+    } else if ch.to_int() < 0x20 ||
+      ch.to_int() == 0x7F ||
+      (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
+      continue last_was_space, count
+    } else {
+      out.write_char(ch)
+      continue false, count + 1
+    }
+  }
+  out.to_string()
+}
+
+///|
+/// A display label for a configured server. HTTP endpoints are shown without
+/// userinfo or query string — both commonly carry credentials.
+fn server_label(server : @mcpconfig.McpServer) -> String {
+  match server {
+    // Arguments are not echoed: they can carry credentials (`--token …`) and
+    // arbitrary control characters. The command plus an argument count
+    // identifies the entry without leaking its values.
+    Stdio(command~, args~, ..) =>
+      if args.is_empty() {
+        "stdio: \{terminal_safe_line(command)}"
+      } else {
+        "stdio: \{terminal_safe_line(command)} [\{args.length()} arg(s)]"
+      }
+    Http(url~, ..) => "http: \{terminal_safe_line(redact_url(url))}"
+  }
+}
+
+///|
+/// Strip userinfo (`user:pass@`) and the query/fragment from `url`, keeping
+/// scheme, host, and path — enough to identify the endpoint without echoing
+/// embedded credentials.
+fn redact_url(url : String) -> String {
+  let cut_query = match url.find("?") {
+    Some(q) => url[:q].to_owned()
+    None => url
+  }
+  let cut_fragment = match cut_query.find("#") {
+    Some(h) => cut_query[:h].to_owned()
+    None => cut_query
+  }
+  // The authority starts after `://` when a scheme is present, else at the
+  // string's start — a schemeless `user:pass@host/…` (which the decoder
+  // accepts) must be redacted too.
+  let host_start = match cut_fragment.find("://") {
+    Some(scheme_end) => scheme_end + 3
+    None => 0
+  }
+  let authority_end = match cut_fragment[host_start:].find("/") {
+    Some(slash) => host_start + slash
+    None => cut_fragment.length()
+  }
+  match cut_fragment[host_start:authority_end].find("@") {
+    Some(at) =>
+      cut_fragment[:host_start].to_owned() +
+      cut_fragment[host_start + at + 1:].to_owned()
+    None => cut_fragment
+  }
+}

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -91,6 +91,68 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     "goal_budget_exhausted" => Some(GoalBudgetExhausted)
     // A turn that ended at the context ceiling: run-terminal, not success.
     "context_yield" => Some(ContextYield(@jsonx.string(object, "answer")))
+    // MCP lifecycle diagnostics, surfaced as notices so a typo'd config or a
+    // dead server is visible in the UI instead of silently yielding no tools.
+    "mcp_tools_registered" => {
+      let tools = @jsonx.int(object, "tools")
+      let servers = @jsonx.int(object, "servers")
+      // `servers` counts the configuration's entries, not successful
+      // contributors — say so, since some may have failed or been skipped.
+      Some(
+        BackgroundNotice(
+          "MCP: registered \{tools} tool(s) from \{servers} configured server(s)",
+        ),
+      )
+    }
+    "mcp_connect_failed" =>
+      Some(
+        BackgroundNotice(
+          "MCP: server `\{mcp_safe(object, "server")}` failed to connect",
+        ),
+      )
+    "mcp_list_tools_failed" | "mcp_list_tools_timeout" =>
+      Some(
+        BackgroundNotice(
+          "MCP: server `\{mcp_safe(object, "server")}` did not list its tools",
+        ),
+      )
+    "mcp_config_unreadable" | "mcp_config_invalid" =>
+      Some(
+        BackgroundNotice(
+          "MCP config error (\{mcp_safe(object, "path")}): \{mcp_safe(object, "error")}",
+        ),
+      )
     _ => None
   }
+}
+
+///|
+/// A field of an MCP diagnostic, made terminal-safe for a notice: whitespace
+/// runs collapse to one space, C0/C1 controls and DEL are dropped (the
+/// transcript layout strips C0 but not C1, and these strings carry
+/// configuration metadata), and anything past 120 characters is elided.
+fn mcp_safe(object : Json, key : String) -> String {
+  let text = @jsonx.string(object, key)
+  let out = StringBuilder()
+  for ch in text.trim(); last_was_space = false, count = 0 {
+    if count >= 120 {
+      out.write_char('…')
+      break
+    }
+    if ch is (' ' | '\t' | '\n' | '\r') {
+      if !last_was_space {
+        out.write_char(' ')
+        continue true, count + 1
+      }
+      continue true, count
+    } else if ch.to_int() < 0x20 ||
+      ch.to_int() == 0x7F ||
+      (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
+      continue last_was_space, count
+    } else {
+      out.write_char(ch)
+      continue false, count + 1
+    }
+  }
+  out.to_string()
 }

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -207,3 +207,38 @@ test "a context yield decodes as its own run terminal" {
     is Some(ContextYield("[context ceiling] checkpointed")),
   )
 }
+
+///|
+test "decode_event surfaces MCP diagnostics as notices" {
+  guard @event.decode_event({
+      "event": "mcp_tools_registered",
+      "servers": 2,
+      "tools": 5,
+    })
+    is Some(BackgroundNotice(registered)) else {
+    fail("expected a notice")
+  }
+  assert_eq(registered, "MCP: registered 5 tool(s) from 2 configured server(s)")
+  guard @event.decode_event({ "event": "mcp_connect_failed", "server": "fs" })
+    is Some(BackgroundNotice(failed)) else {
+    fail("expected a notice")
+  }
+  assert_eq(failed, "MCP: server `fs` failed to connect")
+  guard @event.decode_event({
+      "event": "mcp_config_invalid",
+      "path": "/x/mcp.json",
+      "error": "boom",
+    })
+    is Some(BackgroundNotice(config)) else {
+    fail("expected a notice")
+  }
+  assert_eq(config, "MCP config error (/x/mcp.json): boom")
+  guard @event.decode_event({
+      "event": "mcp_list_tools_timeout",
+      "server": "slow",
+    })
+    is Some(BackgroundNotice(timeout)) else {
+    fail("expected a notice")
+  }
+  assert_eq(timeout, "MCP: server `slow` did not list its tools")
+}

--- a/mcp/tools/pkg.generated.mbti
+++ b/mcp/tools/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub const DefaultDiscoveryTimeoutMs : Int = 30000
 
 pub async fn[X] build(@agent_runtime.AgentTaskScope[X], Array[@config.McpServer], client_name~ : String, client_version~ : String, workspace_root? : String, discovery_timeout_ms? : Int) -> Array[@agent_tool.AgentToolDefinition]
 
+pub async fn[X] build_grouped(@agent_runtime.AgentTaskScope[X], Array[@config.McpServer], client_name~ : String, client_version~ : String, workspace_root? : String, discovery_timeout_ms? : Int) -> Array[(String, Array[@agent_tool.AgentToolDefinition])]
+
 pub fn tool_name(String, String) -> String
 
 pub async fn tools_for_client(String, @mcp.McpClient) -> Array[@agent_tool.AgentToolDefinition]

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -136,10 +136,45 @@ pub async fn[X] build(
   discovery_timeout_ms? : Int = DefaultDiscoveryTimeoutMs,
 ) -> Array[@agent_tool.AgentToolDefinition] {
   let tools = []
+  for
+    entry in build_grouped(
+      scope,
+      servers,
+      client_name~,
+      client_version~,
+      workspace_root?,
+      discovery_timeout_ms~,
+    ) {
+    let (_, contributed) = entry
+    for tool in contributed {
+      tools.push(tool)
+    }
+  }
+  tools
+}
+
+///|
+/// Like `build`, grouped by server in config order — each entry pairs the
+/// server's name with the tools it contributed after cross-server
+/// uniquification and the global budget, so a diagnostic can attribute the
+/// registry without reconstructing ownership from names. Flattening the groups
+/// yields exactly `build`'s registry.
+pub async fn[X] build_grouped(
+  scope : @agent_runtime.AgentTaskScope[X],
+  servers : Array[@config.McpServer],
+  client_name~ : String,
+  client_version~ : String,
+  workspace_root? : String,
+  discovery_timeout_ms? : Int = DefaultDiscoveryTimeoutMs,
+) -> Array[(String, Array[@agent_tool.AgentToolDefinition])] {
+  let groups : Array[(String, Array[@agent_tool.AgentToolDefinition])] = []
+  let mut total = 0
   let seen : Map[String, Unit] = Map([])
   for server in servers {
+    let mine : Array[@agent_tool.AgentToolDefinition] = []
+    groups.push((server.name(), mine))
     // Budget exhausted: don't launch servers whose tools could not register.
-    if tools.length() >= MaxTotalMcpTools {
+    if total >= MaxTotalMcpTools {
       @xlog.warn() <?
         { "event": "mcp_server_skipped_over_cap", "server": server.name() }
       continue
@@ -155,7 +190,7 @@ pub async fn[X] build(
     for tool in discovered {
       // The provider accepts at most 128 function definitions per request; the
       // MCP budget leaves room for the built-ins. Beyond it, drop with a log.
-      if tools.length() >= MaxTotalMcpTools {
+      if total >= MaxTotalMcpTools {
         @xlog.warn() <?
           {
             "event": "mcp_tools_capped",
@@ -172,7 +207,8 @@ pub async fn[X] build(
           { "event": "mcp_tool_renamed", "from": tool.name, "to": name }
       }
       seen[name] = ()
-      tools.push(
+      total = total + 1
+      mine.push(
         @agent_tool.AgentToolDefinition(
           name~,
           description=tool.description,
@@ -182,7 +218,7 @@ pub async fn[X] build(
       )
     }
   }
-  tools
+  groups
 }
 
 ///|

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -27,6 +27,7 @@ Commands:
   tui       OpenSeek terminal UI.
   run       Run one task headlessly; stream JSONL events on stdout.
   serve     Session server: read JSONL commands (prompt/steer/cancel/compact) from stdin.
+  mcp       List configured MCP servers and the tools they expose.
   review    Read-only code review of base...HEAD; prints a JSON ReviewReport.
   sessions  Manage durable sessions.
 


### PR DESCRIPTION
## What

Final PR in the **MCP client support** series — the polish that makes the feature discoverable and debuggable.

- **`openseek mcp`** — connect each configured server and print a human-readable summary of its tools (transport, names, briefs), so a user can validate an `mcp.json` without starting a session. Logs are discarded; stdout carries only the summary.
- **TUI notices** — the MCP lifecycle diagnostics (`mcp_tools_registered`, connect failed, discovery failed/timeout, config unreadable/invalid) decode into `BackgroundNotice` events, so a typo'd config or dead server is visible in the UI instead of silently yielding no tools (a gap the PR-4 adversarial review flagged).
- **README** — an *MCP Servers* section documenting the config shape (stdio + HTTP), namespacing, the safety bounds, and the diagnostic subcommand. Resources and prompts are documented as deliberate non-goals: openseek's agent is tool-driven, and a server that wants to feed it context can expose a tool.
- Cram CLI docs cover the new subcommand.

## Verified

Dogfooded against a real MCP server:

```
$ openseek mcp --mcp-config mcp.json
mcp.json: 1 server(s)
- codex (stdio: codex mcp-server): 2 tool(s)
    mcp__codex__codex — Run a Codex session. Accepts configuration parameters…
    mcp__codex__codex-reply — Continue a Codex conversation by providing the thread id…
```

19 tests (TUI decode + bridge) and cram (23/23) green; `moon check --deny-warn` / `moon info` / `moon fmt` clean.

## Series
1. #489 · 2. #490 · 3. #491 · 4. #492 · 5. #493 — all merged · 6. **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)