### PR TITLE
refactor: idiomatic cleanups across the post-07-10 (MCP-era) code

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -124,15 +124,10 @@ async fn edit_file(
     )
     let first_line = line_number_at_offset(content, at)
     let last_line = first_line + inserted_line_span(input.new_string) - 1
-    let span = if last_line > first_line {
-      "lines \{first_line}-\{last_line}"
+    let (span, brief_span) = if last_line > first_line {
+      ("lines \{first_line}-\{last_line}", "\{first_line}-\{last_line}")
     } else {
-      "line \{first_line}"
-    }
-    let brief_span = if last_line > first_line {
-      "\{first_line}-\{last_line}"
-    } else {
-      "\{first_line}"
+      ("line \{first_line}", "\{first_line}")
     }
     let (summary, ok_brief) = if at == content.length() {
       (

--- a/agent_tool/shell/review_guard.mbt
+++ b/agent_tool/shell/review_guard.mbt
@@ -32,14 +32,7 @@ fn command_is_mutating_moon(command : @shell_parse.SimpleCommand) -> Bool {
 /// is not worth crippling the review's ability to investigate.
 fn review_read_only_blocks(parsed : @shell_parse.ParseResult) -> Bool {
   match parsed {
-    Simple(commands) => {
-      for command in commands {
-        if command_is_mutating_moon(command) {
-          return true
-        }
-      }
-      false
-    }
+    Simple(commands) => commands.any(command_is_mutating_moon)
     _ => false
   }
 }

--- a/jsonrpc/client.mbt
+++ b/jsonrpc/client.mbt
@@ -199,10 +199,7 @@ pub async fn Client::run_writer(self : Client) -> Unit {
 /// transport error, or cancellation — so `is_closed` is always truthful and no
 /// request is left hanging.
 pub async fn Client::run_message_pump(self : Client) -> Unit {
-  for ;; {
-    if self.closed {
-      break
-    }
+  while !self.closed {
     let ended = self.route_next() catch {
       error => {
         self.close()

--- a/mcp/stdio/ndjson.mbt
+++ b/mcp/stdio/ndjson.mbt
@@ -48,7 +48,7 @@ pub impl @jsonrpc.Transport for NdjsonTransport with fn recv(self) {
       _ => None
     }
     guard line is Some(line) else { return None }
-    let trimmed = line.trim(chars="\r\n").to_owned()
+    let trimmed = line.trim(chars="\r\n")
     if trimmed == "" {
       continue
     }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -949,11 +949,7 @@ fn tool_call_view(
   }
   // A plan is the task's live state, not noisy arguments: its card starts
   // unfolded (still collapsible), where every other call folds by default.
-  let open_by_default : Bool? = if plan_steps is Some(_) {
-    Some(true)
-  } else {
-    None
-  }
+  let open_by_default = plan_steps.map(_ => true)
   @html.details(open?=open_by_default, id?=anchor, class=cls) <| [
     @html.summary(class="tool-call-name") <| name_row,
     rendered,
@@ -1354,7 +1350,7 @@ fn steps_with_errors(
   let flagged : Map[Int, Unit] = Map([])
   for event in session.events() {
     guard event.item() is Tool(result) && result.is_error() else { continue }
-    for index = seqs.length() - 1; index >= 0; index = index - 1 {
+    for index in (seqs.length() - 1)>=..0 {
       if seqs[index] <= event.sequence() {
         flagged.set(index, ())
         break


### PR DESCRIPTION
A focused, quality-only simplification sweep of code merged since the last repo-wide sweep (baseline `4ace8ce0`, 2026-07-10) — primarily the new MCP client subsystem (`mcp/`, `jsonrpc/`), the `remove`/`file_state` additions in `agent_tool/`, and recent `viz/` changes. Behavior-preserving; **no** public-API, wire-format, or user-visible-text changes.

Discovery fanned out three review agents over the un-swept surface; the new subsystem is genuinely clean (heavy prior review), so this is a small, high-confidence set. Net **−19 lines**.

### Commits (grouped by package for per-commit review)
1. **mcp,jsonrpc** — `run_message_pump`'s `for ;; { if self.closed { break } .. }` → `while !self.closed` (matches its sibling `run_writer`); drop a dead `.to_owned()` on a `trim()` view that `@json.parse`/`== ""` already accept.
2. **agent_tool** — `review_read_only_blocks`' for-loop-early-return → `Array::any` (matches `command_policy.mbt`); fold `edit_file`'s two identically-conditioned `span`/`brief_span` `if`s into one tuple binding.
3. **viz** — the change set's only C-style loop → end-inclusive descending range `for index in (seqs.length() - 1)>=..0` (matches `goal.mbt`); `if plan_steps is Some(_) { Some(true) } else { None }` → `plan_steps.map(_ => true)`.

### Verification
- `moon check --deny-warn` clean.
- `moon test` on affected packages: 27 passed (js) + 396 passed (native).

### Deliberately skipped
- The vestigial `self`/`ignore(self)` in `mcp/streamhttp/transport.mbt` — removing it forces a method→free-function change that breaks symmetry with sibling methods.
- The `tui/completion.mbt` single-use `redraw_after_completion_selection` — reads as a deliberately-named UI action.
- Cross-package `mcp_safe`/`terminal_safe_line` duplication — consolidating needs a new shared util across package boundaries, beyond a clean local pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)