### PR TITLE
feat(desktop): display model tiers

### DIFF
--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -69,17 +69,35 @@ fn settings_group(
 }
 
 ///|
+/// Product-facing service tier for a model wire name. Unknown models retain
+/// their wire name so a future/custom model never renders as a blank label.
+fn model_label(model : String) -> String {
+  match model {
+    "deepseek-v4-pro" => "High"
+    "deepseek-v4-flash" => "Low"
+    other => other
+  }
+}
+
+///|
+test "DeepSeek models display as product tiers" {
+  inspect(model_label("deepseek-v4-pro"), content="High")
+  inspect(model_label("deepseek-v4-flash"), content="Low")
+  inspect(model_label("custom-model"), content="custom-model")
+}
+
+///|
 fn model_select(dispatch : @cmd.Emit[Msg], selected : String) -> @html.Html {
   @html.select(on_change=dispatch.map(value => ModelChanged(value)), [
     @html.option(
       value="deepseek-v4-pro",
       selected=selected == "deepseek-v4-pro",
-      "deepseek-v4-pro",
+      model_label("deepseek-v4-pro"),
     ),
     @html.option(
       value="deepseek-v4-flash",
       selected=selected == "deepseek-v4-flash",
-      "deepseek-v4-flash",
+      model_label("deepseek-v4-flash"),
     ),
   ])
 }
@@ -1347,7 +1365,7 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     @html.span(
       class="composer-model",
       title=model.selected_model,
-      model.selected_model,
+      model_label(model.selected_model),
     ),
   ]
   if conv.branch is Some(branch) && !branch.is_empty() {


### PR DESCRIPTION
## Summary

- display `deepseek-v4-pro` as **High**
- display `deepseek-v4-flash` as **Low**
- preserve raw model IDs for engine requests and tooltips

## Why

Present product-facing service tiers in the desktop UI without coupling the UI wording to provider model identifiers.

## Validation

- `moon -C desktop check --target js --deny-warn`
- `moon -C desktop test frontend --target js` (116 passed)
- `moon -C desktop info --target js`
- `moon -C desktop fmt frontend/view.mbt`
- rebuilt and code-sign verified the macOS bundle
- visually verified the composer chip and Settings selector
