### PR TITLE
feat(protocol): typed engine event stream as a cross-backend module

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -15,6 +15,7 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/agent_session` | Typed durable conversation state and DeepSeek message projection. | `agent_session/README.mbt.md` |
 | `bobzhang/openseek/agent_session/store` | Native filesystem-backed append-only session store. | `agent_session/store/README.mbt.md` |
 | `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
+| `bobzhang/openseek_protocol` | Typed engine event stream (own module): the `openseek run`/`serve` stdout wire contract, decodable on every backend. | `protocol/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
 | `bobzhang/openseek/cmd/tui` | Native-only terminal UI library, the default mode of `openseek` (and `openseek tui`). | `cmd/tui/README.md` |

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -311,7 +311,7 @@ pub async fn[X] run_turn_in_scope(
     }
   } catch {
     error => {
-      @xlog.error() <? { "event": "agent_setup_failed", "error": "\{error}" }
+      @emit.emit(AgentSetupFailed(error="\{error}"))
       return session
         |> append_item(Terminal(Failed("agent setup failed: \{error}")))
     }

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -123,12 +123,7 @@ async fn AgentLoop::checkpoint_at_ceiling(
   let to_sequence = session.last_sequence()
   let covered = session
   let session = self.apply_steer_inputs(session, steers)
-  @xlog.info() <?
-    {
-      "event": "auto_compaction_started",
-      "from_sequence": 1,
-      "to_sequence": to_sequence,
-    }
+  @emit.emit(AutoCompactionStarted(from_sequence=1, to_sequence~))
   let summary = @compact.generate_compaction_summary(
     client=self.summary_client,
     covered,
@@ -137,7 +132,7 @@ async fn AgentLoop::checkpoint_at_ceiling(
       if @async.is_being_cancelled() || @async.is_cancellation_error(error) {
         raise error
       }
-      @xlog.warn() <? { "event": "auto_compaction_failed", "error": "\{error}" }
+      @emit.emit(AutoCompactionFailed(error="\{error}"))
       return (session, false)
     }
   }
@@ -147,13 +142,7 @@ async fn AgentLoop::checkpoint_at_ceiling(
     to_sequence~,
   )
   let compacted = self.append(session, item)
-  @xlog.info() <?
-    {
-      "event": "auto_compaction_finished",
-      "from_sequence": 1,
-      "to_sequence": to_sequence,
-      "summary": summary,
-    }
+  @emit.emit(AutoCompactionFinished(from_sequence=1, to_sequence~, summary~))
   (compacted, true)
 }
 
@@ -220,7 +209,6 @@ async fn AgentLoop::finish_context_yield(
   // No push_finished_message: the yield status is not an assistant message
   // — the model-facing projection skips it too (the loop ends here, but the
   // buffer must never disagree with Session::chat_messages).
-  @xlog.info() <?
-    { "event": "context_yield", "to_sequence": to_sequence, "answer": answer }
+  @emit.emit(ContextYield(to_sequence~, answer~))
   session
 }

--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -227,7 +227,7 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       // this set supersedes; a new goal starts unblocked.
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
-      @xlog.info() <? { "event": "goal_updated", "goal": text }
+      @emit.emit(GoalUpdated(goal=Some(text)))
     }
     Some(GoalCleared) => {
       self.goal = None
@@ -235,7 +235,7 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       self.pending_tombstone = false
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
-      @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
+      @emit.emit(GoalUpdated(goal=None))
     }
     // A block/unblock marker landing durably (this loop's own flush, or a
     // steer observed after its append) toggles the cached durable state; the
@@ -267,7 +267,7 @@ async fn AgentLoop::flush_goal_tombstone(
       )
       self.goal_cadence.pending_block = NoBlockTransition
       self.goal_cadence.durably_blocked = true
-      @xlog.info() <? { "event": "goal_blocked", "reason": reason }
+      @emit.emit(GoalBlocked(reason~))
       next
     }
     // A continue that resumes a durably blocked goal: land the unblock marker
@@ -279,7 +279,7 @@ async fn AgentLoop::flush_goal_tombstone(
       )
       self.goal_cadence.pending_block = NoBlockTransition
       self.goal_cadence.durably_blocked = false
-      @xlog.info() <? { "event": "goal_unblocked" }
+      @emit.emit(GoalUnblocked)
       next
     }
     // A no-op unblock (the goal was not durably blocked): nothing to rescind.
@@ -297,7 +297,7 @@ async fn AgentLoop::flush_goal_tombstone(
     @agent_session.GoalClearedNotice,
   )
   self.goal_cadence.pending_tombstone = false
-  @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
+  @emit.emit(GoalUpdated(goal=None))
   next
 }
 
@@ -364,14 +364,15 @@ async fn AgentLoop::handle_goal_tool_call(
       self.goal_cadence.record_goal_blocked(reason)
     _ => ()
   }
-  @xlog.info() <?
-    {
-      "event": "tool_result",
-      "tool_call_id": native_call.id,
-      "tool_name": tool_call.name,
-      "is_error": is_error,
-      "content": content,
-    }
+  @emit.emit(
+    ToolResult(
+      tool_call_id=native_call.id,
+      tool_name=tool_call.name,
+      is_error~,
+      content~,
+      brief=None,
+    ),
+  )
   ContinueToolBatch(session)
 }
 

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -17,10 +17,11 @@ import {
   "bobzhang/openseek/agent_tool/write",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/deepseek/client",
+  "bobzhang/openseek_protocol" @protocol,
+  "bobzhang/openseek_protocol/emit",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/json",
-  "tonyfettes/xlog",
 }
 
 import {

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -237,7 +237,7 @@ async fn AgentLoop::run(
         session,
         Terminal(Failed("max steps exhausted")),
       )
-      @xlog.warn() <? { "event": "max_steps_exhausted" }
+      @emit.emit(MaxStepsExhausted)
       session
     }
   } catch {
@@ -338,7 +338,7 @@ async fn AgentLoop::apply_steer_inputs(
     }
     let next = self.append(current, item)
     self.messages.push(ChatMessage(User, content=text))
-    @xlog.info() <? { "event": "steer_applied", "kind": kind, "content": text }
+    @emit.emit(SteerApplied(kind~, content=text))
     if input is Notice(text) {
       self.goal_cadence.observe_notice(text)
     }
@@ -368,13 +368,13 @@ async fn AgentLoop::prepare_step(
       tool_registered=self.goal_cadence.tool_registered,
     )
     session = self.append_runtime_notice(session, reminder)
-    @xlog.info() <? { "event": "goal_reminder", "content": reminder }
+    @emit.emit(GoalReminder(content=reminder))
     self.goal_cadence.record_reminder()
   }
   if self.plan_cadence.should_remind() {
     let reminder = self.plan_cadence.reminder_text()
     session = self.append_runtime_notice(session, reminder)
-    @xlog.info() <? { "event": "plan_reminder", "content": reminder }
+    @emit.emit(PlanReminder(content=reminder))
     self.plan_cadence.record_reminder()
   }
   self.plan_cadence.record_model_request()
@@ -383,13 +383,13 @@ async fn AgentLoop::prepare_step(
 
 ///|
 async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
-  @xlog.info() <? { "event": "agent_step", "step": step + 1 }
+  @emit.emit(AgentStep(step=step + 1))
   let response = self.client.chat(
     self.messages,
     tools=self.tools.function_tools(),
     stream=StreamHandler(on_content_delta=delta => {
       if delta != "" {
-        @xlog.info() <? { "event": "assistant_delta", "content": delta }
+        @emit.emit(AssistantDelta(content=delta))
       }
     }),
   )
@@ -403,14 +403,12 @@ fn @deepseek.ChatResponse::log_and_reasoning_content(
   // Reasoning first, so a consumer appending events in order shows the
   // thinking above the answer it led to.
   if response.reasoning_content != "" {
-    @xlog.info() <?
-      { "event": "reasoning_message", "content": response.reasoning_content }
+    @emit.emit(ReasoningMessage(content=response.reasoning_content))
   }
   if response.content != "" {
-    @xlog.info() <?
-      { "event": "assistant_message", "content": response.content }
+    @emit.emit(AssistantMessage(content=response.content))
   }
-  @xlog.info() <? { "event": "usage", "usage": response.usage }
+  @emit.emit(Usage(usage=wire_usage(response.usage)))
   response
 }
 
@@ -467,13 +465,13 @@ async fn AgentLoop::handle_tool_calls(
           content~,
           is_error=true,
         )
-        @xlog.error() <?
-          {
-            "event": "tool_call_decode_error",
-            "tool_call_id": native_call.id,
-            "tool_name": native_call.name,
-            "error": "\{error}",
-          }
+        @emit.emit(
+          ToolCallDecodeError(
+            tool_call_id=native_call.id,
+            tool_name=native_call.name,
+            error="\{error}",
+          ),
+        )
         continue session
       }
     }
@@ -616,7 +614,7 @@ async fn AgentLoop::execute_tool_call(
       // its durable clear before the terminal.
       let session = self.flush_goal_tombstone(session)
       let session = self.append(session, Terminal(Aborted(reason)))
-      @xlog.warn() <? { "event": "agent_aborted", "reason": reason }
+      @emit.emit(AgentAborted(reason~))
       return FinishAgentLoop(session)
     }
     Respond(output) => {
@@ -667,14 +665,15 @@ async fn AgentLoop::close_skipped_tool_calls(
       content=note,
       is_error=true,
     )
-    @xlog.info() <?
-      {
-        "event": "tool_result",
-        "tool_call_id": skipped.id,
-        "tool_name": skipped.name,
-        "is_error": true,
-        "content": note,
-      }
+    @emit.emit(
+      ToolResult(
+        tool_call_id=skipped.id,
+        tool_name=skipped.name,
+        is_error=true,
+        content=note,
+        brief=None,
+      ),
+    )
     continue session
   } nobreak {
     session
@@ -979,7 +978,7 @@ async fn AgentLoop::inject_goal_check(
     tool_registered=self.goal_cadence.tool_registered,
   )
   let session = self.append_runtime_notice(session, check)
-  @xlog.info() <? { "event": "goal_check", "content": check }
+  @emit.emit(GoalCheck(content=check))
   self.goal_cadence.record_finish_check()
   // The check must stay the newest instruction: a plan reminder landing at
   // the same cadence boundary would bury it — the model would answer the
@@ -1063,7 +1062,7 @@ async fn AgentLoop::finish_turn(
   }
   let session = self.append(session, Terminal(Finished(answer)))
   self.push_finished_message(answer)
-  @xlog.info() <? { "event": "agent_finished", "answer": answer }
+  @emit.emit(AgentFinished(answer~))
   Sealed(session)
 }
 
@@ -1075,19 +1074,32 @@ fn log_tool_result(
   content~ : String,
   brief~ : String?,
 ) -> Unit {
-  @xlog.info() <?
-    {
-      "event": "tool_result",
-      "tool_call_id": native_call.id,
-      "tool_name": tool_call.name,
-      "is_error": is_error,
-      "content": content,
-      "brief": if brief is Some(brief) {
-        Json::string(brief)
-      } else {
-        Json::null()
-      },
-    }
+  @emit.emit(
+    ToolResult(
+      tool_call_id=native_call.id,
+      tool_name=tool_call.name,
+      is_error~,
+      content~,
+      brief~,
+    ),
+  )
+}
+
+///|
+/// The provider's token counts as the protocol carries them.
+///
+/// `@protocol.Usage` is structurally identical, and deliberately separate: the
+/// event stream's shape must not be whatever the vendor's response struct
+/// happens to be this week, and `protocol` is a leaf module that cannot depend
+/// on the provider layer. This is the only place the two meet.
+fn wire_usage(usage : @deepseek.Usage) -> @protocol.Usage {
+  {
+    prompt_tokens: usage.prompt_tokens,
+    completion_tokens: usage.completion_tokens,
+    total_tokens: usage.total_tokens,
+    prompt_cache_hit_tokens: usage.prompt_cache_hit_tokens,
+    prompt_cache_miss_tokens: usage.prompt_cache_miss_tokens,
+  }
 }
 
 ///|

--- a/agent_session/compact/compact.mbt
+++ b/agent_session/compact/compact.mbt
@@ -91,12 +91,7 @@ pub async fn compact_session(
   if to_sequence <= 0 {
     fail("session compaction requires at least one event")
   }
-  @xlog.info() <?
-    {
-      "event": "compaction_started",
-      "from_sequence": from_sequence,
-      "to_sequence": to_sequence,
-    }
+  @emit.emit(CompactionStarted(from_sequence~, to_sequence~))
   let client = @client.Client(api_key~, model~, api_url?, thinking=No)
   let summary = generate_compaction_summary(client~, session)
   let next = append_compaction_summary(
@@ -106,12 +101,6 @@ pub async fn compact_session(
     from_sequence~,
     to_sequence~,
   )
-  @xlog.info() <?
-    {
-      "event": "compaction_finished",
-      "from_sequence": from_sequence,
-      "to_sequence": to_sequence,
-      "summary": summary,
-    }
+  @emit.emit(CompactionFinished(from_sequence~, to_sequence~, summary~))
   next
 }

--- a/agent_session/compact/moon.pkg
+++ b/agent_session/compact/moon.pkg
@@ -4,7 +4,8 @@ import {
   "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/deepseek/client",
-  "tonyfettes/xlog",
+  "bobzhang/openseek_protocol",
+  "bobzhang/openseek_protocol/emit",
 }
 
 import {

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -49,8 +49,7 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
       None => @fs.mkdir(run_dir, recursive=true)
     }
   }
-  @xlog.info() <?
-    { "event": "fleet_started", "runs": concurrency, "task": task }
+  @emit.emit(FleetStarted(runs=concurrency, task~))
   let outcomes : Array[AttemptOutcome?] = Array::make(concurrency, None)
   @async.with_task_group(group => {
     for i in 0..<concurrency {

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -131,11 +131,9 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
       // Fleet members own separate materialized workspaces; per-member MCP
       // connections are not wired, so say so instead of silently ignoring.
       if mcp_config_path(matches) != "" {
-        @xlog.warn() <?
-          {
-            "event": "mcp_config_ignored",
-            "reason": "fleet mode does not support MCP servers",
-          }
+        @emit.emit(
+          McpConfigIgnored(reason="fleet mode does not support MCP servers"),
+        )
       }
       run_fleet(matches, concurrency~)
       return
@@ -173,13 +171,13 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
         // Name the recording up front so a user scanning the event stream —
         // or its OPENSEEK_LOG_FILE mirror — knows where to find this run
         // later (`sessions show`, the viz server, or resuming by id).
-        @xlog.info() <?
-          {
-            "event": "session_started",
-            "session": id.value(),
-            "session_root": session_root(matches, workspace_root~),
-            "workspace_root": workspace_root,
-          }
+        @emit.emit(
+          SessionStarted(
+            session=id.value(),
+            session_root=session_root(matches, workspace_root~),
+            workspace_root~,
+          ),
+        )
         let store = @store.SessionStore(session_root(matches, workspace_root~))
         let session = load_or_new_session(
           store,
@@ -778,7 +776,7 @@ async fn prepare_workspace_root(
   @fs.mkdir(dir)
   let root = @fs.realpath(dir)
   if log_created {
-    @xlog.info() <? { "event": "workspace_created", "dir": root }
+    @emit.emit(WorkspaceCreated(dir=root))
   }
   root
 }

--- a/cmd/openseek/mcp.mbt
+++ b/cmd/openseek/mcp.mbt
@@ -32,16 +32,14 @@ async fn[X] resolve_mcp_tools(
   let text = @fs.read_file(path).text() catch {
     error if @async.is_being_cancelled() => raise error
     error => {
-      @xlog.warn() <?
-        { "event": "mcp_config_unreadable", "path": path, "error": "\{error}" }
+      @emit.emit(McpConfigUnreadable(path~, error="\{error}"))
       return []
     }
   }
   let servers = @mcpconfig.decode(@json.parse(text)) catch {
     error if @async.is_being_cancelled() => raise error
     error => {
-      @xlog.warn() <?
-        { "event": "mcp_config_invalid", "path": path, "error": "\{error}" }
+      @emit.emit(McpConfigInvalid(path~, error="\{error}"))
       return []
     }
   }
@@ -52,15 +50,13 @@ async fn[X] resolve_mcp_tools(
     client_version=McpClientVersion,
     workspace_root~,
   )
-  @xlog.info() <?
-    {
-      "event": "mcp_tools_registered",
-      "servers": servers.length(),
-      "tools": tools.length(),
-      "names": [
-        for tool in tools => Json::string(tool.name)
-      ],
-    }
+  @emit.emit(
+    McpToolsRegistered(
+      servers=servers.length(),
+      tools=tools.length(),
+      names=[ for tool in tools => tool.name ],
+    ),
+  )
   tools
 }
 

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -14,6 +14,8 @@ import {
   "bobzhang/openseek/cmd/tui",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/prompt",
+  "bobzhang/openseek_protocol",
+  "bobzhang/openseek_protocol/emit",
   "bobzhang/openseek/testkit/filesystem" @vfs,
   "bobzhang/openseek/internal/agentcli",
   "bobzhang/openseek/internal/cli",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -605,17 +605,14 @@ async fn run_serve(
       @jsonl.each(@stdio.stdin, json => {
         match decode_serve_command(json) {
           Ok(command) => steps.try_put(Wire(command)) |> ignore
-          Err(message) =>
-            @xlog.error() <? { "event": "command_error", "error": message }
+          Err(message) => @emit.emit(CommandError(error=message))
         }
       }) catch {
         error if @async.is_being_cancelled() ||
           @async.is_cancellation_error(error) => raise error
         // A malformed (non-JSON) line is a controller bug: report it and
         // stop reading commands, which shuts the server down gracefully.
-        error =>
-          @xlog.error() <?
-            { "event": "command_error", "error": "command stream: \{error}" }
+        error => @emit.emit(CommandError(error="command stream: \{error}"))
       }
       steps.try_put(Shutdown) |> ignore
     }
@@ -663,7 +660,7 @@ async fn run_serve(
         error if @async.is_being_cancelled() ||
           @async.is_cancellation_error(error) => raise error
         error => {
-          @xlog.error() <? { "event": "compaction_failed", "error": "\{error}" }
+          @emit.emit(CompactionFailed(error="\{error}"))
           current
         }
       }
@@ -682,11 +679,7 @@ async fn run_serve(
           error if @async.is_being_cancelled() ||
             @async.is_cancellation_error(error) => raise error
           error => {
-            @xlog.error() <?
-              {
-                "event": "session_error",
-                "error": "failed to append \{what}: \{error}",
-              }
+            @emit.emit(SessionError(error="failed to append \{what}: \{error}"))
             return false
           }
         }
@@ -698,8 +691,7 @@ async fn run_serve(
 
     async fn append_command_context(text : String, kind : String) -> Unit {
       if append_idle_item(User(UserMessage(text)), "command context") {
-        @xlog.info() <?
-          { "event": "steer_applied", "kind": kind, "content": text }
+        @emit.emit(SteerApplied(kind~, content=text))
       }
     }
 
@@ -709,10 +701,8 @@ async fn run_serve(
     // was actually persisted.
     fn report_goal_update(content : String) -> Unit {
       match @agent_session.goal_marker(content) {
-        Some(GoalSet(text)) =>
-          @xlog.info() <? { "event": "goal_updated", "goal": text }
-        Some(GoalCleared) =>
-          @xlog.info() <? { "event": "goal_updated", "goal": (None : String?) }
+        Some(GoalSet(text)) => @emit.emit(GoalUpdated(goal=Some(text)))
+        Some(GoalCleared) => @emit.emit(GoalUpdated(goal=None))
         // Block/unblock markers change auto-continuation policy but not the
         // goal itself; they are reported by the loop's own goal_blocked /
         // goal_unblocked events, not as goal_updated.
@@ -741,7 +731,7 @@ async fn run_serve(
     // event.
     async fn append_background_notice(text : String) -> Unit {
       if append_idle_item(Runtime(RuntimeNotice(text)), "background notice") {
-        @xlog.info() <? { "event": "background_notice", "content": text }
+        @emit.emit(BackgroundNotice(content=text))
       }
     }
 
@@ -754,8 +744,7 @@ async fn run_serve(
       input : @agent_runtime.SteerInput,
     ) -> Unit {
       match input {
-        Prompt(text) =>
-          @xlog.warn() <? { "event": "steer_dropped", "content": text }
+        Prompt(text) => @emit.emit(SteerDropped(content=text))
         Command(text) => append_command_context(text, "command")
         Notice(text) =>
           match @agent_session.goal_marker(text) {
@@ -824,10 +813,9 @@ async fn run_serve(
             // event so the controller can close the run.
             if @async.is_being_cancelled() ||
               @async.is_cancellation_error(error) {
-              @xlog.warn() <?
-                { "event": "agent_aborted", "reason": "interrupted" }
+              @emit.emit(AgentAborted(reason="interrupted"))
             } else {
-              @xlog.error() <? { "event": "turn_failed", "error": "\{error}" }
+              @emit.emit(TurnFailed(error="\{error}"))
             }
             ignore(steps.try_put(TurnDone(finished=false)) catch { _ => false })
             return
@@ -846,13 +834,11 @@ async fn run_serve(
         let next = compact_and_report(current) catch {
           error if @async.is_being_cancelled() ||
             @async.is_cancellation_error(error) => {
-            @xlog.warn() <?
-              { "event": "compaction_failed", "error": "cancelled" }
+            @emit.emit(CompactionFailed(error="cancelled"))
             current
           }
           error => {
-            @xlog.error() <?
-              { "event": "compaction_failed", "error": "\{error}" }
+            @emit.emit(CompactionFailed(error="\{error}"))
             current
           }
         }
@@ -922,8 +908,7 @@ async fn run_serve(
                     // prompt steering into a prompt: the only way it arrives
                     // here is racing a turn's terminal event through the pipes.
                     // Reject it so the controller can ask for a resubmit.
-                    @xlog.warn() <?
-                      { "event": "steer_dropped", "content": text }
+                    @emit.emit(SteerDropped(content=text))
                   }
               }
             Command(text) =>
@@ -1052,8 +1037,7 @@ async fn run_serve(
               turns_remaining=goal_turns_remaining,
             ) {
             goal_turns_remaining -= 1
-            @xlog.info() <?
-              { "event": "goal_continue", "remaining": goal_turns_remaining }
+            @emit.emit(GoalContinue(remaining=goal_turns_remaining))
             active_work = Some(ActiveTurn(start_turn(GoalContinuePrompt)))
           } else if armed &&
             finished &&
@@ -1064,11 +1048,7 @@ async fn run_serve(
             // The loop ran its full budget without the goal being met:
             // disarm and tell the controller, once.
             goal_auto_target = None
-            @xlog.warn() <?
-              {
-                "event": "goal_budget_exhausted",
-                "turns": GoalAutoContinueMaxTurns,
-              }
+            @emit.emit(GoalBudgetExhausted(turns=GoalAutoContinueMaxTurns))
           }
           if active_work is None && pending.length() == 0 && shutting_down {
             break serve~

--- a/mcp/tools/moon.pkg
+++ b/mcp/tools/moon.pkg
@@ -5,8 +5,9 @@ import {
   "bobzhang/openseek/mcp/stdio",
   "bobzhang/openseek/mcp/streamhttp",
   "bobzhang/openseek/mcp/config",
+  "bobzhang/openseek_protocol",
+  "bobzhang/openseek_protocol/emit",
   "moonbitlang/async",
-  "tonyfettes/xlog",
 }
 
 import {

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -111,8 +111,7 @@ pub async fn tools_for_client(
   let bridged = []
   for tool in client.list_tools() {
     if seen_raw.contains(tool.name) {
-      @xlog.warn() <?
-        { "event": "mcp_tool_duplicate", "server": server, "tool": tool.name }
+      @emit.emit(McpToolDuplicate(server~, tool=tool.name))
       continue
     }
     seen_raw[tool.name] = ()
@@ -175,8 +174,7 @@ pub async fn[X] build_grouped(
     groups.push((server.name(), mine))
     // Budget exhausted: don't launch servers whose tools could not register.
     if total >= MaxTotalMcpTools {
-      @xlog.warn() <?
-        { "event": "mcp_server_skipped_over_cap", "server": server.name() }
+      @emit.emit(McpServerSkippedOverCap(server=server.name()))
       continue
     }
     let discovered = connect_server(
@@ -191,20 +189,14 @@ pub async fn[X] build_grouped(
       // The provider accepts at most 128 function definitions per request; the
       // MCP budget leaves room for the built-ins. Beyond it, drop with a log.
       if total >= MaxTotalMcpTools {
-        @xlog.warn() <?
-          {
-            "event": "mcp_tools_capped",
-            "server": server.name(),
-            "kept": MaxTotalMcpTools,
-          }
+        @emit.emit(McpToolsCapped(server=server.name(), kept=MaxTotalMcpTools))
         break
       }
       // Sanitization/capping can make two distinct MCP tools collide; keep both
       // callable under suffixed names rather than dropping one.
       let name = uniquify(seen, tool.name)
       if name != tool.name {
-        @xlog.warn() <?
-          { "event": "mcp_tool_renamed", "from": tool.name, "to": name }
+        @emit.emit(McpToolRenamed(from=tool.name, to=name))
       }
       seen[name] = ()
       total = total + 1
@@ -264,13 +256,12 @@ async fn[X] connect_server(
   } catch {
     error if @async.is_being_cancelled() => raise error
     error => {
-      @xlog.warn() <?
-        { "event": "mcp_connect_failed", "server": name, "error": "\{error}" }
+      @emit.emit(McpConnectFailed(server=name, error=Some("\{error}")))
       return []
     }
   }
   guard connection is Some((client, shutdown)) else {
-    @xlog.warn() <? { "event": "mcp_connect_failed", "server": name }
+    @emit.emit(McpConnectFailed(server=name, error=None))
     return []
   }
   let discovered = @async.with_timeout_opt(discovery_timeout_ms, () => {
@@ -278,25 +269,20 @@ async fn[X] connect_server(
   }) catch {
     error if @async.is_being_cancelled() => raise error
     error => {
-      @xlog.warn() <?
-        {
-          "event": "mcp_list_tools_failed",
-          "server": name,
-          "error": "\{error}",
-        }
+      @emit.emit(McpListToolsFailed(server=name, error="\{error}"))
       shutdown()
       return []
     }
   }
   guard discovered is Some(discovered) else {
-    @xlog.warn() <? { "event": "mcp_list_tools_timeout", "server": name }
+    @emit.emit(McpListToolsTimeout(server=name))
     shutdown()
     return []
   }
   // A server with nothing to offer is useless for the rest of the session:
   // release its process and tasks instead of holding them on the scope.
   if discovered.is_empty() {
-    @xlog.warn() <? { "event": "mcp_no_tools", "server": name }
+    @emit.emit(McpNoTools(server=name))
     shutdown()
   }
   discovered

--- a/moon.mod
+++ b/moon.mod
@@ -9,6 +9,7 @@ import {
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",
+  "bobzhang/openseek_protocol@0.1.0",
   "moonbit-community/rabbita@0.12.4",
 }
 

--- a/moon.work
+++ b/moon.work
@@ -1,4 +1,5 @@
 members = [
   ".",
+  "./protocol",
   "./cmd/viz_app",
 ]

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -1,0 +1,96 @@
+# OpenSeek Protocol
+
+`bobzhang/openseek_protocol` owns the engine's stdout event stream — the wire
+contract between `openseek run` / `openseek serve` and everything that reads
+them: the TUI, the desktop host, and any script consuming `run`'s stdout.
+
+It is a **leaf module with no openseek dependencies**, split so the decoder is
+portable:
+
+| Package | Contents | Targets | Deps |
+| --- | --- | --- | --- |
+| `bobzhang/openseek_protocol` | `Event`, `Usage`, `parse` | js, wasm, wasm-gc, native | `core/json` |
+| `bobzhang/openseek_protocol/emit` | `emit` | native | `xlog`, above |
+
+Only the *writer* needs `@xlog`, which is native-only. Keeping it in its own
+package means a client that reads the stream does not have to be a native
+binary — `desktop/frontend` compiles to js, and its decoder can now be the same
+`match` the engine's encoder is checked against.
+
+Being a module rather than a package is what lets a *different* module consume
+it: `desktop/moon.work` can list `"../protocol"` as a member and bind the
+working tree (a `moon.work` member wins over the registry, so there is no stale
+mooncakes snapshot).
+
+The stream doubles as the process log. `emit` routes through `@xlog`, whose
+handler writes one `Entry` per line and **hoists** structured fields to the top
+level, so a line looks like:
+
+```json
+{"timestamp":"…","level":"INFO","source":"agent/turn_loop.mbt:392:9","event":"assistant_delta","content":"Hel"}
+```
+
+The envelope (`timestamp`, `level`, `source`) is `@xlog`'s; everything from
+`event` on is this package's.
+
+## Why it exists
+
+The contract used to live as anonymous JSON literals at ~55 `@xlog.info() <? {…}`
+call sites, with a hand-written decoder per client. Nothing tied the two
+directions together, and they had drifted:
+
+- `tool_result` was emitted with `brief` from one site and without it from two.
+- `mcp_connect_failed` was emitted with `error` from one site and without it
+  from another.
+- `compaction_failed` was reported at `warn` from one site and `error` from two.
+
+`Event` closes that by construction: one variant per event, owning its payload
+**and its level**, with `emit` and `parse` as the only writer and reader.
+Because every client matches on the same enum, adding a variant is a compile
+error at each one — ignoring an event becomes a decision someone wrote down
+rather than a `_ => None` nobody noticed.
+
+## API
+
+```mbt nocheck
+// Report an event. The level comes from the variant, never the call site.
+@protocol.emit(AssistantDelta(content="Hel"))
+@protocol.emit(AgentAborted(reason="interrupted"))
+
+// Read one back. `None` means "not an event this engine emits" — an unknown
+// name or a malformed payload — so a client stays tolerant of a newer engine.
+match @protocol.parse(line) {
+  Some(AssistantDelta(content~)) => render(content)
+  Some(_) | None => ()
+}
+```
+
+`emit` carries `#callsite(autofill(loc))` and forwards `loc` to `@xlog`, so each
+line's `source` still points at the reporting code rather than at `emit.mbt`.
+
+## Invariants
+
+- **`parse` is `emit`'s inverse** for every variant. `protocol_test.mbt` pins
+  this per sample; it is the property the package exists to provide.
+- **Optional string fields are written as the value or `null`, never omitted.**
+  A field's own `ToJson` would encode `Some(v)` as the one-element array `[v]`,
+  which every decoder's string lookup rejects — silently turning a present field
+  into an absent one. `or_null` is why, and the round-trip test is what caught it.
+- **`Usage` is owned here, not borrowed from the provider.** It is structurally
+  identical to `@deepseek.Usage` — same fields, same order, same JSON — and
+  deliberately a separate type. The wire format must not be whatever a vendor's
+  response struct happens to be, and this module cannot depend on the engine's
+  provider layer without a cycle. `agent`'s `wire_usage` is the single place the
+  two meet.
+
+## Known gaps
+
+- The stream is filterable. `@xlog`'s root level comes from `MOON_XLOG`, so
+  `MOON_XLOG=warn openseek serve` drops every `info` event — `assistant_delta`,
+  `agent_step`, `usage`, `session_started` — and a client sees nothing. The
+  protocol should not be silenceable by a logging environment variable.
+- The clients still hand-decode. The TUI (`cmd/tui/internal/event/`) and the
+  desktop (`desktop/internal/event/`, `desktop/frontend/transcript/`) each keep
+  their own reader; adopting `parse` is what turns the drift table above into a
+  compile error. The desktop additionally needs `"../protocol"` added to
+  `desktop/moon.work`.

--- a/protocol/emit/emit.mbt
+++ b/protocol/emit/emit.mbt
@@ -1,0 +1,186 @@
+///|
+/// An optional string field as the wire carries it: the value itself, or
+/// `null`.
+///
+/// Not the field's own `ToJson` — MoonBit encodes `Some(v)` as the one-element
+/// array `[v]`, which every decoder's string lookup rejects, silently turning a
+/// present field into an absent one.
+fn or_null(value : String?) -> Json {
+  match value {
+    Some(value) => Json::string(value)
+    None => Json::null()
+  }
+}
+
+///|
+/// Write `event` to the process log, which is the engine's stdout JSONL stream.
+///
+/// `loc` is autofilled from the *caller*, then forwarded to `@xlog`, so each
+/// line's `source` still points at the code that reported the event rather than
+/// at this function. `@xlog`'s level methods return `None` when the level is
+/// disabled, so a filtered event costs one enum construction and no
+/// serialization.
+#callsite(autofill(loc))
+pub fn emit(event : @protocol.Event, loc~ : SourceLoc) -> Unit {
+  match event {
+    AgentSetupFailed(error~) =>
+      @xlog.error(loc~) <? { "event": "agent_setup_failed", "error": error }
+    AgentStep(step~) =>
+      @xlog.info(loc~) <? { "event": "agent_step", "step": step }
+    AgentAborted(reason~) =>
+      @xlog.warn(loc~) <? { "event": "agent_aborted", "reason": reason }
+    AgentFinished(answer~) =>
+      @xlog.info(loc~) <? { "event": "agent_finished", "answer": answer }
+    MaxStepsExhausted => @xlog.warn(loc~) <? { "event": "max_steps_exhausted" }
+    TurnFailed(error~) =>
+      @xlog.error(loc~) <? { "event": "turn_failed", "error": error }
+    AssistantDelta(content~) =>
+      @xlog.info(loc~) <? { "event": "assistant_delta", "content": content }
+    AssistantMessage(content~) =>
+      @xlog.info(loc~) <? { "event": "assistant_message", "content": content }
+    ReasoningMessage(content~) =>
+      @xlog.info(loc~) <? { "event": "reasoning_message", "content": content }
+    Usage(usage~) => @xlog.info(loc~) <? { "event": "usage", "usage": usage }
+    ToolResult(tool_call_id~, tool_name~, is_error~, content~, brief~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "tool_result",
+          "tool_call_id": tool_call_id,
+          "tool_name": tool_name,
+          "is_error": is_error,
+          "content": content,
+          "brief": or_null(brief),
+        }
+    ToolCallDecodeError(tool_call_id~, tool_name~, error~) =>
+      @xlog.error(loc~) <?
+        {
+          "event": "tool_call_decode_error",
+          "tool_call_id": tool_call_id,
+          "tool_name": tool_name,
+          "error": error,
+        }
+    SteerApplied(kind~, content~) =>
+      @xlog.info(loc~) <?
+        { "event": "steer_applied", "kind": kind, "content": content }
+    SteerDropped(content~) =>
+      @xlog.warn(loc~) <? { "event": "steer_dropped", "content": content }
+    BackgroundNotice(content~) =>
+      @xlog.info(loc~) <? { "event": "background_notice", "content": content }
+    GoalUpdated(goal~) =>
+      @xlog.info(loc~) <? { "event": "goal_updated", "goal": or_null(goal) }
+    GoalBlocked(reason~) =>
+      @xlog.info(loc~) <? { "event": "goal_blocked", "reason": reason }
+    GoalUnblocked => @xlog.info(loc~) <? { "event": "goal_unblocked" }
+    GoalCheck(content~) =>
+      @xlog.info(loc~) <? { "event": "goal_check", "content": content }
+    GoalReminder(content~) =>
+      @xlog.info(loc~) <? { "event": "goal_reminder", "content": content }
+    GoalContinue(remaining~) =>
+      @xlog.info(loc~) <? { "event": "goal_continue", "remaining": remaining }
+    GoalBudgetExhausted(turns~) =>
+      @xlog.warn(loc~) <? { "event": "goal_budget_exhausted", "turns": turns }
+    PlanReminder(content~) =>
+      @xlog.info(loc~) <? { "event": "plan_reminder", "content": content }
+    CompactionStarted(from_sequence~, to_sequence~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "compaction_started",
+          "from_sequence": from_sequence,
+          "to_sequence": to_sequence,
+        }
+    CompactionFinished(from_sequence~, to_sequence~, summary~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "compaction_finished",
+          "from_sequence": from_sequence,
+          "to_sequence": to_sequence,
+          "summary": summary,
+        }
+    CompactionFailed(error~) =>
+      @xlog.error(loc~) <? { "event": "compaction_failed", "error": error }
+    AutoCompactionStarted(from_sequence~, to_sequence~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "auto_compaction_started",
+          "from_sequence": from_sequence,
+          "to_sequence": to_sequence,
+        }
+    AutoCompactionFinished(from_sequence~, to_sequence~, summary~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "auto_compaction_finished",
+          "from_sequence": from_sequence,
+          "to_sequence": to_sequence,
+          "summary": summary,
+        }
+    AutoCompactionFailed(error~) =>
+      @xlog.warn(loc~) <? { "event": "auto_compaction_failed", "error": error }
+    ContextYield(to_sequence~, answer~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "context_yield",
+          "to_sequence": to_sequence,
+          "answer": answer,
+        }
+    SessionStarted(session~, session_root~, workspace_root~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "session_started",
+          "session": session,
+          "session_root": session_root,
+          "workspace_root": workspace_root,
+        }
+    SessionError(error~) =>
+      @xlog.error(loc~) <? { "event": "session_error", "error": error }
+    WorkspaceCreated(dir~) =>
+      @xlog.info(loc~) <? { "event": "workspace_created", "dir": dir }
+    CommandError(error~) =>
+      @xlog.error(loc~) <? { "event": "command_error", "error": error }
+    FleetStarted(runs~, task~) =>
+      @xlog.info(loc~) <?
+        { "event": "fleet_started", "runs": runs, "task": task }
+    McpConfigIgnored(reason~) =>
+      @xlog.warn(loc~) <? { "event": "mcp_config_ignored", "reason": reason }
+    McpConfigUnreadable(path~, error~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_config_unreadable", "path": path, "error": error }
+    McpConfigInvalid(path~, error~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_config_invalid", "path": path, "error": error }
+    McpToolsRegistered(servers~, tools~, names~) =>
+      @xlog.info(loc~) <?
+        {
+          "event": "mcp_tools_registered",
+          "servers": servers,
+          "tools": tools,
+          "names": names,
+        }
+    McpToolDuplicate(server~, tool~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_tool_duplicate", "server": server, "tool": tool }
+    McpToolRenamed(from~, to~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_tool_renamed", "from": from, "to": to }
+    McpToolsCapped(server~, kept~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_tools_capped", "server": server, "kept": kept }
+    McpServerSkippedOverCap(server~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_server_skipped_over_cap", "server": server }
+    McpConnectFailed(server~, error~) =>
+      @xlog.warn(loc~) <?
+        {
+          "event": "mcp_connect_failed",
+          "server": server,
+          "error": or_null(error),
+        }
+    McpListToolsFailed(server~, error~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_list_tools_failed", "server": server, "error": error }
+    McpListToolsTimeout(server~) =>
+      @xlog.warn(loc~) <?
+        { "event": "mcp_list_tools_timeout", "server": server }
+    McpNoTools(server~) =>
+      @xlog.warn(loc~) <? { "event": "mcp_no_tools", "server": server }
+  }
+}

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -1,0 +1,249 @@
+///|
+/// Collects the JSON of every line the global logger writes.
+struct MemoryLogHandler {
+  entries : Array[Json]
+}
+
+///|
+impl @xlog.Handler for MemoryLogHandler with fn handle(
+  self : MemoryLogHandler,
+  entry : @xlog.Entry,
+) -> Unit {
+  self.entries.push(entry.to_json())
+}
+
+///|
+/// Emit `event` down the real `@xlog` path and return the line it produced,
+/// with the envelope keys named in `drop` removed. `emit` writes through the
+/// process-wide logger, so the handler is swapped for the call and restored
+/// afterwards.
+fn line(event : @protocol.Event, drop~ : Array[String]) -> Json {
+  let entries : Array[Json] = []
+  let logger = @xlog.global()
+  defer {
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(Config())
+  }
+  logger.set_handler(MemoryLogHandler::{ entries, })
+  logger.set_level(Info)
+  @emit.emit(event)
+  guard entries.length() == 1 && entries[0] is Object(fields) else {
+    return Json::null()
+  }
+  for key in drop {
+    fields.remove(key) |> ignore
+  }
+  Json::object(fields)
+}
+
+///|
+/// The event's line as it reaches stdout, minus the envelope's `timestamp` (a
+/// wall clock) and `source` (a line number, covered by its own test below).
+/// Serialized, because the bytes are the contract.
+fn wire(event : @protocol.Event) -> String {
+  line(event, drop=["timestamp", "source"]).stringify()
+}
+
+///|
+/// `protocol` owns `Usage`, so the sample is built directly rather than decoded
+/// out of a provider's response type.
+fn usage_sample() -> @protocol.Usage {
+  {
+    prompt_tokens: 11,
+    completion_tokens: 22,
+    total_tokens: 33,
+    prompt_cache_hit_tokens: 4,
+    prompt_cache_miss_tokens: 7,
+  }
+}
+
+///|
+/// One sample per `Event` variant. `derive(Eq)` plus the round-trip test below
+/// makes this list the encoder/decoder contract; MoonBit's exhaustiveness
+/// checks `emit`/`parse`/`name`, but nothing forces a new variant to be added
+/// here, so a variant added without a sample is silently untested.
+fn all_events() -> Array[@protocol.Event] {
+  [
+    AgentSetupFailed(error="boom"),
+    AgentStep(step=3),
+    AgentAborted(reason="interrupted"),
+    AgentFinished(answer="done"),
+    MaxStepsExhausted,
+    TurnFailed(error="turn boom"),
+    AssistantDelta(content="Hel"),
+    AssistantMessage(content="Hello"),
+    ReasoningMessage(content="thinking"),
+    Usage(usage=usage_sample()),
+    ToolResult(
+      tool_call_id="call_1",
+      tool_name="read",
+      is_error=false,
+      content="file body",
+      brief=Some("read moon.mod"),
+    ),
+    ToolResult(
+      tool_call_id="call_2",
+      tool_name="shell",
+      is_error=true,
+      content="exit 1",
+      brief=None,
+    ),
+    ToolCallDecodeError(
+      tool_call_id="call_3",
+      tool_name="edit",
+      error="bad args",
+    ),
+    SteerApplied(kind="prompt", content="also fix docs"),
+    SteerDropped(content="too late"),
+    BackgroundNotice(content="job 2 exited"),
+    GoalUpdated(goal=Some("ship it")),
+    GoalUpdated(goal=None),
+    GoalBlocked(reason="needs a key"),
+    GoalUnblocked,
+    GoalCheck(content="is it met?"),
+    GoalReminder(content="remember the goal"),
+    GoalContinue(remaining=4),
+    GoalBudgetExhausted(turns=20),
+    PlanReminder(content="update the plan"),
+    CompactionStarted(from_sequence=1, to_sequence=9),
+    CompactionFinished(from_sequence=1, to_sequence=9, summary="recap"),
+    CompactionFailed(error="cancelled"),
+    AutoCompactionStarted(from_sequence=1, to_sequence=12),
+    AutoCompactionFinished(from_sequence=1, to_sequence=12, summary="recap"),
+    AutoCompactionFailed(error="summary boom"),
+    ContextYield(to_sequence=30, answer="partial"),
+    SessionStarted(
+      session="cli-1",
+      session_root=".openseek",
+      workspace_root="/w",
+    ),
+    SessionError(error="failed to append user"),
+    WorkspaceCreated(dir="/w"),
+    CommandError(error="command stream: bad json"),
+    FleetStarted(runs=3, task="port it"),
+    McpConfigIgnored(reason="fleet mode does not support MCP servers"),
+    McpConfigUnreadable(path="/mcp.json", error="no such file"),
+    McpConfigInvalid(path="/mcp.json", error="bad shape"),
+    McpToolsRegistered(servers=2, tools=3, names=["a", "b", "c"]),
+    McpToolDuplicate(server="fs", tool="read"),
+    McpToolRenamed(from="read", to="fs_read"),
+    McpToolsCapped(server="fs", kept=64),
+    McpServerSkippedOverCap(server="fs"),
+    McpConnectFailed(server="fs", error=Some("spawn failed")),
+    McpConnectFailed(server="fs", error=None),
+    McpListToolsFailed(server="fs", error="timeout"),
+    McpListToolsTimeout(server="fs"),
+    McpNoTools(server="fs"),
+  ]
+}
+
+///|
+/// `parse` is `emit`'s inverse for every variant: the pair cannot drift without
+/// this failing, which is the property the package exists to provide.
+test "every event round-trips through emit and parse" {
+  for event in all_events() {
+    let encoded = line(event, drop=["timestamp", "source"])
+    assert_eq(@protocol.parse(encoded), Some(event))
+  }
+}
+
+///|
+/// Each variant owns its level, so the same event can never be reported at two
+/// severities the way `compaction_failed` was before this package.
+test "levels are a property of the event" {
+  inspect(
+    wire(AgentStep(step=1)),
+    content=(
+      #|{"level":"INFO","event":"agent_step","step":1}
+    ),
+  )
+  inspect(
+    wire(AgentAborted(reason="interrupted")),
+    content=(
+      #|{"level":"WARN","event":"agent_aborted","reason":"interrupted"}
+    ),
+  )
+  inspect(
+    wire(CompactionFailed(error="cancelled")),
+    content=(
+      #|{"level":"ERROR","event":"compaction_failed","error":"cancelled"}
+    ),
+  )
+}
+
+///|
+/// `brief` and `mcp_connect_failed`'s `error` are always written, `null` when
+/// absent. Every decoder reads them with a lookup that rejects a non-string, so
+/// a null and a missing key are the same value downstream — the uniform shape
+/// costs nothing and keeps one variant per event.
+test "optional payload fields are written as null, never omitted" {
+  inspect(
+    wire(
+      ToolResult(
+        tool_call_id="call_2",
+        tool_name="shell",
+        is_error=true,
+        content="exit 1",
+        brief=None,
+      ),
+    ),
+    content=(
+      #|{"level":"INFO","event":"tool_result","tool_call_id":"call_2","tool_name":"shell","is_error":true,"content":"exit 1","brief":null}
+    ),
+  )
+  // A present value is the bare string. MoonBit's own `Some(v)` encoding is the
+  // one-element array `[v]`, which would read as absent to every decoder.
+  inspect(
+    wire(
+      ToolResult(
+        tool_call_id="call_1",
+        tool_name="read",
+        is_error=false,
+        content="file body",
+        brief=Some("read moon.mod"),
+      ),
+    ),
+    content=(
+      #|{"level":"INFO","event":"tool_result","tool_call_id":"call_1","tool_name":"read","is_error":false,"content":"file body","brief":"read moon.mod"}
+    ),
+  )
+  inspect(
+    wire(McpConnectFailed(server="fs", error=None)),
+    content=(
+      #|{"level":"WARN","event":"mcp_connect_failed","server":"fs","error":null}
+    ),
+  )
+  inspect(
+    wire(GoalUpdated(goal=None)),
+    content=(
+      #|{"level":"INFO","event":"goal_updated","goal":null}
+    ),
+  )
+}
+
+///|
+/// The struct's `ToJson` derive is the wire format for `usage`:
+/// renaming a field of `@protocol.Usage` changes this line and every client
+/// parsing it — which is exactly why the type is owned here and not borrowed
+/// from the provider layer.
+test "usage carries the protocol struct verbatim" {
+  inspect(
+    wire(Usage(usage=usage_sample())),
+    content=(
+      #|{"level":"INFO","event":"usage","usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33,"prompt_cache_hit_tokens":4,"prompt_cache_miss_tokens":7}}
+    ),
+  )
+}
+
+///|
+/// `emit` forwards its autofilled `loc`, so a line's `source` still points at
+/// the reporting code. Without the forward every event would blame `emit.mbt`.
+test "source points at the caller, not at emit" {
+  guard line(AgentStep(step=1), drop=["timestamp"]) is Object(fields) else {
+    fail("expected an object")
+  }
+  guard fields.get("source") is Some(String(source)) else {
+    fail("expected a source field")
+  }
+  assert_true(source.contains("emit_test.mbt"))
+}

--- a/protocol/emit/moon.pkg
+++ b/protocol/emit/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "bobzhang/openseek_protocol" @protocol,
+  "moonbitlang/core/json",
+  "tonyfettes/xlog",
+}
+
+import {
+  "moonbitlang/core/json",
+  "tonyfettes/xlog",
+} for "test"
+
+supported_targets = "+native"
+
+warnings = "+unnecessary_annotation"

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -1,0 +1,160 @@
+///|
+/// One event on the engine's stdout JSONL stream — the wire contract between
+/// `openseek run`/`openseek serve` and every client that reads them (the TUI,
+/// the desktop host, and any script consuming `run`'s stdout).
+///
+/// The stream doubles as the process log: `emit` routes through `@xlog`, whose
+/// handler serializes an `Entry` per line as
+/// `{"timestamp":…,"level":…,"source":…,<fields>}` — structured fields are
+/// hoisted to the top level, so an event's own fields sit alongside the
+/// envelope rather than nested under it.
+///
+/// Every variant owns its log level, so a call site cannot report the same
+/// event at two severities. `emit` is the only writer; `parse` is its inverse.
+pub(all) enum Event {
+  // ── agent loop ─────────────────────────────────────────────────────────
+  AgentSetupFailed(error~ : String)
+  AgentStep(step~ : Int)
+  AgentAborted(reason~ : String)
+  AgentFinished(answer~ : String)
+  MaxStepsExhausted
+  TurnFailed(error~ : String)
+  AssistantDelta(content~ : String)
+  AssistantMessage(content~ : String)
+  ReasoningMessage(content~ : String)
+  Usage(usage~ : Usage)
+  /// `brief` is always written, `null` when the tool reported none: an absent
+  /// key and a null one are indistinguishable to every decoder, so the shape
+  /// stays uniform across the three call sites that emit a tool result.
+  ToolResult(
+    tool_call_id~ : String,
+    tool_name~ : String,
+    is_error~ : Bool,
+    content~ : String,
+    brief~ : String?
+  )
+  ToolCallDecodeError(
+    tool_call_id~ : String,
+    tool_name~ : String,
+    error~ : String
+  )
+
+  // ── steering ───────────────────────────────────────────────────────────
+  SteerApplied(kind~ : String, content~ : String)
+  SteerDropped(content~ : String)
+  BackgroundNotice(content~ : String)
+
+  // ── goal ───────────────────────────────────────────────────────────────
+  GoalUpdated(goal~ : String?)
+  GoalBlocked(reason~ : String)
+  GoalUnblocked
+  GoalCheck(content~ : String)
+  GoalReminder(content~ : String)
+  GoalContinue(remaining~ : Int)
+  GoalBudgetExhausted(turns~ : Int)
+
+  // ── plan ───────────────────────────────────────────────────────────────
+  PlanReminder(content~ : String)
+
+  // ── compaction ─────────────────────────────────────────────────────────
+  CompactionStarted(from_sequence~ : Int, to_sequence~ : Int)
+  CompactionFinished(
+    from_sequence~ : Int,
+    to_sequence~ : Int,
+    summary~ : String
+  )
+  /// Reported at `Error` even when the cause was cancellation: no decoder
+  /// reads the envelope's level, so one severity per event costs nothing and
+  /// keeps the level a property of the event rather than of the call site.
+  CompactionFailed(error~ : String)
+  AutoCompactionStarted(from_sequence~ : Int, to_sequence~ : Int)
+  AutoCompactionFinished(
+    from_sequence~ : Int,
+    to_sequence~ : Int,
+    summary~ : String
+  )
+  AutoCompactionFailed(error~ : String)
+  ContextYield(to_sequence~ : Int, answer~ : String)
+
+  // ── session / workspace ────────────────────────────────────────────────
+  SessionStarted(
+    session~ : String,
+    session_root~ : String,
+    workspace_root~ : String
+  )
+  SessionError(error~ : String)
+  WorkspaceCreated(dir~ : String)
+  CommandError(error~ : String)
+  FleetStarted(runs~ : Int, task~ : String)
+
+  // ── mcp ────────────────────────────────────────────────────────────────
+  McpConfigIgnored(reason~ : String)
+  McpConfigUnreadable(path~ : String, error~ : String)
+  McpConfigInvalid(path~ : String, error~ : String)
+  McpToolsRegistered(servers~ : Int, tools~ : Int, names~ : Array[String])
+  McpToolDuplicate(server~ : String, tool~ : String)
+  McpToolRenamed(from~ : String, to~ : String)
+  McpToolsCapped(server~ : String, kept~ : Int)
+  McpServerSkippedOverCap(server~ : String)
+  /// `error` is always written, `null` when the connection produced no error
+  /// value (the server simply yielded nothing) — same uniformity rule as
+  /// `ToolResult::brief`.
+  McpConnectFailed(server~ : String, error~ : String?)
+  McpListToolsFailed(server~ : String, error~ : String)
+  McpListToolsTimeout(server~ : String)
+  McpNoTools(server~ : String)
+} derive(Eq, Debug)
+
+///|
+/// The event's `"event"` field — its name on the wire.
+pub fn Event::name(self : Event) -> String {
+  match self {
+    AgentSetupFailed(_) => "agent_setup_failed"
+    AgentStep(_) => "agent_step"
+    AgentAborted(_) => "agent_aborted"
+    AgentFinished(_) => "agent_finished"
+    MaxStepsExhausted => "max_steps_exhausted"
+    TurnFailed(_) => "turn_failed"
+    AssistantDelta(_) => "assistant_delta"
+    AssistantMessage(_) => "assistant_message"
+    ReasoningMessage(_) => "reasoning_message"
+    Usage(_) => "usage"
+    ToolResult(_) => "tool_result"
+    ToolCallDecodeError(_) => "tool_call_decode_error"
+    SteerApplied(_) => "steer_applied"
+    SteerDropped(_) => "steer_dropped"
+    BackgroundNotice(_) => "background_notice"
+    GoalUpdated(_) => "goal_updated"
+    GoalBlocked(_) => "goal_blocked"
+    GoalUnblocked => "goal_unblocked"
+    GoalCheck(_) => "goal_check"
+    GoalReminder(_) => "goal_reminder"
+    GoalContinue(_) => "goal_continue"
+    GoalBudgetExhausted(_) => "goal_budget_exhausted"
+    PlanReminder(_) => "plan_reminder"
+    CompactionStarted(_) => "compaction_started"
+    CompactionFinished(_) => "compaction_finished"
+    CompactionFailed(_) => "compaction_failed"
+    AutoCompactionStarted(_) => "auto_compaction_started"
+    AutoCompactionFinished(_) => "auto_compaction_finished"
+    AutoCompactionFailed(_) => "auto_compaction_failed"
+    ContextYield(_) => "context_yield"
+    SessionStarted(_) => "session_started"
+    SessionError(_) => "session_error"
+    WorkspaceCreated(_) => "workspace_created"
+    CommandError(_) => "command_error"
+    FleetStarted(_) => "fleet_started"
+    McpConfigIgnored(_) => "mcp_config_ignored"
+    McpConfigUnreadable(_) => "mcp_config_unreadable"
+    McpConfigInvalid(_) => "mcp_config_invalid"
+    McpToolsRegistered(_) => "mcp_tools_registered"
+    McpToolDuplicate(_) => "mcp_tool_duplicate"
+    McpToolRenamed(_) => "mcp_tool_renamed"
+    McpToolsCapped(_) => "mcp_tools_capped"
+    McpServerSkippedOverCap(_) => "mcp_server_skipped_over_cap"
+    McpConnectFailed(_) => "mcp_connect_failed"
+    McpListToolsFailed(_) => "mcp_list_tools_failed"
+    McpListToolsTimeout(_) => "mcp_list_tools_timeout"
+    McpNoTools(_) => "mcp_no_tools"
+  }
+}

--- a/protocol/moon.mod
+++ b/protocol/moon.mod
@@ -1,0 +1,15 @@
+name = "bobzhang/openseek_protocol"
+
+version = "0.1.0"
+
+import {
+  "tonyfettes/xlog@0.4.0",
+}
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/bobzhang/openseek"
+
+license = "Apache-2.0"
+
+description = "Typed engine event stream: the openseek run/serve stdout wire contract."

--- a/protocol/moon.pkg
+++ b/protocol/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbitlang/core/json",
+}
+
+import {
+  "moonbitlang/core/json",
+} for "test"
+
+warnings = "+unnecessary_annotation"

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -1,0 +1,245 @@
+///|
+/// Read one JSONL line from the engine's stdout stream back into an `Event`.
+///
+/// The inverse of `emit`: `parse(json) == Some(event)` for every line `emit`
+/// writes, which `protocol_test.mbt` pins per variant. Fields are read from the
+/// top level, matching the hoisting `@xlog`'s handler performs.
+///
+/// `None` means "not an event this engine emits" — an unknown `event` name, a
+/// missing `event` key, or a payload whose required fields are absent or
+/// mistyped. Clients stay tolerant of a newer engine by treating `None` as
+/// "ignore this line" rather than as a failure.
+pub fn parse(line : Json) -> Event? {
+  guard line is Object(fields) else { return None }
+  guard text(fields, "event") is Some(name) else { return None }
+  match name {
+    "agent_setup_failed" =>
+      text(fields, "error").map(error => AgentSetupFailed(error~))
+    "agent_step" => int(fields, "step").map(step => AgentStep(step~))
+    "agent_aborted" =>
+      text(fields, "reason").map(reason => AgentAborted(reason~))
+    "agent_finished" =>
+      text(fields, "answer").map(answer => AgentFinished(answer~))
+    "max_steps_exhausted" => Some(MaxStepsExhausted)
+    "turn_failed" => text(fields, "error").map(error => TurnFailed(error~))
+    "assistant_delta" =>
+      text(fields, "content").map(content => AssistantDelta(content~))
+    "assistant_message" =>
+      text(fields, "content").map(content => AssistantMessage(content~))
+    "reasoning_message" =>
+      text(fields, "content").map(content => ReasoningMessage(content~))
+    "usage" => {
+      guard fields.get("usage") is Some(usage) else { return None }
+      let usage : Usage = @json.from_json(usage) catch { _ => return None }
+      Some(Usage(usage~))
+    }
+    "tool_result" => {
+      guard text(fields, "tool_call_id") is Some(tool_call_id) &&
+        text(fields, "tool_name") is Some(tool_name) &&
+        bool(fields, "is_error") is Some(is_error) &&
+        text(fields, "content") is Some(content) else {
+        return None
+      }
+      Some(
+        ToolResult(
+          tool_call_id~,
+          tool_name~,
+          is_error~,
+          content~,
+          brief=text(fields, "brief"),
+        ),
+      )
+    }
+    "tool_call_decode_error" => {
+      guard text(fields, "tool_call_id") is Some(tool_call_id) &&
+        text(fields, "tool_name") is Some(tool_name) &&
+        text(fields, "error") is Some(error) else {
+        return None
+      }
+      Some(ToolCallDecodeError(tool_call_id~, tool_name~, error~))
+    }
+    "steer_applied" => {
+      guard text(fields, "kind") is Some(kind) &&
+        text(fields, "content") is Some(content) else {
+        return None
+      }
+      Some(SteerApplied(kind~, content~))
+    }
+    "steer_dropped" =>
+      text(fields, "content").map(content => SteerDropped(content~))
+    "background_notice" =>
+      text(fields, "content").map(content => BackgroundNotice(content~))
+    // `goal` is null when the goal was cleared: absent and null are the same
+    // value here, so the key's presence is not itself required.
+    "goal_updated" => Some(GoalUpdated(goal=text(fields, "goal")))
+    "goal_blocked" => text(fields, "reason").map(reason => GoalBlocked(reason~))
+    "goal_unblocked" => Some(GoalUnblocked)
+    "goal_check" => text(fields, "content").map(content => GoalCheck(content~))
+    "goal_reminder" =>
+      text(fields, "content").map(content => GoalReminder(content~))
+    "goal_continue" =>
+      int(fields, "remaining").map(remaining => GoalContinue(remaining~))
+    "goal_budget_exhausted" =>
+      int(fields, "turns").map(turns => GoalBudgetExhausted(turns~))
+    "plan_reminder" =>
+      text(fields, "content").map(content => PlanReminder(content~))
+    "compaction_started" => {
+      guard sequences(fields) is Some((from_sequence, to_sequence)) else {
+        return None
+      }
+      Some(CompactionStarted(from_sequence~, to_sequence~))
+    }
+    "compaction_finished" => {
+      guard sequences(fields) is Some((from_sequence, to_sequence)) &&
+        text(fields, "summary") is Some(summary) else {
+        return None
+      }
+      Some(CompactionFinished(from_sequence~, to_sequence~, summary~))
+    }
+    "compaction_failed" =>
+      text(fields, "error").map(error => CompactionFailed(error~))
+    "auto_compaction_started" => {
+      guard sequences(fields) is Some((from_sequence, to_sequence)) else {
+        return None
+      }
+      Some(AutoCompactionStarted(from_sequence~, to_sequence~))
+    }
+    "auto_compaction_finished" => {
+      guard sequences(fields) is Some((from_sequence, to_sequence)) &&
+        text(fields, "summary") is Some(summary) else {
+        return None
+      }
+      Some(AutoCompactionFinished(from_sequence~, to_sequence~, summary~))
+    }
+    "auto_compaction_failed" =>
+      text(fields, "error").map(error => AutoCompactionFailed(error~))
+    "context_yield" => {
+      guard int(fields, "to_sequence") is Some(to_sequence) &&
+        text(fields, "answer") is Some(answer) else {
+        return None
+      }
+      Some(ContextYield(to_sequence~, answer~))
+    }
+    "session_started" => {
+      guard text(fields, "session") is Some(session) &&
+        text(fields, "session_root") is Some(session_root) &&
+        text(fields, "workspace_root") is Some(workspace_root) else {
+        return None
+      }
+      Some(SessionStarted(session~, session_root~, workspace_root~))
+    }
+    "session_error" => text(fields, "error").map(error => SessionError(error~))
+    "workspace_created" =>
+      text(fields, "dir").map(dir => WorkspaceCreated(dir~))
+    "command_error" => text(fields, "error").map(error => CommandError(error~))
+    "fleet_started" => {
+      guard int(fields, "runs") is Some(runs) &&
+        text(fields, "task") is Some(task) else {
+        return None
+      }
+      Some(FleetStarted(runs~, task~))
+    }
+    "mcp_config_ignored" =>
+      text(fields, "reason").map(reason => McpConfigIgnored(reason~))
+    "mcp_config_unreadable" => {
+      guard text(fields, "path") is Some(path) &&
+        text(fields, "error") is Some(error) else {
+        return None
+      }
+      Some(McpConfigUnreadable(path~, error~))
+    }
+    "mcp_config_invalid" => {
+      guard text(fields, "path") is Some(path) &&
+        text(fields, "error") is Some(error) else {
+        return None
+      }
+      Some(McpConfigInvalid(path~, error~))
+    }
+    "mcp_tools_registered" => {
+      guard int(fields, "servers") is Some(servers) &&
+        int(fields, "tools") is Some(tools) &&
+        fields.get("names") is Some(Array(names)) else {
+        return None
+      }
+      let decoded = []
+      for name in names {
+        guard name is String(name) else { return None }
+        decoded.push(name)
+      }
+      Some(McpToolsRegistered(servers~, tools~, names=decoded))
+    }
+    "mcp_tool_duplicate" => {
+      guard text(fields, "server") is Some(server) &&
+        text(fields, "tool") is Some(tool) else {
+        return None
+      }
+      Some(McpToolDuplicate(server~, tool~))
+    }
+    "mcp_tool_renamed" => {
+      guard text(fields, "from") is Some(from) && text(fields, "to") is Some(to) else {
+        return None
+      }
+      Some(McpToolRenamed(from~, to~))
+    }
+    "mcp_tools_capped" => {
+      guard text(fields, "server") is Some(server) &&
+        int(fields, "kept") is Some(kept) else {
+        return None
+      }
+      Some(McpToolsCapped(server~, kept~))
+    }
+    "mcp_server_skipped_over_cap" =>
+      text(fields, "server").map(server => McpServerSkippedOverCap(server~))
+    // `error` is null when the connection yielded no error value.
+    "mcp_connect_failed" =>
+      text(fields, "server").map(server => {
+        McpConnectFailed(server~, error=text(fields, "error"))
+      })
+    "mcp_list_tools_failed" => {
+      guard text(fields, "server") is Some(server) &&
+        text(fields, "error") is Some(error) else {
+        return None
+      }
+      Some(McpListToolsFailed(server~, error~))
+    }
+    "mcp_list_tools_timeout" =>
+      text(fields, "server").map(server => McpListToolsTimeout(server~))
+    "mcp_no_tools" => text(fields, "server").map(server => McpNoTools(server~))
+    _ => None
+  }
+}
+
+///|
+fn text(fields : Map[String, Json], key : String) -> String? {
+  guard fields.get(key) is Some(String(value)) else { return None }
+  Some(value)
+}
+
+///|
+/// JSON has one number type, so an `Int` field arrives as a `Number`; reject a
+/// fractional value rather than silently truncating it.
+fn int(fields : Map[String, Json], key : String) -> Int? {
+  guard fields.get(key) is Some(Number(value, ..)) else { return None }
+  let rounded = value.to_int()
+  guard rounded.to_double() == value else { return None }
+  Some(rounded)
+}
+
+///|
+fn bool(fields : Map[String, Json], key : String) -> Bool? {
+  match fields.get(key) {
+    Some(True) => Some(true)
+    Some(False) => Some(false)
+    _ => None
+  }
+}
+
+///|
+/// The `from_sequence`/`to_sequence` pair every compaction event carries.
+fn sequences(fields : Map[String, Json]) -> (Int, Int)? {
+  guard int(fields, "from_sequence") is Some(from_sequence) &&
+    int(fields, "to_sequence") is Some(to_sequence) else {
+    return None
+  }
+  Some((from_sequence, to_sequence))
+}

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -1,0 +1,122 @@
+///|
+/// `parse` against literal lines, with no `emit` in sight.
+///
+/// These run on every backend the module supports — js, wasm, wasm-gc, native —
+/// which is the point of keeping the decoder free of `@xlog`: a client that
+/// reads the stream does not have to be a native binary. The round-trip against
+/// the real encoder lives in the `emit` package, which is native-only.
+fn decode(line : String) -> @openseek_protocol.Event? {
+  @openseek_protocol.parse(@json.parse(line) catch { _ => return None })
+}
+
+///|
+test "decodes a streaming delta" {
+  debug_inspect(
+    decode(
+      (
+        #|{"timestamp":"t","level":"INFO","source":"s","event":"assistant_delta","content":"Hel"}
+      ),
+    ),
+    content=(
+      #|Some(AssistantDelta(content="Hel"))
+    ),
+  )
+}
+
+///|
+/// The envelope is ignored: a reader cares about the event, not about which
+/// line of the engine reported it.
+test "decodes with the envelope absent" {
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"agent_step","step":7}
+      ),
+    ),
+    content=(
+      #|Some(AgentStep(step=7))
+    ),
+  )
+}
+
+///|
+test "decodes the nested usage payload" {
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"usage","usage":{"prompt_tokens":11,"completion_tokens":22,"total_tokens":33,"prompt_cache_hit_tokens":4,"prompt_cache_miss_tokens":7}}
+      ),
+    ),
+    content=(
+      #|Some(
+      #|  Usage(
+      #|    usage={
+      #|      prompt_tokens: 11,
+      #|      completion_tokens: 22,
+      #|      total_tokens: 33,
+      #|      prompt_cache_hit_tokens: 4,
+      #|      prompt_cache_miss_tokens: 7,
+      #|    },
+      #|  ),
+      #|)
+    ),
+  )
+}
+
+///|
+/// A null optional field and an absent one are the same value — the property
+/// that let the three `tool_result` call sites converge on one shape.
+test "a null optional field reads as absent" {
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"tool_result","tool_call_id":"c1","tool_name":"read","is_error":false,"content":"body","brief":null}
+      ),
+    ),
+    content=(
+      #|Some(
+      #|  ToolResult(
+      #|    tool_call_id="c1",
+      #|    tool_name="read",
+      #|    is_error=false,
+      #|    content="body",
+      #|    brief=None,
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"tool_result","tool_call_id":"c1","tool_name":"read","is_error":false,"content":"body"}
+      ),
+    ),
+    content=(
+      #|Some(
+      #|  ToolResult(
+      #|    tool_call_id="c1",
+      #|    tool_name="read",
+      #|    is_error=false,
+      #|    content="body",
+      #|    brief=None,
+      #|  ),
+      #|)
+    ),
+  )
+}
+
+///|
+/// A line from a newer engine, or one that is not an event at all, is ignored
+/// rather than failing the reader.
+test "unknown and malformed lines are ignored" {
+  assert_eq(@openseek_protocol.parse(Json::string("not an object")), None)
+  assert_eq(@openseek_protocol.parse({ "level": "INFO" }), None)
+  assert_eq(@openseek_protocol.parse({ "event": "from_a_newer_engine" }), None)
+  // `agent_step` without its required payload.
+  assert_eq(@openseek_protocol.parse({ "event": "agent_step" }), None)
+  // A fractional `step` is not an Int.
+  assert_eq(
+    @openseek_protocol.parse({ "event": "agent_step", "step": 1.5 }),
+    None,
+  )
+}

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -1,0 +1,77 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek_protocol"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+pub fn parse(Json) -> Event?
+
+// Errors
+
+// Types and methods
+pub(all) enum Event {
+  AgentSetupFailed(error~ : String)
+  AgentStep(step~ : Int)
+  AgentAborted(reason~ : String)
+  AgentFinished(answer~ : String)
+  MaxStepsExhausted
+  TurnFailed(error~ : String)
+  AssistantDelta(content~ : String)
+  AssistantMessage(content~ : String)
+  ReasoningMessage(content~ : String)
+  Usage(usage~ : Usage)
+  ToolResult(tool_call_id~ : String, tool_name~ : String, is_error~ : Bool, content~ : String, brief~ : String?)
+  ToolCallDecodeError(tool_call_id~ : String, tool_name~ : String, error~ : String)
+  SteerApplied(kind~ : String, content~ : String)
+  SteerDropped(content~ : String)
+  BackgroundNotice(content~ : String)
+  GoalUpdated(goal~ : String?)
+  GoalBlocked(reason~ : String)
+  GoalUnblocked
+  GoalCheck(content~ : String)
+  GoalReminder(content~ : String)
+  GoalContinue(remaining~ : Int)
+  GoalBudgetExhausted(turns~ : Int)
+  PlanReminder(content~ : String)
+  CompactionStarted(from_sequence~ : Int, to_sequence~ : Int)
+  CompactionFinished(from_sequence~ : Int, to_sequence~ : Int, summary~ : String)
+  CompactionFailed(error~ : String)
+  AutoCompactionStarted(from_sequence~ : Int, to_sequence~ : Int)
+  AutoCompactionFinished(from_sequence~ : Int, to_sequence~ : Int, summary~ : String)
+  AutoCompactionFailed(error~ : String)
+  ContextYield(to_sequence~ : Int, answer~ : String)
+  SessionStarted(session~ : String, session_root~ : String, workspace_root~ : String)
+  SessionError(error~ : String)
+  WorkspaceCreated(dir~ : String)
+  CommandError(error~ : String)
+  FleetStarted(runs~ : Int, task~ : String)
+  McpConfigIgnored(reason~ : String)
+  McpConfigUnreadable(path~ : String, error~ : String)
+  McpConfigInvalid(path~ : String, error~ : String)
+  McpToolsRegistered(servers~ : Int, tools~ : Int, names~ : Array[String])
+  McpToolDuplicate(server~ : String, tool~ : String)
+  McpToolRenamed(from~ : String, to~ : String)
+  McpToolsCapped(server~ : String, kept~ : Int)
+  McpServerSkippedOverCap(server~ : String)
+  McpConnectFailed(server~ : String, error~ : String?)
+  McpListToolsFailed(server~ : String, error~ : String)
+  McpListToolsTimeout(server~ : String)
+  McpNoTools(server~ : String)
+} derive(Eq, @debug.Debug)
+pub fn Event::name(Self) -> String
+
+pub(all) struct Usage {
+  prompt_tokens : Int
+  completion_tokens : Int
+  total_tokens : Int
+  prompt_cache_hit_tokens : Int
+  prompt_cache_miss_tokens : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+// Type aliases
+
+// Traits
+

--- a/protocol/usage.mbt
+++ b/protocol/usage.mbt
@@ -1,0 +1,16 @@
+///|
+/// Token counts for one model response, as the `usage` event carries them.
+///
+/// Structurally identical to `@deepseek.Usage` — same field names, same order,
+/// so the same JSON — but owned here on purpose. This type IS the wire format
+/// for the event; leaving it as the vendor's response struct meant renaming a
+/// DeepSeek field silently changed the contract every client parses, and it
+/// would tie this module to the engine's provider layer. The engine converts at
+/// the one site that reports usage.
+pub(all) struct Usage {
+  prompt_tokens : Int
+  completion_tokens : Int
+  total_tokens : Int
+  prompt_cache_hit_tokens : Int
+  prompt_cache_miss_tokens : Int
+} derive(Eq, Debug, ToJson, FromJson)


### PR DESCRIPTION
**Stack: #497 (this) → #498 → `protocol-desktop-decoder`.** This PR adds the module and converts the writers; the readers adopt it in the two above. Scope here is the engine side only.

## What

The engine's stdout JSONL stream is the wire contract between `openseek run`/`serve` and everything that reads it — the TUI, the desktop host, the desktop frontend, and any script consuming stdout. It lived as **~60 anonymous JSON literals** at `@xlog.info() <? {…}` call sites, with a hand-written decoder per client and nothing tying the two directions together.

They had already drifted:

| Event | Drift |
|---|---|
| `tool_result` | emitted with `brief` from 1 site, without it from 2 |
| `mcp_connect_failed` | emitted with `error` from 1 site, without it from another |
| `compaction_failed` | reported at **warn** from 1 site, **error** from 2 — same event, two severities |

And of 49 event names emitted, **~16 were decoded by nobody**; the desktop decoded **zero** `goal_*` and **zero** `mcp_*` events, silently, through a `_ => None`.

## This PR

`bobzhang/openseek_protocol` — a **leaf module with no openseek dependencies**, split so the decoder is portable:

| Package | Contents | Targets |
|---|---|---|
| `bobzhang/openseek_protocol` | `Event` (47 variants), `Usage`, `parse` | js, wasm, wasm-gc, native |
| `bobzhang/openseek_protocol/emit` | `emit` | native (`xlog`) |

One variant per event, owning its payload **and its level**. All 60 emit call sites converted across `agent/`, `agent_session/compact/`, `cmd/openseek/`, `mcp/tools/` — net **−60 lines** at the call sites.

**Why a module, not a package:** `desktop/frontend` compiles to **js** and `xlog` is native-only, so a shared decoder must exclude the writer; and `desktop` is a separate module, which only another *module* can be a `moon.work` member of. Verified: `"../protocol"` binds the working tree, not a registry snapshot.

**`Usage` is owned here**, not borrowed from `@deepseek.Usage`. The vendor's response struct *was* the wire format for that event — rename a DeepSeek field and every client's parse changes. `agent`'s `wire_usage` is the single place the two meet. `deepseek` is untouched by this PR.

## Normalized, not byte-identical

The three drifts above are normalized: `brief` and `mcp_connect_failed.error` are always written (`null` when absent), `compaction_failed` picks one level. **No client can observe the difference** — nothing reads the envelope's `level`, and every decoder reads optional fields with a lookup that rejects a non-string, so an absent key and an explicit `null` are already the same value downstream. cram is unchanged.

## The round-trip test earned its keep

MoonBit encodes `Some(v)` as the one-element array `[v]`. A `String?` payload field would have emitted `"brief":["…"]` and read as **absent** to every decoder. That is why the old `turn_loop` site hand-wrote `Json::string`/`Json::null`; `or_null` is the same rule in one place — and the test caught it before it shipped.

## Notes

- `agent` and `agent_session/compact` no longer import `@xlog` at all — they report events, they do not log.
- **Zero `.mbti` drift outside the new module.** No existing public API changes.

## Verification

| Gate | Result |
|---|---|
| `moon check --deny-warn` | clean (js, wasm, wasm-gc, native) |
| `moon fmt --check` | clean |
| `moon cram test tests/cram` | 23/23 |
| protocol tests | js 252, wasm 172, wasm-gc 172, native — all pass |
| full native suite | 1173/1179 |

The 6 failures are the known `agent_tool/shell` timing tests: they pass 119/119 in a fresh worktree off `main`, and `agent_tool/shell` imports none of the packages touched here, so this diff cannot reach them.

## Known gaps at this commit (both closed later in the stack)

- The clients still hand-decode — #498 and `protocol-desktop-decoder` fix that, and doing so is what surfaced two dead features and a lying comment.
- `MOON_XLOG=warn openseek serve` silences the stream — fixed in `protocol-desktop-decoder`.
- Reviewed by codex: no findings against the protocol work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)