### PR TITLE
feat(tui): decode the engine stream through the typed protocol

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -131,9 +131,9 @@ tool. This keeps the surface small; revisit if a concrete need appears.
 The terminal UI is the **default** mode of the single `openseek` binary (the
 `cmd/tui` library, also reachable as `openseek tui`): a scrolling transcript with
 a live composer. It spawns the `openseek` engine (by default this same binary in
-`serve` mode) and renders its JSONL event stream — streamed thinking and answer
-text appear live on the activity line, and each turn's reasoning is kept as a dim
-`✻` transcript aside above its answer.
+`serve` mode) and renders its JSONL event stream — streamed answer text appears
+live on the activity line, and each turn's reasoning is kept as a dim `✻`
+transcript aside above its answer.
 
 ```bash
 export DEEPSEEK=sk-...

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -1,128 +1,136 @@
-// Mapping from the engine's decoded JSONL values to typed `AgentEvent`s. Reading
-// lines, skipping blanks, and parsing each as JSON is `bobzhang/jsonl`'s job
-// (`@jsonl.each` in `cmd/tui`); this module only maps an already-parsed value,
-// keyed by its `"event"` discriminator.
+// Mapping from the engine's typed protocol events to the TUI's `AgentEvent`.
+// Reading lines, skipping blanks, and parsing each as JSON is `bobzhang/jsonl`'s
+// job (`@jsonl.each` in `cmd/tui`); `@protocol.parse` turns a parsed value into
+// an `Event`; this module maps that into what the UI actually renders.
 
 ///|
-/// Map one decoded JSONL value from the engine into an `AgentEvent`.
+/// Map one JSONL value from the engine into an `AgentEvent`.
 ///
-/// Returns `None` for a non-object value or an unrecognized `"event"` string so
-/// a noisy or newer engine never crashes the UI; the caller simply drops it.
+/// `AgentEvent` is a view model, not a mirror of the wire: several engine events
+/// fold into one UI concept (`agent_setup_failed`, `turn_failed` and
+/// `compaction_failed` all read as `AgentError`), and most carry less than the
+/// wire does (`usage` keeps only the derived total).
+///
+/// The match over `@protocol.Event` is exhaustive on purpose. Every event the
+/// engine can report is either mapped or listed in the ignore arm below, so
+/// adding one to the protocol breaks this build until someone decides which it
+/// is — the reason this indirection exists at all. `None` here means "the engine
+/// said something the UI has nothing to show for", never "we forgot".
 pub fn decode_event(object : Json) -> AgentEvent? {
-  match @jsonx.string(object, "event") {
-    "agent_step" => Some(AgentStep)
-    "assistant_delta" => Some(AssistantDelta(@jsonx.string(object, "content")))
-    "reasoning_delta" => Some(ReasoningDelta(@jsonx.string(object, "content")))
-    "reasoning_message" =>
-      Some(ReasoningMessage(@jsonx.string(object, "content")))
-    "steer_applied" => {
-      let content = @jsonx.string(object, "content")
-      match @jsonx.string(object, "kind") {
+  guard @protocol.parse(object) is Some(event) else {
+    // Not an event this engine emits: a blank-ish line, or one from a newer
+    // engine. Dropping it keeps a mixed-version pair usable.
+    return None
+  }
+  match event {
+    AgentStep(_) => Some(AgentStep)
+    AssistantDelta(content~) => Some(AssistantDelta(content))
+    ReasoningMessage(content~) => Some(ReasoningMessage(content))
+    SteerApplied(kind~, content~) =>
+      match kind {
         "command" => Some(SteerApplied(Command(content)))
         "notice" => Some(SteerApplied(Notice(content)))
         _ => Some(SteerApplied(Prompt(content)))
       }
-    }
-    "steer_dropped" => Some(SteerDropped(@jsonx.string(object, "content")))
-    "background_notice" =>
-      Some(BackgroundNotice(@jsonx.string(object, "content")))
-    "assistant_message" =>
-      Some(AssistantMessage(@jsonx.string(object, "content")))
-    "session_error" => Some(SessionError(@jsonx.string(object, "error")))
-    "usage" => {
-      let usage : @deepseek.Usage = @json.from_json(
-        @jsonx.field(object, "usage").unwrap_or_default(),
-      ) catch {
-        // Drop malformed usage events rather than crashing the UI.
-        _ => return None
-      }
+    SteerDropped(content~) => Some(SteerDropped(content))
+    BackgroundNotice(content~) => Some(BackgroundNotice(content))
+    AssistantMessage(content~) => Some(AssistantMessage(content))
+    SessionError(error~) => Some(SessionError(error))
+    // Only the derived total reaches the status line.
+    Usage(usage~) =>
       Some(
         Usage({ total_tokens: usage.prompt_tokens + usage.completion_tokens }),
       )
-    }
-    "tool_result" =>
+    ToolResult(tool_name~, content~, is_error~, ..) =>
+      Some(ToolResult({ name: tool_name, content, is_error }))
+    // A call the engine could not decode never ran: show it as a failed result
+    // so the transcript still accounts for the model's request.
+    ToolCallDecodeError(tool_name~, error~, ..) =>
       Some(
         ToolResult({
-          name: @jsonx.string(object, "tool_name"),
-          content: @jsonx.string(object, "content"),
-          is_error: @jsonx.bool(object, "is_error"),
-        }),
-      )
-    "tool_call_decode_error" =>
-      Some(
-        ToolResult({
-          name: @jsonx.string(object, "tool_name"),
-          content: "error: \{@jsonx.string(object, "error")}",
+          name: tool_name,
+          content: "error: \{error}",
           is_error: true,
         }),
       )
-    "agent_finished" => Some(AgentFinished(@jsonx.string(object, "answer")))
-    "agent_aborted" => Some(AgentAborted(@jsonx.string(object, "reason")))
-    "max_steps_exhausted" => Some(MaxStepsExhausted)
-    "agent_setup_failed" =>
-      Some(AgentError("agent setup failed: \{@jsonx.string(object, "error")}"))
+    AgentFinished(answer~) => Some(AgentFinished(answer))
+    AgentAborted(reason~) => Some(AgentAborted(reason))
+    MaxStepsExhausted => Some(MaxStepsExhausted)
+    AgentSetupFailed(error~) => Some(AgentError("agent setup failed: \{error}"))
     // A serve-mode turn that died with a non-cancellation error. Terminal for
     // the run even though the engine process lives on.
-    "turn_failed" =>
-      Some(AgentError("turn failed: \{@jsonx.string(object, "error")}"))
+    TurnFailed(error~) => Some(AgentError("turn failed: \{error}"))
     // The engine rejected a command and keeps serving (no terminal event of its
     // own). Whether this should end a run depends on which command was rejected
     // — only the controller knows the active operation — so this stays a
     // non-terminal event the loop resolves (see `CommandRejected` handling).
-    "command_error" => Some(CommandRejected(@jsonx.string(object, "error")))
-    // Compaction lifecycle on a serve engine. `compaction_started` carries no
-    // controller-visible state — the run is already shown busy — so it is left
-    // to drop as an unknown event. The two outcomes are terminal for the
-    // compaction run: success carries the summary (the new context) for a
-    // preview, failure folds into the general agent-error category like a
-    // failed turn.
-    "compaction_finished" =>
-      Some(CompactionFinished(@jsonx.string(object, "summary")))
-    "compaction_failed" =>
-      Some(AgentError("compaction failed: \{@jsonx.string(object, "error")}"))
-    // A durably recorded goal update. Decoded null-aware — a cleared goal is
-    // {"goal": null}, which must not collapse into an empty-string set.
-    "goal_updated" =>
-      match object {
-        { "goal": String(goal), .. } => Some(GoalUpdated(Some(goal)))
-        _ => Some(GoalUpdated(None))
-      }
-    "goal_continue" => Some(GoalContinue(@jsonx.int(object, "remaining")))
-    "goal_budget_exhausted" => Some(GoalBudgetExhausted)
+    CommandError(error~) => Some(CommandRejected(error))
+    // Compaction outcomes are terminal for the compaction run: success carries
+    // the summary (the new context) for a preview, failure folds into the
+    // general agent-error category like a failed turn.
+    CompactionFinished(summary~, ..) => Some(CompactionFinished(summary))
+    CompactionFailed(error~) => Some(AgentError("compaction failed: \{error}"))
+    GoalUpdated(goal~) => Some(GoalUpdated(goal))
+    GoalContinue(remaining~) => Some(GoalContinue(remaining))
+    GoalBudgetExhausted(_) => Some(GoalBudgetExhausted)
     // A turn that ended at the context ceiling: run-terminal, not success.
-    "context_yield" => Some(ContextYield(@jsonx.string(object, "answer")))
+    ContextYield(answer~, ..) => Some(ContextYield(answer))
     // MCP lifecycle diagnostics, surfaced as notices so a typo'd config or a
     // dead server is visible in the UI instead of silently yielding no tools.
-    "mcp_tools_registered" => {
-      let tools = @jsonx.int(object, "tools")
-      let servers = @jsonx.int(object, "servers")
-      // `servers` counts the configuration's entries, not successful
-      // contributors — say so, since some may have failed or been skipped.
+    // `servers` counts the configuration's entries, not successful contributors
+    // — say so, since some may have failed or been skipped.
+    McpToolsRegistered(servers~, tools~, ..) =>
       Some(
         BackgroundNotice(
           "MCP: registered \{tools} tool(s) from \{servers} configured server(s)",
         ),
       )
-    }
-    "mcp_connect_failed" =>
+    McpConnectFailed(server~, ..) =>
+      Some(
+        BackgroundNotice("MCP: server `\{mcp_safe(server)}` failed to connect"),
+      )
+    McpListToolsFailed(server~, ..) | McpListToolsTimeout(server~) =>
       Some(
         BackgroundNotice(
-          "MCP: server `\{mcp_safe(object, "server")}` failed to connect",
+          "MCP: server `\{mcp_safe(server)}` did not list its tools",
         ),
       )
-    "mcp_list_tools_failed" | "mcp_list_tools_timeout" =>
+    McpConfigUnreadable(path~, error~) | McpConfigInvalid(path~, error~) =>
       Some(
         BackgroundNotice(
-          "MCP: server `\{mcp_safe(object, "server")}` did not list its tools",
+          "MCP config error (\{mcp_safe(path)}): \{mcp_safe(error)}",
         ),
       )
-    "mcp_config_unreadable" | "mcp_config_invalid" =>
-      Some(
-        BackgroundNotice(
-          "MCP config error (\{mcp_safe(object, "path")}): \{mcp_safe(object, "error")}",
-        ),
-      )
-    _ => None
+    // Deliberately not shown. Each of these is a decision, and the compiler now
+    // holds us to making one: a new protocol event lands here as a build error
+    // rather than as a line the UI drops without anyone noticing.
+    //
+    // `compaction_started` and the auto-compaction lifecycle carry no
+    // controller-visible state — the run already reads busy. The goal and plan
+    // reminders, checks, and block/unblock markers are instructions to the
+    // model, not news for the user; the standing goal reaches the UI as
+    // `goal_updated`. `session_started`, `workspace_created` and `fleet_started`
+    // describe a headless run's setup, which the TUI performs itself. The
+    // remaining MCP events are per-tool registry bookkeeping, already summarized
+    // by `mcp_tools_registered`.
+    CompactionStarted(..)
+    | AutoCompactionStarted(..)
+    | AutoCompactionFinished(..)
+    | AutoCompactionFailed(..)
+    | GoalBlocked(..)
+    | GoalUnblocked
+    | GoalCheck(..)
+    | GoalReminder(..)
+    | PlanReminder(..)
+    | SessionStarted(..)
+    | WorkspaceCreated(..)
+    | FleetStarted(..)
+    | McpConfigIgnored(..)
+    | McpToolDuplicate(..)
+    | McpToolRenamed(..)
+    | McpToolsCapped(..)
+    | McpServerSkippedOverCap(..)
+    | McpNoTools(..) => None
   }
 }
 
@@ -131,8 +139,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
 /// runs collapse to one space, C0/C1 controls and DEL are dropped (the
 /// transcript layout strips C0 but not C1, and these strings carry
 /// configuration metadata), and anything past 120 characters is elided.
-fn mcp_safe(object : Json, key : String) -> String {
-  let text = @jsonx.string(object, key)
+fn mcp_safe(text : String) -> String {
   let out = StringBuilder()
   for ch in text.trim(); last_was_space = false, count = 0 {
     if count >= 120 {

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -12,10 +12,6 @@ test "decode maps each engine event kind" {
     is Some(AssistantDelta("tok")),
   )
   assert_true(
-    @event.decode_event({ "event": "reasoning_delta", "content": "hmm" })
-    is Some(ReasoningDelta("hmm")),
-  )
-  assert_true(
     @event.decode_event({
       "event": "reasoning_message",
       "content": "full thought",

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -35,7 +35,6 @@ pub(all) struct ToolResultEvent {
 pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
-  ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)

--- a/cmd/tui/internal/event/moon.pkg
+++ b/cmd/tui/internal/event/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "bobzhang/openseek/agent_runtime",
-  "bobzhang/openseek/cmd/tui/internal/jsonx",
-  "bobzhang/openseek/deepseek",
+  "bobzhang/openseek_protocol" @protocol,
   "moonbitlang/core/json",
 }
 

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -14,7 +14,6 @@ pub fn decode_event(Json) -> AgentEvent?
 pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
-  ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -380,7 +380,6 @@ fn handle_agent_event(
     AgentStep => {
       state.step_response = None
       state.streaming_response = None
-      state.streaming_reasoning = None
     }
     AssistantDelta(text) =>
       if text != "" {
@@ -389,22 +388,13 @@ fn handle_agent_event(
         )
         // Content starting means the thinking phase is over; the content
         // preview replaces the reasoning one.
-        state.streaming_reasoning = None
-      }
-    ReasoningDelta(text) =>
-      if text != "" {
-        state.streaming_reasoning = Some(
-          append_streaming_preview(state.streaming_reasoning, text),
-        )
       }
     // The turn's full reasoning, emitted once streaming ends and before the
     // assistant message commits — so the transcript reads thought → answer.
-    ReasoningMessage(text) => {
-      state.streaming_reasoning = None
+    ReasoningMessage(text) =>
       if !text.trim().is_empty() {
         cmds.push(AppendItem(reasoning_item(text)))
       }
-    }
     // Prompt steering took effect at the engine's step boundary: echo the input
     // into the transcript at its true conversational position, the way the
     // model actually saw it.
@@ -437,7 +427,6 @@ fn handle_agent_event(
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None
-      state.streaming_reasoning = None
       if !text.trim().is_empty() {
         cmds.push(AppendItem(Response(text)))
       }
@@ -1950,18 +1939,11 @@ test "streamed newlines collapse so the preview stays one line" {
 }
 
 ///|
-test "reasoning_message commits a thought item and clears the preview" {
+test "reasoning_message commits a thought item" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
   let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    { "event": "reasoning_delta", "content": "Let me think" },
-    items,
-  )
-  assert_true(state.streaming_reasoning is Some("Let me think"))
-  // The full reasoning lands as one `✻` thought item, and the live preview
-  // is finished with.
+  // The turn's reasoning lands as one `✻` thought item.
   append_items(
     state,
     {
@@ -1970,43 +1952,10 @@ test "reasoning_message commits a thought item and clears the preview" {
     },
     items,
   )
-  assert_true(state.streaming_reasoning is None)
   guard items is [Thought(_)] else { fail("expected a single Thought item") }
   // Blank reasoning never appends an empty aside.
   append_items(state, { "event": "reasoning_message", "content": "  " }, items)
   assert_eq(items.length(), 1)
-}
-
-///|
-test "reasoning_delta drives the thinking preview until content arrives" {
-  let state = drain_test_state()
-  let _ = update(state, UiInput(Steer(Prompt("do it"))))
-  let items : Array[@ui.TranscriptItem] = []
-  append_items(
-    state,
-    { "event": "reasoning_delta", "content": "Let me think" },
-    items,
-  )
-  assert_true(state.streaming_reasoning is Some("Let me think"))
-  assert_true(state.streaming_response is None)
-  assert_eq(items.length(), 0)
-  // The first content delta ends the thinking phase: the content preview
-  // replaces the reasoning one.
-  append_items(
-    state,
-    { "event": "assistant_delta", "content": "Answer" },
-    items,
-  )
-  assert_true(state.streaming_reasoning is None)
-  assert_true(state.streaming_response is Some("Answer"))
-  // The committed message clears both previews.
-  append_items(
-    state,
-    { "event": "assistant_message", "content": "Answer" },
-    items,
-  )
-  assert_true(state.streaming_response is None)
-  assert_true(state.streaming_reasoning is None)
 }
 
 ///|

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -99,11 +99,9 @@ priv struct State {
   // Incremental assistant text currently arriving from `assistant_delta`
   // events. Cleared once the final assistant message is committed.
   mut streaming_response : String?
-  // Incremental thinking-mode text arriving from `reasoning_delta` events.
   // Shown only until the first content delta arrives, so the activity line
   // moves during the (often long) reasoning phase instead of sitting on
   // "Working (Ns)".
-  mut streaming_reasoning : String?
   // Steering input sent to the engine but not yet confirmed (no
   // steer_applied/steer_dropped back). Shown on the activity line so the
   // moment of pressing Enter is acknowledged immediately — the transcript
@@ -140,7 +138,6 @@ fn State::new(config : AppConfig) -> State {
     pending_steers: [],
     step_response: None,
     streaming_response: None,
-    streaming_reasoning: None,
     usage: None,
     schedule: None,
     goal: None,
@@ -157,7 +154,6 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run = Running(started_ms)
   self.step_response = None
   self.streaming_response = None
-  self.streaming_reasoning = None
   self.run_id
 }
 
@@ -182,7 +178,6 @@ fn State::finish_run(self : State) -> Unit {
   self.pending_steers.clear()
   self.step_response = None
   self.streaming_response = None
-  self.streaming_reasoning = None
 }
 
 ///|

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -189,20 +189,6 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
     )
     return Some(Text(spans + steer_segment))
   }
-  // Thinking-mode runs spend their first (often long) stretch emitting only
-  // reasoning deltas; show their tail dimmed so the line moves from the first
-  // token rather than sitting on "Working (Ns)" until content starts.
-  if state.streaming_reasoning is Some(reasoning) &&
-    !reasoning.trim().is_empty() {
-    let spans = streaming_activity_spans(
-      "Thinking ",
-      reasoning,
-      cols~,
-      dim_preview=true,
-      reserved~,
-    )
-    return Some(Text(spans + steer_segment))
-  }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @env.now().reinterpret_as_int64()),
   )

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -58,13 +58,15 @@ pub fn parse(line : Json) -> Event? {
       }
       Some(ToolCallDecodeError(tool_call_id~, tool_name~, error~))
     }
-    "steer_applied" => {
-      guard text(fields, "kind") is Some(kind) &&
-        text(fields, "content") is Some(content) else {
-        return None
-      }
-      Some(SteerApplied(kind~, content~))
-    }
+    // `kind` is defaulted, not required: engines older than 2026-06-25
+    // (9b2f6c43, which added it) emit `steer_applied` with only `content`, and
+    // the TUI launches whichever `openseek` is on PATH — so a new reader against
+    // an old engine is a real pairing. "prompt" reproduces what those engines
+    // meant, and is what every client defaulted to before this package existed.
+    "steer_applied" =>
+      text(fields, "content").map(content => {
+        SteerApplied(kind=text(fields, "kind").unwrap_or("prompt"), content~)
+      })
     "steer_dropped" =>
       text(fields, "content").map(content => SteerDropped(content~))
     "background_notice" =>
@@ -155,16 +157,20 @@ pub fn parse(line : Json) -> Event? {
       }
       Some(McpConfigInvalid(path~, error~))
     }
+    // `names` is defaulted to empty rather than required: it is the one field
+    // here no reader uses (the TUI renders only the two counts), so demanding it
+    // would let a field nobody reads decide whether the notice appears at all.
     "mcp_tools_registered" => {
       guard int(fields, "servers") is Some(servers) &&
-        int(fields, "tools") is Some(tools) &&
-        fields.get("names") is Some(Array(names)) else {
+        int(fields, "tools") is Some(tools) else {
         return None
       }
       let decoded = []
-      for name in names {
-        guard name is String(name) else { return None }
-        decoded.push(name)
+      if fields.get("names") is Some(Array(names)) {
+        for name in names {
+          guard name is String(name) else { return None }
+          decoded.push(name)
+        }
       }
       Some(McpToolsRegistered(servers~, tools~, names=decoded))
     }

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -106,6 +106,41 @@ test "a null optional field reads as absent" {
 }
 
 ///|
+/// An engine older than 2026-06-25 (9b2f6c43) emits `steer_applied` with only
+/// `content`. The TUI launches whichever `openseek` is on PATH, so that pairing
+/// is real, and a reader that dropped those lines would silently lose steers.
+/// `kind` therefore defaults instead of being required — the rule every client
+/// applied by hand before this package, now written down once and tested.
+test "an older engine's steer_applied still decodes" {
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"steer_applied","content":"go left"}
+      ),
+    ),
+    content=(
+      #|Some(SteerApplied(kind="prompt", content="go left"))
+    ),
+  )
+}
+
+///|
+/// `names` is the one payload field no reader uses, so its absence must not
+/// decide whether the event decodes at all.
+test "mcp_tools_registered decodes without the names it nobody reads" {
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"mcp_tools_registered","servers":2,"tools":5}
+      ),
+    ),
+    content=(
+      #|Some(McpToolsRegistered(servers=2, tools=5, names=[]))
+    ),
+  )
+}
+
+///|
 /// A line from a newer engine, or one that is not an event at all, is ignored
 /// rather than failing the reader.
 test "unknown and malformed lines are ignored" {


### PR DESCRIPTION
**Stack: #497 → #498 (this) → `protocol-desktop-decoder`.** Review #497 first; this diff is only the TUI adoption plus the `parse` correction it forced.

## What

#497 built the typed protocol, but no client used it — so its headline property, *adding a variant is a compile error in every client*, was not yet real. This is the first client to buy it.

The TUI hand-decoded the engine's JSONL by `"event"` string and ended in `_ => None`, so any event it did not handle vanished silently. It now matches **exhaustively** over `@protocol.Event`: every event is either mapped to an `AgentEvent` or named in the ignore arm, with the reason written down.

`AgentEvent` stays a view model — several engine events fold into one UI concept (`agent_setup_failed`, `turn_failed`, `compaction_failed` all read as `AgentError`) and most carry less than the wire does (`usage` keeps only the derived total). The indirection is the point: the match is what the compiler checks.

## It immediately found a dead feature

`a85d5682` ("Suppress streaming reasoning delta logs", **2026-06-21**) removed `on_reasoning_delta` from the engine's `StreamHandler`. `reasoning_delta` had not been emitted for three weeks. The TUI still had:

- `ReasoningDelta` in `AgentEvent` + its decode branch
- `state.streaming_reasoning`
- a `status_view` branch rendering a dimmed **"Thinking …"** activity line
- **two tests that passed** — because they fabricate the JSON the engine no longer sends

and `README.mbt.md` still advertised *"streamed thinking … appear live on the activity line."*

Users saw `Working (Ns)` instead of live thinking since June 21. Nothing caught it, because the wire had no schema and a client's tests were free to invent one.

The dead path is removed and the README now says what the TUI does. **Restoring live thinking is a separate question** — it needs the engine to emit deltas again, which `a85d5682` deliberately stopped for log noise. That trade only exists because *the log IS the protocol*.

## It also caught `parse` being too strict — before any client depended on it

Both found by existing TUI tests:

| Field | Why it cannot be required |
|---|---|
| `steer_applied.kind` | Engines older than 2026-06-25 (`9b2f6c43`) emit only `content`. The TUI launches whichever `openseek` is on **PATH**, so new-reader/old-engine is a real pairing — a strict parse would silently drop those steers. Defaults to `"prompt"`, which is what every client did by hand. |

The rule was refined once more in `protocol-desktop-decoder` after two desktop fixtures failed: **a field is defaulted iff it was added after its event already existed.** "No reader uses it" is *not* a reason — that reasoning had also defaulted `names`, which is reverted there. Only `kind` qualifies.

Leniency never weakens the round-trip: `emit` always writes every field, so it only affects lines `emit` never produced.

## Verification

Clean worktree, full suite green:

| Gate | Result |
|---|---|
| native | **1168/1168** |
| js | 254/254 |
| wasm-gc | 7/7 |
| `moon check --deny-warn` | clean |
| `moon fmt --check` | clean |
| `moon cram test tests/cram` | 23/23 |

(The 6 `agent_tool/shell` failures seen in the main checkout do not occur here — checkout-specific, as #497 notes.)

`.mbti` drift: one line, the removed dead variant.

Reviewed by codex: no findings — *"preserves the TUI's supported event behavior, handles the documented legacy fields, and exhaustively classifies protocol events."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)