### PR TITLE
feat(protocol): type the command direction too

### DIFF
--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -14,7 +14,7 @@ import {
   "bobzhang/openseek/cmd/tui",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/prompt",
-  "bobzhang/openseek_protocol",
+  "bobzhang/openseek_protocol" @protocol,
   "bobzhang/openseek_protocol/emit",
   "bobzhang/openseek/testkit/filesystem" @vfs,
   "bobzhang/openseek/internal/agentcli",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -143,23 +143,38 @@ priv enum ServeStep {
 /// The mapping stays here because `SteerInput` is the runtime's, and the
 /// protocol is a leaf module that must not depend on the engine — the same
 /// reason every client keeps its own view model.
+///
+/// So is the blank-goal refusal. `{"action":"set","text":"  "}` is a
+/// well-formed command that this engine will not stand: the shape is the
+/// protocol's to read, whether it is acceptable is this loop's to say. Keeping
+/// the check in `parse` would have made `GoalSet(text="  ")` a value the
+/// protocol's own type holds and `to_json` writes but `parse` rejects.
 fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
-  @protocol.Command::parse(json).map(command => {
-    match command {
-      Prompt(text~) => Prompt(text)
-      Steer(kind~, text~) =>
+  let command = match @protocol.Command::parse(json) {
+    Ok(command) => command
+    Err(message) => return Err(message)
+  }
+  match command {
+    Prompt(text~) => Ok(Prompt(text))
+    Steer(kind~, text~) =>
+      Ok(
         Steer(
           match kind {
             Prompt => Prompt(text)
             Command => Command(text)
           },
-        )
-      Compact => Compact
-      Cancel => Cancel
-      GoalSet(text~, auto~) => Goal(SetGoal(text, auto~))
-      GoalClear => Goal(ClearGoal)
-    }
-  })
+        ),
+      )
+    Compact => Ok(Compact)
+    Cancel => Ok(Cancel)
+    GoalSet(text~, auto~) =>
+      if text.trim().is_empty() {
+        Err("goal text must not be blank")
+      } else {
+        Ok(Goal(SetGoal(text, auto~)))
+      }
+    GoalClear => Ok(Goal(ClearGoal))
+  }
 }
 
 ///|

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -133,44 +133,33 @@ priv enum ServeStep {
 /// is an `Err` whose text is emitted as a `command_error` event — a controller
 /// bug must be visible on the wire, not silently swallowed, but it must not kill
 /// the session either.
+/// Map one controller line onto the loop's own command type.
+///
+/// `@protocol.Command` owns the wire — the same type the TUI and the desktop
+/// now encode with, so the engine's reader and its controllers cannot spell a
+/// command differently. They did: the desktop sent `steer` without a `kind` and
+/// worked only because this decoder happened to default it.
+///
+/// The mapping stays here because `SteerInput` is the runtime's, and the
+/// protocol is a leaf module that must not depend on the engine — the same
+/// reason every client keeps its own view model.
 fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
-  match json {
-    { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text))
-    { "command": "steer", .. } =>
-      decode_steer_input(json).map(input => Steer(input))
-    { "command": "prompt", .. } => Err("expected a string \"text\" field")
-    { "command": "compact", .. } => Ok(Compact)
-    { "command": "cancel", .. } => Ok(Cancel)
-    { "command": "goal", "action": "set", "text": String(text), .. } =>
-      if text.trim().is_empty() {
-        Err("goal text must not be blank")
-      } else {
-        Ok(Goal(SetGoal(text, auto=json is { "auto": True, .. })))
-      }
-    { "command": "goal", "action": "clear", .. } => Ok(Goal(ClearGoal))
-    { "command": "goal", .. } =>
-      Err(
-        "expected {\"action\": \"set\", \"text\": ...} or {\"action\": \"clear\"}",
-      )
-    { "command": String(other), .. } => Err("unknown command: \{other}")
-    _ => Err("expected a {\"command\": ...} object")
-  }
-}
-
-///|
-fn decode_steer_input(json : Json) -> Result[@agent_runtime.SteerInput, String] {
-  match json {
-    { "kind": String(kind), "text": String(text), .. } =>
-      match kind {
-        "prompt" => Ok(Prompt(text))
-        "command" => Ok(Command(text))
-        other => Err("unknown steer kind: \{other}")
-      }
-    { "kind": _, "text": String(_), .. } =>
-      Err("expected a string \"kind\" field")
-    { "text": String(text), .. } => Ok(Prompt(text))
-    _ => Err("expected a string \"text\" field")
-  }
+  @protocol.Command::parse(json).map(command => {
+    match command {
+      Prompt(text~) => Prompt(text)
+      Steer(kind~, text~) =>
+        Steer(
+          match kind {
+            Prompt => Prompt(text)
+            Command => Command(text)
+          },
+        )
+      Compact => Compact
+      Cancel => Cancel
+      GoalSet(text~, auto~) => Goal(SetGoal(text, auto~))
+      GoalClear => Goal(ClearGoal)
+    }
+  })
 }
 
 ///|

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -294,7 +294,7 @@ async fn[G] EngineClient::prompt(
       }
     }
   }
-  self.open_run(run_id, { "command": "prompt", "text": text })
+  self.open_run(run_id, (Prompt(text~) : @protocol.Command).to_json())
 }
 
 ///|
@@ -345,22 +345,17 @@ async fn[G] EngineClient::steer(
     Prompt(text) | Notice(text) =>
       match self.live {
         Some(live) if live.run_open =>
-          self.send(live.latest_run, {
-            "command": "steer",
-            "kind": "prompt",
-            "text": text,
-          })
+          self.send(
+            live.latest_run,
+            (Steer(kind=Prompt, text~) : @protocol.Command).to_json(),
+          )
         _ => self.messages.put(SteerDropped(text))
       }
     Command(text) => {
       guard self.live_for(group, "command context") is Some(live) else {
         return
       }
-      let command : Json = {
-        "command": "steer",
-        "kind": "command",
-        "text": text,
-      }
+      let command : Json = (Steer(kind=Command, text~) : @protocol.Command).to_json()
       // Delivery here is fire-and-forget by design. The serve protocol's
       // contract is that every accepted command context is answered with
       // exactly one terminal ack — `steer_applied` (persisted) or
@@ -410,8 +405,10 @@ async fn[G] EngineClient::goal(
 ) -> Unit {
   guard self.live_for(group, "goal update") is Some(live) else { return }
   let command : Json = match goal {
-    Some(text) => { "command": "goal", "action": "set", "text": text }
-    None => { "command": "goal", "action": "clear" }
+    // The TUI only ever sets a manual goal; `auto` is the serve protocol's
+    // affordance for a headless controller.
+    Some(text) => (GoalSet(text~, auto=false) : @protocol.Command).to_json()
+    None => (GoalClear : @protocol.Command).to_json()
   }
   // Registered BEFORE the write: a fast engine can append the marker and
   // emit goal_updated while the write call is still yielding, and the
@@ -451,7 +448,7 @@ async fn[G] EngineClient::compact(
       }
     }
   }
-  self.open_run(run_id, { "command": "compact" })
+  self.open_run(run_id, (Compact : @protocol.Command).to_json())
 }
 
 ///|
@@ -459,7 +456,7 @@ async fn[G] EngineClient::compact(
 /// silent no-op — the turn the user wanted dead is already gone.
 async fn EngineClient::cancel_turn(self : EngineClient) -> Unit {
   if self.live is Some(live) && live.run_open {
-    self.send(live.latest_run, { "command": "cancel" })
+    self.send(live.latest_run, (Cancel : @protocol.Command).to_json())
   }
 }
 

--- a/cmd/tui/moon.pkg
+++ b/cmd/tui/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek_protocol" @protocol,
   "bobzhang/jsonl",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_session",

--- a/desktop/internal/protocol/engine_command.mbt
+++ b/desktop/internal/protocol/engine_command.mbt
@@ -1,71 +1,63 @@
+// The host's outgoing half of the serve protocol. The commands themselves are
+// `@wire.Command` — the same type `openseek serve` decodes and the TUI encodes
+// — so the three ends of this wire cannot spell a command differently. They
+// did: this package used to model the commands itself, and its `steer` omitted
+// the `kind` field the TUI sends, working only because the engine's decoder
+// happened to default it. Nothing on this side said so.
+//
+// The constructors remain because they are the host's vocabulary: `ops.mbt`
+// asks for a prompt, not for a variant. They are now one line each.
+
 ///|
-/// One stdin command sent from the desktop host to an `openseek serve`
-/// engine. The enum is package-local; it models the host's outgoing half of
-/// the serve protocol without widening any cross-module API.
-enum EngineCommand {
-  Prompt(String)
-  Steer(String)
+/// Send `text` as a new turn's prompt.
+pub fn prompt(text : String) -> @wire.Command {
+  Prompt(text~)
+}
+
+///|
+/// Steer the open turn with user text.
+///
+/// `Prompt` is what the host has always meant here — it has no other kind —
+/// and it now says so on the wire instead of relying on the engine's default.
+pub fn steer(text : String) -> @wire.Command {
+  Steer(kind=Prompt, text~)
+}
+
+///|
+/// Ask the idle engine to compact the durable record.
+pub fn compact() -> @wire.Command {
   Compact
+}
+
+///|
+/// Cancel the open turn.
+pub fn cancel() -> @wire.Command {
   Cancel
 }
 
 ///|
-pub fn prompt(text : String) -> EngineCommand {
-  Prompt(text)
-}
-
-///|
-pub fn steer(text : String) -> EngineCommand {
-  Steer(text)
-}
-
-///|
-pub fn compact() -> EngineCommand {
-  Compact
-}
-
-///|
-pub fn cancel() -> EngineCommand {
-  Cancel
-}
-
-///|
-fn EngineCommand::to_json(self : EngineCommand) -> Json {
-  match self {
-    Prompt(text) => { "command": "prompt", "text": text }
-    Steer(text) => { "command": "steer", "text": text }
-    Compact => { "command": "compact" }
-    Cancel => { "command": "cancel" }
-  }
-}
-
-///|
-pub fn EngineCommand::to_jsonl(self : EngineCommand) -> String {
-  self.to_json().stringify() + "\n"
-}
-
-///|
-test "engine commands encode serve protocol json" {
-  let prompt : EngineCommand = Prompt("hello")
+/// The host sends no `goal` command: the desktop has no goal UI. That is a
+/// product gap rather than a protocol one — `@wire.Command` carries `GoalSet`
+/// and `GoalClear`, and this package gains a constructor the day the UI does.
+test "the host's commands are the protocol's" {
+  assert_true(prompt("hello").to_json()
+    is { "command": String("prompt"), "text": String("hello"), .. })
   assert_true(
-    prompt.to_json()
-    is { "command": String("prompt"), "text": String("hello"), .. },
+    steer("go left").to_json()
+    is {
+      "command": String("steer"),
+      "kind": String("prompt"),
+      "text": String("go left"),
+      ..
+    },
   )
-  let steer : EngineCommand = Steer("go left")
-  assert_true(
-    steer.to_json()
-    is { "command": String("steer"), "text": String("go left"), .. },
-  )
-  let compact : EngineCommand = Compact
-  assert_true(compact.to_json() is { "command": String("compact"), .. })
-  let cancel : EngineCommand = Cancel
-  assert_true(cancel.to_json() is { "command": String("cancel"), .. })
+  assert_true(compact().to_json() is { "command": String("compact"), .. })
+  assert_true(cancel().to_json() is { "command": String("cancel"), .. })
 }
 
 ///|
 test "engine commands encode one json line" {
-  let command : EngineCommand = Prompt("quote \" newline\n")
-  let line = command.to_jsonl()
+  let line = prompt("quote \" newline\n").to_jsonl()
   assert_true(line.has_suffix("\n"))
   guard @json.parse(line.trim())
     is { "command": String("prompt"), "text": String("quote \" newline\n"), .. } else {

--- a/desktop/internal/protocol/moon.pkg
+++ b/desktop/internal/protocol/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "bobzhang/openseek_protocol" @wire,
+
   "moonbitlang/core/json",
 }
 

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1,20 +1,22 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "openseek_desktop/internal/protocol"
 
+import {
+  "bobzhang/openseek_protocol",
+}
+
 // Values
-pub fn cancel() -> EngineCommand
+pub fn cancel() -> @openseek_protocol.Command
 
-pub fn compact() -> EngineCommand
+pub fn compact() -> @openseek_protocol.Command
 
-pub fn prompt(String) -> EngineCommand
+pub fn prompt(String) -> @openseek_protocol.Command
 
-pub fn steer(String) -> EngineCommand
+pub fn steer(String) -> @openseek_protocol.Command
 
 // Errors
 
 // Types and methods
-type EngineCommand
-pub fn EngineCommand::to_jsonl(Self) -> String
 
 // Type aliases
 

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -1,0 +1,128 @@
+///|
+/// How a mid-turn steer reaches the model.
+///
+/// The wire spells these `"prompt"` and `"command"`. `Notice` is deliberately
+/// absent: the engine synthesizes notices for itself (a background job
+/// finishing), and reports them back as `steer_applied` with `kind: "notice"`,
+/// but no controller may send one — `decode` has always rejected an unknown
+/// kind, and a notice is not a thing a client has to say.
+pub(all) enum SteerKind {
+  Prompt
+  Command
+} derive(Eq, Debug)
+
+///|
+/// One command a controller writes to `openseek serve`'s stdin.
+///
+/// The other half of the serve protocol: `Event` is what the engine reports,
+/// this is what it is told. Both directions used to be anonymous JSON at each
+/// end — the events for ~60 call sites and three decoders, these for one
+/// decoder and two encoders that had already drifted apart:
+///
+/// - the TUI sent `steer` with a `kind`; the desktop sent it without one, and
+///   worked only because `parse` falls back to `Prompt`. Neither end wrote that
+///   rule down.
+/// - the desktop had no `goal` at all, so the same protocol meant different
+///   things to its two clients, and nothing said whether that was a decision.
+///
+/// One type, one encoder, one decoder — the same shape the event direction now
+/// has.
+pub(all) enum Command {
+  Prompt(text~ : String)
+  Steer(kind~ : SteerKind, text~ : String)
+  Compact
+  Cancel
+  /// `auto` arms autonomous continuation toward the goal. No in-repo client
+  /// sends it — the TUI's `/goal` always sets a manual goal — but `serve` is a
+  /// protocol, not a private channel, and an external controller drives this.
+  GoalSet(text~ : String, auto~ : Bool)
+  GoalClear
+} derive(Eq, Debug)
+
+///|
+/// The command as the line a controller writes.
+pub fn Command::to_json(self : Command) -> Json {
+  match self {
+    Prompt(text~) => { "command": "prompt", "text": text }
+    Steer(kind~, text~) =>
+      {
+        "command": "steer",
+        "kind": match kind {
+          Prompt => "prompt"
+          Command => "command"
+        },
+        "text": text,
+      }
+    Compact => { "command": "compact" }
+    Cancel => { "command": "cancel" }
+    // `auto` is written only when set: an engine older than the flag ignores an
+    // unknown key, but the field's absence is also what `false` has always
+    // looked like on this wire, so omitting it keeps the common line unchanged.
+    GoalSet(text~, auto~) =>
+      if auto {
+        { "command": "goal", "action": "set", "text": text, "auto": true }
+      } else {
+        { "command": "goal", "action": "set", "text": text }
+      }
+    GoalClear => { "command": "goal", "action": "clear" }
+  }
+}
+
+///|
+/// The command as a JSONL line, newline included.
+pub fn Command::to_jsonl(self : Command) -> String {
+  self.to_json().stringify() + "\n"
+}
+
+///|
+/// Read one stdin line back into a `Command`.
+///
+/// `Err` carries the text the engine reports to its controller as a
+/// `command_error` event, so these strings are themselves wire contract, not
+/// diagnostics — they are what a controller reads to learn what it got wrong.
+///
+/// Unlike `parse` for events, this returns a `Result`: an unreadable event is
+/// a line to ignore, but an unreadable command is a request that will never be
+/// answered, and silence is the one reply a controller cannot act on.
+///
+/// `steer` without a `kind` is `Prompt`. That is not leniency for its own sake:
+/// the desktop has always sent exactly that, and it is what every controller
+/// meant before the field existed.
+pub fn Command::parse(line : Json) -> Result[Command, String] {
+  match line {
+    { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text~))
+    { "command": "steer", .. } => parse_steer(line)
+    { "command": "prompt", .. } => Err("expected a string \"text\" field")
+    { "command": "compact", .. } => Ok(Compact)
+    { "command": "cancel", .. } => Ok(Cancel)
+    { "command": "goal", "action": "set", "text": String(text), .. } =>
+      if text.trim().is_empty() {
+        Err("goal text must not be blank")
+      } else {
+        Ok(GoalSet(text~, auto=line is { "auto": True, .. }))
+      }
+    { "command": "goal", "action": "clear", .. } => Ok(GoalClear)
+    { "command": "goal", .. } =>
+      Err(
+        "expected {\"action\": \"set\", \"text\": ...} or {\"action\": \"clear\"}",
+      )
+    { "command": String(other), .. } => Err("unknown command: \{other}")
+    _ => Err("expected a {\"command\": ...} object")
+  }
+}
+
+///|
+fn parse_steer(line : Json) -> Result[Command, String] {
+  match line {
+    { "kind": String(kind), "text": String(text), .. } =>
+      match kind {
+        "prompt" => Ok(Steer(kind=Prompt, text~))
+        "command" => Ok(Steer(kind=Command, text~))
+        other => Err("unknown steer kind: \{other}")
+      }
+    { "kind": _, "text": String(_), .. } =>
+      Err("expected a string \"kind\" field")
+    { "text": String(text), .. } => Ok(Steer(kind=Prompt, text~))
+    _ => Err("expected a string \"text\" field")
+  }
+}

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -81,6 +81,13 @@ pub fn Command::to_jsonl(self : Command) -> String {
 /// `command_error` event, so these strings are themselves wire contract, not
 /// diagnostics — they are what a controller reads to learn what it got wrong.
 ///
+/// It reports a line this protocol cannot read, and nothing else. Whether a
+/// readable command is *acceptable* is the engine's to say: a blank goal is
+/// well-formed and refused, and `serve` refuses it. Were that check here,
+/// `GoalSet(text="  ")` would be a value this type holds and `to_json` writes
+/// but `parse` rejects — breaking the round-trip below for a value the type
+/// itself offers.
+///
 /// Unlike `parse` for events, this returns a `Result`: an unreadable event is
 /// a line to ignore, but an unreadable command is a request that will never be
 /// answered, and silence is the one reply a controller cannot act on.
@@ -112,12 +119,14 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
     { "command": "prompt", .. } => Err("expected a string \"text\" field")
     { "command": "compact", .. } => Ok(Compact)
     { "command": "cancel", .. } => Ok(Cancel)
+    // A blank goal decodes: `{"action":"set","text":"  "}` is a well-formed
+    // command, and refusing it is the engine's policy, not the wire's shape.
+    // Keeping the check here would make `GoalSet(text="  ")` a value this type
+    // can hold, `to_json` can write, and `parse` then rejects — a round-trip
+    // the type advertises and would not have. `serve` rejects it, in the same
+    // words, where the policy lives.
     { "command": "goal", "action": "set", "text": String(text), .. } =>
-      if text.trim().is_empty() {
-        Err("goal text must not be blank")
-      } else {
-        Ok(GoalSet(text~, auto=line is { "auto": True, .. }))
-      }
+      Ok(GoalSet(text~, auto=line is { "auto": True, .. }))
     { "command": "goal", "action": "clear", .. } => Ok(GoalClear)
     { "command": "goal", .. } =>
       Err(

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -85,9 +85,26 @@ pub fn Command::to_jsonl(self : Command) -> String {
 /// a line to ignore, but an unreadable command is a request that will never be
 /// answered, and silence is the one reply a controller cannot act on.
 ///
-/// `steer` without a `kind` is `Prompt`. That is not leniency for its own sake:
-/// the desktop has always sent exactly that, and it is what every controller
-/// meant before the field existed.
+/// ## When a field may be absent
+///
+/// The same rule `parse` states for events, and both of its cases apply here —
+/// one field each, verified against `git log -S` for the field versus its
+/// command's introducing commit:
+///
+/// 1. **Added after its command existed.** `steer`'s `kind` arrived in
+///    9b2f6c43; `steer` itself in 17562cc1. An engine from between them is sent
+///    a `kind` it ignores, and a controller older than the field sends none —
+///    so absent means `Prompt`, which is what every controller meant before
+///    there was a choice. The desktop was still sending exactly that.
+/// 2. **Optional since the command shipped.** `goal`'s `auto` arrived *with*
+///    `goal` (c8cc6ad7), so case (1) does not cover it — but the engine has
+///    read `auto` as absent-means-false from the first line it ever decoded.
+///    It is a flag with a default, not a value that can go missing.
+///
+/// The distinction matters because only (1) is about talking to an old
+/// binary. A field that is merely unread — `text` on a command nobody
+/// inspects — is still required: its absence means the line is not what it
+/// claims.
 pub fn Command::parse(line : Json) -> Result[Command, String] {
   match line {
     { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text~))

--- a/protocol/command_test.mbt
+++ b/protocol/command_test.mbt
@@ -20,6 +20,11 @@ fn all_commands() -> Array[@openseek_protocol.Command] {
     Cancel,
     GoalSet(text="ship it", auto=false),
     GoalSet(text="grind it out", auto=true),
+    // Well-formed and unacceptable are different things: `serve` refuses a
+    // blank goal, but the wire carries it, so this type must hold it and
+    // round-trip it. Keeping that refusal here would have made this sample
+    // a value `to_json` writes and `parse` rejects.
+    GoalSet(text="   ", auto=false),
     GoalClear,
   ]
 }
@@ -103,16 +108,6 @@ test "a rejected command explains itself in the engine's own words" {
     ),
     content=(
       #|Err("expected a string \"kind\" field")
-    ),
-  )
-  debug_inspect(
-    cmd(
-      (
-        #|{"command":"goal","action":"set","text":"   "}
-      ),
-    ),
-    content=(
-      #|Err("goal text must not be blank")
     ),
   )
   debug_inspect(

--- a/protocol/command_test.mbt
+++ b/protocol/command_test.mbt
@@ -1,0 +1,148 @@
+///|
+fn cmd(line : String) -> Result[@openseek_protocol.Command, String] {
+  @openseek_protocol.Command::parse(
+    @json.parse(line) catch {
+      _ => return Err("not json")
+    },
+  )
+}
+
+///|
+/// One sample per variant. `parse` is `to_json`'s inverse for all of them —
+/// the property that stops the engine's reader and its two controllers from
+/// spelling the same command differently, which is what they did.
+fn all_commands() -> Array[@openseek_protocol.Command] {
+  [
+    Prompt(text="do it"),
+    Steer(kind=Prompt, text="also fix docs"),
+    Steer(kind=Command, text="<user_shell_command>"),
+    Compact,
+    Cancel,
+    GoalSet(text="ship it", auto=false),
+    GoalSet(text="grind it out", auto=true),
+    GoalClear,
+  ]
+}
+
+///|
+test "every command round-trips through to_json and parse" {
+  for command in all_commands() {
+    assert_eq(@openseek_protocol.Command::parse(command.to_json()), Ok(command))
+  }
+}
+
+///|
+/// The desktop has always sent `steer` with no `kind`, and works because this
+/// falls back to `Prompt`. The rule lived in the engine's decoder and nowhere
+/// the desktop could see it; it is now the protocol's, and tested.
+test "a steer without a kind is a prompt steer" {
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"steer","text":"go left"}
+      ),
+    ),
+    content=(
+      #|Ok(Steer(kind=Prompt, text="go left"))
+    ),
+  )
+}
+
+///|
+/// `auto` is absent rather than `false`, so the line a controller writes for an
+/// ordinary goal is byte for byte what the TUI has always written.
+test "goal set omits auto unless it is armed" {
+  inspect(
+    (GoalSet(text="ship it", auto=false) : @openseek_protocol.Command)
+    .to_json()
+    .stringify(),
+    content=(
+      #|{"command":"goal","action":"set","text":"ship it"}
+    ),
+  )
+  inspect(
+    (GoalSet(text="grind it out", auto=true) : @openseek_protocol.Command)
+    .to_json()
+    .stringify(),
+    content=(
+      #|{"command":"goal","action":"set","text":"grind it out","auto":true}
+    ),
+  )
+}
+
+///|
+/// These strings reach the controller as a `command_error` event, so they are
+/// wire contract rather than diagnostics: a controller reads them to learn what
+/// it got wrong. They are the engine's, verbatim.
+test "a rejected command explains itself in the engine's own words" {
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"prompt","text":7}
+      ),
+    ),
+    content=(
+      #|Err("expected a string \"text\" field")
+    ),
+  )
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"steer","kind":"runtime","text":"x"}
+      ),
+    ),
+    content=(
+      #|Err("unknown steer kind: runtime")
+    ),
+  )
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"steer","kind":7,"text":"x"}
+      ),
+    ),
+    content=(
+      #|Err("expected a string \"kind\" field")
+    ),
+  )
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"goal","action":"set","text":"   "}
+      ),
+    ),
+    content=(
+      #|Err("goal text must not be blank")
+    ),
+  )
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"goal","action":"toggle"}
+      ),
+    ),
+    content=(
+      #|Err("expected {\"action\": \"set\", \"text\": ...} or {\"action\": \"clear\"}")
+    ),
+  )
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"inject","text":"x"}
+      ),
+    ),
+    content=(
+      #|Err("unknown command: inject")
+    ),
+  )
+  debug_inspect(
+    cmd(
+      (
+        #|["not an object"]
+      ),
+    ),
+    content=(
+      #|Err("expected a {\"command\": ...} object")
+    ),
+  )
+}

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -12,10 +12,17 @@
 ///
 /// ## When a field may be absent
 ///
-/// A field is defaulted **if and only if it was added after its event already
-/// existed**, because engines older than that field still emit the event
-/// without it — and the TUI and desktop launch whichever `openseek` is on
-/// PATH, so a new reader against an old engine is a real pairing.
+/// A field is defaulted only when one of two things is true of it:
+///
+/// 1. **It was added after its event already existed**, so engines older than
+///    the field still emit the event without it — and the TUI and desktop
+///    launch whichever `openseek` is on PATH, making a new reader against an
+///    old engine a real pairing. Every event field defaulted here is this case.
+/// 2. **The engine has treated it as optional since the event shipped** — a
+///    flag whose absence has always meant something definite, rather than a
+///    value gone missing. No *event* field is this case; `Command`'s `auto` is,
+///    which is why that rule is stated separately in `command.mbt` rather than
+///    by pointing here.
 ///
 /// Everything else is required. "No reader uses it" is *not* a reason to
 /// default a field: `tool_call_id`, `usage`'s cache counters and
@@ -24,9 +31,10 @@
 /// absence means the line is not what it claims to be. Guessing there would
 /// hide a real wire break behind a fabricated value.
 ///
-/// Three fields qualify today, each verified against `git log -S` for the field
-/// versus its event's introducing commit — the check to run before adding a
-/// fourth, and the one that catches a field wrongly made required:
+/// Three fields qualify today, all under (1), each verified against `git log -S`
+/// for the field versus its event's introducing commit — the check to run
+/// before adding a fourth, and the one that catches a field wrongly made
+/// required, as `workspace_root` was:
 ///
 /// - `steer_applied`'s `kind` — added 9b2f6c43 (2026-06-25) to an event from
 ///   56140618.

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -11,6 +11,18 @@ pub fn parse(Json) -> Event?
 // Errors
 
 // Types and methods
+pub(all) enum Command {
+  Prompt(text~ : String)
+  Steer(kind~ : SteerKind, text~ : String)
+  Compact
+  Cancel
+  GoalSet(text~ : String, auto~ : Bool)
+  GoalClear
+} derive(Eq, @debug.Debug)
+pub fn Command::parse(Json) -> Result[Self, String]
+pub fn Command::to_json(Self) -> Json
+pub fn Command::to_jsonl(Self) -> String
+
 pub(all) enum Event {
   AgentSetupFailed(error~ : String)
   AgentStep(step~ : Int)
@@ -61,6 +73,11 @@ pub(all) enum Event {
   McpNoTools(server~ : String)
 } derive(Eq, @debug.Debug)
 pub fn Event::to_json(Self) -> Json
+
+pub(all) enum SteerKind {
+  Prompt
+  Command
+} derive(Eq, @debug.Debug)
 
 pub(all) struct Usage {
   prompt_tokens : Int


### PR DESCRIPTION
Follow-up to #500. That typed what the engine **reports**; this types what it is **told** — the other half of the serve protocol, and the half still in exactly the state the events were in before: **one hand-written decoder, two hand-written encoders, no shared schema.**

## It had already drifted, the same way

| Drift | Detail |
|---|---|
| `steer`'s `kind` | The TUI sends it; the desktop **didn't**. It worked only because `serve`'s decoder falls back to `Prompt` — a rule that lived in `serve.mbt` and nowhere the desktop could see. Neither end wrote it down; the desktop happened to be right. |
| `goal` | The desktop has **no goal command at all**, so one protocol meant two different things to its two controllers, and nothing recorded whether that was intentional. It is — there's no goal UI — and that's now said out loud rather than inferred. |

Same disease as the event side, same cause: three implementations of a contract with no owner.

## The change

`@protocol.Command` — one type, one encoder, one decoder, mirroring `Event` for the opposite direction:

```
Prompt(text)  Steer(kind, text)  Compact  Cancel  GoalSet(text, auto)  GoalClear
```

- **`serve`** decodes through it, then maps to its own `ServeCommand` — because `SteerInput` is the runtime's and the protocol is a leaf module that must not depend on the engine.
- **The TUI** and **the desktop host** encode through it, keeping their own vocabulary (`ops.mbt` asks for a prompt, not a variant).

Same view-model seam the readers already use.

## `parse` returns `Result`, not `Option`

Deliberately unlike the event side. An unreadable *event* is a line to ignore; an unreadable *command* is a request that will never be answered, and silence is the one reply a controller cannot act on.

The error strings are the engine's **verbatim**, because they reach the controller as `command_error` — they're wire contract, not diagnostics, and they're tested as such.

**That the extraction is faithful isn't an assertion:** serve's existing decoder tests, which pin every one of those messages, pass unchanged against the shared type.

## Two deliberate wire notes

- The desktop's `steer` now sends `kind: "prompt"` **explicitly** instead of relying on the default. Same meaning, and the engine has always accepted both — but the host now says what it means rather than being accidentally correct.
- `GoalSet` omits `auto` when false, so the ordinary goal line is byte for byte what the TUI has always written. `auto` is the protocol's affordance for a headless controller, which no in-repo client is.

## Verification

| Gate | Result |
|---|---|
| root | 1168 native / 27 js / 12 wasm-gc |
| protocol | 259 js |
| desktop | 230 native / 216 js |
| cram | 24/24 |
| `moon check --deny-warn` | clean, both workspaces |
| `moon fmt --check` | clean, incl. CI's scoped desktop run |

## Note on CI

`check (nightly)` and the desktop app builds are red on `main` right now — a language change to `with`-pattern syntax that pre-existing `deepseek/json_decode.mbt` hasn't caught up to. Unrelated to this branch; `main`'s own CI re-run fails identically on the same line. Owned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)