### PR TITLE
refactor(protocol): delete the third copy of the rule it kept getting wrong

### DIFF
--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -1,15 +1,16 @@
 # OpenSeek Protocol
 
-`bobzhang/openseek_protocol` owns the engine's stdout event stream — the wire
-contract between `openseek run` / `openseek serve` and everything that reads
-them: the TUI, the desktop host, and any script consuming `run`'s stdout.
+`bobzhang/openseek_protocol` owns **both directions** of the serve protocol: the
+stdout event stream the engine reports (`Event`), and the stdin command stream it
+is told (`Command`). Between them they are the whole wire contract with the TUI,
+the desktop host, the desktop frontend, and any script driving `run` or `serve`.
 
 It is a **leaf module with no openseek dependencies**, split so the decoder is
 portable:
 
 | Package | Contents | Targets | Deps |
 | --- | --- | --- | --- |
-| `bobzhang/openseek_protocol` | `Event`, `Usage`, `to_json`, `parse` | js, wasm, wasm-gc, native | `core/json` |
+| `bobzhang/openseek_protocol` | `Event`, `Usage`, `Command`, `SteerKind`, `to_json`, `parse` | js, wasm, wasm-gc, native | `core/json` |
 | `bobzhang/openseek_protocol/emit` | `emit` (level + `to_json` + log) | native | `xlog`, above |
 
 Only the *writer* needs `@xlog`, which is native-only. Keeping it in its own
@@ -86,23 +87,53 @@ line's `source` still points at the reporting code rather than at `emit.mbt`.
 
 ## When a field may be absent
 
-A field is defaulted **iff it was added after its event already existed** —
-engines older than the field still emit the event without it, and the clients
-launch whichever `openseek` is on `PATH`. Exactly one qualifies today:
-`steer_applied`'s `kind` (added 2026-06-25 in 9b2f6c43, to an event from
-56140618).
+**The rule and the fields it covers live in `parse`'s doc comment** (events) and
+`Command::parse`'s (commands) — beside the code that enforces them, and nowhere
+else. This file used to restate the rule and the list, and within a month it was
+wrong on both: it still said "exactly one field qualifies" after the count went
+to three, and stated an "iff" after a second case was found. A rule copied is a
+rule that drifts, which is the failure this package exists to prevent — so the
+copy is gone rather than corrected.
 
-"No reader uses it" is *not* a reason. `tool_call_id`, `usage`'s cache counters
-and `mcp_tools_registered`'s `names` are unread by every client, yet every engine
-that emitted those events emitted those fields — so absence means the line is not
-what it claims, and defaulting would hide a real break behind a fabricated value.
-Check `git log -S` for the field against its event's introducing commit before
-adding another.
+What is worth knowing here: a field is defaulted only for a reason the git
+history can settle, never because no reader happens to use it. Run `git log -S`
+for the field against its event's introducing commit before adding another; the
+doc comment says what to look for.
+
+## The command direction
+
+`Command` is the same shape for the opposite direction: one type, one encoder
+(`to_json`/`to_jsonl`), one decoder (`Command::parse`), and every controller
+encodes through it — `cmd/tui` and the desktop host both, where each used to
+model the commands itself. They drifted exactly as the events had: the TUI sent
+`steer` with a `kind` and the desktop sent it without one, working only because
+the engine's decoder happened to default it.
+
+```mbt nocheck
+// A controller writes a line.
+let line = (Prompt(text="do it") : @protocol.Command).to_jsonl()
+
+// The engine reads one back. `Err` is a line it cannot read — and only that:
+// whether a readable command is *acceptable* is the engine's to say, which is
+// why `serve`, not `parse`, refuses a blank goal.
+match @protocol.Command::parse(line) {
+  Ok(Prompt(text~)) => start_turn(text)
+  Ok(_) => ()
+  Err(message) => report(message)
+}
+```
+
+`Command::parse` returns `Result`, not `Option`, unlike `parse` for events. An
+unreadable event is a line to ignore; an unreadable command is a request that
+will never be answered, and silence is the one reply a controller cannot act on.
+Its `Err` strings reach the controller as `command_error`, so they are wire
+contract too.
 
 ## Invariants
 
-- **`parse` is `emit`'s inverse** for every variant. `protocol_test.mbt` pins
-  this per sample; it is the property the package exists to provide.
+- **`parse` is `emit`'s inverse** for every variant. `emit/emit_test.mbt` pins
+  this per sample — it needs both halves, so it lives with the writer; it is the
+  property the package exists to provide.
 - **Optional string fields are written as the value or `null`, never omitted.**
   A field's own `ToJson` would encode `Some(v)` as the one-element array `[v]`,
   which every decoder's string lookup rejects — silently turning a present field

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -139,16 +139,18 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
 
 ///|
 fn parse_steer(line : Json) -> Result[Command, String] {
+  // `text` is required whatever the kind says, so it is checked once here
+  // rather than restated in three arms, where the precedence between "no text"
+  // and "bad kind" was emergent from their order.
+  guard line is { "text": String(text), .. } else {
+    return Err("expected a string \"text\" field")
+  }
   match line {
-    { "kind": String(kind), "text": String(text), .. } =>
-      match kind {
-        "prompt" => Ok(Steer(kind=Prompt, text~))
-        "command" => Ok(Steer(kind=Command, text~))
-        other => Err("unknown steer kind: \{other}")
-      }
-    { "kind": _, "text": String(_), .. } =>
-      Err("expected a string \"kind\" field")
-    { "text": String(text), .. } => Ok(Steer(kind=Prompt, text~))
-    _ => Err("expected a string \"text\" field")
+    { "kind": String("prompt"), .. } => Ok(Steer(kind=Prompt, text~))
+    { "kind": String("command"), .. } => Ok(Steer(kind=Command, text~))
+    { "kind": String(other), .. } => Err("unknown steer kind: \{other}")
+    { "kind": _, .. } => Err("expected a string \"kind\" field")
+    // A steer with no kind at all is a prompt steer: see the rule above.
+    _ => Ok(Steer(kind=Prompt, text~))
   }
 }

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -59,9 +59,16 @@ fn usage_sample() -> @protocol.Usage {
 
 ///|
 /// One sample per `Event` variant. `derive(Eq)` plus the round-trip test below
-/// makes this list the encoder/decoder contract; MoonBit's exhaustiveness
-/// checks `emit`/`parse`/`name`, but nothing forces a new variant to be added
-/// here, so a variant added without a sample is silently untested.
+/// makes this list the encoder/decoder contract.
+///
+/// Two gaps this list does not close, both worth knowing before adding a
+/// variant. Exhaustiveness covers `to_json` and `parse` — `emit` itself matches
+/// nothing, it delegates — but nothing forces a new variant to be added *here*,
+/// so one added without a sample is silently untested. And `level`'s `_ => Info`
+/// catch-all means nothing forces it a severity either: a new event that should
+/// warn ships at `Info` with no error. One variant still cannot hold two levels,
+/// which is what this package set out to stop; being made to choose one is a
+/// weaker promise than the comment here used to imply.
 fn all_events() -> Array[@protocol.Event] {
   [
     AgentSetupFailed(error="boom"),

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -2,7 +2,8 @@
 /// Read one JSONL line from the engine's stdout stream back into an `Event`.
 ///
 /// The inverse of `emit`: `parse(json) == Some(event)` for every line `emit`
-/// writes, which `protocol_test.mbt` pins per variant. Fields are read from the
+/// writes, which `emit/emit_test.mbt` pins per variant — it needs both halves,
+/// so it lives with the writer. Fields are read from the
 /// top level, matching the hoisting `@xlog`'s handler performs.
 ///
 /// `None` means "not an event this engine emits" — an unknown `event` name, a


### PR DESCRIPTION
Sweep of the `protocol` module, which had never had one. **Its five source files came back clean** — the finder explicitly declined to collapse the repeated compaction literals in `to_json`, on the grounds that the literal table *is* the contract and a helper branching on an absent `summary` is how you'd get a byte change nobody reviews. Agreed.

Everything below is documentation that drifted out from under the code **within a month**, in the package built to stop exactly that.

## The README kept a third copy of the absence rule

It sat beside the two in `parse.mbt` and `command.mbt`. Commit `3906fcea` corrected those two and never touched it, so it still claimed:

> A field is defaulted **iff it was added after its event already existed** … Exactly one qualifies today

while `parse.mbt` nine files away says **three** qualify, and `command.mbt` documents a **second case** that the README's "iff" explicitly excludes.

**It is deleted, not corrected.** A rule copied is a rule that drifts, and this one proved it in under a month. The README now names the rule and points at the doc comment beside the code that enforces it.

## The README documented half the module

`Command`, `SteerKind`, and the whole command direction (added in `f11f384e`) were absent from the opener and the package table. A reader looking for the command wire contract would conclude there isn't one **and hand-roll a second encoder** — precisely what `f11f384e` deleted from the desktop host.

## The invariant's stated proof was a dangling pointer

`parse`'s doc comment cited `protocol_test.mbt` as where the round-trip is pinned. **That file has never existed in this repo** (`git log --all` confirms). The test is `emit/emit_test.mbt` — it needs both halves, so it lives with the writer.

## A comment claimed a check that isn't running

It said MoonBit's exhaustiveness covers `emit`/`parse`/`name`. There is no `name` (`aa4c10ad` removed it), and `emit` matches nothing — it delegates to `to_json`. Worse, it reassured about the check where it matters most: **`level`'s `_ => Info` means a new variant that should warn ships at `Info` with no error.**

One variant still cannot hold two levels — what the package set out to stop. But *being made to choose one* is a weaker promise than that comment implied, and it now says so. I did not expand the catch-all into 40 arms; that's a design call, and longer.

## The one code change

`parse_steer` restated `"text": String(..)` in three arms, and the precedence between "no text" and "bad kind" was **emergent from arm order**. A guard hoists it once and flattens the nested match.

All seven error strings are wire contract — they reach a controller as `command_error` — and `command_test.mbt` pins each verbatim.

## Verification

| Gate | Result |
|---|---|
| protocol | 259 js / 179 wasm / 179 wasm-gc |
| root | 1186 native |
| `moon check --deny-warn` | clean |
| `moon fmt --check` | clean |
| `.mbti` drift | none |

**Codex: clean** — *"The executable change preserves the existing `parse_steer` behavior while simplifying validation."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)