### PR TITLE
refactor(mcp/streamhttp): one error shape, one decision, no unused self

### DIFF
--- a/mcp/streamhttp/streamhttp_test.mbt
+++ b/mcp/streamhttp/streamhttp_test.mbt
@@ -87,19 +87,6 @@ async fn mock_mcp_endpoint(
                 _ => ()
               }
             }
-            let reply : Json = {
-              "jsonrpc": "2.0",
-              "id": id,
-              "result": {
-                "tools": [
-                  {
-                    "name": "fetch",
-                    "description": "Fetch a URL",
-                    "inputSchema": { "type": "object" },
-                  },
-                ],
-              },
-            }
             conn.send_response(200, "OK", extra_headers={
               "Content-Type": "text/event-stream",
             })
@@ -111,8 +98,9 @@ async fn mock_mcp_endpoint(
             )
             conn.flush()
             // Split at a token boundary: SSE joins the lines with a newline,
-            // which JSON tolerates only between tokens.
-            ignore(reply)
+            // which JSON tolerates only between tokens. The reply is spelled
+            // out here rather than built and stringified, because the split is
+            // the point of the test.
             conn.write(
               "data: {\"jsonrpc\":\"2.0\",\"id\":\{id.stringify()},\r\ndata: \"result\":{\"tools\":[{\"name\":\"fetch\",\"description\":\"Fetch a URL\",\"inputSchema\":{\"type\":\"object\"}}]}}\r\n\r\n",
             )
@@ -135,16 +123,7 @@ async fn mock_mcp_endpoint(
 async test "http connect handshakes, lists tools over SSE, and echoes session headers" {
   @async.with_task_group() <| group => {
     guard mock_mcp_endpoint(group) is Some((url, seen)) else { return }
-    guard @streamhttp.connect(
-        group,
-        url~,
-        client_name="openseek",
-        client_version="0.1",
-        handshake_timeout_ms=10000,
-      )
-      is Some(conn) else {
-      fail("expected the http connect to succeed")
-    }
+    let conn = connect_or_fail(group, url)
     assert_eq(conn.init().server_name, "http-mock")
     assert_eq(conn.init().protocol_version, "2025-11-25")
     let tools = conn.client().list_tools()
@@ -202,17 +181,8 @@ async test "a server ping mid-stream is answered while the stream is open" {
             _ => Json::null()
           }
           match message {
-            { "method": String("initialize"), "id": id, .. } => {
-              let reply : Json = {
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": { "protocolVersion": "2025-11-25" },
-              }
-              conn.send_response(200, "OK", extra_headers={
-                "Content-Type": "application/json",
-              })
-              conn.write(reply.stringify())
-            }
+            { "method": String("initialize"), "id": id, .. } =>
+              answer_initialize(conn, id)
             { "method": String("tools/list"), "id": id, .. } => {
               conn.send_response(200, "OK", extra_headers={
                 "Content-Type": "text/event-stream",
@@ -244,16 +214,10 @@ async test "a server ping mid-stream is answered while the stream is open" {
         max_connections=8,
       )
     }
-    guard @streamhttp.connect(
-        group,
-        url="http://127.0.0.1:\{server.addr.port()}/mcp",
-        client_name="openseek",
-        client_version="0.1",
-        handshake_timeout_ms=10000,
-      )
-      is Some(conn) else {
-      fail("expected the http connect to succeed")
-    }
+    let conn = connect_or_fail(
+      group,
+      "http://127.0.0.1:\{server.addr.port()}/mcp",
+    )
     let tools = @async.with_timeout_opt(10000, () => conn.client().list_tools())
     guard tools is Some(tools) else {
       fail("tools/list deadlocked behind the mid-stream ping")
@@ -279,17 +243,8 @@ async test "an http error fails the request fast" {
             _ => Json::null()
           }
           match message {
-            { "method": String("initialize"), "id": id, .. } => {
-              let reply : Json = {
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": { "protocolVersion": "2025-11-25" },
-              }
-              conn.send_response(200, "OK", extra_headers={
-                "Content-Type": "application/json",
-              })
-              conn.write(reply.stringify())
-            }
+            { "method": String("initialize"), "id": id, .. } =>
+              answer_initialize(conn, id)
             { "method": String("tools/list"), .. } => {
               conn.send_response(500, "Internal Server Error", extra_headers={
                 "Content-Type": "text/plain",
@@ -302,16 +257,10 @@ async test "an http error fails the request fast" {
         max_connections=8,
       )
     }
-    guard @streamhttp.connect(
-        group,
-        url="http://127.0.0.1:\{server.addr.port()}/mcp",
-        client_name="openseek",
-        client_version="0.1",
-        handshake_timeout_ms=10000,
-      )
-      is Some(conn) else {
-      fail("expected the http connect to succeed")
-    }
+    let conn = connect_or_fail(
+      group,
+      "http://127.0.0.1:\{server.addr.port()}/mcp",
+    )
     // Bounded well below any outer timeout: the failure must arrive promptly.
     let outcome = @async.with_timeout_opt(5000, () => {
       try {
@@ -350,17 +299,8 @@ async test "tools/list waits for the initialized notification to complete" {
             _ => Json::null()
           }
           match message {
-            { "method": String("initialize"), "id": id, .. } => {
-              let reply : Json = {
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": { "protocolVersion": "2025-11-25" },
-              }
-              conn.send_response(200, "OK", extra_headers={
-                "Content-Type": "application/json",
-              })
-              conn.write(reply.stringify())
-            }
+            { "method": String("initialize"), "id": id, .. } =>
+              answer_initialize(conn, id)
             { "method": String("notifications/initialized"), .. } => {
               // A slow lifecycle handler: without the transport's gate, the
               // detached tools/list POST overtakes this notification.
@@ -386,19 +326,48 @@ async test "tools/list waits for the initialized notification to complete" {
         max_connections=8,
       )
     }
-    guard @streamhttp.connect(
-        group,
-        url="http://127.0.0.1:\{server.addr.port()}/mcp",
-        client_name="openseek",
-        client_version="0.1",
-        handshake_timeout_ms=10000,
-      )
-      is Some(conn) else {
-      fail("expected the http connect to succeed")
-    }
+    let conn = connect_or_fail(
+      group,
+      "http://127.0.0.1:\{server.addr.port()}/mcp",
+    )
     let tools = conn.client().list_tools()
     assert_eq(tools[0].name, "ordered")
     assert_true(list_saw_initialized.val)
     conn.shutdown()
   }
+} ///|
+/// Connect to a mock endpoint, failing the test rather than returning None.
+/// Every test but the unreachable-endpoint one wants exactly this.
+
+///|
+async fn connect_or_fail(
+  group : @async.TaskGroup[Unit],
+  url : String,
+) -> @streamhttp.HttpConnection {
+  guard @streamhttp.connect(
+      group,
+      url~,
+      client_name="openseek",
+      client_version="0.1",
+      handshake_timeout_ms=10000,
+    )
+    is Some(conn) else {
+    fail("expected the http connect to succeed")
+  }
+  conn
+}
+
+///|
+/// Answer a handshake the way every mock here does: 200, JSON, the protocol
+/// version the client asked for.
+async fn answer_initialize(conn : @http.ServerConnection, id : Json) -> Unit {
+  let reply : Json = {
+    "jsonrpc": "2.0",
+    "id": id,
+    "result": { "protocolVersion": "2025-11-25" },
+  }
+  conn.send_response(200, "OK", extra_headers={
+    "Content-Type": "application/json",
+  })
+  conn.write(reply.stringify())
 }

--- a/mcp/streamhttp/streamhttp_test.mbt
+++ b/mcp/streamhttp/streamhttp_test.mbt
@@ -63,7 +63,7 @@ async fn mock_mcp_endpoint(
         }
         let message = @json.parse(text) catch { _ => Json::null() }
         match message {
-          { "method": String("initialize"), "id": id, .. } => {
+          { "method": "initialize", "id": id, .. } => {
             let reply : Json = {
               "jsonrpc": "2.0",
               "id": id,
@@ -78,7 +78,7 @@ async fn mock_mcp_endpoint(
             })
             conn.write(reply.stringify())
           }
-          { "method": String("tools/list"), "id": id, .. } => {
+          { "method": "tools/list", "id": id, .. } => {
             for key, value in request.headers {
               match key.to_lower() {
                 "mcp-session-id" => seen.session_id = value
@@ -181,9 +181,9 @@ async test "a server ping mid-stream is answered while the stream is open" {
             _ => Json::null()
           }
           match message {
-            { "method": String("initialize"), "id": id, .. } =>
+            { "method": "initialize", "id": id, .. } =>
               answer_initialize(conn, id)
-            { "method": String("tools/list"), "id": id, .. } => {
+            { "method": "tools/list", "id": id, .. } => {
               conn.send_response(200, "OK", extra_headers={
                 "Content-Type": "text/event-stream",
               })
@@ -195,7 +195,7 @@ async test "a server ping mid-stream is answered while the stream is open" {
               )
               conn.flush()
               let pong = pongs.get()
-              assert_true(pong is { "id": String("srv-ping"), "result": _, .. })
+              assert_true(pong is { "id": "srv-ping", "result": _, .. })
               let reply : Json = {
                 "jsonrpc": "2.0",
                 "id": id,
@@ -204,7 +204,7 @@ async test "a server ping mid-stream is answered while the stream is open" {
               conn.write("data: \{reply.stringify()}\n\n")
             }
             // The pong (a response, no method) — route it to the stream handler.
-            { "id": String("srv-ping"), .. } => {
+            { "id": "srv-ping", .. } => {
               pongs.put(message)
               conn.send_response(202, "Accepted")
             }
@@ -243,9 +243,9 @@ async test "an http error fails the request fast" {
             _ => Json::null()
           }
           match message {
-            { "method": String("initialize"), "id": id, .. } =>
+            { "method": "initialize", "id": id, .. } =>
               answer_initialize(conn, id)
-            { "method": String("tools/list"), .. } => {
+            { "method": "tools/list", .. } => {
               conn.send_response(500, "Internal Server Error", extra_headers={
                 "Content-Type": "text/plain",
               })
@@ -299,16 +299,16 @@ async test "tools/list waits for the initialized notification to complete" {
             _ => Json::null()
           }
           match message {
-            { "method": String("initialize"), "id": id, .. } =>
+            { "method": "initialize", "id": id, .. } =>
               answer_initialize(conn, id)
-            { "method": String("notifications/initialized"), .. } => {
+            { "method": "notifications/initialized", .. } => {
               // A slow lifecycle handler: without the transport's gate, the
               // detached tools/list POST overtakes this notification.
               @async.sleep(150)
               initialized_done.val = true
               conn.send_response(202, "Accepted")
             }
-            { "method": String("tools/list"), "id": id, .. } => {
+            { "method": "tools/list", "id": id, .. } => {
               list_saw_initialized.val = initialized_done.val
               let reply : Json = {
                 "jsonrpc": "2.0",

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -182,15 +182,14 @@ pub impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
   }
   // Remember the initialize request's id so its reply can fix the negotiated
   // protocol version for later headers.
-  if message is { "method": String("initialize"), "id": id, .. } {
+  if message is { "method": "initialize", "id": id, .. } {
     self.initialize_id = Some(id)
   }
   // The lifecycle notification opens the ordering gate; every later POST must
   // wait behind it (see `initialized_gate`). Which gate (if any) this POST
   // awaits is decided HERE, at dispatch order, not when the task first runs.
   let gate = self.initialized_gate
-  let opens_gate = message
-    is { "method": String("notifications/initialized"), .. }
+  let opens_gate = message is { "method": "notifications/initialized", .. }
   let completion : @async.Queue[Unit]? = if opens_gate {
     let completion : @async.Queue[Unit] = Queue(kind=Unbounded)
     self.initialized_gate = Some(completion)
@@ -386,7 +385,7 @@ async fn HttpTransport::exchange(
   let response = client.end_request()
   // The spec assigns the session id on the initialize response only; capturing
   // it elsewhere would let a later (or misbehaving) response rebind the session.
-  if message is { "method": String("initialize"), .. } &&
+  if message is { "method": "initialize", .. } &&
     header_value(response.headers, "Mcp-Session-Id") is Some(session_id) {
     self.session_id = Some(session_id)
   }

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -126,17 +126,15 @@ fn HttpTransport::request_headers(self : HttpTransport) -> Map[String, String] {
 /// layer computes. Case-insensitive (differently cased user keys would
 /// otherwise emit conflicting duplicates on the wire).
 fn reserved_header(name : String) -> Bool {
-  match name.to_lower() {
-    "content-type"
-    | "accept"
-    | "accept-encoding"
-    | "mcp-session-id"
-    | "mcp-protocol-version"
-    | "content-length"
-    | "transfer-encoding"
-    | "host" => true
-    _ => false
-  }
+  name.to_lower()
+  is ("content-type"
+  | "accept"
+  | "accept-encoding"
+  | "mcp-session-id"
+  | "mcp-protocol-version"
+  | "content-length"
+  | "transfer-encoding"
+  | "host")
 }
 
 ///|
@@ -176,14 +174,9 @@ pub impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
   // rather than growing tasks and connections without bound.
   if self.pending_posts.length() >= MaxInFlightExchanges {
     if request_id is Some(id) {
-      self.deliver({
-        "jsonrpc": "2.0",
-        "id": id,
-        "error": {
-          "code": -32000,
-          "message": "too many in-flight MCP exchanges (server flooding or stalling)",
-        },
-      })
+      self.deliver_error(
+        id, "too many in-flight MCP exchanges (server flooding or stalling)",
+      )
     }
     return
   }
@@ -353,42 +346,28 @@ async fn HttpTransport::run_post(
       // has nothing to answer.
       if request_id is Some(id) && !answered {
         answered = true
-        self.deliver({
-          "jsonrpc": "2.0",
-          "id": id,
-          "error": {
-            "code": -32000,
-            "message": "MCP endpoint exchange failed: \{error}",
-          },
-        })
+        self.deliver_error(id, "MCP endpoint exchange failed: \{error}")
       }
       return
     }
   }
-  // Deadline expiry: the endpoint held the exchange open past any useful
-  // lifetime; fail the request and release this slot.
-  if bounded is None && request_id is Some(id) && !answered {
-    answered = true
-    self.deliver({
-      "jsonrpc": "2.0",
-      "id": id,
-      "error": {
-        "code": -32000,
-        "message": "MCP endpoint exchange exceeded \{ExchangeTimeoutMs / 1000}s",
-      },
-    })
-  }
-  // The response ended without answering the request (e.g. an SSE stream closed
-  // early): fail it rather than leaving the caller to an outer timeout.
+  // A request the exchange never answered: fail it rather than leave the caller
+  // to an outer timeout. `bounded is None` is the deadline expiring — the
+  // endpoint held the exchange open past any useful lifetime — and otherwise
+  // the response simply ended first, e.g. an SSE stream closed early.
+  //
+  // These were two blocks, the first assigning `answered` for no reason but to
+  // make the second skip. They are one decision on `bounded`, and nothing
+  // suspends between them.
   if request_id is Some(id) && !answered {
-    self.deliver({
-      "jsonrpc": "2.0",
-      "id": id,
-      "error": {
-        "code": -32000,
-        "message": "MCP endpoint response ended without answering the request",
+    self.deliver_error(
+      id,
+      if bounded is None {
+        "MCP endpoint exchange exceeded \{ExchangeTimeoutMs / 1000}s"
+      } else {
+        "MCP endpoint response ended without answering the request"
       },
-    })
+    )
   }
 }
 
@@ -425,7 +404,7 @@ async fn HttpTransport::exchange(
     .unwrap_or("")
     .to_lower()
   if content_type.contains("text/event-stream") {
-    self.read_sse_stream(client, deliver, answered~)
+    read_sse_stream(client, deliver, answered~)
   } else if content_type.contains("application/json") {
     let text = client.read_all().text()
     deliver(@json.parse(text))
@@ -440,13 +419,11 @@ async fn HttpTransport::exchange(
 /// message. Multi-line `data:` fields are joined with newlines per the SSE spec;
 /// `event:`/`id:`/comment lines are ignored. Raises on a read failure (which
 /// fails the owning request) rather than masking it as a clean end of stream.
-async fn HttpTransport::read_sse_stream(
-  self : HttpTransport,
+async fn read_sse_stream(
   client : @http.Client,
   deliver : (Json) -> Unit,
   answered~ : () -> Bool,
 ) -> Unit {
-  ignore(self)
   let data = StringBuilder()
   let mut has_data = false
   let lines = SseLineReader::new(client)
@@ -581,6 +558,23 @@ fn SseLineReader::take(
   self.start = consumed
   self.scan = consumed
   @utf8.decode(bytes)
+}
+
+///|
+/// Fail a pending request with a synthesized JSON-RPC error. The endpoint
+/// never answered, so this is the only reply its caller will get; -32000 is
+/// the code the transport uses for every one of them, and it was spelled out
+/// at each site.
+fn HttpTransport::deliver_error(
+  self : HttpTransport,
+  id : Json,
+  message : String,
+) -> Unit {
+  self.deliver({
+    "jsonrpc": "2.0",
+    "id": id,
+    "error": { "code": -32000, "message": message },
+  })
 }
 
 ///|


### PR DESCRIPTION
Sweep of the MCP transports. **`mcp/stdio` came back clean** — its four cancellation blocks look duplicated but each carries different progressive cleanup and returns out of the enclosing function, which is exactly the code to leave alone. So this is `streamhttp` only, in two commits: tests, then source.

## Tests (−31)

- **A dead 13-line reply.** The mock endpoint built a `tools/list` Json and then `ignore(reply)`d it — the bytes it appears to produce are hand-written below, deliberately split at a token boundary, which is the *point* of that test. It was 14 lines pretending to be the fixture.
- **Four connect-or-fail prologs** byte-identical modulo the url, and **three `initialize` arms** byte-identical outright → `connect_or_fail` / `answer_initialize`. The unreachable-endpoint test keeps its own call: different timeout, and it wants the `None`.

## Source (all private, no `.mbti` drift)

- **`deliver_error`** — the synthesized JSON-RPC error was spelled out four times, once per way an exchange can fail a pending request. Each site now names only its message, the one thing that ever differed.
- **`run_post`'s two tail blocks were one decision.** The first fired on deadline expiry and set `answered = true` for no reason but to make the second skip. They're mutually exclusive on `bounded`, nothing suspends between them, and the flag was pure sequencing. Case check: `(None, !answered)` → timeout (before: via the flag); `(Some, !answered)` → ended-without-answering (before: via the first guard failing); `answered` → neither, both ways.
- **`read_sse_stream`** was a method opening with `ignore(self)` and never touching it — the `ignore` existed only to silence a parameter it didn't need. Plain function now.
- **`reserved_header`** was a 12-line match whose only job was `true`/`false`. Now the `is` expression it always was — the idiom already used in `cmd/viz_server` and `desktop/internal/shellenv`.

## Declined

`delete_session`'s three identical cancellation catches collapse into one `try`/`catch`, and the finder's reasoning was sound. It's the only finding touching cancellation flow, and a sweep is the wrong place to spend that risk. Left for someone with a reason to be in that function.

## Verification — and a caveat about it

| Gate | Result |
|---|---|
| root | 1168 native / 27 js / 12 wasm-gc |
| `moon check --deny-warn` | clean |
| `moon fmt --check` | clean |
| `.mbti` drift | none |
| `mcp/streamhttp` | 5/5, **all actually executed** |

**Read the codex verdict on the tests with care.** Its sandbox can't bind TCP, so four of the five streamhttp tests were skipped in its run — its clean verdict validates the source refactor, not the test one. Locally all five bind and run (`-v` confirms no `skipping` lines), which is where the test-helper change is actually exercised.

Codex: *"The production changes are behavior-preserving refactors, and the test helper extraction preserves the previous setup."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)