### PR TITLE
refactor(mcp): one optional-string read, one string-map decode, one assert

### DIFF
--- a/mcp/client.mbt
+++ b/mcp/client.mbt
@@ -14,7 +14,9 @@ pub const ProtocolVersion : String = "2025-11-25"
 /// The tool surface (`tools/list`, `tools/call`) is stable across these
 /// revisions.
 fn is_supported_version(version : String) -> Bool {
-  version == "2025-11-25" ||
+  // The preferred version is named, not respelled: this list is the one place
+  // a bump to `ProtocolVersion` would otherwise silently leave behind.
+  version == ProtocolVersion ||
   version == "2025-06-18" ||
   version == "2025-03-26" ||
   version == "2024-11-05"
@@ -79,9 +81,7 @@ pub async fn McpClient::list_tools(self : McpClient) -> Array[McpTool] {
     }
     let result = self.rpc.request(method_="tools/list", params~)
     let (page, next) = decode_tools_page(result)
-    for tool in page {
-      tools.push(tool)
-    }
+    tools.append(page)
     match next {
       Some(next) => cursor = Some(next)
       None => break

--- a/mcp/client_test.mbt
+++ b/mcp/client_test.mbt
@@ -223,8 +223,8 @@ async test "list_tools returns tools with pass-through schemas" {
     assert_true(
       tools[0].input_schema
       is {
-        "type": String("object"),
-        "properties": { "text": { "type": String("string"), .. }, .. },
+        "type": "object",
+        "properties": { "text": { "type": "string", .. }, .. },
         ..
       },
     )

--- a/mcp/config/config.mbt
+++ b/mcp/config/config.mbt
@@ -81,18 +81,7 @@ fn decode_server(name : String, entry : Json) -> McpServer raise {
       args.push(arg)
     }
   }
-  let env : Map[String, String] = Map([])
-  if entry is { "env": env_value, .. } {
-    guard env_value is Object(vars) else {
-      raise Invalid("server `\{name}`: `env` must be an object of strings")
-    }
-    for key, value in vars {
-      guard value is String(text) else {
-        raise Invalid("server `\{name}`: every `env` value must be a string")
-      }
-      env[key] = text
-    }
-  }
+  let env = decode_string_map(name, entry, "env")
   Stdio(name~, command~, args~, env~)
 }
 
@@ -108,19 +97,32 @@ fn decode_http_server(name : String, entry : Json) -> McpServer raise {
       "server `\{name}`: give `command` (stdio) or `url` (http), not both",
     )
   }
-  let headers : Map[String, String] = Map([])
-  if entry is { "headers": headers_value, .. } {
-    guard headers_value is Object(vars) else {
-      raise Invalid("server `\{name}`: `headers` must be an object of strings")
-    }
-    for key, value in vars {
-      guard value is String(text) else {
-        raise Invalid(
-          "server `\{name}`: every `headers` value must be a string",
-        )
-      }
-      headers[key] = text
-    }
-  }
+  let headers = decode_string_map(name, entry, "headers")
   Http(name~, url~, headers~)
+} ///|
+/// An optional object-of-strings field: absent yields empty, present-but-
+/// mistyped is an error. `env` and `headers` were the same twelve lines twice,
+/// differing only in the field name — which already appeared verbatim inside
+/// both of their error messages.
+
+///|
+fn decode_string_map(
+  name : String,
+  entry : Json,
+  field : String,
+) -> Map[String, String] raise {
+  let out : Map[String, String] = Map([])
+  guard entry is Object(fields) && fields.get(field) is Some(value) else {
+    return out
+  }
+  guard value is Object(vars) else {
+    raise Invalid("server `\{name}`: `\{field}` must be an object of strings")
+  }
+  for key, item in vars {
+    guard item is String(text) else {
+      raise Invalid("server `\{name}`: every `\{field}` value must be a string")
+    }
+    out[key] = text
+  }
+  out
 }

--- a/mcp/config/config_wbtest.mbt
+++ b/mcp/config/config_wbtest.mbt
@@ -1,4 +1,20 @@
 ///|
+/// Assert that `decode` rejects this configuration. Every test below differs
+/// only in its fixture; the chain that turns the raise into a comparable
+/// string — and the `_ => "other"` arm that keeps an unexpected error from
+/// reading as a pass — was copied into each of them.
+fn assert_invalid(json : Json) -> Unit raise {
+  let outcome = try {
+    decode(json) |> ignore
+    "no error"
+  } catch {
+    Invalid(_) => "invalid"
+    _ => "other"
+  }
+  assert_eq(outcome, "invalid")
+}
+
+///|
 test "decode parses a stdio server with args and env" {
   let servers = decode({
     "mcpServers": {
@@ -36,64 +52,29 @@ test "decode accepts an empty mcpServers object" {
 
 ///|
 test "decode raises without an mcpServers object" {
-  let outcome = try {
-    decode(Json::empty_object()) |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(outcome, "invalid")
+  assert_invalid(Json::empty_object())
 }
 
 ///|
 test "decode raises for a server missing a command" {
-  let outcome = try {
-    decode({ "mcpServers": { "x": { "args": ["a"] } } }) |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(outcome, "invalid")
+  assert_invalid({ "mcpServers": { "x": { "args": ["a"] } } })
 }
 
 ///|
 test "decode raises for a non-string arg" {
-  let outcome = try {
-    decode({ "mcpServers": { "x": { "command": "run", "args": [1] } } })
-    |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(outcome, "invalid")
+  assert_invalid({ "mcpServers": { "x": { "command": "run", "args": [1] } } })
 }
 
 ///|
 test "decode raises for a present but mistyped args" {
-  let outcome = try {
-    decode({ "mcpServers": { "x": { "command": "run", "args": "--flag" } } })
-    |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(outcome, "invalid")
+  assert_invalid({
+    "mcpServers": { "x": { "command": "run", "args": "--flag" } },
+  })
 }
 
 ///|
 test "decode raises for a present but mistyped env" {
-  let outcome = try {
-    decode({ "mcpServers": { "x": { "command": "run", "env": [] } } }) |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(outcome, "invalid")
+  assert_invalid({ "mcpServers": { "x": { "command": "run", "env": [] } } })
 }
 
 ///|
@@ -134,17 +115,9 @@ test "decode defaults missing http headers" {
 
 ///|
 test "decode rejects a server with both command and url" {
-  let outcome = try {
-    decode({
-      "mcpServers": { "x": { "command": "run", "url": "http://h/mcp" } },
-    })
-    |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(outcome, "invalid")
+  assert_invalid({
+    "mcpServers": { "x": { "command": "run", "url": "http://h/mcp" } },
+  })
 }
 
 ///|

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -151,12 +151,12 @@ fn decode_call_result(result : Json) -> CallToolResult raise {
 /// `type`.
 fn decode_content_block(block : Json) -> ContentBlock raise {
   match block {
-    { "type": String("text"), "text": String(text), .. } => Text(text)
-    { "type": String("image"), .. } => {
+    { "type": "text", "text": String(text), .. } => Text(text)
+    { "type": "image", .. } => {
       let mime_type = optional_string(block, "mimeType").unwrap_or("")
       Image(mime_type~)
     }
-    { "type": String("resource"), "resource": resource, .. } => {
+    { "type": "resource", "resource": resource, .. } => {
       let uri = optional_string(resource, "uri").unwrap_or("")
       let text = optional_string(resource, "text")
       Resource(uri~, text~)

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -90,10 +90,7 @@ fn decode_initialize_result(result : Json) -> InitializeResult raise {
     { "serverInfo": { "version": String(version), .. }, .. } => version
     _ => ""
   }
-  let instructions = match result {
-    { "instructions": String(text), .. } => Some(text)
-    _ => None
-  }
+  let instructions = optional_string(result, "instructions")
   { protocol_version, server_name, server_version, instructions }
 }
 
@@ -105,14 +102,8 @@ fn decode_tools_page(result : Json) -> (Array[McpTool], String?) raise {
   guard result is { "tools": Array(entries), .. } else {
     raise Protocol("tools/list result is missing a `tools` array")
   }
-  let tools = []
-  for entry in entries {
-    tools.push(decode_tool(entry))
-  }
-  let cursor = match result {
-    { "nextCursor": String(cursor), .. } => Some(cursor)
-    _ => None
-  }
+  let tools = entries.map(decode_tool)
+  let cursor = optional_string(result, "nextCursor")
   (tools, cursor)
 }
 
@@ -122,10 +113,7 @@ fn decode_tool(entry : Json) -> McpTool raise {
   guard entry is { "name": String(name), .. } else {
     raise Protocol("tool entry is missing a string `name`")
   }
-  let description = match entry {
-    { "description": String(description), .. } => description
-    _ => ""
-  }
+  let description = optional_string(entry, "description").unwrap_or("")
   let input_schema = match entry {
     { "inputSchema": schema, .. } => schema
     _ => default_object_schema()
@@ -165,21 +153,12 @@ fn decode_content_block(block : Json) -> ContentBlock raise {
   match block {
     { "type": String("text"), "text": String(text), .. } => Text(text)
     { "type": String("image"), .. } => {
-      let mime_type = match block {
-        { "mimeType": String(mime_type), .. } => mime_type
-        _ => ""
-      }
+      let mime_type = optional_string(block, "mimeType").unwrap_or("")
       Image(mime_type~)
     }
     { "type": String("resource"), "resource": resource, .. } => {
-      let uri = match resource {
-        { "uri": String(uri), .. } => uri
-        _ => ""
-      }
-      let text = match resource {
-        { "text": String(text), .. } => Some(text)
-        _ => None
-      }
+      let uri = optional_string(resource, "uri").unwrap_or("")
+      let text = optional_string(resource, "text")
       Resource(uri~, text~)
     }
     { "type": String(kind), .. } => Other(kind~)
@@ -229,4 +208,16 @@ pub fn CallToolResult::render_text(self : CallToolResult) -> String {
     }
     None => text
   }
+} ///|
+/// The string at `key`, or nothing when the field is absent or not a string.
+///
+/// Only for the fields MCP lets a server omit — every `guard ... else raise
+/// Protocol` in this file stays exactly as strict as it was.
+
+///|
+fn optional_string(json : Json, key : String) -> String? {
+  guard json is Object(fields) && fields.get(key) is Some(String(text)) else {
+    return None
+  }
+  Some(text)
 }

--- a/mcp/types_wbtest.mbt
+++ b/mcp/types_wbtest.mbt
@@ -9,7 +9,7 @@ test "decode_tool reads all fields" {
   })
   assert_eq(tool.name, "search")
   assert_eq(tool.description, "Search the web")
-  assert_true(tool.input_schema is { "type": String("object"), .. })
+  assert_true(tool.input_schema is { "type": "object", .. })
 }
 
 ///|
@@ -17,7 +17,7 @@ test "decode_tool defaults a missing description and schema" {
   let tool = decode_tool({ "name": "bare" })
   assert_eq(tool.name, "bare")
   assert_eq(tool.description, "")
-  assert_true(tool.input_schema is { "type": String("object"), .. })
+  assert_true(tool.input_schema is { "type": "object", .. })
 }
 
 ///|


### PR DESCRIPTION
Sweep of the MCP core and its config decoder. Both are strict where they should be, and **every change preserves that exactly** — no `guard … else raise Protocol` is touched, and every error message is byte-identical.

## Source

- **`optional_string`** — `types.mbt` read "the string at this key, or nothing" **six times**, in two spellings: four wanting an `Option`, two defaulting to `""`. Stated once; the defaulting sites now say `.unwrap_or("")`, which is the difference they actually have. It reads only the fields MCP lets a server omit — the required ones still raise.
- **`decode_string_map`** — `env` and `headers` were the same twelve lines twice, differing only in the field name, *which already appeared verbatim inside both of their error messages*. Only two sites, under the usual 3+ bar, but the parameterization is exact and costs nothing.
- **Two push loops** are what they meant: `entries.map(decode_tool)` (`map` is raise-polymorphic, so `Protocol` propagates identically) and `tools.append(page)`.
- **`is_supported_version`** respelled `"2025-11-25"` nine lines under the `ProtocolVersion` const that defines it — the one line a version bump would silently leave behind. It names the const now.

## Tests

`config_wbtest.mbt` copied the same try/catch/assert chain into **six** tests, differing only in the fixture. `assert_invalid` takes it; each test is now the configuration it's about. The `_ => "other"` arm — the thing that keeps an unexpected error from reading as a pass — exists once.

## For the next sweep

`Json::value` is **deprecated** (suggestion: `if json is Object(obj) { obj.get(key) }`). The finder verified it exists but not that it's live; `--deny-warn` caught it, so both new helpers pattern-match instead.

## Verification

| Gate | Result |
|---|---|
| root | 1168 native / 27 js / 12 wasm-gc |
| `mcp` | 23/23 |
| `mcp/config` | 13/13 |
| `moon check --deny-warn` | clean |
| `.mbti` drift | none |

**Codex: clean** — *"The refactors preserve existing decoding, pagination, validation, and protocol-version behavior."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)