### PR TITLE
refactor(mcp/tools): flatten with append, name the provider alphabet

### DIFF
--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -56,11 +56,7 @@ pub fn tool_name(server : String, tool : String) -> String {
 fn sanitize_segment(segment : String) -> String {
   let out = StringBuilder()
   for ch in segment {
-    if (ch >= 'a' && ch <= 'z') ||
-      (ch >= 'A' && ch <= 'Z') ||
-      (ch >= '0' && ch <= '9') ||
-      ch == '_' ||
-      ch == '-' {
+    if ch.is_ascii_alphabetic() || ch.is_ascii_digit() || ch == '_' || ch == '-' {
       out.write_char(ch)
     } else {
       out.write_char('-')
@@ -145,9 +141,7 @@ pub async fn[X] build(
       discovery_timeout_ms~,
     ) {
     let (_, contributed) = entry
-    for tool in contributed {
-      tools.push(tool)
-    }
+    tools.append(contributed)
   }
   tools
 }

--- a/mcp/tools/tools_test.mbt
+++ b/mcp/tools/tools_test.mbt
@@ -119,7 +119,7 @@ async test "tools_for_client bridges tools with namespaced names and schemas" {
     assert_eq(tools[0].name, "mcp__srv__echo")
     assert_eq(tools[0].description, "Echoes")
     let @agent_tool.JsonSchema(schema) = tools[0].schema
-    assert_true(schema is { "type": String("object"), .. })
+    assert_true(schema is { "type": "object", .. })
   })
 }
 
@@ -276,9 +276,9 @@ async test "build bridges and dispatches tools from an http server" {
             _ => Json::null()
           }
           match message {
-            { "method": String("initialize"), .. } =>
+            { "method": "initialize", .. } =>
               respond_json(conn, id, { "protocolVersion": "2025-11-25" })
-            { "method": String("tools/list"), .. } =>
+            { "method": "tools/list", .. } =>
               respond_json(conn, id, {
                 "tools": [
                   {
@@ -288,7 +288,7 @@ async test "build bridges and dispatches tools from an http server" {
                   },
                 ],
               })
-            { "method": String("tools/call"), .. } =>
+            { "method": "tools/call", .. } =>
               respond_json(conn, id, {
                 "content": [{ "type": "text", "text": "pong" }],
               })


### PR DESCRIPTION
Sweep of the MCP tool registry. Two findings; the rest of the package — the name capping, uniquifying, and the schema/description budgets — is guard code and stays exactly as written.

- **`build`** delegated to `build_grouped` and then copied each group's tools out one at a time. `append` says what it meant: flatten the groups.
- **`sanitize_segment`** open-coded `[A-Za-z0-9_-]` as three range comparisons. `is_ascii_alphabetic`/`is_ascii_digit` are exactly those ranges, so the accepted set is **preserved verbatim rather than re-derived** — which matters, because this is the guard keeping a server's tool name inside the provider's function-name rules. It's the idiom `tui/internal/composer/text_cursor.mbt` already uses; core has no `is_ascii_alphanumeric`.

## Considered and left

- `CallTimeoutMs`/`DefaultDiscoveryTimeoutMs` are `pub` with no consumer outside the package — but so are the sibling tunables in `mcp/stdio`, `mcp/streamhttp` and `agent_tool/shell`. That's house convention, not dead code.
- A helper for the three stdio `build` tests would need four parameters to serve three sites: the parameterization costs what the duplication does.

Tests: **7/7**, including the sanitizer's accepted-set assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)