### PR TITLE
test(jsonrpc): one failing-request helper, not six copies of the plumbing

### DIFF
--- a/jsonrpc/client_wbtest.mbt
+++ b/jsonrpc/client_wbtest.mbt
@@ -137,8 +137,8 @@ async test "concurrent requests each get their own reply even when answered out 
     let second = group.spawn(() => {
       client.request(method_="second", params=Json::empty_object())
     })
-    assert_true(first.wait() is { "method": String("first"), .. })
-    assert_true(second.wait() is { "method": String("second"), .. })
+    assert_true(first.wait() is { "method": "first", .. })
+    assert_true(second.wait() is { "method": "second", .. })
   })
 }
 
@@ -162,12 +162,12 @@ async test "a delivered reply never waits behind other outstanding requests" {
     let mut third_request = Json::null()
     for _ in 0..<3 {
       let sent = transport.outbound.get()
-      if sent is { "method": String("third"), .. } {
+      if sent is { "method": "third", .. } {
         third_request = sent
       }
     }
     transport.inbound.put(reply_for(third_request))
-    assert_true(third.wait() is { "method": String("third"), .. })
+    assert_true(third.wait() is { "method": "third", .. })
   })
 }
 
@@ -247,8 +247,8 @@ async test "a batched array reply routes each element" {
     let b = group.spawn(() => {
       client.request(method_="b", params=Json::empty_object())
     })
-    assert_true(a.wait() is { "method": String("a"), .. })
-    assert_true(b.wait() is { "method": String("b"), .. })
+    assert_true(a.wait() is { "method": "a", .. })
+    assert_true(b.wait() is { "method": "b", .. })
   })
 }
 
@@ -292,7 +292,7 @@ async test "a reply for an unknown id is dropped and the client stays usable" {
       transport.inbound.put(reply_for(request))
     })
     let result = client.request(method_="real", params=Json::empty_object())
-    assert_true(result is { "method": String("real"), .. })
+    assert_true(result is { "method": "real", .. })
   })
 }
 
@@ -401,7 +401,7 @@ async test "notify enqueues an id-less message the writer sends" {
       params=Json::empty_object(),
     )
     let sent = transport.outbound.get()
-    assert_true(sent is { "method": String("notifications/initialized"), .. })
+    assert_true(sent is { "method": "notifications/initialized", .. })
     assert_true(!(sent is { "id": _, .. }))
   })
 }

--- a/jsonrpc/client_wbtest.mbt
+++ b/jsonrpc/client_wbtest.mbt
@@ -102,6 +102,23 @@ fn error_for(request : Json, code : Int, message : String) -> Json {
 }
 
 ///|
+/// Issue a request expected to fail, rendering the outcome as a comparable
+/// string — so an unexpected success is a readable assertion rather than a
+/// hang. The cancellation guard is the easy thing to forget when adding the
+/// next one of these; it lives here now, once.
+async fn request_outcome(client : Client, method_ : String) -> String {
+  try {
+    client.request(method_~, params=Json::empty_object()) |> ignore
+    "no error raised"
+  } catch {
+    Failed(code~, message~) => "failed \{code} \{message}"
+    Closed => "closed"
+    error if @async.is_being_cancelled() => raise error
+    _ => "other error"
+  }
+}
+
+///|
 async test "concurrent requests each get their own reply even when answered out of order" {
   @async.with_task_group(group => {
     let transport = new_transport()
@@ -163,15 +180,7 @@ async test "a request raises Failed on a JSON-RPC error reply" {
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       transport.inbound.put(error_for(transport.outbound.get(), -32601, "nope"))
     })
-    let outcome = try {
-      client.request(method_="tools/call", params=Json::empty_object())
-      |> ignore
-      "no error raised"
-    } catch {
-      Failed(code~, message~) => "failed \{code} \{message}"
-      error if @async.is_being_cancelled() => raise error
-      _ => "other error"
-    }
+    let outcome = request_outcome(client, "tools/call")
     assert_eq(outcome, "failed -32601 nope")
   })
 }
@@ -193,14 +202,7 @@ async test "a reply with both result and error surfaces the error" {
         "error": { "code": -32000, "message": "both" },
       })
     })
-    let outcome = try {
-      client.request(method_="x", params=Json::empty_object()) |> ignore
-      "no error raised"
-    } catch {
-      Failed(code~, message~) => "failed \{code} \{message}"
-      error if @async.is_being_cancelled() => raise error
-      _ => "other error"
-    }
+    let outcome = request_outcome(client, "x")
     assert_eq(outcome, "failed -32000 both")
   })
 }
@@ -320,14 +322,7 @@ async test "a request fails with Closed when the transport ends without a reply"
       transport.outbound.get() |> ignore
       transport.inbound.close()
     })
-    let outcome = try {
-      client.request(method_="ping", params=Json::empty_object()) |> ignore
-      "no error raised"
-    } catch {
-      Closed => "closed"
-      error if @async.is_being_cancelled() => raise error
-      _ => "other error"
-    }
+    let outcome = request_outcome(client, "ping")
     assert_eq(outcome, "closed")
     assert_true(client.is_closed())
   })
@@ -343,14 +338,7 @@ async test "a failed send closes the client and stops both tasks" {
     })
     let pump = group.spawn(() => client.run_message_pump())
     let writer = group.spawn(() => client.run_writer())
-    let outcome = try {
-      client.request(method_="ping", params=Json::empty_object()) |> ignore
-      "no error raised"
-    } catch {
-      Closed => "closed"
-      error if @async.is_being_cancelled() => raise error
-      _ => "other error"
-    }
+    let outcome = request_outcome(client, "ping")
     assert_eq(outcome, "closed")
     assert_true(client.is_closed())
     pump.wait()
@@ -391,14 +379,7 @@ async test "a request after close raises Closed and notify is a no-op" {
     let client = Client::new(transport)
     client.close()
     assert_true(client.is_closed())
-    let outcome = try {
-      client.request(method_="ping", params=Json::empty_object()) |> ignore
-      "returned"
-    } catch {
-      Closed => "closed"
-      error if @async.is_being_cancelled() => raise error
-      _ => "other error"
-    }
+    let outcome = request_outcome(client, "ping")
     assert_eq(outcome, "closed")
     // notify after close must not raise.
     client.notify(

--- a/jsonrpc/protocol_wbtest.mbt
+++ b/jsonrpc/protocol_wbtest.mbt
@@ -7,8 +7,8 @@ test "build_request carries jsonrpc, numeric id, method and params" {
     is {
       "jsonrpc": String("2.0"),
       "id": Number(7, ..),
-      "method": String("tools/list"),
-      "params": { "name": String("list"), "cursor": String("abc"), .. },
+      "method": "tools/list",
+      "params": { "name": "list", "cursor": "abc", .. },
       ..
     },
   )
@@ -20,7 +20,7 @@ test "build_notification omits the id" {
     "notifications/initialized",
     Json::empty_object(),
   )
-  assert_true(note is { "method": String("notifications/initialized"), .. })
+  assert_true(note is { "method": "notifications/initialized", .. })
   assert_true(!(note is { "id": _, .. }))
 }
 

--- a/jsonrpc/protocol_wbtest.mbt
+++ b/jsonrpc/protocol_wbtest.mbt
@@ -160,10 +160,7 @@ test "classify_incoming treats a present null id as a peer request" {
 
 ///|
 test "classify_incoming treats an id-less, method-less message as unknown" {
-  match classify_incoming({ "jsonrpc": "2.0" }) {
-    Unknown => ()
-    _ => fail("expected Unknown")
-  }
+  assert_true(classify_incoming({ "jsonrpc": "2.0" }) is Unknown)
 }
 
 ///|


### PR DESCRIPTION
Sweep of the `jsonrpc` package. **Its library code came back clean** — `protocol.mbt` and `client.mbt` have no duplication, no dead public API (every `.mbti` item is reached; `set_notification_handler` and `is_closed` from `desktop/internal/lsp`), and no hand-rolled loop core would replace. This is tests only.

## The win

Six tests each carried the same eight lines: issue a request, stringify the outcome, catch `Failed`/`Closed`, re-raise cancellation, fall through to `"other error"`. Only the method name differed.

**The point isn't the ~30 lines.** It's that the cancellation guard — the arm you forget when adding the seventh of these, and whose absence turns a cancelled test into a *hang* rather than a failure — now exists once.

Two sentinels unify: two sites said `"returned"` where four said `"no error raised"`. Both are only reachable when the test is already failing, and every site asserts a different string, so pass/fail is identical at each.

Also: a 4-line `match { Unknown => (); _ => fail(...) }` became the `assert_true(… is Unknown)` the same file already uses two tests earlier. Two more like it have multi-line arguments and are left — 4 lines each, not worth a fragile rewrite.

## Verification

| Gate | Result |
|---|---|
| `jsonrpc` | 29/29 |
| root | 1168 native / 27 js / 12 wasm-gc |
| `moon check --deny-warn` | clean |
| `.mbti` drift | none |

🤖 Generated with [Claude Code](https://claude.com/claude-code)