### PR TITLE
Refactor goal argument decoding and documentation

### DIFF
--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -310,6 +310,29 @@ async fn AgentLoop::flush_goal_tombstone(
 /// finish check. Either with no standing goal is an error result — a
 /// semantic assertion against missing state should read as model confusion
 /// in the transcript, not success.
+fn decode_goal_status(arguments : Json) -> Result[@goal.GoalStatus, String] {
+  try @goal.decode_status(arguments) catch {
+    error => Err(goal_decode_failure_message("\{error}"))
+  } noraise {
+    status => Ok(status)
+  }
+}
+
+///|
+/// Strip MoonBit's source-bearing `fail(...)` wrapper at the agent boundary.
+/// Tool packages normally share `agent_tool/internal/error`, but the agent is
+/// outside that internal visibility boundary.
+fn goal_decode_failure_message(error_text : String) -> String {
+  let marker = " FAILED: "
+  guard error_text.rev_find(marker) is Some(cut) else { return error_text }
+  let message = error_text[cut + marker.length():]
+  match message.strip_suffix(")") {
+    Some(trimmed) => trimmed.to_owned()
+    None => message.to_owned()
+  }
+}
+
+///|
 async fn AgentLoop::handle_goal_tool_call(
   self : Self,
   session : @agent_session.Session,
@@ -317,7 +340,7 @@ async fn AgentLoop::handle_goal_tool_call(
   tool_call : @agent_tool.AgentToolCall,
 ) -> ToolCallOutcome {
   let verdict = (
-    @goal.decode_status(tool_call.arguments),
+    decode_goal_status(tool_call.arguments),
     self.goal_cadence.goal,
   )
   // A continue that resumes a durably blocked goal reports the resume, so the

--- a/agent/goal_wbtest.mbt
+++ b/agent/goal_wbtest.mbt
@@ -1,0 +1,9 @@
+///|
+test "raising goal decoder errors stay actionable at the agent boundary" {
+  debug_inspect(
+    decode_goal_status({ "status": "continuing" }),
+    content=(
+      #|Err("goal requires a string \"remaining\" when status is \"continuing\"")
+    ),
+  )
+}

--- a/agent_tool/goal/README.mbt.md
+++ b/agent_tool/goal/README.mbt.md
@@ -1,47 +1,70 @@
-# `goal` — the structured goal-status tool
+# Goal Tool
 
-The `goal` tool is how the model reports where the **standing session goal**
-stands, as data instead of prose. It exists so the engine can stop, chain, or
-keep working on a durable signal — never on parsing the model's phrasing.
+`goal` reports a structured verdict about the standing session goal. The
+agent loop uses that verdict to decide whether to stop autonomous work,
+continue it in another turn, or pause for the user. It never has to infer goal
+state from prose in the assistant response.
+
+The tool is registered only while a goal stands. Calling it without a standing
+goal is a semantic error handled by the agent loop.
 
 ## Arguments
 
-- `status` (string, required): `"met"` or `"continuing"`.
-- `remaining` (string, required when `status` is `"continuing"`): what is
-  still left to do — must be non-blank, because this text is the durable
-  record whoever (or whatever turn) resumes the goal will read.
+| `status` | Required companion field | Meaning |
+| --- | --- | --- |
+| `"met"` | none | The goal is fully achieved and verified. |
+| `"continuing"` | `remaining` (non-blank string) | Work remains and can continue autonomously. |
+| `"blocked"` | `reason` (non-blank string) | Progress requires user action or an external-state change. |
 
-## Result
+`blocked` is for a genuine impasse, not a failed command or another recoverable
+problem. A later `continuing` verdict resumes a blocked goal.
 
-This package only **decodes**; the action is the agent loop's. The loop
-intercepts a `goal` call instead of dispatching it like an ordinary tool:
+The JSON schema declares unknown fields invalid. Conditional requirements for
+`remaining` and `reason` are enforced by the decoder in
+`agent_tool/goal/internal/decode`.
 
-- `goal(met)` — the standing goal stops standing immediately (the finish
-  check disarms) and a durable `[goal cleared]` tombstone lands at the next
-  batch-safe boundary. Under auto-continue this is the **structural stop**:
-  the chain ends on the tombstone, not on trusting an answer's wording.
-- `goal(continuing)` — answers exactly what the finish check asks, so the
-  check disarms for the rest of the turn and the turn may end with the goal
-  still standing; `remaining` is recorded for the next turn.
-- Invalid arguments come back as an error tool result naming the exact
-  problem, so the model can re-issue the call without guessing.
+## Lifecycle Effects
 
-The tool is registered only while a goal stands; `GoalCadence` selects the
-tool-aware finish-check wording when it is (see `agent/goal.mbt`).
+- `met` clears the standing goal. The loop writes a durable `[goal cleared]`
+  marker at the next batch-safe boundary; under auto-continuation, that marker
+  is the structural stop signal.
+- `continuing` records the actionable remainder and satisfies the finish check
+  for the current turn. The goal remains standing. If it was blocked, the loop
+  also records `[goal unblocked]` and resumes auto-continuation.
+- `blocked` records why work cannot proceed and writes `[goal blocked]`. The
+  goal remains standing for the user, but auto-continuation pauses.
 
-## Example
+The agent loop intercepts `goal` calls because it owns the standing state and
+durable log. The definition's executor is only a stateless fallback for direct
+registry dispatch: it validates the arguments and responds without changing
+goal state.
 
-```moonbit check
+## Schema
+
+This checked example doubles as a readable snapshot of the tool's public JSON
+contract:
+
+```mbt check
 ///|
-test "goal arguments decode to structured verdicts" {
-  assert_true(@goal.decode_status({ "status": "met" }) is Ok(Met))
-  assert_true(
-    @goal.decode_status({ "status": "continuing", "remaining": "wire the CLI" })
-    is Ok(Continuing("wire the CLI")),
-  )
-  // A blank `remaining` is rejected: the durable record must be actionable.
-  assert_true(
-    @goal.decode_status({ "status": "continuing", "remaining": "  " }) is Err(_),
-  )
+test "goal tool schema" {
+  let tool = @goal.definition()
+  assert_eq(tool.name, "goal")
+  assert_true(tool.control)
+  json_inspect(tool.schema.0, content={
+    "type": "object",
+    "properties": {
+      "status": { "type": "string", "enum": ["met", "continuing", "blocked"] },
+      "remaining": {
+        "type": "string",
+        "description": "Required when status is \"continuing\": one or two lines on what is left to reach the goal.",
+      },
+      "reason": {
+        "type": "string",
+        "description": "Why the goal cannot proceed; required with status \"blocked\".",
+      },
+    },
+    "required": ["status"],
+    "additionalProperties": false,
+  })
 }
 ```

--- a/agent_tool/goal/README.mbt.md
+++ b/agent_tool/goal/README.mbt.md
@@ -68,3 +68,85 @@ test "goal tool schema" {
   })
 }
 ```
+
+## Decoded Verdicts
+
+`decode_status` is the public facade used by the agent loop. It preserves the
+package-owned `GoalStatus` type while delegating raw JSON validation to the
+internal decoder:
+
+```mbt check
+///|
+test "decode every goal verdict" {
+  debug_inspect(
+    [
+      @goal.decode_status({ "status": "met" }),
+      @goal.decode_status({
+        "status": "continuing",
+        "remaining": "run the integration tests",
+      }),
+      @goal.decode_status({
+        "status": "blocked",
+        "reason": "waiting for repository access",
+      }),
+    ],
+    content=(
+      #|[
+      #|  Met,
+      #|  Continuing("run the integration tests"),
+      #|  Blocked("waiting for repository access"),
+      #|]
+    ),
+  )
+}
+```
+
+## Stateless Fallback
+
+Normal agent-loop dispatch intercepts `goal` and performs the lifecycle effects
+described above. Direct registry dispatch uses the definition's stateless
+fallback instead: valid arguments receive an acknowledgment, while malformed
+arguments receive an actionable error without changing standing-goal state.
+
+```mbt check
+///|
+async test "goal fallback validates registry calls" {
+  let tools = @agent_tool.Tools([@goal.definition()])
+  let accepted = @agent_tool.AgentToolCall(
+    ToolCall(
+      id="call_goal_met",
+      name="goal",
+      arguments=(
+        #|{ "status": "met" }
+      ),
+    ),
+  )
+  let rejected = @agent_tool.AgentToolCall(
+    ToolCall(
+      id="call_goal_continuing",
+      name="goal",
+      arguments=(
+        #|{ "status": "continuing" }
+      ),
+    ),
+  )
+  debug_inspect(
+    [
+      @agent_tool.execute_tool_call(accepted, tools),
+      @agent_tool.execute_tool_call(rejected, tools),
+    ],
+    content=(
+      #|[
+      #|  Respond({ content: "goal status recorded", is_error: false, brief: None }),
+      #|  Respond(
+      #|    {
+      #|      content: "error: goal requires a string \"remaining\" when status is \"continuing\"",
+      #|      is_error: true,
+      #|      brief: None,
+      #|    },
+      #|  ),
+      #|]
+    ),
+  )
+}
+```

--- a/agent_tool/goal/goal.mbt
+++ b/agent_tool/goal/goal.mbt
@@ -1,44 +1,29 @@
 ///|
-/// Decoded `goal` tool arguments: the model's structured verdict on the
-/// standing session goal.
+/// The model's structured verdict about the standing session goal.
+///
+/// This public type is owned by the `goal` package because the agent loop
+/// consumes it. Raw JSON decoding is delegated to `internal/decode` and mapped
+/// into this package-owned API.
 pub(all) enum GoalStatus {
+  /// The goal is fully achieved and verified.
   Met
+  /// Work remains and can continue autonomously.
   Continuing(String)
-  /// The goal cannot proceed (impossible, blocked, or superseded): it
-  /// keeps standing for the user, but auto-continuation pauses.
+  /// Progress requires user action or an external-state change.
   Blocked(String)
 } derive(Debug)
 
 ///|
-/// Decode and validate `goal` tool-call arguments. `met` needs nothing else;
-/// `continuing` requires a non-blank `remaining` — the durable record must be
-/// actionable for whoever (or whatever turn) resumes the goal.
-pub fn decode_status(arguments : Json) -> Result[GoalStatus, String] {
-  match arguments {
-    { "status": "met", .. } => Ok(Met)
-    { "status": "continuing", "remaining": String(remaining), .. } =>
-      if remaining.trim().is_empty() {
-        Err(
-          "goal requires a non-blank \"remaining\" when status is \"continuing\"",
-        )
-      } else {
-        Ok(Continuing(remaining))
-      }
-    { "status": "continuing", .. } =>
-      Err("goal requires a string \"remaining\" when status is \"continuing\"")
-    { "status": "blocked", "reason": String(reason), .. } =>
-      if reason.trim().is_empty() {
-        Err("goal requires a non-blank \"reason\" when status is \"blocked\"")
-      } else {
-        Ok(Blocked(reason))
-      }
-    { "status": "blocked", .. } =>
-      Err("goal requires a string \"reason\" when status is \"blocked\"")
-    { "status": String(other), .. } =>
-      Err(
-        "goal status must be \"met\", \"continuing\", or \"blocked\", got \"\{other}\"",
-      )
-    _ => Err("goal requires a string \"status\" field")
+/// Decode and validate a `goal` verdict.
+///
+/// The argument-shape rules live in `internal/decode`; this facade keeps the
+/// public result type owned by `agent_tool/goal` so sibling packages do not
+/// depend on an internal implementation package.
+pub fn decode_status(arguments : Json) -> GoalStatus raise {
+  match @decode.decode(arguments) {
+    Met => Met
+    Continuing(remaining) => Continuing(remaining)
+    Blocked(reason) => Blocked(reason)
   }
 }
 
@@ -46,7 +31,8 @@ pub fn decode_status(arguments : Json) -> Result[GoalStatus, String] {
 /// Tool definition for `goal`: record the standing goal's status as
 /// structured state instead of prose, so the engine can act on it — `met`
 /// durably clears the goal (the auto-continue termination signal) and
-/// `continuing` records what remains.
+/// `continuing` records what remains. `blocked` keeps the goal standing but
+/// pauses auto-continuation until the user intervenes or work resumes.
 ///
 /// The agent loop intercepts calls to this tool before execution: only the
 /// loop knows whether a goal currently stands and owns the durable log, and
@@ -82,9 +68,12 @@ pub fn definition() -> @agent_tool.AgentToolDefinition {
 
 ///|
 fn execute(arguments : Json) -> @agent_tool.ToolAction {
-  match decode_status(arguments) {
-    Ok(_) => @agent_tool.ToolAction::respond("goal status recorded")
-    Err(message) =>
+  try @decode.decode(arguments) catch {
+    error => {
+      let message = @tool_error.failure_message("\{error}")
       @agent_tool.ToolAction::respond("error: \{message}", is_error=true)
+    }
+  } noraise {
+    _ => @agent_tool.ToolAction::respond("goal status recorded")
   }
 }

--- a/agent_tool/goal/goal_test.mbt
+++ b/agent_tool/goal/goal_test.mbt
@@ -1,35 +1,27 @@
 ///|
-test "goal status decodes met and continuing" {
-  assert_true(@goal.decode_status({ "status": "met" }) is Ok(Met))
-  assert_true(
-    @goal.decode_status({ "status": "continuing", "remaining": "parser left" })
-    is Ok(Continuing("parser left")),
+test "goal status facade exposes decoded verdicts" {
+  debug_inspect(
+    [
+      @goal.decode_status({ "status": "met" }),
+      @goal.decode_status({ "status": "continuing", "remaining": "parser left" }),
+      @goal.decode_status({
+        "status": "blocked",
+        "reason": "waiting for credentials",
+      }),
+    ],
+    content=(
+      #|[Met, Continuing("parser left"), Blocked("waiting for credentials")]
+    ),
   )
 }
 
 ///|
-test "goal status rejects malformed arguments" {
-  guard @goal.decode_status({ "status": "continuing" }) is Err(message) else {
-    fail("continuing without remaining accepted")
-  }
-  assert_true(message.contains("remaining"))
-  guard @goal.decode_status({ "status": "continuing", "remaining": "  " })
-    is Err(message) else {
-    fail("blank remaining accepted")
-  }
-  assert_true(message.contains("non-blank"))
-  guard @goal.decode_status({ "status": "done" }) is Err(message) else {
-    fail("unknown status accepted")
-  }
-  assert_true(message.contains("met"))
-  guard @goal.decode_status({ "remaining": "x" }) is Err(message) else {
-    fail("missing status accepted")
-  }
-  assert_true(message.contains("status"))
-}
-
-///|
-test "goal definition validates through its fallback execute" {
+test "goal definition identifies a control tool" {
   let definition = @goal.definition()
-  assert_eq(definition.name, "goal")
+  debug_inspect(
+    (definition.name, definition.control),
+    content=(
+      #|("goal", true)
+    ),
+  )
 }

--- a/agent_tool/goal/internal/decode/README.mbt.md
+++ b/agent_tool/goal/internal/decode/README.mbt.md
@@ -1,0 +1,86 @@
+# Goal Argument Decoder
+
+`bobzhang/openseek/agent_tool/goal/internal/decode` converts raw JSON tool
+arguments into a typed `GoalStatus` consumed by the parent `goal` package.
+The parent maps it to its own public `GoalStatus`, which keeps sibling packages
+from depending on this internal implementation package.
+
+This package owns only argument-shape validation. It does not inspect or
+change the standing goal, write durable markers, or control auto-continuation;
+those stateful effects belong to the agent loop.
+
+## API
+
+- `GoalStatus` is `Met`, `Continuing(remaining)`, or `Blocked(reason)`.
+- `decode(arguments)` returns `GoalStatus` or raises an actionable `Failure`.
+
+## Decoding Rules
+
+| `status` | Required companion field | Decoded value |
+| --- | --- | --- |
+| `"met"` | none | `Met` |
+| `"continuing"` | non-blank string `remaining` | `Continuing(remaining)` |
+| `"blocked"` | non-blank string `reason` | `Blocked(reason)` |
+
+Blankness is checked after trimming, but successful text is preserved exactly
+for the durable record. Extra fields are ignored by this decoder; the parent
+tool's JSON schema declares them invalid for callers.
+
+## Successful Verdicts
+
+The snapshot shows the complete typed result for every supported status:
+
+```mbt check
+///|
+test "decode supported goal verdicts" {
+  debug_inspect(
+    [
+      @decode.decode({ "status": "met" }),
+      @decode.decode({ "status": "continuing", "remaining": "wire the CLI" }),
+      @decode.decode({
+        "status": "blocked",
+        "reason": "waiting for credentials",
+      }),
+    ],
+    content=(
+      #|[Met, Continuing("wire the CLI"), Blocked("waiting for credentials")]
+    ),
+  )
+}
+```
+
+## Validation Errors
+
+Failures say which field must be repaired, making the returned tool error
+useful without parsing or pattern matching in the caller:
+
+```mbt check
+///|
+test "decode actionable validation errors" {
+  debug_inspect(
+    [
+      decode_error_for_docs({ "status": "continuing" }),
+      decode_error_for_docs({ "status": "blocked", "reason": "  " }),
+      decode_error_for_docs({ "status": "done" }),
+      decode_error_for_docs({ "remaining": "wire the CLI" }),
+    ],
+    content=(
+      #|[
+      #|  "goal requires a string \"remaining\" when status is \"continuing\"",
+      #|  "goal requires a non-blank \"reason\" when status is \"blocked\"",
+      #|  "goal status must be \"met\", \"continuing\", or \"blocked\", got \"done\"",
+      #|  "goal requires a string \"status\" field",
+      #|]
+    ),
+  )
+}
+
+///|
+fn decode_error_for_docs(arguments : Json) -> String {
+  try @decode.decode(arguments) catch {
+    error => @tool_error.failure_message("\{error}")
+  } noraise {
+    status => "unexpected success: \{to_repr(status)}"
+  }
+}
+```

--- a/agent_tool/goal/internal/decode/decode.mbt
+++ b/agent_tool/goal/internal/decode/decode.mbt
@@ -1,0 +1,47 @@
+///|
+/// A decoded verdict about the standing session goal.
+pub(all) enum GoalStatus {
+  /// The goal is fully achieved and verified.
+  Met
+  /// Work remains and can continue autonomously.
+  Continuing(String)
+  /// Progress requires user action or an external-state change.
+  Blocked(String)
+} derive(Debug)
+
+///|
+/// Decode and validate `goal` tool-call arguments.
+///
+/// `met` needs no companion field. `continuing` requires a non-blank
+/// `remaining`, and `blocked` requires a non-blank `reason`. The original text
+/// is preserved after its trimmed form is checked, so the durable record has
+/// exactly the wording supplied by the model. Malformed arguments raise a
+/// `Failure` whose message identifies the field to repair.
+pub fn decode(arguments : Json) -> GoalStatus raise {
+  match arguments {
+    { "status": "met", .. } => Met
+    { "status": "continuing", "remaining": String(remaining), .. } =>
+      if remaining.trim().is_empty() {
+        fail(
+          "goal requires a non-blank \"remaining\" when status is \"continuing\"",
+        )
+      } else {
+        Continuing(remaining)
+      }
+    { "status": "continuing", .. } =>
+      fail("goal requires a string \"remaining\" when status is \"continuing\"")
+    { "status": "blocked", "reason": String(reason), .. } =>
+      if reason.trim().is_empty() {
+        fail("goal requires a non-blank \"reason\" when status is \"blocked\"")
+      } else {
+        Blocked(reason)
+      }
+    { "status": "blocked", .. } =>
+      fail("goal requires a string \"reason\" when status is \"blocked\"")
+    { "status": String(other), .. } =>
+      fail(
+        "goal status must be \"met\", \"continuing\", or \"blocked\", got \"\{other}\"",
+      )
+    _ => fail("goal requires a string \"status\" field")
+  }
+}

--- a/agent_tool/goal/internal/decode/decode_test.mbt
+++ b/agent_tool/goal/internal/decode/decode_test.mbt
@@ -1,0 +1,62 @@
+///|
+test "decode all goal verdicts" {
+  debug_inspect(
+    [
+      @decode.decode({ "status": "met" }),
+      @decode.decode({ "status": "continuing", "remaining": "wire the CLI" }),
+      @decode.decode({
+        "status": "blocked",
+        "reason": "waiting for credentials",
+      }),
+    ],
+    content=(
+      #|[Met, Continuing("wire the CLI"), Blocked("waiting for credentials")]
+    ),
+  )
+}
+
+///|
+test "decode explains how to repair malformed arguments" {
+  debug_inspect(
+    [
+      decode_error({ "status": "continuing" }),
+      decode_error({ "status": "continuing", "remaining": "  " }),
+      decode_error({ "status": "blocked" }),
+      decode_error({ "status": "blocked", "reason": "\n" }),
+      decode_error({ "status": "done" }),
+      decode_error({ "remaining": "wire the CLI" }),
+    ],
+    content=(
+      #|[
+      #|  "goal requires a string \"remaining\" when status is \"continuing\"",
+      #|  "goal requires a non-blank \"remaining\" when status is \"continuing\"",
+      #|  "goal requires a string \"reason\" when status is \"blocked\"",
+      #|  "goal requires a non-blank \"reason\" when status is \"blocked\"",
+      #|  "goal status must be \"met\", \"continuing\", or \"blocked\", got \"done\"",
+      #|  "goal requires a string \"status\" field",
+      #|]
+    ),
+  )
+}
+
+///|
+test "decode preserves actionable text exactly" {
+  debug_inspect(
+    @decode.decode({
+      "status": "continuing",
+      "remaining": "  keep the original spacing  ",
+    }),
+    content=(
+      #|Continuing("  keep the original spacing  ")
+    ),
+  )
+}
+
+///|
+fn decode_error(arguments : Json) -> String {
+  try @decode.decode(arguments) catch {
+    error => @tool_error.failure_message("\{error}")
+  } noraise {
+    status => "unexpected success: \{to_repr(status)}"
+  }
+}

--- a/agent_tool/goal/internal/decode/moon.pkg
+++ b/agent_tool/goal/internal/decode/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+} for "test"
+
+warnings = "+unnecessary_annotation"

--- a/agent_tool/goal/internal/decode/pkg.generated.mbti
+++ b/agent_tool/goal/internal/decode/pkg.generated.mbti
@@ -1,15 +1,12 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "bobzhang/openseek/agent_tool/goal"
+package "bobzhang/openseek/agent_tool/goal/internal/decode"
 
 import {
-  "bobzhang/openseek/agent_tool",
   "moonbitlang/core/debug",
 }
 
 // Values
-pub fn decode_status(Json) -> GoalStatus raise
-
-pub fn definition() -> @agent_tool.AgentToolDefinition
+pub fn decode(Json) -> GoalStatus raise
 
 // Errors
 

--- a/agent_tool/goal/moon.pkg
+++ b/agent_tool/goal/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/goal/internal/decode",
+  "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "moonbitlang/core/json",
 }
 

--- a/agent_tool/goal/moon.pkg
+++ b/agent_tool/goal/moon.pkg
@@ -5,6 +5,10 @@ import {
   "moonbitlang/core/json",
 }
 
+import {
+  "moonbitlang/async",
+} for "test"
+
 warnings = "+unnecessary_annotation"
 
 supported_targets = "+native"


### PR DESCRIPTION
## Summary

- move raw `goal` JSON decoding into `agent_tool/goal/internal/decode`
- follow the other tool decoders by returning typed values and raising actionable failures
- keep `GoalStatus` owned by the public `goal` package and normalize failures at the agent boundary
- expand the goal and decoder documentation with snapshot-tested examples

## Why

The goal decoder previously lived in the public tool package and returned `Result`, unlike the other tool argument decoders. Splitting the decoder clarifies package responsibilities, keeps the agent-facing type in its proper owner, and makes the documentation tests show concrete values and errors.

## Impact

Malformed goal arguments continue to produce the same clean tool error messages. The public `decode_status` API now raises instead of returning `Result`, matching the project convention.

## Validation

- `moon check --warn-list +unnecessary_annotation`
- `moon test agent_tool/goal/internal/decode`
- `moon test agent_tool/goal`
- `moon test agent`
- `moon test` (1173 tests passed)
- `moon info && moon fmt`