### PR TITLE
feat(desktop): bundle app in .dmg so user are guided to move it to Application

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -227,19 +227,20 @@ jobs:
           done
           exit 1
 
-      # No --sign argument, so the bundle is ad-hoc signed: fine for
-      # debugging, but downloads are quarantined by Gatekeeper on other
-      # machines — clear it before launching:
-      #   xattr -dr com.apple.quarantine "OpenSeek Desktop.app"
+      # No --sign or --notarize argument, so the app is only ad-hoc signed,
+      # the DMG container is unsigned, and neither artifact is intended for
+      # end-user distribution.
       # Unstamped — no OPENSEEK_CLIENT_TOKEN in CI; see the Linux job's note.
-      - name: Build the app bundle
+      - name: Build the macOS artifacts
         run: moon -C desktop run --target native package/macos
 
-      - name: Upload app artifact
+      - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:
           name: OpenSeek-Desktop-macos-arm64
-          path: desktop/dist/OpenSeek Desktop-macos-arm64.zip
+          path: |
+            desktop/dist/OpenSeek Desktop-macos-arm64.zip
+            desktop/dist/OpenSeek Desktop-macos-arm64.dmg
           if-no-files-found: error
 
   desktop-windows:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -134,16 +134,18 @@ After the webview connects, the host fetches the hosted release manifest
 `internal/version` for the version it compares against) in the background.
 On macOS, when the manifest lists a `macos-arm64` package and the running
 bundle is Developer ID signed, the host downloads the zip, checks its
-sha256 against the manifest, extracts it, and verifies the new bundle's
-code signature carries the same team — only then does a sticky toast offer
-"restart and update". Clicking it swaps the bundle on disk (macOS allows
-renaming a running .app; the old one is parked as `<name>.app.old` and
-removed on the next launch), the window closes through the normal path,
-and `main` relaunches the new bundle via `open -n` after the run loop
-exits. Anything less than that fully verified path — other platforms, dev
-binaries, ad-hoc signatures, a failed download — degrades to a toast that
-opens the release page in the browser, and every check failure just means
-no toast at all.
+sha256 against the manifest, extracts it, and verifies that the new bundle is
+notarized and has a valid code signature from the same team — only then does a
+sticky toast offer "restart and update". The updater never removes the
+`com.apple.quarantine` attribute to bypass Gatekeeper. Clicking the toast swaps
+the bundle on disk (macOS allows renaming a running .app; the old one is parked
+as `<name>.app.old` and removed on the next launch), the window closes through
+the normal path, and `main` relaunches the new bundle via `open -n` after the
+run loop exits. If the current installation cannot be replaced, the Update
+button is not shown; a check or installation failure is reported in the
+bottom-right notification area. Anything less than the fully verified path —
+other platforms, dev binaries, or ad-hoc signatures — degrades to a toast that
+opens the release page in the browser.
 
 ## Prerequisites
 
@@ -335,7 +337,13 @@ The target machine also needs Microsoft WebView2 Runtime installed.
 
 `package/macos` runs all of the above (including the codegen bootstrap),
 builds the `openseek` engine from the monorepo's `cmd/openseek` source, and
-produces a signed `dist/OpenSeek Desktop.app` plus a zip:
+produces a signed app plus two distribution artifacts:
+
+- `dist/OpenSeek Desktop-macos-arm64.dmg` is for first-time installation. It
+  contains the app and an `/Applications` shortcut so users can install by
+  dragging the app into Applications.
+- `dist/OpenSeek Desktop-macos-arm64.zip` carries the same app for in-app
+  updates.
 
 ```sh
 moon run --target native package/macos
@@ -352,9 +360,9 @@ host initializes a writable copy under the per-user runtime directory before
 setting `MOON_HOME` for the engine.
 
 By default the bundle is ad-hoc signed: it runs on the build machine, but
-Gatekeeper quarantines it everywhere else. For distribution, sign with a
-Developer ID Application identity (hardened runtime and a secure timestamp
-are applied automatically) and optionally notarize:
+it is not a distributable build that Gatekeeper will trust on another machine.
+For distribution, sign with a Developer ID Application identity (hardened
+runtime and a secure timestamp are applied automatically) and notarize:
 
 ```sh
 # one-time: xcrun notarytool store-credentials openseek \
@@ -364,9 +372,14 @@ moon run --target native package/macos -- \
   --notarize openseek
 ```
 
-`--notarize` submits the zip with `notarytool --wait`, staples the ticket to
-the app, and rebuilds the zip; without it the app is signed but unnotarized
-(Gatekeeper still warns on other machines).
+`--notarize` submits only the signed DMG with `notarytool --wait`. Apple scans
+the DMG and its nested app in that single submission. After approval, the
+packager staples and validates tickets on both the built app and the DMG, then
+creates the final updater ZIP from that stapled app. The ZIP is therefore only
+a transport for the notarized app and is not submitted separately. Without
+`--notarize`, neither artifact is notarized; without `--sign`, the app is only
+ad-hoc signed and the DMG container is unsigned. Such outputs are not intended
+for distribution.
 
 ## Package (Linux)
 

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -52,10 +52,15 @@ priv enum UpdateUx {
 ///|
 /// A decoded `check_update` reply. Kinds mirror the wire contract; see the
 /// host's `CheckUpdateReply` for what each means and how loud it deserves
-/// to be.
+/// to be. `unavailable_reason` is present only when this installation failed
+/// the host's replacement preflight; package-less platforms stay quiet.
 priv enum UpdateCheck {
   CheckUpToDate
-  CheckFound(version~ : String, installable~ : Bool)
+  CheckFound(
+    version~ : String,
+    installable~ : Bool,
+    unavailable_reason~ : String?
+  )
   CheckUnreachable(reason~ : String)
   CheckMalformed(reason~ : String)
   CheckBroken(version~ : String, reason~ : String)
@@ -77,7 +82,13 @@ fn decode_update_check(text : String) -> UpdateCheck? {
         @jsonx.json_bool(reply, "installable") is Some(installable) else {
         return None
       }
-      Some(CheckFound(version~, installable~))
+      Some(
+        CheckFound(
+          version~,
+          installable~,
+          unavailable_reason=@jsonx.json_text(reply, "unavailable_reason"),
+        ),
+      )
     }
     "unreachable" => reason.map(reason => CheckUnreachable(reason~))
     "malformed" => reason.map(reason => CheckMalformed(reason~))

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -810,11 +810,15 @@ fn update_msg(
         return (@cmd.none, model)
       }
       match result {
-        CheckFound(version~, installable~) =>
-          (
-            @cmd.none,
-            { ..model, update_ux: UpdateAvailable(version~, installable~) },
-          )
+        CheckFound(version~, installable~, unavailable_reason~) => {
+          let (cmd, next) = if !installable &&
+            unavailable_reason is Some(reason) {
+            model.notify_error(dispatch, reason)
+          } else {
+            (@cmd.none, model)
+          }
+          (cmd, { ..next, update_ux: UpdateAvailable(version~, installable~) })
+        }
         CheckUpToDate =>
           (
             @cmd.none,
@@ -919,12 +923,15 @@ fn update_msg(
         (@cmd.none, model)
       }
     UpdateFailed(message~) => {
-      // Download or swap failed: say why, and put the button back so the
-      // user can retry.
+      // A failed download can be retried. A failed swap means the preflight
+      // no longer considers this location replaceable, so withdraw the
+      // button until a fresh check says otherwise. Both failures say why.
       let (cmd, next) = model.notify_error(dispatch, message)
       let update_ux = match next.update_ux {
-        DownloadingUpdate(version~) | RestartingForUpdate(version~) =>
+        DownloadingUpdate(version~) =>
           UpdateAvailable(version~, installable=true)
+        RestartingForUpdate(version~) =>
+          UpdateAvailable(version~, installable=false)
         other => other
       }
       (cmd, { ..next, update_ux, })
@@ -3375,13 +3382,65 @@ test "a startup check surfaces an installable release as the Update button" {
   let (_, model) = update(
     dispatch,
     UpdateCheckFinished(
-      result=CheckFound(version="0.2.0", installable=true),
+      result=CheckFound(
+        version="0.2.0",
+        installable=true,
+        unavailable_reason=None,
+      ),
       explicit=false,
     ),
     test_model(),
   )
   assert_true(
     model.update_ux is UpdateAvailable(version="0.2.0", installable=true),
+  )
+  assert_eq(model.notifications.length(), 0)
+}
+
+///|
+test "an unavailable startup update reports why without offering Update" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+  let msg = UpdateCheckFinished(
+    result=CheckFound(
+      version="0.2.0",
+      installable=false,
+      unavailable_reason=Some("Move OpenSeek Desktop.app to Applications."),
+    ),
+    explicit=false,
+  )
+  let (_, first) = update(dispatch, msg, model)
+  let (_, replayed) = update(dispatch, msg, model)
+  for result in [first, replayed] {
+    assert_true(
+      result.update_ux is UpdateAvailable(version="0.2.0", installable=false),
+    )
+    assert_eq(result.notifications.length(), 1)
+    inspect(
+      result.notifications[0].message,
+      content="Move OpenSeek Desktop.app to Applications.",
+    )
+    assert_eq(result.notification_seq, 1)
+  }
+}
+
+///|
+test "a package-less release stays informational" {
+  let dispatch = test_dispatch()
+  let (_, model) = update(
+    dispatch,
+    UpdateCheckFinished(
+      result=CheckFound(
+        version="0.2.0",
+        installable=false,
+        unavailable_reason=None,
+      ),
+      explicit=false,
+    ),
+    test_model(),
+  )
+  assert_true(
+    model.update_ux is UpdateAvailable(version="0.2.0", installable=false),
   )
   assert_eq(model.notifications.length(), 0)
 }
@@ -3492,6 +3551,26 @@ test "a failed download says why and restores the offer" {
 }
 
 ///|
+test "a failed apply says why and withdraws the offer" {
+  let dispatch = test_dispatch()
+  let restarting = {
+    ..test_model(),
+    update_ux: RestartingForUpdate(version="0.2.0"),
+  }
+  let msg = UpdateFailed(message="the app location became read-only")
+  let (_, first) = update(dispatch, msg, restarting)
+  let (_, replayed) = update(dispatch, msg, restarting)
+  for failed in [first, replayed] {
+    assert_eq(failed.notifications.length(), 1)
+    assert_true(failed.notifications[0].message.contains("read-only"))
+    assert_eq(failed.notification_seq, 1)
+    assert_true(
+      failed.update_ux is UpdateAvailable(version="0.2.0", installable=false),
+    )
+  }
+}
+
+///|
 test "a stale check reply cannot clobber a download in flight" {
   let dispatch = test_dispatch()
   let downloading = {
@@ -3529,9 +3608,23 @@ test "check_update replies decode by kind" {
   )
   assert_true(
     decode_update_check(
-      "{\"kind\":\"available\",\"version\":\"0.2.0\",\"installable\":true}",
+      "{\"kind\":\"available\",\"version\":\"0.2.0\",\"installable\":true,\"unavailable_reason\":null}",
     )
-    is Some(CheckFound(version="0.2.0", installable=true)),
+    is Some(
+      CheckFound(version="0.2.0", installable=true, unavailable_reason=None)
+    ),
+  )
+  assert_true(
+    decode_update_check(
+      "{\"kind\":\"available\",\"version\":\"0.2.0\",\"installable\":false,\"unavailable_reason\":\"move the app\"}",
+    )
+    is Some(
+      CheckFound(
+        version="0.2.0",
+        installable=false,
+        unavailable_reason=Some("move the app")
+      )
+    ),
   )
   // The host always writes `installable` on an `available` reply; one
   // without it is malformed rather than "not installable".

--- a/desktop/internal/extension/update_check.mbt
+++ b/desktop/internal/extension/update_check.mbt
@@ -71,9 +71,15 @@ fn UpdateChannelPayload::to_channel(
 /// each kind is worth a different amount of noise: `broken` can only be the
 /// publisher's fault (toast material), `malformed` also happens under
 /// captive portals (log material), `unreachable` is routine offline life.
+/// An available release carries an optional actionable reason when this
+/// installation itself cannot be replaced.
 priv enum CheckUpdateReply {
   UpToDate
-  Available(version~ : String, installable~ : Bool)
+  Available(
+    version~ : String,
+    installable~ : Bool,
+    unavailable_reason~ : String?
+  )
   Unreachable(reason~ : String)
   Malformed(reason~ : String)
   Broken(version~ : String, reason~ : String)
@@ -83,8 +89,18 @@ priv enum CheckUpdateReply {
 impl ToJson for CheckUpdateReply with fn to_json(self) {
   match self {
     UpToDate => { "kind": "up_to_date" }
-    Available(version~, installable~) =>
-      { "kind": "available", "version": version, "installable": installable }
+    Available(version~, installable~, unavailable_reason~) => {
+      let unavailable_reason = match unavailable_reason {
+        Some(reason) => Json::string(reason)
+        None => Json::null()
+      }
+      {
+        "kind": "available",
+        "version": version,
+        "installable": installable,
+        "unavailable_reason": unavailable_reason,
+      }
+    }
     Unreachable(reason~) => { "kind": "unreachable", "reason": reason }
     Malformed(reason~) => { "kind": "malformed", "reason": reason }
     Broken(version~, reason~) =>
@@ -94,8 +110,10 @@ impl ToJson for CheckUpdateReply with fn to_json(self) {
 
 ///|
 /// Ask the channel's manifest for a newer release. `installable` reports
-/// whether `download_update` would work here: a real signed .app bundle
-/// with a package published for this platform.
+/// whether `download_update` would work here: a real signed .app bundle in a
+/// replaceable location, with a package published for this platform. Only a
+/// failed installation preflight carries `unavailable_reason`; a platform
+/// without a package remains the existing informational fallback.
 async fn check_update_op(
   state : UpdateState,
   payload : UpdateChannelPayload,
@@ -122,11 +140,18 @@ async fn check_update_op(
     error => raise error
   }
   guard info is Some(info) else { return UpToDate }
+  let unavailable_reason = if info.artifact is Some(_) &&
+    state.work_dir is Some(_) &&
+    state.bundle_path is Some(bundle) {
+    @update.self_update_unavailable_reason(bundle_path=bundle)
+  } else {
+    None
+  }
   let installable = info.artifact is Some(_) &&
     state.work_dir is Some(_) &&
-    state.bundle_path is Some(bundle) &&
-    @update.can_self_update(bundle_path=bundle)
-  Available(version=info.version, installable~)
+    state.bundle_path is Some(_) &&
+    unavailable_reason is None
+  Available(version=info.version, installable~, unavailable_reason~)
 }
 
 ///|

--- a/desktop/internal/extension/update_check_wbtest.mbt
+++ b/desktop/internal/extension/update_check_wbtest.mbt
@@ -1,0 +1,26 @@
+///|
+test "available update replies carry an optional unavailability reason" {
+  assert_true(
+    Available(
+      version="0.2.0",
+      installable=false,
+      unavailable_reason=Some("move the app to Applications"),
+    ).to_json()
+    is {
+      "kind": String("available"),
+      "version": String("0.2.0"),
+      "installable": False,
+      "unavailable_reason": String("move the app to Applications"),
+      ..
+    },
+  )
+  assert_true(
+    Available(version="0.2.0", installable=true, unavailable_reason=None).to_json()
+    is {
+      "kind": String("available"),
+      "installable": True,
+      "unavailable_reason": Null,
+      ..
+    },
+  )
+}

--- a/desktop/internal/extension/update_check_wbtest.mbt
+++ b/desktop/internal/extension/update_check_wbtest.mbt
@@ -1,11 +1,13 @@
 ///|
 test "available update replies carry an optional unavailability reason" {
   assert_true(
-    Available(
-      version="0.2.0",
-      installable=false,
-      unavailable_reason=Some("move the app to Applications"),
-    ).to_json()
+    ToJson::to_json(
+      Available(
+        version="0.2.0",
+        installable=false,
+        unavailable_reason=Some("move the app to Applications"),
+      ),
+    )
     is {
       "kind": String("available"),
       "version": String("0.2.0"),
@@ -15,7 +17,9 @@ test "available update replies carry an optional unavailability reason" {
     },
   )
   assert_true(
-    Available(version="0.2.0", installable=true, unavailable_reason=None).to_json()
+    ToJson::to_json(
+      Available(version="0.2.0", installable=true, unavailable_reason=None),
+    )
     is {
       "kind": String("available"),
       "installable": True,

--- a/desktop/internal/update/apply.mbt
+++ b/desktop/internal/update/apply.mbt
@@ -30,6 +30,9 @@ pub async fn apply_staged(staged_app~ : String, bundle_path~ : String) -> Unit {
   guard @fs.exists(staged_app) else {
     raise UpdateError("the staged update disappeared; restart to try again")
   }
+  if bundle_replacement_failure(bundle_path) is Some(reason) {
+    raise UpdateError(reason)
+  }
   let aside = aside_path(bundle_path)
   remove_tree(aside)
   @fs.rename(bundle_path, aside) catch {

--- a/desktop/internal/update/apply_wbtest.mbt
+++ b/desktop/internal/update/apply_wbtest.mbt
@@ -1,0 +1,51 @@
+///|
+#cfg(not(platform="windows"))
+async test "bundle replacement checks the containing directory" {
+  @async.with_task_group() <| group => {
+    let root = @fs.tmpdir(prefix="openseek-update-replacement-")
+    group.add_defer(() => {
+      @fs.chmod(root, 0o700)
+      @fs.rmdir(root, recursive=true)
+    })
+    let bundle = root + "/OpenSeek Desktop.app"
+    @fs.mkdir(bundle)
+    @debug.assert_eq(bundle_replacement_failure(bundle), None)
+    @fs.chmod(root, 0o500)
+    @debug.assert_eq(
+      bundle_replacement_failure(bundle),
+      Some(BundleReplacementFailureMessage),
+    )
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "an unavailable destination stops apply before any mutation" {
+  @async.with_task_group() <| group => {
+    let root = @fs.tmpdir(prefix="openseek-update-apply-")
+    group.add_defer(() => {
+      @fs.chmod(root, 0o700)
+      @fs.rmdir(root, recursive=true)
+    })
+    let bundle = root + "/OpenSeek Desktop.app"
+    let staged = root + "/Staged.app"
+    let aside = aside_path(bundle)
+    @fs.mkdir(bundle)
+    @fs.mkdir(staged)
+    @fs.mkdir(aside)
+    @fs.write_file(bundle + "/version", "current", create_mode=CreateOrTruncate)
+    @fs.write_file(staged + "/version", "staged", create_mode=CreateOrTruncate)
+    @fs.write_file(aside + "/version", "parked", create_mode=CreateOrTruncate)
+    @fs.chmod(root, 0o500)
+    try apply_staged(staged_app=staged, bundle_path=bundle) catch {
+      UpdateError(message) =>
+        assert_eq(message, BundleReplacementFailureMessage)
+      error => raise error
+    } noraise {
+      _ => fail("apply unexpectedly accepted an unwritable destination")
+    }
+    assert_eq(@fs.read_file(bundle + "/version").text(), "current")
+    assert_eq(@fs.read_file(staged + "/version").text(), "staged")
+    assert_eq(@fs.read_file(aside + "/version").text(), "parked")
+  }
+}

--- a/desktop/internal/update/moon.pkg
+++ b/desktop/internal/update/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/string",
   "moonbitlang/x/crypto",
+  "moonbitlang/x/path",
 }
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/update/pkg.generated.mbti
+++ b/desktop/internal/update/pkg.generated.mbti
@@ -8,11 +8,11 @@ import {
 // Values
 pub async fn apply_staged(staged_app~ : String, bundle_path~ : String) -> Unit
 
-pub async fn can_self_update(bundle_path~ : String) -> Bool
-
 pub async fn check_for_update(current~ : String, channel~ : UpdateChannel) -> UpdateInfo?
 
 pub async fn cleanup_leftovers(work_dir~ : String, bundle_path~ : String) -> Unit
+
+pub async fn self_update_unavailable_reason(bundle_path~ : String) -> String?
 
 pub async fn stage_update(UpdateInfo, work_dir~ : String, bundle_path~ : String) -> StagedUpdate
 

--- a/desktop/internal/update/stage.mbt
+++ b/desktop/internal/update/stage.mbt
@@ -1,9 +1,9 @@
 // Downloading and verifying a macOS update bundle. Staging is the paranoid
 // half of self-update: nothing here touches the running bundle, and nothing
 // gets handed to apply until the archive digest matched the manifest and
-// the extracted bundle carries a valid signature from the same Developer ID
-// team as the running app — a compromised download source can therefore
-// nudge, but not install.
+// the extracted bundle carries a valid notarized signature from the same
+// Developer ID team as the running app — a compromised download source can
+// therefore nudge, but not install.
 
 ///|
 /// A staging or apply failure, with a user-facing message.
@@ -35,8 +35,8 @@ fn staging_dir(work_dir : String) -> String {
 
 ///|
 /// Download `info`'s platform package into the staging directory, verify
-/// its digest and code signature, and return the staged bundle. The running
-/// bundle must be signed by a real team (an ad-hoc dev build never
+/// its digest, code signature, and notarization, and return the staged bundle.
+/// The running bundle must be signed by a real team (an ad-hoc dev build never
 /// self-updates), and the staged bundle must be signed by the same one.
 pub async fn stage_update(
   info : UpdateInfo,
@@ -58,13 +58,16 @@ pub async fn stage_update(
   let extract_dir = "\{staging}/extract"
   run_tool("ditto", ["-x", "-k", archive, extract_dir])
   let app_path = extracted_app(extract_dir)
-  // The zip may carry quarantine attributes; the bundle is notarized, but
-  // stripping them keeps the relaunch from stopping at a Gatekeeper prompt.
-  // Best-effort: a failure only means the prompt shows once.
-  ignore(@process.run("xattr", ["-dr", "com.apple.quarantine", app_path]))
   run_tool("codesign", ["--verify", "--deep", "--strict", app_path])
   guard team_identifier(app_path) is Some(new_team) && new_team == team else {
     raise UpdateError("the downloaded bundle is signed by a different team")
+  }
+  run_tool("codesign", [
+    "--verify", "--check-notarization", "--test-requirement", "=notarized", app_path,
+  ]) catch {
+    UpdateError(message) =>
+      raise UpdateError("the downloaded bundle is not notarized: \{message}")
+    error => raise error
   }
   { version: info.version, app_path }
 }

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -115,12 +115,41 @@ pub async fn check_for_update(
 }
 
 ///|
-/// Whether this installation can swap a downloaded bundle in by itself:
-/// it must be a real .app bundle signed by a Developer ID team — the same
-/// requirement `stage_update` enforces, checked here so a "can I install"
-/// answer never turns into a download that was doomed from the start.
-pub async fn can_self_update(bundle_path~ : String) -> Bool {
-  team_identifier(bundle_path) is Some(_)
+/// The actionable explanation shared by the capability check and the final
+/// apply-time check when the running bundle's directory cannot be changed.
+const BundleReplacementFailureMessage : String = "OpenSeek cannot replace the app in its current location. Move OpenSeek Desktop.app to Applications, reopen it, and try again."
+
+///|
+/// Why `bundle_path` cannot be renamed within its current directory. Rename
+/// permission belongs to the parent directory, not to the bundle itself; both
+/// write and search access are required. A read-only filesystem reports an
+/// error rather than `false`, so every non-cancellation failure has the same
+/// concise, actionable user-facing answer.
+async fn bundle_replacement_failure(bundle_path : String) -> String? {
+  let parent = @path.Path(bundle_path).dirname().to_string()
+  let replaceable = (@fs.can_write(parent) && @fs.can_execute(parent)) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => false
+  }
+  if replaceable {
+    None
+  } else {
+    Some(BundleReplacementFailureMessage)
+  }
+}
+
+///|
+/// Why this installation cannot swap a downloaded bundle in by itself, or
+/// None when it can: it must be a real .app bundle signed by a Developer ID
+/// team and its containing directory must permit replacement. This is a UI
+/// preflight only; `apply_staged` checks the directory again immediately
+/// before touching the running bundle.
+pub async fn self_update_unavailable_reason(bundle_path~ : String) -> String? {
+  if team_identifier(bundle_path) is Some(_) {
+    bundle_replacement_failure(bundle_path)
+  } else {
+    Some("The running OpenSeek bundle is not Developer ID signed.")
+  }
 }
 
 ///|

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -5,6 +5,12 @@ const AppPath : String = "dist/OpenSeek Desktop.app"
 const ZipPath : String = "dist/OpenSeek Desktop-macos-arm64.zip"
 
 ///|
+const DmgPath : String = "dist/OpenSeek Desktop-macos-arm64.dmg"
+
+///|
+const DmgStagingPath : String = "dist/OpenSeek Desktop-dmg-root"
+
+///|
 const ContentsPath : String = AppPath + "/Contents"
 
 ///|
@@ -185,6 +191,8 @@ async fn assemble_macos_cef_runtime(
 async fn reset_bundle_dirs(ws : @packaging.Workspace) -> Unit {
   @packaging.remove_path_if_exists(ws.at(AppPath))
   @packaging.remove_path_if_exists(ws.at(ZipPath))
+  @packaging.remove_path_if_exists(ws.at(DmgPath))
+  @packaging.remove_path_if_exists(ws.at(DmgStagingPath))
   @packaging.ensure_dir(ws.at(MacOSPath))
   @packaging.ensure_dir(ws.at(ResourcesPath))
   @packaging.ensure_dir(ws.at(AppAssetDir))
@@ -656,7 +664,7 @@ priv struct SignConfig {
 fn package_command() -> @argparse.Command {
   Command(
     "package/macos",
-    about="Build the macOS app bundle and zip archive.",
+    about="Build the macOS app bundle, DMG, and zip archive.",
     options=[
       OptionArg(
         "sign",
@@ -771,8 +779,57 @@ async fn zip_app(ws : @packaging.Workspace) -> Unit {
 }
 
 ///|
-/// Notarize and staple when `--notarize` named a keychain profile. The zip is
-/// rebuilt afterwards so the distributed archive carries the stapled ticket.
+async fn create_dmg(ws : @packaging.Workspace, sign : SignConfig) -> Unit {
+  @packaging.remove_path_if_exists(ws.at(DmgStagingPath))
+  @packaging.ensure_dir(ws.at(DmgStagingPath))
+  // ditto preserves the signed bundle's metadata while placing it beside the
+  // conventional /Applications shortcut used by drag-to-install DMGs.
+  @packaging.run_checked(
+    "ditto",
+    [AppPath, DmgStagingPath + "/OpenSeek Desktop.app"],
+    dir=ws.dir(),
+  )
+  @packaging.run_checked(
+    "ln",
+    ["-s", "/Applications", DmgStagingPath + "/Applications"],
+    dir=ws.dir(),
+  )
+  @packaging.run_checked(
+    "hdiutil",
+    [
+      "create",
+      "-volname",
+      "OpenSeek Desktop",
+      "-srcfolder",
+      DmgStagingPath,
+      "-format",
+      "UDZO",
+      "-ov",
+      DmgPath,
+    ],
+    dir=ws.dir(),
+  )
+  @packaging.remove_path_if_exists(ws.at(DmgStagingPath))
+  if sign.identity is Some(identity) {
+    @packaging.run_checked(
+      "codesign",
+      ["--force", "--timestamp", "--sign", identity, DmgPath],
+      dir=ws.dir(),
+    )
+    @packaging.run_checked(
+      "codesign",
+      ["--verify", "--strict", "--verbose=2", DmgPath],
+      dir=ws.dir(),
+    )
+  }
+  @packaging.run_checked("hdiutil", ["verify", DmgPath], dir=ws.dir())
+}
+
+///|
+/// Submit only the signed DMG when `--notarize` names a keychain profile.
+/// Apple records tickets for the outer image and its nested app in that one
+/// submission, so both artifacts can be stapled and validated before the
+/// updater zip is built from the now-stapled source app.
 async fn notarize_if_configured(
   ws : @packaging.Workspace,
   sign : SignConfig,
@@ -780,19 +837,30 @@ async fn notarize_if_configured(
   guard sign.notary_profile is Some(profile) else { return }
   @packaging.run_checked(
     "xcrun",
-    ["notarytool", "submit", ZipPath, "--keychain-profile", profile, "--wait"],
+    ["notarytool", "submit", DmgPath, "--keychain-profile", profile, "--wait"],
     dir=ws.dir(),
   )
+  @packaging.run_checked("xcrun", ["stapler", "staple", DmgPath], dir=ws.dir())
   @packaging.run_checked("xcrun", ["stapler", "staple", AppPath], dir=ws.dir())
-  @packaging.remove_path_if_exists(ws.at(ZipPath))
-  zip_app(ws)
+  @packaging.run_checked(
+    "xcrun",
+    ["stapler", "validate", DmgPath],
+    dir=ws.dir(),
+  )
+  @packaging.run_checked(
+    "xcrun",
+    ["stapler", "validate", AppPath],
+    dir=ws.dir(),
+  )
+  @packaging.run_checked("hdiutil", ["verify", DmgPath], dir=ws.dir())
 }
 
 ///|
-async fn sign_and_zip(ws : @packaging.Workspace, sign : SignConfig) -> Unit {
+async fn sign_and_package(ws : @packaging.Workspace, sign : SignConfig) -> Unit {
   sign_app(ws, sign)
-  zip_app(ws)
+  create_dmg(ws, sign)
   notarize_if_configured(ws, sign)
+  zip_app(ws)
 }
 
 ///|
@@ -805,8 +873,9 @@ async fn main {
   reset_bundle_dirs(ws)
   copy_bundle_files(ws)
   write_bundle_metadata(ws)
-  sign_and_zip(ws, sign)
+  sign_and_package(ws, sign)
   println("generated \{ws.at(AppPath)}")
+  println("generated \{ws.at(DmgPath)}")
   println("generated \{ws.at(ZipPath)}")
   println(
     "release with scripts/publish-release.sh — it uploads the zip to openseek-api and publishes the version",


### PR DESCRIPTION
Self-update won't work in directories like `~/Downloads`, etc., because apple will mount the application runtime directory to a readonly filesystem. The suggested way is to do self-update in `~/Application`, and the runtime directory is mounted as read-write so we can do self-update.

Therefore, we use the .dmg format, where the user are guided to move the application into `Application` upon opening up the `.dmg` image.