### PR TITLE
fix: migrate to the 2026-07 toolchain (with-pattern parens + ToDoc extend)

### DIFF
--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -112,11 +112,11 @@ pub fn tally_diagnostics(text : String, truncated~ : Bool) -> CheckErrors {
       {
         "level": String("error"),
         "path"? : Some(String(path))
-        | _ with path = "",
+        | (_ with path = ""),
         "loc"? : Some(String(loc))
-        | _ with loc = "",
+        | (_ with loc = ""),
         "message"? : Some(String(message))
-        | _ with message = "",
+        | (_ with message = ""),
         ..
       } => {
         error_count = error_count + 1

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -209,11 +209,11 @@ fn decide_parse_gate(
         "level": String("error"),
         "error_code": Number(code, ..),
         "loc"? : Some(String(loc))
-        | _ with loc = "",
+        | (_ with loc = ""),
         "message"? : Some(String(message))
-        | _ with message = "",
+        | (_ with message = ""),
         "context"? : Some(String(context))
-        | _ with context = "",
+        | (_ with context = ""),
         ..
       } if is_parse_error_code(code) => errors.push({ loc, message, context })
       _ => ()

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -20,8 +20,7 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
     {
       values: {
         "session"? : Some([session, ..])
-        | (Some([])
-        | None) with session = "",
+        | (Some([]) | None with session = ""),
         "dir": [dir, ..],
         "session-root": [session_root, ..],
         ..

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -378,13 +378,12 @@ async fn resolved_session_id(
     {
       values: {
         "session"? : Some([session, ..])
-        | (Some([])
-        | None) with session = "",
+        | (Some([]) | None with session = ""),
         ..
       },
       flags: {
         "no-session"? : Some(no_session)
-        | None with no_session = false,
+        | (None with no_session = false),
         ..
       },
       ..,

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -542,8 +542,7 @@ async fn run_serve(
     {
       values: {
         "session"? : Some([session, ..])
-        | (Some([])
-        | None) with session = "",
+        | (Some([]) | None with session = ""),
         ..
       },
       ..,

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -147,13 +147,12 @@ fn continue_requested(matches : @argparse.Matches) -> Bool raise {
     {
       flags: {
         "continue"? : Some(continue_flag)
-        | None with continue_flag = false,
+        | (None with continue_flag = false),
         ..
       },
       values: {
         "session"? : Some([session, ..])
-        | (Some([])
-        | None) with session = "",
+        | (Some([]) | None with session = ""),
         ..
       },
       ..,
@@ -206,15 +205,12 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
       values: {
         "api-url": [api_url, ..],
         "session"? : Some([session, ..])
-        | (Some([])
-        | None) with session = "",
+        | (Some([]) | None with session = ""),
         "session-root": [session_root, ..],
         "engine"? : Some([engine, ..])
-        | (Some([])
-        | None) with engine = "",
+        | (Some([]) | None with engine = ""),
         "engine-mode"? : Some([engine_mode, ..])
-        | (Some([])
-        | None) with engine_mode = "serve",
+        | (Some([]) | None with engine_mode = "serve"),
         "model": [model, ..],
         "thinking": [thinking, ..],
         ..
@@ -336,8 +332,7 @@ fn initial_task(matches : @argparse.Matches) -> String? {
     {
       values: {
         "prompt"? : Some([prompt, ..])
-        | (Some([])
-        | None) with prompt = "",
+        | (Some([]) | None with prompt = ""),
         ..
       },
       ..,

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1558,7 +1558,7 @@ fn session_row_of(json : Json) -> SessionRow? {
     is {
       "id": String(id),
       "first_prompt"? : Some(String(first_prompt))
-      | _ with first_prompt = "",
+      | (_ with first_prompt = ""),
       ..
     } else {
     return None
@@ -1569,7 +1569,7 @@ fn session_row_of(json : Json) -> SessionRow? {
   }
   let root_label = match json {
     { "root_label": String(value), .. } => value
-    { "root"? : Some(String(value)) | _ with value = "", .. } => value
+    { "root"? : Some(String(value)) | (_ with value = ""), .. } => value
     _ => ""
   }
   let last_active = match json {

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -6,15 +6,15 @@ fn Usage::from_json(
   match json {
     {
       "prompt_tokens"? : Some(Number(prompt_tokens, ..))
-      | None with prompt_tokens = 0,
+      | (None with prompt_tokens = 0),
       "completion_tokens"? : Some(Number(completion_tokens, ..))
-      | None with completion_tokens = 0,
+      | (None with completion_tokens = 0),
       "total_tokens"? : Some(Number(total_tokens, ..))
-      | None with total_tokens = 0,
+      | (None with total_tokens = 0),
       "prompt_cache_hit_tokens"? : Some(Number(prompt_cache_hit_tokens, ..))
-      | None with prompt_cache_hit_tokens = 0,
+      | (None with prompt_cache_hit_tokens = 0),
       "prompt_cache_miss_tokens"? : Some(Number(prompt_cache_miss_tokens, ..))
-      | None with prompt_cache_miss_tokens = 0,
+      | (None with prompt_cache_miss_tokens = 0),
       ..
     } =>
       {
@@ -148,7 +148,7 @@ pub impl FromJson for ChatResponse with fn from_json(
     _ => []
   }
   let content = match message_fields {
-    { "content"? : Some(String(content)) | Some(Null) with content = "", .. } =>
+    { "content"? : Some(String(content)) | (Some(Null) with content = ""), .. } =>
       content
     { "content"? : None, .. } if tool_calls.length() > 0 => ""
     { "content"? : None, .. } =>
@@ -165,8 +165,7 @@ pub impl FromJson for ChatResponse with fn from_json(
   let reasoning_content = match message_fields {
     {
       "reasoning_content"? : Some(String(reasoning_content))
-      | (Some(Null)
-      | None) with reasoning_content = "",
+      | (Some(Null) | None with reasoning_content = ""),
       ..
     } => reasoning_content
     _ =>

--- a/internal/agentcli/agentcli.mbt
+++ b/internal/agentcli/agentcli.mbt
@@ -19,14 +19,11 @@ pub fn api_key(
     {
       values: {
         "api-key"? : Some([generic_key, ..])
-        | (Some([])
-        | None) with generic_key = "",
+        | (Some([]) | None with generic_key = ""),
         "deepseek-api-key"? : Some([deepseek_key, ..])
-        | (Some([])
-        | None) with deepseek_key = "",
+        | (Some([]) | None with deepseek_key = ""),
         "kimi-api-key"? : Some([kimi_key, ..])
-        | (Some([])
-        | None) with kimi_key = "",
+        | (Some([]) | None with kimi_key = ""),
         ..
       },
       ..,

--- a/tui/core/input.mbt
+++ b/tui/core/input.mbt
@@ -43,6 +43,12 @@ pub fn Input::text(self : Input) -> String {
 }
 
 ///|
+/// Make `ToDoc::to_doc` callable as a plain method on `Input` (used by
+/// `TranscriptItem::to_doc`). Explicit, because implicit promotion of a
+/// trait method to a regular method is deprecated.
+extend Input with @doc.ToDoc::{to_doc}
+
+///|
 /// Project the input into a renderable `@doc.Doc`: the first line carries the
 /// input's `prefix` and continuation lines are indented two columns, all in the
 /// prompt style.


### PR DESCRIPTION
Makes the repo build and check clean on the current toolchain (`moon 0.1.20260713` / `moonc 2026-07-15`, which is what stable `latest` now serves). Two independent toolchain-migration fixes, one commit each; #512's `extend` commit was folded in here so this PR fixes CI whole.

## 1. Parenthesize with-patterns (parser change)

`p | q with x = v` no longer parses — the `with` clause must sit inside parens, `p | (q with x = v)`. Every existing `with`-pattern used the old spelling, so `main` didn't compile (the nightly `unexpected token with` failure). All 28 sites across 9 files moved to the parenthesized form; three shapes, the subtle one being `Some(String(c)) | (Some(Null) with c = "")` (the clause binds the branch, not the payload). Pure spelling change; net −12 lines after fmt collapses.

## 2. `extend Input with ToDoc` (trait-promotion deprecation)

The one remaining `--deny-warn` error: `input.to_doc()` relied on `impl @doc.ToDoc for Input` being *implicitly* callable as a method, now deprecated. One `extend Input with @doc.ToDoc::{to_doc}` next to the impl makes it explicit. Call site untouched, no `.mbti` drift. (The message's suggested `{to_doc, ..}` doesn't parse; `{to_doc}` does.)

## On the "stable formatter will break" concern (codex P1, refuted)

CI runs `moon fmt --check` on both stable and nightly. Codex flagged that stable might strip these parens. **Investigated:** `version.json` shows stable `latest` = `moon 0.1.20260713` + `moonc 2026-07-15` — the new parser, identical to the build toolchain, where fmt *keeps* the parens. Stable was bumped to the 07-15 moonc; both jobs now want the parenthesized form. Codex's re-review confirmed and withdrew it.

## Verification (root + desktop, all targets)

`moon check --deny-warn` clean · `moon fmt --check` clean · desktop native+js clean · tests 1175 native / 27 js / 12 wasm-gc. Both commits codex-signed-off (see #511/#512 comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)