### PR TITLE
fix: extend Input with ToDoc (clears the last --deny-warn error)

### DIFF
--- a/tui/core/input.mbt
+++ b/tui/core/input.mbt
@@ -43,6 +43,12 @@ pub fn Input::text(self : Input) -> String {
 }
 
 ///|
+/// Make `ToDoc::to_doc` callable as a plain method on `Input` (used by
+/// `TranscriptItem::to_doc`). Explicit, because implicit promotion of a
+/// trait method to a regular method is deprecated.
+extend Input with @doc.ToDoc::{to_doc}
+
+///|
 /// Project the input into a renderable `@doc.Doc`: the first line carries the
 /// input's `prefix` and continuation lines are indented two columns, all in the
 /// prompt style.


### PR DESCRIPTION
Stacked on #511. Together the two make CI green: #511 lets the repo **parse** on the new toolchain, this clears the one remaining **`--deny-warn`** error.

## What

The new toolchain deprecates calling a trait method as a plain method when it was only *implicitly* promoted. Exactly one site hits it repo-wide: `input.to_doc()` in `TranscriptItem::to_doc` (`tui/core/transcript.mbt:124`) relied on `impl @doc.ToDoc for Input` (`tui/core/input.mbt:49`) being silently available as `Input::to_doc`. Under `moon check --deny-warn` — which CI runs on both stable and nightly — that deprecation is an error.

One declaration next to the impl makes it explicit:

```moonbit
extend Input with @doc.ToDoc::{to_doc}
```

The call site is untouched; resolution finds the same function. **No `.mbti` drift** — the method was already reachable, this only stops it being reached implicitly.

Footnote: the deprecation message suggests `{to_doc, ..}`, which does not parse. The list form is `{to_doc}`.

## Verification

With this + #511, on the current toolchain (= stable `latest`, `moon 0.1.20260713` / `moonc 2026-07-15`):

| Gate | root | desktop |
|---|---|---|
| `moon check --deny-warn` (all targets) | clean | clean (native + js) |
| `moon fmt --check` | clean | — |
| tests | 1175 native / 27 js / 12 wasm-gc | — |

That's the whole CI surface green. I checked the desktop workspace separately for the same class of deprecation — **zero**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)