### PR TITLE
refactor: array/byte patterns for last-element and prefix checks

### DIFF
--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -280,7 +280,7 @@ pub fn format_parse_gate_errors(
 /// the excerpt stays faithful.
 fn indent_context(context : String) -> String {
   let lines = split_owned(context, "\n")
-  if !lines.is_empty() && lines[lines.length() - 1] == "" {
+  if lines is [.., ""] {
     let _ = lines.pop()
   }
   [ for line in lines => "  \{line}" ].join("\n")

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -703,8 +703,8 @@ fn success_summary(writes : Array[PreparedWrite]) -> String {
 ///|
 fn success_brief(writes : Array[PreparedWrite]) -> String {
   let total = total_edit_count(writes)
-  if writes.length() == 1 {
-    "multi_edit \{@agent_tool.brief_basename(writes[0].path)} (\{total}×)"
+  if writes is [only] {
+    "multi_edit \{@agent_tool.brief_basename(only.path)} (\{total}×)"
   } else {
     "multi_edit \{writes.length()} files (\{total}×)"
   }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -2315,10 +2315,11 @@ fn heredoc_line_matches_delimiter(
 
 ///|
 fn strip_trailing_cr(line : String) -> String {
-  if line.has_suffix("\r") {
-    line[:line.length() - 1].to_owned()
-  } else {
-    line
+  // `\r` is one code unit and one Char, so dropping the trailing Char here is
+  // exactly the old `line[:length-1]` code-unit slice.
+  match line {
+    [.. rest, '\r'] => rest.to_owned()
+    _ => line
   }
 }
 

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -337,7 +337,7 @@ fn workspace_sessions_rel(session_root_value : String) -> String {
 /// Whether `data` starts with a `#!` shebang, marking an executable script whose
 /// executable bit should survive the copy.
 fn has_shebang(data : Bytes) -> Bool {
-  data.length() >= 2 && data[0].to_int() == 0x23 && data[1].to_int() == 0x21
+  data is [b'#', b'!', ..]
 }
 
 ///|

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -122,13 +122,13 @@ const SteerSegmentMaxColumns : Int = 44
 /// and the transcript echo — which during a long tool call can be many
 /// seconds — so without it a steer reads as an eaten keystroke.
 fn pending_steer_segment(steers : Array[String]) -> Array[@doc.Span] {
-  guard steers.length() > 0 else { return [] }
+  guard steers is [.., latest_steer] else { return [] }
   let label = if steers.length() > 1 {
     " · steering ×\{steers.length()}: "
   } else {
     " · steering: "
   }
-  let latest = collapse_preview_whitespace(steers[steers.length() - 1])
+  let latest = collapse_preview_whitespace(latest_steer)
   let budget = SteerSegmentMaxColumns - @displaytext.DisplayText(label).width()
   [
     Span(DisplayText(label), style=@style.dim),


### PR DESCRIPTION
Readability pass using MoonBit's array/byte patterns — five spots where a length guard plus an index (or a hex byte compare) reads more directly as a pattern. All function-body-internal, **no `.mbti` drift**, behavior-identical, full suite green.

| file / fn | before | after |
|---|---|---|
| `concurrent.mbt` `has_shebang` | `length()>=2 && data[0].to_int()==0x23 && data[1].to_int()==0x21` | `data is [b'#', b'!', ..]` |
| `parse_gate.mbt` `indent_context` | `!lines.is_empty() && lines[lines.length()-1] == ""` | `lines is [.., ""]` |
| `sandbox.mbt` `strip_trailing_cr` | `has_suffix("\r")` + `[:length-1]` | `match line { [.. rest, '\r'] => rest.to_owned(); _ => line }` |
| `status_view.mbt` `pending_steer_segment` | `guard steers.length()>0` + `steers[steers.length()-1]` | `guard steers is [.., latest]` |
| `multi_edit.mbt` `success_brief` | `length()==1` + `writes[0]` | `writes is [only]` |

## Behavior-identical, verified

- The byte literals `b'#'`/`b'!'` are `0x23`/`0x21`; `[b'#', b'!', ..]` requires ≥2 bytes and pins them — the exact test. Byte-patterns are already used in production here (`desktop/package/internal/pe/pe.mbt` `dos_header is [b'M', b'Z', ..]`).
- `strip_trailing_cr`: `\r` is **one** UTF-16 code unit **and one** `Char`, so dropping the trailing Char equals the old `[:length-1]` slice exactly. Noted in a comment because the equivalence is ASCII-only — it would *not* hold for a non-ASCII suffix.
- `lines is [.., ""]` leaves `lines` mutable for the following `pop()`; the `length()` calls that genuinely count things (steer `×N`, multi-file brief) stay.

## Deliberately not taken

`desktop/frontend/view.mbt` `capitalize` mixes an iter-`Char` first with a code-unit `text[1:]` slice. A `[first, .. rest]` pattern reads better **and** would change behavior for a non-BMP first char (fixing a latent dangling-surrogate bug) — so it's *not* a behavior-identical refactor, and stays out of this readability pass. Flagged for a separate correctness look.

Verification: `moon check --deny-warn` clean · `moon fmt --check` clean · 1175 native / 27 js / 12 wasm-gc · no `.mbti` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)