### PR TITLE
refactor(desktop): last-element patterns instead of get(length-1)

### DIFF
--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -147,7 +147,7 @@ pub fn read_file(
 pub fn basename(path : @pathx.Relative) -> String {
   match path.0.split("/").collect() {
     [] => path.0
-    segments => segments[segments.length() - 1].to_owned()
+    [.., last] => last.to_owned()
   }
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1083,8 +1083,7 @@ fn Conversation::sweep_pending_steers(self : Conversation) -> Conversation {
 
 ///|
 fn Conversation::last_assistant_content(self : Conversation) -> String? {
-  if self.messages.get(self.messages.length() - 1) is Some(item) &&
-    item.kind is Assistant(_) {
+  if self.messages is [.., item] && item.kind is Assistant(_) {
     Some(item.content)
   } else {
     None

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -190,10 +190,7 @@ fn append_terminal_item(
 
 ///|
 fn ends_with_assistant(items : Array[TranscriptItem], content : String) -> Bool {
-  match items.get(items.length() - 1) {
-    Some(item) => item.kind is Assistant(_) && item.content == content
-    None => false
-  }
+  items is [.., item] && item.kind is Assistant(_) && item.content == content
 }
 
 // Tests for decoding the host's session replies: the sidebar list and the

--- a/desktop/internal/extension/fs_watch.mbt
+++ b/desktop/internal/extension/fs_watch.mbt
@@ -51,15 +51,9 @@ async fn watch_workspace_op(
 /// under it, so matching the leaf segment is enough.
 fn ignored_watch_path(path : String) -> Bool {
   match path.split("/").collect() {
-    [] => false
-    segments =>
-      segments[segments.length() - 1]
-      is (".git"
-      | "target"
-      | "_build"
-      | "node_modules"
-      | ".mooncakes"
-      | ".repos")
+    [.., ".git" | "target" | "_build" | "node_modules" | ".mooncakes" | ".repos"] =>
+      true
+    _ => false
   }
 }
 


### PR DESCRIPTION
Companion to #513, desktop workspace. Four spots that reach for the last element via `get(length - 1)` or index the tail of a `split` — each reads more directly as a pattern. Function-body-internal, **no `.mbti` drift**, behavior-identical; desktop native + js suites green.

| file / fn | before | after |
|---|---|---|
| `transcript/sessions.mbt` `ends_with_assistant` | `match items.get(length-1) { Some(item) => …; None => false }` | `items is [.., item] && …` |
| `model.mbt` `last_assistant_content` | `messages.get(length-1) is Some(item)` | `messages is [.., item]` |
| `fileeditor/files.mbt` `basename` | `segments => segments[length-1].to_owned()` | `[.., last] => last.to_owned()` |
| `internal/extension/fs_watch.mbt` `ignored_watch_path` | `[] => false; segments => segments[length-1] is (".git" \| …)` | `[.., ".git" \| …] => true; _ => false` |

## Behavior-identical

- `[.., item]` binds the last element and fails on empty — exactly what `get(length-1)` returning `None` did. `sessions`/`model` are Bool/Option-returning, so the whole `None => false` / `else None` arm collapses out.
- `basename`: the `[]` arm already handled empty, so `[.., last]` is precisely the non-empty case it replaces.
- `fs_watch`: empty and non-matching-last both fall to `_ => false`; a matching last yields `true` — the same truth table.

All last-element, on `String`/struct elements — no Char/code-unit concern (that hazard only applies to string-*character* patterns, which none of these are).

Verification: desktop `--deny-warn` clean (native + js) · `fmt --check` clean (CI's scoped form) · tests 230 native / 216 js · no `.mbti` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)