### PR TITLE
fix(desktop): capitalize crashes on a non-BMP first char

### DIFF
--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -644,10 +644,13 @@ fn tool_group_summary(items : Array[@transcript.TranscriptItem]) -> String {
 
 ///|
 fn capitalize(text : String) -> String {
-  if text.iter().next() is Some(first) {
-    "\{first.to_ascii_uppercase()}" + text[1:].to_owned()
-  } else {
-    text
+  // `[first, .. rest]` binds the first Unicode scalar and the true remainder.
+  // The old `iter().next()` + `text[1:]` mixed a scalar with a code-unit slice:
+  // a non-BMP first char left `text[1:]` inside its surrogate pair, corrupting
+  // the tail on native and *panicking* on js (StringView sub mid-surrogate).
+  match text {
+    [first, .. rest] => "\{first.to_ascii_uppercase()}" + rest.to_owned()
+    [] => text
   }
 }
 
@@ -2301,6 +2304,15 @@ fn tool_item(
   is_error? : Bool = false,
 ) -> @transcript.TranscriptItem {
   { kind: Tool(name~, is_error~, brief=None), content: "output" }
+}
+
+///|
+test "capitalize is Unicode-safe on a non-BMP first char" {
+  inspect(capitalize("hello world"), content="Hello world")
+  // 🎉 = U+1F389, a surrogate pair. The old text[1:] sliced into it — corrupt
+  // on native, a panic on js. It must survive whole with the remainder intact.
+  inspect(capitalize("🎉 done"), content="🎉 done")
+  inspect(capitalize(""), content="")
 }
 
 ///|


### PR DESCRIPTION
Follow-up to #513/#514 — you noted string pattern matching is Unicode-safe, and that turns the `capitalize` case I'd flagged from "latent readability holdout" into a real **crash fix**.

## The bug

```moonbit
fn capitalize(text : String) -> String {
  if text.iter().next() is Some(first) {          // a Unicode scalar
    "\{first.to_ascii_uppercase()}" + text[1:].to_owned()   // a UTF-16 code-unit slice
  } else { text }
}
```

`iter().next()` yields the first **scalar**; `text[1:]` slices by **code unit**. When the first char is non-BMP (a surrogate pair), `text[1:]` starts at the *second* surrogate — the tail is corrupted on native, and **on js the StringView sub panics mid-surrogate**, so `capitalize` of any such string is a crash.

## The fix

```moonbit
match text {
  [first, .. rest] => "\{first.to_ascii_uppercase()}" + rest.to_owned()
  [] => text
}
```

String patterns iterate by Unicode scalar (verified on this toolchain: `match "🎉ok" { [first, .. rest] => … }` binds `first = 🎉`, `rest = "ok"`, while `"🎉ok".length()` is 4 code units). So `first` is the whole character and `rest` the true remainder — the reason patterns, not `s[i]`/`s[i:]`, are the right tool for string decomposition.

## Teeth

No live trigger today (callers pass English summaries), so it's latent — but the regression test pins it, and I confirmed it fails on the old body: reverting panics the **js** test at `String::sub` mid-surrogate.

```
capitalize("hello world") == "Hello world"
capitalize("🎉 done")     == "🎉 done"   // survives whole; old code crashed here
capitalize("")            == ""
```

Verified: desktop native 230 / js 217 · `--deny-warn` + `fmt --check` clean · no `.mbti` drift.

Sibling sites checked, left alone: `app_initial` (takes only the first char, no slice — already correct) and `trigger_query` (comment documents the trigger is ASCII, so `[1:]` is deliberately safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)