### PR TITLE
fix(eval): short_text truncates at a scalar boundary, not mid-surrogate

### DIFF
--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -373,9 +373,12 @@ fn row(
 ///|
 fn short_text(text : String) -> String {
   let squashed = text.replace_all(old="\n", new=" ")
-  if squashed.length() <= 160 {
-    squashed
-  } else {
-    "\{squashed[:160]}..."
+  // Truncate at a scalar boundary, not a code-unit one: `[:160]` could slice
+  // inside a surrogate pair (this is free tool/model text). `offset_of_nth_char`
+  // is `Some` only when there are more than 160 chars — the same shape
+  // `agent_tool/shell` `text_prefix_by_chars` uses.
+  match squashed.offset_of_nth_char(160) {
+    Some(end) => "\{squashed[:end]}..."
+    None => squashed
   }
 }


### PR DESCRIPTION
The surrogate-split sweep (prompted by #515's `capitalize` fix) came back **essentially clean** — every other truncator in the repo already slices at scalar boundaries (`offset_of_nth_char`, or scalar iteration into a `StringBuilder`). This is the single holdout.

`short_text` truncates free tool/model text with `squashed[:160]` — a UTF-16 code-unit slice that can land inside a surrogate pair, leaving a lone surrogate in the diagnostic. The package is native-only, so it's *corruption* rather than the js panic `capitalize` had, and it's an eval failure message — **low impact, but a real bug**.

```moonbit
match squashed.offset_of_nth_char(160) {
  Some(end) => "\{squashed[:end]}..."   // scalar boundary; Some only when > 160 chars
  None => squashed
}
```

This is the exact shape `agent_tool/shell` `text_prefix_by_chars` already uses. The threshold shifts from 160 *code units* to 160 *chars* — the more natural reading, and identical for ASCII.

The sweep's rejection list was thorough and worth noting: it verified that `find`/`rev_find`-derived slices, ASCII-by-construction slugs/tool-names, `has_prefix`-guarded slices, and `Array[Char]` indexing are all safe — a good "well-built" signal for the codebase's Unicode handling.

Verified: eval/tool_harness 3/3, `moon check --deny-warn` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)