### PR TITLE
refactor(agent_skill): idiomatic string building and tests

### DIFF
--- a/agent_skill/pkg.generated.mbti
+++ b/agent_skill/pkg.generated.mbti
@@ -8,16 +8,14 @@ import {
 // Values
 pub async fn discover_skills(String) -> Array[Skill]
 
-pub fn merge_skills(Array[Skill], overrides~ : Array[Skill]) -> Array[Skill]
+pub fn merge_skills(ArrayView[Skill], overrides~ : ArrayView[Skill]) -> Array[Skill]
 
 pub fn skills_prompt_section(Array[Skill]) -> String?
 
 // Errors
 
 // Types and methods
-pub struct Skill {
-  // private fields
-} derive(@debug.Debug)
+type Skill derive(@debug.Debug)
 pub fn Skill::description(Self) -> String
 pub fn Skill::name(Self) -> String
 pub fn Skill::path(Self) -> String

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -4,10 +4,10 @@
 /// one-line description, and the file path to `read` — the body itself stays
 /// out of the prompt until the model decides it is relevant, so a large
 /// skill library costs a few listing lines, not its full text.
-pub struct Skill {
-  priv name : String
-  priv description : String
-  priv path : String
+struct Skill {
+  name : String
+  description : String
+  path : String
 } derive(Debug)
 
 ///|
@@ -42,7 +42,7 @@ pub fn Skill::path(self : Skill) -> String {
 fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) {
   let mut name = fallback_name
   let mut description = ""
-  let lines = text.split("\n").collect()
+  let lines = [..text.split("\n")]
   guard lines is [first, .. rest] && first.trim() == "---" else {
     return (name, description)
   }
@@ -134,15 +134,11 @@ async fn add_skill_file(skills : Array[Skill], path : String) -> Unit {
 /// re-sorted by name, keeping the prompt listing deterministic regardless
 /// of which library each skill came from.
 pub fn merge_skills(
-  base : Array[Skill],
-  overrides~ : Array[Skill],
+  base : ArrayView[Skill],
+  overrides~ : ArrayView[Skill],
 ) -> Array[Skill] {
-  let merged : Array[Skill] = []
-  let taken : Set[String] = Set([])
-  for skill in overrides {
-    taken.add(skill.name)
-    merged.push(skill)
-  }
+  let merged = overrides.to_owned()
+  let taken : Set[String] = Set([ for skill in overrides => skill.name ])
   for skill in base {
     if !taken.contains(skill.name) {
       merged.push(skill)
@@ -158,19 +154,28 @@ pub fn merge_skills(
 /// use a skill: read the listed file first, then follow it.
 pub fn skills_prompt_section(skills : Array[Skill]) -> String? {
   guard skills.length() > 0 else { return None }
-  let lines : Array[String] = []
-  lines.push("## Skills")
-  lines.push("")
-  lines.push(
-    "Reusable skills are available. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it. Listed skill files are pre-approved reads even when they sit outside the working directory.",
-  )
-  for skill in skills {
-    let description = if skill.description() == "" {
-      "(no description)"
-    } else {
-      skill.description()
+  // Stream the listing into the multiline block's writer: the `$|` separator
+  // supplies the newline before the first entry, so each entry only needs a
+  // leading newline once another already precedes it.
+  fn list(out : StringBuilder) {
+    for index, skill in skills {
+      let description = if skill.description() == "" {
+        "(no description)"
+      } else {
+        skill.description()
+      }
+      if index > 0 {
+        out <+ "\n"
+      }
+      out <+ "- \{skill.name()} — \{description} (file: \{skill.path()})"
     }
-    lines.push("- \{skill.name()} — \{description} (file: \{skill.path()})")
   }
-  Some(lines.join("\n"))
+
+  let sb = StringBuilder()
+  sb <+
+    $|## Skills
+    $|
+    $|Reusable skills are available. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it. Listed skill files are pre-approved reads even when they sit outside the working directory.
+    $|\{out => list(out)}
+  Some(sb.to_string())
 }

--- a/agent_skill/skill_test.mbt
+++ b/agent_skill/skill_test.mbt
@@ -7,7 +7,7 @@ async fn write_skill(path : String, text : String) -> Unit {
 async test "discovery reads flat files and SKILL.md directories, sorted" {
   @vfs.with_tmpdir(prefix="openseek-skills-", dir => {
     write_skill(
-      dir + "/zeta.md",
+      "\{dir}/zeta.md",
       (
         #|---
         #|name: zeta-protocol
@@ -16,9 +16,9 @@ async test "discovery reads flat files and SKILL.md directories, sorted" {
         #|Body text.
       ),
     )
-    @fs.mkdir(dir + "/alpha", recursive=true)
+    @fs.mkdir("\{dir}/alpha", recursive=true)
     write_skill(
-      dir + "/alpha/SKILL.md",
+      "\{dir}/alpha/SKILL.md",
       (
         #|---
         #|description: Alpha steps.
@@ -27,25 +27,31 @@ async test "discovery reads flat files and SKILL.md directories, sorted" {
       ),
     )
     // No frontmatter at all: still listed under its file stem.
-    write_skill(dir + "/bare.md", "Just instructions, no header.")
+    write_skill("\{dir}/bare.md", "Just instructions, no header.")
     // A dotted directory name survives intact ("node.js", not "node").
-    @fs.mkdir(dir + "/node.js", recursive=true)
-    write_skill(dir + "/node.js/SKILL.md", "Node skill body.")
+    @fs.mkdir("\{dir}/node.js", recursive=true)
+    write_skill("\{dir}/node.js/SKILL.md", "Node skill body.")
     // A non-skill directory and a stray file are ignored.
-    @fs.mkdir(dir + "/not-a-skill", recursive=true)
-    write_skill(dir + "/notes.txt", "not markdown")
+    @fs.mkdir("\{dir}/not-a-skill", recursive=true)
+    write_skill("\{dir}/notes.txt", "not markdown")
     let skills = @agent_skill.discover_skills(dir)
     assert_eq(skills.length(), 4)
+    let prompt = @agent_skill.skills_prompt_section(skills).unwrap()
     // Sorted by name (String order is length-first, so "bare" precedes
-    // "alpha"); the SKILL.md layout names itself after its directory.
-    assert_eq(skills[0].name(), "bare")
-    assert_eq(skills[0].description(), "")
-    assert_eq(skills[1].name(), "alpha")
-    assert_eq(skills[1].description(), "Alpha steps.")
-    assert_eq(skills[1].path(), dir + "/alpha/SKILL.md")
-    assert_eq(skills[2].name(), "node.js")
-    assert_eq(skills[3].name(), "zeta-protocol")
-    assert_eq(skills[3].description(), "How to zeta.")
+    // "alpha"); the SKILL.md layout names itself after its directory
+    // ("node.js", not "node").
+    inspect(
+      prompt,
+      content=(
+        $|## Skills
+        $|
+        $|Reusable skills are available. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it. Listed skill files are pre-approved reads even when they sit outside the working directory.
+        $|- bare — (no description) (file: \{dir}/bare.md)
+        $|- alpha — Alpha steps. (file: \{dir}/alpha/SKILL.md)
+        $|- node.js — (no description) (file: \{dir}/node.js/SKILL.md)
+        $|- zeta-protocol — How to zeta. (file: \{dir}/zeta.md)
+      ),
+    )
   })
 }
 
@@ -54,7 +60,7 @@ async test "a malformed frontmatter never hides the skill" {
   @vfs.with_tmpdir(prefix="openseek-skills-malformed-", dir => {
     // Opening --- with no closing fence: keys still parse until EOF.
     write_skill(
-      dir + "/open.md",
+      "\{dir}/open.md",
       (
         #|---
         #|name: still-found
@@ -72,23 +78,23 @@ async test "workspace skills shadow same-named global skills on merge" {
   @vfs.with_tmpdir(prefix="openseek-skills-global-", global_dir => {
     @vfs.with_tmpdir(prefix="openseek-skills-workspace-", workspace_dir => {
       write_skill(
-        global_dir + "/deploy.md",
+        "\{global_dir}/deploy.md",
         (
           #|---
           #|description: Generic deploy steps.
           #|---
         ),
       )
-      write_skill(global_dir + "/lint.md", "Global lint steps.")
+      write_skill("\{global_dir}/lint.md", "Global lint steps.")
       write_skill(
-        workspace_dir + "/deploy.md",
+        "\{workspace_dir}/deploy.md",
         (
           #|---
           #|description: This project's deploy steps.
           #|---
         ),
       )
-      write_skill(workspace_dir + "/triage.md", "Workspace triage steps.")
+      write_skill("\{workspace_dir}/triage.md", "Workspace triage steps.")
       let merged = @agent_skill.merge_skills(
         @agent_skill.discover_skills(global_dir),
         overrides=@agent_skill.discover_skills(workspace_dir),
@@ -97,10 +103,10 @@ async test "workspace skills shadow same-named global skills on merge" {
       // global library; everything stays name-sorted across both sources.
       assert_eq(merged.length(), 3)
       assert_eq(merged[0].name(), "lint")
-      assert_eq(merged[0].path(), global_dir + "/lint.md")
+      assert_eq(merged[0].path(), "\{global_dir}/lint.md")
       assert_eq(merged[1].name(), "deploy")
       assert_eq(merged[1].description(), "This project's deploy steps.")
-      assert_eq(merged[1].path(), workspace_dir + "/deploy.md")
+      assert_eq(merged[1].path(), "\{workspace_dir}/deploy.md")
       assert_eq(merged[2].name(), "triage")
     })
   })
@@ -117,7 +123,7 @@ async test "a missing skills directory is an empty library" {
 async test "the prompt section lists usage, names, and paths" {
   @vfs.with_tmpdir(prefix="openseek-skills-prompt-", dir => {
     write_skill(
-      dir + "/release.md",
+      "\{dir}/release.md",
       (
         #|---
         #|name: release
@@ -130,11 +136,13 @@ async test "the prompt section lists usage, names, and paths" {
     guard @agent_skill.skills_prompt_section(skills) is Some(section) else {
       fail("expected a section")
     }
-    assert_true(section.contains("## Skills"))
-    assert_true(section.contains("read its file with the read tool"))
-    assert_true(
-      section.contains(
-        "- release — Cut a release of this project. (file: \{dir}/release.md)",
+    inspect(
+      section,
+      content=(
+        $|## Skills
+        $|
+        $|Reusable skills are available. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it. Listed skill files are pre-approved reads even when they sit outside the working directory.
+        $|- release — Cut a release of this project. (file: \{dir}/release.md)
       ),
     )
   })


### PR DESCRIPTION
## Summary

Idiomatic cleanup of the `agent_skill` package, with matching test updates.

- **`skills_prompt_section`** now builds the prompt with a `StringBuilder` and `<+` — a `#|` raw multiline block for the static header, string interpolation for each skill line — instead of accumulating an `Array[String]` and `join("\n")`. Output is byte-for-byte identical.
- **`merge_skills`** takes `ArrayView[Skill]` and seeds the result with `overrides.to_owned()` + a set comprehension, dropping the manual push loop.
- **`parse_frontmatter`** uses `[..text.split("\n")]` instead of `.collect()`.
- **Tests**: skill paths use `"\{dir}/..."` interpolation instead of `dir + "..."` concatenation, and the prompt output is asserted with `inspect` snapshots using interpolated `$|` content (matching the existing `environment_prompt_section` test idiom) — no `replace_all` normalization needed.

## Test plan

- `moon fmt` — clean
- `moon check agent_skill` — clean
- `moon test -p agent_skill` — 5/5 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)