### PR TITLE
refactor: generalize #518's string-building and view idioms repo-wide

### DIFF
--- a/agent_review/prompt.mbt
+++ b/agent_review/prompt.mbt
@@ -1,21 +1,27 @@
 ///|
 /// System prompt for review mode: a read-only, compiler-grounded reviewer.
 pub fn review_system_prompt() -> String {
-  "You are OpenSeek in code-review mode. You review code changes; you do not modify them.\n\n" +
-  "Principles:\n" +
-  "- Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.\n" +
-  "- Report, do not rewrite. You have no edit tools. Point at exact file:line.\n" +
-  "- Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.\n" +
-  "- When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text."
+  (
+    #|You are OpenSeek in code-review mode. You review code changes; you do not modify them.
+    #|
+    #|Principles:
+    #|- Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.
+    #|- Report, do not rewrite. You have no edit tools. Point at exact file:line.
+    #|- Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.
+    #|- When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text.
+  )
 }
 
 ///|
 /// The review task: inspect the change set between `base` and HEAD.
 pub fn review_task(base : String) -> String {
-  "Review the code changes between \{base} and HEAD in the current repository.\n\n" +
-  "Steps:\n" +
-  "1. Run `git diff \{base}...HEAD` and `git diff --name-only \{base}...HEAD` to see the change set.\n" +
-  "2. Read the changed files and enough surrounding context to judge correctness.\n" +
-  "3. Run `moon check --target all` to confirm it compiles across targets; run `moon test` if feasible. Treat compiler/test output as ground truth.\n" +
-  "4. Call submit_review once with findings (file, line when known, severity, category, title, detail, optional suggestion), a summary, and stats (set build/tests from what moon check/test actually reported)."
+  (
+    $|Review the code changes between \{base} and HEAD in the current repository.
+    $|
+    $|Steps:
+    $|1. Run `git diff \{base}...HEAD` and `git diff --name-only \{base}...HEAD` to see the change set.
+    $|2. Read the changed files and enough surrounding context to judge correctness.
+    $|3. Run `moon check --target all` to confirm it compiles across targets; run `moon test` if feasible. Treat compiler/test output as ground truth.
+    $|4. Call submit_review once with findings (file, line when known, severity, category, title, detail, optional suggestion), a summary, and stats (set build/tests from what moon check/test actually reported).
+  )
 }

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -136,7 +136,7 @@ fn missing_field(
   name : String,
   prefix : String,
 ) -> String {
-  let keys = fields.keys().collect()
+  let keys = [..fields.keys()]
   keys.sort()
   "\{prefix} to include \{name} (present keys: \{keys.join(", ")})"
 }

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -108,7 +108,7 @@ async fn read_file(
       brief~,
     )
   }
-  let lines = content.split("\n").collect()
+  let lines = [..content.split("\n")]
   let total_lines = lines.length()
   // Clamp both bounds into [0, total_lines] so the render loop only visits
   // valid lines — a start past the last line selects nothing.

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -197,9 +197,10 @@ async test "read renders a whole file as numbered lines with a status footer" {
     assert_eq(brief, "read test.txt")
     assert_eq(
       output.content,
-      [
-        "1 |hello read", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
-      ].join("\n"),
+      (
+        #|1 |hello read
+        #|<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>
+      ),
     )
   })
 }
@@ -221,9 +222,10 @@ async test "read resolves relative paths under the workspace root" {
     assert_false(output.is_error)
     assert_eq(
       output.content,
-      [
-        "1 |workspace read", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
-      ].join("\n"),
+      (
+        #|1 |workspace read
+        #|<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>
+      ),
     )
   })
 }
@@ -254,9 +256,11 @@ async test "read treats a single-newline file as one blank line, not empty" {
     // "\n" splits into two empty lines, so this is not the empty-file case.
     assert_eq(
       output.content,
-      [
-        "1 |", "2 |", "<system>start_line=1 shown_lines=2 total_lines=2 truncated=false</system>",
-      ].join("\n"),
+      (
+        #|1 |
+        #|2 |
+        #|<system>start_line=1 shown_lines=2 total_lines=2 truncated=false</system>
+      ),
     )
   })
 }
@@ -275,9 +279,13 @@ async test "read numbers every line including a trailing blank from a final newl
     assert_false(output.is_error)
     assert_eq(
       output.content,
-      [
-        "1 |line one", "2 |line two", "3 |line three", "4 |", "<system>start_line=1 shown_lines=4 total_lines=4 truncated=false</system>",
-      ].join("\n"),
+      (
+        #|1 |line one
+        #|2 |line two
+        #|3 |line three
+        #|4 |
+        #|<system>start_line=1 shown_lines=4 total_lines=4 truncated=false</system>
+      ),
     )
   })
 }
@@ -298,9 +306,11 @@ async test "read returns a requested line range and reports more lines remain" {
     // still unread; there is no separate `line_limited` flag.
     assert_eq(
       output.content,
-      [
-        "2 |line two", "3 |line three", "<system>start_line=2 shown_lines=2 total_lines=4 truncated=false</system>",
-      ].join("\n"),
+      (
+        #|2 |line two
+        #|3 |line three
+        #|<system>start_line=2 shown_lines=2 total_lines=4 truncated=false</system>
+      ),
     )
   })
 }
@@ -334,9 +344,10 @@ async test "read caps oversized output without marking it as an error" {
     assert_eq(brief, "read capped.txt (truncated)")
     assert_eq(
       output.content,
-      [
-        "1 |a", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
-      ].join("\n"),
+      (
+        #|1 |a
+        #|<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>
+      ),
     )
   })
 }
@@ -357,9 +368,13 @@ async test "read counts the line-number gutter against the output budget" {
     // included); the fifth gutter would overrun, so the body stops at line 4.
     assert_eq(
       output.content,
-      [
-        " 1 |x", " 2 |x", " 3 |x", " 4 |x", "<system>start_line=1 shown_lines=4 total_lines=80 truncated=true</system>",
-      ].join("\n"),
+      (
+        #| 1 |x
+        #| 2 |x
+        #| 3 |x
+        #| 4 |x
+        #|<system>start_line=1 shown_lines=4 total_lines=80 truncated=true</system>
+      ),
     )
   })
 }
@@ -376,9 +391,10 @@ async test "read caps unicode content on character boundaries" {
     assert_false(output.is_error)
     assert_eq(
       output.content,
-      [
-        "1 |😀", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
-      ].join("\n"),
+      (
+        #|1 |😀
+        #|<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>
+      ),
     )
     // Budget 4 leaves one unit after the gutter, which would split "😀". Rather
     // than emit a lone surrogate (a slice mid-pair actually panics), the whole
@@ -389,9 +405,10 @@ async test "read caps unicode content on character boundaries" {
     assert_false(output.content.contains("😀"))
     assert_eq(
       output.content,
-      [
-        "1 |", "<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>",
-      ].join("\n"),
+      (
+        #|1 |
+        #|<system>start_line=1 shown_lines=1 total_lines=1 truncated=true</system>
+      ),
     )
   })
 }
@@ -524,9 +541,11 @@ async test "a huge max_lines returns the remaining lines without overflow" {
     assert_false(output.is_error)
     assert_eq(
       output.content,
-      [
-        "2 |b", "3 |c", "<system>start_line=2 shown_lines=2 total_lines=3 truncated=false</system>",
-      ].join("\n"),
+      (
+        #|2 |b
+        #|3 |c
+        #|<system>start_line=2 shown_lines=2 total_lines=3 truncated=false</system>
+      ),
     )
   })
 }

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -183,6 +183,5 @@ fn looks_like_env_assignment(word : String) -> Bool {
   if word.contains("/") || word.contains("-") {
     return false
   }
-  let parts = word.split("=").collect()
-  parts.length() == 2 && parts[0] != "" && parts[1] != ""
+  [..word.split("=")] is [name, value] && !name.is_empty() && !value.is_empty()
 }

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -209,15 +209,13 @@ fn is_fd_word(word : String) -> Bool {
 
 ///|
 fn split_env_assignment(word : String) -> EnvAssignment? {
-  let parts = word.split("=").collect()
-  if parts.length() < 2 {
+  guard [..word.split("=")] is [first, .. values] && !values.is_empty() else {
     return None
   }
-  let name = parts[0].to_owned()
+  let name = first.to_owned()
   if !is_valid_env_name(name) {
     return None
   }
-  let values = [ for part in parts[1:] => part.to_owned() ]
   Some({ name, value: values.join("=") })
 }
 

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1582,11 +1582,7 @@ fn command_text_env_no_arg_option(arg : String) -> Bool {
 
 ///|
 fn command_text_env_assignment_word(word : String) -> Bool {
-  let parts = word.split("=").collect()
-  if parts.length() < 2 {
-    return false
-  }
-  command_text_valid_env_name(parts[0])
+  [..word.split("=")] is [name, _, ..] && command_text_valid_env_name(name)
 }
 
 ///|

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -287,7 +287,7 @@ async fn cached_source_write_profile_valid(
 fn source_write_regex(real_workspace_root : String) -> String {
   let root = regex_escape(strip_trailing_slash(real_workspace_root))
   let source_file = "([^/]*(\\.mbt\\.md|\\.mbt|\\.mbti)|(moon\\.mod\\.json|moon\\.pkg\\.json|moon\\.mod|moon\\.pkg|moon\\.work))"
-  "^" + root + "(/|$)(.*/)?\{source_file}$"
+  "^\{root}(/|$)(.*/)?\{source_file}$"
 }
 
 ///|
@@ -298,7 +298,7 @@ fn source_write_regex(real_workspace_root : String) -> String {
 /// `is_moon_managed_workspace_path`.
 fn source_write_build_carveout_regex(real_workspace_root : String) -> String {
   let root = regex_escape(strip_trailing_slash(real_workspace_root))
-  "^" + root + "/(.*/)?(_build|\\.mooncakes)(/|$)"
+  "^\{root}/(.*/)?(_build|\\.mooncakes)(/|$)"
 }
 
 ///|

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -366,23 +366,28 @@ async fn print_fleet_summary(
   let finished = outcomes
     .iter()
     .count_if(outcome => outcome is Some(result) && result.ok)
-  let lines : Array[String] = [
-    "",
-    "openseek: \{total} run(s) of \"\{one_line_brief(task, 60)}\" — \{finished} finished, \{total - finished} not",
-  ]
-  for outcome in outcomes {
-    match outcome {
-      Some(result) =>
-        lines.push(
-          "  #\{result.index + 1}  \{result.status}  \{result.session}  \{result.dir}  \{one_line_brief(result.detail, 60)}",
-        )
-      None => lines.push("  (run did not report)")
+  // Each row writes its own leading newline, so a fleet with no rows leaves
+  // the scaffold untouched.
+  fn rows(out : StringBuilder) {
+    for outcome in outcomes {
+      match outcome {
+        Some(result) =>
+          out <+
+            "\n  #\{result.index + 1}  \{result.status}  \{result.session}  \{result.dir}  \{one_line_brief(result.detail, 60)}"
+        None => out <+ "\n  (run did not report)"
+      }
     }
   }
-  lines.push("")
-  lines.push("inspect a run:  \{inspect_hint(session_root_value)}")
-  lines.push("")
-  @stdio.stderr.write(lines.join("\n")) catch {
+
+  @stdio.stderr.write(
+    (
+      $|
+      $|openseek: \{total} run(s) of "\{one_line_brief(task, 60)}" — \{finished} finished, \{total - finished} not\{out => rows(out)}
+      $|
+      $|inspect a run:  \{inspect_hint(session_root_value)}
+      $|
+    ),
+  ) catch {
     _ => ()
   }
 }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1842,7 +1842,7 @@ async test "session list json reports titles newest first with husks last" {
     store.create(newer)
     // A directory with no session files at all still appears — last, with no
     // timestamp — matching the human-readable listing's behavior.
-    @fs.mkdir(root + "/sessions/husk", recursive=true)
+    @fs.mkdir("\{root}/sessions/husk", recursive=true)
     guard session_list_json(store) is Array(entries) else {
       fail("expected a JSON array")
     }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -444,9 +444,7 @@ fn failure_message(error_text : String) -> String {
     return "\{message}"
   }
   let marker = " FAILED: "
-  guard error_text.split(marker).collect() is [_, .., last] else {
-    return error_text
-  }
+  guard [..error_text.split(marker)] is [_, .., last] else { return error_text }
   "\{last.strip_suffix(")").unwrap_or(last)}"
 }
 

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -219,7 +219,7 @@ fn show_file_in_viewer(
     // scheme never parses as a model path and hover stays off.
     let uri = match absolute {
       Some(absolute) => model_uri_of(absolute)
-      None => app_uri("openseek-notice", "/" + name)
+      None => app_uri("openseek-notice", "/\{name}")
     }
     // Whether anything needs redrawing is decided here, against the document
     // the viewer really shows — the update loop only says "show this", it

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -158,7 +158,7 @@ fn child_path(parent : @pathx.Relative, name : String) -> @pathx.Relative {
   if parent.is_root() {
     Relative(name)
   } else {
-    Relative(parent.0 + "/" + name)
+    Relative("\{parent.0}/\{name}")
   }
 }
 

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -145,7 +145,7 @@ pub fn read_file(
 /// A workspace-relative path's final `/`-segment, for a mention chip's jump
 /// target — it carries only the path, not a display name.
 pub fn basename(path : @pathx.Relative) -> String {
-  match path.0.split("/").collect() {
+  match [..path.0.split("/")] {
     [] => path.0
     [.., last] => last.to_owned()
   }

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -466,9 +466,8 @@ fn tights_text(tights : @cmark.Seq[@cmark.Tight]) -> String {
 ///|
 test "markdown survives every streaming prefix of a list-heavy answer" {
   let answer = "你好！😊 我是 OpenSeek，一个专注于 MoonBit 语言的 AI 编程助手。\n\n我可以帮你：\n\n- 🛠️ **写 MoonBit 代码**：函数、模块、测试\n- 🔍 **解释代码**：阅读和理解现有项目\n- 🐛 **修 bug**：定位并修复问题\n\n1. 第一步\n2. 第二步\n\n| 列 | 表 |\n|---|---|\n| a | b |\n"
-  let chars = answer.iter().collect()
   let buf = StringBuilder::new()
-  for ch in chars {
+  for ch in answer {
     buf.write_char(ch)
     let nodes = markdown_nodes(buf.to_string())
     assert_true(nodes.length() > 0)

--- a/desktop/frontend/session.mbt
+++ b/desktop/frontend/session.mbt
@@ -40,7 +40,7 @@ fn random_salt() -> String {
 fn pad(value : Int, width : Int) -> String {
   let mut text = value.to_string()
   while text.length() < width {
-    text = "0" + text
+    text = "0\{text}"
   }
   text
 }

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -163,7 +163,7 @@ fn append_terminal_item(
         content: if message.is_empty() {
           "aborted"
         } else {
-          "aborted: " + message
+          "aborted: \{message}"
         },
       })
     "interrupted" =>
@@ -172,7 +172,7 @@ fn append_terminal_item(
         content: if message.is_empty() {
           "cancelled"
         } else {
-          "cancelled: " + message
+          "cancelled: \{message}"
         },
       })
     "failed" =>

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -425,7 +425,7 @@ fn apply_engine_event(
       let content = if reason.trim().is_empty() {
         "aborted"
       } else {
-        "aborted: " + reason
+        "aborted: \{reason}"
       }
       (true, conv.clear_streams().append_item(Assistant(true), content))
     }
@@ -438,7 +438,7 @@ fn apply_engine_event(
       let content = if reason.trim().is_empty() {
         "setup failed"
       } else {
-        "setup failed: " + reason
+        "setup failed: \{reason}"
       }
       (true, conv.clear_streams().append_item(Assistant(true), content))
     }
@@ -484,7 +484,7 @@ fn apply_engine_event(
       let content = if reason.trim().is_empty() {
         "compaction failed"
       } else {
-        "compaction failed: " + reason
+        "compaction failed: \{reason}"
       }
       (
         true,
@@ -1514,7 +1514,7 @@ fn update_msg(
       if conv is Some(conv) {
         let content = if diagnostics is Some(diagnostics) &&
           !diagnostics.trim().is_empty() {
-          message + "\n\n" + diagnostics
+          "\{message}\n\n\{diagnostics}"
         } else {
           message
         }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1798,10 +1798,7 @@ test "new chat keeps the model intact until the rotation lands" {
 ///|
 test "generated session ids include a random suffix" {
   let id = generated_session_id()
-  let parts : Array[String] = id
-    .split("-")
-    .map(piece => piece.to_owned())
-    .collect()
+  let parts = [..id.split("-")]
   inspect(parts.length(), content="5")
   inspect(parts[0], content="desktop")
   inspect(parts[1].length(), content="8")

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -817,16 +817,15 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
 fn truncate_output(content : String) -> String {
   let head_limit = 60
   let tail_limit = 40
-  let lines = content.split("\n").map(line => line.to_owned()).to_array()
+  let lines = [..content.split("\n")]
   if lines.length() <= head_limit + tail_limit + 1 {
     return content
   }
-  let parts = lines[0:head_limit].to_owned()
-  parts.push(
+  [
+    ..lines[0:head_limit],
     "⋯ \{lines.length() - head_limit - tail_limit} lines skipped ⋯",
-  )
-  parts.append(lines[lines.length() - tail_limit:].to_owned())
-  parts.join("\n")
+    ..lines[lines.length() - tail_limit:],
+  ].join("\n")
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2341,11 +2341,8 @@ test "a tool group's summary counts calls by what the tools do" {
 test "tool output truncation keeps the head and tail around a skip marker" {
   let short = "a\nb\nc"
   inspect(truncate_output(short), content="a\nb\nc")
-  let lines : Array[String] = []
-  for index in 0..<200 {
-    lines.push("line \{index}")
-  }
-  let clamped = truncate_output(lines.join("\n")).split("\n").to_array()
+  let lines = [ for index in 0..<200 => "line \{index}" ]
+  let clamped = [..truncate_output(lines.join("\n")).split("\n")]
   inspect(clamped.length(), content="101")
   inspect(clamped[0], content="line 0")
   inspect(clamped[59], content="line 59")

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -649,7 +649,7 @@ fn capitalize(text : String) -> String {
   // a non-BMP first char left `text[1:]` inside its surrogate pair, corrupting
   // the tail on native and *panicking* on js (StringView sub mid-surrogate).
   match text {
-    [first, .. rest] => "\{first.to_ascii_uppercase()}" + rest.to_owned()
+    [first, .. rest] => "\{first.to_ascii_uppercase()}\{rest}"
     [] => text
   }
 }
@@ -850,7 +850,7 @@ fn inline_code_nodes(content : String) -> Array[@html.Html] {
       }
       None => {
         if in_code {
-          nodes.push(@html.text("`" + rest))
+          nodes.push(@html.text("`\{rest}"))
         } else if !rest.is_empty() {
           nodes.push(@html.text(rest))
         }

--- a/desktop/internal/applauncher/applauncher.mbt
+++ b/desktop/internal/applauncher/applauncher.mbt
@@ -222,7 +222,7 @@ fn app_search_dirs() -> Array[String] {
     "/Applications", "/System/Applications", "/System/Applications/Utilities", "/System/Library/CoreServices",
   ]
   if @home.dir() is Some(home) {
-    dirs.push(home.to_string() + "/Applications")
+    dirs.push("\{home}/Applications")
   }
   dirs
 }
@@ -295,7 +295,7 @@ async fn app_icon_data_url(id : String, app_path : String) -> String {
 #cfg(not(platform="windows"))
 fn icon_cache_dir() -> String? {
   if @home.dir() is Some(home) {
-    Some(home.to_string() + "/Library/Caches/OpenSeek/app-icons")
+    Some("\{home}/Library/Caches/OpenSeek/app-icons")
   } else {
     None
   }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -828,7 +828,7 @@ async fn serve_engine_consumer(
             let reason = if diagnostics.is_empty() {
               "engine exited during compaction"
             } else {
-              "engine exited during compaction:\n" + diagnostics
+              "engine exited during compaction:\n\{diagnostics}"
             }
             emit_compaction_failed(sink, engine, reason)
           }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -486,7 +486,7 @@ fn prepend_to_path_env(bin_dir : String, current_path : String?) -> String {
 ///|
 fn first_path_entry(path : String?) -> String {
   guard path is Some(path) else { return "" }
-  match path.split(PathSep).collect() {
+  match [..path.split(PathSep)] {
     [first, ..] => first.to_owned()
     [] => ""
   }

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -356,7 +356,7 @@ async fn session_group(
     "sessions", "list", "--session-root", root, "--format", "json",
   ]) catch {
     error if @async.is_being_cancelled() => raise error
-    EngineError(detail) => return failed("session list failed: " + detail)
+    EngineError(detail) => return failed("session list failed: \{detail}")
     error => return failed("session list failed: \{error}")
   }
   let sessions = @json.parse(output) catch {
@@ -395,7 +395,7 @@ pub async fn load_session(
     "--session-root",
     root.to_string(),
   ]) catch {
-    EngineError(detail) => raise EngineError("session load failed: " + detail)
+    EngineError(detail) => raise EngineError("session load failed: \{detail}")
     error => raise error
   }
   let json = @json.parse(output) catch {
@@ -425,7 +425,7 @@ async test "one-shot session engine overrides ambient OPENSEEK_DIR" {
   let previous = @sys.get_env_var("OPENSEEK_DIR")
   @sys.set_env_var("OPENSEEK_DIR", "/missing/openseek-dir")
   let dir = @fs.tmpdir(prefix="openseek-session-env-")
-  let engine = dir + "/engine.sh"
+  let engine = "\{dir}/engine.sh"
   @fs.write_file(
     engine,
     "#!/bin/sh\nprintf '%s' \"$OPENSEEK_DIR\"\n",

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -252,18 +252,18 @@ async test "real_contains rejects a symlink escaping the boundary" {
   let outside = @fs.tmpdir(prefix="openseek-outside-")
   // A real file inside the boundary, and a symlink inside the boundary that
   // points at a file outside it (the escape the lexical check misses).
-  let inside = root + "/inside.txt"
+  let inside = "\{root}/inside.txt"
   @fs.write_file(inside, b"x", create_mode=CreateOrTruncate)
-  let secret = outside + "/secret.txt"
+  let secret = "\{outside}/secret.txt"
   @fs.write_file(secret, b"s", create_mode=CreateOrTruncate)
-  let link = root + "/link.txt"
+  let link = "\{root}/link.txt"
   @fs.symlink(target=secret, link)
   // Capture the verdicts, then clean up before asserting — `@fs.rmdir` is
   // async so it cannot run in a `defer`, and a failed assertion must not leak
   // the temp trees.
   let inside_ok = real_contains(root, inside)
   // A path that does not exist is trusted: no link to follow, no file to leak.
-  let missing_ok = real_contains(root, root + "/missing.txt")
+  let missing_ok = real_contains(root, "\{root}/missing.txt")
   let link_escapes = real_contains(root, link)
   @fs.rmdir(root, recursive=true) catch {
     _ => ()

--- a/desktop/internal/engine/wsl.mbt
+++ b/desktop/internal/engine/wsl.mbt
@@ -186,7 +186,7 @@ const WslEnvPassthrough : String = "DEEPSEEK/u:OPENSEEK_MODEL/u:OPENSEEK_MAX_STE
 /// extended with the engine's variables.
 fn wslenv_with_passthrough(existing : String?) -> String {
   match existing {
-    Some(value) if !value.trim().is_empty() => value + ":" + WslEnvPassthrough
+    Some(value) if !value.trim().is_empty() => "\{value}:\{WslEnvPassthrough}"
     _ => WslEnvPassthrough
   }
 }

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -46,10 +46,10 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     ContextYield(answer~, ..) => Some(ContextYield(answer))
     AgentAborted(reason~) => Some(AgentAborted(reason))
     MaxStepsExhausted => Some(MaxStepsExhausted)
-    AgentSetupFailed(error~) => Some(AgentError("agent setup failed: " + error))
+    AgentSetupFailed(error~) => Some(AgentError("agent setup failed: \{error}"))
     // A serve-mode turn that died with a non-cancellation error. Terminal for
     // the run even though the engine process lives on.
-    TurnFailed(error~) => Some(AgentError("turn failed: " + error))
+    TurnFailed(error~) => Some(AgentError("turn failed: \{error}"))
     // Compaction lifecycle: `started` is informational; finished/failed mean the
     // engine is done touching the durable record, which the host gates archiving
     // on. Not terminal for any run — compaction happens between turns.

--- a/desktop/internal/extension/fs_ops.mbt
+++ b/desktop/internal/extension/fs_ops.mbt
@@ -112,7 +112,7 @@ async fn collect_files(
     let relative = if prefix.is_empty() {
       entry.name
     } else {
-      prefix + "/" + entry.name
+      "\{prefix}/\{entry.name}"
     }
     if entry.is_dir {
       if ignored_watch_path(relative) {

--- a/desktop/internal/extension/fs_watch.mbt
+++ b/desktop/internal/extension/fs_watch.mbt
@@ -50,7 +50,7 @@ async fn watch_workspace_op(
 /// watch root and `/`-separated; pruning a directory prunes everything
 /// under it, so matching the leaf segment is enough.
 fn ignored_watch_path(path : String) -> Bool {
-  match path.split("/").collect() {
+  match [..path.split("/")] {
     [.., ".git" | "target" | "_build" | "node_modules" | ".mooncakes" | ".repos"] =>
       true
     _ => false

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -56,7 +56,7 @@ async fn get_moonc_version(
       "failed to read bundled MoonBit compiler version: \{output.text().trim()}",
     )
   }
-  match output.text().trim().split(" ").collect() {
+  match [..output.text().trim().split(" ")] {
     [['v', .. version], ..] => version.to_owned()
     [version, ..] => version.to_owned()
     [] => ""

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -71,7 +71,7 @@ pub fn relative_to(path : String, root~ : String) -> String? {
   if path == root {
     return Some("")
   }
-  let prefix = if root.has_suffix("/") { root } else { root + "/" }
+  let prefix = if root.has_suffix("/") { root } else { "\{root}/" }
   match path.strip_prefix(prefix) {
     Some(rest) => Some(rest.to_owned())
     None => None

--- a/desktop/internal/update/apply.mbt
+++ b/desktop/internal/update/apply.mbt
@@ -18,7 +18,7 @@ fn aside_path(bundle_path : String) -> String {
 /// The marker `main` consults after the run loop exits: present means
 /// "relaunch this bundle". Written only after a successful swap.
 fn relaunch_marker_path(work_dir : String) -> String {
-  work_dir + "/relaunch"
+  "\{work_dir}/relaunch"
 }
 
 ///|

--- a/desktop/internal/update/stage.mbt
+++ b/desktop/internal/update/stage.mbt
@@ -30,7 +30,7 @@ pub struct StagedUpdate {
 /// The staging directory under the app's per-user work directory. Wiped
 /// before every download and by `cleanup_leftovers`.
 fn staging_dir(work_dir : String) -> String {
-  work_dir + "/update"
+  "\{work_dir}/update"
 }
 
 ///|
@@ -52,10 +52,10 @@ pub async fn stage_update(
   let staging = staging_dir(work_dir)
   remove_tree(staging)
   @fs.mkdir(staging, recursive=true)
-  let archive = staging + "/package.zip"
+  let archive = "\{staging}/package.zip"
   download(artifact.url, archive)
   verify_digest(archive, artifact.sha256)
-  let extract_dir = staging + "/extract"
+  let extract_dir = "\{staging}/extract"
   run_tool("ditto", ["-x", "-k", archive, extract_dir])
   let app_path = extracted_app(extract_dir)
   // The zip may carry quarantine attributes; the bundle is notarized, but
@@ -95,7 +95,7 @@ async fn verify_digest(archive : String, expected : String) -> Unit {
 async fn extracted_app(extract_dir : String) -> String {
   for entry in @fs.readdir(extract_dir) {
     if entry.has_suffix(".app") {
-      return extract_dir + "/" + entry
+      return "\{extract_dir}/\{entry}"
     }
   }
   raise UpdateError("the update package contains no .app bundle")

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -227,7 +227,7 @@ fn parse_version(text : String) -> (Int, Int, Int)? {
       view = view[:index]
     }
   }
-  let parts = view.split(".").collect()
+  let parts = [..view.split(".")]
   guard parts.length() == 3 else { return None }
   let numbers = []
   for part in parts {

--- a/desktop/package/internal/moonbit/toolchain.mbt
+++ b/desktop/package/internal/moonbit/toolchain.mbt
@@ -260,7 +260,7 @@ async fn compiler_version(
       "failed to read MoonBit compiler version from \{compiler}: \{output.text().trim()}",
     )
   }
-  let version = output.text().trim().split(" ").collect()[0].to_owned()
+  let version = output.text().trim().split(" ").head().unwrap_or("").to_owned()
   if version.strip_prefix("v") is Some(version) {
     version.to_owned()
   } else {

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -234,7 +234,7 @@ fn relocate_workspace_path(
   if relocated != trial.workspace {
     relocated
   } else if old_out_dir != new_out_dir {
-    new_out_dir + "/workspaces/" + padded_index(trial.index)
+    "\{new_out_dir}/workspaces/\{padded_index(trial.index)}"
   } else {
     trial.workspace
   }
@@ -249,7 +249,7 @@ fn relocate_output_path(
   if path == "" || old_out_dir == "" || old_out_dir == new_out_dir {
     return path
   }
-  let prefix = old_out_dir + "/"
+  let prefix = "\{old_out_dir}/"
   match path.strip_prefix(prefix) {
     Some(rest) => "\{new_out_dir}/\{rest}"
     None => path
@@ -418,7 +418,7 @@ fn path_under_dir(path : String, dir : String) -> Bool {
   if path == "" || dir == "" {
     return false
   }
-  path == dir || path.has_prefix(dir + "/")
+  path == dir || path.has_prefix("\{dir}/")
 }
 
 ///|
@@ -444,7 +444,7 @@ async fn validate_workspace(
   ]
   let failures = [
     for result in results if !result.passed => {
-      result.name + ": " + result.reason
+      "\{result.name}: \{result.reason}"
     }
   ]
   {
@@ -516,7 +516,7 @@ fn probe_output_result(
     return ProbeResult(
       name=spec.name,
       passed=false,
-      reason="debug/panic output leaked: " + summarize(combined),
+      reason="debug/panic output leaked: \{summarize(combined)}",
     )
   }
   if spec.expect_exit >= 0 && code != spec.expect_exit {
@@ -561,7 +561,7 @@ fn probe_output_result(
         return ProbeResult(
           name=spec.name,
           passed=false,
-          reason="stdout is not JSON: \{error}; stdout=" + summarize(stdout),
+          reason="stdout is not JSON: \{error}; stdout=\{summarize(stdout)}",
         )
     }
   }
@@ -586,7 +586,7 @@ fn workspace_path(workspace : String, path : String) -> String {
   if path.has_prefix("/") {
     path
   } else {
-    workspace + "/" + path
+    "\{workspace}/\{path}"
   }
 }
 

--- a/eval/prompt_task/harness/manifest.mbt
+++ b/eval/prompt_task/harness/manifest.mbt
@@ -122,7 +122,7 @@ pub fn RunManifest::RunManifest(
 ///|
 /// Path to the run manifest under an eval output directory.
 pub fn manifest_path(out_dir : String) -> String {
-  out_dir + "/" + manifest_file_name
+  "\{out_dir}/\{manifest_file_name}"
 }
 
 ///|

--- a/eval/prompt_task/harness/report.mbt
+++ b/eval/prompt_task/harness/report.mbt
@@ -14,7 +14,7 @@ async fn write_report_files(report : EvalReport) -> Unit {
 ///|
 async fn write_eval_result_files(out_dir : String, result : EvalResult) -> Unit {
   @report.write_files(
-    out_dir + "/eval_results/" + eval_result_artifact_name(result),
+    "\{out_dir}/eval_results/\{eval_result_artifact_name(result)}",
     result.markdown(),
     result.to_json(),
     html=result.html(),
@@ -167,7 +167,7 @@ fn EvalResult::as_report(
   out_dir~ : String,
 ) -> @report.Report {
   Report(
-    title="Prompt Task Eval Result: " + eval_result_name(self),
+    title="Prompt Task Eval Result: \{eval_result_name(self)}",
     summary=[
       Metric(name="session", value=empty_dash(self.session_id)),
       Metric(name="prompt", value=empty_dash(self.prompt_label)),
@@ -303,7 +303,7 @@ fn relative_artifact_path(out_dir : String, path : String) -> String {
   if out_dir == "" || path == "" {
     return path
   }
-  let prefix = out_dir + "/"
+  let prefix = "\{out_dir}/"
   match path.strip_prefix(prefix) {
     Some(rest) => "\{rest}"
     None => path

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -793,9 +793,8 @@ fn suite_success_summary(report : SuiteReport) -> String {
 
 ///|
 fn problem_id_from_report(report : EvalReport) -> String {
-  let pieces = report.prompt_label.split(":").collect()
-  if pieces.length() > 0 {
-    pieces[0].to_owned()
+  if report.prompt_label.split(":").head() is Some(first) {
+    first.to_owned()
   } else {
     report.prompt_label
   }
@@ -890,7 +889,7 @@ fn resolve_relative_path(base_dir : String, path : String) -> String {
 
 ///|
 fn dirname(path : String) -> String {
-  let pieces = path.split("/").collect()
+  let pieces = [..path.split("/")]
   if pieces.length() <= 1 {
     return "."
   }

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -189,7 +189,7 @@ pub fn SuiteReport::SuiteReport(
 ///|
 /// Path to the suite manifest under a suite output directory.
 pub fn suite_manifest_path(out_dir : String) -> String {
-  out_dir + "/" + suite_manifest_file_name
+  "\{out_dir}/\{suite_manifest_file_name}"
 }
 
 ///|
@@ -350,7 +350,7 @@ async fn prepare_suite_output_dir(out_dir : String) -> Unit {
   if @fs.exists(out_dir) {
     @fs.rmdir(out_dir, recursive=true)
   }
-  @fs.mkdir(out_dir + "/combos", recursive=true)
+  @fs.mkdir("\{out_dir}/combos", recursive=true)
 }
 
 ///|
@@ -395,7 +395,7 @@ async fn run_suite_job(
     out_dir=job.out_dir,
     repo_root=suite.repo_root,
     engine=suite.engine,
-    prompt_label=job.problem.prompt_label + ":" + job.model.to_string(),
+    prompt_label="\{job.problem.prompt_label}:\{job.model}",
     task_file=job.problem.task_file,
     validation_probes=job.problem.validation_probes,
     system_prompt_file=suite.system_prompt_file,
@@ -428,7 +428,7 @@ async fn write_suite_manifests(
           }
         }
       }
-      let prompt_label = problem.prompt_label + ":" + model_name
+      let prompt_label = "\{problem.prompt_label}:\{model_name}"
       let manifest = RunManifest(
         model=model_name,
         problem_id=problem.id,
@@ -883,7 +883,7 @@ fn resolve_relative_path(base_dir : String, path : String) -> String {
   if path.has_prefix("/") || base_dir == "." {
     path
   } else {
-    base_dir + "/" + path
+    "\{base_dir}/\{path}"
   }
 }
 

--- a/scripts/internal/markdown_comments/markdown_comments_test.mbt
+++ b/scripts/internal/markdown_comments/markdown_comments_test.mbt
@@ -5,7 +5,7 @@ fn strip(markdown : String) -> String {
 
 ///|
 fn visible_cr(markdown : String) -> String {
-  markdown.split("\r").collect().join("|")
+  [..markdown.split("\r")].join("|")
 }
 
 ///|

--- a/testkit/filesystem/filesystem.mbt
+++ b/testkit/filesystem/filesystem.mbt
@@ -72,7 +72,7 @@ pub fn FileSystem::validate(self : FileSystem) -> Unit raise {
 /// Raises when the JSON violates the filesystem convention.
 pub fn FileSystem::entries(self : FileSystem) -> Array[FileEntry] raise {
   let fields = self.object_fields()
-  let paths = fields.keys().collect()
+  let paths = [..fields.keys()]
   paths.sort()
   [
     for path in paths => {

--- a/testkit/filesystem/outline.mbt
+++ b/testkit/filesystem/outline.mbt
@@ -42,7 +42,7 @@ async fn collect_dirs(
     let child = "\{dir}/\{name}"
     let kind = @fs.kind(child, follow_symlink=false) catch { _ => continue }
     guard kind is Directory else { continue }
-    out.push(outline_indent(depth) + sanitize_name(name) + "/")
+    out.push("\{outline_indent(depth)}\{sanitize_name(name)}/")
     collect_dirs(child, depth + 1, max_depth, max_dirs, out)
   }
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1067,16 +1067,16 @@ fn generate_diff(old : String, new : String) -> String {
   }
   [
     ..[
-      for line in old_lines[:pre] => "  " + line
+      for line in old_lines[:pre] => "  \{line}"
     ],
     ..[
-      for line in old_lines[pre:n - suf] => "- " + line
+      for line in old_lines[pre:n - suf] => "- \{line}"
     ],
     ..[
-      for line in new_lines[pre:m - suf] => "+ " + line
+      for line in new_lines[pre:m - suf] => "+ \{line}"
     ],
     ..[
-      for line in old_lines[n - suf:] => "  " + line
+      for line in old_lines[n - suf:] => "  \{line}"
     ],
   ].join("\n")
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -510,7 +510,9 @@ fn split_plan_checklist(content : String) -> (String, Array[String])? {
   for index, line in lines {
     if line.trim_end().has_suffix("Current plan:") {
       let steps = [
-        for step in lines[index + 1:] if !step.trim().is_empty() => step
+        for step in lines[index + 1:] if !step.trim().is_empty() => {
+          step.to_owned()
+        }
       ]
       if steps.is_empty() {
         return None
@@ -1082,15 +1084,15 @@ fn generate_diff(old : String, new : String) -> String {
 }
 
 ///|
-/// Split `text` into lines on `\n`.
-fn string_lines(text : String) -> Array[String] {
-  text.split("\n").map(line => line.to_owned()).collect()
+/// Split `text` into lines on `\n`, as views into `text`.
+fn string_lines(text : String) -> Array[StringView] {
+  [..text.split("\n")]
 }
 
 ///|
 /// Prefix every line of `text` with `marker` (for all-added / all-removed diffs).
 fn prefix_lines(text : String, marker : String) -> String {
-  string_lines(text).map(line => marker + line).join("\n")
+  string_lines(text).map(line => "\{marker}\{line}").join("\n")
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -148,7 +148,7 @@ fn multi_step_session() -> @agent_session.Session {
 
 ///|
 fn occurrences(text : String, needle : String) -> Int {
-  text.split(needle).collect().length() - 1
+  text.split(needle).count() - 1
 }
 
 ///|


### PR DESCRIPTION
## Summary

Generalizes the simplifications from #518 (agent_skill idiomatic cleanup) to the rest of the repo, one pattern per commit:

- **agent_review prompts** (`1d719b40`): the review system prompt and task build with `#|` / `$|` raw multiline blocks instead of `\n`-embedded string concatenation. Byte-identical output.
- **`[..x.split(sep)]` spread instead of `.collect()`** (`94ee154d`): across cmd, agent_tool, testkit, eval, viz, scripts, and desktop. The shell env-assignment predicates now match `[name, value]` / `[name, _, ..]` array patterns instead of length-checking and indexing; `occurrences()` counts the iterator directly; version parsing takes `head()` instead of `collect()[0]`; the markdown streaming test iterates the string without materializing a char array.
- **Raw blocks / stream writers instead of line-array joins** (`d1f3a393`): read-tool tests assert expected output with `#|` blocks; `print_fleet_summary` streams rows into the `$|` scaffold via a writer lambda (rows carry their own leading newline, so no-row output is unchanged); desktop's `truncate_output` splices head/marker/tail with view spreads instead of owning every line.
- **Interpolation instead of `+` concatenation** (`76605f2d`): `"\{dir}/name"` replaces `dir + "/name"` chains and `"label: \{detail}"` replaces `"label: " + detail` in the core module and desktop harness code. Vendored `.mooncakes`, eval task fixtures, and `desktop/lepus` (submodule) are untouched; `desktop/package` keeps concat because its path scaffolding hangs off `const` initializers, which cannot interpolate.
- **viz line views** (`58b76165`): `string_lines` returns split views; only plan-checklist steps that outlive the call are owned.

## Test plan

- `moon fmt` / `moon check --deny-warn` / `moon check --target all` — clean (root and desktop modules)
- `moon test` root: 1175/1175; desktop native: 212/212; desktop frontend (js): 189/189
- `moon build cmd/viz_app --target js` — bundle builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)