### PR TITLE
docs: verified refresh + architecture page with mermaid diagrams

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -4,6 +4,10 @@ OpenSeek is a small MoonBit foundation for a DeepSeek-backed coding agent. The
 module is split into pure data, HTTP transport, agent orchestration, and a CLI
 entry point so request encoding can be tested without network access.
 
+For a picture of how the pieces fit together — module architecture, the core
+data model, and the life of one agent turn — see
+[`docs/architecture.md`](docs/architecture.md).
+
 ## Packages
 
 | Package | Purpose | Docs |
@@ -14,18 +18,33 @@ entry point so request encoding can be tested without network access.
 | `bobzhang/openseek/agent_runtime` | Native-only agent task-group and extensible runtime event queue. | `agent_runtime/README.mbt.md` |
 | `bobzhang/openseek/agent_session` | Typed durable conversation state and DeepSeek message projection. | `agent_session/README.mbt.md` |
 | `bobzhang/openseek/agent_session/store` | Native filesystem-backed append-only session store. | `agent_session/store/README.mbt.md` |
-| `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types. | `agent_tool/README.mbt.md` |
+| `bobzhang/openseek/agent_session/log` | Lenient session-file reader: header plus events, with per-line error capture. | — |
+| `bobzhang/openseek/agent_session/compact` | Context-checkpoint (compaction) request building and summary handling. | — |
+| `bobzhang/openseek/agent_tool` | Tool registry, executor, output, and control-action types; one subpackage per built-in tool. | `agent_tool/README.mbt.md` |
+| `bobzhang/openseek/agent_skill` | Workspace skills: markdown playbooks discovered from skill libraries and listed in the system prompt. | `agent_skill/README.mbt.md` |
+| `bobzhang/openseek/jsonrpc` | Duplex JSON-RPC 2.0 client (concurrent requests, notifications, out-of-order replies). | — |
+| `bobzhang/openseek/mcp` (+ `config`, `stdio`, `streamhttp`, `tools`) | MCP client: `mcp.json` decoding, stdio and Streamable HTTP transports, and the bridge that namespaces server tools into the registry. | — |
+| `bobzhang/openseek/prompt` | Built-in system prompt text (generated from Markdown) and prompt-selection policy. | `prompt/README.mbt.md` |
 | `bobzhang/openseek_protocol` | Typed engine event stream (own module): the `openseek run`/`serve` stdout wire contract, decodable on every backend. | `protocol/README.mbt.md` |
 | `bobzhang/openseek_protocol/emit` | Native-only writer for that stream: owns each event's log level. | `protocol/emit/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
+| `bobzhang/openseek/agent_review` | Read-only, compiler-grounded code-review engine behind `openseek review`. | `agent_review/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only command-line entry point. | `cmd/openseek/README.md` |
 | `bobzhang/openseek/cmd/tui` | Native-only terminal UI library, the default mode of `openseek` (and `openseek tui`). | `cmd/tui/README.md` |
+| `bobzhang/openseek/tui` | Reusable terminal-UI framework (transcript, composer, rendering) the OpenSeek TUI builds on. | `tui/README.md` |
+| `bobzhang/openseek/viz` | Browser viewer for durable session logs (JS). | `viz/README.md` |
+| `bobzhang/openseek/cmd/viz_server` | Native HTTP server that serves the visualizer over recorded sessions. | `cmd/viz_server/README.md` |
+| `bobzhang/openseek/cmd/viz_app` | JS entry point compiled into the visualizer bundle. | `viz/README.md` |
+| `bobzhang/openseek/internal/{cli,agentcli,workspace_path}` | Shared CLI accessors and workspace-path resolution for the command mains. | — |
 | `bobzhang/openseek/testkit/filesystem` | JSON-backed virtual filesystem for tests and eval fixtures. | `testkit/filesystem/README.mbt.md` |
 | `bobzhang/openseek/eval/report` | Shared Markdown/JSON report primitive for deterministic and model evals. | `eval/report/README.mbt.md` |
 | `bobzhang/openseek/eval/tool_harness` | Deterministic host-side harness that dispatches every built-in tool. | `eval/tool_harness/README.mbt.md` |
 | `bobzhang/openseek/eval/file_edit/cases` | Deterministic file-editing eval case definitions. | `eval/file_edit/README.md` |
 | `bobzhang/openseek/eval/file_edit/harness` | Reusable file-editing eval runner, oracle, and reporter. | `eval/file_edit/README.md` |
 | `bobzhang/openseek/eval/file_edit/cmd/main` | Native-only CLI wrapper for the file-editing eval harness. | `eval/file_edit/README.md` |
+| `bobzhang/openseek/eval/prompt_task/harness` | Prompt-task eval: runs the real agent over isolated per-trial workspaces. | `eval/prompt_task/README.md` |
+| `bobzhang/openseek/eval/session_analyzer` | Post-hoc session-log analyzer producing Markdown/HTML/JSON reports. | — |
+| `openseek_desktop` (in `desktop/`, own module) | Desktop app: CEF shell (lepus submodule) plus a JS frontend driving the engine over JSONL. | `desktop/README.md` |
 
 The `deepseek` subpackage is pure and exposes chat data plus JSON helpers:
 
@@ -67,9 +86,11 @@ filesystem, and process APIs.
 
 The `cmd/openseek` package is the single-binary entry point — a subcommand tree
 (default: the terminal UI; `run`/`serve`/`review`/`sessions` for the headless
-engine). `openseek run` parses arguments and runs the agent package. The agent
-sends DeepSeek native function tools and supports seven local tools: `shell`,
-`read`, `edit`, `multi_edit`, `write`, `plan`, and `finish`.
+engine; `mcp` to validate MCP configuration). `openseek run` parses arguments
+and runs the agent package. The agent sends DeepSeek native function tools and
+supports eleven local tools: `shell` (with `shell_output` and `shell_stop` for
+background jobs — on Windows the plain foreground shell only), `read`, `edit`,
+`multi_edit`, `write`, `remove`, `plan`, `goal`, and `finish`.
 
 ```bash
 export DEEPSEEK=sk-...
@@ -126,6 +147,16 @@ moon run cmd/openseek -- mcp --mcp-config mcp.json
 Resources and prompts (the other MCP capabilities) are not consumed: openseek's
 agent is tool-driven, and a server that wants to feed it context can expose a
 tool. This keeps the surface small; revisit if a concrete need appears.
+
+## Skills
+
+Reusable markdown playbooks the agent loads on demand. A skill is a
+`<name>.md` file or a `<name>/SKILL.md` directory layout with optional
+`name:`/`description:` frontmatter. Two libraries are merged: the global one
+(`~/.openseek/skills`, or `--global-skills-dir`) and the workspace one
+(`.openseek/skills`), with workspace skills shadowing same-named global ones.
+The system prompt lists each skill's name, description, and file path; the
+agent reads the file before applying it. See `agent_skill/README.mbt.md`.
 
 ## Terminal UI
 

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -34,7 +34,7 @@ data model, and the life of one agent turn — see
 | `bobzhang/openseek/tui` | Reusable terminal-UI framework (transcript, composer, rendering) the OpenSeek TUI builds on. | `tui/README.md` |
 | `bobzhang/openseek/viz` | Browser viewer for durable session logs (JS). | `viz/README.md` |
 | `bobzhang/openseek/cmd/viz_server` | Native HTTP server that serves the visualizer over recorded sessions. | `cmd/viz_server/README.md` |
-| `bobzhang/openseek/cmd/viz_app` | JS entry point compiled into the visualizer bundle. | `viz/README.md` |
+| `bobzhang/openseek-viz-app` (in `cmd/viz_app/`, own module) | JS entry point compiled into the visualizer bundle. | `viz/README.md` |
 | `bobzhang/openseek/internal/{cli,agentcli,workspace_path}` | Shared CLI accessors and workspace-path resolution for the command mains. | — |
 | `bobzhang/openseek/testkit/filesystem` | JSON-backed virtual filesystem for tests and eval fixtures. | `testkit/filesystem/README.mbt.md` |
 | `bobzhang/openseek/eval/report` | Shared Markdown/JSON report primitive for deterministic and model evals. | `eval/report/README.mbt.md` |

--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -104,12 +104,16 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 `build_tools(runtime, scope)` returns the standard local tool registry:
 
 - `shell`: run a command under the workspace root or an explicit cwd (including
-  `moon check` for compiler feedback);
+  `moon check` for compiler feedback), with `run_in_background` support;
+- `shell_output` / `shell_stop`: read or stop a background shell job (omitted on
+  Windows, where background jobs are not wired);
 - `read`: read a text file;
 - `edit`: replace exact text in a file;
 - `multi_edit`: apply several explicit line-anchored replacements to one file;
 - `write`: overwrite a file;
+- `remove`: delete a file the agent created (or that git tracks);
 - `plan`: record or replace the step-by-step plan for a multi-step task;
+- `goal`: set or clear the standing goal for the session;
 - `finish`: end the task with a final answer.
 
 File-oriented tools capture `runtime.workspace_root()` when the registry is

--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -111,7 +111,7 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `edit`: replace exact text in a file;
 - `multi_edit`: apply several explicit line-anchored replacements to one file;
 - `write`: overwrite a file;
-- `remove`: delete a file the agent created (or that git tracks);
+- `remove`: delete a file the agent itself created earlier in the session;
 - `plan`: record or replace the step-by-step plan for a multi-step task;
 - `goal`: set or clear the standing goal for the session;
 - `finish`: end the task with a final answer.

--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -113,7 +113,8 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `write`: overwrite a file;
 - `remove`: delete a file the agent itself created earlier in the session;
 - `plan`: record or replace the step-by-step plan for a multi-step task;
-- `goal`: set or clear the standing goal for the session;
+- `goal`: report standing-goal status (`met`, `continuing`, or `blocked`;
+  `met` clears the goal — setting one is the serve `goal` command's job);
 - `finish`: end the task with a final answer.
 
 File-oriented tools capture `runtime.workspace_root()` when the registry is

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -102,8 +102,8 @@ async fn[X] shell_tools(
 ///
 /// The returned registry contains the built-in local tools: `shell` (plus
 /// `shell_output` and `shell_stop` where background jobs are supported — see
-/// `shell_tools`), `read`, `edit`, `multi_edit`, `write`, `remove`, `plan`, and
-/// `finish`.
+/// `shell_tools`), `read`, `edit`, `multi_edit`, `write`, `remove`, `plan`,
+/// `goal`, and `finish`.
 /// Each tool lives in its own subpackage of `agent_tool` and exposes a
 /// `definition()` constructor; this function bundles them into the `Tools`
 /// value the loop dispatches against. File-oriented tools capture

--- a/agent_review/README.mbt.md
+++ b/agent_review/README.mbt.md
@@ -3,7 +3,7 @@
 `agent_review` is OpenSeek's **code-review engine**. It runs a read-only,
 compiler-grounded review of a change set and returns a single structured
 `ReviewReport`. The engine is deliberately front-end-agnostic: the headless
-`openseek --review` CLI is one caller today, and the same `ReviewReport` JSON is
+`openseek review` CLI is one caller today, and the same `ReviewReport` JSON is
 the boundary other coding agents (e.g. Codex, Claude) spawn and consume when they
 dispatch a review to OpenSeek.
 
@@ -83,14 +83,14 @@ clean), exit code by severity:
 ```bash
 # 0 = clean or non-blocking findings, 1 = the review produced no report,
 # 2 = blocker findings present
-openseek --review --base origin/main
+openseek review --base origin/main
 ```
 
 Because the report is a stable JSON document on stdout, any orchestrator that can
 run a subprocess can use it:
 
 ```bash
-openseek --review --base origin/main | jq '.findings[] | select(.severity=="blocker")'
+openseek review --base origin/main | jq '.findings[] | select(.severity=="blocker")'
 ```
 
 ## Ensembling for confidence

--- a/agent_tool/README.mbt.md
+++ b/agent_tool/README.mbt.md
@@ -10,8 +10,11 @@ Concrete built-in tools live in subpackages:
 - `agent_tool/edit`
 - `agent_tool/multi_edit`
 - `agent_tool/write`
-- `agent_tool/shell`
+- `agent_tool/remove`
+- `agent_tool/shell` (with `agent_tool/shell_output` and `agent_tool/shell_stop`
+  for background jobs, and `agent_tool/bgjobs` as their shared runtime)
 - `agent_tool/plan`
+- `agent_tool/goal`
 - `agent_tool/finish`
 
 ## API Shape

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -4,8 +4,9 @@ This package is the native-only entry point for OpenSeek — the single `opensee
 binary. It is a subcommand tree: the interactive terminal UI is the **default**
 (see [`cmd/tui`](../tui/README.md)), and the headless engine lives under named
 subcommands. It parses arguments with `moonbitlang/core/argparse`, reads defaults
-from environment variables, and calls `bobzhang/openseek/agent.run` for one-shot
-tasks or `agent.run_turn_with_append` for durable sessions.
+from environment variables, and drives turns through
+`bobzhang/openseek/agent.run_turn_in_scope` (both one-shot `run` and durable
+sessions; fleet mode's independent attempts use `agent.run_turn_with_append`).
 
 ```
 openseek [--prompt "…"]        interactive UI (default)

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -245,7 +245,7 @@ async fn run_task_turn(
 
 ///|
 /// `openseek serve` — the persistent JSONL command server the TUI drives: read
-/// prompt/steer/cancel/compact on stdin, stream events on stdout.
+/// prompt/steer/cancel/compact/goal on stdin, stream events on stdout.
 async fn run_serve_command(matches : @argparse.Matches) -> Unit {
   // Serve is ephemeral by default (durable only with --session); --no-session
   // makes that explicit and, as in every mode, contradicts an explicit --session.
@@ -595,7 +595,7 @@ fn root_command() -> @argparse.Command {
       ),
       Command(
         "serve",
-        about="Session server: read JSONL commands (prompt/steer/cancel/compact) from stdin.",
+        about="Session server: read JSONL commands (prompt/steer/cancel/compact/goal) from stdin.",
         options=agent_options(),
         flags=[
           FlagArg(

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -3,7 +3,8 @@
 A [Lepus](https://github.com/moonbit-community/lepus) + [Rabbita](https://mooncakes.io/docs/moonbit-community/rabbita) desktop client for the OpenSeek agent, written in MoonBit.
 
 - `main.mbt` — entry point: wires the window manifest, the IPC extensions, the per-user runtime directory, and the launch log.
-- `internal/engine/` — the native host: keeps one persistent `openseek serve` engine per conversation, streams its JSONL events to the webview, exposes `connect` / `start` / `steer` / `cancel` / `list_sessions` / `load_session` commands plus the `skills_*` / `skill_*` ops backing the Skills panel; also owns where conversations live on disk (per-session workspace directories and the durable session store root) and the bundled frontend/engine lookup.
+- `internal/engine/` — the native host: keeps one persistent `openseek serve` engine per conversation, streams its JSONL events to the webview, and owns where conversations live on disk (per-session workspace directories, the durable session store root, and archiving).
+- `internal/extension/` — the IPC bridge registration: the `connect` / `start` / `steer` / `cancel` / `list_sessions` / `load_session` handlers, the `skills_*` / `skill_*` ops backing the Skills panel, and bundled frontend asset lookup.
 - `internal/skillmarket/` — the mooncakes.io skill registry client and the local skills-library manager: catalog browsing, digest-verified installs into the engine's global skills directory, and uninstall of what the app itself installed.
 - `internal/env/` — process-environment reads (blank means unset).
 - `internal/home/` — the user's home directory and `~` expansion.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -3,15 +3,12 @@
 A [Lepus](https://github.com/moonbit-community/lepus) + [Rabbita](https://mooncakes.io/docs/moonbit-community/rabbita) desktop client for the OpenSeek agent, written in MoonBit.
 
 - `main.mbt` — entry point: wires the window manifest, the IPC extensions, the per-user runtime directory, and the launch log.
-- `internal/host/` — the native host: keeps one persistent `openseek serve` engine per conversation, streams its JSONL events to the webview, exposes `connect` / `start` / `steer` / `cancel` / `list_sessions` / `load_session` commands plus the `skills_*` / `skill_*` ops backing the Skills panel.
+- `internal/engine/` — the native host: keeps one persistent `openseek serve` engine per conversation, streams its JSONL events to the webview, exposes `connect` / `start` / `steer` / `cancel` / `list_sessions` / `load_session` commands plus the `skills_*` / `skill_*` ops backing the Skills panel; also owns where conversations live on disk (per-session workspace directories and the durable session store root) and the bundled frontend/engine lookup.
 - `internal/skillmarket/` — the mooncakes.io skill registry client and the local skills-library manager: catalog browsing, digest-verified installs into the engine's global skills directory, and uninstall of what the app itself installed.
-- `internal/appdirs/` — the installed app's own footprint: bundled frontend, engine, and MoonBit seed lookup, plus the per-user runtime directory.
-- `internal/sessiondirs/` — where conversations live on disk: per-session workspace directories and the durable session store root.
 - `internal/env/` — process-environment reads (blank means unset).
 - `internal/home/` — the user's home directory and `~` expansion.
 - `internal/userdirs/` — the user's Documents folder, answered by each platform's authority: the Windows known folder, the XDG user-dirs override, or `~/Documents`.
 - `internal/event/` — engine event decoding.
-- `internal/menu/` — the macOS main menu (App/Edit/Window): macOS dispatches ⌘ key equivalents through the main menu and the webview library never creates one, so without it the editing shortcuts (⌘A/⌘C/⌘V, undo, quit) are silently dropped. No-op on other platforms.
 - `frontend/` — the JS (Rabbita) UI bundled to `frontend.js`: the Elm-style model/update/view plus the command files talking to the host bridge.
 - `frontend/transcript/` — pure decoders from the engine's wire data to display items: engine events, session-list and session-replay replies, runtime updates.
 - `frontend/markdown/` — markdown rendering for transcript content (cmark to Rabbita nodes, panic-guarded).
@@ -47,7 +44,7 @@ Sessions are stored under the first
 of: the `session_root` start-payload field, `OPENSEEK_SESSION_ROOT`, or
 `~/.openseek` (absolute, so a packaged app whose working directory is `/`
 still works). They are interoperable with the CLI/TUI stores: resume one with
-`openseek-tui --session-root ~/.openseek --session <id>`.
+`openseek tui --session-root ~/.openseek --session <id>`.
 
 Each conversation also gets its own workspace directory, used as the engine's
 working directory: `Documents/OpenSeek/<session-id>` (Documents as the
@@ -71,10 +68,9 @@ refreshes when the bridge connects and after each run. Switching while runs
 are active is fine — a conversation already open in this app run switches
 back instantly with its live state intact, without replaying the store.
 
-While a turn runs, the UI renders the engine's `reasoning_delta` /
-`assistant_delta` events as live "Thinking" and answer bubbles with a
-streaming caret; the committed `reasoning_message` / `assistant_message`
-events then replace them with permanent transcript items.
+While a turn runs, the UI renders the engine's `assistant_delta` events as a
+live answer bubble with a streaming caret; the committed `reasoning_message` /
+`assistant_message` events then land as permanent transcript items.
 
 Submitting while a turn runs steers it instead of starting a new prompt: the
 text rides the serve engine's lossless steering queue and is folded into the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,9 @@ natively by GitHub.
 
 ## System overview
 
-One binary, three frontends. `cmd/openseek` is the engine: its `serve` mode
+One shared engine, three frontends. `cmd/openseek` is the engine (the TUI
+and headless modes live in the same binary; the desktop app and the viz
+server are separate executables that spawn or read from it): its `serve` mode
 reads JSONL commands on stdin and streams typed JSONL events
 (`bobzhang/openseek_protocol`) on stdout. The terminal UI, the desktop app,
 and headless `run` all drive that same engine and event stream. Durable state
@@ -169,15 +171,23 @@ sequenceDiagram
     Turn->>DS: chat(messages, tool schemas)
     DS-->>Turn: streamed deltas, then the assistant message
     Turn-->>UI: AssistantDelta stream · ReasoningMessage · AssistantMessage
-    Turn->>Store: append Assistant (message + tool calls)
-    Turn->>Tool: execute_tool_call(name, args)
-    Tool-->>Turn: ToolAction (Respond / Control)
-    Turn->>Store: append Tool result
-    Turn-->>UI: ToolResult event
+    alt assistant returned tool calls
+      Turn->>Store: append Assistant (message + tool calls)
+      Turn->>Tool: execute_tool_call(name, args)
+      Tool-->>Turn: ToolAction (Respond / Control)
+      Turn->>Store: append Tool result
+      Turn-->>UI: ToolResult event (Respond actions)
+    else plain final answer
+      Note over Turn,Store: no Assistant append — the answer persists only in the Terminal
+    end
     Note over Turn: queued steers/notices are folded in between steps
   end
   Turn->>Store: append Terminal(Finished(answer))
-  Turn-->>UI: AgentFinished(answer)
+  alt normal completion
+    Turn-->>UI: AgentFinished(answer)
+  else context ceiling
+    Turn-->>UI: ContextYield ("[context ceiling]" answer)
+  end
 ```
 
 Two pressure valves shape long turns:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,200 @@
+# OpenSeek Architecture
+
+How the pieces fit together: the module map, the core data model, and the
+life of one agent turn. Package-level details live in each package's README
+(see the table in the [root README](../README.md)); this page is the map, not
+the territory. Diagrams are [Mermaid](https://mermaid.js.org/), rendered
+natively by GitHub.
+
+## System overview
+
+One binary, three frontends. `cmd/openseek` is the engine: its `serve` mode
+reads JSONL commands on stdin and streams typed JSONL events
+(`bobzhang/openseek_protocol`) on stdout. The terminal UI, the desktop app,
+and headless `run` all drive that same engine and event stream. Durable state
+lives in append-only session files that the visualizer reads directly.
+
+```mermaid
+flowchart LR
+  subgraph frontends [Frontends]
+    TUI["cmd/tui — terminal UI<br/>(built on the tui framework)"]
+    DESKTOP["openseek_desktop — desktop app<br/>(CEF shell + JS frontend)"]
+    VIZ["cmd/viz_server + viz —<br/>session visualizer (browser)"]
+  end
+
+  subgraph engine ["openseek engine (cmd/openseek)"]
+    SERVE["serve / run / review / sessions / mcp"]
+    AGENT["agent — turn loop"]
+    TOOLS["agent_tool — registry:<br/>shell·read·edit·multi_edit·write<br/>remove·plan·goal·finish"]
+    MCP["mcp — client + tool bridge<br/>(mcp__server__tool)"]
+    PROMPT["prompt + agent_skill —<br/>system prompt & skills"]
+    SESSION["agent_session (+ store) —<br/>durable event log"]
+  end
+
+  subgraph outside [Outside]
+    API["DeepSeek / Kimi chat API"]
+    MCPSRV["MCP servers<br/>(stdio & Streamable HTTP)"]
+    FILES[("openseek_session-&lt;id&gt;.jsonl<br/>under .openseek/")]
+  end
+
+  TUI -- "JSONL commands (stdin)" --> SERVE
+  DESKTOP -- "JSONL commands" --> SERVE
+  SERVE -- "protocol events (stdout)" --> TUI
+  SERVE -- "protocol events" --> DESKTOP
+  SERVE --> AGENT
+  PROMPT --> AGENT
+  AGENT -- "chat + tool schemas" --> API
+  AGENT -- dispatch --> TOOLS
+  AGENT -- dispatch --> MCP
+  MCP --> MCPSRV
+  AGENT -- append --> SESSION
+  SESSION --> FILES
+  FILES --> VIZ
+```
+
+The engine ↔ frontend wire contract is `bobzhang/openseek_protocol`: commands
+in (`prompt`, `steer`, `cancel`, `compact`, `goal`), events out (steps,
+deltas, tool results, goal/plan reminders, compaction, terminals). The
+protocol module is backend-neutral so any frontend — including the JS ones —
+can decode it; only `protocol/emit` (the writer) is native-only.
+
+## Core data model
+
+The durable log and the tool boundary are the two type families everything
+else leans on.
+
+```mermaid
+classDiagram
+  class Session {
+    id: SessionId
+    system_prompt: String
+    events: Vector~SessionEvent~
+    append(SessionItem) Session
+    chat_messages() Array~ChatMessage~
+    compact(content, from, to) Session
+    current_goal() StandingGoal?
+  }
+  class SessionEvent {
+    sequence: Int
+    unix_ms: Int64
+    item: SessionItem
+  }
+  class SessionItem {
+    <<enumeration>>
+    User(UserMessage)
+    Assistant(AssistantMessage)
+    Tool(ToolResult)
+    Runtime(RuntimeNotice)
+    Summary(SessionSummary)
+    Terminal(TurnTerminal)
+  }
+  class TurnTerminal {
+    <<enumeration>>
+    Finished(String)
+    Aborted(String)
+    Interrupted(String)
+    Failed(String)
+  }
+  Session "1" *-- "many" SessionEvent
+  SessionEvent *-- SessionItem
+  SessionItem ..> TurnTerminal
+
+  class Tools {
+    find(name) AgentToolDefinition?
+    function_tools() Array~ToolDefinition~
+  }
+  class AgentToolDefinition {
+    name: String
+    description: String
+    schema: JsonSchema
+    execute: ToolExecutor
+    control: Bool
+  }
+  class ToolExecutor {
+    <<enumeration>>
+    Sync(fn)
+    Async(async fn)
+  }
+  class ToolAction {
+    <<enumeration>>
+    Respond(ToolOutput)
+    Control(Finish | Abort)
+  }
+  class AgentRuntime {
+    workspace_root() String
+    queue_steer(SteerInput)
+    drain_steers() Array~SteerInput~
+  }
+  Tools "1" *-- "many" AgentToolDefinition
+  AgentToolDefinition *-- ToolExecutor
+  ToolExecutor ..> ToolAction : returns
+```
+
+Key invariants:
+
+- **The session is the only memory.** `Session::chat_messages()` projects the
+  event log into the provider's chat shape each turn; nothing conversational
+  lives outside the log. Compaction rewrites a `[from, to]` range into one
+  `Summary` item, and the projection starts from the latest summary.
+- **Events are append-only and sequenced.** `SessionEvent.sequence` is
+  contiguous; the store (`agent_session/store`) persists a header line plus
+  one JSON event per line, so a torn final line is recoverable
+  (`agent_session/log` reads leniently).
+- **Tools are data.** A tool is a name, a JSON schema, and an executor.
+  Normal tools return `Respond(ToolOutput)`; control tools (`finish`) end the
+  turn via `Control`. MCP tools enter the same registry namespaced as
+  `mcp__<server>__<tool>`, so the loop dispatches them identically.
+
+## One turn, end to end
+
+A `serve` turn as driven by the TUI (headless `run` is the same loop without
+the stdin command pump):
+
+```mermaid
+sequenceDiagram
+  participant UI as TUI / desktop
+  participant Serve as openseek serve
+  participant Turn as agent turn loop
+  participant DS as DeepSeek/Kimi API
+  participant Tool as agent_tool / mcp
+  participant Store as session store
+
+  UI->>Serve: {"command":"prompt","text":…}
+  Serve->>Turn: run_turn_in_scope(session, task)
+  Turn->>Store: append User(task)
+  loop until a control tool or the context ceiling
+    Turn->>DS: chat(messages, tool schemas)
+    DS-->>Turn: assistant delta / tool_calls
+    Turn-->>UI: AssistantDelta · ReasoningMessage · AgentStep
+    Turn->>Tool: execute_tool_call(name, args)
+    Tool-->>Turn: ToolAction (Respond / Control)
+    Turn->>Store: append Assistant + Tool items
+    Turn-->>UI: ToolResult event
+    Note over Turn: queued steers/notices are folded in between steps
+  end
+  Turn->>Store: append Terminal(Finished(answer))
+  Turn-->>UI: AgentFinished(answer)
+```
+
+Two pressure valves shape long turns:
+
+- **Steps**: with `--max-steps` unset, a turn is bounded by the model's
+  context window instead of a step count — when the window fills, the loop
+  checkpoints (auto-compaction) and yields a `[context ceiling]` answer that
+  the next turn continues from.
+- **Steering**: `steer` commands and background-job completion notices are
+  queued losslessly in `AgentRuntime` and surfaced to the model at the next
+  step boundary, so a running turn can absorb new instructions without
+  restarting.
+
+## Where things live on disk
+
+```text
+.openseek/                       # per-workspace session root (--session-root)
+  openseek_session-<id>.jsonl    # header line + append-only events
+.openseek/skills/<name>.md       # workspace skills (shadow global ones)
+~/.openseek/skills/              # global skill library (--global-skills-dir)
+```
+
+The visualizer (`openseek` sessions in a browser: `cmd/viz_server`) and
+`sessions list` both read these files directly; nothing else is persisted.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,7 @@ sequenceDiagram
   UI->>Serve: {"command":"prompt","text":…}
   Serve->>Turn: run_turn_in_scope(session, task)
   Turn->>Store: append User(task)
-  loop until a control tool or the context ceiling
+  loop until a plain final answer, a control tool, or the context ceiling
     Turn->>DS: chat(messages, tool schemas)
     DS-->>Turn: assistant delta / tool_calls
     Turn-->>UI: AssistantDelta · ReasoningMessage · AgentStep
@@ -200,4 +200,7 @@ Two pressure valves shape long turns:
 ```
 
 The visualizer (`openseek` sessions in a browser: `cmd/viz_server`) and
-`sessions list` both read these files directly; nothing else is persisted.
+`sessions list` both read these files directly. The engine persists nothing
+else; the desktop app additionally keeps its own metadata under the session
+root (`workspaces.json`, `archived/sessions`) and its settings in webview
+localStorage.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ flowchart LR
   PROMPT --> AGENT
   AGENT -- "chat + tool schemas" --> API
   AGENT -- dispatch --> TOOLS
-  AGENT -- dispatch --> MCP
+  MCP -- "tool definitions<br/>(extra_tools)" --> TOOLS
   MCP --> MCPSRV
   AGENT -- append --> SESSION
   SESSION --> FILES
@@ -134,8 +134,10 @@ Key invariants:
 
 - **The session is the only memory.** `Session::chat_messages()` projects the
   event log into the provider's chat shape each turn; nothing conversational
-  lives outside the log. Compaction rewrites a `[from, to]` range into one
-  `Summary` item, and the projection starts from the latest summary.
+  lives outside the log. Compaction appends a `Summary` item covering a
+  `[from, to]` range — raw events are never rewritten — and the projection
+  replaces covered events with their summary while keeping uncovered events
+  and every surviving summary.
 - **Events are append-only and sequenced.** `SessionEvent.sequence` is
   contiguous; the store (`agent_session/store`) persists a header line plus
   one JSON event per line, so a torn final line is recoverable
@@ -191,7 +193,8 @@ Two pressure valves shape long turns:
 
 ```text
 .openseek/                       # per-workspace session root (--session-root)
-  openseek_session-<id>.jsonl    # header line + append-only events
+  sessions/<id>/
+    openseek_session-<id>.jsonl  # header line + append-only events
 .openseek/skills/<name>.md       # workspace skills (shadow global ones)
 ~/.openseek/skills/              # global skill library (--global-skills-dir)
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ flowchart LR
   subgraph engine ["openseek engine (cmd/openseek)"]
     SERVE["serve / run / review / sessions / mcp"]
     AGENT["agent — turn loop"]
-    TOOLS["agent_tool — registry:<br/>shell·read·edit·multi_edit·write<br/>remove·plan·goal·finish"]
+    TOOLS["agent_tool — registry:<br/>shell·shell_output·shell_stop<br/>read·edit·multi_edit·write<br/>remove·plan·goal·finish"]
     MCP["mcp — client + tool bridge<br/>(mcp__server__tool)"]
     PROMPT["prompt + agent_skill —<br/>system prompt & skills"]
     SESSION["agent_session (+ store) —<br/>durable event log"]
@@ -165,12 +165,14 @@ sequenceDiagram
   Serve->>Turn: run_turn_in_scope(session, task)
   Turn->>Store: append User(task)
   loop until a plain final answer, a control tool, or the context ceiling
+    Turn-->>UI: AgentStep
     Turn->>DS: chat(messages, tool schemas)
-    DS-->>Turn: assistant delta / tool_calls
-    Turn-->>UI: AssistantDelta · ReasoningMessage · AgentStep
+    DS-->>Turn: streamed deltas, then the assistant message
+    Turn-->>UI: AssistantDelta stream · ReasoningMessage · AssistantMessage
+    Turn->>Store: append Assistant (message + tool calls)
     Turn->>Tool: execute_tool_call(name, args)
     Tool-->>Turn: ToolAction (Respond / Control)
-    Turn->>Store: append Assistant + Tool items
+    Turn->>Store: append Tool result
     Turn-->>UI: ToolResult event
     Note over Turn: queued steers/notices are folded in between steps
   end
@@ -195,12 +197,13 @@ Two pressure valves shape long turns:
 .openseek/                       # per-workspace session root (--session-root)
   sessions/<id>/
     openseek_session-<id>.jsonl  # header line + append-only events
+    session.lock                 # store coordination file
 .openseek/skills/<name>.md       # workspace skills (shadow global ones)
 ~/.openseek/skills/              # global skill library (--global-skills-dir)
 ```
 
 The visualizer (`openseek` sessions in a browser: `cmd/viz_server`) and
-`sessions list` both read these files directly. The engine persists nothing
-else; the desktop app additionally keeps its own metadata under the session
-root (`workspaces.json`, `archived/sessions`) and its settings in webview
-localStorage.
+`sessions list` both read these files directly. The engine's durable state is
+exactly these per-session directories; the desktop app additionally keeps its
+own metadata under the session root (`workspaces.json`, `archived/sessions`)
+and its settings in webview localStorage.

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -26,7 +26,7 @@ DeepSeek-backed MoonBit coding agent — runs the interactive UI by default.
 Commands:
   tui       OpenSeek terminal UI.
   run       Run one task headlessly; stream JSONL events on stdout.
-  serve     Session server: read JSONL commands (prompt/steer/cancel/compact) from stdin.
+  serve     Session server: read JSONL commands (prompt/steer/cancel/compact/goal) from stdin.
   mcp       List configured MCP servers and the tools they expose.
   review    Read-only code review of base...HEAD; prints a JSON ReviewReport.
   sessions  Manage durable sessions.


### PR DESCRIPTION
## Summary

Docs cleanup pass: every claim below was verified against the code (a read-only verification agent swept all 23 package docs; 18 were already clean).

**Top-level (`README.mbt.md`)**
- The package table now covers what has landed since it was written: agent_skill, agent_review, the mcp family, jsonrpc, prompt, the tui framework, viz + viz_server + viz_app, session log/compact, the prompt_task and session_analyzer evals, and the desktop module.
- Tool list corrected from the seven-tool era to the eleven-tool registry (with the Windows caveat); adds a Skills section; subcommand list gains `mcp`.
- `serve`'s help line (and its cram pin) now names the `goal` command the JSONL protocol already accepts; `build_tools`' doc comment lists `goal`.

**New: [`docs/architecture.md`](../blob/docs-and-diagrams/docs/architecture.md)**
- System flowchart (frontends / engine / outside world), core data-model class diagram (Session/SessionItem + Tools/ToolAction), and a one-turn sequence diagram — all three mermaid blocks are parse-verified with mermaid 11, plus the on-disk layout.

**Package READMEs** (all findings from the verification sweep)
- agent: Standard Tools bullets now list all eleven tools (the compile-checked fence below them already did).
- agent_tool: subpackage list gains remove, goal, shell_output, shell_stop, bgjobs.
- agent_review: `openseek review` subcommand, not `--review` (3 spots).
- cmd/openseek: names the agent entry points actually called (run_turn_in_scope; run_turn_with_append is fleet-only).
- desktop: internal/host→internal/engine (which absorbed appdirs/sessiondirs roles), menu package removed, `openseek tui` not `openseek-tui`, and no `reasoning_delta` event — only `assistant_delta` streams live.

## Test plan

- `moon check --deny-warn` clean (validates the .mbt.md checked fences)
- `moon cram test tests/cram` — 24/24 (covers the updated serve help line)
- `moon test -p agent agent_tool agent_review` — 974/974
- mermaid blocks parse-checked (mermaid@11 + jsdom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)