### PR TITLE
refactor(eval): shared trial runner; drop duplicated harness tests

### DIFF
--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -61,10 +61,12 @@ priv struct AgentLogSummary {
 /// aggregated report; rendering and exit-status decisions stay with the
 /// caller.
 pub async fn run_suite(config : Config) -> EvalReport {
-  prepare_output_dir(config.out_dir)
-  let results = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
-    run_trial(config, index)
-  })
+  @runner.prepare_output_dir(config.out_dir)
+  let results = @runner.run_indexed_with_concurrency(
+    config.runs,
+    config.concurrency,
+    index => run_trial(config, index),
+  )
   let report : EvalReport = {
     model: config.model.to_string(),
     prompt_label: config.prompt_label,
@@ -80,38 +82,9 @@ pub async fn run_suite(config : Config) -> EvalReport {
 }
 
 ///|
-async fn[X] run_indexed_with_concurrency(
-  count : Int,
-  concurrency : Int,
-  run : async (Int) -> X,
-) -> Array[X] {
-  let limit = @async.Semaphore(concurrency)
-  @async.all(
-    [
-      for index in 0..<count => {
-        () => {
-          limit.acquire()
-          defer limit.release()
-          run(index)
-        }
-      }
-    ],
-  )
-}
-
-///|
-async fn prepare_output_dir(out_dir : String) -> Unit {
-  if @fs.exists(out_dir) {
-    @fs.rmdir(out_dir, recursive=true)
-  }
-  @fs.mkdir("\{out_dir}/workspaces", recursive=true)
-  @fs.mkdir("\{out_dir}/logs", recursive=true)
-}
-
-///|
 async fn run_trial(config : Config, index : Int) -> TrialResult {
   let case = @cases.case_for_trial(index)
-  let workspace = "\{config.out_dir}/workspaces/\{padded_index(index + 1)}-\{case.id}"
+  let workspace = "\{config.out_dir}/workspaces/\{@runner.padded_index(index + 1)}-\{case.id}"
   @fs.mkdir(workspace, recursive=true)
   case.initial.write_to(workspace)
   let real_workspace = @fs.realpath(workspace)
@@ -151,7 +124,7 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
     cwd=real_workspace,
   )
   let log_text = output.text()
-  let log_path = "\{config.out_dir}/logs/\{padded_index(index + 1)}-\{case.id}.log"
+  let log_path = "\{config.out_dir}/logs/\{@runner.padded_index(index + 1)}-\{case.id}.log"
   @fs.write_file(log_path, log_text, create_mode=CreateOrTruncate)
   evaluate_trial(
     config.prompt_label,
@@ -368,21 +341,6 @@ async fn run_validation(
 }
 
 ///|
-fn padded_index(value : Int) -> String {
-  value.to_string().pad_start(2, '0')
-}
-
-///|
-async test "prepare output dir creates a missing output directory" {
-  @vfs.with_tmpdir(prefix="openseek-file-edit-output", root => {
-    let out_dir = root + "/out"
-    prepare_output_dir(out_dir)
-    assert_true(@fs.exists(out_dir + "/workspaces"))
-    assert_true(@fs.exists(out_dir + "/logs"))
-  })
-}
-
-///|
 async test "dry run exact replacement oracle" {
   @vfs.with_tmpdir(prefix="openseek-file-edit-harness", root => {
     let case = @cases.case_for_trial(0)
@@ -459,23 +417,6 @@ async test "dry run exact replacement oracle with jsonl agent log" {
     assert_true(result.marker_present)
     assert_eq(result.warnings, "shell tool used 1 time(s)")
   })
-}
-
-///|
-async test "indexed runner honors concurrency and preserves order" {
-  let mut active = 0
-  let mut max_active = 0
-  let results = run_indexed_with_concurrency(5, 2, index => {
-    active += 1
-    if active > max_active {
-      max_active = active
-    }
-    @async.sleep(20)
-    active -= 1
-    index
-  })
-  json_inspect(results, content=[0, 1, 2, 3, 4])
-  assert_eq(max_active, 2)
 }
 
 ///|

--- a/eval/file_edit/harness/moon.pkg
+++ b/eval/file_edit/harness/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/eval/file_edit/cases",
   "bobzhang/openseek/eval/internal/metrics",
+  "bobzhang/openseek/eval/internal/runner",
   "bobzhang/openseek/eval/report",
   "bobzhang/openseek/testkit/filesystem" @vfs,
   "moonbitlang/async",

--- a/eval/internal/runner/moon.pkg
+++ b/eval/internal/runner/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+}
+
+import {
+  "moonbitlang/async" @async_test,
+  "moonbitlang/async/fs" @fs_test,
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/eval/internal/runner/pkg.generated.mbti
+++ b/eval/internal/runner/pkg.generated.mbti
@@ -1,0 +1,18 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/eval/internal/runner"
+
+// Values
+pub fn padded_index(Int) -> String
+
+pub async fn prepare_output_dir(String) -> Unit
+
+pub async fn[X] run_indexed_with_concurrency(Int, Int, async (Int) -> X) -> Array[X]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/eval/internal/runner/runner.mbt
+++ b/eval/internal/runner/runner.mbt
@@ -1,0 +1,41 @@
+// Shared plumbing for the eval harnesses (file_edit, prompt_task): the
+// bounded-concurrency trial runner and the standard on-disk run layout.
+
+///|
+/// Run `run(index)` for every index in `0..<count`, at most `concurrency` at
+/// a time, returning the results in index order.
+pub async fn[X] run_indexed_with_concurrency(
+  count : Int,
+  concurrency : Int,
+  run : async (Int) -> X,
+) -> Array[X] {
+  let limit = @async.Semaphore(concurrency)
+  @async.all(
+    [
+      for index in 0..<count => {
+        () => {
+          limit.acquire()
+          defer limit.release()
+          run(index)
+        }
+      }
+    ],
+  )
+}
+
+///|
+/// Reset `out_dir` to the standard eval-run layout — empty `workspaces/` and
+/// `logs/` directories — removing any previous run's artifacts first.
+pub async fn prepare_output_dir(out_dir : String) -> Unit {
+  if @fs.exists(out_dir) {
+    @fs.rmdir(out_dir, recursive=true)
+  }
+  @fs.mkdir("\{out_dir}/workspaces", recursive=true)
+  @fs.mkdir("\{out_dir}/logs", recursive=true)
+}
+
+///|
+/// Two-digit zero-padded trial index, for stable artifact file names.
+pub fn padded_index(value : Int) -> String {
+  value.to_string().pad_start(2, '0')
+}

--- a/eval/internal/runner/runner_test.mbt
+++ b/eval/internal/runner/runner_test.mbt
@@ -1,0 +1,33 @@
+///|
+async test "prepare output dir creates runner artifact directories" {
+  @vfs.with_tmpdir(prefix="openseek-eval-runner-output", root => {
+    let out_dir = "\{root}/out"
+    @runner.prepare_output_dir(out_dir)
+    assert_true(@fs_test.exists("\{out_dir}/workspaces"))
+    assert_true(@fs_test.exists("\{out_dir}/logs"))
+  })
+}
+
+///|
+async test "indexed runner honors concurrency and preserves order" {
+  let mut active = 0
+  let mut max_active = 0
+  let results = @runner.run_indexed_with_concurrency(5, 2, index => {
+    active += 1
+    if active > max_active {
+      max_active = active
+    }
+    @async_test.sleep(20)
+    active -= 1
+    index
+  })
+  json_inspect(results, content=[0, 1, 2, 3, 4])
+  assert_eq(max_active, 2)
+}
+
+///|
+test "padded index zero-pads to two digits" {
+  assert_eq(@runner.padded_index(1), "01")
+  assert_eq(@runner.padded_index(42), "42")
+  assert_eq(@runner.padded_index(100), "100")
+}

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -234,7 +234,7 @@ fn relocate_workspace_path(
   if relocated != trial.workspace {
     relocated
   } else if old_out_dir != new_out_dir {
-    "\{new_out_dir}/workspaces/\{padded_index(trial.index)}"
+    "\{new_out_dir}/workspaces/\{@runner.padded_index(trial.index)}"
   } else {
     trial.workspace
   }

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -150,57 +150,6 @@ test "line counter documents all-match behavior" {
 }
 
 ///|
-test "latest non-finished terminal determines success" {
-  let session = @agent_session.Session(
-      SessionId("multi-turn"),
-      system_prompt="",
-    )
-    .append(User(UserMessage("first")))
-    .append(Terminal(Finished("done")))
-    .append(User(UserMessage("second")))
-    .append(Terminal(Failed("agent failed")))
-  let result = eval_session_for_test(session)
-  assert_false(result.success)
-  assert_false(result.finished)
-  assert_eq(result.terminal_status, "failed")
-  assert_true(result.reason.contains("agent terminal failed"))
-}
-
-///|
-test "finish tool terminal does not double count a model step" {
-  let session = @agent_session.Session(
-      SessionId("trial-finish"),
-      system_prompt="",
-    )
-    .append(User(UserMessage("finish")))
-    .append(
-      Assistant(
-        AssistantMessage("", tool_calls=[
-          ToolCall(
-            id="call_finish",
-            name="finish",
-            arguments="{\"answer\":\"done\"}",
-          ),
-        ]),
-      ),
-    )
-    .append(
-      Tool(
-        ToolResult(
-          tool_call_id="call_finish",
-          tool_name="finish",
-          content="finished: done",
-        ),
-      ),
-    )
-    .append(Terminal(Finished("done")))
-  let result = eval_session_for_test(session)
-  assert_eq(result.steps, 1)
-  assert_eq(result.tool_results, 1)
-  assert_true(result.finished)
-}
-
-///|
 test "same output dir preserves absolute workspace paths" {
   let manifest = RunManifest(
     model="deepseek-v4-flash",

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -5,11 +5,13 @@
 /// validation or report analysis is performed in this phase.
 pub async fn run_experiments(config : Config) -> RunManifest {
   require_api_access(config.api_key, config.model)
-  prepare_output_dir(config.out_dir)
+  @runner.prepare_output_dir(config.out_dir)
   let task_template = @fs.read_file(config.task_file).text()
-  let trials = run_indexed_with_concurrency(config.runs, config.concurrency, index => {
-    run_trial(config, task_template, index)
-  })
+  let trials = @runner.run_indexed_with_concurrency(
+    config.runs,
+    config.concurrency,
+    index => run_trial(config, task_template, index),
+  )
   let manifest = RunManifest(
     model=config.model.to_string(),
     problem_id=config.problem_id,
@@ -28,41 +30,12 @@ pub async fn run_experiments(config : Config) -> RunManifest {
 }
 
 ///|
-async fn prepare_output_dir(out_dir : String) -> Unit {
-  if @fs.exists(out_dir) {
-    @fs.rmdir(out_dir, recursive=true)
-  }
-  @fs.mkdir("\{out_dir}/workspaces", recursive=true)
-  @fs.mkdir("\{out_dir}/logs", recursive=true)
-}
-
-///|
-async fn[X] run_indexed_with_concurrency(
-  count : Int,
-  concurrency : Int,
-  run : async (Int) -> X,
-) -> Array[X] {
-  let limit = @async.Semaphore(concurrency)
-  @async.all(
-    [
-      for index in 0..<count => {
-        () => {
-          limit.acquire()
-          defer limit.release()
-          run(index)
-        }
-      }
-    ],
-  )
-}
-
-///|
 async fn run_trial(
   config : Config,
   task_template : String,
   index : Int,
 ) -> TrialArtifact {
-  let trial_name = padded_index(index + 1)
+  let trial_name = @runner.padded_index(index + 1)
   let workspace = "\{config.out_dir}/workspaces/\{trial_name}"
   @fs.mkdir(workspace, recursive=true)
   let real_workspace = @fs.realpath(workspace)
@@ -228,9 +201,4 @@ fn should_skip_scan_dir(name : String) -> Bool {
   name == "node_modules" ||
   name == ".mooncakes" ||
   name == "_build"
-}
-
-///|
-fn padded_index(value : Int) -> String {
-  value.to_string().pad_start(2, '0')
 }

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -1,31 +1,4 @@
 ///|
-async test "prepare output dir creates runner artifact directories" {
-  @vfs.with_tmpdir(prefix="openseek-prompt-task-output", root => {
-    let out_dir = root + "/out"
-    prepare_output_dir(out_dir)
-    assert_true(@fs.exists(out_dir + "/workspaces"))
-    assert_true(@fs.exists(out_dir + "/logs"))
-  })
-}
-
-///|
-async test "indexed runner honors concurrency and preserves order" {
-  let mut active = 0
-  let mut max_active = 0
-  let results = run_indexed_with_concurrency(5, 2, index => {
-    active += 1
-    if active > max_active {
-      max_active = active
-    }
-    @async.sleep(20)
-    active -= 1
-    index
-  })
-  json_inspect(results, content=[0, 1, 2, 3, 4])
-  assert_eq(max_active, 2)
-}
-
-///|
 test "trial environment pins workspace-local session root" {
   let config = Config(
     api_key="key",

--- a/eval/prompt_task/harness/moon.pkg
+++ b/eval/prompt_task/harness/moon.pkg
@@ -3,9 +3,9 @@ import {
   "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek/eval/internal/metrics",
+  "bobzhang/openseek/eval/internal/runner",
   "bobzhang/openseek/eval/report",
   "bobzhang/openseek/eval/session_analyzer",
-  "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
   "moonbitlang/core/env",
@@ -14,6 +14,7 @@ import {
 
 import {
   "bobzhang/openseek/testkit/filesystem" @vfs,
+  "moonbitlang/async",
 } for "wbtest"
 
 warnings = "+unnecessary_annotation"

--- a/eval/prompt_task/harness/report.mbt
+++ b/eval/prompt_task/harness/report.mbt
@@ -313,7 +313,7 @@ fn relative_artifact_path(out_dir : String, path : String) -> String {
 ///|
 fn eval_result_name(result : EvalResult) -> String {
   if result.index > 0 {
-    "trial-\{padded_index(result.index)}"
+    "trial-\{@runner.padded_index(result.index)}"
   } else if result.session_id != "" {
     result.session_id
   } else {

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -335,7 +335,7 @@ pub async fn run_suite(config : SuiteConfig) -> SuiteManifest {
   prepare_suite_output_dir(config.out_dir)
   let jobs = suite_jobs(config)
   prepare_combo_output_dirs(jobs)
-  let artifacts = run_indexed_with_concurrency(
+  let artifacts = @runner.run_indexed_with_concurrency(
     jobs.length(),
     config.concurrency,
     index => run_suite_job(config, jobs[index]),
@@ -359,7 +359,7 @@ async fn prepare_combo_output_dirs(jobs : Array[SuiteJob]) -> Unit {
   for job in jobs {
     if !seen.contains(job.out_dir) {
       seen.push(job.out_dir)
-      prepare_output_dir(job.out_dir)
+      @runner.prepare_output_dir(job.out_dir)
     }
   }
 }

--- a/eval/prompt_task/harness/suite_wbtest.mbt
+++ b/eval/prompt_task/harness/suite_wbtest.mbt
@@ -171,15 +171,15 @@ fn eval_result_for_suite_test(index : Int, success : Bool) -> EvalResult {
     } else {
       "validation failed"
     },
-    workspace: "out/workspaces/" + padded_index(index),
-    log_path: "out/logs/" + padded_index(index) + ".log",
-    session_id: "trial-" + padded_index(index),
+    workspace: "out/workspaces/" + @runner.padded_index(index),
+    log_path: "out/logs/" + @runner.padded_index(index) + ".log",
+    session_id: "trial-" + @runner.padded_index(index),
     events_path: "out/workspaces/" +
-    padded_index(index) +
+    @runner.padded_index(index) +
     "/.openseek/sessions/trial-" +
-    padded_index(index) +
+    @runner.padded_index(index) +
     "/openseek_session-trial-" +
-    padded_index(index) +
+    @runner.padded_index(index) +
     ".jsonl",
     exit_code: 0,
     steps: index * 2,


### PR DESCRIPTION
## Summary

Test/code dedupe across the eval harnesses, found by scanning all 1,648 tests for duplicate names and normalized bodies:

- `eval/file_edit/harness` and `eval/prompt_task/harness` each carried **byte-identical copies** of `run_indexed_with_concurrency`, `prepare_output_dir`, and `padded_index` — plus copies of the tests pinning them. They now live once in a new `eval/internal/runner` package (tests included, plus a new `padded_index` test), imported by both harnesses.
- `eval/prompt_task`'s analyzer wbtests included two tests that re-asserted `@session_analyzer.analyze_session` pass-through fields on fixtures identical to session_analyzer's own tests — dropped as duplicates; the wrapper's own additions keep their coverage in the remaining eight wbtests.

Notable near-dupes deliberately left alone: the per-tool `internal/decode` tests (same shape, different unit under test), viz's parser smoke tests (thin wrapper checks, not copies), the two eval CLIs' threshold tests (separate CLIs), and `desktop/internal/jsonrpc` (a vendored copy of the root `jsonrpc` package — deduping that is an architectural change, noted for a future pass).

Net: −6 duplicated tests, +3 consolidated ones.

## Test plan

- `moon check --deny-warn` — clean
- Full suite: 1172/1172 (was 1175 with the 6 duplicates and without the 3 new)
- `moon info` — only the new package's .mbti added; harness interfaces unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)