### PR TITLE
test(agent_tool): scope the always-failing executor inside its test

### DIFF
--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -447,13 +447,14 @@ async test "execute_tool_call dispatches to async executor" {
 }
 
 ///|
-async fn async_boom(_args : Json) -> ToolAction {
-  @async.pause()
-  fail("disk on fire")
-}
-
-///|
 async test "execute_tool_call turns a tool failure into a recoverable error result" {
+  // Local to the test on purpose: an always-failing executor must not be
+  // callable from anywhere else in the package.
+  async fn async_boom(_args : Json) -> ToolAction {
+    @async.pause()
+    fail("disk on fire")
+  }
+
   let tools = Tools([
     {
       name: "boom",


### PR DESCRIPTION
Follow-up to #524: `async_boom` moves from file scope into the dispatch-boundary test as a local fn, so the always-failing executor cannot be referenced from anywhere else in the package. `moon test -p agent_tool` 486/486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)