### PR TITLE
docs: ASCII call-flow skeletons for the three deepest control flows

### DIFF
--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -99,6 +99,27 @@ fn ToolCallOutcome::of_finish(outcome : FinishOutcome) -> ToolCallOutcome {
 let ceiling_skip_note : String = "skipped: the turn is yielding at the context ceiling; re-issue after the checkpoint if still needed"
 
 ///|
+/// Turn skeleton — one provider round per step; every exit lands in exactly
+/// one labeled terminal:
+///
+///   for step < max_steps:
+///     prepare_step ── chat(step)
+///     ├─ no tool calls
+///     │   ├─ no steers ── goal unchecked? ─ goal-check round ─ (seal │ continue)
+///     │   │               else finish_turn ─────────────────── (seal │ continue)
+///     │   └─ steers ── record answer as a plain assistant message
+///     │                ├─ soft ceiling ── yield (checkpoint; steers survive)
+///     │                └─ apply steers ── continue
+///     ├─ hard ceiling ── record assistant ── salvage a finish?
+///     │   ├─ salvaged ── (done │ continue │ yield)
+///     │   └─ close the batch with skip notes ── yield
+///     └─ tool batch ── handle_tool_calls ── (continue │ done │ budget yield)
+///   nobreak ── Terminal(Failed("max steps exhausted"))
+///   catch   ── Terminal(Interrupted │ Failed) ── re-raise
+///
+/// "seal │ continue": finishing consults the checkpoint policy — a turn that
+/// completes at the ceiling checkpoints first, and a steer landing during that
+/// checkpoint converts the finish into a continuation.
 async fn AgentLoop::run(
   self : Self,
   session : @agent_session.Session,

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -174,6 +174,17 @@ priv struct PreparedFile {
 /// file first; if any edit fails (or any file can't be read or is write-guarded)
 /// nothing is written. Writes happen only once the entire batch is clean, which
 /// keeps partial application limited to a raw filesystem write error.
+/// Batch pipeline — validate everything, gate, then write; failures before the
+/// first write always mean "no changes applied":
+///
+///   resolve paths ── group contiguous edits per resolved file
+///   validate every group ── load ── anchor-check each edit ── plan the write
+///     └─ ANY failure ── aggregate all failures ── report; nothing written
+///   parse gate ── would-be content worse than the original? ── reject batch
+///   apply writes in file order
+///     └─ IO fault mid-batch ── report with "earlier files may be written"
+///   auto check (source files) ── errors above revert_when_errors_above?
+///     └─ revert every written file ── report per-file revert status
 async fn multi_edit_files(
   workspace_root : String,
   edits : Array[@decode.MultiEditItem],

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -531,6 +531,24 @@ test "auto-continue requires a finished idle serving turn with budget" {
 /// did not ask for. `cancel` interrupts the current active work but never the
 /// process. stdin EOF is the shutdown signal: the running work finishes
 /// first, then the loop drains and exits.
+/// Session-server skeleton — one steps queue, three producers, one pump;
+/// `active_work` is the only mode state (turn │ compact │ idle):
+///
+///   producers: stdin reader ──────────── Wire(command)
+///              turn/compact completions ─ TurnDone(finished~) │ CompactDone
+///              background-job exits ───── BackgroundNotice
+///   pump: for ;; match step
+///     ├─ Wire(Prompt)          ── active? queue pending : start turn
+///     ├─ Wire(Steer(Prompt))   ── turn running? queue steer : reject (resubmit)
+///     ├─ Wire(Steer(Command│Notice)) ── queue losslessly; idle ⇒ drain to log
+///     ├─ Wire(Cancel)          ── cancel active work; disarm auto-continue
+///     ├─ Wire(Compact)         ── idle? start compact : queue
+///     ├─ Wire(Goal)            ── durable marker; auto=true arms auto-continue
+///     ├─ BackgroundNotice      ── idle? drain queued context to the log
+///     ├─ TurnDone              ── drain context ── start next pending work
+///     │                           └─ armed goal(auto) unmet ⇒ auto-continue
+///     ├─ CompactDone           ── adopt compacted session ── start next pending
+///     └─ Shutdown              ── exit serve~
 async fn run_serve(
   matches : @argparse.Matches,
   workspace_root~ : String,

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -539,7 +539,7 @@ test "auto-continue requires a finished idle serving turn with budget" {
 ///              background-job exits ───── BackgroundNotice
 ///   pump: for ;; match step
 ///     ├─ Wire(Prompt)          ── active? queue pending : start turn
-///     ├─ Wire(Steer(Prompt))   ── turn running? queue steer : reject (resubmit)
+///     ├─ Wire(Steer(Prompt))   ── turn running │ prompt queued? queue steer : reject
 ///     ├─ Wire(Steer(Command│Notice)) ── queue losslessly; idle ⇒ drain to log
 ///     ├─ Wire(Cancel)          ── cancel active work; disarm auto-continue
 ///     ├─ Wire(Compact)         ── idle? start compact : queue


### PR DESCRIPTION
## Summary

Extends #527's in-source-diagram convention (plain `///` lines — monospace in source and `git diff`, ignored by the doc-test harness) to the three functions whose control flow is genuinely hard to hold in your head:

- **`AgentLoop::run`** — the per-step fork tree: no-tool-call vs hard-ceiling vs tool-batch, the steer/goal-check interleavings, and the `nobreak`/`catch` terminals.
- **`run_serve`** — the steps-queue pump: three producers (stdin, turn/compact completions, background wakes) × the `active_work` modes, one line per command arm.
- **`multi_edit_files`** — the validate → gate → apply → revert pipeline and where the "no changes applied" guarantee holds.

Each diagram was written against a fresh reading of the function body. Comments only — no behavior change, no `.mbti` drift.

## Test plan
- `moon check --deny-warn` clean; `moon test -p agent cmd/openseek agent_tool/multi_edit` 1037/1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)