### PR TITLE
ci: check and test the js-only packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
         run: moon test
 
       # The js-only packages (viz, cmd/viz_app) already compile via
-      # per-package target fallback, but the default target never builds
-      # their test drivers — viz's unit tests only run under --target js,
-      # which also checks the rest of the workspace on the js backend.
+      # per-package target fallback, and viz_app's tests run by default —
+      # but viz's test driver is only built under --target js, which also
+      # checks the other js-capable packages on that backend.
       - name: Check (js target, deny warnings)
         run: moon check --deny-warn --target js
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,14 @@ jobs:
       - name: Test
         run: moon test
 
+      # The default target never compiles the js-only packages (viz,
+      # cmd/viz_app), so without these steps a regression there would not
+      # fail CI.
+      - name: Check (js target, deny warnings)
+        run: moon check --deny-warn --target js
+
+      - name: Test (js target)
+        run: moon test --target js
+
       - name: Cram (offline CLI docs)
         run: moon cram test tests/cram

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,10 @@ jobs:
       - name: Test
         run: moon test
 
-      # The default target never compiles the js-only packages (viz,
-      # cmd/viz_app), so without these steps a regression there would not
-      # fail CI.
+      # The js-only packages (viz, cmd/viz_app) already compile via
+      # per-package target fallback, but the default target never builds
+      # their test drivers — viz's unit tests only run under --target js,
+      # which also checks the rest of the workspace on the js backend.
       - name: Check (js target, deny warnings)
         run: moon check --deny-warn --target js
 


### PR DESCRIPTION
## Motivation

`improvement.md` flags that CI does not exercise the JS packages. The precise gap is narrower than "never compiled": the default `moon check` already compiles the js-only packages (`viz`, `cmd/viz_app`) via moon's per-package target fallback, and `viz_app`'s tests run in the default `Test` step. What never runs is `viz`'s own test driver — its 49 unit tests in `viz_test.mbt` only execute under `--target js`, which also checks the other js-capable packages on that backend.

## Change

Add two steps to the existing `check` job, after the native `Test` step:

- `moon check --deny-warn --target js`
- `moon test --target js`

They run on both existing matrix legs (nightly and stable).

## Validation

On this branch with moon 0.1.20260713 / moonc v0.10.4 (stable):

- `moon check --deny-warn --target js` — clean
- `moon test --target js` — 264/264 passed, including `viz`'s unit tests, which never execute on the default target