### PR TITLE
prompt: consolidate probes/automation on run_moonbit; drop moon run -e guidance

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -122,9 +122,7 @@ Common `moon` subcommands:
   `target` defaults to native. It runs isolated, so a local-package import binds
   the STALE mooncakes.io snapshot, never your working tree — to exercise local
   package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
-  (above). Shell `moon run -e`/`moon run -` remain only for what the tool cannot
-  express (e.g. a `fn main raise` stack-trace probe:
-  `moon run --warn-list -a -e 'fn main raise { fail("bad input") }'`).
+  (above).
 - shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
   use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
   Example: `moon cram test tests/cram`.
@@ -240,17 +238,7 @@ options(
   `moon ide find-references Symbol`, and `moon ide hover Symbol --loc
   file.mbt:line:col` for types.
 - Use the `run_moonbit` tool for quick core-language probes and MoonBit
-  automation, in preference to shell `python`/`node`. Do not use `moon run -c`;
-  `-c` is easy to confuse with `-C`.
-- `-e` requires the MoonBit code as the next command argument, for example
-  `moon run -e 'fn main { println("ok") }'`. Do not run `moon run -e` and
-  send the code on stdin.
-- One-off `moon run -e` or `moon run -` snippets do not see project `moon.pkg`
-  imports by default, but `.mbtx` snippets may include an `import` block for
-  quick dependency probes.
-- For multi-line probes, use shell with a heredoc, for example
-  `moon run - <<'EOF'`. Add `--target native` when the snippet needs async or
-  native-only APIs.
+  automation, in preference to shell `python`/`node`.
 - MoonBit has no `await`; async functions/tests are marked with `async`, and
   async calls are written normally.
 - Parameter and receiver bindings cannot be `mut`: write `fn f(x : Int)` and
@@ -270,16 +258,12 @@ test {
 }
 ```
 
-## Multi-Line Strings And Probes
+## Multi-Line Strings
 
 - Raw multi-line strings use `#|`. Each content line starts with `#|`, and
   text is kept literally.
 - Interpolated multi-line strings use `$|`. Each content line starts with
   `$|`, and interpolation is written as `\{expr}`.
-- Do not use `moon run -e` for multi-line snippets unless there is a strong
-  reason. Shell quoting around newlines, quotes, backslashes, `#|`, `$|`, and
-  `\{...}` is easy to get wrong. Prefer `moon run - <<'EOF'`
-  for anything longer than one short line.
 
 ```mbt check
 ///|
@@ -294,21 +278,6 @@ test {
   assert_true(raw =~ re"second line")
   assert_true(rendered =~ re"hello MoonBit") // re"..." is regex literal
 }
-```
-
-Verified async probe with `moon run --target native -` and a heredoc:
-
-```sh
-moon run --target native - <<'EOF'
-import {
-  "moonbitlang/async",
-}
-
-async fn main {
-  @async.sleep(0)
-  println("async ok")
-}
-EOF
 ```
 
 ## Checked Error Handling

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -127,9 +127,7 @@ fn default_prompt() -> String {
     #|  `target` defaults to native. It runs isolated, so a local-package import binds
     #|  the STALE mooncakes.io snapshot, never your working tree — to exercise local
     #|  package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
-    #|  (above). Shell `moon run -e`/`moon run -` remain only for what the tool cannot
-    #|  express (e.g. a `fn main raise` stack-trace probe:
-    #|  `moon run --warn-list -a -e 'fn main raise { fail("bad input") }'`).
+    #|  (above).
     #|- shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
     #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
     #|  Example: `moon cram test tests/cram`.
@@ -245,17 +243,7 @@ fn default_prompt() -> String {
     #|  `moon ide find-references Symbol`, and `moon ide hover Symbol --loc
     #|  file.mbt:line:col` for types.
     #|- Use the `run_moonbit` tool for quick core-language probes and MoonBit
-    #|  automation, in preference to shell `python`/`node`. Do not use `moon run -c`;
-    #|  `-c` is easy to confuse with `-C`.
-    #|- `-e` requires the MoonBit code as the next command argument, for example
-    #|  `moon run -e 'fn main { println("ok") }'`. Do not run `moon run -e` and
-    #|  send the code on stdin.
-    #|- One-off `moon run -e` or `moon run -` snippets do not see project `moon.pkg`
-    #|  imports by default, but `.mbtx` snippets may include an `import` block for
-    #|  quick dependency probes.
-    #|- For multi-line probes, use shell with a heredoc, for example
-    #|  `moon run - <<'EOF'`. Add `--target native` when the snippet needs async or
-    #|  native-only APIs.
+    #|  automation, in preference to shell `python`/`node`.
     #|- MoonBit has no `await`; async functions/tests are marked with `async`, and
     #|  async calls are written normally.
     #|- Parameter and receiver bindings cannot be `mut`: write `fn f(x : Int)` and
@@ -275,16 +263,12 @@ fn default_prompt() -> String {
     #|}
     #|```
     #|
-    #|## Multi-Line Strings And Probes
+    #|## Multi-Line Strings
     #|
     #|- Raw multi-line strings use `#|`. Each content line starts with `#|`, and
     #|  text is kept literally.
     #|- Interpolated multi-line strings use `$|`. Each content line starts with
     #|  `$|`, and interpolation is written as `\{expr}`.
-    #|- Do not use `moon run -e` for multi-line snippets unless there is a strong
-    #|  reason. Shell quoting around newlines, quotes, backslashes, `#|`, `$|`, and
-    #|  `\{...}` is easy to get wrong. Prefer `moon run - <<'EOF'`
-    #|  for anything longer than one short line.
     #|
     #|```mbt check
     #|///|
@@ -299,21 +283,6 @@ fn default_prompt() -> String {
     #|  assert_true(raw =~ re"second line")
     #|  assert_true(rendered =~ re"hello MoonBit") // re"..." is regex literal
     #|}
-    #|```
-    #|
-    #|Verified async probe with `moon run --target native -` and a heredoc:
-    #|
-    #|```sh
-    #|moon run --target native - <<'EOF'
-    #|import {
-    #|  "moonbitlang/async",
-    #|}
-    #|
-    #|async fn main {
-    #|  @async.sleep(0)
-    #|  println("async ok")
-    #|}
-    #|EOF
     #|```
     #|
     #|## Checked Error Handling


### PR DESCRIPTION
Now that `run_moonbit` is the agent's MoonBit scripting/probe surface (#531, A/B-validated), the default prompt still carried older, **competing** `moon run -e` / heredoc probe guidance that steers the agent back into the shell-quoting path `run_moonbit` was built to avoid.

## Change (agent prompt only)
`prompt/default_prompt.mbt.md` — remove the redundant/competing `moon run -e` probe mechanics:
- the `run_moonbit` restatement + `moon run -c` note + `-e`/`moon run -`/heredoc mechanics;
- the "don't use `moon run -e` for multi-line — use a heredoc" bullet + the heredoc async-probe example;
- the "`moon run -e` remains for what the tool cannot express (`fn main raise` stack-trace probe)" fallback — **verified false**: `run_moonbit` runs `fn main raise { fail(...) }` and prints the full `PanicError` trace.

**Kept**: general MoonBit knowledge (async/`mut`/`()` gotchas, `#|`/`$|` strings + example, checked-error section) and the two correct `moon run -e` references (never probe local packages with it; prefer `run_moonbit` over it). `base_prompt.mbt.md`'s factual moon reference is left untouched.

Regenerated `generated_default_prompt.mbt` (in sync); `moon check prompt --deny-warn` clean, 19/19 prompt tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)