### PR TITLE
fix(shell): whitelist `moon new` against the source-write sandbox

### DIFF
--- a/agent_tool/shell/review_guard.mbt
+++ b/agent_tool/shell/review_guard.mbt
@@ -10,9 +10,18 @@ fn command_is_mutating_moon(command : @shell_parse.SimpleCommand) -> Bool {
       match parse_moon_invocation(command.argv, index, ".") {
         Some(invocation) =>
           !invocation.dry_run &&
-          is_auto_check_moon_subcommand(
-            command.argv,
-            invocation.subcommand_index,
+          (
+            is_auto_check_moon_subcommand(
+              command.argv,
+              invocation.subcommand_index,
+            ) ||
+            // A review is read-only: scaffolding a project (`moon new`) creates
+            // manifests and source and must be blocked here too, independently
+            // of post-command auto-checking.
+            is_moon_scaffold_subcommand(
+              command.argv,
+              invocation.subcommand_index,
+            )
           )
         None => false
       }
@@ -24,7 +33,7 @@ fn command_is_mutating_moon(command : @shell_parse.SimpleCommand) -> Bool {
 /// Whether read-only (review) mode should refuse this parsed command. This is a
 /// best-effort guard, not an airtight guarantee: it blocks the obvious bulk
 /// source-rewriters — a source-mutating moon command (fmt / info / test
-/// --update / ...) anywhere in a `Simple` parse, including `&&`/`;` chains,
+/// --update / `new` scaffolding / ...) anywhere in a `Simple` parse, including `&&`/`;` chains,
 /// pipes, and env prefixes — so a review does not reformat or regenerate the
 /// tree wholesale. Opaque commands (`TooComplex`: subshells, command
 /// substitution) are allowed: a review that runs `moon check`/`moon test` can
@@ -42,6 +51,12 @@ test "read-only guard blocks mutating moon anywhere; allows read-only commands" 
   // mutating moon — plain, chained either way, and env-prefixed (all bypasses)
   assert_true(
     review_read_only_blocks(@shell_parse.parse_for_policy("moon fmt")),
+  )
+  assert_true(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon new app")),
+  )
+  assert_true(
+    review_read_only_blocks(@shell_parse.parse_for_policy("moon new -- --help")),
   )
   assert_true(
     review_read_only_blocks(@shell_parse.parse_for_policy("moon info")),

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -258,6 +258,13 @@ fn moon_new_target(
 /// `moon new --name main <dir-with-loose-source>`). A genuinely new or empty
 /// target has nothing to clobber and stays trusted; an unsafe or undeterminable
 /// target is reported so the caller re-applies the source-write sandbox.
+///
+/// This is a best-effort, good-will-agent guard: it catches an honest `moon new`
+/// aimed at an existing directory. The target is resolved lexically against the
+/// parsed cwd, so an agent deliberately defeating it (symlink tricks, a
+/// preceding `cd`, or a chain that repopulates the target between this check and
+/// launch) could still slip through — hard, race-free containment is the planned
+/// wasm backend's job.
 async fn parse_scaffolds_unsafe_target(
   parsed : @shell_parse.ParseResult,
   base_cwd : String,
@@ -277,7 +284,12 @@ async fn parse_scaffolds_unsafe_target(
       None => return true
       Some(target) =>
         if @fs.exists(target) {
-          let entries = @fs.readdir(target) catch { _ => return true }
+          let entries = @fs.readdir(target) catch {
+            // A cancellation must abort the launch, not be turned into a
+            // "treat as unsafe" verdict that lets setup continue.
+            error if @async.is_being_cancelled() => raise error
+            _ => return true
+          }
           if entries.length() > 0 {
             return true
           }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -35,6 +35,20 @@ async fn agent_shell_launch(
     None => None
   }
   let mode = source_write_mode_for_parse(parsed, real_workspace_root, real_cwd)
+  // `moon new` is trusted to scaffold, but only into a genuinely new or empty
+  // target. A scaffold that would land in an existing non-empty directory is
+  // downgraded to the source-write sandbox so it cannot overwrite existing
+  // files (moon new refuses an existing Moon project, but overwrites loose
+  // `.mbt` files in a non-project directory).
+  let mode = if mode is TrustedSourceWrite &&
+    parse_scaffolds_unsafe_target(
+      parsed,
+      real_cwd.unwrap_or(real_workspace_root),
+    ) {
+    SourceReadOnly
+  } else {
+    mode
+  }
   if mode is TrustedSourceWrite || !@sandbox.sandbox_exec_available() {
     return {
       program: @sandbox.PlatformShellProgram,
@@ -170,14 +184,17 @@ fn trusted_moon_command_class(
         command.argv,
         invocation.subcommand_index,
       ) => TrustedCommandWrite
-    Some(invocation) if is_source_readonly_moon_subcommand(
-        command.argv,
-        invocation.subcommand_index,
-      ) => TrustedCommandRead
+    // Scaffolding is checked before the read-only arm: `moon new -- --help`
+    // scaffolds a directory named `--help`, but that arm's help scan runs past
+    // `--` and would otherwise misclassify it as read-only.
     Some(invocation) if is_moon_scaffold_subcommand(
         command.argv,
         invocation.subcommand_index,
       ) => TrustedCommandWrite
+    Some(invocation) if is_source_readonly_moon_subcommand(
+        command.argv,
+        invocation.subcommand_index,
+      ) => TrustedCommandRead
     _ => UntrustedCommand
   }
 }
@@ -195,8 +212,79 @@ fn is_moon_scaffold_subcommand(
   argv : Array[String],
   subcommand_index : Int,
 ) -> Bool {
+  // Detect help only BEFORE `--`; `moon new -- --help` scaffolds a directory
+  // literally named `--help`, so that trailing token is a path, not a flag.
   argv[subcommand_index] == "new" &&
-  !argv_contains_help_flag(argv, subcommand_index + 1)
+  !argv_contains_help_flag_before_double_dash(argv, subcommand_index + 1)
+}
+
+///|
+/// The `<PATH>` positional of a `moon new` invocation, resolved against the
+/// command's cwd. Grammar is `moon new [OPTIONS] <PATH>`: `--user`/`--name`/
+/// `--target-dir` take a value, the rest are boolean flags, and every token
+/// after `--` is positional. Returns the first positional as a normalized path,
+/// or None when none is present.
+fn moon_new_target(
+  argv : Array[String],
+  new_index : Int,
+  cwd : String,
+) -> String? {
+  let mut index = new_index + 1
+  let mut after_double_dash = false
+  while index < argv.length() {
+    let arg = argv[index]
+    if !after_double_dash && arg == "--" {
+      after_double_dash = true
+      index += 1
+      continue
+    }
+    if !after_double_dash &&
+      (arg == "--user" || arg == "--name" || arg == "--target-dir") {
+      index += 2
+      continue
+    }
+    if !after_double_dash && arg.has_prefix("-") && arg != "-" {
+      index += 1
+      continue
+    }
+    return Some(@path.Path(cwd).join(Path(arg)).normalize().to_string())
+  }
+  None
+}
+
+///|
+/// Whether the parse scaffolds (`moon new`) into a target that already exists
+/// and is NON-EMPTY — where moon new could overwrite existing files (e.g.
+/// `moon new --name main <dir-with-loose-source>`). A genuinely new or empty
+/// target has nothing to clobber and stays trusted; an unsafe or undeterminable
+/// target is reported so the caller re-applies the source-write sandbox.
+async fn parse_scaffolds_unsafe_target(
+  parsed : @shell_parse.ParseResult,
+  base_cwd : String,
+) -> Bool {
+  guard parsed is Simple(commands) else { return false }
+  for command in commands {
+    guard moon_command_start(command) is Some(moon_index) else { continue }
+    guard parse_moon_invocation(command.argv, moon_index, base_cwd)
+      is Some(invocation) else {
+      continue
+    }
+    guard is_moon_scaffold_subcommand(command.argv, invocation.subcommand_index) else {
+      continue
+    }
+    match
+      moon_new_target(command.argv, invocation.subcommand_index, invocation.cwd) {
+      None => return true
+      Some(target) =>
+        if @fs.exists(target) {
+          let entries = @fs.readdir(target) catch { _ => return true }
+          if entries.length() > 0 {
+            return true
+          }
+        }
+    }
+  }
+  false
 }
 
 ///|

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -174,8 +174,29 @@ fn trusted_moon_command_class(
         command.argv,
         invocation.subcommand_index,
       ) => TrustedCommandRead
+    Some(invocation) if is_moon_scaffold_subcommand(
+        command.argv,
+        invocation.subcommand_index,
+      ) => TrustedCommandWrite
     _ => UntrustedCommand
   }
+}
+
+///|
+/// Whether the moon subcommand scaffolds a new project — `moon new`, which
+/// writes `moon.mod` and starter `.mbt` files into a fresh directory. That is a
+/// legitimate source write, so it must be trusted; otherwise the sandbox's
+/// source-write deny blocks the generated files and `moon new` fails. Kept
+/// separate from `is_auto_check_moon_subcommand` so it grants ONLY the sandbox
+/// trust here, without also triggering a post-command `moon check` (which would
+/// run against the current package, not the freshly created one). A `--help`
+/// invocation writes nothing, so it is not treated as a source write.
+fn is_moon_scaffold_subcommand(
+  argv : Array[String],
+  subcommand_index : Int,
+) -> Bool {
+  argv[subcommand_index] == "new" &&
+  !argv_contains_help_flag(argv, subcommand_index + 1)
 }
 
 ///|

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -5,6 +5,7 @@ test "sandbox trusts only narrow moon source-writing commands" {
   assert_true(mode_for("moon new ./pkg") is TrustedSourceWrite)
   assert_true(mode_for("cd sub && moon new app") is TrustedSourceWrite)
   assert_true(mode_for("moon new --help") is SourceReadOnly)
+  assert_true(mode_for("moon new --name demo -- --help") is TrustedSourceWrite)
   assert_true(mode_for("moon info") is TrustedSourceWrite)
   assert_true(
     mode_for("moon ide rename old new --loc main.mbt:1:8 --apply")
@@ -1487,5 +1488,54 @@ async test "sandbox scans source writes after arithmetic left shifts" {
     // A bare arithmetic command with no source write stays allowed.
     let arith_only = "echo $((1 << 8))\n"
     assert_true(dyn_tree_target(arith_only, real_root, Some(real_root)) is None)
+  })
+}
+
+///|
+async test "moon new is a trusted scaffold only for a new or empty target" {
+  @vfs.with_tmpdir(prefix="moon-new-scaffold-", root => {
+    // a genuinely new target: nothing to overwrite -> safe (stays trusted)
+    assert_false(
+      parse_scaffolds_unsafe_target(
+        @shell_parse.parse_for_policy("moon new \{root}/fresh"),
+        root,
+      ),
+    )
+    // an existing EMPTY directory -> still safe
+    @fs.mkdir("\{root}/emptydir")
+    assert_false(
+      parse_scaffolds_unsafe_target(
+        @shell_parse.parse_for_policy("moon new \{root}/emptydir"),
+        root,
+      ),
+    )
+    // an existing NON-EMPTY directory (loose source) -> UNSAFE: moon new could
+    // overwrite it, so this must fall back to the source-write sandbox
+    @fs.mkdir("\{root}/pkg")
+    @fs.write_file(
+      "\{root}/pkg/main.mbt",
+      "fn main {  }\n",
+      create_mode=CreateOrTruncate,
+    )
+    assert_true(
+      parse_scaffolds_unsafe_target(
+        @shell_parse.parse_for_policy("moon new \{root}/pkg"),
+        root,
+      ),
+    )
+    // no target at all -> undeterminable -> treated as unsafe
+    assert_true(
+      parse_scaffolds_unsafe_target(
+        @shell_parse.parse_for_policy("moon new"),
+        root,
+      ),
+    )
+    // a non-scaffold command is never an unsafe scaffold
+    assert_false(
+      parse_scaffolds_unsafe_target(
+        @shell_parse.parse_for_policy("moon fmt"),
+        root,
+      ),
+    )
   })
 }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1,6 +1,10 @@
 ///|
 test "sandbox trusts only narrow moon source-writing commands" {
   assert_true(mode_for("moon fmt") is TrustedSourceWrite)
+  assert_true(mode_for("moon new my_project") is TrustedSourceWrite)
+  assert_true(mode_for("moon new ./pkg") is TrustedSourceWrite)
+  assert_true(mode_for("cd sub && moon new app") is TrustedSourceWrite)
+  assert_true(mode_for("moon new --help") is SourceReadOnly)
   assert_true(mode_for("moon info") is TrustedSourceWrite)
   assert_true(
     mode_for("moon ide rename old new --loc main.mbt:1:8 --apply")


### PR DESCRIPTION
`moon new <dir>` writes `moon.mod`/`moon.pkg`/starter `.mbt` files, but the shell sandbox classified it as `UntrustedCommand` → the batch ran in `SourceReadOnly` mode and the sandbox **denied those writes**, so scaffolding failed:

```
Error: Failed to create file: newproj/moon.pkg
Caused by: Operation not permitted (os error 1)
```
(reproduced directly under a source-write-deny profile).

## Fix
Classify `moon new` as a trusted source write via a dedicated `is_moon_scaffold_subcommand`, used **only** in the sandbox trust path — deliberately *not* shared with `is_auto_check_moon_subcommand`, so it doesn't also trigger a post-command `moon check` against the current package (the scaffolded project is separate). `moon new --help` writes nothing, so it's excluded.

`mode_for("moon new ...")` is now `TrustedSourceWrite`; 115 shell tests pass; predicate is private so the `.mbti` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)