### PR TITLE
fix(agent): salvage any control-declared completion at the context ceiling

### DIFF
--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -586,6 +586,149 @@ async test "a pressured finish batch salvages the completion" {
 }
 
 ///|
+/// A completion tool under a custom name: control-declared, seals via
+/// Control(Finish) exactly like the built-in `finish` — the salvage matches
+/// the control declaration, not the name (a sub-run's submit tool is the
+/// production shape).
+async test "a pressured custom control completion is salvaged at the ceiling" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("SUBMIT-SUMMARY"))
+      } else {
+        main_requests += 1
+        Sse(
+          sse_tool_calls(
+            [("call_1", "probe"), ("call_2", "submit_report")],
+            900_000,
+          ),
+        )
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let tools : @agent_tool.Tools = Tools([
+      AgentToolDefinition(
+        name="submit_report",
+        description="Submit the final report.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => @agent_tool.ToolAction::finish("report captured")),
+        control=true,
+      ),
+      AgentToolDefinition(
+        name="probe",
+        description="Probe tool.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+      ),
+    ])
+    let session = @agent_session.Session(
+      SessionId("custom-completion-pressure"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="wrap it up",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools~,
+    )
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    // A completed task, not a yield: the custom completion's answer verbatim.
+    assert_eq(finished_answer(result), "report captured")
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        // The probe may not execute: its result could grow the checkpoint
+        // request and cannot change the decided answer.
+        assert_true(tool_result.content() != "result-1")
+      }
+    }
+  }
+}
+
+///|
+/// Control calls without any sealing completion still execute at the
+/// ceiling — skip-closing a durable verdict (the goal(met) shape) would
+/// discard completed work — and the turn then yields as usual.
+async test "a lone control verdict without a finish executes then yields" {
+  @async.with_task_group() <| group => {
+    let checkpoint_requests : Array[Json] = []
+    let mut main_requests = 0
+    let handle = request => {
+      if is_checkpoint_request(request) {
+        checkpoint_requests.push(request)
+        Body(checkpoint_body("VERDICT-SUMMARY"))
+      } else {
+        main_requests += 1
+        Sse(
+          sse_tool_calls([("call_1", "record"), ("call_2", "probe")], 900_000),
+        )
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let tools : @agent_tool.Tools = Tools([
+      AgentToolDefinition(
+        name="record",
+        description="Record a verdict.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => {
+          @agent_tool.ToolAction::respond("verdict recorded")
+        }),
+        control=true,
+      ),
+      AgentToolDefinition(
+        name="probe",
+        description="Probe tool.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+      ),
+    ])
+    let session = @agent_session.Session(
+      SessionId("control-verdict-pressure"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="keep grinding",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools~,
+    )
+    assert_eq(main_requests, 1)
+    assert_eq(checkpoint_requests.length(), 1)
+    let mut verdict_recorded = false
+    let mut probe_skipped = false
+    for event in result.events() {
+      if event.item() is Tool(tool_result) {
+        assert_true(tool_result.content() != "result-1")
+        if tool_result.content() == "verdict recorded" {
+          assert_false(tool_result.is_error())
+          verdict_recorded = true
+        }
+        if tool_result.is_error() &&
+          tool_result.content().contains("yielding at the context ceiling") {
+          probe_skipped = true
+        }
+      }
+    }
+    assert_true(verdict_recorded)
+    assert_true(probe_skipped)
+    assert_true(finished_answer(result).contains("[context ceiling]"))
+  }
+}
+
+///|
 async test "a pressured finish tool losing to a steer yields instead" {
   @async.with_task_group() <| group => {
     let runtime = @agent_runtime.AgentRuntime()

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -735,8 +735,10 @@ async fn AgentLoop::close_skipped_tool_calls(
 /// running budget stopped execution mid-batch — calls before it already
 /// executed and have results (their growth arrives as
 /// `spent_result_chars`, so a salvaged completion still checkpoints).
-/// Control calls are exempt from the budget: their results are a few bytes
-/// of loop flow, not tool output.
+/// Control calls are exempt from the PRE-execution fit check (their
+/// results are bounded by contract), but a non-sealing control's recorded
+/// result still accumulates into the running total, so a later sealing
+/// control sizes its checkpoint against what was actually appended.
 async fn AgentLoop::salvage_control_calls_at_ceiling(
   self : Self,
   session : @agent_session.Session,
@@ -753,7 +755,7 @@ async fn AgentLoop::salvage_control_calls_at_ceiling(
   }) else {
     return None
   }
-  let session = for index = from, session = session {
+  let session = for index = from, session = session, spent = spent_result_chars {
     if index >= response.tool_calls.length() {
       break session
     }
@@ -773,10 +775,23 @@ async fn AgentLoop::salvage_control_calls_at_ceiling(
               index,
               call,
               tool_call,
-              spent_result_chars~,
+              spent_result_chars=spent,
               last_step~,
             ) {
-            ContinueToolBatch(next) => continue index + 1, next
+            // A non-sealing control appended an ordinary result (a goal
+            // verdict echo, a rejected submit): its growth must ride along
+            // like an executed prefix's, or a LATER sealing control would
+            // size its compact-on-finish decision against stale usage
+            // while the reserved checkpoint headroom is already spent.
+            ContinueToolBatch(next) => {
+              let growth = if next.events().peek() is Some(event) &&
+                event.item() is Tool(result) {
+                result.content().length().to_int64()
+              } else {
+                0
+              }
+              continue index + 1, next, spent + growth
+            }
             // The control already closed the batch remainder and prepared a
             // continuation (e.g. a control finish converted into a goal
             // check): re-scanning the same calls would duplicate results
@@ -798,7 +813,8 @@ async fn AgentLoop::salvage_control_calls_at_ceiling(
         session,
         response.tool_calls[index:index + 1],
         note=ceiling_skip_note,
-      )
+      ),
+      spent
   }
   // Controls ran but none sealed or continued the turn: every call is
   // closed (executed or skip-noted), so yield at the ceiling with the

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -202,7 +202,7 @@ async fn AgentLoop::run(
           tool_calls=response.tool_calls,
         )
         match
-          self.salvage_finish_at_ceiling(
+          self.salvage_control_calls_at_ceiling(
             session,
             response,
             last_step=step + 1 >= max_steps,
@@ -453,13 +453,14 @@ async fn AgentLoop::handle_tool_calls(
     // pessimizes one call ahead — no pre-execution estimate over the whole
     // batch, no false positives at low usage.
     if !self.next_call_fits(response.usage, spent_result_chars) {
-      // A finish call in the unexecuted remainder is a completion, not
-      // more output — on small-window models the budget can trip well
-      // below the hard ceiling, and skip-closing the finish would turn an
-      // already-completed task into a context yield. The executed prefix's
-      // growth rides along so the salvaged finish still checkpoints.
+      // A control call in the unexecuted remainder is a completion in
+      // progress, not more output — on small-window models the budget can
+      // trip well below the hard ceiling, and skip-closing a finish (or a
+      // goal verdict) would turn an already-completed task into a context
+      // yield. The executed prefix's growth rides along so a salvaged
+      // completion still checkpoints.
       match
-        self.salvage_finish_at_ceiling(
+        self.salvage_control_calls_at_ceiling(
           session,
           response,
           from=call_index,
@@ -702,33 +703,41 @@ async fn AgentLoop::close_skipped_tool_calls(
 }
 
 ///|
-/// At the context ceiling, a batch carrying the built-in `finish` call is a
-/// completion, not more work — honor it instead of discarding it. Calls
-/// before the finish are skip-closed (their results cannot change the
-/// already-decided answer, and executing them would grow the checkpoint
-/// request); the finish call itself executes — a few bytes of result — and
-/// its Control(Finish) path closes the remainder, checkpoints, and seals
-/// the real answer. `finish` is matched by name: it is the loop's
-/// documented structured-completion contract (see agent_tool/finish). A
-/// custom tool returning Control(Finish) under another name still works
-/// whenever its batch executes; it just cannot be salvaged at the ceiling.
+/// At the context ceiling, a batch carrying control-registered calls is a
+/// completion in progress, not more work — honor those calls instead of
+/// discarding them. A control tool's action is loop flow bounded to a few
+/// bytes by contract (see `AgentToolDefinition::control`), so executing it
+/// cannot grow the checkpoint request the way ordinary tool output would.
+/// Non-control calls are skip-closed: their results cannot change an
+/// already-decided completion, and executing them would grow the
+/// checkpoint request. The built-in `finish` seals the turn through its
+/// Control(Finish) path, which also closes the remainder and checkpoints;
+/// `goal(met)` records its durable verdict rather than being skip-closed
+/// into a resurrected goal; a custom completion tool declaring control
+/// (e.g. a review engine's submit tool) seals the same way finish does. A
+/// non-control tool — including one shadowing a control name like
+/// `finish` — is skip-closed like any other call here.
 ///
-/// Returns None when the batch carries no decodable finish call — nothing
-/// was appended and the caller proceeds with the plain yield. Otherwise
-/// the outcome distinguishes a sealed turn (StepDone: finished or yielded)
-/// from a continuation (StepContinue: a steer arriving during the salvaged
-/// finish's checkpoint converted it into ContinueTurn — treating that as a
-/// failed salvage would close already-closed calls again and fold the
-/// steer into a second summary).
+/// Returns None when the batch carries no control-registered call —
+/// nothing was appended and the caller proceeds with the plain yield.
+/// Otherwise the outcome distinguishes a sealed turn (StepDone: finished
+/// or yielded) from a continuation (StepContinue: a steer arriving during
+/// a salvaged completion's checkpoint converted it into ContinueTurn —
+/// treating that as a failed salvage would close already-closed calls
+/// again and fold the steer into a second summary). When the executed
+/// controls all return ordinary results (e.g. a goal verdict with no
+/// finish, or a completion override answering with Respond), every call
+/// ends up closed and the turn yields at the ceiling with those durable
+/// results kept.
 ///
 /// `from` is where the unexecuted remainder starts: 0 when the whole batch
 /// is being skipped (hard ceiling), or the tripping call's index when the
 /// running budget stopped execution mid-batch — calls before it already
 /// executed and have results (their growth arrives as
-/// `spent_result_chars`, so the salvaged finish still checkpoints). The
-/// finish call itself is exempt from the budget: its result is a few bytes
-/// of completion, not tool output.
-async fn AgentLoop::salvage_finish_at_ceiling(
+/// `spent_result_chars`, so a salvaged completion still checkpoints).
+/// Control calls are exempt from the budget: their results are a few bytes
+/// of loop flow, not tool output.
+async fn AgentLoop::salvage_control_calls_at_ceiling(
   self : Self,
   session : @agent_session.Session,
   response : @deepseek.ChatResponse,
@@ -736,28 +745,16 @@ async fn AgentLoop::salvage_finish_at_ceiling(
   spent_result_chars? : Int64 = 0,
   last_step~ : Bool,
 ) -> AgentStepOutcome? {
-  // The registry must declare the finish tool a CONTROL tool: that is how
+  // The registry must declare a call's tool a CONTROL tool: that is how
   // the loop knows — without executing — that honoring the call appends a
-  // few bytes, not tool output. A custom non-control tool shadowing the
-  // name is skip-closed like any other call at the ceiling.
-  guard self.tools.find("finish") is Some(definition) && definition.is_control() else {
+  // few bytes, not tool output.
+  guard response.tool_calls[from:].any(call => {
+    self.tools.find(call.name) is Some(definition) && definition.is_control()
+  }) else {
     return None
   }
-  guard response.tool_calls[from:].search_by(call => call.name == "finish")
-    is Some(offset) else {
-    return None
-  }
-  let finish_index = from + offset
-  let native_call = response.tool_calls[finish_index]
-  let tool_call = @agent_tool.AgentToolCall(native_call) catch {
-    _ => return None
-  }
-  // Control-registered calls in the prefix are bounded by contract and can
-  // carry the completion's substance — the goal check text asks for
-  // goal(met) BEFORE finish, and skip-closing it would resurrect a
-  // completed goal for auto-continue. Execute them; skip everything else.
   let session = for index = from, session = session {
-    if index >= finish_index {
+    if index >= response.tool_calls.length() {
       break session
     }
     let call = response.tool_calls[index]
@@ -785,11 +782,14 @@ async fn AgentLoop::salvage_finish_at_ceiling(
             // check): re-scanning the same calls would duplicate results
             // and bypass the injected check.
             ContinueAgentLoop(next) => return Some(StepContinue(next))
-            // A prefix control that SEALED the turn (e.g. an abort) owns
-            // the terminal: executing the finish after it would append
-            // past a terminal and override the intended outcome.
+            // A control that SEALED the turn (finish, a custom completion,
+            // or an abort) owns the terminal: executing anything after it
+            // would append past a terminal and override the intended
+            // outcome.
             FinishAgentLoop(next) => return Some(StepDone(next))
           }
+        // An undecodable control call cannot be honored; close it like a
+        // skipped call so the batch stays API-valid.
         None => ()
       }
     }
@@ -800,35 +800,14 @@ async fn AgentLoop::salvage_finish_at_ceiling(
         note=ceiling_skip_note,
       )
   }
-  match
-    self.execute_tool_call(
-      session,
-      response,
-      finish_index,
-      native_call,
-      tool_call,
-      spent_result_chars~,
-      last_step~,
-    ) {
-    FinishAgentLoop(next) => Some(StepDone(next))
-    // The finish ran but a steer converted it into a continuation: its
-    // remainder is already closed and the checkpoint appended.
-    ContinueAgentLoop(next) => Some(StepContinue(next))
-    // A tool named `finish` that did not finish (custom override returning
-    // Respond): close the remainder and fall back to the ceiling yield.
-    ContinueToolBatch(next) => {
-      let next = self.close_skipped_tool_calls(
-        next,
-        response.tool_calls[finish_index + 1:],
-        note=ceiling_skip_note,
-      )
-      Some(
-        StepDone(
-          self.yield_at_context_ceiling(next, self.runtime.pending_steers()),
-        ),
-      )
-    }
-  }
+  // Controls ran but none sealed or continued the turn: every call is
+  // closed (executed or skip-noted), so yield at the ceiling with the
+  // recorded results carried into the checkpoint.
+  Some(
+    StepDone(
+      self.yield_at_context_ceiling(session, self.runtime.pending_steers()),
+    ),
+  )
 }
 
 ///|

--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -4,6 +4,12 @@
 /// validates the arguments, captures a valid report into `captured`, and ends
 /// the run via Finish. Malformed output is rejected with an error so the model
 /// retries instead of finishing with no report.
+///
+/// Declared a control tool: its action is loop flow with a few bytes of
+/// result, so the loop's ceiling salvage honors a pending `submit_review`
+/// instead of skip-closing it — without this, a review that hits the
+/// context ceiling on its submitting step would lose its finished report
+/// and fail with `ReviewError`.
 fn submit_review_tool(
   captured : Ref[ReviewReport?],
 ) -> @agent_tool.AgentToolDefinition {
@@ -12,6 +18,7 @@ fn submit_review_tool(
     description="Submit the final structured code-review report and end the review. Call this exactly once, when the review is complete. Every finding must cite a file (and a line when known) and a severity of blocker|high|medium|low|nit.",
     schema=JsonSchema(report_schema()),
     execute=Sync(args => submit(captured, args)),
+    control=true,
   )
 }
 
@@ -93,6 +100,15 @@ fn report_schema() -> Json {
     },
     "required": ["schema_version", "scope", "findings", "summary", "stats"],
   }
+}
+
+///|
+test "submit_review declares itself a control tool" {
+  // The ceiling salvage honors control-declared completions; without this
+  // a review hitting the context ceiling on its submitting step would
+  // skip-close submit_review and fail with ReviewError.
+  let captured : Ref[ReviewReport?] = { val: None }
+  assert_true(submit_review_tool(captured).is_control())
 }
 
 ///|


### PR DESCRIPTION
## What

The context-ceiling salvage honored only a tool literally named `finish`. Two consequences:

1. A completion arriving through a **custom control tool** was skip-closed at the ceiling. Concretely: `agent_review`'s `submit_review` — a review that hits the ceiling on its submitting step loses its finished report and fails with `ReviewError`.
2. A **lone `goal(met)` verdict** without a trailing `finish` in the batch was skip-closed, resurrecting a completed goal for auto-continue — the exact hazard the prefix-execution comment already warned about, but only defended when a `finish` followed in the same batch.

## How

- `salvage_finish_at_ceiling` → `salvage_control_calls_at_ceiling`: a single walk over the unexecuted remainder that executes every control-registered, decodable call (bounded to a few bytes by the `control` contract) and skip-closes the rest. A sealing control (`Control(Finish)`/`Abort`) owns the terminal exactly as before; controls that only record results (goal verdicts, `Respond`-answering overrides) execute, then the turn yields at the ceiling with their durable results carried into the checkpoint. Returns `None` (caller's plain-yield path) only when the batch carries no control-registered call.
- `submit_review` now declares `control=true`.

Existing semantics preserved: `[probe, finish, probe]` salvage, `[goal, finish]` salvage-both, the non-control `finish` shadow being skip-closed, and steer-beats-finish all pass unchanged.

Behavior change (intended): control calls in a ceiling batch now execute even when no `finish` follows — previously they were skip-closed with the rest.

## Tests

- `a pressured custom control completion is salvaged at the ceiling` — seals with the custom tool's answer; probes never execute; checkpoint still runs.
- `a lone control verdict without a finish executes then yields` — verdict recorded durably, non-control call skip-closed, `[context ceiling]` yield.
- `submit_review declares itself a control tool`.
- `moon check --target all` clean; `agent` suite 69/70 (the 1 failure is the known-flaky background-job timing test, fails identically on clean main); `agent_review` 10/10; `moon fmt`/`moon info` clean (no public API change).

Context: PR A1 of the subagent-substrate series (explore tool + review gate), sequenced and design-reviewed via subal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)