### PR TITLE
feat(agent): route all turn events through a per-loop EventSink

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -226,6 +226,12 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// a fresh registry for this call only. `api_url` is forwarded to the DeepSeek
 /// client. The caller owns the lifetime of `runtime`, `scope`, and any shared
 /// `tools` registry passed here.
+///
+/// `event_sink` is where every protocol event this turn produces goes —
+/// including the pre-loop setup failure. The default forwards to the process
+/// log (today's behavior). A nested sub-run passes an isolating sink so its
+/// lifecycle events (most critically `AgentFinished`) stay out of the
+/// host-facing stream, where they would read as the OUTER run's terminal.
 pub async fn[X] run_turn_in_scope(
   runtime~ : @agent_runtime.AgentRuntime,
   scope~ : @agent_runtime.AgentTaskScope[X],
@@ -238,6 +244,7 @@ pub async fn[X] run_turn_in_scope(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   tools? : @agent_tool.Tools,
+  event_sink? : @emit.EventSink = @emit.EventSink::global(),
 ) -> @agent_session.Session {
   let client = @client.Client(api_key~, model~, thinking~, api_url?)
   let summary_client = @client.Client(api_key~, model~, api_url?, thinking=No)
@@ -249,14 +256,23 @@ pub async fn[X] run_turn_in_scope(
     }
   } catch {
     error => {
-      @emit.emit(AgentSetupFailed(error="\{error}"))
+      // Pre-loop failure: no AgentLoop exists yet, so this site must route
+      // through the sink itself or a sub-run's setup error would leak into
+      // the host-facing stream.
+      event_sink.emit(AgentSetupFailed(error="\{error}"))
       return session
         |> append_item(Terminal(Failed("agent setup failed: \{error}")))
     }
   }
-  AgentLoop(runtime~, client~, summary_client~, tools~, append_item~, session~).run(
-    session, max_steps,
-  )
+  AgentLoop(
+    runtime~,
+    client~,
+    summary_client~,
+    tools~,
+    append_item~,
+    session~,
+    events=event_sink,
+  ).run(session, max_steps)
 }
 
 ///|

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -123,7 +123,7 @@ async fn AgentLoop::checkpoint_at_ceiling(
   let to_sequence = session.last_sequence()
   let covered = session
   let session = self.apply_steer_inputs(session, steers)
-  @emit.emit(AutoCompactionStarted(from_sequence=1, to_sequence~))
+  self.events.emit(AutoCompactionStarted(from_sequence=1, to_sequence~))
   let summary = @compact.generate_compaction_summary(
     client=self.summary_client,
     covered,
@@ -132,7 +132,7 @@ async fn AgentLoop::checkpoint_at_ceiling(
       if @async.is_being_cancelled() || @async.is_cancellation_error(error) {
         raise error
       }
-      @emit.emit(AutoCompactionFailed(error="\{error}"))
+      self.events.emit(AutoCompactionFailed(error="\{error}"))
       return (session, false)
     }
   }
@@ -142,7 +142,9 @@ async fn AgentLoop::checkpoint_at_ceiling(
     to_sequence~,
   )
   let compacted = self.append(session, item)
-  @emit.emit(AutoCompactionFinished(from_sequence=1, to_sequence~, summary~))
+  self.events.emit(
+    AutoCompactionFinished(from_sequence=1, to_sequence~, summary~),
+  )
   (compacted, true)
 }
 
@@ -209,6 +211,6 @@ async fn AgentLoop::finish_context_yield(
   // No push_finished_message: the yield status is not an assistant message
   // — the model-facing projection skips it too (the loop ends here, but the
   // buffer must never disagree with Session::chat_messages).
-  @emit.emit(ContextYield(to_sequence~, answer~))
+  self.events.emit(ContextYield(to_sequence~, answer~))
   session
 }

--- a/agent/event_sink_test.mbt
+++ b/agent/event_sink_test.mbt
@@ -1,0 +1,97 @@
+///|
+/// The event kind tag of a collected protocol event.
+fn event_kind(event : @protocol.Event) -> String {
+  guard event.to_json() is Object(fields) &&
+    fields.get("event") is Some(String(kind)) else {
+    return ""
+  }
+  kind
+}
+
+///|
+/// Every protocol event a turn produces flows through the loop's sink —
+/// the property a sub-run relies on to keep its lifecycle (most critically
+/// `agent_finished`, which the TUI and desktop hosts treat as run-terminal)
+/// out of the host-facing stream.
+async test "a turn's events all flow through the provided sink" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = _request => {
+      Sse(sse_final("sinked done", 100_000))
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let collected : Array[@protocol.Event] = []
+    let sink = @emit.EventSink((event, _loc) => collected.push(event))
+    let session = @agent_session.Session(
+      SessionId("event-sink"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="answer briefly",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      event_sink=sink,
+    )
+    assert_eq(finished_answer(result), "sinked done")
+    let kinds = collected.map(event_kind)
+    assert_true(kinds.contains("agent_step"))
+    assert_true(kinds.contains("assistant_message"))
+    assert_true(kinds.contains("usage"))
+    // The terminal arrives at the sink — and, for an isolating sink, ONLY
+    // at the sink.
+    assert_true(kinds[kinds.length() - 1] is "agent_finished")
+  }
+}
+
+///|
+/// Tool-batch and goal-machinery events route through the sink too — the
+/// goal tool's verdict path and the tool-result log share the loop's sink
+/// rather than reaching for the process log.
+async test "tool and goal events route through the sink" {
+  @async.with_task_group() <| group => {
+    let mut step = 0
+    let handle : (Json) -> MockReply raise = _request => {
+      step += 1
+      if step == 1 {
+        Sse(sse_tool_call("call_1", "probe", 100_000))
+      } else {
+        Sse(sse_final("all done", 110_000))
+      }
+    }
+    guard auto_compact_test_server(group, handle) is Some(url) else { return }
+    let collected : Array[@protocol.Event] = []
+    let sink = @emit.EventSink((event, _loc) => collected.push(event))
+    let tools : @agent_tool.Tools = Tools([
+      AgentToolDefinition(
+        name="probe",
+        description="Probe tool.",
+        schema=JsonSchema({ "type": "object" }),
+        execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+      ),
+    ])
+    let session = @agent_session.Session(
+      SessionId("event-sink-tools"),
+      system_prompt="system",
+    )
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session~,
+      task="probe then finish",
+      append_item=(session, item) => session.append(item),
+      api_url=url,
+      tools~,
+      event_sink=sink,
+    )
+    assert_eq(finished_answer(result), "all done")
+    let kinds = collected.map(event_kind)
+    assert_true(kinds.contains("tool_result"))
+    assert_true(kinds.contains("agent_finished"))
+  }
+}

--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -207,10 +207,15 @@ fn GoalCadence::record_reminder(self : GoalCadence) -> Unit {
 
 ///|
 /// Track a durably applied notice steer. A goal set/clear marker updates the
-/// live cadence and reports the new state as a `goal_updated` event. The
-/// event is emitted here — after the durable append, never at queue time —
-/// so a controller can only learn a goal that was actually persisted.
-fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
+/// live cadence and reports the new state as a `goal_updated` event through
+/// the owning loop's sink. The event is emitted here — after the durable
+/// append, never at queue time — so a controller can only learn a goal that
+/// was actually persisted.
+fn GoalCadence::observe_notice(
+  self : GoalCadence,
+  content : String,
+  events~ : @emit.EventSink,
+) -> Unit {
   match @agent_session.goal_marker(content) {
     Some(GoalSet(text)) => {
       self.goal = Some(text)
@@ -227,7 +232,7 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       // this set supersedes; a new goal starts unblocked.
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
-      @emit.emit(GoalUpdated(goal=Some(text)))
+      events.emit(GoalUpdated(goal=Some(text)))
     }
     Some(GoalCleared) => {
       self.goal = None
@@ -235,7 +240,7 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       self.pending_tombstone = false
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
-      @emit.emit(GoalUpdated(goal=None))
+      events.emit(GoalUpdated(goal=None))
     }
     // A block/unblock marker landing durably (this loop's own flush, or a
     // steer observed after its append) toggles the cached durable state; the
@@ -267,7 +272,7 @@ async fn AgentLoop::flush_goal_tombstone(
       )
       self.goal_cadence.pending_block = NoBlockTransition
       self.goal_cadence.durably_blocked = true
-      @emit.emit(GoalBlocked(reason~))
+      self.events.emit(GoalBlocked(reason~))
       next
     }
     // A continue that resumes a durably blocked goal: land the unblock marker
@@ -279,7 +284,7 @@ async fn AgentLoop::flush_goal_tombstone(
       )
       self.goal_cadence.pending_block = NoBlockTransition
       self.goal_cadence.durably_blocked = false
-      @emit.emit(GoalUnblocked)
+      self.events.emit(GoalUnblocked)
       next
     }
     // A no-op unblock (the goal was not durably blocked): nothing to rescind.
@@ -297,7 +302,7 @@ async fn AgentLoop::flush_goal_tombstone(
     @agent_session.GoalClearedNotice,
   )
   self.goal_cadence.pending_tombstone = false
-  @emit.emit(GoalUpdated(goal=None))
+  self.events.emit(GoalUpdated(goal=None))
   next
 }
 
@@ -387,7 +392,7 @@ async fn AgentLoop::handle_goal_tool_call(
       self.goal_cadence.record_goal_blocked(reason)
     _ => ()
   }
-  @emit.emit(
+  self.events.emit(
     ToolResult(
       tool_call_id=native_call.id,
       tool_name=tool_call.name,
@@ -409,12 +414,18 @@ test "a new goal observed after met drops the stale tombstone" {
   assert_true(cadence.pending_tombstone)
   // A steered-in set supersedes the met verdict: flushing the old
   // tombstone after the new marker would wipe the new goal.
-  cadence.observe_notice("\{@agent_session.GoalPrefix}\nnew objective")
+  cadence.observe_notice(
+    "\{@agent_session.GoalPrefix}\nnew objective",
+    events=@emit.EventSink::global(),
+  )
   assert_false(cadence.pending_tombstone)
   assert_true(cadence.goal is Some("new objective"))
   // A durable clear also settles a pending tombstone.
   cadence.record_goal_met() |> ignore
-  cadence.observe_notice(@agent_session.GoalClearedNotice)
+  cadence.observe_notice(
+    @agent_session.GoalClearedNotice,
+    events=@emit.EventSink::global(),
+  )
   assert_false(cadence.pending_tombstone)
   assert_true(cadence.goal is None)
 }
@@ -511,7 +522,10 @@ test "met and a superseding set/clear reset the block state" {
   // A superseding set clears the durable-blocked cache for the new goal.
   let other = GoalCadence(blocked_goal_session(), tool_registered=true)
   assert_true(other.durably_blocked)
-  other.observe_notice("\{@agent_session.GoalPrefix}\nnew objective")
+  other.observe_notice(
+    "\{@agent_session.GoalPrefix}\nnew objective",
+    events=@emit.EventSink::global(),
+  )
   assert_false(other.durably_blocked)
   assert_true(other.pending_block is NoBlockTransition)
 }
@@ -523,11 +537,17 @@ test "a goal set after an earlier check re-arms the finish check" {
     system_prompt="sys",
   )
   let cadence = GoalCadence(session, tool_registered=false)
-  cadence.observe_notice("\{@agent_session.GoalPrefix}\nfirst objective")
+  cadence.observe_notice(
+    "\{@agent_session.GoalPrefix}\nfirst objective",
+    events=@emit.EventSink::global(),
+  )
   cadence.record_finish_check()
   assert_true(cadence.due_finish_check() is None)
   // A NEW goal deserves its own check — the earlier one confirmed a
   // different objective.
-  cadence.observe_notice("\{@agent_session.GoalPrefix}\nsecond objective")
+  cadence.observe_notice(
+    "\{@agent_session.GoalPrefix}\nsecond objective",
+    events=@emit.EventSink::global(),
+  )
   assert_true(cadence.due_finish_check() is Some("second objective"))
 }

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/deepseek",
+  "bobzhang/openseek_protocol/emit",
 }
 
 // Values
@@ -15,7 +16,7 @@ pub let plan_reminder_after_steps : Int
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
-pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, event_sink? : @emit.EventSink) -> @agent_session.Session
 
 pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
 

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -15,6 +15,10 @@ priv struct AgentLoop {
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
   goal_cadence : GoalCadence
+  /// Where this loop's protocol events go. The top-level loop forwards to
+  /// the process log; a nested sub-run loop gets an isolating sink so its
+  /// lifecycle events cannot masquerade as the outer run's.
+  events : @emit.EventSink
   /// Latest session returned by a successful append. The run-level error
   /// handler uses it to persist a terminal failure/interruption even when the
   /// local loop state is behind the last durable session.
@@ -29,6 +33,7 @@ fn AgentLoop::AgentLoop(
   tools~ : @agent_tool.Tools,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   session~ : @agent_session.Session,
+  events~ : @emit.EventSink,
 ) -> AgentLoop {
   {
     runtime,
@@ -36,6 +41,7 @@ fn AgentLoop::AgentLoop(
     summary_client,
     tools,
     append_item,
+    events,
     messages: session.chat_messages(),
     plan_cadence: PlanCadence(registered=tools.find("plan") is Some(_)),
     goal_cadence: GoalCadence(
@@ -258,7 +264,7 @@ async fn AgentLoop::run(
         session,
         Terminal(Failed("max steps exhausted")),
       )
-      @emit.emit(MaxStepsExhausted)
+      self.events.emit(MaxStepsExhausted)
       session
     }
   } catch {
@@ -359,9 +365,9 @@ async fn AgentLoop::apply_steer_inputs(
     }
     let next = self.append(current, item)
     self.messages.push(ChatMessage(User, content=text))
-    @emit.emit(SteerApplied(kind~, content=text))
+    self.events.emit(SteerApplied(kind~, content=text))
     if input is Notice(text) {
-      self.goal_cadence.observe_notice(text)
+      self.goal_cadence.observe_notice(text, events=self.events)
     }
     continue next
   } nobreak {
@@ -389,13 +395,13 @@ async fn AgentLoop::prepare_step(
       tool_registered=self.goal_cadence.tool_registered,
     )
     session = self.append_runtime_notice(session, reminder)
-    @emit.emit(GoalReminder(content=reminder))
+    self.events.emit(GoalReminder(content=reminder))
     self.goal_cadence.record_reminder()
   }
   if self.plan_cadence.should_remind() {
     let reminder = self.plan_cadence.reminder_text()
     session = self.append_runtime_notice(session, reminder)
-    @emit.emit(PlanReminder(content=reminder))
+    self.events.emit(PlanReminder(content=reminder))
     self.plan_cadence.record_reminder()
   }
   self.plan_cadence.record_model_request()
@@ -404,32 +410,33 @@ async fn AgentLoop::prepare_step(
 
 ///|
 async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
-  @emit.emit(AgentStep(step=step + 1))
+  self.events.emit(AgentStep(step=step + 1))
   let response = self.client.chat(
     self.messages,
     tools=self.tools.function_tools(),
     stream=StreamHandler(on_content_delta=delta => {
       if delta != "" {
-        @emit.emit(AssistantDelta(content=delta))
+        self.events.emit(AssistantDelta(content=delta))
       }
     }),
   )
-  response.log_and_reasoning_content()
+  response.log_and_reasoning_content(events=self.events)
 }
 
 ///|
 fn @deepseek.ChatResponse::log_and_reasoning_content(
   response : Self,
+  events~ : @emit.EventSink,
 ) -> @deepseek.ChatResponse {
   // Reasoning first, so a consumer appending events in order shows the
   // thinking above the answer it led to.
   if response.reasoning_content != "" {
-    @emit.emit(ReasoningMessage(content=response.reasoning_content))
+    events.emit(ReasoningMessage(content=response.reasoning_content))
   }
   if response.content != "" {
-    @emit.emit(AssistantMessage(content=response.content))
+    events.emit(AssistantMessage(content=response.content))
   }
-  @emit.emit(Usage(usage=wire_usage(response.usage)))
+  events.emit(Usage(usage=wire_usage(response.usage)))
   response
 }
 
@@ -487,7 +494,7 @@ async fn AgentLoop::handle_tool_calls(
           content~,
           is_error=true,
         )
-        @emit.emit(
+        self.events.emit(
           ToolCallDecodeError(
             tool_call_id=native_call.id,
             tool_name=native_call.name,
@@ -636,7 +643,7 @@ async fn AgentLoop::execute_tool_call(
       // its durable clear before the terminal.
       let session = self.flush_goal_tombstone(session)
       let session = self.append(session, Terminal(Aborted(reason)))
-      @emit.emit(AgentAborted(reason~))
+      self.events.emit(AgentAborted(reason~))
       return FinishAgentLoop(session)
     }
     Respond(output) => {
@@ -660,6 +667,7 @@ async fn AgentLoop::execute_tool_call(
         is_error=output.is_error,
         content~,
         brief=output.brief,
+        events=self.events,
       )
       ContinueToolBatch(session)
     }
@@ -687,7 +695,7 @@ async fn AgentLoop::close_skipped_tool_calls(
       content=note,
       is_error=true,
     )
-    @emit.emit(
+    self.events.emit(
       ToolResult(
         tool_call_id=skipped.id,
         tool_name=skipped.name,
@@ -994,7 +1002,7 @@ async fn AgentLoop::inject_goal_check(
     tool_registered=self.goal_cadence.tool_registered,
   )
   let session = self.append_runtime_notice(session, check)
-  @emit.emit(GoalCheck(content=check))
+  self.events.emit(GoalCheck(content=check))
   self.goal_cadence.record_finish_check()
   // The check must stay the newest instruction: a plan reminder landing at
   // the same cadence boundary would bury it — the model would answer the
@@ -1078,7 +1086,7 @@ async fn AgentLoop::finish_turn(
   }
   let session = self.append(session, Terminal(Finished(answer)))
   self.push_finished_message(answer)
-  @emit.emit(AgentFinished(answer~))
+  self.events.emit(AgentFinished(answer~))
   Sealed(session)
 }
 
@@ -1089,8 +1097,9 @@ fn log_tool_result(
   is_error~ : Bool,
   content~ : String,
   brief~ : String?,
+  events~ : @emit.EventSink,
 ) -> Unit {
-  @emit.emit(
+  events.emit(
     ToolResult(
       tool_call_id=native_call.id,
       tool_name=tool_call.name,

--- a/protocol/emit/emit.mbt
+++ b/protocol/emit/emit.mbt
@@ -57,3 +57,34 @@ pub fn emit(event : @protocol.Event, loc~ : SourceLoc) -> Unit {
   }
   entry.write_object_end()
 }
+
+///|
+/// A per-loop event destination. The engine's top-level loop uses the
+/// process-log sink (`EventSink::global`); a nested agent loop — a sub-run
+/// such as the review engine, once it runs inside a live session — installs
+/// an isolating sink so its lifecycle and progress events stay out of the
+/// host-facing stream, where a child's `AgentFinished` would read as the
+/// OUTER run's terminal (the TUI and desktop hosts both treat any
+/// `AgentFinished` as run-terminal). The wrapped function receives the
+/// original call site, so forwarded log lines keep pointing at the code
+/// that reported the event, not at the sink.
+pub(all) struct EventSink((@protocol.Event, SourceLoc) -> Unit)
+
+///|
+/// Forward an event to this sink, autofilling the caller's location.
+#callsite(autofill(loc))
+pub fn EventSink::emit(
+  self : EventSink,
+  event : @protocol.Event,
+  loc~ : SourceLoc,
+) -> Unit {
+  (self.0)(event, loc)
+}
+
+///|
+/// The process-log sink: forwards to `emit`, preserving the reporting call
+/// site. Every top-level loop uses this; it is the behavior-preserving
+/// default wherever a sink parameter is accepted.
+pub fn EventSink::global() -> EventSink {
+  EventSink((event, loc) => emit(event, loc~))
+}

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -280,3 +280,40 @@ test "source points at the caller, not at emit" {
   }
   assert_true(source.contains("emit_test.mbt"))
 }
+
+///|
+/// A custom sink receives the event and the ORIGINAL call site — the
+/// property that lets a sub-run's isolating sink forward selected events
+/// without every log line blaming the sink itself.
+test "a custom EventSink receives the event and the caller's location" {
+  let seen : Array[(Json, String)] = []
+  let sink = @emit.EventSink((event, loc) => {
+    seen.push((event.to_json(), "\{loc}"))
+  })
+  sink.emit(MaxStepsExhausted)
+  guard seen is [(event_json, loc)] else { fail("expected one sinked event") }
+  assert_true(event_json.stringify().contains("max_steps_exhausted"))
+  assert_true(loc.contains("emit_test.mbt"))
+}
+
+///|
+/// The global sink is `emit` behind a value: same wire line, and the
+/// envelope's `source` still points at the code that reported the event,
+/// not at the sink plumbing.
+test "the global EventSink forwards to emit with the caller's source" {
+  let entries : Array[Json] = []
+  let logger = @xlog.global()
+  defer {
+    logger.set_handler(@xlog.Stdout())
+    logger.set_config(Config())
+  }
+  logger.set_handler(MemoryLogHandler::{ entries, })
+  logger.set_level(Info)
+  @emit.EventSink::global().emit(AgentStep(step=7))
+  guard entries is [Object(fields)] else { fail("expected one logged line") }
+  guard fields.get("source") is Some(String(source)) else {
+    fail("expected a source field")
+  }
+  assert_true(source.contains("emit_test.mbt"))
+  assert_true(fields.get("step") is Some(Number(7, ..)))
+}


### PR DESCRIPTION
## What

PR A2 of the subagent-substrate series. Every protocol event the loop produces currently goes straight to the process-wide log. A nested agent loop (a sub-run such as the review engine running inside a live session) therefore cannot exist safely: its ordinary `AgentFinished` lands in the host-facing stream, and the TUI engine client (`engine_client.mbt:171`), TUI loop, and desktop host (`engine.mbt:363,748`) all treat any `AgentFinished` as the **outer** run's terminal. Event isolation is the prerequisite for shipping any subrun tool.

## How

- New `@emit.EventSink`: wraps `(Event, SourceLoc) -> Unit`; its `emit` autofills the **caller's** location so forwarded log lines keep pointing at the reporting code, never the sink plumbing. `EventSink::global()` forwards to `emit` — the behavior-preserving default.
- `AgentLoop` carries an `events` sink used by every emit site in the loop (`turn_loop`, `auto_compact`, `goal`). `GoalCadence::observe_notice` and the two non-method helpers (`log_and_reasoning_content`, `log_tool_result`) take the sink as a parameter.
- `run_turn_in_scope` gains `event_sink?` (default global) and routes the pre-loop `AgentSetupFailed` through it — a setup failure must not leak past an isolating sink either.
- The global xlog handler is never swapped; isolation is per-loop by construction.

No behavior change for existing callers: the default sink is exactly today's global emit.

## Tests

- `protocol/emit`: a custom sink receives the event + the caller's location; the global sink writes the same wire line with caller `source` attribution.
- `agent/event_sink_test.mbt`: a full mock-server turn's events (`agent_step` / `assistant_message` / `usage` / terminal `agent_finished`) all arrive at a collecting sink; `tool_result` events from a tool batch route through it too.
- `moon check --target all` clean; agent suite 71/72 (the 1 failure is the known-flaky background-job timing test, pre-existing on main); emit 8/8; agent_review 10/10; `fmt`/`info` clean (`agent/pkg.generated.mbti` picks up the new optional parameter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)