### PR TITLE
feat(agent_subrun): extract the sub-run substrate; refactor agent_review onto it

### DIFF
--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -8,7 +8,7 @@ pub suberror ReviewError {
 
 ///|
 /// Default step budget for one review run.
-let default_review_max_steps : Int = 120
+pub let default_review_max_steps : Int = 120
 
 ///|
 /// Run a code review of the changes between `base` and HEAD and return the
@@ -19,6 +19,12 @@ let default_review_max_steps : Int = 120
 /// pre-build source generation, so the checkout is not guaranteed byte-for-byte
 /// unchanged. Raises `ReviewError` if the model finishes without submitting a
 /// report.
+///
+/// Runs on the `@agent_subrun` substrate: an ephemeral child session whose
+/// report is captured through the `submit_review` control tool. The child's
+/// events go to the process log as before (the review CLI installs a
+/// discarding handler; a future in-session gate passes an isolating sink and
+/// a wall deadline instead).
 pub async fn run_review(
   api_key : String,
   model : @deepseek.Model,
@@ -28,34 +34,29 @@ pub async fn run_review(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
 ) -> ReviewReport {
-  let captured : Ref[ReviewReport?] = { val: None }
-  let tools = @agent_tool.Tools([
-    @read.definition(workspace_root~),
-    @shell.definition(workspace_root~, read_only=true),
-    submit_review_tool(captured),
-  ])
-  let session = @agent_session.Session(
-    @agent_session.SessionId("review"),
-    system_prompt=review_system_prompt(),
+  let result = @agent_subrun.run_subrun(
+    {
+      session_id: "review",
+      system_prompt: review_system_prompt(),
+      task: review_task(base),
+      tools: captured => {
+        @agent_tool.Tools([
+          @read.definition(workspace_root~),
+          @shell.definition(workspace_root~, read_only=true),
+          submit_review_tool(captured),
+        ])
+      },
+      max_steps,
+      wall_deadline_ms: None,
+    },
+    api_key~,
+    model~,
+    thinking~,
+    api_url?,
+    workspace_root~,
+    event_sink=@emit.EventSink::global(),
   )
-  let task = review_task(base)
-  // Review is read-only and ephemeral; the final session is not persisted.
-  let _ : @agent_session.Session = @async.with_task_group() <| group => {
-    @agent.run_turn_in_scope(
-      runtime=@agent_runtime.AgentRuntime(workspace_root~),
-      scope=@agent_runtime.AgentTaskScope(group),
-      api_key~,
-      model~,
-      session~,
-      task~,
-      append_item=(s, i) => s.append(i),
-      max_steps~,
-      thinking~,
-      api_url?,
-      tools~,
-    )
-  }
-  match captured.val {
+  match result.value() {
     Some(report) => report
     None =>
       raise ReviewError(

--- a/agent_review/moon.pkg
+++ b/agent_review/moon.pkg
@@ -1,12 +1,10 @@
 import {
-  "bobzhang/openseek/agent",
-  "bobzhang/openseek/agent_runtime",
-  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/read",
   "bobzhang/openseek/agent_tool/shell",
   "bobzhang/openseek/deepseek",
-  "moonbitlang/async",
+  "bobzhang/openseek_protocol/emit",
   "moonbitlang/core/json",
 }
 

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 // Values
 pub let current_schema_version : Int
 
+pub let default_review_max_steps : Int
+
 pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String) -> ReviewReport
 
 pub fn severities() -> Array[String]

--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -13,42 +13,34 @@
 fn submit_review_tool(
   captured : Ref[ReviewReport?],
 ) -> @agent_tool.AgentToolDefinition {
-  AgentToolDefinition(
+  @agent_subrun.capture_tool(
     name="submit_review",
     description="Submit the final structured code-review report and end the review. Call this exactly once, when the review is complete. Every finding must cite a file (and a line when known) and a severity of blocker|high|medium|low|nit.",
     schema=JsonSchema(report_schema()),
-    execute=Sync(args => submit(captured, args)),
-    control=true,
+    parse=parse_submission,
+    captured,
+    finished_note=report => {
+      "review submitted (\{report.findings.length()} finding(s))"
+    },
   )
 }
 
 ///|
-fn submit(captured : Ref[ReviewReport?], args : Json) -> @agent_tool.ToolAction {
+/// Parse-and-validate for the capture tool: JSON decode problems and contract
+/// violations both reject, so the model retries instead of finishing with no
+/// report.
+fn parse_submission(args : Json) -> Result[ReviewReport, Array[String]] {
   match ReviewReport::parse(args) {
-    Err(msg) => reject(msg)
+    Err(msg) => Err([msg])
     Ok(report) => {
       let problems = report.validate()
       if problems.length() > 0 {
-        reject(problems.join("; "))
+        Err(problems)
       } else {
-        captured.val = Some(report)
-        @agent_tool.ToolAction::finish(
-          "review submitted (\{report.findings.length()} finding(s))",
-        )
+        Ok(report)
       }
     }
   }
-}
-
-///|
-/// Reject malformed `submit_review` output with an error response so the model
-/// retries instead of finishing with no report.
-fn reject(reason : String) -> @agent_tool.ToolAction {
-  @agent_tool.ToolAction::respond(
-    "submit_review rejected: \{reason}",
-    is_error=true,
-    brief="submit_review",
-  )
 }
 
 ///|
@@ -103,6 +95,18 @@ fn report_schema() -> Json {
 }
 
 ///|
+/// Run the submit tool's Sync executor directly, as the loop would.
+fn submit_action(
+  captured : Ref[ReviewReport?],
+  args : Json,
+) -> @agent_tool.ToolAction raise {
+  guard submit_review_tool(captured).execute is Sync(execute) else {
+    fail("submit_review should be a Sync executor")
+  }
+  execute(args)
+}
+
+///|
 test "submit_review declares itself a control tool" {
   // The ceiling salvage honors control-declared completions; without this
   // a review hitting the context ceiling on its submitting step would
@@ -114,8 +118,9 @@ test "submit_review declares itself a control tool" {
 ///|
 test "submit captures a valid report and finishes" {
   let captured : Ref[ReviewReport?] = { val: None }
-  let action = submit(captured, sample_report().to_json())
-  guard action is Control(Finish(_)) else { fail("expected Finish") }
+  let action = submit_action(captured, sample_report().to_json())
+  guard action is Control(Finish(note)) else { fail("expected Finish") }
+  assert_true(note.contains("2 finding(s)"))
   guard captured.val is Some(_) else { fail("expected captured report") }
 }
 
@@ -136,8 +141,9 @@ test "submit rejects an invalid report without capturing" {
       },
     ],
   }
-  let action = submit(captured, bad.to_json())
+  let action = submit_action(captured, bad.to_json())
   guard action is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
+  assert_true(output.content.contains("submit_review rejected"))
   guard captured.val is None else { fail("must not capture an invalid report") }
 }

--- a/agent_subrun/README.mbt.md
+++ b/agent_subrun/README.mbt.md
@@ -1,0 +1,25 @@
+# agent_subrun
+
+The substrate for nested, ephemeral agent turns — sub-runs. A sub-run is one
+bounded child turn with a fresh in-memory session, a restricted caller-built
+toolset, and a structured result captured through a submit-style control tool
+(`capture_tool`). The review engine runs on it today; the `explore` tool and
+the goal-review gate are its next clients.
+
+Guarantees:
+
+- **Event isolation.** The child's protocol events go to the caller's
+  `event_sink` — by default nowhere. A child's `AgentFinished` must never
+  reach the host stream, where the TUI and desktop hosts would read it as
+  the outer run's terminal.
+- **Cost accounting.** `SubrunResult` reports the steps and provider tokens
+  the child actually spent, observed from its own event stream.
+- **Bounded execution.** A step ceiling always; a wall deadline
+  (`wall_deadline_ms`) that cancels the child internally and reports
+  `TimedOut` when set.
+- **Cancellation discipline.** External cancellation re-raises; only the
+  runner-owned deadline is absorbed. A value captured before the deadline
+  cut the turn still reports `Captured`.
+- **Ceiling salvage.** Capture tools declare `control=true`, so a child
+  hitting its context ceiling on the submitting step seals with its report
+  instead of losing it (see the loop's control-call salvage).

--- a/agent_subrun/README.md
+++ b/agent_subrun/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_subrun/capture.mbt
+++ b/agent_subrun/capture.mbt
@@ -1,0 +1,40 @@
+///|
+/// Build a submit-style capture tool: the child calls it exactly once with
+/// its structured result; `parse` validates, a valid value is captured into
+/// the runner-owned ref, and the run ends via `Control(Finish)`. Invalid
+/// output is rejected with an error result so the model retries instead of
+/// finishing with nothing.
+///
+/// Declared a control tool: its action is loop flow with a few bytes of
+/// result, so the context-ceiling salvage honors a pending capture instead
+/// of skip-closing it — without this, a child hitting the ceiling on its
+/// submitting step would lose its finished result.
+pub fn[T] capture_tool(
+  name~ : String,
+  description~ : String,
+  schema~ : @agent_tool.JsonSchema,
+  parse~ : (Json) -> Result[T, Array[String]],
+  captured : Ref[T?],
+  finished_note? : (T) -> String = _value => "submitted",
+) -> @agent_tool.AgentToolDefinition {
+  @agent_tool.AgentToolDefinition(
+    name~,
+    description~,
+    schema~,
+    execute=Sync(args => {
+      match parse(args) {
+        Err(problems) =>
+          @agent_tool.ToolAction::respond(
+            "\{name} rejected: \{problems.join("; ")}",
+            is_error=true,
+            brief=name,
+          )
+        Ok(value) => {
+          captured.val = Some(value)
+          @agent_tool.ToolAction::finish(finished_note(value))
+        }
+      }
+    }),
+    control=true,
+  )
+}

--- a/agent_subrun/moon.pkg
+++ b/agent_subrun/moon.pkg
@@ -1,0 +1,22 @@
+import {
+  "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+  "bobzhang/openseek_protocol/emit",
+  "bobzhang/openseek_protocol" @protocol,
+  "moonbitlang/async",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek_protocol/emit",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/json",
+} for "test"
+
+supported_targets = "+native"

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -1,0 +1,56 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_subrun"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+  "bobzhang/openseek_protocol/emit",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/ref",
+}
+
+// Values
+pub fn[T] capture_tool(name~ : String, description~ : String, schema~ : @agent_tool.JsonSchema, parse~ : (Json) -> Result[T, Array[String]], @ref.Ref[T?], finished_note? : (T) -> String) -> @agent_tool.AgentToolDefinition
+
+pub async fn[T] run_subrun(SubrunSpec[T], api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, event_sink? : @emit.EventSink) -> SubrunResult[T]
+
+pub fn suppressing_sink() -> @emit.EventSink
+
+// Errors
+
+// Types and methods
+pub struct SubrunResult[T] {
+  value : T?
+  terminal : SubrunTerminal
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+} derive(@debug.Debug)
+pub fn[T] SubrunResult::completion_tokens(Self[T]) -> Int
+pub fn[T] SubrunResult::prompt_tokens(Self[T]) -> Int
+pub fn[T] SubrunResult::steps_used(Self[T]) -> Int
+pub fn[T] SubrunResult::terminal(Self[T]) -> SubrunTerminal
+pub fn[T] SubrunResult::value(Self[T]) -> T?
+
+pub(all) struct SubrunSpec[T] {
+  session_id : String
+  system_prompt : String
+  task : String
+  tools : (@ref.Ref[T?]) -> @agent_tool.Tools raise
+  max_steps : Int
+  wall_deadline_ms : Int?
+}
+
+pub(all) enum SubrunTerminal {
+  Captured
+  NoReport
+  MaxSteps
+  ContextYield
+  TimedOut
+  Failed(String)
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/agent_subrun/subrun.mbt
+++ b/agent_subrun/subrun.mbt
@@ -1,0 +1,257 @@
+///|
+/// `agent_subrun` runs one nested, ephemeral agent turn — a sub-run — with a
+/// restricted toolset and a structured result captured through a submit-style
+/// control tool. It is the substrate under every specialized subagent surface
+/// (the review engine today; explore and the goal-review gate next): fresh
+/// session, caller-chosen tools, bounded steps and wall clock, and event
+/// isolation so a child's lifecycle events cannot masquerade as the outer
+/// run's.
+
+///|
+/// How a sub-run ended. External cancellation is deliberately NOT a terminal:
+/// it re-raises out of `run_subrun` so structured concurrency sees it, per
+/// the engine-wide rule that cancellation is never folded into an ordinary
+/// failure.
+pub(all) enum SubrunTerminal {
+  /// The capture tool sealed the run with a valid value. Also reported when
+  /// a value landed just before the wall deadline cut the turn: the value
+  /// is usable either way.
+  Captured
+  /// The child ended (final answer or finish) without ever capturing.
+  NoReport
+  /// The child exhausted its step budget without capturing.
+  MaxSteps
+  /// The child yielded at its context ceiling without capturing.
+  ContextYield
+  /// The runner-owned wall deadline cancelled the child internally. Unlike
+  /// external cancellation this is absorbed here: the deadline belongs to
+  /// the sub-run, not the caller.
+  TimedOut
+  /// The child raised a non-cancellation error (API failure, setup failure).
+  Failed(String)
+} derive(Debug, Eq)
+
+///|
+/// The outcome of one sub-run: the captured value when there is one, plus
+/// the cost actually spent — steps and provider tokens — for budget
+/// reconciliation and eval attribution. Costs are observed from the child's
+/// own event stream, so they are exact for the requests the child made.
+pub struct SubrunResult[T] {
+  value : T?
+  terminal : SubrunTerminal
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+} derive(Debug)
+
+///|
+/// The captured value, when the child submitted one.
+pub fn[T] SubrunResult::value(self : SubrunResult[T]) -> T? {
+  self.value
+}
+
+///|
+/// How the sub-run ended.
+pub fn[T] SubrunResult::terminal(self : SubrunResult[T]) -> SubrunTerminal {
+  self.terminal
+}
+
+///|
+/// Model requests the child actually made.
+pub fn[T] SubrunResult::steps_used(self : SubrunResult[T]) -> Int {
+  self.steps_used
+}
+
+///|
+/// Provider prompt tokens the child consumed, summed over its requests.
+pub fn[T] SubrunResult::prompt_tokens(self : SubrunResult[T]) -> Int {
+  self.prompt_tokens
+}
+
+///|
+/// Provider completion tokens the child consumed, summed over its requests.
+pub fn[T] SubrunResult::completion_tokens(self : SubrunResult[T]) -> Int {
+  self.completion_tokens
+}
+
+///|
+/// One sub-run's static shape. `tools` receives the capture ref that
+/// `run_subrun` owns and must build the FULL child registry around it —
+/// handing the same ref to a `capture_tool` — so the tool registry and the
+/// result channel cannot disagree.
+pub(all) struct SubrunSpec[T] {
+  /// Session id for the ephemeral child session (never persisted).
+  session_id : String
+  system_prompt : String
+  task : String
+  /// Builds the child's toolset around the runner-owned capture ref.
+  tools : (Ref[T?]) -> @agent_tool.Tools raise
+  /// Step ceiling for the child turn.
+  max_steps : Int
+  /// Runner-owned wall deadline in milliseconds; on expiry the child is
+  /// cancelled internally and the run reports `TimedOut`. `None` runs
+  /// without a deadline (the standalone review CLI's historical behavior);
+  /// in-session sub-runs should always set one.
+  wall_deadline_ms : Int?
+}
+
+///|
+/// Sightings the accounting sink collects from the child's event stream.
+priv struct SubrunObservations {
+  mut steps : Int
+  mut prompt_tokens : Int
+  mut completion_tokens : Int
+  mut max_steps_exhausted : Bool
+  mut context_yield : Bool
+  mut failure : String?
+}
+
+///|
+/// Wrap the caller's sink with cost/terminal accounting. Every child event
+/// passes through here; `forward` (default: drop everything) decides what,
+/// if anything, the host stream sees. Dropping is the safe default — a
+/// child's `AgentFinished` in the host stream reads as the OUTER run's
+/// terminal.
+fn observing_sink(
+  observations : SubrunObservations,
+  forward : @emit.EventSink,
+) -> @emit.EventSink {
+  @emit.EventSink((event, loc) => {
+    match event {
+      @protocol.AgentStep(step~) =>
+        if step > observations.steps {
+          observations.steps = step
+        }
+      @protocol.Usage(usage~) => {
+        observations.prompt_tokens += usage.prompt_tokens
+        observations.completion_tokens += usage.completion_tokens
+      }
+      @protocol.MaxStepsExhausted => observations.max_steps_exhausted = true
+      @protocol.ContextYield(..) => observations.context_yield = true
+      @protocol.TurnFailed(error~) | @protocol.AgentSetupFailed(error~) =>
+        observations.failure = Some(error)
+      @protocol.AgentAborted(reason~) => observations.failure = Some(reason)
+      _ => ()
+    }
+    forward.emit(event, loc~)
+  })
+}
+
+///|
+/// A sink that drops every event: the default isolation for a sub-run.
+pub fn suppressing_sink() -> @emit.EventSink {
+  @emit.EventSink((_event, _loc) => ())
+}
+
+///|
+/// Run one sub-run to completion and report what happened and what it cost.
+///
+/// The child gets a fresh in-memory session (never persisted), a fresh
+/// runtime (steers cannot cross between parent and child), its own task
+/// group, and the toolset `spec.tools` builds around the runner-owned
+/// capture ref. `event_sink` is what the HOST stream sees of the child —
+/// the default forwards nothing; cost accounting observes the child's
+/// events either way.
+///
+/// Error contract: external cancellation re-raises (never a terminal); the
+/// wall deadline is absorbed as `TimedOut`; any other child error becomes
+/// `Failed`. A value captured before the deadline cut the turn still
+/// reports `Captured`.
+pub async fn[T] run_subrun(
+  spec : SubrunSpec[T],
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  thinking? : @deepseek.ThinkingMode = Max,
+  api_url? : String,
+  workspace_root? : String = ".",
+  event_sink? : @emit.EventSink = suppressing_sink(),
+) -> SubrunResult[T] {
+  let captured : Ref[T?] = { val: None }
+  let observations = SubrunObservations::{
+    steps: 0,
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    max_steps_exhausted: false,
+    context_yield: false,
+    failure: None,
+  }
+  let sink = observing_sink(observations, event_sink)
+  let tools = (spec.tools)(captured) catch {
+    error =>
+      return {
+        value: None,
+        terminal: Failed("subrun toolset failed: \{error}"),
+        steps_used: 0,
+        prompt_tokens: 0,
+        completion_tokens: 0,
+      }
+  }
+  let session = @agent_session.Session(
+    @agent_session.SessionId(spec.session_id),
+    system_prompt=spec.system_prompt,
+  )
+  async fn child_turn() -> Unit {
+    let _ : @agent_session.Session = @async.with_task_group() <| group => {
+      @agent.run_turn_in_scope(
+        runtime=@agent_runtime.AgentRuntime(workspace_root~),
+        scope=@agent_runtime.AgentTaskScope(group),
+        api_key~,
+        model~,
+        session~,
+        task=spec.task,
+        append_item=(session, item) => session.append(item),
+        max_steps=spec.max_steps,
+        thinking~,
+        api_url?,
+        tools~,
+        event_sink=sink,
+      )
+    }
+  }
+  // The deadline wraps the whole child turn: on expiry the timeout cancels
+  // the child's task group (tearing down any tool subprocesses) and returns
+  // None. External cancellation of the caller propagates out of
+  // with_timeout_opt untouched. No deadline -> Some(()) unconditionally.
+  let completed = try {
+    match spec.wall_deadline_ms {
+      Some(deadline) => @async.with_timeout_opt(deadline, child_turn)
+      None => {
+        child_turn()
+        Some(())
+      }
+    }
+  } catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      return {
+        value: captured.val,
+        terminal: match captured.val {
+          Some(_) => Captured
+          None => Failed("\{error}")
+        },
+        steps_used: observations.steps,
+        prompt_tokens: observations.prompt_tokens,
+        completion_tokens: observations.completion_tokens,
+      }
+  }
+  let terminal = match (captured.val, completed) {
+    // A captured value is usable even when the deadline cut the turn just
+    // after the capture landed.
+    (Some(_), _) => Captured
+    (None, None) => TimedOut
+    (None, Some(_)) =>
+      match observations.failure {
+        Some(error) => Failed(error)
+        None if observations.max_steps_exhausted => MaxSteps
+        None if observations.context_yield => ContextYield
+        None => NoReport
+      }
+  }
+  {
+    value: captured.val,
+    terminal,
+    steps_used: observations.steps,
+    prompt_tokens: observations.prompt_tokens,
+    completion_tokens: observations.completion_tokens,
+  }
+}

--- a/agent_subrun/subrun_test.mbt
+++ b/agent_subrun/subrun_test.mbt
@@ -1,0 +1,380 @@
+///|
+/// Local mock-endpoint harness, mirroring the agent package's: the main loop
+/// streams SSE, the checkpoint summary call is plain JSON, and fabricated
+/// usage counts drive the ceiling machinery.
+priv enum MockReply {
+  Sse(String)
+  Body(Json)
+  /// Sleep before replying — long enough that a runner deadline fires first.
+  Stall
+}
+
+///|
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}
+
+///|
+async fn subrun_test_server(
+  group : @async.TaskGroup[Unit],
+  handle : (Json) -> MockReply raise,
+) -> String? {
+  guard bind_test_server("local TCP bind unavailable; skipping subrun test")
+    is Some(server) else {
+    return None
+  }
+  group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        match handle(@json.parse(body.read_all().text())) {
+          Sse(payload) => {
+            conn.send_response(200, "OK", extra_headers={
+              "Content-Type": "text/event-stream",
+            })
+            conn.write("data: \{payload}\n\n")
+            conn.write("data: [DONE]\n\n")
+          }
+          Body(json) => {
+            conn.send_response(200, "OK", extra_headers={
+              "Content-Type": "application/json",
+            })
+            conn.write(json.stringify())
+          }
+          Stall => @async.sleep(60_000)
+        }
+      },
+      max_connections=8,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+fn usage_json(total_tokens : Int) -> Json {
+  {
+    "prompt_tokens": total_tokens - 1_000,
+    "completion_tokens": 1_000,
+    "total_tokens": total_tokens,
+  }
+}
+
+///|
+/// A streamed tool-call response; each call is (id, name, raw JSON args).
+fn sse_tool_calls(
+  calls : Array[(String, String, String)],
+  total_tokens : Int,
+) -> String {
+  let entries : Array[Json] = [
+    for index, call in calls => {
+      let (id, name, arguments) = call
+      (
+        {
+          "index": index,
+          "id": id,
+          "type": "function",
+          "function": { "name": name, "arguments": arguments },
+        } : Json)
+    }
+  ]
+  (
+    {
+      "choices": [{ "delta": { "tool_calls": entries.to_json() } }],
+      "usage": usage_json(total_tokens),
+    } : Json).stringify()
+}
+
+///|
+fn sse_final(content : String, total_tokens : Int) -> String {
+  (
+    {
+      "choices": [{ "delta": { "content": content } }],
+      "usage": usage_json(total_tokens),
+    } : Json).stringify()
+}
+
+///|
+fn is_checkpoint_request(request : Json) -> Bool {
+  guard request is { "messages": Array(messages), .. } &&
+    messages.last() is Some({ "content": String(content), .. }) else {
+    return false
+  }
+  !(request is { "stream": True, .. }) &&
+  content.contains("CONTEXT CHECKPOINT COMPACTION")
+}
+
+///|
+/// The standard spec under test: one `submit` capture tool expecting
+/// `{"answer": <string>}`, plus a plain probe tool.
+fn answer_spec(
+  session_id : String,
+  max_steps? : Int = 8,
+  wall_deadline_ms? : Int? = None,
+) -> @agent_subrun.SubrunSpec[String] {
+  {
+    session_id,
+    system_prompt: "You are a test subagent.",
+    task: "Answer via the submit tool.",
+    tools: captured => {
+      @agent_tool.Tools([
+        @agent_subrun.capture_tool(
+          name="submit",
+          description="Submit the final answer.",
+          schema=JsonSchema({ "type": "object" }),
+          parse=args => {
+            match args {
+              { "answer": String(answer), .. } => Ok(answer)
+              _ => Err(["answer must be a string"])
+            }
+          },
+          captured,
+        ),
+        AgentToolDefinition(
+          name="probe",
+          description="Probe tool.",
+          schema=JsonSchema({ "type": "object" }),
+          execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+        ),
+      ])
+    },
+    max_steps,
+    wall_deadline_ms,
+  }
+}
+
+///|
+async fn run_answer_subrun(
+  url : String,
+  spec : @agent_subrun.SubrunSpec[String],
+  event_sink? : @emit.EventSink,
+) -> @agent_subrun.SubrunResult[String] {
+  @agent_subrun.run_subrun(
+    spec,
+    api_key="test-key",
+    model=Deepseek(V4Flash),
+    api_url=url,
+    event_sink?,
+  )
+}
+
+///|
+async test "a valid submission captures and accounts cost" {
+  @async.with_task_group() <| group => {
+    let mut step = 0
+    let handle : (Json) -> MockReply raise = _request => {
+      step += 1
+      if step == 1 {
+        Sse(
+          sse_tool_calls(
+            [("call_1", "submit", "{\"answer\": \"forty-two\"}")],
+            100_000,
+          ),
+        )
+      } else {
+        Sse(sse_final("should not be reached", 110_000))
+      }
+    }
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let forwarded : Array[String] = []
+    let sink = @emit.EventSink((event, _loc) => {
+      guard event.to_json() is Object(fields) &&
+        fields.get("event") is Some(String(kind)) else {
+        return
+      }
+      forwarded.push(kind)
+    })
+    let result = run_answer_subrun(url, answer_spec("capture"), event_sink=sink)
+    assert_true(result.value() is Some("forty-two"))
+    debug_inspect(result.terminal(), content="Captured")
+    assert_eq(result.steps_used(), 1)
+    assert_eq(result.prompt_tokens(), 99_000)
+    assert_eq(result.completion_tokens(), 1_000)
+    // Forwarding is the caller's choice: this sink sees the child's stream.
+    assert_true(forwarded.contains("agent_step"))
+    assert_true(forwarded.contains("agent_finished"))
+  }
+}
+
+///|
+async test "a rejected submission is retried and then captured" {
+  @async.with_task_group() <| group => {
+    let mut step = 0
+    let handle : (Json) -> MockReply raise = _request => {
+      step += 1
+      if step == 1 {
+        // Invalid: answer is a number, the parse rejects, the model retries.
+        Sse(sse_tool_calls([("call_1", "submit", "{\"answer\": 7}")], 100_000))
+      } else {
+        Sse(
+          sse_tool_calls(
+            [("call_2", "submit", "{\"answer\": \"second try\"}")],
+            110_000,
+          ),
+        )
+      }
+    }
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let result = run_answer_subrun(url, answer_spec("retry"))
+    assert_true(result.value() is Some("second try"))
+    debug_inspect(result.terminal(), content="Captured")
+    assert_eq(result.steps_used(), 2)
+  }
+}
+
+///|
+async test "a run that never captures reports NoReport" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = _request => {
+      Sse(sse_final("plain answer, no submit", 100_000))
+    }
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let result = run_answer_subrun(url, answer_spec("no-report"))
+    assert_true(result.value() is None)
+    debug_inspect(result.terminal(), content="NoReport")
+  }
+}
+
+///|
+async test "step exhaustion without a capture reports MaxSteps" {
+  @async.with_task_group() <| group => {
+    let mut step = 0
+    let handle : (Json) -> MockReply raise = _request => {
+      step += 1
+      Sse(sse_tool_calls([("call_\{step}", "probe", "{}")], 100_000))
+    }
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let result = run_answer_subrun(url, answer_spec("max-steps", max_steps=2))
+    assert_true(result.value() is None)
+    debug_inspect(result.terminal(), content="MaxSteps")
+    assert_eq(result.steps_used(), 2)
+  }
+}
+
+///|
+/// The A1 interlock: at the context ceiling a pending capture call is
+/// salvaged (control-declared), so the child seals with its report instead
+/// of losing it to a skip-close.
+async test "a capture at the context ceiling is salvaged" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = request => {
+      if is_checkpoint_request(request) {
+        Body({
+          "choices": [
+            { "message": { "role": "assistant", "content": "SUMMARY" } },
+          ],
+        })
+      } else {
+        Sse(
+          sse_tool_calls(
+            [
+              ("call_1", "probe", "{}"),
+              ("call_2", "submit", "{\"answer\": \"under pressure\"}"),
+            ],
+            900_000,
+          ),
+        )
+      }
+    }
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let result = run_answer_subrun(url, answer_spec("ceiling-capture"))
+    assert_true(result.value() is Some("under pressure"))
+    debug_inspect(result.terminal(), content="Captured")
+  }
+}
+
+///|
+async test "a ceiling yield without a capture reports ContextYield" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = request => {
+      if is_checkpoint_request(request) {
+        Body({
+          "choices": [
+            { "message": { "role": "assistant", "content": "SUMMARY" } },
+          ],
+        })
+      } else {
+        Sse(sse_tool_calls([("call_1", "probe", "{}")], 900_000))
+      }
+    }
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let result = run_answer_subrun(url, answer_spec("ceiling-yield"))
+    assert_true(result.value() is None)
+    debug_inspect(result.terminal(), content="ContextYield")
+  }
+}
+
+///|
+async test "the wall deadline absorbs into TimedOut" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = _request => Stall
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let result = run_answer_subrun(
+      url,
+      answer_spec("deadline", wall_deadline_ms=Some(200)),
+    )
+    assert_true(result.value() is None)
+    debug_inspect(result.terminal(), content="TimedOut")
+  }
+}
+
+///|
+/// External cancellation must re-raise, never fold into a terminal: an
+/// outer timeout around a deadline-free hanging sub-run gets its None back,
+/// which only happens when the cancellation propagated out of run_subrun.
+async test "external cancellation re-raises out of the sub-run" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = _request => Stall
+    guard subrun_test_server(group, handle) is Some(url) else { return }
+    let outcome = @async.with_timeout_opt(200, () => {
+      run_answer_subrun(url, answer_spec("external-cancel"))
+    })
+    assert_true(outcome is None)
+  }
+}
+
+///|
+async test "a toolset builder failure reports Failed without a run" {
+  let spec : @agent_subrun.SubrunSpec[String] = {
+    session_id: "bad-tools",
+    system_prompt: "sys",
+    task: "task",
+    tools: _captured => {
+      @agent_tool.Tools([
+        AgentToolDefinition(
+          name="dup",
+          description="One.",
+          schema=JsonSchema({ "type": "object" }),
+          execute=Sync(_args => @agent_tool.ToolAction::respond("1")),
+        ),
+        AgentToolDefinition(
+          name="dup",
+          description="Two.",
+          schema=JsonSchema({ "type": "object" }),
+          execute=Sync(_args => @agent_tool.ToolAction::respond("2")),
+        ),
+      ])
+    },
+    max_steps: 3,
+    wall_deadline_ms: None,
+  }
+  let result = @agent_subrun.run_subrun(
+    spec,
+    api_key="unused",
+    model=Deepseek(V4Flash),
+    api_url="http://127.0.0.1:1/unused",
+  )
+  assert_true(result.value() is None)
+  guard result.terminal() is Failed(reason) else { fail("expected Failed") }
+  assert_true(reason.contains("subrun toolset failed"))
+  assert_eq(result.steps_used(), 0)
+}


### PR DESCRIPTION
## What

PR B of the subagent-substrate series (stacked on #535 / PR A2 — the diff here is the top commit only). Extracts the nested-ephemeral-turn shape out of `agent_review` into a reusable `agent_subrun` package; `explore` (PR D) and the goal-review gate (PR F) are its next clients.

## Design (per the subal-reviewed plan)

- **`SubrunSpec[T]`** — session id, prompts, a tools *builder* that receives the runner-owned capture ref (so the registry and result channel cannot disagree), step ceiling, optional wall deadline.
- **`SubrunResult[T]`** — captured value, terminal (`Captured | NoReport | MaxSteps | ContextYield | TimedOut | Failed`), plus the steps and provider tokens the child actually spent, observed from the child's own event stream via the A2 sink — the data budget reconciliation and eval attribution need.
- **Event isolation by default** — the child's events forward to the caller's `event_sink`, defaulting to a suppressing sink. A child's `AgentFinished` must never reach the host stream (TUI/desktop treat any `AgentFinished` as the outer run's terminal).
- **Cancellation contract** — external cancellation re-raises, never folds into a terminal; the runner-owned deadline cancels the child internally and absorbs into `TimedOut`; a value captured just before the deadline still reports `Captured`.
- **`capture_tool[T]`** — the generalized submit tool: parse/validate, reject-with-retry, capture + `Control(Finish)`, `control=true` so the A1 ceiling salvage honors a pending capture.

`agent_review` refactors onto the substrate with its public contract unchanged: same report type, same `ReviewError` text, global sink (the CLI's `DiscardLog` still governs visibility), no deadline (its historical unbounded behavior).

## Tests

Mock-endpoint lifecycle suite in `agent_subrun` (9 tests): capture + exact cost accounting + forwarding, reject-then-retry, `NoReport`, `MaxSteps`, **ceiling salvage of a pending capture** (the A1 interlock), `ContextYield`, wall-deadline `TimedOut`, **external-cancellation re-raise**, toolset-failure `Failed`. `agent_review` 10/10 unchanged; `moon check --target all` clean; `fmt`/`info` clean.

Note: subal per-commit review is pending — quota exhausted until Jul 26 (#535 has the same caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)