### PR TITLE
feat(protocol): SubrunStarted/SubrunFinished events; render them in the TUI

### DIFF
--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -75,6 +75,11 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     GoalBudgetExhausted(_) => Some(GoalBudgetExhausted)
     // A turn that ended at the context ceiling: run-terminal, not success.
     ContextYield(answer~, ..) => Some(ContextYield(answer))
+    // A sub-run's lifecycle brackets. The id pairs starts with finishes on
+    // the wire; the UI shows them as ordered transcript notices, so only
+    // the display fields survive decoding.
+    SubrunStarted(kind~, label~, ..) => Some(SubrunStarted(kind~, label~))
+    SubrunFinished(status~, steps~, ..) => Some(SubrunFinished(status~, steps~))
     // MCP lifecycle diagnostics, surfaced as notices so a typo'd config or a
     // dead server is visible in the UI instead of silently yielding no tools.
     // `servers` counts the configuration's entries, not successful contributors

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -239,3 +239,32 @@ test "decode_event surfaces MCP diagnostics as notices" {
   }
   assert_eq(timeout, "MCP: server `slow` did not list its tools")
 }
+
+///|
+test "subrun lifecycle brackets decode to their display forms" {
+  assert_true(
+    @event.decode_event({
+      "event": "subrun_started",
+      "id": "sr-1",
+      "kind": "review",
+      "label": "goal review",
+    })
+    is Some(SubrunStarted(kind="review", label="goal review")),
+  )
+  // The id and token counts are wire-only: the UI shows status and steps.
+  assert_true(
+    @event.decode_event({
+      "event": "subrun_finished",
+      "id": "sr-1",
+      "status": "captured",
+      "steps": 12,
+      "prompt_tokens": 34000,
+      "completion_tokens": 5600,
+    })
+    is Some(SubrunFinished(status="captured", steps=12)),
+  )
+  // A finish missing its required fields drops rather than misrendering.
+  assert_true(
+    @event.decode_event({ "event": "subrun_finished", "id": "sr-1" }) is None,
+  )
+}

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -75,4 +75,11 @@ pub(all) enum AgentEvent {
   // terminal for the run, but NOT task success — the work continues in a
   // new turn the user (or a controller) starts.
   ContextYield(String)
+  // A nested sub-run (a review, an explore) began inside the active run.
+  // `label` is a short display string, never the raw query.
+  SubrunStarted(kind~ : String, label~ : String)
+  // The paired completion: the child's terminal status ("captured",
+  // "failed", …) and how many model steps it spent. Non-terminal for the
+  // outer run — the parent turn continues.
+  SubrunFinished(status~ : String, steps~ : Int)
 }

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -32,6 +32,8 @@ pub(all) enum AgentEvent {
   GoalContinue(Int)
   GoalBudgetExhausted
   ContextYield(String)
+  SubrunStarted(kind~ : String, label~ : String)
+  SubrunFinished(status~ : String, steps~ : Int)
 }
 
 pub(all) struct ToolResultEvent {

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -434,6 +434,17 @@ fn handle_agent_event(
     SessionError(error) => cmds.push(AppendItem(Error(error)))
     Usage(usage) => state.usage = Some(usage)
     ToolResult(result) => cmds.push(AppendItem(tool_item(result)))
+    // Sub-run lifecycle brackets, shown as transcript notices so the child's
+    // interleaved tool calls read as belonging to the sub-run. Non-terminal:
+    // the outer run stays busy throughout.
+    SubrunStarted(kind~, label~) =>
+      cmds.push(AppendItem(Input(Notice("\{kind} subrun started: \{label}"))))
+    SubrunFinished(status~, steps~) =>
+      cmds.push(
+        AppendItem(
+          Input(Notice("subrun finished: \{status} (\{steps} step(s))")),
+        ),
+      )
     AgentFinished(answer) => {
       let already_appended = state.step_response is Some(response) &&
         response == answer

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -83,6 +83,14 @@ pub fn decode_engine_event(raw : Map[String, Json]) -> EngineEvent? {
     CompactionStarted(..) => Some(CompactionStarted)
     CompactionFinished(summary~, ..) => Some(CompactionFinished(summary))
     CompactionFailed(error~) => Some(CompactionFailed(error))
+    // A sub-run's lifecycle brackets, rendered as runtime notices so the
+    // child's interleaved tool results read as belonging to the sub-run —
+    // the same treatment the TUI gives them. The id and token counts are
+    // wire-only pairing/accounting data.
+    SubrunStarted(kind~, label~, ..) =>
+      Some(RuntimeUpdate("\{kind} subrun started: \{label}"))
+    SubrunFinished(status~, steps~, ..) =>
+      Some(RuntimeUpdate("subrun finished: \{status} (\{steps} step(s))"))
     // Not shown, and now each one a recorded decision rather than a line the
     // view drops unnoticed. `plan_reminder`, the goal reminders/checks and the
     // block/unblock markers are model-directed text, not news for the user (the
@@ -318,5 +326,33 @@ test "decode recognizes the compaction lifecycle events" {
     )
     is Some(CompactionFailed("empty summary")) else {
     fail("compaction_failed not decoded")
+  }
+}
+
+///|
+test "decode maps subrun brackets onto the runtime-update path" {
+  guard decode_engine_event(
+      event_fields({
+        "event": "subrun_started",
+        "id": "sr-1",
+        "kind": "review",
+        "label": "goal review",
+      }),
+    )
+    is Some(RuntimeUpdate("review subrun started: goal review")) else {
+    fail("subrun_started not decoded")
+  }
+  guard decode_engine_event(
+      event_fields({
+        "event": "subrun_finished",
+        "id": "sr-1",
+        "status": "captured",
+        "steps": 12,
+        "prompt_tokens": 34000,
+        "completion_tokens": 5600,
+      }),
+    )
+    is Some(RuntimeUpdate("subrun finished: captured (12 step(s))")) else {
+    fail("subrun_finished not decoded")
   }
 }

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -58,13 +58,17 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     CompactionFailed(_) => Some(CompactionFailed)
     // Not the host's business. Streaming text, reasoning, notices and every
     // goal/plan signal are the webview's to render off the raw stream; the
+    // sub-run lifecycle brackets are likewise the webview's (the outer run
+    // already reads busy to the host throughout a sub-run); the
     // auto-compaction lifecycle is internal to a turn and never gates
     // archiving the way an explicit compaction does; `session_started`,
     // `workspace_created` and `fleet_started` describe a headless run's setup,
     // which the host performs itself; `command_error` reports a rejected
     // control command, which the host learns from the command's own reply; the
     // MCP registry events are diagnostics the UI surfaces.
-    AssistantDelta(..)
+    SubrunStarted(..)
+    | SubrunFinished(..)
+    | AssistantDelta(..)
     | ReasoningMessage(..)
     | BackgroundNotice(..)
     | SessionError(..)

--- a/desktop/internal/event/decode_test.mbt
+++ b/desktop/internal/event/decode_test.mbt
@@ -92,3 +92,29 @@ test "context_yield is its own run terminal" {
     _ => fail("expected context yield")
   }
 }
+
+///|
+test "subrun brackets are the webview's, not the host's" {
+  // The outer run reads busy to the host throughout a sub-run; the webview
+  // renders the brackets itself off the raw stream.
+  assert_true(
+    @event.decode_event({
+      "event": "subrun_started",
+      "id": "sr-1",
+      "kind": "review",
+      "label": "goal review",
+    })
+    is None,
+  )
+  assert_true(
+    @event.decode_event({
+      "event": "subrun_finished",
+      "id": "sr-1",
+      "status": "captured",
+      "steps": 12,
+      "prompt_tokens": 34000,
+      "completion_tokens": 5600,
+    })
+    is None,
+  )
+}

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -119,6 +119,14 @@ fn all_events() -> Array[@protocol.Event] {
     AutoCompactionFinished(from_sequence=1, to_sequence=12, summary="recap"),
     AutoCompactionFailed(error="summary boom"),
     ContextYield(to_sequence=30, answer="partial"),
+    SubrunStarted(id="sr-1", kind="review", label="goal review"),
+    SubrunFinished(
+      id="sr-1",
+      status="captured",
+      steps=12,
+      prompt_tokens=34_000,
+      completion_tokens=5_600,
+    ),
     SessionStarted(
       session="cli-1",
       session_root=".openseek",

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -82,8 +82,11 @@ pub(all) enum Event {
   /// its finish; `kind` names the surface ("review", "explore"); `label` is
   /// a short, bounded display string — never the raw query or prompt.
   SubrunStarted(id~ : String, kind~ : String, label~ : String)
-  /// The paired completion — emitted on success, failure, AND cancellation,
-  /// so a reader never shows a sub-run as running forever. `status` is the
+  /// The paired completion. The emitter's contract (the sub-run runner —
+  /// wire-first: this variant ships ahead of it): emit on success, failure,
+  /// AND cancellation, and BEFORE the parent turn's own terminal event (the
+  /// TUI's stale-run guard drops run-tagged events after a terminal), so a
+  /// reader never shows a sub-run as running forever. `status` is the
   /// sub-run terminal in snake_case ("captured", "no_report", "max_steps",
   /// "context_yield", "timed_out", "failed", "cancelled"); `steps` and the
   /// token counts are the child's actual spend, for cost attribution.

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -76,6 +76,25 @@ pub(all) enum Event {
   AutoCompactionFailed(error~ : String)
   ContextYield(to_sequence~ : Int, answer~ : String)
 
+  // ── subrun ─────────────────────────────────────────────────────────────
+  /// A nested sub-run (a review, an explore) began inside this run. `id` is
+  /// unique within the stream so overlapping sub-runs pair each start with
+  /// its finish; `kind` names the surface ("review", "explore"); `label` is
+  /// a short, bounded display string — never the raw query or prompt.
+  SubrunStarted(id~ : String, kind~ : String, label~ : String)
+  /// The paired completion — emitted on success, failure, AND cancellation,
+  /// so a reader never shows a sub-run as running forever. `status` is the
+  /// sub-run terminal in snake_case ("captured", "no_report", "max_steps",
+  /// "context_yield", "timed_out", "failed", "cancelled"); `steps` and the
+  /// token counts are the child's actual spend, for cost attribution.
+  SubrunFinished(
+    id~ : String,
+    status~ : String,
+    steps~ : Int,
+    prompt_tokens~ : Int,
+    completion_tokens~ : Int
+  )
+
   // ── session / workspace ────────────────────────────────────────────────
   /// `workspace_root` is optional because it postdates the event: engines
   /// between d11e04c2 (which added `session_started`) and d5d0b208 (which

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -151,6 +151,26 @@ pub fn parse(line : Json) -> Event? {
     }
     "compaction_failed" =>
       text(fields, "error").map(error => CompactionFailed(error~))
+    "subrun_started" => {
+      guard text(fields, "id") is Some(id) &&
+        text(fields, "kind") is Some(kind) &&
+        text(fields, "label") is Some(label) else {
+        return None
+      }
+      Some(SubrunStarted(id~, kind~, label~))
+    }
+    "subrun_finished" => {
+      guard text(fields, "id") is Some(id) &&
+        text(fields, "status") is Some(status) &&
+        int(fields, "steps") is Some(steps) &&
+        int(fields, "prompt_tokens") is Some(prompt_tokens) &&
+        int(fields, "completion_tokens") is Some(completion_tokens) else {
+        return None
+      }
+      Some(
+        SubrunFinished(id~, status~, steps~, prompt_tokens~, completion_tokens~),
+      )
+    }
     "auto_compaction_started" => {
       guard sequences(fields) is Some((from_sequence, to_sequence)) else {
         return None

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -54,6 +54,8 @@ pub(all) enum Event {
   AutoCompactionFinished(from_sequence~ : Int, to_sequence~ : Int, summary~ : String)
   AutoCompactionFailed(error~ : String)
   ContextYield(to_sequence~ : Int, answer~ : String)
+  SubrunStarted(id~ : String, kind~ : String, label~ : String)
+  SubrunFinished(id~ : String, status~ : String, steps~ : Int, prompt_tokens~ : Int, completion_tokens~ : Int)
   SessionStarted(session~ : String, session_root~ : String, workspace_root~ : String?)
   SessionError(error~ : String)
   WorkspaceCreated(dir~ : String)

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -84,6 +84,17 @@ pub fn Event::to_json(self : Event) -> Json {
         "summary": summary,
       }
     CompactionFailed(error~) => { "event": "compaction_failed", "error": error }
+    SubrunStarted(id~, kind~, label~) =>
+      { "event": "subrun_started", "id": id, "kind": kind, "label": label }
+    SubrunFinished(id~, status~, steps~, prompt_tokens~, completion_tokens~) =>
+      {
+        "event": "subrun_finished",
+        "id": id,
+        "status": status,
+        "steps": steps,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+      }
     AutoCompactionStarted(from_sequence~, to_sequence~) =>
       {
         "event": "auto_compaction_started",


### PR DESCRIPTION
## What

PR C1 of the subagent-substrate series — independent of #535/#536, branched off and targeting `main` directly. Adds the sub-run lifecycle brackets to the wire protocol and renders them in **all three readers** (TUI, desktop host, desktop frontend).

## Design

- **Protocol**: `SubrunStarted{id, kind, label}` / `SubrunFinished{id, status, steps, prompt_tokens, completion_tokens}`. The `id` pairs overlapping sub-runs' starts with finishes; `label` is a short bounded display string (never the raw query); `status` is the sub-run terminal in snake_case, including `"cancelled"` — the finish event's contract is that it is emitted on success, failure, **and** cancellation, so a reader can never show a sub-run as running forever. Token/step fields carry the child's actual spend for cost attribution.
- **TUI**: the deliberately-exhaustive decoder maps both variants (wire-only fields dropped at the view layer) and the loop renders transcript notices bracketing the child's interleaved activity. Live activity-line integration is deferred to a polish pass.
- **Desktop**: `desktop/moon.work` binds `../protocol` as a workspace member — the **working tree**, not a registry snapshot (an earlier revision of this description claimed otherwise; commit 2 corrects it). The new variants therefore broke the desktop's exhaustive decoders immediately, exactly as that pattern intends. Host: the brackets join the documented ignore arm (the outer run already reads busy to the host; the webview renders the stream itself). Frontend: both map onto the `RuntimeUpdate` transcript-notice path, mirroring the TUI.

## Tests

- Protocol round-trip via the exhaustive `all_events` sample list — 12/12.
- TUI: positive decode both variants + missing-required-fields drop + unknown-kind tolerance — 13/13; full `cmd/tui` 83/83.
- Desktop: frontend maps both brackets to `RuntimeUpdate`; host ignores both; full desktop suite 213/213.
- `moon check --target all` clean in the root workspace; desktop workspace `moon check` clean. Root-suite failures are only the documented environment-flaky shell/bgjob family (identical on clean main). Stale-local-fmt output on untouched desktop files was reverted, not committed (nightly CI owns desktop formatting).

Note: subal per-commit review pending on quota reset (Jul 26), same as #535/#536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)