### PR TITLE
feat(agent_explore): the explore tool — delegated, cited API/codebase answers

### DIFF
--- a/agent_explore/README.mbt.md
+++ b/agent_explore/README.mbt.md
@@ -1,0 +1,22 @@
+# agent_explore
+
+The `explore` tool: delegate one self-contained question to a read-only scout
+subagent (an `@agent_subrun` child) and get back a bounded, cited answer.
+
+Why it exists: long autonomous runs burn their context on fan-out reading,
+and MoonBit is young enough that model priors about its APIs are unreliable.
+The scout answers workspace questions ("where is X handled") and MoonBit API
+questions (what a package offers, exact signatures) with `moon ide doc` as
+its primary instrument, returning `file:line` citations the parent can
+spot-check — conclusions enter the parent's context, never file dumps.
+
+Contract highlights:
+
+- Child toolset: `read` + `shell(read_only=true)` + `submit_answer` — no edit
+  tools, no nested subagent tools.
+- Every report field is capped at submission (`ExploreReport::validate`), so
+  the rendered result stays far below the loop's tool-result clamp.
+- Cost is reserved from the shared per-turn `SubrunBudget` BEFORE launch and
+  reconciled after; an exhausted budget refuses without spending anything.
+- Failure is graceful: no report / timeout / budget exhaustion all return an
+  is_error result telling the parent to fall back to reading directly.

--- a/agent_explore/README.md
+++ b/agent_explore/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_explore/moon.pkg
+++ b/agent_explore/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "bobzhang/openseek/agent_subrun",
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/read",
+  "bobzhang/openseek/agent_tool/shell",
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/json",
+} for "test"
+
+supported_targets = "+native"

--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -1,0 +1,56 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_explore"
+
+import {
+  "bobzhang/openseek/agent_subrun",
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+pub let current_schema_version : Int
+
+pub let default_explore_deadline_ms : Int
+
+pub let default_explore_max_steps : Int
+
+pub fn definition(api_key~ : String, model~ : @deepseek.Model, workspace_root~ : String, budget~ : @agent_subrun.SubrunBudget, api_url? : String) -> @agent_tool.AgentToolDefinition
+
+pub let max_answer_chars : Int
+
+pub let max_citation_file_chars : Int
+
+pub let max_citation_note_chars : Int
+
+pub let max_citations : Int
+
+pub let max_hints_chars : Int
+
+pub let max_query_chars : Int
+
+pub let max_unresolved_chars : Int
+
+// Errors
+
+// Types and methods
+pub(all) struct Citation {
+  file : String
+  line : Int?
+  note : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ExploreReport {
+  schema_version : Int
+  answer : String
+  citations : Array[Citation]
+  unresolved : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ExploreReport::parse(Json) -> Result[Self, String]
+pub fn ExploreReport::validate(Self) -> Array[String]
+
+// Type aliases
+
+// Traits
+

--- a/agent_explore/prompt.mbt
+++ b/agent_explore/prompt.mbt
@@ -1,0 +1,61 @@
+///|
+/// System prompt for explore mode: a read-only scout that answers ONE
+/// question with instrument-grounded citations. The instrument hierarchy is
+/// the point — MoonBit is young, model priors about its APIs are
+/// unreliable, and this prompt encodes where the truth actually lives.
+fn explore_system_prompt() -> String {
+  (
+    #|You are OpenSeek in explore mode: a read-only scout. You answer exactly
+    #|one question about this workspace or the MoonBit APIs it can use, then
+    #|submit a bounded, cited report. You do not modify anything.
+    #|
+    #|Where API truth lives, in order:
+    #|- `moon ide doc "<query>"` is the authoritative instrument for API
+    #|  discovery — workspace packages, the core stdlib, and the pinned
+    #|  dependency versions this workspace actually builds against. Prefer it
+    #|  over grepping and over your own memory of MoonBit.
+    #|- `moon ide peek-def` / `outline` / `find-references` for semantic
+    #|  navigation; read source files for behavior the docs do not settle.
+    #|- Checked-in `pkg.generated.mbti` files summarize public APIs but are
+    #|  generated snapshots — they can be STALE during active edits; trust
+    #|  `moon ide doc` and the source over them when they disagree.
+    #|- Never hardcode toolchain paths (like a home-directory moon install):
+    #|  run the tools and let the active toolchain resolve itself.
+    #|
+    #|Rules:
+    #|- Ground every claim. Workspace claims cite file:line; stdlib and
+    #|  dependency claims cite the doc/source path your instrument reported.
+    #|- Prefer a precise partial answer over a padded complete-looking one.
+    #|  What you could not determine goes in `unresolved` — stated ignorance
+    #|  beats a fabricated claim.
+    #|- Stay bounded: the answer field is capped, citations are capped, and
+    #|  oversized submissions are rejected for retry.
+    #|- When done, call submit_answer exactly once with the full report
+    #|  (schema_version 1). Do not finish with plain text.
+  )
+}
+
+///|
+/// The child's task: the parent's question, plus optional hints about where
+/// to look.
+fn explore_task(query : String, hints : String?) -> String {
+  match hints {
+    Some(hints) =>
+      (
+        $|Question:
+        $|\{query}
+        $|
+        $|The caller suggests starting from:
+        $|\{hints}
+        $|
+        $|Answer the question and submit_answer once, with citations.
+      )
+    None =>
+      (
+        $|Question:
+        $|\{query}
+        $|
+        $|Answer the question and submit_answer once, with citations.
+      )
+  }
+}

--- a/agent_explore/submit.mbt
+++ b/agent_explore/submit.mbt
@@ -1,0 +1,89 @@
+///|
+/// The `submit_answer` capture tool: parse + validate against the bounded
+/// contract, reject-with-retry on problems, capture and end the child run.
+/// Control-declared via `capture_tool`, so a child hitting its context
+/// ceiling on the submitting step still seals with its report.
+fn submit_answer_tool(
+  captured : Ref[ExploreReport?],
+) -> @agent_tool.AgentToolDefinition {
+  @agent_subrun.capture_tool(
+    name="submit_answer",
+    description="Submit the final explore report and end the run. Call this exactly once, when the question is answered. Every workspace claim needs a file (and line when known) citation; put what you could not determine in `unresolved`.",
+    schema=JsonSchema(report_schema()),
+    parse=parse_submission,
+    captured,
+    finished_note=report => {
+      "explore answered (\{report.citations.length()} citation(s))"
+    },
+  )
+}
+
+///|
+fn parse_submission(args : Json) -> Result[ExploreReport, Array[String]] {
+  match ExploreReport::parse(args) {
+    Err(msg) => Err([msg])
+    Ok(report) => {
+      let problems = report.validate()
+      if problems.length() > 0 {
+        Err(problems)
+      } else {
+        Ok(report)
+      }
+    }
+  }
+}
+
+///|
+/// JSON schema mirroring `ExploreReport`. `line` and `note` are optional per
+/// citation; `unresolved` is optional.
+fn report_schema() -> Json {
+  {
+    "type": "object",
+    "properties": {
+      "schema_version": { "type": "integer" },
+      "answer": {
+        "type": "string",
+        "description": "The complete answer, at most \{max_answer_chars} characters.",
+      },
+      "citations": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "file": { "type": "string" },
+            "line": { "type": "integer" },
+            "note": { "type": "string" },
+          },
+          "required": ["file"],
+        },
+        "description": "Supporting references, at most \{max_citations}.",
+      },
+      "unresolved": {
+        "type": "string",
+        "description": "What could not be determined, stated plainly.",
+      },
+    },
+    "required": ["schema_version", "answer", "citations"],
+  }
+}
+
+///|
+test "submit_answer declares itself a control tool" {
+  let captured : Ref[ExploreReport?] = { val: None }
+  assert_true(submit_answer_tool(captured).is_control())
+}
+
+///|
+test "submission parse rejects contract violations" {
+  guard parse_submission(sample_report().to_json()) is Ok(_) else {
+    fail("expected a valid submission")
+  }
+  guard parse_submission({ "answer": "no version" }) is Err(_) else {
+    fail("expected a parse rejection")
+  }
+  guard parse_submission({ ..sample_report(), answer: "" }.to_json())
+    is Err(problems) else {
+    fail("expected a validation rejection")
+  }
+  assert_true(problems.length() > 0)
+}

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -1,0 +1,171 @@
+///|
+/// Step ceiling requested for one explore child. Exploration must stay
+/// cheap: it reads and cites, it does not build.
+pub let default_explore_max_steps : Int = 40
+
+///|
+/// Wall deadline for one explore child. A scout that has not answered in
+/// five minutes is lost, not thorough.
+pub let default_explore_deadline_ms : Int = 300_000
+
+///|
+/// Input caps: a question is a question, not a document.
+pub let max_query_chars : Int = 2_000
+
+///|
+/// Hints cap, same reasoning as the query cap.
+pub let max_hints_chars : Int = 2_000
+
+///|
+/// Tool definition for `explore`: delegate one self-contained question to a
+/// read-only child agent and get back a bounded, cited answer.
+///
+/// The child runs on the `@agent_subrun` substrate with `read`,
+/// `shell(read_only=true)` (its instrument for `moon ide doc` and friends),
+/// and `submit_answer` — no edit tools, no nested subagent tools. Its
+/// events are suppressed from the host stream; its cost is reserved from
+/// the shared per-turn `SubrunBudget` BEFORE launch and reconciled after.
+///
+/// Failure is graceful by contract: a child that produces no report, times
+/// out, or exhausts the budget returns an is_error result telling the
+/// parent to fall back to reading directly — never a broken turn.
+pub fn definition(
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  workspace_root~ : String,
+  budget~ : @agent_subrun.SubrunBudget,
+  api_url? : String,
+) -> @agent_tool.AgentToolDefinition {
+  @agent_tool.AgentToolDefinition(
+    name="explore",
+    description="Delegate ONE self-contained question to a read-only scout subagent and get a bounded, cited answer. Use it when answering would mean reading MANY files or discovering MoonBit APIs you are not sure about — (a) workspace questions (\"where is X handled, how does Y flow\") where you want the conclusion, not the file dumps; (b) MoonBit stdlib/dependency API discovery (what a package offers, exact signatures) — prefer this over guessing APIs from memory. For a single direct lookup you can do in one step (one `moon ide doc` query, one file read), do it yourself instead. The scout cannot edit anything and returns file:line citations you can verify.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "The one question to answer, self-contained (the scout sees nothing else of this conversation).",
+        },
+        "hints": {
+          "type": "string",
+          "description": "Optional pointers: paths, package names, or symbols the scout should start from.",
+        },
+      },
+      "required": ["query"],
+    }),
+    execute=Async(arguments => {
+      execute(api_key, model, workspace_root, budget, api_url, arguments)
+    }),
+  )
+}
+
+///|
+async fn execute(
+  api_key : String,
+  model : @deepseek.Model,
+  workspace_root : String,
+  budget : @agent_subrun.SubrunBudget,
+  api_url : String?,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "query": String(query), .. } && query.trim() != "" else {
+    return @agent_tool.ToolAction::respond(
+      "error: explore requires a non-empty string `query`",
+      is_error=true,
+    )
+  }
+  guard query.length() <= max_query_chars else {
+    return @agent_tool.ToolAction::respond(
+      "error: explore query exceeds \{max_query_chars} chars — ask one self-contained question",
+      is_error=true,
+    )
+  }
+  let hints : String? = match arguments {
+    { "hints": String(hints), .. } if hints.trim() != "" => Some(hints)
+    _ => None
+  }
+  guard !(hints is Some(h) && h.length() > max_hints_chars) else {
+    return @agent_tool.ToolAction::respond(
+      "error: explore hints exceed \{max_hints_chars} chars",
+      is_error=true,
+    )
+  }
+  // Reserve BEFORE launch: the child's effective ceiling comes out of the
+  // turn's shared allowance, so one child cannot overshoot what remains.
+  guard budget.reserve(default_explore_max_steps) is Some(granted_steps) else {
+    return @agent_tool.ToolAction::respond(
+      "explore budget exhausted for this turn — answer from what you already know, or read the files directly.",
+      is_error=true,
+      brief="explore (budget exhausted)",
+    )
+  }
+  let result = @agent_subrun.run_subrun(
+    {
+      session_id: "explore",
+      system_prompt: explore_system_prompt(),
+      task: explore_task(query, hints),
+      tools: captured => {
+        @agent_tool.Tools([
+          @read.definition(workspace_root~),
+          @shell.definition(workspace_root~, read_only=true),
+          submit_answer_tool(captured),
+        ])
+      },
+      max_steps: granted_steps,
+      wall_deadline_ms: Some(default_explore_deadline_ms),
+    },
+    api_key~,
+    model~,
+    api_url?,
+    workspace_root~,
+  )
+  budget.reconcile(reserved=granted_steps, used=result.steps_used())
+  match result.value() {
+    Some(report) =>
+      @agent_tool.ToolAction::respond(
+        render_report(report),
+        brief="explore (\{report.citations.length()} citation(s), \{result.steps_used()} step(s))",
+      )
+    None =>
+      @agent_tool.ToolAction::respond(
+        "explore produced no report (\{to_repr(result.terminal())}) — fall back to reading directly.",
+        is_error=true,
+        brief="explore (no report)",
+      )
+  }
+}
+
+///|
+/// Render the bounded report as the tool result. Every field was capped at
+/// submission, so the rendered whole stays far below the loop's 60K clamp.
+fn render_report(report : ExploreReport) -> String {
+  let out = StringBuilder()
+  out <+ "\{report.answer}"
+  if report.citations.length() > 0 {
+    out <+ "\n\nCitations:"
+    for citation in report.citations {
+      let line = match citation.line {
+        Some(line) => ":\{line}"
+        None => ""
+      }
+      let note = match citation.note {
+        Some(note) => " — \{note}"
+        None => ""
+      }
+      out <+ "\n- \{citation.file}\{line}\{note}"
+    }
+  }
+  if report.unresolved is Some(unresolved) {
+    out <+ "\n\nUnresolved: \{unresolved}"
+  }
+  out.to_string()
+}
+
+///|
+test "render_report shows answer, citations, and unresolved" {
+  let rendered = render_report(sample_report())
+  assert_true(rendered.contains("Buffer::to_bytes"))
+  assert_true(rendered.contains("- protocol/event.mbt:14 — Event enum"))
+  assert_true(rendered.contains("- moonbitlang/core/buffer"))
+  assert_true(rendered.contains("Unresolved: did not check the js backend"))
+}

--- a/agent_explore/tool_test.mbt
+++ b/agent_explore/tool_test.mbt
@@ -1,0 +1,193 @@
+///|
+/// Mock-endpoint harness for the explore executor, mirroring the
+/// agent_subrun one: SSE main loop, JSON checkpoint replies unused here.
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}
+
+///|
+async fn explore_test_server(
+  group : @async.TaskGroup[Unit],
+  handle : (Json) -> String raise,
+) -> String? {
+  guard bind_test_server("local TCP bind unavailable; skipping explore test")
+    is Some(server) else {
+    return None
+  }
+  group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        let payload = handle(@json.parse(body.read_all().text()))
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write("data: \{payload}\n\n")
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=8,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+fn sse_submit_answer(answer : String, total_tokens : Int) -> String {
+  let report : Json = {
+    "schema_version": 1,
+    "answer": answer,
+    "citations": [{ "file": "protocol/event.mbt", "line": 14 }],
+  }
+  (
+    {
+      "choices": [
+        {
+          "delta": {
+            "tool_calls": [
+              {
+                "index": 0,
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                  "name": "submit_answer",
+                  "arguments": report.stringify(),
+                },
+              },
+            ],
+          },
+        },
+      ],
+      "usage": {
+        "prompt_tokens": total_tokens - 1_000,
+        "completion_tokens": 1_000,
+        "total_tokens": total_tokens,
+      },
+    } : Json).stringify()
+}
+
+///|
+fn sse_plain(content : String, total_tokens : Int) -> String {
+  (
+    {
+      "choices": [{ "delta": { "content": content } }],
+      "usage": {
+        "prompt_tokens": total_tokens - 1_000,
+        "completion_tokens": 1_000,
+        "total_tokens": total_tokens,
+      },
+    } : Json).stringify()
+}
+
+///|
+async fn run_explore(
+  url : String,
+  budget : @agent_subrun.SubrunBudget,
+  query : String,
+) -> @agent_tool.ToolAction {
+  let tool = @agent_explore.definition(
+    api_key="test-key",
+    model=Deepseek(V4Flash),
+    workspace_root=".",
+    budget~,
+    api_url=url,
+  )
+  guard tool.execute is Async(execute) else { fail("explore should be async") }
+  execute({ "query": query.to_json() })
+}
+
+///|
+async test "a cited answer renders with budget reconciliation" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> String raise = _request => {
+      sse_submit_answer("The Event enum lives in protocol/event.mbt.", 100_000)
+    }
+    guard explore_test_server(group, handle) is Some(url) else { return }
+    let budget = @agent_subrun.SubrunBudget(
+      max_calls_per_turn=2,
+      max_steps_per_turn=100,
+    )
+    let action = run_explore(url, budget, "Where is the Event enum defined?")
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("The Event enum lives in"))
+    assert_true(output.content.contains("- protocol/event.mbt:14"))
+    guard output.brief is Some(brief) else { fail("expected a brief") }
+    assert_true(brief.contains("1 citation(s)"))
+    // The child used 1 step of its 40-step grant: 39 flow back, so a
+    // second reservation still gets a full grant from the 100-step turn.
+    assert_true(budget.reserve(40) is Some(40))
+  }
+}
+
+///|
+async test "an exhausted budget refuses before launching a child" {
+  @async.with_task_group() <| group => {
+    let mut requests = 0
+    let handle : (Json) -> String raise = _request => {
+      requests += 1
+      sse_submit_answer("answer", 100_000)
+    }
+    guard explore_test_server(group, handle) is Some(url) else { return }
+    let budget = @agent_subrun.SubrunBudget(
+      max_calls_per_turn=1,
+      max_steps_per_turn=100,
+    )
+    let first = run_explore(url, budget, "first question")
+    guard first is Respond(output) && !output.is_error else {
+      fail("expected the first explore to succeed")
+    }
+    let second = run_explore(url, budget, "second question")
+    guard second is Respond(refused) else { fail("expected Respond") }
+    assert_true(refused.is_error)
+    assert_true(refused.content.contains("budget exhausted"))
+    // The refusal never reached the model endpoint.
+    assert_eq(requests, 1)
+  }
+}
+
+///|
+async test "a child that never submits reports no-report gracefully" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> String raise = _request => {
+      sse_plain("plain text, no submit", 100_000)
+    }
+    guard explore_test_server(group, handle) is Some(url) else { return }
+    let budget = @agent_subrun.SubrunBudget()
+    let action = run_explore(url, budget, "unanswerable")
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("produced no report"))
+    assert_true(output.content.contains("NoReport"))
+  }
+}
+
+///|
+async test "input validation rejects before spending anything" {
+  let budget = @agent_subrun.SubrunBudget(
+    max_calls_per_turn=1,
+    max_steps_per_turn=100,
+  )
+  let tool = @agent_explore.definition(
+    api_key="unused",
+    model=Deepseek(V4Flash),
+    workspace_root=".",
+    budget~,
+    api_url="http://127.0.0.1:1/unused",
+  )
+  guard tool.execute is Async(execute) else { fail("explore should be async") }
+  let action = execute({ "query": "   " })
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  // The rejection consumed no budget.
+  assert_true(budget.reserve(10) is Some(10))
+}

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -1,0 +1,161 @@
+///|
+/// `ExploreReport` is the bounded, citation-carrying answer an explore child
+/// submits. Every bound here is load-bearing: the rendered result must stay
+/// far below the loop's 60K tool-result clamp AND keep the parent's
+/// char-denominated batch budget honest, so validation — not hope — caps
+/// every field and count.
+
+///|
+/// The schema version this build emits and accepts.
+pub let current_schema_version : Int = 1
+
+///|
+/// Field and count ceilings, enforced by `validate`.
+pub let max_answer_chars : Int = 8_000
+
+///|
+/// Citation-count ceiling, enforced by `validate`.
+pub let max_citations : Int = 20
+
+///|
+/// Per-citation file-path length ceiling.
+pub let max_citation_file_chars : Int = 300
+
+///|
+/// Per-citation note length ceiling.
+pub let max_citation_note_chars : Int = 200
+
+///|
+/// `unresolved` length ceiling.
+pub let max_unresolved_chars : Int = 1_000
+
+///|
+/// One supporting reference: a workspace `file:line`, or the source/`.mbti`
+/// path `moon ide doc` reported for a stdlib or dependency claim.
+pub(all) struct Citation {
+  file : String
+  line : Int?
+  note : String?
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// The child's full answer. `unresolved` names what it could NOT determine —
+/// stated ignorance beats a fabricated claim.
+pub(all) struct ExploreReport {
+  schema_version : Int
+  answer : String
+  citations : Array[Citation]
+  unresolved : String?
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// Validate a report against the contract. Returns the list of problems; an
+/// empty list means the report is valid. The `submit_answer` capture tool
+/// uses this to reject oversized or empty output so the model retries with
+/// a bounded report instead of finishing with an unusable one.
+pub fn ExploreReport::validate(self : ExploreReport) -> Array[String] {
+  let problems : Array[String] = []
+  if self.schema_version != current_schema_version {
+    problems.push(
+      "schema_version must be \{current_schema_version}, got \{self.schema_version}",
+    )
+  }
+  if self.answer.trim() == "" {
+    problems.push("answer must not be empty")
+  }
+  if self.answer.length() > max_answer_chars {
+    problems.push(
+      "answer exceeds \{max_answer_chars} chars (\{self.answer.length()}); tighten it",
+    )
+  }
+  if self.citations.length() > max_citations {
+    problems.push(
+      "at most \{max_citations} citations (\{self.citations.length()} given); keep the strongest",
+    )
+  }
+  for citation in self.citations {
+    if citation.file == "" {
+      problems.push("a citation has an empty file path")
+    }
+    if citation.file.length() > max_citation_file_chars {
+      problems.push(
+        "a citation file path exceeds \{max_citation_file_chars} chars",
+      )
+    }
+    if citation.note is Some(note) && note.length() > max_citation_note_chars {
+      problems.push("a citation note exceeds \{max_citation_note_chars} chars")
+    }
+  }
+  if self.unresolved is Some(unresolved) &&
+    unresolved.length() > max_unresolved_chars {
+    problems.push("unresolved exceeds \{max_unresolved_chars} chars")
+  }
+  problems
+}
+
+///|
+/// Parse a report from JSON, returning the report or a human-readable error.
+pub fn ExploreReport::parse(json : Json) -> Result[ExploreReport, String] {
+  let report : ExploreReport = @json.from_json(json) catch {
+    e => return Err("invalid explore report JSON: \{e}")
+  }
+  Ok(report)
+}
+
+///|
+fn sample_report() -> ExploreReport {
+  {
+    schema_version: 1,
+    answer: "Use @buffer.new(size_hint?) and Buffer::to_bytes.",
+    citations: [
+      { file: "protocol/event.mbt", line: Some(14), note: Some("Event enum") },
+      { file: "moonbitlang/core/buffer", line: None, note: None },
+    ],
+    unresolved: Some("did not check the js backend"),
+  }
+}
+
+///|
+test "explore report round-trips through json" {
+  let report = sample_report()
+  guard ExploreReport::parse(report.to_json()) is Ok(parsed) else {
+    fail("parse failed")
+  }
+  assert_eq(parsed, report)
+}
+
+///|
+test "validate accepts a good report" {
+  assert_eq(sample_report().validate().length(), 0)
+}
+
+///|
+test "validate rejects empties and oversizes" {
+  assert_true({ ..sample_report(), answer: "  " }.validate().length() > 0)
+  assert_true({ ..sample_report(), schema_version: 2 }.validate().length() > 0)
+  let long = StringBuilder()
+  for _ in 0..<(max_answer_chars + 1) {
+    long.write_char('a')
+  }
+  assert_true(
+    { ..sample_report(), answer: long.to_string() }.validate().length() > 0,
+  )
+  let many : Array[Citation] = []
+  for i in 0..<=max_citations {
+    many.push({ file: "f\{i}.mbt", line: None, note: None })
+  }
+  assert_true({ ..sample_report(), citations: many }.validate().length() > 0)
+  assert_true(
+    { ..sample_report(), citations: [{ file: "", line: None, note: None }] }
+    .validate()
+    .length() >
+    0,
+  )
+}
+
+///|
+test "parse reports an error on malformed json" {
+  guard ExploreReport::parse(Json::null()) is Err(_) else {
+    fail("expected parse error")
+  }
+}

--- a/agent_subrun/budget.mbt
+++ b/agent_subrun/budget.mbt
@@ -1,0 +1,137 @@
+///|
+/// Below this many remaining steps a child cannot do useful work (read a few
+/// files and submit), so `reserve` refuses rather than launching a doomed
+/// run that burns its allowance on a truncated attempt.
+pub let min_useful_subrun_steps : Int = 8
+
+///|
+/// The per-turn allowance shared by EVERY subrun tool in a session (explore,
+/// the goal-review gate, callable review): one child must not be able to
+/// stretch a turn unboundedly, and the tools must not each carry a private
+/// quota that sums to one.
+///
+/// The owner is the CLI layer: it creates one budget per session, passes it
+/// to every subrun tool definition, and calls `reset_turn` at each turn
+/// start. Enforcement is reserve-BEFORE-launch: the executor reserves the
+/// child's requested steps up front — deriving the child's effective
+/// `max_steps` from what remains — and `reconcile`s the unused part after
+/// the run. Debit-only-after-return would let one child overshoot the whole
+/// remaining allowance.
+pub struct SubrunBudget {
+  max_calls_per_turn : Int
+  max_steps_per_turn : Int
+  mut used_calls : Int
+  mut reserved_steps : Int
+}
+
+///|
+/// Defaults sized for explore-style children: a few delegations per turn,
+/// each bounded well below a whole child allowance.
+pub fn SubrunBudget::SubrunBudget(
+  max_calls_per_turn? : Int = 4,
+  max_steps_per_turn? : Int = 120,
+) -> SubrunBudget {
+  { max_calls_per_turn, max_steps_per_turn, used_calls: 0, reserved_steps: 0 }
+}
+
+///|
+/// Start a new parent turn: the allowance refills.
+pub fn SubrunBudget::reset_turn(self : SubrunBudget) -> Unit {
+  self.used_calls = 0
+  self.reserved_steps = 0
+}
+
+///|
+/// Reserve capacity for one child BEFORE launching it. Returns the child's
+/// effective step ceiling — `requested_steps` clamped to the remaining
+/// allowance — or `None` when the per-turn call count is spent or the
+/// remaining steps could not fund a useful run. The reservation holds until
+/// `reconcile` returns the unused portion.
+pub fn SubrunBudget::reserve(
+  self : SubrunBudget,
+  requested_steps : Int,
+) -> Int? {
+  if self.used_calls >= self.max_calls_per_turn {
+    return None
+  }
+  let remaining = self.max_steps_per_turn - self.reserved_steps
+  if remaining < min_useful_subrun_steps {
+    return None
+  }
+  let effective = if requested_steps < remaining {
+    requested_steps
+  } else {
+    remaining
+  }
+  self.used_calls += 1
+  self.reserved_steps += effective
+  Some(effective)
+}
+
+///|
+/// Return a reservation's unused part after the child ran. `reserved` is
+/// what `reserve` granted; `used` is the child's actual `steps_used` (from
+/// its `SubrunResult`). Steps the child never took flow back into the
+/// turn's allowance; the call count does not.
+pub fn SubrunBudget::reconcile(
+  self : SubrunBudget,
+  reserved~ : Int,
+  used~ : Int,
+) -> Unit {
+  let spent = if used < 0 {
+    0
+  } else if used > reserved {
+    reserved
+  } else {
+    used
+  }
+  self.reserved_steps -= reserved - spent
+}
+
+///|
+test "reserve clamps to the remaining allowance and refuses dust" {
+  let budget = SubrunBudget(max_calls_per_turn=3, max_steps_per_turn=50)
+  // First reservation: full request fits.
+  assert_true(budget.reserve(40) is Some(40))
+  // Second: only 10 remain, clamped.
+  assert_true(budget.reserve(40) is Some(10))
+  // Third: nothing useful remains.
+  assert_true(budget.reserve(40) is None)
+}
+
+///|
+test "the call count is its own ceiling" {
+  let budget = SubrunBudget(max_calls_per_turn=2, max_steps_per_turn=1_000)
+  assert_true(budget.reserve(10) is Some(10))
+  assert_true(budget.reserve(10) is Some(10))
+  assert_true(budget.reserve(10) is None)
+}
+
+///|
+test "reconcile returns unused steps but never the call slot" {
+  let budget = SubrunBudget(max_calls_per_turn=2, max_steps_per_turn=40)
+  guard budget.reserve(30) is Some(granted) else { fail("expected a grant") }
+  // The child used 5 of its 30: 25 flow back.
+  budget.reconcile(reserved=granted, used=5)
+  assert_true(budget.reserve(40) is Some(35))
+  // Both call slots are now spent regardless of steps returned.
+  assert_true(budget.reserve(10) is None)
+}
+
+///|
+test "reset_turn refills everything" {
+  let budget = SubrunBudget(max_calls_per_turn=1, max_steps_per_turn=20)
+  assert_true(budget.reserve(20) is Some(20))
+  assert_true(budget.reserve(20) is None)
+  budget.reset_turn()
+  assert_true(budget.reserve(20) is Some(20))
+}
+
+///|
+test "reconcile clamps a pathological used count" {
+  let budget = SubrunBudget(max_calls_per_turn=2, max_steps_per_turn=30)
+  guard budget.reserve(20) is Some(granted) else { fail("expected a grant") }
+  // used > reserved must not mint steps; used < 0 must not either.
+  budget.reconcile(reserved=granted, used=99)
+  assert_true(budget.reserve(30) is Some(10))
+}

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Values
 pub fn[T] capture_tool(name~ : String, description~ : String, schema~ : @agent_tool.JsonSchema, parse~ : (Json) -> Result[T, Array[String]], @ref.Ref[T?], finished_note? : (T) -> String) -> @agent_tool.AgentToolDefinition
 
+pub let min_useful_subrun_steps : Int
+
 pub async fn[T] run_subrun(SubrunSpec[T], api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, event_sink? : @emit.EventSink) -> SubrunResult[T]
 
 pub fn suppressing_sink() -> @emit.EventSink
@@ -19,6 +21,17 @@ pub fn suppressing_sink() -> @emit.EventSink
 // Errors
 
 // Types and methods
+pub struct SubrunBudget {
+  max_calls_per_turn : Int
+  max_steps_per_turn : Int
+  mut used_calls : Int
+  mut reserved_steps : Int
+}
+pub fn SubrunBudget::SubrunBudget(max_calls_per_turn? : Int, max_steps_per_turn? : Int) -> Self
+pub fn SubrunBudget::reconcile(Self, reserved~ : Int, used~ : Int) -> Unit
+pub fn SubrunBudget::reserve(Self, Int) -> Int?
+pub fn SubrunBudget::reset_turn(Self) -> Unit
+
 pub struct SubrunResult[T] {
   value : T?
   terminal : SubrunTerminal

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -223,7 +223,18 @@ async fn run_task_turn(
   @async.with_task_group() <| group => {
     let runtime = @agent_runtime.AgentRuntime(workspace_root~)
     let scope = @agent_runtime.AgentTaskScope(group)
-    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~)
+    // One-shot = one turn, so a fresh per-turn subrun budget needs no reset.
+    let subrun_budget = @agent_subrun.SubrunBudget()
+    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
+      [
+        @agent_explore.definition(
+          api_key~,
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          api_url?,
+        ),
+      ]
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
     ignore(
       @agent.run_turn_in_scope(

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "bobzhang/jsonl",
   "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_explore",
+  "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_review",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -613,7 +613,19 @@ async fn run_serve(
     // completion instead of leaving it queued until the next prompt.
     // Tools from any configured MCP servers, connected once per engine (their
     // reader/writer tasks live on this group) and reused across turns.
-    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~)
+    // The subrun budget is shared by every subrun tool and refills at each
+    // turn start (see start_turn) — the registry itself lives across turns.
+    let subrun_budget = @agent_subrun.SubrunBudget()
+    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
+      [
+        @agent_explore.definition(
+          api_key~,
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          api_url?,
+        ),
+      ]
     let tools = @agent.build_tools(
       runtime,
       scope,
@@ -806,6 +818,9 @@ async fn run_serve(
     }
 
     fn start_turn(task_text : String) -> @async.Task[Unit] {
+      // Each turn refills the shared subrun allowance; the registry (and the
+      // budget object the explore tool holds) lives across turns.
+      subrun_budget.reset_turn()
       group.spawn() <| () => {
         let _ = @agent.run_turn_in_scope(
           runtime~,

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -123,6 +123,15 @@ Common `moon` subcommands:
   the STALE mooncakes.io snapshot, never your working tree — to exercise local
   package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
   (above).
+- `explore` tool: delegate ONE self-contained question to a read-only scout
+  subagent when answering it yourself would mean reading MANY files or a
+  fan-out search — "where is X handled", "how does Y flow end to end", "what
+  does this package offer for Z" — and you want the cited conclusion, not the
+  file contents in your context. For a single direct lookup (one
+  `moon ide doc` query, one file read), do it yourself instead. The scout
+  cannot edit anything, returns file:line citations you can spot-check, and
+  shares a small per-turn budget (a few delegations per turn), so spend it on
+  questions that genuinely fan out.
 - shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
   use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
   Example: `moon cram test tests/cram`.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -128,6 +128,15 @@ fn default_prompt() -> String {
     #|  the STALE mooncakes.io snapshot, never your working tree — to exercise local
     #|  package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
     #|  (above).
+    #|- `explore` tool: delegate ONE self-contained question to a read-only scout
+    #|  subagent when answering it yourself would mean reading MANY files or a
+    #|  fan-out search — "where is X handled", "how does Y flow end to end", "what
+    #|  does this package offer for Z" — and you want the cited conclusion, not the
+    #|  file contents in your context. For a single direct lookup (one
+    #|  `moon ide doc` query, one file read), do it yourself instead. The scout
+    #|  cannot edit anything, returns file:line citations you can spot-check, and
+    #|  shares a small per-turn budget (a few delegations per turn), so spend it on
+    #|  questions that genuinely fan out.
     #|- shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
     #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
     #|  Example: `moon cram test tests/cram`.


### PR DESCRIPTION
## What

PR D of the subagent-substrate series (stacked on #536 — the diff here is the top commit only; retargets `main` after the stack lands, per the rebase-against-origin/main merge policy).

`explore` delegates one self-contained question to a read-only scout child on the `agent_subrun` substrate and returns a bounded, cited answer. Two use cases the tool description and prompt rule teach: workspace questions ("where is X handled, how does Y flow") and MoonBit API discovery — `moon ide doc` under the active toolchain is the scout's primary instrument, per the corrected ground-truth hierarchy from the design review (checked-in `.mbti` may be stale; no hardcoded toolchain paths; `run_moonbit` deliberately excluded from the v1 child toolset).

## Key mechanics

- **`SubrunBudget`** (in `agent_subrun`): one per-turn allowance shared by every subrun tool, **reserve-before-launch** — the child's effective `max_steps` comes out of the remaining allowance up front, unused steps flow back on reconcile. Serve refills it at each turn start; one-shot creates one per run. Exhaustion refuses *before* any model call.
- **Bounded by validation, not hope**: answer ≤8K chars, ≤20 citations (each capped), so the rendered result sits far below the loop's 60K clamp and keeps the parent's batch budget honest. Query/hints are validated too.
- **Graceful failure contract**: no-report / timeout (5-min wall deadline) / budget exhaustion all return an `is_error` result telling the parent to fall back to reading directly.
- **Prompt change (flagging explicitly for review)**: `default_prompt.mbt.md` gains the conservative delegation rule — do single lookups yourself, delegate genuine fan-out questions — since the existing "always prefer `moon ide doc`" guidance would suppress adoption entirely. This is the one behavior-affecting edit; it's the exact thing the planned A/B eval measures.

## Tests

25/25 across `agent_explore` + `agent_subrun` (budget unit suite; report round-trip/caps; control-declared submit; renderer; mock-endpoint executor: cited answer + reconciliation, refusal-before-endpoint, graceful no-report, validation-spends-nothing). `prompt` 19/19 with regenerated output; `moon check --target all`, `fmt`, `info` clean.

Note: subal per-commit review pending on quota reset (Jul 26), like the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)