### PR TITLE
docs(agent_tool)+test(mcp): pin control as a built-in-only privilege

### DIFF
--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -47,6 +47,13 @@ pub struct AgentToolDefinition {
   /// WITHOUT executing, that a call is safe to honor at the context
   /// ceiling: the built-in `finish` declares it, and a custom completion
   /// override must too or it is skip-closed like any other call there.
+  ///
+  /// This is a BUILT-IN-ONLY privilege: the ceiling salvage executes every
+  /// control-registered call sight-unseen precisely when context headroom
+  /// is gone, so a definition built from dynamic input (an MCP server's
+  /// listing, any config-supplied tool) must never set it — arbitrary work
+  /// with unbounded output at the ceiling is exactly what the salvage
+  /// guard exists to prevent (see mcp/tools, which pins this with a test).
   control : Bool
 } derive(Debug(ignore=ToolExecutor))
 

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -48,12 +48,14 @@ pub struct AgentToolDefinition {
   /// ceiling: the built-in `finish` declares it, and a custom completion
   /// override must too or it is skip-closed like any other call there.
   ///
-  /// This is a BUILT-IN-ONLY privilege: the ceiling salvage executes every
-  /// control-registered call sight-unseen precisely when context headroom
-  /// is gone, so a definition built from dynamic input (an MCP server's
-  /// listing, any config-supplied tool) must never set it — arbitrary work
-  /// with unbounded output at the ceiling is exactly what the salvage
-  /// guard exists to prevent (see mcp/tools, which pins this with a test).
+  /// This is a BUILT-IN-ONLY privilege: the ceiling salvage executes
+  /// control-registered calls sight-unseen (decodable ones; the rest are
+  /// skip-closed) precisely when context headroom is gone, so a definition
+  /// built from dynamic input (an MCP server's listing, any config-supplied
+  /// tool) must never set it — arbitrary work with unbounded output at the
+  /// ceiling is exactly what the salvage guard exists to prevent (mcp/tools
+  /// pins this with tests on BOTH construction sites: the bridge and the
+  /// build_grouped re-wrap).
   control : Bool
 } derive(Debug(ignore=ToolExecutor))
 

--- a/mcp/tools/tools_test.mbt
+++ b/mcp/tools/tools_test.mbt
@@ -120,6 +120,10 @@ async test "tools_for_client bridges tools with namespaced names and schemas" {
     assert_eq(tools[0].description, "Echoes")
     let @agent_tool.JsonSchema(schema) = tools[0].schema
     assert_true(schema is { "type": "object", .. })
+    // The control flag is a built-in-only privilege: the ceiling salvage
+    // executes control-registered calls sight-unseen, so a server-supplied
+    // definition must never carry it.
+    assert_false(tools[0].is_control())
   })
 }
 

--- a/mcp/tools/tools_test.mbt
+++ b/mcp/tools/tools_test.mbt
@@ -190,6 +190,12 @@ async test "build suffixes tools whose sanitized names collide" {
     }
     let names = [ for tool in tools => tool.name ]
     assert_eq(names, ["mcp__s__a-b", "mcp__s__a-b-2"])
+    // The control invariant must hold through build_grouped's RE-construction
+    // too (it rebuilds every bridged definition under the uniquified name) —
+    // pinning only the inner bridge would let a flag slip in at the re-wrap.
+    for tool in tools {
+      assert_false(tool.is_control())
+    }
   })
 }
 
@@ -318,6 +324,8 @@ async test "build bridges and dispatches tools from an http server" {
     )
     assert_eq(tools.length(), 1)
     assert_eq(tools[0].name, "mcp__remote__ping")
+    // Full production path (build -> build_grouped re-wrap): still no control.
+    assert_false(tools[0].is_control())
     guard tools[0].execute is @agent_tool.Async(exec) else {
       fail("expected an async executor")
     }


### PR DESCRIPTION
Follow-up hardening from revisiting #534 (A1). The generalized ceiling salvage executes every control-registered call sight-unseen precisely when context headroom is gone — so the `control` flag is now a real privilege. No dynamic path can set it today (both MCP `AgentToolDefinition` sites omit the field), but that invariant held only by omission. This states it on the field doc and pins it with an assertion in the MCP bridging test, so any future registration path that forwards a server-supplied flag fails a test instead of running arbitrary external work at the ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)