### PR TITLE
feat(agent_subrun): process-based subagents — substrate, explore scout, subrun child mode

### DIFF
--- a/agent_explore/README.mbt.md
+++ b/agent_explore/README.mbt.md
@@ -1,0 +1,22 @@
+# agent_explore
+
+The `explore` tool: delegate one self-contained question to a read-only scout
+subagent (a dedicated `openseek subrun explore` child process on the `@agent_subrun` substrate) and get back a bounded, cited answer.
+
+Why it exists: long autonomous runs burn their context on fan-out reading,
+and MoonBit is young enough that model priors about its APIs are unreliable.
+The scout answers workspace questions ("where is X handled") and MoonBit API
+questions (what a package offers, exact signatures) with `moon ide doc` as
+its primary instrument, returning `file:line` citations the parent can
+spot-check — conclusions enter the parent's context, never file dumps.
+
+Contract highlights:
+
+- Child toolset: `read` + `shell(read_only=true)` + `submit_answer` — no edit
+  tools, no nested subagent tools.
+- Every report field is capped at submission (`ExploreReport::validate`), so
+  the rendered result stays far below the loop's tool-result clamp.
+- Cost is reserved from the shared per-turn `SubrunBudget` BEFORE launch and
+  reconciled after; an exhausted budget refuses without spending anything.
+- Failure is graceful: no report / timeout / budget exhaustion all return an
+  is_error result telling the parent to fall back to reading directly.

--- a/agent_explore/README.md
+++ b/agent_explore/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_explore/moon.pkg
+++ b/agent_explore/moon.pkg
@@ -7,4 +7,12 @@ import {
   "moonbitlang/core/json",
 }
 
+import {
+  "bobzhang/openseek/agent_tool",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/json",
+} for "test"
+
 supported_targets = "+native"

--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -1,0 +1,58 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_explore"
+
+import {
+  "bobzhang/openseek/agent_subrun",
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+pub let current_schema_version : Int
+
+pub let default_explore_deadline_ms : Int
+
+pub let default_explore_max_steps : Int
+
+pub fn definition(self_exe~ : String, model~ : @deepseek.Model, workspace_root~ : String, budget~ : @agent_subrun.SubrunBudget, api_url? : String) -> @agent_tool.AgentToolDefinition
+
+pub let max_answer_chars : Int
+
+pub let max_citation_file_chars : Int
+
+pub let max_citation_note_chars : Int
+
+pub let max_citations : Int
+
+pub let max_hints_chars : Int
+
+pub let max_query_chars : Int
+
+pub let max_unresolved_chars : Int
+
+pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> ExploreReport?
+
+// Errors
+
+// Types and methods
+pub(all) struct Citation {
+  file : String
+  line : Int?
+  note : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ExploreReport {
+  schema_version : Int
+  answer : String
+  citations : Array[Citation]
+  unresolved : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ExploreReport::parse(Json) -> Result[Self, String]
+pub fn ExploreReport::validate(Self) -> Array[String]
+
+// Type aliases
+
+// Traits
+

--- a/agent_explore/prompt.mbt
+++ b/agent_explore/prompt.mbt
@@ -1,0 +1,61 @@
+///|
+/// System prompt for explore mode: a read-only scout that answers ONE
+/// question with instrument-grounded citations. The instrument hierarchy is
+/// the point — MoonBit is young, model priors about its APIs are
+/// unreliable, and this prompt encodes where the truth actually lives.
+fn explore_system_prompt() -> String {
+  (
+    #|You are OpenSeek in explore mode: a read-only scout. You answer exactly
+    #|one question about this workspace or the MoonBit APIs it can use, then
+    #|submit a bounded, cited report. You do not modify anything.
+    #|
+    #|Where API truth lives, in order:
+    #|- `moon ide doc "<query>"` is the authoritative instrument for API
+    #|  discovery — workspace packages, the core stdlib, and the pinned
+    #|  dependency versions this workspace actually builds against. Prefer it
+    #|  over grepping and over your own memory of MoonBit.
+    #|- `moon ide peek-def` / `outline` / `find-references` for semantic
+    #|  navigation; read source files for behavior the docs do not settle.
+    #|- Checked-in `pkg.generated.mbti` files summarize public APIs but are
+    #|  generated snapshots — they can be STALE during active edits; trust
+    #|  `moon ide doc` and the source over them when they disagree.
+    #|- Never hardcode toolchain paths (like a home-directory moon install):
+    #|  run the tools and let the active toolchain resolve itself.
+    #|
+    #|Rules:
+    #|- Ground every claim. Workspace claims cite file:line; stdlib and
+    #|  dependency claims cite the doc/source path your instrument reported.
+    #|- Prefer a precise partial answer over a padded complete-looking one.
+    #|  What you could not determine goes in `unresolved` — stated ignorance
+    #|  beats a fabricated claim.
+    #|- Stay bounded: the answer field is capped, citations are capped, and
+    #|  oversized submissions are rejected for retry.
+    #|- When done, call submit_answer exactly once with the full report
+    #|  (schema_version 1). Do not finish with plain text.
+  )
+}
+
+///|
+/// The child's task: the parent's question, plus optional hints about where
+/// to look.
+fn explore_task(query : String, hints : String?) -> String {
+  match hints {
+    Some(hints) =>
+      (
+        $|Question:
+        $|\{query}
+        $|
+        $|The caller suggests starting from:
+        $|\{hints}
+        $|
+        $|Answer the question and submit_answer once, with citations.
+      )
+    None =>
+      (
+        $|Question:
+        $|\{query}
+        $|
+        $|Answer the question and submit_answer once, with citations.
+      )
+  }
+}

--- a/agent_explore/submit.mbt
+++ b/agent_explore/submit.mbt
@@ -1,0 +1,89 @@
+///|
+/// The `submit_answer` capture tool: parse + validate against the bounded
+/// contract, reject-with-retry on problems, capture and end the child run.
+/// Control-declared via `capture_tool`, so a child hitting its context
+/// ceiling on the submitting step still seals with its report.
+fn submit_answer_tool(
+  captured : Ref[ExploreReport?],
+) -> @agent_tool.AgentToolDefinition {
+  @agent_subrun.capture_tool(
+    name="submit_answer",
+    description="Submit the final explore report and end the run. Call this exactly once, when the question is answered. Every workspace claim needs a file (and line when known) citation; put what you could not determine in `unresolved`.",
+    schema=JsonSchema(report_schema()),
+    parse=parse_submission,
+    captured,
+    finished_note=report => {
+      "explore answered (\{report.citations.length()} citation(s))"
+    },
+  )
+}
+
+///|
+fn parse_submission(args : Json) -> Result[ExploreReport, Array[String]] {
+  match ExploreReport::parse(args) {
+    Err(msg) => Err([msg])
+    Ok(report) => {
+      let problems = report.validate()
+      if problems.length() > 0 {
+        Err(problems)
+      } else {
+        Ok(report)
+      }
+    }
+  }
+}
+
+///|
+/// JSON schema mirroring `ExploreReport`. `line` and `note` are optional per
+/// citation; `unresolved` is optional.
+fn report_schema() -> Json {
+  {
+    "type": "object",
+    "properties": {
+      "schema_version": { "type": "integer" },
+      "answer": {
+        "type": "string",
+        "description": "The complete answer, at most \{max_answer_chars} characters.",
+      },
+      "citations": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "file": { "type": "string" },
+            "line": { "type": "integer" },
+            "note": { "type": "string" },
+          },
+          "required": ["file"],
+        },
+        "description": "Supporting references, at most \{max_citations}.",
+      },
+      "unresolved": {
+        "type": "string",
+        "description": "What could not be determined, stated plainly.",
+      },
+    },
+    "required": ["schema_version", "answer", "citations"],
+  }
+}
+
+///|
+test "submit_answer declares itself a control tool" {
+  let captured : Ref[ExploreReport?] = { val: None }
+  assert_true(submit_answer_tool(captured).is_control())
+}
+
+///|
+test "submission parse rejects contract violations" {
+  guard parse_submission(sample_report().to_json()) is Ok(_) else {
+    fail("expected a valid submission")
+  }
+  guard parse_submission({ "answer": "no version" }) is Err(_) else {
+    fail("expected a parse rejection")
+  }
+  guard parse_submission({ ..sample_report(), answer: "" }.to_json())
+    is Err(problems) else {
+    fail("expected a validation rejection")
+  }
+  assert_true(problems.length() > 0)
+}

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -128,6 +128,9 @@ async fn execute(
     wall_deadline_ms=default_explore_deadline_ms,
     cwd=workspace_root,
   )
+  // On external cancellation run_subrun re-raises before this line: the
+  // reservation stays debited for the rest of the turn — deliberately
+  // conservative, since the dead child's true spend is unknown.
   budget.reconcile(reserved=granted_steps, used=result.steps_used())
   match result.value() {
     Some(report) =>

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -1,0 +1,254 @@
+///|
+/// Step ceiling requested for one explore child. Exploration must stay
+/// cheap: it reads and cites, it does not build.
+pub let default_explore_max_steps : Int = 40
+
+///|
+/// Wall deadline for one explore child. A scout that has not answered in
+/// five minutes is lost, not thorough.
+pub let default_explore_deadline_ms : Int = 300_000
+
+///|
+/// Input caps: a question is a question, not a document.
+pub let max_query_chars : Int = 2_000
+
+///|
+/// Hints cap, same reasoning as the query cap.
+pub let max_hints_chars : Int = 2_000
+
+///|
+/// Tool definition for `explore`: delegate one self-contained question to a
+/// read-only scout subagent and get back a bounded, cited answer.
+///
+/// The scout runs in a DEDICATED CHILD PROCESS: `self_exe` (the parent's
+/// own executable — never PATH, so parent and child are the same binary and
+/// the report's derived JSON codecs cannot drift) invoked as
+/// `subrun explore`. The child's toolset is `read`,
+/// `shell(read_only=true)` (its instrument for `moon ide doc` and friends),
+/// and `submit_answer` — no edit tools, no nested subagent tools. The
+/// child inherits the environment for its API key; model and endpoint ride
+/// argv. Its cost is reserved from the shared per-turn `SubrunBudget`
+/// BEFORE launch and reconciled after from the observed event stream.
+///
+/// Failure is graceful by contract: a child that produces no report, times
+/// out, or exhausts the budget returns an is_error result telling the
+/// parent to fall back to reading directly — never a broken turn.
+pub fn definition(
+  self_exe~ : String,
+  model~ : @deepseek.Model,
+  workspace_root~ : String,
+  budget~ : @agent_subrun.SubrunBudget,
+  api_url? : String,
+) -> @agent_tool.AgentToolDefinition {
+  @agent_tool.AgentToolDefinition(
+    name="explore",
+    description="Delegate ONE self-contained question to a read-only scout subagent and get a bounded, cited answer. Use it when answering would mean reading MANY files or discovering MoonBit APIs you are not sure about — (a) workspace questions (\"where is X handled, how does Y flow\") where you want the conclusion, not the file dumps; (b) MoonBit stdlib/dependency API discovery (what a package offers, exact signatures) — prefer this over guessing APIs from memory. For a single direct lookup you can do in one step (one `moon ide doc` query, one file read), do it yourself instead. The scout cannot edit anything and returns file:line citations you can verify.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "The one question to answer, self-contained (the scout sees nothing else of this conversation).",
+        },
+        "hints": {
+          "type": "string",
+          "description": "Optional pointers: paths, package names, or symbols the scout should start from.",
+        },
+      },
+      "required": ["query"],
+    }),
+    execute=Async(arguments => {
+      execute(self_exe, model, workspace_root, budget, api_url, arguments)
+    }),
+  )
+}
+
+///|
+async fn execute(
+  self_exe : String,
+  model : @deepseek.Model,
+  workspace_root : String,
+  budget : @agent_subrun.SubrunBudget,
+  api_url : String?,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "query": String(query), .. } && query.trim() != "" else {
+    return @agent_tool.ToolAction::respond(
+      "error: explore requires a non-empty string `query`",
+      is_error=true,
+    )
+  }
+  guard query.length() <= max_query_chars else {
+    return @agent_tool.ToolAction::respond(
+      "error: explore query exceeds \{max_query_chars} chars — ask one self-contained question",
+      is_error=true,
+    )
+  }
+  let hints : String? = match arguments {
+    { "hints": String(hints), .. } if hints.trim() != "" => Some(hints)
+    _ => None
+  }
+  guard !(hints is Some(h) && h.length() > max_hints_chars) else {
+    return @agent_tool.ToolAction::respond(
+      "error: explore hints exceed \{max_hints_chars} chars",
+      is_error=true,
+    )
+  }
+  // Reserve BEFORE launch: the child's effective ceiling comes out of the
+  // turn's shared allowance, so one child cannot overshoot what remains.
+  guard budget.reserve(default_explore_max_steps) is Some(granted_steps) else {
+    return @agent_tool.ToolAction::respond(
+      "explore budget exhausted for this turn — answer from what you already know, or read the files directly.",
+      is_error=true,
+      brief="explore (budget exhausted)",
+    )
+  }
+  // API key rides the inherited environment, never argv (visible in ps).
+  let args = [
+    "subrun",
+    "explore",
+    "--model",
+    "\{model}",
+    "--max-steps",
+    "\{granted_steps}",
+  ]
+  if api_url is Some(url) {
+    args.push("--api-url")
+    args.push(url)
+  }
+  let input : Json = match hints {
+    Some(hints) => { "query": query, "hints": hints }
+    None => { "query": query }
+  }
+  let result = @agent_subrun.run_subrun(
+    command=self_exe,
+    args~,
+    input~,
+    parse_report=parse_child_report,
+    wall_deadline_ms=default_explore_deadline_ms,
+    cwd=workspace_root,
+  )
+  budget.reconcile(reserved=granted_steps, used=result.steps_used())
+  match result.value() {
+    Some(report) =>
+      @agent_tool.ToolAction::respond(
+        render_report(report),
+        brief="explore (\{report.citations.length()} citation(s), \{result.steps_used()} step(s))",
+      )
+    None =>
+      @agent_tool.ToolAction::respond(
+        "explore produced no report (\{to_repr(result.terminal())}) — fall back to reading directly.",
+        is_error=true,
+        brief="explore (no report)",
+      )
+  }
+}
+
+///|
+/// Parse-and-validate the child's report line: the same contract
+/// `submit_answer` enforced in the child, re-checked at the trust boundary —
+/// the line is same-binary JSON, but the parent still refuses an oversized
+/// or malformed report rather than rendering it.
+fn parse_child_report(json : Json) -> Result[ExploreReport, String] {
+  match ExploreReport::parse(json) {
+    Err(msg) => Err(msg)
+    Ok(report) => {
+      let problems = report.validate()
+      if problems.length() > 0 {
+        Err(problems.join("; "))
+      } else {
+        Ok(report)
+      }
+    }
+  }
+}
+
+///|
+/// The CHILD-side entry for `openseek subrun explore`: decode the input
+/// line, run the scout kind in this process, and return the report (the
+/// dispatch prints it as the final `subrun_report` line). `None` when the
+/// child finished without a valid submission or the input is malformed.
+pub async fn run_child(
+  input : Json,
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  max_steps~ : Int,
+  thinking? : @deepseek.ThinkingMode = Max,
+  api_url? : String,
+  workspace_root? : String = ".",
+) -> ExploreReport? {
+  guard input is { "query": String(query), .. } && query.trim() != "" else {
+    return None
+  }
+  let hints : String? = match input {
+    { "hints": String(hints), .. } if hints.trim() != "" => Some(hints)
+    _ => None
+  }
+  @agent_subrun.execute_kind(
+    session_id="explore",
+    system_prompt=explore_system_prompt(),
+    task=explore_task(query, hints),
+    tools=captured => {
+      @agent_tool.Tools([
+        @read.definition(workspace_root~),
+        @shell.definition(workspace_root~, read_only=true),
+        submit_answer_tool(captured),
+      ])
+    },
+    max_steps~,
+    api_key~,
+    model~,
+    thinking~,
+    api_url?,
+    workspace_root~,
+  )
+}
+
+///|
+/// Render the bounded report as the tool result. Every field was capped at
+/// submission, so the rendered whole stays far below the loop's 60K clamp.
+fn render_report(report : ExploreReport) -> String {
+  let out = StringBuilder()
+  out <+ "\{report.answer}"
+  if report.citations.length() > 0 {
+    out <+ "\n\nCitations:"
+    for citation in report.citations {
+      let line = match citation.line {
+        Some(line) => ":\{line}"
+        None => ""
+      }
+      let note = match citation.note {
+        Some(note) => " — \{note}"
+        None => ""
+      }
+      out <+ "\n- \{citation.file}\{line}\{note}"
+    }
+  }
+  if report.unresolved is Some(unresolved) {
+    out <+ "\n\nUnresolved: \{unresolved}"
+  }
+  out.to_string()
+}
+
+///|
+test "render_report shows answer, citations, and unresolved" {
+  let rendered = render_report(sample_report())
+  assert_true(rendered.contains("Buffer::to_bytes"))
+  assert_true(rendered.contains("- protocol/event.mbt:14 — Event enum"))
+  assert_true(rendered.contains("- moonbitlang/core/buffer"))
+  assert_true(rendered.contains("Unresolved: did not check the js backend"))
+}
+
+///|
+test "parse_child_report re-checks the contract at the trust boundary" {
+  guard parse_child_report(sample_report().to_json()) is Ok(_) else {
+    fail("expected a valid report")
+  }
+  guard parse_child_report({ "answer": "no version" }) is Err(_) else {
+    fail("expected a parse rejection")
+  }
+  guard parse_child_report({ ..sample_report(), answer: "" }.to_json())
+    is Err(_) else {
+    fail("expected a validation rejection")
+  }
+}

--- a/agent_explore/tool_test.mbt
+++ b/agent_explore/tool_test.mbt
@@ -1,0 +1,163 @@
+///|
+/// Mock-endpoint harness for the CHILD-side kind execution (`run_child`
+/// runs the scout's turn in this process, exactly as `openseek subrun
+/// explore` will in a child process). The parent-side spawn/reap path is
+/// covered by the runner's own tests with scripted children.
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}
+
+///|
+async fn explore_test_server(
+  group : @async.TaskGroup[Unit],
+  handle : (Json) -> String raise,
+) -> String? {
+  guard bind_test_server("local TCP bind unavailable; skipping explore test")
+    is Some(server) else {
+    return None
+  }
+  group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        let payload = handle(@json.parse(body.read_all().text()))
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write("data: \{payload}\n\n")
+        conn.write("data: [DONE]\n\n")
+      },
+      max_connections=8,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+fn sse_submit_answer(answer : String, total_tokens : Int) -> String {
+  let report : Json = {
+    "schema_version": 1,
+    "answer": answer,
+    "citations": [{ "file": "protocol/event.mbt", "line": 14 }],
+  }
+  (
+    {
+      "choices": [
+        {
+          "delta": {
+            "tool_calls": [
+              {
+                "index": 0,
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                  "name": "submit_answer",
+                  "arguments": report.stringify(),
+                },
+              },
+            ],
+          },
+        },
+      ],
+      "usage": {
+        "prompt_tokens": total_tokens - 1_000,
+        "completion_tokens": 1_000,
+        "total_tokens": total_tokens,
+      },
+    } : Json).stringify()
+}
+
+///|
+fn sse_plain(content : String, total_tokens : Int) -> String {
+  (
+    {
+      "choices": [{ "delta": { "content": content } }],
+      "usage": {
+        "prompt_tokens": total_tokens - 1_000,
+        "completion_tokens": 1_000,
+        "total_tokens": total_tokens,
+      },
+    } : Json).stringify()
+}
+
+///|
+async test "run_child answers a well-formed input with a cited report" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> String raise = _request => {
+      sse_submit_answer("The Event enum lives in protocol/event.mbt.", 100_000)
+    }
+    guard explore_test_server(group, handle) is Some(url) else { return }
+    let report = @agent_explore.run_child(
+      { "query": "Where is the Event enum defined?", "hints": "protocol/" },
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      max_steps=8,
+      api_url=url,
+    )
+    guard report is Some(report) else { fail("expected a report") }
+    assert_true(report.answer.contains("Event enum lives"))
+    assert_eq(report.citations.length(), 1)
+  }
+}
+
+///|
+async test "run_child returns None when the scout never submits" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> String raise = _request => {
+      sse_plain("plain text, no submit", 100_000)
+    }
+    guard explore_test_server(group, handle) is Some(url) else { return }
+    let report = @agent_explore.run_child(
+      { "query": "unanswerable" },
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      max_steps=2,
+      api_url=url,
+    )
+    assert_true(report is None)
+  }
+}
+
+///|
+async test "run_child rejects malformed input without a model call" {
+  let report = @agent_explore.run_child(
+    { "not_query": 1 },
+    api_key="unused",
+    model=Deepseek(V4Flash),
+    max_steps=2,
+    api_url="http://127.0.0.1:1/unused",
+  )
+  assert_true(report is None)
+}
+
+///|
+/// Input validation and budget refusal both fire BEFORE any child process
+/// exists: a nonexistent self_exe proves nothing was spawned.
+async test "the tool validates input and budget before spawning anything" {
+  let budget = @agent_subrun.SubrunBudget(
+    max_calls_per_turn=1,
+    max_steps_per_turn=100,
+  )
+  let tool = @agent_explore.definition(
+    self_exe="/nonexistent/openseek-not-here",
+    model=Deepseek(V4Flash),
+    workspace_root=".",
+    budget~,
+  )
+  guard tool.execute is Async(execute) else { fail("explore should be async") }
+  let action = execute({ "query": "   " })
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  // The rejection consumed no budget.
+  assert_true(budget.reserve(10) is Some(10))
+}

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -1,0 +1,161 @@
+///|
+/// `ExploreReport` is the bounded, citation-carrying answer an explore child
+/// submits. Every bound here is load-bearing: the rendered result must stay
+/// far below the loop's 60K tool-result clamp AND keep the parent's
+/// char-denominated batch budget honest, so validation — not hope — caps
+/// every field and count.
+
+///|
+/// The schema version this build emits and accepts.
+pub let current_schema_version : Int = 1
+
+///|
+/// Field and count ceilings, enforced by `validate`.
+pub let max_answer_chars : Int = 8_000
+
+///|
+/// Citation-count ceiling, enforced by `validate`.
+pub let max_citations : Int = 20
+
+///|
+/// Per-citation file-path length ceiling.
+pub let max_citation_file_chars : Int = 300
+
+///|
+/// Per-citation note length ceiling.
+pub let max_citation_note_chars : Int = 200
+
+///|
+/// `unresolved` length ceiling.
+pub let max_unresolved_chars : Int = 1_000
+
+///|
+/// One supporting reference: a workspace `file:line`, or the source/`.mbti`
+/// path `moon ide doc` reported for a stdlib or dependency claim.
+pub(all) struct Citation {
+  file : String
+  line : Int?
+  note : String?
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// The child's full answer. `unresolved` names what it could NOT determine —
+/// stated ignorance beats a fabricated claim.
+pub(all) struct ExploreReport {
+  schema_version : Int
+  answer : String
+  citations : Array[Citation]
+  unresolved : String?
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// Validate a report against the contract. Returns the list of problems; an
+/// empty list means the report is valid. The `submit_answer` capture tool
+/// uses this to reject oversized or empty output so the model retries with
+/// a bounded report instead of finishing with an unusable one.
+pub fn ExploreReport::validate(self : ExploreReport) -> Array[String] {
+  let problems : Array[String] = []
+  if self.schema_version != current_schema_version {
+    problems.push(
+      "schema_version must be \{current_schema_version}, got \{self.schema_version}",
+    )
+  }
+  if self.answer.trim() == "" {
+    problems.push("answer must not be empty")
+  }
+  if self.answer.length() > max_answer_chars {
+    problems.push(
+      "answer exceeds \{max_answer_chars} chars (\{self.answer.length()}); tighten it",
+    )
+  }
+  if self.citations.length() > max_citations {
+    problems.push(
+      "at most \{max_citations} citations (\{self.citations.length()} given); keep the strongest",
+    )
+  }
+  for citation in self.citations {
+    if citation.file == "" {
+      problems.push("a citation has an empty file path")
+    }
+    if citation.file.length() > max_citation_file_chars {
+      problems.push(
+        "a citation file path exceeds \{max_citation_file_chars} chars",
+      )
+    }
+    if citation.note is Some(note) && note.length() > max_citation_note_chars {
+      problems.push("a citation note exceeds \{max_citation_note_chars} chars")
+    }
+  }
+  if self.unresolved is Some(unresolved) &&
+    unresolved.length() > max_unresolved_chars {
+    problems.push("unresolved exceeds \{max_unresolved_chars} chars")
+  }
+  problems
+}
+
+///|
+/// Parse a report from JSON, returning the report or a human-readable error.
+pub fn ExploreReport::parse(json : Json) -> Result[ExploreReport, String] {
+  let report : ExploreReport = @json.from_json(json) catch {
+    e => return Err("invalid explore report JSON: \{e}")
+  }
+  Ok(report)
+}
+
+///|
+fn sample_report() -> ExploreReport {
+  {
+    schema_version: 1,
+    answer: "Use @buffer.new(size_hint?) and Buffer::to_bytes.",
+    citations: [
+      { file: "protocol/event.mbt", line: Some(14), note: Some("Event enum") },
+      { file: "moonbitlang/core/buffer", line: None, note: None },
+    ],
+    unresolved: Some("did not check the js backend"),
+  }
+}
+
+///|
+test "explore report round-trips through json" {
+  let report = sample_report()
+  guard ExploreReport::parse(report.to_json()) is Ok(parsed) else {
+    fail("parse failed")
+  }
+  assert_eq(parsed, report)
+}
+
+///|
+test "validate accepts a good report" {
+  assert_eq(sample_report().validate().length(), 0)
+}
+
+///|
+test "validate rejects empties and oversizes" {
+  assert_true({ ..sample_report(), answer: "  " }.validate().length() > 0)
+  assert_true({ ..sample_report(), schema_version: 2 }.validate().length() > 0)
+  let long = StringBuilder()
+  for _ in 0..<(max_answer_chars + 1) {
+    long.write_char('a')
+  }
+  assert_true(
+    { ..sample_report(), answer: long.to_string() }.validate().length() > 0,
+  )
+  let many : Array[Citation] = []
+  for i in 0..<=max_citations {
+    many.push({ file: "f\{i}.mbt", line: None, note: None })
+  }
+  assert_true({ ..sample_report(), citations: many }.validate().length() > 0)
+  assert_true(
+    { ..sample_report(), citations: [{ file: "", line: None, note: None }] }
+    .validate()
+    .length() >
+    0,
+  )
+}
+
+///|
+test "parse reports an error on malformed json" {
+  guard ExploreReport::parse(Json::null()) is Err(_) else {
+    fail("expected parse error")
+  }
+}

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -19,6 +19,11 @@ let default_review_max_steps : Int = 120
 /// pre-build source generation, so the checkout is not guaranteed byte-for-byte
 /// unchanged. Raises `ReviewError` if the model finishes without submitting a
 /// report.
+///
+/// Runs the review kind IN THIS PROCESS via `@agent_subrun.execute_kind`: the
+/// standalone CLI is already a dedicated process, and a future in-session
+/// gate spawns `openseek subrun review` — a child process whose dispatch
+/// calls this same code path.
 pub async fn run_review(
   api_key : String,
   model : @deepseek.Model,
@@ -28,34 +33,25 @@ pub async fn run_review(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
 ) -> ReviewReport {
-  let captured : Ref[ReviewReport?] = { val: None }
-  let tools = @agent_tool.Tools([
-    @read.definition(workspace_root~),
-    @shell.definition(workspace_root~, read_only=true),
-    submit_review_tool(captured),
-  ])
-  let session = @agent_session.Session(
-    @agent_session.SessionId("review"),
+  let report = @agent_subrun.execute_kind(
+    session_id="review",
     system_prompt=review_system_prompt(),
+    task=review_task(base),
+    tools=captured => {
+      @agent_tool.Tools([
+        @read.definition(workspace_root~),
+        @shell.definition(workspace_root~, read_only=true),
+        submit_review_tool(captured),
+      ])
+    },
+    max_steps~,
+    api_key~,
+    model~,
+    thinking~,
+    api_url?,
+    workspace_root~,
   )
-  let task = review_task(base)
-  // Review is read-only and ephemeral; the final session is not persisted.
-  let _ : @agent_session.Session = @async.with_task_group() <| group => {
-    @agent.run_turn_in_scope(
-      runtime=@agent_runtime.AgentRuntime(workspace_root~),
-      scope=@agent_runtime.AgentTaskScope(group),
-      api_key~,
-      model~,
-      session~,
-      task~,
-      append_item=(s, i) => s.append(i),
-      max_steps~,
-      thinking~,
-      api_url?,
-      tools~,
-    )
-  }
-  match captured.val {
+  match report {
     Some(report) => report
     None =>
       raise ReviewError(

--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -13,42 +13,34 @@
 fn submit_review_tool(
   captured : Ref[ReviewReport?],
 ) -> @agent_tool.AgentToolDefinition {
-  AgentToolDefinition(
+  @agent_subrun.capture_tool(
     name="submit_review",
     description="Submit the final structured code-review report and end the review. Call this exactly once, when the review is complete. Every finding must cite a file (and a line when known) and a severity of blocker|high|medium|low|nit.",
     schema=JsonSchema(report_schema()),
-    execute=Sync(args => submit(captured, args)),
-    control=true,
+    parse=parse_submission,
+    captured,
+    finished_note=report => {
+      "review submitted (\{report.findings.length()} finding(s))"
+    },
   )
 }
 
 ///|
-fn submit(captured : Ref[ReviewReport?], args : Json) -> @agent_tool.ToolAction {
+/// Parse-and-validate for the capture tool: JSON decode problems and contract
+/// violations both reject, so the model retries instead of finishing with no
+/// report.
+fn parse_submission(args : Json) -> Result[ReviewReport, Array[String]] {
   match ReviewReport::parse(args) {
-    Err(msg) => reject(msg)
+    Err(msg) => Err([msg])
     Ok(report) => {
       let problems = report.validate()
       if problems.length() > 0 {
-        reject(problems.join("; "))
+        Err(problems)
       } else {
-        captured.val = Some(report)
-        @agent_tool.ToolAction::finish(
-          "review submitted (\{report.findings.length()} finding(s))",
-        )
+        Ok(report)
       }
     }
   }
-}
-
-///|
-/// Reject malformed `submit_review` output with an error response so the model
-/// retries instead of finishing with no report.
-fn reject(reason : String) -> @agent_tool.ToolAction {
-  @agent_tool.ToolAction::respond(
-    "submit_review rejected: \{reason}",
-    is_error=true,
-    brief="submit_review",
-  )
 }
 
 ///|
@@ -103,6 +95,18 @@ fn report_schema() -> Json {
 }
 
 ///|
+/// Run the submit tool's Sync executor directly, as the loop would.
+fn submit_action(
+  captured : Ref[ReviewReport?],
+  args : Json,
+) -> @agent_tool.ToolAction raise {
+  guard submit_review_tool(captured).execute is Sync(execute) else {
+    fail("submit_review should be a Sync executor")
+  }
+  execute(args)
+}
+
+///|
 test "submit_review declares itself a control tool" {
   // The ceiling salvage honors control-declared completions; without this
   // a review hitting the context ceiling on its submitting step would
@@ -114,8 +118,9 @@ test "submit_review declares itself a control tool" {
 ///|
 test "submit captures a valid report and finishes" {
   let captured : Ref[ReviewReport?] = { val: None }
-  let action = submit(captured, sample_report().to_json())
-  guard action is Control(Finish(_)) else { fail("expected Finish") }
+  let action = submit_action(captured, sample_report().to_json())
+  guard action is Control(Finish(note)) else { fail("expected Finish") }
+  assert_true(note.contains("2 finding(s)"))
   guard captured.val is Some(_) else { fail("expected captured report") }
 }
 
@@ -136,8 +141,9 @@ test "submit rejects an invalid report without capturing" {
       },
     ],
   }
-  let action = submit(captured, bad.to_json())
+  let action = submit_action(captured, bad.to_json())
   guard action is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
+  assert_true(output.content.contains("submit_review rejected"))
   guard captured.val is None else { fail("must not capture an invalid report") }
 }

--- a/agent_subrun/README.mbt.md
+++ b/agent_subrun/README.mbt.md
@@ -1,0 +1,30 @@
+# agent_subrun
+
+The substrate for subagents in DEDICATED CHILD PROCESSES. A sub-run spawns
+the engine's own binary as `openseek subrun <kind>`, writes one JSON input
+line on stdin (holding the pipe open — closing it is the graceful-cancel
+signal), drains the child's standard JSONL event stream for exact cost
+accounting, and captures the final `{"subrun_report": ...}` line. Parent and
+child are the same binary, so the report's derived `to_json`/`from_json`
+codecs cannot drift: the process boundary still carries a typed channel.
+
+Layers:
+
+- `run_subrun` (parent side): spawn/drain/deadline/teardown. The wall
+  deadline closes stdin and grants `cancel_grace_ms` before terminating; a
+  report arriving in the grace window still counts. External cancellation
+  re-raises — never folded into a terminal. Crash isolation is structural:
+  a dead child is a `Failed` result, not a dead engine.
+- `execute_kind` (child side): one bounded turn with a restricted toolset
+  and a `capture_tool` submit channel — run by the `subrun` child mode, by
+  the standalone review CLI (already its own process), and by unit tests
+  (the full capture/retry/ceiling-salvage lifecycle needs no spawning).
+- `SubrunBudget`: the per-turn allowance shared by every subrun tool,
+  reserve-before-launch with post-run reconciliation.
+- `capture_tool`: parse/validate, reject-with-retry, capture +
+  `Control(Finish)`, `control=true` so the loop's ceiling salvage honors a
+  pending submission.
+
+Known limits: a hard-killed child can orphan its own tool subprocesses (the
+upstream group-kill gap) — the stdin-EOF grace path is the mitigation;
+Windows support is deferred with background jobs.

--- a/agent_subrun/README.md
+++ b/agent_subrun/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_subrun/budget.mbt
+++ b/agent_subrun/budget.mbt
@@ -1,0 +1,137 @@
+///|
+/// Below this many remaining steps a child cannot do useful work (read a few
+/// files and submit), so `reserve` refuses rather than launching a doomed
+/// run that burns its allowance on a truncated attempt.
+pub let min_useful_subrun_steps : Int = 8
+
+///|
+/// The per-turn allowance shared by EVERY subrun tool in a session (explore,
+/// the goal-review gate, callable review): one child must not be able to
+/// stretch a turn unboundedly, and the tools must not each carry a private
+/// quota that sums to one.
+///
+/// The owner is the CLI layer: it creates one budget per session, passes it
+/// to every subrun tool definition, and calls `reset_turn` at each turn
+/// start. Enforcement is reserve-BEFORE-launch: the executor reserves the
+/// child's requested steps up front — deriving the child's effective
+/// `max_steps` from what remains — and `reconcile`s the unused part after
+/// the run. Debit-only-after-return would let one child overshoot the whole
+/// remaining allowance.
+pub struct SubrunBudget {
+  max_calls_per_turn : Int
+  max_steps_per_turn : Int
+  mut used_calls : Int
+  mut reserved_steps : Int
+}
+
+///|
+/// Defaults sized for explore-style children: a few delegations per turn,
+/// each bounded well below a whole child allowance.
+pub fn SubrunBudget::SubrunBudget(
+  max_calls_per_turn? : Int = 4,
+  max_steps_per_turn? : Int = 120,
+) -> SubrunBudget {
+  { max_calls_per_turn, max_steps_per_turn, used_calls: 0, reserved_steps: 0 }
+}
+
+///|
+/// Start a new parent turn: the allowance refills.
+pub fn SubrunBudget::reset_turn(self : SubrunBudget) -> Unit {
+  self.used_calls = 0
+  self.reserved_steps = 0
+}
+
+///|
+/// Reserve capacity for one child BEFORE launching it. Returns the child's
+/// effective step ceiling — `requested_steps` clamped to the remaining
+/// allowance — or `None` when the per-turn call count is spent or the
+/// remaining steps could not fund a useful run. The reservation holds until
+/// `reconcile` returns the unused portion.
+pub fn SubrunBudget::reserve(
+  self : SubrunBudget,
+  requested_steps : Int,
+) -> Int? {
+  if self.used_calls >= self.max_calls_per_turn {
+    return None
+  }
+  let remaining = self.max_steps_per_turn - self.reserved_steps
+  if remaining < min_useful_subrun_steps {
+    return None
+  }
+  let effective = if requested_steps < remaining {
+    requested_steps
+  } else {
+    remaining
+  }
+  self.used_calls += 1
+  self.reserved_steps += effective
+  Some(effective)
+}
+
+///|
+/// Return a reservation's unused part after the child ran. `reserved` is
+/// what `reserve` granted; `used` is the child's actual `steps_used` (from
+/// its `SubrunResult`). Steps the child never took flow back into the
+/// turn's allowance; the call count does not.
+pub fn SubrunBudget::reconcile(
+  self : SubrunBudget,
+  reserved~ : Int,
+  used~ : Int,
+) -> Unit {
+  let spent = if used < 0 {
+    0
+  } else if used > reserved {
+    reserved
+  } else {
+    used
+  }
+  self.reserved_steps -= reserved - spent
+}
+
+///|
+test "reserve clamps to the remaining allowance and refuses dust" {
+  let budget = SubrunBudget(max_calls_per_turn=3, max_steps_per_turn=50)
+  // First reservation: full request fits.
+  assert_true(budget.reserve(40) is Some(40))
+  // Second: only 10 remain, clamped.
+  assert_true(budget.reserve(40) is Some(10))
+  // Third: nothing useful remains.
+  assert_true(budget.reserve(40) is None)
+}
+
+///|
+test "the call count is its own ceiling" {
+  let budget = SubrunBudget(max_calls_per_turn=2, max_steps_per_turn=1_000)
+  assert_true(budget.reserve(10) is Some(10))
+  assert_true(budget.reserve(10) is Some(10))
+  assert_true(budget.reserve(10) is None)
+}
+
+///|
+test "reconcile returns unused steps but never the call slot" {
+  let budget = SubrunBudget(max_calls_per_turn=2, max_steps_per_turn=40)
+  guard budget.reserve(30) is Some(granted) else { fail("expected a grant") }
+  // The child used 5 of its 30: 25 flow back.
+  budget.reconcile(reserved=granted, used=5)
+  assert_true(budget.reserve(40) is Some(35))
+  // Both call slots are now spent regardless of steps returned.
+  assert_true(budget.reserve(10) is None)
+}
+
+///|
+test "reset_turn refills everything" {
+  let budget = SubrunBudget(max_calls_per_turn=1, max_steps_per_turn=20)
+  assert_true(budget.reserve(20) is Some(20))
+  assert_true(budget.reserve(20) is None)
+  budget.reset_turn()
+  assert_true(budget.reserve(20) is Some(20))
+}
+
+///|
+test "reconcile clamps a pathological used count" {
+  let budget = SubrunBudget(max_calls_per_turn=2, max_steps_per_turn=30)
+  guard budget.reserve(20) is Some(granted) else { fail("expected a grant") }
+  // used > reserved must not mint steps; used < 0 must not either.
+  budget.reconcile(reserved=granted, used=99)
+  assert_true(budget.reserve(30) is Some(10))
+}

--- a/agent_subrun/budget.mbt
+++ b/agent_subrun/budget.mbt
@@ -51,6 +51,11 @@ pub fn SubrunBudget::reserve(
   self : SubrunBudget,
   requested_steps : Int,
 ) -> Int? {
+  // A request below the useful floor (including a pathological negative one,
+  // which would MINT steps through the clamp) is refused outright.
+  if requested_steps < min_useful_subrun_steps {
+    return None
+  }
   if self.used_calls >= self.max_calls_per_turn {
     return None
   }
@@ -134,4 +139,13 @@ test "reconcile clamps a pathological used count" {
   // used > reserved must not mint steps; used < 0 must not either.
   budget.reconcile(reserved=granted, used=99)
   assert_true(budget.reserve(30) is Some(10))
+}
+
+///|
+test "a pathological reserve request cannot mint steps" {
+  let budget = SubrunBudget(max_calls_per_turn=2, max_steps_per_turn=30)
+  assert_true(budget.reserve(-50) is None)
+  assert_true(budget.reserve(0) is None)
+  // The refusals consumed nothing.
+  assert_true(budget.reserve(30) is Some(30))
 }

--- a/agent_subrun/capture.mbt
+++ b/agent_subrun/capture.mbt
@@ -1,0 +1,40 @@
+///|
+/// Build a submit-style capture tool: the child calls it exactly once with
+/// its structured result; `parse` validates, a valid value is captured into
+/// the runner-owned ref, and the run ends via `Control(Finish)`. Invalid
+/// output is rejected with an error result so the model retries instead of
+/// finishing with nothing.
+///
+/// Declared a control tool: its action is loop flow with a few bytes of
+/// result, so the context-ceiling salvage honors a pending capture instead
+/// of skip-closing it — without this, a child hitting the ceiling on its
+/// submitting step would lose its finished result.
+pub fn[T] capture_tool(
+  name~ : String,
+  description~ : String,
+  schema~ : @agent_tool.JsonSchema,
+  parse~ : (Json) -> Result[T, Array[String]],
+  captured : Ref[T?],
+  finished_note? : (T) -> String = _value => "submitted",
+) -> @agent_tool.AgentToolDefinition {
+  @agent_tool.AgentToolDefinition(
+    name~,
+    description~,
+    schema~,
+    execute=Sync(args => {
+      match parse(args) {
+        Err(problems) =>
+          @agent_tool.ToolAction::respond(
+            "\{name} rejected: \{problems.join("; ")}",
+            is_error=true,
+            brief=name,
+          )
+        Ok(value) => {
+          captured.val = Some(value)
+          @agent_tool.ToolAction::finish(finished_note(value))
+        }
+      }
+    }),
+    control=true,
+  )
+}

--- a/agent_subrun/child.mbt
+++ b/agent_subrun/child.mbt
@@ -1,0 +1,76 @@
+///|
+/// The CHILD-side executor: run one bounded agent turn in THIS process with a
+/// restricted toolset and a structured value captured through a submit-style
+/// control tool. Three callers share it: the `openseek subrun <kind>` child
+/// mode (where this process IS the sub-run), the standalone review CLI (its
+/// own process by construction), and kind-internals unit tests (which get
+/// the full lifecycle — capture, reject-retry, ceiling salvage — against a
+/// mock endpoint without spawning anything).
+///
+/// Parent-side concerns deliberately absent: the wall deadline, cost
+/// accounting, and terminal classification live in the process runner
+/// (`run_subrun`), which observes this process from outside through its
+/// event stream and exit. Events go to the process log as always — in a
+/// child process, stdout IS the report channel the parent reads.
+pub async fn[T] execute_kind(
+  session_id~ : String,
+  system_prompt~ : String,
+  task~ : String,
+  tools~ : (Ref[T?]) -> @agent_tool.Tools raise,
+  max_steps~ : Int,
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  thinking? : @deepseek.ThinkingMode = Max,
+  api_url? : String,
+  workspace_root? : String = ".",
+) -> T? {
+  let captured : Ref[T?] = { val: None }
+  let tools = tools(captured)
+  let session = @agent_session.Session(
+    @agent_session.SessionId(session_id),
+    system_prompt~,
+  )
+  let _ : @agent_session.Session = @async.with_task_group() <| group => {
+    @agent.run_turn_in_scope(
+      runtime=@agent_runtime.AgentRuntime(workspace_root~),
+      scope=@agent_runtime.AgentTaskScope(group),
+      api_key~,
+      model~,
+      session~,
+      task~,
+      append_item=(session, item) => session.append(item),
+      max_steps~,
+      thinking~,
+      api_url?,
+      tools~,
+    )
+  }
+  captured.val
+}
+
+///|
+/// The distinguished final line a child writes after its turn: the typed
+/// report. Parent and child are the same binary, so the derived
+/// `to_json`/`from_json` pair on the report type cannot drift — this line is
+/// a typed channel despite the process boundary.
+pub fn report_line(report : Json) -> String {
+  ({ "subrun_report": report } : Json).stringify()
+}
+
+///|
+/// The report a parent extracts from one child stdout line, or `None` for
+/// every other line (protocol events, stray output).
+pub fn parse_report_line(line : Json) -> Json? {
+  match line {
+    { "subrun_report": report, .. } => Some(report)
+    _ => None
+  }
+}
+
+///|
+test "report lines round-trip and ordinary lines are not reports" {
+  let report : Json = { "answer": "x" }
+  let line = @json.parse(report_line(report))
+  assert_eq(parse_report_line(line), Some(report))
+  assert_eq(parse_report_line({ "event": "agent_step", "step": 1 }), None)
+}

--- a/agent_subrun/child_test.mbt
+++ b/agent_subrun/child_test.mbt
@@ -1,0 +1,246 @@
+///|
+/// Mock-endpoint harness for the child-side executor: `execute_kind` runs
+/// the kind's turn in THIS process, exactly as the `openseek subrun` child
+/// mode does — so the full internal lifecycle (capture, reject-retry,
+/// ceiling salvage) is unit-testable without spawning anything.
+priv enum MockReply {
+  Sse(String)
+  Body(Json)
+}
+
+///|
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}
+
+///|
+async fn child_test_server(
+  group : @async.TaskGroup[Unit],
+  handle : (Json) -> MockReply raise,
+) -> String? {
+  guard bind_test_server("local TCP bind unavailable; skipping child test")
+    is Some(server) else {
+    return None
+  }
+  group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => {
+        assert_eq(request.path, "/chat/completions")
+        match handle(@json.parse(body.read_all().text())) {
+          Sse(payload) => {
+            conn.send_response(200, "OK", extra_headers={
+              "Content-Type": "text/event-stream",
+            })
+            conn.write("data: \{payload}\n\n")
+            conn.write("data: [DONE]\n\n")
+          }
+          Body(json) => {
+            conn.send_response(200, "OK", extra_headers={
+              "Content-Type": "application/json",
+            })
+            conn.write(json.stringify())
+          }
+        }
+      },
+      max_connections=8,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}
+
+///|
+fn usage_json(total_tokens : Int) -> Json {
+  {
+    "prompt_tokens": total_tokens - 1_000,
+    "completion_tokens": 1_000,
+    "total_tokens": total_tokens,
+  }
+}
+
+///|
+fn sse_tool_calls(
+  calls : Array[(String, String, String)],
+  total_tokens : Int,
+) -> String {
+  let entries : Array[Json] = [
+    for index, call in calls => {
+      let (id, name, arguments) = call
+      (
+        {
+          "index": index,
+          "id": id,
+          "type": "function",
+          "function": { "name": name, "arguments": arguments },
+        } : Json)
+    }
+  ]
+  (
+    {
+      "choices": [{ "delta": { "tool_calls": entries.to_json() } }],
+      "usage": usage_json(total_tokens),
+    } : Json).stringify()
+}
+
+///|
+fn sse_final(content : String, total_tokens : Int) -> String {
+  (
+    {
+      "choices": [{ "delta": { "content": content } }],
+      "usage": usage_json(total_tokens),
+    } : Json).stringify()
+}
+
+///|
+fn is_checkpoint_request(request : Json) -> Bool {
+  guard request is { "messages": Array(messages), .. } &&
+    messages.last() is Some({ "content": String(content), .. }) else {
+    return false
+  }
+  !(request is { "stream": True, .. }) &&
+  content.contains("CONTEXT CHECKPOINT COMPACTION")
+}
+
+///|
+/// The standard kind under test: one `submit` capture tool expecting
+/// `{"answer": <string>}`, plus a plain probe tool.
+async fn run_answer_kind(
+  url : String,
+  session_id : String,
+  max_steps? : Int = 8,
+) -> String? {
+  @agent_subrun.execute_kind(
+    session_id~,
+    system_prompt="You are a test subagent.",
+    task="Answer via the submit tool.",
+    tools=captured => {
+      @agent_tool.Tools([
+        @agent_subrun.capture_tool(
+          name="submit",
+          description="Submit the final answer.",
+          schema=JsonSchema({ "type": "object" }),
+          parse=args => {
+            match args {
+              { "answer": String(answer), .. } => Ok(answer)
+              _ => Err(["answer must be a string"])
+            }
+          },
+          captured,
+        ),
+        AgentToolDefinition(
+          name="probe",
+          description="Probe tool.",
+          schema=JsonSchema({ "type": "object" }),
+          execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+        ),
+      ])
+    },
+    max_steps~,
+    api_key="test-key",
+    model=Deepseek(V4Flash),
+    api_url=url,
+  )
+}
+
+///|
+async test "a valid submission is captured" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = _request => {
+      Sse(
+        sse_tool_calls(
+          [("call_1", "submit", "{\"answer\": \"forty-two\"}")],
+          100_000,
+        ),
+      )
+    }
+    guard child_test_server(group, handle) is Some(url) else { return }
+    assert_true(run_answer_kind(url, "capture") is Some("forty-two"))
+  }
+}
+
+///|
+async test "a rejected submission is retried and then captured" {
+  @async.with_task_group() <| group => {
+    let mut step = 0
+    let handle : (Json) -> MockReply raise = _request => {
+      step += 1
+      if step == 1 {
+        Sse(sse_tool_calls([("call_1", "submit", "{\"answer\": 7}")], 100_000))
+      } else {
+        Sse(
+          sse_tool_calls(
+            [("call_2", "submit", "{\"answer\": \"second try\"}")],
+            110_000,
+          ),
+        )
+      }
+    }
+    guard child_test_server(group, handle) is Some(url) else { return }
+    assert_true(run_answer_kind(url, "retry") is Some("second try"))
+  }
+}
+
+///|
+async test "a run that never captures returns None" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = _request => {
+      Sse(sse_final("plain answer, no submit", 100_000))
+    }
+    guard child_test_server(group, handle) is Some(url) else { return }
+    assert_true(run_answer_kind(url, "no-report") is None)
+  }
+}
+
+///|
+async test "step exhaustion without a capture returns None" {
+  @async.with_task_group() <| group => {
+    let mut step = 0
+    let handle : (Json) -> MockReply raise = _request => {
+      step += 1
+      Sse(sse_tool_calls([("call_\{step}", "probe", "{}")], 100_000))
+    }
+    guard child_test_server(group, handle) is Some(url) else { return }
+    assert_true(run_answer_kind(url, "max-steps", max_steps=2) is None)
+  }
+}
+
+///|
+/// The A1 interlock: at the context ceiling a pending capture call is
+/// salvaged (control-declared), so the child seals with its report instead
+/// of losing it to a skip-close.
+async test "a capture at the context ceiling is salvaged" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = request => {
+      if is_checkpoint_request(request) {
+        Body({
+          "choices": [
+            { "message": { "role": "assistant", "content": "SUMMARY" } },
+          ],
+        })
+      } else {
+        Sse(
+          sse_tool_calls(
+            [
+              ("call_1", "probe", "{}"),
+              ("call_2", "submit", "{\"answer\": \"under pressure\"}"),
+            ],
+            900_000,
+          ),
+        )
+      }
+    }
+    guard child_test_server(group, handle) is Some(url) else { return }
+    assert_true(
+      run_answer_kind(url, "ceiling-capture") is Some("under pressure"),
+    )
+  }
+}

--- a/agent_subrun/moon.pkg
+++ b/agent_subrun/moon.pkg
@@ -1,0 +1,22 @@
+import {
+  "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+  "bobzhang/openseek_protocol" @protocol,
+  "moonbitlang/async",
+  "moonbitlang/async/process",
+  "moonbitlang/async/io",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/json",
+} for "test"
+
+supported_targets = "+native"

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -1,0 +1,65 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_subrun"
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/ref",
+}
+
+// Values
+pub let cancel_grace_ms : Int
+
+pub fn[T] capture_tool(name~ : String, description~ : String, schema~ : @agent_tool.JsonSchema, parse~ : (Json) -> Result[T, Array[String]], @ref.Ref[T?], finished_note? : (T) -> String) -> @agent_tool.AgentToolDefinition
+
+pub async fn[T] execute_kind(session_id~ : String, system_prompt~ : String, task~ : String, tools~ : (@ref.Ref[T?]) -> @agent_tool.Tools raise, max_steps~ : Int, api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> T?
+
+pub let min_useful_subrun_steps : Int
+
+pub fn parse_report_line(Json) -> Json?
+
+pub fn report_line(Json) -> String
+
+pub async fn[T] run_subrun(command~ : String, args~ : Array[String], input~ : Json, parse_report~ : (Json) -> Result[T, String], wall_deadline_ms~ : Int, cwd? : String) -> SubrunResult[T]
+
+// Errors
+
+// Types and methods
+pub struct SubrunBudget {
+  max_calls_per_turn : Int
+  max_steps_per_turn : Int
+  mut used_calls : Int
+  mut reserved_steps : Int
+}
+pub fn SubrunBudget::SubrunBudget(max_calls_per_turn? : Int, max_steps_per_turn? : Int) -> Self
+pub fn SubrunBudget::reconcile(Self, reserved~ : Int, used~ : Int) -> Unit
+pub fn SubrunBudget::reserve(Self, Int) -> Int?
+pub fn SubrunBudget::reset_turn(Self) -> Unit
+
+pub struct SubrunResult[T] {
+  value : T?
+  terminal : SubrunTerminal
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+} derive(@debug.Debug)
+pub fn[T] SubrunResult::completion_tokens(Self[T]) -> Int
+pub fn[T] SubrunResult::prompt_tokens(Self[T]) -> Int
+pub fn[T] SubrunResult::steps_used(Self[T]) -> Int
+pub fn[T] SubrunResult::terminal(Self[T]) -> SubrunTerminal
+pub fn[T] SubrunResult::value(Self[T]) -> T?
+
+pub(all) enum SubrunTerminal {
+  Captured
+  NoReport
+  MaxSteps
+  ContextYield
+  TimedOut
+  Failed(String)
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits
+

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -111,8 +111,9 @@ fn ChildObservations::observe(self : ChildObservations, line : String) -> Unit {
     }
     Some(MaxStepsExhausted) => self.max_steps_exhausted = true
     Some(ContextYield(..)) => self.context_yield = true
-    Some(TurnFailed(error~)) | Some(AgentSetupFailed(error~)) =>
-      self.failure = Some(error)
+    Some(TurnFailed(error~))
+    | Some(AgentSetupFailed(error~))
+    | Some(CommandError(error~)) => self.failure = Some(error)
     Some(AgentAborted(reason~)) => self.failure = Some(reason)
     _ => ()
   }
@@ -202,12 +203,30 @@ pub async fn[T] run_subrun(
         observations.observe(line)
       }
     }
-    try {
+    async fn feed_and_drain() -> Unit {
       // One input line; the pipe stays open — EOF is the cancel signal, not
-      // the end of input.
+      // the end of input. The write sits INSIDE the deadline scope: an input
+      // larger than the pipe capacity against a child that never reads must
+      // hit the wall deadline, not block forever (review finding).
       stdin_writer.write("\{input.stringify()}\n")
-      match @async.with_timeout_opt(wall_deadline_ms, drain) {
-        Some(_) => ()
+      drain()
+    }
+    try {
+      match @async.with_timeout_opt(wall_deadline_ms, feed_and_drain) {
+        Some(_) =>
+          // Clean EOF: the child closed stdout. Read its exit status — a
+          // crash-class failure (panic, signal, nonzero exit) emits no
+          // failure event, and without this the runner is structurally
+          // blind to it and would misclassify the run as NoReport. Bounded:
+          // a child that closed stdout but lingers falls through to the
+          // cancel below.
+          match @async.with_timeout_opt(2_000, () => process.wait()) {
+            Some(code) if code != 0 &&
+              observations.report is None &&
+              observations.failure is None =>
+              observations.failure = Some("subrun exited \{code}")
+            _ => ()
+          }
         None => {
           // Deadline: graceful cancel first — close stdin, let the child
           // flush; a report arriving in the grace window still counts.

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -1,0 +1,271 @@
+///|
+/// After the wall deadline closes the child's stdin (the graceful-cancel
+/// signal), the child gets this long to flush and exit before the runner
+/// terminates it. A well-behaved child cancels its turn on EOF and exits
+/// quickly; the kill is the backstop.
+pub let cancel_grace_ms : Int = 5_000
+
+///|
+/// How a sub-run ended. External cancellation of the CALLER is deliberately
+/// not a terminal: it re-raises out of `run_subrun` (tearing the child down
+/// on the way) so structured concurrency sees it, per the engine-wide rule
+/// that cancellation is never folded into an ordinary failure.
+pub(all) enum SubrunTerminal {
+  /// The child submitted a valid report before exiting.
+  Captured
+  /// The child exited cleanly without ever submitting a report.
+  NoReport
+  /// The child exhausted its step budget without a report.
+  MaxSteps
+  /// The child yielded at its context ceiling without a report.
+  ContextYield
+  /// The runner's wall deadline expired: stdin was closed (graceful cancel)
+  /// and the child was terminated after the grace period. A report that
+  /// arrived before the cut still reports `Captured`.
+  TimedOut
+  /// The child failed: spawn failure, a turn/setup failure it reported, a
+  /// garbled report, or an exit with none of the above observed.
+  Failed(String)
+} derive(Debug, Eq)
+
+///|
+/// The outcome of one sub-run: the parsed report when there is one, plus the
+/// cost the child actually spent — observed from the child's own event
+/// stream (`usage` summed, `agent_step` maxed), so it is exact for the
+/// requests the child made.
+pub struct SubrunResult[T] {
+  value : T?
+  terminal : SubrunTerminal
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+} derive(Debug)
+
+///|
+/// The parsed report, when the child submitted one.
+pub fn[T] SubrunResult::value(self : SubrunResult[T]) -> T? {
+  self.value
+}
+
+///|
+/// How the sub-run ended.
+pub fn[T] SubrunResult::terminal(self : SubrunResult[T]) -> SubrunTerminal {
+  self.terminal
+}
+
+///|
+/// Model requests the child actually made.
+pub fn[T] SubrunResult::steps_used(self : SubrunResult[T]) -> Int {
+  self.steps_used
+}
+
+///|
+/// Provider prompt tokens the child consumed, summed over its requests.
+pub fn[T] SubrunResult::prompt_tokens(self : SubrunResult[T]) -> Int {
+  self.prompt_tokens
+}
+
+///|
+/// Provider completion tokens the child consumed, summed over its requests.
+pub fn[T] SubrunResult::completion_tokens(self : SubrunResult[T]) -> Int {
+  self.completion_tokens
+}
+
+///|
+/// What the runner accumulates while draining the child's stdout.
+priv struct ChildObservations {
+  mut steps : Int
+  mut prompt_tokens : Int
+  mut completion_tokens : Int
+  mut max_steps_exhausted : Bool
+  mut context_yield : Bool
+  mut failure : String?
+  mut report : Json?
+  mut garbled_report : String?
+}
+
+///|
+/// Classify one child stdout line. The child's stdout carries its xlog JSONL
+/// event stream (each line an envelope whose event fields are hoisted to the
+/// top level — `@protocol.parse` reads exactly that shape) and, last, the
+/// distinguished `{"subrun_report": ...}` line. Non-JSON lines are skipped:
+/// a tool subprocess that leaks to stdout must not poison the run.
+fn ChildObservations::observe(self : ChildObservations, line : String) -> Unit {
+  let trimmed = line.trim(chars="\r\n")
+  if trimmed == "" {
+    return
+  }
+  guard (Some(@json.parse(trimmed.to_owned())) catch { _ => None })
+    is Some(json) else {
+    return
+  }
+  if parse_report_line(json) is Some(report) {
+    self.report = Some(report)
+    return
+  }
+  match @protocol.parse(json) {
+    Some(AgentStep(step~)) => if step > self.steps { self.steps = step }
+    Some(Usage(usage~)) => {
+      self.prompt_tokens += usage.prompt_tokens
+      self.completion_tokens += usage.completion_tokens
+    }
+    Some(MaxStepsExhausted) => self.max_steps_exhausted = true
+    Some(ContextYield(..)) => self.context_yield = true
+    Some(TurnFailed(error~)) | Some(AgentSetupFailed(error~)) =>
+      self.failure = Some(error)
+    Some(AgentAborted(reason~)) => self.failure = Some(reason)
+    _ => ()
+  }
+}
+
+///|
+/// Run one sub-run in a DEDICATED CHILD PROCESS and report what happened and
+/// what it cost.
+///
+/// `command`/`args` name the child — in production the parent's own
+/// executable with `["subrun", <kind>, ...]` (same binary, so the report's
+/// derived JSON codecs cannot drift), in tests any script that speaks the
+/// contract. The runner writes `input` as one JSON line on the child's
+/// stdin and HOLDS THE PIPE OPEN: closing it is the graceful-cancel signal.
+/// It drains the child's stdout, summing `usage` and `agent_step` events
+/// for cost and capturing the final `{"subrun_report": ...}` line, which
+/// `parse_report` turns into the typed value (rejects become `Failed`).
+///
+/// Deadline: after `wall_deadline_ms` the runner closes stdin and gives the
+/// child `cancel_grace_ms` to flush and exit — a report that lands during
+/// the grace still counts — then terminates it. External cancellation of
+/// the caller re-raises after teardown; it is never folded into a terminal.
+pub async fn[T] run_subrun(
+  command~ : String,
+  args~ : Array[String],
+  input~ : Json,
+  parse_report~ : (Json) -> Result[T, String],
+  wall_deadline_ms~ : Int,
+  cwd? : String,
+) -> SubrunResult[T] {
+  let observations = ChildObservations::{
+    steps: 0,
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    max_steps_exhausted: false,
+    context_yield: false,
+    failure: None,
+    report: None,
+    garbled_report: None,
+  }
+  let mut timed_out = false
+  @async.with_task_group() <| group => {
+    let (child_stdin, stdin_writer) = @process.write_to_process() catch {
+      error if @async.is_being_cancelled() => raise error
+      error => {
+        observations.failure = Some("subrun pipes unavailable: \{error}")
+        return
+      }
+    }
+    let (stdout_reader, child_stdout) = @process.read_from_process() catch {
+      error if @async.is_being_cancelled() => {
+        stdin_writer.close()
+        raise error
+      }
+      error => {
+        stdin_writer.close()
+        observations.failure = Some("subrun pipes unavailable: \{error}")
+        return
+      }
+    }
+    // `no_wait`: the group terminates the child at teardown rather than
+    // waiting for an exit that may only come once its stdin is closed.
+    let process = @process.spawn(
+      group,
+      command,
+      args,
+      inherit_env=true,
+      stdin=child_stdin,
+      stdout=child_stdout,
+      cwd?=cwd.map(dir => dir.view()),
+      no_wait=true,
+    ) catch {
+      error if @async.is_being_cancelled() => {
+        stdout_reader.close()
+        stdin_writer.close()
+        raise error
+      }
+      error => {
+        stdout_reader.close()
+        stdin_writer.close()
+        observations.failure = Some("subrun spawn failed: \{error}")
+        return
+      }
+    }
+    async fn drain() -> Unit {
+      while stdout_reader.read_until("\n") is Some(line) {
+        observations.observe(line)
+      }
+    }
+    try {
+      // One input line; the pipe stays open — EOF is the cancel signal, not
+      // the end of input.
+      stdin_writer.write("\{input.stringify()}\n")
+      match @async.with_timeout_opt(wall_deadline_ms, drain) {
+        Some(_) => ()
+        None => {
+          // Deadline: graceful cancel first — close stdin, let the child
+          // flush; a report arriving in the grace window still counts.
+          timed_out = true
+          stdin_writer.close()
+          let _ = @async.with_timeout_opt(cancel_grace_ms, drain)
+        }
+      }
+    } catch {
+      error => {
+        // External cancellation (or a pipe failure): tear the child down and
+        // re-raise cancellation; fold anything else into the terminal.
+        @async.protect_from_cancel(() => {
+          stdout_reader.close()
+          stdin_writer.close()
+          process.cancel()
+        })
+        if @async.is_being_cancelled() {
+          raise error
+        }
+        if observations.failure is None {
+          observations.failure = Some("subrun stream failed: \{error}")
+        }
+        return
+      }
+    }
+    stdout_reader.close()
+    stdin_writer.close()
+    process.cancel()
+  }
+  let value : T? = match observations.report {
+    Some(report) =>
+      match parse_report(report) {
+        Ok(value) => Some(value)
+        Err(problem) => {
+          observations.garbled_report = Some(problem)
+          None
+        }
+      }
+    None => None
+  }
+  let terminal = match (value, observations.garbled_report) {
+    (Some(_), _) => Captured
+    (None, Some(problem)) => Failed("subrun report rejected: \{problem}")
+    (None, None) =>
+      match observations.failure {
+        Some(error) => Failed(error)
+        None if timed_out => TimedOut
+        None if observations.max_steps_exhausted => MaxSteps
+        None if observations.context_yield => ContextYield
+        None => NoReport
+      }
+  }
+  {
+    value,
+    terminal,
+    steps_used: observations.steps,
+    prompt_tokens: observations.prompt_tokens,
+    completion_tokens: observations.completion_tokens,
+  }
+}

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -155,107 +155,122 @@ pub async fn[T] run_subrun(
     garbled_report: None,
   }
   let mut timed_out = false
-  @async.with_task_group() <| group => {
-    let (child_stdin, stdin_writer) = @process.write_to_process() catch {
-      error if @async.is_being_cancelled() => raise error
-      error => {
-        observations.failure = Some("subrun pipes unavailable: \{error}")
-        return
-      }
-    }
-    let (stdout_reader, child_stdout) = @process.read_from_process() catch {
-      error if @async.is_being_cancelled() => {
-        stdin_writer.close()
-        raise error
-      }
-      error => {
-        stdin_writer.close()
-        observations.failure = Some("subrun pipes unavailable: \{error}")
-        return
-      }
-    }
-    // `no_wait`: the group terminates the child at teardown rather than
-    // waiting for an exit that may only come once its stdin is closed.
-    let process = @process.spawn(
-      group,
-      command,
-      args,
-      inherit_env=true,
-      stdin=child_stdin,
-      stdout=child_stdout,
-      cwd?=cwd.map(dir => dir.view()),
-      no_wait=true,
-    ) catch {
-      error if @async.is_being_cancelled() => {
-        stdout_reader.close()
-        stdin_writer.close()
-        raise error
-      }
-      error => {
-        stdout_reader.close()
-        stdin_writer.close()
-        observations.failure = Some("subrun spawn failed: \{error}")
-        return
-      }
-    }
-    async fn drain() -> Unit {
-      while stdout_reader.read_until("\n") is Some(line) {
-        observations.observe(line)
-      }
-    }
-    async fn feed_and_drain() -> Unit {
-      // One input line; the pipe stays open — EOF is the cancel signal, not
-      // the end of input. The write sits INSIDE the deadline scope: an input
-      // larger than the pipe capacity against a child that never reads must
-      // hit the wall deadline, not block forever (review finding).
-      stdin_writer.write("\{input.stringify()}\n")
-      drain()
-    }
-    try {
-      match @async.with_timeout_opt(wall_deadline_ms, feed_and_drain) {
-        Some(_) =>
-          // Clean EOF: the child closed stdout. Read its exit status — a
-          // crash-class failure (panic, signal, nonzero exit) emits no
-          // failure event, and without this the runner is structurally
-          // blind to it and would misclassify the run as NoReport. Bounded:
-          // a child that closed stdout but lingers falls through to the
-          // cancel below.
-          match @async.with_timeout_opt(2_000, () => process.wait()) {
-            Some(code) if code != 0 &&
-              observations.report is None &&
-              observations.failure is None =>
-              observations.failure = Some("subrun exited \{code}")
-            _ => ()
-          }
-        None => {
-          // Deadline: graceful cancel first — close stdin, let the child
-          // flush; a report arriving in the grace window still counts.
-          timed_out = true
-          stdin_writer.close()
-          let _ = @async.with_timeout_opt(cancel_grace_ms, drain)
+  // The group call is itself fold-guarded: a spawn failure can surface
+  // ASYNCHRONOUSLY (the spawn's internal reaper task raising at group
+  // exit, e.g. EAGAIN under fork pressure), bypassing the per-call
+  // catches inside. Cancellation still re-raises; anything else becomes
+  // a Failed terminal — a loaded machine must degrade the sub-run, never
+  // crash the parent's turn.
+  try
+    @async.with_task_group() <| group => {
+      let (child_stdin, stdin_writer) = @process.write_to_process() catch {
+        error if @async.is_being_cancelled() => raise error
+        error => {
+          observations.failure = Some("subrun pipes unavailable: \{error}")
+          return
         }
       }
-    } catch {
-      error => {
-        // External cancellation (or a pipe failure): tear the child down and
-        // re-raise cancellation; fold anything else into the terminal.
-        @async.protect_from_cancel(() => {
-          stdout_reader.close()
+      let (stdout_reader, child_stdout) = @process.read_from_process() catch {
+        error if @async.is_being_cancelled() => {
           stdin_writer.close()
-          process.cancel()
-        })
-        if @async.is_being_cancelled() {
           raise error
         }
-        if observations.failure is None {
-          observations.failure = Some("subrun stream failed: \{error}")
+        error => {
+          stdin_writer.close()
+          observations.failure = Some("subrun pipes unavailable: \{error}")
+          return
         }
-        return
       }
+      // `no_wait`: the group terminates the child at teardown rather than
+      // waiting for an exit that may only come once its stdin is closed.
+      let process = @process.spawn(
+        group,
+        command,
+        args,
+        inherit_env=true,
+        stdin=child_stdin,
+        stdout=child_stdout,
+        cwd?=cwd.map(dir => dir.view()),
+        no_wait=true,
+      ) catch {
+        error if @async.is_being_cancelled() => {
+          stdout_reader.close()
+          stdin_writer.close()
+          raise error
+        }
+        error => {
+          stdout_reader.close()
+          stdin_writer.close()
+          observations.failure = Some("subrun spawn failed: \{error}")
+          return
+        }
+      }
+      async fn drain() -> Unit {
+        while stdout_reader.read_until("\n") is Some(line) {
+          observations.observe(line)
+        }
+      }
+      async fn feed_and_drain() -> Unit {
+        // One input line; the pipe stays open — EOF is the cancel signal, not
+        // the end of input. The write sits INSIDE the deadline scope: an input
+        // larger than the pipe capacity against a child that never reads must
+        // hit the wall deadline, not block forever (review finding).
+        stdin_writer.write("\{input.stringify()}\n")
+        drain()
+      }
+      try {
+        match @async.with_timeout_opt(wall_deadline_ms, feed_and_drain) {
+          Some(_) =>
+            // Clean EOF: the child closed stdout. Read its exit status — a
+            // crash-class failure (panic, signal, nonzero exit) emits no
+            // failure event, and without this the runner is structurally
+            // blind to it and would misclassify the run as NoReport. Bounded:
+            // a child that closed stdout but lingers falls through to the
+            // cancel below.
+            match @async.with_timeout_opt(2_000, () => process.wait()) {
+              Some(code) if code != 0 &&
+                observations.report is None &&
+                observations.failure is None =>
+                observations.failure = Some("subrun exited \{code}")
+              _ => ()
+            }
+          None => {
+            // Deadline: graceful cancel first — close stdin, let the child
+            // flush; a report arriving in the grace window still counts.
+            timed_out = true
+            stdin_writer.close()
+            let _ = @async.with_timeout_opt(cancel_grace_ms, drain)
+          }
+        }
+      } catch {
+        error => {
+          // External cancellation (or a pipe failure): tear the child down and
+          // re-raise cancellation; fold anything else into the terminal.
+          @async.protect_from_cancel(() => {
+            stdout_reader.close()
+            stdin_writer.close()
+            process.cancel()
+          })
+          if @async.is_being_cancelled() {
+            raise error
+          }
+          if observations.failure is None {
+            observations.failure = Some("subrun stream failed: \{error}")
+          }
+          return
+        }
+      }
+      stdout_reader.close()
+      stdin_writer.close()
+      process.cancel()
     }
-    stdout_reader.close()
-    stdin_writer.close()
-    process.cancel()
+  catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    error =>
+      if observations.failure is None {
+        observations.failure = Some("subrun runner failed: \{error}")
+      }
   }
   let value : T? = match observations.report {
     Some(report) =>

--- a/agent_subrun/runner_test.mbt
+++ b/agent_subrun/runner_test.mbt
@@ -1,0 +1,155 @@
+///|
+/// Parent-runner tests against SCRIPTED children: any process that speaks
+/// the contract (JSONL events on stdout, a final `subrun_report` line,
+/// stdin EOF as cancel) exercises spawn/drain/deadline/teardown without a
+/// model or a built binary — the same hermetic trick the MCP stdio tests
+/// use. Skips cleanly where the sandbox forbids spawning `sh`.
+fn parse_answer(json : Json) -> Result[String, String] {
+  match json {
+    { "answer": String(answer), .. } => Ok(answer)
+    _ => Err("answer must be a string")
+  }
+}
+
+///|
+async fn run_script(
+  script : String,
+  wall_deadline_ms? : Int = 10_000,
+) -> @agent_subrun.SubrunResult[String] {
+  @agent_subrun.run_subrun(
+    command="sh",
+    args=["-c", script],
+    input={ "query": "q" },
+    parse_report=parse_answer,
+    wall_deadline_ms~,
+  )
+}
+
+///|
+/// A child that could not even spawn is a Failed terminal, not a crash.
+async test "a spawn failure folds into Failed" {
+  let result = @agent_subrun.run_subrun(
+    command="/nonexistent/openseek-not-here",
+    args=[],
+    input={ "query": "q" },
+    parse_report=parse_answer,
+    wall_deadline_ms=2_000,
+  )
+  guard result.terminal() is Failed(reason) else {
+    // Some sandboxes surface spawn refusal as an immediate empty exit:
+    // accept NoReport there but never a hang or crash.
+    assert_true(result.terminal() is NoReport)
+    return
+  }
+  assert_true(reason.contains("spawn") || reason.contains("subrun"))
+}
+
+///|
+async test "events and the report line are drained and accounted" {
+  let script =
+    #|read line
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":1}\n'
+    #|printf 'not json at all\n'
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"usage","usage":{"prompt_tokens":90,"completion_tokens":10,"total_tokens":100,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":90}}\n'
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":2}\n'
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"usage","usage":{"prompt_tokens":95,"completion_tokens":5,"total_tokens":100,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":95}}\n'
+    #|printf '{"subrun_report": {"answer": "forty-two"}}\n'
+  let result = run_script(script)
+  if result.terminal() is Failed(_) {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  assert_true(result.value() is Some("forty-two"))
+  debug_inspect(result.terminal(), content="Captured")
+  assert_eq(result.steps_used(), 2)
+  assert_eq(result.prompt_tokens(), 185)
+  assert_eq(result.completion_tokens(), 15)
+}
+
+///|
+async test "a clean exit without a report is NoReport" {
+  let script =
+    #|read line
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":1}\n'
+  let result = run_script(script)
+  if result.terminal() is Failed(_) {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  assert_true(result.value() is None)
+  debug_inspect(result.terminal(), content="NoReport")
+}
+
+///|
+async test "an observed step exhaustion without a report is MaxSteps" {
+  let script =
+    #|read line
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"max_steps_exhausted"}\n'
+  let result = run_script(script)
+  if result.terminal() is Failed(_) {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  debug_inspect(result.terminal(), content="MaxSteps")
+}
+
+///|
+async test "a garbled report is Failed, never rendered" {
+  let script =
+    #|read line
+    #|printf '{"subrun_report": {"answer": 42}}\n'
+  let result = run_script(script)
+  if result.terminal() is Failed(reason) && reason.contains("spawn") {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  assert_true(result.value() is None)
+  guard result.terminal() is Failed(reason) else { fail("expected Failed") }
+  assert_true(reason.contains("report rejected"))
+}
+
+///|
+/// The deadline closes stdin (graceful cancel); a child that answers the
+/// EOF with its report inside the grace window still counts as Captured.
+async test "a report arriving in the cancel grace window still captures" {
+  let script =
+    #|read line
+    #|read _ignored
+    #|printf '{"subrun_report": {"answer": "flushed on eof"}}\n'
+  let result = run_script(script, wall_deadline_ms=300)
+  if result.terminal() is Failed(_) {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  assert_true(result.value() is Some("flushed on eof"))
+  debug_inspect(result.terminal(), content="Captured")
+}
+
+///|
+/// A child that ignores the graceful cancel is terminated after the grace
+/// and reported TimedOut.
+async test "a stalling child times out after deadline and grace" {
+  let script =
+    #|read line
+    #|sleep 60
+  let result = run_script(script, wall_deadline_ms=300)
+  if result.terminal() is Failed(_) {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  assert_true(result.value() is None)
+  debug_inspect(result.terminal(), content="TimedOut")
+}
+
+///|
+/// External cancellation re-raises out of run_subrun: an outer timeout gets
+/// its None back, which only happens when the cancellation propagated.
+async test "external cancellation re-raises out of the runner" {
+  let script =
+    #|read line
+    #|sleep 60
+  let outcome = @async.with_timeout_opt(300, () => {
+    run_script(script, wall_deadline_ms=30_000)
+  })
+  assert_true(outcome is None)
+}

--- a/agent_subrun/runner_test.mbt
+++ b/agent_subrun/runner_test.mbt
@@ -34,7 +34,9 @@ async fn can_spawn_sh() -> Bool {
   let script =
     #|read line
     #|printf '{"subrun_report": {"answer": "probe"}}\n'
-  let result = run_script(script)
+  // The probe must never throw: under fork pressure (EAGAIN) or a
+  // spawn-hostile sandbox it reports false and the test skips.
+  let result = run_script(script) catch { _ => return false }
   result.value() is Some("probe")
 }
 

--- a/agent_subrun/runner_test.mbt
+++ b/agent_subrun/runner_test.mbt
@@ -26,6 +26,19 @@ async fn run_script(
 }
 
 ///|
+/// One-time spawnability probe: a trivial child that must succeed wherever
+/// `sh` can spawn at all. Tests guard on THIS and then assert hard — a
+/// skip-on-Failed guard inside a real test would silently hide a regression
+/// that wrongly folds stream errors into Failed (review finding).
+async fn can_spawn_sh() -> Bool {
+  let script =
+    #|read line
+    #|printf '{"subrun_report": {"answer": "probe"}}\n'
+  let result = run_script(script)
+  result.value() is Some("probe")
+}
+
+///|
 /// A child that could not even spawn is a Failed terminal, not a crash.
 async test "a spawn failure folds into Failed" {
   let result = @agent_subrun.run_subrun(
@@ -54,11 +67,11 @@ async test "events and the report line are drained and accounted" {
     #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":2}\n'
     #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"usage","usage":{"prompt_tokens":95,"completion_tokens":5,"total_tokens":100,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":95}}\n'
     #|printf '{"subrun_report": {"answer": "forty-two"}}\n'
-  let result = run_script(script)
-  if result.terminal() is Failed(_) {
+  guard can_spawn_sh() else {
     println("skipped: cannot spawn sh")
     return
   }
+  let result = run_script(script)
   assert_true(result.value() is Some("forty-two"))
   debug_inspect(result.terminal(), content="Captured")
   assert_eq(result.steps_used(), 2)
@@ -71,11 +84,11 @@ async test "a clean exit without a report is NoReport" {
   let script =
     #|read line
     #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":1}\n'
-  let result = run_script(script)
-  if result.terminal() is Failed(_) {
+  guard can_spawn_sh() else {
     println("skipped: cannot spawn sh")
     return
   }
+  let result = run_script(script)
   assert_true(result.value() is None)
   debug_inspect(result.terminal(), content="NoReport")
 }
@@ -85,11 +98,11 @@ async test "an observed step exhaustion without a report is MaxSteps" {
   let script =
     #|read line
     #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"max_steps_exhausted"}\n'
-  let result = run_script(script)
-  if result.terminal() is Failed(_) {
+  guard can_spawn_sh() else {
     println("skipped: cannot spawn sh")
     return
   }
+  let result = run_script(script)
   debug_inspect(result.terminal(), content="MaxSteps")
 }
 
@@ -98,11 +111,11 @@ async test "a garbled report is Failed, never rendered" {
   let script =
     #|read line
     #|printf '{"subrun_report": {"answer": 42}}\n'
-  let result = run_script(script)
-  if result.terminal() is Failed(reason) && reason.contains("spawn") {
+  guard can_spawn_sh() else {
     println("skipped: cannot spawn sh")
     return
   }
+  let result = run_script(script)
   assert_true(result.value() is None)
   guard result.terminal() is Failed(reason) else { fail("expected Failed") }
   assert_true(reason.contains("report rejected"))
@@ -116,11 +129,11 @@ async test "a report arriving in the cancel grace window still captures" {
     #|read line
     #|read _ignored
     #|printf '{"subrun_report": {"answer": "flushed on eof"}}\n'
-  let result = run_script(script, wall_deadline_ms=300)
-  if result.terminal() is Failed(_) {
+  guard can_spawn_sh() else {
     println("skipped: cannot spawn sh")
     return
   }
+  let result = run_script(script, wall_deadline_ms=300)
   assert_true(result.value() is Some("flushed on eof"))
   debug_inspect(result.terminal(), content="Captured")
 }
@@ -132,24 +145,79 @@ async test "a stalling child times out after deadline and grace" {
   let script =
     #|read line
     #|sleep 60
-  let result = run_script(script, wall_deadline_ms=300)
-  if result.terminal() is Failed(_) {
+  guard can_spawn_sh() else {
     println("skipped: cannot spawn sh")
     return
   }
+  let result = run_script(script, wall_deadline_ms=300)
   assert_true(result.value() is None)
   debug_inspect(result.terminal(), content="TimedOut")
 }
 
 ///|
-/// External cancellation re-raises out of run_subrun: an outer timeout gets
-/// its None back, which only happens when the cancellation propagated.
+/// External cancellation must RE-RAISE out of run_subrun, never fold into a
+/// terminal. Pinned by awaiting the cancelled task directly: a runner that
+/// swallowed the cancellation would complete with a SubrunResult and fail
+/// this test. (An outer with_timeout_opt cannot pin this — it returns None
+/// whether or not the body re-raised; review finding.)
 async test "external cancellation re-raises out of the runner" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
   let script =
     #|read line
     #|sleep 60
-  let outcome = @async.with_timeout_opt(300, () => {
-    run_script(script, wall_deadline_ms=30_000)
-  })
-  assert_true(outcome is None)
+  @async.with_task_group() <| group => {
+    let task = group.spawn(() => run_script(script, wall_deadline_ms=30_000))
+    @async.sleep(300)
+    task.cancel()
+    let mut reraised = false
+    let outcome : @agent_subrun.SubrunResult[String]? = Some(task.wait()) catch {
+      error => {
+        reraised = @async.is_cancellation_error(error) ||
+          @async.is_being_cancelled()
+        None
+      }
+    }
+    assert_true(reraised)
+    assert_true(outcome is None)
+  }
+}
+
+///|
+/// The input pipe must stay OPEN after the write — stdin EOF is the cancel
+/// signal, so a runner that closes it early cancels every child at startup.
+/// Pinned via exit-status classification: this child exits 7 the moment its
+/// stdin closes. Held open, that happens only when the DEADLINE closes it,
+/// inside the grace window -> TimedOut. Closed early, the child exits 7
+/// before the deadline -> the normal path reads exit status -> Failed.
+async test "the input pipe stays open until the deadline" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let script =
+    #|read line
+    #|read second || exit 7
+    #|exit 7
+  let result = run_script(script, wall_deadline_ms=500)
+  assert_true(result.value() is None)
+  debug_inspect(result.terminal(), content="TimedOut")
+}
+
+///|
+/// A crash-class child — nonzero exit, no failure event, no report — is
+/// classified Failed via its exit status, never NoReport.
+async test "a nonzero exit without a report is Failed by exit status" {
+  let script =
+    #|read line
+    #|exit 3
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let result = run_script(script)
+  guard result.terminal() is Failed(reason) else { fail("expected Failed") }
+  assert_true(reason.contains("exited 3"))
 }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -30,6 +30,7 @@ async fn dispatch() -> Unit {
     Some(("run", m)) => run_task_command(m)
     Some(("serve", m)) => run_serve_command(m)
     Some(("review", m)) => run_review_command(m)
+    Some(("subrun", m)) => run_subrun_command(m)
     Some(("mcp", m)) => run_mcp_command(m)
     Some(("sessions", m)) => run_sessions_command(m)
     // argparse rejects unknown subcommands during parse, so this is unreachable.
@@ -223,7 +224,18 @@ async fn run_task_turn(
   @async.with_task_group() <| group => {
     let runtime = @agent_runtime.AgentRuntime(workspace_root~)
     let scope = @agent_runtime.AgentTaskScope(group)
-    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~)
+    // One-shot = one turn, so a fresh per-turn subrun budget needs no reset.
+    let subrun_budget = @agent_subrun.SubrunBudget()
+    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
+      [
+        @agent_explore.definition(
+          self_exe=self_executable(),
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          api_url?,
+        ),
+      ]
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
     ignore(
       @agent.run_turn_in_scope(
@@ -622,6 +634,18 @@ fn root_command() -> @argparse.Command {
             long="base",
             default_values=["origin/main"],
             about="Base ref: review the diff base...HEAD.",
+          ),
+        ],
+      ),
+      Command(
+        "subrun",
+        about="INTERNAL: run one subagent kind as a child of this engine (input JSON on stdin; stdin EOF cancels).",
+        options=agent_options(),
+        positionals=[
+          PositionArg(
+            "kind",
+            num_args=ValueRange(lower=1),
+            about="Subagent kind: explore | echo.",
           ),
         ],
       ),

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "bobzhang/jsonl",
   "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_explore",
+  "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_review",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -613,7 +613,19 @@ async fn run_serve(
     // completion instead of leaving it queued until the next prompt.
     // Tools from any configured MCP servers, connected once per engine (their
     // reader/writer tasks live on this group) and reused across turns.
-    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~)
+    // The subrun budget is shared by every subrun tool and refills at each
+    // turn start (see start_turn) — the registry itself lives across turns.
+    let subrun_budget = @agent_subrun.SubrunBudget()
+    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
+      [
+        @agent_explore.definition(
+          self_exe=self_executable(),
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          api_url?,
+        ),
+      ]
     let tools = @agent.build_tools(
       runtime,
       scope,
@@ -806,6 +818,9 @@ async fn run_serve(
     }
 
     fn start_turn(task_text : String) -> @async.Task[Unit] {
+      // Each turn refills the shared subrun allowance; the registry (and the
+      // budget object the explore tool holds) lives across turns.
+      subrun_budget.reset_turn()
       group.spawn() <| () => {
         let _ = @agent.run_turn_in_scope(
           runtime~,

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -7,10 +7,18 @@
 /// line. The API key rides the inherited environment; model, endpoint, and
 /// the step ceiling ride argv.
 ///
-/// Kinds: `explore` (the read-only scout) and `echo` (a modelless test kind
-/// that emits two canned events and echoes its input as the report — the
-/// hermetic end-to-end probe for the parent runner and cram tests).
+/// Failure paths NEVER `@sys.exit` from inside the logging scope: the event
+/// queue drains asynchronously, and an immediate exit would discard the
+/// very failure event the parent classifies on. Every path returns
+/// normally; `with_jsonl_stdout`'s teardown flushes the events, and the
+/// report — printed only after that teardown — is the final line by
+/// construction.
+///
+/// Kinds: `explore` (the read-only scout) and `echo` (a modelless probe
+/// that emits two canned events and echoes its input as the report — used
+/// by the parent-runner tests and the cram end-to-end doc).
 async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
+  let report : Ref[Json?] = { val: None }
   with_jsonl_stdout(() => {
     let workspace_root = prepare_workspace_root(matches, log_created=false)
     let (model, thinking, api_url) = agent_settings(matches)
@@ -28,14 +36,26 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
       })
       is Some(input) else {
       @emit.emit(CommandError(error="subrun input is not JSON"))
-      @sys.exit(1)
       return
     }
     @async.with_task_group() <| group => {
+      // Failures are caught INSIDE the task: a spawned task's failure
+      // cancels the group body, so a catch around `work.wait()` observes
+      // only the ambient cancellation and can never see the real error
+      // (adversarial-review finding). In here, cancellation still
+      // re-raises; every real error becomes the TurnFailed event the
+      // parent classifies on, and the task completes normally.
       let work = group.spawn(() => {
         dispatch_kind(
           kind, input, matches, model, thinking, api_url, workspace_root,
-        )
+        ) catch {
+          error if @async.is_being_cancelled() ||
+            @async.is_cancellation_error(error) => raise error
+          error => {
+            @emit.emit(TurnFailed(error="subrun \{kind} failed: \{error}"))
+            None
+          }
+        }
       })
       // The cancel channel: the parent closing our stdin means "stop now,
       // gracefully" — cancel the kind's turn (its loop records Interrupted
@@ -46,23 +66,26 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
         }
         work.cancel()
       }
-      work.wait() catch {
+      report.val = work.wait() catch {
+        // Parent-initiated cancel (stdin EOF): exit without a report; the
+        // parent is already classifying the run from what it observed.
         error if @async.is_being_cancelled() ||
-          @async.is_cancellation_error(error) =>
-          // Parent-initiated cancel: exit quietly; the parent is already
-          // classifying the run from what it observed.
-          ()
-        error => {
-          @emit.emit(TurnFailed(error="subrun \{kind} failed: \{error}"))
-          @sys.exit(1)
-        }
+          @async.is_cancellation_error(error) => None
+        error => raise error
       }
     }
   })
+  // Logging is closed: every queued event line reached stdout. Writing the
+  // report through the SAME channel (@stdio.stdout, like the review CLI)
+  // keeps one tracked writer on fd 1 — mixing println's C-stdio offset in
+  // corrupts output when stdout is a regular file (review finding).
+  if report.val is Some(value) {
+    @stdio.stdout.write(@agent_subrun.report_line(value) + "\n")
+  }
 }
 
 ///|
-/// Run one kind in this process and print its report line, if any.
+/// Run one kind in this process and return its report, if any.
 async fn dispatch_kind(
   kind : String,
   input : Json,
@@ -71,7 +94,7 @@ async fn dispatch_kind(
   thinking : @deepseek.ThinkingMode,
   api_url : String?,
   workspace_root : String,
-) -> Unit {
+) -> Json? {
   match kind {
     "explore" => {
       let api_key = @agentcli.api_key(matches, model)
@@ -86,14 +109,12 @@ async fn dispatch_kind(
         api_url?,
         workspace_root~,
       )
-      if report is Some(report) {
-        println(@agent_subrun.report_line(report.to_json()))
-      }
+      report.map(report => report.to_json())
     }
     "echo" => {
       // Modelless probe: two canned events plus the input echoed back —
-      // enough for a parent to exercise spawn, drain, accounting, and the
-      // typed report channel end to end.
+      // enough to exercise spawn, drain, accounting, and the typed report
+      // channel end to end.
       @emit.emit(AgentStep(step=1))
       @emit.emit(
         Usage(usage={
@@ -104,11 +125,11 @@ async fn dispatch_kind(
           prompt_cache_miss_tokens: 7,
         }),
       )
-      println(@agent_subrun.report_line(input))
+      Some(input)
     }
     _ => {
       @emit.emit(CommandError(error="unknown subrun kind: \{kind}"))
-      @sys.exit(1)
+      None
     }
   }
 }

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -1,0 +1,135 @@
+///|
+/// `openseek subrun <kind>` — the INTERNAL child mode the engine spawns for
+/// one sub-run. Contract (see `agent_subrun`): the parent writes one JSON
+/// input line on stdin and holds the pipe open; stdin EOF is the graceful
+/// cancel signal; this process emits its standard JSONL events on stdout
+/// and, when the kind produced a value, one final `{"subrun_report": ...}`
+/// line. The API key rides the inherited environment; model, endpoint, and
+/// the step ceiling ride argv.
+///
+/// Kinds: `explore` (the read-only scout) and `echo` (a modelless test kind
+/// that emits two canned events and echoes its input as the report — the
+/// hermetic end-to-end probe for the parent runner and cram tests).
+async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
+  with_jsonl_stdout(() => {
+    let workspace_root = prepare_workspace_root(matches, log_created=false)
+    let (model, thinking, api_url) = agent_settings(matches)
+    let kind = match matches {
+      { values: { "kind": [kind, ..], .. }, .. } => "\{kind}"
+      _ => fail("missing parsed argument: kind")
+    }
+    // One input line; the pipe stays open afterwards as the cancel channel.
+    guard @stdio.stdin.read_until("\n") is Some(line) else {
+      // EOF before input: the parent gave up before we started.
+      return
+    }
+    guard (Some(@json.parse(line.trim(chars="\r\n").to_owned())) catch {
+        _ => None
+      })
+      is Some(input) else {
+      @emit.emit(CommandError(error="subrun input is not JSON"))
+      @sys.exit(1)
+      return
+    }
+    @async.with_task_group() <| group => {
+      let work = group.spawn(() => {
+        dispatch_kind(
+          kind, input, matches, model, thinking, api_url, workspace_root,
+        )
+      })
+      // The cancel channel: the parent closing our stdin means "stop now,
+      // gracefully" — cancel the kind's turn (its loop records Interrupted
+      // and tears its tool subprocesses down) and exit without a report.
+      group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+        while @stdio.stdin.read_until("\n") is Some(_) {
+          // Drain anything the parent writes; only EOF is meaningful.
+        }
+        work.cancel()
+      }
+      work.wait() catch {
+        error if @async.is_being_cancelled() ||
+          @async.is_cancellation_error(error) =>
+          // Parent-initiated cancel: exit quietly; the parent is already
+          // classifying the run from what it observed.
+          ()
+        error => {
+          @emit.emit(TurnFailed(error="subrun \{kind} failed: \{error}"))
+          @sys.exit(1)
+        }
+      }
+    }
+  })
+}
+
+///|
+/// Run one kind in this process and print its report line, if any.
+async fn dispatch_kind(
+  kind : String,
+  input : Json,
+  matches : @argparse.Matches,
+  model : @deepseek.Model,
+  thinking : @deepseek.ThinkingMode,
+  api_url : String?,
+  workspace_root : String,
+) -> Unit {
+  match kind {
+    "explore" => {
+      let api_key = @agentcli.api_key(matches, model)
+      let report = @agent_explore.run_child(
+        input,
+        api_key~,
+        model~,
+        max_steps=max_steps(matches).unwrap_or(
+          @agent_explore.default_explore_max_steps,
+        ),
+        thinking~,
+        api_url?,
+        workspace_root~,
+      )
+      if report is Some(report) {
+        println(@agent_subrun.report_line(report.to_json()))
+      }
+    }
+    "echo" => {
+      // Modelless probe: two canned events plus the input echoed back —
+      // enough for a parent to exercise spawn, drain, accounting, and the
+      // typed report channel end to end.
+      @emit.emit(AgentStep(step=1))
+      @emit.emit(
+        Usage(usage={
+          prompt_tokens: 7,
+          completion_tokens: 3,
+          total_tokens: 10,
+          prompt_cache_hit_tokens: 0,
+          prompt_cache_miss_tokens: 7,
+        }),
+      )
+      println(@agent_subrun.report_line(input))
+    }
+    _ => {
+      @emit.emit(CommandError(error="unknown subrun kind: \{kind}"))
+      @sys.exit(1)
+    }
+  }
+}
+
+///|
+/// The executable to spawn for a child sub-run: this process's own binary,
+/// resolved from argv[0]. A path with a separator is made absolute (the
+/// child runs with a different cwd, so a relative path would break); a bare
+/// name stays PATH-resolved, matching however this process was launched.
+/// Never hardcode a name: parent and child must be the SAME binary, or the
+/// typed report channel's same-codec guarantee is gone.
+async fn self_executable() -> String {
+  let argv0 = match @env.args() {
+    [first, ..] => first
+    _ => "openseek"
+  }
+  if argv0.contains("/") || argv0.contains("\\") {
+    @fs.realpath(argv0) catch {
+      _ => argv0
+    }
+  } else {
+    argv0
+  }
+}

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -146,6 +146,13 @@ async fn self_executable() -> String {
     [first, ..] => first
     _ => "openseek"
   }
+  // Under `moon run` on the tcc debug path argv0 is the generated .c
+  // SOURCE, not an executable: spawning it would fail every explore call.
+  // Fall back to PATH resolution — the same case the TUI handles for its
+  // engine spawn (cmd/tui `moon_native_tcc_run_args`).
+  if argv0.has_suffix(".c") {
+    return "openseek"
+  }
   if argv0.contains("/") || argv0.contains("\\") {
     @fs.realpath(argv0) catch {
       _ => argv0

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -123,6 +123,15 @@ Common `moon` subcommands:
   the STALE mooncakes.io snapshot, never your working tree — to exercise local
   package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
   (above).
+- `explore` tool: delegate ONE self-contained question to a read-only scout
+  subagent when answering it yourself would mean reading MANY files or a
+  fan-out search — "where is X handled", "how does Y flow end to end", "what
+  does this package offer for Z" — and you want the cited conclusion, not the
+  file contents in your context. For a single direct lookup (one
+  `moon ide doc` query, one file read), do it yourself instead. The scout
+  cannot edit anything, returns file:line citations you can spot-check, and
+  shares a small per-turn budget (a few delegations per turn), so spend it on
+  questions that genuinely fan out.
 - shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
   use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
   Example: `moon cram test tests/cram`.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -128,6 +128,15 @@ fn default_prompt() -> String {
     #|  the STALE mooncakes.io snapshot, never your working tree — to exercise local
     #|  package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
     #|  (above).
+    #|- `explore` tool: delegate ONE self-contained question to a read-only scout
+    #|  subagent when answering it yourself would mean reading MANY files or a
+    #|  fan-out search — "where is X handled", "how does Y flow end to end", "what
+    #|  does this package offer for Z" — and you want the cited conclusion, not the
+    #|  file contents in your context. For a single direct lookup (one
+    #|  `moon ide doc` query, one file read), do it yourself instead. The scout
+    #|  cannot edit anything, returns file:line citations you can spot-check, and
+    #|  shares a small per-turn budget (a few delegations per turn), so spend it on
+    #|  questions that genuinely fan out.
     #|- shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
     #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
     #|  Example: `moon cram test tests/cram`.

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -29,6 +29,7 @@ Commands:
   serve     Session server: read JSONL commands (prompt/steer/cancel/compact/goal) from stdin.
   mcp       List configured MCP servers and the tools they expose.
   review    Read-only code review of base...HEAD; prints a JSON ReviewReport.
+  subrun    INTERNAL: run one subagent kind as a child of this engine (input JSON on stdin; stdin EOF cancels).
   sessions  Manage durable sessions.
 
 Options:

--- a/tests/cram/subrun.md
+++ b/tests/cram/subrun.md
@@ -1,0 +1,29 @@
+# Verified `openseek subrun` Child-Mode Contract
+
+These examples are executed by `moon cram test tests/cram`. They exercise the
+INTERNAL child mode end to end through the real binary: one JSON input line on
+stdin (the `sleep` holds the pipe open the way a parent runner does — stdin EOF
+is the cancel signal), standard JSONL events on stdout, and a final
+`{"subrun_report": ...}` line. The `echo` kind is modelless, so the suite needs
+no API key and makes no network calls. Timestamps and source locations vary, so
+they are normalized with `sed`.
+
+## Echo Kind: Events Then the Typed Report Line
+
+```mooncram
+$ (printf '{"probe": 42}\n'; sleep 1) | openseek.exe subrun echo | sed -E 's/"timestamp":"[^"]*"/"timestamp":"T"/; s/"source":"[^"]*"/"source":"S"/'
+{"timestamp":"T","level":"INFO","source":"S","event":"agent_step","step":1}
+{"timestamp":"T","level":"INFO","source":"S","event":"usage","usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":7}}
+{"subrun_report":{"probe":42}}
+```
+
+## Failure Events Survive to the Wire
+
+An unknown kind must deliver its `command_error` event — the parent's only
+classification signal — before exiting; an early `exit()` would discard the
+asynchronously drained queue.
+
+```mooncram
+$ (printf '{}\n'; sleep 1) | openseek.exe subrun nope | sed -E 's/"timestamp":"[^"]*"/"timestamp":"T"/; s/"source":"[^"]*"/"source":"S"/'
+{"timestamp":"T","level":"ERROR","source":"S","event":"command_error","error":"unknown subrun kind: nope"}
+```


### PR DESCRIPTION
## What

The subagent substrate rebuilt on the owner's architecture decision: **a sub-run is a dedicated child process**, driven the way the TUI drives the engine. Supersedes and replaces the in-process stack — closes #535 (EventSink: isolation is now structural), #536, and #538, whose contracts and content survive here with a process runner core. Targets `main` directly (only merged dependency is #534's ceiling salvage).

## Design

- **Parent runner** (`agent_subrun.run_subrun`): spawns `openseek subrun <kind>` from the parent's **own executable path** — same binary, so the report's derived `to_json`/`from_json` codecs cannot drift: a typed channel across the process boundary. One JSON input line on stdin, **pipe held open — closing it is the graceful cancel**; the child's standard JSONL event stream is drained for exact cost (`usage` summed, `agent_step` maxed) plus the final `{"subrun_report": …}` line. The wall deadline closes stdin, grants a 5s grace (a report landing inside it still captures), then terminates. External cancellation re-raises; a dead child is a `Failed` result, never a dead engine.
- **Child side** (`execute_kind` + `openseek subrun <kind>`): one bounded turn, restricted registry, `capture_tool` submit channel (`control=true` riding #534's salvage). stdin-EOF watcher cancels the turn gracefully — the same EOF-is-shutdown semantic serve already has. Kinds: `explore`, plus a modelless `echo` probe for hermetic end-to-end testing. API key rides inherited env, never argv.
- **`SubrunBudget`**: per-turn allowance shared by all subrun tools, reserve-before-launch, reconciled from observed cost; serve refills at each turn start.
- **Explore**: unchanged above the runner — `moon ide doc` as primary instrument, validation-capped report, graceful failure contract, conservative prompt delegation rule (the one behavior-affecting prompt edit — flagged for review).
- `agent_review` refactors onto `execute_kind`/`capture_tool` with its public contract unchanged; the standalone CLI keeps running the kind in its own (already dedicated) process.

## Tests

- Child lifecycle vs mock endpoint: capture, reject-retry, **ceiling salvage of a pending submission**, NoReport, MaxSteps — 5 tests, no spawning.
- Parent runner vs **scripted `sh` children** (the MCP-test trick): cost accounting with garbage lines skipped, garbled-report rejection, **grace-window capture after stdin close**, TimedOut after grace, external-cancel re-raise, spawn-failure fold — 8 tests, hermetic.
- `echo` kind smoke-tested end to end through the real built binary (envelope events + typed report line verified on the wire).
- Suites: agent_subrun 19/19, agent_explore 12/12, agent_review 10/10, cmd/openseek 64/64, prompt 19/19; `moon check --target all`, `fmt`, `info` clean.

Known limits (documented in the README): hard-killed children can orphan their own tool subprocesses (upstream group-kill gap — the stdin-EOF grace path is the mitigation); Windows deferred with background jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)