### PR TITLE
feat(goal): capture a worktree baseline when a goal is set

### DIFF
--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -358,6 +358,15 @@ async fn AgentLoop::apply_steer_inputs(
       Notice(text) => ("notice", text, Runtime(RuntimeNotice(text)))
     }
     let next = self.append(current, item)
+    // A goal-baseline notice is transport for the durable pairing record:
+    // it must land in the session (adjacent to its marker) but carries
+    // nothing for the model — a commit sha as user input is pure noise —
+    // and nothing for controllers, who would only have to filter it back
+    // out of every echo path.
+    if input is Notice(text) &&
+      @agent_session.parse_goal_baseline(text) is Some(_) {
+      continue next
+    }
     self.messages.push(ChatMessage(User, content=text))
     @emit.emit(SteerApplied(kind~, content=text))
     if input is Notice(text) {

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -216,13 +216,18 @@ pub fn parse_goal_baseline(content : String) -> GoalBaseline? {
 ///|
 /// The baseline recorded for the CURRENT standing goal, or `None` when no
 /// goal stands or its set marker has no baseline immediately before it.
-/// Pairing is by adjacency: every goal-set path appends the baseline notice
+/// Pairing is by adjacency: every goal-set path appends a baseline record
 /// and the set marker back to back with nothing in between (the serve loop
 /// is the single appender on the idle/drain paths, and the steer path
-/// applies its drained inputs sequentially), so the event directly
-/// preceding the set marker either is this goal's baseline or the goal has
-/// none. An orphan baseline (its set marker's append failed) is never
-/// returned: it precedes nothing that stands.
+/// applies its drained inputs sequentially). A failed CAPTURE still appends
+/// an `unavailable` record, so the marker's preceding slot is owned by its
+/// own set and a stale orphan from an earlier fault cannot be inherited by
+/// position. Residual honesty: if a baseline APPEND lands durably and its
+/// marker's append is then lost (store fault or torn tail), AND a later
+/// set's own record append also fails, that later marker could sit
+/// directly after the stale orphan and claim it — a double store fault.
+/// Consumers must treat the baseline as an advisory audit anchor, never a
+/// correctness input.
 pub fn Session::current_goal_baseline(self : Session) -> GoalBaseline? {
   guard self.current_goal() is Some(goal) else { return None }
   let events = self.events()

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -169,3 +169,68 @@ pub fn Session::current_goal(self : Session) -> StandingGoal? {
   }
   None
 }
+
+///|
+/// The goal-baseline marker prefix: `[goal baseline] sha=<sha> dirty=<bool>`,
+/// appended IMMEDIATELY BEFORE its `[goal]` set marker by every goal-set
+/// path. Single-line by design (unlike the set marker, it carries no user
+/// text). Unknown to older readers, it degrades to a plain notice.
+pub const GoalBaselinePrefix : String = "[goal baseline]"
+
+///|
+/// The workspace snapshot recorded when a goal was set: the commit the
+/// worktree sat on, and whether the worktree was already dirty — the
+/// review gate's audit anchor and its attribution caveat.
+pub(all) struct GoalBaseline {
+  sha : String
+  dirty : Bool
+} derive(Debug, Eq)
+
+///|
+/// Render the baseline notice content for `sha`/`dirty`.
+pub fn goal_baseline_notice(sha~ : String, dirty~ : Bool) -> String {
+  "\{GoalBaselinePrefix} sha=\{sha} dirty=\{dirty}"
+}
+
+///|
+/// Parse a runtime-notice content as a goal baseline, if it is one. Strict
+/// on shape (both fields, in order) so a mangled line degrades to a plain
+/// notice rather than a half-parsed baseline.
+pub fn parse_goal_baseline(content : String) -> GoalBaseline? {
+  guard content.strip_prefix("\{GoalBaselinePrefix} sha=") is Some(rest) else {
+    return None
+  }
+  guard rest.find(" dirty=") is Some(cut) else { return None }
+  let sha = rest[:cut].to_owned()
+  let dirty = match rest[cut + 7:].to_owned() {
+    "true" => true
+    "false" => false
+    _ => return None
+  }
+  if sha.is_empty() {
+    return None
+  }
+  Some({ sha, dirty })
+}
+
+///|
+/// The baseline recorded for the CURRENT standing goal, or `None` when no
+/// goal stands or its set marker has no baseline immediately before it.
+/// Pairing is by adjacency: every goal-set path appends the baseline notice
+/// and the set marker back to back with nothing in between (the serve loop
+/// is the single appender on the idle/drain paths, and the steer path
+/// applies its drained inputs sequentially), so the event directly
+/// preceding the set marker either is this goal's baseline or the goal has
+/// none. An orphan baseline (its set marker's append failed) is never
+/// returned: it precedes nothing that stands.
+pub fn Session::current_goal_baseline(self : Session) -> GoalBaseline? {
+  guard self.current_goal() is Some(goal) else { return None }
+  let events = self.events()
+  for index in (events.length() - 1)>=..1 {
+    if events[index].sequence() == goal.set_sequence() {
+      guard events[index - 1].item() is Runtime(notice) else { return None }
+      return parse_goal_baseline(notice.content())
+    }
+  }
+  None
+}

--- a/agent_session/goal_test.mbt
+++ b/agent_session/goal_test.mbt
@@ -96,3 +96,107 @@ test "a compaction summary covering the set marker does not hide the goal" {
   assert_eq(goal.text(), "long objective")
   assert_true(goal.answered_since_set())
 }
+
+///|
+test "goal baseline round-trips through its notice" {
+  let notice = @agent_session.goal_baseline_notice(sha="abc123", dirty=false)
+  assert_eq(notice, "[goal baseline] sha=abc123 dirty=false")
+  debug_inspect(
+    @agent_session.parse_goal_baseline(notice),
+    content=(
+      #|Some({ sha: "abc123", dirty: false })
+    ),
+  )
+  // Strict shape: mangled lines degrade to plain notices.
+  assert_true(@agent_session.parse_goal_baseline("[goal baseline]") is None)
+  assert_true(
+    @agent_session.parse_goal_baseline("[goal baseline] sha= dirty=true")
+    is None,
+  )
+  assert_true(
+    @agent_session.parse_goal_baseline("[goal baseline] sha=x dirty=maybe")
+    is None,
+  )
+}
+
+///|
+test "current_goal_baseline pairs by adjacency" {
+  let session = @agent_session.Session(SessionId("b1"), system_prompt="sys")
+    .append(
+      Runtime(
+        RuntimeNotice(
+          @agent_session.goal_baseline_notice(sha="abc123", dirty=true),
+        ),
+      ),
+    )
+    .append(Runtime(RuntimeNotice("[goal]\nship it")))
+  debug_inspect(
+    session.current_goal_baseline(),
+    content=(
+      #|Some({ sha: "abc123", dirty: true })
+    ),
+  )
+}
+
+///|
+test "a set marker without an adjacent baseline has none" {
+  // Baseline exists but something landed between it and the marker: the
+  // adjacency contract is broken, so no baseline is claimed.
+  let session = @agent_session.Session(SessionId("b2"), system_prompt="sys")
+    .append(
+      Runtime(
+        RuntimeNotice(
+          @agent_session.goal_baseline_notice(sha="abc123", dirty=false),
+        ),
+      ),
+    )
+    .append(User(UserMessage("interleaved")))
+    .append(Runtime(RuntimeNotice("[goal]\nship it")))
+  assert_true(session.current_goal_baseline() is None)
+}
+
+///|
+test "an orphan baseline is never returned" {
+  // The set marker's append failed: the baseline precedes nothing.
+  let session = @agent_session.Session(SessionId("b3"), system_prompt="sys").append(
+    Runtime(
+      RuntimeNotice(
+        @agent_session.goal_baseline_notice(sha="abc123", dirty=false),
+      ),
+    ),
+  )
+  assert_true(session.current_goal() is None)
+  assert_true(session.current_goal_baseline() is None)
+}
+
+///|
+test "a replacement goal pairs with ITS baseline, and a clear drops it" {
+  let session = @agent_session.Session(SessionId("b4"), system_prompt="sys")
+    .append(
+      Runtime(
+        RuntimeNotice(
+          @agent_session.goal_baseline_notice(sha="old000", dirty=false),
+        ),
+      ),
+    )
+    .append(Runtime(RuntimeNotice("[goal]\nfirst")))
+    .append(
+      Runtime(
+        RuntimeNotice(
+          @agent_session.goal_baseline_notice(sha="new111", dirty=true),
+        ),
+      ),
+    )
+    .append(Runtime(RuntimeNotice("[goal]\nsecond")))
+  debug_inspect(
+    session.current_goal_baseline(),
+    content=(
+      #|Some({ sha: "new111", dirty: true })
+    ),
+  )
+  // A replacement WITHOUT a baseline must not inherit the old one.
+  let replaced = session.append(Runtime(RuntimeNotice("[goal]\nthird")))
+  assert_true(replaced.current_goal_baseline() is None)
+  let cleared = session.append(Runtime(RuntimeNotice("[goal cleared]")))
+  assert_true(cleared.current_goal_baseline() is None)
+}

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -11,6 +11,8 @@ import {
 // Values
 pub const ContextYieldAnswerPrefix : String = "[context ceiling]"
 
+pub const GoalBaselinePrefix : String = "[goal baseline]"
+
 pub const GoalBlockedPrefix : String = "[goal blocked]"
 
 pub const GoalCheckPrefix : String = "[goal check]"
@@ -25,7 +27,11 @@ pub const GoalUnblockedNotice : String = "[goal unblocked]"
 
 pub const PlanReminderPrefix : String = "[plan reminder]"
 
+pub fn goal_baseline_notice(sha~ : String, dirty~ : Bool) -> String
+
 pub fn goal_marker(String) -> GoalMarker?
+
+pub fn parse_goal_baseline(String) -> GoalBaseline?
 
 // Errors
 
@@ -37,6 +43,11 @@ pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.
 pub fn AssistantMessage::content(Self) -> String
 pub fn AssistantMessage::reasoning_content(Self) -> String?
 pub fn AssistantMessage::tool_calls(Self) -> Array[@deepseek.ToolCall]
+
+pub(all) struct GoalBaseline {
+  sha : String
+  dirty : Bool
+} derive(Eq, @debug.Debug)
 
 pub enum GoalMarker {
   GoalSet(String)
@@ -60,6 +71,7 @@ pub fn Session::append_event(Self, SessionItem, unix_ms? : Int64) -> (Self, Sess
 pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
 pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int, unix_ms? : Int64) -> Self raise
 pub fn Session::current_goal(Self) -> StandingGoal?
+pub fn Session::current_goal_baseline(Self) -> GoalBaseline?
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int

--- a/cmd/openseek/baseline.mbt
+++ b/cmd/openseek/baseline.mbt
@@ -1,109 +1,75 @@
 ///|
-/// One bounded wall-clock budget for the WHOLE baseline capture (both git
-/// probes): a goal set is a rare, explicit command, but it runs on the
-/// serve loop's single consumer, so a hung git must cost seconds, not the
-/// session.
-const BaselineCaptureBudgetMs : Int = 2_000
+/// Per-probe wall budget. Each git probe gets its own bound so a slow
+/// `status` (large or cold-cache repos) cannot discard an already-obtained
+/// sha — on status timeout the baseline keeps the sha and reports
+/// dirty=true, the conservative direction for an audit anchor.
+const BaselineProbeBudgetMs : Int = 2_000
+
+///|
+/// The record appended when a goal is set but the baseline could not be
+/// captured (not a repo, no git, over budget). Appending it — rather than
+/// nothing — keeps the marker's preceding slot OWNED by this goal-set, so
+/// a stale orphan baseline from an earlier fault cannot be stolen by
+/// adjacency. `parse_goal_baseline` rejects it, yielding "no baseline".
+const GoalBaselineUnavailable : String = "[goal baseline] unavailable"
 
 ///|
 /// Run `command args...` in `cwd`, capturing stdout. `Some(output)` only on
-/// exit 0; any failure — spawn, nonzero exit, pipe trouble — is `None`.
+/// exit 0 within the budget; any failure — spawn, nonzero exit, timeout —
+/// is `None`. `collect_stdout` owns the pipe lifecycle (defer-closed on
+/// every path, including cancellation mid-wait).
 async fn run_capture(
   command : String,
   args : Array[String],
   cwd : String,
 ) -> String? {
-  let (stdout_reader, child_stdout) = @process.read_from_process() catch {
+  let outcome = @async.with_timeout_opt(BaselineProbeBudgetMs, () => {
+    @process.collect_stdout(
+      command.view(),
+      args,
+      inherit_env=true,
+      cwd=cwd.view(),
+    )
+  }) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
   }
-  let mut exit_code = -1
-  let output = StringBuilder()
-  (@async.with_task_group() <| group => {
-    let process = @process.spawn(
-      group,
-      command,
-      args,
-      inherit_env=true,
-      stdout=child_stdout,
-      cwd=cwd.view(),
-      no_wait=true,
-    ) catch {
-      error if @async.is_being_cancelled() => {
-        stdout_reader.close()
-        raise error
-      }
-      _ => {
-        stdout_reader.close()
-        return
-      }
-    }
-    try {
-      while stdout_reader.read_until("\n") is Some(line) {
-        output.write_string(line)
-      }
-    } catch {
-      error if @async.is_being_cancelled() => {
-        stdout_reader.close()
-        process.cancel()
-        raise error
-      }
-      _ => ()
-    }
-    exit_code = process.wait() catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => -1
-    }
-    stdout_reader.close()
-    process.cancel()
-  }) catch {
-    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
-      raise error
-    _ => return None
-  }
-  if exit_code == 0 {
-    Some(output.to_string())
-  } else {
-    None
+  match outcome {
+    Some((0, data)) => Some(data.text().to_string())
+    _ => None
   }
 }
 
 ///|
-/// Capture the goal-baseline notice for `workspace_root`: the commit the
-/// worktree sits on plus whether it is dirty. `None` when the workspace is
-/// not a git repo, git is unavailable, or the probe exceeds its budget —
-/// the goal still sets; only the future review gate loses its anchor. A
-/// failed dirty probe reports dirty=true: the conservative direction for an
-/// audit anchor.
-async fn capture_goal_baseline(workspace_root : String) -> String? {
-  let probe = @async.with_timeout_opt(BaselineCaptureBudgetMs, () => {
-    guard run_capture("git", ["rev-parse", "HEAD"], workspace_root)
-      is Some(sha_line) else {
-      return None
-    }
-    let sha = sha_line.trim().to_owned()
-    if sha.is_empty() {
-      return None
-    }
-    let dirty = match
-      run_capture("git", ["status", "--porcelain"], workspace_root) {
-      Some(status) => !status.trim().is_empty()
-      None => true
-    }
-    Some(@agent_session.goal_baseline_notice(sha~, dirty~))
-  }) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
+/// The goal-baseline notice for `workspace_root`: the commit the worktree
+/// sits on plus whether it is dirty. Never `None` for a set — a failed sha
+/// probe yields the `unavailable` record so the marker's preceding slot is
+/// still owned by this set (see `GoalBaselineUnavailable`); a failed or
+/// timed-out dirty probe keeps the sha and reports dirty=true.
+async fn capture_goal_baseline(workspace_root : String) -> String {
+  guard run_capture("git", ["rev-parse", "HEAD"], workspace_root)
+    is Some(sha_line) else {
+    return GoalBaselineUnavailable
   }
-  probe.bind(x => x)
+  let sha = sha_line.trim().to_owned()
+  if sha.is_empty() {
+    return GoalBaselineUnavailable
+  }
+  let dirty = match
+    run_capture("git", ["status", "--porcelain"], workspace_root) {
+    Some(status) => !status.trim().is_empty()
+    None => true
+  }
+  @agent_session.goal_baseline_notice(sha~, dirty~)
 }
 
 ///|
 async test "capture_goal_baseline probes the enclosing repo" {
   // Needs git and spawn permission; this checkout is a git repo. Guarded
-  // rather than asserted: sandboxes without spawn or git report None.
+  // rather than asserted: sandboxes without spawn or git report the
+  // unavailable record.
   let notice = capture_goal_baseline(".")
-  guard notice is Some(notice) else {
+  guard notice != GoalBaselineUnavailable else {
     println("skipped: git probe unavailable")
     return
   }
@@ -112,4 +78,11 @@ async test "capture_goal_baseline probes the enclosing repo" {
   }
   // A full commit id, not a short one: the gate resolves it exactly.
   assert_eq(baseline.sha.length(), 40)
+}
+
+///|
+test "the unavailable record is not a parseable baseline" {
+  assert_true(
+    @agent_session.parse_goal_baseline(GoalBaselineUnavailable) is None,
+  )
 }

--- a/cmd/openseek/baseline.mbt
+++ b/cmd/openseek/baseline.mbt
@@ -1,0 +1,115 @@
+///|
+/// One bounded wall-clock budget for the WHOLE baseline capture (both git
+/// probes): a goal set is a rare, explicit command, but it runs on the
+/// serve loop's single consumer, so a hung git must cost seconds, not the
+/// session.
+const BaselineCaptureBudgetMs : Int = 2_000
+
+///|
+/// Run `command args...` in `cwd`, capturing stdout. `Some(output)` only on
+/// exit 0; any failure — spawn, nonzero exit, pipe trouble — is `None`.
+async fn run_capture(
+  command : String,
+  args : Array[String],
+  cwd : String,
+) -> String? {
+  let (stdout_reader, child_stdout) = @process.read_from_process() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return None
+  }
+  let mut exit_code = -1
+  let output = StringBuilder()
+  (@async.with_task_group() <| group => {
+    let process = @process.spawn(
+      group,
+      command,
+      args,
+      inherit_env=true,
+      stdout=child_stdout,
+      cwd=cwd.view(),
+      no_wait=true,
+    ) catch {
+      error if @async.is_being_cancelled() => {
+        stdout_reader.close()
+        raise error
+      }
+      _ => {
+        stdout_reader.close()
+        return
+      }
+    }
+    try {
+      while stdout_reader.read_until("\n") is Some(line) {
+        output.write_string(line)
+      }
+    } catch {
+      error if @async.is_being_cancelled() => {
+        stdout_reader.close()
+        process.cancel()
+        raise error
+      }
+      _ => ()
+    }
+    exit_code = process.wait() catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => -1
+    }
+    stdout_reader.close()
+    process.cancel()
+  }) catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    _ => return None
+  }
+  if exit_code == 0 {
+    Some(output.to_string())
+  } else {
+    None
+  }
+}
+
+///|
+/// Capture the goal-baseline notice for `workspace_root`: the commit the
+/// worktree sits on plus whether it is dirty. `None` when the workspace is
+/// not a git repo, git is unavailable, or the probe exceeds its budget —
+/// the goal still sets; only the future review gate loses its anchor. A
+/// failed dirty probe reports dirty=true: the conservative direction for an
+/// audit anchor.
+async fn capture_goal_baseline(workspace_root : String) -> String? {
+  let probe = @async.with_timeout_opt(BaselineCaptureBudgetMs, () => {
+    guard run_capture("git", ["rev-parse", "HEAD"], workspace_root)
+      is Some(sha_line) else {
+      return None
+    }
+    let sha = sha_line.trim().to_owned()
+    if sha.is_empty() {
+      return None
+    }
+    let dirty = match
+      run_capture("git", ["status", "--porcelain"], workspace_root) {
+      Some(status) => !status.trim().is_empty()
+      None => true
+    }
+    Some(@agent_session.goal_baseline_notice(sha~, dirty~))
+  }) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return None
+  }
+  probe.bind(x => x)
+}
+
+///|
+async test "capture_goal_baseline probes the enclosing repo" {
+  // Needs git and spawn permission; this checkout is a git repo. Guarded
+  // rather than asserted: sandboxes without spawn or git report None.
+  let notice = capture_goal_baseline(".")
+  guard notice is Some(notice) else {
+    println("skipped: git probe unavailable")
+    return
+  }
+  guard @agent_session.parse_goal_baseline(notice) is Some(baseline) else {
+    fail("expected a parseable baseline notice: \{notice}")
+  }
+  // A full commit id, not a short one: the gate resolves it exactly.
+  assert_eq(baseline.sha.length(), 40)
+}

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -24,6 +24,7 @@ import {
   "bobzhang/openseek/internal/workspace_path",
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/process",
   "moonbitlang/async/io",
   "moonbitlang/async/os_error",
   "moonbitlang/async/stdio",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -90,9 +90,12 @@ priv enum PendingWork {
   // The marker plus the command context that PRECEDED it at arrival: the
   // drain replays true wire order — context arriving later stays in the
   // runtime queue and lands after the goal.
-  // marker, arrival-context snapshot, and whether THIS command carried
-  // auto: promotion fires only on the auto entry's own durable append.
-  PendingGoal(String, Array[@agent_runtime.SteerInput], Bool, Int)
+  // marker, arrival-context snapshot, whether THIS command carried auto
+  // (promotion fires only on the auto entry's own durable append), the
+  // command serial, and the baseline notice captured at command receipt —
+  // appended immediately before the marker at drain, preserving the
+  // adjacency contract Session::current_goal_baseline pairs by.
+  PendingGoal(String, Array[@agent_runtime.SteerInput], Bool, Int, String?)
   // Context that arrived AFTER a queued goal: fenced into the ordered
   // queue so it cannot overtake the goal via the runtime steer queue (an
   // earlier pending prompt would otherwise drain it first).
@@ -296,7 +299,7 @@ fn has_pending_prompt(pending : Array[PendingWork]) -> Bool {
 
 ///|
 fn has_pending_goal(pending : Array[PendingWork]) -> Bool {
-  pending.any(work => work is PendingGoal(_, _, _, _))
+  pending.any(work => work is PendingGoal(_, _, _, _, _))
 }
 
 ///|
@@ -304,7 +307,7 @@ test "pending prompt helpers ignore queued compactions and goals" {
   let pending : Array[PendingWork] = []
   assert_false(has_pending_prompt(pending))
   pending.push(PendingCompact)
-  pending.push(PendingGoal("[goal]\nship it", [], false, 1))
+  pending.push(PendingGoal("[goal]\nship it", [], false, 1, None))
   assert_false(has_pending_prompt(pending))
   pending.push(PendingPrompt("next"))
   assert_true(has_pending_prompt(pending))
@@ -313,7 +316,7 @@ test "pending prompt helpers ignore queued compactions and goals" {
   assert_false(has_pending_prompt(pending))
   assert_eq(pending.length(), 2)
   assert_true(pending[0] is PendingCompact)
-  assert_true(pending[1] is PendingGoal(_, _, _, _))
+  assert_true(pending[1] is PendingGoal(_, _, _, _, _))
 }
 
 ///|
@@ -748,6 +751,18 @@ async fn run_serve(
     // queue time — so a controller can only learn a goal that was actually
     // persisted; callers gate their promotion tails on the returned Bool for
     // the same reason.
+    // Persist the captured baseline notice, if any, IMMEDIATELY before its
+    // goal marker: Session::current_goal_baseline pairs strictly by
+    // adjacency, and this loop is the single appender on the idle/drain
+    // paths. A failed baseline append is absorbed — the goal still sets;
+    // only the future review gate loses its anchor.
+    async fn append_goal_baseline(baseline : String?) -> Unit {
+      if baseline is Some(notice) {
+        append_idle_item(Runtime(RuntimeNotice(notice)), "goal baseline")
+        |> ignore
+      }
+    }
+
     async fn append_goal_marker(marker : String) -> Bool {
       if append_idle_item(Runtime(RuntimeNotice(marker)), "goal update") {
         report_goal_update(marker)
@@ -780,18 +795,27 @@ async fn run_serve(
         Prompt(text) => @emit.emit(SteerDropped(content=text))
         Command(text) => append_command_context(text, "command")
         Notice(text) =>
-          match @agent_session.goal_marker(text) {
-            // A goal marker deferred behind a live turn lands here when the
-            // turn ends before its next step boundary. Its notice leg is
-            // transport: persist and report it as a goal update, so no
-            // controller ever sees it dressed as a background notice.
-            Some(_) =>
-              if append_goal_marker(text) {
-                // Drained at idle: the finished turn never saw this marker,
-                // so its first turn belongs to the controller.
-                maybe_promote_goal_auto(true)
-              }
-            None => append_background_notice(text)
+          if @agent_session.parse_goal_baseline(text) is Some(_) {
+            // The steer-path baseline landing at idle (its turn ended
+            // first): persist it exactly where it sits in the drain order —
+            // its goal marker is the very next input — without dressing it
+            // as a background notice.
+            append_idle_item(Runtime(RuntimeNotice(text)), "goal baseline")
+            |> ignore
+          } else {
+            match @agent_session.goal_marker(text) {
+              // A goal marker deferred behind a live turn lands here when the
+              // turn ends before its next step boundary. Its notice leg is
+              // transport: persist and report it as a goal update, so no
+              // controller ever sees it dressed as a background notice.
+              Some(_) =>
+                if append_goal_marker(text) {
+                  // Drained at idle: the finished turn never saw this marker,
+                  // so its first turn belongs to the controller.
+                  maybe_promote_goal_auto(true)
+                }
+              None => append_background_notice(text)
+            }
           }
       }
     }
@@ -897,10 +921,11 @@ async fn run_serve(
           // and durable order must match arrival order.
           // Fenced context: apply at its ordered position and keep draining.
           PendingContext(input) => apply_idle_context_input(input)
-          PendingGoal(marker, context, is_auto, serial) => {
+          PendingGoal(marker, context, is_auto, serial, baseline) => {
             for input in context {
               apply_idle_context_input(input)
             }
+            append_goal_baseline(baseline)
             // Promotion tied to THIS entry's durable append: with two
             // same-text goals queued, an earlier append must not arm an
             // auto command whose own marker is not durable yet.
@@ -1011,6 +1036,13 @@ async fn run_serve(
             SetGoal(text, ..) => "\{@agent_session.GoalPrefix}\n\{text}"
             ClearGoal => @agent_session.GoalClearedNotice
           }
+          // Captured at COMMAND RECEIPT (bounded; see baseline.mbt) so every
+          // path records the worktree as it stood when the user set the
+          // goal, not when the marker eventually lands.
+          let baseline : String? = match action {
+            SetGoal(_, ..) => capture_goal_baseline(workspace_root)
+            ClearGoal => None
+          }
           if pending.length() > 0 || active_work is Some(ActiveCompact(_)) {
             // ANY queued work ahead in wire order — a pipelined prompt as
             // much as a compaction — must precede this goal, or a pending
@@ -1034,7 +1066,9 @@ async fn run_serve(
               take_context_before_goal()
             }
             pending.push(
-              PendingGoal(marker, context, is_auto, goal_command_serial),
+              PendingGoal(
+                marker, context, is_auto, goal_command_serial, baseline,
+              ),
             )
           } else if active_work is Some(ActiveTurn(_)) {
             // A live turn: the lossless steer queue makes the marker
@@ -1042,9 +1076,18 @@ async fn run_serve(
             // durable append); if the turn ends first, the TurnDone drain
             // persists it before any queued prompt starts, so the next turn
             // still sees it.
+            // Two consecutive synchronous queue_steer calls: nothing can
+            // interleave between them, so the loop applies (or the idle
+            // drain persists) baseline and marker adjacently.
+            if baseline is Some(notice) {
+              runtime.queue_steer(Notice(notice))
+            }
             runtime.queue_steer(Notice(marker))
-          } else if append_goal_marker(marker) {
-            maybe_promote_goal_auto(false)
+          } else {
+            append_goal_baseline(baseline)
+            if append_goal_marker(marker) {
+              maybe_promote_goal_auto(false)
+            }
           }
         }
         // A background job finished. If a turn is active, its next step boundary

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -1038,9 +1038,12 @@ async fn run_serve(
           }
           // Captured at COMMAND RECEIPT (bounded; see baseline.mbt) so every
           // path records the worktree as it stood when the user set the
-          // goal, not when the marker eventually lands.
+          // goal, not when the marker eventually lands. For a QUEUED goal
+          // behind a long turn this anchor may predate that turn's commits
+          // — a known divergence: the gate treats the baseline as advisory
+          // context for a current-worktree audit, never exact attribution.
           let baseline : String? = match action {
-            SetGoal(_, ..) => capture_goal_baseline(workspace_root)
+            SetGoal(_, ..) => Some(capture_goal_baseline(workspace_root))
             ClearGoal => None
           }
           if pending.length() > 0 || active_work is Some(ActiveCompact(_)) {

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -413,7 +413,8 @@ fn handle_agent_event(
     // making the tagged BackgroundNotice path unreachable — but render it
     // the same way for completeness.
     SteerApplied(Notice(text)) | BackgroundNotice(text) =>
-      if @agent_session.goal_marker(text) is None {
+      if @agent_session.goal_marker(text) is None &&
+        @agent_session.parse_goal_baseline(text) is None {
         cmds.push(AppendItem(Input(Notice(text))))
       }
     // Normally unreachable from the wire: the engine client routes
@@ -772,7 +773,8 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // their notice leg is transport, and goal_updated carries the
     // confirmation (defense in depth against engine version skew).
     EngineBackgroundNotice(text) =>
-      if @agent_session.goal_marker(text) is None {
+      if @agent_session.goal_marker(text) is None &&
+        @agent_session.parse_goal_baseline(text) is None {
         cmds.push(AppendItem(Input(Notice(text))))
       }
     // The engine's durable-append confirmation is the only writer of the

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -53,6 +53,10 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
     // path where markers are filtered and goal_updated is what renders.
     Runtime(notice) if @agent_session.goal_marker(notice.content()) is Some(_) =>
       None
+    // The baseline pairing record is transport too: filtered on the live
+    // path, so resume must not resurrect it as a notice card.
+    Runtime(notice) if @agent_session.parse_goal_baseline(notice.content())
+      is Some(_) => None
     Runtime(notice) => Some(runtime_notice_item(notice.content()))
     Summary(summary) => Some(summary_item(summary))
     Terminal(terminal) => terminal_item(terminal)

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -113,7 +113,13 @@ fn append_session_item(
       })
     }
     "runtime_notice" =>
-      if content is Some(content) && !content.trim().is_empty() {
+      // Goal-family notices are transport (set/clear/block markers, the
+      // baseline pairing record) or model-directed text — never display
+      // cards. Local prefix check: this js-only package cannot depend on
+      // agent_session's parsers.
+      if content is Some(content) &&
+        !content.trim().is_empty() &&
+        !content.has_prefix("[goal") {
         let update = parse_runtime_update(content)
         if !update.status.is_empty() || update.diagnostics.length() > 0 {
           items.push({


### PR DESCRIPTION
E of the subagent series — the review gate's audit anchor.

- `[goal baseline] sha=<sha> dirty=<bool>` notice, appended **immediately before** its `[goal]` set marker on every goal-set path; `Session::current_goal_baseline()` pairs strictly by adjacency (the serve loop is the single appender on idle/drain paths; the steer path queues both notices with consecutive synchronous calls). Orphan baselines pair with nothing; a marker without a baseline simply has none; replacements pair with **their** baseline and never inherit.
- Captured at **command receipt** (the worktree as the user saw it), bounded to 2s across both git probes; failure of any kind means the goal still sets and only the future gate loses its anchor. A failed dirty probe reports `dirty=true` — conservative for an audit.
- All three `/goal` paths wired: idle append, live-turn steer (the idle drain persists the pair adjacently when the turn ends first, without dressing the baseline as a background notice), and queued (`PendingGoal` carries it to its drain).
- TUI filters baseline notices from the transcript like goal markers; older TUIs show a harmless one-liner.

Tests: notice round-trip + strict-parse rejections, adjacency pairing, broken-adjacency yields none, orphan ignored, replacement/clear semantics, and a guarded live-repo probe pinning the 40-char sha. agent_session 35/35, cmd 65/65, TUI 82/82, cram 26/26; `check --target all`/`fmt`/`info` clean.

Panel review (fresh-context + K3) to follow per the standing bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)