### PR TITLE
feat(gate): the advisory goal-met review — audit the worktree before the claim stands

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -238,6 +238,7 @@ pub async fn[X] run_turn_in_scope(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   tools? : @agent_tool.Tools,
+  on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
 ) -> @agent_session.Session {
   let client = @client.Client(api_key~, model~, thinking~, api_url?)
   let summary_client = @client.Client(api_key~, model~, api_url?, thinking=No)
@@ -254,9 +255,15 @@ pub async fn[X] run_turn_in_scope(
         |> append_item(Terminal(Failed("agent setup failed: \{error}")))
     }
   }
-  AgentLoop(runtime~, client~, summary_client~, tools~, append_item~, session~).run(
-    session, max_steps,
-  )
+  AgentLoop(
+    runtime~,
+    client~,
+    summary_client~,
+    tools~,
+    append_item~,
+    session~,
+    on_goal_met?,
+  ).run(session, max_steps)
 }
 
 ///|

--- a/agent/auto_compact.mbt
+++ b/agent/auto_compact.mbt
@@ -168,6 +168,10 @@ async fn AgentLoop::yield_at_context_ceiling(
   // lost — current_goal() would resurrect a goal the model already met,
   // and auto-continue would keep chaining toward it.
   let session = self.flush_goal_tombstone(session)
+  // A met claim yielding at the ceiling still gets its owed audit: the
+  // digest lands durably BEFORE the yield terminal, so the auto-continued
+  // next turn inherits the verdict instead of an unaudited claim.
+  let session = self.run_pending_review(session)
   let to_sequence = session.last_sequence()
   let (session, compacted) = self.checkpoint_at_ceiling(session, steers)
   // The summary request takes seconds; steers submitted while it was in

--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -111,10 +111,6 @@ priv struct GoalCadence {
   /// record. Consumed at the next batch-safe boundary; only set when the
   /// loop carries an `on_goal_met` callback.
   mut pending_review : (String, @agent_session.GoalBaseline?)?
-  /// Bumped whenever a durable goal set/clear is observed: a scheduled
-  /// review belongs to the generation it captured, and a goal superseded
-  /// while the reviewer ran must discard the stale audit.
-  mut review_generation : Int
 }
 
 ///|
@@ -132,7 +128,6 @@ fn GoalCadence::GoalCadence(
     pending_block: NoBlockTransition,
     pending_tombstone: false,
     pending_review: None,
-    review_generation: 0,
   }
 }
 
@@ -244,9 +239,10 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       // this set supersedes; a new goal starts unblocked.
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
-      // A new goal supersedes any still-owed review of the previous one.
+      // A new goal supersedes a still-owed (unlaunched) review of the
+      // previous one; an audit already IN FLIGHT completes and lands
+      // before this marker — bound to the met claim, not to us.
       self.pending_review = None
-      self.review_generation += 1
       @emit.emit(GoalUpdated(goal=Some(text)))
     }
     Some(GoalCleared) => {
@@ -256,7 +252,6 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
       self.pending_review = None
-      self.review_generation += 1
       @emit.emit(GoalUpdated(goal=None))
     }
     // A block/unblock marker landing durably (this loop's own flush, or a

--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -106,6 +106,15 @@ priv struct GoalCadence {
   /// turn finish) — a mid-batch runtime notice would make replay synthesize
   /// exited-errors for the batch's remaining tool calls.
   mut pending_tombstone : Bool
+  /// A goal(met) whose advisory gate review is still owed: the goal text
+  /// and the baseline captured BEFORE the tombstone clears the durable
+  /// record. Consumed at the next batch-safe boundary; only set when the
+  /// loop carries an `on_goal_met` callback.
+  mut pending_review : (String, @agent_session.GoalBaseline?)?
+  /// Bumped whenever a durable goal set/clear is observed: a scheduled
+  /// review belongs to the generation it captured, and a goal superseded
+  /// while the reviewer ran must discard the stale audit.
+  mut review_generation : Int
 }
 
 ///|
@@ -122,6 +131,8 @@ fn GoalCadence::GoalCadence(
     durably_blocked: standing.map(goal => goal.blocked()).unwrap_or(false),
     pending_block: NoBlockTransition,
     pending_tombstone: false,
+    pending_review: None,
+    review_generation: 0,
   }
 }
 
@@ -134,6 +145,12 @@ fn GoalCadence::due_finish_check(self : GoalCadence) -> String? {
   } else {
     self.goal
   }
+}
+
+///|
+/// Whether a goal(met) review is still owed at the next batch-safe boundary.
+fn GoalCadence::due_review(self : GoalCadence) -> Bool {
+  self.pending_review is Some(_)
 }
 
 ///|
@@ -227,6 +244,9 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       // this set supersedes; a new goal starts unblocked.
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
+      // A new goal supersedes any still-owed review of the previous one.
+      self.pending_review = None
+      self.review_generation += 1
       @emit.emit(GoalUpdated(goal=Some(text)))
     }
     Some(GoalCleared) => {
@@ -235,6 +255,8 @@ fn GoalCadence::observe_notice(self : GoalCadence, content : String) -> Unit {
       self.pending_tombstone = false
       self.pending_block = NoBlockTransition
       self.durably_blocked = false
+      self.pending_review = None
+      self.review_generation += 1
       @emit.emit(GoalUpdated(goal=None))
     }
     // A block/unblock marker landing durably (this loop's own flush, or a
@@ -377,7 +399,17 @@ async fn AgentLoop::handle_goal_tool_call(
   // append must not leave a pending tombstone (the error-path flush would
   // then durably clear a goal whose met verdict was never persisted).
   match verdict {
-    (Ok(Met), Some(_)) => self.goal_cadence.record_goal_met()
+    (Ok(Met), Some(goal_text)) => {
+      self.goal_cadence.record_goal_met()
+      // Schedule the advisory gate review BEFORE the tombstone clears the
+      // durable record: the baseline is readable now or never. Executed at
+      // the next batch-safe boundary, never mid-batch.
+      if !(self.on_goal_met is None) {
+        self.goal_cadence.pending_review = Some(
+          (goal_text, session.current_goal_baseline()),
+        )
+      }
+    }
     // Continuing answers the finish check and, if the goal is durably
     // blocked, schedules a `[goal unblocked]` marker so serve resumes.
     (Ok(Continuing(_)), Some(_)) => self.goal_cadence.record_goal_continuing()

--- a/agent/goal_gate_test.mbt
+++ b/agent/goal_gate_test.mbt
@@ -1,0 +1,251 @@
+///|
+/// A session with a baselined standing goal, already answered.
+fn baselined_goal_session(id : String) -> @agent_session.Session {
+  @agent_session.Session(SessionId(id), system_prompt="system")
+  .append(
+    Runtime(
+      RuntimeNotice(
+        @agent_session.goal_baseline_notice(sha="abc123", dirty=false),
+      ),
+    ),
+  )
+  .append(Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nship the gate")))
+  .append(Terminal(Finished("earlier answer")))
+}
+
+///|
+fn goal_met_payload() -> String {
+  (
+    #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}}]}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+  )
+}
+
+///|
+fn gate_final_payload(text : String) -> String {
+  (
+    $|{"choices":[{"delta":{"content":"\{text}"}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+  )
+}
+
+///|
+fn review_notice_count(session : @agent_session.Session) -> Int {
+  let mut count = 0
+  for event in session.events() {
+    if event.item() is Runtime(notice) &&
+      notice.content().has_prefix("[review]") {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+/// goal(met) recorded mid-turn: the gate runs once at the next batch-safe
+/// boundary — before the following model request — and injects its digest
+/// as a durable notice the model then sees.
+async test "a met goal runs the gate once before the next request" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        goal_met_payload(),
+        gate_final_payload("done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let calls : Array[(String, String)] = []
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-basic"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([@goal.definition()]),
+      on_goal_met=(goal, baseline) => {
+        calls.push((goal, "\{to_repr(baseline)}"))
+        Some("[review] goal-met audit: 0 finding(s) — clean")
+      },
+    )
+    // met batch, then one more request that already sees the notice.
+    assert_eq(bodies.length(), 2)
+    guard calls is [(goal, baseline)] else {
+      fail("expected exactly one gate call, got \{calls.length()}")
+    }
+    assert_eq(goal, "ship the gate")
+    assert_true(baseline.contains("abc123"))
+    assert_true(baseline.contains("dirty: false"))
+    assert_eq(review_notice_count(result), 1)
+    // The request AFTER the gate carried the digest to the model.
+    assert_true(bodies[1].contains("goal-met audit"))
+  }
+}
+
+///|
+/// met and finish in the SAME batch: the finish converts into a review
+/// continuation (mirroring the goal check), the model sees the digest, and
+/// the next finish seals.
+async test "a same-batch met plus finish continues through the gate" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let met_then_finish =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}},{"index":1,"id":"c2","function":{"name":"finish","arguments":"{\"answer\":\"all done\"}"}}]}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+    guard goal_check_test_server(group, bodies, [
+        met_then_finish,
+        gate_final_payload("confirmed done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let mut gate_calls = 0
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-same-batch"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([@goal.definition(), @finish.definition()]),
+      on_goal_met=(_goal, _baseline) => {
+        gate_calls += 1
+        Some(
+          "[review] goal-met audit: 1 finding(s) (1 blocker, 0 high) — vacuous test",
+        )
+      },
+    )
+    assert_eq(bodies.length(), 2)
+    assert_eq(gate_calls, 1)
+    assert_eq(review_notice_count(result), 1)
+    assert_true(bodies[1].contains("vacuous test"))
+    assert_true(finished_answer(result).contains("confirmed done"))
+  }
+}
+
+///|
+/// The gate is advisory: a reviewer failure folds into an `unavailable`
+/// notice and the turn proceeds.
+async test "a failing gate folds into an unavailable notice" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        goal_met_payload(),
+        gate_final_payload("done anyway"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-fail"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([@goal.definition()]),
+      on_goal_met=(_goal, _baseline) => fail("reviewer exploded"),
+    )
+    assert_eq(review_notice_count(result), 1)
+    let mut unavailable = false
+    for event in result.events() {
+      if event.item() is Runtime(notice) &&
+        notice.content().has_prefix("[review] unavailable") {
+        unavailable = true
+      }
+    }
+    assert_true(unavailable)
+    assert_true(finished_answer(result).contains("done anyway"))
+  }
+}
+
+///|
+/// Without a callback the met flow is exactly what it was before the gate.
+async test "no callback means no gate and no notice" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        goal_met_payload(),
+        gate_final_payload("done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-off"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([@goal.definition()]),
+    )
+    assert_eq(review_notice_count(result), 0)
+    assert_eq(bodies.length(), 2)
+  }
+}
+
+///|
+/// A replacement goal queued before the boundary cancels the owed review:
+/// the superseded audit never launches.
+async test "a replacement goal cancels the pending review before launch" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let bodies : Array[String] = []
+    let met_then_probe =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}},{"index":1,"id":"c2","function":{"name":"probe","arguments":"{}"}}]}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+    guard goal_check_test_server(group, bodies, [
+        met_then_probe,
+        gate_final_payload("onward"),
+        gate_final_payload("done"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let mut gate_calls = 0
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-superseded"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([
+        @goal.definition(),
+        AgentToolDefinition(
+          name="probe",
+          description="Queues a replacement goal mid-batch.",
+          schema=JsonSchema({ "type": "object" }),
+          execute=Sync(_args => {
+            // The replacement arrives WHILE the met batch is executing:
+            // the next boundary applies it before the owed review would
+            // launch, and the superseded audit is cancelled.
+            runtime.queue_steer(
+              Notice("\{@agent_session.GoalPrefix}\na brand new objective"),
+            )
+            @agent_tool.ToolAction::respond("queued")
+          }),
+        ),
+      ]),
+      on_goal_met=(_goal, _baseline) => {
+        gate_calls += 1
+        Some("[review] should never appear")
+      },
+    )
+    assert_eq(gate_calls, 0)
+    assert_eq(review_notice_count(result), 0)
+  }
+}

--- a/agent/goal_gate_test.mbt
+++ b/agent/goal_gate_test.mbt
@@ -249,3 +249,184 @@ async test "a replacement goal cancels the pending review before launch" {
     assert_eq(review_notice_count(result), 0)
   }
 }
+
+///|
+/// The panel's executable repro: same-batch met+finish under ceiling
+/// pressure with a FAILING checkpoint must neither resurrect the met goal
+/// nor lose the audit — the fail-open seal flushes the tombstone and runs
+/// the review before sealing.
+async test "a failed checkpoint neither resurrects the goal nor loses the audit" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let met_then_finish_pressured =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}},{"index":1,"id":"c2","function":{"name":"finish","arguments":"{\"answer\":\"all done\"}"}}]}}],"usage":{"prompt_tokens":749000,"completion_tokens":1000,"total_tokens":750000}}
+    // goal_check_test_server answers EVERY request with SSE — including the
+    // checkpoint's non-streaming summary call, whose junk reply fails it.
+    guard goal_check_test_server(group, bodies, [
+        met_then_finish_pressured,
+        gate_final_payload("unreached"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let mut gate_calls = 0
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-failed-checkpoint"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([@goal.definition(), @finish.definition()]),
+      on_goal_met=(_goal, _baseline) => {
+        gate_calls += 1
+        Some("[review] survived the failed checkpoint")
+      },
+    )
+    // The met goal must NOT resurrect for auto-continue…
+    assert_true(result.current_goal() is None)
+    // …and the audit must not be lost with the checkpoint.
+    assert_eq(gate_calls, 1)
+    assert_eq(review_notice_count(result), 1)
+  }
+}
+
+///|
+/// met+finish on the LAST bounded step: the model cannot react, but the
+/// audit still runs and its digest lands durably for the user (and any
+/// auto-continued turn) to judge the claim.
+async test "a last-step met still gets its audit durably" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let met_then_finish =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}},{"index":1,"id":"c2","function":{"name":"finish","arguments":"{\"answer\":\"all done\"}"}}]}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+    guard goal_check_test_server(group, bodies, [met_then_finish]) is Some(url) else {
+      return
+    }
+    let mut gate_calls = 0
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-last-step"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      api_url=url,
+      tools=Tools([@goal.definition(), @finish.definition()]),
+      on_goal_met=(_goal, _baseline) => {
+        gate_calls += 1
+        Some("[review] last-step audit")
+      },
+    )
+    assert_eq(gate_calls, 1)
+    assert_eq(review_notice_count(result), 1)
+    assert_true(finished_answer(result).contains("all done"))
+  }
+}
+
+///|
+/// met followed by a context yield: the audit runs before the yield seals,
+/// so the auto-continued next turn inherits the verdict, not an unaudited
+/// claim.
+async test "a met claim yielding at the ceiling still gets its audit" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let met_pressured =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"goal","arguments":"{\"status\":\"met\"}"}}]}}],"usage":{"prompt_tokens":899000,"completion_tokens":1000,"total_tokens":900000}}
+    // Two responses: the pressured batch, then SSE junk for the ceiling
+    // checkpoint's summary request (failing it exercises the same yield).
+    guard goal_check_test_server(group, bodies, [
+        met_pressured,
+        gate_final_payload("checkpoint junk"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let mut gate_calls = 0
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-yield"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([@goal.definition()]),
+      on_goal_met=(_goal, _baseline) => {
+        gate_calls += 1
+        Some("[review] audited before the yield")
+      },
+    )
+    assert_true(result.current_goal() is None)
+    assert_eq(gate_calls, 1)
+    assert_eq(review_notice_count(result), 1)
+  }
+}
+
+///|
+/// The bound-to-the-met-claim semantics: a replacement goal queued WHILE
+/// the reviewer runs does not discard the audit — the notice lands first
+/// (chronologically truthful), then the replacement applies and stands.
+async test "an in-flight audit completes before a queued replacement applies" {
+  @async.with_task_group() <| group => {
+    let runtime = @agent_runtime.AgentRuntime()
+    let bodies : Array[String] = []
+    // Four rounds: the met batch; the answer that arrives with the queued
+    // replacement steer (kept, turn continues); the answer that trips the
+    // NEW goal's finish check; the confirmation that seals.
+    guard goal_check_test_server(group, bodies, [
+        goal_met_payload(),
+        gate_final_payload("onward"),
+        gate_final_payload("done"),
+        gate_final_payload("confirmed"),
+      ])
+      is Some(url) else {
+      return
+    }
+    let result = @agent.run_turn_in_scope(
+      runtime~,
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=baselined_goal_session("gate-inflight"),
+      task="wrap up the goal",
+      append_item=(session, item) => session.append(item),
+      max_steps=6,
+      api_url=url,
+      tools=Tools([@goal.definition()]),
+      on_goal_met=(_goal, _baseline) => {
+        // The user replaces the goal while the reviewer is mid-flight.
+        runtime.queue_steer(
+          Notice("\{@agent_session.GoalPrefix}\na brand new objective"),
+        )
+        Some("[review] audit of the met claim")
+      },
+    )
+    assert_eq(review_notice_count(result), 1)
+    guard result.current_goal() is Some(goal) else {
+      fail("expected the replacement goal to stand")
+    }
+    assert_eq(goal.text(), "a brand new objective")
+    // Durable order: the audit notice precedes the replacement marker.
+    let mut notice_seq = 0
+    let mut marker_seq = 0
+    for event in result.events() {
+      if event.item() is Runtime(notice) {
+        if notice.content().has_prefix("[review]") {
+          notice_seq = event.sequence()
+        }
+        if notice.content().contains("a brand new objective") {
+          marker_seq = event.sequence()
+        }
+      }
+    }
+    assert_true(notice_seq > 0 && marker_seq > notice_seq)
+  }
+}

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub let plan_reminder_after_steps : Int
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
-pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
 
 pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
 

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -150,10 +150,7 @@ async fn AgentLoop::run(
         let steer_inputs = self.runtime.pending_steers()
         if steer_inputs.is_empty() {
           if step + 1 < max_steps &&
-            (
-              self.goal_cadence.due_finish_check() is Some(_) ||
-              self.goal_cadence.due_review()
-            ) {
+            self.goal_cadence.due_finish_check() is Some(_) {
             // The model considers itself done, but the standing goal is
             // unconfirmed: keep the would-be answer as an ordinary assistant
             // message and ask once whether the goal is met. The model may
@@ -931,8 +928,7 @@ async fn AgentLoop::record_tool_result(
 /// without a pending review or a callback. Failure folding: external
 /// cancellation re-raises; any other reviewer failure becomes an
 /// `[review] unavailable` notice — the gate is advisory and must never
-/// break the turn. A goal set or cleared while the reviewer ran bumps the
-/// cadence generation and the stale audit is discarded unappended.
+/// break the turn.
 async fn AgentLoop::run_pending_review(
   self : Self,
   session : @agent_session.Session,
@@ -942,16 +938,18 @@ async fn AgentLoop::run_pending_review(
   }
   self.goal_cadence.pending_review = None
   guard self.on_goal_met is Some(callback) else { return session }
-  let generation = self.goal_cadence.review_generation
+  // The audit is bound to the MET CLAIM, not to whichever goal currently
+  // stands: a replacement queued while the reviewer runs is applied at the
+  // next boundary, AFTER this notice — chronologically truthful ordering.
+  // (Pre-launch economy is separate: a replacement observed before this
+  // point already cleared the pending slot and no audit was spawned.)
   let notice = callback(goal, baseline) catch {
     error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
       raise error
-    error => Some("[review] unavailable: \{error}")
-  }
-  if self.goal_cadence.review_generation != generation {
-    // Superseded while the reviewer ran: the audit describes a goal the
-    // user has already replaced.
-    return session
+    error =>
+      Some(
+        "[review] unavailable: \{@agent_tool.brief_line("\{error}", limit=200)}",
+      )
   }
   match notice {
     Some(text) => self.append_runtime_notice(session, text)
@@ -969,6 +967,14 @@ async fn AgentLoop::continue_into_goal_check(
   keep_only_when_compacted~ : Bool,
   reasoning_content? : String,
 ) -> FinishOutcome {
+  // Flush the deferred goal tombstone FIRST: the review-gate disjunct
+  // makes this flow reachable with a pending tombstone (same-batch
+  // goal(met)+finish), and the fail-open arm below seals via
+  // finish_context_yield — sealing without the flush would resurrect a
+  // met goal for auto-continue, and the flush-first order also keeps
+  // [goal cleared] ahead of the [review] notice in the durable log. A
+  // no-op on every pre-gate entry.
+  let session = self.flush_goal_tombstone(session)
   let at_ceiling = self.at_soft_context_ceiling(
     usage,
     extra_result_chars=spent_result_chars,
@@ -998,6 +1004,9 @@ async fn AgentLoop::continue_into_goal_check(
       session,
       self.runtime.pending_steers(),
     )
+    // The owed audit still runs on this fail-open seal: its durable digest
+    // is what the next (auto-continued) turn inherits.
+    let session = self.run_pending_review(session)
     return Sealed(
       self.finish_context_yield(session, to_sequence, compacted=false),
     )
@@ -1032,8 +1041,7 @@ async fn AgentLoop::continue_into_goal_check(
   }
   // The owed goal-met review lands here too: same batch-safe boundary,
   // same continuation — the model sees the audit before it may finish
-  // again. Runs after the check injection; a superseding set during the
-  // reviewer's await discards the stale audit via the generation guard.
+  // again.
   let session = self.run_pending_review(session)
   if at_ceiling {
     // Re-seed the in-flight buffer from the compacted projection: the
@@ -1092,6 +1100,12 @@ async fn AgentLoop::finish_turn(
   spent_result_chars? : Int64 = 0,
   reasoning_content? : String,
 ) -> FinishOutcome {
+  // A met claim reaching a seal that skipped the review continuation (the
+  // last bounded step) still gets its audit: the model cannot react this
+  // turn, but the durable digest is exactly what the user — or the next
+  // auto-continued turn — needs to judge the claim. No-op when nothing is
+  // owed.
+  let session = self.run_pending_review(session)
   // A goal met in the turn's final batch still needs its durable clear
   // before the terminal seals the turn — and before any compact-on-finish
   // checkpoint, so the tombstone is covered like the rest of the history.

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -15,6 +15,11 @@ priv struct AgentLoop {
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
   goal_cadence : GoalCadence
+  /// The advisory goal-met gate: given the met goal's text and its
+  /// captured baseline, produce the notice to append (or None for
+  /// nothing). Review-neutral by type — the CLI layer supplies a callback
+  /// that runs the reviewer child; the loop only schedules and injects.
+  on_goal_met : (async (String, @agent_session.GoalBaseline?) -> String?)?
   /// Latest session returned by a successful append. The run-level error
   /// handler uses it to persist a terminal failure/interruption even when the
   /// local loop state is behind the last durable session.
@@ -29,6 +34,7 @@ fn AgentLoop::AgentLoop(
   tools~ : @agent_tool.Tools,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   session~ : @agent_session.Session,
+  on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
 ) -> AgentLoop {
   {
     runtime,
@@ -36,6 +42,7 @@ fn AgentLoop::AgentLoop(
     summary_client,
     tools,
     append_item,
+    on_goal_met,
     messages: session.chat_messages(),
     plan_cadence: PlanCadence(registered=tools.find("plan") is Some(_)),
     goal_cadence: GoalCadence(
@@ -143,7 +150,10 @@ async fn AgentLoop::run(
         let steer_inputs = self.runtime.pending_steers()
         if steer_inputs.is_empty() {
           if step + 1 < max_steps &&
-            self.goal_cadence.due_finish_check() is Some(_) {
+            (
+              self.goal_cadence.due_finish_check() is Some(_) ||
+              self.goal_cadence.due_review()
+            ) {
             // The model considers itself done, but the standing goal is
             // unconfirmed: keep the would-be answer as an ordinary assistant
             // message and ask once whether the goal is met. The model may
@@ -388,10 +398,13 @@ async fn AgentLoop::prepare_step(
   let session = self.flush_goal_tombstone(session)
   // Steering first: user-visible mid-turn input should be applied before plan
   // reminders or the next model request.
-  let mut session = self.apply_steer_inputs(
-    session,
-    self.runtime.pending_steers(),
-  )
+  let session = self.apply_steer_inputs(session, self.runtime.pending_steers())
+  // A goal met without a finish attempt still gets its owed review before
+  // the next model request (the finish seams handle the met-then-finish
+  // shapes; this covers met-then-keep-working). AFTER the steers: a queued
+  // replacement goal observed just above clears the pending review, so a
+  // superseded audit is cancelled before it ever launches.
+  let mut session = self.run_pending_review(session)
   if self.goal_cadence.due_reminder() is Some(goal) {
     let reminder = goal_reminder_text(
       goal,
@@ -595,7 +608,11 @@ async fn AgentLoop::execute_tool_call(
         // On the final bounded step there is no request budget left for a
         // check round: injecting one would exit into "max steps exhausted"
         // and turn a successful bounded turn into a failure. Finish.
-        if !last_step && self.goal_cadence.due_finish_check() is Some(_) {
+        if !last_step &&
+          (
+            self.goal_cadence.due_finish_check() is Some(_) ||
+            self.goal_cadence.due_review()
+          ) {
           return ToolCallOutcome::of_finish(
             self.continue_into_goal_check(
               session,
@@ -910,6 +927,39 @@ async fn AgentLoop::record_tool_result(
 /// get. Only the no-tool arm passes reasoning: the finish tool's answer is
 /// synthetic (its reasoning lives on the batch's covered assistant
 /// message; re-attaching it would duplicate what Kimi preserves there).
+/// Run the owed goal-met review, if any, and append its notice. A no-op
+/// without a pending review or a callback. Failure folding: external
+/// cancellation re-raises; any other reviewer failure becomes an
+/// `[review] unavailable` notice — the gate is advisory and must never
+/// break the turn. A goal set or cleared while the reviewer ran bumps the
+/// cadence generation and the stale audit is discarded unappended.
+async fn AgentLoop::run_pending_review(
+  self : Self,
+  session : @agent_session.Session,
+) -> @agent_session.Session {
+  guard self.goal_cadence.pending_review is Some((goal, baseline)) else {
+    return session
+  }
+  self.goal_cadence.pending_review = None
+  guard self.on_goal_met is Some(callback) else { return session }
+  let generation = self.goal_cadence.review_generation
+  let notice = callback(goal, baseline) catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    error => Some("[review] unavailable: \{error}")
+  }
+  if self.goal_cadence.review_generation != generation {
+    // Superseded while the reviewer ran: the audit describes a goal the
+    // user has already replaced.
+    return session
+  }
+  match notice {
+    Some(text) => self.append_runtime_notice(session, text)
+    None => session
+  }
+}
+
+///|
 async fn AgentLoop::continue_into_goal_check(
   self : Self,
   session : @agent_session.Session,
@@ -980,6 +1030,11 @@ async fn AgentLoop::continue_into_goal_check(
     Some(current) => self.inject_goal_check(session, current)
     None => session
   }
+  // The owed goal-met review lands here too: same batch-safe boundary,
+  // same continuation — the model sees the audit before it may finish
+  // again. Runs after the check injection; a superseding set during the
+  // reviewer's await discards the stale audit via the generation guard.
+  let session = self.run_pending_review(session)
   if at_ceiling {
     // Re-seed the in-flight buffer from the compacted projection: the
     // whole point of the checkpoint is that the check round is small.

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -143,8 +143,9 @@ pub fn ReviewReport::digest(self : ReviewReport) -> String {
       "[\{finding.severity}] \{finding.file}\{line} — \{finding.title}",
       limit=digest_max_line_chars,
     )
-    // The total cap wins over per-line room: stop before overflowing.
-    if out.to_string().length() + entry.length() + 3 > digest_max_chars {
+    // The total cap wins over per-line room: stop before overflowing,
+    // reserving room for the trailers appended below (~200 chars).
+    if out.to_string().length() + entry.length() + 200 > digest_max_chars {
       out <+ "\n… digest cap reached"
       break
     }

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -1,0 +1,207 @@
+///|
+/// Default step budget for one goal audit: leaner than a full review — the
+/// audit reads the worktree against one goal, it does not survey a branch.
+pub let default_audit_max_steps : Int = 80
+
+///|
+/// System prompt for the goal audit: a read-only skeptic asking one
+/// question — does the worktree actually satisfy the goal the agent just
+/// recorded as met?
+fn audit_system_prompt() -> String {
+  (
+    #|You are OpenSeek in goal-audit mode. An agent just recorded a standing
+    #|goal as MET. Your one question: does the CURRENT WORKTREE actually
+    #|satisfy that goal? You review; you do not modify.
+    #|
+    #|Principles:
+    #|- Audit the worktree as it stands. The agent edits without committing,
+    #|  so committed diffs alone prove nothing: read `git status --porcelain`
+    #|  and the working-tree diffs, and read the files themselves.
+    #|- Ground every finding in evidence: run `moon check`/`moon test` (or the
+    #|  project's own gates) rather than trusting claims. The compiler is
+    #|  reliable; your intuition is not.
+    #|- Hunt specifically for VACUOUS success: tests that assert nothing,
+    #|  hardcoded outputs, disabled checks, criteria quietly narrowed.
+    #|- Be precise and skeptical; prefer few real findings over many
+    #|  speculative ones. Severity: blocker|high|medium|low|nit — a blocker
+    #|  means the goal is NOT met.
+    #|- When done, call submit_review exactly once with the full structured
+    #|  report (schema_version 1); set scope.head to "WORKTREE". Do not
+    #|  finish with plain text.
+  )
+}
+
+///|
+/// The audit task: the goal text plus whatever baseline anchor exists.
+fn audit_task(goal : String, baseline : @agent_session.GoalBaseline?) -> String {
+  let anchor = match baseline {
+    Some(baseline) =>
+      if baseline.dirty {
+        (
+          $|The worktree sat on commit \{baseline.sha} when this goal was set,
+          $|and was ALREADY DIRTY then — `git diff \{baseline.sha}` overstates
+          $|this goal's work; treat it as supporting context only.
+        )
+      } else {
+        (
+          $|The worktree sat on commit \{baseline.sha} (clean) when this goal
+          $|was set: `git diff \{baseline.sha}` plus untracked files is a good
+          $|approximation of this goal's work. Supporting context — the
+          $|worktree itself is what you audit.
+        )
+      }
+    None =>
+      (
+        #|No baseline was captured for this goal: audit the worktree on its
+        #|own terms (`git status --porcelain`, working-tree diffs, the files).
+      )
+  }
+  (
+    $|The goal recorded as met:
+    $|\{goal}
+    $|
+    $|\{anchor}
+    $|
+    $|Audit the current worktree against the goal's own criteria and
+    $|submit_review once, with scope.head = "WORKTREE".
+  )
+}
+
+///|
+/// Run the goal audit IN THIS PROCESS (the `openseek subrun review` child
+/// mode calls this; the standalone shape mirrors `run_review`). `None`
+/// when the auditor finished without a valid submission.
+pub async fn run_goal_audit(
+  goal~ : String,
+  baseline~ : @agent_session.GoalBaseline?,
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  max_steps~ : Int,
+  thinking? : @deepseek.ThinkingMode = Max,
+  api_url? : String,
+  workspace_root? : String = ".",
+) -> ReviewReport? {
+  @agent_subrun.execute_kind(
+    session_id="goal-audit",
+    system_prompt=audit_system_prompt(),
+    task=audit_task(goal, baseline),
+    tools=captured => {
+      @agent_tool.Tools([
+        @read.definition(workspace_root~),
+        @shell.definition(workspace_root~, read_only=true),
+        submit_review_tool(captured),
+      ])
+    },
+    max_steps~,
+    api_key~,
+    model~,
+    thinking~,
+    api_url?,
+    workspace_root~,
+  )
+}
+
+///|
+/// Digest bounds: the gate injects this into the model's context and the
+/// durable log UNCLAMPED, so the caps live here, not in hope.
+pub let digest_max_findings : Int = 10
+
+///|
+/// Per-finding line cap in the digest.
+pub let digest_max_line_chars : Int = 200
+
+///|
+/// Total digest cap: the notice enters model context and the durable log
+/// unclamped, so this bound is the only one.
+pub let digest_max_chars : Int = 4_000
+
+///|
+/// The bounded `[review]` notice for a report: severity tally, trimmed
+/// summary, and up to `digest_max_findings` one-line findings with an
+/// explicit omission count — never more than `digest_max_chars` total.
+pub fn ReviewReport::digest(self : ReviewReport) -> String {
+  let blockers = self.findings.filter(f => f.severity == "blocker").length()
+  let highs = self.findings.filter(f => f.severity == "high").length()
+  let out = StringBuilder()
+  out <+ "[review] goal-met audit: \{self.findings.length()} finding(s)"
+  if blockers > 0 || highs > 0 {
+    out <+ " (\{blockers} blocker, \{highs} high)"
+  }
+  out <+ " — \{@agent_tool.brief_line(self.summary, limit=160)}"
+  let shown = if self.findings.length() < digest_max_findings {
+    self.findings.length()
+  } else {
+    digest_max_findings
+  }
+  for index in 0..<shown {
+    let finding = self.findings[index]
+    let line = match finding.line {
+      Some(line) => ":\{line}"
+      None => ""
+    }
+    let entry = @agent_tool.brief_line(
+      "[\{finding.severity}] \{finding.file}\{line} — \{finding.title}",
+      limit=digest_max_line_chars,
+    )
+    // The total cap wins over per-line room: stop before overflowing.
+    if out.to_string().length() + entry.length() + 3 > digest_max_chars {
+      out <+ "\n… digest cap reached"
+      break
+    }
+    out <+ "\n- \{entry}"
+  }
+  if self.findings.length() > shown {
+    out <+ "\n+\{self.findings.length() - shown} more finding(s) in the audit"
+  }
+  if blockers > 0 {
+    out <+
+      "\nA blocker means the goal is NOT met: address it or explain why the audit is wrong before finishing."
+  }
+  out.to_string()
+}
+
+///|
+test "digest is bounded and counts severities" {
+  let many : Array[Finding] = []
+  for index in 0..<25 {
+    many.push({
+      file: "src/file\{index}.mbt",
+      line: Some(index),
+      severity: if index < 2 {
+        "blocker"
+      } else {
+        "low"
+      },
+      category: "correctness",
+      title: "finding number \{index} with a reasonably descriptive title",
+      detail: "detail",
+      suggestion: None,
+    })
+  }
+  let report : ReviewReport = {
+    schema_version: 1,
+    scope: { base: "abc", head: "WORKTREE", files: [] },
+    findings: many,
+    summary: "many findings",
+    stats: { files_reviewed: 5, findings: 25, build: "pass", tests: "fail" },
+  }
+  let digest = report.digest()
+  assert_true(digest.length() <= digest_max_chars)
+  assert_true(digest.contains("25 finding(s) (2 blocker, 0 high)"))
+  assert_true(digest.contains("+15 more finding(s)"))
+  assert_true(digest.contains("NOT met"))
+}
+
+///|
+test "a clean digest is one line of good news" {
+  let report : ReviewReport = {
+    schema_version: 1,
+    scope: { base: "abc", head: "WORKTREE", files: ["a.mbt"] },
+    findings: [],
+    summary: "goal satisfied; tests pass",
+    stats: { files_reviewed: 3, findings: 0, build: "pass", tests: "pass" },
+  }
+  let digest = report.digest()
+  assert_true(digest.contains("0 finding(s)"))
+  assert_false(digest.contains("blocker"))
+}

--- a/agent_review/moon.pkg
+++ b/agent_review/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/read",

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/agent_review"
 
 import {
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/deepseek",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
@@ -9,6 +10,16 @@ import {
 
 // Values
 pub let current_schema_version : Int
+
+pub let default_audit_max_steps : Int
+
+pub let digest_max_chars : Int
+
+pub let digest_max_findings : Int
+
+pub let digest_max_line_chars : Int
+
+pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> ReviewReport?
 
 pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String) -> ReviewReport
 
@@ -37,6 +48,7 @@ pub struct ReviewReport {
   summary : String
   stats : ReviewStats
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ReviewReport::digest(Self) -> String
 pub fn ReviewReport::parse(Json) -> Result[Self, String]
 pub fn ReviewReport::to_json_string(Self) -> String
 pub fn ReviewReport::validate(Self) -> Array[String]

--- a/cmd/openseek/gate.mbt
+++ b/cmd/openseek/gate.mbt
@@ -82,7 +82,7 @@ fn build_goal_met_gate(
       Some(report) => Some(report.digest())
       None =>
         Some(
-          "[review] unavailable (\{to_repr(result.terminal())}) — treat the met claim as unaudited.",
+          "[review] unavailable (\{@agent_tool.brief_line("\{to_repr(result.terminal())}", limit=200)}) — treat the met claim as unaudited.",
         )
     }
   }

--- a/cmd/openseek/gate.mbt
+++ b/cmd/openseek/gate.mbt
@@ -1,0 +1,99 @@
+///|
+/// Wall deadline for one gate audit: a reviewer that has not reported in
+/// ten minutes is stuck, not thorough.
+const GateDeadlineMs : Int = 600_000
+
+///|
+/// Whether `--review-gate` was passed: the advisory goal-met audit is
+/// opt-in while its precision is being calibrated on dogfood runs.
+fn review_gate_enabled(matches : @argparse.Matches) -> Bool {
+  matches is { flags: { "review-gate": true, .. }, .. }
+}
+
+///|
+/// Parse-and-validate the audit child's report line — the same contract the
+/// child's submit tool enforced, re-checked at the trust boundary.
+fn parse_audit_report(
+  json : Json,
+) -> Result[@agent_review.ReviewReport, String] {
+  match @agent_review.ReviewReport::parse(json) {
+    Err(msg) => Err(msg)
+    Ok(report) => {
+      let problems = report.validate()
+      if problems.length() > 0 {
+        Err(problems.join("; "))
+      } else {
+        Ok(report)
+      }
+    }
+  }
+}
+
+///|
+/// Build the advisory goal-met gate: on a durably recorded met, spawn the
+/// `subrun review` child against the goal's baseline and return the bounded
+/// digest notice. Advisory by contract — every failure shape (budget
+/// exhausted, no report, timeout, spawn trouble) degrades to an
+/// `[review] unavailable` notice; only external cancellation re-raises
+/// (through run_subrun's own contract).
+fn build_goal_met_gate(
+  self_exe~ : String,
+  model~ : @deepseek.Model,
+  api_url~ : String?,
+  budget~ : @agent_subrun.SubrunBudget,
+  workspace_root~ : String,
+) -> async (String, @agent_session.GoalBaseline?) -> String? {
+  (goal, baseline) => {
+    guard budget.reserve(@agent_review.default_audit_max_steps)
+      is Some(granted_steps) else {
+      return Some(
+        "[review] unavailable: subrun budget exhausted for this turn — the met claim is unaudited.",
+      )
+    }
+    let args = [
+      "subrun",
+      "review",
+      "--model",
+      "\{model}",
+      "--max-steps",
+      "\{granted_steps}",
+    ]
+    if api_url is Some(url) {
+      args.push("--api-url")
+      args.push(url)
+    }
+    let input : Json = match baseline {
+      Some(baseline) =>
+        { "goal": goal, "sha": baseline.sha, "dirty": baseline.dirty }
+      None => { "goal": goal }
+    }
+    let result = @agent_subrun.run_subrun(
+      command=self_exe,
+      args~,
+      input~,
+      parse_report=parse_audit_report,
+      wall_deadline_ms=GateDeadlineMs,
+      kind="review",
+      label=@agent_tool.brief_line(goal, limit=48),
+      cwd=workspace_root,
+    )
+    budget.reconcile(reserved=granted_steps, used=result.steps_used())
+    match result.value() {
+      Some(report) => Some(report.digest())
+      None =>
+        Some(
+          "[review] unavailable (\{to_repr(result.terminal())}) — treat the met claim as unaudited.",
+        )
+    }
+  }
+}
+
+///|
+/// The `--review-gate` flag, shared by `run` and `serve`.
+fn review_gate_flag() -> @argparse.FlagArg {
+  FlagArg(
+    "review-gate",
+    long="review-gate",
+    about="On goal(met), audit the worktree against the goal with a review subagent and inject the findings as an advisory notice.",
+  )
+}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -226,10 +226,11 @@ async fn run_task_turn(
     let scope = @agent_runtime.AgentTaskScope(group)
     // One-shot = one turn, so a fresh per-turn subrun budget needs no reset.
     let subrun_budget = @agent_subrun.SubrunBudget()
+    let exe = self_executable()
     let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
       [
         @agent_explore.definition(
-          self_exe=self_executable(),
+          self_exe=exe,
           model~,
           workspace_root~,
           budget=subrun_budget,
@@ -237,6 +238,19 @@ async fn run_task_turn(
         ),
       ]
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
+    let on_goal_met = if review_gate_enabled(matches) {
+      Some(
+        build_goal_met_gate(
+          self_exe=exe,
+          model~,
+          api_url~,
+          budget=subrun_budget,
+          workspace_root~,
+        ),
+      )
+    } else {
+      None
+    }
     ignore(
       @agent.run_turn_in_scope(
         runtime~,
@@ -250,6 +264,7 @@ async fn run_task_turn(
         thinking~,
         api_url?,
         tools~,
+        on_goal_met?,
       ),
     )
   }
@@ -598,6 +613,7 @@ fn root_command() -> @argparse.Command {
             long="no-session",
             about="Run ephemerally: do not record this run to a durable session.",
           ),
+          review_gate_flag(),
         ],
         positionals=[
           PositionArg(
@@ -617,6 +633,7 @@ fn root_command() -> @argparse.Command {
             long="no-session",
             about="Run ephemerally: do not record this server's conversation to a durable session.",
           ),
+          review_gate_flag(),
         ],
       ),
       Command(

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -619,16 +619,32 @@ async fn run_serve(
     // The subrun budget is shared by every subrun tool and refills at each
     // turn start (see start_turn) — the registry itself lives across turns.
     let subrun_budget = @agent_subrun.SubrunBudget()
+    let exe = self_executable()
     let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
       [
         @agent_explore.definition(
-          self_exe=self_executable(),
+          self_exe=exe,
           model~,
           workspace_root~,
           budget=subrun_budget,
           api_url?,
         ),
       ]
+    // The advisory goal-met gate (--review-gate): built once, shared by
+    // every turn; it draws from the same per-turn subrun budget as explore.
+    let on_goal_met = if review_gate_enabled(matches) {
+      Some(
+        build_goal_met_gate(
+          self_exe=exe,
+          model~,
+          api_url~,
+          budget=subrun_budget,
+          workspace_root~,
+        ),
+      )
+    } else {
+      None
+    }
     let tools = @agent.build_tools(
       runtime,
       scope,
@@ -853,6 +869,7 @@ async fn run_serve(
           model~,
           session~,
           task=task_text,
+          on_goal_met?,
           append_item=(current, item) => {
             let next = match store {
               Some(store) => store.append(current, item)

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -111,6 +111,33 @@ async fn dispatch_kind(
       )
       report.map(report => report.to_json())
     }
+    "review" => {
+      guard input is { "goal": String(goal), .. } && goal.trim() != "" else {
+        @emit.emit(
+          CommandError(error="subrun review requires a non-empty goal"),
+        )
+        return None
+      }
+      let baseline : @agent_session.GoalBaseline? = match input {
+        { "sha": String(sha), "dirty": dirty, .. } =>
+          Some({ sha: sha.to_string(), dirty: dirty is True })
+        _ => None
+      }
+      let api_key = @agentcli.api_key(matches, model)
+      let report = @agent_review.run_goal_audit(
+        goal~,
+        baseline~,
+        api_key~,
+        model~,
+        max_steps=max_steps(matches).unwrap_or(
+          @agent_review.default_audit_max_steps,
+        ),
+        thinking~,
+        api_url?,
+        workspace_root~,
+      )
+      report.map(report => report.to_json())
+    }
     "echo" => {
       // Modelless probe: two canned events plus the input echoed back —
       // enough to exercise spawn, drain, accounting, and the typed report

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -138,6 +138,7 @@ Options:
   --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION]
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
   --no-session                                                 Run ephemerally: do not record this run to a durable session.
+  --review-gate                                                On goal(met), audit the worktree against the goal with a review subagent and inject the findings as an advisory notice.
   --dir <dir>                                                  Workspace directory for relative paths; creates only the final path component if its parent exists. [env: OPENSEEK_DIR] [default: .]
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]


### PR DESCRIPTION
F of the subagent series — the goodhart-catcher this whole effort aims at. Off by default (`--review-gate`) while advisory precision is calibrated on dogfood runs.

**Flow**: `goal(met)` → the loop schedules an audit (capturing the goal's baseline before the tombstone clears it) → at the next batch-safe boundary a `subrun review` child audits the **current worktree** against the goal's own criteria (the v3-decided contract: worktree audit, base diff as supporting context, `dirty` stated as the attribution caveat, `scope.head = "WORKTREE"`, no schema change) → the bounded digest lands as a durable notice the model sees before it can finish. A same-batch met+finish converts into a review continuation exactly like the goal check; last-step finishes skip; a superseding goal cancels the pending audit pre-launch (steer-ordering) or discards it post-run (generation guard); reviewer failure folds to `[review] unavailable` — the gate can never break a turn.

**Everything rides the merged substrate**: the child is `openseek subrun review` (typed report line, stdin-EOF cancel, 10-min deadline), it draws from the same per-turn `SubrunBudget` as explore, and its lifecycle is visible via the `SubrunStarted/Finished` brackets (`kind="review"`).

**Tests**: five mock-endpoint gate-flow tests with an injectable callback (once-per-met with the digest in the next request's body; same-batch continuation; failure folding; no-callback passthrough; replacement-goal cancellation driven from *inside* the met batch), digest bound pins, cram updated for the flag. Suites green across agent/agent_review/cmd; `check --target all`/`fmt`/`info` clean.

Panel review (fresh-context + K3, own worktrees) to follow per the standing bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)