### PR TITLE
feat(review-tool): model-initiated worktree audits

### DIFF
--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -9,9 +9,11 @@ pub let default_audit_max_steps : Int = 80
 /// recorded as met?
 fn audit_system_prompt() -> String {
   (
-    #|You are OpenSeek in goal-audit mode. An agent just recorded a standing
-    #|goal as MET. Your one question: does the CURRENT WORKTREE actually
-    #|satisfy that goal? You review; you do not modify.
+    #|You are OpenSeek in audit mode. An agent asked for an independent
+    #|audit of its work — typically a standing goal it believes met, or
+    #|criteria it wants checked before claiming completion. Your one
+    #|question: does the CURRENT WORKTREE actually satisfy the stated
+    #|criteria? You review; you do not modify.
     #|
     #|Principles:
     #|- Audit the worktree as it stands. The agent edits without committing,
@@ -57,7 +59,8 @@ fn audit_task(goal : String, baseline : @agent_session.GoalBaseline?) -> String 
       )
   }
   (
-    $|The goal recorded as met:
+    $|The criteria under audit (a standing goal, or the caller's stated
+    $|focus):
     $|\{goal}
     $|
     $|\{anchor}
@@ -123,7 +126,7 @@ pub fn ReviewReport::digest(self : ReviewReport) -> String {
   let blockers = self.findings.filter(f => f.severity == "blocker").length()
   let highs = self.findings.filter(f => f.severity == "high").length()
   let out = StringBuilder()
-  out <+ "[review] goal-met audit: \{self.findings.length()} finding(s)"
+  out <+ "[review] worktree audit: \{self.findings.length()} finding(s)"
   if blockers > 0 || highs > 0 {
     out <+ " (\{blockers} blocker, \{highs} high)"
   }
@@ -156,7 +159,7 @@ pub fn ReviewReport::digest(self : ReviewReport) -> String {
   }
   if blockers > 0 {
     out <+
-      "\nA blocker means the goal is NOT met: address it or explain why the audit is wrong before finishing."
+      "\nA blocker means the audited claim does NOT hold: address it or explain why the audit is wrong before finishing."
   }
   out.to_string()
 }
@@ -188,9 +191,11 @@ test "digest is bounded and counts severities" {
   }
   let digest = report.digest()
   assert_true(digest.length() <= digest_max_chars)
-  assert_true(digest.contains("25 finding(s) (2 blocker, 0 high)"))
+  assert_true(
+    digest.contains("worktree audit: 25 finding(s) (2 blocker, 0 high)"),
+  )
   assert_true(digest.contains("+15 more finding(s)"))
-  assert_true(digest.contains("NOT met"))
+  assert_true(digest.contains("does NOT hold"))
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -227,6 +227,16 @@ async fn run_task_turn(
     // One-shot = one turn, so a fresh per-turn subrun budget needs no reset.
     let subrun_budget = @agent_subrun.SubrunBudget()
     let exe = self_executable()
+    // Mirror the latest appended session so the review tool audits against
+    // the LIVE standing goal, not the turn-start snapshot.
+    let latest_session : Ref[@agent_session.Session] = { val: session }
+    let review_context = () => {
+      let goal = latest_session.val.current_goal()
+      (
+        goal.map(goal => goal.text()),
+        latest_session.val.current_goal_baseline(),
+      )
+    }
     let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
       [
         @agent_explore.definition(
@@ -234,6 +244,14 @@ async fn run_task_turn(
           model~,
           workspace_root~,
           budget=subrun_budget,
+          api_url?,
+        ),
+        review_tool_definition(
+          self_exe=exe,
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          context=review_context,
           api_url?,
         ),
       ]
@@ -259,7 +277,11 @@ async fn run_task_turn(
         model~,
         session~,
         task~,
-        append_item~,
+        append_item=(current, item) => {
+          let next = append_item(current, item)
+          latest_session.val = next
+          next
+        },
         max_steps?,
         thinking~,
         api_url?,

--- a/cmd/openseek/pkg.generated.mbti
+++ b/cmd/openseek/pkg.generated.mbti
@@ -1,15 +1,7 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/openseek/cmd/openseek"
 
-import {
-  "bobzhang/openseek/agent_session",
-  "bobzhang/openseek/agent_subrun",
-  "bobzhang/openseek/agent_tool",
-  "bobzhang/openseek/deepseek",
-}
-
 // Values
-pub fn review_tool_definition(self_exe~ : String, model~ : @deepseek.Model, workspace_root~ : String, budget~ : @agent_subrun.SubrunBudget, context~ : () -> (String?, @agent_session.GoalBaseline?), api_url? : String) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/cmd/openseek/pkg.generated.mbti
+++ b/cmd/openseek/pkg.generated.mbti
@@ -1,7 +1,15 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/openseek/cmd/openseek"
 
+import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_subrun",
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/deepseek",
+}
+
 // Values
+pub fn review_tool_definition(self_exe~ : String, model~ : @deepseek.Model, workspace_root~ : String, budget~ : @agent_subrun.SubrunBudget, context~ : () -> (String?, @agent_session.GoalBaseline?), api_url? : String) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -5,11 +5,9 @@
 ///
 /// `context` supplies the live standing goal and its baseline (serve wires
 /// a closure over its session; one-shot mirrors the latest appended
-/// session). The model may narrow the audit with `focus`; with neither a
-/// focus nor a standing goal the child audits against the task's own
-/// success criteria as stated in `focus` — so the parameter is required
-/// exactly when no goal stands.
-pub fn review_tool_definition(
+/// session). The model may narrow the audit with `focus`; when no goal
+/// stands, `focus` supplies the criteria outright and is required.
+fn review_tool_definition(
   self_exe~ : String,
   model~ : @deepseek.Model,
   workspace_root~ : String,
@@ -19,7 +17,7 @@ pub fn review_tool_definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="review",
-    description="Request an INDEPENDENT audit of the current worktree by a review subagent — use it before declaring substantial work or a standing goal complete, or when you want a skeptical second reading of what you built. The auditor reads files, runs the project's own checks, hunts for vacuous success (tests asserting nothing, hardcoded outputs, quietly narrowed criteria), and returns severity-tagged findings with file:line citations. It audits against the standing goal when one exists; pass `focus` to narrow or replace the criteria. Costs a bounded subagent run from the shared per-turn budget.",
+    description="Request an INDEPENDENT audit of the current worktree by a review subagent — use it before declaring substantial work or a standing goal complete, or when you want a skeptical second reading of what you built. The auditor reads files, runs the project's own checks, hunts for vacuous success (tests asserting nothing, hardcoded outputs, quietly narrowed criteria), and returns severity-tagged findings with file:line citations. It audits against the standing goal when one exists; pass `focus` to narrow the criteria (with no standing goal, `focus` IS the criteria). Costs a bounded subagent run from the shared per-turn budget.",
     schema=JsonSchema({
       "type": "object",
       "properties": {

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -1,0 +1,159 @@
+///|
+/// Tool definition for `review`: a model-initiated worktree audit — the
+/// same reviewer child the goal-met gate spawns, callable mid-run before
+/// claiming substantial work complete.
+///
+/// `context` supplies the live standing goal and its baseline (serve wires
+/// a closure over its session; one-shot mirrors the latest appended
+/// session). The model may narrow the audit with `focus`; with neither a
+/// focus nor a standing goal the child audits against the task's own
+/// success criteria as stated in `focus` — so the parameter is required
+/// exactly when no goal stands.
+pub fn review_tool_definition(
+  self_exe~ : String,
+  model~ : @deepseek.Model,
+  workspace_root~ : String,
+  budget~ : @agent_subrun.SubrunBudget,
+  context~ : () -> (String?, @agent_session.GoalBaseline?),
+  api_url? : String,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="review",
+    description="Request an INDEPENDENT audit of the current worktree by a review subagent — use it before declaring substantial work or a standing goal complete, or when you want a skeptical second reading of what you built. The auditor reads files, runs the project's own checks, hunts for vacuous success (tests asserting nothing, hardcoded outputs, quietly narrowed criteria), and returns severity-tagged findings with file:line citations. It audits against the standing goal when one exists; pass `focus` to narrow or replace the criteria. Costs a bounded subagent run from the shared per-turn budget.",
+    schema=JsonSchema({
+      "type": "object",
+      "properties": {
+        "focus": {
+          "type": "string",
+          "description": "What to audit against: specific criteria, a component, or a claim to verify. Optional when a standing goal exists (the goal is the default criteria).",
+        },
+      },
+    }),
+    execute=Async(arguments => {
+      execute_review(
+        self_exe, model, workspace_root, budget, context, api_url, arguments,
+      )
+    }),
+  )
+}
+
+///|
+async fn execute_review(
+  self_exe : String,
+  model : @deepseek.Model,
+  workspace_root : String,
+  budget : @agent_subrun.SubrunBudget,
+  context : () -> (String?, @agent_session.GoalBaseline?),
+  api_url : String?,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  let focus : String? = match arguments {
+    { "focus": String(focus), .. } if focus.trim() != "" =>
+      Some(focus.to_string())
+    _ => None
+  }
+  let (standing_goal, baseline) = context()
+  let criteria = match (focus, standing_goal) {
+    (Some(focus), Some(goal)) => "\{goal}\n\nAudit focus:\n\{focus}"
+    (Some(focus), None) => focus
+    (None, Some(goal)) => goal
+    (None, None) =>
+      return @agent_tool.ToolAction::respond(
+        "error: no standing goal exists — pass `focus` with the criteria to audit against",
+        is_error=true,
+      )
+  }
+  guard budget.reserve(@agent_review.default_audit_max_steps)
+    is Some(granted_steps) else {
+    return @agent_tool.ToolAction::respond(
+      "review budget exhausted for this turn — validate directly (run the checks yourself).",
+      is_error=true,
+      brief="review (budget exhausted)",
+    )
+  }
+  let args = [
+    "subrun",
+    "review",
+    "--model",
+    "\{model}",
+    "--max-steps",
+    "\{granted_steps}",
+  ]
+  if api_url is Some(url) {
+    args.push("--api-url")
+    args.push(url)
+  }
+  let input : Json = match baseline {
+    Some(baseline) =>
+      { "goal": criteria, "sha": baseline.sha, "dirty": baseline.dirty }
+    None => { "goal": criteria }
+  }
+  let result = @agent_subrun.run_subrun(
+    command=self_exe,
+    args~,
+    input~,
+    parse_report=parse_audit_report,
+    wall_deadline_ms=GateDeadlineMs,
+    kind="review",
+    label=@agent_tool.brief_line(criteria, limit=48),
+    cwd=workspace_root,
+  )
+  budget.reconcile(reserved=granted_steps, used=result.steps_used())
+  match result.value() {
+    Some(report) =>
+      @agent_tool.ToolAction::respond(
+        report.digest(),
+        is_error=report.findings.filter(f => f.severity == "blocker").length() >
+          0,
+        brief="review (\{report.findings.length()} finding(s), \{result.steps_used()} step(s))",
+      )
+    None =>
+      @agent_tool.ToolAction::respond(
+        "review produced no report (\{@agent_tool.brief_line("\{to_repr(result.terminal())}", limit=200)}) — validate directly instead.",
+        is_error=true,
+        brief="review (no report)",
+      )
+  }
+}
+
+///|
+async test "review without a goal or focus errors before spending anything" {
+  let budget = @agent_subrun.SubrunBudget(
+    max_calls_per_turn=1,
+    max_steps_per_turn=100,
+  )
+  let tool = review_tool_definition(
+    self_exe="/nonexistent/openseek-not-here",
+    model=Deepseek(V4Flash),
+    workspace_root=".",
+    budget~,
+    context=() => (None, None),
+  )
+  guard tool.execute is Async(execute) else { fail("review should be async") }
+  let action = execute(Json::empty_object())
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("no standing goal"))
+  // Nothing was reserved or spawned.
+  assert_true(budget.reserve(10) is Some(10))
+}
+
+///|
+async test "review budget exhaustion refuses before spawning" {
+  let budget = @agent_subrun.SubrunBudget(
+    max_calls_per_turn=0,
+    max_steps_per_turn=100,
+  )
+  let tool = review_tool_definition(
+    self_exe="/nonexistent/openseek-not-here",
+    model=Deepseek(V4Flash),
+    workspace_root=".",
+    budget~,
+    context=() => (Some("ship it"), None),
+  )
+  guard tool.execute is Async(execute) else { fail("review should be async") }
+  let action = execute(Json::empty_object())
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("budget exhausted"))
+}

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -620,6 +620,14 @@ async fn run_serve(
     // turn start (see start_turn) — the registry itself lives across turns.
     let subrun_budget = @agent_subrun.SubrunBudget()
     let exe = self_executable()
+    // The callable review tool audits against the LIVE standing goal: the
+    // closure reads the loop-updated session at call time, never a
+    // snapshot.
+    let review_context = () => {
+      let goal = session.current_goal()
+      (goal.map(goal => goal.text()), session.current_goal_baseline())
+    }
+
     let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
       [
         @agent_explore.definition(
@@ -627,6 +635,14 @@ async fn run_serve(
           model~,
           workspace_root~,
           budget=subrun_budget,
+          api_url?,
+        ),
+        review_tool_definition(
+          self_exe=exe,
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          context=review_context,
           api_url?,
         ),
       ]

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -123,6 +123,12 @@ Common `moon` subcommands:
   the STALE mooncakes.io snapshot, never your working tree — to exercise local
   package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
   (above).
+- `review` tool: before declaring substantial work or a standing goal
+  complete, request an independent worktree audit — a review subagent reads
+  the files, runs the project's own checks, hunts for vacuous success, and
+  returns severity-tagged findings with file:line citations. A blocker
+  finding means the claim does not hold yet. Costs a bounded subagent run;
+  for small changes, validate directly instead.
 - `explore` tool: delegate ONE self-contained question to a read-only scout
   subagent when answering it yourself would mean reading MANY files or a
   fan-out search — "where is X handled", "how does Y flow end to end", "what

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -128,6 +128,12 @@ fn default_prompt() -> String {
     #|  the STALE mooncakes.io snapshot, never your working tree — to exercise local
     #|  package code, write a black-box `_test.mbt` and run `moon test <pkg> --filter`
     #|  (above).
+    #|- `review` tool: before declaring substantial work or a standing goal
+    #|  complete, request an independent worktree audit — a review subagent reads
+    #|  the files, runs the project's own checks, hunts for vacuous success, and
+    #|  returns severity-tagged findings with file:line citations. A blocker
+    #|  finding means the claim does not hold yet. Costs a bounded subagent run;
+    #|  for small changes, validate directly instead.
     #|- `explore` tool: delegate ONE self-contained question to a read-only scout
     #|  subagent when answering it yourself would mean reading MANY files or a
     #|  fan-out search — "where is X handled", "how does Y flow end to end", "what


### PR DESCRIPTION
G of the subagent series (stacked on #544 — top commit only; retargets main after the gate lands).

The same reviewer child the goal-met gate spawns, callable by the model mid-run: `review(focus?)` audits the current worktree against the **live** standing goal (context closure over the loop-updated session in serve; a latest-append mirror in one-shot) or the stated focus, returning the bounded severity-tagged digest — a blocker arrives as an `is_error` result. Shares the per-turn `SubrunBudget`; no-goal-no-focus and budget exhaustion both refuse before spending anything. Prompt gains the validate-before-claiming rule (regenerated).

Tests: pre-spend refusals (no criteria; exhausted budget — both proven spawn-free via a nonexistent exe); the spawn/report path is the gate's, already panel-reviewed in #544. Suites green; cram 26/26; `check --target all`/`fmt`/`info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)