### PR TITLE
Subagent transcripts: persist child sessions and visualize them (chips, inline nesting, sidebar tree)

### DIFF
--- a/agent_explore/moon.pkg
+++ b/agent_explore/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/read",

--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/agent_explore"
 
 import {
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/deepseek",
@@ -16,7 +17,7 @@ pub let default_explore_deadline_ms : Int
 
 pub let default_explore_max_steps : Int
 
-pub fn definition(self_exe~ : String, model~ : @deepseek.Model, workspace_root~ : String, budget~ : @agent_subrun.SubrunBudget, api_url? : String) -> @agent_tool.AgentToolDefinition
+pub fn definition(self_exe~ : String, model~ : @deepseek.Model, workspace_root~ : String, budget~ : @agent_subrun.SubrunBudget, api_url? : String, child_session? : @agent_subrun.ChildSession) -> @agent_tool.AgentToolDefinition
 
 pub let max_answer_chars : Int
 
@@ -32,7 +33,7 @@ pub let max_query_chars : Int
 
 pub let max_unresolved_chars : Int
 
-pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> ExploreReport?
+pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> ExploreReport?
 
 // Errors
 

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -44,6 +44,7 @@ pub fn definition(
   workspace_root~ : String,
   budget~ : @agent_subrun.SubrunBudget,
   api_url? : String,
+  child_session? : @agent_subrun.ChildSession,
 ) -> @agent_tool.AgentToolDefinition {
   @agent_tool.AgentToolDefinition(
     name="explore",
@@ -63,7 +64,9 @@ pub fn definition(
       "required": ["query"],
     }),
     execute=Async(arguments => {
-      execute(self_exe, model, workspace_root, budget, api_url, arguments)
+      execute(
+        self_exe, model, workspace_root, budget, api_url, child_session, arguments,
+      )
     }),
   )
 }
@@ -75,6 +78,7 @@ async fn execute(
   workspace_root : String,
   budget : @agent_subrun.SubrunBudget,
   api_url : String?,
+  child_session : @agent_subrun.ChildSession?,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   guard arguments is { "query": String(query), .. } && query.trim() != "" else {
@@ -134,21 +138,26 @@ async fn execute(
     kind="explore",
     label=@agent_tool.brief_line(query, limit=48),
     cwd=workspace_root,
+    child_session?,
   )
   // On external cancellation run_subrun re-raises before this line: the
   // reservation stays debited for the rest of the turn — deliberately
   // conservative, since the dead child's true spend is unknown.
+  // The sub-run id in the brief pairs the result with its lifecycle
+  // brackets — and, when the child persisted a transcript, names the
+  // sibling session the viewer links to. Display-only: the model never
+  // sees briefs.
   match result.value() {
     Some(report) =>
       @agent_tool.ToolAction::respond(
         render_report(report),
-        brief="explore (\{report.citations.length()} citation(s), \{result.steps_used()} step(s))",
+        brief="explore \{result.subrun_id()} (\{report.citations.length()} citation(s), \{result.steps_used()} step(s))",
       )
     None =>
       @agent_tool.ToolAction::respond(
         "explore produced no report (\{to_repr(result.terminal())}) — fall back to reading directly.",
         is_error=true,
-        brief="explore (no report)",
+        brief="explore \{result.subrun_id()} (no report)",
       )
   }
 }
@@ -185,6 +194,8 @@ pub async fn run_child(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
+  session_id? : String = "explore",
+  append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
 ) -> ExploreReport? {
   guard input is { "query": String(query), .. } && query.trim() != "" else {
     return None
@@ -194,7 +205,8 @@ pub async fn run_child(
     _ => None
   }
   @agent_subrun.execute_kind(
-    session_id="explore",
+    session_id~,
+    append_item?,
     system_prompt=explore_system_prompt(),
     task=explore_task(query, hints),
     tools=captured => {

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -90,9 +90,12 @@ pub async fn run_goal_audit(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
+  session_id? : String = "goal-audit",
+  append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
 ) -> ReviewReport? {
   @agent_subrun.execute_kind(
-    session_id="goal-audit",
+    session_id~,
+    append_item?,
     system_prompt=audit_system_prompt(),
     task=audit_task(goal, baseline),
     tools=captured => {

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -19,7 +19,7 @@ pub let digest_max_findings : Int
 
 pub let digest_max_line_chars : Int
 
-pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> ReviewReport?
+pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> ReviewReport?
 
 pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String) -> ReviewReport
 

--- a/agent_subrun/child.mbt
+++ b/agent_subrun/child.mbt
@@ -23,6 +23,7 @@ pub async fn[T] execute_kind(
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
   workspace_root? : String = ".",
+  append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
 ) -> T? {
   let captured : Ref[T?] = { val: None }
   let tools = tools(captured)
@@ -30,6 +31,13 @@ pub async fn[T] execute_kind(
     @agent_session.SessionId(session_id),
     system_prompt~,
   )
+  // Default: the transcript lives and dies with this process. A caller
+  // wires a store-backed append (the `subrun` child mode when the parent
+  // is durable) to make the child's transcript a first-class session.
+  let append = match append_item {
+    Some(append) => append
+    None => (session, item) => session.append(item)
+  }
   let _ : @agent_session.Session = @async.with_task_group() <| group => {
     @agent.run_turn_in_scope(
       runtime=@agent_runtime.AgentRuntime(workspace_root~),
@@ -38,7 +46,7 @@ pub async fn[T] execute_kind(
       model~,
       session~,
       task~,
-      append_item=(session, item) => session.append(item),
+      append_item=append,
       max_steps~,
       thinking~,
       api_url?,

--- a/agent_subrun/child_test.mbt
+++ b/agent_subrun/child_test.mbt
@@ -244,3 +244,55 @@ async test "a capture at the context ceiling is salvaged" {
     )
   }
 }
+
+///|
+/// `append_item` makes the child's transcript durable: with a store-backed
+/// append the session file materializes as the turn runs, holding the same
+/// items an in-memory child accumulates — system prompt, task, tool
+/// round-trip, terminal.
+async test "a store-backed append_item persists the child transcript" {
+  @async.with_task_group() <| group => {
+    let handle : (Json) -> MockReply raise = _request => {
+      Sse(
+        sse_tool_calls(
+          [("call_1", "submit", "{\"answer\": \"persisted\"}")],
+          100_000,
+        ),
+      )
+    }
+    guard child_test_server(group, handle) is Some(url) else { return }
+    let store = @store.SessionStore(@fs.tmpdir(prefix="openseek-subrun-child-"))
+    let value = @agent_subrun.execute_kind(
+      session_id="parent-sr-1",
+      system_prompt="You are a test subagent.",
+      task="Answer via the submit tool.",
+      tools=captured => {
+        @agent_tool.Tools([
+          @agent_subrun.capture_tool(
+            name="submit",
+            description="Submit the final answer.",
+            schema=JsonSchema({ "type": "object" }),
+            parse=args => {
+              match args {
+                { "answer": String(answer), .. } => Ok(answer)
+                _ => Err(["answer must be a string"])
+              }
+            },
+            captured,
+          ),
+        ])
+      },
+      max_steps=8,
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      api_url=url,
+      append_item=(session, item) => store.append(session, item),
+    )
+    assert_true(value is Some("persisted"))
+    let loaded = store.load(@agent_session.SessionId("parent-sr-1"))
+    assert_eq(loaded.system_prompt(), "You are a test subagent.")
+    // The durable transcript holds the whole turn, not just a header.
+    assert_true(loaded.events().length() >= 3)
+    @fs.rmdir(store.root(), recursive=true)
+  }
+}

--- a/agent_subrun/moon.pkg
+++ b/agent_subrun/moon.pkg
@@ -13,9 +13,12 @@ import {
 }
 
 import {
+  "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek_protocol" @protocol,
   "moonbitlang/async",
+  "moonbitlang/async/fs",
   "moonbitlang/async/http",
   "moonbitlang/async/socket",
   "moonbitlang/core/json",

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -31,8 +31,9 @@ pub async fn[T] run_subrun(command~ : String, args~ : Array[String], input~ : Js
 pub struct ChildSession {
   root : String
   parent : String
+  first_free : Int
 }
-pub fn ChildSession::ChildSession(root~ : String, parent~ : String) -> Self
+pub fn ChildSession::ChildSession(root~ : String, parent~ : String, first_free? : Int) -> Self
 
 pub struct SubrunBudget {
   max_calls_per_turn : Int

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "bobzhang/openseek/agent_subrun"
 
 import {
+  "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek_protocol",
@@ -14,7 +15,7 @@ pub let cancel_grace_ms : Int
 
 pub fn[T] capture_tool(name~ : String, description~ : String, schema~ : @agent_tool.JsonSchema, parse~ : (Json) -> Result[T, Array[String]], @ref.Ref[T?], finished_note? : (T) -> String) -> @agent_tool.AgentToolDefinition
 
-pub async fn[T] execute_kind(session_id~ : String, system_prompt~ : String, task~ : String, tools~ : (@ref.Ref[T?]) -> @agent_tool.Tools raise, max_steps~ : Int, api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> T?
+pub async fn[T] execute_kind(session_id~ : String, system_prompt~ : String, task~ : String, tools~ : (@ref.Ref[T?]) -> @agent_tool.Tools raise, max_steps~ : Int, api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> T?
 
 pub let min_useful_subrun_steps : Int
 
@@ -22,11 +23,17 @@ pub fn parse_report_line(Json) -> Json?
 
 pub fn report_line(Json) -> String
 
-pub async fn[T] run_subrun(command~ : String, args~ : Array[String], input~ : Json, parse_report~ : (Json) -> Result[T, String], wall_deadline_ms~ : Int, kind~ : String, label~ : String, cwd? : String, emit_event? : (@openseek_protocol.Event) -> Unit) -> SubrunResult[T]
+pub async fn[T] run_subrun(command~ : String, args~ : Array[String], input~ : Json, parse_report~ : (Json) -> Result[T, String], wall_deadline_ms~ : Int, kind~ : String, label~ : String, cwd? : String, child_session? : ChildSession, emit_event? : (@openseek_protocol.Event) -> Unit) -> SubrunResult[T]
 
 // Errors
 
 // Types and methods
+pub struct ChildSession {
+  root : String
+  parent : String
+}
+pub fn ChildSession::ChildSession(root~ : String, parent~ : String) -> Self
+
 pub struct SubrunBudget {
   max_calls_per_turn : Int
   mut used_calls : Int
@@ -41,10 +48,12 @@ pub struct SubrunResult[T] {
   steps_used : Int
   prompt_tokens : Int
   completion_tokens : Int
+  subrun_id : String
 } derive(@debug.Debug)
 pub fn[T] SubrunResult::completion_tokens(Self[T]) -> Int
 pub fn[T] SubrunResult::prompt_tokens(Self[T]) -> Int
 pub fn[T] SubrunResult::steps_used(Self[T]) -> Int
+pub fn[T] SubrunResult::subrun_id(Self[T]) -> String
 pub fn[T] SubrunResult::terminal(Self[T]) -> SubrunTerminal
 pub fn[T] SubrunResult::value(Self[T]) -> T?
 

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -39,6 +39,7 @@ pub struct SubrunResult[T] {
   steps_used : Int
   prompt_tokens : Int
   completion_tokens : Int
+  subrun_id : String
 } derive(Debug)
 
 ///|
@@ -67,6 +68,16 @@ pub fn[T] SubrunResult::prompt_tokens(self : SubrunResult[T]) -> Int {
 
 ///|
 /// Provider completion tokens the child consumed, summed over its requests.
+/// The runner-assigned sub-run id ("sr-N"): the same id the
+/// SubrunStarted/SubrunFinished brackets carried, and — when the child was
+/// launched with a `ChildSession` — the suffix of the child's durable
+/// session id.
+pub fn[T] SubrunResult::subrun_id(self : SubrunResult[T]) -> String {
+  self.subrun_id
+}
+
+///|
+/// Completion tokens summed from the child's observed usage events.
 pub fn[T] SubrunResult::completion_tokens(self : SubrunResult[T]) -> Int {
   self.completion_tokens
 }
@@ -154,9 +165,18 @@ pub async fn[T] run_subrun(
   kind~ : String,
   label~ : String,
   cwd? : String,
+  child_session? : ChildSession,
   emit_event? : (@protocol.Event) -> Unit = event => @emit.emit(event),
 ) -> SubrunResult[T] {
   let id = next_subrun_id()
+  // The child persists its own transcript under `<parent>-<id>` when the
+  // parent is durable: the id exists only after allocation, so the session
+  // argv is the runner's to append, not the caller's.
+  let args = match child_session {
+    Some(spec) =>
+      [..args, "--session", "\{spec.parent}-\{id}", "--session-root", spec.root]
+    None => args
+  }
   emit_event(
     SubrunStarted(id~, kind~, label=@agent_tool.brief_line(label, limit=72)),
   )
@@ -333,7 +353,28 @@ pub async fn[T] run_subrun(
     steps_used: observations.steps,
     prompt_tokens: observations.prompt_tokens,
     completion_tokens: observations.completion_tokens,
+    subrun_id: id,
   }
+}
+
+///|
+/// Where a child persists its own transcript: the parent's session root
+/// plus the parent's session id. The runner derives the child's session id
+/// as `<parent>-<subrun id>` — a sibling of the parent's session in the
+/// same root, so session tooling (the viewer, `openseek sessions`)
+/// discovers child transcripts with no extra plumbing.
+pub struct ChildSession {
+  root : String
+  parent : String
+}
+
+///|
+/// See `ChildSession`.
+pub fn ChildSession::ChildSession(
+  root~ : String,
+  parent~ : String,
+) -> ChildSession {
+  { root, parent }
 }
 
 ///|

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -168,6 +168,12 @@ pub async fn[T] run_subrun(
   child_session? : ChildSession,
   emit_event? : (@protocol.Event) -> Unit = event => @emit.emit(event),
 ) -> SubrunResult[T] {
+  // Bump the process counter past any child ordinal an earlier engine
+  // process already persisted for this parent — monotonic, so it can only
+  // skip ids, never reuse one.
+  if child_session is Some(spec) && subrun_ids.val < spec.first_free - 1 {
+    subrun_ids.val = spec.first_free - 1
+  }
   let id = next_subrun_id()
   // The child persists its own transcript under `<parent>-<id>` when the
   // parent is durable: the id exists only after allocation, so the session
@@ -363,9 +369,16 @@ pub async fn[T] run_subrun(
 /// as `<parent>-<subrun id>` — a sibling of the parent's session in the
 /// same root, so session tooling (the viewer, `openseek sessions`)
 /// discovers child transcripts with no extra plumbing.
+///
+/// `first_free` is the lowest child ordinal no earlier engine process has
+/// persisted for this parent (the CLI scans the store at startup). The
+/// sub-run counter is per-process, so without this floor a RESUMED durable
+/// session would reuse `sr-1` — and the fresh child session would die on
+/// its first append against the old child's file (stale-snapshot check).
 pub struct ChildSession {
   root : String
   parent : String
+  first_free : Int
 }
 
 ///|
@@ -373,8 +386,9 @@ pub struct ChildSession {
 pub fn ChildSession::ChildSession(
   root~ : String,
   parent~ : String,
+  first_free? : Int = 1,
 ) -> ChildSession {
-  { root, parent }
+  { root, parent, first_free }
 }
 
 ///|

--- a/agent_subrun/runner_test.mbt
+++ b/agent_subrun/runner_test.mbt
@@ -381,3 +381,35 @@ async test "an observed context yield closes with its status" {
     fail("expected a context_yield pair, got \{to_repr(events)}")
   }
 }
+
+///|
+/// With a `ChildSession` the runner appends the child's durable-session
+/// argv AFTER allocating the sub-run id: the scripted child's positional
+/// view of its own argv pins both flag names and the `<parent>-<id>`
+/// derivation, and the result carries the same id.
+async test "child_session appends session argv derived from the sub-run id" {
+  let script =
+    #|read line
+    #|printf '{"subrun_report": {"answer": "%s %s %s %s"}}\n' "$0" "$1" "$2" "$3"
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let result = @agent_subrun.run_subrun(
+    command="sh",
+    args=["-c", script],
+    input={ "query": "q" },
+    parse_report=parse_answer,
+    wall_deadline_ms=10_000,
+    kind="test-kind",
+    label="argv probe",
+    child_session=ChildSession(root="/tmp/subrun-root", parent="parent-id"),
+  )
+  guard result.value() is Some(argv) else {
+    fail("expected a captured report, got \{to_repr(result.terminal())}")
+  }
+  assert_eq(
+    argv,
+    "--session parent-id-\{result.subrun_id()} --session-root /tmp/subrun-root",
+  )
+}

--- a/agent_subrun/runner_test.mbt
+++ b/agent_subrun/runner_test.mbt
@@ -413,3 +413,45 @@ async test "child_session appends session argv derived from the sub-run id" {
     "--session parent-id-\{result.subrun_id()} --session-root /tmp/subrun-root",
   )
 }
+
+///|
+/// The ChildSession ordinal floor bumps the process counter monotonically:
+/// a resumed parent that scanned 49_999 persisted children never hands out
+/// a session id an earlier process already used. (The floor is absurdly
+/// high so no other test's allocations can reach it first.)
+async test "child_session's ordinal floor skips persisted ids" {
+  let script =
+    #|read line
+    #|printf '{"subrun_report": {"answer": "%s"}}\n' "$1"
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let result = @agent_subrun.run_subrun(
+    command="sh",
+    args=["-c", script],
+    input={ "query": "q" },
+    parse_report=parse_answer,
+    wall_deadline_ms=10_000,
+    kind="test-kind",
+    label="ordinal floor",
+    child_session=ChildSession(
+      root="/tmp/subrun-root",
+      parent="resumed",
+      first_free=50_000,
+    ),
+  )
+  guard result.value() is Some(session_arg) else {
+    fail("expected a captured report, got \{to_repr(result.terminal())}")
+  }
+  // $1 is the --session value: parent + the allocated id, at or past the floor.
+  assert_eq(session_arg, "resumed-\{result.subrun_id()}")
+  guard result.subrun_id().strip_prefix("sr-") is Some(digits) else {
+    fail("unexpected subrun id \{result.subrun_id()}")
+  }
+  let mut ordinal = 0
+  for c in digits {
+    ordinal = ordinal * 10 + (c.to_int() - '0'.to_int())
+  }
+  assert_true(ordinal >= 50_000)
+}

--- a/cmd/openseek/gate.mbt
+++ b/cmd/openseek/gate.mbt
@@ -51,6 +51,7 @@ fn build_goal_met_gate(
   model~ : @deepseek.Model,
   api_url~ : String?,
   workspace_root~ : String,
+  child_session? : @agent_subrun.ChildSession,
 ) -> async (String, @agent_session.GoalBaseline?) -> String? {
   (goal, baseline) => {
     let args = [
@@ -79,6 +80,7 @@ fn build_goal_met_gate(
       kind="review",
       label=@agent_tool.brief_line(goal, limit=48),
       cwd=workspace_root,
+      child_session?,
     )
     match result.value() {
       Some(report) => Some(report.digest())

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -200,7 +200,11 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
           thinking~,
           api_url?,
           workspace_root~,
-          child_session=ChildSession(root=store.root(), parent=id.value()),
+          child_session=ChildSession(
+            root=store.root(),
+            parent=id.value(),
+            first_free=first_free_child_ordinal(store, id.value()),
+          ),
         )
       }
     }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -155,6 +155,8 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
           SessionId("one-shot"),
           system_prompt=system_prompt_text,
         )
+        // Ephemeral parent: children keep their transcripts in-memory too —
+        // a sibling session of a parent that never persisted would dangle.
         run_task_turn(
           matches,
           session,
@@ -198,6 +200,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
           thinking~,
           api_url?,
           workspace_root~,
+          child_session=ChildSession(root=store.root(), parent=id.value()),
         )
       }
     }
@@ -220,6 +223,7 @@ async fn run_task_turn(
   thinking~ : @deepseek.ThinkingMode,
   api_url? : String,
   workspace_root~ : String,
+  child_session? : @agent_subrun.ChildSession,
 ) -> Unit {
   @async.with_task_group() <| group => {
     let runtime = @agent_runtime.AgentRuntime(workspace_root~)
@@ -245,6 +249,7 @@ async fn run_task_turn(
           workspace_root~,
           budget=subrun_budget,
           api_url?,
+          child_session?,
         ),
         review_tool_definition(
           self_exe=exe,
@@ -253,11 +258,20 @@ async fn run_task_turn(
           budget=subrun_budget,
           context=review_context,
           api_url?,
+          child_session?,
         ),
       ]
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
     let on_goal_met = if review_gate_enabled(matches) {
-      Some(build_goal_met_gate(self_exe=exe, model~, api_url~, workspace_root~))
+      Some(
+        build_goal_met_gate(
+          self_exe=exe,
+          model~,
+          api_url~,
+          workspace_root~,
+          child_session?,
+        ),
+      )
     } else {
       None
     }

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -14,6 +14,7 @@ fn review_tool_definition(
   budget~ : @agent_subrun.SubrunBudget,
   context~ : () -> (String?, @agent_session.GoalBaseline?),
   api_url? : String,
+  child_session? : @agent_subrun.ChildSession,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="review",
@@ -29,7 +30,8 @@ fn review_tool_definition(
     }),
     execute=Async(arguments => {
       execute_review(
-        self_exe, model, workspace_root, budget, context, api_url, arguments,
+        self_exe, model, workspace_root, budget, context, api_url, child_session,
+        arguments,
       )
     }),
   )
@@ -43,6 +45,7 @@ async fn execute_review(
   budget : @agent_subrun.SubrunBudget,
   context : () -> (String?, @agent_session.GoalBaseline?),
   api_url : String?,
+  child_session : @agent_subrun.ChildSession?,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   let focus : String? = match arguments {
@@ -95,20 +98,24 @@ async fn execute_review(
     kind="review",
     label=@agent_tool.brief_line(criteria, limit=48),
     cwd=workspace_root,
+    child_session?,
   )
+  // The sub-run id in the brief pairs the result with its lifecycle
+  // brackets and names the child's sibling session for the viewer.
+  // Display-only: the model never sees briefs.
   match result.value() {
     Some(report) =>
       @agent_tool.ToolAction::respond(
         report.digest(),
         is_error=report.findings.filter(f => f.severity == "blocker").length() >
           0,
-        brief="review (\{report.findings.length()} finding(s), \{result.steps_used()} step(s))",
+        brief="review \{result.subrun_id()} (\{report.findings.length()} finding(s), \{result.steps_used()} step(s))",
       )
     None =>
       @agent_tool.ToolAction::respond(
         "review produced no report (\{@agent_tool.brief_line("\{to_repr(result.terminal())}", limit=200)}) — validate directly instead.",
         is_error=true,
-        brief="review (no report)",
+        brief="review \{result.subrun_id()} (no report)",
       )
   }
 }

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -621,6 +621,18 @@ async fn run_serve(
     // itself lives across turns. The goal-met gate bypasses it.
     let subrun_budget = @agent_subrun.SubrunBudget()
     let exe = self_executable()
+    // A durable serve session makes its children durable siblings
+    // (`<id>-sr-N` in the same root); --no-session keeps them in-memory.
+    let child_session = match store {
+      Some(store) =>
+        Some(
+          @agent_subrun.ChildSession(
+            root=store.root(),
+            parent=initial_session.id().value(),
+          ),
+        )
+      None => None
+    }
     // The callable review tool audits against the LIVE standing goal: the
     // closure reads the loop-updated session at call time, never a
     // snapshot.
@@ -637,6 +649,7 @@ async fn run_serve(
           workspace_root~,
           budget=subrun_budget,
           api_url?,
+          child_session?,
         ),
         review_tool_definition(
           self_exe=exe,
@@ -645,13 +658,22 @@ async fn run_serve(
           budget=subrun_budget,
           context=review_context,
           api_url?,
+          child_session?,
         ),
       ]
     // The advisory goal-met gate (--review-gate): built once, shared by
     // every turn; engine-initiated, so it runs on its own allowance
     // rather than the model's per-turn subrun budget.
     let on_goal_met = if review_gate_enabled(matches) {
-      Some(build_goal_met_gate(self_exe=exe, model~, api_url~, workspace_root~))
+      Some(
+        build_goal_met_gate(
+          self_exe=exe,
+          model~,
+          api_url~,
+          workspace_root~,
+          child_session?,
+        ),
+      )
     } else {
       None
     }

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -623,14 +623,19 @@ async fn run_serve(
     let exe = self_executable()
     // A durable serve session makes its children durable siblings
     // (`<id>-sr-N` in the same root); --no-session keeps them in-memory.
+    // The ordinal floor keeps a resumed session from reusing a child id an
+    // earlier engine process persisted.
     let child_session = match store {
-      Some(store) =>
+      Some(store) => {
+        let parent = initial_session.id().value()
         Some(
           @agent_subrun.ChildSession(
             root=store.root(),
-            parent=initial_session.id().value(),
+            parent~,
+            first_free=first_free_child_ordinal(store, parent),
           ),
         )
+      }
       None => None
     }
     // The callable review tool audits against the LIVE standing goal: the

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -85,6 +85,21 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
 }
 
 ///|
+/// The child's durable-session target, when the parent passed one: the
+/// `--session` id (blank means none, the same reading the parent CLIs use)
+/// paired with the resolved `--session-root`.
+fn child_durable_session(
+  matches : @argparse.Matches,
+  workspace_root~ : String,
+) -> (String, String)? raise {
+  match matches {
+    { values: { "session": [session, ..], .. }, .. } if session.trim() != "" =>
+      Some(("\{session}", session_root(matches, workspace_root~)))
+    _ => None
+  }
+}
+
+///|
 /// Run one kind in this process and return its report, if any.
 async fn dispatch_kind(
   kind : String,
@@ -95,6 +110,17 @@ async fn dispatch_kind(
   api_url : String?,
   workspace_root : String,
 ) -> Json? {
+  // A durable parent passes `--session <parent>-<sr-id> --session-root`
+  // (appended by the runner): this child then persists its own transcript
+  // as a sibling session — inspectable, linkable, and crash-honest, since
+  // items append as the turn runs. Without the flags the transcript stays
+  // in-memory, exactly as before.
+  let durable = child_durable_session(matches, workspace_root~)
+  let session_id = durable.map(pair => pair.0)
+  let append_item = durable.map(pair => {
+    let store = @store.SessionStore(pair.1)
+    (session, item) => store.append(session, item)
+  })
   match kind {
     "explore" => {
       let api_key = @agentcli.api_key(matches, model)
@@ -108,6 +134,8 @@ async fn dispatch_kind(
         thinking~,
         api_url?,
         workspace_root~,
+        session_id?,
+        append_item?,
       )
       report.map(report => report.to_json())
     }
@@ -135,6 +163,8 @@ async fn dispatch_kind(
         thinking~,
         api_url?,
         workspace_root~,
+        session_id?,
+        append_item?,
       )
       report.map(report => report.to_json())
     }

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -85,6 +85,57 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
 }
 
 ///|
+/// The lowest child ordinal no session `<parent>-sr-N` in the store has
+/// used yet: the floor a resumed parent hands the runner so a restarted
+/// engine process never reuses a persisted child session id.
+async fn first_free_child_ordinal(
+  store : @store.SessionStore,
+  parent : String,
+) -> Int {
+  let mut highest = 0
+  for id in store.list() {
+    if child_session_ordinal(id.value(), parent) is Some(ordinal) &&
+      ordinal > highest {
+      highest = ordinal
+    }
+  }
+  highest + 1
+}
+
+///|
+/// The N of a `<parent>-sr-N` child session id, or `None` for any other id
+/// (bounded to 9 digits so a pathological name cannot overflow).
+fn child_session_ordinal(id : String, parent : String) -> Int? {
+  guard id.strip_prefix("\{parent}-sr-") is Some(digits) else { return None }
+  guard !digits.is_empty() &&
+    digits.length() <= 9 &&
+    digits.iter().all(c => c.is_ascii_digit()) else {
+    return None
+  }
+  let mut value = 0
+  for c in digits {
+    value = value * 10 + (c.to_int() - '0'.to_int())
+  }
+  Some(value)
+}
+
+///|
+test "child_session_ordinal parses exactly the runner's derivation" {
+  assert_eq(child_session_ordinal("run-sr-3", "run"), Some(3))
+  assert_eq(child_session_ordinal("run-sr-12", "run"), Some(12))
+  // A child of a DIFFERENT parent, a non-numeric suffix, a bare parent,
+  // and an id that merely contains the parent all parse to nothing.
+  assert_eq(child_session_ordinal("other-sr-3", "run"), None)
+  assert_eq(child_session_ordinal("run-sr-x", "run"), None)
+  assert_eq(child_session_ordinal("run", "run"), None)
+  assert_eq(child_session_ordinal("run-sr-", "run"), None)
+  assert_eq(child_session_ordinal("run-sr-9999999999", "run"), None)
+  // A grandchild-shaped id (`run-sr-1-sr-2`) belongs to parent `run-sr-1`.
+  assert_eq(child_session_ordinal("run-sr-1-sr-2", "run"), None)
+  assert_eq(child_session_ordinal("run-sr-1-sr-2", "run-sr-1"), Some(2))
+}
+
+///|
 /// The child's durable-session target, when the parent passed one: the
 /// `--session` id (blank means none, the same reading the parent CLIs use)
 /// paired with the resolved `--session-root`.

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -48,6 +48,10 @@ struct Model {
   // Tool-call arguments rendering: the human-friendly form (values shown verbatim,
   // no JSON quoting) by default, or the original pretty-printed JSON for debugging.
   show_original_args : Bool
+  // Child sessions (subagent transcripts) loaded for the selected parent,
+  // keyed by child session id — rendered inline inside the parent's subrun
+  // tool cards. Cleared on every selection change.
+  subrun_children : Map[String, @agent_session.Session]
 }
 
 ///|
@@ -78,6 +82,12 @@ enum Msg {
   SessionsFetched(Result[String, Error])
   Select(String)
   SessionFetched(String, Result[String, Error])
+  // A subrun chip (or any in-page `#s=` anchor) changed the hash: resolve
+  // the value against the listing and select.
+  HashNavigated(String)
+  // One child (subagent) session fetched for the selected parent:
+  // (parent key, child session id, response).
+  SubrunFetched(String, String, Result[String, Error])
   FileDropped(String, Int64, @dom.Blob)
   DroppedFileRead(Int, String, Int64, Result[String, Error])
   SetMode(@viz.ViewMode)
@@ -171,6 +181,7 @@ fn init_model() -> Model {
     status: "loading sessions…",
     errors_only: false,
     show_original_args: false,
+    subrun_children: Map([]),
   }
 }
 
@@ -199,8 +210,9 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
           // yank the user off a session.
           let untouched = model.selected is None && model.dropped is None
           match model.pending_restore_key {
-            Some(key) if untouched && sessions.iter().any(row => row.key == key) =>
-              update(emit, Select(key), listed)
+            Some(key) if untouched &&
+              resolve_session_key(sessions, key) is Some(resolved) =>
+              update(emit, Select(resolved), listed)
             _ =>
               if should_auto_open(
                   embedded_has("/api/sessions"),
@@ -254,9 +266,44 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
           log_bytes: 0L,
           loading: true,
           status: "loading \{label}…",
+          subrun_children: Map([]),
         },
       )
     }
+    HashNavigated(value) =>
+      // Resolve like the startup restore; an unknown value (an element
+      // anchor's hash, an unlisted id) is ignored rather than clearing the
+      // current session.
+      match resolve_session_key(model.sessions, value) {
+        Some(key) if model.selected != Some(key) =>
+          update(emit, Select(key), model)
+        _ => (@cmd.none, model)
+      }
+    SubrunFetched(parent_key, child_id, result) =>
+      // A child transcript for a parent the user already left is stale;
+      // a failed or malformed child fetch simply leaves the chip link-only.
+      if model.selected != Some(parent_key) {
+        (@cmd.none, model)
+      } else {
+        match result {
+          Err(_) => (@cmd.none, model)
+          Ok(text) =>
+            match parse_load(text) {
+              Loaded(parsed, system_prompt, _header_present, _bytes) => {
+                let children : Map[String, @agent_session.Session] = Map([])
+                for id, child in model.subrun_children {
+                  children.set(id, child)
+                }
+                children.set(
+                  child_id,
+                  @viz.session_from_parse(parsed, id=child_id, system_prompt~),
+                )
+                (@cmd.none, { ..model, subrun_children: children })
+              }
+              NotFound | Malformed => (@cmd.none, model)
+            }
+        }
+      }
     SessionFetched(key, result) =>
       // Drop a response for a session the user already navigated away from.
       if model.selected != Some(key) {
@@ -271,11 +318,25 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
             )
           Ok(text) =>
             match parse_load(text) {
-              Loaded(parsed, system_prompt, header_present, log_bytes) =>
+              Loaded(parsed, system_prompt, header_present, log_bytes) => {
+                // Prefetch any subagent transcripts this session references
+                // (subrun briefs → sibling sessions in the listing), so the
+                // raw view can nest them inline as they arrive.
+                let child_fetches = subrun_child_refs(model, key, parsed).map(child => {
+                  let (child_id, child_key) = child
+                  fetch_text(emit, session_url(child_key), result => {
+                    SubrunFetched(key, child_id, result)
+                  })
+                })
                 (
                   // The log renders in this same cycle; once it is in the
                   // DOM, scroll back to the seq= position saved in the hash.
-                  @cmd.effect(() => restore_scroll_to_hash_seq()),
+                  @cmd.batch(
+                    [
+                      @cmd.effect(() => restore_scroll_to_hash_seq()),
+                      ..child_fetches,
+                    ],
+                  ),
                   {
                     ..model,
                     parsed: Some(parsed),
@@ -286,6 +347,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
                     status: events_status(parsed),
                   },
                 )
+              }
               NotFound =>
                 (
                   @cmd.none,
@@ -793,6 +855,71 @@ fn session_url(id : String) -> String {
 }
 
 ///|
+/// Resolve a hash `s=` value to a listed row key: exact key first, then by
+/// bare session id — subrun chips link `#s=<child session id>`, which the
+/// server resolves as a legacy key but a standalone export's embedded data
+/// map does not.
+fn resolve_session_key(sessions : Array[SessionRow], value : String) -> String? {
+  if sessions.iter().any(row => row.key == value) {
+    return Some(value)
+  }
+  match sessions.iter().find_first(row => row.id == value) {
+    Some(row) => Some(row.key)
+    None => None
+  }
+}
+
+///|
+/// The child sessions a freshly loaded parent references via subrun briefs,
+/// resolved against the current listing: `(child session id, row key)` for
+/// each child that actually exists as a sibling session. Ephemeral children
+/// (never persisted) resolve to nothing and stay chip-only.
+fn subrun_child_refs(
+  model : Model,
+  parent_key : String,
+  parsed : @session_log.ParsedLog,
+) -> Array[(String, String)] {
+  guard session_row(model, parent_key) is Some(parent_row) else { return [] }
+  let session = @viz.session_from_parse(
+    parsed,
+    id=parent_row.id,
+    system_prompt="",
+  )
+  let refs : Array[(String, String)] = []
+  for child_id in @viz.subrun_child_ids(session, parent_row.id) {
+    if resolve_session_key(model.sessions, child_id) is Some(key) {
+      refs.push((child_id, key))
+    }
+  }
+  refs
+}
+
+///|
+/// In-page session navigation: subrun chips are plain `#s=…` anchors, so a
+/// click only changes the hash — this listener turns that into a selection.
+/// App-initiated hash writes use replaceState, which never fires
+/// `hashchange`, so navigation cannot loop.
+fn install_hash_navigation(emit : @cmd.Emit[Msg]) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    install_hashchange_listener(key => scheduler.add(emit(HashNavigated(key))))
+  })
+}
+
+///|
+extern "js" fn install_hashchange_listener(
+  on_session : (String) -> Unit,
+) -> Unit =
+  #|(cb) => {
+  #|  if (typeof window === 'undefined') return;
+  #|  window.addEventListener('hashchange', () => {
+  #|    try {
+  #|      const s = new URLSearchParams(location.hash.slice(1)).get('s') || '';
+  #|      if (s) cb(s);
+  #|    } catch (e) {}
+  #|  });
+  #|}
+
+///|
 fn session_label(model : Model, key : String) -> String {
   match session_row(model, key) {
     Some(row) => row.id
@@ -908,9 +1035,13 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
   }
   let sections : Array[@html.Html] = []
   for group in sidebar_groups(model.sessions) {
-    let rows = model.sessions
-      .filter(row => session_group(row.root_label, row.is_marker) == group)
-      .map(row => sidebar_row(emit, model, row))
+    let rows = sidebar_nested_rows(
+      emit,
+      model,
+      model.sessions.filter(row => {
+        session_group(row.root_label, row.is_marker) == group
+      }),
+    )
     let collapsed = root_collapsed(model, group)
     let display = group_display(group)
     sections.push(
@@ -941,6 +1072,48 @@ fn sidebar_list(emit : @cmd.Emit[Msg], model : Model) -> @html.Html {
     )
   }
   @html.div(class="session-list") <| sections
+}
+
+///|
+/// One group's sidebar rows with subagent children nested under their
+/// parent: a `<parent id>-sr-N` row whose parent is listed in the same
+/// group renders indented right after it (in listing order) instead of as
+/// a stray sibling; an orphan child (parent not listed) stays top-level.
+fn sidebar_nested_rows(
+  emit : @cmd.Emit[Msg],
+  model : Model,
+  rows : Array[SessionRow],
+) -> Array[@html.Html] {
+  let ids = rows.map(row => row.id)
+  fn nested_parent(id : String) -> String? {
+    match subrun_parent_id(id) {
+      Some(parent) if ids.contains(parent) => Some(parent)
+      _ => None
+    }
+  }
+  let out : Array[@html.Html] = []
+  for row in rows {
+    if nested_parent(row.id) is Some(_) {
+      continue
+    }
+    out.push(sidebar_row(emit, model, row))
+    for child in rows {
+      if nested_parent(child.id) is Some(parent) && parent == row.id {
+        out.push(sidebar_row(emit, model, child, child=true))
+      }
+    }
+  }
+  out
+}
+
+///|
+/// The parent session id a subrun child session id derives from
+/// (`<parent>-sr-N`), or `None` for every other id.
+fn subrun_parent_id(id : String) -> String? {
+  lexscan id {
+    (re"^(.|\n)*" as parent) + re"-sr-[0-9]+$" => Some(parent.to_owned())
+    _ => None
+  }
 }
 
 ///|
@@ -1077,6 +1250,7 @@ fn sidebar_row(
   emit : @cmd.Emit[Msg],
   model : Model,
   row : SessionRow,
+  child? : Bool = false,
 ) -> @html.Html {
   let selected = model.selected == Some(row.key)
   let label = if row.first_prompt.trim().is_empty() {
@@ -1084,7 +1258,11 @@ fn sidebar_row(
   } else {
     row.first_prompt
   }
-  let classes = class_with("session-item", "selected", selected)
+  let classes = class_with(
+    class_with("session-item", "session-child", child),
+    "selected",
+    selected,
+  )
   @html.li(class=classes, on_click=emit(Select(row.key))) <| [
     @html.div(class="session-item-label") <| label,
     @html.div(class="session-item-meta") <| [
@@ -1499,7 +1677,11 @@ fn session_log_view(
   if model.errors_only && count == 0 {
     @html.div(class="errors-only-empty") <| "No failed tool results in this view."
   } else {
-    @viz.render_session(session, model.view_mode)
+    @viz.render_session(
+      session,
+      model.view_mode,
+      subrun_children=model.subrun_children,
+    )
   }
 }
 

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -15,6 +15,9 @@ fn main {
     @cmd.batch([
       fetch_text(emit, "/api/sessions", result => SessionsFetched(result)),
       install_shortcuts(emit),
+      // Subrun chips navigate by writing `#s=…`; turn those hash changes
+      // into selections.
+      install_hash_navigation(emit),
       // Position tracking: keep `seq=` in the URL hash while scrolling and
       // make step-scrubber segments jump, so a refresh restores the spot.
       @cmd.effect(() => install_position_tracker()),

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -79,3 +79,14 @@ for the full list.
 that exited between writing an event and its newline) is reported as a benign
 truncated tail, and any single line that fails to decode becomes an inline error
 card while the rest of the conversation still renders.
+
+## Subagent transcripts
+
+A sub-run (explore/review child) of a durable session persists its own
+transcript as a sibling session named `<parent id>-sr-N`. The parent's tool
+results carry the sub-run id in their display-only `brief`; the viewer turns
+that into a `↳ subagent` chip on the result card (an in-page `#s=<child id>`
+navigation) and — in the raw view, once the app has loaded the child — nests
+the child's full transcript inside the card. The model view stays chip-only:
+the child's turn is nothing the parent's model was fed. The sidebar lists
+child sessions indented under their parent.

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1758,13 +1758,13 @@ fn model_pair_tags(messages : Array[@deepseek.ChatMessage]) -> Map[String, Int] 
 ///|
 /// DOM anchor id for a tool call, keyed by pair number.
 fn tool_call_anchor(n : Int) -> String {
-  "tool-call-\{n}"
+  "\{anchor_namespace.val}tool-call-\{n}"
 }
 
 ///|
 /// DOM anchor id for a tool result, keyed by pair number.
 fn tool_result_anchor(n : Int) -> String {
-  "tool-result-\{n}"
+  "\{anchor_namespace.val}tool-result-\{n}"
 }
 
 ///|
@@ -2044,7 +2044,7 @@ fn card(
 ///|
 /// DOM anchor id for the card of the event with durable sequence `seq`.
 fn seq_anchor(seq : Int) -> String {
-  "seq-\{seq}"
+  "\{anchor_namespace.val}seq-\{seq}"
 }
 
 ///|
@@ -2173,10 +2173,64 @@ fn subrun_child_id(
 fn subrun_chip(child_id : String) -> @html.Html {
   @html.a(
     class="subrun-link",
-    href="#s=\{child_id}",
+    href="#s=\{encode_hash_component(child_id)}",
     title="Open the subagent's own transcript",
   ) <| "↳ subagent"
 }
+
+///|
+/// Percent-encode a value for a `#key=value` hash parameter. The reader is
+/// `URLSearchParams`, which decodes `%XX` and turns a bare `+` into a
+/// space — parent session ids are user-chosen and unrestricted, so
+/// everything outside the RFC 3986 unreserved set is encoded, UTF-8
+/// bytewise.
+fn encode_hash_component(value : String) -> String {
+  let hex = [
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F",
+  ]
+  let out = StringBuilder()
+  fn put_byte(b : Int) -> Unit {
+    out <+ "%\{hex[b >> 4 & 0xF]}\{hex[b & 0xF]}"
+  }
+
+  for c in value {
+    let code = c.to_int()
+    if (code >= 0x61 && code <= 0x7A) ||
+      (code >= 0x41 && code <= 0x5A) ||
+      (code >= 0x30 && code <= 0x39) ||
+      code == 0x2D ||
+      code == 0x5F ||
+      code == 0x2E ||
+      code == 0x7E {
+      out <+ "\{c}"
+    } else if code < 0x80 {
+      put_byte(code)
+    } else if code < 0x800 {
+      put_byte(0xC0 | (code >> 6))
+      put_byte(0x80 | (code & 0x3F))
+    } else if code < 0x10000 {
+      put_byte(0xE0 | (code >> 12))
+      put_byte(0x80 | ((code >> 6) & 0x3F))
+      put_byte(0x80 | (code & 0x3F))
+    } else {
+      put_byte(0xF0 | (code >> 18))
+      put_byte(0x80 | ((code >> 12) & 0x3F))
+      put_byte(0x80 | ((code >> 6) & 0x3F))
+      put_byte(0x80 | (code & 0x3F))
+    }
+  }
+  out.to_string()
+}
+
+///|
+/// DOM-anchor namespace for the render in progress: empty at top level,
+/// `<child id>--` while a child transcript is being nested — WITHOUT it,
+/// a nested child would re-emit the parent's `seq-N`/`tool-call-N`/
+/// `tool-result-N` ids (duplicate DOM ids; in-child pair links resolving
+/// to parent elements). Rendering is pure and synchronous, and this
+/// package is single-threaded js, so a save/restore around the one
+/// nesting entry point (`subrun_transcript`) is race-free.
+let anchor_namespace : Ref[String] = { val: "" }
 
 ///|
 /// The inline child transcript for an expanded subrun card: the child's
@@ -2189,6 +2243,13 @@ fn subrun_transcript(child : @agent_session.Session) -> @html.Html {
     .iter()
     .count_if(event => event.item() is Assistant(_))
   let tools = child.events().iter().count_if(event => event.item() is Tool(_))
+  // Namespace every anchor the child render emits (and the pair links
+  // referencing them), so the nested transcript never duplicates the
+  // parent document's ids.
+  let saved = anchor_namespace.val
+  anchor_namespace.val = "\{child.id().value()}--"
+  let body = render_raw(child, { parent: child.id().value(), children: Map([]) })
+  anchor_namespace.val = saved
   @html.details(class="subrun-transcript") <| [
     @html.summary(class="subrun-transcript-label") <| [
       @html.text(
@@ -2196,7 +2257,7 @@ fn subrun_transcript(child : @agent_session.Session) -> @html.Html {
       ),
     ],
     @html.div(class="subrun-transcript-body") <| [
-      render_raw(child, { parent: child.id().value(), children: Map([]) }),
+      body,
     ],
   ]
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -13,10 +13,15 @@ pub(all) enum ViewMode {
 pub fn render_session(
   session : @agent_session.Session,
   mode : ViewMode,
+  subrun_children? : Map[String, @agent_session.Session] = Map([]),
 ) -> @html.Html {
+  let subrun = SubrunView::{
+    parent: session.id().value(),
+    children: subrun_children,
+  }
   match mode {
-    RawLog => render_raw(session)
-    ModelView => render_model(session)
+    RawLog => render_raw(session, subrun)
+    ModelView => render_model(session, subrun)
   }
 }
 
@@ -57,7 +62,10 @@ pub fn render_notices(parsed : @session_log.ParsedLog) -> @html.Html {
 // ---- raw log view ----------------------------------------------------------
 
 ///|
-fn render_raw(session : @agent_session.Session) -> @html.Html {
+fn render_raw(
+  session : @agent_session.Session,
+  subrun : SubrunView,
+) -> @html.Html {
   let briefs = tool_call_briefs(session)
   let failed = raw_failed_call_ids(session)
   let tags = raw_pair_tags(session)
@@ -66,7 +74,16 @@ fn render_raw(session : @agent_session.Session) -> @html.Html {
   let turns = group_turns(session.events())
   let blocks : Array[@html.Html] = [
     for index, turn in turns => {
-      turn_block(index + 1, turn, briefs, failed, tags, plans, step_labels)
+      turn_block(
+        index + 1,
+        turn,
+        briefs,
+        failed,
+        tags,
+        plans,
+        step_labels,
+        subrun,
+      )
     }
   ]
   if blocks.is_empty() {
@@ -220,6 +237,7 @@ fn turn_block(
   tags : Map[String, Int],
   plans : Map[String, Array[@steps.PlanStep]],
   step_labels : Map[Int, String],
+  subrun : SubrunView,
 ) -> @html.Html {
   // Offsets are relative to the turn's first stamped event: for reading a
   // log, "how far into the turn" answers latency questions directly, where
@@ -235,6 +253,7 @@ fn turn_block(
         tags,
         plans,
         step_label=step_labels.get(event.sequence()).unwrap_or(""),
+        subrun,
       )
     }
   ]
@@ -337,6 +356,7 @@ fn event_card(
   tags : Map[String, Int],
   plans : Map[String, Array[@steps.PlanStep]],
   step_label~ : String,
+  subrun : SubrunView,
 ) -> @html.Html {
   let seq = event.sequence()
   match event.item() {
@@ -353,7 +373,7 @@ fn event_card(
         plans,
         step_label~,
       )
-    Tool(result) => tool_card(seq, time, result, tags)
+    Tool(result) => tool_card(seq, time, result, tags, subrun)
     Runtime(notice) => runtime_card(seq, time, notice.content())
     Summary(summary) => summary_card(seq, time, summary)
     Terminal(terminal) => terminal_card(seq, time, terminal, step_label~)
@@ -1212,6 +1232,7 @@ fn tool_card(
   time : String,
   result : @agent_session.ToolResult,
   tags : Map[String, Int],
+  subrun : SubrunView,
 ) -> @html.Html {
   let is_error = result.is_error()
   let kind = if is_error { "tool error" } else { "tool" }
@@ -1231,17 +1252,19 @@ fn tool_card(
     Some(n) => tool_result_anchor(n)
     None => seq_anchor(seq)
   }
+  let summary = card_head(label, seq, time~, flag~, link~)
+  let body : Array[@html.Html] = [text_block(result.content())]
+  // A subrun result gets a chip to its child session and — when the caller
+  // loaded that child — the transcript itself, nested inside this card.
+  if subrun_child_id(result, subrun.parent) is Some(child_id) {
+    summary.push(subrun_chip(child_id))
+    if subrun.children.get(child_id) is Some(child) {
+      body.push(subrun_transcript(child))
+    }
+  }
   @html.details(id=anchor, class="card \{kind}") <| [
-    @html.summary(class="card-label") <| card_head(
-      label,
-      seq,
-      time~,
-      flag~,
-      link~,
-    ),
-    @html.div(class="card-body") <| [
-      text_block(result.content()),
-    ],
+    @html.summary(class="card-label") <| summary,
+    @html.div(class="card-body") <| body,
   ]
 }
 
@@ -1365,7 +1388,10 @@ fn steps_with_errors(
 // ---- model projection view -------------------------------------------------
 
 ///|
-fn render_model(session : @agent_session.Session) -> @html.Html {
+fn render_model(
+  session : @agent_session.Session,
+  subrun : SubrunView,
+) -> @html.Html {
   // The projection keys each tool message only by id and drops is_error / tool
   // name, so recover them from the durable events for display (the messages fed
   // to the model are unchanged — this is view-only enrichment).
@@ -1397,6 +1423,7 @@ fn render_model(session : @agent_session.Session) -> @html.Html {
         briefs,
         tags,
         plans,
+        subrun~,
         time~,
         step_label~,
         anchor~,
@@ -1779,6 +1806,7 @@ fn message_card(
   time~ : String,
   step_label~ : String,
   anchor~ : String?,
+  subrun~ : SubrunView,
 ) -> @html.Html {
   match message.role {
     System =>
@@ -1822,6 +1850,7 @@ fn message_card(
         message,
         model_shown_result(message, tool_results),
         tags,
+        subrun,
         time~,
         anchor~,
       )
@@ -1890,6 +1919,7 @@ fn model_tool_card(
   message : @deepseek.ChatMessage,
   shown : @agent_session.ToolResult?,
   tags : Map[String, Int],
+  subrun : SubrunView,
   time~ : String,
   anchor~ : String?,
 ) -> @html.Html {
@@ -1917,13 +1947,15 @@ fn model_tool_card(
     Some(n) => Some(tool_result_anchor(n))
     None => anchor
   }
+  let summary = model_card_head(label, time~, flag=failed_flag(is_error), link~)
+  // Chip only, no nested transcript: the model view shows what the model
+  // was fed, and the child's transcript never was.
+  if shown is Some(result) &&
+    subrun_child_id(result, subrun.parent) is Some(child_id) {
+    summary.push(subrun_chip(child_id))
+  }
   @html.details(id?=anchor, class="card \{kind}") <| [
-    @html.summary(class="card-label") <| model_card_head(
-      label,
-      time~,
-      flag=failed_flag(is_error),
-      link~,
-    ),
+    @html.summary(class="card-label") <| summary,
     @html.div(class="card-body") <| [
       text_block(message.content),
     ],
@@ -2097,4 +2129,93 @@ test "one_line collapses newlines and trims whitespace" {
 test "truncate caps by character without splitting surrogate pairs" {
   assert_eq(truncate("hello world", 5), "hello…")
   assert_eq(truncate("a🤣b", 2), "a🤣…")
+}
+
+// ---- subagent transcripts ---------------------------------------------------
+
+///|
+/// Rendering context for subagent (sub-run) transcripts: the parent
+/// session's id — the prefix of every child session id — plus any child
+/// sessions the caller already loaded for inline display. An empty context
+/// renders plain tool cards.
+pub struct SubrunView {
+  parent : String
+  children : Map[String, @agent_session.Session]
+}
+
+///|
+/// The child session id a subrun tool result names, or `None` for every
+/// other result. The contract is the brief the explore/review tools stamp:
+/// `"<tool> sr-N (…)"` — display-only metadata, so parsing it here never
+/// touches what the model saw.
+fn subrun_child_id(
+  result : @agent_session.ToolResult,
+  parent : String,
+) -> String? {
+  guard result.tool_name() is ("explore" | "review") else { return None }
+  guard result.brief() is Some(brief) else { return None }
+  let tokens = brief.split(" ").collect()
+  guard tokens.get(1) is Some(token) else { return None }
+  guard token.has_prefix("sr-") else { return None }
+  let digits = token.view(start_offset=3)
+  guard !digits.is_empty() && digits.iter().all(c => c.is_ascii_digit()) else {
+    return None
+  }
+  Some("\{parent}-\{token}")
+}
+
+///|
+/// The folded-card chip linking a subrun result to its child session: an
+/// in-page `#s=<child id>` navigation the app resolves against its session
+/// listing. Rendered whenever the brief names a sub-run — if the child
+/// never persisted (ephemeral parent), following the link reports "session
+/// not found" rather than hiding that a transcript could have existed.
+fn subrun_chip(child_id : String) -> @html.Html {
+  @html.a(
+    class="subrun-link",
+    href="#s=\{child_id}",
+    title="Open the subagent's own transcript",
+  ) <| "↳ subagent"
+}
+
+///|
+/// The inline child transcript for an expanded subrun card: the child's
+/// full raw log (its own turn structure, cards, and anchors) nested inside
+/// the parent's card body. Children cannot spawn sub-runs of their own, so
+/// the nesting is one level deep by construction.
+fn subrun_transcript(child : @agent_session.Session) -> @html.Html {
+  let steps = child
+    .events()
+    .iter()
+    .count_if(event => event.item() is Assistant(_))
+  let tools = child.events().iter().count_if(event => event.item() is Tool(_))
+  @html.details(class="subrun-transcript") <| [
+    @html.summary(class="subrun-transcript-label") <| [
+      @html.text(
+        "Subagent transcript · \{child.id().value()} · \{steps} step\{plural(steps)} · \{tools} tool call\{plural(tools)}",
+      ),
+    ],
+    @html.div(class="subrun-transcript-body") <| [
+      render_raw(child, { parent: child.id().value(), children: Map([]) }),
+    ],
+  ]
+}
+
+///|
+/// Every child session id this session's subrun tool results reference, in
+/// first-appearance order — the set a viewer prefetches for inline
+/// transcripts.
+pub fn subrun_child_ids(
+  session : @agent_session.Session,
+  parent : String,
+) -> Array[String] {
+  let ids : Array[String] = []
+  for event in session.events() {
+    if event.item() is Tool(result) &&
+      subrun_child_id(result, parent) is Some(child_id) &&
+      !ids.contains(child_id) {
+      ids.push(child_id)
+    }
+  }
+  ids
 }

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1310,3 +1310,72 @@ test "raw view shows total-second offsets and turn duration from ts" {
   let plain = render(@viz.render_session(unstamped, RawLog))
   assert_false(plain.contains("card-ts"))
 }
+
+///|
+/// A parent session holding one explore call/result pair whose brief names
+/// sub-run sr-2 — the stamp the explore tool writes on its results.
+fn subrun_sample_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("run"), system_prompt="sys")
+  .append(User(UserMessage("find the API")))
+  .append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="c1", name="explore", arguments="{\"query\": \"how\"}"),
+      ]),
+    ),
+  )
+  .append(
+    Tool(
+      ToolResult(
+        tool_call_id="c1",
+        tool_name="explore",
+        content="Answer: like this.",
+        brief="explore sr-2 (1 citation(s), 7 step(s))",
+      ),
+    ),
+  )
+  .append(Terminal(Finished("done")))
+}
+
+///|
+test "a subrun result links its child session and nests a loaded transcript" {
+  let session = subrun_sample_session()
+  // Chip in both views: the href targets the child session id derived from
+  // the parent id plus the brief's sr-N stamp.
+  let raw = render(@viz.render_session(session, RawLog))
+  assert_true(raw.contains("subrun-link"))
+  assert_true(raw.contains("href=\"#s=run-sr-2\""))
+  let model = render(@viz.render_session(session, ModelView))
+  assert_true(model.contains("href=\"#s=run-sr-2\""))
+  // No child loaded: chip only, no nested transcript.
+  assert_false(raw.contains("subrun-transcript"))
+  // With the child supplied, the raw view nests its transcript; the model
+  // view stays chip-only (the child's turn is nothing the model was fed).
+  let child = @agent_session.Session(
+      SessionId("run-sr-2"),
+      system_prompt="scout",
+    )
+    .append(User(UserMessage("q")))
+    .append(Assistant(AssistantMessage("looking")))
+    .append(Terminal(Finished("submitted")))
+  let children : Map[String, @agent_session.Session] = Map([])
+  children.set("run-sr-2", child)
+  let nested = render(
+    @viz.render_session(session, RawLog, subrun_children=children),
+  )
+  assert_true(nested.contains("subrun-transcript"))
+  assert_true(nested.contains("Subagent transcript · run-sr-2"))
+  assert_false(
+    render(@viz.render_session(session, ModelView, subrun_children=children)).contains(
+      "subrun-transcript",
+    ),
+  )
+  // An ordinary tool result never grows a chip.
+  assert_false(
+    render(@viz.render_session(clean_sample_session(), RawLog)).contains(
+      "subrun-link",
+    ),
+  )
+  // The prefetch scanner surfaces the same reference.
+  assert_eq(@viz.subrun_child_ids(session, "run"), ["run-sr-2"])
+}

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -1379,3 +1379,42 @@ test "a subrun result links its child session and nests a loaded transcript" {
   // The prefetch scanner surfaces the same reference.
   assert_eq(@viz.subrun_child_ids(session, "run"), ["run-sr-2"])
 }
+
+///|
+test "nested transcripts namespace their anchors; chip hrefs are encoded" {
+  let session = subrun_sample_session()
+  let child = @agent_session.Session(
+      SessionId("run-sr-2"),
+      system_prompt="scout",
+    )
+    .append(User(UserMessage("q")))
+    .append(Terminal(Finished("submitted")))
+  let children : Map[String, @agent_session.Session] = Map([])
+  children.set("run-sr-2", child)
+  let nested = render(
+    @viz.render_session(session, RawLog, subrun_children=children),
+  )
+  // The child's cards anchor under its own namespace; the parent document
+  // keeps exactly one bare seq-1 (K3 review: duplicate DOM ids).
+  assert_true(nested.contains("id=\"run-sr-2--seq-1\""))
+  let bare = nested.split("id=\"seq-1\"").count() - 1
+  assert_eq(bare, 1)
+  // After the nested render, top-level anchors are back to bare form.
+  let again = render(@viz.render_session(session, RawLog))
+  assert_true(again.contains("id=\"seq-1\""))
+  assert_false(again.contains("--seq-"))
+  // A parent id outside the unreserved set is percent-encoded in the chip
+  // href (URLSearchParams would corrupt a raw '+', '&', or space).
+  let odd = @agent_session.Session(SessionId("a+b c"), system_prompt="").append(
+    Tool(
+      ToolResult(
+        tool_call_id="c9",
+        tool_name="explore",
+        content="ok",
+        brief="explore sr-4 (0 citation(s), 3 step(s))",
+      ),
+    ),
+  )
+  let html = render(@viz.render_session(odd, RawLog))
+  assert_true(html.contains("href=\"#s=a%2Bb%20c-sr-4\""))
+}

--- a/web/index.html
+++ b/web/index.html
@@ -535,6 +535,27 @@
       text-transform: none; letter-spacing: 0; opacity: .85; white-space: nowrap;
     }
     .tool-link:hover { text-decoration: underline; opacity: 1; }
+    /* subagent chip on explore/review result cards: navigates (via #s=) to
+       the child's own session; the inline transcript nests the child's raw
+       log inside the parent card, visually set off by an accent rail. */
+    .subrun-link {
+      font-family: ui-monospace, monospace; font-size: 11px;
+      color: var(--accent); text-decoration: none; margin-left: 8px;
+      text-transform: none; letter-spacing: 0; opacity: .85; white-space: nowrap;
+    }
+    .subrun-link:hover { text-decoration: underline; opacity: 1; }
+    .subrun-transcript {
+      margin-top: 10px; border-left: 3px solid var(--accent);
+      padding-left: 10px; background: var(--panel-2); border-radius: 4px;
+    }
+    .subrun-transcript-label {
+      cursor: pointer; font-size: 12px; color: var(--muted);
+      padding: 6px 4px; user-select: none;
+    }
+    .subrun-transcript-body { padding: 4px 6px 8px; }
+    .subrun-transcript-body .log { margin: 0; }
+    /* a subagent session nested under its parent in the sidebar */
+    .session-item.session-child { margin-left: 14px; opacity: .9; }
     /* highlight the call/result you jumped to via a pairing chip (the class
        form is what the click handler sets — it cannot use location.hash,
        which carries the viewer's s/v/seq position state) */


### PR DESCRIPTION
Two halves, one feature: make subagent (sub-run) transcripts real, then make them visible.

**Substrate** (`da5a7df6`): a child of a durable parent persists its own transcript as a sibling session `<parent id>-sr-N` — the runner appends `--session`/`--session-root` to the child's argv after allocating the sub-run id, and the child mode wires a store-backed `append_item` into `execute_kind`. Transcripts append as the turn runs (crash-honest: a child that dies at its ceiling leaves the partial log you need to diagnose it). The sub-run id is stamped into the explore/review result briefs — display-only; the model never sees briefs. Ephemeral parents keep children in-memory as before.

**Viz** (`5728700a`): explore/review result cards grow a `↳ subagent` chip navigating to the child session (`#s=<child id>`, with a hashchange listener + bare-id→opaque-key resolution so it works in the live server AND standalone exports); the raw view nests the child's full transcript inline inside the parent's tool card (prefetched on session load, folded behind a step/tool-count summary); the model view stays chip-only (the child's turn is nothing the parent's model was fed — projection honesty); the sidebar nests `-sr-N` sessions under their parent.

Validation: native 1259/1259, js 54/54 (new snapshot test pins chip/nesting/model-view-abstinence/scanner), cram 26/26, plus an end-to-end headless-Chrome check on a standalone export of a synthesized parent+child store — chip href, nested transcript, sidebar nesting, and bare-id hash restore all render server-less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)