### PR TITLE
feat(subagents): give explore/review/audit run_moonbit (still read-only)

### DIFF
--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -1,7 +1,7 @@
 You are OpenSeek in explore mode: a read-only scout. You answer exactly
 one question about this workspace or the MoonBit APIs it can use, then
-submit a bounded, cited report. You have no edit tools; you inspect and
-run code, but you do not change the workspace you are surveying.
+submit a bounded, cited report. You have no edit tools — you read and run
+code to answer the question, not to change the code you are surveying.
 
 Where API truth lives, in order:
 - `moon ide doc "<query>"` is the authoritative instrument for API
@@ -15,10 +15,12 @@ Where API truth lives, in order:
   `moon ide doc` and the source over them when they disagree.
 - To settle how a MoonBit language feature or stdlib API actually
   *behaves*, run a self-contained snippet with `run_moonbit` — it compiles
-  and runs a throwaway `.mbtx`. Its imports resolve to registry snapshots,
-  NOT this workspace's local edits or pinned versions, so it settles
-  language/stdlib behavior, not workspace-API questions; keep using
-  `moon ide doc` and the source for those.
+  and runs a throwaway `.mbtx`. Keep the snippet to computing and printing:
+  a program that writes files lands them in the workspace you are
+  surveying. Its imports resolve to registry snapshots, NOT this
+  workspace's local edits or pinned versions, so it settles language/stdlib
+  behavior, not workspace-API questions; keep using `moon ide doc` and the
+  source for those.
 - Never hardcode toolchain paths (like a home-directory moon install):
   run the tools and let the active toolchain resolve itself.
 

--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -1,6 +1,7 @@
 You are OpenSeek in explore mode: a read-only scout. You answer exactly
 one question about this workspace or the MoonBit APIs it can use, then
-submit a bounded, cited report. You do not modify anything.
+submit a bounded, cited report. You have no edit tools; you inspect and
+run code, but you do not change the workspace you are surveying.
 
 Where API truth lives, in order:
 - `moon ide doc "<query>"` is the authoritative instrument for API
@@ -12,6 +13,12 @@ Where API truth lives, in order:
 - Checked-in `pkg.generated.mbti` files summarize public APIs but are
   generated snapshots — they can be STALE during active edits; trust
   `moon ide doc` and the source over them when they disagree.
+- To settle how a MoonBit language feature or stdlib API actually
+  *behaves*, run a self-contained snippet with `run_moonbit` — it compiles
+  and runs a throwaway `.mbtx`. Its imports resolve to registry snapshots,
+  NOT this workspace's local edits or pinned versions, so it settles
+  language/stdlib behavior, not workspace-API questions; keep using
+  `moon ide doc` and the source for those.
 - Never hardcode toolchain paths (like a home-directory moon install):
   run the tools and let the active toolchain resolve itself.
 

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -5,8 +5,8 @@ fn explore_system_prompt() -> String {
   (
     #|You are OpenSeek in explore mode: a read-only scout. You answer exactly
     #|one question about this workspace or the MoonBit APIs it can use, then
-    #|submit a bounded, cited report. You have no edit tools; you inspect and
-    #|run code, but you do not change the workspace you are surveying.
+    #|submit a bounded, cited report. You have no edit tools — you read and run
+    #|code to answer the question, not to change the code you are surveying.
     #|
     #|Where API truth lives, in order:
     #|- `moon ide doc "<query>"` is the authoritative instrument for API
@@ -20,10 +20,12 @@ fn explore_system_prompt() -> String {
     #|  `moon ide doc` and the source over them when they disagree.
     #|- To settle how a MoonBit language feature or stdlib API actually
     #|  *behaves*, run a self-contained snippet with `run_moonbit` — it compiles
-    #|  and runs a throwaway `.mbtx`. Its imports resolve to registry snapshots,
-    #|  NOT this workspace's local edits or pinned versions, so it settles
-    #|  language/stdlib behavior, not workspace-API questions; keep using
-    #|  `moon ide doc` and the source for those.
+    #|  and runs a throwaway `.mbtx`. Keep the snippet to computing and printing:
+    #|  a program that writes files lands them in the workspace you are
+    #|  surveying. Its imports resolve to registry snapshots, NOT this
+    #|  workspace's local edits or pinned versions, so it settles language/stdlib
+    #|  behavior, not workspace-API questions; keep using `moon ide doc` and the
+    #|  source for those.
     #|- Never hardcode toolchain paths (like a home-directory moon install):
     #|  run the tools and let the active toolchain resolve itself.
     #|

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -5,7 +5,8 @@ fn explore_system_prompt() -> String {
   (
     #|You are OpenSeek in explore mode: a read-only scout. You answer exactly
     #|one question about this workspace or the MoonBit APIs it can use, then
-    #|submit a bounded, cited report. You do not modify anything.
+    #|submit a bounded, cited report. You have no edit tools; you inspect and
+    #|run code, but you do not change the workspace you are surveying.
     #|
     #|Where API truth lives, in order:
     #|- `moon ide doc "<query>"` is the authoritative instrument for API
@@ -17,6 +18,12 @@ fn explore_system_prompt() -> String {
     #|- Checked-in `pkg.generated.mbti` files summarize public APIs but are
     #|  generated snapshots — they can be STALE during active edits; trust
     #|  `moon ide doc` and the source over them when they disagree.
+    #|- To settle how a MoonBit language feature or stdlib API actually
+    #|  *behaves*, run a self-contained snippet with `run_moonbit` — it compiles
+    #|  and runs a throwaway `.mbtx`. Its imports resolve to registry snapshots,
+    #|  NOT this workspace's local edits or pinned versions, so it settles
+    #|  language/stdlib behavior, not workspace-API questions; keep using
+    #|  `moon ide doc` and the source for those.
     #|- Never hardcode toolchain paths (like a home-directory moon install):
     #|  run the tools and let the active toolchain resolve itself.
     #|

--- a/agent_explore/moon.pkg
+++ b/agent_explore/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/read",
+  "bobzhang/openseek/agent_tool/run_moonbit",
   "bobzhang/openseek/agent_tool/shell",
   "bobzhang/openseek/deepseek",
   "moonbitlang/core/json",

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -29,7 +29,9 @@ pub let max_hints_chars : Int = 2_000
 /// the report's derived JSON codecs cannot drift) invoked as
 /// `subrun explore`. The child's toolset is `read`,
 /// `shell(read_only=true)` (its instrument for `moon ide doc` and friends),
-/// and `submit_answer` — no edit tools, no nested subagent tools. The
+/// `run_moonbit` (run a self-contained snippet to check language/stdlib
+/// behavior), and `submit_answer` — no edit tools, no nested subagent
+/// tools. The
 /// child inherits the environment for its API key; model and endpoint ride
 /// argv. Launching consumes one slot of the shared per-turn `SubrunBudget`
 /// call allowance BEFORE the child exists; the child runs at its full step
@@ -201,6 +203,7 @@ pub async fn run_child(
       @agent_tool.Tools([
         @read.definition(workspace_root~),
         @shell.definition(workspace_root~, read_only=true),
+        @run_moonbit.definition(workspace_root~),
         submit_answer_tool(captured),
       ])
     },

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -70,6 +70,7 @@ pub async fn run_goal_audit(
       @agent_tool.Tools([
         @read.definition(workspace_root~),
         @shell.definition(workspace_root~, read_only=true),
+        @run_moonbit.definition(workspace_root~),
         submit_review_tool(captured),
       ])
     },

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -11,6 +11,10 @@ Principles:
 - Ground every finding in evidence: run `moon check`/`moon test` (or the
   project's own gates) rather than trusting claims. The compiler is
   reliable; your intuition is not.
+- To reproduce a claim in isolation — does a stdlib API really behave as
+  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`. Its
+  imports resolve to registry snapshots, not the worktree, so exercise the
+  worktree's own code with `moon check`/`moon test`, not run_moonbit.
 - Hunt specifically for VACUOUS success: tests that assert nothing,
   hardcoded outputs, disabled checks, criteria quietly narrowed.
 - Be precise and skeptical; prefer few real findings over many

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -12,9 +12,11 @@ Principles:
   project's own gates) rather than trusting claims. The compiler is
   reliable; your intuition is not.
 - To reproduce a claim in isolation — does a stdlib API really behave as
-  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`. Its
-  imports resolve to registry snapshots, not the worktree, so exercise the
-  worktree's own code with `moon check`/`moon test`, not run_moonbit.
+  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`; keep
+  it to computing and printing, since a snippet that writes files would
+  dirty the very worktree you are auditing. Its imports resolve to registry
+  snapshots, not the worktree, so exercise the worktree's own code with
+  `moon check`/`moon test`, not run_moonbit.
 - Hunt specifically for VACUOUS success: tests that assert nothing,
   hardcoded outputs, disabled checks, criteria quietly narrowed.
 - Be precise and skeptical; prefer few real findings over many

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -12,9 +12,10 @@ let default_review_max_steps : Int = 120
 
 ///|
 /// Run a code review of the changes between `base` and HEAD and return the
-/// structured report. The toolset is `read`, `shell` (in read-only mode), and
-/// `submit_review` — no edit/multi_edit/write — so the review reports rather
-/// than edits. Read-only is best-effort: the shell refuses obvious
+/// structured report. The toolset is `read`, `shell` (in read-only mode),
+/// `run_moonbit`, and `submit_review` — no edit/multi_edit/write — so the
+/// review reports rather than edits. Read-only is best-effort: the shell
+/// refuses obvious
 /// source-mutating moon commands, but `moon check`/`moon test` may still trigger
 /// pre-build source generation, so the checkout is not guaranteed byte-for-byte
 /// unchanged. Raises `ReviewError` if the model finishes without submitting a
@@ -41,6 +42,7 @@ pub async fn run_review(
       @agent_tool.Tools([
         @read.definition(workspace_root~),
         @shell.definition(workspace_root~, read_only=true),
+        @run_moonbit.definition(workspace_root~),
         submit_review_tool(captured),
       ])
     },

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -15,9 +15,10 @@ let default_review_max_steps : Int = 120
 /// structured report. The toolset is `read`, `shell` (in read-only mode),
 /// `run_moonbit`, and `submit_review` — no edit/multi_edit/write — so the
 /// review reports rather than edits. Read-only is best-effort: the shell
-/// refuses obvious
-/// source-mutating moon commands, but `moon check`/`moon test` may still trigger
-/// pre-build source generation, so the checkout is not guaranteed byte-for-byte
+/// refuses obvious source-mutating moon commands and `run_moonbit` is
+/// sandboxed against source writes on macOS, but `moon check`/`moon test`
+/// may still trigger pre-build source generation and `run_moonbit` can write
+/// non-source files, so the checkout is not guaranteed byte-for-byte
 /// unchanged. Raises `ReviewError` if the model finishes without submitting a
 /// report.
 ///

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -16,6 +16,10 @@ fn audit_system_prompt() -> String {
     #|- Ground every finding in evidence: run `moon check`/`moon test` (or the
     #|  project's own gates) rather than trusting claims. The compiler is
     #|  reliable; your intuition is not.
+    #|- To reproduce a claim in isolation — does a stdlib API really behave as
+    #|  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`. Its
+    #|  imports resolve to registry snapshots, not the worktree, so exercise the
+    #|  worktree's own code with `moon check`/`moon test`, not run_moonbit.
     #|- Hunt specifically for VACUOUS success: tests that assert nothing,
     #|  hardcoded outputs, disabled checks, criteria quietly narrowed.
     #|- Be precise and skeptical; prefer few real findings over many

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -17,9 +17,11 @@ fn audit_system_prompt() -> String {
     #|  project's own gates) rather than trusting claims. The compiler is
     #|  reliable; your intuition is not.
     #|- To reproduce a claim in isolation — does a stdlib API really behave as
-    #|  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`. Its
-    #|  imports resolve to registry snapshots, not the worktree, so exercise the
-    #|  worktree's own code with `moon check`/`moon test`, not run_moonbit.
+    #|  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`; keep
+    #|  it to computing and printing, since a snippet that writes files would
+    #|  dirty the very worktree you are auditing. Its imports resolve to registry
+    #|  snapshots, not the worktree, so exercise the worktree's own code with
+    #|  `moon check`/`moon test`, not run_moonbit.
     #|- Hunt specifically for VACUOUS success: tests that assert nothing,
     #|  hardcoded outputs, disabled checks, criteria quietly narrowed.
     #|- Be precise and skeptical; prefer few real findings over many

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -7,7 +7,7 @@ fn review_system_prompt() -> String {
     #|
     #|Principles:
     #|- Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.
-    #|- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit`. Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
+    #|- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit` (keep it to computing and printing; a snippet that writes files lands them in the repo). Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
     #|- Report, do not rewrite. You have no edit tools. Point at exact file:line.
     #|- Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.
     #|- When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text.

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -7,6 +7,7 @@ fn review_system_prompt() -> String {
     #|
     #|Principles:
     #|- Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.
+    #|- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit`. Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
     #|- Report, do not rewrite. You have no edit tools. Point at exact file:line.
     #|- Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.
     #|- When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text.

--- a/agent_review/moon.pkg
+++ b/agent_review/moon.pkg
@@ -3,6 +3,7 @@ import {
   "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/read",
+  "bobzhang/openseek/agent_tool/run_moonbit",
   "bobzhang/openseek/agent_tool/shell",
   "bobzhang/openseek/deepseek",
   "moonbitlang/core/json",

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -2,6 +2,7 @@ You are OpenSeek in code-review mode. You review code changes; you do not modify
 
 Principles:
 - Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.
+- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit`. Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
 - Report, do not rewrite. You have no edit tools. Point at exact file:line.
 - Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.
 - When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text.

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -2,7 +2,7 @@ You are OpenSeek in code-review mode. You review code changes; you do not modify
 
 Principles:
 - Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.
-- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit`. Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
+- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit` (keep it to computing and printing; a snippet that writes files lands them in the repo). Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
 - Report, do not rewrite. You have no edit tools. Point at exact file:line.
 - Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.
 - When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text.


### PR DESCRIPTION
## What

The explore scout and the review/audit children could `read` files and run a **read-only** `shell`, but not execute MoonBit. This adds the **`run_moonbit`** tool to all three subagent toolsets so they can compile+run a self-contained `.mbtx` — to verify how a language feature or stdlib API actually behaves, or reproduce a finding in isolation.

Crucially they gain **no** `edit`/`multi_edit`/`write`/`remove` tool, so they stay read-only verifiers. Their identities are unchanged and still accurate:
- explore — "read-only scout"
- review — "Report, do not rewrite. You have no edit tools."
- audit — "You review; you do not modify."

## Toolsets (before → after)

| subagent | before | after |
|---|---|---|
| explore (`agent_explore/tool.mbt`) | read, shell(ro), submit_answer | read, shell(ro), **run_moonbit**, submit_answer |
| review (`agent_review/engine.mbt`) | read, shell(ro), submit_review | read, shell(ro), **run_moonbit**, submit_review |
| audit (`agent_review/audit.mbt`) | read, shell(ro), submit_review | read, shell(ro), **run_moonbit**, submit_review |

## Prompt updates (the markdown from #547)

Each of the three `*_system_prompt.mbt.md` files gains a `run_moonbit` instrument line that spells out the tool's key caveat honestly, so the model doesn't misuse it:

> `run_moonbit`'s imports resolve to **registry snapshots, NOT the working tree or pinned versions**, so it settles *language/stdlib behavior* — workspace-API and working-tree questions still belong to `moon ide doc` and `moon check`/`moon test`.

The explore prompt's opening line softened from "You do not modify anything" to "You have no edit tools; you inspect and **run code**, but you do not change the workspace you are surveying" — accurate now that it can execute.

## Notes

- `run_moonbit` is best-effort sandboxed (source-write-readonly on macOS; unsandboxed elsewhere) and can write *non-source* scratch files to the workspace cwd — it is not a hard read-only boundary. It's the same tool the main interactive agent already has; this just extends it to the read-only children.
- Two `moon.pkg` files gain the `agent_tool/run_moonbit` import; the toolset doc comments in `tool.mbt`/`engine.mbt` were updated to list it.
- Generated `*.mbt` prompt files regenerated via the #547 dev_build rule.

## Verification (in the worktree)

- `moon check --target native` — clean (251 tasks)
- `moon fmt --check` — clean
- `moon test -p agent_explore` — 12/12
- `moon test -p agent_review` — 12/12
- Confirmed no test hardcodes the old 3-tool subagent set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)