### PR TITLE
agent: adjacent concurrent-safe tool calls execute in parallel (parallel subagents)

### DIFF
--- a/agent/concurrent_tools_test.mbt
+++ b/agent/concurrent_tools_test.mbt
@@ -20,7 +20,7 @@ fn probe_tool(
   journal : Array[String],
   concurrent_safe~ : Bool,
 ) -> @agent_tool.AgentToolDefinition {
-  @agent_tool.AgentToolDefinition(
+  AgentToolDefinition(
     name="probe",
     description="Probe tool.",
     schema=JsonSchema({ "type": "object" }),
@@ -70,10 +70,7 @@ async test "adjacent concurrent-safe calls overlap and keep result order" {
       scope=AgentTaskScope(group),
       api_key="test-key",
       model=Deepseek(V4Flash),
-      session=@agent_session.Session(
-        SessionId("concurrent-probes"),
-        system_prompt="system",
-      ),
+      session=Session(SessionId("concurrent-probes"), system_prompt="system"),
       task="probe twice",
       append_item=(session, item) => session.append(item),
       max_steps=4,
@@ -104,10 +101,7 @@ async test "unflagged adjacent calls stay sequential" {
       scope=AgentTaskScope(group),
       api_key="test-key",
       model=Deepseek(V4Flash),
-      session=@agent_session.Session(
-        SessionId("sequential-probes"),
-        system_prompt="system",
-      ),
+      session=Session(SessionId("sequential-probes"), system_prompt="system"),
       task="probe twice",
       append_item=(session, item) => session.append(item),
       max_steps=4,
@@ -116,5 +110,44 @@ async test "unflagged adjacent calls stay sequential" {
     )
     assert_eq(journal, ["start-a", "end-a", "start-b", "end-b"])
     assert_eq(probe_results(result), ["ok-a", "ok-b"])
+  }
+}
+
+///|
+/// Calls behind a batch-sealing control call never prefetch: the sealed
+/// batch discards its remainder, and children sequential execution never
+/// launches must not run. The finish at index 0 seals; neither probe
+/// journals anything.
+async test "no prefetch behind a batch-sealing control call" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    let finish_then_probes =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c0","function":{"name":"finish","arguments":"{\"answer\":\"done early\"}"}},{"index":1,"id":"c1","function":{"name":"probe","arguments":"{\"tag\": \"a\"}"}},{"index":2,"id":"c2","function":{"name":"probe","arguments":"{\"tag\": \"b\"}"}}]}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+    guard goal_check_test_server(group, bodies, [finish_then_probes])
+      is Some(url) else {
+      return
+    }
+    let journal : Array[String] = []
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=Session(SessionId("sealed-batch"), system_prompt="system"),
+      task="finish immediately",
+      append_item=(session, item) => session.append(item),
+      max_steps=4,
+      api_url=url,
+      tools=Tools([
+        probe_tool(journal, concurrent_safe=true),
+        @finish.definition(),
+      ]),
+    )
+    assert_eq(journal, ([] : Array[String]))
+    guard result.events().iter().last() is Some(event) &&
+      event.item() is Terminal(Finished(answer)) else {
+      fail("expected a sealed finish")
+    }
+    assert_eq(answer, "done early")
   }
 }

--- a/agent/concurrent_tools_test.mbt
+++ b/agent/concurrent_tools_test.mbt
@@ -1,0 +1,120 @@
+///|
+/// A batch payload holding two calls to the same tool, then a plain finish.
+fn two_probe_calls_payload() -> String {
+  (
+    #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"probe","arguments":"{\"tag\": \"a\"}"}},{"index":1,"id":"c2","function":{"name":"probe","arguments":"{\"tag\": \"b\"}"}}]}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+  )
+}
+
+///|
+fn probe_final_payload() -> String {
+  (
+    #|{"choices":[{"delta":{"content":"done"}}],"usage":{"prompt_tokens":9000,"completion_tokens":1000,"total_tokens":10000}}
+  )
+}
+
+///|
+/// A slow tool that journals its own start/end, so a test can distinguish
+/// overlapped execution from sequential.
+fn probe_tool(
+  journal : Array[String],
+  concurrent_safe~ : Bool,
+) -> @agent_tool.AgentToolDefinition {
+  @agent_tool.AgentToolDefinition(
+    name="probe",
+    description="Probe tool.",
+    schema=JsonSchema({ "type": "object" }),
+    concurrent_safe~,
+    execute=Async(arguments => {
+      let tag = match arguments {
+        { "tag": String(tag), .. } => tag.to_string()
+        _ => "?"
+      }
+      journal.push("start-\{tag}")
+      @async.sleep(60)
+      journal.push("end-\{tag}")
+      @agent_tool.ToolAction::respond("ok-\{tag}")
+    }),
+  )
+}
+
+///|
+/// The recorded tool results for the batch, in session order.
+fn probe_results(session : @agent_session.Session) -> Array[String] {
+  let out : Array[String] = []
+  for event in session.events() {
+    if event.item() is Tool(result) && result.tool_name() == "probe" {
+      out.push(result.content())
+    }
+  }
+  out
+}
+
+///|
+/// Two adjacent concurrent-safe calls overlap: both start before either
+/// ends, while the recorded results keep call order. This is the batch
+/// shape a model uses to fan out two subagent delegations at once.
+async test "adjacent concurrent-safe calls overlap and keep result order" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        two_probe_calls_payload(),
+        probe_final_payload(),
+      ])
+      is Some(url) else {
+      return
+    }
+    let journal : Array[String] = []
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=@agent_session.Session(
+        SessionId("concurrent-probes"),
+        system_prompt="system",
+      ),
+      task="probe twice",
+      append_item=(session, item) => session.append(item),
+      max_steps=4,
+      api_url=url,
+      tools=Tools([probe_tool(journal, concurrent_safe=true)]),
+    )
+    assert_eq(journal, ["start-a", "start-b", "end-a", "end-b"])
+    assert_eq(probe_results(result), ["ok-a", "ok-b"])
+  }
+}
+
+///|
+/// The same batch WITHOUT the flag stays strictly sequential — the default
+/// for every tool that never declared adjacent-call safety.
+async test "unflagged adjacent calls stay sequential" {
+  @async.with_task_group() <| group => {
+    let bodies : Array[String] = []
+    guard goal_check_test_server(group, bodies, [
+        two_probe_calls_payload(),
+        probe_final_payload(),
+      ])
+      is Some(url) else {
+      return
+    }
+    let journal : Array[String] = []
+    let result = @agent.run_turn_in_scope(
+      runtime=AgentRuntime(),
+      scope=AgentTaskScope(group),
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=@agent_session.Session(
+        SessionId("sequential-probes"),
+        system_prompt="system",
+      ),
+      task="probe twice",
+      append_item=(session, item) => session.append(item),
+      max_steps=4,
+      api_url=url,
+      tools=Tools([probe_tool(journal, concurrent_safe=false)]),
+    )
+    assert_eq(journal, ["start-a", "end-a", "start-b", "end-b"])
+    assert_eq(probe_results(result), ["ok-a", "ok-b"])
+  }
+}

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -562,13 +562,20 @@ async fn AgentLoop::handle_tool_calls(
 /// so recording, budget accounting, ceiling handling, and result ordering
 /// are byte-identical to sequential execution — only the waiting overlaps.
 ///
-/// A group prefetches only when the ENTIRE batch prefix through its last
-/// call fits the running batch budget worst-case: a child must never be
-/// launched for a call the ceiling would then skip-close (its spend would
-/// be silently wasted). Goal calls (loop-intercepted), undecodable calls,
-/// and unknown tools never prefetch — the loop's own paths handle them.
-/// Only cancellation escapes a prefetch; tool failures fold into the
-/// action `execute_tool_call` already returns.
+/// A group prefetches only when a call sequential execution might skip
+/// cannot be in it: the ENTIRE batch prefix through the group's last call
+/// must fit the running batch budget worst-case (no child for a call the
+/// ceiling would skip-close), and NOTHING after a control-registered call
+/// in the batch prefetches at all — a sealing finish/abort ends the batch
+/// early, and sequential execution would never have launched the calls
+/// behind it. Goal calls (loop-intercepted), control tools, undecodable
+/// calls, and unknown tools never prefetch — the loop's own paths handle
+/// them. Only cancellation escapes a prefetch; tool failures fold into
+/// the action `execute_tool_call` already returns.
+///
+/// The durable session is byte-identical to sequential execution; the
+/// LIVE event stream is not — a prefetched group's child brackets emit
+/// while earlier batch calls are still recording. Readers pair by id.
 async fn AgentLoop::prefetch_concurrent_results(
   self : Self,
   response : @deepseek.ChatResponse,
@@ -584,8 +591,16 @@ async fn AgentLoop::prefetch_concurrent_results(
   }
 
   for index, native in response.tool_calls {
-    let safe = self.tools.find(native.name) is Some(tool) &&
+    let tool = self.tools.find(native.name)
+    // Nothing prefetches from behind a batch-sealing call; the group
+    // already accumulated BEFORE it executes either way, so it stays.
+    if tool is Some(tool) && tool.is_control() {
+      flush()
+      break
+    }
+    let safe = tool is Some(tool) &&
       tool.is_concurrent_safe() &&
+      !tool.is_control() &&
       !(native.name == "goal" && self.goal_cadence.tool_registered)
     guard safe else {
       flush()

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -464,6 +464,7 @@ async fn AgentLoop::handle_tool_calls(
     response,
     tool_calls=response.tool_calls,
   )
+  let prefetched = self.prefetch_concurrent_results(response)
   let mut spent_result_chars : Int64 = 0
   for call_index, native_call in response.tool_calls; session = session {
     // Running batch budget: stop BEFORE a call whose worst case could push
@@ -525,6 +526,7 @@ async fn AgentLoop::handle_tool_calls(
         tool_call,
         spent_result_chars~,
         last_step~,
+        prefetched?=prefetched.get(call_index),
       ) {
       ContinueToolBatch(next) => {
         // Account the result actually recorded for this call (the loop
@@ -554,6 +556,72 @@ async fn AgentLoop::handle_tool_calls(
 }
 
 ///|
+/// Execute maximal runs of ADJACENT concurrent-safe tool calls up front,
+/// concurrently, returning their actions keyed by batch index. The
+/// sequential batch loop then consumes the cached actions in call order,
+/// so recording, budget accounting, ceiling handling, and result ordering
+/// are byte-identical to sequential execution — only the waiting overlaps.
+///
+/// A group prefetches only when the ENTIRE batch prefix through its last
+/// call fits the running batch budget worst-case: a child must never be
+/// launched for a call the ceiling would then skip-close (its spend would
+/// be silently wasted). Goal calls (loop-intercepted), undecodable calls,
+/// and unknown tools never prefetch — the loop's own paths handle them.
+/// Only cancellation escapes a prefetch; tool failures fold into the
+/// action `execute_tool_call` already returns.
+async fn AgentLoop::prefetch_concurrent_results(
+  self : Self,
+  response : @deepseek.ChatResponse,
+) -> Map[Int, @agent_tool.ToolAction] {
+  let results : Map[Int, @agent_tool.ToolAction] = Map([])
+  let groups : Array[Array[(Int, @agent_tool.AgentToolCall)]] = []
+  let current : Array[(Int, @agent_tool.AgentToolCall)] = []
+  fn flush() -> Unit {
+    if current.length() >= 2 {
+      groups.push(current.copy())
+    }
+    current.clear()
+  }
+
+  for index, native in response.tool_calls {
+    let safe = self.tools.find(native.name) is Some(tool) &&
+      tool.is_concurrent_safe() &&
+      !(native.name == "goal" && self.goal_cadence.tool_registered)
+    guard safe else {
+      flush()
+      continue
+    }
+    let call = @agent_tool.AgentToolCall(native) catch {
+      error if @async.is_being_cancelled() ||
+        @async.is_cancellation_error(error) => raise error
+      _ => {
+        flush()
+        continue
+      }
+    }
+    current.push((index, call))
+  }
+  flush()
+  for group in groups {
+    guard group.last() is Some((last_index, _)) else { continue }
+    // Worst case for every call before and inside the group: each records
+    // a full clamped result. Conservative — refusing a prefetch only means
+    // the calls run sequentially, exactly as before.
+    let worst_prior = last_index.to_int64() * max_tool_result_chars.to_int64()
+    guard self.next_call_fits(response.usage, worst_prior) else { continue }
+    @async.with_task_group() <| scope => {
+      for entry in group {
+        let (index, call) = entry
+        scope.spawn_bg(() => {
+          results.set(index, @agent_tool.execute_tool_call(call, self.tools))
+        })
+      }
+    }
+  }
+  results
+}
+
+///|
 async fn AgentLoop::execute_tool_call(
   self : Self,
   session : @agent_session.Session,
@@ -563,6 +631,7 @@ async fn AgentLoop::execute_tool_call(
   tool_call : @agent_tool.AgentToolCall,
   spent_result_chars~ : Int64,
   last_step~ : Bool,
+  prefetched? : @agent_tool.ToolAction,
 ) -> ToolCallOutcome {
   // The goal status tool is loop-intercepted: only the loop knows whether a
   // goal currently stands, and the durable clear must be sequenced by the
@@ -572,7 +641,12 @@ async fn AgentLoop::execute_tool_call(
   if tool_call.name == "goal" && self.goal_cadence.tool_registered {
     return self.handle_goal_tool_call(session, native_call, tool_call)
   }
-  let result = @agent_tool.execute_tool_call(tool_call, self.tools)
+  let result = match prefetched {
+    // Already executed concurrently with its batch siblings; recording and
+    // accounting proceed exactly as for a fresh execution.
+    Some(action) => action
+    None => @agent_tool.execute_tool_call(tool_call, self.tools)
+  }
   match result {
     Control(Finish(answer)) => {
       let session = self.record_tool_result(

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -50,7 +50,8 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   @agent_tool.AgentToolDefinition(
     name="explore",
-    description="Delegate ONE self-contained question to a read-only scout subagent and get a bounded, cited answer. Use it when answering would mean reading MANY files or discovering MoonBit APIs you are not sure about — (a) workspace questions (\"where is X handled, how does Y flow\") where you want the conclusion, not the file dumps; (b) MoonBit stdlib/dependency API discovery (what a package offers, exact signatures) — prefer this over guessing APIs from memory. For a single direct lookup you can do in one step (one `moon ide doc` query, one file read), do it yourself instead. The scout cannot edit anything and returns file:line citations you can verify.",
+    concurrent_safe=true,
+    description="Delegate ONE self-contained question to a read-only scout subagent and get a bounded, cited answer. Use it when answering would mean reading MANY files or discovering MoonBit APIs you are not sure about — (a) workspace questions (\"where is X handled, how does Y flow\") where you want the conclusion, not the file dumps; (b) MoonBit stdlib/dependency API discovery (what a package offers, exact signatures) — prefer this over guessing APIs from memory. For a single direct lookup you can do in one step (one `moon ide doc` query, one file read), do it yourself instead. The scout cannot edit anything and returns file:line citations you can verify. Independent questions? Issue SEVERAL explore calls in the same step — they run concurrently.",
     schema=JsonSchema({
       "type": "object",
       "properties": {

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -57,6 +57,16 @@ pub struct AgentToolDefinition {
   /// pins this with tests on BOTH construction sites: the bridge and the
   /// build_grouped re-wrap).
   control : Bool
+  /// Safe to execute CONCURRENTLY with adjacent same-flagged calls in one
+  /// tool batch: the tool must not mutate the workspace or loop state,
+  /// must not return `Control` actions, and its result must not depend on
+  /// a sibling call's result. The built-in subagent launchers (explore,
+  /// the callable review) declare it — each runs an isolated child
+  /// process — so a batch of independent delegations overlaps instead of
+  /// serializing. Like `control`, this is a BUILT-IN-ONLY privilege:
+  /// never set it on a definition built from dynamic input (MCP listings,
+  /// config-supplied tools).
+  concurrent_safe : Bool
 } derive(Debug(ignore=ToolExecutor))
 
 ///|
@@ -68,14 +78,24 @@ pub fn AgentToolDefinition::AgentToolDefinition(
   schema~ : JsonSchema,
   execute~ : ToolExecutor,
   control? : Bool = false,
+  concurrent_safe? : Bool = false,
 ) -> AgentToolDefinition {
-  { name, description, schema, execute, control }
+  { name, description, schema, execute, control, concurrent_safe }
 }
 
 ///|
 /// Whether this tool declared itself a control tool (see the field doc).
 pub fn AgentToolDefinition::is_control(self : AgentToolDefinition) -> Bool {
   self.control
+}
+
+///|
+/// Whether this tool declared itself safe for adjacent-call concurrency
+/// (see the field doc).
+pub fn AgentToolDefinition::is_concurrent_safe(
+  self : AgentToolDefinition,
+) -> Bool {
+  self.concurrent_safe
 }
 
 ///|
@@ -351,6 +371,7 @@ test "Tools::function_tools converts the registry to deepseek tool definitions" 
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("ok")),
       control: false,
+      concurrent_safe: false,
     },
   ])
   let function_tools = tools.function_tools()
@@ -367,6 +388,7 @@ test "Tools::find returns the registered definition by name" {
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("ok")),
       control: false,
+      concurrent_safe: false,
     },
   ])
   guard tools.find("echo") is Some(definition) else { fail("missing echo") }
@@ -383,6 +405,7 @@ test "Tools::Tools raises on duplicate tool names" {
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("first")),
       control: false,
+      concurrent_safe: false,
     },
     {
       name: "echo",
@@ -390,6 +413,7 @@ test "Tools::Tools raises on duplicate tool names" {
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("second")),
       control: false,
+      concurrent_safe: false,
     },
   ]) catch {
     error => {
@@ -425,6 +449,7 @@ async test "execute_tool_call dispatches to registered executor" {
         }
       }),
       control: false,
+      concurrent_safe: false,
     },
   ])
   let call = AgentToolCall(
@@ -454,6 +479,7 @@ async test "execute_tool_call dispatches to async executor" {
       schema: JsonSchema({ "type": "object" }),
       execute: Async(async_echo),
       control: false,
+      concurrent_safe: false,
     },
   ])
   let call = AgentToolCall(
@@ -481,6 +507,7 @@ async test "execute_tool_call turns a tool failure into a recoverable error resu
       schema: JsonSchema({ "type": "object" }),
       execute: Async(async_boom),
       control: false,
+      concurrent_safe: false,
     },
   ])
   let call = AgentToolCall(ToolCall(id="call_1", name="boom", arguments="{}"))
@@ -504,6 +531,7 @@ test "Tools::function_tools preserves description and schema" {
       }),
       execute: Sync(_args => ToolAction::respond("ok")),
       control: false,
+      concurrent_safe: false,
     },
   ])
   let function_tools = tools.function_tools()
@@ -530,6 +558,7 @@ test "Tools::function_tools yields one entry per definition" {
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("1")),
       control: false,
+      concurrent_safe: false,
     },
     {
       name: "second",
@@ -537,6 +566,7 @@ test "Tools::function_tools yields one entry per definition" {
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("2")),
       control: false,
+      concurrent_safe: false,
     },
     {
       name: "third",
@@ -544,6 +574,7 @@ test "Tools::function_tools yields one entry per definition" {
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(_args => ToolAction::respond("3")),
       control: false,
+      concurrent_safe: false,
     },
   ])
   let function_tools = tools.function_tools()

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -35,8 +35,10 @@ pub struct AgentToolDefinition {
   schema : JsonSchema
   execute : ToolExecutor
   control : Bool
+  concurrent_safe : Bool
 } derive(@debug.Debug)
-pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool) -> Self
+pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool, concurrent_safe? : Bool) -> Self
+pub fn AgentToolDefinition::is_concurrent_safe(Self) -> Bool
 pub fn AgentToolDefinition::is_control(Self) -> Bool
 
 pub enum FileState {

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -125,7 +125,9 @@ test "read tool advertises the expected schema" {
       #|  ),
       #|  execute: ...,
       #|  control: false,
+      #|  concurrent_safe: false,
       #|}
+
     ),
   )
 }

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -127,7 +127,6 @@ test "read tool advertises the expected schema" {
       #|  control: false,
       #|  concurrent_safe: false,
       #|}
-
     ),
   )
 }

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -18,6 +18,7 @@ fn review_tool_definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="review",
+    concurrent_safe=true,
     description="Request an INDEPENDENT audit of the current worktree by a review subagent — use it before declaring substantial work or a standing goal complete, or when you want a skeptical second reading of what you built. The auditor reads files, runs the project's own checks, hunts for vacuous success (tests asserting nothing, hardcoded outputs, quietly narrowed criteria), and returns severity-tagged findings with file:line citations. It audits against the standing goal when one exists; pass `focus` to narrow the criteria (with no standing goal, `focus` IS the criteria). Costs a bounded subagent run from the shared per-turn budget.",
     schema=JsonSchema({
       "type": "object",


### PR DESCRIPTION
Two subagent delegations in one batch used to serialize (launch, wait minutes, reason, launch again). Sub-runs are isolated read-only child processes, so adjacent calls can safely overlap.

- `AgentToolDefinition.concurrent_safe` — built-in-only privilege like `control`: no workspace/loop-state mutation, no `Control` actions, no sibling-result dependence. `explore` + callable `review` declare it; explore's description invites batching independent questions.
- The loop prefetches maximal runs of ADJACENT flagged calls concurrently; the unchanged sequential batch loop then consumes cached actions — recording, budgets, ceiling handling, and result order are byte-identical, only the waiting overlaps.
- No wasted child spend: a group prefetches only when the whole batch prefix through its last call fits the running batch budget worst-case (otherwise it falls back to today's sequential path).

Validation: full suite 1263/1263 native, cram 26/26; new tests pin the overlap (`start-a,start-b,end-a,end-b` + call-order results) and the sequential default for unflagged tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)