### PR TITLE
Subagent scratch labs: read-only children get one writable place to verify claims empirically

### DIFF
--- a/agent_explore/README.mbt.md
+++ b/agent_explore/README.mbt.md
@@ -13,7 +13,9 @@ spot-check — conclusions enter the parent's context, never file dumps.
 Contract highlights:
 
 - Child toolset: `read` + `shell(read_only=true)` + `submit_answer` — no edit
-  tools, no nested subagent tools.
+  tools, no nested subagent tools. A per-child scratch lab (temp dir) is
+  the one writable place: the scout may scaffold throwaway projects and
+  run any moon command there to verify claims empirically.
 - Every report field is capped at submission (`ExploreReport::validate`), so
   the rendered result stays far below the loop's tool-result clamp.
 - Launching takes one slot of the shared per-turn `SubrunBudget` call

--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -27,6 +27,13 @@ Where API truth lives, in order:
 Rules:
 - Ground every claim. Workspace claims cite file:line; stdlib and
   dependency claims cite the doc/source path your instrument reported.
+- VERIFY BY EXPERIMENT when docs do not settle it: your task names a
+  writable scratch lab where you may create files and whole projects and
+  run any moon command (moon new / check / test). Syntax and behavior
+  questions are usually a 3-step experiment — write the minimal file, run
+  the tool, read the error — which beats 30 steps of doc archaeology.
+  Grepping binaries with `strings` is never the answer. Everything
+  outside the lab stays read-only.
 - Answer EARLY: the moment your instruments settle the question,
   submit — do not keep surveying for completeness the caller never
   asked for. Your step budget is bounded; a scout that dies at its

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -32,6 +32,13 @@ fn explore_system_prompt() -> String {
     #|Rules:
     #|- Ground every claim. Workspace claims cite file:line; stdlib and
     #|  dependency claims cite the doc/source path your instrument reported.
+    #|- VERIFY BY EXPERIMENT when docs do not settle it: your task names a
+    #|  writable scratch lab where you may create files and whole projects and
+    #|  run any moon command (moon new / check / test). Syntax and behavior
+    #|  questions are usually a 3-step experiment — write the minimal file, run
+    #|  the tool, read the error — which beats 30 steps of doc archaeology.
+    #|  Grepping binaries with `strings` is never the answer. Everything
+    #|  outside the lab stays read-only.
     #|- Answer EARLY: the moment your instruments settle the question,
     #|  submit — do not keep surveying for completeness the caller never
     #|  asked for. Your step budget is bounded; a scout that dies at its

--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -33,7 +33,7 @@ pub let max_query_chars : Int
 
 pub let max_unresolved_chars : Int
 
-pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> ExploreReport?
+pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ExploreReport?
 
 // Errors
 

--- a/agent_explore/prompt.mbt
+++ b/agent_explore/prompt.mbt
@@ -8,7 +8,24 @@
 ///|
 /// The child's task: the parent's question, plus optional hints about where
 /// to look.
-fn explore_task(query : String, hints : String?) -> String {
+fn explore_task(
+  query : String,
+  hints : String?,
+  scratch_dir : String?,
+) -> String {
+  let lab = match scratch_dir {
+    Some(lab) =>
+      (
+        $|
+        $|Your scratch lab (writable): \{lab}
+        $|Create files and projects THERE and run any moon command there
+        $|(moon new / check / test) to verify claims empirically — a 3-step
+        $|experiment beats 30 steps of doc archaeology, and grepping
+        $|binaries with `strings` is never the answer. The workspace itself
+        $|stays read-only.
+      )
+    None => ""
+  }
   match hints {
     Some(hints) =>
       (
@@ -17,14 +34,14 @@ fn explore_task(query : String, hints : String?) -> String {
         $|
         $|The caller suggests starting from:
         $|\{hints}
-        $|
+        $|\{lab}
         $|Answer the question and submit_answer once, with citations.
       )
     None =>
       (
         $|Question:
         $|\{query}
-        $|
+        $|\{lab}
         $|Answer the question and submit_answer once, with citations.
       )
   }

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -28,7 +28,9 @@ pub let max_hints_chars : Int = 2_000
 /// own executable — never PATH, so parent and child are the same binary and
 /// the report's derived JSON codecs cannot drift) invoked as
 /// `subrun explore`. The child's toolset is `read`,
-/// `shell(read_only=true)` (its instrument for `moon ide doc` and friends),
+/// `shell(read_only=true)` (its instrument for `moon ide doc` and friends;
+/// a per-child scratch lab is the one writable place, where the scout may
+/// scaffold throwaway projects to verify claims empirically),
 /// `run_moonbit` (run a self-contained snippet to check language/stdlib
 /// behavior), and `submit_answer` — no edit tools, no nested subagent
 /// tools. The
@@ -199,6 +201,7 @@ pub async fn run_child(
   workspace_root? : String = ".",
   session_id? : String = "explore",
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
+  scratch_dir? : String,
 ) -> ExploreReport? {
   guard input is { "query": String(query), .. } && query.trim() != "" else {
     return None
@@ -211,11 +214,11 @@ pub async fn run_child(
     session_id~,
     append_item?,
     system_prompt=explore_system_prompt(),
-    task=explore_task(query, hints),
+    task=explore_task(query, hints, scratch_dir),
     tools=captured => {
       @agent_tool.Tools([
         @read.definition(workspace_root~),
-        @shell.definition(workspace_root~, read_only=true),
+        @shell.definition(workspace_root~, read_only=true, scratch_dir?),
         @run_moonbit.definition(workspace_root~),
         submit_answer_tool(captured),
       ])

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -13,7 +13,22 @@ pub let default_audit_max_steps : Int = 100
 
 ///|
 /// The audit task: the goal text plus whatever baseline anchor exists.
-fn audit_task(goal : String, baseline : @agent_session.GoalBaseline?) -> String {
+fn audit_task(
+  goal : String,
+  baseline : @agent_session.GoalBaseline?,
+  scratch_dir : String?,
+) -> String {
+  let lab = match scratch_dir {
+    Some(lab) =>
+      (
+        $|
+        $|Your scratch lab (writable): \{lab}
+        $|Create files and projects THERE and run any moon command there to
+        $|verify a claim empirically before reporting it. The worktree under
+        $|audit stays read-only.
+      )
+    None => ""
+  }
   let anchor = match baseline {
     Some(baseline) =>
       if baseline.dirty {
@@ -42,7 +57,7 @@ fn audit_task(goal : String, baseline : @agent_session.GoalBaseline?) -> String 
     $|\{goal}
     $|
     $|\{anchor}
-    $|
+    $|\{lab}
     $|Audit the current worktree against the goal's own criteria and
     $|submit_review once, with scope.head = "WORKTREE".
   )
@@ -63,16 +78,17 @@ pub async fn run_goal_audit(
   workspace_root? : String = ".",
   session_id? : String = "goal-audit",
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
+  scratch_dir? : String,
 ) -> ReviewReport? {
   @agent_subrun.execute_kind(
     session_id~,
     append_item?,
     system_prompt=audit_system_prompt(),
-    task=audit_task(goal, baseline),
+    task=audit_task(goal, baseline, scratch_dir),
     tools=captured => {
       @agent_tool.Tools([
         @read.definition(workspace_root~),
-        @shell.definition(workspace_root~, read_only=true),
+        @shell.definition(workspace_root~, read_only=true, scratch_dir?),
         @run_moonbit.definition(workspace_root~),
         submit_review_tool(captured),
       ])

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -10,7 +10,9 @@ Principles:
   and the working-tree diffs, and read the files themselves.
 - Ground every finding in evidence: run `moon check`/`moon test` (or the
   project's own gates) rather than trusting claims. The compiler is
-  reliable; your intuition is not.
+  reliable; your intuition is not. When a claim needs an experiment the
+  worktree cannot host, use the writable scratch lab your task names —
+  the worktree under audit stays read-only.
 - To reproduce a claim in isolation — does a stdlib API really behave as
   the code assumes? — run a self-contained `.mbtx` with `run_moonbit`; keep
   it to computing and printing, since a snippet that writes files would

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -15,7 +15,9 @@ fn audit_system_prompt() -> String {
     #|  and the working-tree diffs, and read the files themselves.
     #|- Ground every finding in evidence: run `moon check`/`moon test` (or the
     #|  project's own gates) rather than trusting claims. The compiler is
-    #|  reliable; your intuition is not.
+    #|  reliable; your intuition is not. When a claim needs an experiment the
+    #|  worktree cannot host, use the writable scratch lab your task names —
+    #|  the worktree under audit stays read-only.
     #|- To reproduce a claim in isolation — does a stdlib API really behave as
     #|  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`; keep
     #|  it to computing and printing, since a snippet that writes files would

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -19,7 +19,7 @@ pub let digest_max_findings : Int
 
 pub let digest_max_line_chars : Int
 
-pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> ReviewReport?
+pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ReviewReport?
 
 pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String) -> ReviewReport
 

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -16,6 +16,8 @@ pub fn is_under_workspace_root(String, String) -> Bool
 
 pub fn path_basename(String) -> String
 
+pub fn path_is_under_lab(String, String) -> Bool
+
 pub fn platform_shell_args(String) -> Array[String]
 
 pub fn sandbox_exec_args(String, String) -> Array[String]
@@ -24,7 +26,7 @@ pub async fn sandbox_exec_available() -> Bool
 
 pub fn sbpl_string_escape(String) -> String
 
-pub async fn source_write_readonly_profile_data(String) -> SourceWriteProfileData
+pub async fn source_write_readonly_profile_data(String, writable_lab? : String) -> SourceWriteProfileData
 
 // Errors
 

--- a/agent_tool/internal/sandbox/sandbox.mbt
+++ b/agent_tool/internal/sandbox/sandbox.mbt
@@ -179,6 +179,32 @@ async fn cleanup_sandbox_probe(
 /// (reads and non-source writes). Also returns the denied subjects.
 pub async fn source_write_readonly_profile_data(
   real_workspace_root : String,
+  writable_lab? : String,
+) -> SourceWriteProfileData {
+  let base = source_write_readonly_profile_base(real_workspace_root)
+  match writable_lab {
+    None => base
+    // SBPL is last-match-wins: one allow-subpath appended AFTER every deny
+    // re-opens exactly the lab — a per-child scratch directory where a
+    // read-only subagent may scaffold projects and write source to verify
+    // claims empirically. The composed profile is not cached (labs are
+    // per-child temp dirs); the base underneath still is.
+    Some(lab) => {
+      let lab = @workspace_path.strip_trailing_slash(
+        @path.Path(lab).normalize().to_string(),
+      )
+      {
+        profile: base.profile +
+        "(allow file-write* (subpath \"\{sbpl_string_escape(lab)}\"))\n",
+        denial_subjects: base.denial_subjects,
+      }
+    }
+  }
+}
+
+///|
+async fn source_write_readonly_profile_base(
+  real_workspace_root : String,
 ) -> SourceWriteProfileData {
   let real_workspace_root = @workspace_path.strip_trailing_slash(
     @path.Path(real_workspace_root).normalize().to_string(),
@@ -389,6 +415,23 @@ pub fn path_basename(path : String) -> String {
 ///|
 /// Whether `target` is a protected MoonBit source file inside the workspace
 /// and not under a Moon-managed `_build`/`.mooncakes` tree.
+/// Whether `target` sits under `lab` (inclusive), after normalizing both.
+/// The policy predicate for scratch-lab carve-outs: a path under the lab is
+/// the child's to write, whatever its name looks like.
+pub fn path_is_under_lab(target : String, lab : String) -> Bool {
+  let lab = @workspace_path.strip_trailing_slash(
+    @path.Path(lab).normalize().to_string(),
+  )
+  guard !lab.is_empty() && lab != "/" else { return false }
+  let target = @workspace_path.strip_trailing_slash(
+    @path.Path(target).normalize().to_string(),
+  )
+  target == lab || target.has_prefix("\{lab}/")
+}
+
+///|
+/// Whether `target` names a protected MoonBit source path of the workspace
+/// (by location under the root or by protected-source naming).
 pub fn is_protected_workspace_source_path(
   real_workspace_root : String,
   target : String,

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
 
-pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, default_timeout_ms? : Int) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, default_timeout_ms? : Int, scratch_dir? : String) -> @agent_tool.AgentToolDefinition
 
 pub fn source_write_denial_feedback() -> String
 

--- a/agent_tool/shell/review_guard.mbt
+++ b/agent_tool/shell/review_guard.mbt
@@ -39,72 +39,240 @@ fn command_is_mutating_moon(command : @shell_parse.SimpleCommand) -> Bool {
 /// substitution) are allowed: a review that runs `moon check`/`moon test` can
 /// already trigger pre-build source generation, so chasing every last mutation
 /// is not worth crippling the review's ability to investigate.
-fn review_read_only_blocks(parsed : @shell_parse.ParseResult) -> Bool {
+///
+/// `scratch_dir` is the one carve-out: a mutating/scaffold moon command that
+/// PROVABLY operates inside the child's scratch lab (its effective cwd —
+/// tracked through `cd` chains and `-C` — resolves under the lab, and a
+/// scaffold's target lands there too) is the empiricism the lab exists for.
+/// Anything ambiguous (unknown cwd, env prefixes, out-of-lab paths) keeps
+/// the block: the guard still errs toward blocking.
+fn review_read_only_blocks(
+  parsed : @shell_parse.ParseResult,
+  base_cwd~ : String,
+  scratch_dir~ : String?,
+) -> Bool {
   match parsed {
-    Simple(commands) => commands.any(command_is_mutating_moon)
+    Simple(commands) => {
+      let mut state = source_write_initial_cwd_state(base_cwd)
+      for index, command in commands {
+        if mutating_moon_blocked(command, state, scratch_dir) {
+          return true
+        }
+        state = source_write_next_cwd_state(
+          command,
+          state,
+          next_command_separator(commands, index),
+        )
+      }
+      false
+    }
     _ => false
   }
+}
+
+///|
+/// Whether one mutating/scaffold moon command must be refused given the
+/// chain's tracked cwd candidates. Without a lab every mutating moon blocks
+/// (the original rule); with one, the command must prove EVERY candidate
+/// interpretation stays inside the lab.
+fn mutating_moon_blocked(
+  command : @shell_parse.SimpleCommand,
+  state : SourceWriteCwdState,
+  scratch_dir : String?,
+) -> Bool {
+  guard command_is_mutating_moon(command) else { return false }
+  guard scratch_dir is Some(lab) else { return true }
+  // Env prefixes stay blocked, mirroring the original guard's refusal to
+  // reason about them.
+  if command_has_custom_environment(command) {
+    return true
+  }
+  guard moon_command_start(command) is Some(moon_index) else { return true }
+  for cwd in state.active {
+    guard cwd is Some(cwd) else { return true }
+    guard parse_moon_invocation(command.argv, moon_index, cwd)
+      is Some(invocation) else {
+      return true
+    }
+    if is_moon_scaffold_subcommand(command.argv, invocation.subcommand_index) {
+      // A scaffold is judged by where it LANDS. Any argument that names a
+      // location (absolute, or containing a path separator — flag VALUES
+      // like `--user t` are bare words) must resolve under the lab: an
+      // out-of-lab target with an in-lab cwd is the escape this closes.
+      // With no location-shaped argument the scaffold lands in the
+      // effective cwd, which must itself be under the lab.
+      let mut has_path_target = false
+      for index in (invocation.subcommand_index + 1)..<command.argv.length() {
+        let argument = command.argv[index]
+        if argument.has_prefix("-") || !argument.contains("/") {
+          continue
+        }
+        has_path_target = true
+        guard @sandbox.path_is_under_lab(
+          resolve_command_cwd(invocation.cwd, argument),
+          lab,
+        ) else {
+          return true
+        }
+      }
+      guard has_path_target || @sandbox.path_is_under_lab(invocation.cwd, lab) else {
+        return true
+      }
+    } else {
+      // A mutating (non-scaffold) moon command is judged by where it RUNS.
+      guard @sandbox.path_is_under_lab(invocation.cwd, lab) else { return true }
+    }
+  }
+  false
 }
 
 ///|
 test "read-only guard blocks mutating moon anywhere; allows read-only commands" {
   // mutating moon — plain, chained either way, and env-prefixed (all bypasses)
   assert_true(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon fmt")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon fmt"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   assert_true(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon new app")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon new app"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   assert_true(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon new -- --help")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon new -- --help"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   assert_true(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon info")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon info"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   assert_true(
     review_read_only_blocks(
       @shell_parse.parse_for_policy("moon fmt && git diff"),
+      base_cwd=".",
+      scratch_dir=None,
     ),
   )
   assert_true(
     review_read_only_blocks(
       @shell_parse.parse_for_policy("git diff && moon fmt"),
+      base_cwd=".",
+      scratch_dir=None,
     ),
   )
   assert_true(
     review_read_only_blocks(
       @shell_parse.parse_for_policy("moon test --update; true"),
+      base_cwd=".",
+      scratch_dir=None,
     ),
   )
   assert_true(
-    review_read_only_blocks(@shell_parse.parse_for_policy("FOO=bar moon fmt")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("FOO=bar moon fmt"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   // a pipe segment that mutates is still caught (pipes parse as Simple)
   assert_true(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon fmt | tee out")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon fmt | tee out"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   // a read-only pipe is allowed (no mutating segment)
   assert_false(
-    review_read_only_blocks(@shell_parse.parse_for_policy("git diff | head")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("git diff | head"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   // read-only commands — allowed
   assert_false(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon check")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon check"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   assert_false(
     review_read_only_blocks(
       @shell_parse.parse_for_policy("moon check --target all"),
+      base_cwd=".",
+      scratch_dir=None,
     ),
   )
   assert_false(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon test")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon test"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   assert_false(
-    review_read_only_blocks(@shell_parse.parse_for_policy("moon fmt --check")),
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy("moon fmt --check"),
+      base_cwd=".",
+      scratch_dir=None,
+    ),
   )
   assert_false(
     review_read_only_blocks(
       @shell_parse.parse_for_policy("git diff origin/main"),
+      base_cwd=".",
+      scratch_dir=None,
     ),
   )
+}
+
+///|
+test "the scratch lab re-opens exactly the lab, nothing else" {
+  let lab = "/tmp/openseek-explore-lab-x"
+  fn blocks(cmd : String) -> Bool {
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy(cmd),
+      base_cwd="/repo",
+      scratch_dir=Some(lab),
+    )
+  }
+  // Inside the lab: scaffolding and mutating moon are the point.
+  assert_false(blocks("moon new \{lab}/probe"))
+  assert_false(blocks("cd \{lab} && moon new probe"))
+  assert_false(blocks("cd \{lab}/probe && moon fmt"))
+  assert_false(blocks("moon -C \{lab}/probe test --update"))
+  assert_false(blocks("cd \{lab} && moon new probe && cd probe && moon check"))
+  // Outside (or not provably inside): the original block stands.
+  assert_true(blocks("moon fmt"))
+  assert_true(blocks("moon new app"))
+  assert_true(blocks("moon new /tmp/elsewhere"))
+  assert_true(blocks("cd /repo && moon fmt"))
+  assert_true(blocks("cd \{lab} && cd /repo && moon fmt"))
+  // An in-lab cwd with an out-of-lab scaffold target is the escape the
+  // target rule closes.
+  assert_true(blocks("cd \{lab} && moon new /repo/pwned"))
+  assert_true(blocks("cd \{lab} && moon new ../outside"))
+  // Flag values are bare words, not landing spots; a bare-name scaffold
+  // lands in the cwd, so the cwd rule decides it.
+  assert_false(blocks("moon new \{lab}/probe --user t --name probe"))
+  assert_false(blocks("cd \{lab} && moon new probe --user t"))
+  assert_true(blocks("moon new probe --user t"))
+  // Env prefixes stay out of scope, exactly like the original guard.
+  assert_true(blocks("cd \{lab} && FOO=bar moon fmt"))
+  // Read-only moon commands never blocked, lab or not.
+  assert_false(blocks("moon check"))
+  assert_false(blocks("cd /repo && moon test"))
 }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -52,6 +52,13 @@ async fn agent_shell_launch(
     Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
     None => None
   }
+  // The lab is realpath'd because sandbox-exec matches `file-write*` rules
+  // against the kernel-canonical path (macOS `/tmp` → `/private/tmp`): the
+  // allow-subpath must name the real path or it never matches.
+  let scratch_dir = match scratch_dir {
+    Some(lab) => Some(@fs.realpath(lab) catch { _ => lab })
+    None => None
+  }
   let mode = source_write_mode_for_parse(parsed, real_workspace_root, real_cwd)
   // `moon new` is trusted to scaffold, but only into a genuinely new or empty
   // target. A scaffold that would land in an existing non-empty directory is
@@ -63,6 +70,19 @@ async fn agent_shell_launch(
       parsed,
       real_cwd.unwrap_or(real_workspace_root),
     ) {
+    SourceReadOnly
+  } else {
+    mode
+  }
+  // A scratch lab means this is a read-only subagent child whose ONLY
+  // sanctioned writes are lab-local. The static guard admitted this
+  // command as lab-bound, but "trusted" moon writes (e.g. `moon new`) would
+  // otherwise run UNSANDBOXED — making the guard the sole defense (K3
+  // review). Force the sandbox with the lab-allow profile so the kernel
+  // denies any workspace-source write regardless of guard precision.
+  let mode = if scratch_dir is Some(_) &&
+    mode is TrustedSourceWrite &&
+    @sandbox.sandbox_exec_available() {
     SourceReadOnly
   } else {
     mode

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -23,11 +23,29 @@ priv struct AgentShellOutput {
 }
 
 ///|
+/// A pre-block target that sits inside the child's scratch lab is not a
+/// violation: the lab is the one place a read-only subagent MAY fabricate
+/// and rewrite source to verify claims empirically. Everything else keeps
+/// the pre-block. (Mixed commands that also touch real source still run
+/// SANDBOXED, and the SBPL profile allows writes only under the lab — the
+/// kernel enforces what this static filter waives.)
+fn preblock_target_outside_lab(
+  target : String?,
+  scratch_dir : String?,
+) -> String? {
+  match (target, scratch_dir) {
+    (Some(target), Some(lab)) if @sandbox.path_is_under_lab(target, lab) => None
+    (target, _) => target
+  }
+}
+
+///|
 async fn agent_shell_launch(
   workspace_root : String,
   cmd : String,
   parsed : @shell_parse.ParseResult,
   cwd? : String,
+  scratch_dir? : String,
 ) -> AgentShellLaunch {
   let real_workspace_root = @fs.realpath(workspace_root)
   let real_cwd = match cwd {
@@ -59,6 +77,7 @@ async fn agent_shell_launch(
   }
   let profile_data = @sandbox.source_write_readonly_profile_data(
     real_workspace_root,
+    writable_lab?=scratch_dir,
   )
   {
     program: @sandbox.SandboxExecPath,

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1539,3 +1539,38 @@ async test "moon new is a trusted scaffold only for a new or empty target" {
     )
   })
 }
+
+///|
+/// The scratch-lab backstop (K3 review): with a lab present, a "trusted"
+/// source-writing moon command (e.g. `moon new`) that would otherwise
+/// launch UNSANDBOXED is forced onto the sandboxed profile — so the kernel,
+/// not just the static guard, denies any workspace-source write. Without a
+/// lab the same command stays trusted/unsandboxed.
+async test "a scratch lab forces trusted source-writes onto the sandbox" {
+  guard @sandbox.sandbox_exec_available() else {
+    println("sandbox-exec unavailable; skipping")
+    return
+  }
+  let ws = @fs.tmpdir(prefix="openseek-lab-ws-")
+  let lab = @fs.tmpdir(prefix="openseek-lab-scratch-")
+  // No lab: `moon new` in the lab is the trusted, unsandboxed path.
+  let without = agent_shell_launch(
+    ws,
+    "moon new \{lab}/probe",
+    @shell_parse.parse_for_policy("moon new \{lab}/probe"),
+    cwd=lab,
+  )
+  assert_false(without.source_write_sandboxed)
+  // With the lab wired, the same command is sandboxed instead — the
+  // profile allows lab writes, the kernel denies workspace writes.
+  let with_lab = agent_shell_launch(
+    ws,
+    "moon new \{lab}/probe",
+    @shell_parse.parse_for_policy("moon new \{lab}/probe"),
+    cwd=lab,
+    scratch_dir=lab,
+  )
+  assert_true(with_lab.source_write_sandboxed)
+  @fs.rmdir(ws, recursive=true)
+  @fs.rmdir(lab, recursive=true)
+}

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -57,6 +57,7 @@ pub fn definition(
   read_only? : Bool = false,
   bg_runtime? : @bgjobs.BgJobRuntime,
   default_timeout_ms? : Int,
+  scratch_dir? : String,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell",
@@ -113,6 +114,7 @@ pub fn definition(
         read_only~,
         bg_runtime?,
         default_timeout_ms?,
+        scratch_dir?,
       )
     }),
   )
@@ -147,6 +149,7 @@ async fn execute_with_workspace(
   read_only~ : Bool,
   bg_runtime? : @bgjobs.BgJobRuntime,
   default_timeout_ms? : Int,
+  scratch_dir? : String,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -164,9 +167,16 @@ async fn execute_with_workspace(
   // best-effort: opaque commands are allowed and `moon check`/`moon test` may
   // still pre-build, so it only stops a review from reformatting/regenerating
   // the tree wholesale, not every possible mutation.
-  if read_only && review_read_only_blocks(parsed_command) {
+  if read_only &&
+    review_read_only_blocks(
+      parsed_command,
+      base_cwd=@workspace_path.resolve_cwd(workspace_root, input.cwd).unwrap_or(
+        workspace_root,
+      ),
+      scratch_dir~,
+    ) {
     return @agent_tool.ToolAction::respond(
-      "blocked in read-only review mode: `\{input.cmd}` runs a source-mutating moon command (fmt/info/test --update); a review reports rather than rewrites the tree. Use plain `moon check`/`moon test` (no --update), `git`, or `read`.",
+      "blocked in read-only review mode: `\{input.cmd}` runs a source-mutating moon command (fmt/info/test --update) outside your scratch lab; a review reports rather than rewrites the tree. Use plain `moon check`/`moon test` (no --update), `git`, `read` — or run the experiment inside your scratch lab.",
       is_error=true,
     )
   }
@@ -185,6 +195,7 @@ async fn execute_with_workspace(
     workspace_root,
     bg_runtime?,
     default_timeout_ms?,
+    scratch_dir?,
   ) catch {
     error =>
       @agent_tool.ToolAction::respond(
@@ -229,6 +240,7 @@ async fn shell(
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
   workspace_root : String,
+  scratch_dir? : String,
   bg_runtime? : @bgjobs.BgJobRuntime,
   default_timeout_ms? : Int,
 ) -> @agent_tool.ToolAction {
@@ -254,7 +266,10 @@ async fn shell(
       )
     }
   }
-  if direct_source_write_redirect_target(parsed_command, workspace_root, cwd)
+  if preblock_target_outside_lab(
+      direct_source_write_redirect_target(parsed_command, workspace_root, cwd),
+      scratch_dir,
+    )
     is Some(target) {
     return @agent_tool.ToolAction::respond(
       direct_source_blocked_content("source file write redirect", target),
@@ -441,12 +456,22 @@ async fn run_agent_shell_with_tree_precheck(
   timeout_ms~ : Int,
   foreground_spawn? : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution,
   on_timeout_detach? : (@shell_exec.ShellExecution, AgentShellLaunch) -> String,
+  scratch_dir? : String,
 ) -> ShellRunResult {
-  if source_tree_operation_target(parsed_command, cmd, workspace_root, cwd)
+  if preblock_target_outside_lab(
+      source_tree_operation_target(parsed_command, cmd, workspace_root, cwd),
+      scratch_dir,
+    )
     is Some(target) {
     return ShellPreblockedSourceTree(target)
   }
-  let launch = agent_shell_launch(workspace_root, cmd, parsed_command, cwd?)
+  let launch = agent_shell_launch(
+    workspace_root,
+    cmd,
+    parsed_command,
+    cwd?,
+    scratch_dir?,
+  )
   match foreground_spawn {
     // Foreground on the shared execution model: spawn on the session group and
     // await it (up to `timeout_ms`). The session-group process outlives this
@@ -545,6 +570,7 @@ async fn start_background(
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
   workspace_root : String,
+  scratch_dir? : String,
   bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   guard bg_runtime is Some(runtime) else {
@@ -559,11 +585,14 @@ async fn start_background(
       is_error=true,
     )
   }
-  if source_tree_operation_target(
-      parsed_command,
-      input.cmd,
-      workspace_root,
-      cwd,
+  if preblock_target_outside_lab(
+      source_tree_operation_target(
+        parsed_command,
+        input.cmd,
+        workspace_root,
+        cwd,
+      ),
+      scratch_dir,
     )
     is Some(target) {
     return @agent_tool.ToolAction::respond(
@@ -577,6 +606,7 @@ async fn start_background(
     input.cmd,
     parsed_command,
     cwd?,
+    scratch_dir?,
   )
   let id = runtime.start(
     program=launch.program,
@@ -805,4 +835,31 @@ test "shell formats output limit metadata" {
     ).content,
     "abc\n<system>exit=0 truncated=true output_limit_reached=true shown_chars=3 max_output_chars=3</system>",
   )
+}
+
+///|
+/// The read-only gate admits lab-bound moon commands end to end: with a
+/// scratch lab configured, `moon new <lab>/probe` passes the guard (the
+/// command actually runs and scaffolds), while the same scaffold aimed
+/// anywhere else still refuses before any process spawns.
+async test "read-only shell admits lab scaffolds and still blocks the rest" {
+  let lab = @fs.tmpdir(prefix="openseek-shell-lab-")
+  let allowed = execute_with_workspace(
+    ".",
+    { "cmd": "moon new \{lab}/probe --user t --name probe 2>&1 | tail -1" },
+    read_only=true,
+    scratch_dir=lab,
+  )
+  guard allowed is Respond(output) else { fail("expected Respond") }
+  assert_false(output.content.contains("read-only review mode"))
+  let blocked = execute_with_workspace(
+    ".",
+    { "cmd": "moon new /tmp/openseek-shell-lab-escape" },
+    read_only=true,
+    scratch_dir=lab,
+  )
+  guard blocked is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("read-only review mode"))
+  @fs.rmdir(lab, recursive=true)
 }

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -172,9 +172,14 @@ async fn dispatch_kind(
     let store = @store.SessionStore(pair.1)
     (session, item) => store.append(session, item)
   })
+  // Every model-driven kind gets its own scratch lab: a temp directory
+  // where the otherwise read-only child MAY scaffold projects and write
+  // source to verify claims empirically (the sr-2 lesson: denied the
+  // 3-step experiment, a scout greps compiler binaries for 60 steps).
   match kind {
     "explore" => {
       let api_key = @agentcli.api_key(matches, model)
+      let scratch_dir = @fs.tmpdir(prefix="openseek-explore-lab-")
       let report = @agent_explore.run_child(
         input,
         api_key~,
@@ -187,6 +192,7 @@ async fn dispatch_kind(
         workspace_root~,
         session_id?,
         append_item?,
+        scratch_dir~,
       )
       report.map(report => report.to_json())
     }
@@ -203,6 +209,7 @@ async fn dispatch_kind(
         _ => None
       }
       let api_key = @agentcli.api_key(matches, model)
+      let scratch_dir = @fs.tmpdir(prefix="openseek-review-lab-")
       let report = @agent_review.run_goal_audit(
         goal~,
         baseline~,
@@ -216,6 +223,7 @@ async fn dispatch_kind(
         workspace_root~,
         session_id?,
         append_item?,
+        scratch_dir~,
       )
       report.map(report => report.to_json())
     }

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -151,6 +151,30 @@ fn child_durable_session(
 }
 
 ///|
+/// Create a child's scratch lab, realpath'd so the path the child is told,
+/// the read-only guard, and the sandbox profile all name the SAME
+/// kernel-canonical directory (macOS `/tmp` → `/private/tmp`) — otherwise
+/// the sandbox's allow-subpath would never match the writes it means to
+/// permit.
+async fn new_scratch_lab(prefix : String) -> String {
+  let dir = @fs.tmpdir(prefix~)
+  @fs.realpath(dir) catch {
+    _ => dir
+  }
+}
+
+///|
+/// Remove a child's scratch lab after it finishes: `moon check` inside a
+/// lab leaves a `_build` tree, so a long run's labs would otherwise
+/// accumulate until the OS cleans temp. Best-effort — a failed cleanup is
+/// not worth failing the sub-run over.
+async fn remove_scratch_lab(dir : String) -> Unit {
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
 /// Run one kind in this process and return its report, if any.
 async fn dispatch_kind(
   kind : String,
@@ -179,7 +203,7 @@ async fn dispatch_kind(
   match kind {
     "explore" => {
       let api_key = @agentcli.api_key(matches, model)
-      let scratch_dir = @fs.tmpdir(prefix="openseek-explore-lab-")
+      let scratch_dir = new_scratch_lab("openseek-explore-lab-")
       let report = @agent_explore.run_child(
         input,
         api_key~,
@@ -194,6 +218,9 @@ async fn dispatch_kind(
         append_item?,
         scratch_dir~,
       )
+      // `defer` cannot host an async cleanup; a child cancelled mid-run
+      // re-raises before here and its lab is left to OS temp-cleaning.
+      remove_scratch_lab(scratch_dir)
       report.map(report => report.to_json())
     }
     "review" => {
@@ -209,7 +236,7 @@ async fn dispatch_kind(
         _ => None
       }
       let api_key = @agentcli.api_key(matches, model)
-      let scratch_dir = @fs.tmpdir(prefix="openseek-review-lab-")
+      let scratch_dir = new_scratch_lab("openseek-review-lab-")
       let report = @agent_review.run_goal_audit(
         goal~,
         baseline~,
@@ -225,6 +252,7 @@ async fn dispatch_kind(
         append_item?,
         scratch_dir~,
       )
+      remove_scratch_lab(scratch_dir)
       report.map(report => report.to_json())
     }
     "echo" => {


### PR DESCRIPTION
Run11's sr-2 is the motivating transcript: 63 steps and 1.34M tokens on a `moon.mod` syntax question, a WRONG final answer — and four refused attempts to just *try it* (scratch `moon new`, a `/tmp` `moon.mod` heredoc). The review guard blocks scaffold/mutating moon commands anywhere; the source-write analysis classifies by name, not location. Denied the 3-step experiment, the scout grepped compiler binaries with `strings`.

Each subrun child now gets a **scratch lab** — a temp dir created at dispatch and named in its task — the one place a read-only child may fabricate projects and run any moon command to verify claims before reporting them.

- **Review guard**: admits a mutating/scaffold moon command only when it provably operates in the lab (effective cwd tracked through `cd` chains and `-C`; a scaffold's location-shaped arguments must land there; flag values are bare words; env prefixes/unknown cwds/out-of-lab paths keep the block — err-toward-blocking survives).
- **Pre-block filter + SBPL**: an offending target under the lab stops pre-blocking; mixed commands still run sandboxed, and the profile appends one `(allow file-write* (subpath <lab>))` after every deny — the kernel enforces what the static filter waives. The 17 static analyzers are untouched.
- **Prompts**: explore learns the experiment idiom ("a 3-step experiment beats 30 steps of doc archaeology; `strings`-grepping binaries is never the answer"); the audit learns the lab exists.

Validation: full native suite 1268/1268, cram 26/26; 14-case guard matrix + end-to-end shell test (`moon new <lab>/probe` passes the gate, out-of-lab scaffolds refuse pre-spawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)