### PR TITLE
run_moonbit: explain a sandbox source-write denial instead of a bare EPERM

### DIFF
--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -26,6 +26,8 @@ pub async fn sandbox_exec_available() -> Bool
 
 pub fn sbpl_string_escape(String) -> String
 
+pub fn source_write_denied_in_text(String, Array[String]) -> Bool
+
 pub async fn source_write_readonly_profile_data(String, writable_lab? : String) -> SourceWriteProfileData
 
 // Errors

--- a/agent_tool/internal/sandbox/sandbox.mbt
+++ b/agent_tool/internal/sandbox/sandbox.mbt
@@ -554,6 +554,82 @@ pub fn sbpl_string_escape(text : String) -> String {
 }
 
 ///|
+/// Whether `output_text` shows a source-write denial from the sandbox: a
+/// "not permitted"/"denied" line naming a protected source suffix or one of
+/// the profile's `denial_subjects`. This is the text-side counterpart of the
+/// source-write profile above — tools that run under it (`shell`,
+/// `run_moonbit`) use it to recognize a denial in command output and attach
+/// their own guidance instead of leaving a bare OS error.
+pub fn source_write_denied_in_text(
+  output_text : String,
+  denial_subjects : Array[String],
+) -> Bool {
+  output_text
+  .split("\n")
+  .any(line => {
+    sandbox_denial_line_mentions_denial(line) &&
+    (
+      sandbox_denial_line_mentions_source_path(line) ||
+      sandbox_denial_line_mentions_known_subject(line, denial_subjects)
+    )
+  })
+}
+
+///|
+fn sandbox_denial_line_mentions_known_subject(
+  line : StringView,
+  denial_subjects : Array[String],
+) -> Bool {
+  denial_subjects.any(subject => {
+    subject != "" && sandbox_denial_line_mentions_literal_subject(line, subject)
+  })
+}
+
+///|
+fn sandbox_denial_line_mentions_literal_subject(
+  line : StringView,
+  subject : String,
+) -> Bool {
+  line.contains("\{subject}:") ||
+  line.contains("\{subject}'") ||
+  line.contains("\{subject}\"") ||
+  // MoonBit's own OSError Show output escapes the quotes around the path
+  // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
+  // followed by `\"`, not a bare quote — run_moonbit's denial shape.
+  line.contains("\{subject}\\\"") ||
+  line.contains("\{subject}`") ||
+  (
+    sandbox_denial_line_has_denial_colon_before_subject(line) &&
+    line.has_suffix(subject)
+  )
+}
+
+///|
+fn sandbox_denial_line_mentions_source_path(line : StringView) -> Bool {
+  [
+    ".mbt.md", ".mbt", ".mbti", "moon.mod.json", "moon.pkg.json", "moon.mod", "moon.pkg",
+    "moon.work",
+  ].any(suffix => sandbox_denial_line_mentions_literal_subject(line, suffix))
+}
+
+///|
+fn sandbox_denial_line_mentions_denial(line : StringView) -> Bool {
+  line.contains("Operation not permitted") ||
+  line.contains("operation not permitted") ||
+  line.contains(": Permission denied") ||
+  line.contains("Permission denied:")
+}
+
+///|
+fn sandbox_denial_line_has_denial_colon_before_subject(
+  line : StringView,
+) -> Bool {
+  line.contains("Operation not permitted:") ||
+  line.contains("operation not permitted:") ||
+  line.contains("Permission denied:")
+}
+
+///|
 /// The platform shell program `sandbox_exec_args` runs commands through.
 #cfg(platform="windows")
 pub const PlatformShellProgram : String = "pwsh"

--- a/agent_tool/internal/sandbox/sandbox_wbtest.mbt
+++ b/agent_tool/internal/sandbox/sandbox_wbtest.mbt
@@ -111,6 +111,57 @@ async test "sandbox profile blocks existing directories that contain source" {
 }
 
 ///|
+test "source-write denial detection in command output" {
+  // run_moonbit's shape: a MoonBit runtime error for a denied source write.
+  assert_true(
+    source_write_denied_in_text(
+      "OSError(\"@fs.open(): \\\"keep.mbt\\\": Operation not permitted\")",
+      [],
+    ),
+  )
+  assert_true(
+    source_write_denied_in_text("sh: main.mbt: Operation not permitted\n", []),
+  )
+  assert_true(
+    source_write_denied_in_text("sh: moon.work: Operation not permitted\n", []),
+  )
+  // Generic denials and prose mentions are not source-write denials.
+  assert_false(source_write_denied_in_text("Permission denied\n", []))
+  assert_false(
+    source_write_denied_in_text("Permission denied while reading main.mbt\n", []),
+  )
+  assert_false(
+    source_write_denied_in_text(
+      "Permission denied while reading 'main.mbt'\n",
+      [],
+    ),
+  )
+  // The subject may follow the denial (python's errno shape, plain colon).
+  assert_true(
+    source_write_denied_in_text(
+      "PermissionError: [Errno 1] Operation not permitted: 'main.mbt'\n",
+      [],
+    ),
+  )
+  assert_true(
+    source_write_denied_in_text("Operation not permitted: main.mbt\n", []),
+  )
+  assert_true(source_write_denied_in_text("Permission denied: main.mbt\n", []))
+  // A denied directory is recognized only as a known denial subject.
+  let dir_rename = "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n"
+  assert_false(source_write_denied_in_text(dir_rename, []))
+  assert_true(source_write_denied_in_text(dir_rename, ["pkg"]))
+  assert_false(
+    source_write_denied_in_text("foo: Operation not permitted\n", []),
+  )
+  assert_false(
+    source_write_denied_in_text("foo: Operation not permitted\n", ["pkg"]),
+  )
+  // A source path without any denial wording is not a denial either.
+  assert_false(source_write_denied_in_text("compiled keep.mbt: ok", []))
+}
+
+///|
 async test "sandbox profile cache invalidates when source tree changes" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-profile-invalidate-", root => {
     @fs.mkdir("\{root}/assets")

--- a/agent_tool/run_moonbit/README.mbt.md
+++ b/agent_tool/run_moonbit/README.mbt.md
@@ -50,6 +50,14 @@ anywhere except the throwaway build dir — the same profile the `shell` tool
 uses. A snippet can still read anything and write non-source outputs (e.g.
 `people.json`).
 
+A denied write surfaces inside the program as a bare OS error (e.g.
+`OSError("@fs.open(): \"keep.mbt\": Operation not permitted")`), which on its
+own reads like a filesystem fault. When a sandboxed run's output shows such a
+denial on a protected source path, the tool result appends an explanation: the
+sandbox denied the write by design, the snippet should not try to work around
+it, and source changes belong to the `edit` tool. The run is reported as an
+error even if the snippet caught the failure and exited 0, matching `shell`.
+
 This is **best-effort, not a hard boundary**: `shell` also statically preflights
 its command text to catch directory-rename tricks, which is impossible for an
 arbitrary snippet — so a determined program can still smuggle sources in or out

--- a/agent_tool/run_moonbit/moon.pkg
+++ b/agent_tool/run_moonbit/moon.pkg
@@ -19,3 +19,7 @@ import {
   "moonbitlang/async",
   "bobzhang/openseek/testkit/filesystem" @vfs,
 } for "test"
+
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "wbtest"

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -233,9 +233,10 @@ async fn execute(
     // (the raw OS error is otherwise a dead end) and treat the run as failed
     // even if the snippet swallowed the error and exited 0 — the same
     // semantics the shell tool applies to its command output. Detection scans
-    // the WHOLE on-disk log, not the capped display prefix, and runs for the
-    // timeout arm too: a snippet can flood past the cap before hitting the
-    // denial, or print a caught denial and then hang.
+    // the on-disk log far past the capped display prefix (bounded to a fixed
+    // head+tail byte budget), and runs for the timeout arm too: a snippet can
+    // flood past the cap before hitting the denial, or print a caught denial
+    // and then hang.
     let sandbox_denied = sandbox_data is Some(data) &&
       log_shows_source_write_denial(log, data.denial_subjects)
     let action = match result {
@@ -320,32 +321,82 @@ fn rewrite_temp_paths(text : String, bases : Array[String]) -> String {
 }
 
 ///|
-/// Chunk size for the full-log denial scan, and the carry kept when a single
-/// line outgrows a chunk — the tail is far larger than any denial pattern, so
-/// only a pattern split exactly at a trim point of a >64KB line is missed.
+/// Chunk size for the log denial scan, and the carry kept when a single line
+/// outgrows a chunk — the tail is far larger than any denial pattern, so only
+/// a pattern split exactly at a trim point of a >64KB line is missed.
 const DenialScanChunkBytes : Int = 65_536
 
 ///|
 const DenialScanCarryTailChars : Int = 4_096
 
 ///|
-/// Whether the on-disk output log shows a source-write denial, scanning the
-/// WHOLE file in bounded memory — the display cap must not bound detection.
-/// Chunked with a trailing-partial-line carry, so a denial line split across
-/// chunk boundaries is reassembled before the line-level detector sees it.
+/// Byte budget for the denial scan at EACH end of the log. The scan runs after
+/// the run's 60s deadline has already expired, so its work must not scale with
+/// how hard a snippet flooded stdout — a fixed budget keeps the tool call's
+/// wall-clock bounded whatever the log's size.
+const DenialScanBudgetBytes : Int = 16_777_216
+
+///|
+/// Whether the on-disk output log shows a source-write denial. Detection must
+/// not be bounded by the 48KB display cap (a snippet can flood past it before
+/// the denied write), but it must stay bounded in bytes and time: a log larger
+/// than twice `DenialScanBudgetBytes` is scanned at its head and tail only. An
+/// uncaught denial crashes the snippet, so its OSError line is the log's tail;
+/// a caught-and-printed denial lands where it happened, inside the head for
+/// realistic probes. Only a denial buried in the MIDDLE of a >32MB flood is
+/// missed — the price of a bounded scan. `budget_bytes` is parameterized for
+/// tests only.
 async fn log_shows_source_write_denial(
   path : String,
   denial_subjects : Array[String],
+  budget_bytes? : Int = DenialScanBudgetBytes,
 ) -> Bool {
   let file = @fs.open(path, mode=ReadOnly) catch { _ => return false }
   defer file.close()
+  let size = file.size() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  let budget = budget_bytes.to_int64()
+  if size <= budget * 2 {
+    denial_scan_region(file, 0, size, denial_subjects)
+  } else {
+    denial_scan_region(file, 0, budget, denial_subjects) ||
+    denial_scan_region(file, size - budget, budget, denial_subjects)
+  }
+}
+
+///|
+/// Scan `len` bytes of `file` starting at `start` for a source-write denial,
+/// chunked with a trailing-partial-line carry so a denial line split across
+/// chunk boundaries is reassembled before the line-level detector sees it. (A
+/// region that starts mid-line can only truncate a pattern, never fabricate
+/// one, so the tail region needs no line alignment.)
+async fn denial_scan_region(
+  file : @fs.File,
+  start : Int64,
+  len : Int64,
+  denial_subjects : Array[String],
+) -> Bool {
   let buf = FixedArray::make(DenialScanChunkBytes, b'\x00')
   let mut carry = ""
-  for ;; {
-    let n = file.read(buf, max_len=DenialScanChunkBytes)
+  let mut position = start
+  let end = start + len
+  while position < end {
+    let remaining = end - position
+    let want = if remaining < DenialScanChunkBytes.to_int64() {
+      remaining.to_int()
+    } else {
+      DenialScanChunkBytes
+    }
+    let n = file.read_at(buf, position~, len=want) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => break
+    }
     if n <= 0 {
       break
     }
+    position += n.to_int64()
     let text = carry + @utf8.decode_lossy(Bytes::from_array(buf[:n]))
     match text.rev_find("\n") {
       Some(cut) => {

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -228,18 +228,21 @@ async fn execute(
       )
       (exit_code, read_capped(log))
     })
+    // A "not permitted" line naming a protected source path in a sandboxed run
+    // is the source-write policy firing, not an environment fault: explain it
+    // (the raw OS error is otherwise a dead end) and treat the run as failed
+    // even if the snippet swallowed the error and exited 0 — the same
+    // semantics the shell tool applies to its command output. Detection scans
+    // the WHOLE on-disk log, not the capped display prefix, and runs for the
+    // timeout arm too: a snippet can flood past the cap before hitting the
+    // denial, or print a caught denial and then hang.
+    let sandbox_denied = sandbox_data is Some(data) &&
+      log_shows_source_write_denial(log, data.denial_subjects)
     let action = match result {
       Some((exit_code, raw)) => {
         // Rewrite the throwaway temp path to `source` so the model reads
         // `source:LINE:COL` about its own input, not a random temp path.
         let text = rewrite_temp_paths(raw, [real, dir])
-        // A "not permitted" line naming a protected source path in a sandboxed
-        // run is the source-write policy firing, not an environment fault:
-        // explain it (the raw OS error is otherwise a dead end) and treat the
-        // run as failed even if the snippet swallowed the error and exited 0 —
-        // the same semantics the shell tool applies to its command output.
-        let sandbox_denied = sandbox_data is Some(data) &&
-          @sandbox.source_write_denied_in_text(text, data.denial_subjects)
         // PREPEND the exit status so it survives the agent loop's outer 60k
         // result clamp (which cuts the tail); the output cap is below 60k so
         // both the status line and the body are retained.
@@ -272,6 +275,11 @@ async fn execute(
           head
         } else {
           "\{head}\n[partial output before the timeout]\n\{partial}"
+        }
+        let body = if sandbox_denied {
+          "\{body}\n\n\{SandboxSourceWriteFeedback}"
+        } else {
+          body
         }
         @agent_tool.ToolAction::respond(
           body,
@@ -309,6 +317,58 @@ fn rewrite_temp_paths(text : String, bases : Array[String]) -> String {
     }
   }
   out
+}
+
+///|
+/// Chunk size for the full-log denial scan, and the carry kept when a single
+/// line outgrows a chunk — the tail is far larger than any denial pattern, so
+/// only a pattern split exactly at a trim point of a >64KB line is missed.
+const DenialScanChunkBytes : Int = 65_536
+
+///|
+const DenialScanCarryTailChars : Int = 4_096
+
+///|
+/// Whether the on-disk output log shows a source-write denial, scanning the
+/// WHOLE file in bounded memory — the display cap must not bound detection.
+/// Chunked with a trailing-partial-line carry, so a denial line split across
+/// chunk boundaries is reassembled before the line-level detector sees it.
+async fn log_shows_source_write_denial(
+  path : String,
+  denial_subjects : Array[String],
+) -> Bool {
+  let file = @fs.open(path, mode=ReadOnly) catch { _ => return false }
+  defer file.close()
+  let buf = FixedArray::make(DenialScanChunkBytes, b'\x00')
+  let mut carry = ""
+  for ;; {
+    let n = file.read(buf, max_len=DenialScanChunkBytes)
+    if n <= 0 {
+      break
+    }
+    let text = carry + @utf8.decode_lossy(Bytes::from_array(buf[:n]))
+    match text.rev_find("\n") {
+      Some(cut) => {
+        if @sandbox.source_write_denied_in_text(
+            text[:cut].to_owned(),
+            denial_subjects,
+          ) {
+          return true
+        }
+        carry = text[cut + 1:].to_owned()
+      }
+      None => carry = text
+    }
+    // A single line larger than a chunk must not grow the carry unboundedly:
+    // scan what accumulated, keep only a pattern-sized tail.
+    if carry.length() > DenialScanChunkBytes {
+      if @sandbox.source_write_denied_in_text(carry, denial_subjects) {
+        return true
+      }
+      carry = carry[carry.length() - DenialScanCarryTailChars:].to_owned()
+    }
+  }
+  @sandbox.source_write_denied_in_text(carry, denial_subjects)
 }
 
 ///|

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -12,6 +12,13 @@ const RunTimeoutMs : Int = 60_000
 const OutputCapBytes : Int = 48_000
 
 ///|
+/// Guidance appended when a sandboxed run's output shows a source-write denial
+/// ("Operation not permitted" on a protected source path). Without it the model
+/// reads a bare OS error and debugs the filesystem — or worse, tries to escape
+/// the sandbox — instead of using `edit`.
+const SandboxSourceWriteFeedback : String = "run_moonbit sandbox: the \"Operation not permitted\" failure above is this tool's sandbox denying a write to a protected MoonBit source file (`*.mbt`, `*.mbti`, `*.mbt.md`, `moon.mod`/`moon.pkg`/`moon.work`) — not a filesystem or permissions problem to debug. Snippets run source-write-readonly by design; writing non-source files (data, logs, reports) stays allowed. Do NOT try to work around the block from inside a snippet (renames, copies, temp-then-move, or other sandbox escapes) — make source changes with the line-anchored `edit` tool instead, and keep run_moonbit for compute, probing, and non-source IO."
+
+///|
 /// Best-effort refusal of the two obvious native escapes: process spawning
 /// (`moonbitlang/async/process` — the `shell` tool owns commands) and native
 /// FFI (`extern`, which can bind libc `system`). A substring scan is NOT a
@@ -184,21 +191,30 @@ async fn execute(
     // preflights the command) an arbitrary snippet can still smuggle sources via
     // directory renames; full containment is the wasm backend's job. Elsewhere
     // (or in a nested sandbox where it cannot enforce) run moon directly.
-    let (prog, argv) = if @sandbox.sandbox_exec_available() {
-      let base = @sandbox.source_write_readonly_profile_data(
+    // The profile data is kept (not just its text) so a denial showing up in the
+    // program's output can be recognized and explained below.
+    let sandbox_data = if @sandbox.sandbox_exec_available() {
+      Some(
+        @sandbox.source_write_readonly_profile_data(
           @fs.realpath(workspace_root) catch {
             _ => workspace_root
           },
-        ).profile
-      // Re-allow the throwaway build dir: if it falls INSIDE the workspace root
-      // (e.g. `workspace_root=/tmp`, where `@fs.tmpdir` lands under it) the shared
-      // deny would otherwise block moon's own generated `snippet.mbt`. SBPL is
-      // last-match-wins, so this appended allow overrides the deny for `dir` only.
-      let profile = base +
-        "\n(allow file-write* (subpath \"\{@sandbox.sbpl_string_escape(real)}\"))\n"
-      (@sandbox.SandboxExecPath, ["-p", profile, "moon", ..moon_argv])
+        ),
+      )
     } else {
-      ("moon", moon_argv)
+      None
+    }
+    let (prog, argv) = match sandbox_data {
+      Some(data) => {
+        // Re-allow the throwaway build dir: if it falls INSIDE the workspace root
+        // (e.g. `workspace_root=/tmp`, where `@fs.tmpdir` lands under it) the shared
+        // deny would otherwise block moon's own generated `snippet.mbt`. SBPL is
+        // last-match-wins, so this appended allow overrides the deny for `dir` only.
+        let profile = data.profile +
+          "\n(allow file-write* (subpath \"\{@sandbox.sbpl_string_escape(real)}\"))\n"
+        (@sandbox.SandboxExecPath, ["-p", profile, "moon", ..moon_argv])
+      }
+      None => ("moon", moon_argv)
     }
     let result = @async.with_timeout_opt(RunTimeoutMs, () => {
       let exit_code = @process.run(
@@ -217,6 +233,13 @@ async fn execute(
         // Rewrite the throwaway temp path to `source` so the model reads
         // `source:LINE:COL` about its own input, not a random temp path.
         let text = rewrite_temp_paths(raw, [real, dir])
+        // A "not permitted" line naming a protected source path in a sandboxed
+        // run is the source-write policy firing, not an environment fault:
+        // explain it (the raw OS error is otherwise a dead end) and treat the
+        // run as failed even if the snippet swallowed the error and exited 0 —
+        // the same semantics the shell tool applies to its command output.
+        let sandbox_denied = sandbox_data is Some(data) &&
+          @sandbox.source_write_denied_in_text(text, data.denial_subjects)
         // PREPEND the exit status so it survives the agent loop's outer 60k
         // result clamp (which cuts the tail); the output cap is below 60k so
         // both the status line and the body are retained.
@@ -227,9 +250,14 @@ async fn execute(
         } else {
           text
         }
+        let body = if sandbox_denied {
+          "\{body}\n\n\{SandboxSourceWriteFeedback}"
+        } else {
+          body
+        }
         @agent_tool.ToolAction::respond(
           body,
-          is_error=exit_code != 0,
+          is_error=exit_code != 0 || sandbox_denied,
           brief="run_moonbit (exit=\{exit_code})",
         )
       }

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -140,6 +140,39 @@ test "the description encourages batched same-turn probing" {
 }
 
 ///|
+async test "an uncaught sandbox denial is explained, not left as a bare EPERM" {
+  guard @sandbox.sandbox_exec_available() else { return }
+  @vfs.with_tmpdir(ws => {
+    @fs.write_file(
+      "\{ws}/keep.mbt",
+      "fn main {  }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // Unlike the test above, the snippet does NOT catch the write failure, so
+    // the run dies with the raw OS error — the case where the model previously
+    // saw only `Operation not permitted` with no idea the sandbox caused it.
+    let out = run_in(ws, {
+      "source": (
+        #|import { "moonbitlang/async", "moonbitlang/async/fs" }
+        #|
+        #|async fn main {
+        #|  @fs.write_file("keep.mbt", "// CORRUPTED\n", create_mode=CreateOrTruncate)
+        #|}
+      ),
+    })
+    assert_true(out.is_error)
+    // the raw OS error stays visible...
+    assert_true(out.content.contains("Operation not permitted"))
+    // ...now followed by the sandbox explanation and anti-workaround guidance
+    assert_true(out.content.contains("run_moonbit sandbox"))
+    assert_true(out.content.contains("Do NOT try to work around"))
+    assert_true(out.content.contains("`edit`"))
+    // the protected source file is untouched
+    assert_true(@fs.read_file("\{ws}/keep.mbt").text().contains("fn main {  }"))
+  })
+}
+
+///|
 async test "rejects non-string source arguments" {
   let out = run_in(".", { "code": "x" })
   assert_true(out.is_error)

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -173,6 +173,42 @@ async test "an uncaught sandbox denial is explained, not left as a bare EPERM" {
 }
 
 ///|
+async test "a denial past the display cap is still detected and explained" {
+  guard @sandbox.sandbox_exec_available() else { return }
+  @vfs.with_tmpdir(ws => {
+    @fs.write_file(
+      "\{ws}/keep.mbt",
+      "fn main {  }\n",
+      create_mode=CreateOrTruncate,
+    )
+    // ~200KB of flood BEFORE the uncaught denied write: the OSError line lands
+    // beyond the 48KB display cap (and beyond one 64KB scan chunk), so only
+    // the full-log scan can see it.
+    let out = run_in(ws, {
+      "source": (
+        #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/async/stdio" }
+        #|
+        #|async fn main {
+        #|  let filler = String::make(1000, 'x')
+        #|  for _i in 0..<200 {
+        #|    @stdio.stdout.write("\{filler}\n")
+        #|  }
+        #|  @fs.write_file("keep.mbt", "// CORRUPTED\n", create_mode=CreateOrTruncate)
+        #|}
+      ),
+    })
+    assert_true(out.is_error)
+    // the displayed prefix is the truncated flood, not the denial line (the
+    // feedback itself quotes "Operation not permitted", so pin on OSError)...
+    assert_true(out.content.contains("output truncated"))
+    assert_false(out.content.contains("OSError"))
+    // ...yet the guidance still lands, from the full-log scan
+    assert_true(out.content.contains("run_moonbit sandbox"))
+    assert_true(@fs.read_file("\{ws}/keep.mbt").text().contains("fn main {  }"))
+  })
+}
+
+///|
 async test "rejects non-string source arguments" {
   let out = run_in(".", { "code": "x" })
   assert_true(out.is_error)

--- a/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
@@ -1,0 +1,36 @@
+///|
+/// The denial scan runs after the run's deadline has expired, so its work must
+/// stay bounded however hard a snippet flooded: an over-budget log is scanned
+/// at its head and tail only. With a tiny test budget, a denial in either
+/// scanned region is found; one buried in the skipped middle is (by design)
+/// not; a log within budget is scanned whole.
+async test "denial scan is bounded to the log's head and tail" {
+  @vfs.with_tmpdir(prefix="run-moonbit-denial-scan-", dir => {
+    let denial = "sh: main.mbt: Operation not permitted\n"
+    let filler_line = "\{String::make(63, 'x')}\n"
+    fn filler(lines : Int) -> String {
+      let out = StringBuilder()
+      for _ in 0..<lines {
+        out.write_string(filler_line)
+      }
+      out.to_string()
+    }
+
+    async fn scan(name : String, content : String) -> Bool {
+      let path = "\{dir}/\{name}.log"
+      @fs.write_file(path, content, create_mode=CreateOrTruncate)
+      log_shows_source_write_denial(path, [], budget_bytes=1024)
+    }
+
+    // within budget (<= 2KB): scanned whole, wherever the denial sits
+    assert_true(scan("small", filler(10) + denial + filler(10)))
+    // over budget: the head region sees a leading denial
+    assert_true(scan("head", denial + filler(64)))
+    // over budget: the tail region sees a trailing denial
+    assert_true(scan("tail", filler(64) + denial))
+    // over budget with the denial only in the skipped middle: missed by design
+    assert_false(scan("middle", filler(20) + denial + filler(20)))
+    // no denial at all
+    assert_false(scan("clean", filler(64)))
+  })
+}

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -13,8 +13,6 @@ pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bg
 
 pub fn source_write_denial_feedback() -> String
 
-pub fn source_write_denied_in_text(String, Array[String]) -> Bool
-
 // Errors
 
 // Types and methods

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -5339,37 +5339,10 @@ fn agent_output_has_shell_sandbox_denial(
   agent_output : AgentShellOutput,
 ) -> Bool {
   agent_output.source_write_sandboxed &&
-  sandbox_denied_source_write(
-    agent_output.output,
+  @sandbox.source_write_denied_in_text(
+    agent_output.output.text,
     agent_output.sandbox_denial_subjects,
   )
-}
-
-///|
-fn sandbox_denied_source_write(
-  output : ShellOutput,
-  denial_subjects : Array[String],
-) -> Bool {
-  source_write_denied_in_text(output.text, denial_subjects)
-}
-
-///|
-/// Whether `output_text` shows a sandboxed source-write denial for
-/// `denial_subjects`. Exposed so `shell_output` can apply the same detection to a
-/// background job's output that the foreground path applies inline.
-pub fn source_write_denied_in_text(
-  output_text : String,
-  denial_subjects : Array[String],
-) -> Bool {
-  output_text
-  .split("\n")
-  .any(line => {
-    sandbox_denial_line_mentions_denial(line) &&
-    (
-      sandbox_denial_line_mentions_source_path(line) ||
-      sandbox_denial_line_mentions_known_subject(line, denial_subjects)
-    )
-  })
 }
 
 ///|
@@ -5377,54 +5350,4 @@ pub fn source_write_denied_in_text(
 /// source-write denial. Exposed for `shell_output`.
 pub fn source_write_denial_feedback() -> String {
   SandboxSourceWriteFeedback
-}
-
-///|
-fn sandbox_denial_line_mentions_known_subject(
-  line : StringView,
-  denial_subjects : Array[String],
-) -> Bool {
-  denial_subjects.any(subject => {
-    subject != "" && sandbox_denial_line_mentions_literal_subject(line, subject)
-  })
-}
-
-///|
-fn sandbox_denial_line_mentions_literal_subject(
-  line : StringView,
-  subject : String,
-) -> Bool {
-  line.contains("\{subject}:") ||
-  line.contains("\{subject}'") ||
-  line.contains("\{subject}\"") ||
-  line.contains("\{subject}`") ||
-  (
-    sandbox_denial_line_has_denial_colon_before_subject(line) &&
-    line.has_suffix(subject)
-  )
-}
-
-///|
-fn sandbox_denial_line_mentions_source_path(line : StringView) -> Bool {
-  [
-    ".mbt.md", ".mbt", ".mbti", "moon.mod.json", "moon.pkg.json", "moon.mod", "moon.pkg",
-    "moon.work",
-  ].any(suffix => sandbox_denial_line_mentions_literal_subject(line, suffix))
-}
-
-///|
-fn sandbox_denial_line_mentions_denial(line : StringView) -> Bool {
-  line.contains("Operation not permitted") ||
-  line.contains("operation not permitted") ||
-  line.contains(": Permission denied") ||
-  line.contains("Permission denied:")
-}
-
-///|
-fn sandbox_denial_line_has_denial_colon_before_subject(
-  line : StringView,
-) -> Bool {
-  line.contains("Operation not permitted:") ||
-  line.contains("operation not permitted:") ||
-  line.contains("Permission denied:")
 }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1184,12 +1184,14 @@ fn is_some_path(value : String?, expected : String) -> Bool {
 
 ///|
 test "sandbox denial detection ignores masked exit code" {
+  // Line-level detection pins live with `source_write_denied_in_text` in
+  // `agent_tool/internal/sandbox`; here only the shell-side gate is covered:
+  // the denial fires despite exit_code 0, and only for a sandboxed command.
   let output = {
     exit_code: Some(0),
     text: "sh: main.mbt: Operation not permitted\n",
     output_limit_reached: false,
   }
-  assert_true(sandbox_denied_source_write(output, []))
   assert_true(
     agent_output_has_shell_sandbox_denial({
       output,
@@ -1204,79 +1206,35 @@ test "sandbox denial detection ignores masked exit code" {
       sandbox_denial_subjects: [],
     }),
   )
-  let generic = {
-    exit_code: Some(0),
-    text: "Permission denied\n",
-    output_limit_reached: false,
-  }
-  assert_false(sandbox_denied_source_write(generic, []))
-  let prose = {
-    exit_code: Some(0),
-    text: "Permission denied while reading main.mbt\n",
-    output_limit_reached: false,
-  }
-  assert_false(sandbox_denied_source_write(prose, []))
-  let quoted_prose = {
-    exit_code: Some(0),
-    text: "Permission denied while reading 'main.mbt'\n",
-    output_limit_reached: false,
-  }
-  assert_false(sandbox_denied_source_write(quoted_prose, []))
-  let python = {
-    exit_code: Some(0),
-    text: "PermissionError: [Errno 1] Operation not permitted: 'main.mbt'\n",
-    output_limit_reached: false,
-  }
-  assert_true(sandbox_denied_source_write(python, []))
-  let subject_after_denial = {
-    exit_code: Some(0),
-    text: "Operation not permitted: main.mbt\n",
-    output_limit_reached: false,
-  }
-  assert_true(sandbox_denied_source_write(subject_after_denial, []))
-  let permission_subject = {
-    exit_code: Some(0),
-    text: "Permission denied: main.mbt\n",
-    output_limit_reached: false,
-  }
-  assert_true(sandbox_denied_source_write(permission_subject, []))
-  let directory_rename_subject = {
-    exit_code: Some(0),
-    text: "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n",
-    output_limit_reached: false,
-  }
-  assert_false(sandbox_denied_source_write(directory_rename_subject, []))
-  assert_true(sandbox_denied_source_write(directory_rename_subject, ["pkg"]))
   assert_true(
     agent_output_has_shell_sandbox_denial({
-      output: directory_rename_subject,
+      output: {
+        exit_code: Some(0),
+        text: "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n",
+        output_limit_reached: false,
+      },
       source_write_sandboxed: true,
       sandbox_denial_subjects: ["pkg"],
     }),
   )
-  let unrelated_readonly_output = {
-    exit_code: Some(0),
-    text: "foo: Operation not permitted\n",
-    output_limit_reached: false,
-  }
-  assert_false(sandbox_denied_source_write(unrelated_readonly_output, []))
-  assert_false(sandbox_denied_source_write(unrelated_readonly_output, ["pkg"]))
   assert_false(
     agent_output_has_shell_sandbox_denial({
-      output: unrelated_readonly_output,
+      output: {
+        exit_code: Some(0),
+        text: "foo: Operation not permitted\n",
+        output_limit_reached: false,
+      },
       source_write_sandboxed: true,
       sandbox_denial_subjects: ["pkg"],
     }),
   )
-  let moon_work = {
-    exit_code: Some(0),
-    text: "sh: moon.work: Operation not permitted\n",
-    output_limit_reached: false,
-  }
-  assert_true(sandbox_denied_source_write(moon_work, []))
   assert_false(
     agent_output_has_shell_sandbox_denial({
-      output: generic,
+      output: {
+        exit_code: Some(0),
+        text: "Permission denied\n",
+        output_limit_reached: false,
+      },
       source_write_sandboxed: true,
       sandbox_denial_subjects: [],
     }),

--- a/agent_tool/shell_output/moon.pkg
+++ b/agent_tool/shell_output/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/internal/sandbox",
   "bobzhang/openseek/agent_tool/shell",
   "moonbitlang/core/json",
 }

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -86,7 +86,7 @@ async fn execute(
   // job — so a full read is done only in that rare case.
   let sandbox_denied = if snapshot.source_write_sandboxed {
     let full = bg_runtime.read_output(job_id).unwrap_or(output)
-    @shell.source_write_denied_in_text(full, snapshot.sandbox_denial_subjects)
+    @sandbox.source_write_denied_in_text(full, snapshot.sandbox_denial_subjects)
   } else {
     false
   }


### PR DESCRIPTION
## Problem

When a `run_moonbit` snippet writes a protected source file, the sandbox kills the write and the tool result is just:

```
[run_moonbit: exited 1]
OSError("@fs.open(): \"keep.mbt\": Operation not permitted")
```

Nothing says the sandbox caused it, so the model reads a filesystem fault and either debugs the wrong thing or starts probing for ways around the block.

## Change

- A sandboxed run whose output shows a source-write denial now gets an appended explanation: the block is the tool's deliberate source-write-readonly policy (not an environment fault), the snippet must NOT try to work around it (renames, copies, temp-then-move), and source changes belong to the line-anchored `edit` tool. The run is reported `is_error` even if the snippet swallowed the failure and exited 0 — the same semantics `shell` applies.
- The text-side denial detector (`source_write_denied_in_text` + line helpers) moves from `agent_tool/shell` to the shared `agent_tool/internal/sandbox`, since both tools run under the same profile; `shell`/`shell_output` now delegate to it.
- **Real bug found while verifying**: MoonBit's `OSError` Show output escapes the quotes around the path (`keep.mbt\":`), so the detector's bare-quote pattern (`subject + '"'`) never matched run_moonbit's own denial shape. The detector now also recognizes the backslash-escaped-quote form — pinned against a live `sandbox-exec` reproduction.
- Line-level detection pins move to the internal/sandbox wbtest; the shell wbtest keeps only the sandboxed-command gate it still owns. New e2e test: an uncaught denial yields the raw OS error **plus** the sandbox explanation, and the protected file stays untouched.

## Verification

- Reproduced the bare-EPERM failure with a live `sandbox-exec` run before the fix; the new e2e test covers the exact shape.
- `moon check --deny-warn` clean, `moon fmt`/`moon info` fresh, affected package tests: sandbox+run_moonbit 20/20, shell+shell_output 129/129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)