### PR TITLE
shrink: second interface sweep — post-#522 packages

### DIFF
--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -11,47 +11,27 @@ import {
 }
 
 // Values
-pub let current_schema_version : Int
-
-pub let default_explore_deadline_ms : Int
-
 pub let default_explore_max_steps : Int
 
 pub fn definition(self_exe~ : String, model~ : @deepseek.Model, workspace_root~ : String, budget~ : @agent_subrun.SubrunBudget, api_url? : String, child_session? : @agent_subrun.ChildSession) -> @agent_tool.AgentToolDefinition
-
-pub let max_answer_chars : Int
-
-pub let max_citation_file_chars : Int
-
-pub let max_citation_note_chars : Int
-
-pub let max_citations : Int
-
-pub let max_hints_chars : Int
-
-pub let max_query_chars : Int
-
-pub let max_unresolved_chars : Int
 
 pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ExploreReport?
 
 // Errors
 
 // Types and methods
-pub(all) struct Citation {
+pub struct Citation {
   file : String
   line : Int?
   note : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct ExploreReport {
+pub struct ExploreReport {
   schema_version : Int
   answer : String
   citations : Array[Citation]
   unresolved : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn ExploreReport::parse(Json) -> Result[Self, String]
-pub fn ExploreReport::validate(Self) -> Array[String]
 
 // Type aliases
 

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -10,15 +10,15 @@ pub let default_explore_max_steps : Int = 100
 /// ten minutes is lost, not thorough. Sized with the step ceiling: at the
 /// few seconds per step observed in dogfood runs, a child must be able to
 /// spend its full step allowance without dying by the clock instead.
-pub let default_explore_deadline_ms : Int = 600_000
+let default_explore_deadline_ms : Int = 600_000
 
 ///|
 /// Input caps: a question is a question, not a document.
-pub let max_query_chars : Int = 2_000
+let max_query_chars : Int = 2_000
 
 ///|
 /// Hints cap, same reasoning as the query cap.
-pub let max_hints_chars : Int = 2_000
+let max_hints_chars : Int = 2_000
 
 ///|
 /// Tool definition for `explore`: delegate one self-contained question to a

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -7,32 +7,32 @@
 
 ///|
 /// The schema version this build emits and accepts.
-pub let current_schema_version : Int = 1
+let current_schema_version : Int = 1
 
 ///|
 /// Field and count ceilings, enforced by `validate`.
-pub let max_answer_chars : Int = 8_000
+let max_answer_chars : Int = 8_000
 
 ///|
 /// Citation-count ceiling, enforced by `validate`.
-pub let max_citations : Int = 20
+let max_citations : Int = 20
 
 ///|
 /// Per-citation file-path length ceiling.
-pub let max_citation_file_chars : Int = 300
+let max_citation_file_chars : Int = 300
 
 ///|
 /// Per-citation note length ceiling.
-pub let max_citation_note_chars : Int = 200
+let max_citation_note_chars : Int = 200
 
 ///|
 /// `unresolved` length ceiling.
-pub let max_unresolved_chars : Int = 1_000
+let max_unresolved_chars : Int = 1_000
 
 ///|
 /// One supporting reference: a workspace `file:line`, or the source/`.mbti`
 /// path `moon ide doc` reported for a stdlib or dependency claim.
-pub(all) struct Citation {
+pub struct Citation {
   file : String
   line : Int?
   note : String?
@@ -41,7 +41,7 @@ pub(all) struct Citation {
 ///|
 /// The child's full answer. `unresolved` names what it could NOT determine —
 /// stated ignorance beats a fabricated claim.
-pub(all) struct ExploreReport {
+pub struct ExploreReport {
   schema_version : Int
   answer : String
   citations : Array[Citation]
@@ -53,7 +53,7 @@ pub(all) struct ExploreReport {
 /// empty list means the report is valid. The `submit_answer` capture tool
 /// uses this to reject oversized or empty output so the model retries with
 /// a bounded report instead of finishing with an unusable one.
-pub fn ExploreReport::validate(self : ExploreReport) -> Array[String] {
+fn ExploreReport::validate(self : ExploreReport) -> Array[String] {
   let problems : Array[String] = []
   if self.schema_version != current_schema_version {
     problems.push(
@@ -95,7 +95,7 @@ pub fn ExploreReport::validate(self : ExploreReport) -> Array[String] {
 
 ///|
 /// Parse a report from JSON, returning the report or a human-readable error.
-pub fn ExploreReport::parse(json : Json) -> Result[ExploreReport, String] {
+fn ExploreReport::parse(json : Json) -> Result[ExploreReport, String] {
   let report : ExploreReport = @json.from_json(json) catch {
     e => return Err("invalid explore report JSON: \{e}")
   }

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -105,16 +105,16 @@ pub async fn run_goal_audit(
 ///|
 /// Digest bounds: the gate injects this into the model's context and the
 /// durable log UNCLAMPED, so the caps live here, not in hope.
-pub let digest_max_findings : Int = 10
+let digest_max_findings : Int = 10
 
 ///|
 /// Per-finding line cap in the digest.
-pub let digest_max_line_chars : Int = 200
+let digest_max_line_chars : Int = 200
 
 ///|
 /// Total digest cap: the notice enters model context and the durable log
 /// unclamped, so this bound is the only one.
-pub let digest_max_chars : Int = 4_000
+let digest_max_chars : Int = 4_000
 
 ///|
 /// The bounded `[review]` notice for a report: severity tally, trimmed

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -13,12 +13,6 @@ pub let current_schema_version : Int
 
 pub let default_audit_max_steps : Int
 
-pub let digest_max_chars : Int
-
-pub let digest_max_findings : Int
-
-pub let digest_max_line_chars : Int
-
 pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ReviewReport?
 
 pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String) -> ReviewReport

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -175,7 +175,7 @@ pub fn Session::current_goal(self : Session) -> StandingGoal? {
 /// appended IMMEDIATELY BEFORE its `[goal]` set marker by every goal-set
 /// path. Single-line by design (unlike the set marker, it carries no user
 /// text). Unknown to older readers, it degrades to a plain notice.
-pub const GoalBaselinePrefix : String = "[goal baseline]"
+const GoalBaselinePrefix : String = "[goal baseline]"
 
 ///|
 /// The workspace snapshot recorded when a goal was set: the commit the

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -11,8 +11,6 @@ import {
 // Values
 pub const ContextYieldAnswerPrefix : String = "[context ceiling]"
 
-pub const GoalBaselinePrefix : String = "[goal baseline]"
-
 pub const GoalBlockedPrefix : String = "[goal blocked]"
 
 pub const GoalCheckPrefix : String = "[goal check]"

--- a/agent_subrun/budget.mbt
+++ b/agent_subrun/budget.mbt
@@ -4,7 +4,7 @@
 /// doomed run. Requests come from per-kind constants, not the model — this
 /// floor is a guard against a miswired constant, and against a
 /// pathological negative request reaching a child's `--max-steps`.
-pub let min_useful_subrun_steps : Int = 8
+let min_useful_subrun_steps : Int = 8
 
 ///|
 /// The per-turn subrun call allowance shared by every MODEL-initiated

--- a/agent_subrun/child.mbt
+++ b/agent_subrun/child.mbt
@@ -68,7 +68,7 @@ pub fn report_line(report : Json) -> String {
 ///|
 /// The report a parent extracts from one child stdout line, or `None` for
 /// every other line (protocol events, stray output).
-pub fn parse_report_line(line : Json) -> Json? {
+fn parse_report_line(line : Json) -> Json? {
   match line {
     { "subrun_report": report, .. } => Some(report)
     _ => None

--- a/agent_subrun/exports.mbt
+++ b/agent_subrun/exports.mbt
@@ -1,0 +1,18 @@
+// Deliberate exports with no in-repo production consumer (see
+// shrink_package.md): test seams, round-trip/protocol surface, and
+// future-proof API kept on purpose. Each entry documents its reason.
+
+///|
+/// Provider prompt tokens the child consumed, summed over its requests.
+/// Token accounting is part of the runner's observable contract — the
+/// runner tests assert it — and completes the `steps_used`/`subrun_id`
+/// getter family.
+pub fn[T] SubrunResult::prompt_tokens(self : SubrunResult[T]) -> Int {
+  self.prompt_tokens
+}
+
+///|
+/// Completion tokens summed from the child's observed usage events.
+pub fn[T] SubrunResult::completion_tokens(self : SubrunResult[T]) -> Int {
+  self.completion_tokens
+}

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -11,15 +11,9 @@ import {
 }
 
 // Values
-pub let cancel_grace_ms : Int
-
 pub fn[T] capture_tool(name~ : String, description~ : String, schema~ : @agent_tool.JsonSchema, parse~ : (Json) -> Result[T, Array[String]], @ref.Ref[T?], finished_note? : (T) -> String) -> @agent_tool.AgentToolDefinition
 
 pub async fn[T] execute_kind(session_id~ : String, system_prompt~ : String, task~ : String, tools~ : (@ref.Ref[T?]) -> @agent_tool.Tools raise, max_steps~ : Int, api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> T?
-
-pub let min_useful_subrun_steps : Int
-
-pub fn parse_report_line(Json) -> Json?
 
 pub fn report_line(Json) -> String
 
@@ -58,7 +52,7 @@ pub fn[T] SubrunResult::subrun_id(Self[T]) -> String
 pub fn[T] SubrunResult::terminal(Self[T]) -> SubrunTerminal
 pub fn[T] SubrunResult::value(Self[T]) -> T?
 
-pub(all) enum SubrunTerminal {
+pub enum SubrunTerminal {
   Captured
   NoReport
   MaxSteps

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -3,14 +3,14 @@
 /// signal), the child gets this long to flush and exit before the runner
 /// terminates it. A well-behaved child cancels its turn on EOF and exits
 /// quickly; the kill is the backstop.
-pub let cancel_grace_ms : Int = 5_000
+let cancel_grace_ms : Int = 5_000
 
 ///|
 /// How a sub-run ended. External cancellation of the CALLER is deliberately
 /// not a terminal: it re-raises out of `run_subrun` (tearing the child down
 /// on the way) so structured concurrency sees it, per the engine-wide rule
 /// that cancellation is never folded into an ordinary failure.
-pub(all) enum SubrunTerminal {
+pub enum SubrunTerminal {
   /// The child submitted a valid report before exiting.
   Captured
   /// The child exited cleanly without ever submitting a report.
@@ -61,25 +61,12 @@ pub fn[T] SubrunResult::steps_used(self : SubrunResult[T]) -> Int {
 }
 
 ///|
-/// Provider prompt tokens the child consumed, summed over its requests.
-pub fn[T] SubrunResult::prompt_tokens(self : SubrunResult[T]) -> Int {
-  self.prompt_tokens
-}
-
-///|
-/// Provider completion tokens the child consumed, summed over its requests.
 /// The runner-assigned sub-run id ("sr-N"): the same id the
 /// SubrunStarted/SubrunFinished brackets carried, and — when the child was
 /// launched with a `ChildSession` — the suffix of the child's durable
 /// session id.
 pub fn[T] SubrunResult::subrun_id(self : SubrunResult[T]) -> String {
   self.subrun_id
-}
-
-///|
-/// Completion tokens summed from the child's observed usage events.
-pub fn[T] SubrunResult::completion_tokens(self : SubrunResult[T]) -> Int {
-  self.completion_tokens
 }
 
 ///|

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub async fn source_write_readonly_profile_data(String, writable_lab? : String) 
 // Errors
 
 // Types and methods
-pub(all) struct SourceWriteProfileData {
+pub struct SourceWriteProfileData {
   profile : String
   denial_subjects : Array[String]
 }

--- a/agent_tool/internal/sandbox/sandbox.mbt
+++ b/agent_tool/internal/sandbox/sandbox.mbt
@@ -38,7 +38,7 @@ priv struct CachedSourceWriteProfile {
 
 ///|
 /// A built SBPL profile plus the source subjects it denies writes to.
-pub(all) struct SourceWriteProfileData {
+pub struct SourceWriteProfileData {
   profile : String
   denial_subjects : Array[String]
 }

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -4,11 +4,6 @@
 let default_max_output_chars : Int = 12000
 
 ///|
-/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
-/// tool call can never flood the conversation with an arbitrarily large file.
-pub let hard_max_output_chars : Int = 50000
-
-///|
 /// Decoded arguments of the `read` tool: one file path, starting from the
 /// 1-based `start_line`, at most `max_lines` lines (unbounded when `None`),
 /// truncated to `max_output_chars` rendered UTF-16 code units.

--- a/agent_tool/read/internal/decode/exports.mbt
+++ b/agent_tool/read/internal/decode/exports.mbt
@@ -1,0 +1,10 @@
+// Deliberate exports with no in-repo production consumer (see
+// shrink_package.md): test seams, round-trip/protocol surface, and
+// future-proof API kept on purpose. Each entry documents its reason.
+
+///|
+/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
+/// tool call can never flood the conversation with an arbitrarily large
+/// file. Exported as a test seam: `read`'s own tests assert the decoded
+/// input clamps to exactly this ceiling.
+pub let hard_max_output_chars : Int = 50000

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -4,11 +4,6 @@
 pub let default_max_output_chars : Int = 12000
 
 ///|
-/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
-/// command's output can never flood the conversation.
-pub let hard_max_output_chars : Int = 50000
-
-///|
 /// Decoded arguments of the `shell` tool: run `cmd` through the platform
 /// shell, in `cwd` when given, killed after `timeout_ms` when given, with
 /// captured output truncated to `max_output_chars` characters.

--- a/agent_tool/shell/internal/decode/exports.mbt
+++ b/agent_tool/shell/internal/decode/exports.mbt
@@ -1,0 +1,10 @@
+// Deliberate exports with no in-repo production consumer (see
+// shrink_package.md): test seams, round-trip/protocol surface, and
+// future-proof API kept on purpose. Each entry documents its reason.
+
+///|
+/// Ceiling a caller-supplied `max_output_chars` is clamped to, so a single
+/// command's output can never flood the conversation. Exported as a test
+/// seam: `shell`'s own tests assert the decoded input clamps to exactly
+/// this ceiling.
+pub let hard_max_output_chars : Int = 50000

--- a/eval/tool_harness/exports.mbt
+++ b/eval/tool_harness/exports.mbt
@@ -1,0 +1,16 @@
+// Deliberate exports with no in-repo production consumer (see
+// shrink_package.md): test seams, round-trip/protocol surface, and
+// future-proof API kept on purpose. Each entry documents its reason.
+
+///|
+/// Exercise every agent tool once through the real registry — decode,
+/// dispatch, execute, and check each tool's happy path plus a
+/// representative failure — and return the per-case report. This is the
+/// offline tool smoke test: no model involved, so a failure localizes to
+/// the tool layer itself. The package's own test driver is the intended
+/// caller — this export IS the harness entry point.
+pub async fn run_harness() -> @report.Report {
+  @async.with_task_group() <| group => {
+    run_harness_with_runtime(AgentRuntime(), AgentTaskScope(group))
+  }
+}

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -1,16 +1,4 @@
 ///|
-/// Exercise every agent tool once through the real registry — decode,
-/// dispatch, execute, and check each tool's happy path plus a
-/// representative failure — and return the per-case report. This is the
-/// offline tool smoke test: no model involved, so a failure localizes to
-/// the tool layer itself.
-pub async fn run_harness() -> @report.Report {
-  @async.with_task_group() <| group => {
-    run_harness_with_runtime(AgentRuntime(), AgentTaskScope(group))
-  }
-}
-
-///|
 async fn run_harness_with_runtime(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[@report.Report],

--- a/shrink_package.md
+++ b/shrink_package.md
@@ -10,7 +10,18 @@ packages actually use. Repo-agnostic; drive it with `moon ide analyze`.
    `usage: N (M in test)`. Real usage = `N − M`. It also flags `pub(all)` /
    `pub(open)` that can narrow to `pub`. Script the sweep: run it over every
    package first and rank packages by zero-real-usage count — fix the worst
-   first.
+   first. Two count semantics to internalize:
+   - **Counts are cross-package only.** Same-package references never count,
+     so a symbol used ten times in its own package still shows `usage: 0`.
+     Those are the easiest wins: drop `pub` and nothing else moves (the
+     definition stays used, so no unused-symbol warning fires).
+   - **Blessed exports still list — filter on the annotation.** A symbol
+     kept in `exports.mbt` is NOT dropped from the output; it appears with
+     `, in exports.mbt` appended to its usage comment. A sweep script that
+     strips or ignores everything after `//` (this round's did) re-surfaces
+     every deliberately kept export as a zero-usage candidate and drowns the
+     ranking in already-classified keeps. Parse the annotation and subtract
+     those rows first.
 2. **Classify each zero-real symbol** — the deny-warn gate forces exactly
    three outcomes:
    - **Test-only usage (`N > 0, N == M`)** → first check HOW consumers import
@@ -40,8 +51,19 @@ packages actually use. Repo-agnostic; drive it with `moon ide analyze`.
   `moon.work`, a JS app module, a desktop shell) shows zero usage here while
   being load-bearing there. Union usage from every workspace that imports it
   before shrinking — and put the symbols such a consumer needs in
-  `exports.mbt` with a comment naming that consumer. `moon ide analyze`
-  respects the convention, so they stop showing up as shrink candidates.
+  `exports.mbt` with a comment naming that consumer. (The analyzer keeps
+  listing them, annotated `, in exports.mbt` — see step 1; filter on that
+  marker in the sweep script.)
+- **Target-only consumers are invisible too — including to the narrowability
+  flags.** A JS-only package errors out of `moon ide analyze` ("no package
+  directories found in input paths") AND its usages of everything else are
+  missing from the counts and from the `(all) or (open) can be removed`
+  hints. Real case: `ParsedLog` was flagged narrowable while the js-only viz
+  app constructs it with a struct literal — narrowing compiles clean under
+  native `moon check --deny-warn` (which never builds the js app) and breaks
+  the bundle build. Grep js/web consumers for every candidate, and verify
+  with `moon check --target js` (or the app's bundle build) after any
+  narrowing a js package might construct.
 - **Published modules**: if the module is on a registry, everything `pub` is
   potentially someone's dependency. Get the owner's explicit OK that
   in-repo usage is the yardstick (here: yes).

--- a/tui/internal/geometry/README.md
+++ b/tui/internal/geometry/README.md
@@ -21,8 +21,7 @@ Placing an area for a desired height against a terminal size:
 
 ```mbt
 let height = @geometry.clamp_height(size, height=4)          // into 1 ..= rows
-let max_top = @geometry.calculate_max_top(size, height)      // lowest fully-on-screen start
-let top = @geometry.clamp_top(size, height~, top=cursor_row) // into 1 ..= max_top
+let top = @geometry.clamp_top(size, height~, top=cursor_row) // into 1 ..= the lowest fully-on-screen start
 ```
 
 Internal to `tui/` — only importable within the module.

--- a/tui/internal/geometry/geometry.mbt
+++ b/tui/internal/geometry/geometry.mbt
@@ -79,10 +79,7 @@ pub fn clamp_height(size : @terminal_size.TerminalSize, height~ : Int) -> Int {
 /// - 1 = 24` sits exactly on the screen bottom. `height` is pre-clamped to
 /// `<= rows` by `clamp_height`, so the bound is always `>= 1` and the clamp
 /// range stays non-empty.
-pub fn calculate_max_top(
-  size : @terminal_size.TerminalSize,
-  height : Int,
-) -> Int {
+fn calculate_max_top(size : @terminal_size.TerminalSize, height : Int) -> Int {
   (size.rows() - height + 1).max(1)
 }
 
@@ -98,4 +95,13 @@ pub fn clamp_top(
   top~ : Int,
 ) -> Int {
   top.clamp(min=1, max=calculate_max_top(size, height))
+}
+
+///|
+test "calculate_max_top leaves room for height and floors at row 1" {
+  let size = @terminal_size.TerminalSize(rows=10, cols=80)
+  inspect(calculate_max_top(size, 4), content="7")
+  inspect(calculate_max_top(size, 10), content="1")
+  // Live area taller than the screen still starts at row 1.
+  inspect(calculate_max_top(size, 20), content="1")
 }

--- a/tui/internal/geometry/geometry_test.mbt
+++ b/tui/internal/geometry/geometry_test.mbt
@@ -7,15 +7,6 @@ test "@geometry.clamp_height clamps into 1..=rows" {
 }
 
 ///|
-test "@geometry.calculate_max_top leaves room for height and floors at row 1" {
-  let size = @terminal_size.TerminalSize(rows=10, cols=80)
-  inspect(@geometry.calculate_max_top(size, 4), content="7")
-  inspect(@geometry.calculate_max_top(size, 10), content="1")
-  // Live area taller than the screen still starts at row 1.
-  inspect(@geometry.calculate_max_top(size, 20), content="1")
-}
-
-///|
 test "@geometry.clamp_top clamps into 1..=@geometry.calculate_max_top" {
   let size = @terminal_size.TerminalSize(rows=10, cols=80)
   inspect(@geometry.clamp_top(size, height=4, top=0), content="1")

--- a/tui/internal/geometry/pkg.generated.mbti
+++ b/tui/internal/geometry/pkg.generated.mbti
@@ -6,8 +6,6 @@ import {
 }
 
 // Values
-pub fn calculate_max_top(@terminal_size.TerminalSize, Int) -> Int
-
 pub fn clamp_height(@terminal_size.TerminalSize, height~ : Int) -> Int
 
 pub fn clamp_top(@terminal_size.TerminalSize, height~ : Int, top~ : Int) -> Int

--- a/tui/internal/surface/exports.mbt
+++ b/tui/internal/surface/exports.mbt
@@ -1,0 +1,15 @@
+// Deliberate exports with no in-repo production consumer (see
+// shrink_package.md): test seams, round-trip/protocol surface, and
+// future-proof API kept on purpose. Each entry documents its reason.
+
+///|
+/// The line's text content with styling stripped. The render-assertion
+/// seam: test suites across tui (core, composer, render, history, doc) and
+/// the surface tests themselves read rendered lines back as plain text.
+pub fn Line::text(self : Line) -> String {
+  let builder = StringBuilder()
+  for span in self.spans {
+    builder <+ "\{span.text.text()}"
+  }
+  builder.to_string()
+}

--- a/tui/internal/surface/surface.mbt
+++ b/tui/internal/surface/surface.mbt
@@ -80,16 +80,6 @@ pub fn Line::spans(self : Line) -> Array[Span] {
 }
 
 ///|
-/// The line's text content with styling stripped.
-pub fn Line::text(self : Line) -> String {
-  let builder = StringBuilder()
-  for span in self.spans {
-    builder <+ "\{span.text.text()}"
-  }
-  builder.to_string()
-}
-
-///|
 /// Build a cursor at a 0-based (row, col) cell offset.
 pub fn Cursor::new(row~ : Int, col~ : Int) -> Cursor {
   { row, col }

--- a/tui/internal/text/pkg.generated.mbti
+++ b/tui/internal/text/pkg.generated.mbti
@@ -12,8 +12,6 @@ pub fn is_control_unit(StringView) -> Bool
 
 pub fn sanitize(String) -> String
 
-pub fn sanitize_lines(String) -> Array[@displaytext.DisplayText]
-
 pub fn sanitize_oneline(String) -> @displaytext.DisplayText
 
 pub fn unit_width(@displaytext.DisplayText, start~ : @displaytext.TextualPosition, end~ : @displaytext.TextualPosition) -> Int

--- a/tui/internal/text/text.mbt
+++ b/tui/internal/text/text.mbt
@@ -49,7 +49,7 @@ pub fn sanitize(text : String) -> String {
 /// applying the same policy as `sanitize` (drop C0 controls and `DEL`, expand
 /// tabs, keep `\n` as the line split). Callers that need segmented lines should
 /// use this directly instead of re-splitting `sanitize`'s joined output.
-pub fn sanitize_lines(text : String) -> Array[@displaytext.DisplayText] {
+fn sanitize_lines(text : String) -> Array[@displaytext.DisplayText] {
   @displaytext.split_lines(text).map(line => DisplayText(sanitize_line(line)))
 }
 


### PR DESCRIPTION
Second round of the `shrink_package.md` interface sweep, covering the packages added or grown since #522 (subagent stack, sandbox, review digest, goal baseline, plus a few pre-existing stragglers).

## What changed

**Demoted (pub with only in-package use → package-private):**
- `agent_explore`: `current_schema_version`, 8 `max_*`/deadline consts, `ExploreReport::parse`/`::validate`
- `agent_subrun`: `cancel_grace_ms`, `min_useful_subrun_steps`, `parse_report_line`
- `agent_review`: `digest_max_chars` / `digest_max_findings` / `digest_max_line_chars`
- `agent_session`: `GoalBaselinePrefix`
- `tui/internal/text`: `sanitize_lines`; `tui/internal/geometry`: `calculate_max_top` (its blackbox test moved inline)

**Narrowed `pub(all)` → `pub`** (no external construction anywhere, including tests): `ExploreReport`, `Citation`, `SubrunTerminal`, `SourceWriteProfileData`.

**Moved to `exports.mbt` (deliberate seams, documented):** `SubrunResult::prompt_tokens`/`::completion_tokens` (runner tests assert token accounting), `Line::text` (render-assertion seam for 6 tui test suites), both `hard_max_output_chars` caps (parents' tests assert the clamp), `run_harness` (its test driver is the entry point).

**Kept, with reasons:**
- `ParsedLog` stays `pub(all)`: the analyzer flagged it narrowable, but the **js-only** `cmd/viz_app` constructs it with a struct literal (`app.mbt:1812`) — js consumers are invisible to the analyzer, and native `moon check` never compiles them. False positive.
- `agent_session` `FromJson` impls: round-trip protocol surface on durable session records.
- `mcp/stdio|streamhttp` `Transport` impls: the trait object crosses into `jsonrpc`, conformance must stay public.

**Playbook (`shrink_package.md`) updates from this round:**
- usage counts are cross-package only (in-package refs never count);
- blessed exports still list, annotated `, in exports.mbt` — sweep scripts must filter on the marker;
- js-only packages are invisible on both sides (can't be analyzed; their usages missing from counts AND narrowability hints) — verify narrowings with `moon check --target js`.

Drive-by: removed a stray doc line on `SubrunResult::subrun_id` left from an earlier edit.

## Verification
- `moon check --deny-warn` clean (native), `moon check --target js` clean
- `moon test`: 1269/1269 pass
- `moon info` regenerated; the `.mbti` diff is the review artifact: −42 exported lines across 7 packages, seam moves interface-neutral
- Re-ran `moon ide analyze` on every touched package: remaining rows are unshrinkable field/variant lines and the documented keeps only

🤖 Generated with [Claude Code](https://claude.com/claude-code)