### PR TITLE
Wrap long single-line string literals into #| multi-line blocks

### DIFF
--- a/agent_explore/submit.mbt
+++ b/agent_explore/submit.mbt
@@ -8,7 +8,11 @@ fn submit_answer_tool(
 ) -> @agent_tool.AgentToolDefinition {
   @agent_subrun.capture_tool(
     name="submit_answer",
-    description="Submit the final explore report and end the run. Call this exactly once, when the question is answered. Every workspace claim needs a file (and line when known) citation; put what you could not determine in `unresolved`.",
+    description=(
+      #|Submit the final explore report and end the run. Call this exactly once, when the
+      #|question is answered. Every workspace claim needs a file (and line when known)
+      #|citation; put what you could not determine in `unresolved`.
+    ),
     schema=JsonSchema(report_schema()),
     parse=parse_submission,
     captured,

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -53,7 +53,18 @@ pub fn definition(
   @agent_tool.AgentToolDefinition(
     name="explore",
     concurrent_safe=true,
-    description="Delegate ONE self-contained question to a read-only scout subagent and get a bounded, cited answer. Use it when answering would mean reading MANY files or discovering MoonBit APIs you are not sure about — (a) workspace questions (\"where is X handled, how does Y flow\") where you want the conclusion, not the file dumps; (b) MoonBit stdlib/dependency API discovery (what a package offers, exact signatures) — prefer this over guessing APIs from memory. For a single direct lookup you can do in one step (one `moon ide doc` query, one file read), do it yourself instead. The scout cannot edit anything and returns file:line citations you can verify. Independent questions? Issue SEVERAL explore calls in the same step — they run concurrently.",
+    description=(
+      #|Delegate ONE self-contained question to a read-only scout subagent and get a
+      #|bounded, cited answer. Use it when answering would mean reading MANY files or
+      #|discovering MoonBit APIs you are not sure about — (a) workspace questions ("where
+      #|is X handled, how does Y flow") where you want the conclusion, not the file dumps;
+      #|(b) MoonBit stdlib/dependency API discovery (what a package offers, exact
+      #|signatures) — prefer this over guessing APIs from memory. For a single direct
+      #|lookup you can do in one step (one `moon ide doc` query, one file read), do it
+      #|yourself instead. The scout cannot edit anything and returns file:line citations
+      #|you can verify. Independent questions? Issue SEVERAL explore calls in the same
+      #|step — they run concurrently.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {

--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -15,7 +15,11 @@ fn submit_review_tool(
 ) -> @agent_tool.AgentToolDefinition {
   @agent_subrun.capture_tool(
     name="submit_review",
-    description="Submit the final structured code-review report and end the review. Call this exactly once, when the review is complete. Every finding must cite a file (and a line when known) and a severity of blocker|high|medium|low|nit.",
+    description=(
+      #|Submit the final structured code-review report and end the review. Call this
+      #|exactly once, when the review is complete. Every finding must cite a file (and a
+      #|line when known) and a severity of blocker|high|medium|low|nit.
+    ),
     schema=JsonSchema(report_schema()),
     parse=parse_submission,
     captured,

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -47,7 +47,29 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
-    description="Replace the first exact text span at or after arguments.start_line in arguments.path with arguments.new_string. Optional end_line restricts the search to a 1-based inclusive line range. Because start_line anchors the location, old_string can be a small exact span instead of a large context block. To INSERT new code instead of replacing, set old_string to the empty string: new_string is inserted at the start of start_line. To APPEND at end of file, pass any start_line past the last line (e.g. 999999) — no need to know the file's length; the result reports the actual inclusive line range the new content landed on. In MoonBit top-level order does not matter, so add new functions, tests, or types by appending at end of file — an append cannot mismatch an anchor; reserve mid-file insertion for grouping related code. An edit that would introduce lex/parse errors into a syntax-checkable file (.mbt, .mbt.md, moon.mod, moon.pkg) is rejected BEFORE writing and the parse errors are returned — see revert_on_parse_errors. For multiple compiler-feedback fixes in one file, use multi_edit with explicit line-anchored edits. To change EVERY occurrence of a string, pass replace_all_preview=true: the file is not modified; instead every match site is listed with context plus a ready-to-review multi_edit edits array — keep the entries to apply, drop the rest. That preview-select-apply path is for text the compiler cannot see (comments, docs, .mbt.md prose, string literals); for typed-code renames prefer the compiler loop (add the new name, deprecate the old, fix what moon check flags).",
+    description=(
+      #|Replace the first exact text span at or after arguments.start_line in
+      #|arguments.path with arguments.new_string. Optional end_line restricts the search
+      #|to a 1-based inclusive line range. Because start_line anchors the location,
+      #|old_string can be a small exact span instead of a large context block. To INSERT
+      #|new code instead of replacing, set old_string to the empty string: new_string is
+      #|inserted at the start of start_line. To APPEND at end of file, pass any start_line
+      #|past the last line (e.g. 999999) — no need to know the file's length; the result
+      #|reports the actual inclusive line range the new content landed on. In MoonBit
+      #|top-level order does not matter, so add new functions, tests, or types by
+      #|appending at end of file — an append cannot mismatch an anchor; reserve mid-file
+      #|insertion for grouping related code. An edit that would introduce lex/parse errors
+      #|into a syntax-checkable file (.mbt, .mbt.md, moon.mod, moon.pkg) is rejected
+      #|BEFORE writing and the parse errors are returned — see revert_on_parse_errors. For
+      #|multiple compiler-feedback fixes in one file, use multi_edit with explicit
+      #|line-anchored edits. To change EVERY occurrence of a string, pass
+      #|replace_all_preview=true: the file is not modified; instead every match site is
+      #|listed with context plus a ready-to-review multi_edit edits array — keep the
+      #|entries to apply, drop the rest. That preview-select-apply path is for text the
+      #|compiler cannot see (comments, docs, .mbt.md prose, string literals); for
+      #|typed-code renames prefer the compiler loop (add the new name, deprecate the old,
+      #|fix what moon check flags).
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -58,12 +80,33 @@ pub fn definition(
         "end_line": { "type": "integer" },
         "revert_on_parse_errors": {
           "type": "boolean",
-          "description": "Syntax gate, on by default. Before the edit is written to a syntax-checkable file (.mbt, .mbt.md, moon.mod, moon.pkg), the edited result is parsed standalone (moonc syncheck); an edit that would INTRODUCE new lex/parse errors — measured against the pre-edit content parsed the same way, so pre-existing parse errors are ignored — is REJECTED, the file is left untouched, and the call returns the errors with excerpts of the would-be content. Type errors never trigger the gate (they may be a legitimate transient state); in .mbt.md only the checked (`mbt check` / `moonbit check`) fenced blocks are parsed. Set false only to intentionally produce content that does not parse (e.g. a fixture).",
+          "description": (
+            #|Syntax gate, on by default. Before the edit is written to a syntax-checkable
+            #|file (.mbt, .mbt.md, moon.mod, moon.pkg), the edited result is parsed
+            #|standalone (moonc syncheck); an edit that would INTRODUCE new lex/parse
+            #|errors — measured against the pre-edit content parsed the same way, so
+            #|pre-existing parse errors are ignored — is REJECTED, the file is left
+            #|untouched, and the call returns the errors with excerpts of the would-be
+            #|content. Type errors never trigger the gate (they may be a legitimate
+            #|transient state); in .mbt.md only the checked (`mbt check` / `moonbit
+            #|check`) fenced blocks are parsed. Set false only to intentionally produce
+            #|content that does not parse (e.g. a fixture).
+          ),
           "examples": [false],
         },
         "replace_all_preview": {
           "type": "boolean",
-          "description": "Preview mode: the file is NOT modified. Every match of old_string in the start_line/end_line range is listed with surrounding context lines, plus a ready-to-use multi_edit `edits` array — REVIEW the sites, keep the entries to apply, drop the rest, and pass them to multi_edit (which then verifies the batch with moon check). Use this where the compiler cannot see — comments, doc prose, .mbt.md text, string literals; for typed-code renames prefer the compiler loop (add the new name, deprecate the old, fix what moon check flags), and if the match list turns out to be code-heavy or type-ambiguous, switch to that loop instead of applying.",
+          "description": (
+            #|Preview mode: the file is NOT modified. Every match of old_string in the
+            #|start_line/end_line range is listed with surrounding context lines, plus a
+            #|ready-to-use multi_edit `edits` array — REVIEW the sites, keep the entries
+            #|to apply, drop the rest, and pass them to multi_edit (which then verifies
+            #|the batch with moon check). Use this where the compiler cannot see —
+            #|comments, doc prose, .mbt.md text, string literals; for typed-code renames
+            #|prefer the compiler loop (add the new name, deprecate the old, fix what moon
+            #|check flags), and if the match list turns out to be code-heavy or
+            #|type-ambiguous, switch to that loop instead of applying.
+          ),
           "examples": [true],
         },
       },

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -14,7 +14,31 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="multi_edit",
-    description="Apply many exact line-anchored replacements across one or more files in a single validated batch — the efficient path for compiler-feedback repair: when `moon check` (or another analyzer) reports several known locations, fix them all in one call instead of many separate `edit` calls. Supply the edits two ways and either or both are used (they are concatenated): `edits` is an inline array of edit objects; `edits_file` is the path to a JSON file holding an array of the same objects — for large batches, generate that file from compiler diagnostics with a script and pass its path. Each edit is {file, old_string, new_string, start_line, optional end_line}: `file` is the path to change; `start_line` (1-based) anchors the search and `end_line` bounds it, so old_string can be the small exact span instead of a large context block; each edit replaces the first matching span in its range. Make old_string uniquely identify the flagged code — include the receiver, e.g. `args.length()` — so a rename cannot stray onto a same-named call elsewhere on the line. List all edits for a given file contiguously. To INSERT instead of replace, set old_string to the empty string: new_string is inserted at the start of start_line (any start_line past the last line appends at end of file — e.g. 999999; in MoonBit top-level order does not matter, so append new functions and tests at end of file rather than inserting mid-file). Combine changes on the same line (or one tight span) into a single edit, because adjacent or overlapping edits collide and the whole batch is rejected. Every edit is validated against the original files before anything is written; a batch that would introduce lex/parse errors into a .mbt file is also rejected BEFORE writing (see revert_on_parse_errors); if any edit fails, no files are changed.",
+    description=(
+      #|Apply many exact line-anchored replacements across one or more files in a single
+      #|validated batch — the efficient path for compiler-feedback repair: when `moon
+      #|check` (or another analyzer) reports several known locations, fix them all in one
+      #|call instead of many separate `edit` calls. Supply the edits two ways and either
+      #|or both are used (they are concatenated): `edits` is an inline array of edit
+      #|objects; `edits_file` is the path to a JSON file holding an array of the same
+      #|objects — for large batches, generate that file from compiler diagnostics with a
+      #|script and pass its path. Each edit is {file, old_string, new_string, start_line,
+      #|optional end_line}: `file` is the path to change; `start_line` (1-based) anchors
+      #|the search and `end_line` bounds it, so old_string can be the small exact span
+      #|instead of a large context block; each edit replaces the first matching span in
+      #|its range. Make old_string uniquely identify the flagged code — include the
+      #|receiver, e.g. `args.length()` — so a rename cannot stray onto a same-named call
+      #|elsewhere on the line. List all edits for a given file contiguously. To INSERT
+      #|instead of replace, set old_string to the empty string: new_string is inserted at
+      #|the start of start_line (any start_line past the last line appends at end of file
+      #|— e.g. 999999; in MoonBit top-level order does not matter, so append new functions
+      #|and tests at end of file rather than inserting mid-file). Combine changes on the
+      #|same line (or one tight span) into a single edit, because adjacent or overlapping
+      #|edits collide and the whole batch is rejected. Every edit is validated against the
+      #|original files before anything is written; a batch that would introduce lex/parse
+      #|errors into a .mbt file is also rejected BEFORE writing (see
+      #|revert_on_parse_errors); if any edit fails, no files are changed.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -45,17 +69,42 @@ pub fn definition(
         },
         "edits_file": {
           "type": "string",
-          "description": "Path to a JSON file holding an array of the same edit objects — a response file for large, script-generated batches. Concatenated with inline edits when both are given.",
+          "description": (
+            #|Path to a JSON file holding an array of the same edit objects — a response
+            #|file for large, script-generated batches. Concatenated with inline edits
+            #|when both are given.
+          ),
           "examples": ["fixes.json"],
         },
         "revert_when_errors_above": {
           "type": "integer",
-          "description": "Auto-revert safety net. After the batch is written, `moon check` runs; if this batch INTRODUCES more than this many new compile errors (measured against the pre-batch error count, so pre-existing errors and all warnings are ignored), the entire batch is rolled back to its pre-batch contents and the call returns an error listing the first few new errors — so an over-matching replace cannot leave a broken tree to untangle. Default 5; the host caps the effective value (you can make it stricter, e.g. 0 to revert on any new error, but cannot disable it). A batch that keeps or reduces the error count is never reverted.",
+          "description": (
+            #|Auto-revert safety net. After the batch is written, `moon check` runs; if
+            #|this batch INTRODUCES more than this many new compile errors (measured
+            #|against the pre-batch error count, so pre-existing errors and all warnings
+            #|are ignored), the entire batch is rolled back to its pre-batch contents and
+            #|the call returns an error listing the first few new errors — so an
+            #|over-matching replace cannot leave a broken tree to untangle. Default 5; the
+            #|host caps the effective value (you can make it stricter, e.g. 0 to revert on
+            #|any new error, but cannot disable it). A batch that keeps or reduces the
+            #|error count is never reverted.
+          ),
           "examples": [5],
         },
         "revert_on_parse_errors": {
           "type": "boolean",
-          "description": "Syntax gate, on by default. Before the batch is written, each edited syntax-checkable file's (.mbt, .mbt.md, moon.mod, moon.pkg) rendered result is parsed standalone (moonc syncheck); if any file would gain new lex/parse errors — measured against its pre-batch content parsed the same way, so pre-existing parse errors are ignored — the WHOLE batch is rejected with no files changed, and the call returns the errors with excerpts of the would-be content. Type errors never trigger this gate (the post-write revert_when_errors_above guard covers those); in .mbt.md only the checked (`mbt check` / `moonbit check`) fenced blocks are parsed. Set false only to intentionally produce content that does not parse (e.g. a fixture).",
+          "description": (
+            #|Syntax gate, on by default. Before the batch is written, each edited
+            #|syntax-checkable file's (.mbt, .mbt.md, moon.mod, moon.pkg) rendered result
+            #|is parsed standalone (moonc syncheck); if any file would gain new lex/parse
+            #|errors — measured against its pre-batch content parsed the same way, so
+            #|pre-existing parse errors are ignored — the WHOLE batch is rejected with no
+            #|files changed, and the call returns the errors with excerpts of the would-be
+            #|content. Type errors never trigger this gate (the post-write
+            #|revert_when_errors_above guard covers those); in .mbt.md only the checked
+            #|(`mbt check` / `moonbit check`) fenced blocks are parsed. Set false only to
+            #|intentionally produce content that does not parse (e.g. a fixture).
+          ),
           "examples": [false],
         },
       },

--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -101,7 +101,7 @@ test "read tool advertises the expected schema" {
     content=(
       #|{
       #|  name: "read",
-      #|  description: "Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Output is right-aligned `<line-number> |<content>` numbered lines followed by a `<system>` status footer.",
+      #|  description: "Read arguments.path as text. For several known independent files, batch separate\nread tool calls in one assistant response when possible. Do not use read for\ndirectories: inspect them with `ls` or `tree`, then read specific files. Supports\noptional start_line, max_lines, and max_output_chars for focused single-file\nreads. Output is right-aligned `<line-number> |<content>` numbered lines followed\nby a `<system>` status footer.",
       #|  schema: JsonSchema(
       #|    Object(
       #|      {

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -38,7 +38,14 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="read",
-    description="Read arguments.path as text. For several known independent files, batch separate read tool calls in one assistant response when possible. Do not use read for directories: inspect them with `ls` or `tree`, then read specific files. Supports optional start_line, max_lines, and max_output_chars for focused single-file reads. Output is right-aligned `<line-number> |<content>` numbered lines followed by a `<system>` status footer.",
+    description=(
+      #|Read arguments.path as text. For several known independent files, batch separate
+      #|read tool calls in one assistant response when possible. Do not use read for
+      #|directories: inspect them with `ls` or `tree`, then read specific files. Supports
+      #|optional start_line, max_lines, and max_output_chars for focused single-file
+      #|reads. Output is right-aligned `<line-number> |<content>` numbered lines followed
+      #|by a `<system>` status footer.
+    ),
     schema=JsonSchema({
       "type": "object",
       "required": ["path"],
@@ -431,8 +438,11 @@ async test "read numbers lines with an aligned gutter and no header block" {
 ///|
 test "read description encourages batched reads and directory inspection" {
   let tool = definition()
-  assert_true(tool.description.contains("batch separate read tool calls"))
-  assert_true(tool.description.contains("Do not use read for directories"))
+  // The description is a wrapped `#|` block, so newlines fall mid-phrase;
+  // normalize them to spaces before matching the guidance phrases.
+  let desc = tool.description.replace_all(old="\n", new=" ")
+  assert_true(desc.contains("batch separate read tool calls"))
+  assert_true(desc.contains("Do not use read for directories"))
   let JsonSchema(schema) = tool.schema
   let schema_text = schema.stringify()
   assert_true(schema_text.contains("\"path\""))

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -43,14 +43,29 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="remove",
-    description="Delete a file the agent created earlier THIS session (tracked in the session's file-state record). Only a file the agent itself created this session can be removed — a pre-existing file is refused, since deleting it could lose work the agent never made; change existing source with edit/multi_edit. Handles any file type: the only in-workflow way to delete a source file (the shell sandbox blocks rm on source paths), and the provenance-gated path for other files too. Deleting a .mbt/.mbt.md file runs moon check so any break it causes is reported. Requires a `reason` — a short, non-empty explanation of why the file is deleted — recorded with the result for auditing this destructive action; a blank reason is rejected. The path must name an existing regular file.",
+    description=(
+      #|Delete a file the agent created earlier THIS session (tracked in the session's
+      #|file-state record). Only a file the agent itself created this session can be
+      #|removed — a pre-existing file is refused, since deleting it could lose work the
+      #|agent never made; change existing source with edit/multi_edit. Handles any file
+      #|type: the only in-workflow way to delete a source file (the shell sandbox blocks
+      #|rm on source paths), and the provenance-gated path for other files too. Deleting a
+      #|.mbt/.mbt.md file runs moon check so any break it causes is reported. Requires a
+      #|`reason` — a short, non-empty explanation of why the file is deleted — recorded
+      #|with the result for auditing this destructive action; a blank reason is rejected.
+      #|The path must name an existing regular file.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
         "path": { "type": "string" },
         "reason": {
           "type": "string",
-          "description": "A short, non-empty explanation of why this file is being deleted, recorded in the result so a destructive action can be audited later. A blank reason is rejected.",
+          "description": (
+            #|A short, non-empty explanation of why this file is being deleted, recorded
+            #|in the result so a destructive action can be audited later. A blank reason
+            #|is rejected.
+          ),
         },
       },
       "required": ["path", "reason"],
@@ -126,7 +141,11 @@ async fn remove_file(
     @agent_tool.content_digest(current_text),
   ) else {
     return err(
-      "the agent created this file this session but its content has changed since (rebound or externally modified) — refusing to remove what may no longer be the file it created",
+      (
+        #|the agent created this file this session but its content has changed since
+        #|(rebound or externally modified) — refusing to remove what may no longer be the
+        #|file it created
+      ),
     )
   }
   @fs.remove(path)

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -16,7 +16,15 @@ const OutputCapBytes : Int = 48_000
 /// ("Operation not permitted" on a protected source path). Without it the model
 /// reads a bare OS error and debugs the filesystem — or worse, tries to escape
 /// the sandbox — instead of using `edit`.
-const SandboxSourceWriteFeedback : String = "run_moonbit sandbox: the \"Operation not permitted\" failure above is this tool's sandbox denying a write to a protected MoonBit source file (`*.mbt`, `*.mbti`, `*.mbt.md`, `moon.mod`/`moon.pkg`/`moon.work`) — not a filesystem or permissions problem to debug. Snippets run source-write-readonly by design; writing non-source files (data, logs, reports) stays allowed. Do NOT try to work around the block from inside a snippet (renames, copies, temp-then-move, or other sandbox escapes) — make source changes with the line-anchored `edit` tool instead, and keep run_moonbit for compute, probing, and non-source IO."
+const SandboxSourceWriteFeedback : String =
+  #|run_moonbit sandbox: the "Operation not permitted" failure above is this tool's
+  #|sandbox denying a write to a protected MoonBit source file (`*.mbt`, `*.mbti`,
+  #|`*.mbt.md`, `moon.mod`/`moon.pkg`/`moon.work`) — not a filesystem or permissions
+  #|problem to debug. Snippets run source-write-readonly by design; writing non-source
+  #|files (data, logs, reports) stays allowed. Do NOT try to work around the block from
+  #|inside a snippet (renames, copies, temp-then-move, or other sandbox escapes) — make
+  #|source changes with the line-anchored `edit` tool instead, and keep run_moonbit for
+  #|compute, probing, and non-source IO.
 
 ///|
 /// Cached `--warn-list` spec for `warning: "off"` — derived once per process.
@@ -226,7 +234,29 @@ fn native_escape(source : String) -> String? {
 pub fn definition(workspace_root~ : String) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="run_moonbit",
-    description="Compile and run a self-contained MoonBit program (a `.mbtx` single-file script) and return its merged stdout/stderr and exit status. Use this for scripting automation (read/transform files, parse JSON, compute) and for probing MoonBit language behavior — PREFER it over shell python/node so the automation is MoonBit. `source` may begin with an inline `import { \"pkg\", ... }` block (comma-separated module paths such as `\"moonbitlang/async\", \"moonbitlang/async/fs\", \"moonbitlang/core/json\"`) followed by the program including its own `main`; use `async fn main` for IO (add `\"moonbitlang/async\"` to the import block for it). It runs with your workspace as the working directory by default, so RELATIVE paths like `@fs.read_file(\"data.json\")` reach workspace files and files the program writes land in the workspace; pass `cwd` to run elsewhere. Build artifacts stay in a temp dir (your `_build` is untouched), and imports resolve against the registry (NOT your uncommitted edits) — to exercise working-tree code, add a `*_test.mbt` to that package and run `moon test` via shell instead. Compiler warnings are suppressed by default (throwaway scripts trip unused-value noise constantly); pass `warning: \"on\"` when the warnings are what you want to see. Bounded to 60s. When probing language or API behavior, don't probe serially one turn at a time: emit SEVERAL independent run_moonbit calls in the SAME assistant turn — one small program per hypothesis — and read all the results together; batching saves a full model round-trip per hypothesis and keeps each probe minimal instead of one growing mega-program.",
+    description=(
+      #|Compile and run a self-contained MoonBit program (a `.mbtx` single-file script)
+      #|and return its merged stdout/stderr and exit status. Use this for scripting
+      #|automation (read/transform files, parse JSON, compute) and for probing MoonBit
+      #|language behavior — PREFER it over shell python/node so the automation is MoonBit.
+      #|`source` may begin with an inline `import { "pkg", ... }` block (comma-separated
+      #|module paths such as `"moonbitlang/async", "moonbitlang/async/fs",
+      #|"moonbitlang/core/json"`) followed by the program including its own `main`; use
+      #|`async fn main` for IO (add `"moonbitlang/async"` to the import block for it). It
+      #|runs with your workspace as the working directory by default, so RELATIVE paths
+      #|like `@fs.read_file("data.json")` reach workspace files and files the program
+      #|writes land in the workspace; pass `cwd` to run elsewhere. Build artifacts stay in
+      #|a temp dir (your `_build` is untouched), and imports resolve against the registry
+      #|(NOT your uncommitted edits) — to exercise working-tree code, add a `*_test.mbt`
+      #|to that package and run `moon test` via shell instead. Compiler warnings are
+      #|suppressed by default (throwaway scripts trip unused-value noise constantly); pass
+      #|`warning: "on"` when the warnings are what you want to see. Bounded to 60s. When
+      #|probing language or API behavior, don't probe serially one turn at a time: emit
+      #|SEVERAL independent run_moonbit calls in the SAME assistant turn — one small
+      #|program per hypothesis — and read all the results together; batching saves a full
+      #|model round-trip per hypothesis and keeps each probe minimal instead of one
+      #|growing mega-program.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -243,7 +273,11 @@ pub fn definition(workspace_root~ : String) -> @agent_tool.AgentToolDefinition {
         "warning": {
           "type": "string",
           "enum": ["off", "on"],
-          "description": "Whether compiler warnings appear in the output; defaults to off (a snippet is a throwaway script, so unused-variable style noise is suppressed). Set \"on\" only when the warnings themselves are what you are probing.",
+          "description": (
+            #|Whether compiler warnings appear in the output; defaults to off (a snippet
+            #|is a throwaway script, so unused-variable style noise is suppressed). Set
+            #|"on" only when the warnings themselves are what you are probing.
+          ),
         },
       },
       "required": ["source"],

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -134,7 +134,12 @@ test "the description encourages batched same-turn probing" {
   // The batching guidance lives in the tool description (and the default
   // prompt): several independent probes in ONE assistant turn, not serial
   // single-probe turns.
-  let description = @run_moonbit.definition(workspace_root=".").description
+  // The description is a wrapped `#|` block, so newlines fall mid-phrase;
+  // normalize them to spaces before matching the guidance phrases.
+  let description = @run_moonbit.definition(workspace_root=".").description.replace_all(
+    old="\n",
+    new=" ",
+  )
   assert_true(description.contains("SAME assistant turn"))
   assert_true(description.contains("one small program per hypothesis"))
 }

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -37,7 +37,11 @@ fn moon_cmd_error_message() -> String {
 
 ///|
 fn sed_in_place_error_message() -> String {
-  "error: `sed -i` edits files in place and is unreliable for code changes; use line-anchored `edit` (or `multi_edit` for several fixes in one file) for source changes"
+  (
+    #|error: `sed -i` edits files in place and is unreliable for code changes; use
+    #|line-anchored `edit` (or `multi_edit` for several fixes in one file) for source
+    #|changes
+  )
 }
 
 ///|

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -1,5 +1,13 @@
 ///|
-const SandboxSourceWriteFeedback : String = "shell sandbox: source file writes from shell are blocked. Editing source through the shell is not how this project works — it is discouraged, not a temporary obstacle to route around. Our practice is to make source changes with line-anchored `edit` (or `multi_edit` for several fixes in one file) so each change stays small and reviewable. For compiler-feedback or mechanical fixes, use `edit`, not shell-generated rewrites. Do NOT try to work around this block (redirects, `sed`/`awk`/scripts, `git apply`, or stage-then-checkout tricks) — apply the change with `edit`. Keep `shell` for read-only analysis and validation commands."
+const SandboxSourceWriteFeedback : String =
+  #|shell sandbox: source file writes from shell are blocked. Editing source through the
+  #|shell is not how this project works — it is discouraged, not a temporary obstacle to
+  #|route around. Our practice is to make source changes with line-anchored `edit` (or
+  #|`multi_edit` for several fixes in one file) so each change stays small and reviewable.
+  #|For compiler-feedback or mechanical fixes, use `edit`, not shell-generated rewrites.
+  #|Do NOT try to work around this block (redirects, `sed`/`awk`/scripts, `git apply`, or
+  #|stage-then-checkout tricks) — apply the change with `edit`. Keep `shell` for read-only
+  #|analysis and validation commands.
 
 ///|
 priv enum SourceWriteMode {

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -86,7 +86,11 @@ pub fn definition(
             "max_output_chars": { "type": "number" },
             "run_in_background": {
               "type": "boolean",
-              "description": "Run as a background job: returns a job id immediately and a completion notice arrives when it exits. Use for long-running commands instead of blocking or sleeping.",
+              "description": (
+                #|Run as a background job: returns a job id immediately and a completion
+                #|notice arrives when it exits. Use for long-running commands instead of
+                #|blocking or sleeping.
+              ),
             },
           },
           "required": ["cmd"],
@@ -127,19 +131,38 @@ pub fn definition(
 /// a notice, so `sleep N && cmd` chains and shell_output polling loops are both
 /// unnecessary and wasteful.
 fn background_description() -> String {
-  " For long-running work (builds, long test suites, servers, watchers) set run_in_background=true: the call returns a job id immediately and a notice arrives automatically when the job finishes — so never block the turn waiting on time (no `sleep N && cmd` chains, no repeated polling); keep working, or finish the turn, and act on the completion notice. Read a job's recent output with shell_output and cancel it with shell_stop. A foreground command that outlives timeout_ms (default 120000ms when omitted) is moved to the background as a job (not killed); pass a larger timeout_ms (up to 600000) only when you must block on the result."
+  (
+    #| For long-running work (builds, long test suites, servers, watchers) set
+    #|run_in_background=true: the call returns a job id immediately and a notice arrives
+    #|automatically when the job finishes — so never block the turn waiting on time (no
+    #|`sleep N && cmd` chains, no repeated polling); keep working, or finish the turn, and
+    #|act on the completion notice. Read a job's recent output with shell_output and
+    #|cancel it with shell_stop. A foreground command that outlives timeout_ms (default
+    #|120000ms when omitted) is moved to the background as a job (not killed); pass a
+    #|larger timeout_ms (up to 600000) only when you must block on the result.
+  )
 }
 
 ///|
 #cfg(platform="windows")
 fn shell_description() -> String {
-  "Run arguments.cmd through PowerShell (pwsh -NoProfile -Command), optionally in arguments.cwd, and return exit code plus output. Use PowerShell syntax and cmdlets in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit (or multi_edit for several fixes in one file); do not use shell rewrites."
+  (
+    #|Run arguments.cmd through PowerShell (pwsh -NoProfile -Command), optionally in
+    #|arguments.cwd, and return exit code plus output. Use PowerShell syntax and cmdlets
+    #|in arguments.cmd. Source file edits for compiler feedback belong in line-anchored
+    #|edit (or multi_edit for several fixes in one file); do not use shell rewrites.
+  )
 }
 
 ///|
 #cfg(not(platform="windows"))
 fn shell_description() -> String {
-  "Run arguments.cmd through the POSIX shell (sh -c), optionally in arguments.cwd, and return exit code plus output. Use POSIX shell syntax in arguments.cmd. Source file edits for compiler feedback belong in line-anchored edit (or multi_edit for several fixes in one file); do not use shell rewrites."
+  (
+    #|Run arguments.cmd through the POSIX shell (sh -c), optionally in arguments.cwd, and
+    #|return exit code plus output. Use POSIX shell syntax in arguments.cmd. Source file
+    #|edits for compiler feedback belong in line-anchored edit (or multi_edit for several
+    #|fixes in one file); do not use shell rewrites.
+  )
 }
 
 ///|

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -7,14 +7,26 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell_output",
-    description="Read a background shell job's recent output and status by its job_id (returned by shell run_in_background, or by a command moved to the background on timeout). Returns the most recent window of captured output (with truncation metadata naming the total size when output exceeds the window) and whether the job is still running. If you need the job's result before you can continue and have no other work to do, pass wait_ms to block until it finishes instead of checking repeatedly.",
+    description=(
+      #|Read a background shell job's recent output and status by its job_id (returned by
+      #|shell run_in_background, or by a command moved to the background on timeout).
+      #|Returns the most recent window of captured output (with truncation metadata naming
+      #|the total size when output exceeds the window) and whether the job is still
+      #|running. If you need the job's result before you can continue and have no other
+      #|work to do, pass wait_ms to block until it finishes instead of checking
+      #|repeatedly.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
         "job_id": { "type": "string" },
         "wait_ms": {
           "type": "number",
-          "description": "Wait up to this many milliseconds (capped at 120000) for the job to finish before reading. Use when you need the result now and have nothing else to do; never poll in a loop.",
+          "description": (
+            #|Wait up to this many milliseconds (capped at 120000) for the job to finish
+            #|before reading. Use when you need the result now and have nothing else to
+            #|do; never poll in a loop.
+          ),
         },
       },
       "required": ["job_id"],

--- a/agent_tool/shell_stop/shell_stop.mbt
+++ b/agent_tool/shell_stop/shell_stop.mbt
@@ -5,7 +5,11 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell_stop",
-    description="Stop a running background shell job by its job_id (from shell run_in_background, or a command moved to the background on timeout). Cancels the process; a job that already finished is a no-op.",
+    description=(
+      #|Stop a running background shell job by its job_id (from shell run_in_background,
+      #|or a command moved to the background on timeout). Cancels the process; a job that
+      #|already finished is a no-op.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": { "job_id": { "type": "string" } },

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -35,7 +35,16 @@ pub fn definition(
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="write",
-    description="Create a new file at arguments.path with arguments.content (missing parent directories are created), or overwrite an existing non-source file. Overwriting an existing .mbt/.mbt.md source file is rejected: use edit or multi_edit to change existing source (an empty old_string inserts new code). New syntax-checkable content (.mbt, .mbt.md, moon.mod, moon.pkg) that fails to lex/parse is rejected BEFORE writing and the parse errors are returned — see revert_on_parse_errors. Do not use write to route shell-generated rewrites back into source files. Do not create Markdown or README files unless the user explicitly asks for them.",
+    description=(
+      #|Create a new file at arguments.path with arguments.content (missing parent
+      #|directories are created), or overwrite an existing non-source file. Overwriting an
+      #|existing .mbt/.mbt.md source file is rejected: use edit or multi_edit to change
+      #|existing source (an empty old_string inserts new code). New syntax-checkable
+      #|content (.mbt, .mbt.md, moon.mod, moon.pkg) that fails to lex/parse is rejected
+      #|BEFORE writing and the parse errors are returned — see revert_on_parse_errors. Do
+      #|not use write to route shell-generated rewrites back into source files. Do not
+      #|create Markdown or README files unless the user explicitly asks for them.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
@@ -43,7 +52,19 @@ pub fn definition(
         "content": { "type": "string" },
         "revert_on_parse_errors": {
           "type": "boolean",
-          "description": "Syntax gate, on by default. Before a new syntax-checkable file (.mbt, .mbt.md, moon.mod, moon.pkg) is written, its content is parsed standalone (moonc syncheck); content with lex/parse errors is REJECTED — nothing is written — and the call returns the errors with excerpts of the offending lines. A file that does not parse is never a valid intermediate state, and write cannot overwrite existing source, so the retry is another write with corrected content. Type errors never trigger the gate (they may be a legitimate transient state during multi-file work); in .mbt.md only the checked (`mbt check` / `moonbit check`) fenced blocks are parsed. Set false only to intentionally create a file that does not parse (e.g. a test fixture).",
+          "description": (
+            #|Syntax gate, on by default. Before a new syntax-checkable file (.mbt,
+            #|.mbt.md, moon.mod, moon.pkg) is written, its content is parsed standalone
+            #|(moonc syncheck); content with lex/parse errors is REJECTED — nothing is
+            #|written — and the call returns the errors with excerpts of the offending
+            #|lines. A file that does not parse is never a valid intermediate state, and
+            #|write cannot overwrite existing source, so the retry is another write with
+            #|corrected content. Type errors never trigger the gate (they may be a
+            #|legitimate transient state during multi-file work); in .mbt.md only the
+            #|checked (`mbt check` / `moonbit check`) fenced blocks are parsed. Set false
+            #|only to intentionally create a file that does not parse (e.g. a test
+            #|fixture).
+          ),
           "examples": [false],
         },
       },

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -19,7 +19,16 @@ fn review_tool_definition(
   AgentToolDefinition(
     name="review",
     concurrent_safe=true,
-    description="Request an INDEPENDENT audit of the current worktree by a review subagent — use it before declaring substantial work or a standing goal complete, or when you want a skeptical second reading of what you built. The auditor reads files, runs the project's own checks, hunts for vacuous success (tests asserting nothing, hardcoded outputs, quietly narrowed criteria), and returns severity-tagged findings with file:line citations. It audits against the standing goal when one exists; pass `focus` to narrow the criteria (with no standing goal, `focus` IS the criteria). Costs a bounded subagent run from the shared per-turn budget.",
+    description=(
+      #|Request an INDEPENDENT audit of the current worktree by a review subagent — use it
+      #|before declaring substantial work or a standing goal complete, or when you want a
+      #|skeptical second reading of what you built. The auditor reads files, runs the
+      #|project's own checks, hunts for vacuous success (tests asserting nothing,
+      #|hardcoded outputs, quietly narrowed criteria), and returns severity-tagged
+      #|findings with file:line citations. It audits against the standing goal when one
+      #|exists; pass `focus` to narrow the criteria (with no standing goal, `focus` IS the
+      #|criteria). Costs a bounded subagent run from the shared per-turn budget.
+    ),
     schema=JsonSchema({
       "type": "object",
       "properties": {


### PR DESCRIPTION
## What

Wraps long single-line prose string literals (past ~90 columns) into raw `#|` multi-line blocks so source lines stay readable: tool/param `description=` fields, both `SandboxSourceWriteFeedback` constants, and the shell command-policy error message.

Breaking happens **only at spaces**, so string content is unchanged except that inter-word spaces at wrap points become newlines. Every physical source line is ≤ 90 chars.

## Left as-is (intentional)

- **Data literals** — SVG path data (`desktop/frontend/icons.mbt`), the eval report CSS blob, JSON/SSE test fixtures, byte strings, and the WSLENV passthrough spec. Wrapping would corrupt data or break exact-match test comparisons.
- **Aligned / exact runtime output** — clap `--help` text and tool-output error messages. Injecting newlines would break the `--help` column layout (cram snapshot) or exact-match output tests, so these stay single-line.

## Test impact

Wrapped tool descriptions now contain newlines mid-phrase, so:

- `read` and `run_moonbit` description tests normalize `\n` → space before their `.contains(...)` phrase assertions (intent preserved, just wrap-tolerant).
- The `read` schema snapshot (`agent_tool/read/README.mbt.md`) is regenerated to the wrapped form.

`moon check` → 0 warnings, 0 errors. `moon test` → **1292 / 1292 pass**. `moon cram test tests/cram` → **26 / 26**. Output is `moon fmt`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
