### PR TITLE
simplify: idiom sweep over the new subagent/edit/review packages

### DIFF
--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -252,14 +252,8 @@ fn render_report(report : ExploreReport) -> String {
   if report.citations.length() > 0 {
     out <+ "\n\nCitations:"
     for citation in report.citations {
-      let line = match citation.line {
-        Some(line) => ":\{line}"
-        None => ""
-      }
-      let note = match citation.note {
-        Some(note) => " — \{note}"
-        None => ""
-      }
+      let line = citation.line.map(line => ":\{line}").unwrap_or("")
+      let note = citation.note.map(note => " — \{note}").unwrap_or("")
       out <+ "\n- \{citation.file}\{line}\{note}"
     }
   }

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -129,17 +129,10 @@ pub fn ReviewReport::digest(self : ReviewReport) -> String {
     out <+ " (\{blockers} blocker, \{highs} high)"
   }
   out <+ " — \{@agent_tool.brief_line(self.summary, limit=160)}"
-  let shown = if self.findings.length() < digest_max_findings {
-    self.findings.length()
-  } else {
-    digest_max_findings
-  }
+  let shown = self.findings.length().min(digest_max_findings)
   for index in 0..<shown {
     let finding = self.findings[index]
-    let line = match finding.line {
-      Some(line) => ":\{line}"
-      None => ""
-    }
+    let line = finding.line.map(line => ":\{line}").unwrap_or("")
     let entry = @agent_tool.brief_line(
       "[\{finding.severity}] \{finding.file}\{line} — \{finding.title}",
       limit=digest_max_line_chars,

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -102,7 +102,7 @@ fn ChildObservations::observe(self : ChildObservations, line : String) -> Unit {
     return
   }
   match @protocol.parse(json) {
-    Some(AgentStep(step~)) => if step > self.steps { self.steps = step }
+    Some(AgentStep(step~)) => self.steps = self.steps.max(step)
     Some(Usage(usage~)) => {
       self.prompt_tokens += usage.prompt_tokens
       self.completion_tokens += usage.completion_tokens

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -528,12 +528,7 @@ fn render_site_context(
 
 ///|
 fn preview_pad(value : Int, width : Int) -> String {
-  let text = "\{value}"
-  let mut padded = text
-  while padded.length() < width {
-    padded = " " + padded
-  }
-  padded
+  "\{value}".pad_start(width, ' ')
 }
 
 ///|

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -564,10 +564,7 @@ async fn revert_guarded_response(
   // fires on errors this batch INTRODUCED, not on ones that were already there.
   let restore_failures = write_files(writes, write => write.original_content)
   let before = count_errors_or_none(check_path)
-  let before_count = match before {
-    Some(before) => before.error_count
-    None => 0
-  }
+  let before_count = before.map(b => b.error_count).unwrap_or(0)
   let introduced = after.error_count - before_count
   if introduced > threshold {
     // Real breakage. Stay reverted (the originals are already back on disk).

--- a/cmd/openseek/baseline.mbt
+++ b/cmd/openseek/baseline.mbt
@@ -35,7 +35,7 @@ async fn run_capture(
     _ => return None
   }
   match outcome {
-    Some((0, data)) => Some(data.text().to_string())
+    Some((0, data)) => Some(data.text())
     _ => None
   }
 }
@@ -55,11 +55,9 @@ async fn capture_goal_baseline(workspace_root : String) -> String {
   if sha.is_empty() {
     return GoalBaselineUnavailable
   }
-  let dirty = match
-    run_capture("git", ["status", "--porcelain"], workspace_root) {
-    Some(status) => !status.trim().is_empty()
-    None => true
-  }
+  let dirty = run_capture("git", ["status", "--porcelain"], workspace_root)
+    .map(status => !status.trim().is_empty())
+    .unwrap_or(true)
   @agent_session.goal_baseline_notice(sha~, dirty~)
 }
 

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -59,8 +59,7 @@ async fn execute_review(
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   let focus : String? = match arguments {
-    { "focus": String(focus), .. } if focus.trim() != "" =>
-      Some(focus.to_string())
+    { "focus": String(focus), .. } if focus.trim() != "" => Some(focus)
     _ => None
   }
   let (standing_goal, baseline) = context()
@@ -117,8 +116,7 @@ async fn execute_review(
     Some(report) =>
       @agent_tool.ToolAction::respond(
         report.digest(),
-        is_error=report.findings.filter(f => f.severity == "blocker").length() >
-          0,
+        is_error=report.findings.any(f => f.severity == "blocker"),
         brief="review \{result.subrun_id()} (\{report.findings.length()} finding(s), \{result.steps_used()} step(s))",
       )
     None =>

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -232,7 +232,7 @@ async fn dispatch_kind(
       }
       let baseline : @agent_session.GoalBaseline? = match input {
         { "sha": String(sha), "dirty": dirty, .. } =>
-          Some({ sha: sha.to_string(), dirty: dirty is True })
+          Some({ sha, dirty: dirty is True })
         _ => None
       }
       let api_key = @agentcli.api_key(matches, model)


### PR DESCRIPTION
A project-level simplification of the code added since the last sweep (subagent substrate, edit-preview, review/gate tooling) — found by three parallel read-only scan agents, curated down to genuine wins only.

**Imperative → declarative**
- `edit.mbt` `preview_pad` while-loop left-pad → `.pad_start(width, ' ')` (the blessed idiom; sibling `parse_gate.mbt` already does this)
- `audit.mbt` digest `shown` if/else → `.min(digest_max_findings)`
- `runner.mbt` running-max `if step > self.steps` → `.max(step)`
- `review_tool.mbt` `filter(...).length() > 0` → `.any(...)` (cold path)

**Option-combinator convention** (`match Some/None` → `.map().unwrap_or()`)
- digest/citation line+note rendering, baseline dirty-probe, multi_edit before-count

**Redundant coercion removal**
- dropped no-op `.to_string()` on values already `String` (Json `String(_)` bindings, `@io.Data::text`)

Behavior-preserving: **no `.mbti` drift**, `moon check --deny-warn` clean, touched-package tests 199/199, net **−25 lines** across 8 files. The scan agents also reported (and I preserved) the deliberate non-candidates: named prompt/task-builder seams, constant-space newline counters, required `.to_owned()` on lexscan views, and a `raise`-arm match that only *looks* like `unwrap_or_else`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)