### PR TITLE
deps: upgrade moonbitlang/x to 0.4.46

### DIFF
--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -268,11 +268,12 @@ fn is_moon_scaffold_subcommand(
 }
 
 ///|
-/// The `<PATH>` positional of a `moon new` invocation, resolved against the
-/// command's cwd. Grammar is `moon new [OPTIONS] <PATH>`: `--user`/`--name`/
-/// `--target-dir` take a value, the rest are boolean flags, and every token
-/// after `--` is positional. Returns the first positional as a normalized path,
-/// or None when none is present.
+/// The `<PATH>` positional of a `moon new` invocation. Absolute paths are
+/// normalized directly; relative paths are resolved against the command's cwd.
+/// Grammar is `moon new [OPTIONS] <PATH>`: `--user`/`--name`/`--target-dir`
+/// take a value, the rest are boolean flags, and every token after `--` is
+/// positional. Returns the first positional as a normalized path, or None when
+/// none is present.
 fn moon_new_target(
   argv : Array[String],
   new_index : Int,
@@ -296,7 +297,13 @@ fn moon_new_target(
       index += 1
       continue
     }
-    return Some(@path.Path(cwd).join(Path(arg)).normalize().to_string())
+    let target = @path.Path(arg)
+    let resolved_target = if target.is_absolute() {
+      target
+    } else {
+      @path.Path(cwd).join(target)
+    }
+    return Some(resolved_target.normalize().to_string())
   }
   None
 }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1481,6 +1481,14 @@ async test "moon new is a trusted scaffold only for a new or empty target" {
         root,
       ),
     )
+    // The same non-empty target expressed relative to the command cwd must be
+    // classified the same way.
+    assert_true(
+      parse_scaffolds_unsafe_target(
+        @shell_parse.parse_for_policy("moon new pkg"),
+        root,
+      ),
+    )
     // no target at all -> undeterminable -> treated as unsafe
     assert_true(
       parse_scaffolds_unsafe_target(

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -9,7 +9,7 @@ import {
   "moonbit-community/editor@0.1.0",
   "moonbit-community/fuzzy_match@0.2.5",
   "moonbit-community/rabbita@0.12.4",
-  "moonbitlang/x@0.4.45",
+  "moonbitlang/x@0.4.46",
   "moonbitlang/async@0.20.1",
   "justjavac/proton@0.1.10",
   "tonyfettes/platform@0.1.1",

--- a/moon.mod
+++ b/moon.mod
@@ -5,7 +5,7 @@ version = "0.2.2"
 import {
   "moonbit-community/tty@0.3.0",
   "moonbitlang/async@0.20.1",
-  "moonbitlang/x@0.4.45",
+  "moonbitlang/x@0.4.46",
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",

--- a/scripts/moon.mod
+++ b/scripts/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "moonbitlang/async@0.19.1",
-  "moonbitlang/x@0.4.45",
+  "moonbitlang/x@0.4.46",
   "moonbit-community/cmark@0.4.4",
 }
 


### PR DESCRIPTION
## Summary

- upgrade `moonbitlang/x` from 0.4.45 to 0.4.46 in the root, `scripts`, and `desktop` modules
- preserve absolute `moon new` targets instead of joining them to the command cwd
- resolve only relative targets against the command cwd
- cover both absolute and relative non-empty targets in the sandbox policy test

## Why

`moonbitlang/x@0.4.46` changes `Path::join` so an absolute right-hand path no longer replaces the left-hand path. `moon_new_target` relied on the old behavior, which could duplicate an absolute target path and classify an existing non-empty directory as safe.

Keeping the path-resolution fix and dependency upgrade in one PR makes the compatibility requirement explicit and lets the workspace move to 0.4.46 safely.

## Impact

The OpenSeek root, scripts, and desktop modules now resolve `moonbitlang/x@0.4.46`, while `moon new` sandbox checks remain correct for both absolute and relative targets.

## Validation

- `moon check --target native`
- `moon check --target js`
- `moon test agent_tool/shell/sandbox_wbtest.mbt --target native --filter 'moon new is a trusted scaffold only for a new or empty target'`
- root JS tests: 280 passed
- scripts native tests: 28 passed
- desktop native tests: 231 passed
- desktop JS tests: 218 passed
- `moon info` produced no interface changes
