### PR TITLE
fix(desktop): check CMake before packaging

### DIFF
--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -186,12 +186,13 @@ pub fn engine_package() -> String {
 }
 
 ///|
-/// The workspace-local Proton CLI (`cef setup`, codegen).
+/// The Proton CLI (`cef setup`, codegen) built from the checked-out Lepus
+/// submodule.
 const ProtonCliSource : String = "./lepus/cli"
 
 ///|
-/// Marker for the installed Proton CLI source, so stale registry-installed
-/// binaries are replaced after the workspace switches to the Lepus submodule.
+/// Marker for the installed Proton CLI source, so a registry-installed binary
+/// is replaced by the CLI from the checked-out Lepus submodule.
 const ProtonCliSourceMarker : String = "target/proton-tools/.proton_cli_source"
 
 ///|
@@ -349,6 +350,30 @@ pub async fn copy_tree(source : String, destination : String) -> Unit {
 /// Resolve a path to an absolute path using the host filesystem rules.
 pub fn absolute_path(path : String) -> String {
   (path : @path.Path).resolve().to_string()
+}
+
+///|
+const CmakeUnavailableMessage : String = "CMake is required to package OpenSeek Desktop, but `cmake --version` could not be run. Install CMake and ensure `cmake` is on PATH, then rerun the package command. On macOS with Homebrew, run `brew install cmake`."
+
+///|
+/// Verify CMake can be launched before a packager performs any build or
+/// download work that depends on it. `command` defaults to the executable on
+/// `PATH` and is injectable so tests can exercise the missing-command path.
+pub async fn ensure_cmake(ws : Workspace, command? : String = "cmake") -> Unit {
+  println("$ [\{ws.dir()}] \{command} --version")
+  let code = @process.run(
+    command,
+    ["--version"],
+    inherit_env=true,
+    cwd=ws.dir().view(),
+  ) catch {
+    _ => raise PackageError(CmakeUnavailableMessage)
+  }
+  if code != 0 {
+    raise PackageError(
+      "CMake was found, but `cmake --version` failed with exit code \{code}. Fix the CMake installation and rerun the package command.",
+    )
+  }
 }
 
 ///|
@@ -692,6 +717,19 @@ async test "client token needle matches the committed host source" {
   let ws = locate_workspace()
   let source = @asyncfs.read_file(ws.at(ClientTokenSource)).text()
   assert_true(source.contains(ClientTokenNeedle))
+}
+
+///|
+async test "missing CMake reports an actionable package error" {
+  let ws = locate_workspace()
+  try
+    ensure_cmake(ws, command="openseek-cmake-probe-command-that-does-not-exist")
+  catch {
+    error =>
+      assert_eq(error.to_string(), "package error: " + CmakeUnavailableMessage)
+  } noraise {
+    _ => fail("expected the missing CMake probe to fail")
+  }
 }
 
 ///|

--- a/desktop/package/internal/packaging/pkg.generated.mbti
+++ b/desktop/package/internal/packaging/pkg.generated.mbti
@@ -20,6 +20,8 @@ pub async fn copy_tree(String, String) -> Unit
 
 pub fn engine_package() -> String
 
+pub async fn ensure_cmake(Workspace, command? : String) -> Unit
+
 pub async fn ensure_dir(String) -> Unit
 
 pub async fn ensure_proton_cli(Workspace, String) -> Unit

--- a/desktop/package/linux/main.mbt
+++ b/desktop/package/linux/main.mbt
@@ -198,6 +198,7 @@ async fn build_appimage(ws : @packaging.Workspace, tool : String) -> Unit {
 ///|
 async fn main {
   let ws = @packaging.locate_workspace()
+  @packaging.ensure_cmake(ws)
   build_outputs(ws)
   println("built openseek engine: \{ws.engine_binary()}")
   reset_bundle_dirs(ws)

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -868,6 +868,7 @@ async fn main {
   // Parse first: a mistyped flag must fail before the build, not after it.
   let sign = parse_sign_config()
   let ws = @packaging.locate_workspace()
+  @packaging.ensure_cmake(ws)
   build_outputs(ws)
   println("built openseek engine: \{ws.engine_binary()}")
   reset_bundle_dirs(ws)

--- a/desktop/package/windows/main.mbt
+++ b/desktop/package/windows/main.mbt
@@ -281,6 +281,7 @@ async fn build_installer(ws : @packaging.Workspace) -> Unit {
 async fn main {
   ignore(package_command().parse())
   let ws = @packaging.locate_workspace()
+  @packaging.ensure_cmake(ws)
   ensure_makensis(ws)
   let with_wsl_engine = build_outputs(ws)
   println("built openseek engine: \{ws.engine_binary()}")


### PR DESCRIPTION
## Summary

- verify that `cmake --version` succeeds before desktop packaging starts build or download work
- report actionable CMake installation errors instead of a raw process `OSError`
- apply the CMake prerequisite check consistently to macOS, Linux, and Windows packagers
- continue installing `proton_cli` from the checked-out `./lepus/cli` source

## Why

Packaging environments without CMake previously failed late with an opaque `No such file or directory` error when the packager attempted to launch CMake. The new preflight check fails early and explains how to install or repair CMake.

The Lepus submodule intentionally remains an external prerequisite: `desktop/moon.work` references `./lepus/proton`, so Moon must resolve the checked-out submodule before the packaging executable can compile and run. CI and documented setup therefore continue to initialize it before invoking Moon.

## Validation

- `moon -C desktop test package/internal/packaging --target native` — 5 tests passed
- `moon -C desktop test` — 12 wasm-gc and 217 native tests passed
- `moon -C desktop info`
- `moon -C desktop fmt package/internal/packaging/packaging.mbt package/macos/main.mbt package/linux/main.mbt package/windows/main.mbt`
- `moon run ./desktop/package/macos` — generated and verified the app, DMG, and ZIP
- `git diff --check`