### PR TITLE
fix(desktop): allow inline composer completion

### DIFF
--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -1,8 +1,8 @@
-// The composer's completion menu: typing a leading `/` lists built-in
-// conversation commands, a leading `$` lists installed skills whose name is
-// dropped into the prompt. Both filter as the user types and are driven from
-// the model so the keyboard (↑/↓, Enter/Tab, Esc) and the popup view stay in
-// sync.
+// The composer's completion menu: a leading `/` lists built-in conversation
+// commands, while a trailing `$` or `#` token lists installed skills or
+// workspace symbols after ordinary prompt text. All three filter as the user
+// types and are driven from the model so the keyboard (↑/↓, Enter/Tab, Esc)
+// and the popup view stay in sync.
 
 ///|
 /// The built-in slash commands, in menu order. `command` is the id
@@ -22,13 +22,52 @@ fn slash_command_items() -> Array[CompletionItem] {
 }
 
 ///|
+/// The live completion token at the end of a draft. Slash commands keep their
+/// whole-draft semantics and therefore only parse at the beginning; `$` and
+/// `#` mentions parse after any whitespace so they can follow ordinary prompt
+/// text. `task_without_token` is the exact preceding text that accepting a
+/// mention preserves.
+priv struct CompletionTrigger {
+  kind : CompletionKind
+  query : String
+  task_without_token : String
+}
+
+///|
+fn CompletionTrigger::parse(text : String) -> CompletionTrigger? {
+  if text =~ (re"^/", after=query) && query =~ re"^[^[:space:]]*$" {
+    return Some({
+      kind: SlashCommands,
+      query: query.to_owned(),
+      task_without_token: "",
+    })
+  }
+  // The trailing anchor skips earlier `$`/`#` text. The separate boundary
+  // check rejects a marker embedded in a word without consuming the whitespace
+  // that accepting the completion must preserve.
+  guard text =~ (re"[$#][^[:space:]]*$" as token, before=task) &&
+    (task.is_empty() || task =~ re"[[:space:]]$") &&
+    token =~ (re"^[$#]" as trigger, after=query) else {
+    return None
+  }
+  Some({
+    kind: if trigger is '$' {
+      SkillMentions
+    } else {
+      Symbols
+    },
+    query: query.to_owned(),
+    task_without_token: task.to_owned(),
+  })
+}
+
+///|
 /// Build the composer completion menu for a draft, or `None` when the draft
-/// does not begin with a live trigger. The menu opens on a leading `/`
-/// (commands), `$` (installed skills), or `#` (workspace symbols) and stays
-/// open only while the token after the trigger holds no spaces — once the user
-/// types past the word, the command/mention/reference is complete and the menu
-/// closes. The highlight resets to the first row on every rebuild, since
-/// filtering reorders what is shown.
+/// has no live trigger. The menu opens on a leading `/` command or a trailing
+/// `$`/`#` token after any whitespace. Once the user types whitespace past the
+/// token, the mention/reference is complete and the menu closes. The highlight
+/// resets to the first row on every rebuild, since filtering reorders what is
+/// shown.
 ///
 /// Symbols differ from the other two: their rows are fetched asynchronously and
 /// arrive via `SymbolsLoaded`, so they come from `symbols` (cached against
@@ -40,53 +79,68 @@ fn compute_completion(
   symbols : SymbolCache,
   session : String,
 ) -> Completion? {
-  if text.has_prefix("/") {
-    let query = trigger_query(text)
-    guard query is Some(query) else { return None }
-    let items = slash_command_items().filter(item => {
-      completion_matches(query, [item.label])
-    })
-    if items.is_empty() {
-      None
-    } else {
-      Some({ kind: SlashCommands, items, selected: 0, loading: false })
-    }
-  } else if text.has_prefix("$") {
-    let query = trigger_query(text)
-    guard query is Some(query) else { return None }
-    let items : Array[CompletionItem] = []
-    for skill in installed {
-      if completion_matches(query, [skill.name, skill.description]) {
-        items.push({
-          label: "$" + skill.name,
-          detail: skill.description,
-          command: "",
-          insert: skill.name + " ",
-          path: None,
-          range: None,
+  guard CompletionTrigger::parse(text) is Some(trigger) else { return None }
+  match trigger.kind {
+    SlashCommands => {
+      let items = slash_command_items().filter(item => {
+        completion_matches(trigger.query, [item.label])
+      })
+      if items.is_empty() {
+        None
+      } else {
+        Some({
+          kind: SlashCommands,
+          items,
+          selected: 0,
+          loading: false,
+          task_without_token: trigger.task_without_token,
         })
       }
     }
-    if items.is_empty() {
-      None
-    } else {
-      Some({ kind: SkillMentions, items, selected: 0, loading: false })
+    SkillMentions => {
+      let items : Array[CompletionItem] = []
+      for skill in installed {
+        if completion_matches(trigger.query, [skill.name, skill.description]) {
+          items.push({
+            label: "$\{skill.name}",
+            detail: skill.description,
+            command: "",
+            insert: "\{skill.name} ",
+            path: None,
+            range: None,
+          })
+        }
+      }
+      if items.is_empty() {
+        None
+      } else {
+        Some({
+          kind: SkillMentions,
+          items,
+          selected: 0,
+          loading: false,
+          task_without_token: trigger.task_without_token,
+        })
+      }
     }
-  } else if text.has_prefix("#") {
-    let query = trigger_query(text)
-    guard query is Some(query) else { return None }
-    // A bare `#` lists everything — an empty query asks the server for all
-    // symbols — and narrows as the user types.
-    let items = symbols.items.filter(item => {
-      completion_matches(query, [item.label, item.detail])
-    })
-    // The cache answers this exact query for this conversation only when both
-    // match; otherwise a fetch is in flight (or about to be) and the menu shows
-    // whatever the cache narrows to meanwhile, marked loading.
-    let loading = symbols.session != session || symbols.query != query
-    Some({ kind: Symbols, items, selected: 0, loading })
-  } else {
-    None
+    Symbols => {
+      // A bare `#` lists everything — an empty query asks the server for all
+      // symbols — and narrows as the user types.
+      let items = symbols.items.filter(item => {
+        completion_matches(trigger.query, [item.label, item.detail])
+      })
+      // The cache answers this exact query for this conversation only when both
+      // match; otherwise a fetch is in flight (or about to be) and the menu
+      // shows whatever the cache narrows to meanwhile, marked loading.
+      let loading = symbols.session != session || symbols.query != trigger.query
+      Some({
+        kind: Symbols,
+        items,
+        selected: 0,
+        loading,
+        task_without_token: trigger.task_without_token,
+      })
+    }
   }
 }
 
@@ -114,20 +168,6 @@ fn push_mention(mentions : Array[Mention], mention : Mention) -> Array[Mention] 
 /// With no chips this is just the text.
 fn compose_prompt(mentions : Array[Mention], task : String) -> String {
   @mention_context.encode(mentions.map(mention => mention.ref_), task)
-}
-
-///|
-/// The text after a single-character trigger, or `None` once it contains a
-/// space — the marker the user has finished the command/mention word and the
-/// menu should close. The trigger is ASCII (`/` or `$`), so slicing one code
-/// unit off the front is safe.
-fn trigger_query(text : String) -> String? {
-  let rest = text[1:].to_owned()
-  if rest.contains(" ") {
-    None
-  } else {
-    Some(rest)
-  }
 }
 
 ///|
@@ -247,6 +287,34 @@ test "dollar trigger lists installed skills, name or description matching" {
 }
 
 ///|
+test "skill completion follows prompt text and preserves that text" {
+  let skills = [installed_skill("review-pr", "Review a pull request")]
+  guard menu_for("Please use $rev", skills) is Some(menu) else {
+    fail("a skill token after prompt text should open the menu")
+  }
+  assert_true(menu.kind is SkillMentions)
+  assert_eq(menu.items[0].label, "$review-pr")
+  assert_eq(menu.task_without_token, "Please use ")
+  // Newlines are valid token boundaries too.
+  guard menu_for("First line\n$rev", skills) is Some(after_newline) else {
+    fail("a skill token after a newline should open the menu")
+  }
+  assert_eq(after_newline.task_without_token, "First line\n")
+}
+
+///|
+test "inline completion requires a trailing whitespace-delimited token" {
+  let skills = [installed_skill("review-pr", "Review a pull request")]
+  // A trigger embedded in a word is ordinary prompt text.
+  assert_true(menu_for("price$rev", skills) is None)
+  // Once more text follows the token, it is no longer the live trailing token.
+  assert_true(menu_for("Use $rev for this", skills) is None)
+  // Slash commands retain whole-draft semantics: accepting one never discards
+  // prompt text that happened to precede it.
+  assert_true(menu_for("Please /comp", skills) is None)
+}
+
+///|
 test "plain text opens no completion menu" {
   assert_true(menu_for("hello world", []) is None)
   assert_true(menu_for("", []) is None)
@@ -282,6 +350,18 @@ test "hash trigger lists cached symbols, filtered, marked not loading on match" 
   assert_eq(menu.items[0].label, "parse_hover")
   // Accepting drops a backticked reference plus location into the composer.
   assert_eq(menu.items[0].insert, "`parse_hover` — src/main.mbt:1 ")
+}
+
+///|
+test "symbol completion follows prompt text and preserves that text" {
+  let cache = symbol_cache("s1", "parse", ["parse_hover"])
+  guard compute_completion("Inspect #parse", [], cache, "s1") is Some(menu) else {
+    fail("a symbol token after prompt text should open the menu")
+  }
+  assert_true(menu.kind is Symbols)
+  assert_false(menu.loading)
+  assert_eq(menu.items[0].label, "parse_hover")
+  assert_eq(menu.task_without_token, "Inspect ")
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -268,15 +268,17 @@ priv struct Mention {
 
 ///|
 /// The composer's open completion menu: the trigger that opened it, the
-/// currently matching rows, and which row is highlighted. Absent when the
-/// composer text does not begin with a live trigger. `loading` is set only for
-/// a `#` menu whose results for the current query have not arrived yet, so the
-/// empty menu can say "Searching…" rather than "No symbols".
+/// currently matching rows, which row is highlighted, and the exact draft text
+/// before the live token. Absent when the composer has no live trigger.
+/// `loading` is set only for a `#` menu whose results for the current query have
+/// not arrived yet, so the empty menu can say "Searching…" rather than
+/// "No symbols".
 priv struct Completion {
   kind : CompletionKind
   items : Array[CompletionItem]
   selected : Int
   loading : Bool
+  task_without_token : String
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -41,7 +41,7 @@ fn is_idle_event(event : @transcript.EngineEvent) -> Bool {
 /// Apply an accepted completion row: a slash command runs its action, while a
 /// skill mention or symbol reference becomes a chip in the composer's mention
 /// tray (its expansion is spliced into the prompt on send). Either way the menu
-/// closes and the typed trigger token is cleared from the textarea.
+/// closes and only the typed trigger token is removed from the textarea.
 fn accept_completion(
   dispatch : @cmd.Emit[Msg],
   model : Model,
@@ -58,6 +58,7 @@ fn accept_completion(
         model,
         Skill(name=item.insert.trim().to_owned()),
         range=None,
+        task=menu.task_without_token,
       )
     Symbols => {
       let (file, line) = if item.path is Some(path) && item.range is Some(range) {
@@ -69,6 +70,7 @@ fn accept_completion(
         model,
         Symbol(name=item.label, file~, line~),
         range=item.range,
+        task=menu.task_without_token,
       )
     }
   }
@@ -76,18 +78,20 @@ fn accept_completion(
 
 ///|
 /// Attach a mention chip to the active conversation's draft (deduplicated),
-/// clear the typed trigger token, and close the menu.
+/// remove the typed trigger token while preserving preceding prompt text, and
+/// close the menu.
 fn accept_mention(
   model : Model,
   ref_ : @mention_context.MentionRef,
   range~ : @common.Range?,
+  task~ : String,
 ) -> (@cmd.Cmd, Model) {
   let conv = model.active()
   let mentions = push_mention(conv.mentions, { ref_, range })
   (
     @cmd.none,
     {
-      ..model.replace_conversation({ ..conv, task: "", mentions }),
+      ..model.replace_conversation({ ..conv, task, mentions }),
       completion: None,
     },
   )
@@ -177,18 +181,20 @@ fn open_editor_at(
 
 ///|
 /// The command, if any, to fetch workspace symbols for a changed draft. Fires
-/// only when the draft is a live `#` query (a non-empty token, no spaces) whose
-/// results are not already cached for this conversation — so a fresh keystroke
-/// refetches but a repeat of the same query does not.
+/// only when the draft ends in a live `#` query whose results are not already
+/// cached for this conversation — so a fresh keystroke refetches but a repeat
+/// of the same query does not.
 fn symbol_fetch_cmd(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   value : String,
   session : String,
 ) -> @cmd.Cmd {
-  guard value.has_prefix("#") && trigger_query(value) is Some(query) else {
+  guard CompletionTrigger::parse(value) is Some(trigger) &&
+    trigger.kind is Symbols else {
     return @cmd.none
   }
+  let query = trigger.query
   if model.symbol_cache.session == session && model.symbol_cache.query == query {
     return @cmd.none
   }
@@ -213,9 +219,9 @@ fn apply_symbol_reply(
 ) -> (@cmd.Cmd, Model) {
   let draft = model.active().task
   guard session == model.active().session_id &&
-    draft.has_prefix("#") &&
-    trigger_query(draft) is Some(live) &&
-    live == query else {
+    CompletionTrigger::parse(draft) is Some(trigger) &&
+    trigger.kind is Symbols &&
+    trigger.query == query else {
     return (@cmd.none, model)
   }
   let cache : SymbolCache = { session, query, items }
@@ -2208,6 +2214,66 @@ test "the composer draft stays with its conversation across a switch" {
   let (_, back) = update(dispatch, OpenSession("desktop-test"), switched)
   // … and the original draft is still waiting where it was typed.
   inspect(back.active().task, content="half a thought")
+}
+
+///|
+test "update is pure: accepting an inline skill preserves prompt text" {
+  let dispatch = test_dispatch()
+  let model = {
+    ..test_model(),
+    installed_skills: [installed_skill("review-pr", "Review a pull request")],
+  }
+  let (_, drafted) = update(dispatch, TaskChanged("Please use $rev"), model)
+  guard drafted.completion is Some(menu) else {
+    fail("the inline skill token should open completion")
+  }
+  assert_eq(menu.task_without_token, "Please use ")
+  let (_, once) = update(dispatch, CompletionAccept, drafted)
+  let (_, twice) = update(dispatch, CompletionAccept, drafted)
+  // The same message and model always produce the same plain-data state.
+  assert_eq(once.active().task, "Please use ")
+  assert_eq(twice.active().task, "Please use ")
+  assert_eq(once.active().mentions.length(), 1)
+  assert_eq(twice.active().mentions.length(), 1)
+  assert_true(
+    once.active().mentions[0].ref_ is Skill(name="review-pr") &&
+    twice.active().mentions[0].ref_ is Skill(name="review-pr"),
+  )
+  assert_true(once.completion is None && twice.completion is None)
+}
+
+///|
+test "an inline symbol reply rebuilds the live completion menu" {
+  let dispatch = test_dispatch()
+  let (_, searching) = update(
+    dispatch,
+    TaskChanged("Inspect #parse"),
+    test_model(),
+  )
+  guard searching.completion is Some(pending) else {
+    fail("the inline symbol token should open completion")
+  }
+  assert_true(pending.kind is Symbols)
+  assert_true(pending.loading)
+  assert_eq(pending.task_without_token, "Inspect ")
+  let item = symbol_item(
+    "parse_hover",
+    container=None,
+    path="src/main.mbt",
+    range=@common.Range::Range(4, 2, 4, 13),
+  )
+  let (_, loaded) = update(
+    dispatch,
+    SymbolsLoaded(session="desktop-test", query="parse", items=[item]),
+    searching,
+  )
+  guard loaded.completion is Some(menu) else {
+    fail("the matching inline symbol reply should rebuild completion")
+  }
+  assert_false(menu.loading)
+  assert_eq(menu.items.length(), 1)
+  assert_eq(menu.items[0].label, "parse_hover")
+  assert_eq(menu.task_without_token, "Inspect ")
 }
 
 ///|


### PR DESCRIPTION
TL;DR: allow `#` and `$` to trigger symbol completion in a half-way drafted composition.

<img width="1232" height="904" alt="image" src="https://github.com/user-attachments/assets/61b4ad5c-dd54-4aea-bb7c-6fed76125b94" />

<img width="1232" height="904" alt="image" src="https://github.com/user-attachments/assets/aadb5c8c-a38e-44b2-8591-a5d289a4c21a" />


## Summary

- allow trailing, whitespace-delimited `$` skill and `#` symbol completion tokens after ordinary prompt text
- preserve the draft text before the trigger token when a completion is accepted
- use the same token parser for asynchronous symbol requests and replies while keeping slash commands whole-draft-only

## Root cause

Desktop completion only recognized a trigger when the entire draft began with `/`, `$`, or `#`. Accepting a skill or symbol also cleared the entire composer draft, so simply broadening the trigger check would have discarded the text before an inline token.

## User impact

Users can now type prompts such as `Please use $review-pr` or `Inspect #parse_hover`, accept the completion, and keep the preceding prompt text intact.

## Validation

- `moon -C desktop fmt --check frontend/completion.mbt frontend/model.mbt frontend/update.mbt`
- `moon -C desktop info`
- `moon -C desktop check --target js`
- `moon -C desktop test --target js` (226/226 passed)
- `moon -C desktop check --target native`
- `git diff origin/main...HEAD --check`