### PR TITLE
fix(desktop): sort installed_skills like the engine's discovery

### DIFF
--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -246,6 +246,9 @@ pub async fn installed_skills(
       skills.push({ id: entry, name, description, source })
     }
   }
+  // Sort like the engine's discovery does: readdir order is platform-defined,
+  // and the marketplace listing should be stable across runs and platforms.
+  skills.sort_by((a, b) => a.name.compare(b.name))
   skills
 }
 

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -260,6 +260,30 @@ async test "a skill whose SKILL.md is missing reports it plainly" {
 }
 
 ///|
+/// Regression test: the listing used to surface raw readdir order, which is
+/// platform-defined (insertion order on some filesystems, name hash on
+/// others) — the suite passed on macOS and failed on Linux ext4. The listing
+/// must be name-sorted like the engine's own discovery.
+async test "listing is name-sorted regardless of creation order" {
+  let lib = @fs.tmpdir(prefix="skillmarket-")
+  for name in ["ddd", "aaa", "eee", "ccc"] {
+    @fs.mkdir("\{lib}/\{name}", recursive=true)
+    @fs.write_file(
+      "\{lib}/\{name}/SKILL.md",
+      "---\nname: \{name}\ndescription: d\n---\nbody",
+      create_mode=CreateOrTruncate,
+    )
+  }
+  @fs.write_file(
+    "\{lib}/bbb.md",
+    "---\nname: bbb\ndescription: d\n---\nbody",
+    create_mode=CreateOrTruncate,
+  )
+  let ids = @skillmarket.installed_skills(library_dir=lib).map(skill => skill.id)
+  assert_eq(ids, ["aaa", "bbb", "ccc", "ddd", "eee"])
+}
+
+///|
 async test "listing mirrors the engine's discovery for hand-written skills" {
   let lib = @fs.tmpdir(prefix="skillmarket-")
   @fs.write_file(


### PR DESCRIPTION
TL;DR: sort skills to make CI deterministic.

## Summary
- `installed_skills` documents itself as mirroring the engine's discovery rules, but returned entries in raw `readdir` order, which is platform-defined: the listing test passed on macOS (APFS name-hash order happened to match the expected sequence) and fails on Linux ext4. Found while running the desktop tests on Ubuntu for the first time in #569.
- Sort by name with the same comparator the engine's `discover_skills` uses, keeping the marketplace listing stable across runs and platforms.
- Add a regression test that creates entries in scrambled order and pins the full name-sorted sequence — verified to fail without the sort on APFS as well (`["ddd", "eee", "ccc", "aaa", "bbb"]`), so it bites even on the macOS-only desktop test job.

## Test plan
- `moon -C desktop test --target native -p openseek_desktop/internal/skillmarket` — 17/17 pass; with the sort removed, the new test fails as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)