### PR TITLE
fix(editor): align hover replacement and isolate bundle builds

### DIFF
--- a/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
@@ -34,6 +34,17 @@ pub(all) struct RenderedContentHover {
 }
 
 ///|
+/// Monaco's `RenderedContentHoverParts` prepares a detached
+/// `DocumentFragment` and the lifetimes owned by those rows before
+/// `ContentHoverWidget._setRenderedHover` releases the previous render.
+/// Keep that browser-only preparation private instead of widening the
+/// data-only `RenderedContentHover` boundary.
+priv struct PreparedHoverContent {
+  fragment : @rdom.DocumentFragment
+  disposables : Array[@base_common.Disposable]
+}
+
+///|
 /// Per-render lifetime drain. Replacement, hide, and retained-widget teardown
 /// all converge here so no shared Markdown listener survives the DOM it owns.
 fn dispose_hover_render_disposables(
@@ -95,7 +106,7 @@ pub struct ContentHoverWidget {
   host : ContentHoverWidgetHost
   mut rendered_hover : RenderedContentHover?
   mut position_preference : @view.ContentWidgetPositionPreference?
-  priv render_disposables : Array[@base_common.Disposable]
+  priv mut render_disposables : Array[@base_common.Disposable]
 }
 
 ///|
@@ -249,47 +260,66 @@ pub fn ContentHoverWidget::is_visible(self : ContentHoverWidget) -> Bool {
 }
 
 ///|
-/// Monaco `_setRenderedHover` (`contentHoverWidget.ts:278-283`): swap the
-/// rendered state and toggle the container's `hidden` class.
+/// Monaco `_setRenderedHover` (`contentHoverWidget.ts:278-283`): release the
+/// previous rendered hover, adopt the prepared render lifetime, swap the
+/// rendered state, and toggle the container's `hidden` class.
 fn ContentHoverWidget::set_rendered_hover(
   self : ContentHoverWidget,
   rendered_hover : RenderedContentHover?,
+  render_disposables : Array[@base_common.Disposable],
 ) -> Unit {
+  dispose_hover_render_disposables(self.render_disposables)
+  self.render_disposables = render_disposables
   self.rendered_hover = rendered_hover
   let hidden = if rendered_hover is Some(_) { "" } else { " hidden" }
   self.hover.set_attribute("class", "monaco-hover fade-in" + hidden)
 }
 
 ///|
-/// Monaco `_updateContent` (`contentHoverWidget.ts:295-300`) +
-/// `RenderedContentHoverParts._registerListenersOnRenderedParts`' `tabIndex = 0`
-/// per rendered part row. Rows are rebuilt as retained DOM. Markdown contents
-/// render through the shared browser renderer into their caller-created
-/// `.hover-contents` target; no hover-private HTML insertion path remains.
-fn ContentHoverWidget::update_content(
-  self : ContentHoverWidget,
+/// Monaco `RenderedContentHoverParts` (`contentHoverRendered.ts:221-253`):
+/// render every row and register its lifetime in a detached fragment before
+/// touching the currently displayed hover. Each row receives the source's
+/// `_registerListenersOnRenderedParts` `tabIndex = 0`.
+fn prepare_hover_content(
   parts : Array[@hover.HoverPart],
   language_id : String,
-) -> Unit {
-  dispose_hover_render_disposables(self.render_disposables)
-  for child in self.scrollable.content.get_children() {
-    self.scrollable.content.remove_child(child.as_node())
-  }
+) -> PreparedHoverContent {
+  let fragment = @rdom.document().create_document_fragment()
+  let disposables : Array[@base_common.Disposable] = []
   for part in parts {
     let row = match part {
       MarkdownHover(contents~, ..) =>
-        render_markdown_hover_row(
-          self.render_disposables,
-          contents,
-          language_id,
-        )
+        render_markdown_hover_row(disposables, contents, language_id)
       MarkerHover(marker~, ..) => marker_hover_row(marker.message)
       LoadingHover(message~, ..) => standard_hover_row(message)
     }
     row.set_attribute("tabindex", "0")
-    self.scrollable.content.append_child(row.as_node())
+    fragment.append_child(row.as_node())
   }
+  { fragment, disposables }
 }
+
+///|
+/// Monaco `_updateContent` (`contentHoverWidget.ts:295-300`): reset the resize
+/// padding, clear all child nodes via `textContent`, then transfer the prepared
+/// fragment in one append.
+fn ContentHoverWidget::update_content(
+  self : ContentHoverWidget,
+  fragment : @rdom.DocumentFragment,
+) -> Unit {
+  replace_hover_contents(self.scrollable.content, fragment)
+}
+
+///|
+extern "js" fn replace_hover_contents(
+  contents : @rdom.Element,
+  fragment : @rdom.DocumentFragment,
+) -> Unit =
+  #| (contents, fragment) => {
+  #|   contents.style.paddingBottom = '';
+  #|   contents.textContent = '';
+  #|   contents.appendChild(fragment);
+  #| }
 
 ///|
 /// One Markdown participant part is one row with one `.markdown-hover` child
@@ -406,8 +436,12 @@ fn ContentHoverWidget::render_rendered_hover(
   self : ContentHoverWidget,
   rendered_hover : RenderedContentHover,
 ) -> Unit {
-  self.set_rendered_hover(Some(rendered_hover))
-  self.update_content(rendered_hover.parts, rendered_hover.language_id)
+  let prepared = prepare_hover_content(
+    rendered_hover.parts,
+    rendered_hover.language_id,
+  )
+  self.set_rendered_hover(Some(rendered_hover), prepared.disposables)
+  self.update_content(prepared.fragment)
   self.handle_contents_changed()
   // Simply force a synchronous render on the editor
   // such that the widget does not really render with left = '0px'
@@ -442,12 +476,11 @@ pub fn ContentHoverWidget::show(
 /// `get_position()` is now `None`, so the content-widget layer hides the
 /// node), and give focus back to the editor when the hover had stolen it.
 pub fn ContentHoverWidget::hide(self : ContentHoverWidget) -> Unit {
-  dispose_hover_render_disposables(self.render_disposables)
   guard self.rendered_hover is Some(_) else { return }
   let hover_stole_focus = @base_browser.element_contains_active_element(
     self.wrapper,
   )
-  self.set_rendered_hover(None)
+  self.set_rendered_hover(None, [])
   (self.host.layout_content_widget)()
   if hover_stole_focus {
     (self.host.focus_editor)()

--- a/editor/internal/viewer/contrib/hover/browser/content_hover_widget_wbtest.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/content_hover_widget_wbtest.mbt
@@ -84,7 +84,7 @@ test "hover render lifetimes dispose on replacement hide and teardown" {
     @base_common.Disposable::from(() => second_count.val = second_count.val + 1),
   )
 
-  // `update_content` begins a replacement with the same clear operation.
+  // `_setRenderedHover` begins a replacement with the same clear operation.
   dispose_hover_render_disposables(lifetimes)
   assert_eq(first_count.val, 1)
   assert_eq(second_count.val, 1)

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbitlang/editor"
 
-version = "0.2.1"
+version = "0.2.2"
 
 readme = "README.md"
 

--- a/editor/scripts/build-browser-tests.mbtx
+++ b/editor/scripts/build-browser-tests.mbtx
@@ -4,6 +4,29 @@ import {
   "moonbitlang/async/process",
 }
 
+///|
+/// Keep bundle output independent from a parent `moon.work`. Without this
+/// override, the same package is emitted under a workspace-qualified path and
+/// a stale tree from the other mode can be copied into `web/dist`.
+async fn build_js_package(package_path : String) -> Unit {
+  let status = @process.run(
+    "moon",
+    [
+      "build",
+      "--target",
+      "js",
+      "--target-dir",
+      "_build",
+      package_path,
+    ],
+    extra_env={ "MOON_WORK": "off" },
+  )
+  if status != 0 {
+    fail("moon build failed for \{package_path} with exit code \{status}")
+  }
+}
+
+///|
 async fn main {
   let monaco_entry = "vscode/src/vs/editor/editor.main.ts"
   if !@fs.exists(monaco_entry) {
@@ -11,140 +34,27 @@ async fn main {
       "browser test build requires the pinned VS Code checkout at " + monaco_entry,
     )
   }
-  let component_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
+  for package_path in [
     "tests/browser/moonbit/component",
-  ])
-  if component_status != 0 {
-    fail("moon build failed with exit code \{component_status}")
-  }
-  let perf_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/perf",
-  ])
-  if perf_status != 0 {
-    fail("moon build failed with exit code \{perf_status}")
-  }
-  let reveal_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/reveal",
-  ])
-  if reveal_status != 0 {
-    fail("moon build failed with exit code \{reveal_status}")
-  }
-  let read_api_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/read_api",
-  ])
-  if read_api_status != 0 {
-    fail("moon build failed with exit code \{read_api_status}")
-  }
-  let whitespace_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/whitespace",
-  ])
-  if whitespace_status != 0 {
-    fail("moon build failed with exit code \{whitespace_status}")
-  }
-  let whitespace_selection_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/whitespace_selection",
-  ])
-  if whitespace_selection_status != 0 {
-    fail("moon build failed with exit code \{whitespace_selection_status}")
-  }
-  let agent_feedback_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/agent_feedback",
-  ])
-  if agent_feedback_status != 0 {
-    fail("moon build failed with exit code \{agent_feedback_status}")
-  }
-  let model_swap_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/model_swap",
-  ])
-  if model_swap_status != 0 {
-    fail("moon build failed with exit code \{model_swap_status}")
-  }
-  let folding_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/folding",
-  ])
-  if folding_status != 0 {
-    fail("moon build failed with exit code \{folding_status}")
-  }
-  let folding_nested_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/folding_nested",
-  ])
-  if folding_nested_status != 0 {
-    fail("moon build failed with exit code \{folding_nested_status}")
-  }
-  let quick_diff_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/quick_diff",
-  ])
-  if quick_diff_status != 0 {
-    fail("moon build failed with exit code \{quick_diff_status}")
-  }
-  let set_value_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
     "tests/browser/moonbit/set_value",
-  ])
-  if set_value_status != 0 {
-    fail("moon build failed with exit code \{set_value_status}")
+  ] {
+    build_js_package(package_path)
   }
 
-  let build_dir = "_build/js/debug/build/moonbitlang/editor/tests/browser/moonbit"
+  let build_dir = "_build/js/debug/build/tests/browser/moonbit"
+  if !@fs.exists(build_dir) {
+    fail("isolated MoonBit browser build did not produce its expected output")
+  }
   let component_source_dir = build_dir + "/component"
   let perf_source_dir = build_dir + "/perf"
   let reveal_source_dir = build_dir + "/reveal"

--- a/editor/scripts/build-web.mbtx
+++ b/editor/scripts/build-web.mbtx
@@ -4,32 +4,38 @@ import {
   "moonbitlang/async/process",
 }
 
-async fn main {
-  let status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
-    "internal/shell/web",
-  ])
+///|
+/// Keep bundle output independent from a parent `moon.work`. Without this
+/// override, the same package is emitted under a workspace-qualified path and
+/// a stale tree from the other mode can be copied into `web/dist`.
+async fn build_js_package(package_path : String) -> Unit {
+  let status = @process.run(
+    "moon",
+    [
+      "build",
+      "--target",
+      "js",
+      "--target-dir",
+      "_build",
+      package_path,
+    ],
+    extra_env={ "MOON_WORK": "off" },
+  )
   if status != 0 {
-    fail("moon build failed with exit code \{status}")
+    fail("moon build failed for \{package_path} with exit code \{status}")
   }
-  let embed_status = @process.run("moon", [
-    "build",
-    "--target",
-    "js",
-    "--target-dir",
-    "_build",
-    "internal/shell/examples/embedded_viewer",
-  ])
-  if embed_status != 0 {
-    fail("moon build failed with exit code \{embed_status}")
-  }
+}
 
-  let source_dir = "_build/js/debug/build/moonbitlang/editor/internal/shell/web"
-  let embed_source_dir = "_build/js/debug/build/moonbitlang/editor/internal/shell/examples/embedded_viewer"
+///|
+async fn main {
+  build_js_package("internal/shell/web")
+  build_js_package("internal/shell/examples/embedded_viewer")
+
+  let source_dir = "_build/js/debug/build/internal/shell/web"
+  let embed_source_dir = "_build/js/debug/build/internal/shell/examples/embedded_viewer"
+  if !@fs.exists(source_dir) || !@fs.exists(embed_source_dir) {
+    fail("isolated MoonBit web build did not produce its expected output")
+  }
   let target_dir = "web/dist"
   if !@fs.exists(target_dir) {
     @fs.mkdir(target_dir, recursive=true)

--- a/editor/tests/browser/component/viewer_api.spec.js
+++ b/editor/tests/browser/component/viewer_api.spec.js
@@ -163,11 +163,37 @@ test('runs MoonBit viewer API component checks in the browser', async ({ page },
       return null;
     });
     expect(keepsPoint).not.toBeNull();
-    await page.mouse.move(keepsPoint.x, keepsPoint.y);
-    await expect(page.locator('[data-content-widget="editor.contrib.resizableContentHoverWidget"] .monaco-hover')).toContainText(
-      'wrapped component hover',
-      { timeout: 3_000 },
+    const hoverSelector =
+      '[data-content-widget="editor.contrib.resizableContentHoverWidget"] .monaco-hover';
+    const hover = page.locator(hoverSelector);
+    const visibleHover = page.locator(`${hoverSelector}:not(.hidden)`);
+    const visibleRows = visibleHover.locator(
+      '.monaco-hover-content > .hover-row',
     );
+    const expectedRows = [
+      'wrapped component diagnostic',
+      'wrapped component hover',
+    ];
+    const expectCompleteHover = async () => {
+      await expect(visibleHover).toBeVisible({ timeout: 5_000 });
+      await expect(visibleRows).toHaveText(expectedRows, { timeout: 5_000 });
+    };
+
+    await page.mouse.move(keepsPoint.x, keepsPoint.y);
+    await expectCompleteHover();
+
+    // The widget remains mounted while hidden. Leave the editor, then return
+    // to the exact same glyph coordinate so the second render replaces two
+    // retained rows instead of benefiting from a different hover target.
+    const exitPoint = await page.evaluate(() => ({
+      x: Math.max(1, window.innerWidth - 4),
+      y: Math.max(1, window.innerHeight - 4),
+    }));
+    await page.mouse.move(exitPoint.x, exitPoint.y);
+    await expect(hover).toHaveClass(/\bhidden\b/, { timeout: 2_000 });
+
+    await page.mouse.move(keepsPoint.x, keepsPoint.y);
+    await expectCompleteHover();
   } finally {
     reporter.dispose();
   }


### PR DESCRIPTION
## Summary

- prepare Hover rows and render lifetimes in a detached `DocumentFragment` before replacing the currently displayed content
- match Monaco's replacement order: clear resize padding, assign `textContent = ''`, then append the prepared fragment
- keep Hover hide/replacement disposal ordering consistent and add a natural two-row hide/reshow regression
- force production and browser-test child builds to use `MOON_WORK=off` and copy from deterministic unprefixed output paths
- bump `moonbitlang/editor` from `0.2.1` to `0.2.2`

## Root cause

The earlier Hover cleanup iterated a live `Element.children` collection while removing its members, so moving or deleting one child changed subsequent indices and could leave alternating rows behind. The build scripts also read workspace-qualified `_build` paths even when isolated editor builds emitted fresh bundles under unprefixed paths, allowing old bundles to be copied silently.

## Review structure

1. `fix(editor): align hover content replacement with Monaco` — final Hover behavior and regression only
2. `fix(editor): isolate browser bundle build outputs` — build-mode and output-path isolation
3. `chore(editor): bump version to 0.2.2` — release metadata only

The superseded public snapshot helper and the unrelated Markdown diagram execution plan are intentionally absent from this PR.

## Validation

- `MOON_WORK=off moon info && MOON_WORK=off moon fmt`
- `MOON_WORK=off just check`
- `MOON_WORK=off just test` — JS 1541/1541, native 1053/1053
- `MOON_WORK=off just build`
- targeted `base/browser` and Hover JS tests — 12/12 each
- `READONLY_EDITOR_BASE_URL=http://127.0.0.1:5174 MOON_WORK=off just test-browser` — 98/98
