### PR TITLE
simplify(desktop/frontend): dedup the resize clamp; inline single-use helpers

### DIFF
--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -5,16 +5,16 @@ fn is_submit_shortcut(event : @dom.KeyboardEvent) -> Bool {
 
 ///|
 fn scroll_transcript_after_render() -> @cmd.Cmd {
-  @cmd.custom_cmd(_ => scroll_transcript(), kind=@cmd.after_render)
-}
-
-///|
-fn scroll_transcript() -> Unit {
-  match @dom.document().get_element_by_id("transcript").to_option() {
-    Some(transcript) =>
-      transcript.set_scroll_top(transcript.get_scroll_height())
-    None => ()
-  }
+  @cmd.custom_cmd(
+    _ => {
+      match @dom.document().get_element_by_id("transcript").to_option() {
+        Some(transcript) =>
+          transcript.set_scroll_top(transcript.get_scroll_height())
+        None => ()
+      }
+    },
+    kind=@cmd.after_render,
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/editor_resize.mbt
+++ b/desktop/frontend/fileeditor/editor_resize.mbt
@@ -64,7 +64,7 @@ fn request_resize_handle_mount() -> @cmd.Cmd {
       )
       let document : @js.Value = @js.globalThis.get_with_string("document")
       @interop.add_capture_listener(document, "mousemove", on_resize_move)
-      @interop.add_capture_listener(document, "mouseup", end_resize)
+      @interop.add_capture_listener(document, "mouseup", _ => end_drag(resizing))
       resize_installed.val = true
     },
     kind=@cmd.after_render,
@@ -96,27 +96,38 @@ fn on_resize_move(event : @dom.Event) -> Unit {
     return
   }
   let rect = content.get_bounding_client_rect()
-  let floor = MinEditorWidth.to_double()
-  let max = rect.get_width() - MinChatWidth.to_double()
-  // On a very narrow window the floor wins, even past the ceiling.
+  set_editor_width(
+    drag_size(
+      rect.get_right() - mouse.get_client_x().to_double(),
+      floor=MinEditorWidth.to_double(),
+      max=rect.get_width() - MinChatWidth.to_double(),
+    ),
+  )
+  schedule_remeasure()
+}
+
+///|
+/// Clamp a dragged edge-to-cursor distance into the pane's allowed range.
+/// Shared by the editor's width drag and both of the tree panel's axes.
+/// On a very narrow window the floor wins, even past the ceiling.
+fn drag_size(raw : Double, floor~ : Double, max~ : Double) -> Int {
   let ceiling = if max > floor { max } else { floor }
-  let raw = rect.get_right() - mouse.get_client_x().to_double()
-  let width = if raw < floor {
+  let size = if raw < floor {
     floor
   } else if raw > ceiling {
     ceiling
   } else {
     raw
   }
-  set_editor_width(width.to_int())
-  schedule_remeasure()
+  size.to_int()
 }
 
 ///|
-/// End the drag and give the viewer a final, exact re-measure.
-fn end_resize(_event : @dom.Event) -> Unit {
-  guard resizing.val else { return }
-  resizing.val = false
+/// End a drag and give the viewer a final, exact re-measure. `active` is the
+/// drag flag of whichever resizer is ending — see `resizing` / `tree_resizing`.
+fn end_drag(active : Ref[Bool]) -> Unit {
+  guard active.val else { return }
+  active.val = false
   set_root_class("")
   if mounted_viewer() is Some(viewer) {
     viewer.layout()

--- a/desktop/frontend/fileeditor/editor_resize_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_resize_wbtest.mbt
@@ -1,0 +1,36 @@
+// `drag_size` is shared by three drags (editor width, tree width, tree
+// height), so its rules are pinned once here rather than in any one of them.
+// The DOM-driven halves of the resizers (`end_drag`, the listener install)
+// need a browser and are covered by using the app, not by these tests.
+
+///|
+test "a dragged size passes through inside its range and saturates outside" {
+  assert_eq(drag_size(300.0, floor=100.0, max=500.0), 300)
+  assert_eq(drag_size(40.0, floor=100.0, max=500.0), 100)
+  assert_eq(drag_size(900.0, floor=100.0, max=500.0), 500)
+}
+
+///|
+/// The bounds are exact, not exclusive.
+test "a drag exactly on either bound keeps that bound" {
+  assert_eq(drag_size(100.0, floor=100.0, max=500.0), 100)
+  assert_eq(drag_size(500.0, floor=100.0, max=500.0), 500)
+}
+
+///|
+/// On a window too narrow (or too short) to honour both bounds the ceiling
+/// falls below the floor, and the floor wins: the pane keeps its minimum
+/// instead of collapsing. This is the rule that was copied three times.
+test "the floor outranks a ceiling that fell below it" {
+  assert_eq(drag_size(900.0, floor=360.0, max=200.0), 360)
+  assert_eq(drag_size(300.0, floor=360.0, max=200.0), 360)
+  assert_eq(drag_size(10.0, floor=360.0, max=200.0), 360)
+}
+
+///|
+/// The size becomes a whole-pixel CSS custom property; the conversion
+/// truncates toward zero rather than rounding.
+test "a fractional drag truncates to whole pixels" {
+  assert_eq(drag_size(300.9, floor=100.0, max=500.0), 300)
+  assert_eq(drag_size(99.9, floor=10.0, max=500.0), 99)
+}

--- a/desktop/frontend/fileeditor/tree_resize.mbt
+++ b/desktop/frontend/fileeditor/tree_resize.mbt
@@ -74,9 +74,9 @@ fn request_tree_resize_mount() -> @cmd.Cmd {
       )
       let document : @js.Value = @js.globalThis.get_with_string("document")
       @interop.add_capture_listener(document, "mousemove", on_tree_resize_move)
-      @interop.add_capture_listener(document, "mouseup", _ => end_drag(
-        tree_resizing,
-      ))
+      @interop.add_capture_listener(document, "mouseup", _ => {
+        end_drag(tree_resizing)
+      })
       tree_resize_installed.val = true
     },
     kind=@cmd.after_render,

--- a/desktop/frontend/fileeditor/tree_resize.mbt
+++ b/desktop/frontend/fileeditor/tree_resize.mbt
@@ -74,7 +74,9 @@ fn request_tree_resize_mount() -> @cmd.Cmd {
       )
       let document : @js.Value = @js.globalThis.get_with_string("document")
       @interop.add_capture_listener(document, "mousemove", on_tree_resize_move)
-      @interop.add_capture_listener(document, "mouseup", end_tree_resize)
+      @interop.add_capture_listener(document, "mouseup", _ => end_drag(
+        tree_resizing,
+      ))
       tree_resize_installed.val = true
     },
     kind=@cmd.after_render,
@@ -108,44 +110,21 @@ fn on_tree_resize_move(event : @dom.Event) -> Unit {
   }
   let rect = body.get_bounding_client_rect()
   if tree_docked_right() {
-    let floor = MinTreeWidth.to_double()
-    let max = rect.get_width() - MinViewerWidth.to_double()
-    // On a very narrow window the floor wins, even past the ceiling.
-    let ceiling = if max > floor { max } else { floor }
-    let raw = rect.get_right() - mouse.get_client_x().to_double()
-    let width = if raw < floor {
-      floor
-    } else if raw > ceiling {
-      ceiling
-    } else {
-      raw
-    }
-    set_tree_width(width.to_int())
+    set_tree_width(
+      drag_size(
+        rect.get_right() - mouse.get_client_x().to_double(),
+        floor=MinTreeWidth.to_double(),
+        max=rect.get_width() - MinViewerWidth.to_double(),
+      ),
+    )
   } else {
-    let floor = MinTreeHeight.to_double()
-    let max = rect.get_height() - MinViewerHeight.to_double()
-    // On a very short window the floor wins, even past the ceiling.
-    let ceiling = if max > floor { max } else { floor }
-    let raw = rect.get_bottom() - mouse.get_client_y().to_double()
-    let height = if raw < floor {
-      floor
-    } else if raw > ceiling {
-      ceiling
-    } else {
-      raw
-    }
-    set_tree_height(height.to_int())
+    set_tree_height(
+      drag_size(
+        rect.get_bottom() - mouse.get_client_y().to_double(),
+        floor=MinTreeHeight.to_double(),
+        max=rect.get_height() - MinViewerHeight.to_double(),
+      ),
+    )
   }
   schedule_remeasure()
-}
-
-///|
-/// End the drag and give the viewer a final, exact re-measure.
-fn end_tree_resize(_event : @dom.Event) -> Unit {
-  guard tree_resizing.val else { return }
-  tree_resizing.val = false
-  set_root_class("")
-  if mounted_viewer() is Some(viewer) {
-    viewer.layout()
-  }
 }

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -26,20 +26,12 @@ pub fn markdown_nodes(
   open_file? : (String) -> @cmd.Cmd,
 ) -> Array[@html.Html] {
   @js.Error_::wrap(() => {
-    @js.Value::cast_from(parsed_markdown_nodes(source, open_file?))
+    let doc = @cmark.Doc::from_string(source, strict=false)
+    let render = MarkdownRender::{ defs: doc.defs, open_file }
+    @js.Value::cast_from(render.block_nodes(doc.block))
   }) catch {
     _ => [@html.pre(class="markdown-fallback", source)]
   }
-}
-
-///|
-fn parsed_markdown_nodes(
-  source : String,
-  open_file? : (String) -> @cmd.Cmd,
-) -> Array[@html.Html] {
-  let doc = @cmark.Doc::from_string(source, strict=false)
-  let render = MarkdownRender::{ defs: doc.defs, open_file }
-  render.block_nodes(doc.block)
 }
 
 ///|


### PR DESCRIPTION
Part of a project-level simplification/dedup sweep, one PR per package group. This one covers `desktop/frontend` — the desktop module has never been swept.

## What

The editor side-panel resizer and the file-tree resizer are structural twins. Their clamp arithmetic was copied **three times verbatim** (editor width, tree width, tree height), carrying the same *"floor wins on a narrow window"* comment each time; `end_resize` and `end_tree_resize` were identical modulo which drag flag they read.

- extract `drag_size(raw, floor~, max~)` — replaces the three copies of the clamp
- extract `end_drag(active)` — replaces the two identical drag-enders
- both land in `editor_resize.mbt`, which already hosts the shared root-style writer, `set_root_class` and `schedule_remeasure`
- inline `parsed_markdown_nodes` into its one caller `markdown_nodes` (3 lines, reads as well inside the `@js.Error_::wrap` it guards)
- inline `scroll_transcript` into `scroll_transcript_after_render`, its only caller and a bare one-line wrapper

Net **-18 lines**.

## Deliberately kept

Scanned every single-use private fn in the package; these are house-rule exceptions, not misses:

- **symmetric families** — the nine `save_*` storage setters, the `*_msg` bridge decoders, `plain_text`/`tights_text`, the three `set_*` size setters, `request_hover`/`request_lsp_open`
- **documented policy predicates** — `is_submit_shortcut`, `is_absolute_path`, `is_idle_event`, `host_prefers_dark`, `host_is_windows`, `file_extension`, `diagnostic_severity`
- **model seams** used cross-file — `Model::settings_status`, `Conversation::last_assistant_content`, `Model::any_conversation_busy`

## Verification

- `moon -C desktop check --target js` — clean
- `moon -C desktop check --target native` — clean
- `moon -C desktop info --target native` — **no .mbti drift** (all changes are private)
- `moon -C desktop test --release` — **1511/1511 passed**

Note: `--deny-warn` is not clean on `main` right now, independent of this PR — the 2026-07-24 nightly toolchain deprecated two call sites (`agent_session/json.mbt:168`, `agent_tool/multi_edit/multi_edit.mbt:883`). Gated without the flag and confirmed this branch adds no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)