### PR TITLE
simplify(desktop/internal): one home for the PATH-variable handling

### DIFF
--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -467,26 +467,9 @@ fn resolved_global_skills_dir() -> @path.Path? {
 }
 
 ///|
-#cfg(platform="windows")
-const PathSep : String = ";"
-
-///|
-#cfg(not(platform="windows"))
-const PathSep : String = ":"
-
-///|
-fn prepend_to_path_env(bin_dir : String, current_path : String?) -> String {
-  if current_path is Some(path) && !path.is_empty() {
-    "\{bin_dir}\{PathSep}\{path}"
-  } else {
-    bin_dir
-  }
-}
-
-///|
 fn first_path_entry(path : String?) -> String {
   guard path is Some(path) else { return "" }
-  match [..path.split(PathSep)] {
+  match [..path.split(@env.PathSep)] {
     [first, ..] => first.to_owned()
     [] => ""
   }
@@ -502,39 +485,6 @@ fn path_env_value(env : Map[String, String]) -> String? {
     }
   }
   None
-}
-
-///|
-/// Prepend `bin_dir` to the environment block's path variable, in place, and
-/// return the updated value. Windows blocks commonly spell the key `Path`
-/// (and `@sys.get_env_vars` preserves that spelling); the block is passed to
-/// the child with `inherit_env=false`, so writing a separate uppercase
-/// `PATH` beside it would leave two path variables and make which one the
-/// child observes a runtime coin toss. Update the spelling that already
-/// exists and drop any duplicates.
-fn prepend_path_env_entry(
-  env : Map[String, String],
-  bin_dir : String,
-) -> String {
-  let mut key = "PATH"
-  let mut current : String? = None
-  let duplicates : Array[String] = []
-  for name, value in env {
-    if name.to_upper() == "PATH" {
-      if current is None {
-        key = name
-        current = Some(value)
-      } else {
-        duplicates.push(name)
-      }
-    }
-  }
-  for name in duplicates {
-    env.remove(name)
-  }
-  let joined = prepend_to_path_env(bin_dir, current)
-  env[key] = joined
-  joined
 }
 
 ///|
@@ -557,12 +507,12 @@ async fn add_moonbit_path_for_native_engine(
   let moon_exe = moon_bin_dir.join("moon.exe")
   // The agent tools spawn `moon` by name, so prepend the bundled bin to the
   // path variable (updating `Path` in place on Windows — see
-  // `prepend_path_env_entry`). Deliberately do not set `MOON_HOME` (it would
+  // `@env.prepend_path_entry`). Deliberately do not set `MOON_HOME` (it would
   // redirect registry/cache lookup into the bundled payload) and drop any
   // ambient `MOON_HOME` the launching shell exported: moon prefers it over
   // the executable-relative home and would otherwise run the bundled binary
   // against the user's (possibly missing or incompatible) MoonBit home.
-  let path = prepend_path_env_entry(env, moon_bin_dir.to_string())
+  let path = @env.prepend_path_entry(env, moon_bin_dir.to_string())
   env.remove("MOON_HOME")
   @xlog.debug() <?
     {
@@ -944,16 +894,6 @@ test "new turn events clear stale settling state" {
 }
 
 ///|
-test "bundled moonbit bin is prepended to native engine path" {
-  assert_eq(prepend_to_path_env("/toolchain/bin", None), "/toolchain/bin")
-  assert_eq(prepend_to_path_env("/toolchain/bin", Some("")), "/toolchain/bin")
-  assert_eq(
-    prepend_to_path_env("/toolchain/bin", Some("/usr/bin")),
-    "/toolchain/bin\{PathSep}/usr/bin",
-  )
-}
-
-///|
 async test "native engine env has one authoritative bundled moon path" {
   let ambient_path = @sys.get_env_var("PATH")
   let root = @path.Path(@fs.tmpdir(prefix="openseek-engine-env-"))
@@ -1000,7 +940,7 @@ async test "native engine env has one authoritative bundled moon path" {
   @fs.rmdir(root.to_string(), recursive=true)
   let moon_bin = moon_home.join("bin").to_string()
   let expected_path = if ambient_path is Some(path) && !path.is_empty() {
-    moon_bin + PathSep + path
+    moon_bin + @env.PathSep + path
   } else {
     moon_bin
   }

--- a/desktop/internal/env/path.mbt
+++ b/desktop/internal/env/path.mbt
@@ -1,0 +1,53 @@
+// The path variable: its separator, and the two ways this app prepends a
+// directory to it. Shared by the engine's child environments and the bundled
+// MoonBit toolchain's, which spawn children the same way and must agree on
+// the platform separator and on the Windows `Path`-vs-`PATH` rule.
+
+///|
+#cfg(platform="windows")
+pub const PathSep : String = ";"
+
+///|
+#cfg(not(platform="windows"))
+pub const PathSep : String = ":"
+
+///|
+/// `bin_dir` prepended to `current_path`, or `bin_dir` alone when there is no
+/// path to extend.
+pub fn prepend_to_path_env(bin_dir : String, current_path : String?) -> String {
+  if current_path is Some(path) && !path.is_empty() {
+    "\{bin_dir}\{PathSep}\{path}"
+  } else {
+    bin_dir
+  }
+}
+
+///|
+/// Prepend `bin_dir` to the environment block's path variable, in place, and
+/// return the updated value. Windows blocks commonly spell the key `Path`
+/// (and `@sys.get_env_vars` preserves that spelling); a block passed to a
+/// child with `inherit_env=false` that carried a separate uppercase `PATH`
+/// beside it would leave two path variables and make which one the child
+/// observes a runtime coin toss. Update the spelling that already exists and
+/// drop any duplicates.
+pub fn prepend_path_entry(env : Map[String, String], bin_dir : String) -> String {
+  let mut key = "PATH"
+  let mut current : String? = None
+  let duplicates : Array[String] = []
+  for name, value in env {
+    if name.to_upper() == "PATH" {
+      if current is None {
+        key = name
+        current = Some(value)
+      } else {
+        duplicates.push(name)
+      }
+    }
+  }
+  for name in duplicates {
+    env.remove(name)
+  }
+  let joined = prepend_to_path_env(bin_dir, current)
+  env[key] = joined
+  joined
+}

--- a/desktop/internal/env/path.mbt
+++ b/desktop/internal/env/path.mbt
@@ -30,7 +30,10 @@ pub fn prepend_to_path_env(bin_dir : String, current_path : String?) -> String {
 /// beside it would leave two path variables and make which one the child
 /// observes a runtime coin toss. Update the spelling that already exists and
 /// drop any duplicates.
-pub fn prepend_path_entry(env : Map[String, String], bin_dir : String) -> String {
+pub fn prepend_path_entry(
+  env : Map[String, String],
+  bin_dir : String,
+) -> String {
   let mut key = "PATH"
   let mut current : String? = None
   let duplicates : Array[String] = []

--- a/desktop/internal/env/path_test.mbt
+++ b/desktop/internal/env/path_test.mbt
@@ -1,0 +1,36 @@
+///|
+test "a bin dir is prepended to the path, and stands alone when there is none" {
+  assert_eq(
+    @env.prepend_to_path_env("/toolchain/bin", None),
+    "/toolchain/bin",
+  )
+  assert_eq(
+    @env.prepend_to_path_env("/toolchain/bin", Some("")),
+    "/toolchain/bin",
+  )
+  assert_eq(
+    @env.prepend_to_path_env("/toolchain/bin", Some("/usr/bin")),
+    "/toolchain/bin\{@env.PathSep}/usr/bin",
+  )
+}
+
+///|
+/// Windows environment blocks commonly spell the key `Path`; the child gets
+/// exactly one path variable, under the spelling that was already there.
+test "prepending updates the existing spelling and drops duplicate keys" {
+  let env = { "Path": "/usr/bin" }
+  assert_eq(
+    @env.prepend_path_entry(env, "/toolchain/bin"),
+    "/toolchain/bin\{@env.PathSep}/usr/bin",
+  )
+  assert_eq(env.get("Path"), Some("/toolchain/bin\{@env.PathSep}/usr/bin"))
+  assert_eq(env.get("PATH"), None)
+  assert_eq(env.length(), 1)
+}
+
+///|
+test "an empty block gains an uppercase PATH" {
+  let env : Map[String, String] = Map([])
+  assert_eq(@env.prepend_path_entry(env, "/toolchain/bin"), "/toolchain/bin")
+  assert_eq(env.get("PATH"), Some("/toolchain/bin"))
+}

--- a/desktop/internal/env/path_test.mbt
+++ b/desktop/internal/env/path_test.mbt
@@ -17,7 +17,7 @@ test "a bin dir is prepended to the path, and stands alone when there is none" {
 ///|
 /// Windows environment blocks commonly spell the key `Path`; the child gets
 /// exactly one path variable, under the spelling that was already there.
-test "prepending updates the existing spelling and drops duplicate keys" {
+test "prepending updates the existing spelling" {
   let env = { "Path": "/usr/bin" }
   assert_eq(
     @env.prepend_path_entry(env, "/toolchain/bin"),
@@ -26,6 +26,25 @@ test "prepending updates the existing spelling and drops duplicate keys" {
   assert_eq(env.get("Path"), Some("/toolchain/bin\{@env.PathSep}/usr/bin"))
   assert_eq(env.get("PATH"), None)
   assert_eq(env.length(), 1)
+}
+
+///|
+/// The branch that matters for `inherit_env=false` children: a block carrying
+/// both spellings must come out with exactly one, so which one the child reads
+/// is not a coin toss. Which spelling survives follows the block's own
+/// iteration order, so assert the invariant rather than a particular winner.
+test "a duplicate path key is dropped so the child sees exactly one" {
+  let env = { "Path": "/usr/bin", "PATH": "/opt/bin" }
+  let joined = @env.prepend_path_entry(env, "/toolchain/bin")
+  assert_eq(env.length(), 1)
+  assert_true(
+    joined == "/toolchain/bin\{@env.PathSep}/usr/bin" ||
+    joined == "/toolchain/bin\{@env.PathSep}/opt/bin",
+  )
+  for key, value in env {
+    assert_true(key == "Path" || key == "PATH")
+    assert_eq(value, joined)
+  }
 }
 
 ///|

--- a/desktop/internal/env/path_test.mbt
+++ b/desktop/internal/env/path_test.mbt
@@ -1,9 +1,6 @@
 ///|
 test "a bin dir is prepended to the path, and stands alone when there is none" {
-  assert_eq(
-    @env.prepend_to_path_env("/toolchain/bin", None),
-    "/toolchain/bin",
-  )
+  assert_eq(@env.prepend_to_path_env("/toolchain/bin", None), "/toolchain/bin")
   assert_eq(
     @env.prepend_to_path_env("/toolchain/bin", Some("")),
     "/toolchain/bin",

--- a/desktop/internal/env/pkg.generated.mbti
+++ b/desktop/internal/env/pkg.generated.mbti
@@ -2,7 +2,13 @@
 package "openseek_desktop/internal/env"
 
 // Values
+pub const PathSep : String = ":"
+
 pub fn get(String) -> String?
+
+pub fn prepend_path_entry(Map[String, String], String) -> String
+
+pub fn prepend_to_path_env(String, String?) -> String
 
 // Errors
 

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -2,7 +2,7 @@
 fn moonbit_process_env(moon_home : @path.Path) -> Map[String, String] {
   {
     "MOON_HOME": moon_home.to_string(),
-    "PATH": prepend_to_path_env(
+    "PATH": @env.prepend_to_path_env(
       moonbit_bin_dir(moon_home).to_string(),
       @env.get("PATH"),
     ),
@@ -274,23 +274,7 @@ pub async fn prepare_bundled_home(
 /// exists and drop any duplicates, so the child sees exactly one path variable.
 pub fn bundled_tool_env(bin_dir : @path.Path) -> Map[String, String] {
   let env = @sys.get_env_vars()
-  let mut key = "PATH"
-  let mut current : String? = None
-  let duplicates : Array[String] = []
-  for name, value in env {
-    if name.to_upper() == "PATH" {
-      if current is None {
-        key = name
-        current = Some(value)
-      } else {
-        duplicates.push(name)
-      }
-    }
-  }
-  for name in duplicates {
-    env.remove(name)
-  }
-  env[key] = prepend_to_path_env(bin_dir.to_string(), current)
+  @env.prepend_path_entry(env, bin_dir.to_string()) |> ignore
   env.remove("MOON_HOME")
   env
 }

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -154,19 +154,3 @@ fn moonbit_wasm_gc_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
   moon_home.join("lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi")
 }
 
-///|
-#cfg(platform="windows")
-const PathSep : String = ";"
-
-///|
-#cfg(not(platform="windows"))
-const PathSep : String = ":"
-
-///|
-fn prepend_to_path_env(bin_dir : String, current_path : String?) -> String {
-  if current_path is Some(path) && !path.is_empty() {
-    "\{bin_dir}\{PathSep}\{path}"
-  } else {
-    bin_dir
-  }
-}

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -153,4 +153,3 @@ fn moonbit_native_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
 fn moonbit_wasm_gc_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
   moon_home.join("lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi")
 }
-


### PR DESCRIPTION
Part of a project-level simplification/dedup sweep, one PR per package group. Follows #574 (`desktop/frontend`).

## What

`internal/engine` and `internal/moonbit` both spawn children with an explicit environment block, and both had grown their own copy of the same three things:

| duplicated | copy 1 | copy 2 |
|---|---|---|
| `#cfg(platform="windows")` `PathSep` const pair | `engine/engine.mbt` | `moonbit/toolchain_paths.mbt` |
| `prepend_to_path_env` | `engine/engine.mbt` | `moonbit/toolchain_paths.mbt` |
| Windows `Path`-vs-`PATH` reconciliation loop | `engine`'s `prepend_path_env_entry` | body of `@moonbit.bundled_tool_env` |

The first two were byte-identical. The third was duplicated down to near-identical doc prose — and it is the risky kind: it encodes a subtle rule about `inherit_env=false` blocks (find the spelling that already exists, drop duplicate keys, write back under that spelling), so a fix to one copy would silently leave the other spawning children with two path variables and a coin toss over which one wins.

All three move into `internal/env` — already native-only, already imported by both packages, already the home for process-environment reads. `bundled_tool_env` keeps its signature and drops to four lines.

## Tests

The unit test for `prepend_to_path_env` moves with the code it now covers, and **gains coverage for the reconciliation rule it never had**: the existing-spelling-wins case, duplicate-key removal, and the empty block. Net +2 tests.

## Verification

- `moon -C desktop check --target native` — clean
- `moon -C desktop check --target js` — clean
- `moon -C desktop info --target native` — the **only** `.mbti` change is `internal/env` gaining the three shared symbols; `engine` and `moonbit` interfaces are untouched, confirming no public surface moved
- `moon -C desktop test --release` — **1513/1513 passed**

Note: `--deny-warn` is not clean on `main` right now, independent of this PR (two 2026-07-24 nightly deprecations in `agent_session` / `agent_tool`). Gated without the flag; this branch adds no new warnings.

## Also examined, deliberately not changed

Every single-use private fn in `desktop/internal/*` and `desktop/package/*` was scanned. The rest are house-rule keeps, not misses:

- **op-handler families** — the `*_op` handlers in `internal/extension` are a registration table
- **platform families** — the three `reset_bundle_dirs` (linux/macos/windows) share a name but have genuinely per-platform bodies; not duplication
- **path-accessor family** — `moonbit_bin_dir`, `moonbit_lsp_command`, `moonbit_seed_version_path`, the two bundle-probe paths
- **documented named concepts** — `openseek_client_token`, `resolved_run_cwd`, `resolved_global_skills_dir`, `prepare_engine_stdin`, `path_env_value`, `unquote_xdg_value`, `parse_outcome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)