### PR TITLE
simplify(editor/syntax): hoist the lexer helpers the lang_* packages copy

### DIFF
--- a/editor/syntax/README.md
+++ b/editor/syntax/README.md
@@ -41,6 +41,14 @@ implementing `LineTokenizer`. Concrete languages are selected by hosts, examples
 or tests; reusable viewer core packages must not import them. There is no runtime
 grammar-loading or `setMonarchTokensProvider` equivalent.
 
+Helpers every stateful lexer needs live in this package rather than in each
+`lang_*`, which otherwise carry identical copies: `is_capitalized` (the
+identifier-is-a-type heuristic), `push_token` (append a token, coalescing it
+into the previous one when the tag and offsets are contiguous), and
+`decode_mode_stack` / `encode_mode_stack` (the nesting-mode stack a lexer
+carries between lines, packed into `TokenizerState`; an empty state decodes to
+the base mode `'n'`).
+
 When translating a Monarch or CodeMirror grammar:
 
 - Use `lexmatch ... with longest`; equal-length matches choose the earliest arm.

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -37,7 +37,7 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
   line_text,
   state,
 ) {
-  let stack = decode_stack(state)
+  let stack = @syntax.decode_mode_stack(state)
   let tokens : Array[@syntax.LineToken] = []
   let mut at = 0
   let mut view = line_text[:]
@@ -52,13 +52,13 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
     let consumed = view.length() - rest.length()
     match op {
       Blank => ()
-      Emit(tag) => push_token(tokens, at, at + consumed, tag)
+      Emit(tag) => @syntax.push_token(tokens, at, at + consumed, tag)
       Push(tag, mode) => {
-        push_token(tokens, at, at + consumed, tag)
+        @syntax.push_token(tokens, at, at + consumed, tag)
         stack.push(mode)
       }
       Pop(tag) => {
-        push_token(tokens, at, at + consumed, tag)
+        @syntax.push_token(tokens, at, at + consumed, tag)
         if stack.length() > 1 {
           ignore(stack.pop())
         }
@@ -67,28 +67,7 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
     at = at + consumed
     view = rest
   }
-  (tokens, encode_stack(stack))
-}
-
-///|
-fn decode_stack(state : @syntax.TokenizerState) -> Array[Char] {
-  let stack : Array[Char] = []
-  for mode in state.0 {
-    stack.push(mode)
-  }
-  if stack.length() == 0 {
-    stack.push('n')
-  }
-  stack
-}
-
-///|
-fn encode_stack(stack : Array[Char]) -> @syntax.TokenizerState {
-  let encoded = StringBuilder()
-  for mode in stack {
-    encoded.write_char(mode)
-  }
-  TokenizerState(encoded.to_string())
+  (tokens, @syntax.encode_mode_stack(stack))
 }
 
 ///|
@@ -97,25 +76,6 @@ priv enum StepOp {
   Emit(@syntax.HighlightTag)
   Push(@syntax.HighlightTag, Char)
   Pop(@syntax.HighlightTag)
-}
-
-///|
-/// Contiguous same-tag lexemes coalesce so a quoted string renders as a
-/// single span.
-fn push_token(
-  tokens : Array[@syntax.LineToken],
-  start : Int,
-  end : Int,
-  tag : @syntax.HighlightTag,
-) -> Unit {
-  if tokens.length() > 0 {
-    let last = tokens[tokens.length() - 1]
-    if last.tag == tag && last.end == start {
-      tokens[tokens.length() - 1] = { start: last.start, end, tag }
-      return
-    }
-  }
-  tokens.push({ start, end, tag })
 }
 
 ///|

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -36,7 +36,7 @@ pub impl @syntax.LineTokenizer for MoonbitTokenizer with fn tokenize_line(
   line_text,
   state,
 ) {
-  let stack = decode_stack(state)
+  let stack = @syntax.decode_mode_stack(state)
   let tokens : Array[@syntax.LineToken] = []
   let mut at = 0
   let mut view = line_text[:]
@@ -50,13 +50,13 @@ pub impl @syntax.LineTokenizer for MoonbitTokenizer with fn tokenize_line(
     let consumed = view.length() - rest.length()
     match op {
       Blank => ()
-      Emit(tag) => push_token(tokens, at, at + consumed, tag)
+      Emit(tag) => @syntax.push_token(tokens, at, at + consumed, tag)
       Push(tag, mode) => {
-        push_token(tokens, at, at + consumed, tag)
+        @syntax.push_token(tokens, at, at + consumed, tag)
         stack.push(mode)
       }
       Pop(tag) => {
-        push_token(tokens, at, at + consumed, tag)
+        @syntax.push_token(tokens, at, at + consumed, tag)
         if stack.length() > 1 {
           ignore(stack.pop())
         }
@@ -66,38 +66,6 @@ pub impl @syntax.LineTokenizer for MoonbitTokenizer with fn tokenize_line(
     view = rest
   }
   (tokens, TokenizerState("n"))
-}
-
-///|
-/// Contiguous same-tag lexemes coalesce into one token, so a plain
-/// string renders as a single `String`-tagged token (quote, content, quote)
-/// instead of three.
-fn push_token(
-  tokens : Array[@syntax.LineToken],
-  start : Int,
-  end : Int,
-  tag : @syntax.HighlightTag,
-) -> Unit {
-  if tokens.length() > 0 {
-    let last = tokens[tokens.length() - 1]
-    if last.tag == tag && last.end == start {
-      tokens[tokens.length() - 1] = { start: last.start, end, tag }
-      return
-    }
-  }
-  tokens.push({ start, end, tag })
-}
-
-///|
-fn decode_stack(state : @syntax.TokenizerState) -> Array[Char] {
-  let stack : Array[Char] = []
-  for mode in state.0 {
-    stack.push(mode)
-  }
-  if stack.length() == 0 {
-    stack.push('n')
-  }
-  stack
 }
 
 ///|

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -7,7 +7,13 @@ import {
 }
 
 // Values
+pub fn decode_mode_stack(TokenizerState) -> Array[Char]
+
+pub fn encode_mode_stack(Array[Char]) -> TokenizerState
+
 pub fn is_capitalized(StringView) -> Bool
+
+pub fn push_token(Array[LineToken], Int, Int, HighlightTag) -> Unit
 
 pub let tokenization_registry : TokenizationRegistry
 

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -273,3 +273,54 @@ pub fn is_capitalized(word : StringView) -> Bool {
   let unit = word[0].to_int()
   65 <= unit && unit <= 90
 }
+
+///|
+/// Append `start`..`end` tagged `tag`, coalescing it into the previous token
+/// when that token carries the same tag and ends exactly where this one
+/// begins. Contiguous same-tag lexemes therefore render as one span — a
+/// quoted string arrives as quote, content, quote and leaves as a single
+/// `String` token. Shared by the language lexers (`lang_*`), which otherwise
+/// carry identical copies.
+pub fn push_token(
+  tokens : Array[LineToken],
+  start : Int,
+  end : Int,
+  tag : HighlightTag,
+) -> Unit {
+  if tokens.length() > 0 {
+    let last = tokens[tokens.length() - 1]
+    if last.tag == tag && last.end == start {
+      tokens[tokens.length() - 1] = { start: last.start, end, tag }
+      return
+    }
+  }
+  tokens.push({ start, end, tag })
+}
+
+///|
+/// The nesting-mode stack a stateful lexer carries between lines, decoded from
+/// its `TokenizerState`. Each character is one open mode; an empty state
+/// decodes to the base mode `'n'`, so a fresh line always has a mode to read.
+/// Shared by the language lexers (`lang_*`), which otherwise carry identical
+/// copies. Inverse of `encode_mode_stack`.
+pub fn decode_mode_stack(state : TokenizerState) -> Array[Char] {
+  let stack : Array[Char] = []
+  for mode in state.0 {
+    stack.push(mode)
+  }
+  if stack.length() == 0 {
+    stack.push('n')
+  }
+  stack
+}
+
+///|
+/// The mode stack packed back into a `TokenizerState` for the next line.
+/// Inverse of `decode_mode_stack`.
+pub fn encode_mode_stack(stack : Array[Char]) -> TokenizerState {
+  let encoded = StringBuilder()
+  for mode in stack {
+    encoded.write_char(mode)
+  }
+  TokenizerState(encoded.to_string())
+}


### PR DESCRIPTION
Part of a project-level simplification/dedup sweep, one PR per package group. Follows #574 and #575 (desktop). This is the first pass over `editor`, scoped to `syntax`.

## Why this shape

`syntax` **already** keeps a shared lexer helper for exactly this reason. `is_capitalized`'s doc comment reads:

> Shared by the language lexers (`lang_*`), which otherwise carry identical copies.

Two more helpers had drifted into that same copied state, so this PR follows the precedent the package already set rather than inventing a new home.

## What

| helper | was duplicated in | notes |
|---|---|---|
| `push_token` | `lang_moonbit`, `lang_javascript` | byte-identical; the two copies documented the same rule differently |
| `decode_stack` | `lang_moonbit`, `lang_javascript` | byte-identical |
| `encode_stack` | `lang_javascript` | the inverse of the above |

`push_token` encodes the coalescing rule — contiguous same-tag lexemes become one span, so a quoted string arrives as quote/content/quote and leaves as a single `String` token. Worth having once.

The stack codec operates on `TokenizerState`, which is a `syntax` type, so the encoding of that state belongs beside it rather than in whichever lexer needed it first. It is renamed **`decode_mode_stack` / `encode_mode_stack`**: `decode_stack` was clear enough as a file-local name but says nothing on a shared public surface, and the pair now travels together instead of leaving the inverse stranded in one lexer.

`lang_json` is deliberately untouched — it pushes tokens directly and does not coalesce.

Per this module's docs-are-contracts convention, `syntax/README.md` documents the shared helpers.

## Verification

- `moon check --target all --warn-list +73` — clean (zero warnings under `editor/`; the warn-73 hits in the output are pre-existing ones in `desktop/`, now visible because the workspace was unified)
- `moon fmt --check` on the touched packages — clean
- `moon test` over `syntax` + all three `lang_*` — **22/22 on `js` and 22/22 on `native`**. These are the golden token-stream tests: they render every token's offsets, tag and text for each lexer, so a behavior change in `push_token` or the state codec could not pass them unchanged.
- `moon info` — the only `.mbti` change is the three hoisted symbols appearing in `syntax`, beside `is_capitalized`

## Deliberately not changed

The three `lang_*/lexer_test.mbt` files carry a **35-line golden-rendering harness that differs by exactly one line** (which tokenizer it constructs). Deduping it needs a shared test-support package plus a `moon.mod` publish-exclude entry — a structural change to this module that I'd rather propose separately than smuggle into a dedup PR. Flagging it here as a known follow-up.

Also examined and kept as house-rule exceptions: `plain.mbt`'s `is_space` / `is_ident_continue` / `is_ident_start` / `is_digit` (char-class family), `lang_json`'s `colon_follows` (documented, and cited by the README), and the per-lexer `normal_step` / `comment_step` / `template_step` / `string_step` / `dollar_step` families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)