### PR TITLE
simplify(editor): drop indirection the call site or core already provides

### DIFF
--- a/editor/base/common/line_range.mbt
+++ b/editor/base/common/line_range.mbt
@@ -165,7 +165,7 @@ pub fn LineRangeSet::add_range(self : LineRangeSet, range : LineRange) -> Unit {
     }) +
     1
   if join_range_start_idx == join_range_end_idx_exclusive {
-    array_splice_insert(ranges, join_range_start_idx, range)
+    ranges.insert(join_range_start_idx, range)
   } else if join_range_start_idx == join_range_end_idx_exclusive - 1 {
     let join_range = ranges[join_range_start_idx]
     ranges[join_range_start_idx] = join_range.join(range)
@@ -322,21 +322,6 @@ fn find_last_monotonous(
   } else {
     Some(array[idx])
   }
-}
-
-///|
-fn array_splice_insert(
-  array : Array[LineRange],
-  index : Int,
-  item : LineRange,
-) -> Unit {
-  array.push(item)
-  let mut i = array.length() - 1
-  while i > index {
-    array[i] = array[i - 1]
-    i -= 1
-  }
-  array[index] = item
 }
 
 ///|

--- a/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_editor_widget.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_editor_widget.mbt
@@ -179,7 +179,7 @@ fn AgentFeedbackEditorWidget::update_title(
   self : AgentFeedbackEditorWidget,
 ) -> Unit {
   if self.comments.length() == 1 {
-    self.title.set_inner_html(widget_escape_html(self.comments[0].text))
+    self.title.set_inner_html(input_escape_html(self.comments[0].text))
   } else {
     self.title.set_inner_html(self.comments.length().to_string() + " comments")
   }
@@ -785,11 +785,6 @@ fn feedback_comment_target_key(comment_id : String) -> String {
 ///|
 fn feedback_reply_target_key(comment_id : String, reply_index : Int) -> String {
   "reply:" + comment_id + ":" + reply_index.to_string()
-}
-
-///|
-fn widget_escape_html(text : String) -> String {
-  input_escape_html(text)
 }
 
 ///|

--- a/editor/viewer/common/cursor/single_cursor_state.mbt
+++ b/editor/viewer/common/cursor/single_cursor_state.mbt
@@ -63,7 +63,7 @@ pub fn SingleCursorState::collapsed(
 fn SingleCursorState::selection_start_is_empty(
   self : SingleCursorState,
 ) -> Bool {
-  position_eq(self.selection_start_start, self.selection_start_end)
+  self.selection_start_start.equals(self.selection_start_end)
 }
 
 ///|
@@ -121,9 +121,4 @@ fn not_before_or_equal(
   b : @base_common.Position,
 ) -> Bool {
   !a.is_before_or_equal(b)
-}
-
-///|
-fn position_eq(a : @base_common.Position, b : @base_common.Position) -> Bool {
-  a.equals(b)
 }


### PR DESCRIPTION
Final PR of a project-level simplification/dedup sweep. Follows #574, #575 (desktop) and #576 (editor/syntax). This one covers the remaining `editor` packages: `base/**`, `viewer/**`, `internal/viewer/**`, `internal/shell/**`, `language`, `platform/log`.

## What

Three single-use private helpers that carried no information their call sites did not already have:

- **`array_splice_insert`** (`base/common/line_range.mbt`) hand-rolled a push-then-shift-right loop that is exactly **`Array::insert`**, which core provides. Eleven lines replaced by the primitive they reimplemented.
- **`position_eq(a, b)`** (`viewer/common/cursor`) — an undocumented alias for `a.equals(b)`, called once from a one-line predicate.
- **`widget_escape_html(text)`** (`contrib/agent_feedback/browser`) — an undocumented alias for `input_escape_html(text)`, called once.

Note the contrast with **`not_before_or_equal`**, left alone *directly beside* `position_eq`: it documents a Monaco expression (`!a.isBeforeOrEqual(b)`) and so earns its name. That distinction is the bar used throughout this pass.

## Verification

- `moon check --target all --warn-list +73` — **zero warnings under `editor/`**
- `moon fmt` — clean
- `moon info` — **no `.mbti` drift**; all three symbols were private
- `moon test --target js` (full editor suite) — **2035/2035**
- `moon test --target native` (full editor suite) — 2580/**2582**

The two native failures are `OSError("@fs.mkdir(): \"_build\": File exists")` in `internal/shell/server_host_native/native_host_test.mbt`, a package this PR does not touch. Verified pre-existing: they reproduce identically on unmodified `main` (`fdbc6012`).

`base/common/line_range.mbt` is a 1:1 Monaco port with reference tests, so the `Array::insert` swap was gated specifically: `base/common` + `viewer/common/cursor` are **127/127 on both js and native**.

## Finding: editor is largely not a dedup target

I scanned every package in the module. Worth recording, because it is the main result of this pass:

**Editor's structure deliberately mirrors Monaco, and its single-use helpers are overwhelmingly load-bearing.** Inlining them mechanically would damage the port. The categories I found and left alone:

- **Monaco lifecycle-contract ports** — `view_zones_prepare_render`, `overlay_widgets_prepare_render`, `editor_scrollbar_prepare_render`, `on_content_changed`, `on_zones_changed`. Bodies are intentionally empty with a source citation; they exist to complete a part's lifecycle surface.
- **Fidelity ports whose name is the Monaco symbol** — `scheme_fix` (`_schemeFix`, uri.ts:54), `not_before_or_equal`, `compute_code_point`.
- **Cross-file encapsulation seams** — `install_current`, `is_current_generation`, `invalidate_rendered_window`, `remove_owned_placeholder_dom`, `typed_lookup_available`, `Cursor::reproject` (cited by ONE-028).
- **Symmetric families** — `ease_in_cubic`/`ease_out_cubic`, `emit_model_rendered`/`emit_hover_resolved`, `first_non_whitespace_index_of`/`last_non_whitespace_index_of`, the `icon_*` set, `warn_invalid_range`/`warn_overlap`, `is_space`/`is_ident_start`/`is_ident_continue`/`is_digit`.
- **`require_contract_*`** in `examples/embedded_viewer` — a deliberate compile-time public-API contract check.

Two structural duplications were found and deliberately **not** changed:

1. `ViewLinesConfiguration` re-declares `ViewLineOptions`' optional parameters to forward them — a public builder-convenience pattern, not accidental copying.
2. The three `lang_*/lexer_test.mbt` golden harnesses differ by one line (carried over from #576) — deduping needs a shared test-support package plus a `moon.mod` publish-exclude entry, which deserves its own proposal.

Reference tests (`*_reference_test.mbt` / `*_reference_wbtest.mbt`) were excluded from dedup entirely, per `docs/quality.md`: they must preserve source labels, inputs, ordering and boundary values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)