### PR TITLE
fix: keep #cfg consts out of generated interfaces

### DIFF
--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -2,11 +2,11 @@
 package "bobzhang/openseek/agent_tool/internal/sandbox"
 
 // Values
-pub const PlatformShellProgram : String = "sh"
-
 pub const SandboxExecPath : String = "/usr/bin/sandbox-exec"
 
 pub fn platform_shell_args(String) -> Array[String]
+
+pub fn platform_shell_program() -> String
 
 pub fn sandbox_exec_args(String, String) -> Array[String]
 

--- a/agent_tool/internal/sandbox/sandbox_exec.mbt
+++ b/agent_tool/internal/sandbox/sandbox_exec.mbt
@@ -152,22 +152,25 @@ async fn cleanup_sandbox_probe(
 }
 
 ///|
-/// The platform shell program used to interpret command text.
-///
-/// This is `pwsh` on Windows and `sh` on other targets. It is used by both
-/// `sandbox_exec_args` and callers that need the same unsandboxed command
-/// semantics.
 #cfg(platform="windows")
-pub const PlatformShellProgram : String = "pwsh"
+const PlatformShellProgram : String = "pwsh"
 
 ///|
-/// The platform shell program used to interpret command text.
-///
-/// This is `pwsh` on Windows and `sh` on other targets. It is used by both
-/// `sandbox_exec_args` and callers that need the same unsandboxed command
-/// semantics.
 #cfg(not(platform="windows"))
-pub const PlatformShellProgram : String = "sh"
+const PlatformShellProgram : String = "sh"
+
+///|
+/// The platform shell program used to interpret command text: `pwsh` on
+/// Windows and `sh` on other targets. Used by `sandbox_exec_args` and by
+/// callers that need the same unsandboxed command semantics.
+///
+/// Deliberately a function, not a `pub const`. A public `#cfg` const bakes
+/// whichever value survived into `pkg.generated.mbti`, so regenerating the
+/// interface on Windows rewrites it to `"pwsh"` and the committed one no
+/// longer matches.
+pub fn platform_shell_program() -> String {
+  PlatformShellProgram
+}
 
 ///|
 /// Build arguments that make `PlatformShellProgram` interpret `cmd` as shell

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -99,7 +99,7 @@ async fn agent_shell_launch(
   }
   if mode is TrustedSourceWrite || !@sandbox.sandbox_exec_available() {
     return {
-      program: @sandbox.PlatformShellProgram,
+      program: @sandbox.platform_shell_program(),
       args: @sandbox.platform_shell_args(cmd),
       source_write_sandboxed: false,
       sandbox_denial_subjects: [],

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -687,7 +687,7 @@ pub async fn collect_shell_output(
   max_output_chars? : Int = @decode.default_max_output_chars,
 ) -> ShellOutput {
   collect_process_output(
-    @sandbox.PlatformShellProgram,
+    @sandbox.platform_shell_program(),
     @sandbox.platform_shell_args(cmd),
     cwd?,
     max_output_chars~,

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -469,7 +469,7 @@ fn resolved_global_skills_dir() -> @path.Path? {
 ///|
 fn first_path_entry(path : String?) -> String {
   guard path is Some(path) else { return "" }
-  match [..path.split(@env.PathSep)] {
+  match [..path.split(@env.path_sep())] {
     [first, ..] => first.to_owned()
     [] => ""
   }
@@ -940,7 +940,7 @@ async test "native engine env has one authoritative bundled moon path" {
   @fs.rmdir(root.to_string(), recursive=true)
   let moon_bin = moon_home.join("bin").to_string()
   let expected_path = if ambient_path is Some(path) && !path.is_empty() {
-    moon_bin + @env.PathSep + path
+    moon_bin + @env.path_sep() + path
   } else {
     moon_bin
   }

--- a/desktop/internal/env/path.mbt
+++ b/desktop/internal/env/path.mbt
@@ -17,8 +17,7 @@ const PathSep : String = ":"
 /// Deliberately a function, not a `pub const`. A public `#cfg` const bakes
 /// whichever value survived into `pkg.generated.mbti`, so regenerating the
 /// interface on Windows rewrites it and the committed one no longer matches
-/// — every other `#cfg` const here (`ExecutableSuffix`) stays private for the
-/// same reason.
+/// — `ExecutableSuffix` next door stays private for the same reason.
 pub fn path_sep() -> String {
   PathSep
 }

--- a/desktop/internal/env/path.mbt
+++ b/desktop/internal/env/path.mbt
@@ -5,11 +5,23 @@
 
 ///|
 #cfg(platform="windows")
-pub const PathSep : String = ";"
+const PathSep : String = ";"
 
 ///|
 #cfg(not(platform="windows"))
-pub const PathSep : String = ":"
+const PathSep : String = ":"
+
+///|
+/// The platform's path-variable separator: `;` on Windows, `:` elsewhere.
+///
+/// Deliberately a function, not a `pub const`. A public `#cfg` const bakes
+/// whichever value survived into `pkg.generated.mbti`, so regenerating the
+/// interface on Windows rewrites it and the committed one no longer matches
+/// — every other `#cfg` const here (`ExecutableSuffix`) stays private for the
+/// same reason.
+pub fn path_sep() -> String {
+  PathSep
+}
 
 ///|
 /// `bin_dir` prepended to `current_path`, or `bin_dir` alone when there is no

--- a/desktop/internal/env/path_test.mbt
+++ b/desktop/internal/env/path_test.mbt
@@ -7,7 +7,7 @@ test "a bin dir is prepended to the path, and stands alone when there is none" {
   )
   assert_eq(
     @env.prepend_to_path_env("/toolchain/bin", Some("/usr/bin")),
-    "/toolchain/bin\{@env.PathSep}/usr/bin",
+    "/toolchain/bin\{@env.path_sep()}/usr/bin",
   )
 }
 
@@ -18,9 +18,9 @@ test "prepending updates the existing spelling" {
   let env = { "Path": "/usr/bin" }
   assert_eq(
     @env.prepend_path_entry(env, "/toolchain/bin"),
-    "/toolchain/bin\{@env.PathSep}/usr/bin",
+    "/toolchain/bin\{@env.path_sep()}/usr/bin",
   )
-  assert_eq(env.get("Path"), Some("/toolchain/bin\{@env.PathSep}/usr/bin"))
+  assert_eq(env.get("Path"), Some("/toolchain/bin\{@env.path_sep()}/usr/bin"))
   assert_eq(env.get("PATH"), None)
   assert_eq(env.length(), 1)
 }
@@ -35,8 +35,8 @@ test "a duplicate path key is dropped so the child sees exactly one" {
   let joined = @env.prepend_path_entry(env, "/toolchain/bin")
   assert_eq(env.length(), 1)
   assert_true(
-    joined == "/toolchain/bin\{@env.PathSep}/usr/bin" ||
-    joined == "/toolchain/bin\{@env.PathSep}/opt/bin",
+    joined == "/toolchain/bin\{@env.path_sep()}/usr/bin" ||
+    joined == "/toolchain/bin\{@env.path_sep()}/opt/bin",
   )
   for key, value in env {
     assert_true(key == "Path" || key == "PATH")

--- a/desktop/internal/env/pkg.generated.mbti
+++ b/desktop/internal/env/pkg.generated.mbti
@@ -2,9 +2,9 @@
 package "openseek_desktop/internal/env"
 
 // Values
-pub const PathSep : String = ":"
-
 pub fn get(String) -> String?
+
+pub fn path_sep() -> String
 
 pub fn prepend_path_entry(Map[String, String], String) -> String
 


### PR DESCRIPTION
Self-review follow-up to the merged #575, extended after cross-model review. Fixes a whole hazard class rather than the one instance I introduced.

## The problem

`moon info` bakes a `pub const`'s **value** into the checked-in `pkg.generated.mbti`. When the const is `#cfg`-gated, only the branch that survived the current target's compile exists at generation time — so regenerating on another platform rewrites the line and the committed interface stops matching. CI's interface check runs on ubuntu, so the effect is a Windows contributor carrying a spurious diff, or turning the check red if they commit it.

A systematic sweep of every `pub const` reaching a committed `.mbti` finds exactly **two** `#cfg` cases:

| symbol | committed `.mbti` says | on Windows | introduced by |
|---|---|---|---|
| `desktop/internal/env` `PathSep` | `":"` | `";"` | #575 (mine) |
| `agent_tool/internal/sandbox` `PlatformShellProgram` | `"sh"` | `"pwsh"` | pre-existing |

The convention the repo already follows elsewhere is to keep such consts **private** — `ExecutableSuffix` in `desktop/internal/moonbit/toolchain_paths.mbt` sits under the identical `#cfg` pair and is private for exactly this reason. #575 broke that convention without noticing.

## The fix

Both become a private `#cfg` const behind a public accessor, so the interface records a *signature* rather than a value:

```diff
-pub const PathSep : String = ":"
+pub fn path_sep() -> String
```
```diff
-pub const PlatformShellProgram : String = "sh"
+pub fn platform_shell_program() -> String
```

Call sites repointed: `engine.mbt`'s `first_path_entry`, one engine test and the `internal/env` tests; `agent_tool/shell/shell.mbt` and `agent_tool/shell/sandbox.mbt`. No behavior change — the accessor returns the same const the callers were reading.

## Verification

- `moon check` (root) and `moon -C desktop check --target native` / `--target js` — clean
- `moon info` + `moon -C desktop info --target native` — both interfaces trade the const for the accessor; nothing else drifts
- `moon test` — **1514/1514 passed**

## Review note

Kimi K3 approved the first commit and caught that its "only such case in the repo" claim was wrong — my original grep for the hazard had been narrowed to separator characters and missed `PlatformShellProgram`. The second commit fixes that instance too and corrects the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)