### PR TITLE
simplify(agent_tool/sandbox): inline the single-use probe profile

### DIFF
--- a/agent_tool/internal/sandbox/sandbox_exec.mbt
+++ b/agent_tool/internal/sandbox/sandbox_exec.mbt
@@ -66,7 +66,10 @@ async fn probe_sandbox_exec_available() -> Bool {
     .join(Path("blocked"))
     .normalize()
     .to_string()
-  let probe_profile = sandbox_denial_probe_profile(blocked_path)
+  let probe_profile =
+    $|(version 1)
+    $|(allow default)
+    $|(deny file-write* (literal "\{sbpl_string_escape(blocked_path)}"))
   let noop_exit = run_probe_exit(
     SandboxExecPath,
     sandbox_exec_args(probe_profile, PlatformNoopCommand),
@@ -127,15 +130,6 @@ const PlatformNoopCommand : String = "exit 0"
 ///|
 #cfg(not(platform="windows"))
 const PlatformNoopCommand : String = ":"
-
-///|
-fn sandbox_denial_probe_profile(blocked_path : String) -> String {
-  (
-    $|(version 1)
-    $|(allow default)
-    $|(deny file-write* (literal "\{sbpl_string_escape(blocked_path)}"))
-  )
-}
 
 ///|
 fn shell_quote(text : String) -> String {


### PR DESCRIPTION
Follow-up to #580, which was merged before this commit landed on the branch.

`sandbox_denial_probe_profile` had one call site and no doc comment, so the name bought nothing its three-line SBPL literal does not already say. It is now bound where it is used, next to the comment explaining why `blocked_path` is resolved first.

Private, so `pkg.generated.mbti` is unchanged.

## Test plan

- `moon check --target native` — clean
- `moon info` — no interface diff
- `moon test agent_tool/internal/sandbox agent_tool/shell --target native` — 124/124

🤖 Generated with [Claude Code](https://claude.com/claude-code)