### PR TITLE
simplify: string interpolation instead of `+` concatenation

### DIFF
--- a/agent_tool/internal/sandbox/source_write_profile.mbt
+++ b/agent_tool/internal/sandbox/source_write_profile.mbt
@@ -77,8 +77,7 @@ pub async fn source_write_readonly_profile_data(
         @path.Path(lab).normalize().to_string(),
       )
       {
-        profile: base.profile +
-        "(allow file-write* (subpath \"\{sbpl_string_escape(lab)}\"))\n",
+        profile: "\{base.profile}(allow file-write* (subpath \"\{sbpl_string_escape(lab)}\"))\n",
         denial_subjects: base.denial_subjects,
       }
     }

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -361,9 +361,9 @@ fn moon_attached_cwd_option(option : String) -> String? {
 ///|
 fn moon_attached_value_option(option : String, name : String) -> Bool {
   if name.has_prefix("--") {
-    option_value_after_prefix(option, name + "=") is Some(_)
-  } else if option.has_prefix(name + "=") {
-    option_value_after_prefix(option, name + "=") is Some(_)
+    option_value_after_prefix(option, "\{name}=") is Some(_)
+  } else if option.has_prefix("\{name}=") {
+    option_value_after_prefix(option, "\{name}=") is Some(_)
   } else {
     option_value_after_prefix(option, name) is Some(_)
   }

--- a/desktop/internal/applauncher/applauncher.mbt
+++ b/desktop/internal/applauncher/applauncher.mbt
@@ -310,7 +310,7 @@ async fn find_app_icns(app_path : String) -> String? {
   let resources = "\{app_path}/Contents/Resources"
   let named = read_icon_name("\{app_path}/Contents/Info")
   if !named.is_empty() {
-    let file = if named.has_suffix(".icns") { named } else { named + ".icns" }
+    let file = if named.has_suffix(".icns") { named } else { "\{named}.icns" }
     let path = "\{resources}/\{file}"
     if (@fs.exists(path) catch { _ => false }) {
       return Some(path)

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -211,7 +211,7 @@ async fn migrate_legacy_archive(manager : EngineManager) -> Unit {
       _ => ()
     }
   } else {
-    @fsx.write_text(list, remaining.join("\n") + "\n") catch {
+    @fsx.write_text(list, "\{remaining.join("\n")}\n") catch {
       error if @async.is_being_cancelled() => raise error
       _ => ()
     }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -335,7 +335,7 @@ async fn prepare_engine_stdin(
   let path = if runtime_dir is Some(dir) {
     dir.join("engine.stdin")
   } else {
-    engine.to_string() + ".stdin"
+    "\{engine}.stdin"
   }
   @fs.write_file(path.to_string(), "", create_mode=CreateOrTruncate)
   @process.redirect_from_file(path.to_string())
@@ -375,7 +375,7 @@ async fn handle_decoded_event(
       true
     }
     AgentAborted(reason) => {
-      emit_error(sink, "agent aborted: " + reason, run_id~)
+      emit_error(sink, "agent aborted: \{reason}", run_id~)
       emit_finished(sink, run_id, Aborted)
       true
     }
@@ -752,7 +752,7 @@ async fn serve_engine_consumer(
             } else {
               emit_error(
                 sink,
-                "engine exited without a result:\n" + diagnostics,
+                "engine exited without a result:\n\{diagnostics}",
                 run_id=engine.latest_run,
                 exit_code=code,
                 diagnostics~,
@@ -940,7 +940,7 @@ async test "native engine env has one authoritative bundled moon path" {
   @fs.rmdir(root.to_string(), recursive=true)
   let moon_bin = moon_home.join("bin").to_string()
   let expected_path = if ambient_path is Some(path) && !path.is_empty() {
-    moon_bin + @env.path_sep + path
+    "\{moon_bin}\{@env.path_sep}\{path}"
   } else {
     moon_bin
   }

--- a/desktop/internal/engine/workspaces.mbt
+++ b/desktop/internal/engine/workspaces.mbt
@@ -193,9 +193,9 @@ async fn exclude_store_from_git(dir : @path.Path) -> Unit {
     }
   }
   let updated = if existing.is_empty() || existing.has_suffix("\n") {
-    existing + ".openseek/\n"
+    "\{existing}.openseek/\n"
   } else {
-    existing + "\n.openseek/\n"
+    "\{existing}\n.openseek/\n"
   }
   @fsx.ensure_dir(git_dir.join("info")) catch {
     error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/engine/wsl.mbt
+++ b/desktop/internal/engine/wsl.mbt
@@ -245,7 +245,7 @@ test "wslenv extends the user's own sharing list" {
   assert_eq(wslenv_with_passthrough(Some("  ")), WslEnvPassthrough)
   assert_eq(
     wslenv_with_passthrough(Some("MYVAR/u")),
-    "MYVAR/u:" + WslEnvPassthrough,
+    "MYVAR/u:\{WslEnvPassthrough}",
   )
 }
 

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -36,7 +36,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
       Some(
         ToolResult({
           name: tool_name,
-          content: "error: " + error,
+          content: "error: \{error}",
           is_error: true,
         }),
       )

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -31,7 +31,7 @@ async fn prepare_tool_stdin(
   let path = if runtime_dir is Some(dir) {
     dir.join("moonbit-tool.stdin")
   } else {
-    command.to_string() + ".stdin"
+    "\{command}.stdin"
   }
   @fs.write_file(path.to_string(), "", create_mode=CreateOrTruncate)
   @process.redirect_from_file(path.to_string())

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -140,7 +140,7 @@ fn session_local(key : String) -> Bool {
 /// Single-quote `text` for a POSIX shell command line, escaping embedded
 /// single quotes as `'\''`.
 fn shell_quote(text : String) -> String {
-  "'" + text.replace_all(old="'", new="'\\''") + "'"
+  "'\{text.replace_all(old="'", new="'\\''")}'"
 }
 
 ///|

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -94,7 +94,7 @@ fn slugify(name : String) -> String {
 /// provenance sidecar. The registry's per-skill API exposes no SKILL.md digest
 /// to verify against, so this is our own record of what we wrote, not a check.
 fn content_digest(content : Bytes) -> String {
-  "sha256:" + @crypto.bytes_to_hex_string(@crypto.sha256(content))
+  "sha256:\{@crypto.bytes_to_hex_string(@crypto.sha256(content))}"
 }
 
 ///|

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -244,7 +244,7 @@ test "slug validation rejects anything that could escape the library" {
   assert_false(valid_slug("a b"))
   let mut long = ""
   for _ in 0..<65 {
-    long = long + "a"
+    long = "\{long}a"
   }
   assert_false(valid_slug(long))
 }

--- a/desktop/internal/update/apply.mbt
+++ b/desktop/internal/update/apply.mbt
@@ -11,7 +11,7 @@
 /// Where the old bundle is parked during a swap; removed by
 /// `cleanup_leftovers` on the next launch, once no process runs from it.
 fn aside_path(bundle_path : String) -> String {
-  bundle_path + ".old"
+  "\{bundle_path}.old"
 }
 
 ///|

--- a/desktop/internal/update/apply_wbtest.mbt
+++ b/desktop/internal/update/apply_wbtest.mbt
@@ -7,7 +7,7 @@ async test "bundle replacement checks the containing directory" {
       @fs.chmod(root, 0o700)
       @fs.rmdir(root, recursive=true)
     })
-    let bundle = root + "/OpenSeek Desktop.app"
+    let bundle = "\{root}/OpenSeek Desktop.app"
     @fs.mkdir(bundle)
     @debug.assert_eq(bundle_replacement_failure(bundle), None)
     @fs.chmod(root, 0o500)
@@ -27,15 +27,15 @@ async test "an unavailable destination stops apply before any mutation" {
       @fs.chmod(root, 0o700)
       @fs.rmdir(root, recursive=true)
     })
-    let bundle = root + "/OpenSeek Desktop.app"
-    let staged = root + "/Staged.app"
+    let bundle = "\{root}/OpenSeek Desktop.app"
+    let staged = "\{root}/Staged.app"
     let aside = aside_path(bundle)
     @fs.mkdir(bundle)
     @fs.mkdir(staged)
     @fs.mkdir(aside)
-    @fs.write_file(bundle + "/version", "current", create_mode=CreateOrTruncate)
-    @fs.write_file(staged + "/version", "staged", create_mode=CreateOrTruncate)
-    @fs.write_file(aside + "/version", "parked", create_mode=CreateOrTruncate)
+    @fs.write_file("\{bundle}/version", "current", create_mode=CreateOrTruncate)
+    @fs.write_file("\{staged}/version", "staged", create_mode=CreateOrTruncate)
+    @fs.write_file("\{aside}/version", "parked", create_mode=CreateOrTruncate)
     @fs.chmod(root, 0o500)
     try apply_staged(staged_app=staged, bundle_path=bundle) catch {
       UpdateError(message) =>
@@ -44,8 +44,8 @@ async test "an unavailable destination stops apply before any mutation" {
     } noraise {
       _ => fail("apply unexpectedly accepted an unwritable destination")
     }
-    assert_eq(@fs.read_file(bundle + "/version").text(), "current")
-    assert_eq(@fs.read_file(staged + "/version").text(), "staged")
-    assert_eq(@fs.read_file(aside + "/version").text(), "parked")
+    assert_eq(@fs.read_file("\{bundle}/version").text(), "current")
+    assert_eq(@fs.read_file("\{staged}/version").text(), "staged")
+    assert_eq(@fs.read_file("\{aside}/version").text(), "parked")
   }
 }

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -424,10 +424,10 @@ test "a malformed platforms entry raises with what is wrong" {
 ///|
 test "manifest digests normalize to bare lowercase hex" {
   @debug.assert_eq(
-    normalized_sha256("sha256:" + TestSha.to_upper()),
+    normalized_sha256("sha256:\{TestSha.to_upper()}"),
     Some(TestSha),
   )
   @debug.assert_eq(normalized_sha256(TestSha), Some(TestSha))
-  @debug.assert_eq(normalized_sha256("zz" + TestSha), None)
+  @debug.assert_eq(normalized_sha256("zz\{TestSha}"), None)
   @debug.assert_eq(normalized_sha256("deadbeef"), None)
 }


### PR DESCRIPTION
## Summary

`a + "b"` and `"\{a}b"` are the same operation, but the interpolated form reads as the string being built rather than as an expression that assembles one — and it stays readable when a third piece arrives, where `+` chains do not:

```diff
-    moon_bin + @env.path_sep + path
+    "\{moon_bin}\{@env.path_sep}\{path}"
```

Every literal-adjacent concatenation in `agent_tool` and `desktop/internal`: 30 sites across 15 files. `desktop/internal/shellenv`'s `shell_quote` now matches the `agent_tool/internal/sandbox` one it mirrors.

## Left alone deliberately

- **`re"^[0-9]*" + re">&$"`** in `agent_tool/shell/sandbox.mbt` — that `+` composes regex patterns in a match arm, not strings.
- **`editor/internal` and `scripts`**, which hold roughly 470 more candidate sites. A sweep that size wants its own review; happy to do it as a follow-up.
- **Variable-to-variable concatenations** are not greppable without type information, so this pass caught only those adjacent to a literal.

## Test plan

- `moon check --target native` and `moon -C desktop check --target native` — both clean
- `moon info` — no interface changes in either module
- `moon test agent_tool/internal/sandbox agent_tool/shell --target native` — 124/124
- `moon -C desktop test --target native` — 2585/2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)