### PR TITLE
simplify(agent_tool/sandbox): emit SBPL with `<+` and template strings

### DIFF
--- a/agent_tool/internal/sandbox/sandbox_wbtest.mbt
+++ b/agent_tool/internal/sandbox/sandbox_wbtest.mbt
@@ -10,6 +10,24 @@ test "sandbox source write profile regex covers source and manifests" {
 }
 
 ///|
+/// Pins the emitted SBPL byte for byte. The `contains` assertions elsewhere
+/// would not notice a lost trailing newline, and
+/// `source_write_readonly_profile_data` appends the lab rule straight onto this
+/// text, so the final newline is load-bearing.
+async test "sandbox profile text" {
+  inspect(
+    source_write_readonly_profile_data("/workspace").profile,
+    content=(
+      #|(version 1)
+      #|(allow default)
+      #|(deny file-write* (regex "^\\/workspace(/|$)(.*/)?([^/]*(\\.mbt\\.md|\\.mbt|\\.mbti)|(moon\\.mod\\.json|moon\\.pkg\\.json|moon\\.mod|moon\\.pkg|moon\\.work))$"))
+      #|(allow file-write* (regex "^\\/workspace/(.*/)?(_build|\\.mooncakes)(/|$)"))
+      #|
+    ),
+  )
+}
+
+///|
 async test "sandbox profile is cached per normalized workspace root" {
   let profile = source_write_readonly_profile_data("/workspace").profile
   let cached = source_write_readonly_profile_data("/workspace/").profile

--- a/agent_tool/internal/sandbox/source_write_profile.mbt
+++ b/agent_tool/internal/sandbox/source_write_profile.mbt
@@ -107,22 +107,20 @@ async fn source_write_readonly_profile_base(
     real_workspace_root,
   )
   let profile = StringBuilder()
-  profile.write_string("(version 1)\n")
-  profile.write_string("(allow default)\n")
   // `file-write*` already covers `file-write-create`, so this single deny blocks
   // both rewriting existing source and creating new source files. SBPL is
   // last-match-wins, so the following carve-out re-allows Moon-managed build and
   // cache trees without the deny regex having to special-case them.
-  profile.write_string(
-    "(deny file-write* (regex \"\{sbpl_string_escape(source_regex)}\"))\n",
-  )
-  profile.write_string(
-    "(allow file-write* (regex \"\{sbpl_string_escape(build_carveout_regex)}\"))\n",
-  )
+  profile <+
+    $|(version 1)
+    $|(allow default)
+    $|(deny file-write* (regex "\{sbpl_string_escape(source_regex)}"))
+    $|(allow file-write* (regex "\{sbpl_string_escape(build_carveout_regex)}"))
+    $|
   for dir in scan.literal_paths {
-    profile.write_string(
-      "(deny file-write* (literal \"\{sbpl_string_escape(dir)}\"))\n",
-    )
+    profile <+
+      $|(deny file-write* (literal "\{sbpl_string_escape(dir)}"))
+      $|
   }
   let profile = profile.to_string()
   if scan.cacheable {


### PR DESCRIPTION
Rebased onto `main` now that #582 has merged — the interpolation commit was dropped as already-applied, so this PR is its own two commits.

## Summary

The profile builder emitted SBPL through six `write_string` calls, each carrying a hand-escaped rule with a `\n` glued to the end. With `<+` and `$|` template strings it carries SBPL instead:

```diff
-  profile.write_string("(version 1)\n")
-  profile.write_string("(allow default)\n")
-  profile.write_string(
-    "(deny file-write* (regex \"\{sbpl_string_escape(source_regex)}\"))\n",
-  )
+  profile <+
+    $|(version 1)
+    $|(allow default)
+    $|(deny file-write* (regex "\{sbpl_string_escape(source_regex)}"))
```

`$|` escapes nothing but `\{}`, so the `\"` pairs disappear and each line reads as the rule it emits. Line structure becomes the block's shape rather than a `\n` on every literal — with the trailing empty `$|` supplying the final newline.

## Why the first commit is a test

That final newline is load-bearing: `source_write_readonly_profile_data` appends the lab rule straight onto this text. Nothing pinned it — every existing profile assertion is a `contains`, which a lost trailing newline passes cleanly.

So the first commit adds `test "sandbox profile text"`, an `inspect` of the emitted profile captured from the **old** code. The second commit then passes it with no `--update`. The snapshot being untouched in that diff is the evidence the emitted bytes are identical, not merely similar.

## Test plan

Re-verified after the rebase onto `main`:

- `moon check --target native` — clean
- `moon fmt --check` — clean
- `moon info` — no interface change
- `moon test agent_tool/internal/sandbox agent_tool/shell --target native` — 125/125, snapshot passing without `--update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)