### PR TITLE
docs(agent_tool): thirteen READMEs whose examples are the test suite

### DIFF
--- a/agent_tool/finish/internal/decode/README.mbt.md
+++ b/agent_tool/finish/internal/decode/README.mbt.md
@@ -1,0 +1,85 @@
+# agent_tool/finish/internal/decode
+
+Argument decoding for the `finish` control tool: the one call an agent makes to
+end its run and hand back a final answer.
+
+This package is internal to `agent_tool/finish`. It owns only argument-shape
+decoding; what happens to the answer afterwards stays in the parent package.
+
+## `decode` cannot fail — on purpose
+
+Every other tool's decoder raises on a malformed payload, so the error goes back
+to the model and it retries with corrected arguments. `finish` is the one place
+where that is the wrong behavior: the call whose entire job is to *stop* the run
+would instead keep an already-finished run alive, and the retry has nothing new
+to say.
+
+So the signature is `Json -> FinishInput`, with no `raise`. Anything that is not
+a string `answer` decodes to the empty answer, and the run ends.
+
+```mbt check
+///|
+test "a well-formed call carries the answer through" {
+  debug_inspect(
+    @decode.decode({ "answer": "All 482 tasks pass; moon check is clean." }),
+    content=(
+      #|{ answer: "All 482 tasks pass; moon check is clean." }
+    ),
+  )
+}
+
+///|
+test "every malformed shape ends the run with an empty answer" {
+  // Missing field.
+  debug_inspect(
+    @decode.decode(Json::empty_object()),
+    content=(
+      #|{ answer: "" }
+    ),
+  )
+  // Present but not a string — a number, an object, or null.
+  debug_inspect(
+    @decode.decode({ "answer": 42 }),
+    content=(
+      #|{ answer: "" }
+    ),
+  )
+  debug_inspect(
+    @decode.decode({ "answer": Json::null() }),
+    content=(
+      #|{ answer: "" }
+    ),
+  )
+  // Not even an object.
+  debug_inspect(
+    @decode.decode(Json::null()),
+    content=(
+      #|{ answer: "" }
+    ),
+  )
+  debug_inspect(
+    @decode.decode(["answer"]),
+    content=(
+      #|{ answer: "" }
+    ),
+  )
+}
+```
+
+The trade this makes is explicit: a garbled `finish` loses the answer text rather
+than trapping the agent in a retry loop it cannot escape. Extra fields are
+ignored, and an empty answer is a legitimate decode result, not a signal of
+failure — the parent package cannot distinguish "the model sent `answer: ""`"
+from "the model sent nonsense", and does not need to.
+
+```mbt check
+///|
+test "extra fields are ignored" {
+  debug_inspect(
+    @decode.decode({ "answer": "done", "confidence": 0.9 }),
+    content=(
+      #|{ answer: "done" }
+    ),
+  )
+}
+```

--- a/agent_tool/finish/internal/decode/README.md
+++ b/agent_tool/finish/internal/decode/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/auto_check/README.mbt.md
+++ b/agent_tool/internal/auto_check/README.mbt.md
@@ -1,0 +1,319 @@
+# agent_tool/internal/auto_check
+
+The guardrails that run around a write. `write`, `edit`, `multi_edit`, and
+`remove` all use this package to answer three questions about a change to
+MoonBit source:
+
+1. **Does the candidate content even parse?** — `gate_paths` and
+   `content_parse_errors`, checked *before* the write lands.
+2. **Did the change break the build?** — `count_errors`, whose tally drives the
+   caller's revert decision.
+3. **What should the model be told?** — `append_summary` and
+   `format_parse_gate_errors`.
+
+## Everything here fails open
+
+Each entry point returns `None` (or the content unchanged) when it cannot do its
+job — the path is not MoonBit, there is no project, `moonc` is missing, the
+scratch directory is unwritable, the check timed out. A guard that could not run
+never blocks a write.
+
+That is a deliberate trade: an agent that cannot write files because a tool is
+missing is useless, while an agent that writes a file the build then rejects has
+merely produced a normal, recoverable error. The one thing the gate must never
+do is *certify* content it did not actually parse to completion.
+
+```mbt check
+///|
+async test "a non-MoonBit path is not gated, checked, or annotated" {
+  inspect(
+    @auto_check.content_parse_errors("notes.md", "# hi") is None,
+    content="true",
+  )
+  inspect(@auto_check.count_errors("notes.md") is None, content="true")
+  // `append_summary` returns the tool result untouched rather than None.
+  inspect(
+    @auto_check.append_summary("notes.md", "ok: wrote 4 chars"),
+    content="ok: wrote 4 chars",
+  )
+}
+```
+
+## The parse gate
+
+The gate runs `moonc syncheck` — moonc's parse-only front end — over candidate
+content in a **scratch file**, before the content reaches its destination. A
+rejection therefore leaves no broken file to delete or restore, which is what
+makes it safe to run on every write.
+
+Only lexer and parser diagnostics gate. Type and resolution errors do not: they
+are a legitimate transient state mid-edit, and refusing them would stop an agent
+from making a change in two steps.
+
+```mbt check
+///|
+async test "the gate parses candidate content that never touches disk" {
+  // `path` selects the input KIND only. Nothing reads or writes src/main.mbt.
+  let clean = @auto_check.content_parse_errors(
+    "src/main.mbt", "pub fn hi() -> Int { 1 }\n",
+  )
+  guard clean is Some(gate) else { fail("gate could not run") }
+  inspect(gate.errors.is_empty(), content="true")
+  inspect(gate.truncated, content="false")
+
+  // An unterminated block is a parse error, so the gate flags it.
+  let broken = @auto_check.content_parse_errors(
+    "src/main.mbt", "pub fn hi() -> Int {\n",
+  )
+  guard broken is Some(gate) else { fail("gate could not run") }
+  inspect(gate.errors.is_empty(), content="false")
+
+  // A type error is NOT a parse error, so it passes the gate untouched.
+  let unresolved = @auto_check.content_parse_errors(
+    "src/main.mbt", "pub fn hi() -> Int { missing_name }\n",
+  )
+  guard unresolved is Some(gate) else { fail("gate could not run") }
+  inspect(gate.errors.is_empty(), content="true")
+}
+```
+
+`truncated` marks `errors` a **lower bound**, not a tally. Callers that compare
+error counts before and after a change have to account for that, which is why it
+is on the struct rather than folded into the error list.
+
+### `gate_paths` — which input kinds to check
+
+`syncheck` recognizes its input by *name*: `.mbt`, `.mbt.md` (where it parses
+only ` ```mbt check ` fences), and an exact `moon.mod` or `moon.pkg`. `gate_paths`
+returns the distinct kinds named by a path and its resolved symlink target, as
+representative paths to hand to `content_parse_errors`.
+
+Usually that is one entry. It is two only when a symlink **crosses kinds**:
+
+```mbt check
+///|
+test "one entry per distinct syncheck input kind" {
+  // A regular file: pass the same value twice.
+  debug_inspect(
+    @auto_check.gate_paths("src/main.mbt", "src/main.mbt"),
+    content=(
+      #|["src/main.mbt"]
+    ),
+  )
+  // A symlink whose target shares its kind collapses to one check.
+  debug_inspect(
+    @auto_check.gate_paths("link.mbt", "real.mbt"),
+    content=(
+      #|["link.mbt"]
+    ),
+  )
+  // A symlink that CROSSES kinds is checked both ways: moon may classify it by
+  // the directory entry it globs OR by the file it resolves to, so a caller
+  // rejects if either kind flags the content. The caller's own spelling is
+  // listed first.
+  debug_inspect(
+    @auto_check.gate_paths("link.mbt", "doc.mbt.md"),
+    content=(
+      #|["link.mbt", "doc.mbt.md"]
+    ),
+  )
+  // Only one side is a syncheck input.
+  debug_inspect(
+    @auto_check.gate_paths("link.mbt", "notes.md"),
+    content=(
+      #|["link.mbt"]
+    ),
+  )
+}
+```
+
+An empty result means the gate does not apply — the caller writes without it.
+Note which manifests are *not* syncheck inputs:
+
+```mbt check
+///|
+test "manifests must be an exact basename, and moon.work is never gated" {
+  debug_inspect(
+    @auto_check.gate_paths("moon.pkg", "moon.pkg"),
+    content=(
+      #|["moon.pkg"]
+    ),
+  )
+  debug_inspect(
+    @auto_check.gate_paths("pkg/moon.mod", "pkg/moon.mod"),
+    content=(
+      #|["pkg/moon.mod"]
+    ),
+  )
+  // `moon.work` and the legacy JSON manifests are not syncheck inputs.
+  debug_inspect(@auto_check.gate_paths("moon.work", "moon.work"), content="[]")
+  debug_inspect(
+    @auto_check.gate_paths("moon.pkg.json", "moon.pkg.json"),
+    content="[]",
+  )
+  // Not an exact basename.
+  debug_inspect(
+    @auto_check.gate_paths("foo.moon.pkg", "foo.moon.pkg"),
+    content="[]",
+  )
+  debug_inspect(@auto_check.gate_paths("notes.md", "notes.md"), content="[]")
+}
+```
+
+### `format_parse_gate_errors` — the model's only view of the breakage
+
+Because rejected content never lands anywhere, the model cannot go read the
+broken file. The excerpt in the report is all it gets, so each error renders as
+`path:loc: message` followed by numbered source lines.
+
+The compiler's own `context` excerpt is preferred when present; it is indented
+two spaces and its trailing blank line dropped.
+
+```mbt check
+///|
+test "the compiler's own excerpt is indented and reused" {
+  debug_inspect(
+    @auto_check.format_parse_gate_errors("src/main.mbt", "unused\n", [
+      {
+        loc: "5:2-5:2",
+        message: "Parse error, unexpected token `end of file`.",
+        context: "4 |  match x {\n5 |}\n",
+      },
+    ]),
+    content=(
+      #|["src/main.mbt:5:2-5:2: Parse error, unexpected token `end of file`.\n  4 |  match x {\n  5 |}"]
+    ),
+  )
+}
+```
+
+When `context` is empty the excerpt is synthesized from the in-memory content
+using the diagnostic's `loc` — one line of leading context plus the error span,
+in the compiler's own `N |text` shape:
+
+```mbt check
+///|
+test "a missing excerpt is synthesized from the candidate content" {
+  let content = "fn main {\n  let x = 1\nlet y\n"
+  debug_inspect(
+    @auto_check.format_parse_gate_errors("src/main.mbt", content, [
+      { loc: "3:1-3:6", message: "Parse error", context: "" },
+    ]),
+    content=(
+      #|["src/main.mbt:3:1-3:6: Parse error\n  2 |  let x = 1\n  3 |let y"]
+    ),
+  )
+}
+
+///|
+test "a diagnostic with no location renders as a bare header" {
+  debug_inspect(
+    @auto_check.format_parse_gate_errors("moon.pkg", "", [
+      { loc: "", message: "Invalid configuration", context: "" },
+    ]),
+    content=(
+      #|["moon.pkg: Invalid configuration"]
+    ),
+  )
+}
+```
+
+At most five errors are rendered. Parse errors cascade, so a handful shows the
+shape of the breakage without dumping pages of noise:
+
+```mbt check
+///|
+test "the report is capped at five errors" {
+  let errors : Array[@auto_check.ParseGateError] = [
+    for i in 0..<8 => { loc: "", message: "e\{i}", context: "" }
+  ]
+  debug_inspect(
+    @auto_check.format_parse_gate_errors("a.mbt", "", errors).length(),
+    content="5",
+  )
+}
+```
+
+## `count_errors` — the tally behind a revert
+
+After a write lands, `count_errors` runs `moon check --output-json` from the
+containing module and tallies diagnostics by level. JSON Lines is used rather
+than the human summary so `level == "error"` can be counted exactly instead of
+inferred from warning-heavy prose.
+
+```mbt check
+///|
+async test "a real check tallies errors separately from warnings" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-readme-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/auto_check_readme\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/moon.pkg",
+      "warnings = \"+unnecessary_annotation\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn bad() -> Int { missing_name }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let tally = @auto_check.count_errors("\{dir}/main.mbt")
+    guard tally is Some(errors) else { fail("check did not run") }
+    inspect(errors.error_count >= 1, content="true")
+    inspect(errors.truncated, content="false")
+    // `first_errors` renders as `path:loc: message`, the same shape the human
+    // `moon check` output uses, so a reverted batch points straight at the site.
+    inspect(errors.first_errors.length() >= 1, content="true")
+  })
+}
+```
+
+`first_errors` holds at most ten entries while `error_count` stays exact, so a
+revert report can show the shape of an over-match without dumping a broken
+build. When the capture budget overflows, `truncated` is set and both counts
+become lower bounds — which only ever makes a caller's guard fire more readily,
+never less.
+
+## `append_summary` — the human-facing tail
+
+The last step: run the bounded `moon check` from
+`agent_tool/internal/moon_check` and append its rendered output to the tool
+result. This is raw compiler output, deliberately not summarized.
+
+```mbt check
+///|
+async test "a check summary is appended after the tool's own result line" {
+  @vfs.with_tmpdir(prefix="openseek-auto-check-readme-summary-", dir => {
+    @fs.write_file(
+      "\{dir}/moon.mod",
+      "name = \"tmp/auto_check_readme_summary\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/moon.pkg",
+      "warnings = \"+unnecessary_annotation\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/main.mbt",
+      "pub fn bad() -> Int { missing_name }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let result = @auto_check.append_summary(
+      "\{dir}/main.mbt",
+      "ok: wrote 37 chars",
+    )
+    inspect(
+      result.has_prefix("ok: wrote 37 chars\nmoon check:\n"),
+      content="true",
+    )
+    inspect(result.contains("Error:"), content="true")
+  })
+}
+```
+
+The check runs from the module or workspace root rather than the file's own
+directory, so an edit in one package surfaces breakage it caused in another.

--- a/agent_tool/internal/auto_check/README.md
+++ b/agent_tool/internal/auto_check/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/error/README.mbt.md
+++ b/agent_tool/internal/error/README.mbt.md
@@ -1,0 +1,98 @@
+# agent_tool/internal/error
+
+One function, `failure_message`, that takes MoonBit's rendering of a raised
+`fail(...)` and gives back just the message the code meant to say.
+
+Ten packages depend on it — `edit`, `goal`, `multi_edit`, `plan`, `read`,
+`remove`, `run_moonbit`, `shell`, `write`, and `goal/internal/decode` — because
+argument validation lives in internal decode packages that signal problems with
+`fail("arguments.path")`. The string a tool would otherwise hand back to the
+model looks like this:
+
+```text
+Failure(agent_tool/read/internal/decode/decode.mbt:41:7-41:29@decode FAILED: arguments.path)
+```
+
+That leaks a source location into a message whose whole job is to tell the model
+which argument to fix. `failure_message` strips the wrapper so the tool result
+reads `arguments.path` and stays stable when the raising code moves to another
+line or another file.
+
+## Behavior
+
+The wrapper comes off; anything that is not wrapped passes through unchanged.
+There is no error case — this is a formatting normalizer, not a parser.
+
+```mbt check
+///|
+test "the wrapper comes off, and unwrapped text is left alone" {
+  inspect(
+    @error.failure_message(
+      "Failure(agent_tool/read/internal/decode/decode.mbt:41:7-41:29@decode FAILED: arguments.path)",
+    ),
+    content="arguments.path",
+  )
+  // A message that was never wrapped is already the answer, so applying this
+  // twice is safe.
+  inspect(@error.failure_message("arguments.path"), content="arguments.path")
+  inspect(@error.failure_message(""), content="")
+}
+```
+
+The point of the package is that this works on a *real* raised error, not just
+on a hand-written string. The location in the raw text depends on where `fail`
+is called, so only the extracted message is stable enough to pin:
+
+```mbt check
+///|
+/// Stands in for the argument validation a decode package performs.
+fn reject_argument() -> String raise {
+  fail("arguments.max_output_chars to be a positive number")
+}
+
+///|
+test "a real raised failure round-trips to just its message" {
+  let extracted = try reject_argument() catch {
+    err => @error.failure_message("\{err}")
+  } noraise {
+    _ => "no error was raised"
+  }
+  inspect(
+    extracted,
+    content="arguments.max_output_chars to be a positive number",
+  )
+}
+```
+
+## Edges worth knowing
+
+A message containing a literal `)` survives, because exactly one trailing
+parenthesis — the wrapper's own — is removed:
+
+```mbt check
+///|
+test "one closing paren is removed, not every one" {
+  inspect(
+    @error.failure_message("Failure(decode.mbt:1:1-1:2@d FAILED: expected (a))"),
+    content="expected (a)",
+  )
+}
+```
+
+The scan is greedy to the **last** ` FAILED: ` marker, so a failure message that
+itself contains that exact marker is cut at the wrong place. No message in this
+repository does, and the alternative — matching the first marker — would break
+on nested renderings instead. It is a documented limit, not a bug to route
+around:
+
+```mbt check
+///|
+test "a message containing ` FAILED: ` is cut at the last marker" {
+  inspect(
+    @error.failure_message(
+      "Failure(d.mbt:1:1-1:2@d FAILED: step FAILED: badly)",
+    ),
+    content="badly",
+  )
+}
+```

--- a/agent_tool/internal/error/README.md
+++ b/agent_tool/internal/error/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/manifest_path/README.mbt.md
+++ b/agent_tool/internal/manifest_path/README.mbt.md
@@ -1,0 +1,136 @@
+# agent_tool/internal/manifest_path
+
+Four predicates that answer "is this path a MoonBit manifest?" — the shared
+vocabulary behind the write tools' manifest guards. `internal/manifest_error`
+uses them to reject known-bad manifest rewrites before `edit`, `multi_edit`, and
+`write` touch the file; `internal/auto_check` uses them to decide which paths
+deserve a follow-up `moon check`.
+
+Every function is a pure string operation. Nothing here opens, stats, or
+resolves anything on disk, so a path that does not exist classifies exactly like
+one that does.
+
+## The contract
+
+- **Backslashes are separators.** Input is normalized `\` → `/` first, so a
+  Windows path from a tool call classifies the same as its POSIX form and needs
+  no pre-cleaning.
+- **Matching is case-sensitive**, on every platform.
+- **`.` and `..` are not interpreted.** These are name tests, not containment
+  tests; normalize first if that matters.
+- **Basename or full path both work.** A bare `moon.mod` classifies the same as
+  `packages/demo/moon.mod`.
+
+## The three manifest predicates
+
+`is_moon_mod_path`, `is_moon_mod_json_path`, and `is_moon_pkg_path` are anchored
+at a separator: the match is either the whole path or a complete final
+component. That anchoring is the point — it is what keeps a file merely *named*
+like a manifest from being treated as one.
+
+```mbt check
+///|
+test "manifest predicates match a whole final component" {
+  inspect(@manifest_path.is_moon_mod_path("moon.mod"), content="true")
+  inspect(
+    @manifest_path.is_moon_mod_path("packages/demo/moon.mod"),
+    content="true",
+  )
+  // Windows input classifies identically.
+  inspect(
+    @manifest_path.is_moon_mod_path("packages\\demo\\moon.mod"),
+    content="true",
+  )
+  // Anchored at the separator: a name that merely ends in "moon.mod" is not a
+  // manifest, so `notmoon.mod` stays writable.
+  inspect(@manifest_path.is_moon_mod_path("notmoon.mod"), content="false")
+  // Case-sensitive.
+  inspect(@manifest_path.is_moon_mod_path("MOON.MOD"), content="false")
+}
+
+///|
+test "the module manifest and its legacy JSON form are separate questions" {
+  inspect(
+    @manifest_path.is_moon_mod_json_path("packages/demo/moon.mod.json"),
+    content="true",
+  )
+  // `moon.mod.json` is NOT a `moon.mod`: the suffixes are distinct, so a caller
+  // that wants "either module manifest" must ask both.
+  inspect(@manifest_path.is_moon_mod_path("moon.mod.json"), content="false")
+  inspect(@manifest_path.is_moon_mod_json_path("moon.mod"), content="false")
+}
+
+///|
+test "package manifests, and the JSON form this package does not classify" {
+  inspect(@manifest_path.is_moon_pkg_path("moon.pkg"), content="true")
+  inspect(
+    @manifest_path.is_moon_pkg_path("agent_tool/read/moon.pkg"),
+    content="true",
+  )
+  // There is deliberately no `is_moon_pkg_json_path`. Only `moon.mod.json` has
+  // a predicate here, because only that legacy form is guarded on creation.
+  inspect(@manifest_path.is_moon_pkg_path("moon.pkg.json"), content="false")
+}
+```
+
+## The generated-interface predicate
+
+`is_generated_mbti_path` is the odd one out: it is a **plain suffix test**, not
+an anchored component test, because `*.generated.mbti` names a file by its
+extension rather than by a fixed filename. Any basename may precede it.
+
+```mbt check
+///|
+test "generated interfaces are matched by extension, not by filename" {
+  inspect(
+    @manifest_path.is_generated_mbti_path("agent_tool/read/pkg.generated.mbti"),
+    content="true",
+  )
+  // Any stem works — the extension is what is being recognized.
+  inspect(
+    @manifest_path.is_generated_mbti_path("anything.generated.mbti"),
+    content="true",
+  )
+  // A hand-written interface is not a generated one.
+  inspect(@manifest_path.is_generated_mbti_path("pkg.mbti"), content="false")
+  // The leading dot is part of the suffix, so a bare `generated.mbti` misses.
+  inspect(
+    @manifest_path.is_generated_mbti_path("generated.mbti"),
+    content="false",
+  )
+}
+```
+
+## Edges worth knowing
+
+Trailing slashes are *not* normalized. These predicates classify files, and a
+path ending in `/` names a directory, so it correctly fails every test — but the
+failure is silent, and a caller that strips its own trailing slashes elsewhere
+should strip them before asking here too.
+
+```mbt check
+///|
+test "a trailing slash defeats every predicate" {
+  inspect(@manifest_path.is_moon_mod_path("demo/moon.mod/"), content="false")
+  inspect(@manifest_path.is_moon_pkg_path("demo/moon.pkg/"), content="false")
+}
+
+///|
+test "`..` is not interpreted, because these are name tests" {
+  // Both of these are about the final component only; neither says anything
+  // about where the path actually lands.
+  inspect(
+    @manifest_path.is_moon_mod_path("demo/../../../etc/moon.mod"),
+    content="true",
+  )
+  inspect(
+    @manifest_path.is_moon_mod_path("demo/moon.mod/../x"),
+    content="false",
+  )
+}
+```
+
+For "is this path inside the workspace?" — the question these predicates
+deliberately do not answer — see `internal/workspace_path`, and
+`agent_tool/internal/source_write_policy` for the combined protected-source
+decision.

--- a/agent_tool/internal/manifest_path/README.md
+++ b/agent_tool/internal/manifest_path/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/moon_check/README.mbt.md
+++ b/agent_tool/internal/moon_check/README.mbt.md
@@ -1,0 +1,159 @@
+# agent_tool/internal/moon_check
+
+The shared vocabulary for running a follow-up `moon check`: the command, its
+bounds, how its result is rendered, and where it should run from.
+
+Two callers need to agree on all four. `agent_tool/internal/auto_check` runs a
+check after `write`, `edit`, `multi_edit`, and `remove` change a MoonBit file;
+`agent_tool/shell` recognizes the same check when the model runs it itself. If
+the two disagreed on the command or the output shape, the same failure would
+reach the model looking like two different failures.
+
+This package holds no policy about *when* to check — only what the check is.
+
+## The bounds
+
+```mbt check
+///|
+test "the command and its bounds are constants, not caller choices" {
+  inspect(@moon_check.Command, content="moon check --diagnostic-limit 1")
+  inspect(@moon_check.TimeoutMs, content="30000")
+  inspect(@moon_check.MaxOutputChars, content="12000")
+}
+```
+
+`--diagnostic-limit 1` is the reason this is cheap enough to run after every
+write: the model needs to know *that* it broke the build and *where*, not the
+full cascade. A 30-second ceiling and a 12000-character capture keep a
+pathological project from stalling a tool call or flooding the conversation.
+
+## `format_output` — success is the absence of an exit line
+
+The rendering is deliberately terse. A clean check adds one header line and the
+output; anything abnormal adds a labeled line for it. There is no `exit=0`,
+because the common case should cost the model as little context as possible.
+
+```mbt check
+///|
+test "a successful check renders as a header and the output" {
+  inspect(
+    @moon_check.format_output(
+      Some(0),
+      "Finished. moon: ran 2 tasks, now up to date",
+      false,
+    ),
+    content=(
+      #|moon check:
+      #|Finished. moon: ran 2 tasks, now up to date
+    ),
+  )
+}
+
+///|
+test "a failure carries its exit code" {
+  inspect(
+    @moon_check.format_output(
+      Some(255),
+      (
+        #|Error: Failed to calculate build plan
+        #|
+        #|Caused by:
+        #|    0: Failed to resolve the module dependency graph
+      ),
+      false,
+    ),
+    content=(
+      #|moon check:
+      #|exit=255
+      #|Error: Failed to calculate build plan
+      #|
+      #|Caused by:
+      #|    0: Failed to resolve the module dependency graph
+    ),
+  )
+}
+```
+
+The two abnormal conditions are named rather than inferred. A cancelled check
+has no exit code at all — distinct from exiting non-zero, and the model should
+not read it as a build failure. A truncated capture is flagged so the model
+knows the diagnostics it can see may not be all of them.
+
+```mbt check
+///|
+test "cancellation and truncation are labeled, not implied" {
+  inspect(
+    @moon_check.format_output(None, "long output", true),
+    content=(
+      #|moon check:
+      #|exit=cancelled
+      #|output_limit_reached=true
+      #|long output
+    ),
+  )
+  // Empty output produces the header alone — never a trailing blank line.
+  inspect(@moon_check.format_output(Some(0), "", false), content="moon check:")
+  inspect(
+    @moon_check.format_output(Some(1), "", false),
+    content=(
+      #|moon check:
+      #|exit=1
+    ),
+  )
+}
+```
+
+## `nearest_project_dir` — where to run from
+
+`moon check` must run from a module or workspace root, not from the directory of
+the file that changed. This walks up from `start` looking for a `moon.mod` or
+`moon.work` marker and returns the first directory that has either.
+
+Nearest wins, and the two markers are equal in rank: a `moon.mod` deeper in the
+tree beats a `moon.work` above it, so editing a member of a workspace checks
+that member rather than the whole workspace.
+
+```mbt check
+///|
+async test "the walk stops at the first marker it meets" {
+  @vfs.with_tmpdir(prefix="openseek-moon-check-readme-", dir => {
+    let module_dir = "\{dir}/packages/demo"
+    let source = "\{module_dir}/src"
+    @fs.mkdir(source, recursive=true)
+
+    // Only a workspace marker at the top: the walk climbs all the way up.
+    @fs.write_file(
+      "\{dir}/moon.work",
+      "members = []\n",
+      create_mode=CreateOrTruncate,
+    )
+    inspect(
+      @moon_check.nearest_project_dir(source) is Some(found) && found == dir,
+      content="true",
+    )
+
+    // Add a module marker in between, and it wins — it is nearer.
+    @fs.write_file(
+      "\{module_dir}/moon.mod",
+      "name = \"example/demo\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    inspect(
+      @moon_check.nearest_project_dir(source) is Some(found) &&
+      found == module_dir,
+      content="true",
+    )
+    // A directory holding a marker is its own project root.
+    inspect(
+      @moon_check.nearest_project_dir(module_dir) is Some(found) &&
+      found == module_dir,
+      content="true",
+    )
+  })
+}
+```
+
+The walk terminates at the filesystem root and returns `None` when it finds no
+marker — a file outside any MoonBit project. Callers treat that as "do not
+check" rather than as an error, which is what makes it safe to call this on any
+path a tool just wrote.

--- a/agent_tool/internal/moon_check/README.md
+++ b/agent_tool/internal/moon_check/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/source_write_policy/README.mbt.md
+++ b/agent_tool/internal/source_write_policy/README.mbt.md
@@ -4,23 +4,283 @@ Workspace policy shared by the macOS sandbox profile builder and the `shell`
 tool's static command preflight. This package decides which MoonBit source paths
 are protected; it does not execute commands or emit SBPL.
 
-## API contracts
+Two callers, one answer. `agent_tool/internal/sandbox` turns these predicates
+into SBPL deny rules enforced by `sandbox-exec` at runtime; `agent_tool/shell`
+asks the same questions before spawning anything, so a command is refused the
+same way on a platform where the sandbox is unavailable. The two must agree,
+which is why the rules live here rather than in either caller — and why the
+examples below are tests rather than prose: a drift in behavior fails the build
+instead of quietly letting the enforcement paths diverge.
 
-- `is_protected_source_path(path)` recognizes protected source and manifest
-  names by case-sensitive suffix. It accepts a basename or full path and does
-  not access the filesystem.
-- `is_moon_managed_workspace_path(root, path)` recognizes `_build` and
-  `.mooncakes` components below a workspace root. These trees are writable
-  because Moon generates source files in them.
-- `is_protected_workspace_source_path(root, target)` combines workspace
-  containment, the build-tree exemption, and protected-name classification.
-  The root should be absolute and canonical when the result is used to mirror
-  sandbox behavior.
-- `path_is_under_lab(target, lab)` is the scratch-lab authorization predicate.
-  It normalizes both paths, includes the lab itself, and rejects an empty lab or
-  `/`.
+Every function is a pure string operation. Nothing here opens, stats, or
+resolves symlinks.
+
+## `is_protected_source_path` — is this a source name?
+
+Recognizes protected source and manifest names by case-sensitive suffix. It
+accepts a basename or a full path and asks nothing about location.
+
+```mbt check
+///|
+test "protected names: sources, interfaces, and every manifest" {
+  inspect(
+    @source_write_policy.is_protected_source_path("main.mbt"),
+    content="true",
+  )
+  // `.mbt.md` counts — a documented package's README is executable source.
+  inspect(
+    @source_write_policy.is_protected_source_path(
+      "agent_tool/read/README.mbt.md",
+    ),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.is_protected_source_path("pkg.generated.mbti"),
+    content="true",
+  )
+  // All four manifests, current and legacy, as a bare name or a full path.
+  inspect(
+    @source_write_policy.is_protected_source_path("moon.mod"),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.is_protected_source_path("agent_tool/moon.pkg"),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.is_protected_source_path("moon.work"),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.is_protected_source_path("moon.pkg.json"),
+    content="true",
+  )
+  // Everything else is writable: the policy protects source, not the tree.
+  inspect(
+    @source_write_policy.is_protected_source_path("notes.md"),
+    content="false",
+  )
+  inspect(
+    @source_write_policy.is_protected_source_path("target/debug/app"),
+    content="false",
+  )
+}
+
+///|
+test "matching is case-sensitive and separator-agnostic" {
+  inspect(
+    @source_write_policy.is_protected_source_path("src\\main.mbt"),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.is_protected_source_path("MAIN.MBT"),
+    content="false",
+  )
+}
+```
+
+This predicate alone is **not** an authorization decision. It says nothing about
+where the path is, so a source file anywhere on the machine answers `true`:
+
+```mbt check
+///|
+test "a name test is not a location test" {
+  inspect(
+    @source_write_policy.is_protected_source_path("/etc/cron.d/payload.mbt"),
+    content="true",
+  )
+}
+```
+
+Use `is_protected_workspace_source_path` when the answer will gate a write.
+
+## `is_moon_managed_workspace_path` — did Moon generate this?
+
+Recognizes `_build` and `.mooncakes` components below a workspace root. These
+trees are writable because Moon generates source files in them; protecting them
+would break every build.
+
+```mbt check
+///|
+test "Moon's own trees are exempt, the rest of the workspace is not" {
+  inspect(
+    @source_write_policy.is_moon_managed_workspace_path(
+      "/work", "/work/_build/native/release/gen.mbt",
+    ),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.is_moon_managed_workspace_path(
+      "/work", "/work/.mooncakes/bobzhang/dep/lib.mbt",
+    ),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.is_moon_managed_workspace_path(
+      "/work", "/work/src/main.mbt",
+    ),
+    content="false",
+  )
+  // Outside the root there is nothing for this root to exempt.
+  inspect(
+    @source_write_policy.is_moon_managed_workspace_path(
+      "/work", "/other/_build/gen.mbt",
+    ),
+    content="false",
+  )
+}
+```
+
+The scan runs over components **relative to the root**, and the root itself is
+never Moon-managed. Both rules exist so that pointing a root at a build
+directory cannot exempt everything below it:
+
+```mbt check
+///|
+test "the root is never exempt, and only components below it are scanned" {
+  inspect(
+    @source_write_policy.is_moon_managed_workspace_path(
+      "/work/_build", "/work/_build",
+    ),
+    content="false",
+  )
+  // `_build` is the root here, so it is not a component *below* the root and
+  // the file is treated as ordinary source.
+  inspect(
+    @source_write_policy.is_moon_managed_workspace_path(
+      "/work/_build", "/work/_build/gen.mbt",
+    ),
+    content="false",
+  )
+}
+```
+
+## `is_protected_workspace_source_path` — the decision
+
+Combines workspace containment, the build-tree exemption, and protected-name
+classification. This is the predicate that gates a write. The root should
+already be absolute and canonical when the result is used to mirror sandbox
+behavior.
+
+```mbt check
+///|
+test "protected only when contained, generated-exempt, and source-named" {
+  inspect(
+    @source_write_policy.is_protected_workspace_source_path(
+      "/work", "/work/src/main.mbt",
+    ),
+    content="true",
+  )
+  // Generated: Moon needs to write here.
+  inspect(
+    @source_write_policy.is_protected_workspace_source_path(
+      "/work", "/work/_build/gen.mbt",
+    ),
+    content="false",
+  )
+  // Not source-named: notes and data are the agent's to edit.
+  inspect(
+    @source_write_policy.is_protected_workspace_source_path(
+      "/work", "/work/notes.md",
+    ),
+    content="false",
+  )
+  // Not contained: outside the workspace this policy has no opinion, and a
+  // caller must not read `false` as "safe to write".
+  inspect(
+    @source_write_policy.is_protected_workspace_source_path(
+      "/work", "/etc/cron.d/payload.mbt",
+    ),
+    content="false",
+  )
+}
+```
+
+Unlike the raw helpers in `internal/workspace_path`, this predicate **normalizes
+`.` and `..` before deciding**, so a traversal cannot smuggle a path past
+containment in either direction:
+
+```mbt check
+///|
+test "`..` is resolved before containment is judged" {
+  // Normalizes to /work/main.mbt — still inside, still protected.
+  inspect(
+    @source_write_policy.is_protected_workspace_source_path(
+      "/work", "/work/src/../main.mbt",
+    ),
+    content="true",
+  )
+  // Normalizes to /etc/passwd.mbt — the escape is caught, where the purely
+  // lexical `@workspace_path.is_under_workspace_root` would have said `true`.
+  inspect(
+    @source_write_policy.is_protected_workspace_source_path(
+      "/work", "/work/../etc/passwd.mbt",
+    ),
+    content="false",
+  )
+}
+```
+
+## `path_is_under_lab` — the scratch-lab exception
+
+The authorization predicate for an opt-in writable subtree. It normalizes both
+paths, includes the lab itself, and refuses to authorize everything.
+
+```mbt check
+///|
+test "the lab and everything under it, and nothing else" {
+  inspect(
+    @source_write_policy.path_is_under_lab("/work/lab/scratch.mbt", "/work/lab"),
+    content="true",
+  )
+  // The lab directory itself is included.
+  inspect(
+    @source_write_policy.path_is_under_lab("/work/lab", "/work/lab"),
+    content="true",
+  )
+  // A sibling sharing a name prefix is not under the lab.
+  inspect(
+    @source_write_policy.path_is_under_lab("/work/lab2/x.mbt", "/work/lab"),
+    content="false",
+  )
+  // Traversal is normalized away before the comparison, in both directions.
+  inspect(
+    @source_write_policy.path_is_under_lab(
+      "/work/lab/../lab/x.mbt", "/work/lab",
+    ),
+    content="true",
+  )
+  inspect(
+    @source_write_policy.path_is_under_lab(
+      "/work/lab/../secret.mbt", "/work/lab",
+    ),
+    content="false",
+  )
+}
+```
+
+A lab of `/` or of the empty string is rejected outright, so a caller that
+forgets to configure one cannot accidentally authorize the whole filesystem:
+
+```mbt check
+///|
+test "a degenerate lab authorizes nothing" {
+  inspect(
+    @source_write_policy.path_is_under_lab("/work/src/main.mbt", "/"),
+    content="false",
+  )
+  inspect(
+    @source_write_policy.path_is_under_lab("/work/src/main.mbt", ""),
+    content="false",
+  )
+}
+```
+
+## What callers still owe
 
 The package uses `internal/workspace_path` for generic path operations. Its
 comparisons are lexical and case-sensitive: callers remain responsible for
 resolving symlinks and canonicalizing user-controlled paths where filesystem
-identity matters.
+identity matters. A symlink inside the workspace pointing out of it still tests
+as contained here — which is why `agent_tool/internal/sandbox` resolves its root
+with `@fs.realpath` before emitting a single rule.

--- a/agent_tool/internal/source_write_policy/README.md
+++ b/agent_tool/internal/source_write_policy/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/utils/README.mbt.md
+++ b/agent_tool/internal/utils/README.mbt.md
@@ -1,0 +1,79 @@
+# agent_tool/internal/utils
+
+One function, `code_unit_prefix`, that truncates text to a UTF-16 code-unit
+budget without ever splitting a surrogate pair.
+
+Tool output is capped so a single `read` cannot flood the model's context. The
+cap is counted in UTF-16 code units, but a non-BMP character — an emoji, a rare
+CJK ideograph, a musical symbol — occupies *two* of them. Cutting between the
+two halves produces a lone surrogate: not a character, and not valid UTF-8 once
+the result is serialized into a tool response. This package is where that rule
+lives so it is written once rather than in every tool that renders output.
+
+`agent_tool/read` is the current caller.
+
+## The budget is a ceiling, never a target
+
+The result is at most `max_units` code units and may be shorter — by one, when
+the budget lands mid-pair. It is a *soft* cap in the other direction too: text
+already within budget is returned whole, never padded.
+
+```mbt check
+///|
+test "a surrogate pair is kept whole or dropped entirely" {
+  // "😀Z" is three code units: the emoji takes two, "Z" takes one.
+  inspect(@utils.code_unit_prefix("😀Z", 3), content="😀Z")
+  inspect(@utils.code_unit_prefix("😀Z", 2), content="😀")
+  // A budget of 1 would land between the emoji's two halves, so it steps back
+  // to 0 rather than emit a lone surrogate.
+  inspect(@utils.code_unit_prefix("😀Z", 1), content="")
+  inspect(@utils.code_unit_prefix("😀Z", 0), content="")
+}
+
+///|
+test "text within budget comes back whole" {
+  inspect(@utils.code_unit_prefix("abc", 3), content="abc")
+  inspect(@utils.code_unit_prefix("abc", 10), content="abc")
+  // Non-positive budgets are empty, not an error.
+  inspect(@utils.code_unit_prefix("abc", 0), content="")
+  inspect(@utils.code_unit_prefix("abc", -5), content="")
+}
+```
+
+Only a boundary that would split a pair costs a unit. A budget landing on an
+ordinary character, or just after a complete pair, is used in full:
+
+```mbt check
+///|
+test "only a split boundary costs a code unit" {
+  // Cutting after the pair — no step back needed.
+  inspect(@utils.code_unit_prefix("ab😀cd", 4), content="ab😀")
+  // Cutting inside it — one unit given up.
+  inspect(@utils.code_unit_prefix("ab😀cd", 3), content="ab")
+  // Cutting in plain text — exact.
+  inspect(@utils.code_unit_prefix("ab😀cd", 2), content="ab")
+  inspect(@utils.code_unit_prefix("abcdef", 4), content="abcd")
+}
+```
+
+## Notes for callers
+
+The parameter and result are `StringView`, so a truncation that keeps everything
+— the common case — allocates nothing and the slice shares the original buffer.
+Pass a `String` directly; the conversion is implicit.
+
+This counts **code units, not characters and not grapheme clusters**. A combining
+mark or an emoji ZWJ sequence can still be cut in the middle: the result stays
+valid UTF-16, but a family emoji may render as its separate members. That is
+deliberate — the budget exists to bound bytes, and clustering rules would make
+the bound depend on Unicode tables.
+
+```mbt check
+///|
+test "clusters may split; only pairs are protected" {
+  // "e" followed by a combining acute accent — two code units, one grapheme.
+  // Cutting at 1 keeps the base letter and drops the accent: still valid text,
+  // just a different glyph.
+  inspect(@utils.code_unit_prefix("e\u{0301}", 1), content="e")
+}
+```

--- a/agent_tool/internal/utils/README.md
+++ b/agent_tool/internal/utils/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/plan/steps/README.mbt.md
+++ b/agent_tool/plan/steps/README.mbt.md
@@ -1,0 +1,284 @@
+# agent_tool/plan/steps
+
+The plan vocabulary and its decoder: `PlanStatus`, `PlanStep`, `PlanInput`, and
+the `decode` that turns `plan` tool-call arguments into them.
+
+`agent_tool/plan` decodes calls with it; `viz` renders stored plans with it. The
+types live here rather than in `agent_tool/plan` so the renderer does not have
+to depend on the tool.
+
+## A plan call replaces the whole plan
+
+`steps` is not a delta. Every call carries the complete, ordered list, and an
+empty array is the documented way to clear the plan. That is why `decode` has no
+notion of adding, removing, or reordering — there is only one operation.
+
+```mbt check
+///|
+test "a plan is the whole ordered list, and empty clears it" {
+  debug_inspect(
+    @steps.decode({
+      "steps": [
+        { "title": "reproduce the failing test", "status": "completed" },
+        { "title": "fix the decoder", "status": "in_progress" },
+        { "title": "run moon test", "status": "pending" },
+      ],
+    }),
+    content=(
+      #|{
+      #|  steps: [
+      #|    { title: "reproduce the failing test", status: Completed },
+      #|    { title: "fix the decoder", status: InProgress },
+      #|    { title: "run moon test", status: Pending },
+      #|  ],
+      #|}
+    ),
+  )
+  debug_inspect(
+    @steps.decode({ "steps": [] }),
+    content=(
+      #|{ steps: [] }
+    ),
+  )
+}
+```
+
+## `label` is the wire spelling
+
+`PlanStatus::label` produces exactly the strings `decode` accepts, so a decoded
+plan round-trips. Consumers also use it as a stable machine-readable tag — the
+plan reminder's `[status]` brackets, the viewer's CSS classes — which is why it
+is a method on the enum rather than a formatting detail of either consumer.
+
+```mbt check
+///|
+test "every label decodes back to the status it came from" {
+  let decoded = @steps.decode({
+    "steps": [
+      { "title": "a", "status": "pending" },
+      { "title": "b", "status": "in_progress" },
+      { "title": "c", "status": "completed" },
+    ],
+  })
+  debug_inspect(
+    decoded.steps.map(step => step.status),
+    content="[Pending, InProgress, Completed]",
+  )
+  // Each decoded status spells itself back as the wire form it came from.
+  inspect(
+    decoded.steps.map(step => step.status.label()).join(" "),
+    content="pending in_progress completed",
+  )
+}
+```
+
+The variants are readable but not constructible from outside the package: a
+plan reaches consumers by being decoded, never by being assembled field by
+field.
+
+## Strict by design
+
+`agent_tool/finish/internal/decode` is deliberately lenient because a bad
+`finish` should still end the run. `plan` is the opposite: a malformed plan is
+worth one round-trip to correct, since the plan is shown to the user and
+replayed into context on every subsequent request. Every rule below rejects
+rather than repairs.
+
+```mbt check
+///|
+/// True when decoding `arguments` fails with a message containing `expected`.
+/// The raw error also carries `fail`'s source location, which is why the test
+/// matches on a substring rather than snapshotting the whole string.
+fn rejects(arguments : Json, expected : String) -> Bool {
+  try {
+    ignore(@steps.decode(arguments))
+    false
+  } catch {
+    err => "\{err}".contains(expected)
+  }
+}
+
+///|
+test "the payload must be an object with exactly a steps array" {
+  inspect(
+    rejects(Json::null(), "arguments to be an object with a steps array"),
+    content="true",
+  )
+  inspect(
+    rejects(Json::empty_object(), "arguments.steps to be an array of steps"),
+    content="true",
+  )
+  // Unknown top-level fields are rejected, not ignored.
+  inspect(
+    rejects(
+      { "steps": [], "note": "extra" },
+      "arguments to have only the steps field",
+    ),
+    content="true",
+  )
+}
+
+///|
+test "a step carries exactly a title and a status" {
+  inspect(
+    rejects(
+      { "steps": ["just a string"] },
+      "arguments.steps[0] to be an object",
+    ),
+    content="true",
+  )
+  // Unknown step fields too: models invent `id` and `notes`, and silently
+  // dropping them would lose information the model believed it had recorded.
+  inspect(
+    rejects(
+      { "steps": [{ "title": "a", "status": "pending", "id": 1 }] },
+      "arguments.steps[0] to have only title and status fields",
+    ),
+    content="true",
+  )
+  inspect(
+    rejects(
+      { "steps": [{ "status": "pending" }] },
+      "arguments.steps[0].title to be present",
+    ),
+    content="true",
+  )
+  inspect(
+    rejects(
+      { "steps": [{ "title": "a" }] },
+      "arguments.steps[0].status to be present",
+    ),
+    content="true",
+  )
+  inspect(
+    rejects(
+      { "steps": [{ "title": "a", "status": "done" }] },
+      "arguments.steps[0].status to be one of pending|in_progress|completed",
+    ),
+    content="true",
+  )
+}
+```
+
+## At most one step in progress
+
+The plan answers "what is the agent doing *now*", and two simultaneous answers
+make it useless as a progress display. Zero in-progress steps is fine — that is
+what a finished plan looks like.
+
+```mbt check
+///|
+test "one in_progress step at most; zero is allowed" {
+  inspect(
+    rejects(
+      {
+        "steps": [
+          { "title": "a", "status": "in_progress" },
+          { "title": "b", "status": "in_progress" },
+        ],
+      },
+      "arguments.steps to contain at most one in_progress step",
+    ),
+    content="true",
+  )
+  debug_inspect(
+    @steps.decode({
+      "steps": [
+        { "title": "a", "status": "completed" },
+        { "title": "b", "status": "completed" },
+      ],
+    }),
+    content=(
+      #|{ steps: [{ title: "a", status: Completed }, { title: "b", status: Completed }] }
+    ),
+  )
+}
+```
+
+## Titles are trimmed, then bounded
+
+Titles are rendered into the UI brief and replayed with the tool-call arguments
+on every request, so both limits exist to protect context rather than to enforce
+style. The trimmed form is what gets stored, so two titles differing only in
+surrounding whitespace are the same title.
+
+```mbt check
+///|
+test "surrounding whitespace is trimmed before anything else" {
+  debug_inspect(
+    @steps.decode({
+      "steps": [{ "title": "  fix parser\t", "status": "pending" }],
+    }),
+    content=(
+      #|{ steps: [{ title: "fix parser", status: Pending }] }
+    ),
+  )
+}
+
+///|
+test "the bounds, and the units they are counted in" {
+  inspect(@steps.MAX_STEPS, content="20")
+  inspect(@steps.MAX_TITLE_CHARS, content="120")
+  let too_many : Array[Json] = [
+    for i in 0..<(@steps.MAX_STEPS + 1) => {
+      { "title": "step \{i}", "status": "pending" }
+    }
+  ]
+  inspect(
+    rejects({ "steps": too_many.to_json() }, "at most 20 steps, got 21"),
+    content="true",
+  )
+  // Length counts code points, matching the `maxLength` the advertised JSON
+  // Schema promises — so a schema-valid title is never rejected over its
+  // encoding. 121 astral characters is 242 UTF-16 code units, and still 121.
+  let long_title = "😀".repeat(@steps.MAX_TITLE_CHARS + 1)
+  inspect(
+    rejects(
+      { "steps": [{ "title": long_title, "status": "pending" }] },
+      "title to be at most 120 chars, got 121",
+    ),
+    content="true",
+  )
+}
+```
+
+A title must be non-blank and a single line. Blankness uses the Unicode
+White_Space property rather than ASCII trimming, because a title of no-break or
+ideographic spaces would otherwise render as an empty row. Newlines are refused
+because a title is rendered into a line-oriented brief, where an embedded
+newline could forge extra plan rows.
+
+```mbt check
+///|
+test "blank and multi-line titles are refused" {
+  inspect(
+    rejects(
+      { "steps": [{ "title": "   ", "status": "pending" }] },
+      "arguments.steps[0].title to be non-blank",
+    ),
+    content="true",
+  )
+  // U+00A0 no-break space, U+3000 ideographic space: invisible, not ASCII.
+  inspect(
+    rejects(
+      { "steps": [{ "title": "\u{00A0}\u{3000}", "status": "pending" }] },
+      "arguments.steps[0].title to be non-blank",
+    ),
+    content="true",
+  )
+  inspect(
+    rejects(
+      { "steps": [{ "title": "fix\nparser", "status": "pending" }] },
+      "arguments.steps[0].title to be a single line",
+    ),
+    content="true",
+  )
+}
+```
+
+## Errors never echo model text
+
+Every message above names a *field path* and never interpolates the offending
+value. That is deliberate: `agent_tool/internal/error` recovers the message by
+splitting on a ` FAILED: ` marker, so a crafted title containing that marker
+could truncate the very error meant to correct it.

--- a/agent_tool/plan/steps/README.md
+++ b/agent_tool/plan/steps/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/read/internal/decode/README.mbt.md
+++ b/agent_tool/read/internal/decode/README.mbt.md
@@ -1,0 +1,199 @@
+# agent_tool/read/internal/decode
+
+Argument decoding for the `read` tool, which returns a window of one file's
+contents. This package is internal to `agent_tool/read` and owns only
+argument-shape decoding; opening the file, numbering lines, and rendering the
+window stay in the parent package.
+
+## Arguments
+
+| Name | Type | Required | Decoder behavior |
+| --- | --- | --- | --- |
+| `path` | string | yes | Missing or `null` raises `arguments.path`; empty raises `arguments.path to be a non-empty string`; non-string raises `arguments.path to be a string`. |
+| `start_line` | number | no | 1-based, defaults to `1`. Must be positive. |
+| `max_lines` | number | no | Defaults to unbounded (`None`). Must be positive. |
+| `max_output_chars` | number | no | Defaults to `12000`, clamped to `hard_max_output_chars` (`50000`). Must be positive. |
+| `paths` | — | — | Explicitly rejected. See below. |
+
+Extra fields are ignored. Non-object JSON raises `object arguments`.
+
+```mbt check
+///|
+test "only `path` is required; everything else has a default" {
+  debug_inspect(
+    @decode.decode({ "path": "agent_tool/read/read.mbt" }),
+    content=(
+      #|{
+      #|  path: "agent_tool/read/read.mbt",
+      #|  start_line: 1,
+      #|  max_lines: None,
+      #|  max_output_chars: 12000,
+      #|}
+    ),
+  )
+}
+
+///|
+test "an explicit window overrides every default" {
+  debug_inspect(
+    @decode.decode({
+      "path": "agent_tool/read/read.mbt",
+      "start_line": 40,
+      "max_lines": 25,
+      "max_output_chars": 4000,
+    }),
+    content=(
+      #|{
+      #|  path: "agent_tool/read/read.mbt",
+      #|  start_line: 40,
+      #|  max_lines: Some(25),
+      #|  max_output_chars: 4000,
+      #|}
+    ),
+  )
+}
+```
+
+## `paths` is rejected with an explanation, not ignored
+
+Models reach for a batch form — `paths: [...]` — because most file APIs have
+one. `read` deliberately does not, and silently ignoring the field would return
+one file's contents in answer to a request for several, which the model has no
+way to notice.
+
+So the field is a hard error, and the message says what to do instead: issue
+several `read` calls in a single assistant response, which is already parallel.
+
+```mbt check
+///|
+/// True when decoding `arguments` fails with a message containing `expected`.
+/// The raw error also carries `fail`'s source location, which is why the test
+/// matches on a substring rather than snapshotting the whole string.
+fn decode_error_says(arguments : Json, expected : String) -> Bool {
+  try {
+    ignore(@decode.decode(arguments))
+    false
+  } catch {
+    err => "\{err}".contains(expected)
+  }
+}
+
+///|
+test "the batch-read mistake gets an actionable message" {
+  inspect(
+    decode_error_says(
+      { "path": "a.mbt", "paths": ["a.mbt", "b.mbt"] },
+      "arguments.paths is not supported; batch separate read calls in one assistant response",
+    ),
+    content="true",
+  )
+  // Rejected even when it is the only field, and checked before `path`.
+  inspect(
+    decode_error_says(
+      { "paths": ["a.mbt"] },
+      "arguments.paths is not supported",
+    ),
+    content="true",
+  )
+  // An explicitly-null `paths` is treated as absent, so a client that
+  // serializes unset optional fields still works.
+  debug_inspect(
+    @decode.decode({ "path": "a.mbt", "paths": Json::null() }),
+    content=(
+      #|{
+      #|  path: "a.mbt",
+      #|  start_line: 1,
+      #|  max_lines: None,
+      #|  max_output_chars: 12000,
+      #|}
+    ),
+  )
+}
+```
+
+## The output budget is clamped, not trusted
+
+`max_output_chars` bounds the rendered result in UTF-16 code units. A caller may
+ask for less than the default, but not for more than `hard_max_output_chars`:
+the ceiling exists so one `read` cannot flood the conversation, and a model that
+asks for a million characters gets `50000` rather than an error.
+
+```mbt check
+///|
+test "an oversized budget clamps silently; a smaller one is honored" {
+  inspect(@decode.hard_max_output_chars, content="50000")
+  inspect(
+    @decode.decode({ "path": "a.mbt", "max_output_chars": 999999 }).max_output_chars,
+    content="50000",
+  )
+  inspect(
+    @decode.decode({ "path": "a.mbt", "max_output_chars": 500 }).max_output_chars,
+    content="500",
+  )
+}
+```
+
+The clamp is the only silent adjustment. Zero and negative values are rejected
+rather than clamped, because they express an intent the tool cannot satisfy —
+reading no lines is not a useful read, and it is more likely a bug in the
+caller's arithmetic than a deliberate request.
+
+```mbt check
+///|
+test "non-positive numbers are errors, not clamped to a floor" {
+  inspect(
+    decode_error_says(
+      { "path": "a.mbt", "start_line": 0 },
+      "arguments.start_line to be a positive number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "path": "a.mbt", "max_lines": -1 },
+      "arguments.max_lines to be a positive number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "path": "a.mbt", "max_output_chars": 0 },
+      "arguments.max_output_chars to be a positive number",
+    ),
+    content="true",
+  )
+  // A number of the wrong JSON type names the field too.
+  inspect(
+    decode_error_says(
+      { "path": "a.mbt", "start_line": "40" },
+      "arguments.start_line to be a number",
+    ),
+    content="true",
+  )
+}
+```
+
+## Missing versus empty `path`
+
+Both are errors, and they are distinguished, because they are different
+mistakes: an absent `path` means the model forgot the argument, while `""` means
+it computed one and got nothing.
+
+```mbt check
+///|
+test "absent and empty paths report differently" {
+  inspect(
+    decode_error_says(Json::empty_object(), "arguments.path"),
+    content="true",
+  )
+  inspect(
+    decode_error_says({ "path": "" }, "arguments.path to be a non-empty string"),
+    content="true",
+  )
+  inspect(
+    decode_error_says({ "path": 7 }, "arguments.path to be a string"),
+    content="true",
+  )
+  inspect(decode_error_says(Json::null(), "object arguments"), content="true")
+}
+```

--- a/agent_tool/read/internal/decode/README.md
+++ b/agent_tool/read/internal/decode/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/remove/internal/decode/README.mbt.md
+++ b/agent_tool/remove/internal/decode/README.mbt.md
@@ -1,0 +1,138 @@
+# agent_tool/remove/internal/decode
+
+Argument decoding for the `remove` tool, which deletes a file. This package is
+internal to `agent_tool/remove` and owns only argument-shape decoding —
+resolving the path, checking it exists, and performing the delete stay in the
+parent package.
+
+## Arguments
+
+| Name | Type | Required | Decoder behavior |
+| --- | --- | --- | --- |
+| `path` | string | yes | Missing or non-string raises `arguments.path`. |
+| `reason` | string | yes | Missing or non-string raises `arguments.reason`; blank raises `arguments.reason to be a non-empty explanation`. |
+
+Extra fields are ignored. Non-object JSON raises `object arguments`.
+
+```mbt check
+///|
+test "a well-formed removal decodes to path and reason" {
+  debug_inspect(
+    @decode.decode({
+      "path": "scratch/old_notes.md",
+      "reason": "superseded by the new design doc",
+    }),
+    content=(
+      #|{
+      #|  path: "scratch/old_notes.md",
+      #|  reason: "superseded by the new design doc",
+      #|}
+    ),
+  )
+}
+```
+
+## Why `reason` is required, and why blank is not enough
+
+`remove` is the only destructive file tool: unlike `write` and `edit`, there is
+no previous content to recover from the result. `reason` is what makes that
+auditable after the fact, so it is required rather than optional — and requiring
+a field the model can satisfy with `" "` would buy nothing. A whitespace-only
+reason is rejected.
+
+The blank check is Unicode-aware, which is the reason it is not written as
+`reason.trim() != ""`: `String::trim` strips only ASCII whitespace, so a reason
+made of non-breaking or ideographic spaces would pass and then render as a
+visually empty audit entry.
+
+```mbt check
+///|
+/// True when decoding `arguments` fails with a message containing `expected`.
+/// The raw error also carries `fail`'s source location, which is why the test
+/// matches on a substring rather than snapshotting the whole string.
+fn decode_error_says(arguments : Json, expected : String) -> Bool {
+  try {
+    ignore(@decode.decode(arguments))
+    false
+  } catch {
+    err => "\{err}".contains(expected)
+  }
+}
+
+///|
+test "a blank reason is rejected, ASCII or not" {
+  inspect(
+    decode_error_says(
+      { "path": "a.txt", "reason": "   " },
+      "arguments.reason to be a non-empty explanation",
+    ),
+    content="true",
+  )
+  // U+00A0 no-break space and U+3000 ideographic space: invisible, and not
+  // ASCII whitespace.
+  inspect(
+    decode_error_says(
+      { "path": "a.txt", "reason": "\u{00A0}\u{3000}" },
+      "arguments.reason to be a non-empty explanation",
+    ),
+    content="true",
+  )
+}
+```
+
+## Which field the error names
+
+The decoder reports the *first* problem in a fixed order, so the message always
+points at one specific argument to fix rather than describing the payload as a
+whole.
+
+```mbt check
+///|
+test "rejections name one field, outermost problem first" {
+  // Not an object at all.
+  inspect(decode_error_says(Json::null(), "object arguments"), content="true")
+  inspect(decode_error_says(["a.txt"], "object arguments"), content="true")
+  // An object whose `path` is missing or the wrong type.
+  inspect(
+    decode_error_says({ "reason": "no longer used" }, "arguments.path"),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "path": 7, "reason": "no longer used" },
+      "arguments.path",
+    ),
+    content="true",
+  )
+  // A valid `path`, so the next problem reported is `reason`.
+  inspect(
+    decode_error_says({ "path": "a.txt" }, "arguments.reason"),
+    content="true",
+  )
+  inspect(
+    decode_error_says({ "path": "a.txt", "reason": 7 }, "arguments.reason"),
+    content="true",
+  )
+}
+```
+
+Note the ordering consequence: a payload with *both* fields wrong reports
+`arguments.path`, never `arguments.reason`. The model fixes one field per
+retry.
+
+Unlike `read`, an empty-string `path` is not rejected here — the pattern only
+requires a string. A path that is empty, absent from disk, or outside the
+workspace is the parent package's problem, because answering those questions
+needs the filesystem.
+
+```mbt check
+///|
+test "an empty path decodes; existence is not this package's question" {
+  debug_inspect(
+    @decode.decode({ "path": "", "reason": "cleanup" }),
+    content=(
+      #|{ path: "", reason: "cleanup" }
+    ),
+  )
+}
+```

--- a/agent_tool/remove/internal/decode/README.md
+++ b/agent_tool/remove/internal/decode/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/shell/internal/decode/README.mbt.md
+++ b/agent_tool/shell/internal/decode/README.mbt.md
@@ -1,0 +1,167 @@
+# agent_tool/shell/internal/decode
+
+Argument decoding for the `shell` tool, which runs a command line through the
+platform shell. This package is internal to `agent_tool/shell` and owns only
+argument-shape decoding — the sandbox profile, the git command policy, timeout
+enforcement, and background job bookkeeping all stay in the parent package.
+
+Nothing here inspects the command text. `cmd` is carried through as an opaque
+string; deciding whether it is *allowed* to run is a separate question answered
+by `agent_tool/shell/internal/git_policy` and
+`agent_tool/internal/source_write_policy`.
+
+## Arguments
+
+| Name | Type | Required | Decoder behavior |
+| --- | --- | --- | --- |
+| `cmd` | string | yes | Missing, `null`, or empty raises `arguments.cmd`; non-string raises `arguments.cmd to be a string`. |
+| `cwd` | string | no | Defaults to `None`. Empty is treated as absent, not as an error. |
+| `timeout_ms` | number | no | Defaults to `None` (no timeout). Must be positive. |
+| `max_output_chars` | number | no | Defaults to `default_max_output_chars` (`12000`), clamped to `hard_max_output_chars` (`50000`). Must be positive. |
+| `run_in_background` | boolean | no | Defaults to `false`. `null` also means `false`. |
+
+Extra fields are ignored. Non-object JSON raises `object arguments`.
+
+```mbt check
+///|
+test "only `cmd` is required; everything else has a default" {
+  debug_inspect(
+    @decode.decode({ "cmd": "moon test --target native" }),
+    content=(
+      #|{
+      #|  cmd: "moon test --target native",
+      #|  cwd: None,
+      #|  timeout_ms: None,
+      #|  max_output_chars: 12000,
+      #|  run_in_background: false,
+      #|}
+    ),
+  )
+}
+
+///|
+test "a fully specified invocation overrides every default" {
+  debug_inspect(
+    @decode.decode({
+      "cmd": "moon build",
+      "cwd": "/work/packages/demo",
+      "timeout_ms": 60000,
+      "max_output_chars": 4000,
+      "run_in_background": true,
+    }),
+    content=(
+      #|{
+      #|  cmd: "moon build",
+      #|  cwd: Some("/work/packages/demo"),
+      #|  timeout_ms: Some(60000),
+      #|  max_output_chars: 4000,
+      #|  run_in_background: true,
+      #|}
+    ),
+  )
+}
+```
+
+## Empty means "absent" for `cwd`, but "error" for `cmd`
+
+The two empty strings are treated differently, and the difference is deliberate.
+An empty `cwd` names no directory, and the tool already has a sensible fallback
+— the workspace root — so treating it as absent turns a harmless client quirk
+into the default behavior. An empty `cmd` has no fallback: there is nothing to
+run, and silently succeeding would report a command that never executed.
+
+```mbt check
+///|
+/// True when decoding `arguments` fails with a message containing `expected`.
+/// The raw error also carries `fail`'s source location, which is why the test
+/// matches on a substring rather than snapshotting the whole string.
+fn decode_error_says(arguments : Json, expected : String) -> Bool {
+  try {
+    ignore(@decode.decode(arguments))
+    false
+  } catch {
+    err => "\{err}".contains(expected)
+  }
+}
+
+///|
+test "an empty cwd is absent; an empty cmd is an error" {
+  debug_inspect(@decode.decode({ "cmd": "pwd", "cwd": "" }).cwd, content="None")
+  debug_inspect(
+    @decode.decode({ "cmd": "pwd", "cwd": Json::null() }).cwd,
+    content="None",
+  )
+  inspect(decode_error_says({ "cmd": "" }, "arguments.cmd"), content="true")
+  inspect(
+    decode_error_says(Json::empty_object(), "arguments.cmd"),
+    content="true",
+  )
+  inspect(
+    decode_error_says({ "cmd": 7 }, "arguments.cmd to be a string"),
+    content="true",
+  )
+  inspect(decode_error_says(Json::null(), "object arguments"), content="true")
+}
+```
+
+## The output budget is clamped, not trusted
+
+`max_output_chars` bounds captured stdout+stderr. A caller may ask for less than
+the default, but not for more than `hard_max_output_chars`: the ceiling exists
+so one runaway command cannot flood the conversation, and asking for more is
+quietly reduced rather than rejected.
+
+```mbt check
+///|
+test "an oversized budget clamps silently; a smaller one is honored" {
+  inspect(@decode.default_max_output_chars, content="12000")
+  inspect(@decode.hard_max_output_chars, content="50000")
+  inspect(
+    @decode.decode({ "cmd": "cat big.log", "max_output_chars": 999999 }).max_output_chars,
+    content="50000",
+  )
+  inspect(
+    @decode.decode({ "cmd": "cat big.log", "max_output_chars": 500 }).max_output_chars,
+    content="500",
+  )
+}
+```
+
+`timeout_ms` gets no such treatment: it has no ceiling here, and absent means
+*no timeout at all* rather than some default budget. A long-running build is a
+normal thing to ask for, so bounding it is the parent tool's decision, made with
+context this package does not have.
+
+```mbt check
+///|
+test "non-positive numbers are errors, not clamped to a floor" {
+  inspect(
+    decode_error_says(
+      { "cmd": "sleep 1", "timeout_ms": 0 },
+      "arguments.timeout_ms to be a positive number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "cmd": "echo hi", "max_output_chars": -1 },
+      "arguments.max_output_chars to be a positive number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "cmd": "sleep 1", "timeout_ms": "60s" },
+      "arguments.timeout_ms to be a number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "cmd": "echo hi", "run_in_background": "yes" },
+      "arguments.run_in_background to be a boolean",
+    ),
+    content="true",
+  )
+}
+```

--- a/agent_tool/shell/internal/decode/README.md
+++ b/agent_tool/shell/internal/decode/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/shell/internal/git_policy/README.mbt.md
+++ b/agent_tool/shell/internal/git_policy/README.mbt.md
@@ -1,0 +1,373 @@
+# agent_tool/shell/internal/git_policy
+
+Pure git command-line policy for the `shell` source-write sandbox: parse a git
+invocation's subcommand and classify it. No filesystem, workspace, or
+shell-parse dependencies — just argv/word grammar — so the policy can be read and
+tested in isolation. `agent_tool/shell` supplies the workspace-path glue and the
+trusted-command-class wiring.
+
+## Why a git-specific policy exists at all
+
+The macOS sandbox in `agent_tool/internal/sandbox` denies writes to `*.mbt` and
+the manifests, and that covers most of the problem. It does not cover all of it:
+
+- the sandbox is macOS-only, and a Linux run has no runtime enforcement;
+- `git checkout -- .` legitimately rewrites protected source, so a blanket deny
+  would break normal recovery workflows.
+
+So `shell` also asks a **cross-platform, pre-execution** question: is this
+particular git invocation destructive in a way that cannot be undone? The
+answer is `should_preblock`. Everything else in this package exists to compute
+it or to answer the same question on the degraded text path.
+
+## The classification
+
+The load-bearing distinction is **recoverable** versus **not**.
+
+A subcommand that "writes from the object store" only ever materializes content
+git already has — HEAD, the index, a commit or tree, a stash — or deletes a
+tracked file recoverable from it. Those run freely: the worst case is reviewable
+and reversible through git itself.
+
+```mbt check
+///|
+test "the recoverable writers, and the two that are not" {
+  for subcommand in ["checkout", "switch", "restore", "reset", "stash", "rm"] {
+    inspect(
+      @git_policy.subcommand_writes_from_object_store(subcommand),
+      content="true",
+    )
+  }
+  // `mv` moves arbitrary worktree bytes onto the destination, and `clean`
+  // deletes UNTRACKED files that have no object-store copy at all.
+  inspect(
+    @git_policy.subcommand_writes_from_object_store("mv"),
+    content="false",
+  )
+  inspect(
+    @git_policy.subcommand_writes_from_object_store("clean"),
+    content="false",
+  )
+  // Store feeders take bytes from outside the repository.
+  inspect(
+    @git_policy.subcommand_writes_from_object_store("apply"),
+    content="false",
+  )
+  // Read-only git is not a writer either.
+  inspect(
+    @git_policy.subcommand_writes_from_object_store("status"),
+    content="false",
+  )
+}
+```
+
+`rm` stays on the safe side because it only deletes *tracked* files. `clean`
+does not, because deleting an untracked file is permanent.
+
+## `parse` — find the subcommand, or fail closed
+
+Global options come before the subcommand and some of them take a value, so the
+subcommand is not simply `argv[1]`. `parse` skips the global-option prefix and
+reports both the subcommand and its index; the index is what lets callers scan
+the *global region* separately from the subcommand's own arguments.
+
+```mbt check
+///|
+/// Renders a parse result as `subcommand@index`, or `-` when parsing declines
+/// to guess.
+fn parsed(argv : Array[String]) -> String {
+  match @git_policy.parse(argv, 1) {
+    Some(invocation) =>
+      "\{invocation.subcommand}@\{invocation.subcommand_index}"
+    None => "-"
+  }
+}
+
+///|
+test "global options are skipped, with and without attached values" {
+  inspect(parsed(["git", "status"]), content="status@1")
+  inspect(parsed(["git", "-C", "/tmp", "status"]), content="status@3")
+  inspect(parsed(["git", "-C/tmp", "status"]), content="status@2")
+  inspect(
+    parsed(["git", "-c", "user.name=x", "commit", "-m", "hi"]),
+    content="commit@3",
+  )
+  inspect(parsed(["git", "--git-dir=/tmp/x", "log"]), content="log@2")
+  inspect(parsed(["git", "--no-pager", "diff"]), content="diff@2")
+}
+```
+
+Anything it cannot confidently classify returns `None` — **fail closed**. A
+caller must not read `None` as "no subcommand, therefore harmless"; it means
+"this package has no opinion", and `should_preblock` treats it as not-blocked
+only because the sandbox and the rest of `shell` still apply.
+
+```mbt check
+///|
+test "unrecognized shapes decline rather than guess" {
+  // An unknown option could be a value option whose operand we would then
+  // mistake for the subcommand.
+  inspect(parsed(["git", "--not-a-real-option", "status"]), content="-")
+  // A value option with no value left.
+  inspect(parsed(["git", "-C"]), content="-")
+  // Help, an explicit `--`, and a bare `git`.
+  inspect(parsed(["git", "--help"]), content="-")
+  inspect(parsed(["git", "-h"]), content="-")
+  inspect(parsed(["git", "--", "status"]), content="-")
+  inspect(parsed(["git"]), content="-")
+}
+
+///|
+test "aliases are not resolved" {
+  // Resolving `co` would require reading the user's config, which this package
+  // will not do. The caller sees the literal word.
+  inspect(parsed(["git", "co", "main"]), content="co@1")
+}
+```
+
+## `global_option_reconfigures` — the precursor that changes everything
+
+`git -c filter.x.smudge=<command> checkout` runs arbitrary code during an
+otherwise ordinary checkout. `git -C /elsewhere` and `--work-tree=` point the
+same subcommand at a different tree. Options that repoint config, the exec path,
+the git dir, the namespace, or the cwd/worktree therefore turn a recoverable
+writer into an unbounded one.
+
+```mbt check
+///|
+test "the options that make an object-store writer unsafe" {
+  for
+    arg in [
+      "-c", "-cfilter.x=y", "--config-env", "--config-env=X=y", "--exec-path", "--exec-path=/tmp",
+      "--git-dir", "--git-dir=/tmp/x", "--namespace", "--namespace=n", "-C", "-C/tmp",
+      "--work-tree", "--work-tree=/tmp",
+    ] {
+    inspect(@git_policy.global_option_reconfigures(arg), content="true")
+  }
+  // Options that only change presentation or object lookup do not.
+  for arg in ["--no-pager", "-p", "--paginate", "--bare", "--version", "status"] {
+    inspect(@git_policy.global_option_reconfigures(arg), content="false")
+  }
+}
+```
+
+## `should_preblock` — the decision
+
+Read `true` as "refuse before spawning". Read `false` as "this guard has no
+objection", not as "safe" — the sandbox and the rest of `shell`'s preflight still
+run.
+
+Ordinary git, and the recoverable writers in their plain forms, are not blocked:
+
+```mbt check
+///|
+/// `should_preblock` over a full argv, starting the scan just past `git`.
+fn preblock(argv : Array[String]) -> Bool {
+  @git_policy.should_preblock(argv, 1)
+}
+
+///|
+test "read-only git and plain recoverable writes run" {
+  inspect(preblock(["git", "status"]), content="false")
+  inspect(preblock(["git", "log", "--oneline", "-5"]), content="false")
+  inspect(preblock(["git", "diff"]), content="false")
+  // Plain index restore: the classic "undo my edits" recovery.
+  inspect(preblock(["git", "checkout", "--", "src/main.mbt"]), content="false")
+  inspect(preblock(["git", "restore", "src/main.mbt"]), content="false")
+  // Bare branch switch, reset, stash, and tracked-file removal.
+  inspect(preblock(["git", "checkout", "main"]), content="false")
+  inspect(preblock(["git", "reset", "--hard"]), content="false")
+  inspect(preblock(["git", "stash"]), content="false")
+  inspect(preblock(["git", "rm", "src/old.mbt"]), content="false")
+}
+```
+
+Store feeders and the two non-recoverable writers are blocked outright:
+
+```mbt check
+///|
+test "commands that source bytes from outside the object store are blocked" {
+  inspect(preblock(["git", "am", "patch.mbox"]), content="true")
+  inspect(preblock(["git", "update-index", "--index-info"]), content="true")
+  inspect(preblock(["git", "read-tree", "HEAD"]), content="true")
+  inspect(preblock(["git", "fast-import"]), content="true")
+  // `mv` moves arbitrary worktree bytes onto the destination.
+  inspect(preblock(["git", "mv", "notes.txt", "src/main.mbt"]), content="true")
+}
+```
+
+A recoverable writer becomes blocked as soon as the global region reconfigures
+it:
+
+```mbt check
+///|
+test "reconfiguration promotes a recoverable write to a blocked one" {
+  inspect(
+    preblock(["git", "-c", "filter.x.smudge=curl evil", "checkout", "main"]),
+    content="true",
+  )
+  inspect(preblock(["git", "-C", "/elsewhere", "rm", "f.mbt"]), content="true")
+  inspect(
+    preblock(["git", "--work-tree=/elsewhere", "reset", "--hard"]),
+    content="true",
+  )
+  // Only the region *before* the subcommand counts — a `-c` after it is the
+  // subcommand's own argument, and git does not treat it as global config.
+  inspect(preblock(["git", "stash", "-c"]), content="false")
+}
+```
+
+`--help` on a subcommand prints text and exits, so it is never blocked even for
+a subcommand that would otherwise be:
+
+```mbt check
+///|
+test "asking for help is not running the command" {
+  inspect(preblock(["git", "clean", "--help"]), content="false")
+  inspect(preblock(["git", "am", "-h"]), content="false")
+}
+```
+
+## The two subcommands with real argument analysis
+
+### `checkout` / `switch` / `restore` and untracked files
+
+These are recoverable *for tracked files*. They stop being recoverable when they
+can overwrite an **untracked** file — git's own guard against that is bypassed by
+`-f`, and sourcing paths from another tree writes files the index does not know
+about. Plain index restore stays allowed.
+
+```mbt check
+///|
+test "forced or tree-sourced checkouts are blocked; plain ones are not" {
+  // Force, overlay, and side-picking overwrite regardless of untracked state.
+  inspect(preblock(["git", "checkout", "-f", "main"]), content="true")
+  inspect(preblock(["git", "checkout", "--force", "main"]), content="true")
+  inspect(preblock(["git", "restore", "--ours", "f.mbt"]), content="true")
+  inspect(preblock(["git", "switch", "--force", "other"]), content="true")
+  // `-f` clustered with other short flags still counts.
+  inspect(preblock(["git", "checkout", "-fq", "main"]), content="true")
+  // An explicit source tree-ish, spelled any of the four ways.
+  inspect(
+    preblock(["git", "restore", "--source", "HEAD~1", "f.mbt"]),
+    content="true",
+  )
+  inspect(
+    preblock(["git", "restore", "--source=HEAD~1", "f.mbt"]),
+    content="true",
+  )
+  inspect(preblock(["git", "restore", "-s", "HEAD~1", "f.mbt"]), content="true")
+  inspect(preblock(["git", "restore", "-sHEAD~1", "f.mbt"]), content="true")
+  // A positional tree-ish before `--` is a source too.
+  inspect(
+    preblock(["git", "checkout", "HEAD~1", "--", "f.mbt"]),
+    content="true",
+  )
+  // ...but `--` with nothing before it is plain index restore.
+  inspect(preblock(["git", "checkout", "--", "f.mbt"]), content="false")
+  inspect(preblock(["git", "checkout", "-q", "main"]), content="false")
+}
+```
+
+The `-f` test matches any short cluster containing `f`, which is deliberately
+approximate: enumerating git's clustering rules per subcommand would be a second
+implementation of getopt, and over-blocking a rare flag costs one refused
+command while under-blocking costs an unrecoverable file.
+
+### `clean` and dry runs
+
+`git clean` is blocked because it permanently deletes untracked files — unless it
+is a dry run, which is exactly how an agent should be inspecting what would go.
+
+```mbt check
+///|
+test "clean is blocked unless it is demonstrably a dry run" {
+  inspect(preblock(["git", "clean", "-fd"]), content="true")
+  inspect(preblock(["git", "clean", "-fdx"]), content="true")
+  inspect(preblock(["git", "clean", "-n"]), content="false")
+  inspect(preblock(["git", "clean", "--dry-run"]), content="false")
+  // In `git clean`, `n` inside a cluster always means dry run.
+  inspect(preblock(["git", "clean", "-nfd"]), content="false")
+}
+
+///|
+test "an exclude pattern makes the dry-run reading untrustworthy" {
+  // `-e` takes a pattern operand that can itself look like `-n`, so
+  // `git clean -e -n -fd` deletes files while appearing to be a dry run.
+  // Rather than reimplement getopt, any clean carrying an exclude stays
+  // blocked — including ones that really were dry runs.
+  inspect(preblock(["git", "clean", "-e", "-n", "-fd"]), content="true")
+  inspect(preblock(["git", "clean", "-e", "*.log", "-n"]), content="true")
+  inspect(preblock(["git", "clean", "--exclude=*.log", "-n"]), content="true")
+}
+```
+
+### `apply` and its read-only modes
+
+`git apply` writes the worktree from a patch file — bytes from outside the object
+store — so it is blocked, except in the modes that only validate or describe.
+
+```mbt check
+///|
+test "apply writes unless it is purely informational" {
+  inspect(preblock(["git", "apply", "patch.diff"]), content="true")
+  inspect(preblock(["git", "apply", "--check", "patch.diff"]), content="false")
+  inspect(preblock(["git", "apply", "--stat", "patch.diff"]), content="false")
+  inspect(
+    preblock(["git", "apply", "--numstat", "patch.diff"]),
+    content="false",
+  )
+  inspect(
+    preblock(["git", "apply", "--summary", "patch.diff"]),
+    content="false",
+  )
+  // A read-only flag alongside a forcing one is treated as writing.
+  inspect(
+    preblock(["git", "apply", "--check", "--index", "patch.diff"]),
+    content="true",
+  )
+  inspect(
+    preblock(["git", "apply", "--stat", "--3way", "p.diff"]),
+    content="true",
+  )
+}
+```
+
+## The text path
+
+When `shell` cannot tokenize a command line into a clean argv — pipelines,
+substitutions, anything it classifies as TooComplex — it falls back to a flat
+word list and a `[start, end)` range. The same policy runs over that shape.
+
+```mbt check
+///|
+test "text_should_preblock mirrors should_preblock over a word range" {
+  // `echo hi | git clean -fd` — the git invocation is words[3..7).
+  let words = ["echo", "hi", "|", "git", "clean", "-fd"]
+  inspect(@git_policy.text_should_preblock(words, 4, 6), content="true")
+  let dry = ["echo", "hi", "|", "git", "clean", "-n"]
+  inspect(@git_policy.text_should_preblock(dry, 4, 6), content="false")
+}
+```
+
+`text_invocation_writes_from_object_store` exists because the text path cannot
+see everything the argv path can. A custom environment set *before* `git` — an
+assignment the word list does not expose in `words[start..]` — could redirect a
+recoverable writer. The caller asks this predicate whether the invocation is one
+of those writers, and if so treats the unseen environment as disqualifying.
+
+```mbt check
+///|
+test "the text path can ask whether the writer is the recoverable kind" {
+  let words = ["GIT_DIR=/tmp/x", "git", "checkout", "main"]
+  inspect(
+    @git_policy.text_invocation_writes_from_object_store(words, 2, 4),
+    content="true",
+  )
+  let read_only = ["GIT_DIR=/tmp/x", "git", "status"]
+  inspect(
+    @git_policy.text_invocation_writes_from_object_store(read_only, 2, 3),
+    content="false",
+  )
+}
+```

--- a/agent_tool/shell/internal/git_policy/README.md
+++ b/agent_tool/shell/internal/git_policy/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/write/internal/decode/README.mbt.md
+++ b/agent_tool/write/internal/decode/README.mbt.md
@@ -1,0 +1,137 @@
+# agent_tool/write/internal/decode
+
+Argument decoding for the `write` tool, which creates or overwrites a file with
+exactly the content given. This package is internal to `agent_tool/write` and
+owns only argument-shape decoding; path resolution, the manifest guards, and the
+post-write syntax gate stay in the parent package.
+
+## Arguments
+
+| Name | Type | Required | Decoder behavior |
+| --- | --- | --- | --- |
+| `path` | string | yes | Missing or non-string raises `arguments.path`. |
+| `content` | string | yes | Missing or non-string raises `arguments.content`. Empty is valid. |
+| `revert_on_parse_errors` | boolean | no | Defaults to `true`. `null` also means `true`. A non-boolean raises. |
+
+Extra fields are ignored. Non-object JSON raises `object arguments`.
+
+```mbt check
+///|
+test "a well-formed write decodes, with the syntax gate on by default" {
+  debug_inspect(
+    @decode.decode({
+      "path": "agent_tool/write/notes.md",
+      "content": "# Notes\n",
+    }),
+    content=(
+      #|{
+      #|  path: "agent_tool/write/notes.md",
+      #|  content: "# Notes\n",
+      #|  revert_on_parse_errors: true,
+      #|}
+    ),
+  )
+}
+```
+
+## `revert_on_parse_errors` defaults to on
+
+The parent tool lexes and parses new `.mbt` content before committing the write,
+and reverts when it does not parse. That gate defaults **on**, so a model that
+omits the field gets the safe behavior; opting out has to be deliberate and
+explicit.
+
+`null` is treated as absent rather than as an error, because a client that
+serializes unset optional fields as `null` should behave the same as one that
+omits them. Any other type is a mistake worth reporting.
+
+```mbt check
+///|
+test "absent, null, and explicit true all mean the gate is on" {
+  let absent = @decode.decode({ "path": "a.mbt", "content": "" })
+  let null_valued = @decode.decode({
+    "path": "a.mbt",
+    "content": "",
+    "revert_on_parse_errors": Json::null(),
+  })
+  let explicit = @decode.decode({
+    "path": "a.mbt",
+    "content": "",
+    "revert_on_parse_errors": true,
+  })
+  inspect(absent.revert_on_parse_errors, content="true")
+  inspect(null_valued.revert_on_parse_errors, content="true")
+  inspect(explicit.revert_on_parse_errors, content="true")
+  // Opting out is explicit.
+  inspect(
+    @decode.decode({
+      "path": "a.mbt",
+      "content": "",
+      "revert_on_parse_errors": false,
+    }).revert_on_parse_errors,
+    content="false",
+  )
+}
+```
+
+## Empty content is a valid write
+
+Truncating a file to nothing is a legitimate request, so `content: ""` decodes
+rather than raising. Contrast `path` in `agent_tool/read/internal/decode`, where
+an empty string *is* rejected — there it names a file to open, and no file is
+named by the empty string.
+
+```mbt check
+///|
+test "an empty content field truncates rather than failing" {
+  debug_inspect(
+    @decode.decode({ "path": "scratch/log.txt", "content": "" }),
+    content=(
+      #|{ path: "scratch/log.txt", content: "", revert_on_parse_errors: true }
+    ),
+  )
+}
+```
+
+## Which field the error names
+
+```mbt check
+///|
+/// True when decoding `arguments` fails with a message containing `expected`.
+/// The raw error also carries `fail`'s source location, which is why the test
+/// matches on a substring rather than snapshotting the whole string.
+fn decode_error_says(arguments : Json, expected : String) -> Bool {
+  try {
+    ignore(@decode.decode(arguments))
+    false
+  } catch {
+    err => "\{err}".contains(expected)
+  }
+}
+
+///|
+test "rejections name one field, outermost problem first" {
+  inspect(decode_error_says(Json::null(), "object arguments"), content="true")
+  inspect(
+    decode_error_says({ "content": "hi" }, "arguments.path"),
+    content="true",
+  )
+  // A valid `path`, so the next problem reported is `content`.
+  inspect(
+    decode_error_says({ "path": "a.mbt" }, "arguments.content"),
+    content="true",
+  )
+  inspect(
+    decode_error_says({ "path": "a.mbt", "content": 7 }, "arguments.content"),
+    content="true",
+  )
+  // The flag is checked only once path and content are both valid.
+  inspect(
+    decode_error_says(
+      { "path": "a.mbt", "content": "", "revert_on_parse_errors": "yes" },
+      "arguments.revert_on_parse_errors to be a boolean",
+    ),
+    content="true",
+  )
+}
+```

--- a/agent_tool/write/internal/decode/README.md
+++ b/agent_tool/write/internal/decode/README.md
@@ -1,0 +1,1 @@
+README.mbt.md


### PR DESCRIPTION
Twelve packages under `agent_tool` had no prose at all, and `internal/source_write_policy` had four API bullets with nothing executable behind them.

Each now has a `README.mbt.md` in the shape [`internal/workspace_path`](https://github.com/moonbitlang/openseek/blob/main/internal/workspace_path/README.mbt.md) established: **every example is a `mbt check` block**, so `moon test` runs them and a drift in behavior fails the build rather than quietly making the documentation wrong. Values come from `inspect`/`debug_inspect` snapshots, so the READMEs show what the functions actually return rather than what I believed they return.

## What's covered

**New** — `internal/{manifest_path,error,utils,moon_check,auto_check}`, `plan/steps`, `shell/internal/{git_policy,decode}`, `{finish,read,remove,write}/internal/decode`

**Upgraded** — `internal/source_write_policy`

## The ones worth reading

**`shell/internal/git_policy`** had 365 lines of subtle policy and no entry point into it. The README leads with the distinction the whole package turns on — whether a subcommand's writes are recoverable from git's own object store — and pins the two deliberate over-blocks as documented conservatism rather than bugs: any short cluster containing `f` counts as `--force`, and any `clean` carrying an exclude stays blocked because `-e`'s pattern operand can itself look like `-n`. Both are cheap to over-block and expensive to miss.

**`internal/auto_check`** documents the fail-open rule that unites its three guards, and why the parse gate runs in a scratch file: a reject leaves no broken file to delete or restore. `gate_paths` returning two entries — a symlink crossing input kinds, where moon's own classification is ambiguous — is now shown rather than described.

**The five decode packages** read as one story: `finish` cannot raise, on purpose, because a malformed call that ends the run must still end it; `plan/steps` is strict for the mirror-image reason. Each README says which and why, and every error message is pinned by a test.

**`internal/source_write_policy`**'s prose is unchanged where it was right; each of its four predicates now has a section with executable examples, including the contrast that matters — it normalizes `..` before judging containment, where the lexical helpers in `internal/workspace_path` do not.

## Validation

- 162 tests across the thirteen packages, all passing on native
- `moon fmt --check` clean
- `moon check --deny-warn` clean (CI's stable gate)
- `moon info` reports no `.mbti` change — this is docs and tests only, no API surface moved

`README.md` symlinks to `README.mbt.md` throughout, matching the other documented packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)