### PR TITLE
simplify(agent_tool/sandbox): inline the single-use denial-line helpers

### DIFF
--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -1,4 +1,13 @@
 ///|
+/// Protected MoonBit source and manifest names, as they appear at the end of a
+/// path in a denial line. Matched with `line_names_subject`, so `.mbt` does not
+/// also cover `.mbt.md` — both are listed.
+let protected_source_subjects : ReadOnlyArray[String] = [
+  ".mbt.md", ".mbt", ".mbti", "moon.mod.json", "moon.pkg.json", "moon.mod", "moon.pkg",
+  "moon.work",
+]
+
+///|
 /// Return whether child-process output contains a likely protected-source
 /// write denial.
 ///
@@ -7,6 +16,89 @@
 /// protected source suffix or one of `denial_subjects`. Pass the subjects from
 /// the `SourceWriteProfileData` used for that child. Unrelated permission
 /// errors and mentions of source files without a denial are ignored.
+///
+/// A protected source name is recognized on its own, so the common denials need
+/// no subjects at all — including the shape MoonBit's own runtime produces,
+/// where the path is wrapped in escaped quotes:
+///
+/// ```mbt check
+/// test "denials that name a protected source file" {
+///   inspect(
+///     @sandbox.source_write_denied_in_text(
+///       "sh: main.mbt: Operation not permitted\n",
+///       [],
+///     ),
+///     content="true",
+///   )
+///   inspect(
+///     @sandbox.source_write_denied_in_text(
+///       "sh: moon.work: Operation not permitted\n",
+///       [],
+///     ),
+///     content="true",
+///   )
+///   // run_moonbit's shape: a MoonBit runtime error for a denied source write.
+///   inspect(
+///     @sandbox.source_write_denied_in_text(
+///       "OSError(\"@fs.open(): \\\"keep.mbt\\\": Operation not permitted\")",
+///       [],
+///     ),
+///     content="true",
+///   )
+///   // The subject may also follow the denial (python's errno shape).
+///   inspect(
+///     @sandbox.source_write_denied_in_text(
+///       "PermissionError: [Errno 1] Operation not permitted: 'main.mbt'\n",
+///       [],
+///     ),
+///     content="true",
+///   )
+/// }
+/// ```
+///
+/// Both halves must hold on the same line. That is what keeps an unrelated
+/// permission error, or a build log that merely mentions a source file, from
+/// reading as a sandbox denial:
+///
+/// ```mbt check
+/// test "a denial alone, or a source name alone, is not a source-write denial" {
+///   inspect(
+///     @sandbox.source_write_denied_in_text("Permission denied\n", []),
+///     content="false",
+///   )
+///   inspect(
+///     @sandbox.source_write_denied_in_text(
+///       "Permission denied while reading main.mbt\n",
+///       [],
+///     ),
+///     content="false",
+///   )
+///   inspect(
+///     @sandbox.source_write_denied_in_text("compiled keep.mbt: ok\n", []),
+///     content="false",
+///   )
+/// }
+/// ```
+///
+/// A denied *directory* carries no protected suffix, so it is recognized only
+/// when the profile's own subjects name it. This is why callers must pass the
+/// `denial_subjects` from the `SourceWriteProfileData` they ran the child with,
+/// rather than an empty array:
+///
+/// ```mbt check
+/// test "a directory denial is recognized only through its subject" {
+///   let denial = "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n"
+///   inspect(@sandbox.source_write_denied_in_text(denial, []), content="false")
+///   inspect(@sandbox.source_write_denied_in_text(denial, ["pkg"]), content="true")
+///   // An unrelated name is not rescued by having subjects.
+///   inspect(
+///     @sandbox.source_write_denied_in_text("foo: Operation not permitted\n", [
+///       "pkg",
+///     ]),
+///     content="false",
+///   )
+/// }
+/// ```
 pub fn source_write_denied_in_text(
   output_text : String,
   denial_subjects : Array[String],
@@ -14,29 +106,31 @@ pub fn source_write_denied_in_text(
   output_text
   .split("\n")
   .any(line => {
-    sandbox_denial_line_mentions_denial(line) &&
+    // Both halves must hold on the SAME line. Checking them across the whole
+    // output would match any log that mentions a source file and, separately,
+    // hits an unrelated permission error.
+    let mentions_denial = line.contains("Operation not permitted") ||
+      line.contains("operation not permitted") ||
+      line.contains(": Permission denied") ||
+      line.contains("Permission denied:")
+    mentions_denial &&
     (
-      sandbox_denial_line_mentions_source_path(line) ||
-      sandbox_denial_line_mentions_known_subject(line, denial_subjects)
+      protected_source_subjects.any(suffix => line_names_subject(line, suffix)) ||
+      denial_subjects.any(subject => {
+        subject != "" && line_names_subject(line, subject)
+      })
     )
   })
 }
 
 ///|
-fn sandbox_denial_line_mentions_known_subject(
-  line : StringView,
-  denial_subjects : Array[String],
-) -> Bool {
-  denial_subjects.any(subject => {
-    subject != "" && sandbox_denial_line_mentions_literal_subject(line, subject)
-  })
-}
-
-///|
-fn sandbox_denial_line_mentions_literal_subject(
-  line : StringView,
-  subject : String,
-) -> Bool {
+/// Whether `line` names `subject` as the object of an error rather than merely
+/// containing it as a substring: the tool's own punctuation or quoting follows
+/// it, or the line ends with it after a denial's colon.
+///
+/// Shared by the protected-suffix scan and the profile's denial subjects, which
+/// need the identical notion of "names".
+fn line_names_subject(line : StringView, subject : String) -> Bool {
   line.contains("\{subject}:") ||
   line.contains("\{subject}'") ||
   line.contains("\{subject}\"") ||
@@ -46,32 +140,11 @@ fn sandbox_denial_line_mentions_literal_subject(
   line.contains("\{subject}\\\"") ||
   line.contains("\{subject}`") ||
   (
-    sandbox_denial_line_has_denial_colon_before_subject(line) &&
+    (
+      line.contains("Operation not permitted:") ||
+      line.contains("operation not permitted:") ||
+      line.contains("Permission denied:")
+    ) &&
     line.has_suffix(subject)
   )
-}
-
-///|
-fn sandbox_denial_line_mentions_source_path(line : StringView) -> Bool {
-  [
-    ".mbt.md", ".mbt", ".mbti", "moon.mod.json", "moon.pkg.json", "moon.mod", "moon.pkg",
-    "moon.work",
-  ].any(suffix => sandbox_denial_line_mentions_literal_subject(line, suffix))
-}
-
-///|
-fn sandbox_denial_line_mentions_denial(line : StringView) -> Bool {
-  line.contains("Operation not permitted") ||
-  line.contains("operation not permitted") ||
-  line.contains(": Permission denied") ||
-  line.contains("Permission denied:")
-}
-
-///|
-fn sandbox_denial_line_has_denial_colon_before_subject(
-  line : StringView,
-) -> Bool {
-  line.contains("Operation not permitted:") ||
-  line.contains("operation not permitted:") ||
-  line.contains("Permission denied:")
 }


### PR DESCRIPTION
`source_write_denied_in_text` was spread across six functions, four of which had exactly one caller each and existed only to name a `contains` chain. Reading the predicate meant chasing `sandbox_denial_line_mentions_denial` → `..._mentions_source_path` → `..._mentions_literal_subject` → `..._has_denial_colon_before_subject` through the file to reassemble one boolean.

## What changed

**Inlined the four single-use helpers.**

**`..._mentions_literal_subject` stays** — it has *two* callers (the protected-suffix scan and the profile's denial subjects need the identical notion of "this line NAMES that path"), so it is not a single-use helper. It is renamed `line_names_subject` now that the `sandbox_denial_line_` prefix is no longer disambiguating a family of five.

**The suffix list moves to a top-level `ReadOnlyArray`**, which keeps the inlined expression readable and stops it being rebuilt for every line of output.

**Behavior is unchanged.** `mentions_denial` was already the left operand, so binding it to a `let` evaluates exactly when the call did, and `&&` still short-circuits the subject scan.

## Docstring examples

The docstring gains three `mbt check` blocks, because "a line must contain a recognized denial form **and** name a protected path" is much clearer as the four shapes that match and the three that deliberately do not — including the escaped `\"` quoting MoonBit's own `OSError` renders, and the directory denial that is recognized only when the caller passes the profile's `denial_subjects`.

They run as blackbox tests, hence the `@sandbox.` qualification (unqualified calls trip `test_unqualified_package`, which `--deny-warn` would fail).

`sandbox_wbtest.mbt` keeps the exhaustive line-level pins; the docstring documents the contract rather than replacing that.

## Validation

- sandbox 9 tests, shell 119, shell_output 10, run_moonbit 22 — all passing on native
- `moon fmt --check` clean
- `moon check --deny-warn` clean
- `moon info` reports no `.mbti` change — every symbol touched was private

🤖 Generated with [Claude Code](https://claude.com/claude-code)