### PR TITLE
test(agent_tool/sandbox): move denial detection to a black-box test file

### DIFF
--- a/agent_tool/internal/sandbox/denial_output_test.mbt
+++ b/agent_tool/internal/sandbox/denial_output_test.mbt
@@ -1,0 +1,73 @@
+///|
+/// The exhaustive line-level pins for `source_write_denied_in_text`. The
+/// docstring on that function carries the teaching subset; this is the spec.
+///
+/// Black-box on purpose: detection is entirely a property of the public API, so
+/// these exercise it exactly as `shell`, `shell_output`, and `run_moonbit` do.
+test "source-write denial detection in command output" {
+  // run_moonbit's shape: a MoonBit runtime error for a denied source write.
+  assert_true(
+    @sandbox.source_write_denied_in_text(
+      "OSError(\"@fs.open(): \\\"keep.mbt\\\": Operation not permitted\")",
+      [],
+    ),
+  )
+  assert_true(
+    @sandbox.source_write_denied_in_text(
+      "sh: main.mbt: Operation not permitted\n",
+      [],
+    ),
+  )
+  assert_true(
+    @sandbox.source_write_denied_in_text(
+      "sh: moon.work: Operation not permitted\n",
+      [],
+    ),
+  )
+  // Generic denials and prose mentions are not source-write denials.
+  assert_false(@sandbox.source_write_denied_in_text("Permission denied\n", []))
+  assert_false(
+    @sandbox.source_write_denied_in_text(
+      "Permission denied while reading main.mbt\n",
+      [],
+    ),
+  )
+  assert_false(
+    @sandbox.source_write_denied_in_text(
+      "Permission denied while reading 'main.mbt'\n",
+      [],
+    ),
+  )
+  // The subject may follow the denial (python's errno shape, plain colon).
+  assert_true(
+    @sandbox.source_write_denied_in_text(
+      "PermissionError: [Errno 1] Operation not permitted: 'main.mbt'\n",
+      [],
+    ),
+  )
+  assert_true(
+    @sandbox.source_write_denied_in_text(
+      "Operation not permitted: main.mbt\n",
+      [],
+    ),
+  )
+  assert_true(
+    @sandbox.source_write_denied_in_text("Permission denied: main.mbt\n", []),
+  )
+  // A denied directory is recognized only as a known denial subject.
+  let dir_rename = "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n"
+  assert_false(@sandbox.source_write_denied_in_text(dir_rename, []))
+  assert_true(@sandbox.source_write_denied_in_text(dir_rename, ["pkg"]))
+  assert_false(
+    @sandbox.source_write_denied_in_text("foo: Operation not permitted\n", []),
+  )
+  assert_false(
+    @sandbox.source_write_denied_in_text("foo: Operation not permitted\n", [
+      "pkg",
+    ]),
+  )
+  // A source path without any denial wording is not a denial either.
+  assert_false(
+    @sandbox.source_write_denied_in_text("compiled keep.mbt: ok", []),
+  )
+}

--- a/agent_tool/internal/sandbox/sandbox_wbtest.mbt
+++ b/agent_tool/internal/sandbox/sandbox_wbtest.mbt
@@ -75,57 +75,6 @@ async test "sandbox profile blocks existing directories that contain source" {
 }
 
 ///|
-test "source-write denial detection in command output" {
-  // run_moonbit's shape: a MoonBit runtime error for a denied source write.
-  assert_true(
-    source_write_denied_in_text(
-      "OSError(\"@fs.open(): \\\"keep.mbt\\\": Operation not permitted\")",
-      [],
-    ),
-  )
-  assert_true(
-    source_write_denied_in_text("sh: main.mbt: Operation not permitted\n", []),
-  )
-  assert_true(
-    source_write_denied_in_text("sh: moon.work: Operation not permitted\n", []),
-  )
-  // Generic denials and prose mentions are not source-write denials.
-  assert_false(source_write_denied_in_text("Permission denied\n", []))
-  assert_false(
-    source_write_denied_in_text("Permission denied while reading main.mbt\n", []),
-  )
-  assert_false(
-    source_write_denied_in_text(
-      "Permission denied while reading 'main.mbt'\n",
-      [],
-    ),
-  )
-  // The subject may follow the denial (python's errno shape, plain colon).
-  assert_true(
-    source_write_denied_in_text(
-      "PermissionError: [Errno 1] Operation not permitted: 'main.mbt'\n",
-      [],
-    ),
-  )
-  assert_true(
-    source_write_denied_in_text("Operation not permitted: main.mbt\n", []),
-  )
-  assert_true(source_write_denied_in_text("Permission denied: main.mbt\n", []))
-  // A denied directory is recognized only as a known denial subject.
-  let dir_rename = "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n"
-  assert_false(source_write_denied_in_text(dir_rename, []))
-  assert_true(source_write_denied_in_text(dir_rename, ["pkg"]))
-  assert_false(
-    source_write_denied_in_text("foo: Operation not permitted\n", []),
-  )
-  assert_false(
-    source_write_denied_in_text("foo: Operation not permitted\n", ["pkg"]),
-  )
-  // A source path without any denial wording is not a denial either.
-  assert_false(source_write_denied_in_text("compiled keep.mbt: ok", []))
-}
-
-///|
 async test "sandbox profile cache invalidates when source tree changes" {
   @vfs.with_tmpdir(prefix="openseek-shell-sandbox-profile-invalidate-", root => {
     @fs.mkdir("\{root}/assets")


### PR DESCRIPTION
`source-write denial detection in command output` lived in `sandbox_wbtest.mbt`, but it never needed white-box access: every assertion goes through `source_write_denied_in_text`, which is public and is exactly what `shell`, `shell_output`, and `run_moonbit` call.

Sitting in the white-box file it was *free* to reach for a private helper, and the refactor in #588 that inlined four of them had to be checked against it to be sure it hadn't. Moving it removes that question permanently.

## What moved

Verbatim to `denial_output_test.mbt`, qualified with `@sandbox.` — same test name, same fourteen assertions, same comments. The test now exercises the package the way its callers do.

## What stayed

`sandbox_wbtest.mbt` keeps five tests that genuinely need white-box access — the profile regex test calls `source_write_regex` and `source_write_build_carveout_regex`, neither of which is exported.

## On the overlap with the docstring

The new file names its relationship to the `mbt check` examples added in #588: those are the teaching subset, this is the exhaustive spec. A few assertions appear in both, which is the cost of having runnable docstring examples at all.

## Validation

- **9 sandbox tests before and after** — nothing dropped, only relocated (verified with `moon test -v`: the moved test now reports from `denial_output_test.mbt:7`)
- shell 119, shell_output 10, run_moonbit 22 — all passing on native
- `moon fmt --check` clean
- `moon check --deny-warn` clean
- `moon info` reports no `.mbti` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)