### PR TITLE
refactor: split on the last separator instead of indexing around it

### DIFF
--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -176,9 +176,11 @@ fn is_moonbit_source_path(path : String) -> Bool {
 ///|
 fn containing_dir(path : String) -> String {
   let path = path.replace_all(old="\\", new="/")
-  match path.rev_find("/") {
-    Some(0) => "/"
-    Some(cut) => path[:cut].to_owned()
+  // An empty part before the last slash means the slash was the leading one,
+  // so the containing directory is the root itself rather than "".
+  match path.rev_split_once("/") {
+    Some(([], _)) => "/"
+    Some((dir, _)) => dir.to_owned()
     None => "."
   }
 }
@@ -192,6 +194,16 @@ test "relevant path detection covers MoonBit source and manifests" {
   assert_true(is_relevant_moonbit_path("lib/README.mbt.md"))
   assert_false(is_relevant_moonbit_path("lib/parser.mbti"))
   assert_false(is_relevant_moonbit_path("README.md"))
+}
+
+///|
+test "containing dir keeps the root and normalizes separators" {
+  assert_eq(containing_dir("lib/parser.mbt"), "lib")
+  assert_eq(containing_dir("lib\\parser.mbt"), "lib")
+  // A leading slash leaves nothing before it, and the answer is the root.
+  assert_eq(containing_dir("/parser.mbt"), "/")
+  assert_eq(containing_dir("/work/parser.mbt"), "/work")
+  assert_eq(containing_dir("moon.mod"), ".")
 }
 
 ///|

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -605,15 +605,17 @@ async fn denial_scan_region(
     }
     position += n.to_int64()
     let text = carry + @utf8.decode_lossy(Bytes::from_array(buf[:n]))
-    match text.rev_find("\n") {
-      Some(cut) => {
+    // Split at the last newline: everything before it is whole lines the
+    // detector can judge now, everything after is the partial line to carry.
+    match text.rev_split_once("\n") {
+      Some((whole_lines, partial_line)) => {
         if @sandbox.source_write_denied_in_text(
-            text[:cut].to_owned(),
+            whole_lines.to_owned(),
             denial_subjects,
           ) {
           return true
         }
-        carry = text[cut + 1:].to_owned()
+        carry = partial_line.to_owned()
       }
       None => carry = text
     }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -4061,8 +4061,8 @@ fn script_tree_transfer_markers() -> Array[String] {
 ///|
 fn command_basename(name : String) -> String {
   let normalized = name.replace_all(old="\\", new="/")
-  match normalized.rev_find("/") {
-    Some(slash) => normalized[slash + 1:].to_owned()
+  match normalized.rev_after("/") {
+    Some(base) => base.to_owned()
     None => name
   }
 }
@@ -4257,10 +4257,11 @@ async fn missing_move_source_can_create_workspace_source(
 ///|
 fn looks_like_non_source_file_path(path : String) -> Bool {
   let base = @workspace_path.path_basename(path)
-  match base.rev_find(".") {
-    Some(dot) if dot + 1 < base.length() =>
+  // A trailing dot yields an empty extension, which is not one.
+  match base.rev_after(".") {
+    Some(ext) if !ext.is_empty() =>
       !@source_write_policy.is_protected_source_path(base) &&
-      looks_like_file_extension(base[dot + 1:].to_owned())
+      looks_like_file_extension(ext.to_owned())
     _ => false
   }
 }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1540,3 +1540,16 @@ async test "a scratch lab forces trusted source-writes onto the sandbox" {
   @fs.rmdir(ws, recursive=true)
   @fs.rmdir(lab, recursive=true)
 }
+
+///|
+test "a file path needs a non-empty alphabetic extension to look non-source" {
+  assert_true(looks_like_non_source_file_path("notes/readme.txt"))
+  assert_true(looks_like_non_source_file_path("archive.tar"))
+  // A trailing dot leaves an empty extension, which is not an extension.
+  assert_false(looks_like_non_source_file_path("weird."))
+  // No dot at all, and digits or symbols in place of an extension.
+  assert_false(looks_like_non_source_file_path("Makefile"))
+  assert_false(looks_like_non_source_file_path("archive.tar.7z"))
+  // Protected MoonBit sources stay source-looking however they are spelled.
+  assert_false(looks_like_non_source_file_path("lib/parser.mbt"))
+}

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -59,8 +59,8 @@ pub async fn apply_login_shell_env(
   let command = "\{shell_quote(executable)} --print-env-json \{mark}"
   // csh/tcsh reject the separate `-l` flag; every other shell in practice
   // (bash, zsh, fish, dash) takes interactive+login+command this way.
-  let shell_name = match shell.rev_find("/") {
-    Some(index) => shell[index + 1:].to_owned()
+  let shell_name = match shell.rev_after("/") {
+    Some(name) => name.to_owned()
     None => shell
   }
   let args : Array[String] = if shell_name is ("csh" | "tcsh") {

--- a/editor/internal/shell/server/server.mbt
+++ b/editor/internal/shell/server/server.mbt
@@ -213,8 +213,8 @@ pub fn resolve_remote_directory_uri(
 
 ///|
 fn directory_name(path : String) -> String {
-  match path.rev_find("/") {
-    Some(index) => path[index + 1:].to_owned()
+  match path.rev_after("/") {
+    Some(name) => name.to_owned()
     None => path
   }
 }

--- a/internal/workspace_path/workspace_path.mbt
+++ b/internal/workspace_path/workspace_path.mbt
@@ -29,8 +29,8 @@ pub fn strip_trailing_slash(path : String) -> String {
 /// filesystem and `.` or `..` components are not normalized.
 pub fn path_basename(path : String) -> String {
   let normalized = strip_trailing_slash(path.replace_all(old="\\", new="/"))
-  match normalized.rev_find("/") {
-    Some(slash) => normalized[slash + 1:].to_owned()
+  match normalized.rev_after("/") {
+    Some(base) => base.to_owned()
     None => normalized
   }
 }
@@ -69,9 +69,11 @@ pub fn parent_dir(path : String) -> String? {
     (normalized.length() == 2 && normalized[1] == ':') {
     return None
   }
-  match normalized.rev_find("/") {
-    Some(0) => Some("/")
-    Some(cut) => Some(normalized[:cut].to_owned())
+  // An empty part before the last slash means the slash was the leading one,
+  // so the parent is the root itself rather than "".
+  match normalized.rev_split_once("/") {
+    Some(([], _)) => Some("/")
+    Some((dir, _)) => Some(dir.to_owned())
     None => Some(".")
   }
 }
@@ -134,6 +136,12 @@ test "lexical path helpers preserve roots and normalize separators" {
   assert_eq(strip_trailing_slash("/work///"), "/work")
   assert_eq(strip_trailing_slash("/"), "/")
   assert_true(parent_dir("/") is None)
+  // A leading slash is the whole parent: the part before it is empty, and the
+  // answer is the root rather than "".
+  assert_true(parent_dir("/work") is Some("/"))
+  assert_true(parent_dir("/work/lib") is Some("/work"))
+  assert_true(parent_dir("relative/lib") is Some("relative"))
+  assert_true(parent_dir("bare") is Some("."))
   assert_true(parent_dir("C:") is None)
   assert_true(parent_dir("C:/") is None)
   assert_true(parent_dir("C:/work") is Some("C:"))
@@ -142,6 +150,8 @@ test "lexical path helpers preserve roots and normalize separators" {
   assert_eq(join_child("/work/", "moon.mod"), "/work/moon.mod")
   assert_eq(path_basename("/work/pkg/"), "pkg")
   assert_eq(path_basename("C:\\work\\main.mbt"), "main.mbt")
+  assert_eq(path_basename("bare"), "bare")
+  assert_eq(path_basename("/main.mbt"), "main.mbt")
   assert_true(is_under_workspace_root("/work", "/work"))
   assert_true(is_under_workspace_root("/work/", "/work/pkg/main.mbt"))
   assert_false(is_under_workspace_root("/work", "/workspace/main.mbt"))


### PR DESCRIPTION
## What

`rev_find` hands back an index, so every caller that actually wanted the *text* around the separator did the arithmetic itself — `s[:cut]` before, `s[cut + 1:]` after, with the `+ 1` silently standing in for the separator's length. Core already has the operations these were spelling out by hand.

Started from `run_moonbit.mbt`'s chunked denial scanner and generalized to the six other sites with the same shape.

## The three shapes

**Both halves used → `rev_split_once`.** The denial scanner splits each chunk at the last newline: whole lines get scanned now, the partial line is carried into the next chunk.

```moonbit
match text.rev_split_once("\n") {
  Some((whole_lines, partial_line)) => { …; carry = partial_line.to_owned() }
  None => carry = text
}
```

The two dirname helpers (`parent_dir`, `containing_dir`) also land here. Their leading-slash special case was `Some(0) => "/"` — an index compared against zero — and is now `Some(([], _))`, an empty part before the separator, which is what `Some(0)` meant.

**Only the part after it → `rev_after`.** Three basename helpers (`path_basename`, `command_basename`, the editor's `directory_name`, `shellenv`'s shell name) plus the extension test in `looks_like_non_source_file_path`, whose guard `dot + 1 < base.length()` was a roundabout way of saying the extension is non-empty.

## Deliberately left alone

- `editor/base/common/path.mbt`'s `last_index_of` — it exists to expose the index the way JS `lastIndexOf` does; the index *is* the product.
- `desktop/internal/shellenv/shellenv.mbt:121` — needs the raw index to compare against a separate forward `find` (`last >= start`), so a split doesn't express it.
- The two `edit` tests slicing `close + 1` — they KEEP the bracket they searched for, and `rev_split_once` drops the separator.
- `desktop/lepus/**` — separate submodule repo.

## Tests, and why they are evidence

The arms this touches were thinly covered: `parent_dir("/work")`, `containing_dir("/x")` and a trailing-dot extension had no test at all, so a green suite would not have told us much.

The added tests were written against the **pre-refactor** code and pass on it. That ordering is the point — it makes them a record of the behavior that was already there rather than a description of whatever the rewrite now does. Checked both directions: deleting the root-slash arm fails them (along with an existing `README.mbt.md` doc test).

## Test plan

- `moon fmt --check`, `moon check` — clean (the two deprecation warnings on my local nightly are pre-existing in untouched files)
- `moon test` — 1609/1609 native, 1568/1568 js, 12/12 wasm
- `moon cram test tests/cram` — 26/26
- `moon info` — no `.mbti` drift (no public signature changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)