### PR TITLE
simplify(agent_tool/sandbox): probe via @process.collect_output_merged

### DIFF
--- a/agent_tool/internal/sandbox/sandbox_exec.mbt
+++ b/agent_tool/internal/sandbox/sandbox_exec.mbt
@@ -90,36 +90,18 @@ async fn probe_sandbox_exec_available() -> Bool {
 }
 
 ///|
-/// Spawn `program args`, drain merged stdout+stderr so a child that fills the
-/// pipe buffer cannot deadlock against `wait`, then wait and return the exit
-/// code. Returns `None` when the spawn (or an unexpected IO error) fails; a
-/// cancellation still propagates. The sandbox-availability probe only needs the
-/// exit status plus a follow-up `@fs.exists` check, so the drained bytes are
-/// discarded rather than decoded.
+/// Exit code of `program args`, or `None` when the spawn (or an unexpected IO
+/// error) fails; a cancellation still propagates. A thin wrapper over
+/// `@process.collect_output_merged`, which already drains merged stdout+stderr
+/// before waiting, so a child that fills the pipe buffer cannot deadlock
+/// against `wait`. The sandbox-availability probe only needs the exit status
+/// plus a follow-up `@fs.exists` check, so the collected bytes are discarded.
 async fn run_probe_exit(program : String, args : Array[String]) -> Int? {
-  (@async.with_task_group() <| group => {
-    let (reader, writer) = @process.read_from_process()
-    defer reader.close()
-    let process = @process.spawn(
-      group,
-      program,
-      args,
-      stdout=writer,
-      stderr=writer,
-      cancel_handler=@process.hard_cancel(),
-      no_wait=true,
-    )
-    for ;; {
-      match reader.read_some(max_len=1024) {
-        None => break
-        Some(_) => ()
-      }
-    }
-    Some(process.wait())
-  }) catch {
+  let (exit_code, _) = @process.collect_output_merged(program, args) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => None
+    _ => return None
   }
+  Some(exit_code)
 }
 
 ///|


### PR DESCRIPTION
Answering "do we have a better primitive than rolling our own?" for `run_probe_exit` — yes: `@process.collect_output_merged`.

The hand-rolled version was architecturally identical to the library call: the same `read_from_process` pipe, the same task group, spawn with merged stdout+stderr, drain before waiting (so a child that fills the pipe buffer cannot deadlock against `wait`), then return the exit code. The library replaces all of it; what remains is the one decision it cannot make for us — mapping non-cancellation failures to `None` so the probe reads as "unavailable" rather than raising out of `sandbox_exec_available`.

```moonbit
async fn run_probe_exit(program : String, args : Array[String]) -> Int? {
  let (exit_code, _) = @process.collect_output_merged(program, args) catch {
    error if @async.is_being_cancelled() => raise error
    _ => return None
  }
  Some(exit_code)
}
```

## One deliberate behavior change

The hand-rolled version passed `hard_cancel()`; `collect_output_merged` does not expose a cancel handler and inherits `run`'s default `graceful_cancel(timeout=5000)` — SIGTERM first, SIGKILL after five seconds. The probe children (`sandbox-exec` running `:` or a `printf` redirect) exit on SIGTERM immediately, so a cancelled probe still terminates promptly; it just no longer skips straight to SIGKILL.

## Validation

- The shell suite runs the **real probe** against `/usr/bin/sandbox-exec` on macOS, so the replacement is exercised end to end, not just type-checked
- sandbox 9, shell 120 (61 sandbox-related), shell_output 10, run_moonbit 22 — all passing on native
- `moon fmt --check` clean, `moon check --deny-warn` clean
- `moon info` reports no `.mbti` change — `run_probe_exit` is private

Net −18 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)