### PR TITLE
refactor: let array patterns bind what length checks were guarding

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -365,7 +365,7 @@ async fn preview_replace_all(
     let global = prefix_length + offset
     let first_line = line_at(global)
     let last_line = line_at(global + input.old_string.length() - 1)
-    if sites.length() > 0 && sites[sites.length() - 1].first_line == first_line {
+    if sites is [.., last_site] && last_site.first_line == first_line {
       if single_line {
         // A second match on the same line: two line-anchored edits with the
         // same anchor would both hit the first occurrence, so the site becomes

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -87,15 +87,14 @@ fn parse_warn_off_list(help : String) -> String {
     } else {
       line
     }
+    // A table row ends with the two columns this cares about, whatever
+    // precedes them: `… <id> <state>`.
     let parts = [..line.split(" ")].filter(part => !part.is_empty())
-    guard parts.length() >= 2 else { continue }
-    let state = parts[parts.length() - 1]
+    guard parts is [.., id_column, state] else { continue }
     guard state == "warn" || state == "error" || state == "off" else {
       continue
     }
-    let id = @string.parse_int(parts[parts.length() - 2]) catch {
-      _ => continue
-    }
+    let id = @string.parse_int(id_column) catch { _ => continue }
     guard id > 0 else { continue }
     if id > max_id {
       max_id = id

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -270,25 +270,14 @@ fn too_complex_shell_control_word(argv : Array[String]) -> String? {
 
 ///|
 fn effective_shell_control_word_index(argv : Array[String]) -> Int? {
-  if argv.length() == 0 {
-    return None
-  }
-  match argv[0] {
-    "command" => command_payload_index(argv)
-    "builtin" =>
-      if argv.length() > 1 {
-        if argv[1] == "--" {
-          if argv.length() > 2 {
-            Some(2)
-          } else {
-            None
-          }
-        } else {
-          Some(1)
-        }
-      } else {
-        None
-      }
+  // Unlike `effective_command_index`, a wrapper with nothing to run is no
+  // control word at all rather than the wrapper itself — hence `None` for both
+  // `builtin` and `builtin --`, which the `_ ..` arms below fall through to.
+  match argv {
+    ["command", ..] => command_payload_index(argv)
+    ["builtin", "--", _, ..] => Some(2)
+    ["builtin", "--"] | ["builtin"] | [] => None
+    ["builtin", _, ..] => Some(1)
     _ => Some(0)
   }
 }

--- a/agent_tool/shell/internal/shell_parse/query.mbt
+++ b/agent_tool/shell/internal/shell_parse/query.mbt
@@ -34,23 +34,16 @@ pub fn contains_command(result : ParseResult, name : String) -> Bool {
 
 ///|
 fn effective_command_index(argv : Array[String]) -> Int? {
-  if argv.length() == 0 {
-    return None
-  }
-  match argv[0] {
-    "env" => env_wrapped_command_index(argv)
-    "command" => command_wrapped_command_index(argv)
-    "builtin" =>
-      if argv.length() > 1 {
-        let index = if argv[1] == "--" { 2 } else { 1 }
-        if index < argv.length() {
-          Some(index)
-        } else {
-          Some(0)
-        }
-      } else {
-        Some(0)
-      }
+  // Each arm is the argv shape it handles. The `builtin --` arm has to precede
+  // the general `builtin` one: `--` with nothing behind it is not an
+  // end-of-options marker for a command, it leaves the wrapper as the command.
+  match argv {
+    [] => None
+    ["env", ..] => env_wrapped_command_index(argv)
+    ["command", ..] => command_wrapped_command_index(argv)
+    ["builtin", "--", _, ..] => Some(2)
+    ["builtin", "--"] => Some(0)
+    ["builtin", _, ..] => Some(1)
     _ => Some(0)
   }
 }

--- a/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
+++ b/agent_tool/shell/internal/shell_parse/shell_parse_test.mbt
@@ -445,3 +445,62 @@ test "allow trailing semicolon and blank input" {
   }
   assert_eq(blank.length(), 0)
 }
+
+///|
+/// The `builtin` wrapper's boundaries, which the common `builtin cd …` cases
+/// never reach: a bare wrapper with nothing to run, and a `--` end-of-options
+/// marker with and without a command behind it.
+test "builtin wrapper resolves its own edge shapes" {
+  fn index_of(command : String) -> Int? raise {
+    guard @shell_parse.parse_for_policy(command) is Simple(commands) else {
+      fail("expected simple command")
+    }
+    commands[0].command_index()
+  }
+
+  fn name_of(command : String) -> String? raise {
+    guard @shell_parse.parse_for_policy(command) is Simple(commands) else {
+      fail("expected simple command")
+    }
+    commands[0].command_name()
+  }
+
+  // A command behind `--` is the effective command.
+  assert_true(index_of("builtin -- cd pkg") is Some(2))
+  assert_true(name_of("builtin -- cd pkg") is Some("cd"))
+  // `--` with nothing behind it leaves the wrapper itself as the command.
+  assert_true(index_of("builtin --") is Some(0))
+  assert_true(name_of("builtin --") is Some("builtin"))
+  // A bare wrapper likewise resolves to itself, not to None.
+  assert_true(index_of("builtin") is Some(0))
+  assert_true(name_of("builtin") is Some("builtin"))
+  // Without `--`, the very next word is the command.
+  assert_true(index_of("builtin cd pkg") is Some(1))
+  assert_true(name_of("builtin cd pkg") is Some("cd"))
+  // `command` and `env` wrappers keep their own resolution.
+  assert_true(index_of("command cd pkg") is Some(1))
+  assert_true(index_of("env FOO=bar cd pkg") is Some(2))
+}
+
+///|
+/// `builtin`/`command` can hide a shell control word from the too-complex
+/// check, so the wrapper's edge shapes matter here too: `--` with a control
+/// word behind it must still be seen, and a wrapper with nothing behind it
+/// must not be mistaken for one.
+test "control word detection sees through builtin wrappers" {
+  // The wrapper is seen through with and without `--`, so the control word
+  // behind it is still refused.
+  assert_true(
+    @shell_parse.parse_for_policy("builtin -- while true; do x; done")
+    is TooComplex(_),
+  )
+  assert_true(
+    @shell_parse.parse_for_policy("builtin while true; do x; done")
+    is TooComplex(_),
+  )
+  // Nothing behind the wrapper is no control word at all.
+  assert_true(@shell_parse.parse_for_policy("builtin --") is Simple(_))
+  assert_true(@shell_parse.parse_for_policy("builtin") is Simple(_))
+  // A plain command behind the wrapper stays simple.
+  assert_true(@shell_parse.parse_for_policy("builtin -- cd pkg") is Simple(_))
+}

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -212,7 +212,7 @@ fn cwd_command_effect(
   base_cwd : String,
 ) -> CwdCommandEffect {
   let argv = command.argv
-  if argv.length() > 0 && argv[0] == "env" {
+  if argv is ["env", ..] {
     return NotCwdCommand
   }
   match command.command_index() {

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -2609,8 +2609,7 @@ async fn powershell_rename_target(
   }
   let new_name = match parsed.new_name {
     Some(new_name) => new_name
-    None if parsed.paths.length() >= 2 =>
-      parsed.paths[parsed.paths.length() - 1]
+    None if parsed.paths is [_, .., last] => last
     None =>
       return powershell_remove_target(argv, arg_start, real_workspace_root, cwd)
   }
@@ -5098,12 +5097,12 @@ fn operands_with_optional_dest(
 ) -> MvOperands? {
   match target_directory {
     Some(dest) => Some({ sources: operands, dest: Some(dest) })
+    // Without an explicit target, the last operand is the destination and the
+    // rest are sources — but only if there IS a rest: a lone operand is a
+    // source with nowhere to go, not a destination.
     None =>
-      if operands.length() >= 2 {
-        let sources = [
-          for index in 0..<(operands.length() - 1) => operands[index]
-        ]
-        Some({ sources, dest: Some(operands[operands.length() - 1]) })
+      if operands is [.. sources, dest] && !sources.is_empty() {
+        Some({ sources: sources.to_owned(), dest: Some(dest) })
       } else {
         Some({ sources: [], dest: None })
       }
@@ -5211,7 +5210,7 @@ fn cwd_command_effect_from_unknown_base(
   command : @shell_parse.SimpleCommand,
 ) -> CwdCommandEffect {
   let argv = command.argv
-  if argv.length() > 0 && argv[0] == "env" {
+  if argv is ["env", ..] {
     return NotCwdCommand
   }
   match command.command_index() {

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1553,3 +1553,18 @@ test "a file path needs a non-empty alphabetic extension to look non-source" {
   // Protected MoonBit sources stay source-looking however they are spelled.
   assert_false(looks_like_non_source_file_path("lib/parser.mbt"))
 }
+
+///|
+/// `mv`/`cp` with a single operand names a source and no destination, so there
+/// is no tree transfer to point at. The two-operand forms are covered above;
+/// this pins the boundary between them, which is what tells the last operand
+/// apart from the only operand.
+async test "a lone operand is a source with no destination" {
+  @vfs.with_tmpdir(prefix="openseek-shell-lone-operand-", root => {
+    @fs.mkdir("\{root}/pkg")
+    let real_root = @fs.realpath(root)
+    assert_true(tree_target("mv pkg", real_root, Some(real_root)) is None)
+    assert_true(tree_target("cp pkg", real_root, Some(real_root)) is None)
+    assert_true(tree_target("mv -f pkg", real_root, Some(real_root)) is None)
+  })
+}

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -475,8 +475,8 @@ pub fn update(
       let target = match cursor_index(state, entries) {
         Some(index) => Some(entries[index].0)
         None =>
-          if !state.filter.trim().is_empty() && entries.length() > 0 {
-            Some(entries[0].0)
+          if !state.filter.trim().is_empty() && entries is [(entry, _), ..] {
+            Some(entry)
           } else {
             None
           }

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -398,8 +398,8 @@ async fn resolve_events_path(trial : TrialArtifact) -> String {
   }
   let matches : Array[String] = []
   collect_session_events(trial.workspace, trial.session_id, matches)
-  if matches.length() > 0 {
-    matches[0]
+  if matches is [first, ..] {
+    first
   } else if trial.events_path != "" &&
     path_under_dir(trial.events_path, trial.workspace) {
     trial.events_path

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -160,8 +160,8 @@ async fn discover_session_events(
 ) -> String {
   let matches : Array[String] = []
   collect_session_events(workspace, session_id, matches)
-  if matches.length() > 0 {
-    matches[0]
+  if matches is [first, ..] {
+    first
   } else {
     fallback
   }


### PR DESCRIPTION
## What

Scanned the repo for emptiness/length checks whose body then reaches back into the same container by index — the sites where an array pattern does both jobs at once. Found 34; this converts the 11 outside `editor/`.

```moonbit
if argv.length() > 0 && argv[0] == "env"    ->  if argv is ["env", ..]

guard parts.length() >= 2 else { … }        ->  guard parts is [.., id_column, state]
let state = parts[parts.length() - 1]           else { … }
let id = parts[parts.length() - 2]
```

The two shell-wrapper resolvers gain the most — four levels of nested length-and-index tests spelling out argv shapes, now one arm per shape:

```moonbit
match argv {
  [] => None
  ["env", ..] => env_wrapped_command_index(argv)
  ["command", ..] => command_wrapped_command_index(argv)
  ["builtin", "--", _, ..] => Some(2)
  ["builtin", "--"] => Some(0)
  ["builtin", _, ..] => Some(1)
  _ => Some(0)
}
```

## The trap in that rewrite

`builtin --` resolves to the **wrapper itself**, not to the word behind `--`. Put `["builtin", _, ..]` before `["builtin", "--"]` and `Some(0)` silently becomes `Some(1)` — which is exactly what my first draft did. The two resolvers also disagree here deliberately: `query.mbt` answers `Some(0)`, `parser.mbt` answers `None`.

Nothing covered it. The existing tests reached `builtin cd` and `builtin export`, both of which take the ordinary arm. So the edge shapes are pinned first, and **the new tests were written against the pre-refactor code and pass on it** — that ordering is what makes them a record of the behavior that was already there rather than a description of whatever the rewrite now does.

## One caveat, stated rather than buried

The `mv` operand split keeps a `!sources.is_empty()` guard so `[.. sources, dest]` matches the original `length() >= 2`. I mutation-tested it: dropping the guard does **not** fail the suite, because consumers iterate `sources` and a destination with no sources does nothing. So the guard is currently unobservable. It is kept for exact equivalence rather than relying on no consumer noticing — but it is not test-proven, and reviewers should know that.

A lone `mv`/`cp` operand had no test at all; that path is now covered.

## Deliberately not converted

- **The other ~280 bare emptiness tests.** `xs.is_empty()` already says what it means; `xs is []` is a rename, not a simplification. The idiom pays only where the pattern binds something the code goes on to use.
- **The 23 sites in `editor/`**, listed below. It mirrors Monaco upstream, so idiom drift there makes future syncing noisier — a real cost, and a separate decision rather than one to make inside this sweep.

## Test plan

- `moon fmt --check`, `moon check` — clean (two deprecation warnings on my local nightly are pre-existing in untouched files)
- `moon test` — 1615/1615 native, 1568/1568 js, 12/12 wasm
- `moon cram test tests/cram` — 26/26
- `moon info` — no `.mbti` drift
- Mutation-checked: reordering the `builtin` arms and dropping the operand guard, to see which the suite actually catches

🤖 Generated with [Claude Code](https://claude.com/claude-code)