### PR TITLE
refactor(editor): bind the element the length check was guarding

### DIFF
--- a/editor/base/common/line_range.mbt
+++ b/editor/base/common/line_range.mbt
@@ -78,10 +78,8 @@ pub fn LineRange::join(self : LineRange, other : LineRange) -> LineRange {
 pub fn LineRange::join_many(
   line_ranges : Array[Array[LineRange]],
 ) -> Array[LineRange] {
-  if line_ranges.length() == 0 {
-    return []
-  }
-  let mut result = LineRangeSet(normalized_ranges=line_ranges[0].copy())
+  guard line_ranges is [first, ..] else { return [] }
+  let mut result = LineRangeSet(normalized_ranges=first.copy())
   for index in 1..<line_ranges.length() {
     result = result.get_union(
       LineRangeSet(normalized_ranges=line_ranges[index].copy()),

--- a/editor/internal/shell/workspace/source.mbt
+++ b/editor/internal/shell/workspace/source.mbt
@@ -56,11 +56,8 @@ pub fn SourcePath::normalize_root_relative_path(
       segments.push(segment)
     }
   }
-  if segments.length() == 0 {
-    return SourcePathError(InvalidPath)
-  }
-
-  let mut normalized = segments[0]
+  guard segments is [first, ..] else { return SourcePathError(InvalidPath) }
+  let mut normalized = first
   for i in 1..<segments.length() {
     normalized = normalized + "/" + segments[i]
   }

--- a/editor/internal/viewer/browser/view/view_widgets_cursors_lifecycle.mbt
+++ b/editor/internal/viewer/browser/view/view_widgets_cursors_lifecycle.mbt
@@ -73,13 +73,14 @@ fn view_cursors_on_view_event(part : ViewCursors, event : ViewEvent) -> Bool {
     ViewFlushed => true
     ViewScrollChanged(_) => true
     ViewCursorStateChanged(e) => {
-      self.last_position = if e.selections.length() == 0 {
-        None
-      } else {
-        Some(e.selections[0].get_position())
+      self.last_position = match e.selections {
+        [primary, ..] => Some(primary.get_position())
+        [] => None
       }
-      let selection_is_empty = e.selections.length() == 0 ||
-        e.selections[0].is_empty()
+      let selection_is_empty = match e.selections {
+        [primary, ..] => primary.is_empty()
+        [] => true
+      }
       // `ViewCursors.onCursorStateChanged` updates the layer class
       // synchronously, but only when the selection shape crosses the
       // empty/nonempty boundary. Keep the last rendered cursor rectangle

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -530,8 +530,8 @@ pub fn set_collapse_state_up(
       region,
       _level,
     ) => region.is_collapsed() != do_collapse)
-    if regions.length() > 0 {
-      to_toggle.push(regions[0])
+    if regions is [first, ..] {
+      to_toggle.push(first)
     }
   }
   folding_model.toggle_collapse_state(to_toggle)
@@ -567,8 +567,8 @@ pub fn set_collapse_state_for_rest(
   let filtered_regions : Array[FoldingRegion] = []
   for line_number in blocked_line_numbers {
     let regions = folding_model.get_all_regions_at_line(line_number)
-    if regions.length() > 0 {
-      filtered_regions.push(regions[0])
+    if regions is [first, ..] {
+      filtered_regions.push(first)
     }
   }
   let filter = RegionFilter(region => {

--- a/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
@@ -154,8 +154,8 @@ fn FoldingRegions::ensure_parent_indices(self : FoldingRegions) -> Unit {
           !is_inside_last(start_line_number, end_line_number) {
       parent_indexes.pop() |> ignore
     }
-    let parent_index = if parent_indexes.length() > 0 {
-      parent_indexes[parent_indexes.length() - 1]
+    let parent_index = if parent_indexes is [.., innermost] {
+      innermost
     } else {
       -1
     }

--- a/editor/internal/viewer/contrib/markdown_comments/markdown_comments.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/markdown_comments.mbt
@@ -188,14 +188,10 @@ pub fn normalize_markdown_comment_blocks(
   let non_overlapping : Array[@language.MarkdownCommentBlock] = []
   for entry in indexed {
     let block = entry.block
-    if non_overlapping.length() > 0 &&
+    if non_overlapping is [.., previous] &&
       block.line_range.start_line_number <
-      non_overlapping[non_overlapping.length() - 1].line_range.end_line_number_exclusive {
-      warn_overlap(
-        log_service,
-        non_overlapping[non_overlapping.length() - 1].line_range,
-        block.line_range,
-      )
+      previous.line_range.end_line_number_exclusive {
+      warn_overlap(log_service, previous.line_range, block.line_range)
     } else {
       non_overlapping.push(block)
     }

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -287,12 +287,9 @@ pub fn push_token(
   end : Int,
   tag : HighlightTag,
 ) -> Unit {
-  if tokens.length() > 0 {
-    let last = tokens[tokens.length() - 1]
-    if last.tag == tag && last.end == start {
-      tokens[tokens.length() - 1] = { start: last.start, end, tag }
-      return
-    }
+  if tokens is [.., last] && last.tag == tag && last.end == start {
+    tokens[tokens.length() - 1] = { start: last.start, end, tag }
+    return
   }
   tokens.push({ start, end, tag })
 }

--- a/editor/viewer/common/languages/languages.mbt
+++ b/editor/viewer/common/languages/languages.mbt
@@ -230,10 +230,7 @@ fn Languages::markdown_comment_provider_result_with_log_handle(
   log_service : @log.LogHandle,
 ) -> Array[@language.MarkdownCommentBlock]? {
   let providers = self.markdown_comment_provider.snapshot_matching(model)
-  if providers.length() == 0 {
-    return None
-  }
-  let captured = providers[0]
+  guard providers is [captured, ..] else { return None }
   let result = captured.entry.provider.provide_markdown_comments(model) catch {
     _ => {
       log_provider_failure(

--- a/editor/viewer/common/model/text_model_tokens.mbt
+++ b/editor/viewer/common/model/text_model_tokens.mbt
@@ -136,10 +136,9 @@ fn RangePriorityQueueImpl::RangePriorityQueueImpl() -> RangePriorityQueueImpl {
 ///|
 /// Smallest queued line, or `None`.
 fn RangePriorityQueueImpl::min(self : RangePriorityQueueImpl) -> Int? {
-  if self.ranges.is_empty() {
-    None
-  } else {
-    Some(self.ranges[0].start)
+  match self.ranges {
+    [first, ..] => Some(first.start)
+    [] => None
   }
 }
 

--- a/editor/viewer/common/tokens/contiguous_multiline_tokens_builder.mbt
+++ b/editor/viewer/common/tokens/contiguous_multiline_tokens_builder.mbt
@@ -30,12 +30,9 @@ pub fn ContiguousMultilineTokensBuilder::add(
   line_number : Int,
   line_tokens : Array[UInt],
 ) -> Unit {
-  if self.tokens.length() > 0 {
-    let last = self.tokens[self.tokens.length() - 1]
-    if last.end_line_number() + 1 == line_number {
-      last.append_line_tokens(line_tokens)
-      return
-    }
+  if self.tokens is [.., last] && last.end_line_number() + 1 == line_number {
+    last.append_line_tokens(line_tokens)
+    return
   }
   self.tokens.push(ContiguousMultilineTokens(line_number, [line_tokens]))
 }

--- a/editor/viewer/common/view_layout/render_line_renderer.mbt
+++ b/editor/viewer/common/view_layout/render_line_renderer.mbt
@@ -548,8 +548,8 @@ fn apply_render_whitespace(
       if !is_in_whitespace ||
         (!use_monospace_optimizations && tmp_indent >= tab_size) {
         if generate_for_each {
-          let last_end_index = if result.length() > 0 {
-            result[result.length() - 1].end_index
+          let last_end_index = if result is [.., last] {
+            last.end_index
           } else {
             faux_indent_length
           }
@@ -620,8 +620,8 @@ fn apply_render_whitespace(
   }
   if generate_whitespace {
     if generate_for_each {
-      let last_end_index = if result.length() > 0 {
-        result[result.length() - 1].end_index
+      let last_end_index = if result is [.., last] {
+        last.end_index
       } else {
         faux_indent_length
       }

--- a/editor/viewer/common/view_layout/reveal.mbt
+++ b/editor/viewer/common/view_layout/reveal.mbt
@@ -149,9 +149,9 @@ pub fn ViewLayout::compute_scroll_left_to_reveal(
   vertical_scrollbar_width~ : Double,
   minimal_reveal? : Bool = false,
 ) -> Double? {
-  guard ranges.length() > 0 else { return None }
-  let mut box_start_x = ranges[0].0.round()
-  let mut box_end_x = (ranges[0].0 + ranges[0].1).round()
+  guard ranges is [(first_left, first_width), ..] else { return None }
+  let mut box_start_x = first_left.round()
+  let mut box_end_x = (first_left + first_width).round()
   for index in 1..<ranges.length() {
     let (left, width) = ranges[index]
     box_start_x = min_double(box_start_x, left.round())

--- a/editor/viewer/cursor_event_delivery.mbt
+++ b/editor/viewer/cursor_event_delivery.mbt
@@ -79,8 +79,7 @@ fn CursorEventDelivery::begin_drain(self : CursorEventDelivery) -> Bool {
 fn CursorEventDelivery::take_next_ready(
   self : CursorEventDelivery,
 ) -> @view_model.CursorStateChangedEvent? {
-  guard self.queue.length() > 0 else { return None }
-  let next = self.queue[0]
+  guard self.queue is [next, ..] else { return None }
   if self.content_barrier_depth > 0 &&
     is_model_flush_cursor_event(next) &&
     !self.has_completed_content_version(next.model_version_id) {


### PR DESCRIPTION
## What

The array-pattern pass over `editor/`, held back from #592 because this module mirrors Monaco and idiom drift here costs something at sync time. Sixteen sites earn it — each tested a container for emptiness, then indexed straight back into it for the element the test was about.

```moonbit
if tokens.length() > 0 {                    ->  if tokens is [.., last] &&
  let last = tokens[tokens.length() - 1]          last.tag == tag &&
  if last.tag == tag && last.end == start {       last.end == start {
```

`markdown_comments` gains the most: one binding replaces two spellings of `non_overlapping[non_overlapping.length() - 1]` inside a single condition.

## Left in place, deliberately

- **`get_default_background`'s `color_map.length() > 2 => color_map[2]`.** That literal `2` *is* `ColorId.DefaultBackground`, named in the doc comment directly above. `[_, _, background, ..]` would hide the correspondence to the upstream constant.
- **The `lang_*` lexers' `stack[stack.length() - 1]`.** `decode_mode_stack` guarantees a non-empty stack, so a pattern would force a branch for a state that cannot occur.
- **`scheme_matches_pattern`'s `scheme[0]`.** String subscripting is by code unit; a pattern binds a `Char`. Those differ on non-BMP input, so converting it is a behavior change wearing a refactor's clothes.
- **Bare emptiness tests**, which bind nothing — same bar as #592.

## ⚠️ A verification gap this uncovered

**`moon test` from the repo root does not run this module's tests.** `editor` is `preferred_target = "js"`, and its **2086 tests only execute under `moon test --target js` from `editor/`**. A root-level run reports ~1623 native tests and touches none of this code.

That matters beyond this PR: **CI has the same blind spot.** `ci.yml:142` runs `xvfb-run -a moon test` from the root. The only workflow that runs `moon -C editor test` is `publish-editor.yml`, which is `workflow_dispatch:` only — so **no PR check currently executes the editor test suite**. Worth fixing separately; I have not touched CI here.

Under the right target the suite does have teeth — deliberately breaking `push_token`'s coalescing fails 7 tests. The one arm it does not reach is `selection_is_empty` for an empty selection array; that is left as a readable two-line match rather than folded into a tuple with `last_position`, so its equivalence to the original `length() == 0 || …` can be checked by eye instead of resting on a test that does not exist.

## Test plan

- `moon test --target js` from `editor/` — **2086/2086** (the run that actually covers this diff)
- `moon check --target js` and `--target native` from `editor/` — clean
- Root `moon test` — 1623 native / 1568 js / 12 wasm
- Root `moon fmt --check`, `moon info` (no `.mbti` drift), `moon cram test tests/cram` 26/26
- Mutation-checked `push_token` coalescing and the `selection_is_empty` empty case, to establish which arms the suite actually reaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)