### PR TITLE
refactor(agent_tool/sandbox): make sandboxed commands opaque

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -86,9 +86,9 @@ priv struct BgJob {
   command : String
   cwd : String?
   exec : @shell_exec.ShellExecution
-  // Sandbox metadata carried from the launch (opaque to bgjobs) so a reader can
-  // apply the same source-write-denial detection the foreground path does.
-  denial_classifier : @sandbox.SourceWriteDenialClassifier?
+  // The opaque prepared command is carried from launch so a reader can apply
+  // the same source-write-denial detection the foreground path does.
+  sandboxed_command : @sandbox.SandboxedCommand?
 }
 
 ///|
@@ -109,7 +109,7 @@ pub struct BgJobSnapshot {
   // Preserved so a reader can match the foreground path's error semantics: mark
   // binary output as an error, and detect a sandboxed source-write denial.
   had_invalid_utf8 : Bool
-  denial_classifier : @sandbox.SourceWriteDenialClassifier?
+  sandboxed_command : @sandbox.SandboxedCommand?
   // The job was killed by the output-limit watchdog (flooded past the hard cap),
   // not stopped on request — surfaced so the kill is never silent.
   killed_by_output_limit : Bool
@@ -224,14 +224,14 @@ pub async fn BgJobRuntime::start(
   command~ : String,
   cwd? : String,
   max_output_chars? : Int = default_max_output_chars,
-  denial_classifier? : @sandbox.SourceWriteDenialClassifier,
+  sandboxed_command? : @sandbox.SandboxedCommand,
 ) -> String {
   // Reserve one id and use it for both the spill file and the registry entry, so
   // the job id and its `<id>.out` file never diverge.
   let id = self.next_id()
   let spill_path = self.spill_dir.map(dir => "\{dir}/\{id}.out")
   let exec = (self.spawn_exec)(program, args, cwd, max_output_chars, spill_path)
-  self.register(id, exec, command~, cwd?, denial_classifier?)
+  self.register(id, exec, command~, cwd?, sandboxed_command?)
   id
 }
 
@@ -245,10 +245,10 @@ pub fn BgJobRuntime::adopt(
   exec : @shell_exec.ShellExecution,
   command~ : String,
   cwd? : String,
-  denial_classifier? : @sandbox.SourceWriteDenialClassifier,
+  sandboxed_command? : @sandbox.SandboxedCommand,
 ) -> String {
   let id = self.next_id()
-  self.register(id, exec, command~, cwd?, denial_classifier?)
+  self.register(id, exec, command~, cwd?, sandboxed_command?)
   id
 }
 
@@ -260,9 +260,9 @@ fn BgJobRuntime::register(
   exec : @shell_exec.ShellExecution,
   command~ : String,
   cwd? : String,
-  denial_classifier? : @sandbox.SourceWriteDenialClassifier,
+  sandboxed_command? : @sandbox.SandboxedCommand,
 ) -> Unit {
-  self.jobs[id] = { id, command, cwd, exec, denial_classifier }
+  self.jobs[id] = { id, command, cwd, exec, sandboxed_command }
   // Watch for the job ending on its own and fire `on_job_exit` once: a natural
   // exit, or the output-limit watchdog killing a flooding job — both must be
   // surfaced (a watchdog kill silently eating an unwatched job would look like
@@ -320,7 +320,7 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
     seq: self.exec.seq(),
     exit_code: self.exec.exit_code(),
     had_invalid_utf8: self.exec.had_invalid_utf8(),
-    denial_classifier: self.denial_classifier,
+    sandboxed_command: self.sandboxed_command,
     killed_by_output_limit: self.exec.killed_by_output_limit(),
     killed_by_time_limit: self.exec.killed_by_time_limit(),
   }

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -15,14 +15,14 @@ import {
 pub struct BgJobRuntime {
   // private fields
 }
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, denial_classifier? : @sandbox.SourceWriteDenialClassifier) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
-pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, denial_classifier? : @sandbox.SourceWriteDenialClassifier) -> String
+pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
 pub async fn BgJobRuntime::wait_exit(Self, String, Int) -> Bool
 
@@ -38,7 +38,7 @@ pub struct BgJobSnapshot {
   seq : Int
   exit_code : Int?
   had_invalid_utf8 : Bool
-  denial_classifier : @sandbox.SourceWriteDenialClassifier?
+  sandboxed_command : @sandbox.SandboxedCommand?
   killed_by_output_limit : Bool
   killed_by_time_limit : Bool
 }

--- a/agent_tool/internal/sandbox/README.mbt.md
+++ b/agent_tool/internal/sandbox/README.mbt.md
@@ -1,12 +1,13 @@
 # agent_tool/internal/sandbox
 
-The source-write sandbox as a capability. `shell`, `run_moonbit`, `bgjobs`,
-and `shell_output` share one macOS `sandbox-exec` integration through two
-opaque types and two command records: acquire a `SourceWriteSandbox` for a
-workspace, wrap a command in it, and judge that command's output with the
-classifier it came with.
-Everything SBPL-specific — profile text, escaping, the `sandbox-exec` path,
-the availability probe — stays behind the API.
+The source-write sandbox as one prepared-command capability. `shell`,
+`run_moonbit`, `bgjobs`, and `shell_output` share one macOS `sandbox-exec`
+integration: describe command intent with the `Shell` or `Exec` variants of
+`Command`,
+prepare an opaque `SandboxedCommand`, run its program and arguments, then ask
+that same value to judge the output. Everything SBPL-specific — profile text,
+denial subjects, escaping, the `sandbox-exec` path, and the availability probe
+— stays behind the API.
 
 This package does not own workspace path manipulation or protection-policy
 predicates. Generic lexical operations live in `internal/workspace_path`,
@@ -16,18 +17,18 @@ in `agent_tool/internal/platform_shell`.
 
 ## The contract
 
-Acquire, wrap, run, classify:
+Prepare, run, classify:
 
 ```mbt nocheck
-match @sandbox.SourceWriteSandbox::create_if_available(workspace_root) {
+let command = @sandbox.Shell(cmd)
+match @sandbox.SandboxedCommand::create_if_available(workspace_root, command) {
   None =>
     // Enforcement unavailable here (not macOS, or a nested sandbox).
     // The fallback is the CALLER's decision, made explicitly.
     run_unsandboxed(cmd)
-  Some(sandbox) => {
-    let wrapped = sandbox.wrap_shell_command(cmd)
-    let output = run(wrapped.command.program, wrapped.command.args)
-    if wrapped.denial_classifier.output_reports_denial(output) {
+  Some(prepared) => {
+    let output = run(prepared.program(), prepared.args())
+    if prepared.output_reports_denial(output) {
       // The kernel denied a protected source write: explain it rather than
       // letting the model debug a bare "Operation not permitted".
     }
@@ -41,19 +42,18 @@ raises instead, on every platform, so a caller bug cannot silently disable
 protection where the probe happens to fail. The root is realpath'd inside the
 constructor, because the kernel matches profile rules against real paths.
 
-The profile is built from the tree as it exists at acquisition; renaming the
-root or subtree afterwards makes the rules stale. Acquire close to where the
+The profile is built from the tree as it exists at preparation; renaming the
+root or subtree afterwards makes the rules stale. Prepare close to where the
 command runs.
 
-## Wrapping
+## Commands
 
-`wrap_shell_command(cmd)` runs shell text through the platform shell under
-the profile. `wrap_program(program, args)` wraps a pre-tokenized argv with no
+`Shell(cmd)` runs shell text through the platform shell under the profile.
+`Exec(program, args)` prepares a pre-tokenized argv with no
 shell involved — the shape `run_moonbit` uses to run `moon` directly. Both
-return a `SandboxedCommand`: the `ProcessCommand` to spawn plus the
-`SourceWriteDenialClassifier` for its output. The pair travels together
-because the classifier is only meaningful for output produced under that
-command's profile.
+produce the same opaque `SandboxedCommand`. Its executable, arguments, and
+denial subjects travel together because classification is meaningful only for
+output produced by that prepared invocation.
 
 `writable_subtree` re-allows one directory tree — a scratch lab for a
 read-only subagent, `run_moonbit`'s throwaway build dir — via a
@@ -63,56 +63,17 @@ rejected outright: it would re-allow every write the profile exists to deny.
 ## Classifying denials
 
 A denial surfaces as an "Operation not permitted" line in the child's output.
-The classifier recognizes the shapes the tools actually produce, and only on
-a line that also names a protected source path:
-
-```mbt check
-///|
-test "a denial line must also name protected source" {
-  let classifier = @sandbox.SourceWriteDenialClassifier::with_subjects([])
-  inspect(
-    classifier.output_reports_denial("sh: main.mbt: Operation not permitted\n"),
-    content="true",
-  )
-  // A generic denial, and a mere mention of a source file, both miss.
-  inspect(
-    classifier.output_reports_denial("Permission denied\n"),
-    content="false",
-  )
-  inspect(
-    classifier.output_reports_denial("compiled keep.mbt: ok\n"),
-    content="false",
-  )
-}
-```
+`SandboxedCommand::output_reports_denial` recognizes the shapes the tools
+actually produce, and only on a line that also names a protected source path.
+A generic denial, a read denial, or a mere mention of a source file does not
+match.
 
 A denied *directory* has no protected suffix, so it is recognized only
-through the subjects the profile scan discovered — which is why classifiers
-are issued per command rather than shared globally:
-
-```mbt check
-///|
-test "directory denials need the profile's own subjects" {
-  let denial = "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n"
-  inspect(
-    @sandbox.SourceWriteDenialClassifier::with_subjects([]).output_reports_denial(
-      denial,
-    ),
-    content="false",
-  )
-  inspect(
-    @sandbox.SourceWriteDenialClassifier::with_subjects(["pkg"]).output_reports_denial(
-      denial,
-    ),
-    content="true",
-  )
-}
-```
-
-`with_subjects` exists for exactly this kind of platform-independent test;
-production code takes its classifier from a `SandboxedCommand`. The
-exhaustive line-shape pins live in `denial_output_test.mbt`, and the
-end-to-end kernel tests — a real denied write, a real subtree allow — in
+through the subjects the profile scan discovered. Those subjects never leave
+the prepared command, so a background reader cannot accidentally classify
+output using metadata from another profile. The exhaustive platform-independent
+line-shape pins live in `denial_output_wbtest.mbt`; the end-to-end kernel tests
+— a real denied write and a real subtree allow — live in
 `capability_test.mbt`.
 
 ## The profile underneath
@@ -128,7 +89,7 @@ The generated profile starts from `(allow default)` and then:
 
 The base profile is cached by normalized workspace root; directory mtimes
 from the source-tree scan invalidate the cache when the tree changes. The
-`writable_subtree` variant is composed per acquisition and never cached.
+`writable_subtree` variant is composed per command preparation and never cached.
 `sandbox_wbtest.mbt` pins the emitted SBPL byte for byte.
 
 The profile builder classifies names through `@source_write_policy`; callers
@@ -137,7 +98,7 @@ directly, so the static and kernel layers agree on what counts as source.
 
 ## Availability and limitations
 
-The constructor's availability gate is a cached behavioral probe, not an
+Preparation's availability gate is a cached behavioral probe, not an
 existence check: it requires an allowed no-op to succeed and a denied
 temporary write to fail. Nested sandboxes that prohibit re-sandboxing
 therefore yield `None`, and the result is cached for the process — a probe
@@ -149,7 +110,7 @@ The profile is a best-effort write guard, not a complete process-security
 boundary:
 
 - reads and non-source writes remain allowed;
-- callers may run unsandboxed when acquisition returns `None`;
+- callers may run unsandboxed when preparation returns `None`;
 - filesystem aliasing and directory operations can exceed purely path-based
   policy assumptions;
 - `shell` supplements the runtime profile with static command preflight,

--- a/agent_tool/internal/sandbox/README.mbt.md
+++ b/agent_tool/internal/sandbox/README.mbt.md
@@ -19,19 +19,27 @@ in `agent_tool/internal/platform_shell`.
 
 Prepare, run, classify:
 
-```mbt nocheck
-let command = @sandbox.Shell(cmd)
-match @sandbox.SandboxedCommand::create_if_available(workspace_root, command) {
-  None =>
-    // Enforcement unavailable here (not macOS, or a nested sandbox).
-    // The fallback is the CALLER's decision, made explicitly.
-    run_unsandboxed(cmd)
-  Some(prepared) => {
-    let output = run(prepared.program(), prepared.args())
-    if prepared.output_reports_denial(output) {
-      // The kernel denied a protected source write: explain it rather than
-      // letting the model debug a bare "Operation not permitted".
-    }
+```mbt check
+///|
+async test "prepare, run, and classify a shell command" {
+  let shell_text = "echo sandbox-ready"
+  let prepared = @sandbox.SandboxedCommand::create_if_available(
+    ".",
+    Shell(shell_text),
+  )
+  let (program, args) = match prepared {
+    Some(command) => (command.program(), command.args())
+    // Enforcement is unavailable outside macOS and inside some nested
+    // sandboxes. Running without it is an explicit caller policy decision.
+    None => (@platform_shell.program, @platform_shell.args(shell_text))
+  }
+  let (exit_code, output) = @process.collect_output_merged(program, args)
+  let output = output.text()
+  assert_eq(exit_code, 0)
+  assert_eq(output.trim(), "sandbox-ready")
+  if prepared is Some(command) {
+    // Classify with the same value that supplied the executed program/argv.
+    assert_false(command.output_reports_denial(output))
   }
 }
 ```

--- a/agent_tool/internal/sandbox/capability.mbt
+++ b/agent_tool/internal/sandbox/capability.mbt
@@ -1,63 +1,47 @@
 ///|
-/// A program-plus-arguments pair ready to hand to `@process.spawn`/`run`.
-/// Plain data — `pub(all)` so an unsandboxed launcher can build the same
-/// shape this package's wrappers produce.
-pub(all) struct ProcessCommand {
+/// The command to prepare for source-write-sandboxed execution.
+///
+/// `Shell` runs command text through the platform shell. `Exec` runs a program
+/// with an already-tokenized argument vector and introduces no shell.
+pub(all) enum Command {
+  Shell(String)
+  Exec(String, Array[String])
+}
+
+///|
+/// One prepared source-write-sandboxed invocation. Its process command and
+/// denial subjects stay together so output is always classified against the
+/// profile that produced it.
+struct SandboxedCommand {
   program : String
   args : Array[String]
-}
-
-///|
-/// The source-write sandbox for one workspace: an opaque capability that wraps
-/// commands in a kernel-enforced deny of MoonBit source writes. Obtain one
-/// with `SourceWriteSandbox::create_if_available`; everything SBPL-specific
-/// stays behind it.
-struct SourceWriteSandbox {
-  profile : String
-  classifier : SourceWriteDenialClassifier
-}
-
-///|
-/// Recognizes source-write denials in the output of a sandboxed command. It
-/// carries the denial subjects of the profile that command ran under, so a
-/// caller that judges output later — background jobs, streamed scans — needs
-/// no other sandbox state.
-struct SourceWriteDenialClassifier {
   denial_subjects : Array[String]
 }
 
 ///|
-/// A wrapped invocation: the command line to spawn, and the classifier for
-/// its output. The pair travels together because the classifier is only
-/// meaningful for output produced under this command's profile.
-pub struct SandboxedCommand {
-  command : ProcessCommand
-  denial_classifier : SourceWriteDenialClassifier
-}
-
-///|
-/// Acquire the source-write sandbox for `workspace_root`, or `None` when this
-/// process cannot enforce one — `sandbox-exec` missing, the availability probe
-/// failing, or a nested sandbox that forbids re-sandboxing. `None` means
-/// exactly "enforcement unavailable"; the fallback decision stays with the
-/// caller, explicit at the call site. Invalid input — an unresolvable
-/// `workspace_root`, or a `writable_subtree` that covers the root — raises
-/// instead, so misconfiguration cannot silently disable protection.
+/// Prepare `command` under the source-write sandbox for `workspace_root`, or
+/// return `None` when this process cannot enforce one — `sandbox-exec` missing,
+/// the availability probe failing, or a nested sandbox that forbids
+/// re-sandboxing. `None` means exactly "enforcement unavailable"; the fallback
+/// decision stays with the caller, explicit at the call site. Invalid input —
+/// an unresolvable `workspace_root`, or a `writable_subtree` that covers the
+/// root — raises instead, so misconfiguration cannot silently disable
+/// protection.
 ///
 /// The root is resolved to its real path here, because the kernel matches
-/// profile rules against realpaths; callers no longer pre-resolve. The rules
-/// are built from the tree as it exists now — renaming the root or the
-/// subtree afterwards makes them stale (they deny the old paths), so acquire
-/// the sandbox close to where the command runs.
+/// profile rules against realpaths. The rules are built from the tree as it
+/// exists now — renaming the root or subtree afterwards makes them stale, so
+/// prepare the command close to where it runs.
 ///
-/// `writable_subtree` re-allows writes below one directory — a scratch lab, a
-/// throwaway build dir — via a last-match-wins allow rule. It is resolved
+/// `writable_subtree` re-allows writes below one directory — a scratch lab or
+/// throwaway build directory — via a last-match-wins allow rule. It is resolved
 /// too; when resolution fails the unresolved path is used, which can only
-/// under-allow (writes in the subtree denied), never over-allow.
-pub async fn SourceWriteSandbox::create_if_available(
+/// under-allow, never over-allow.
+pub async fn SandboxedCommand::create_if_available(
   workspace_root : String,
+  command : Command,
   writable_subtree? : String,
-) -> SourceWriteSandbox? {
+) -> SandboxedCommand? {
   // Inputs are validated BEFORE the availability probe, so a caller bug is
   // reported identically on every platform instead of hiding behind `None`
   // wherever enforcement happens to be unavailable.
@@ -86,140 +70,37 @@ pub async fn SourceWriteSandbox::create_if_available(
     real_root,
     writable_lab?=subtree,
   )
+  let args = match command {
+    Shell(cmd) => sandbox_exec_args(data.profile, cmd)
+    Exec(program, args) => ["-p", data.profile, program, ..args]
+  }
   Some({
-    profile: data.profile,
-    // Copied: the profile cache hands out its own array, and a classifier
-    // must keep classifying with the subjects its command actually ran under.
-    classifier: { denial_subjects: data.denial_subjects.copy() },
+    program: SandboxExecPath,
+    args,
+    // Copied: the profile cache hands out its own array, and this command must
+    // keep classifying with the subjects of the profile it actually runs under.
+    denial_subjects: data.denial_subjects.copy(),
   })
 }
 
 ///|
-/// Wrap shell command text: the platform shell runs `cmd` under this
-/// sandbox's profile.
-pub fn SourceWriteSandbox::wrap_shell_command(
-  self : SourceWriteSandbox,
-  cmd : String,
-) -> SandboxedCommand {
-  {
-    command: {
-      program: SandboxExecPath,
-      args: sandbox_exec_args(self.profile, cmd),
-    },
-    denial_classifier: self.classifier,
-  }
+/// The executable of this prepared invocation.
+pub fn SandboxedCommand::program(self : SandboxedCommand) -> String {
+  self.program
 }
 
 ///|
-/// Wrap a program and pre-tokenized argument vector — no shell involved — so
-/// runners that build their own argv (e.g. `moon` invocations) get the same
-/// profile as shell text does.
-pub fn SourceWriteSandbox::wrap_program(
-  self : SourceWriteSandbox,
-  program : String,
-  args : Array[String],
-) -> SandboxedCommand {
-  {
-    command: {
-      program: SandboxExecPath,
-      args: ["-p", self.profile, program, ..args],
-    },
-    denial_classifier: self.classifier,
-  }
+/// A copy of this prepared invocation's argument vector.
+pub fn SandboxedCommand::args(self : SandboxedCommand) -> Array[String] {
+  self.args.copy()
 }
 
 ///|
-/// Build a classifier directly from denial subjects. This exists for tests
-/// and fixtures that exercise denial detection without a live sandbox (the
-/// wiring must stay covered on platforms where the probe cannot pass);
-/// production code receives its classifier from a `SandboxedCommand`.
-pub fn SourceWriteDenialClassifier::with_subjects(
-  denial_subjects : Array[String],
-) -> SourceWriteDenialClassifier {
-  { denial_subjects, }
-}
-
-///|
-/// Whether `output` contains a likely source-write denial from the command
-/// this classifier was issued for. Heuristic line-oriented recognition — a
-/// `true` is strong evidence, not proof, and unrelated permission errors are
-/// deliberately ignored.
-///
-/// A protected source name is recognized on its own, in every denial shape
-/// the tools actually produce — including MoonBit's own runtime error, where
-/// the path arrives wrapped in escaped quotes:
-///
-/// ```mbt check
-/// test "denials that name a protected source file" {
-///   let classifier = @sandbox.SourceWriteDenialClassifier::with_subjects([])
-///   inspect(
-///     classifier.output_reports_denial("sh: main.mbt: Operation not permitted\n"),
-///     content="true",
-///   )
-///   // run_moonbit's shape: a MoonBit runtime error for a denied source write.
-///   inspect(
-///     classifier.output_reports_denial(
-///       "OSError(\"@fs.open(): \\\"keep.mbt\\\": Operation not permitted\")",
-///     ),
-///     content="true",
-///   )
-///   // The subject may also follow the denial (python's errno shape).
-///   inspect(
-///     classifier.output_reports_denial(
-///       "PermissionError: [Errno 1] Operation not permitted: 'main.mbt'\n",
-///     ),
-///     content="true",
-///   )
-/// }
-/// ```
-///
-/// Both halves — a denial form AND a protected name — must hold on the same
-/// line, which is what keeps an unrelated permission error, or a build log
-/// that merely mentions a source file, from reading as a sandbox denial:
-///
-/// ```mbt check
-/// test "a denial alone, or a source name alone, is not a denial report" {
-///   let classifier = @sandbox.SourceWriteDenialClassifier::with_subjects([])
-///   inspect(
-///     classifier.output_reports_denial("Permission denied\n"),
-///     content="false",
-///   )
-///   inspect(
-///     classifier.output_reports_denial(
-///       "Permission denied while reading main.mbt\n",
-///     ),
-///     content="false",
-///   )
-///   inspect(
-///     classifier.output_reports_denial("compiled keep.mbt: ok\n"),
-///     content="false",
-///   )
-/// }
-/// ```
-///
-/// A denied *directory* carries no protected suffix, so it is recognized only
-/// through the profile's own subjects — which is why the classifier travels
-/// with the command it was issued for:
-///
-/// ```mbt check
-/// test "a directory denial is recognized only through its subject" {
-///   let denial = "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n"
-///   inspect(
-///     @sandbox.SourceWriteDenialClassifier::with_subjects([]).output_reports_denial(
-///       denial,
-///     ),
-///     content="false",
-///   )
-///   inspect(
-///     @sandbox.SourceWriteDenialClassifier::with_subjects(["pkg"]).output_reports_denial(
-///       denial,
-///     ),
-///     content="true",
-///   )
-/// }
-/// ```
-pub fn SourceWriteDenialClassifier::output_reports_denial(
-  self : SourceWriteDenialClassifier,
+/// Whether `output` contains a likely protected-source write denial from this
+/// command. Recognition is heuristic and line-oriented: `true` is strong
+/// evidence, not proof, and unrelated permission errors are ignored.
+pub fn SandboxedCommand::output_reports_denial(
+  self : SandboxedCommand,
   output : String,
 ) -> Bool {
   source_write_denied_in_text(output, self.denial_subjects)

--- a/agent_tool/internal/sandbox/capability_test.mbt
+++ b/agent_tool/internal/sandbox/capability_test.mbt
@@ -1,15 +1,18 @@
 ///|
-/// Run a wrapped command and materialize its merged output as text — the same
+/// Run a prepared command and materialize its merged output as text — the same
 /// consumption pattern real callers use, so the tests exercise the capability
 /// exactly as shipped.
-async fn merged_output_text(command : @sandbox.ProcessCommand) -> (Int, String) {
+async fn merged_output_text(
+  command : @sandbox.SandboxedCommand,
+) -> (Int, String) {
   @async.with_task_group() <| group => {
     let (reader, writer) = @process.read_from_process()
     defer reader.close()
+    let args = command.args()
     let child = @process.spawn(
       group,
-      command.program,
-      command.args,
+      command.program(),
+      args,
       stdout=writer,
       stderr=writer,
       no_wait=true,
@@ -23,22 +26,25 @@ async fn merged_output_text(command : @sandbox.ProcessCommand) -> (Int, String) 
 }
 
 ///|
-/// The capability surface, end to end where the platform allows: acquire,
-/// wrap, run, classify. Guarded on real availability so the suite passes
+/// The capability surface, end to end where the platform allows: prepare,
+/// run, classify. Guarded on real availability so the suite passes
 /// (by skipping) where `sandbox-exec` cannot enforce.
-async test "sandbox denies a source write and the classifier recognizes it" {
+async test "sandbox denies a source write and the command reports it" {
   @vfs.with_tmpdir(prefix="openseek-sandbox-capability-", dir => {
-    guard @sandbox.SourceWriteSandbox::create_if_available(dir) is Some(sandbox) else {
+    guard @sandbox.SandboxedCommand::create_if_available(
+        dir,
+        Shell("printf x > \{dir}/new.mbt"),
+      )
+      is Some(command) else {
       return
     }
-    let wrapped = sandbox.wrap_shell_command("printf x > \{dir}/new.mbt")
-    let (exit_code, text) = merged_output_text(wrapped.command)
+    let (exit_code, text) = merged_output_text(command)
     assert_true(exit_code != 0)
-    // The write never landed, and the classifier recognizes the denial.
+    // The write never landed, and the command recognizes the denial.
     assert_false(@fs.exists("\{dir}/new.mbt"))
-    assert_true(wrapped.denial_classifier.output_reports_denial(text))
+    assert_true(command.output_reports_denial(text))
     // Unrelated output does not classify as a denial.
-    assert_false(wrapped.denial_classifier.output_reports_denial("compiled ok"))
+    assert_false(command.output_reports_denial("compiled ok"))
   })
 }
 
@@ -46,37 +52,48 @@ async test "sandbox denies a source write and the classifier recognizes it" {
 async test "a writable subtree is re-allowed; the rest stays denied" {
   @vfs.with_tmpdir(prefix="openseek-sandbox-capability-lab-", dir => {
     @fs.mkdir("\{dir}/lab")
-    guard @sandbox.SourceWriteSandbox::create_if_available(
+    guard @sandbox.SandboxedCommand::create_if_available(
         dir,
+        Shell("printf x > \{dir}/lab/draft.mbt"),
         writable_subtree="\{dir}/lab",
       )
-      is Some(sandbox) else {
+      is Some(allowed) else {
       return
     }
-    let allowed = sandbox.wrap_shell_command("printf x > \{dir}/lab/draft.mbt")
-    let (lab_exit, _) = merged_output_text(allowed.command)
+    let (lab_exit, _) = merged_output_text(allowed)
     assert_eq(lab_exit, 0)
     assert_true(@fs.exists("\{dir}/lab/draft.mbt"))
-    let denied = sandbox.wrap_shell_command("printf x > \{dir}/new.mbt")
-    let (root_exit, _) = merged_output_text(denied.command)
+    guard @sandbox.SandboxedCommand::create_if_available(
+        dir,
+        Shell("printf x > \{dir}/new.mbt"),
+        writable_subtree="\{dir}/lab",
+      )
+      is Some(denied) else {
+      return
+    }
+    let (root_exit, _) = merged_output_text(denied)
     assert_true(root_exit != 0)
     assert_false(@fs.exists("\{dir}/new.mbt"))
   })
 }
 
 ///|
-async test "wrap_program produces the argv shape without a shell" {
+async test "exec command produces the argv shape without a shell" {
   @vfs.with_tmpdir(prefix="openseek-sandbox-capability-argv-", dir => {
-    guard @sandbox.SourceWriteSandbox::create_if_available(dir) is Some(sandbox) else {
+    guard @sandbox.SandboxedCommand::create_if_available(
+        dir,
+        Exec("moon", ["check", "--target", "native"]),
+      )
+      is Some(command) else {
       return
     }
-    let wrapped = sandbox.wrap_program("moon", ["check", "--target", "native"])
-    assert_eq(wrapped.command.program, "/usr/bin/sandbox-exec")
+    assert_eq(command.program(), "/usr/bin/sandbox-exec")
+    let args = command.args()
     // [-p, <profile>, moon, check, --target, native]
-    assert_eq(wrapped.command.args[0], "-p")
-    assert_eq(wrapped.command.args[2], "moon")
-    assert_eq(wrapped.command.args[3], "check")
-    assert_eq(wrapped.command.args.length(), 6)
+    assert_eq(args[0], "-p")
+    assert_eq(args[2], "moon")
+    assert_eq(args[3], "check")
+    assert_eq(args.length(), 6)
   })
 }
 
@@ -100,7 +117,11 @@ async test "a writable subtree covering the root is a caller bug, not a profile"
 async fn create_raises(root : String, writable_subtree~ : String) -> Bool {
   try {
     ignore(
-      @sandbox.SourceWriteSandbox::create_if_available(root, writable_subtree~),
+      @sandbox.SandboxedCommand::create_if_available(
+        root,
+        Shell(":"),
+        writable_subtree~,
+      ),
     )
     false
   } catch {
@@ -109,11 +130,11 @@ async fn create_raises(root : String, writable_subtree~ : String) -> Bool {
 }
 
 ///|
-/// The subjects a profile scan discovers must reach the classifier: a denied
+/// The subjects a profile scan discovers must reach denial reporting: a denied
 /// DIRECTORY carries no protected suffix, so only the flowed-through subject
 /// can recognize it. The canned line is the real errno shape a directory
 /// rename denial produces.
-async test "profile subjects flow into the classifier" {
+async test "profile subjects flow into denial reporting" {
   @vfs.with_tmpdir(prefix="openseek-sandbox-capability-subjects-", dir => {
     @fs.mkdir("\{dir}/pkg")
     @fs.write_file(
@@ -121,19 +142,12 @@ async test "profile subjects flow into the classifier" {
       "pub fn x() -> Int { 1 }\n",
       create_mode=CreateOrTruncate,
     )
-    guard @sandbox.SourceWriteSandbox::create_if_available(dir) is Some(sandbox) else {
+    guard @sandbox.SandboxedCommand::create_if_available(dir, Shell(":"))
+      is Some(command) else {
       return
     }
-    let wrapped = sandbox.wrap_shell_command(":")
     let real_root = @fs.realpath(dir)
     let canned = "PermissionError: [Errno 1] Operation not permitted: '\{real_root}/pkg'\n"
-    // Recognized only through the profile's own subjects...
-    assert_true(wrapped.denial_classifier.output_reports_denial(canned))
-    // ...as proven by an empty-subject classifier missing the same line.
-    assert_false(
-      @sandbox.SourceWriteDenialClassifier::with_subjects([]).output_reports_denial(
-        canned,
-      ),
-    )
+    assert_true(command.output_reports_denial(canned))
   })
 }

--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -24,6 +24,32 @@ fn source_write_denied_in_text(
   output_text : String,
   denial_subjects : Array[String],
 ) -> Bool {
+
+  // Whether `line` names `subject` as the object of an error rather than merely
+  // containing it as a substring: the tool's own punctuation or quoting follows
+  // it, or the line ends with it after a denial's colon.
+  //
+  // Shared by the protected-suffix scan and the profile's denial subjects, which
+  // need the identical notion of "names".
+  fn line_names_subject(line : StringView, subject : String) -> Bool {
+    line.contains("\{subject}:") ||
+    line.contains("\{subject}'") ||
+    line.contains("\{subject}\"") ||
+    // MoonBit's own OSError Show output escapes the quotes around the path
+    // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
+    // followed by `\"`, not a bare quote — run_moonbit's denial shape.
+    line.contains("\{subject}\\\"") ||
+    line.contains("\{subject}`") ||
+    (
+      (
+        line.contains("Operation not permitted:") ||
+        line.contains("operation not permitted:") ||
+        line.contains("Permission denied:")
+      ) &&
+      line.has_suffix(subject)
+    )
+  }
+
   output_text
   .split("\n")
   .any(line => {
@@ -44,28 +70,3 @@ fn source_write_denied_in_text(
   })
 }
 
-///|
-/// Whether `line` names `subject` as the object of an error rather than merely
-/// containing it as a substring: the tool's own punctuation or quoting follows
-/// it, or the line ends with it after a denial's colon.
-///
-/// Shared by the protected-suffix scan and the profile's denial subjects, which
-/// need the identical notion of "names".
-fn line_names_subject(line : StringView, subject : String) -> Bool {
-  line.contains("\{subject}:") ||
-  line.contains("\{subject}'") ||
-  line.contains("\{subject}\"") ||
-  // MoonBit's own OSError Show output escapes the quotes around the path
-  // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
-  // followed by `\"`, not a bare quote — run_moonbit's denial shape.
-  line.contains("\{subject}\\\"") ||
-  line.contains("\{subject}`") ||
-  (
-    (
-      line.contains("Operation not permitted:") ||
-      line.contains("operation not permitted:") ||
-      line.contains("Permission denied:")
-    ) &&
-    line.has_suffix(subject)
-  )
-}

--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -9,10 +9,9 @@ let protected_source_subjects : ReadOnlyArray[String] = [
 
 ///|
 /// Return whether child-process output contains a likely protected-source
-/// write denial. The engine behind
-/// `SourceWriteDenialClassifier::output_reports_denial`, whose docstring
-/// carries the worked examples; `denial_output_test.mbt` holds the exhaustive
-/// line-level pins.
+/// write denial. This is the private engine behind
+/// `SandboxedCommand::output_reports_denial`; `denial_output_wbtest.mbt` holds
+/// the exhaustive line-level pins.
 ///
 /// Matching is line-oriented. A line must contain a recognized
 /// "Operation not permitted" or "Permission denied" form and name either a
@@ -69,4 +68,3 @@ fn source_write_denied_in_text(
     )
   })
 }
-

--- a/agent_tool/internal/sandbox/denial_output_wbtest.mbt
+++ b/agent_tool/internal/sandbox/denial_output_wbtest.mbt
@@ -1,14 +1,10 @@
 ///|
-/// The exhaustive line-level pins for denial classification. The docstring on
-/// `SourceWriteDenialClassifier::output_reports_denial` carries the teaching
-/// subset; this is the spec.
-///
-/// Black-box on purpose: detection is entirely a property of the public API, so
-/// these exercise it exactly as `shell`, `shell_output`, and `run_moonbit` do.
+/// The exhaustive line-level pins for the private denial-classification engine.
+/// Keeping these white-box lets the public API expose only a prepared
+/// `SandboxedCommand`, while this platform-independent behavior remains fully
+/// covered without requiring a live sandbox.
 fn reports(subjects : Array[String], text : String) -> Bool {
-  @sandbox.SourceWriteDenialClassifier::with_subjects(subjects).output_reports_denial(
-    text,
-  )
+  source_write_denied_in_text(text, subjects)
 }
 
 ///|

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -6,24 +6,16 @@ package "bobzhang/openseek/agent_tool/internal/sandbox"
 // Errors
 
 // Types and methods
-pub(all) struct ProcessCommand {
-  program : String
-  args : Array[String]
+pub(all) enum Command {
+  Shell(String)
+  Exec(String, Array[String])
 }
 
-pub struct SandboxedCommand {
-  command : ProcessCommand
-  denial_classifier : SourceWriteDenialClassifier
-}
-
-type SourceWriteDenialClassifier
-pub fn SourceWriteDenialClassifier::output_reports_denial(Self, String) -> Bool
-pub fn SourceWriteDenialClassifier::with_subjects(Array[String]) -> Self
-
-type SourceWriteSandbox
-pub async fn SourceWriteSandbox::create_if_available(String, writable_subtree? : String) -> Self?
-pub fn SourceWriteSandbox::wrap_program(Self, String, Array[String]) -> SandboxedCommand
-pub fn SourceWriteSandbox::wrap_shell_command(Self, String) -> SandboxedCommand
+type SandboxedCommand
+pub fn SandboxedCommand::args(Self) -> Array[String]
+pub async fn SandboxedCommand::create_if_available(String, Command, writable_subtree? : String) -> Self?
+pub fn SandboxedCommand::output_reports_denial(Self, String) -> Bool
+pub fn SandboxedCommand::program(Self) -> String
 
 // Type aliases
 

--- a/agent_tool/internal/sandbox/source_write_profile.mbt
+++ b/agent_tool/internal/sandbox/source_write_profile.mbt
@@ -272,13 +272,7 @@ fn should_prune_profile_scan_path(root : String, path : String) -> Bool {
   relative
   .replace_all(old="\\", new="/")
   .split("/")
-  .any(part => {
-    part == ".git" ||
-    part == ".hg" ||
-    part == ".svn" ||
-    part == ".jj" ||
-    part == "node_modules"
-  })
+  .any(part => part is (".git" | ".hg" | ".svn" | ".jj" | "node_modules"))
 }
 
 ///|
@@ -300,11 +294,8 @@ fn regex_escape(text : String) -> String {
       | '{'
       | '}'
       | '|'
-      | '/' => {
-        escaped.write_char('\\')
-        escaped.write_char(ch)
-      }
-      _ => escaped.write_char(ch)
+      | '/' => escaped <+ "\\\{ch}"
+      _ => escaped <+ "\{ch}"
     }
   }
   escaped.to_string()
@@ -320,14 +311,11 @@ fn sbpl_string_escape(text : String) -> String {
   let escaped = StringBuilder()
   for ch in text {
     match ch {
-      '"' | '\\' => {
-        escaped.write_char('\\')
-        escaped.write_char(ch)
-      }
-      '\n' => escaped.write_string("\\n")
-      '\r' => escaped.write_string("\\r")
-      '\t' => escaped.write_string("\\t")
-      _ => escaped.write_char(ch)
+      '"' | '\\' => escaped <+ "\\\{ch}"
+      '\n' => escaped <+ "\\n"
+      '\r' => escaped <+ "\\r"
+      '\t' => escaped <+ "\\t"
+      _ => escaped <+ "\{ch}"
     }
   }
   escaped.to_string()

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -397,18 +397,19 @@ async fn execute(
     // preflights the command) an arbitrary snippet can still smuggle sources via
     // directory renames; full containment is the wasm backend's job. Elsewhere
     // (or in a nested sandbox where it cannot enforce) run moon directly.
-    // The wrapped command carries its denial classifier, so a denial showing
-    // up in the program's output can be recognized and explained below. The
+    // The prepared command carries its denial subjects, so a denial showing up
+    // in the program's output can be recognized and explained below. The
     // throwaway build dir is the writable subtree: if it falls INSIDE the
     // workspace root (e.g. `workspace_root=/tmp`, where `@fs.tmpdir` lands
     // under it) the shared deny would otherwise block moon's own generated
     // `snippet.mbt`.
-    let wrapped = @sandbox.SourceWriteSandbox::create_if_available(
+    let sandboxed_command = @sandbox.SandboxedCommand::create_if_available(
       workspace_root,
+      Exec("moon", moon_argv),
       writable_subtree=dir,
-    ).map(sandbox => sandbox.wrap_program("moon", moon_argv))
-    let (prog, argv) = match wrapped {
-      Some(wrapped) => (wrapped.command.program, wrapped.command.args)
+    )
+    let (prog, argv) = match sandboxed_command {
+      Some(command) => (command.program(), command.args())
       None => ("moon", moon_argv)
     }
     let result = @async.with_timeout_opt(RunTimeoutMs, () => {
@@ -432,8 +433,10 @@ async fn execute(
     // head+tail byte budget), and runs for the timeout arm too: a snippet can
     // flood past the cap before hitting the denial, or print a caught denial
     // and then hang.
-    let sandbox_denied = wrapped is Some(wrapped) &&
-      log_shows_source_write_denial(log, wrapped.denial_classifier)
+    let sandbox_denied = sandboxed_command is Some(command) &&
+      log_shows_source_write_denial(log, output => {
+        command.output_reports_denial(output)
+      })
     let action = match result {
       Some((exit_code, raw)) => {
         // Rewrite the throwaway temp path to `source` so the model reads
@@ -543,7 +546,7 @@ const DenialScanBudgetBytes : Int = 16_777_216
 /// tests only.
 async fn log_shows_source_write_denial(
   path : String,
-  classifier : @sandbox.SourceWriteDenialClassifier,
+  reports_denial : (String) -> Bool,
   budget_bytes? : Int = DenialScanBudgetBytes,
 ) -> Bool {
   let file = @fs.open(path, mode=ReadOnly) catch { _ => return false }
@@ -554,10 +557,10 @@ async fn log_shows_source_write_denial(
   }
   let budget = budget_bytes.to_int64()
   if size <= budget * 2 {
-    denial_scan_region(file, 0, size, classifier)
+    denial_scan_region(file, 0, size, reports_denial)
   } else {
-    denial_scan_region(file, 0, budget, classifier) ||
-    denial_scan_region(file, size - budget, budget, classifier)
+    denial_scan_region(file, 0, budget, reports_denial) ||
+    denial_scan_region(file, size - budget, budget, reports_denial)
   }
 }
 
@@ -571,7 +574,7 @@ async fn denial_scan_region(
   file : @fs.File,
   start : Int64,
   len : Int64,
-  classifier : @sandbox.SourceWriteDenialClassifier,
+  reports_denial : (String) -> Bool,
 ) -> Bool {
   let buf = FixedArray::make(DenialScanChunkBytes, b'\x00')
   let mut carry = ""
@@ -597,7 +600,7 @@ async fn denial_scan_region(
     // detector can judge now, everything after is the partial line to carry.
     match text.rev_split_once("\n") {
       Some((whole_lines, partial_line)) => {
-        if classifier.output_reports_denial(whole_lines.to_owned()) {
+        if reports_denial(whole_lines.to_owned()) {
           return true
         }
         carry = partial_line.to_owned()
@@ -607,13 +610,13 @@ async fn denial_scan_region(
     // A single line larger than a chunk must not grow the carry unboundedly:
     // scan what accumulated, keep only a pattern-sized tail.
     if carry.length() > DenialScanChunkBytes {
-      if classifier.output_reports_denial(carry) {
+      if reports_denial(carry) {
         return true
       }
       carry = carry[carry.length() - DenialScanCarryTailChars:].to_owned()
     }
   }
-  classifier.output_reports_denial(carry)
+  reports_denial(carry)
 }
 
 ///|

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -94,7 +94,7 @@ async test "a non-existent cwd is reported, not run" {
 }
 
 ///|
-/// Gate on the same acquisition `execute` performs — skip where enforcement is
+/// Gate on the same preparation `execute` performs — skip where enforcement is
 /// unavailable (not macOS, or a nested sandbox). Probed against a throwaway
 /// root so no real workspace is scanned.
 async fn sandbox_enforcement_available() -> Bool {
@@ -102,7 +102,10 @@ async fn sandbox_enforcement_available() -> Bool {
   let dir = @fs.tmpdir(prefix="openseek-run-moonbit-gate-") catch {
     _ => return false
   }
-  let available = @sandbox.SourceWriteSandbox::create_if_available(dir)
+  let available = @sandbox.SandboxedCommand::create_if_available(
+      dir,
+      Shell(":"),
+    )
     is Some(_)
   @fs.rmdir(dir, recursive=true) catch {
     _ => ()

--- a/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
@@ -21,7 +21,7 @@ async test "denial scan is bounded to the log's head and tail" {
       @fs.write_file(path, content, create_mode=CreateOrTruncate)
       log_shows_source_write_denial(
         path,
-        @sandbox.SourceWriteDenialClassifier::with_subjects([]),
+        text => text.contains("main.mbt: Operation not permitted"),
         budget_bytes=1024,
       )
     }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -16,17 +16,23 @@ priv enum SourceWriteMode {
 }
 
 ///|
+priv struct ProcessCommand {
+  program : String
+  args : Array[String]
+}
+
+///|
 priv struct AgentShellLaunch {
-  command : @sandbox.ProcessCommand
-  // `Some` exactly when the command runs under the source-write sandbox; the
-  // classifier judges that command's output for kernel denials.
-  denial_classifier : @sandbox.SourceWriteDenialClassifier?
+  command : ProcessCommand
+  // `Some` exactly when `command` was prepared under the source-write sandbox.
+  // It stays intact so output is judged against the profile that produced it.
+  sandboxed_command : @sandbox.SandboxedCommand?
 }
 
 ///|
 priv struct AgentShellOutput {
   output : ShellOutput
-  denial_classifier : @sandbox.SourceWriteDenialClassifier?
+  sandboxed_command : @sandbox.SandboxedCommand?
 }
 
 ///|
@@ -83,13 +89,14 @@ async fn agent_shell_launch(
     mode
   }
   // A trusted command with no scratch lab can never end up sandboxed, so
-  // skip acquisition entirely — a process that only ever runs trusted
+  // skip preparation entirely — a process that only ever runs trusted
   // commands never pays the profile's workspace scan.
-  let sandbox = match (mode, scratch_dir) {
+  let sandboxed_command = match (mode, scratch_dir) {
     (TrustedSourceWrite, None) => None
     _ =>
-      @sandbox.SourceWriteSandbox::create_if_available(
+      @sandbox.SandboxedCommand::create_if_available(
         real_workspace_root,
+        Shell(cmd),
         writable_subtree?=scratch_dir,
       )
   }
@@ -101,27 +108,25 @@ async fn agent_shell_launch(
   // denies any workspace-source write regardless of guard precision.
   let mode = if scratch_dir is Some(_) &&
     mode is TrustedSourceWrite &&
-    sandbox is Some(_) {
+    sandboxed_command is Some(_) {
     SourceReadOnly
   } else {
     mode
   }
-  match (mode, sandbox) {
+  match (mode, sandboxed_command) {
     (TrustedSourceWrite, _) | (_, None) =>
       {
         command: {
           program: @platform_shell.program,
           args: @platform_shell.args(cmd),
         },
-        denial_classifier: None,
+        sandboxed_command: None,
       }
-    (SourceReadOnly, Some(sandbox)) => {
-      let wrapped = sandbox.wrap_shell_command(cmd)
+    (SourceReadOnly, Some(command)) =>
       {
-        command: wrapped.command,
-        denial_classifier: Some(wrapped.denial_classifier),
+        command: { program: command.program(), args: command.args() },
+        sandboxed_command: Some(command),
       }
-    }
   }
 }
 
@@ -5377,8 +5382,8 @@ fn append_shell_sandbox_feedback_if_needed(
 fn agent_output_has_shell_sandbox_denial(
   agent_output : AgentShellOutput,
 ) -> Bool {
-  agent_output.denial_classifier is Some(classifier) &&
-  classifier.output_reports_denial(agent_output.output.text)
+  agent_output.sandboxed_command is Some(command) &&
+  command.output_reports_denial(agent_output.output.text)
 }
 
 ///|

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1183,62 +1183,40 @@ fn is_some_path(value : String?, expected : String) -> Bool {
 }
 
 ///|
-test "sandbox denial detection ignores masked exit code" {
+async test "sandbox denial detection ignores masked exit code" {
   // Line-level classification pins live in `agent_tool/internal/sandbox`
-  // (`denial_output_test.mbt`); here only the shell-side gate is covered:
+  // (`denial_output_wbtest.mbt`); here only the shell-side gate is covered:
   // the denial fires despite exit_code 0, and only for a sandboxed command.
-  let output = {
-    exit_code: Some(0),
-    text: "sh: main.mbt: Operation not permitted\n",
-    output_limit_reached: false,
-  }
-  assert_true(
-    agent_output_has_shell_sandbox_denial({
-      output,
-      denial_classifier: Some(
-        @sandbox.SourceWriteDenialClassifier::with_subjects([]),
-      ),
-    }),
-  )
-  assert_false(
-    agent_output_has_shell_sandbox_denial({ output, denial_classifier: None }),
-  )
-  assert_true(
-    agent_output_has_shell_sandbox_denial({
-      output: {
-        exit_code: Some(0),
-        text: "PermissionError: [Errno 1] Operation not permitted: 'pkg'\n",
-        output_limit_reached: false,
-      },
-      denial_classifier: Some(
-        @sandbox.SourceWriteDenialClassifier::with_subjects(["pkg"]),
-      ),
-    }),
-  )
-  assert_false(
-    agent_output_has_shell_sandbox_denial({
-      output: {
-        exit_code: Some(0),
-        text: "foo: Operation not permitted\n",
-        output_limit_reached: false,
-      },
-      denial_classifier: Some(
-        @sandbox.SourceWriteDenialClassifier::with_subjects(["pkg"]),
-      ),
-    }),
-  )
-  assert_false(
-    agent_output_has_shell_sandbox_denial({
-      output: {
-        exit_code: Some(0),
-        text: "Permission denied\n",
-        output_limit_reached: false,
-      },
-      denial_classifier: Some(
-        @sandbox.SourceWriteDenialClassifier::with_subjects([]),
-      ),
-    }),
-  )
+  @vfs.with_tmpdir(prefix="openseek-shell-denial-gate-", dir => {
+    guard @sandbox.SandboxedCommand::create_if_available(dir, Shell(":"))
+      is Some(command) else {
+      return
+    }
+    let output = {
+      exit_code: Some(0),
+      text: "sh: main.mbt: Operation not permitted\n",
+      output_limit_reached: false,
+    }
+    assert_true(
+      agent_output_has_shell_sandbox_denial({
+        output,
+        sandboxed_command: Some(command),
+      }),
+    )
+    assert_false(
+      agent_output_has_shell_sandbox_denial({ output, sandboxed_command: None }),
+    )
+    assert_false(
+      agent_output_has_shell_sandbox_denial({
+        output: {
+          exit_code: Some(0),
+          text: "Permission denied\n",
+          output_limit_reached: false,
+        },
+        sandboxed_command: Some(command),
+      }),
+    )
+  })
 }
 
 ///|
@@ -1514,7 +1492,8 @@ async test "moon new is a trusted scaffold only for a new or empty target" {
 /// lab the same command stays trusted/unsandboxed.
 async test "a scratch lab forces trusted source-writes onto the sandbox" {
   let ws = @fs.tmpdir(prefix="openseek-lab-ws-")
-  guard @sandbox.SourceWriteSandbox::create_if_available(ws) is Some(_) else {
+  guard @sandbox.SandboxedCommand::create_if_available(ws, Shell(":"))
+    is Some(_) else {
     println("sandbox-exec unavailable; skipping")
     @fs.rmdir(ws, recursive=true) catch {
       _ => ()
@@ -1529,7 +1508,7 @@ async test "a scratch lab forces trusted source-writes onto the sandbox" {
     @shell_parse.parse_for_policy("moon new \{lab}/probe"),
     cwd=lab,
   )
-  assert_true(without.denial_classifier is None)
+  assert_true(without.sandboxed_command is None)
   // With the lab wired, the same command is sandboxed instead — the
   // profile allows lab writes, the kernel denies workspace writes.
   let with_lab = agent_shell_launch(
@@ -1539,7 +1518,7 @@ async test "a scratch lab forces trusted source-writes onto the sandbox" {
     cwd=lab,
     scratch_dir=lab,
   )
-  assert_true(with_lab.denial_classifier is Some(_))
+  assert_true(with_lab.sandboxed_command is Some(_))
   @fs.rmdir(ws, recursive=true)
   @fs.rmdir(lab, recursive=true)
 }

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -357,7 +357,7 @@ async fn shell(
           exec,
           command=input.cmd,
           cwd?,
-          denial_classifier?=launch.denial_classifier,
+          sandboxed_command?=launch.sandboxed_command,
         )
       }
     },
@@ -556,7 +556,7 @@ async fn run_agent_shell_with_tree_precheck(
       match collected {
         None => ShellTimedOut
         Some(output) =>
-          ShellExecuted({ output, denial_classifier: launch.denial_classifier })
+          ShellExecuted({ output, sandboxed_command: launch.sandboxed_command })
       }
     }
   }
@@ -580,7 +580,7 @@ fn agent_shell_output_from_exec(
       // memory-only one was killed at it (truncated, hard cap == inline cap).
       output_limit_reached: exec.over_inline_cap() || exec.output_truncated(),
     },
-    denial_classifier: launch.denial_classifier,
+    sandboxed_command: launch.sandboxed_command,
   }
 }
 
@@ -636,7 +636,7 @@ async fn start_background(
     command=input.cmd,
     cwd?,
     max_output_chars=input.max_output_chars,
-    denial_classifier?=launch.denial_classifier,
+    sandboxed_command?=launch.sandboxed_command,
   )
   @agent_tool.ToolAction::respond(
     "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -96,9 +96,9 @@ async fn execute(
   // when the command exited 0. Scan the *full* retained output for a denial (the
   // denial line can be earlier than the displayed tail), but only for a sandboxed
   // job — so a full read is done only in that rare case.
-  let sandbox_denied = if snapshot.denial_classifier is Some(classifier) {
+  let sandbox_denied = if snapshot.sandboxed_command is Some(command) {
     let full = bg_runtime.read_output(job_id).unwrap_or(output)
-    classifier.output_reports_denial(full)
+    command.output_reports_denial(full)
   } else {
     false
   }


### PR DESCRIPTION
## What changed

- replace the public `SourceWriteSandbox`, `ProcessCommand`, and standalone denial-classifier types with a small `Command` enum and opaque `SandboxedCommand`
- prepare shell text and argv-style commands in one step while keeping the executable recipe and denial subjects together
- carry the prepared command through foreground, detached, and background shell paths so later output uses the matching denial metadata
- migrate `run_moonbit` and its bounded log scan to the new abstraction
- keep denial-classification internals covered with white-box tests while shrinking the public package interface
- include the accompanying MoonBit cleanup that localizes the small denial helper and uses idiomatic pattern matching/StringBuilder append syntax

## Why

The previous API exposed several low-level types and allowed the command recipe and denial classifier to travel separately. The new API represents one prepared invocation as one opaque value, reducing the public surface and preventing metadata from being paired with the wrong command.

Process execution remains caller-owned because foreground shell execution, retained background jobs, and `run_moonbit` have different timeout and output-retention lifecycles.

## Impact

All in-repository callers have been migrated. Callers now construct `Shell(...)` or `Exec(...)`, call `SandboxedCommand::create_if_available`, then use `program()`, `args()`, and `output_reports_denial(...)`.

## Validation

- fresh `codex review --base origin/main`: no actionable findings
- affected package tests: 177 passed, 0 failed
- full native suite: 2,689 passed, 0 failed
- `moon check --target native`
- `moon info`, `moon fmt`, and `git diff --check`
- Codex's additional cross-target `moon test` run passed wasm-gc and JS; native had one unrelated network-dependent DeepSeek smoke-test DNS failure