### PR TITLE
Simplify run_moonbit warnings and expand checked examples

### DIFF
--- a/agent_tool/internal/sandbox/capability.mbt
+++ b/agent_tool/internal/sandbox/capability.mbt
@@ -13,8 +13,18 @@ pub(all) enum Command {
 /// denial subjects stay together so output is always classified against the
 /// profile that produced it.
 struct SandboxedCommand {
+  /// Executable to spawn for this prepared invocation. It is the first half of
+  /// the process command and must be passed together with `args`. When sandbox
+  /// enforcement is available, this is the platform's `sandbox-exec` binary.
   program : String
+  /// Companion argument vector for `program`: the generated profile followed
+  /// by either the platform-shell invocation or the requested `Exec`
+  /// program/argv. For example, `Shell("moon check")` prepares approximately
+  /// `program = "/usr/bin/sandbox-exec"` with
+  /// `args = ["-p", "<profile>", "sh", "-c", "moon check"]` on macOS.
   args : Array[String]
+  /// Protected paths and basenames derived from the same profile encoded in
+  /// `args`, retained so denial reporting cannot use metadata from another run.
   denial_subjects : Array[String]
 }
 

--- a/agent_tool/run_moonbit/README.mbt.md
+++ b/agent_tool/run_moonbit/README.mbt.md
@@ -34,13 +34,10 @@ diagnostics are the error message when something does not build.
   the `shell` tool.
 - `warning` (string, optional, `"off"`/`"on"`, default `"off"`): whether
   compiler warnings appear in the output. Snippets are throwaway scripts, so
-  unused-value style noise is suppressed — via a `--warn-list` spec derived
-  from the toolchain's own warning table (`moonc build-package -warn-help`,
-  probed once per process) — unless the warnings themselves are what you are
-  probing. Errors are unaffected: warning IDs whose default state is `error`
-  (e.g. `partial_match`) still fail compilation with warnings off, and if the
-  table cannot be probed the tool passes no flag at all, leaving warnings
-  visible rather than ever breaking the run.
+  unused-value style noise is suppressed unless the warnings themselves are
+  what you are probing. Selected correctness diagnostics whose default state
+  is `error` (such as `partial_match`) are maintained as explicit mnemonic
+  exceptions and still fail compilation with warnings off.
 
 Only **dependency resolution** is isolated: a local-package import resolves to
 the **published registry snapshot** (not your uncommitted edits), and a
@@ -90,6 +87,78 @@ async test "run_moonbit runs a pure-core probe" {
   guard action is Respond(output) else { fail("expected Respond") }
   assert_false(output.is_error)
   assert_true(output.content.contains("[1, 4, 9]"))
+}
+```
+
+The workspace root is also the snippet's default working directory, so a
+checked example can exercise real file IO through a relative path:
+
+```mbt check
+///|
+async test "run_moonbit reads a workspace file" {
+  @vfs.with_tmpdir(prefix="run-moonbit-readme-io-", workspace => {
+    @fs.write_file(
+      workspace + "/data.txt",
+      "Ada\nGrace\n",
+      create_mode=CreateOrTruncate,
+    )
+    let source =
+      #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/async/stdio" }
+      #|
+      #|async fn main {
+      #|  let text = @fs.read_file("data.txt").text()
+      #|  let lines = [..text.split("\n")].filter(line => !line.is_empty())
+      #|  @stdio.stdout.write("lines=\{lines.length()}\n")
+      #|}
+    let action = match
+      @run_moonbit.definition(workspace_root=workspace).execute {
+      Async(execute) => execute({ "source": source })
+      Sync(_) => fail("run_moonbit is async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("lines=2"))
+  })
+}
+```
+
+Pure snippets can select another supported backend explicitly:
+
+```mbt check
+///|
+async test "run_moonbit accepts an explicit target" {
+  let action = match @run_moonbit.definition(workspace_root=".").execute {
+    Async(execute) =>
+      execute({ "source": "fn main { println(6 * 7) }", "target": "js" })
+    Sync(_) => fail("run_moonbit is async")
+  }
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content.contains("42"))
+}
+```
+
+Warnings are quiet by default and can be restored for diagnostic probes:
+
+```mbt check
+///|
+async test "run_moonbit can show compiler warnings" {
+  @vfs.with_tmpdir(prefix="run-moonbit-readme-warning-", workspace => {
+    let execute = match
+      @run_moonbit.definition(workspace_root=workspace).execute {
+      Async(execute) => execute
+      Sync(_) => fail("run_moonbit is async")
+    }
+    let source = "fn main { let unused = 1; println(\"done\") }"
+    let quiet = execute({ "source": source })
+    let loud = execute({ "source": source, "warning": "on" })
+    guard quiet is Respond(quiet_output) else { fail("expected Respond") }
+    guard loud is Respond(loud_output) else { fail("expected Respond") }
+    assert_false(quiet_output.is_error)
+    assert_false(quiet_output.content.contains("Warning"))
+    assert_false(loud_output.is_error)
+    assert_true(loud_output.content.contains("unused"))
+  })
 }
 ```
 

--- a/agent_tool/run_moonbit/README.mbt.md
+++ b/agent_tool/run_moonbit/README.mbt.md
@@ -84,9 +84,18 @@ async test "run_moonbit runs a pure-core probe" {
       execute({ "source": "fn main { println([1, 2, 3].map(x => x * x)) }" })
     Sync(_) => fail("run_moonbit is async")
   }
-  guard action is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("[1, 4, 9]"))
+  debug_inspect(
+    action,
+    content=(
+      #|Respond(
+      #|  {
+      #|    content: "[1, 4, 9]\n",
+      #|    is_error: false,
+      #|    brief: Some("run_moonbit (exit=0)"),
+      #|  },
+      #|)
+    ),
+  )
 }
 ```
 
@@ -115,9 +124,18 @@ async test "run_moonbit reads a workspace file" {
       Async(execute) => execute({ "source": source })
       Sync(_) => fail("run_moonbit is async")
     }
-    guard action is Respond(output) else { fail("expected Respond") }
-    assert_false(output.is_error)
-    assert_true(output.content.contains("lines=2"))
+    debug_inspect(
+      action,
+      content=(
+        #|Respond(
+        #|  {
+        #|    content: "lines=2\n",
+        #|    is_error: false,
+        #|    brief: Some("run_moonbit (exit=0)"),
+        #|  },
+        #|)
+      ),
+    )
   })
 }
 ```
@@ -132,9 +150,18 @@ async test "run_moonbit accepts an explicit target" {
       execute({ "source": "fn main { println(6 * 7) }", "target": "js" })
     Sync(_) => fail("run_moonbit is async")
   }
-  guard action is Respond(output) else { fail("expected Respond") }
-  assert_false(output.is_error)
-  assert_true(output.content.contains("42"))
+  debug_inspect(
+    action,
+    content=(
+      #|Respond(
+      #|  {
+      #|    content: "42\n",
+      #|    is_error: false,
+      #|    brief: Some("run_moonbit (exit=0)"),
+      #|  },
+      #|)
+    ),
+  )
 }
 ```
 

--- a/agent_tool/run_moonbit/moon.pkg
+++ b/agent_tool/run_moonbit/moon.pkg
@@ -4,7 +4,6 @@ import {
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/internal/sandbox",
   "bobzhang/openseek/internal/workspace_path",
-  "moonbitlang/core/string",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -27,152 +27,11 @@ const SandboxSourceWriteFeedback : String =
   #|compute, probing, and non-source IO.
 
 ///|
-/// Cached `--warn-list` spec for `warning: "off"` — derived once per process.
-/// `""` means derivation failed: pass no flag and leave warnings visible
-/// (fail-open, never a broken run).
-let warn_off_list_cache : Ref[String?] = { val: None }
-
-///|
-/// The `--warn-list` spec for `warning: "off"`: every id in the toolchain's
-/// warning table disabled EXCEPT those whose default state is `error`
-/// (partial_match and friends) — "warnings off" must never let a program that
-/// previously failed to compile reach a runtime panic instead. The spec is
-/// derived from `moonc build-package -warn-help` rather than hardcoded,
-/// because moonc REJECTS ids beyond its own maximum: a static list breaks
-/// every default run on any toolchain older than the list (the desktop
-/// runtime pins one), while a too-low ceiling silently leaks newer warnings.
-/// `moonc` is resolved from PATH like the `moon` the run spawns — both live
-/// in the same toolchain bin directory. `-a` cannot be used for this: a later
-/// `@id` re-enable does not survive it (probed live).
-async fn warn_off_list() -> String {
-  match warn_off_list_cache.val {
-    Some(spec) => spec
-    None => {
-      // The probe runs OUTSIDE the snippet's own 60s deadline, so it carries
-      // its own bound: a wedged moonc (or PATH wrapper) is torn down after
-      // this and the run proceeds with no flag rather than stalling the turn.
-      let help = match
-        @async.with_timeout_opt(WarnProbeTimeoutMs, () => {
-          capture_merged_output("moonc", ["build-package", "-warn-help"])
-        }) {
-        Some(Some(help)) => help
-        _ => ""
-      }
-      let spec = parse_warn_off_list(help)
-      warn_off_list_cache.val = Some(spec)
-      spec
-    }
-  }
-}
-
-///|
-/// Deadline for the one-shot warning-table probe — generous (the real command
-/// answers in milliseconds) but hard, so it can never hold the tool turn.
-const WarnProbeTimeoutMs : Int = 10_000
-
-///|
-/// Parse `moonc build-package -warn-help` output into the warn-off spec:
-/// table rows end with `<id> <state>` (state ∈ warn|error|off); every id from
-/// 1 through the table's maximum is disabled by ranges that skip the
-/// error-state ids. Returns `""` when no row parses — the caller then passes
-/// no flag at all.
-fn parse_warn_off_list(help : String) -> String {
-  let mut max_id = 0
-  let error_ids : Array[Int] = []
-  for line in help.split("\n") {
-    // A Windows toolchain emits CRLF; without stripping the `\r` every state
-    // token reads `warn\r` and the whole table fails to parse.
-    let line = if line.has_suffix("\r") {
-      line[:line.length() - 1]
-    } else {
-      line
-    }
-    // A table row ends with the two columns this cares about, whatever
-    // precedes them: `… <id> <state>`.
-    let parts = [..line.split(" ")].filter(part => !part.is_empty())
-    guard parts is [.., id_column, state] else { continue }
-    guard state == "warn" || state == "error" || state == "off" else {
-      continue
-    }
-    let id = @string.parse_int(id_column) catch { _ => continue }
-    guard id > 0 else { continue }
-    if id > max_id {
-      max_id = id
-    }
-    if state == "error" {
-      error_ids.push(id)
-    }
-  }
-  guard max_id > 0 else { return "" }
-  error_ids.sort()
-  let spec = StringBuilder()
-  fn emit(from : Int, to : Int) {
-    if from == to {
-      spec.write_string("-\{from}")
-    } else {
-      spec.write_string("-\{from}..\{to}")
-    }
-  }
-
-  let mut start = 1
-  for error_id in error_ids {
-    guard error_id >= start else { continue }
-    if start <= error_id - 1 {
-      emit(start, error_id - 1)
-    }
-    start = error_id + 1
-  }
-  if start <= max_id {
-    emit(start, max_id)
-  }
-  spec.to_string()
-}
-
-///|
-/// Run `program args` and return its merged stdout+stderr (capped at 256KB,
-/// drained past the cap so the child cannot deadlock on a full pipe), or
-/// `None` on spawn failure or non-zero exit. One-shot toolchain probe.
-async fn capture_merged_output(
-  program : String,
-  args : Array[String],
-) -> String? {
-  (@async.with_task_group() <| group => {
-    let (reader, writer) = @process.read_from_process()
-    defer reader.close()
-    let process = @process.spawn(
-      group,
-      program,
-      args,
-      stdout=writer,
-      stderr=writer,
-      cancel_handler=@process.hard_cancel(),
-      no_wait=true,
-    )
-    let cap = 262_144
-    let buf = FixedArray::make(cap, b'\x00')
-    let mut filled = 0
-    for ;; {
-      match reader.read_some(max_len=4096) {
-        None => break
-        Some(chunk) =>
-          for byte in chunk {
-            if filled < cap {
-              buf[filled] = byte
-              filled += 1
-            }
-          }
-      }
-    }
-    if process.wait() == 0 {
-      Some(@utf8.decode_lossy(Bytes::from_array(buf[:filled])))
-    } else {
-      None
-    }
-  }) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => None
-  }
-}
+/// The `--warn-list` spec for `warning: "off"`. `-a` disables all warnings;
+/// each `+name@name` pair then re-enables a selected correctness diagnostic
+/// and promotes it back to an error. Keep this mnemonic list maintained by
+/// hand; `unused_mut` intentionally remains suppressed for throwaway snippets.
+const WarnOffList : String = "-a+partial_match@partial_match+multiline_string_escape@multiline_string_escape+invalid_inline_wasm@invalid_inline_wasm+unannotated_ffi@unannotated_ffi"
 
 ///|
 /// Best-effort refusal of the two obvious native escapes: process spawning
@@ -218,9 +77,9 @@ fn native_escape(source : String) -> String? {
 /// Compiler warnings are suppressed by default: snippets are throwaway
 /// scripts, so unused-value style noise would only pollute the output.
 /// Passing `warning: "on"` restores them, for when the warnings themselves
-/// are the thing being probed. Errors are unaffected either way — including
-/// warning IDs whose default state is `error` (e.g. `partial_match`), which
-/// keep failing compilation with warnings off (see `warn_off_list`).
+/// are the thing being probed. Selected correctness diagnostics such as
+/// `partial_match` keep failing compilation with warnings off (see
+/// `WarnOffList`).
 ///
 /// Note: on macOS the run is wrapped in `sandbox-exec` with the shell tool's
 /// source-write-readonly profile, so a snippet is blocked from directly writing
@@ -297,9 +156,9 @@ async fn execute(
         is_error=true,
       )
   }
-  guard native_escape(input.source) is None else {
+  if native_escape(input.source) is Some(reason) {
     return @agent_tool.ToolAction::respond(
-      "run_moonbit refuses this program: it \{native_escape(input.source).unwrap()}. run_moonbit is the compute/IO surface; deeper containment arrives with the wasm backend.",
+      "run_moonbit refuses this program: it \{reason}. run_moonbit is the compute/IO surface; deeper containment arrives with the wasm backend.",
       is_error=true,
     )
   }
@@ -377,19 +236,10 @@ async fn execute(
       input.target,
       "--target-dir",
       dir,
+      ..if !input.warning {
+        ["--warn-list", WarnOffList]
+      },
     ]
-    // Warnings default OFF: a snippet is a throwaway probe/script, so
-    // unused-variable style noise only burns context and can drown the
-    // program's real output. `warning: "on"` skips the flag, for when the
-    // warnings themselves are the thing being probed. Errors are unaffected
-    // either way — see `warn_off_list` for why the spec is derived, not `-a`.
-    if !input.warning {
-      let spec = warn_off_list()
-      if spec != "" {
-        moon_argv.push("--warn-list")
-        moon_argv.push(spec)
-      }
-    }
     // Wrap `moon run` in sandbox-exec where it can actually enforce (macOS) so a
     // snippet cannot directly overwrite protected source files — reusing the
     // shell tool's source-write-readonly profile keyed on the workspace root.

--- a/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
@@ -38,39 +38,3 @@ async test "denial scan is bounded to the log's head and tail" {
     assert_false(scan("clean", filler(64)))
   })
 }
-
-///|
-/// The warn-off spec must come from the toolchain's own table: moonc rejects
-/// ids beyond its maximum, so a hardcoded ceiling breaks every default run on
-/// an older toolchain (the desktop runtime pins one), and a too-low ceiling
-/// leaks newer warnings. The parser disables 1..max by ranges skipping the
-/// error-state ids, and yields "" (no flag at all) when nothing parses.
-test "warn-off spec derivation from the toolchain warning table" {
-  let help =
-    #|Available warnings:
-    #|mnemonic                   description                 id state
-    #|unused_value               Unused variable.             2 warn
-    #|partial_match              Partial pattern matching.   11 error
-    #|unused_mut                 Unused mutability.          15 error
-    #|deprecated                 Deprecated API usage.       20 warn
-    #|unused_default_value       Default value never used.   32 off
-    #|multiline_string_escape    Deprecated escape.          40 error
-    #|invalid_inline_wasm        Invalid inline-wasm.        44 error
-    #|unannotated_ffi            Unannotated FFI param type  55 error
-    #|type_param_method          Deprecated call.            83 warn
-    #|A                          all warnings
-    #|state: warn = enabled, error = promoted to error, off = disabled
-  assert_eq(
-    parse_warn_off_list(help),
-    "-1..10-12..14-16..39-41..43-45..54-56..83",
-  )
-  // no parsable table → no flag at all (fail-open to visible warnings)
-  assert_eq(parse_warn_off_list(""), "")
-  assert_eq(parse_warn_off_list("mnemonic id state\nnothing here"), "")
-  // error ids at the edges produce no empty or inverted ranges
-  assert_eq(parse_warn_off_list("a x 1 error\nb y 2 warn\nc z 3 error"), "-2")
-  // a lone single-id gap renders as "-n", not a degenerate range
-  assert_eq(parse_warn_off_list("a x 2 error\nb y 3 warn"), "-1-3")
-  // CRLF output (Windows toolchains) parses identically
-  assert_eq(parse_warn_off_list("a x 2 error\r\nb y 3 warn\r\n"), "-1-3")
-}


### PR DESCRIPTION
## Summary

- replace the runtime `moonc -warn-help` probe, cache, and parser with a hand-maintained mnemonic `--warn-list`
- keep selected correctness diagnostics such as `partial_match` promoted to errors while intentionally suppressing `unused_mut` for throwaway snippets
- simplify `moon run` argument construction and remove the now-unused string dependency/parser tests
- document every `SandboxedCommand` field, including how `program` and `args` form one invocation
- add checked `run_moonbit` README examples for workspace file IO, explicit target selection, and warning output

## Why

The dynamic warning-table machinery was disproportionate to the behavior it provided. A mnemonic list is short, readable, and can be maintained alongside Moon toolchain updates without parsing compiler help at runtime.

## Impact

Default snippet output remains quiet. The selected diagnostics in `WarnOffList` still fail compilation; `unused_mut` is now intentionally suppressed when `warning` is off. Passing `warning: "on"` continues to restore normal compiler warning output.

## Validation

- `moon check agent_tool/internal/sandbox --target native --warn-list +73`
- `moon check agent_tool/run_moonbit --target native --warn-list +73`
- `moon test agent_tool/internal/sandbox --target native` — 12/12 passed
- `moon test agent_tool/run_moonbit --target native` — 24/24 passed
- `moon info && moon fmt`
- `git diff --check`
