### PR TITLE
chore(deps): upgrade Rabbita to 0.13.1

### DIFF
--- a/agent_session/log/exports.mbt
+++ b/agent_session/log/exports.mbt
@@ -17,7 +17,7 @@ pub(all) struct ParsedLog {
   events : Array[@agent_session.SessionEvent]
   errors : Array[LineError]
   partial_tail : Bool
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// Parse a session file into a header record and typed `SessionEvent`s,

--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -10,7 +10,7 @@ let session_file_version : Int = 1
 pub(all) struct SessionFileHeader {
   id : String
   system_prompt : String
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// Encode a header record as the JSON stored on a session file's first line.
@@ -78,7 +78,7 @@ pub struct LineError {
   line_number : Int
   content : String
   message : String
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// Build an immutable `Session` from parsed events plus the header values the

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -26,19 +26,19 @@ pub struct LineError {
   line_number : Int
   content : String
   message : String
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 
 pub(all) struct ParsedLog {
   header : SessionFileHeader?
   events : Array[@agent_session.SessionEvent]
   errors : Array[LineError]
   partial_tail : Bool
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 
 pub(all) struct SessionFileHeader {
   id : String
   system_prompt : String
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 pub impl ToJson for SessionFileHeader
 
 // Type aliases

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -36,7 +36,7 @@ pub fn parse_goal_baseline(String) -> GoalBaseline?
 // Types and methods
 pub struct AssistantMessage {
   // private fields
-} derive(ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.ToolCall], reasoning_content? : String) -> Self
 pub fn AssistantMessage::content(Self) -> String
 pub fn AssistantMessage::reasoning_content(Self) -> String?
@@ -56,13 +56,13 @@ pub enum GoalMarker {
 
 pub struct RuntimeNotice {
   // private fields
-} derive(ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn RuntimeNotice::RuntimeNotice(String) -> Self
 pub fn RuntimeNotice::content(Self) -> String
 
 pub struct Session {
   // private fields
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 pub fn Session::Session(SessionId, system_prompt~ : String, events? : @vector.Vector[SessionEvent]) -> Self
 pub fn Session::append(Self, SessionItem, unix_ms? : Int64) -> Self
 pub fn Session::append_event(Self, SessionItem, unix_ms? : Int64) -> (Self, SessionEvent)
@@ -80,14 +80,14 @@ pub impl @json.FromJson for Session
 
 pub struct SessionEvent {
   // private fields
-} derive(ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn SessionEvent::item(Self) -> SessionItem
 pub fn SessionEvent::sequence(Self) -> Int
 pub fn SessionEvent::unix_ms(Self) -> Int64
 
 pub struct SessionId {
   // private fields
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 pub fn SessionId::SessionId(String) -> Self
 pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64, salt? : String) -> Self
 pub fn SessionId::value(Self) -> String
@@ -100,12 +100,12 @@ pub(all) enum SessionItem {
   Runtime(RuntimeNotice)
   Summary(SessionSummary)
   Terminal(TurnTerminal)
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 pub impl @json.FromJson for SessionItem
 
 pub struct SessionSummary {
   // private fields
-} derive(ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn SessionSummary::SessionSummary(content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self
 pub fn SessionSummary::content(Self) -> String
 pub fn SessionSummary::from_sequence(Self) -> Int
@@ -121,7 +121,7 @@ pub fn StandingGoal::text(Self) -> String
 
 pub struct ToolResult {
   // private fields
-} derive(ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool, brief? : String) -> Self
 pub fn ToolResult::brief(Self) -> String?
 pub fn ToolResult::content(Self) -> String
@@ -134,12 +134,12 @@ pub(all) enum TurnTerminal {
   Aborted(String)
   Interrupted(String)
   Failed(String)
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 pub impl @json.FromJson for TurnTerminal
 
 pub struct UserMessage {
   // private fields
-} derive(ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn UserMessage::UserMessage(String) -> Self
 pub fn UserMessage::content(Self) -> String
 

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -25,7 +25,7 @@ pub const ContextYieldAnswerPrefix : String = "[context ceiling]"
 /// paths. Use `generated` for ids created by OpenSeek itself.
 pub struct SessionId {
   priv value : String
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// Wrap a raw id string exactly as supplied.
@@ -99,14 +99,14 @@ pub fn SessionId::generated(
 /// `Session::chat_messages`.
 pub struct UserMessage {
   priv content : String
-} derive(Debug, ToJson, FromJson)
+} derive(Eq, Debug, ToJson, FromJson)
 
 ///|
 priv struct SessionToolCall {
   id : String
   name : String
   arguments : String
-} derive(Debug, ToJson, FromJson)
+} derive(Eq, Debug, ToJson, FromJson)
 
 ///|
 fn SessionToolCall::from_deepseek(call : @deepseek.ToolCall) -> SessionToolCall {
@@ -143,7 +143,7 @@ pub struct AssistantMessage {
   priv content : String
   priv tool_calls : Array[SessionToolCall]
   priv reasoning_content : String?
-} derive(Debug, ToJson, FromJson)
+} derive(Eq, Debug, ToJson, FromJson)
 
 ///|
 /// Build an assistant event payload from model response parts.
@@ -211,7 +211,7 @@ pub struct ToolResult {
   priv content : String
   priv is_error : Bool
   priv brief : String?
-} derive(Debug, ToJson, FromJson)
+} derive(Eq, Debug, ToJson, FromJson)
 
 ///|
 /// Record the outcome of one tool execution.
@@ -268,7 +268,7 @@ pub fn ToolResult::is_error(self : ToolResult) -> Bool {
 /// originate from the user's prompt.
 pub struct RuntimeNotice {
   priv content : String
-} derive(Debug, ToJson, FromJson)
+} derive(Eq, Debug, ToJson, FromJson)
 
 ///|
 /// First line of the runtime notices the agent loop injects as plan-cadence
@@ -299,7 +299,7 @@ pub struct SessionSummary {
   priv content : String
   priv from_sequence : Int
   priv to_sequence : Int
-} derive(Debug, ToJson, FromJson)
+} derive(Eq, Debug, ToJson, FromJson)
 
 ///|
 /// Return the summary text used in model-facing projection.
@@ -341,7 +341,7 @@ pub(all) enum TurnTerminal {
   /// The turn ended because an unexpected error escaped the agent loop. The
   /// failure message projects as an assistant status message.
   Failed(String)
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// Payload vocabulary for one `SessionEvent`.
@@ -376,7 +376,7 @@ pub(all) enum SessionItem {
   /// `Finished(text)` can project as a final assistant message; aborted,
   /// interrupted, and failed terminals project assistant status messages.
   Terminal(TurnTerminal)
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// One append-only event in a session log.
@@ -395,7 +395,7 @@ pub struct SessionEvent {
   // string); milliseconds are exactly representable until year ~2255.
   priv ts : Double
   priv item : SessionItem
-} derive(Debug, ToJson, FromJson)
+} derive(Eq, Debug, ToJson, FromJson)
 
 ///|
 fn SessionEvent::SessionEvent(
@@ -438,7 +438,7 @@ pub struct Session {
   priv system_prompt : String
   priv events : @vector.Vector[SessionEvent]
   priv last_sequence : Int
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// Build a session from identity, system prompt, and an optional event log.

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -12,7 +12,7 @@ struct SessionRow {
   // sidebar strips the last path segment when grouping. Absent → `false`.
   is_marker : Bool
   first_prompt : String
-}
+} derive(Eq)
 
 ///|
 /// The whole viewer state. The current session is kept as the parsed log plus a
@@ -52,7 +52,7 @@ struct Model {
   // keyed by child session id — rendered inline inside the parent's subrun
   // tool cards. Cleared on every selection change.
   subrun_children : Map[String, @agent_session.Session]
-}
+} derive(Eq)
 
 ///|
 /// Colour theme. `System` is the default and follows the OS via a CSS

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -1,27 +1,44 @@
 ///|
+/// Rabbita 0.13 only propagates a state value when its `Eq` comparison changes.
+/// The visualizer model still contains mutable collections and intentionally
+/// preserves the old full-view refresh after every accepted message.
+priv struct AppState(Model)
+
+///|
+impl Eq for AppState with fn equal(_, _) {
+  false
+}
+
+///|
 /// Mount the visualizer onto `#app` and kick off the initial session-list fetch.
 /// The frontend talks only to the read-only viz server's JSON/raw-file API.
 #warnings("-alert_unstable")
 fn main {
-  let (emit, app_cell) = @rabbita.cell_with_emit(
-    model=init_model(),
-    update~,
-    view~,
-  )
-  let app = @rabbita.new(app_cell)
-  // Route the initial listing through fetch_text so a standalone export answers
-  // it from the embedded data map instead of the (absent) server.
-  app.with_init(
-    @cmd.batch([
-      fetch_text(emit, "/api/sessions", result => SessionsFetched(result)),
-      install_shortcuts(emit),
-      // Subrun chips navigate by writing `#s=…`; turn those hash changes
-      // into selections.
-      install_hash_navigation(emit),
-      // Position tracking: keep `seq=` in the URL hash while scrolling and
-      // make step-scrubber segments jump, so a refresh restores the spot.
-      @cmd.effect(() => install_position_tracker()),
-    ]),
-  )
+  let app = @rabbita.new(() => {
+    let (state, emit) = @rabbita.create_state_with_init(
+      init=emit => {
+        (
+          AppState(init_model()),
+          // Route the initial listing through fetch_text so a standalone export
+          // answers it from the embedded data map instead of the absent server.
+          @cmd.batch([
+            fetch_text(emit, "/api/sessions", result => SessionsFetched(result)),
+            install_shortcuts(emit),
+            // Subrun chips navigate by writing `#s=…`; turn those hash changes
+            // into selections.
+            install_hash_navigation(emit),
+            // Keep `seq=` in the URL hash while scrolling and make scrubber
+            // segments jump, so a refresh restores the position.
+            @cmd.effect(() => install_position_tracker()),
+          ]),
+        )
+      },
+      update=(emit, msg, state) => {
+        let (cmd, model) = update(emit, msg, state.0)
+        (AppState(model), cmd)
+      },
+    )
+    state.view(state => view(emit, state.0))
+  })
   app.mount("app")
 }

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -1,16 +1,4 @@
 ///|
-/// Rabbita 0.13 only propagates a state value when its `Eq` comparison changes.
-/// The visualizer rebuilds mutable containers before changing them, but its
-/// parsed-log and session types do not expose structural `Eq` yet. Preserve the
-/// old full-view refresh until equality is available through that type graph.
-priv struct AppState(Model)
-
-///|
-impl Eq for AppState with fn equal(_, _) {
-  false
-}
-
-///|
 /// Mount the visualizer onto `#app` and kick off the initial session-list fetch.
 /// The frontend talks only to the read-only viz server's JSON/raw-file API.
 #warnings("-alert_unstable")
@@ -19,7 +7,7 @@ fn main {
     let (state, emit) = @rabbita.create_state_with_init(
       init=emit => {
         (
-          AppState(init_model()),
+          init_model(),
           // Route the initial listing through fetch_text so a standalone export
           // answers it from the embedded data map instead of the absent server.
           @cmd.batch([
@@ -35,11 +23,11 @@ fn main {
         )
       },
       update=(emit, msg, state) => {
-        let (cmd, model) = update(emit, msg, state.0)
-        (AppState(model), cmd)
+        let (cmd, model) = update(emit, msg, state)
+        (model, cmd)
       },
     )
-    state.view(state => view(emit, state.0))
+    state.view(state => view(emit, state))
   })
   app.mount("app")
 }

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -1,7 +1,8 @@
 ///|
 /// Rabbita 0.13 only propagates a state value when its `Eq` comparison changes.
-/// The visualizer model still contains mutable collections and intentionally
-/// preserves the old full-view refresh after every accepted message.
+/// The visualizer rebuilds mutable containers before changing them, but its
+/// parsed-log and session types do not expose structural `Eq` yet. Preserve the
+/// old full-view refresh until equality is available through that type graph.
 priv struct AppState(Model)
 
 ///|

--- a/cmd/viz_app/moon.mod
+++ b/cmd/viz_app/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "bobzhang/openseek@0.2.0",
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.13.1",
 }
 
 preferred_target = "js"

--- a/cmd/viz_app/pkg.generated.mbti
+++ b/cmd/viz_app/pkg.generated.mbti
@@ -8,11 +8,11 @@ package "bobzhang/openseek-viz-app"
 // Types and methods
 type LoadOutcome
 
-type Model
+type Model derive(Eq)
 
 type Msg
 
-type SessionRow
+type SessionRow derive(Eq)
 
 type Theme derive(Eq)
 

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -45,13 +45,13 @@ pub(all) struct FileEntry {
   name : String
   path : @pathx.Relative
   is_dir : Bool
-}
+} derive(Eq)
 
 pub(all) enum FileIndex {
   IndexEmpty
   IndexLoading
   IndexReady(files~ : Array[@pathx.Relative], truncated~ : Bool)
-}
+} derive(Eq)
 
 pub(all) struct FileStat {
   path : @pathx.Relative
@@ -89,12 +89,12 @@ pub(all) enum Msg {
 pub(all) struct RememberedTab {
   path : @pathx.Relative
   name : String
-}
+} derive(Eq)
 
 pub(all) struct RememberedTabs {
   entries : Array[RememberedTab]
   active : @pathx.Relative?
-}
+} derive(Eq)
 
 pub(all) struct State {
   open : Bool
@@ -112,7 +112,7 @@ pub(all) struct State {
   index : FileIndex
   cursor : @pathx.Relative?
   error : String
-}
+} derive(Eq)
 pub fn State::empty() -> Self
 
 pub(all) struct Tab {
@@ -120,7 +120,7 @@ pub(all) struct Tab {
   name : String
   state : TabState
   stale : Bool
-}
+} derive(Eq)
 
 pub(all) enum TabState {
   TabLoading
@@ -128,12 +128,12 @@ pub(all) enum TabState {
   TabBinary
   TabOversized
   TabDeleted
-}
+} derive(Eq)
 
 pub(all) enum TreeLayout {
   BottomPanel
   RightSidebar
-}
+} derive(Eq)
 pub fn TreeLayout::parse(String) -> Self
 pub fn TreeLayout::wire(Self) -> String
 

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -14,7 +14,7 @@ pub(all) struct FileEntry {
   name : String
   path : @pathx.Relative
   is_dir : Bool
-}
+} derive(Eq)
 
 ///|
 /// A decoded `read_file` reply. Withheld files are their own cases — the
@@ -49,7 +49,7 @@ pub(all) enum TabState {
   // user's bookmark — showing a notice until the file reappears or the tab
   // is closed.
   TabDeleted
-}
+} derive(Eq)
 
 ///|
 /// One open file in the editor's tab strip. Identified by its
@@ -62,7 +62,7 @@ pub(all) struct Tab {
   // The file changed on disk while the tab was in the background; reloaded
   // on activation rather than eagerly, so a build storm costs one read.
   stale : Bool
-}
+} derive(Eq)
 
 ///|
 /// A conversation's tab set, remembered across conversation switches. Only
@@ -72,13 +72,13 @@ pub(all) struct Tab {
 pub(all) struct RememberedTab {
   path : @pathx.Relative
   name : String
-}
+} derive(Eq)
 
 ///|
 pub(all) struct RememberedTabs {
   entries : Array[RememberedTab]
   active : @pathx.Relative?
-}
+} derive(Eq)
 
 ///|
 /// One file's decoded `stat_files` result: its current mtime signature, or
@@ -104,7 +104,7 @@ pub(all) enum FileIndex {
   // `truncated` set means the walk hit the host's cap, so matches may be
   // missing; the filter footer says so.
   IndexReady(files~ : Array[@pathx.Relative], truncated~ : Bool)
-}
+} derive(Eq)
 
 ///|
 /// The editor side-panel's state: a lazily-loaded file tree of the active
@@ -155,7 +155,7 @@ pub(all) struct State {
   cursor : @pathx.Relative?
   // The last directory/file failure, surfaced in the panel header.
   error : String
-}
+} derive(Eq)
 
 ///|
 pub fn State::empty() -> State {
@@ -187,7 +187,7 @@ pub fn State::empty() -> State {
 pub(all) enum TreeLayout {
   BottomPanel
   RightSidebar
-}
+} derive(Eq)
 
 ///|
 /// The stored wire name's inverse; an unknown value falls back to the

--- a/desktop/frontend/main.mbt
+++ b/desktop/frontend/main.mbt
@@ -1,12 +1,26 @@
 ///|
+/// Rabbita 0.13 compares component state before propagating it. The desktop
+/// model still contains mutable collections and JS-backed values, so preserving
+/// its existing whole-view refresh requires treating every result as changed.
+priv struct AppState(Model)
+
+///|
+impl Eq for AppState with fn equal(_, _) {
+  false
+}
+
+///|
 #warnings("-alert_unstable")
 fn main {
-  let (dispatch, cell) = @rabbita.cell_with_emit(
-    model=initial_model(),
-    update~,
-    view~,
-  )
-  let app = @rabbita.new(cell)
-  app.with_init(dispatch(Init))
+  let app = @rabbita.new(() => {
+    let (state, dispatch) = @rabbita.create_state_with_init(
+      init=dispatch => (AppState(initial_model()), dispatch(Init)),
+      update=(dispatch, msg, state) => {
+        let (cmd, model) = update(dispatch, msg, state.0)
+        (AppState(model), cmd)
+      },
+    )
+    state.view(state => view(dispatch, state.0))
+  })
   app.mount("app")
 }

--- a/desktop/frontend/main.mbt
+++ b/desktop/frontend/main.mbt
@@ -1,7 +1,9 @@
 ///|
 /// Rabbita 0.13 compares component state before propagating it. The desktop
-/// model still contains mutable collections and JS-backed values, so preserving
-/// its existing whole-view refresh requires treating every result as changed.
+/// model's arrays and maps are updated copy-on-write, and the imperative viewer
+/// lives outside the model; the remaining blocker to structural equality is
+/// that several nested data types do not expose `Eq`. Until that type graph is
+/// completed, preserve the former whole-view refresh after every message.
 priv struct AppState(Model)
 
 ///|

--- a/desktop/frontend/main.mbt
+++ b/desktop/frontend/main.mbt
@@ -1,28 +1,15 @@
 ///|
-/// Rabbita 0.13 compares component state before propagating it. The desktop
-/// model's arrays and maps are updated copy-on-write, and the imperative viewer
-/// lives outside the model; the remaining blocker to structural equality is
-/// that several nested data types do not expose `Eq`. Until that type graph is
-/// completed, preserve the former whole-view refresh after every message.
-priv struct AppState(Model)
-
-///|
-impl Eq for AppState with fn equal(_, _) {
-  false
-}
-
-///|
 #warnings("-alert_unstable")
 fn main {
   let app = @rabbita.new(() => {
     let (state, dispatch) = @rabbita.create_state_with_init(
-      init=dispatch => (AppState(initial_model()), dispatch(Init)),
+      init=dispatch => (initial_model(), dispatch(Init)),
       update=(dispatch, msg, state) => {
-        let (cmd, model) = update(dispatch, msg, state.0)
-        (AppState(model), cmd)
+        let (cmd, model) = update(dispatch, msg, state)
+        (model, cmd)
       },
     )
-    state.view(state => view(dispatch, state.0))
+    state.view(state => view(dispatch, state))
   })
   app.mount("app")
 }

--- a/desktop/frontend/markdown/markdown_wbtest.mbt
+++ b/desktop/frontend/markdown/markdown_wbtest.mbt
@@ -42,7 +42,7 @@ test "markdown links do not navigate the app frame" {
   let expected =
     #|<a href="https://example.com" target="_blank" rel="noopener noreferrer">example</a>
   inspect(
-    @rabbita.render_to_string(@rabbita.static_cell(node)),
+    @rabbita.render_to_string(() => @rabbita.Val::constant(node)),
     content=expected,
   )
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -56,7 +56,7 @@ priv enum ApiProvider {
   Openseek
   Deepseek
   Custom
-}
+} derive(Eq)
 
 ///|
 fn ApiProvider::wire(self : ApiProvider) -> String {
@@ -102,7 +102,7 @@ priv enum CompactionPhase {
   // The engine reported `compaction_started` and has not yet reported the
   // summary or a failure.
   Compacting
-}
+} derive(Eq)
 
 ///|
 /// The run lifecycle of one conversation, as a single value: the old
@@ -119,7 +119,7 @@ priv enum RunPhase {
   Starting
   // The host's `started` event opened run `run_id`.
   Open(run_id~ : Int, stage~ : TurnStage)
-}
+} derive(Eq)
 
 ///|
 /// How far an open turn has progressed — one axis, like the old status
@@ -134,7 +134,7 @@ priv enum TurnStage {
   AtStep(Int?)
   // A Stop was sent and the engine has not yet honored it.
   Cancelling
-}
+} derive(Eq)
 
 ///|
 /// How a finished run closed, kept for the topbar/sidebar after the run
@@ -143,7 +143,7 @@ priv enum RunEnd {
   RunFailed
   RunErrored
   RunFinished(RunOutcome)
-}
+} derive(Eq)
 
 ///|
 /// One conversation's full client-side state. Each conversation maps to a
@@ -208,7 +208,7 @@ priv struct Conversation {
   // notices when the run ends, so the text never vanishes silently.
   pending_steers : Array[String]
   messages : Array[@transcript.TranscriptItem]
-}
+} derive(Eq)
 
 ///|
 /// What the main area shows: the active conversation, the Skills page, or
@@ -219,7 +219,7 @@ priv enum Screen {
   Chat
   Skills
   Settings
-}
+} derive(Eq)
 
 ///|
 /// Which trigger opened the composer's completion menu: `/` lists built-in
@@ -230,7 +230,7 @@ priv enum CompletionKind {
   SlashCommands
   SkillMentions
   Symbols
-}
+} derive(Eq)
 
 ///|
 /// One row of the composer completion menu.
@@ -251,7 +251,7 @@ priv struct CompletionItem {
   // range anchored at its line.
   path : String?
   range : @common.Range?
-}
+} derive(Eq)
 
 ///|
 /// One accepted mention, shown as a chip above the composer and folded into
@@ -264,7 +264,7 @@ priv struct CompletionItem {
 priv struct Mention {
   ref_ : @mention_context.MentionRef
   range : @common.Range?
-}
+} derive(Eq)
 
 ///|
 /// The composer's open completion menu: the trigger that opened it, the
@@ -279,7 +279,7 @@ priv struct Completion {
   selected : Int
   loading : Bool
   task_without_token : String
-}
+} derive(Eq)
 
 ///|
 /// The last workspace-symbol results, cached so the `#` menu can show them
@@ -291,7 +291,7 @@ priv struct SymbolCache {
   session : String
   query : String
   items : Array[CompletionItem]
-}
+} derive(Eq)
 
 ///|
 fn empty_symbol_cache() -> SymbolCache {
@@ -306,7 +306,7 @@ priv enum SkillsCatalog {
   CatalogLoading
   CatalogReady(Array[@transcript.MarketSkillItem])
   CatalogFailed(String)
-}
+} derive(Eq)
 
 ///|
 /// Whether the host bridge is up — three states the old `bridge_ready` bool
@@ -316,7 +316,7 @@ priv enum BridgeState {
   Connecting
   Connected
   BridgeLost(String)
-}
+} derive(Eq)
 
 ///|
 priv struct Model {
@@ -433,7 +433,7 @@ priv struct Model {
   // download to the restart. One enum, so "checking", "downloading" and
   // "confirming" cannot overlap.
   update_ux : UpdateUx
-}
+} derive(Eq)
 
 ///|
 /// The topbar app launcher's state: whether its menu is open, the detected
@@ -442,7 +442,7 @@ priv struct Model {
 priv struct Launcher {
   open : Bool
   apps : LauncherApps
-}
+} derive(Eq)
 
 ///|
 /// The launcher's probe of the host's installed apps. There is no separate
@@ -453,7 +453,7 @@ priv enum LauncherApps {
   AppsNotFetched
   AppsFetched(Array[@transcript.LauncherAppItem])
   AppsFailed(String)
-}
+} derive(Eq)
 
 ///|
 priv enum Msg {
@@ -1123,7 +1123,7 @@ priv enum RunOutcome {
   Cancelled
   MaxStepsExhausted
   Unknown(String)
-}
+} derive(Eq)
 
 ///|
 fn RunOutcome::parse(wire : String) -> RunOutcome {

--- a/desktop/frontend/notifications.mbt
+++ b/desktop/frontend/notifications.mbt
@@ -13,7 +13,7 @@ const NotificationLifetimeMs : Int = 6000
 priv struct Notification {
   id : Int
   message : String
-}
+} derive(Eq)
 
 ///|
 /// The window corner where toasts stack — a Settings choice, persisted under
@@ -24,7 +24,7 @@ priv enum NotificationCorner {
   TopRight
   BottomLeft
   BottomRight
-}
+} derive(Eq)
 
 ///|
 fn NotificationCorner::parse(value : String) -> NotificationCorner {

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -10,7 +10,7 @@
 priv enum UpdateChannel {
   Production
   Staging
-}
+} derive(Eq)
 
 ///|
 fn UpdateChannel::parse(value : String) -> UpdateChannel {
@@ -47,7 +47,7 @@ priv enum UpdateUx {
   RestartingForUpdate(version~ : String)
   // What the Settings row shows when a check could not answer.
   UpdateCheckFailed(message~ : String)
-}
+} derive(Eq)
 
 ///|
 /// A decoded `check_update` reply. Kinds mirror the wire contract; see the

--- a/desktop/frontend/transcript/launcher.mbt
+++ b/desktop/frontend/transcript/launcher.mbt
@@ -8,7 +8,7 @@ pub(all) struct LauncherAppItem {
   id : String
   name : String
   icon : String
-}
+} derive(Eq)
 
 ///|
 /// Parse a `list_apps` reply. `None` only for structurally unusable JSON;

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -50,7 +50,7 @@ pub(all) struct InstalledSkillItem {
   name : String
   description : String
   source : String
-}
+} derive(Eq)
 
 pub(all) enum ItemKind {
   User
@@ -58,13 +58,13 @@ pub(all) enum ItemKind {
   Reasoning
   Tool(name~ : String, is_error~ : Bool, brief~ : String?)
   Summary
-}
+} derive(Eq)
 
 pub(all) struct LauncherAppItem {
   id : String
   name : String
   icon : String
-}
+} derive(Eq)
 
 pub(all) struct MarketSkillItem {
   name : String
@@ -74,7 +74,7 @@ pub(all) struct MarketSkillItem {
   description : String
   author : String
   repository : String
-}
+} derive(Eq)
 
 pub struct RuntimeUpdateView {
   status : String
@@ -86,12 +86,12 @@ pub(all) struct SessionListItem {
   title : String?
   workspace : String
   workspace_name : String
-}
+} derive(Eq)
 
 pub(all) struct TranscriptItem {
   kind : ItemKind
   content : String
-}
+} derive(Eq)
 
 // Type aliases
 

--- a/desktop/frontend/transcript/skills.mbt
+++ b/desktop/frontend/transcript/skills.mbt
@@ -14,7 +14,7 @@ pub(all) struct MarketSkillItem {
   description : String
   author : String
   repository : String
-}
+} derive(Eq)
 
 ///|
 /// One entry of the local skills library.
@@ -27,7 +27,7 @@ pub(all) struct InstalledSkillItem {
   // `module@version[/package]` for registry installs; "" for a skill the
   // user wrote by hand (which the app never uninstalls).
   source : String
-}
+} derive(Eq)
 
 ///|
 /// The source label a catalog entry would carry once installed — the link

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -18,13 +18,13 @@ pub(all) enum ItemKind {
   // would read as an anonymous tool call and swallow the preceding answer
   // bubble into the fold.
   Summary
-}
+} derive(Eq)
 
 ///|
 pub(all) struct TranscriptItem {
   kind : ItemKind
   content : String
-}
+} derive(Eq)
 
 ///|
 /// A `runtime_update` notice split into the watcher's status and the
@@ -46,4 +46,4 @@ pub(all) struct SessionListItem {
   title : String?
   workspace : String
   workspace_name : String
-}
+} derive(Eq)

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -7,7 +7,7 @@ import {
   "bobzhang/openseek_protocol@0.1.0",
   "moonbit-community/cmark@0.4.4",
   "moonbit-community/fuzzy_match@0.2.5",
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.13.1",
   "moonbitlang/x@0.4.46",
   "moonbitlang/async@0.20.1",
   "justjavac/proton@0.1.10",

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -154,7 +154,7 @@ fn MemoryWorkspace::model(
 ///|
 priv struct EmbedModel {
   status : String
-}
+} derive(Eq)
 
 ///|
 priv enum EmbedMsg {
@@ -289,6 +289,7 @@ fn open_embed_document_cmd(uri : @base_common.Uri) -> @rabbita.Cmd {
 fn view_embed(
   _emit : @rabbita.Emit[EmbedMsg],
   model : EmbedModel,
+  tree_html : @html.Html,
 ) -> @html.Html {
   @html.main_(
     class="editor-shell",
@@ -304,7 +305,7 @@ fn view_embed(
             @html.div(class="workspace-title", [
               @html.span(class="workspace-title-label", "Explorer"),
             ]),
-            embed_tree().view(),
+            tree_html,
           ],
         ),
         // The stable view host: the viewer attaches its imperative DOM
@@ -329,29 +330,36 @@ fn main {
     @lang_moonbit.MoonbitTokenizer(),
   )
   |> ignore
-  let (_, cell) = @rabbita.cell_with_emit(
-    model={ status: "loading" },
-    update=update_embed,
-    view=view_embed,
-    subscriptions=(emit, _model) => {
-      startup_sub(
-        @cmd.custom_cmd(scheduler => {
-          embed_dispatch.val = Some(msg => scheduler.add(emit(msg)))
-          // Boot after the first paint: the view host and the tree cell
-          // must be in the DOM before the viewer attaches and opens.
-          scheduler.add(
-            @cmd.custom_cmd(
-              after => {
-                embed_viewer() |> ignore
-                after.add(emit(Boot))
-              },
-              kind=@cmd.after_render,
-            ),
-          )
-        }),
-      )
-    },
-  )
-  let app = @rabbita.new(cell)
+  let app = @rabbita.new(() => {
+    let tree_view = embed_tree().view()
+    let (model, emit) = @rabbita.create_state(
+      { status: "loading" },
+      update=(emit, msg, model) => {
+        let (cmd, model) = update_embed(emit, msg, model)
+        (model, cmd)
+      },
+      subscriptions=(emit, _model) => {
+        startup_sub(
+          @cmd.custom_cmd(scheduler => {
+            embed_dispatch.val = Some(msg => scheduler.add(emit(msg)))
+            // Boot after the first paint: the view host and tree value must be
+            // in the DOM before the viewer attaches and opens.
+            scheduler.add(
+              @cmd.custom_cmd(
+                after => {
+                  embed_viewer() |> ignore
+                  after.add(emit(Boot))
+                },
+                kind=@cmd.after_render,
+              ),
+            )
+          }),
+        )
+      },
+    )
+    model.view2(tree_view, (model, tree_html) => {
+      view_embed(emit, model, tree_html)
+    })
+  })
   app.mount("app")
 }

--- a/editor/internal/shell/widgets/file_tree/file_tree.mbt
+++ b/editor/internal/shell/widgets/file_tree/file_tree.mbt
@@ -21,17 +21,6 @@ priv enum FileTreeMsg {
 }
 
 ///|
-/// File-tree updates mutate cached nodes in place. Treating every returned
-/// wrapper as changed preserves the widget's existing redraw behavior while it
-/// moves from the removed nested `Cell::view()` API to incremental values.
-priv struct FileTreeState(FileTreeModel)
-
-///|
-impl Eq for FileTreeState with fn equal(_, _) {
-  false
-}
-
-///|
 /// Creates a file tree over a workspace provider and reports file-open
 /// intents to the host.
 pub fn FileTree::FileTree(
@@ -43,15 +32,11 @@ pub fn FileTree::FileTree(
     selected: None,
     pending_reveal: None,
   }
-  let (state, emit) = @rabbita.create_state(FileTreeState(model), update=(
-    emit,
-    msg,
-    state,
-  ) => {
-    let (cmd, model) = update_file_tree(provider, on_open, emit, msg, state.0)
-    (FileTreeState(model), cmd)
+  let (state, emit) = @rabbita.create_state(model, update=(emit, msg, model) => {
+    let (cmd, model) = model.update(provider, on_open, emit, msg)
+    (model, cmd)
   })
-  let view_value = state.view(state => view_file_tree(emit, state.0))
+  let view_value = state.view(model => model.view(emit))
   { emit, view_value }
 }
 
@@ -80,109 +65,114 @@ pub fn FileTree::set_active(
 }
 
 ///|
-fn update_file_tree(
+fn FileTreeModel::update(
+  self : FileTreeModel,
   provider : &@workspace.WorkspaceTreeProvider,
   on_open : (@base_common.Uri) -> Unit,
   emit : @rabbita.Emit[FileTreeMsg],
   msg : FileTreeMsg,
-  model : FileTreeModel,
 ) -> (@rabbita.Cmd, FileTreeModel) {
   match msg {
-    Refresh => (resolve_directory_cmd(provider, emit, provider.root()), model)
+    Refresh =>
+      (FileTree::resolve_directory(provider, emit, provider.root()), self)
     DirectoryResolved(uri, result) =>
-      directory_resolved_update(provider, emit, model, uri, result)
+      self.with_directory_resolved(provider, emit, uri, result)
     ToggleDirectory(uri) =>
-      match model.root {
+      match self.root {
         Some(root) =>
-          match find_node(root, uri) {
-            Some(node) =>
-              match toggle_node(node) {
+          match root.toggle(uri) {
+            Some((root, effect)) => {
+              let model = { ..self, root: Some(root) }
+              match effect {
                 ToggleResolve(uri) =>
-                  (resolve_directory_cmd(provider, emit, uri), model)
+                  (FileTree::resolve_directory(provider, emit, uri), model)
                 ToggleNone => (@rabbita.none, model)
               }
-            None => (@rabbita.none, model)
+            }
+            None => (@rabbita.none, self)
           }
-        None => (@rabbita.none, model)
+        None => (@rabbita.none, self)
       }
-    OpenFile(uri) => {
-      model.selected = Some(uri)
-      (@cmd.custom_cmd(_ => on_open(uri)), model)
-    }
-    SetActive(uri) => {
-      model.selected = Some(uri)
-      model.pending_reveal = Some(uri)
-      continue_reveal(provider, emit, model)
-    }
+    OpenFile(uri) =>
+      (@cmd.custom_cmd(_ => on_open(uri)), { ..self, selected: Some(uri) })
+    SetActive(uri) =>
+      { ..self, selected: Some(uri), pending_reveal: Some(uri) }.continue_reveal(
+        provider, emit,
+      )
   }
 }
 
 ///|
-fn directory_resolved_update(
+fn FileTreeModel::with_directory_resolved(
+  self : FileTreeModel,
   provider : &@workspace.WorkspaceTreeProvider,
   emit : @rabbita.Emit[FileTreeMsg],
-  model : FileTreeModel,
   uri : @base_common.Uri,
   result : @workspace.WorkspaceResolveResult,
 ) -> (@rabbita.Cmd, FileTreeModel) {
   match result {
     WorkspaceResolved(stat) => {
-      if uri == provider.root() {
-        model.root = Some(node_from_stat(stat, expanded=true))
-        if model.pending_reveal is None {
-          model.pending_reveal = model.selected
+      let model = if uri == provider.root() {
+        {
+          ..self,
+          root: Some(TreeNode::from_stat(stat, expanded=true)),
+          pending_reveal: if self.pending_reveal is Some(_) {
+            self.pending_reveal
+          } else {
+            self.selected
+          },
         }
       } else {
-        match model.root {
+        match self.root {
           Some(root) =>
-            match find_node(root, uri) {
-              Some(node) => apply_resolved(node, stat)
-              None => ()
+            match root.with_resolved(uri, stat) {
+              Some(root) => { ..self, root: Some(root) }
+              None => self
             }
-          None => ()
+          None => self
         }
       }
-      continue_reveal(provider, emit, model)
+      model.continue_reveal(provider, emit)
     }
     WorkspaceResolveError(_) => {
       // The folder keeps rendering as an empty-with-error level; children
       // stay unresolved so the next expand retries the resolve.
-      match model.root {
+      let model = match self.root {
         Some(root) =>
-          match find_node(root, uri) {
-            Some(node) => node.resolve_failed = true
-            None => ()
+          match root.with_resolve_failed(uri) {
+            Some(root) => { ..self, root: Some(root), pending_reveal: None }
+            None => { ..self, pending_reveal: None }
           }
-        None => ()
+        None => { ..self, pending_reveal: None }
       }
-      model.pending_reveal = None
       (@rabbita.none, model)
     }
   }
 }
 
 ///|
-fn continue_reveal(
+fn FileTreeModel::continue_reveal(
+  self : FileTreeModel,
   provider : &@workspace.WorkspaceTreeProvider,
   emit : @rabbita.Emit[FileTreeMsg],
-  model : FileTreeModel,
 ) -> (@rabbita.Cmd, FileTreeModel) {
-  match (model.root, model.pending_reveal) {
-    (Some(root), Some(target)) =>
-      match reveal_step(root, provider.root(), target) {
+  match (self.root, self.pending_reveal) {
+    (Some(root), Some(target)) => {
+      let (root, step) = root.reveal_step(target)
+      let model = { ..self, root: Some(root) }
+      match step {
         RevealResolve(uri) =>
-          (resolve_directory_cmd(provider, emit, uri), model)
-        RevealDone | RevealUnreachable => {
-          model.pending_reveal = None
-          (@rabbita.none, model)
-        }
+          (FileTree::resolve_directory(provider, emit, uri), model)
+        RevealDone | RevealUnreachable =>
+          (@rabbita.none, { ..model, pending_reveal: None })
       }
-    _ => (@rabbita.none, model)
+    }
+    _ => (@rabbita.none, self)
   }
 }
 
 ///|
-fn resolve_directory_cmd(
+fn FileTree::resolve_directory(
   provider : &@workspace.WorkspaceTreeProvider,
   emit : @rabbita.Emit[FileTreeMsg],
   uri : @base_common.Uri,
@@ -202,27 +192,31 @@ fn resolve_directory_cmd(
 }
 
 ///|
-fn view_file_tree(
+fn FileTreeModel::view(
+  self : FileTreeModel,
   emit : @rabbita.Emit[FileTreeMsg],
-  model : FileTreeModel,
 ) -> @html.Html {
   let children : Array[@html.Html] = []
-  for row in visible_rows(model.root) {
-    if row.node.kind == Directory {
-      children.push(view_folder_row(emit, row))
-    } else {
-      children.push(view_file_row(emit, model, row))
-    }
+  match self.root {
+    Some(root) =>
+      for row in root.visible_rows() {
+        if row.node.kind == Directory {
+          children.push(row.folder_view(emit))
+        } else {
+          children.push(row.file_view(emit, self))
+        }
+      }
+    None => ()
   }
   @html.div(class="file-tree", children)
 }
 
 ///|
-fn view_folder_row(
+fn TreeRow::folder_view(
+  self : TreeRow,
   emit : @rabbita.Emit[FileTreeMsg],
-  row : TreeRow,
 ) -> @html.Html {
-  let node = row.node
+  let node = self.node
   let class_name = if node.resolve_failed {
     "workspace-item workspace-folder resolve-failed"
   } else {
@@ -236,9 +230,9 @@ fn view_folder_row(
       .data_set("workspace-id", node.uri.to_string())
       .data_set("workspace-kind", "folder")
       .aria_expanded(node.expanded.to_string())
-      .style("--depth", row.depth.to_string()),
+      .style("--depth", self.depth.to_string()),
     [
-      view_indent_guides(row.depth),
+      FileTree::indent_guides(self.depth),
       @html.span(class="workspace-twistie", icon_chevron_right()),
       @html.span(class="workspace-label", node.name),
     ],
@@ -246,12 +240,12 @@ fn view_folder_row(
 }
 
 ///|
-fn view_file_row(
+fn TreeRow::file_view(
+  self : TreeRow,
   emit : @rabbita.Emit[FileTreeMsg],
   model : FileTreeModel,
-  row : TreeRow,
 ) -> @html.Html {
-  let node = row.node
+  let node = self.node
   let selected = model.selected is Some(uri) && uri == node.uri
   let class_name = if selected {
     "workspace-item workspace-file is-selected"
@@ -267,9 +261,9 @@ fn view_file_row(
       .data_set("workspace-kind", "file")
       .data_set("selected", selected.to_string())
       .aria_selected(selected.to_string())
-      .style("--depth", row.depth.to_string()),
+      .style("--depth", self.depth.to_string()),
     [
-      view_indent_guides(row.depth),
+      FileTree::indent_guides(self.depth),
       @html.span(class="workspace-twistie workspace-twistie-spacer", ""),
       @html.span(class="workspace-file-icon", icon_file()),
       @html.span(class="workspace-label", node.name),
@@ -278,7 +272,7 @@ fn view_file_row(
 }
 
 ///|
-fn view_indent_guides(depth : Int) -> @html.Html {
+fn FileTree::indent_guides(depth : Int) -> @html.Html {
   let guides : Array[@html.Html] = []
   for _ in 0..<depth {
     guides.push(@html.span(class="indent-guide", ""))

--- a/editor/internal/shell/widgets/file_tree/file_tree.mbt
+++ b/editor/internal/shell/widgets/file_tree/file_tree.mbt
@@ -8,7 +8,7 @@
 /// never opens documents itself.
 pub struct FileTree {
   priv emit : @rabbita.Emit[FileTreeMsg]
-  priv cell : @rabbita.Cell
+  priv view_value : @rabbita.Val[@html.Html]
 }
 
 ///|
@@ -18,6 +18,17 @@ priv enum FileTreeMsg {
   ToggleDirectory(@base_common.Uri)
   OpenFile(@base_common.Uri)
   SetActive(@base_common.Uri)
+}
+
+///|
+/// File-tree updates mutate cached nodes in place. Treating every returned
+/// wrapper as changed preserves the widget's existing redraw behavior while it
+/// moves from the removed nested `Cell::view()` API to incremental values.
+priv struct FileTreeState(FileTreeModel)
+
+///|
+impl Eq for FileTreeState with fn equal(_, _) {
+  false
 }
 
 ///|
@@ -32,20 +43,22 @@ pub fn FileTree::FileTree(
     selected: None,
     pending_reveal: None,
   }
-  let (emit, cell) = @rabbita.cell_with_emit(
-    model~,
-    update=(emit, msg, model) => {
-      update_file_tree(provider, on_open, emit, msg, model)
-    },
-    view=view_file_tree,
-  )
-  { emit, cell }
+  let (state, emit) = @rabbita.create_state(FileTreeState(model), update=(
+    emit,
+    msg,
+    state,
+  ) => {
+    let (cmd, model) = update_file_tree(provider, on_open, emit, msg, state.0)
+    (FileTreeState(model), cmd)
+  })
+  let view_value = state.view(state => view_file_tree(emit, state.0))
+  { emit, view_value }
 }
 
 ///|
-/// Embeds the tree as a Rabbita child cell.
-pub fn FileTree::view(self : FileTree) -> @html.Html {
-  self.cell.view()
+/// Returns the tree's incremental view for composition by the host component.
+pub fn FileTree::view(self : FileTree) -> @rabbita.Val[@html.Html] {
+  self.view_value
 }
 
 ///|

--- a/editor/internal/shell/widgets/file_tree/moon.pkg
+++ b/editor/internal/shell/widgets/file_tree/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/immut/vector" @vec,
   "moonbitlang/editor/base/common" @base_common,
   "moonbitlang/editor/internal/shell/workspace",
   "moonbit-community/rabbita",

--- a/editor/internal/shell/widgets/file_tree/pkg.generated.mbti
+++ b/editor/internal/shell/widgets/file_tree/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/editor/internal/shell/widgets/file_tree"
 
 import {
+  "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
   "moonbitlang/editor/base/common",
@@ -19,7 +20,7 @@ pub struct FileTree {
 pub fn FileTree::FileTree(&@workspace.WorkspaceTreeProvider, on_open~ : (@common.Uri) -> Unit) -> Self
 pub fn FileTree::refresh(Self) -> @cmd.Cmd
 pub fn FileTree::set_active(Self, @common.Uri) -> @cmd.Cmd
-pub fn FileTree::view(Self) -> @html.Html
+pub fn FileTree::view(Self) -> @rabbita.Val[@html.Html]
 
 // Type aliases
 

--- a/editor/internal/shell/widgets/file_tree/tree_state.mbt
+++ b/editor/internal/shell/widgets/file_tree/tree_state.mbt
@@ -2,22 +2,23 @@
 /// One tree node, the `ExplorerItem` role: a cached `WorkspaceStat` plus
 /// per-node expansion state. `children: None` means the directory level
 /// has not been resolved yet; a resolve result is cached on the node and
-/// survives collapse/expand cycles.
+/// survives collapse/expand cycles. Nodes and their child vectors are immutable:
+/// every change rebuilds the path from the root, preserving prior snapshots.
 priv struct TreeNode {
   uri : @base_common.Uri
   name : String
   kind : @workspace.WorkspaceEntryKind
-  mut children : Array[TreeNode]?
-  mut expanded : Bool
-  mut resolve_failed : Bool
-}
+  children : @vec.Vector[TreeNode]?
+  expanded : Bool
+  resolve_failed : Bool
+} derive(Eq)
 
 ///|
 priv struct FileTreeModel {
-  mut root : TreeNode?
-  mut selected : @base_common.Uri?
-  mut pending_reveal : @base_common.Uri?
-}
+  root : TreeNode?
+  selected : @base_common.Uri?
+  pending_reveal : @base_common.Uri?
+} derive(Eq)
 
 ///|
 priv struct TreeRow {
@@ -42,7 +43,7 @@ priv enum RevealStep {
 /// Builds a node from a resolved stat. Children render directories first,
 /// then files, keeping the provider's name order within each group (the
 /// explorer's default sort).
-fn node_from_stat(
+fn TreeNode::from_stat(
   stat : @workspace.WorkspaceStat,
   expanded~ : Bool,
 ) -> TreeNode {
@@ -50,85 +51,117 @@ fn node_from_stat(
     uri: stat.uri,
     name: stat.name,
     kind: stat.kind,
-    children: stat.children.map(children_from_stats),
+    children: stat.children.map(stats => TreeNode::from_stats(stats)),
     expanded,
     resolve_failed: false,
   }
 }
 
 ///|
-fn children_from_stats(
+fn TreeNode::from_stats(
   stats : Array[@workspace.WorkspaceStat],
-) -> Array[TreeNode] {
+) -> @vec.Vector[TreeNode] {
   let nodes : Array[TreeNode] = []
   for stat in stats {
     if stat.kind == Directory {
-      nodes.push(node_from_stat(stat, expanded=false))
+      nodes.push(TreeNode::from_stat(stat, expanded=false))
     }
   }
   for stat in stats {
     if stat.kind == File {
-      nodes.push(node_from_stat(stat, expanded=false))
+      nodes.push(TreeNode::from_stat(stat, expanded=false))
     }
   }
-  nodes
+  @vec.Vector(nodes)
 }
 
 ///|
-fn find_node(node : TreeNode, uri : @base_common.Uri) -> TreeNode? {
-  if node.uri == uri {
-    return Some(node)
+/// Replaces one resolved level and rebuilds the ancestors leading to it.
+fn TreeNode::with_resolved(
+  self : TreeNode,
+  uri : @base_common.Uri,
+  stat : @workspace.WorkspaceStat,
+) -> TreeNode? {
+  if self.uri == uri {
+    return Some({
+      ..self,
+      children: stat.children.map(stats => TreeNode::from_stats(stats)),
+      resolve_failed: false,
+    })
   }
-  match node.children {
-    Some(children) =>
-      for child in children {
-        match find_node(child, uri) {
-          Some(found) => return Some(found)
-          None => ()
-        }
-      }
-    None => ()
+  guard self.children is Some(children) else { return None }
+  let mut index = 0
+  for child in children {
+    if child.with_resolved(uri, stat) is Some(next) {
+      return Some({ ..self, children: Some(children.set(index, next)) })
+    }
+    index = index + 1
   }
   None
 }
 
 ///|
-/// Caches a freshly resolved level on the node. A re-resolve replaces the
-/// cached children wholesale.
-fn apply_resolved(node : TreeNode, stat : @workspace.WorkspaceStat) -> Unit {
-  node.children = stat.children.map(children_from_stats)
-  node.resolve_failed = false
-}
-
-///|
 /// Collapses an expanded directory, or expands a collapsed one. Expanding
 /// a directory whose children are unresolved (including one whose last
-/// resolve failed) asks for a resolve; cached children expand for free.
-fn toggle_node(node : TreeNode) -> ToggleEffect {
-  if node.expanded {
-    node.expanded = false
-    ToggleNone
-  } else {
-    node.expanded = true
-    match node.children {
-      Some(_) => ToggleNone
-      None => {
-        node.resolve_failed = false
-        ToggleResolve(node.uri)
-      }
+/// resolve failed) asks for a resolve; cached children expand for free. The
+/// returned root shares unchanged branches but never mutates `self`.
+fn TreeNode::toggle(
+  self : TreeNode,
+  uri : @base_common.Uri,
+) -> (TreeNode, ToggleEffect)? {
+  if self.uri == uri {
+    if self.expanded {
+      return Some(({ ..self, expanded: false }, ToggleNone))
     }
+    let next = { ..self, expanded: true, resolve_failed: false }
+    let effect = match self.children {
+      Some(_) => ToggleNone
+      None => ToggleResolve(self.uri)
+    }
+    return Some((next, effect))
   }
+  guard self.children is Some(children) else { return None }
+  let mut index = 0
+  for child in children {
+    if child.toggle(uri) is Some((next, effect)) {
+      return Some(
+        ({ ..self, children: Some(children.set(index, next)) }, effect),
+      )
+    }
+    index = index + 1
+  }
+  None
 }
 
 ///|
-/// The directory URIs between the root (exclusive) and `target`
+/// Records a resolve failure on one node without changing an older root.
+fn TreeNode::with_resolve_failed(
+  self : TreeNode,
+  uri : @base_common.Uri,
+) -> TreeNode? {
+  if self.uri == uri {
+    return Some({ ..self, resolve_failed: true })
+  }
+  guard self.children is Some(children) else { return None }
+  let mut index = 0
+  for child in children {
+    if child.with_resolve_failed(uri) is Some(next) {
+      return Some({ ..self, children: Some(children.set(index, next)) })
+    }
+    index = index + 1
+  }
+  None
+}
+
+///|
+/// The directory URIs between this root (exclusive) and `target`
 /// (exclusive), derived from the root-relative path segments. `None` when
 /// the target does not live under the root.
-fn ancestor_uris(
-  root_uri : @base_common.Uri,
+fn TreeNode::ancestor_uris(
+  self : TreeNode,
   target : @base_common.Uri,
 ) -> Array[@base_common.Uri]? {
-  let root_raw = root_uri.to_string()
+  let root_raw = self.uri.to_string()
   let target_raw = target.to_string()
   if !target_raw.has_prefix(root_raw + "/") {
     return None
@@ -153,53 +186,58 @@ fn ancestor_uris(
 }
 
 ///|
-/// One `autoReveal` step: expands resolved ancestors of `target` from the
-/// root down, stopping at the first unresolved level (which must be
-/// resolved before the reveal can continue).
-fn reveal_step(
-  root : TreeNode,
-  root_uri : @base_common.Uri,
-  target : @base_common.Uri,
-) -> RevealStep {
-  guard ancestor_uris(root_uri, target) is Some(ancestors) else {
-    return RevealUnreachable
-  }
-  let mut node = root
-  for ancestor in ancestors {
-    guard node.children is Some(children) else {
-      return RevealResolve(node.uri)
+/// Expands the remaining resolved ancestor path and rebuilds every changed
+/// parent. The first unresolved node becomes the next resolve request.
+fn TreeNode::reveal_ancestors(
+  self : TreeNode,
+  ancestors : ArrayView[@base_common.Uri],
+  index : Int,
+) -> (TreeNode, RevealStep) {
+  if index == ancestors.length() {
+    return match self.children {
+      Some(_) => (self, RevealDone)
+      None => (self, RevealResolve(self.uri))
     }
-    let mut next : TreeNode? = None
-    for child in children {
-      if child.uri == ancestor {
-        next = Some(child)
-        break
-      }
+  }
+  guard self.children is Some(children) else {
+    return (self, RevealResolve(self.uri))
+  }
+  let mut child_index = 0
+  for child in children {
+    if child.uri == ancestors[index] {
+      let expanded = { ..child, expanded: true }
+      let (next, step) = expanded.reveal_ancestors(ancestors, index + 1)
+      return ({ ..self, children: Some(children.set(child_index, next)) }, step)
     }
-    guard next is Some(found) else { return RevealUnreachable }
-    found.expanded = true
-    node = found
+    child_index = child_index + 1
   }
-  if node.children is None {
-    return RevealResolve(node.uri)
-  }
-  RevealDone
+  (self, RevealUnreachable)
 }
 
 ///|
-/// The rows the tree renders: the root's children at depth zero, then the
+/// One `autoReveal` step: expands resolved ancestors of `target` from the
+/// root down, stopping at the first unresolved level. The returned root is a
+/// new snapshot whenever expansion state changes.
+fn TreeNode::reveal_step(
+  self : TreeNode,
+  target : @base_common.Uri,
+) -> (TreeNode, RevealStep) {
+  guard self.ancestor_uris(target) is Some(ancestors) else {
+    return (self, RevealUnreachable)
+  }
+  self.reveal_ancestors(ancestors[:], 0)
+}
+
+///|
+/// The rows the tree renders: this root's children at depth zero, then the
 /// cached children of every expanded directory. Collapsed or unresolved
 /// directories contribute only their own row.
-fn visible_rows(root : TreeNode?) -> Array[TreeRow] {
+fn TreeNode::visible_rows(self : TreeNode) -> Array[TreeRow] {
   let rows : Array[TreeRow] = []
-  match root {
-    Some(root) =>
-      match root.children {
-        Some(children) =>
-          for child in children {
-            push_rows(rows, child, 0)
-          }
-        None => ()
+  match self.children {
+    Some(children) =>
+      for child in children {
+        child.push_rows(rows, 0)
       }
     None => ()
   }
@@ -207,13 +245,17 @@ fn visible_rows(root : TreeNode?) -> Array[TreeRow] {
 }
 
 ///|
-fn push_rows(rows : Array[TreeRow], node : TreeNode, depth : Int) -> Unit {
-  rows.push({ node, depth })
-  if node.kind == Directory && node.expanded {
-    match node.children {
+fn TreeNode::push_rows(
+  self : TreeNode,
+  rows : Array[TreeRow],
+  depth : Int,
+) -> Unit {
+  rows.push({ node: self, depth })
+  if self.kind == Directory && self.expanded {
+    match self.children {
       Some(children) =>
         for child in children {
-          push_rows(rows, child, depth + 1)
+          child.push_rows(rows, depth + 1)
         }
       None => ()
     }

--- a/editor/internal/shell/widgets/file_tree/tree_state_wbtest.mbt
+++ b/editor/internal/shell/widgets/file_tree/tree_state_wbtest.mbt
@@ -17,8 +17,26 @@ fn file_stat(raw : String, name : String) -> @workspace.WorkspaceStat {
 let root_raw : String = "readonly-remote://workspace"
 
 ///|
+fn TreeNode::find(self : TreeNode, uri : @base_common.Uri) -> TreeNode? {
+  if self.uri == uri {
+    return Some(self)
+  }
+  match self.children {
+    Some(children) =>
+      for child in children {
+        match child.find(uri) {
+          Some(found) => return Some(found)
+          None => ()
+        }
+      }
+    None => ()
+  }
+  None
+}
+
+///|
 fn resolved_root() -> TreeNode {
-  node_from_stat(
+  TreeNode::from_stat(
     {
       uri: uri(root_raw),
       name: "workspace",
@@ -35,7 +53,7 @@ fn resolved_root() -> TreeNode {
 ///|
 test "orders resolved children directories first" {
   let root = resolved_root()
-  let rows = visible_rows(Some(root))
+  let rows = root.visible_rows()
   assert_eq(rows.length(), 2)
   assert_eq(rows[0].node.name, "src")
   assert_true(rows[0].node.kind == Directory)
@@ -45,34 +63,41 @@ test "orders resolved children directories first" {
 
 ///|
 test "directories start collapsed and expansion resolves once" {
-  let root = resolved_root()
-  let src = find_node(root, uri(root_raw + "/src")).unwrap()
-  assert_false(src.expanded)
+  let original = resolved_root()
+  let src_uri = uri(root_raw + "/src")
+  assert_false(original.find(src_uri).unwrap().expanded)
 
   // First expand: unresolved children ask for a provider resolve.
-  match toggle_node(src) {
+  let (expanded, effect) = original.toggle(src_uri).unwrap()
+  match effect {
     ToggleResolve(resolve_uri) =>
       assert_eq(resolve_uri.to_string(), root_raw + "/src")
     ToggleNone => fail("expected resolve effect")
   }
-  assert_true(src.expanded)
-  apply_resolved(src, {
-    uri: src.uri,
-    name: "src",
-    kind: Directory,
-    children: Some([file_stat(root_raw + "/src/main.mbt", "main.mbt")]),
-  })
+  // The original snapshot remains collapsed after producing the new root.
+  assert_false(original.find(src_uri).unwrap().expanded)
+  assert_true(expanded.find(src_uri).unwrap().expanded)
+  let resolved = expanded
+    .with_resolved(src_uri, {
+      uri: src_uri,
+      name: "src",
+      kind: Directory,
+      children: Some([file_stat(root_raw + "/src/main.mbt", "main.mbt")]),
+    })
+    .unwrap()
 
   // Collapse keeps the cache; the next expand is free.
-  match toggle_node(src) {
-    ToggleNone => assert_false(src.expanded)
+  let (collapsed, effect) = resolved.toggle(src_uri).unwrap()
+  match effect {
+    ToggleNone => assert_false(collapsed.find(src_uri).unwrap().expanded)
     ToggleResolve(_) => fail("collapse must not resolve")
   }
-  match toggle_node(src) {
-    ToggleNone => assert_true(src.expanded)
+  let (reexpanded, effect) = collapsed.toggle(src_uri).unwrap()
+  match effect {
+    ToggleNone => assert_true(reexpanded.find(src_uri).unwrap().expanded)
     ToggleResolve(_) => fail("cached children must not re-resolve")
   }
-  let rows = visible_rows(Some(root))
+  let rows = reexpanded.visible_rows()
   assert_eq(rows.length(), 3)
   assert_eq(rows[1].node.name, "main.mbt")
   assert_eq(rows[1].depth, 1)
@@ -80,59 +105,72 @@ test "directories start collapsed and expansion resolves once" {
 
 ///|
 test "failed resolve is retried on the next expand" {
-  let root = resolved_root()
-  let src = find_node(root, uri(root_raw + "/src")).unwrap()
-  ignore(toggle_node(src))
-  src.resolve_failed = true
+  let original = resolved_root()
+  let src_uri = uri(root_raw + "/src")
+  let (expanded, _) = original.toggle(src_uri).unwrap()
+  let failed = expanded.with_resolve_failed(src_uri).unwrap()
+  assert_false(original.find(src_uri).unwrap().resolve_failed)
+  assert_true(failed.find(src_uri).unwrap().resolve_failed)
 
   // Collapse, then expand again: children are still None, so the expand
   // retries the resolve and clears the error state.
-  ignore(toggle_node(src))
-  match toggle_node(src) {
-    ToggleResolve(_) => assert_false(src.resolve_failed)
+  let (collapsed, _) = failed.toggle(src_uri).unwrap()
+  let (retried, effect) = collapsed.toggle(src_uri).unwrap()
+  match effect {
+    ToggleResolve(_) =>
+      assert_false(retried.find(src_uri).unwrap().resolve_failed)
     ToggleNone => fail("expected resolve retry after failure")
   }
 }
 
 ///|
 test "reveal expands resolved ancestors and stops at unresolved levels" {
-  let root = resolved_root()
+  let original = resolved_root()
   let target = uri(root_raw + "/src/lib/util.mbt")
+  let src_uri = uri(root_raw + "/src")
+  let lib_uri = uri(root_raw + "/src/lib")
 
   // src is unresolved: the reveal must resolve it first.
-  match reveal_step(root, uri(root_raw), target) {
+  let (src_expanded, step) = original.reveal_step(target)
+  match step {
     RevealResolve(resolve_uri) =>
       assert_eq(resolve_uri.to_string(), root_raw + "/src")
     _ => fail("expected resolve step for src")
   }
-  let src = find_node(root, uri(root_raw + "/src")).unwrap()
-  assert_true(src.expanded)
-  apply_resolved(src, {
-    uri: src.uri,
-    name: "src",
-    kind: Directory,
-    children: Some([dir_stat(root_raw + "/src/lib", "lib")]),
-  })
+  assert_false(original.find(src_uri).unwrap().expanded)
+  assert_true(src_expanded.find(src_uri).unwrap().expanded)
+  let src_resolved = src_expanded
+    .with_resolved(src_uri, {
+      uri: src_uri,
+      name: "src",
+      kind: Directory,
+      children: Some([dir_stat(root_raw + "/src/lib", "lib")]),
+    })
+    .unwrap()
 
   // lib is now reachable but unresolved.
-  match reveal_step(root, uri(root_raw), target) {
+  let (lib_expanded, step) = src_resolved.reveal_step(target)
+  match step {
     RevealResolve(resolve_uri) =>
       assert_eq(resolve_uri.to_string(), root_raw + "/src/lib")
     _ => fail("expected resolve step for src/lib")
   }
-  let lib = find_node(root, uri(root_raw + "/src/lib")).unwrap()
-  assert_true(lib.expanded)
-  apply_resolved(lib, {
-    uri: lib.uri,
-    name: "lib",
-    kind: Directory,
-    children: Some([file_stat(root_raw + "/src/lib/util.mbt", "util.mbt")]),
-  })
-  match reveal_step(root, uri(root_raw), target) {
+  assert_false(src_resolved.find(lib_uri).unwrap().expanded)
+  assert_true(lib_expanded.find(lib_uri).unwrap().expanded)
+  let lib_resolved = lib_expanded
+    .with_resolved(lib_uri, {
+      uri: lib_uri,
+      name: "lib",
+      kind: Directory,
+      children: Some([file_stat(root_raw + "/src/lib/util.mbt", "util.mbt")]),
+    })
+    .unwrap()
+  let (revealed, step) = lib_resolved.reveal_step(target)
+  match step {
     RevealDone => ()
     _ => fail("expected completed reveal")
   }
-  let rows = visible_rows(Some(root))
+  let rows = revealed.visible_rows()
   assert_eq(rows.length(), 4)
   assert_eq(rows[2].node.name, "util.mbt")
   assert_eq(rows[2].depth, 2)
@@ -141,14 +179,18 @@ test "reveal expands resolved ancestors and stops at unresolved levels" {
 ///|
 test "reveal of targets outside the tree is unreachable" {
   let root = resolved_root()
-  match reveal_step(root, uri(root_raw), uri("memory://other/file.mbt")) {
+  let (outside, step) = root.reveal_step(uri("memory://other/file.mbt"))
+  match step {
     RevealUnreachable => ()
     _ => fail("expected unreachable target outside the root")
   }
-  match reveal_step(root, uri(root_raw), uri(root_raw + "/gone/file.mbt")) {
+  assert_true(outside == root)
+  let (missing, step) = root.reveal_step(uri(root_raw + "/gone/file.mbt"))
+  match step {
     RevealUnreachable => ()
     _ => fail("expected unreachable target in a missing directory")
   }
+  assert_true(missing == root)
 }
 
 ///|
@@ -205,19 +247,22 @@ async test "in-memory provider resolves one level per request" {
   }
   match provider.resolve(provider.root()) {
     WorkspaceResolved(stat) => {
-      let root = node_from_stat(stat, expanded=true)
-      let src = find_node(root, uri(root_raw + "/src")).unwrap()
+      let root = TreeNode::from_stat(stat, expanded=true)
+      let src_uri = uri(root_raw + "/src")
+      let src = root.find(src_uri).unwrap()
       // The resolved level carries unresolved directory children.
       assert_true(src.children is None)
-      match toggle_node(src) {
+      let (expanded, effect) = root.toggle(src_uri).unwrap()
+      let resolved = match effect {
         ToggleResolve(resolve_uri) =>
           match provider.resolve(resolve_uri) {
-            WorkspaceResolved(stat) => apply_resolved(src, stat)
+            WorkspaceResolved(stat) =>
+              expanded.with_resolved(src_uri, stat).unwrap()
             WorkspaceResolveError(error) => fail(error.message)
           }
         ToggleNone => fail("expected resolve effect")
       }
-      let rows = visible_rows(Some(root))
+      let rows = resolved.visible_rows()
       assert_eq(rows.length(), 3)
       assert_eq(rows[1].node.name, "main.mbt")
     }

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -8,7 +8,7 @@ priv struct WorkbenchDocumentView {
   display_name : String
   language_id : String
   revision : String
-}
+} derive(Eq)
 
 ///|
 priv struct WorkbenchModel {
@@ -21,19 +21,7 @@ priv struct WorkbenchModel {
   /// Mirrors whether the viewer holds a rendered frame; while it does not,
   /// the shell renders its own status placeholder instead of the viewer.
   viewer_has_frame : Bool
-}
-
-///|
-/// The workbench's host objects live outside this model, and marker queries
-/// return fresh diagnostic arrays. `Diagnostic` does not expose `Eq` yet, so
-/// preserve the shell's former whole-view refresh until its model can derive
-/// structural equality.
-priv struct WorkbenchState(WorkbenchModel)
-
-///|
-impl Eq for WorkbenchState with fn equal(_, _) {
-  false
-}
+} derive(Eq)
 
 ///|
 /// The shell's scroll policy for an incoming document read: a reload of the
@@ -239,10 +227,10 @@ pub fn mount_app() -> Unit {
   let app = @rabbita.new(() => {
     let tree_view = workspace_file_tree().view()
     let (state, emit) = @rabbita.create_state(
-      WorkbenchState(initial_workbench_model()),
+      initial_workbench_model(),
       update=(emit, msg, state) => {
-        let (cmd, model) = update_workbench(emit, msg, state.0)
-        (WorkbenchState(model), cmd)
+        let (cmd, model) = update_workbench(emit, msg, state)
+        (model, cmd)
       },
       subscriptions=(emit, _state) => {
         @sub.batch([
@@ -268,7 +256,7 @@ pub fn mount_app() -> Unit {
       },
     )
     state.view2(tree_view, (state, tree_html) => {
-      view_workbench(emit, state.0, tree_html)
+      view_workbench(emit, state, tree_html)
     })
   })
   app.mount("app")

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -24,9 +24,10 @@ priv struct WorkbenchModel {
 }
 
 ///|
-/// The workbench model contains mutable arrays and host-facing values. Rabbita
-/// must therefore propagate every accepted update, matching the shell's former
-/// cell behavior instead of suppressing a render through structural equality.
+/// The workbench's host objects live outside this model, and marker queries
+/// return fresh diagnostic arrays. `Diagnostic` does not expose `Eq` yet, so
+/// preserve the shell's former whole-view refresh until its model can derive
+/// structural equality.
 priv struct WorkbenchState(WorkbenchModel)
 
 ///|

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -24,6 +24,17 @@ priv struct WorkbenchModel {
 }
 
 ///|
+/// The workbench model contains mutable arrays and host-facing values. Rabbita
+/// must therefore propagate every accepted update, matching the shell's former
+/// cell behavior instead of suppressing a render through structural equality.
+priv struct WorkbenchState(WorkbenchModel)
+
+///|
+impl Eq for WorkbenchState with fn equal(_, _) {
+  false
+}
+
+///|
 /// The shell's scroll policy for an incoming document read: a reload of the
 /// open document keeps the viewport (`save_view_state`/`restore_view_state`
 /// around `set_model`, the Monaco host pattern), a newly opened document
@@ -224,34 +235,41 @@ fn install_language_tokenizers(services : WorkbenchServices) -> Unit {
 /// Mounts the Rabbita workbench shell and attaches the viewer view after the
 /// first shell paint.
 pub fn mount_app() -> Unit {
-  let (_, cell) = @rabbita.cell_with_emit(
-    model=initial_workbench_model(),
-    update=update_workbench,
-    view=view_workbench,
-    subscriptions=(emit, _model) => {
-      @sub.batch([
-        startup_sub(
-          @cmd.custom_cmd(scheduler => {
-            workbench_dispatch.val = Some(msg => scheduler.add(emit(msg)))
-            protocol_send.val = Some(packet => {
-              scheduler.add(send_client_packet_cmd(emit, packet))
-            })
-            scheduler.add(emit(ConnectProtocol))
-            // The viewer view mounts into the stable host element after the
-            // shell's first paint; the shell never renders children into it.
-            scheduler.add(
-              @cmd.custom_cmd(
-                _ => attach_workbench_viewer(),
-                kind=@cmd.after_render,
-              ),
-            )
-          }),
-        ),
-        @sub.on_resize(emit.map(_ => WindowResized)),
-      ])
-    },
-  )
-  let app = @rabbita.new(cell)
+  let app = @rabbita.new(() => {
+    let tree_view = workspace_file_tree().view()
+    let (state, emit) = @rabbita.create_state(
+      WorkbenchState(initial_workbench_model()),
+      update=(emit, msg, state) => {
+        let (cmd, model) = update_workbench(emit, msg, state.0)
+        (WorkbenchState(model), cmd)
+      },
+      subscriptions=(emit, _state) => {
+        @sub.batch([
+          startup_sub(
+            @cmd.custom_cmd(scheduler => {
+              workbench_dispatch.val = Some(msg => scheduler.add(emit(msg)))
+              protocol_send.val = Some(packet => {
+                scheduler.add(send_client_packet_cmd(emit, packet))
+              })
+              scheduler.add(emit(ConnectProtocol))
+              // The viewer view mounts into the stable host element after the
+              // shell's first paint; the shell never renders children into it.
+              scheduler.add(
+                @cmd.custom_cmd(
+                  _ => attach_workbench_viewer(),
+                  kind=@cmd.after_render,
+                ),
+              )
+            }),
+          ),
+          @sub.on_resize(emit.map(_ => WindowResized)),
+        ])
+      },
+    )
+    state.view2(tree_view, (state, tree_html) => {
+      view_workbench(emit, state.0, tree_html)
+    })
+  })
   app.mount("app")
 }
 
@@ -703,11 +721,12 @@ fn text_model_harness_json(model : @model.TextModel) -> String {
 fn view_workbench(
   emit : @rabbita.Emit[WorkbenchMsg],
   model : WorkbenchModel,
+  tree_html : @html.Html,
 ) -> @html.Html {
   @html.main_(class="editor-shell", attrs=shell_attrs(model), [
     view_topbar(model),
     @html.div(class="editor-main", [
-      view_sidebar(emit, model),
+      view_sidebar(emit, model, tree_html),
       // The stable viewer host: the viewer attaches its imperative DOM
       // into this element after mount, and the shell must never render
       // vdom children into it (Rabbita's diff would not know them).
@@ -746,10 +765,11 @@ fn view_topbar(model : WorkbenchModel) -> @html.Html {
 
 ///|
 /// Sidebar chrome (Explorer title, theme toggle) stays in the shell; the
-/// tree itself is the embedded explorer widget cell.
+/// tree itself is the embedded explorer widget value.
 fn view_sidebar(
   emit : @rabbita.Emit[WorkbenchMsg],
   _model : WorkbenchModel,
+  tree_html : @html.Html,
 ) -> @html.Html {
   @html.aside(
     class="workspace-sidebar",
@@ -768,7 +788,7 @@ fn view_sidebar(
           icon_color_mode(),
         ),
       ]),
-      workspace_file_tree().view(),
+      tree_html,
     ],
   )
 }

--- a/editor/internal/viewer/browser/controller/mouse_target.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_target.mbt
@@ -484,7 +484,7 @@ fn find_attribute_up_to(
       current is Some(el) && !controller_is_document_body(el)
       current = controller_parent_element(el) {
     if element_has_attribute(el, attr) {
-      return Some(el.get_attribute(attr))
+      return el.get_attribute(attr)
     }
     if el.is_same_node(stop_at.as_node()) {
       return None

--- a/editor/internal/viewer/browser/controller/scrollbar_input_wbtest.mbt
+++ b/editor/internal/viewer/browser/controller/scrollbar_input_wbtest.mbt
@@ -292,7 +292,7 @@ test "AbstractScrollbar gesture owns listeners, drag state, and reset branches" 
     0,
   )
   assert_true(handler.drag is None)
-  assert_eq(slider.get_attribute("class"), "slider")
+  assert_eq(slider.get_attribute("class"), Some("slider"))
   assert_eq(
     scrollbar_input_test_dispatch_mouse(slider, "click", 2, 0, 1, 10, 10),
     0,
@@ -320,7 +320,7 @@ test "AbstractScrollbar gesture owns listeners, drag state, and reset branches" 
   )
   assert_true(handler.drag is Some(_))
   assert_true(hover_scrollable.is_dragging)
-  assert_eq(slider.get_attribute("class"), "slider active")
+  assert_eq(slider.get_attribute("class"), Some("slider active"))
   assert_eq(scrollbar_input_test_trace(), "active,monitor,drag-start")
   let expected_from_pointerdown = match handler.drag {
     Some(drag) => drag.initial_state.desired_position_from_delta(20.0)
@@ -354,7 +354,7 @@ test "AbstractScrollbar gesture owns listeners, drag state, and reset branches" 
   |> ignore
   assert_true(handler.drag is None)
   assert_false(hover_scrollable.is_dragging)
-  assert_eq(slider.get_attribute("class"), "slider")
+  assert_eq(slider.get_attribute("class"), Some("slider"))
   assert_eq(scrollbar_input_test_listener_count(slider, "pointermove"), 0)
   // A second pointerup has no retained stop callback or state transition.
   scrollbar_input_test_dispatch_mouse(slider, "pointerup", 0, 0, 3, 10, 30)
@@ -412,7 +412,7 @@ test "AbstractScrollbar gesture owns listeners, drag state, and reset branches" 
   handler.dispose()
   assert_true(handler.drag is None)
   assert_false(hover_scrollable.is_dragging)
-  assert_eq(slider.get_attribute("class"), "slider")
+  assert_eq(slider.get_attribute("class"), Some("slider"))
   assert_eq(scrollbar_input_test_listener_count(slider, "pointerdown"), 0)
   assert_eq(
     scrollbar_input_test_dispatch_mouse(

--- a/editor/internal/viewer/browser/controller/touch_scroll_gesture_reference_wbtest.mbt
+++ b/editor/internal/viewer/browser/controller/touch_scroll_gesture_reference_wbtest.mbt
@@ -297,7 +297,11 @@ test "touch DOM listeners consume boundary moves, reveal, and dispose" {
   assert_eq(layout.position().scroll_left, 20.0)
   assert_eq(layout.position().scroll_top, 80.0)
   assert_true(
-    editor_scrollable.track(true).get_attribute("class").contains("visible"),
+    editor_scrollable
+    .track(true)
+    .get_attribute("class")
+    .unwrap_or("")
+    .contains("visible"),
   )
   dispatch_scrollbar_input_touch(lines_content, "touchcancel", 1, 30.0, 0.0)
   |> ignore

--- a/editor/internal/viewer/browser/view/view_lifecycle_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/view_lifecycle_wbtest.mbt
@@ -121,11 +121,17 @@ test "View mounts both ViewZones containers at the source relative positions" {
       view.view_lines.get_dom_node(),
     ),
   )
-  assert_eq(view.view_zones.dom_node().get_attribute("role"), "presentation")
-  assert_eq(view.view_zones.dom_node().get_attribute("aria-hidden"), "true")
+  assert_eq(
+    view.view_zones.dom_node().get_attribute("role"),
+    Some("presentation"),
+  )
+  assert_eq(
+    view.view_zones.dom_node().get_attribute("aria-hidden"),
+    Some("true"),
+  )
   assert_eq(
     view.view_zones.margin_dom_node().get_attribute("class"),
-    "margin-view-zones",
+    Some("margin-view-zones"),
   )
   restore_view_lifecycle_test_browser()
 }

--- a/editor/internal/viewer/browser/view/view_overlays.mbt
+++ b/editor/internal/viewer/browser/view/view_overlays.mbt
@@ -257,7 +257,7 @@ fn ViewOverlays::render_focused_class(
   } else {
     base_class_name
   }
-  if element.get_attribute("class") != class_name {
+  if element.get_attribute("class") != Some(class_name) {
     element.set_attribute("class", class_name)
   }
 }
@@ -374,7 +374,7 @@ fn ContentViewOverlays::set_focused(
   } else {
     "view-overlays"
   }
-  if element.get_attribute("class") != class_name {
+  if element.get_attribute("class") != Some(class_name) {
     element.set_attribute("class", class_name)
   }
 }

--- a/editor/internal/viewer/browser/view/view_overlays_lifecycle.mbt
+++ b/editor/internal/viewer/browser/view/view_overlays_lifecycle.mbt
@@ -77,7 +77,7 @@ fn margin_view_overlays_render(
   // translation (the viewer's `margin_transform`).
   self.overlays.render_lines(context.viewport)
   let margin_style = "width:" + self.content_left.to_string() + "px"
-  if self.dom_node.get_attribute("style") != margin_style {
+  if self.dom_node.get_attribute("style") != Some(margin_style) {
     self.dom_node.set_attribute("style", margin_style)
   }
   self.render_focused()
@@ -93,7 +93,7 @@ fn margin_view_overlays_render(
     "px;height:" +
     height.to_string() +
     "px"
-  if overlays.get_attribute("style") != overlays_style {
+  if overlays.get_attribute("style") != Some(overlays_style) {
     overlays.set_attribute("style", overlays_style)
   }
 }

--- a/editor/internal/viewer/browser/view/view_zones_branch_matrix_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/view_zones_branch_matrix_wbtest.mbt
@@ -407,7 +407,7 @@ test "ViewZones hidden-area omitted false and true toggle exact heights" {
   let hidden_zero_visible = zero_fixture.view_model.view_layout.get_whitespace_viewport_data()
   zero_fixture.view.view_zones.render(hidden_zero_visible, 0, 0.0, 300.0)
   assert_eq(view_zones_branch_style(zero_node, "display"), "block")
-  assert_eq(zero_node.get_attribute("monaco-visible-view-zone"), "true")
+  assert_eq(zero_node.get_attribute("monaco-visible-view-zone"), Some("true"))
 
   assert_true(
     zero_fixture.view_model.set_hidden_areas(
@@ -422,7 +422,7 @@ test "ViewZones hidden-area omitted false and true toggle exact heights" {
   let shown_zero_visible = zero_fixture.view_model.view_layout.get_whitespace_viewport_data()
   zero_fixture.view.view_zones.render(shown_zero_visible, 0, 0.0, 300.0)
   assert_eq(view_zones_branch_style(zero_node, "display"), "block")
-  assert_eq(zero_node.get_attribute("monaco-visible-view-zone"), "true")
+  assert_eq(zero_node.get_attribute("monaco-visible-view-zone"), Some("true"))
   assert_eq(zero_callbacks.length(), 1)
   zero_fixture.dispose()
 }
@@ -756,8 +756,8 @@ test "ViewZones layoutZone rereads geometry but retains ordinal width and nodes"
       fixture.view.view_zones.margin_dom_node(),
     ),
   )
-  assert_eq(original_node.get_attribute("monaco-view-zone"), id)
-  assert_eq(replacement_node.get_attribute("monaco-view-zone"), "")
+  assert_eq(original_node.get_attribute("monaco-view-zone"), Some(id))
+  assert_eq(replacement_node.get_attribute("monaco-view-zone"), Some(""))
 }
 
 ///|

--- a/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_input_widget.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_input_widget.mbt
@@ -322,7 +322,7 @@ pub fn AgentFeedbackInputWidget::auto_size(
 ) -> Unit {
   let value = self.value()
   let text = if value.is_empty() {
-    self.textarea.get_attribute("placeholder")
+    self.textarea.get_attribute("placeholder").unwrap_or("")
   } else {
     value
   }

--- a/editor/internal/viewer/ui/scrollbar/scrollable_element_wbtest.mbt
+++ b/editor/internal/viewer/ui/scrollbar/scrollable_element_wbtest.mbt
@@ -182,7 +182,7 @@ test "500ms hide timeout is cancellable and inert after disposal" {
   assert_eq(scrollable_timeout_test_active_count(), 1)
   assert_eq(
     scrollable.vertical_bar.get_attribute("class"),
-    "visible scrollbar vertical",
+    Some("visible scrollbar vertical"),
   )
 
   // A replacement schedule cancels the old browser handle rather than only
@@ -229,7 +229,7 @@ test "500ms hide timeout is cancellable and inert after disposal" {
   assert_true(guarded.hide_timeout is None)
   assert_eq(
     guarded.vertical_bar.get_attribute("class"),
-    "invisible scrollbar vertical fade",
+    Some("invisible scrollbar vertical fade"),
   )
   guarded.dispose()
   restore_scrollable_timeout_test_browser()

--- a/editor/language/pkg.generated.mbti
+++ b/editor/language/pkg.generated.mbti
@@ -36,7 +36,7 @@ pub(all) struct Diagnostic {
   severity : DiagnosticSeverity
   message : String
   tags : Array[DiagnosticTag]?
-} derive(@debug.Debug)
+} derive(Eq, @debug.Debug)
 
 pub(all) enum DiagnosticSeverity {
   Error

--- a/editor/language/providers.mbt
+++ b/editor/language/providers.mbt
@@ -49,7 +49,7 @@ pub(all) struct Diagnostic {
   severity : DiagnosticSeverity
   message : String
   tags : Array[DiagnosticTag]?
-} derive(Debug)
+} derive(Eq, Debug)
 
 ///|
 /// Cross-document location result for definition and reference providers.

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -19,7 +19,7 @@ preferred_target = "js"
 import {
   "moonbit-community/cmark@0.4.4",
   "moonbitlang/async@0.20.1",
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.13.1",
   "moonbit-community/piediff@0.0.10",
   "Milky2018/diago@0.3.0",
 }

--- a/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
@@ -365,7 +365,7 @@ fn poll_render_invalidation_ready(
   )
   if line_count > 0 && validation_count > 0 {
     ctx.assert_true(
-      root.get_attribute("class").contains("readonly-editor"),
+      root.get_attribute("class").unwrap_or("").contains("readonly-editor"),
       "viewer root did not finish mounting",
     )
     ctx.metric_int("initialLines", line_count)

--- a/editor/tests/browser/moonbit/model_swap/model_swap_scenario.mbt
+++ b/editor/tests/browser/moonbit/model_swap/model_swap_scenario.mbt
@@ -270,7 +270,7 @@ fn run_model_swap_test() -> Unit {
                     ctx.assert_true(
                       @support.query_count(".swap-overlay-second") == 0 &&
                       second_overlay_node.get_attribute("widgetId") ==
-                      "swap-overlay",
+                      Some("swap-overlay"),
                       "Viewer disposal kept the overlay mounted or destroyed its node",
                     )
                     model_c.dispose()

--- a/editor/viewer/viewer_mount_wbtest.mbt
+++ b/editor/viewer/viewer_mount_wbtest.mbt
@@ -81,7 +81,10 @@ test "mount keeps one host and one placeholder pair across detach" {
     .with_theme("mount-test-theme")
     .with_placeholder("no model"),
   )
-  assert_eq(placeholder_root.get_attribute("data-theme"), "mount-test-theme")
+  assert_eq(
+    placeholder_root.get_attribute("data-theme"),
+    Some("mount-test-theme"),
+  )
   flush_mounted_test_frames()
   assert_false(mounted.has_pending_render())
   assert_eq(mounted_test_node_value(placeholder_text), "no model")
@@ -120,7 +123,10 @@ test "mount keeps one host and one placeholder pair across detach" {
     same_mounted_test_element(restored_pair.root, placeholder_root) &&
     same_mounted_test_element(restored_pair.text, placeholder_text),
   )
-  assert_eq(restored_pair.root.get_attribute("data-theme"), "mount-test-theme")
+  assert_eq(
+    restored_pair.root.get_attribute("data-theme"),
+    Some("mount-test-theme"),
+  )
   subscription.dispose()
 }
 

--- a/moon.mod
+++ b/moon.mod
@@ -10,7 +10,7 @@ import {
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
-  "moonbit-community/rabbita@0.12.4",
+  "moonbit-community/rabbita@0.13.1",
 }
 
 readme = "README.mbt.md"

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -56,7 +56,7 @@ fn events_jsonl(session : @agent_session.Session) -> String {
 ///|
 #warnings("-alert_unstable")
 fn render(html : @html.Html) -> String {
-  @rabbita.render_to_string(@rabbita.static_cell(html))
+  @rabbita.render_to_string(() => @rabbita.Val::constant(html))
 }
 
 ///|


### PR DESCRIPTION
## Stack

- depends on #599, which moves Desktop from the registry editor to the repository's `moonbitlang/editor` workspace member

## Summary

- upgrade every direct `moonbit-community/rabbita` dependency from 0.12.4 to 0.13.1
- migrate the desktop, visualizer, editor shell, and tests to Rabbita 0.13 state/value and optional DOM attribute APIs
- make the editor file-tree model immutable so Rabbita can compare state snapshots safely
- give Desktop, Viz, and Workbench real structural model equality instead of always-invalidating `Eq` wrappers
- refresh affected generated interfaces

## Validation

- `moon fmt --check`
- `moon check --target js --deny-warn --diagnostic-limit 100`
- `moon check --target native --deny-warn --diagnostic-limit 100`
- `moon -C desktop check --target js --deny-warn --diagnostic-limit 100`
- `moon -C desktop check --target native --deny-warn --diagnostic-limit 100`
- `moon -C editor check --target js --deny-warn --diagnostic-limit 100`
- `moon -C editor check --target native --deny-warn --diagnostic-limit 100`
- `moon test --target js --diagnostic-limit 100` (2086 passed before the history-only split)
- `moon test --target native --no-parallelize --diagnostic-limit 100` (2692 passed before the history-only split)
- `moon -C editor test viewer --target js --diagnostic-limit 100` (241 passed)