### PR TITLE
feat(editor): add interactive Markdown diagram viewports

### DIFF
--- a/editor/base/browser/dom_primitives.mbt
+++ b/editor/base/browser/dom_primitives.mbt
@@ -23,6 +23,11 @@ pub extern "js" fn element_offset_height(element : @rdom.Element) -> Double =
   #| (element) => element?.offsetHeight ?? 0
 
 ///|
+/// Whether the element currently participates in an attached document tree.
+pub extern "js" fn element_is_connected(element : @rdom.Element) -> Bool =
+  #| (element) => element?.isConnected === true
+
+///|
 /// Writes one inline CSS property without replacing sibling properties.
 pub extern "js" fn set_style_property(
   element : @rdom.Element,
@@ -30,6 +35,42 @@ pub extern "js" fn set_style_property(
   value : String,
 ) -> Unit =
   #| (element, name, value) => { element.style.setProperty(name, value); }
+
+///|
+/// Reads one inline CSS property without requiring an `HTMLElement` downcast.
+/// This is useful for SVG-capable containers and narrow DOM test doubles.
+pub extern "js" fn element_style_value(
+  element : @rdom.Element,
+  name : String,
+) -> String =
+  #| (element, name) => element?.style?.getPropertyValue?.(name) ?? ''
+
+///|
+/// Reads the priority associated with one inline CSS property.
+pub extern "js" fn element_style_priority(
+  element : @rdom.Element,
+  name : String,
+) -> String =
+  #| (element, name) => element?.style?.getPropertyPriority?.(name) ?? ''
+
+///|
+/// Removes one inline CSS property while preserving sibling declarations.
+pub extern "js" fn remove_style_property(
+  element : @rdom.Element,
+  name : String,
+) -> Unit = "(element, name) => { element?.style?.removeProperty?.(name); }"
+
+///|
+/// Writes one inline CSS property together with its explicit priority.
+pub extern "js" fn set_style_property_with_priority(
+  element : @rdom.Element,
+  name : String,
+  value : String,
+  priority : String,
+) -> Unit =
+  #| (element, name, value, priority) => {
+  #|   element?.style?.setProperty?.(name, value, priority);
+  #| }
 
 ///|
 /// Removes an element if attached. `HTMLElement.remove()` is idempotent; the

--- a/editor/base/browser/pkg.generated.mbti
+++ b/editor/base/browser/pkg.generated.mbti
@@ -19,9 +19,15 @@ pub fn element_contains_active_element(@dom.Element) -> Bool
 
 pub fn element_has_focus(@dom.Element) -> Bool
 
+pub fn element_is_connected(@dom.Element) -> Bool
+
 pub fn element_offset_height(@dom.Element) -> Double
 
 pub fn element_offset_width(@dom.Element) -> Double
+
+pub fn element_style_priority(@dom.Element, String) -> String
+
+pub fn element_style_value(@dom.Element, String) -> String
 
 pub fn event_target_has_matching_ancestor(@dom.Event, @dom.Element, String) -> Bool
 
@@ -35,9 +41,13 @@ pub fn mouse_event_pointer_id(@dom.MouseEvent) -> Int
 
 pub fn native_selection_has_endpoint_in_matching_ancestor(@dom.Element, String) -> Bool
 
+pub fn observe_element_resize(@dom.Element, () -> Unit) -> @common.Disposable?
+
 pub fn queue_microtask(() -> Unit) -> Unit
 
 pub fn remove_element(@dom.Element) -> Unit
+
+pub fn remove_style_property(@dom.Element, String) -> Unit
 
 pub fn run_at_this_or_schedule_at_next_animation_frame(() -> Unit, priority? : Int) -> @common.Disposable
 
@@ -46,6 +56,8 @@ pub fn schedule_at_next_animation_frame(() -> Unit, priority? : Int) -> @common.
 pub fn schedule_timeout(() -> Unit, Int) -> @common.Disposable
 
 pub fn set_style_property(@dom.Element, String, String) -> Unit
+
+pub fn set_style_property_with_priority(@dom.Element, String, String, String) -> Unit
 
 pub fn wall_clock_now_ms() -> Double
 

--- a/editor/base/browser/resize_observer.mbt
+++ b/editor/base/browser/resize_observer.mbt
@@ -1,0 +1,54 @@
+///|
+#external
+priv type NativeResizeObserver
+
+///|
+/// Observes `target` with the `ResizeObserver` constructor from its owning
+/// window. The global constructor is used only by narrow non-browser test DOMs
+/// without `ownerDocument.defaultView`. Creation and `observe` failures are
+/// reported as `None`; the returned lifetime is idempotent.
+pub fn observe_element_resize(
+  target : @rdom.Element,
+  notify : () -> Unit,
+) -> @base_common.Disposable? {
+  let native : Ref[NativeResizeObserver?] = Ref(None)
+  let observed = try_observe_element_resize(target, notify, observer => {
+    native.val = Some(observer)
+  })
+  if !observed {
+    return None
+  }
+  guard native.val is Some(observer) else { return None }
+  Some(
+    @base_common.Disposable::from(() => {
+      native_resize_observer_disconnect(observer)
+    }),
+  )
+}
+
+///|
+extern "js" fn try_observe_element_resize(
+  target : @rdom.Element,
+  notify : () -> Unit,
+  observed : (NativeResizeObserver) -> Unit,
+) -> Bool =
+  #| (target, notify, observed) => {
+  #|   const ResizeObserver = target?.ownerDocument?.defaultView?.ResizeObserver
+  #|     ?? globalThis.ResizeObserver;
+  #|   if (typeof ResizeObserver !== 'function') return false;
+  #|   let observer;
+  #|   try {
+  #|     observer = new ResizeObserver(() => notify());
+  #|     observer.observe(target);
+  #|     observed(observer);
+  #|     return true;
+  #|   } catch (_error) {
+  #|     observer?.disconnect?.();
+  #|     return false;
+  #|   }
+  #| }
+
+///|
+extern "js" fn native_resize_observer_disconnect(
+  observer : NativeResizeObserver,
+) -> Unit = "observer => observer.disconnect()"

--- a/editor/docs/architecture.md
+++ b/editor/docs/architecture.md
@@ -136,7 +136,11 @@ js-only. Concrete browser runtime packages live below the module-private
   returning failures and every other code block to the existing fallback;
   `internal/viewer/browser/markdown` adds JS-only DOM retention, URI/media
   policy, activation listeners, size notification, and per-target disposal.
-  Browser contributions consume these packages instead of owning private
+  Its diagram-wheel listener rechecks wrapper classes for every event:
+  `moonbit-viewer-markdown-diagram-viewport` declines the generic native-scroll
+  handoff so ordinary wheel input reaches the editor, while unmarked hover and
+  agent-feedback diagrams retain their existing inner-scroll behavior. Browser
+  contributions consume these packages instead of owning private
   Markdown-to-`innerHTML` pipelines.
 - `internal/viewer/browser/config` measures fonts and browser geometry.
 - `internal/viewer/browser/controller` owns hit testing, mouse selection, drag
@@ -190,9 +194,19 @@ editor common/browser layers; editor common never depends on them.
 - `internal/viewer/contrib/markdown_comments` owns multi-target whole-line
   comment detection, provider/configuration resolution, and normalized block
   ranges. Its browser sibling owns the stable ViewZone DOM pair and coalesced
-  visible/offscreen size observer; the root `viewer` contribution owns
-  reconciliation, renderer lifetimes, zone ids, and the one hidden-area source.
-  Its emitted stylesheet remains at
+  visible/offscreen size observer. It also owns one opaque diagram-viewport
+  group per rendered target: each successful direct Diago SVG is enhanced
+  independently with bounded pan/zoom/fit controls and a resize handle.
+  MoonBit structs own each group's controllers, geometry state, listeners,
+  observers, queued frame, and disposal. The parent rendered entry guarantees
+  exclusive wrapper ownership and disposes the group before renderer
+  replacement; no ownership state is written onto caller DOM. Resize gestures
+  share a module-private per-document cursor coordinator, while FFI remains
+  limited to missing browser bindings such as `ResizeObserver`, document/body
+  access, style preservation, and a non-passive wheel listener. Inline
+  viewport-height changes report only through a narrow callback. The root
+  `viewer` contribution owns reconciliation, renderer and viewport lifetimes,
+  zone ids, and the one hidden-area source. Its emitted stylesheet remains at
   `viewer/contrib/markdown_comments/browser/markdown_comments.css`.
 
 The root editor registry has two distinct ownership layers. Its process-wide
@@ -224,6 +238,17 @@ observers, removes zones, and clears the contribution's hidden source before
 the outgoing browser `View` is destroyed. Same-model flushes rebuild that
 source with `force_update=true` because the projected line collection was
 recreated even when normalized ranges did not change.
+
+Each rendered entry retains the shared Markdown renderer, its diagram-viewport
+group, and the existing size observer. Same-key body replacement disposes the
+old viewport group before the renderer replaces its target and mounts a fresh
+group; entry teardown orders viewport, renderer, and observer disposal before
+zone removal. The only diagram-to-ViewZone invalidation chain runs from the
+viewport-height callback through
+`MarkdownCommentSizeObserver::request_measure` to
+`Viewer::apply_markdown_comment_height`; the final step keeps the existing
+generation and zone-id checks and remains the sole writer of the live ViewZone
+height.
 
 This central ownership rule supersedes the feature-local instance tables from
 the earlier ownership-divergence work. The completed migration is summarized in

--- a/editor/docs/exec-plans/HISTORY.md
+++ b/editor/docs/exec-plans/HISTORY.md
@@ -12,9 +12,62 @@ Current behavior and ownership live in `docs/architecture.md`, `docs/harness.md`
 `docs/quality.md`, package READMEs, generated interfaces, source, and tests.
 Historical plans are evidence of how a change landed, not current contracts.
 
-As of 2026-07-21 there are no active checked-in execution plans.
+As of 2026-07-24 there are no active checked-in execution plans.
 
 ## Completed Work
+
+### Markdown-comment Diago viewport controls
+
+Successful direct Diago SVGs inside whole-line Markdown comments now mount as
+independent bounded viewports with pan mode, zoom out, zoom in, true Fit, and a
+pointer/keyboard resize handle. Ordinary wheel input reaches the editor;
+Alt-wheel and Ctrl-pinch zoom the diagram, Alt or toggled primary drag pans,
+and the fixed first-version geometry preserves Diago's aspect ratio, defers
+zero-size initialization, uses a 100px resize floor, and preserves the visible
+origin across host-width changes. Hover and agent-feedback diagrams remain
+native inner scrollers, failed fences and other Markdown nodes are untouched,
+and replacing a rendered body intentionally starts with fresh viewport state.
+
+Gate A froze the `vscode` gitlink
+`b18492a288de038fbc7643aae6de8247029d11bd`. DOM, accessibility, event
+ownership, and disposal used a behavior port; pan/zoom/fit/resize and
+host-resize geometry used an algorithm-fidelity port; configuration and
+cross-render state received behavior accounting only. The reviewed product
+deviations keep Diago's SVG sizing metadata, expose true Fit with 16px padding
+instead of preview Reset Zoom, add no settings or global manager, and perform
+stronger zero-geometry and cleanup handling.
+
+Milestone 1 evidence is the focused JS reference suite for direct-target
+selection, DOM/ARIA structure, positive and deferred geometry, fit and zoom
+boundaries, pan and resize branches, responsive arithmetic, independent
+diagrams, cursor ownership, and idempotent cleanup. Milestone 2 stores the
+opaque viewport group beside each rendered Markdown lifetime, disposes it
+before renderer replacement and zone removal, dynamically bypasses the generic
+diagram wheel listener through an event-time marker, and routes every inline
+height change through the existing coalesced size observer and
+generation-checked ViewZone writer. The emitted CSS and existing codicon font
+own the viewport presentation without a new public Viewer option or package
+edge. Real-browser geometry keeps the focus border out of the border-box height
+and reserves the editor's 20px overlay-scrollbar/layout strip while preserving
+the Markdown surface's 12px inner trailing gap.
+
+Milestone 3 evidence extends the direct public-Viewer component scenario over
+initial and offscreen layout, two independent diagrams, four controls,
+modifier input, pointer/keyboard resize relayout, ordinary-wheel editor
+scrolling, host resize, same-key replacement, model swap, double disposal, and
+hidden/visible scrollbar-rail hit testing while retaining the existing
+Markdown image, link, selection, folding, source-truth, and ViewZone cells.
+
+Final validation passed the focused shared-Markdown, diagram-controller, and
+Viewer JS suites at 6, 18, and 241 tests; all 1,555 JS and 1,053 native
+MoonBit tests; the 8-test focused Markdown-comments Playwright spec; and all
+100 browser tests. `moon info --target all`, `moon fmt`,
+`just build-browser-tests`, `just check`, `just test`, `just build`,
+`just test-browser`, and `git diff --check` also passed. The generated
+interface changed only for the opaque viewport handle, constructor, and
+`dispose`; no `moon.pkg` edge changed.
+
+Former artifact: `markdown-comment-diagram-viewport-port.md`.
 
 ### Diago Markdown code-block rendering
 

--- a/editor/docs/harness.md
+++ b/editor/docs/harness.md
@@ -80,9 +80,13 @@ The whole-line Markdown proof is the direct public-Viewer component scenario
 `tests/browser/component/markdown_comments.spec.js`. It does not route through
 the reference shell. The scenario owns its language configuration and models,
 then exposes compact evidence for projected source replacement,
-tokenized Markdown DOM, built-in Diago SVG layout/overflow, measured/offscreen
-ViewZone geometry, native link/selection input, resize/image updates, model
-flush/swap, and disposal.
+tokenized Markdown DOM, measured/offscreen ViewZone geometry, native
+link/selection input, image updates, model flush/swap, and disposal. Its Diago
+cells exercise the public Viewer surface rather than a private controller seam:
+initial bounded layout, independent diagrams, all four controls, modifier
+zoom/pan, pointer and keyboard resizing, ordinary-wheel handoff, host-width
+response, same-key fresh state, retained-node teardown, and editor-scrollbar
+rail hit testing.
 
 The corresponding real-shell proof is
 `tests/browser/smoke/viewer.spec.js`: it opens the fixture through the native

--- a/editor/internal/viewer/browser/markdown/README.md
+++ b/editor/internal/viewer/browser/markdown/README.md
@@ -13,6 +13,13 @@ Scrollable diagram wrappers retain native wheel scrolling while they can
 consume the current delta. When neither axis can consume it, the event is
 allowed to reach the owning hover, widget, or editor scroller.
 
+`moonbit-viewer-markdown-diagram-viewport` is an event-time ownership marker:
+while a wrapper carries it, this generic listener never stops ordinary wheel
+input. The Markdown-comment viewport controller can therefore mount after the
+renderer listener and return ordinary wheel input to the editor while owning
+its modifier-zoom events. Removing the marker restores the native inner-scroll
+handoff, so hover and agent-feedback diagrams keep their existing behavior.
+
 The returned `RenderedMarkdown.dispose` removes all listeners and makes late
 load callbacks inert. Rendering into the same explicit target first disposes
 the target's previous renderer-owned lifetime, while leaving the caller-owned

--- a/editor/internal/viewer/browser/markdown/markdown.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown.mbt
@@ -211,6 +211,8 @@ extern "js" fn install_markdown_dom(
   #|     if (!classes.includes("moonbit-viewer-markdown-diagram")) continue;
   #|     listen(diagram, "wheel", (event) => {
   #|       if (!active) return;
+  #|       const currentClasses = (diagram.getAttribute("class") || "").split(/\s+/);
+  #|       if (currentClasses.includes("moonbit-viewer-markdown-diagram-viewport")) return;
   #|       const deltaX = Number(event.deltaX || (event.shiftKey ? event.deltaY : 0));
   #|       const deltaY = Number(event.shiftKey ? 0 : event.deltaY || 0);
   #|       const consumesX = canScroll(

--- a/editor/internal/viewer/browser/markdown/markdown_wbtest.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown_wbtest.mbt
@@ -175,6 +175,12 @@ extern "js" fn markdown_test_listener_count(
 ) -> Int = "(element, type) => element.listenerCount(type)"
 
 ///|
+extern "js" fn markdown_test_set_class(
+  element : @rdom.Element,
+  value : String,
+) -> Unit = "(element, value) => element.setAttribute('class', value)"
+
+///|
 extern "js" fn markdown_test_same_element(
   left : @rdom.Element,
   right : @rdom.Element,
@@ -360,7 +366,7 @@ test "target reuse replaces children and releases every prior listener" {
 }
 
 ///|
-test "diagram wheel stays native until the scroll boundary and listener disposal" {
+test "diagram wheel ownership follows the dynamic viewport marker and listener lifetime" {
   install_markdown_test_dom()
   let target = markdown_test_target()
   let rendered = render_markdown(
@@ -388,6 +394,15 @@ test "diagram wheel stays native until the scroll boundary and listener disposal
     markdown_test_dispatch_vertical_wheel(diagram, 120, 200, 100, 300),
     0,
   )
+  // The Markdown-comment controller mounts after this generic listener.
+  // Event-time marker reads hand every ordinary wheel delta back to the
+  // interactive component/editor without changing other Markdown consumers.
+  markdown_test_set_class(
+    diagram, "moonbit-viewer-markdown-diagram moonbit-viewer-markdown-diagram-viewport",
+  )
+  assert_eq(markdown_test_dispatch_vertical_wheel(diagram, 120, 0, 100, 300), 0)
+  markdown_test_set_class(diagram, "moonbit-viewer-markdown-diagram")
+  assert_eq(markdown_test_dispatch_vertical_wheel(diagram, 120, 0, 100, 300), 1)
   rendered.dispose.dispose()
   assert_eq(markdown_test_listener_count(diagram, "wheel"), 0)
   assert_eq(markdown_test_dispatch_vertical_wheel(diagram, 120, 0, 100, 300), 0)

--- a/editor/internal/viewer/browser/view/geometry_view_lines_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/geometry_view_lines_wbtest.mbt
@@ -9,6 +9,7 @@ fn geometry_view_lines(
   layout : @view_layout.ViewLayout,
   fixture : ViewLineFixture,
   scheduler? : RunOnceScheduler = RunOnceScheduler(200),
+  lines_content? : @rdom.Element = view_line_fixture_context(fixture),
 ) -> ViewLines {
   let configuration = ViewLinesConfiguration::ViewLinesConfiguration()
   let options_ref = Ref(configuration.view_line_options)
@@ -16,7 +17,7 @@ fn geometry_view_lines(
   last_rendered_data.set_current_visible_range(visible_range)
   {
     dom_node: CachedDomNode(view_line_fixture_context(fixture)),
-    lines_content: CachedDomNode(view_line_fixture_context(fixture)),
+    lines_content: CachedDomNode(lines_content),
     text_range_resting_spot: view_line_fixture_end_node(fixture),
     window,
     lines,
@@ -34,6 +35,9 @@ fn geometry_view_lines(
     max_line_width: 0.0,
     last_layout: Some(layout),
     should_render: true,
+    content_viewport_geometry_lease_count: 0,
+    rendered_scroll_left: None,
+    visible_content_width: None,
   }
 }
 
@@ -103,11 +107,132 @@ fn GeometryTimerSpy::fire_active(self : GeometryTimerSpy) -> Unit {
 }
 
 ///|
+extern "js" fn new_geometry_style_element() -> @rdom.Element =
+  #| () => ({
+  #|   style: {
+  #|     values: Object.create(null),
+  #|     setCount: 0,
+  #|     removeCount: 0,
+  #|     setProperty(name, value) {
+  #|       this.values[name] = String(value);
+  #|       this.setCount += 1;
+  #|     },
+  #|     removeProperty(name) {
+  #|       delete this.values[name];
+  #|       this.removeCount += 1;
+  #|     },
+  #|   },
+  #| })
+
+///|
+extern "js" fn geometry_style_value(
+  element : @rdom.Element,
+  name : String,
+) -> String =
+  #| (element, name) => element.style.values[name] ?? ""
+
+///|
+extern "js" fn geometry_style_set_count(element : @rdom.Element) -> Int = "(element) => element.style.setCount"
+
+///|
+extern "js" fn geometry_style_remove_count(element : @rdom.Element) -> Int = "(element) => element.style.removeCount"
+
+///|
 test "LastRenderedData initializes and replaces the exact visible Range" {
   let data = LastRenderedData::LastRenderedData()
   assert_true(data.get_current_visible_range() == Range(1, 1, 1, 1))
   data.set_current_visible_range(Range(3, 2, 5, 7))
   assert_true(data.get_current_visible_range() == Range(3, 2, 5, 7))
+}
+
+///|
+test "ViewLines content viewport geometry is leased cached and scrollbar-safe" {
+  let fixture = new_view_line_fixture(10.0, 10.0)
+  let lines_content = new_geometry_style_element()
+  let layout = @view_layout.ViewLayout(line_height=20, line_count=1)
+  let view_lines = geometry_view_lines(
+    [],
+    { start: 1, end: 1 },
+    Range(1, 1, 1, 1),
+    layout,
+    fixture,
+    lines_content~,
+  )
+  // Ordinary ViewZones retain the model scroll-plane contract until a
+  // specialized consumer explicitly acquires it.
+  view_lines.publish_content_viewport_geometry(40.0, 200.0)
+  assert_eq(geometry_style_set_count(lines_content), 0)
+  view_lines.should_render = false
+  let first = view_lines.acquire_content_viewport_geometry()
+  assert_true(view_lines.should_render)
+  view_lines.should_render = false
+  let second = view_lines.acquire_content_viewport_geometry()
+  assert_false(view_lines.should_render)
+  assert_eq(view_lines.content_viewport_geometry_lease_count, 2)
+  view_lines.publish_content_viewport_geometry(40.0, 200.0)
+  assert_eq(
+    geometry_style_value(lines_content, rendered_scroll_left_css_variable),
+    "40px",
+  )
+  assert_eq(
+    geometry_style_value(lines_content, visible_content_width_css_variable),
+    "186px",
+  )
+  assert_eq(geometry_style_set_count(lines_content), 2)
+  // Replaying an identical render snapshot performs no redundant DOM writes;
+  // changing only the horizontal position updates only its variable.
+  view_lines.publish_content_viewport_geometry(40.0, 200.0)
+  assert_eq(geometry_style_set_count(lines_content), 2)
+  view_lines.publish_content_viewport_geometry(45.0, 200.0)
+  assert_eq(geometry_style_set_count(lines_content), 3)
+  // The width follows the current configured scrollbar size and clamps at
+  // zero when the rail is wider than the viewport.
+  let wider_scrollbar = {
+    ..view_lines.view_line_options,
+    vertical_scrollbar_size: 20.0,
+  }
+  view_lines.on_options_maybe_changed(wider_scrollbar) |> ignore
+  view_lines.publish_content_viewport_geometry(45.0, 200.0)
+  assert_eq(
+    geometry_style_value(lines_content, visible_content_width_css_variable),
+    "180px",
+  )
+  assert_eq(geometry_style_set_count(lines_content), 4)
+  view_lines.publish_content_viewport_geometry(45.0, 5.0)
+  assert_eq(
+    geometry_style_value(lines_content, visible_content_width_css_variable),
+    "0px",
+  )
+  assert_eq(geometry_style_set_count(lines_content), 5)
+  // Only the last lease removes the inherited contract and resets both
+  // caches. Disposable itself is idempotent.
+  first.dispose()
+  assert_eq(geometry_style_remove_count(lines_content), 0)
+  second.dispose()
+  assert_eq(view_lines.content_viewport_geometry_lease_count, 0)
+  assert_eq(
+    geometry_style_value(lines_content, rendered_scroll_left_css_variable),
+    "",
+  )
+  assert_eq(
+    geometry_style_value(lines_content, visible_content_width_css_variable),
+    "",
+  )
+  assert_eq(geometry_style_remove_count(lines_content), 2)
+  assert_true(view_lines.rendered_scroll_left is None)
+  assert_true(view_lines.visible_content_width is None)
+  second.dispose()
+  assert_eq(geometry_style_remove_count(lines_content), 2)
+  // ViewLines teardown also clears an outstanding lease; a later handle
+  // disposal cannot underflow the refcount or perform duplicate DOM removal.
+  let third = view_lines.acquire_content_viewport_geometry()
+  view_lines.publish_content_viewport_geometry(5.0, 100.0)
+  assert_eq(geometry_style_set_count(lines_content), 7)
+  view_lines.dispose()
+  assert_eq(view_lines.content_viewport_geometry_lease_count, 0)
+  assert_eq(geometry_style_remove_count(lines_content), 4)
+  third.dispose()
+  assert_eq(geometry_style_remove_count(lines_content), 4)
 }
 
 ///|

--- a/editor/internal/viewer/browser/view/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/view/pkg.generated.mbti
@@ -238,6 +238,7 @@ pub fn ViewLineOptions::ViewLineOptions(line_height? : Int, space_width? : Doubl
 pub struct ViewLines {
   // private fields
 }
+pub fn ViewLines::acquire_content_viewport_geometry(Self) -> @common.Disposable
 pub fn ViewLines::get_dom_node(Self) -> @dom.Element
 pub fn ViewLines::get_line_width(Self, Int) -> Double
 pub fn ViewLines::get_position_from_dom_info(Self, @view_model.ViewModel, @dom.Element, Int) -> @common.Position?

--- a/editor/internal/viewer/browser/view/view_lines.mbt
+++ b/editor/internal/viewer/browser/view/view_lines.mbt
@@ -4,6 +4,12 @@
 // `view_lines_zones_lifecycle.mbt`.
 
 ///|
+let rendered_scroll_left_css_variable : String = "--moonbit-viewer-rendered-scroll-left"
+
+///|
+let visible_content_width_css_variable : String = "--moonbit-viewer-visible-content-width"
+
+///|
 /// Live configuration values read by `ViewLines.onConfigurationChanged` in the
 /// same order as Monaco's retained caches. `view_line_options` is the exact
 /// equality-gated subset owned by each retained `ViewLine`.
@@ -166,6 +172,9 @@ pub struct ViewLines {
   priv mut max_line_width : Double
   priv mut last_layout : @view_layout.ViewLayout?
   priv mut should_render : Bool
+  priv mut content_viewport_geometry_lease_count : Int
+  priv mut rendered_scroll_left : Double?
+  priv mut visible_content_width : Double?
 }
 
 ///|
@@ -205,6 +214,9 @@ fn ViewLines::ViewLines(
     max_line_width: 0.0,
     last_layout: None,
     should_render: true,
+    content_viewport_geometry_lease_count: 0,
+    rendered_scroll_left: None,
+    visible_content_width: None,
   }
 }
 
@@ -305,6 +317,84 @@ fn ViewLines::on_options_maybe_changed(
 ///|
 pub fn ViewLines::get_dom_node(self : ViewLines) -> @rdom.Element {
   self.dom_node.element()
+}
+
+///|
+/// Enables the Markdown-comment geometry contract for this model-scoped
+/// `ViewLines`. Ordinary ViewZones keep Monaco's scroll-plane width; while at
+/// least one lease is alive, `render_text` additionally publishes inherited
+/// CSS variables that let selected descendants cancel the lines-content
+/// translation and size against the visible content viewport.
+pub fn ViewLines::acquire_content_viewport_geometry(
+  self : ViewLines,
+) -> @base_common.Disposable {
+  if self.content_viewport_geometry_lease_count == 0 {
+    // The caller schedules the frame (Markdown acquires inside a ViewZones
+    // transaction). Mark the text phase dirty so that frame cannot skip
+    // `render_text` and leave the CSS fallbacks at zero indefinitely.
+    self.should_render = true
+  }
+  self.content_viewport_geometry_lease_count += 1
+  @base_common.Disposable::from(() => {
+    if self.content_viewport_geometry_lease_count <= 0 {
+      return
+    }
+    self.content_viewport_geometry_lease_count -= 1
+    if self.content_viewport_geometry_lease_count == 0 {
+      self.clear_content_viewport_geometry()
+    }
+  })
+}
+
+///|
+/// Publishes both axes from the exact render snapshot used to position
+/// `.lines-content`. The width is the visible content box with the configured
+/// vertical scrollbar rail removed, never the model's potentially wider
+/// `scroll_width`.
+fn ViewLines::publish_content_viewport_geometry(
+  self : ViewLines,
+  scroll_left : Double,
+  viewport_width : Double,
+) -> Unit {
+  if self.content_viewport_geometry_lease_count <= 0 {
+    return
+  }
+  let visible_width = (viewport_width -
+  self.view_line_options.vertical_scrollbar_size).max(0.0)
+  if self.rendered_scroll_left != Some(scroll_left) {
+    @base_browser.set_style_property(
+      self.lines_content.element(),
+      rendered_scroll_left_css_variable,
+      scroll_left.to_string() + "px",
+    )
+    self.rendered_scroll_left = Some(scroll_left)
+  }
+  if self.visible_content_width != Some(visible_width) {
+    @base_browser.set_style_property(
+      self.lines_content.element(),
+      visible_content_width_css_variable,
+      visible_width.to_string() + "px",
+    )
+    self.visible_content_width = Some(visible_width)
+  }
+}
+
+///|
+fn ViewLines::clear_content_viewport_geometry(self : ViewLines) -> Unit {
+  if self.rendered_scroll_left is Some(_) {
+    remove_view_lines_style_property(
+      self.lines_content.element(),
+      rendered_scroll_left_css_variable,
+    )
+    self.rendered_scroll_left = None
+  }
+  if self.visible_content_width is Some(_) {
+    remove_view_lines_style_property(
+      self.lines_content.element(),
+      visible_content_width_css_variable,
+    )
+    self.visible_content_width = None
+  }
 }
 
 ///|
@@ -506,6 +596,7 @@ fn ViewLines::render_text(
     viewport.big_numbers_delta.to_double()
   self.lines_content.set_top(Pixels(-adjusted_scroll_top))
   self.lines_content.set_left(Pixels(-position.scroll_left))
+  self.publish_content_viewport_geometry(position.scroll_left, dimensions.width)
 }
 
 ///|
@@ -886,7 +977,16 @@ fn ViewLines::ensure_max_line_width(
 ///|
 fn ViewLines::dispose(self : ViewLines) -> Unit {
   self.async_update_line_widths.dispose()
+  self.content_viewport_geometry_lease_count = 0
+  self.clear_content_viewport_geometry()
 }
+
+///|
+extern "js" fn remove_view_lines_style_property(
+  element : @rdom.Element,
+  name : String,
+) -> Unit =
+  #| (element, name) => { element?.style?.removeProperty(name); }
 
 ///|
 /// FFI gap-fills for the `.view-line` ancestor walk (element-typed

--- a/editor/internal/viewer/contrib/markdown_comments/browser/README.md
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/README.md
@@ -5,17 +5,38 @@ comments. `MarkdownCommentDom` creates the stable ViewZone outer/content pair;
 the root contribution retains the outer node as its ViewZone DOM and renders
 shared Markdown into the inner node.
 
-`observe_size` watches the auto-height inner content and its nearest editor
-content viewport. Resize notifications and explicit renderer/image
-invalidations are coalesced through the realm-global `base/browser`
-animation-frame coordinator. A connected offscreen ViewZone is temporarily
-laid out invisibly at viewport width, then every touched inline style and
-priority is restored before its integer height is reported. The returned
+`observe_size` watches only the auto-height inner content. The root
+contribution owns one model-scoped viewport-width observer and invalidates all
+live comment size observers when that width changes. Resize notifications and
+explicit viewport/renderer/image invalidations are coalesced through the
+realm-global `base/browser` animation-frame coordinator. A connected offscreen
+ViewZone is temporarily laid out invisibly using its already pinned
+viewport-safe width and horizontal offset; measurement never replaces
+`width` or `left`, and every touched inline style and priority is restored
+before its integer height is reported. The returned
 `MarkdownCommentSizeObserver` exposes `request_measure` and idempotent
 `dispose`; zero-size restore notifications cannot create a feedback loop.
 Disposal disconnects observation, cancels queued frame work, and makes late
-notifications inert. The root contribution remains responsible for generation
-and zone-id freshness.
+notifications inert. The root contribution remains responsible for the shared
+viewport observer, geometry lease, generation, and zone-id freshness.
+
+`MarkdownCommentDiagramViewports` owns every successfully rendered direct
+Diago SVG viewport inside one Markdown-comment target. It mounts the
+transformable content, four controls, resize handle, listeners, animation
+frame, and per-wrapper `ResizeObserver`, while leaving the target and original
+wrapper caller-owned. MoonBit structs retain the group/controller lifetime and
+all pan/zoom/fit/resize state. The root entry's disposal-before-replacement
+contract gives the group exclusive wrapper ownership, so the implementation
+does not place private ownership tokens on DOM nodes. A module-private
+per-document coordinator grants at most one temporary body-cursor lease during
+resize; it restores the exact prior inline value and priority on release.
+Narrow FFI fills browser binding gaps only. Each inline viewport-height change
+invokes the supplied `on_size_changed` callback; the root contribution wires
+that callback to the existing coalesced
+`MarkdownCommentSizeObserver::request_measure` path rather than introducing
+another ViewZone height writer. The root entry disposes the diagram owner
+before the shared Markdown renderer and size observer whenever the body is
+replaced or its ViewZone is removed.
 
 The emitted stylesheet remains at
 `viewer/contrib/markdown_comments/browser/markdown_comments.css`. Run the

--- a/editor/internal/viewer/contrib/markdown_comments/browser/diagram_viewport.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/diagram_viewport.mbt
@@ -1,0 +1,1276 @@
+///|
+let diagram_viewport_class = "moonbit-viewer-markdown-diagram-viewport"
+
+///|
+let diagram_content_class = "moonbit-viewer-markdown-diagram-content"
+
+///|
+let diagram_controls_class = "moonbit-viewer-markdown-diagram-controls"
+
+///|
+let diagram_resize_handle_class = "moonbit-viewer-markdown-diagram-resize-handle"
+
+///|
+let diagram_min_scale = 0.5
+
+///|
+let diagram_max_scale = 10.0
+
+///|
+let diagram_zoom_factor = 0.002
+
+///|
+let diagram_fit_padding = 16.0
+
+///|
+let diagram_minimum_height = 100.0
+
+///|
+let diagram_drag_threshold = 3.0
+
+///|
+priv struct SavedAttribute {
+  present : Bool
+  value : String
+}
+
+///|
+priv struct SavedStyle {
+  value : String
+  priority : String
+}
+
+///|
+priv struct DiagramSize {
+  width : Double
+  height : Double
+}
+
+///|
+priv struct DiagramBodyCursorCoordinator {
+  document : @rdom.Document
+  mut active : Bool
+}
+
+///|
+priv struct DiagramBodyCursorLease {
+  coordinator : DiagramBodyCursorCoordinator
+  body : @rdom.Element
+  saved_cursor : SavedStyle
+  mut active : Bool
+}
+
+///|
+let diagram_body_cursor_coordinators : Array[DiagramBodyCursorCoordinator] = []
+
+///|
+priv struct MarkdownCommentDiagramViewport {
+  wrapper : @rdom.Element
+  content : @rdom.Element
+  svg : @rdom.Element
+  controls : @rdom.Element
+  pan_button : @rdom.Element
+  zoom_out_button : @rdom.Element
+  zoom_in_button : @rdom.Element
+  fit_button : @rdom.Element
+  resize_handle : @rdom.Element
+  owner_document : @rdom.Document
+  owner_window : @rdom.Window
+  saved_tabindex : SavedAttribute
+  saved_aria_label : SavedAttribute
+  saved_height : SavedStyle
+  saved_overflow : SavedStyle
+  saved_cursor : SavedStyle
+  on_size_changed : () -> Unit
+  listeners : Array[@base_common.Disposable]
+  mut observer : @base_common.Disposable?
+  mut pending_frame : (() -> Unit)?
+  mut body_cursor_lease : DiagramBodyCursorLease?
+  mut active : Bool
+  mut initialized : Bool
+  mut scale : Double
+  mut fit_scale : Double
+  mut translate_x : Double
+  mut translate_y : Double
+  mut last_svg_width : Double
+  mut last_svg_height : Double
+  mut custom_height : Double?
+  mut has_interacted : Bool
+  mut pan_mode_enabled : Bool
+  mut is_panning : Bool
+  mut has_dragged : Bool
+  mut pan_pointer_id : Int?
+  mut start_x : Double
+  mut start_y : Double
+  mut previous_move_x : Double
+  mut previous_move_y : Double
+  mut is_resizing : Bool
+  mut resize_pointer_id : Int?
+  mut resize_start_y : Double
+  mut resize_start_height : Double
+}
+
+///|
+priv struct MarkdownCommentDiagramViewportLifetime {
+  controllers : Array[MarkdownCommentDiagramViewport]
+  mut active : Bool
+}
+
+///|
+priv enum DiagramViewportMountResult {
+  Mounted(MarkdownCommentDiagramViewport)
+  Skipped
+  Failed
+}
+
+///|
+/// Owns the interactive diagram viewports mounted in one rendered Markdown
+/// comment. Only successful, direct Diago SVG children are enhanced. The
+/// caller retains ownership of the Markdown target and disposes this handle
+/// before replacing or removing that target.
+pub struct MarkdownCommentDiagramViewports {
+  priv lifetime : MarkdownCommentDiagramViewportLifetime
+}
+
+///|
+/// Synchronously mounts controls and resize handles for every matching direct
+/// Diago SVG. Geometry is initialized at the next animation-frame boundary.
+/// `on_size_changed` invalidates the owning Markdown-comment ViewZone whenever
+/// this component writes a new inline viewport height.
+#alias(new, deprecated)
+pub fn MarkdownCommentDiagramViewports::MarkdownCommentDiagramViewports(
+  target : @rdom.Element,
+  on_size_changed : () -> Unit,
+) -> MarkdownCommentDiagramViewports {
+  let schedule_frame = (callback : () -> Unit) => {
+    let registration = @base_browser.schedule_at_next_animation_frame(callback)
+    () => registration.dispose()
+  }
+  let lifetime : MarkdownCommentDiagramViewportLifetime = {
+    controllers: [],
+    active: true,
+  }
+  let candidates : Array[@rdom.Element] = []
+  collect_diagram_viewport_candidates(target, candidates)
+  for candidate in candidates {
+    if !lifetime.active {
+      break
+    }
+    match
+      mount_diagram_viewport(candidate, target, on_size_changed, schedule_frame) {
+      Mounted(controller) => lifetime.controllers.push(controller)
+      Skipped => ()
+      Failed => lifetime.dispose()
+    }
+  }
+  { lifetime, }
+}
+
+///|
+/// Idempotently releases every viewport listener, observer, animation frame,
+/// owning-window drag, temporary cursor, and DOM reference.
+pub fn MarkdownCommentDiagramViewports::dispose(
+  self : MarkdownCommentDiagramViewports,
+) -> Unit {
+  self.lifetime.dispose()
+}
+
+///|
+fn MarkdownCommentDiagramViewportLifetime::dispose(
+  self : MarkdownCommentDiagramViewportLifetime,
+) -> Unit {
+  if !self.active {
+    return
+  }
+  self.active = false
+  while self.controllers.length() > 0 {
+    let index = self.controllers.length() - 1
+    let controller = self.controllers[index]
+    self.controllers.pop() |> ignore
+    controller.dispose()
+  }
+}
+
+///|
+fn collect_diagram_viewport_candidates(
+  root : @rdom.Element,
+  candidates : Array[@rdom.Element],
+) -> Unit {
+  for child in root.get_children() {
+    if element_has_class(child, "moonbit-viewer-markdown-diagram") &&
+      element_attribute_or_empty(child, "data-diagram-language") == "diago" &&
+      !element_has_class(child, diagram_viewport_class) &&
+      direct_svg_child(child) is Some(_) {
+      candidates.push(child)
+    }
+    collect_diagram_viewport_candidates(child, candidates)
+  }
+}
+
+///|
+fn direct_svg_child(wrapper : @rdom.Element) -> @rdom.Element? {
+  for child in wrapper.get_children() {
+    let name = child.get_node_name()
+    if name == "svg" || name == "SVG" {
+      return Some(child)
+    }
+  }
+  None
+}
+
+///|
+fn mount_diagram_viewport(
+  wrapper : @rdom.Element,
+  fallback_target : @rdom.Element,
+  on_size_changed : () -> Unit,
+  schedule_frame : (() -> Unit) -> () -> Unit,
+) -> DiagramViewportMountResult {
+  guard direct_svg_child(wrapper) is Some(svg) else { return Skipped }
+  let result : Ref[DiagramViewportMountResult] = Ref(Skipped)
+  let found = with_diagram_viewport_environment(wrapper, fallback_target, (
+    owner_document,
+    owner_window,
+  ) => {
+    result.val = mount_diagram_viewport_in_environment(
+      wrapper, svg, owner_document, owner_window, on_size_changed, schedule_frame,
+    )
+  })
+  if found {
+    result.val
+  } else {
+    Skipped
+  }
+}
+
+///|
+fn mount_diagram_viewport_in_environment(
+  wrapper : @rdom.Element,
+  svg : @rdom.Element,
+  owner_document : @rdom.Document,
+  owner_window : @rdom.Window,
+  on_size_changed : () -> Unit,
+  schedule_frame : (() -> Unit) -> () -> Unit,
+) -> DiagramViewportMountResult {
+  let content = owner_document.create_element("div")
+  content.set_attribute("class", diagram_content_class)
+  let controls = owner_document.create_element("div")
+  controls.set_attribute("class", diagram_controls_class)
+  let pan_button = create_diagram_button(
+    owner_document,
+    "moonbit-viewer-markdown-diagram-pan",
+    "Toggle pan mode",
+    "codicon-move",
+    pressed=false,
+  )
+  let zoom_out_button = create_diagram_button(
+    owner_document, "moonbit-viewer-markdown-diagram-zoom-out", "Zoom out", "codicon-zoom-out",
+  )
+  let zoom_in_button = create_diagram_button(
+    owner_document, "moonbit-viewer-markdown-diagram-zoom-in", "Zoom in", "codicon-zoom-in",
+  )
+  let fit_button = create_diagram_button(
+    owner_document, "moonbit-viewer-markdown-diagram-fit", "Fit diagram", "codicon-screen-normal",
+  )
+  controls.append_child(pan_button.as_node())
+  controls.append_child(zoom_out_button.as_node())
+  controls.append_child(zoom_in_button.as_node())
+  controls.append_child(fit_button.as_node())
+  let resize_handle = owner_document.create_element("div")
+  resize_handle.set_attribute("class", diagram_resize_handle_class)
+  resize_handle.set_attribute("title", "Drag to resize")
+  resize_handle.set_attribute("tabindex", "0")
+  resize_handle.set_attribute("role", "separator")
+  resize_handle.set_attribute("aria-label", "Resize diagram")
+  resize_handle.set_attribute("aria-orientation", "horizontal")
+  let controller : MarkdownCommentDiagramViewport = {
+    wrapper,
+    content,
+    svg,
+    controls,
+    pan_button,
+    zoom_out_button,
+    zoom_in_button,
+    fit_button,
+    resize_handle,
+    owner_document,
+    owner_window,
+    saved_tabindex: save_element_attribute(wrapper, "tabindex"),
+    saved_aria_label: save_element_attribute(wrapper, "aria-label"),
+    saved_height: save_element_style(wrapper, "height"),
+    saved_overflow: save_element_style(wrapper, "overflow"),
+    saved_cursor: save_element_style(wrapper, "cursor"),
+    on_size_changed,
+    listeners: [],
+    observer: None,
+    pending_frame: None,
+    body_cursor_lease: None,
+    active: true,
+    initialized: false,
+    scale: 1.0,
+    fit_scale: 1.0,
+    translate_x: 0.0,
+    translate_y: 0.0,
+    last_svg_width: 0.0,
+    last_svg_height: 0.0,
+    custom_height: None,
+    has_interacted: false,
+    pan_mode_enabled: false,
+    is_panning: false,
+    has_dragged: false,
+    pan_pointer_id: None,
+    start_x: 0.0,
+    start_y: 0.0,
+    previous_move_x: 0.0,
+    previous_move_y: 0.0,
+    is_resizing: false,
+    resize_pointer_id: None,
+    resize_start_y: 0.0,
+    resize_start_height: 0.0,
+  }
+  add_element_class(wrapper, diagram_viewport_class)
+  wrapper.set_attribute("tabindex", "0")
+  wrapper.set_attribute("aria-label", "Interactive Diago diagram")
+  @base_browser.set_style_property(wrapper, "overflow", "hidden")
+  @base_browser.set_style_property(content, "transform-origin", "0 0")
+  wrapper.insert_before(
+    content.as_node(),
+    @js.Nullable::from_option(Some(svg.as_node())),
+  )
+  content.append_child(svg.as_node())
+  wrapper.append_child(controls.as_node())
+  wrapper.append_child(resize_handle.as_node())
+  controller.install_listeners()
+  controller.observer = @base_browser.observe_element_resize(wrapper, () => {
+    if controller.active {
+      controller.layout() |> ignore
+    }
+  })
+  if controller.observer is None {
+    controller.dispose()
+    return Failed
+  }
+  let frame_pending = Ref(true)
+  let cancel_frame = schedule_frame(() => {
+    frame_pending.val = false
+    controller.pending_frame = None
+    if controller.active {
+      controller.layout() |> ignore
+    }
+  })
+  if frame_pending.val {
+    controller.pending_frame = Some(cancel_frame)
+  } else {
+    cancel_frame()
+  }
+  controller.set_cursor(false, false)
+  Mounted(controller)
+}
+
+///|
+fn create_diagram_button(
+  document : @rdom.Document,
+  class_name : String,
+  label : String,
+  icon_class : String,
+  pressed? : Bool,
+) -> @rdom.Element {
+  let button = document.create_element("button")
+  button.set_attribute("class", class_name)
+  button.set_attribute("type", "button")
+  button.set_attribute("title", label)
+  button.set_attribute("aria-label", label)
+  match pressed {
+    Some(value) =>
+      button.set_attribute("aria-pressed", if value { "true" } else { "false" })
+    None => ()
+  }
+  let icon = document.create_element("span")
+  icon.set_attribute("class", "codicon \{icon_class}")
+  icon.set_attribute("aria-hidden", "true")
+  button.append_child(icon.as_node())
+  button
+}
+
+///|
+fn MarkdownCommentDiagramViewport::install_listeners(
+  self : MarkdownCommentDiagramViewport,
+) -> Unit {
+  let consume_control_pointer = (event : @rdom.Event) => {
+    event.stop_propagation()
+  }
+  for
+    button in [
+      self.pan_button,
+      self.zoom_out_button,
+      self.zoom_in_button,
+      self.fit_button,
+    ] {
+    self.listen(
+      button.as_event_target(),
+      "pointerdown",
+      consume_control_pointer,
+    )
+    self.listen(button.as_event_target(), "mousedown", consume_control_pointer)
+  }
+  self.listen(self.pan_button.as_event_target(), "click", event => {
+    event.prevent_default()
+    event.stop_propagation()
+    self.pan_mode_enabled = !self.pan_mode_enabled
+    set_element_class_active(self.pan_button, "active", self.pan_mode_enabled)
+    self.pan_button.set_attribute(
+      "aria-pressed",
+      if self.pan_mode_enabled {
+        "true"
+      } else {
+        "false"
+      },
+    )
+    self.set_cursor(false, false)
+  })
+  self.listen(self.zoom_out_button.as_event_target(), "click", event => {
+    event.prevent_default()
+    event.stop_propagation()
+    self.zoom_at_center(0.8) |> ignore
+  })
+  self.listen(self.zoom_in_button.as_event_target(), "click", event => {
+    event.prevent_default()
+    event.stop_propagation()
+    self.zoom_at_center(1.25) |> ignore
+  })
+  self.listen(self.fit_button.as_event_target(), "click", event => {
+    event.prevent_default()
+    event.stop_propagation()
+    self.fit() |> ignore
+  })
+  self.listen(self.wrapper.as_event_target(), "pointerdown", event => {
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    if !self.active ||
+      self.is_panning ||
+      self.is_resizing ||
+      mouse.get_button() != 0 ||
+      (!self.pan_mode_enabled && !mouse.get_alt_key()) {
+      return
+    }
+    if !self.initialized && !self.center_natural_content() {
+      return
+    }
+    event.prevent_default()
+    event.stop_propagation()
+    self.is_panning = true
+    self.has_dragged = false
+    self.pan_pointer_id = Some(@base_browser.mouse_event_pointer_id(mouse))
+    let client_x = Double::from_int(mouse.get_client_x())
+    let client_y = Double::from_int(mouse.get_client_y())
+    self.start_x = client_x - self.translate_x
+    self.start_y = client_y - self.translate_y
+    self.previous_move_x = client_x
+    self.previous_move_y = client_y
+    @base_browser.set_style_property(self.wrapper, "cursor", "grabbing")
+  })
+  self.listen(self.wrapper.as_event_target(), "pointermove", event => {
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    if self.active && !self.is_panning {
+      self.set_cursor(mouse.get_alt_key(), mouse.get_shift_key())
+    }
+  })
+  self.listen(self.wrapper.as_event_target(), "click", event => {
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    if !self.active || !mouse.get_alt_key() || self.has_dragged {
+      return
+    }
+    if !self.initialized && !self.center_natural_content() {
+      return
+    }
+    let rect = self.viewport_rect()
+    if !is_positive_finite(rect.get_width()) ||
+      !is_positive_finite(rect.get_height()) {
+      return
+    }
+    event.prevent_default()
+    event.stop_propagation()
+    self.zoom_at_point(
+      if mouse.get_shift_key() {
+        0.8
+      } else {
+        1.25
+      },
+      Double::from_int(mouse.get_client_x()) - rect.get_left(),
+      Double::from_int(mouse.get_client_y()) - rect.get_top(),
+    )
+    |> ignore
+  })
+  self.listen(
+    self.wrapper.as_event_target(),
+    "wheel",
+    event => {
+      guard event.to_wheel_event() is Some(wheel) else { return }
+      if !self.active || (!wheel.get_ctrl_key() && !wheel.get_alt_key()) {
+        return
+      }
+      if !self.initialized && !self.center_natural_content() {
+        return
+      }
+      let rect = self.viewport_rect()
+      let delta_y = wheel.get_delta_y()
+      if !is_positive_finite(rect.get_width()) ||
+        !is_positive_finite(rect.get_height()) ||
+        !is_finite(delta_y) {
+        return
+      }
+      event.prevent_default()
+      event.stop_propagation()
+      let multiplier = if wheel.get_ctrl_key() { 10.0 } else { 1.0 }
+      let delta = -delta_y * diagram_zoom_factor * multiplier
+      self.zoom_at_point(
+        1.0 + delta,
+        Double::from_int(wheel.get_client_x()) - rect.get_left(),
+        Double::from_int(wheel.get_client_y()) - rect.get_top(),
+      )
+      |> ignore
+    },
+    passive_false=true,
+  )
+  self.listen(self.wrapper.as_event_target(), "pointerenter", event => {
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    if !self.is_panning {
+      self.set_cursor(mouse.get_alt_key(), mouse.get_shift_key())
+    }
+  })
+  let handle_key_change = (event : @rdom.Event) => {
+    guard event.to_keyboard_event() is Some(keyboard) else { return }
+    if (keyboard.key() == "Alt" || keyboard.key() == "Shift") &&
+      !self.is_panning {
+      event.prevent_default()
+      self.set_cursor(keyboard.alt_key(), keyboard.shift_key())
+    }
+  }
+  self.listen(self.owner_window.as_event_target(), "keydown", handle_key_change)
+  self.listen(self.owner_window.as_event_target(), "keyup", handle_key_change)
+  self.listen(self.resize_handle.as_event_target(), "pointerdown", event => {
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    if !self.active ||
+      self.is_resizing ||
+      self.is_panning ||
+      mouse.get_button() != 0 {
+      return
+    }
+    if !self.initialized && !self.center_natural_content() {
+      return
+    }
+    let rect = self.viewport_rect()
+    if !is_positive_finite(rect.get_height()) {
+      return
+    }
+    event.prevent_default()
+    event.stop_propagation()
+    if !self.acquire_body_cursor() {
+      return
+    }
+    self.is_resizing = true
+    self.resize_pointer_id = Some(@base_browser.mouse_event_pointer_id(mouse))
+    self.resize_start_y = Double::from_int(mouse.get_client_y())
+    self.resize_start_height = rect.get_height()
+  })
+  self.listen(self.owner_window.as_event_target(), "pointermove", event => {
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    if !self.active {
+      return
+    }
+    let pointer_id = @base_browser.mouse_event_pointer_id(mouse)
+    if self.is_panning && self.pan_pointer_id == Some(pointer_id) {
+      if mouse.get_buttons() == 0 {
+        self.finish_pan(mouse)
+        return
+      }
+      event.prevent_default()
+      event.stop_propagation()
+      let client_x = Double::from_int(mouse.get_client_x())
+      let client_y = Double::from_int(mouse.get_client_y())
+      let dx = client_x - self.previous_move_x
+      let dy = client_y - self.previous_move_y
+      if dx.abs() > diagram_drag_threshold || dy.abs() > diagram_drag_threshold {
+        self.has_dragged = true
+      }
+      self.previous_move_x = client_x
+      self.previous_move_y = client_y
+      self.translate_x = client_x - self.start_x
+      self.translate_y = client_y - self.start_y
+      self.apply_transform()
+      return
+    }
+    if self.is_resizing && self.resize_pointer_id == Some(pointer_id) {
+      if mouse.get_buttons() == 0 {
+        self.finish_resize()
+        return
+      }
+      event.prevent_default()
+      event.stop_propagation()
+      self.resize_to_height(
+        self.resize_start_height +
+        Double::from_int(mouse.get_client_y()) -
+        self.resize_start_y,
+      )
+      |> ignore
+    }
+  })
+  let finish_pointer_gesture = (event : @rdom.Event) => {
+    guard event.to_mouse_event() is Some(mouse) else { return }
+    let pointer_id = @base_browser.mouse_event_pointer_id(mouse)
+    if self.is_panning && self.pan_pointer_id == Some(pointer_id) {
+      event.prevent_default()
+      event.stop_propagation()
+      self.finish_pan(mouse)
+    }
+    if self.is_resizing && self.resize_pointer_id == Some(pointer_id) {
+      event.prevent_default()
+      event.stop_propagation()
+      self.finish_resize()
+    }
+  }
+  self.listen(
+    self.owner_window.as_event_target(),
+    "pointerup",
+    finish_pointer_gesture,
+  )
+  self.listen(
+    self.owner_window.as_event_target(),
+    "pointercancel",
+    finish_pointer_gesture,
+  )
+  self.listen(self.resize_handle.as_event_target(), "keydown", event => {
+    guard event.to_keyboard_event() is Some(keyboard) else { return }
+    if keyboard.key() != "ArrowUp" && keyboard.key() != "ArrowDown" {
+      return
+    }
+    if !self.initialized && !self.center_natural_content() {
+      return
+    }
+    event.prevent_default()
+    event.stop_propagation()
+    let rect = self.viewport_rect()
+    let current_height = match self.custom_height {
+      Some(height) => height
+      None =>
+        if is_positive_finite(rect.get_height()) {
+          rect.get_height()
+        } else {
+          diagram_minimum_height
+        }
+    }
+    let direction = if keyboard.key() == "ArrowUp" { -1.0 } else { 1.0 }
+    let step = if keyboard.shift_key() { 50.0 } else { 10.0 }
+    self.resize_to_height(current_height + direction * step) |> ignore
+  })
+}
+
+///|
+fn MarkdownCommentDiagramViewport::listen(
+  self : MarkdownCommentDiagramViewport,
+  target : @rdom.EventTarget,
+  event_type : String,
+  listener : @rdom.Listener,
+  passive_false? : Bool = false,
+) -> Unit {
+  if passive_false {
+    add_non_passive_event_listener(target, event_type, listener)
+  } else {
+    target.add_event_listener(event_type, listener)
+  }
+  self.listeners.push(
+    @base_common.Disposable::from(() => {
+      if passive_false {
+        remove_non_passive_event_listener(target, event_type, listener)
+      } else {
+        target.remove_event_listener(event_type, listener)
+      }
+    }),
+  )
+}
+
+///|
+fn MarkdownCommentDiagramViewport::viewport_rect(
+  self : MarkdownCommentDiagramViewport,
+) -> @rdom.DOMRect {
+  self.wrapper.get_bounding_client_rect()
+}
+
+///|
+fn MarkdownCommentDiagramViewport::measure_svg(
+  self : MarkdownCommentDiagramViewport,
+) -> DiagramSize? {
+  let saved_transform = save_element_style(self.content, "transform")
+  @base_browser.set_style_property(self.content, "transform", "none")
+  defer restore_element_style(self.content, "transform", saved_transform)
+  let rect = self.svg.get_bounding_client_rect()
+  if !is_positive_finite(rect.get_width()) ||
+    !is_positive_finite(rect.get_height()) {
+    return None
+  }
+  Some({ width: rect.get_width(), height: rect.get_height() })
+}
+
+///|
+fn MarkdownCommentDiagramViewport::apply_transform(
+  self : MarkdownCommentDiagramViewport,
+) -> Unit {
+  @base_browser.set_style_property(
+    self.content,
+    "transform",
+    "translate(\{self.translate_x}px, \{self.translate_y}px) scale(\{self.scale})",
+  )
+}
+
+///|
+fn MarkdownCommentDiagramViewport::write_height(
+  self : MarkdownCommentDiagramViewport,
+  height : Double,
+) -> Bool {
+  if !is_positive_finite(height) {
+    return false
+  }
+  let css_height = "\{height}px"
+  if @base_browser.element_style_value(self.wrapper, "height") == css_height {
+    return false
+  }
+  @base_browser.set_style_property(self.wrapper, "height", css_height)
+  if self.active {
+    (self.on_size_changed)()
+  }
+  true
+}
+
+///|
+fn MarkdownCommentDiagramViewport::set_cursor(
+  self : MarkdownCommentDiagramViewport,
+  alt_key : Bool,
+  shift_key : Bool,
+) -> Unit {
+  if !self.active {
+    return
+  }
+  let cursor = if self.pan_mode_enabled {
+    "grab"
+  } else if alt_key && shift_key {
+    "zoom-out"
+  } else if alt_key {
+    "grab"
+  } else {
+    "default"
+  }
+  @base_browser.set_style_property(self.wrapper, "cursor", cursor)
+}
+
+///|
+fn MarkdownCommentDiagramViewport::center_natural_content(
+  self : MarkdownCommentDiagramViewport,
+) -> Bool {
+  guard self.measure_svg() is Some(svg_size) else { return false }
+  let before = self.viewport_rect()
+  if !is_positive_finite(before.get_width()) {
+    return false
+  }
+  let height = self.custom_height.unwrap_or(svg_size.height)
+  if !is_positive_finite(height) {
+    return false
+  }
+  self.write_height(height) |> ignore
+  let rect = self.viewport_rect()
+  if !is_positive_finite(rect.get_width()) ||
+    !is_positive_finite(rect.get_height()) {
+    return false
+  }
+  self.last_svg_width = svg_size.width
+  self.last_svg_height = svg_size.height
+  self.scale = 1.0
+  self.fit_scale = 1.0
+  self.translate_x = (rect.get_width() - svg_size.width) / 2.0
+  self.translate_y = 0.0
+  self.apply_transform()
+  self.initialized = true
+  true
+}
+
+///|
+fn MarkdownCommentDiagramViewport::preserve_visible_origin(
+  self : MarkdownCommentDiagramViewport,
+) -> Bool {
+  if !is_positive_finite(self.scale) {
+    return false
+  }
+  let origin_x = -self.translate_x / self.scale
+  let origin_y = -self.translate_y / self.scale
+  let percent_x = if self.last_svg_width > 0.0 {
+    origin_x / self.last_svg_width
+  } else {
+    0.0
+  }
+  let percent_y = if self.last_svg_height > 0.0 {
+    origin_y / self.last_svg_height
+  } else {
+    0.0
+  }
+  guard self.measure_svg() is Some(svg_size) else { return false }
+  let height = self.custom_height.unwrap_or(svg_size.height)
+  if !is_positive_finite(height) {
+    return false
+  }
+  self.write_height(height) |> ignore
+  let rect = self.viewport_rect()
+  if !is_positive_finite(rect.get_width()) ||
+    !is_positive_finite(rect.get_height()) {
+    return false
+  }
+  self.last_svg_width = svg_size.width
+  self.last_svg_height = svg_size.height
+  self.translate_x = -(percent_x * svg_size.width) * self.scale
+  self.translate_y = -(percent_y * svg_size.height) * self.scale
+  self.apply_transform()
+  true
+}
+
+///|
+fn MarkdownCommentDiagramViewport::layout(
+  self : MarkdownCommentDiagramViewport,
+) -> Bool {
+  if !self.active {
+    return false
+  }
+  if !self.initialized {
+    return self.center_natural_content()
+  }
+  if self.has_interacted {
+    self.preserve_visible_origin()
+  } else {
+    self.center_natural_content()
+  }
+}
+
+///|
+fn MarkdownCommentDiagramViewport::zoom_at_point(
+  self : MarkdownCommentDiagramViewport,
+  factor : Double,
+  x : Double,
+  y : Double,
+) -> Bool {
+  if !self.initialized && !self.center_natural_content() {
+    return false
+  }
+  if !is_finite(factor) ||
+    !is_finite(x) ||
+    !is_finite(y) ||
+    !is_positive_finite(self.scale) {
+    return false
+  }
+  let min_allowed_scale = diagram_min_scale.min(self.fit_scale).min(self.scale)
+  let new_scale = (self.scale * factor)
+    .max(min_allowed_scale)
+    .min(diagram_max_scale)
+  if !is_positive_finite(new_scale) {
+    return false
+  }
+  let scale_factor = new_scale / self.scale
+  self.translate_x = x - (x - self.translate_x) * scale_factor
+  self.translate_y = y - (y - self.translate_y) * scale_factor
+  self.scale = new_scale
+  self.has_interacted = true
+  self.apply_transform()
+  true
+}
+
+///|
+fn MarkdownCommentDiagramViewport::zoom_at_center(
+  self : MarkdownCommentDiagramViewport,
+  factor : Double,
+) -> Bool {
+  if !self.initialized && !self.center_natural_content() {
+    return false
+  }
+  let rect = self.viewport_rect()
+  if !is_positive_finite(rect.get_width()) ||
+    !is_positive_finite(rect.get_height()) {
+    return false
+  }
+  self.zoom_at_point(factor, rect.get_width() / 2.0, rect.get_height() / 2.0)
+}
+
+///|
+fn MarkdownCommentDiagramViewport::fit(
+  self : MarkdownCommentDiagramViewport,
+) -> Bool {
+  if !self.initialized && !self.center_natural_content() {
+    return false
+  }
+  guard self.measure_svg() is Some(svg_size) else { return false }
+  let rect = self.viewport_rect()
+  if !is_positive_finite(rect.get_width()) ||
+    !is_positive_finite(rect.get_height()) {
+    return false
+  }
+  let available_width = 1.0.max(rect.get_width() - diagram_fit_padding * 2.0)
+  let available_height = 1.0.max(rect.get_height() - diagram_fit_padding * 2.0)
+  let next_scale = 1.0
+    .min(available_width / svg_size.width)
+    .min(available_height / svg_size.height)
+  if !is_positive_finite(next_scale) {
+    return false
+  }
+  let next_x = (rect.get_width() - svg_size.width * next_scale) / 2.0
+  let next_y = (rect.get_height() - svg_size.height * next_scale) / 2.0
+  if !is_finite(next_x) || !is_finite(next_y) {
+    return false
+  }
+  self.scale = next_scale
+  self.fit_scale = next_scale
+  self.translate_x = next_x
+  self.translate_y = next_y
+  self.last_svg_width = svg_size.width
+  self.last_svg_height = svg_size.height
+  self.initialized = true
+  self.has_interacted = true
+  self.apply_transform()
+  true
+}
+
+///|
+fn MarkdownCommentDiagramViewport::resize_to_height(
+  self : MarkdownCommentDiagramViewport,
+  height : Double,
+) -> Bool {
+  if !is_finite(height) {
+    return false
+  }
+  let next_height = diagram_minimum_height.max(height)
+  self.custom_height = Some(next_height)
+  self.write_height(next_height) |> ignore
+  true
+}
+
+///|
+fn MarkdownCommentDiagramViewport::acquire_body_cursor(
+  self : MarkdownCommentDiagramViewport,
+) -> Bool {
+  if self.body_cursor_lease is Some(_) {
+    return false
+  }
+  let acquired = Ref(false)
+  with_document_body(self.owner_document, body => {
+    let coordinator = body_cursor_coordinator_for(self.owner_document)
+    if coordinator.active {
+      return
+    }
+    coordinator.active = true
+    let lease : DiagramBodyCursorLease = {
+      coordinator,
+      body,
+      saved_cursor: save_element_style(body, "cursor"),
+      active: true,
+    }
+    @base_browser.set_style_property(body, "cursor", "ns-resize")
+    self.body_cursor_lease = Some(lease)
+    acquired.val = true
+  })
+  |> ignore
+  acquired.val
+}
+
+///|
+fn MarkdownCommentDiagramViewport::restore_body_cursor(
+  self : MarkdownCommentDiagramViewport,
+) -> Unit {
+  match self.body_cursor_lease {
+    Some(lease) => release_body_cursor_lease(lease)
+    None => ()
+  }
+  self.body_cursor_lease = None
+}
+
+///|
+fn MarkdownCommentDiagramViewport::finish_pan(
+  self : MarkdownCommentDiagramViewport,
+  event : @rdom.MouseEvent,
+) -> Unit {
+  if !self.is_panning {
+    return
+  }
+  self.is_panning = false
+  self.has_interacted = true
+  self.pan_pointer_id = None
+  self.set_cursor(event.get_alt_key(), event.get_shift_key())
+}
+
+///|
+fn MarkdownCommentDiagramViewport::finish_resize(
+  self : MarkdownCommentDiagramViewport,
+) -> Unit {
+  if !self.is_resizing {
+    return
+  }
+  self.is_resizing = false
+  self.resize_pointer_id = None
+  self.restore_body_cursor()
+}
+
+///|
+fn MarkdownCommentDiagramViewport::dispose(
+  self : MarkdownCommentDiagramViewport,
+) -> Unit {
+  if !self.active {
+    return
+  }
+  self.active = false
+  match self.pending_frame {
+    Some(cancel) => cancel()
+    None => ()
+  }
+  self.pending_frame = None
+  match self.observer {
+    Some(observer) => observer.dispose()
+    None => ()
+  }
+  self.observer = None
+  self.finish_resize()
+  self.is_panning = false
+  self.pan_pointer_id = None
+  while self.listeners.length() > 0 {
+    let index = self.listeners.length() - 1
+    let listener = self.listeners[index]
+    self.listeners.pop() |> ignore
+    listener.dispose()
+  }
+  @base_browser.remove_element(self.controls)
+  @base_browser.remove_element(self.resize_handle)
+  match self.content.get_parent_node().to_option() {
+    Some(parent) =>
+      if parent.is_same_node(self.wrapper.as_node()) {
+        self.wrapper.insert_before(
+          self.svg.as_node(),
+          @js.Nullable::from_option(Some(self.content.as_node())),
+        )
+        @base_browser.remove_element(self.content)
+      }
+    None => ()
+  }
+  remove_element_class(self.wrapper, diagram_viewport_class)
+  restore_element_attribute(self.wrapper, "tabindex", self.saved_tabindex)
+  restore_element_attribute(self.wrapper, "aria-label", self.saved_aria_label)
+  restore_element_style(self.wrapper, "height", self.saved_height)
+  restore_element_style(self.wrapper, "overflow", self.saved_overflow)
+  restore_element_style(self.wrapper, "cursor", self.saved_cursor)
+}
+
+///|
+fn body_cursor_coordinator_for(
+  document : @rdom.Document,
+) -> DiagramBodyCursorCoordinator {
+  for coordinator in diagram_body_cursor_coordinators {
+    if same_document(coordinator.document, document) {
+      return coordinator
+    }
+  }
+  let coordinator : DiagramBodyCursorCoordinator = { document, active: false }
+  diagram_body_cursor_coordinators.push(coordinator)
+  coordinator
+}
+
+///|
+fn release_body_cursor_lease(lease : DiagramBodyCursorLease) -> Unit {
+  if !lease.active {
+    return
+  }
+  lease.active = false
+  restore_element_style(lease.body, "cursor", lease.saved_cursor)
+  lease.coordinator.active = false
+  let retained = diagram_body_cursor_coordinators.filter(coordinator => {
+    coordinator.active ||
+    !same_document(coordinator.document, lease.coordinator.document)
+  })
+  diagram_body_cursor_coordinators.clear()
+  diagram_body_cursor_coordinators.append(retained)
+}
+
+///|
+fn is_finite(value : Double) -> Bool {
+  !value.is_nan() && !value.is_inf()
+}
+
+///|
+fn is_positive_finite(value : Double) -> Bool {
+  is_finite(value) && value > 0.0
+}
+
+///|
+fn element_class_tokens(element : @rdom.Element) -> Array[String] {
+  let tokens : Array[String] = []
+  for token in element_attribute_or_empty(element, "class").split(" ") {
+    let value = token.to_owned()
+    if value != "" {
+      tokens.push(value)
+    }
+  }
+  tokens
+}
+
+///|
+fn element_has_class(element : @rdom.Element, class_name : String) -> Bool {
+  for token in element_class_tokens(element) {
+    if token == class_name {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn add_element_class(element : @rdom.Element, class_name : String) -> Unit {
+  if element_has_class(element, class_name) {
+    return
+  }
+  let tokens = element_class_tokens(element)
+  tokens.push(class_name)
+  element.set_attribute("class", tokens.join(" "))
+}
+
+///|
+fn remove_element_class(element : @rdom.Element, class_name : String) -> Unit {
+  element.set_attribute(
+    "class",
+    element_class_tokens(element).filter(token => token != class_name).join(" "),
+  )
+}
+
+///|
+fn set_element_class_active(
+  element : @rdom.Element,
+  class_name : String,
+  active : Bool,
+) -> Unit {
+  if active {
+    add_element_class(element, class_name)
+  } else {
+    remove_element_class(element, class_name)
+  }
+}
+
+///|
+fn save_element_attribute(
+  element : @rdom.Element,
+  name : String,
+) -> SavedAttribute {
+  {
+    present: element_has_attribute(element, name),
+    value: element_attribute_or_empty(element, name),
+  }
+}
+
+///|
+fn restore_element_attribute(
+  element : @rdom.Element,
+  name : String,
+  saved : SavedAttribute,
+) -> Unit {
+  if saved.present {
+    element.set_attribute(name, saved.value)
+  } else {
+    element.remove_attribute(name)
+  }
+}
+
+///|
+fn save_element_style(element : @rdom.Element, name : String) -> SavedStyle {
+  {
+    value: @base_browser.element_style_value(element, name),
+    priority: @base_browser.element_style_priority(element, name),
+  }
+}
+
+///|
+fn restore_element_style(
+  element : @rdom.Element,
+  name : String,
+  saved : SavedStyle,
+) -> Unit {
+  if saved.value == "" {
+    @base_browser.remove_style_property(element, name)
+  } else if saved.priority == "" {
+    @base_browser.set_style_property(element, name, saved.value)
+  } else {
+    @base_browser.set_style_property_with_priority(
+      element,
+      name,
+      saved.value,
+      saved.priority,
+    )
+  }
+}
+
+///|
+/// `ownerDocument` and `defaultView` are not exposed by the vendored Rabbita
+/// DOM bindings. The callback keeps nullable browser values out of MoonBit.
+extern "js" fn with_diagram_viewport_environment(
+  wrapper : @rdom.Element,
+  fallback_target : @rdom.Element,
+  callback : (@rdom.Document, @rdom.Window) -> Unit,
+) -> Bool =
+  #| (wrapper, fallbackTarget, callback) => {
+  #|   const document = wrapper?.ownerDocument ?? fallbackTarget?.ownerDocument;
+  #|   const window = document?.defaultView;
+  #|   if (!document || !window) return false;
+  #|   callback(document, window);
+  #|   return true;
+  #| }
+
+///|
+/// Rabbita does not currently expose `hasAttribute` or nullable attribute
+/// reads; these two bindings normalize that narrow DOM seam.
+extern "js" fn element_has_attribute(
+  element : @rdom.Element,
+  name : String,
+) -> Bool = "(element, name) => element?.hasAttribute?.(name) === true"
+
+///|
+extern "js" fn element_attribute_or_empty(
+  element : @rdom.Element,
+  name : String,
+) -> String = "(element, name) => element?.getAttribute?.(name) ?? ''"
+
+///|
+/// `Document.body` is not exposed by the current Rabbita DOM bindings. The
+/// coordinator and lease themselves remain MoonBit-owned.
+extern "js" fn with_document_body(
+  document : @rdom.Document,
+  callback : (@rdom.Element) -> Unit,
+) -> Bool =
+  #| (document, callback) => {
+  #|   const body = document?.body;
+  #|   if (!body) return false;
+  #|   callback(body);
+  #|   return true;
+  #| }
+
+///|
+extern "js" fn same_document(
+  left : @rdom.Document,
+  right : @rdom.Document,
+) -> Bool = "(left, right) => left === right"
+
+///|
+/// Wheel zoom must be non-passive so it can suppress browser scrolling after
+/// a modifier gesture has been accepted.
+extern "js" fn add_non_passive_event_listener(
+  target : @rdom.EventTarget,
+  event_type : String,
+  listener : @rdom.Listener,
+) -> Unit =
+  #| (target, eventType, listener) => {
+  #|   target.addEventListener(eventType, listener, { passive: false });
+  #| }
+
+///|
+extern "js" fn remove_non_passive_event_listener(
+  target : @rdom.EventTarget,
+  event_type : String,
+  listener : @rdom.Listener,
+) -> Unit =
+  #| (target, eventType, listener) => {
+  #|   target.removeEventListener(eventType, listener, { passive: false });
+  #| }

--- a/editor/internal/viewer/contrib/markdown_comments/browser/diagram_viewport_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/diagram_viewport_reference_wbtest.mbt
@@ -1,0 +1,1875 @@
+// Algorithm/behavior reference coverage for:
+// - vscode/extensions/mermaid-markdown-features/preview-src/shared/diagramManager.ts
+// - vscode/extensions/mermaid-markdown-features/preview-src/shared/diagramStyles.css
+// - vscode/extensions/mermaid-markdown-features/preview-src/chat/mermaidWebview.ts
+// pinned at b18492a288de038fbc7643aae6de8247029d11bd.
+//
+// The product deviations exercised here are the checked-in plan's true Fit
+// action, zero-size initialization deferral, retained SVG height metadata,
+// fit-aware 0.5 floor, owning-window drag lifetime, and complete disposal.
+//
+// SKIPPED (fixed product defaults): configurable control visibility,
+// resizability, max height, and Always/Never click-drag modes.
+// SKIPPED (product boundary): preview Reset Zoom, cross-render retained state,
+// SVG height-attribute removal, touch-specific gestures, fullscreen, minimap,
+// export/copy, and reset-to-intrinsic controls.
+
+///|
+#external
+type DiagramViewportTestHarness
+
+///|
+extern "js" fn install_diagram_viewport_test_dom() -> DiagramViewportTestHarness =
+  #| () => {
+  #|   const harness = {
+  #|     restored: false,
+  #|     originals: {
+  #|     document: globalThis.document,
+  #|     window: globalThis.window,
+  #|     Element: globalThis.Element,
+  #|     MouseEvent: globalThis.MouseEvent,
+  #|     WheelEvent: globalThis.WheelEvent,
+  #|     KeyboardEvent: globalThis.KeyboardEvent,
+  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     },
+  #|     frames: [],
+  #|     observers: [],
+  #|     wrappers: [],
+  #|     svgMeasureTransforms: [],
+  #|     throwOnObserve: false,
+  #|   };
+  #|
+  #|   class TestStyle {
+  #|     constructor() {
+  #|       this.values = new Map();
+  #|       this.priorities = new Map();
+  #|     }
+  #|     getPropertyValue(name) { return this.values.get(name) ?? ''; }
+  #|     getPropertyPriority(name) { return this.priorities.get(name) ?? ''; }
+  #|     setProperty(name, value, priority = '') {
+  #|       this.values.set(name, String(value));
+  #|       if (priority) this.priorities.set(name, String(priority));
+  #|       else this.priorities.delete(name);
+  #|     }
+  #|     removeProperty(name) {
+  #|       const previous = this.getPropertyValue(name);
+  #|       this.values.delete(name);
+  #|       this.priorities.delete(name);
+  #|       return previous;
+  #|     }
+  #|   }
+  #|
+  #|   class TestTarget {
+  #|     constructor() { this.__listeners = new Map(); }
+  #|     addEventListener(type, listener) {
+  #|       let values = this.__listeners.get(type);
+  #|       if (!values) {
+  #|         values = new Set();
+  #|         this.__listeners.set(type, values);
+  #|       }
+  #|       values.add(listener);
+  #|     }
+  #|     removeEventListener(type, listener) {
+  #|       this.__listeners.get(type)?.delete(listener);
+  #|     }
+  #|     listenerCount(type) { return this.__listeners.get(type)?.size ?? 0; }
+  #|     dispatchEvent(event) {
+  #|       if (!event.target) event.target = this;
+  #|       for (let current = this; current; current = event.bubbles ? current.parentNode : null) {
+  #|         event.currentTarget = current;
+  #|         for (const listener of Array.from(current.__listeners?.get(event.type) ?? [])) {
+  #|           listener.call(current, event);
+  #|           if (event.immediatePropagationStopped) break;
+  #|         }
+  #|         if (event.propagationStopped) break;
+  #|       }
+  #|       return !event.defaultPrevented;
+  #|     }
+  #|   }
+  #|
+  #|   class TestEvent {
+  #|     constructor(type, init = {}) {
+  #|       this.type = type;
+  #|       this.bubbles = init.bubbles ?? false;
+  #|       this.cancelable = init.cancelable ?? false;
+  #|       this.button = init.button ?? 0;
+  #|       this.buttons = init.buttons ?? 0;
+  #|       this.pointerId = init.pointerId ?? 0;
+  #|       this.clientX = init.clientX ?? 0;
+  #|       this.clientY = init.clientY ?? 0;
+  #|       this.altKey = init.altKey ?? false;
+  #|       this.shiftKey = init.shiftKey ?? false;
+  #|       this.ctrlKey = init.ctrlKey ?? false;
+  #|       this.deltaY = init.deltaY ?? 0;
+  #|       this.key = init.key ?? '';
+  #|       this.defaultPrevented = false;
+  #|       this.propagationStopped = false;
+  #|       this.immediatePropagationStopped = false;
+  #|     }
+  #|     preventDefault() {
+  #|       if (this.cancelable) this.defaultPrevented = true;
+  #|     }
+  #|     stopPropagation() { this.propagationStopped = true; }
+  #|     stopImmediatePropagation() {
+  #|       this.immediatePropagationStopped = true;
+  #|       this.propagationStopped = true;
+  #|     }
+  #|   }
+  #|   class TestMouseEvent extends TestEvent {}
+  #|   class TestWheelEvent extends TestMouseEvent {}
+  #|   class TestKeyboardEvent extends TestEvent {}
+  #|
+  #|   class TestElement extends TestTarget {
+  #|     constructor(ownerDocument, tag) {
+  #|       super();
+  #|       this.ownerDocument = ownerDocument;
+  #|       this.nodeType = 1;
+  #|       this.nodeName = String(tag).toUpperCase();
+  #|       this.tagName = this.nodeName;
+  #|       this.attributes = new Map();
+  #|       this.childNodes = [];
+  #|       this.parentNode = null;
+  #|       this.style = new TestStyle();
+  #|       this.__left = 0;
+  #|       this.__top = 0;
+  #|       this.__width = 0;
+  #|       this.__height = 0;
+  #|       this.classList = {
+  #|         contains: name => this.classTokens().includes(name),
+  #|         add: (...names) => {
+  #|           const values = this.classTokens();
+  #|           for (const name of names) if (!values.includes(name)) values.push(name);
+  #|           this.setAttribute('class', values.join(' '));
+  #|         },
+  #|         remove: (...names) => {
+  #|           const removed = new Set(names);
+  #|           this.setAttribute('class', this.classTokens().filter(name => !removed.has(name)).join(' '));
+  #|         },
+  #|         toggle: (name, force) => {
+  #|           const enabled = force === undefined ? !this.classTokens().includes(name) : Boolean(force);
+  #|           if (enabled) this.classList.add(name);
+  #|           else this.classList.remove(name);
+  #|           return enabled;
+  #|         },
+  #|       };
+  #|     }
+  #|     classTokens() {
+  #|       return (this.getAttribute('class') ?? '').split(/\s+/).filter(Boolean);
+  #|     }
+  #|     setAttribute(name, value) { this.attributes.set(String(name).toLowerCase(), String(value)); }
+  #|     getAttribute(name) { return this.attributes.get(String(name).toLowerCase()) ?? null; }
+  #|     hasAttribute(name) { return this.attributes.has(String(name).toLowerCase()); }
+  #|     removeAttribute(name) { this.attributes.delete(String(name).toLowerCase()); }
+  #|     get children() { return this.childNodes.filter(child => child.nodeType === 1); }
+  #|     get firstChild() { return this.childNodes[0] ?? null; }
+  #|     get nextSibling() {
+  #|       if (!this.parentNode) return null;
+  #|       const index = this.parentNode.childNodes.indexOf(this);
+  #|       return this.parentNode.childNodes[index + 1] ?? null;
+  #|     }
+  #|     appendChild(child) {
+  #|       child.parentNode?.removeChild(child);
+  #|       this.childNodes.push(child);
+  #|       child.parentNode = this;
+  #|       return child;
+  #|     }
+  #|     insertBefore(child, reference) {
+  #|       child.parentNode?.removeChild(child);
+  #|       const index = reference === null ? -1 : this.childNodes.indexOf(reference);
+  #|       if (index < 0) this.childNodes.push(child);
+  #|       else this.childNodes.splice(index, 0, child);
+  #|       child.parentNode = this;
+  #|       return child;
+  #|     }
+  #|     removeChild(child) {
+  #|       const index = this.childNodes.indexOf(child);
+  #|       if (index >= 0) this.childNodes.splice(index, 1);
+  #|       child.parentNode = null;
+  #|       return child;
+  #|     }
+  #|     remove() { this.parentNode?.removeChild(this); }
+  #|     matchesDiagramCandidate() {
+  #|       return this.classTokens().includes('moonbit-viewer-markdown-diagram') &&
+  #|         this.getAttribute('data-diagram-language') === 'diago';
+  #|     }
+  #|     querySelectorAll(selector) {
+  #|       const result = [];
+  #|       const visit = node => {
+  #|         for (const child of node.children ?? []) {
+  #|           if (selector === '.moonbit-viewer-markdown-diagram[data-diagram-language="diago"]' &&
+  #|               child.matchesDiagramCandidate()) {
+  #|             result.push(child);
+  #|           } else if (selector.startsWith('.') &&
+  #|                      child.classTokens().includes(selector.slice(1))) {
+  #|             result.push(child);
+  #|           }
+  #|           visit(child);
+  #|         }
+  #|       };
+  #|       visit(this);
+  #|       return result;
+  #|     }
+  #|     getBoundingClientRect() {
+  #|       if (this.tagName === 'SVG' &&
+  #|           this.parentNode?.classTokens?.().includes('moonbit-viewer-markdown-diagram-content')) {
+  #|         harness.svgMeasureTransforms.push(
+  #|           this.parentNode.style.getPropertyValue('transform'),
+  #|         );
+  #|       }
+  #|       const inlineHeight = Number.parseFloat(this.style.getPropertyValue('height'));
+  #|       const height = Number.isFinite(inlineHeight) ? inlineHeight : this.__height;
+  #|       return {
+  #|         left: this.__left,
+  #|         top: this.__top,
+  #|         width: this.__width,
+  #|         height,
+  #|         right: this.__left + this.__width,
+  #|         bottom: this.__top + height,
+  #|       };
+  #|     }
+  #|   }
+  #|
+  #|   class TestResizeObserver {
+  #|     constructor(callback) {
+  #|       this.callback = callback;
+  #|       this.targets = [];
+  #|       this.disconnectCount = 0;
+  #|       harness.observers.push(this);
+  #|     }
+  #|     observe(target) {
+  #|       if (harness.throwOnObserve) {
+  #|         harness.throwOnObserve = false;
+  #|         throw new Error('injected ResizeObserver.observe failure');
+  #|       }
+  #|       this.targets.push(target);
+  #|     }
+  #|     disconnect() { this.disconnectCount += 1; }
+  #|     trigger() { this.callback(this.targets.map(target => ({ target })), this); }
+  #|   }
+  #|
+  #|   const ownerWindow = new TestTarget();
+  #|   ownerWindow.parentNode = null;
+  #|   ownerWindow.ResizeObserver = TestResizeObserver;
+  #|   const document = new TestTarget();
+  #|   document.nodeType = 9;
+  #|   document.ownerDocument = document;
+  #|   document.defaultView = ownerWindow;
+  #|   document.createElement = tag => new TestElement(document, tag);
+  #|   document.body = document.createElement('body');
+  #|   document.body.style.setProperty('cursor', 'crosshair', 'important');
+  #|   ownerWindow.document = document;
+  #|   globalThis.document = document;
+  #|   globalThis.window = ownerWindow;
+  #|   globalThis.Element = TestElement;
+  #|   globalThis.MouseEvent = TestMouseEvent;
+  #|   globalThis.WheelEvent = TestWheelEvent;
+  #|   globalThis.KeyboardEvent = TestKeyboardEvent;
+  #|   globalThis.requestAnimationFrame = callback => {
+  #|     harness.frames.push(callback);
+  #|     return harness.frames.length;
+  #|   };
+  #|   harness.document = document;
+  #|   harness.window = ownerWindow;
+  #|   return harness;
+  #| }
+
+///|
+extern "js" fn DiagramViewportTestHarness::dispose(
+  harness : DiagramViewportTestHarness,
+) -> Unit =
+  #| harness => {
+  #|   if (harness.restored) return;
+  #|   harness.restored = true;
+  #|   const originals = harness.originals;
+  #|   globalThis.document = originals.document;
+  #|   globalThis.window = originals.window;
+  #|   globalThis.Element = originals.Element;
+  #|   globalThis.MouseEvent = originals.MouseEvent;
+  #|   globalThis.WheelEvent = originals.WheelEvent;
+  #|   globalThis.KeyboardEvent = originals.KeyboardEvent;
+  #|   globalThis.requestAnimationFrame = originals.requestAnimationFrame;
+  #| }
+
+///|
+extern "js" fn diagram_viewport_test_target(
+  harness : DiagramViewportTestHarness,
+  mode : String,
+) -> @rdom.Element =
+  #| (harness, mode) => {
+  #|   const document = harness.document;
+  #|   const target = document.createElement('div');
+  #|   target.setAttribute('class', 'moonbit-viewer-markdown-comment-content');
+  #|   const add = (language, direct, width, height, svgWidth, svgHeight) => {
+  #|     const wrapper = document.createElement('div');
+  #|     wrapper.setAttribute('class', 'moonbit-viewer-markdown-diagram');
+  #|     wrapper.setAttribute('data-diagram-language', language);
+  #|     wrapper.style.setProperty('overflow', 'auto');
+  #|     wrapper.__width = width;
+  #|     wrapper.__height = height;
+  #|     const svg = document.createElement('svg');
+  #|     svg.setAttribute('height', String(svgHeight));
+  #|     svg.__width = svgWidth;
+  #|     svg.__height = svgHeight;
+  #|     const nested = document.createElement('svg');
+  #|     nested.__width = svgWidth;
+  #|     nested.__height = svgHeight;
+  #|     svg.appendChild(nested);
+  #|     if (direct) {
+  #|       wrapper.appendChild(svg);
+  #|     } else {
+  #|       const holder = document.createElement('div');
+  #|       holder.appendChild(svg);
+  #|       wrapper.appendChild(holder);
+  #|     }
+  #|     target.appendChild(wrapper);
+  #|     harness.wrappers.push(wrapper);
+  #|     return wrapper;
+  #|   };
+  #|   if (mode === 'none') {
+  #|     target.appendChild(document.createElement('p'));
+  #|   } else if (mode === 'wrong') {
+  #|     add('d2', true, 400, 200, 200, 100);
+  #|   } else if (mode === 'indirect') {
+  #|     add('diago', false, 400, 200, 200, 100);
+  #|   } else if (mode === 'two') {
+  #|     add('diago', true, 400, 200, 200, 100);
+  #|     add('diago', true, 300, 120, 120, 80);
+  #|   } else if (mode === 'mixed') {
+  #|     add('d2', true, 400, 200, 200, 100);
+  #|     add('diago', false, 400, 200, 200, 100);
+  #|     add('diago', true, 400, 200, 200, 100);
+  #|   } else if (mode === 'wide') {
+  #|     add('diago', true, 400, 400, 800, 400);
+  #|   } else {
+  #|     add('diago', true, 400, 100, 200, 100);
+  #|   }
+  #|   return target;
+  #| }
+
+///|
+extern "js" fn diagram_viewport_test_flush_frame(
+  harness : DiagramViewportTestHarness,
+) -> Unit =
+  #| harness => {
+  #|   const callback = harness.frames.shift();
+  #|   if (!callback) throw new Error('missing animation frame');
+  #|   callback(0);
+  #| }
+
+///|
+extern "js" fn diagram_viewport_test_pending_frames(
+  harness : DiagramViewportTestHarness,
+) -> Int = "harness => harness.frames.length"
+
+///|
+extern "js" fn diagram_viewport_test_observer_count(
+  harness : DiagramViewportTestHarness,
+) -> Int = "harness => harness.observers.length"
+
+///|
+extern "js" fn diagram_viewport_test_fail_next_observe(
+  harness : DiagramViewportTestHarness,
+) -> Unit = "harness => { harness.throwOnObserve = true; }"
+
+///|
+extern "js" fn diagram_viewport_test_target_wrapper_state(
+  target : @rdom.Element,
+) -> String =
+  #| target => {
+  #|   const wrapper = target.querySelectorAll(
+  #|     '.moonbit-viewer-markdown-diagram[data-diagram-language="diago"]',
+  #|   )[0];
+  #|   return [
+  #|     wrapper.getAttribute('class') ?? '',
+  #|     wrapper.getAttribute('tabindex') ?? '',
+  #|     wrapper.getAttribute('aria-label') ?? '',
+  #|     wrapper.style.getPropertyValue('height'),
+  #|     wrapper.style.getPropertyValue('overflow'),
+  #|     wrapper.children.map(child => child.tagName).join(','),
+  #|     wrapper.listenerCount('wheel'),
+  #|   ].join('|');
+  #| }
+
+///|
+extern "js" fn diagram_viewport_test_all_svg_measurements_untransformed(
+  harness : DiagramViewportTestHarness,
+) -> Bool =
+  #| harness => {
+  #|   const values = harness.svgMeasureTransforms;
+  #|   return values.length > 0 && values.every(value => value === 'none');
+  #| }
+
+///|
+extern "js" fn diagram_viewport_test_trigger_observer(
+  harness : DiagramViewportTestHarness,
+  index : Int,
+) -> Unit =
+  #| (harness, index) => {
+  #|   const observer = harness.observers[index];
+  #|   if (!observer) throw new Error(`missing observer ${index}`);
+  #|   observer.trigger();
+  #| }
+
+///|
+extern "js" fn diagram_viewport_test_disconnect_count(
+  harness : DiagramViewportTestHarness,
+  index : Int,
+) -> Int =
+  #| (harness, index) => harness.observers[index]?.disconnectCount ?? 0
+
+///|
+extern "js" fn diagram_viewport_test_window_listener_count(
+  harness : DiagramViewportTestHarness,
+  event_type : String,
+) -> Int = "(harness, type) => harness.window.listenerCount(type)"
+
+///|
+fn diagram_viewport_test_controller_count(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+) -> Int {
+  lifetime.controllers.length()
+}
+
+///|
+fn diagram_viewport_test_scale(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Double {
+  lifetime.controllers[index].scale
+}
+
+///|
+fn diagram_viewport_test_translate_x(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Double {
+  lifetime.controllers[index].translate_x
+}
+
+///|
+fn diagram_viewport_test_translate_y(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Double {
+  lifetime.controllers[index].translate_y
+}
+
+///|
+fn diagram_viewport_test_interacted(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Bool {
+  lifetime.controllers[index].has_interacted
+}
+
+///|
+fn diagram_viewport_test_dragged(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Bool {
+  lifetime.controllers[index].has_dragged
+}
+
+///|
+fn diagram_viewport_test_is_panning(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Bool {
+  lifetime.controllers[index].is_panning
+}
+
+///|
+fn diagram_viewport_test_is_resizing(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Bool {
+  lifetime.controllers[index].is_resizing
+}
+
+///|
+fn diagram_viewport_test_custom_height(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Double {
+  lifetime.controllers[index].custom_height.unwrap_or(0.0)
+}
+
+///|
+fn diagram_viewport_test_node(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+  node_name : String,
+) -> @rdom.Element {
+  let controller = lifetime.controllers[index]
+  match node_name {
+    "wrapper" => controller.wrapper
+    "content" => controller.content
+    "svg" => controller.svg
+    "controls" => controller.controls
+    "panButton" => controller.pan_button
+    "zoomOutButton" => controller.zoom_out_button
+    "zoomInButton" => controller.zoom_in_button
+    "fitButton" => controller.fit_button
+    "resizeHandle" => controller.resize_handle
+    _ => abort("unknown diagram viewport test node: \{node_name}")
+  }
+}
+
+///|
+fn diagram_viewport_test_attribute(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+  node_name : String,
+  attribute : String,
+) -> String {
+  element_attribute_or_empty(
+    diagram_viewport_test_node(lifetime, index, node_name),
+    attribute,
+  )
+}
+
+///|
+fn diagram_viewport_test_class_contains(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+  node_name : String,
+  class_name : String,
+) -> Bool {
+  element_has_class(
+    diagram_viewport_test_node(lifetime, index, node_name),
+    class_name,
+  )
+}
+
+///|
+fn diagram_viewport_test_icon_class(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+  node_name : String,
+) -> String {
+  let button = diagram_viewport_test_node(lifetime, index, node_name)
+  match button.get_first_child().to_element() {
+    Some(icon) => element_attribute_or_empty(icon, "class")
+    None => ""
+  }
+}
+
+///|
+extern "js" fn diagram_viewport_test_child_classes_raw(
+  wrapper : @rdom.Element,
+) -> String =
+  #| wrapper => wrapper.children
+  #|   .map(child => child.getAttribute('class') ?? child.tagName.toLowerCase())
+  #|   .join('|')
+
+///|
+fn diagram_viewport_test_child_classes(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> String {
+  diagram_viewport_test_child_classes_raw(lifetime.controllers[index].wrapper)
+}
+
+///|
+fn diagram_viewport_test_transform(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> String {
+  @base_browser.element_style_value(
+    lifetime.controllers[index].content,
+    "transform",
+  )
+}
+
+///|
+fn diagram_viewport_test_wrapper_height(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> String {
+  @base_browser.element_style_value(
+    lifetime.controllers[index].wrapper,
+    "height",
+  )
+}
+
+///|
+fn diagram_viewport_test_svg_height_attribute(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> String {
+  element_attribute_or_empty(lifetime.controllers[index].svg, "height")
+}
+
+///|
+extern "js" fn diagram_viewport_test_set_geometry_raw(
+  wrapper : @rdom.Element,
+  svg : @rdom.Element,
+  viewport_width : Double,
+  viewport_height : Double,
+  svg_width : Double,
+  svg_height : Double,
+) -> Unit =
+  #| (wrapper, svg, viewportWidth, viewportHeight, svgWidth, svgHeight) => {
+  #|   wrapper.__width = viewportWidth;
+  #|   wrapper.__height = viewportHeight;
+  #|   svg.__width = svgWidth;
+  #|   svg.__height = svgHeight;
+  #| }
+
+///|
+fn diagram_viewport_test_set_geometry(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+  viewport_width : Double,
+  viewport_height : Double,
+  svg_width : Double,
+  svg_height : Double,
+) -> Unit {
+  let controller = lifetime.controllers[index]
+  diagram_viewport_test_set_geometry_raw(
+    controller.wrapper,
+    controller.svg,
+    viewport_width,
+    viewport_height,
+    svg_width,
+    svg_height,
+  )
+}
+
+///|
+extern "js" fn diagram_viewport_test_set_invalid_geometry_raw(
+  wrapper : @rdom.Element,
+  svg : @rdom.Element,
+  kind : String,
+) -> Unit =
+  #| (wrapper, svg, kind) => {
+  #|   if (kind === 'zero-viewport') wrapper.__width = 0;
+  #|   else if (kind === 'infinite-viewport') wrapper.__width = Infinity;
+  #|   else if (kind === 'nan-svg') svg.__width = Number.NaN;
+  #| }
+
+///|
+fn diagram_viewport_test_set_invalid_geometry(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+  kind : String,
+) -> Unit {
+  let controller = lifetime.controllers[index]
+  diagram_viewport_test_set_invalid_geometry_raw(
+    controller.wrapper,
+    controller.svg,
+    kind,
+  )
+}
+
+///|
+extern "js" fn diagram_viewport_test_dispatch_event(
+  target : @rdom.EventTarget,
+  event_type : String,
+  button : Int,
+  buttons : Int,
+  pointer_id : Int,
+  client_x : Double,
+  client_y : Double,
+  alt_key : Bool,
+  shift_key : Bool,
+  ctrl_key : Bool,
+  delta_y : Double,
+  key : String,
+) -> String =
+  #| (target, type, button, buttons, pointerId, clientX, clientY, altKey, shiftKey, ctrlKey, deltaY, key) => {
+  #|   const init = {
+  #|     bubbles: true,
+  #|     cancelable: true,
+  #|     button,
+  #|     buttons,
+  #|     pointerId,
+  #|     clientX,
+  #|     clientY,
+  #|     altKey,
+  #|     shiftKey,
+  #|     ctrlKey,
+  #|     deltaY,
+  #|     key,
+  #|   };
+  #|   const event = type === 'wheel'
+  #|     ? new WheelEvent(type, init)
+  #|     : (type === 'keydown' || type === 'keyup')
+  #|       ? new KeyboardEvent(type, init)
+  #|       : new MouseEvent(type, init);
+  #|   target.dispatchEvent(event);
+  #|   return `${event.defaultPrevented}|${event.propagationStopped}`;
+  #| }
+
+///|
+extern "js" fn diagram_viewport_test_body_cursor(
+  harness : DiagramViewportTestHarness,
+) -> String =
+  #| harness => harness.document.body.style.getPropertyValue('cursor')
+
+///|
+extern "js" fn diagram_viewport_test_body_cursor_priority(
+  harness : DiagramViewportTestHarness,
+) -> String =
+  #| harness => harness.document.body.style.getPropertyPriority('cursor')
+
+///|
+extern "js" fn diagram_viewport_test_retain_wrapper(
+  harness : DiagramViewportTestHarness,
+  wrapper : @rdom.Element,
+) -> Unit = "(harness, wrapper) => { harness.retainedWrapper = wrapper; }"
+
+///|
+fn diagram_viewport_test_set_original_wrapper_style(
+  harness : DiagramViewportTestHarness,
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+) -> Unit {
+  // The saved styles were captured before mount. This helper only exists
+  // to make retained-node assertions readable.
+  diagram_viewport_test_retain_wrapper(
+    harness,
+    lifetime.controllers[index].wrapper,
+  )
+}
+
+///|
+extern "js" fn diagram_viewport_test_retained_wrapper_state(
+  harness : DiagramViewportTestHarness,
+) -> String =
+  #| harness => {
+  #|   const wrapper = harness.retainedWrapper;
+  #|   return [
+  #|     wrapper.getAttribute('class') ?? '',
+  #|     wrapper.getAttribute('tabindex') ?? '',
+  #|     wrapper.getAttribute('aria-label') ?? '',
+  #|     wrapper.style.getPropertyValue('height'),
+  #|     wrapper.style.getPropertyValue('overflow'),
+  #|     wrapper.children.map(child => child.tagName).join(','),
+  #|     wrapper.listenerCount('wheel'),
+  #|   ].join('|');
+  #| }
+
+///|
+fn diagram_viewport_event(
+  lifetime : MarkdownCommentDiagramViewportLifetime,
+  index : Int,
+  node_name : String,
+  event_type : String,
+  button? : Int = 0,
+  buttons? : Int = 0,
+  pointer_id? : Int = 1,
+  client_x? : Double = 0.0,
+  client_y? : Double = 0.0,
+  alt_key? : Bool = false,
+  shift_key? : Bool = false,
+  ctrl_key? : Bool = false,
+  delta_y? : Double = 0.0,
+  key? : String = "",
+) -> String {
+  let controller = lifetime.controllers[index]
+  let target = if node_name == "ownerWindow" {
+    controller.owner_window.as_event_target()
+  } else {
+    diagram_viewport_test_node(lifetime, index, node_name).as_event_target()
+  }
+  diagram_viewport_test_dispatch_event(
+    target, event_type, button, buttons, pointer_id, client_x, client_y, alt_key,
+    shift_key, ctrl_key, delta_y, key,
+  )
+}
+
+///|
+fn with_diagram_viewport_test_harness(
+  run : (DiagramViewportTestHarness) -> Unit raise,
+) -> Unit raise {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  run(harness)
+}
+
+///|
+test "empty wrong-language and indirect SVG targets are exact no-ops" {
+  for mode in ["none", "wrong", "indirect"] {
+    with_diagram_viewport_test_harness(harness => {
+      let target = diagram_viewport_test_target(harness, mode)
+      let changes = Ref(0)
+      let viewports = MarkdownCommentDiagramViewports(target, () => {
+        changes.val += 1
+      })
+      defer viewports.dispose()
+      assert_eq(diagram_viewport_test_controller_count(viewports.lifetime), 0)
+      assert_eq(diagram_viewport_test_observer_count(harness), 0)
+      assert_eq(diagram_viewport_test_pending_frames(harness), 0)
+      assert_eq(
+        diagram_viewport_test_window_listener_count(harness, "keydown"),
+        0,
+      )
+      assert_eq(changes.val, 0)
+      viewports.dispose()
+      viewports.dispose()
+    })
+  }
+
+  with_diagram_viewport_test_harness(harness => {
+    let mixed_target = diagram_viewport_test_target(harness, "mixed")
+    let mixed = MarkdownCommentDiagramViewports(mixed_target, () => ())
+    defer mixed.dispose()
+    assert_eq(diagram_viewport_test_controller_count(mixed.lifetime), 1)
+    assert_eq(diagram_viewport_test_observer_count(harness), 1)
+    assert_eq(diagram_viewport_test_pending_frames(harness), 1)
+    mixed.dispose()
+    diagram_viewport_test_flush_frame(harness)
+  })
+}
+
+///|
+test "mount is synchronous while positive geometry waits for the shared frame" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let changes = Ref(0)
+  let viewports = MarkdownCommentDiagramViewports(target, () => changes.val += 1)
+  defer viewports.dispose()
+  assert_eq(diagram_viewport_test_controller_count(viewports.lifetime), 1)
+  assert_eq(
+    diagram_viewport_test_child_classes(viewports.lifetime, 0),
+    "moonbit-viewer-markdown-diagram-content|moonbit-viewer-markdown-diagram-controls|moonbit-viewer-markdown-diagram-resize-handle",
+  )
+  assert_true(
+    diagram_viewport_test_class_contains(
+      viewports.lifetime,
+      0,
+      "wrapper",
+      "moonbit-viewer-markdown-diagram-viewport",
+    ),
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "wrapper",
+      "aria-label",
+    ),
+    "Interactive Diago diagram",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "wrapper",
+      "tabindex",
+    ),
+    "0",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "panButton",
+      "aria-pressed",
+    ),
+    "false",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "panButton",
+      "aria-label",
+    ),
+    "Toggle pan mode",
+  )
+  assert_eq(
+    diagram_viewport_test_icon_class(viewports.lifetime, 0, "panButton"),
+    "codicon codicon-move",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "zoomOutButton",
+      "aria-label",
+    ),
+    "Zoom out",
+  )
+  assert_eq(
+    diagram_viewport_test_icon_class(viewports.lifetime, 0, "zoomOutButton"),
+    "codicon codicon-zoom-out",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "zoomInButton",
+      "aria-label",
+    ),
+    "Zoom in",
+  )
+  assert_eq(
+    diagram_viewport_test_icon_class(viewports.lifetime, 0, "zoomInButton"),
+    "codicon codicon-zoom-in",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "fitButton",
+      "aria-label",
+    ),
+    "Fit diagram",
+  )
+  assert_eq(
+    diagram_viewport_test_icon_class(viewports.lifetime, 0, "fitButton"),
+    "codicon codicon-screen-normal",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "resizeHandle",
+      "role",
+    ),
+    "separator",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "resizeHandle",
+      "aria-label",
+    ),
+    "Resize diagram",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "resizeHandle",
+      "aria-orientation",
+    ),
+    "horizontal",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "resizeHandle",
+      "tabindex",
+    ),
+    "0",
+  )
+  assert_eq(diagram_viewport_test_wrapper_height(viewports.lifetime, 0), "")
+  assert_eq(diagram_viewport_test_pending_frames(harness), 1)
+  assert_eq(
+    diagram_viewport_event(viewports.lifetime, 0, "panButton", "pointerdown"),
+    "false|true",
+  )
+  assert_eq(
+    diagram_viewport_event(viewports.lifetime, 0, "panButton", "mousedown"),
+    "false|true",
+  )
+  assert_eq(
+    diagram_viewport_event(
+      viewports.lifetime,
+      0,
+      "ownerWindow",
+      "keydown",
+      key="Alt",
+      alt_key=true,
+    ),
+    "true|false",
+  )
+  assert_eq(changes.val, 0)
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.0)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 100.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), 0.0)
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "100px",
+  )
+  assert_eq(
+    diagram_viewport_test_svg_height_attribute(viewports.lifetime, 0),
+    "100",
+  )
+  assert_true(diagram_viewport_test_all_svg_measurements_untransformed(harness))
+  assert_eq(changes.val, 1)
+  viewports.dispose()
+}
+
+///|
+test "zero geometry remains pending until a later observer sees positive sizes" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let changes = Ref(0)
+  let viewports = MarkdownCommentDiagramViewports(target, () => changes.val += 1)
+  defer viewports.dispose()
+  diagram_viewport_test_set_geometry(viewports.lifetime, 0, 0.0, 0.0, 0.0, 0.0)
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(diagram_viewport_test_wrapper_height(viewports.lifetime, 0), "")
+  assert_eq(diagram_viewport_test_transform(viewports.lifetime, 0), "")
+  assert_eq(changes.val, 0)
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    320.0,
+    120.0,
+    200.0,
+    120.0,
+  )
+  diagram_viewport_test_trigger_observer(harness, 0)
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "120px",
+  )
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 60.0)
+  assert_eq(changes.val, 1)
+  viewports.dispose()
+}
+
+///|
+test "true Fit uses 16px padding keeps height and installs fit-aware zoom floor" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "wide")
+  let changes = Ref(0)
+  let viewports = MarkdownCommentDiagramViewports(target, () => changes.val += 1)
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "400px",
+  )
+  assert_eq(
+    diagram_viewport_event(viewports.lifetime, 0, "fitButton", "click"),
+    "true|true",
+  )
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 0.46)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 16.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), 108.0)
+  assert_true(diagram_viewport_test_interacted(viewports.lifetime, 0))
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "400px",
+  )
+
+  // Zoom-out at the fitted scale must not jump up to the normal 0.5 floor.
+  diagram_viewport_event(viewports.lifetime, 0, "zoomOutButton", "click")
+  |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 0.46)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 16.0)
+
+  diagram_viewport_event(viewports.lifetime, 0, "zoomInButton", "click")
+  |> ignore
+  assert_true(
+    (diagram_viewport_test_scale(viewports.lifetime, 0) - 0.575).abs() <
+    0.0000001,
+  )
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), -30.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), 85.0)
+  viewports.dispose()
+}
+
+///|
+test "Fit handles tall and already-small SVGs and rejects zero or nonfinite geometry" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "wide")
+  let viewports = MarkdownCommentDiagramViewports(target, () => ())
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    400.0,
+    400.0,
+    100.0,
+    800.0,
+  )
+  diagram_viewport_event(viewports.lifetime, 0, "fitButton", "click") |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 0.46)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 177.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), 16.0)
+
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    400.0,
+    400.0,
+    100.0,
+    50.0,
+  )
+  diagram_viewport_event(viewports.lifetime, 0, "fitButton", "click") |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.0)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 150.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), 175.0)
+  let stable_transform = diagram_viewport_test_transform(viewports.lifetime, 0)
+
+  diagram_viewport_test_set_invalid_geometry(viewports.lifetime, 0, "nan-svg")
+  diagram_viewport_event(viewports.lifetime, 0, "fitButton", "click") |> ignore
+  assert_eq(
+    diagram_viewport_test_transform(viewports.lifetime, 0),
+    stable_transform,
+  )
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    400.0,
+    400.0,
+    100.0,
+    50.0,
+  )
+  diagram_viewport_test_set_invalid_geometry(
+    viewports.lifetime,
+    0,
+    "zero-viewport",
+  )
+  diagram_viewport_event(viewports.lifetime, 0, "fitButton", "click") |> ignore
+  assert_eq(
+    diagram_viewport_test_transform(viewports.lifetime, 0),
+    stable_transform,
+  )
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    400.0,
+    400.0,
+    100.0,
+    50.0,
+  )
+  diagram_viewport_test_set_invalid_geometry(
+    viewports.lifetime,
+    0,
+    "infinite-viewport",
+  )
+  diagram_viewport_event(viewports.lifetime, 0, "fitButton", "click") |> ignore
+  assert_eq(
+    diagram_viewport_test_transform(viewports.lifetime, 0),
+    stable_transform,
+  )
+  viewports.dispose()
+}
+
+///|
+test "ordinary wheel passes through while Alt and Ctrl wheel preserve the event anchor" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let viewports = MarkdownCommentDiagramViewports(target, () => ())
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(
+    diagram_viewport_event(
+      viewports.lifetime,
+      0,
+      "wrapper",
+      "wheel",
+      client_x=100.0,
+      client_y=50.0,
+      delta_y=-100.0,
+    ),
+    "false|false",
+  )
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.0)
+  assert_eq(
+    diagram_viewport_event(
+      viewports.lifetime,
+      0,
+      "wrapper",
+      "wheel",
+      client_x=100.0,
+      client_y=50.0,
+      alt_key=true,
+      delta_y=-100.0,
+    ),
+    "true|true",
+  )
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.2)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 100.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), -10.0)
+
+  // Ctrl pinch uses the exact multiplier 10: delta -10 produces another 20%.
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "wheel",
+    client_x=100.0,
+    client_y=50.0,
+    ctrl_key=true,
+    delta_y=-10.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.44)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 100.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), -22.0)
+
+  // A very large positive delta clamps down instead of treating factor <= 0
+  // as an invalid early return.
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "wheel",
+    client_x=100.0,
+    client_y=50.0,
+    alt_key=true,
+    delta_y=10000.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 0.5)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "wheel",
+    client_x=100.0,
+    client_y=50.0,
+    alt_key=true,
+    delta_y=-10000.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 10.0)
+  viewports.dispose()
+}
+
+///|
+test "pan toggle Alt drag and strict per-move threshold keep click semantics" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let viewports = MarkdownCommentDiagramViewports(target, () => ())
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+
+  // Four 1px moves translate content but never exceed the source's strict
+  // single-move threshold, so the following Alt click still zooms.
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "pointerdown",
+    buttons=1,
+    client_x=10.0,
+    client_y=10.0,
+    alt_key=true,
+  )
+  |> ignore
+  for coordinate in [11.0, 12.0, 13.0, 14.0] {
+    diagram_viewport_event(
+      viewports.lifetime,
+      0,
+      "ownerWindow",
+      "pointermove",
+      buttons=1,
+      client_x=coordinate,
+      client_y=10.0,
+      alt_key=true,
+    )
+    |> ignore
+  }
+  assert_false(diagram_viewport_test_dragged(viewports.lifetime, 0))
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointerup",
+    client_x=14.0,
+    client_y=10.0,
+    alt_key=true,
+  )
+  |> ignore
+  let before_click = diagram_viewport_test_scale(viewports.lifetime, 0)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "click",
+    client_x=14.0,
+    client_y=10.0,
+    alt_key=true,
+  )
+  |> ignore
+  assert_eq(
+    diagram_viewport_test_scale(viewports.lifetime, 0),
+    before_click * 1.25,
+  )
+  let before_shift_click = diagram_viewport_test_scale(viewports.lifetime, 0)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "click",
+    client_x=14.0,
+    client_y=10.0,
+    alt_key=true,
+    shift_key=true,
+  )
+  |> ignore
+  assert_true(
+    (diagram_viewport_test_scale(viewports.lifetime, 0) -
+    before_shift_click * 0.8).abs() <
+    0.0000001,
+  )
+
+  // One 4px move is a drag and suppresses Alt-click zoom.
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "pointerdown",
+    buttons=1,
+    client_x=20.0,
+    client_y=20.0,
+    alt_key=true,
+  )
+  |> ignore
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointermove",
+    buttons=1,
+    client_x=24.0,
+    client_y=20.0,
+    alt_key=true,
+  )
+  |> ignore
+  assert_true(diagram_viewport_test_dragged(viewports.lifetime, 0))
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointerup",
+    client_x=24.0,
+    client_y=20.0,
+    alt_key=true,
+  )
+  |> ignore
+  let after_drag = diagram_viewport_test_scale(viewports.lifetime, 0)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "click",
+    client_x=24.0,
+    client_y=20.0,
+    alt_key=true,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), after_drag)
+
+  // Toggle enables plain primary-button pan and exposes its pressed state.
+  diagram_viewport_event(viewports.lifetime, 0, "panButton", "click") |> ignore
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "panButton",
+      "aria-pressed",
+    ),
+    "true",
+  )
+  assert_true(
+    diagram_viewport_test_class_contains(
+      viewports.lifetime,
+      0,
+      "panButton",
+      "active",
+    ),
+  )
+  let plain_start_x = diagram_viewport_test_translate_x(viewports.lifetime, 0)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "pointerdown",
+    buttons=1,
+    pointer_id=12,
+    client_x=30.0,
+    client_y=30.0,
+  )
+  |> ignore
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointermove",
+    buttons=1,
+    pointer_id=12,
+    client_x=40.0,
+    client_y=30.0,
+  )
+  |> ignore
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointerup",
+    pointer_id=12,
+    client_x=40.0,
+    client_y=30.0,
+  )
+  |> ignore
+  assert_eq(
+    diagram_viewport_test_translate_x(viewports.lifetime, 0),
+    plain_start_x + 10.0,
+  )
+
+  // A move delivered by the owning window with buttons=0 terminates the
+  // gesture even when release happened outside the viewport.
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "pointerdown",
+    buttons=1,
+    pointer_id=13,
+    client_x=40.0,
+    client_y=30.0,
+  )
+  |> ignore
+  assert_true(diagram_viewport_test_is_panning(viewports.lifetime, 0))
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointermove",
+    buttons=0,
+    pointer_id=13,
+    client_x=41.0,
+    client_y=30.0,
+  )
+  |> ignore
+  assert_false(diagram_viewport_test_is_panning(viewports.lifetime, 0))
+  viewports.dispose()
+}
+
+///|
+test "resize pointer and keyboard branches honor 100px and 10/50px steps" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let changes = Ref(0)
+  let viewports = MarkdownCommentDiagramViewports(target, () => changes.val += 1)
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(changes.val, 1)
+  assert_eq(
+    diagram_viewport_event(
+      viewports.lifetime,
+      0,
+      "resizeHandle",
+      "pointerdown",
+      buttons=1,
+      pointer_id=7,
+      client_y=100.0,
+    ),
+    "true|true",
+  )
+  assert_eq(diagram_viewport_test_body_cursor(harness), "ns-resize")
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointermove",
+    buttons=1,
+    pointer_id=7,
+    client_y=40.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_custom_height(viewports.lifetime, 0), 100.0)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointermove",
+    buttons=1,
+    pointer_id=7,
+    client_y=150.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_custom_height(viewports.lifetime, 0), 150.0)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointerup",
+    pointer_id=7,
+    client_y=150.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_body_cursor(harness), "crosshair")
+  assert_eq(diagram_viewport_test_body_cursor_priority(harness), "important")
+
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "resizeHandle",
+    "keydown",
+    key="ArrowUp",
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_custom_height(viewports.lifetime, 0), 140.0)
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "resizeHandle",
+    "keydown",
+    shift_key=true,
+    key="ArrowDown",
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_custom_height(viewports.lifetime, 0), 190.0)
+  // The first clamped pointer move keeps the existing 100px height and does
+  // not report a redundant inline-height write.
+  assert_eq(changes.val, 4)
+
+  // buttons=0 and pointercancel both release an outside resize gesture and
+  // restore the owner-document cursor lease.
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "resizeHandle",
+    "pointerdown",
+    buttons=1,
+    pointer_id=8,
+    client_y=190.0,
+  )
+  |> ignore
+  assert_true(diagram_viewport_test_is_resizing(viewports.lifetime, 0))
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointermove",
+    buttons=0,
+    pointer_id=8,
+    client_y=200.0,
+  )
+  |> ignore
+  assert_false(diagram_viewport_test_is_resizing(viewports.lifetime, 0))
+  assert_eq(diagram_viewport_test_body_cursor(harness), "crosshair")
+
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "resizeHandle",
+    "pointerdown",
+    buttons=1,
+    pointer_id=9,
+    client_y=190.0,
+  )
+  |> ignore
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "ownerWindow",
+    "pointercancel",
+    pointer_id=9,
+    client_y=190.0,
+  )
+  |> ignore
+  assert_false(diagram_viewport_test_is_resizing(viewports.lifetime, 0))
+  assert_eq(diagram_viewport_test_body_cursor(harness), "crosshair")
+
+  // Fit is one-shot and does not discard the custom height. A later host/SVG
+  // resize preserves both the interacted origin and the 190px user height.
+  diagram_viewport_event(viewports.lifetime, 0, "fitButton", "click") |> ignore
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "190px",
+  )
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    600.0,
+    190.0,
+    300.0,
+    150.0,
+  )
+  diagram_viewport_test_trigger_observer(harness, 0)
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "190px",
+  )
+  assert_eq(changes.val, 4)
+  viewports.dispose()
+}
+
+///|
+test "host resize recenters naturally then preserves the interacted SVG origin" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let changes = Ref(0)
+  let viewports = MarkdownCommentDiagramViewports(target, () => changes.val += 1)
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(changes.val, 1)
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    600.0,
+    150.0,
+    300.0,
+    150.0,
+  )
+  diagram_viewport_test_trigger_observer(harness, 0)
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.0)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 150.0)
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "150px",
+  )
+  assert_eq(changes.val, 2)
+
+  // Alt wheel at the origin changes both scale and translation.
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "wrapper",
+    "wheel",
+    client_x=0.0,
+    client_y=0.0,
+    alt_key=true,
+    delta_y=-100.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.2)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 180.0)
+
+  // Old SVG origin is -150 at scale 1.2, or -50% of width. Doubling the
+  // intrinsic SVG width keeps that percentage at the viewport origin.
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    800.0,
+    300.0,
+    600.0,
+    300.0,
+  )
+  diagram_viewport_test_trigger_observer(harness, 0)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 360.0)
+  assert_eq(
+    diagram_viewport_test_wrapper_height(viewports.lifetime, 0),
+    "300px",
+  )
+  assert_eq(changes.val, 3)
+  let stable_transform = diagram_viewport_test_transform(viewports.lifetime, 0)
+  diagram_viewport_test_trigger_observer(harness, 0)
+  diagram_viewport_test_trigger_observer(harness, 0)
+  assert_eq(
+    diagram_viewport_test_transform(viewports.lifetime, 0),
+    stable_transform,
+  )
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 360.0)
+  assert_eq(changes.val, 3)
+  assert_true(diagram_viewport_test_all_svg_measurements_untransformed(harness))
+  viewports.dispose()
+}
+
+///|
+test "two diagrams have independent transforms observers and controls" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "two")
+  let viewports = MarkdownCommentDiagramViewports(target, () => ())
+  defer viewports.dispose()
+  assert_eq(diagram_viewport_test_controller_count(viewports.lifetime), 2)
+  assert_eq(diagram_viewport_test_observer_count(harness), 2)
+  assert_eq(diagram_viewport_test_pending_frames(harness), 1)
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 100.0)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 1), 90.0)
+  diagram_viewport_event(viewports.lifetime, 0, "zoomInButton", "click")
+  |> ignore
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.25)
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 1), 1.0)
+  viewports.dispose()
+  assert_eq(diagram_viewport_test_disconnect_count(harness, 0), 1)
+  assert_eq(diagram_viewport_test_disconnect_count(harness, 1), 1)
+}
+
+///|
+test "owner-document resize cursor lease admits only one live group" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let first_target = diagram_viewport_test_target(harness, "one")
+  let second_target = diagram_viewport_test_target(harness, "one")
+  let first = MarkdownCommentDiagramViewports(first_target, () => ())
+  let second = MarkdownCommentDiagramViewports(second_target, () => ())
+  defer first.dispose()
+  defer second.dispose()
+  diagram_viewport_test_flush_frame(harness)
+
+  diagram_viewport_event(
+    first.lifetime,
+    0,
+    "resizeHandle",
+    "pointerdown",
+    buttons=1,
+    pointer_id=21,
+    client_y=100.0,
+  )
+  |> ignore
+  assert_true(diagram_viewport_test_is_resizing(first.lifetime, 0))
+  assert_eq(diagram_viewport_test_body_cursor(harness), "ns-resize")
+  diagram_viewport_event(
+    second.lifetime,
+    0,
+    "resizeHandle",
+    "pointerdown",
+    buttons=1,
+    pointer_id=22,
+    client_y=100.0,
+  )
+  |> ignore
+  assert_false(diagram_viewport_test_is_resizing(second.lifetime, 0))
+
+  first.dispose()
+  assert_eq(diagram_viewport_test_body_cursor(harness), "crosshair")
+  diagram_viewport_event(
+    second.lifetime,
+    0,
+    "resizeHandle",
+    "pointerdown",
+    buttons=1,
+    pointer_id=22,
+    client_y=100.0,
+  )
+  |> ignore
+  assert_true(diagram_viewport_test_is_resizing(second.lifetime, 0))
+  assert_eq(diagram_viewport_test_body_cursor(harness), "ns-resize")
+  first.dispose()
+  assert_eq(diagram_viewport_test_body_cursor(harness), "ns-resize")
+  diagram_viewport_event(
+    second.lifetime,
+    0,
+    "ownerWindow",
+    "pointercancel",
+    pointer_id=22,
+    client_y=100.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_body_cursor(harness), "crosshair")
+  second.dispose()
+  assert_eq(diagram_body_cursor_coordinators.length(), 0)
+}
+
+///|
+test "parent lifetime restores its wrapper without DOM expando ownership" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let viewports = MarkdownCommentDiagramViewports(target, () => ())
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+  diagram_viewport_test_set_original_wrapper_style(
+    harness,
+    viewports.lifetime,
+    0,
+  )
+  viewports.dispose()
+  assert_eq(diagram_viewport_test_disconnect_count(harness, 0), 1)
+  assert_eq(
+    diagram_viewport_test_window_listener_count(harness, "pointermove"),
+    0,
+  )
+  assert_eq(
+    diagram_viewport_test_retained_wrapper_state(harness),
+    "moonbit-viewer-markdown-diagram||||auto|SVG|0",
+  )
+}
+
+///|
+test "observer setup failure rolls back the provisional mount" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let changes = Ref(0)
+  diagram_viewport_test_fail_next_observe(harness)
+  let viewports = MarkdownCommentDiagramViewports(target, () => changes.val += 1)
+  defer viewports.dispose()
+  assert_eq(diagram_viewport_test_controller_count(viewports.lifetime), 0)
+  assert_eq(changes.val, 0)
+  assert_eq(diagram_viewport_test_observer_count(harness), 1)
+  assert_eq(diagram_viewport_test_disconnect_count(harness, 0), 1)
+  assert_eq(diagram_viewport_test_pending_frames(harness), 0)
+  assert_eq(diagram_viewport_test_window_listener_count(harness, "keydown"), 0)
+  assert_eq(
+    diagram_viewport_test_window_listener_count(harness, "pointermove"),
+    0,
+  )
+  assert_eq(
+    diagram_viewport_test_target_wrapper_state(target),
+    "moonbit-viewer-markdown-diagram||||auto|SVG|0",
+  )
+  viewports.dispose()
+}
+
+///|
+test "dispose cancels pending layout restores retained DOM and cursor and is idempotent" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "one")
+  let changes = Ref(0)
+  let viewports = MarkdownCommentDiagramViewports(target, () => changes.val += 1)
+  defer viewports.dispose()
+  diagram_viewport_test_set_original_wrapper_style(
+    harness,
+    viewports.lifetime,
+    0,
+  )
+  diagram_viewport_event(
+    viewports.lifetime,
+    0,
+    "resizeHandle",
+    "pointerdown",
+    buttons=1,
+    pointer_id=9,
+    client_y=100.0,
+  )
+  |> ignore
+  assert_eq(diagram_viewport_test_body_cursor(harness), "ns-resize")
+  assert_eq(diagram_viewport_test_window_listener_count(harness, "keydown"), 1)
+  assert_eq(
+    diagram_viewport_test_window_listener_count(harness, "pointermove"),
+    1,
+  )
+  viewports.dispose()
+  viewports.dispose()
+  assert_eq(diagram_viewport_test_controller_count(viewports.lifetime), 0)
+  assert_eq(diagram_viewport_test_disconnect_count(harness, 0), 1)
+  assert_eq(diagram_viewport_test_body_cursor(harness), "crosshair")
+  assert_eq(diagram_viewport_test_body_cursor_priority(harness), "important")
+  assert_eq(diagram_viewport_test_window_listener_count(harness, "keydown"), 0)
+  assert_eq(diagram_viewport_test_window_listener_count(harness, "keyup"), 0)
+  assert_eq(
+    diagram_viewport_test_window_listener_count(harness, "pointermove"),
+    0,
+  )
+  assert_eq(
+    diagram_viewport_test_window_listener_count(harness, "pointerup"),
+    0,
+  )
+  assert_eq(
+    diagram_viewport_test_window_listener_count(harness, "pointercancel"),
+    0,
+  )
+  assert_eq(
+    diagram_viewport_test_retained_wrapper_state(harness),
+    "moonbit-viewer-markdown-diagram||||auto|SVG|0",
+  )
+  // The native coordinator frame still drains, but the canceled registration
+  // cannot write height or invoke the owner callback.
+  assert_eq(diagram_viewport_test_pending_frames(harness), 1)
+  diagram_viewport_test_flush_frame(harness)
+  assert_eq(changes.val, 1)
+  diagram_viewport_test_trigger_observer(harness, 0)
+  assert_eq(changes.val, 1)
+  assert_eq(diagram_body_cursor_coordinators.length(), 0)
+}

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
@@ -27,10 +27,31 @@ pub fn MarkdownCommentDom::MarkdownCommentDom(
 }
 
 ///|
+/// Pins the caller-owned ViewZone node to the visible content viewport. The
+/// ordinary ViewZone write performed by `add_zone` deliberately uses the
+/// model's horizontal scroll plane; this contribution-specific write runs
+/// immediately afterwards and consumes geometry published by ViewLines.
+pub fn MarkdownCommentDom::pin_to_content_viewport(
+  self : MarkdownCommentDom,
+) -> Unit {
+  @base_browser.set_style_property(
+    self.outer,
+    "left",
+    "var(--moonbit-viewer-rendered-scroll-left, 0px)",
+  )
+  @base_browser.set_style_property(
+    self.outer,
+    "width",
+    "var(--moonbit-viewer-visible-content-width, 0px)",
+  )
+}
+
+///|
 /// Observes the inner Markdown content and reports its first/changed positive
 /// integer height after one shared animation-frame boundary. Explicit requests
-/// cover renderer replacement/image load while a zone is offscreen. The root
-/// callback owns generation and zone-id stale checks before relayout.
+/// cover renderer replacement, image load, and model-scoped viewport-width
+/// changes while a zone is offscreen. The root callback owns generation and
+/// zone-id stale checks before relayout.
 pub fn MarkdownCommentDom::observe_size(
   self : MarkdownCommentDom,
   on_height_changed : (Int) -> Unit,
@@ -43,7 +64,7 @@ pub fn MarkdownCommentDom::observe_size(
   let measure = () => {
     frame_scheduled.val = false
     pending_frame.val = None
-    if disposed.val || !markdown_comment_element_is_connected(self.content) {
+    if disposed.val || !@base_browser.element_is_connected(self.content) {
       return
     }
     let allow_hidden = force_hidden_measure.val || last_height.val == 0
@@ -77,13 +98,15 @@ pub fn MarkdownCommentDom::observe_size(
       registration.dispose()
     }
   }
-  let observer = markdown_comment_resize_observer(
-    self.content,
-    schedule_measure,
-  )
+  let observer = @base_browser.observe_element_resize(self.content, () => {
+    schedule_measure(false)
+  })
   let lifetime = @base_common.Disposable::from(() => {
     disposed.val = true
-    observer.disconnect()
+    match observer {
+      Some(observer) => observer.dispose()
+      None => ()
+    }
     match pending_frame.val {
       Some(registration) => registration.dispose()
       None => ()
@@ -117,71 +140,153 @@ pub fn MarkdownCommentSizeObserver::dispose(
 }
 
 ///|
-#external
-priv type MarkdownCommentResizeObserver
+/// One model-scoped observer for the editor content viewport. Width transitions
+/// are deduplicated here; zero is remembered but not published so restoring a
+/// previously equal positive width still invalidates hidden comment heights.
+pub fn MarkdownCommentDom::observe_viewport_width(
+  self : MarkdownCommentDom,
+  on_width_changed : () -> Unit,
+) -> MarkdownCommentViewportObserver {
+  let disposed = Ref(false)
+  let lifetime = match markdown_comment_content_viewport(self.outer) {
+    Some(viewport) => {
+      let last_width = Ref(
+        @base_browser.element_client_width(viewport).to_int(),
+      )
+      let observer = @base_browser.observe_element_resize(viewport, () => {
+        if disposed.val {
+          return
+        }
+        let width = @base_browser.element_client_width(viewport).to_int()
+        if width == last_width.val {
+          return
+        }
+        last_width.val = width
+        if width > 0 {
+          on_width_changed()
+        }
+      })
+      @base_common.Disposable::from(() => {
+        disposed.val = true
+        match observer {
+          Some(observer) => observer.dispose()
+          None => ()
+        }
+      })
+    }
+    None => @base_common.Disposable::from(() => disposed.val = true)
+  }
+  { lifetime, }
+}
 
 ///|
-extern "js" fn markdown_comment_resize_observer(
-  target : @rdom.Element,
-  notify : (Bool) -> Unit,
-) -> MarkdownCommentResizeObserver =
-  #| (target, notify) => {
-  #|   const viewport = target.closest?.('.editor-scrollable') ?? null;
-  #|   const observer = new ResizeObserver((entries) => {
-  #|     notify(Boolean(viewport && entries.some((entry) => entry.target === viewport)));
-  #|   });
-  #|   observer.observe(target);
-  #|   if (viewport && viewport !== target) observer.observe(viewport);
-  #|   return observer;
-  #| }
+pub struct MarkdownCommentViewportObserver {
+  priv lifetime : @base_common.Disposable
+}
 
 ///|
-extern "js" fn MarkdownCommentResizeObserver::disconnect(
-  self : MarkdownCommentResizeObserver,
-) -> Unit = "observer => observer.disconnect()"
+pub fn MarkdownCommentViewportObserver::dispose(
+  self : MarkdownCommentViewportObserver,
+) -> Unit {
+  self.lifetime.dispose()
+}
 
 ///|
-extern "js" fn markdown_comment_element_is_connected(
+fn markdown_comment_content_viewport(element : @rdom.Element) -> @rdom.Element? {
+  if element_has_class(element, "editor-scrollable") {
+    return Some(element)
+  }
+  match element.get_parent_node().to_option() {
+    Some(parent) =>
+      match parent.to_element() {
+        Some(parent) => markdown_comment_content_viewport(parent)
+        None => None
+      }
+    None => None
+  }
+}
+
+///|
+priv struct MarkdownCommentSavedStyle {
+  name : String
+  value : String
+  priority : String
+}
+
+///|
+fn save_markdown_comment_style(
   element : @rdom.Element,
-) -> Bool = "element => element?.isConnected === true"
+  name : String,
+) -> MarkdownCommentSavedStyle {
+  {
+    name,
+    value: @base_browser.element_style_value(element, name),
+    priority: @base_browser.element_style_priority(element, name),
+  }
+}
+
+///|
+fn restore_markdown_comment_style(
+  element : @rdom.Element,
+  saved : MarkdownCommentSavedStyle,
+) -> Unit {
+  if saved.value == "" {
+    @base_browser.remove_style_property(element, saved.name)
+  } else {
+    @base_browser.set_style_property_with_priority(
+      element,
+      saved.name,
+      saved.value,
+      saved.priority,
+    )
+  }
+}
 
 ///|
 /// Reads visible content directly. For a connected `display:none` ViewZone,
-/// temporarily lays out the caller-owned outer node invisibly at the editor
-/// content viewport width, then restores every touched inline declaration and
-/// priority before returning. A later zero-size ResizeObserver notification is
-/// not allowed to repeat this hidden path unless the viewport or renderer
-/// explicitly invalidated it.
-extern "js" fn markdown_comment_measured_height(
+/// temporarily lays out the caller-owned outer node invisibly without replacing
+/// its viewport-pinned `left` or `width`, then restores every touched inline
+/// declaration and priority before returning. A later zero-size ResizeObserver
+/// notification is not allowed to repeat this hidden path unless the shared
+/// viewport observer or renderer explicitly invalidated it.
+fn markdown_comment_measured_height(
   outer : @rdom.Element,
   content : @rdom.Element,
   allow_hidden : Bool,
-) -> Int =
-  #| (outer, content, allowHidden) => {
-  #|   const direct = Math.trunc(content?.offsetHeight ?? 0);
-  #|   if (direct > 0 || !allowHidden || content?.isConnected !== true) return direct;
-  #|   const viewport = content.closest?.('.editor-scrollable') ?? null;
-  #|   const width = Math.trunc(viewport?.clientWidth ?? 0);
-  #|   if (width <= 0 || !outer?.style) return 0;
-  #|   const names = ['display', 'visibility', 'pointer-events', 'height', 'width', 'top', 'left'];
-  #|   const saved = names.map((name) => [
-  #|     name,
-  #|     outer.style.getPropertyValue(name),
-  #|     outer.style.getPropertyPriority(name),
-  #|   ]);
-  #|   try {
-  #|     outer.style.setProperty('display', 'block', 'important');
-  #|     outer.style.setProperty('visibility', 'hidden', 'important');
-  #|     outer.style.setProperty('pointer-events', 'none', 'important');
-  #|     outer.style.setProperty('height', 'auto', 'important');
-  #|     outer.style.setProperty('width', `${width}px`, 'important');
-  #|     outer.style.setProperty('top', '0px', 'important');
-  #|     outer.style.setProperty('left', '0px', 'important');
-  #|     return Math.trunc(content.offsetHeight ?? 0);
-  #|   } finally {
-  #|     for (const [name, value, priority] of saved) {
-  #|       if (value === '') outer.style.removeProperty(name);
-  #|       else outer.style.setProperty(name, value, priority);
-  #|     }
-  #|   }
-  #| }
+) -> Int {
+  let direct = @base_browser.element_offset_height(content).to_int()
+  if direct > 0 || !allow_hidden || !@base_browser.element_is_connected(content) {
+    return direct
+  }
+  let saved = ["display", "visibility", "pointer-events", "height", "top"].map(name => {
+    save_markdown_comment_style(outer, name)
+  })
+  defer (for declaration in saved {
+    restore_markdown_comment_style(outer, declaration)
+  })
+  @base_browser.set_style_property_with_priority(
+    outer, "display", "block", "important",
+  )
+  @base_browser.set_style_property_with_priority(
+    outer, "visibility", "hidden", "important",
+  )
+  @base_browser.set_style_property_with_priority(
+    outer, "pointer-events", "none", "important",
+  )
+  @base_browser.set_style_property_with_priority(
+    outer, "height", "auto", "important",
+  )
+  @base_browser.set_style_property_with_priority(
+    outer, "top", "0px", "important",
+  )
+  let rect_width = outer.get_bounding_client_rect().get_width()
+  let width = if rect_width > 0.0 {
+    rect_width
+  } else {
+    @base_browser.element_offset_width(outer)
+  }
+  if width <= 0.0 {
+    return 0
+  }
+  @base_browser.element_offset_height(content).to_int()
+}

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom_wbtest.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom_wbtest.mbt
@@ -1,26 +1,40 @@
 ///|
-extern "js" fn install_markdown_comment_browser_test_dom() -> Unit =
+#external
+type MarkdownCommentBrowserTestHarness
+
+///|
+extern "js" fn install_markdown_comment_browser_test_dom() -> MarkdownCommentBrowserTestHarness =
   #| () => {
-  #|   globalThis.__markdownCommentBrowserOriginals = {
-  #|     document: globalThis.document,
-  #|     Element: globalThis.Element,
-  #|     ResizeObserver: globalThis.ResizeObserver,
-  #|     requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|   const harness = {
+  #|     restored: false,
+  #|     originals: {
+  #|       document: globalThis.document,
+  #|       Element: globalThis.Element,
+  #|       HTMLElement: globalThis.HTMLElement,
+  #|       ResizeObserver: globalThis.ResizeObserver,
+  #|       requestAnimationFrame: globalThis.requestAnimationFrame,
+  #|     },
+  #|     frames: [],
+  #|     observers: [],
+  #|     hiddenMeasureCount: 0,
   #|   };
-  #|   globalThis.__markdownCommentBrowserFrames = [];
-  #|   globalThis.__markdownCommentBrowserObservers = [];
-  #|   globalThis.__markdownCommentHiddenMeasureCount = 0;
   #|
   #|   class TestStyle {
-  #|     constructor() { this.values = new Map(); this.priorities = new Map(); }
+  #|     constructor() {
+  #|       this.values = new Map();
+  #|       this.priorities = new Map();
+  #|       this.writes = [];
+  #|     }
   #|     getPropertyValue(name) { return this.values.get(name) ?? ""; }
   #|     getPropertyPriority(name) { return this.priorities.get(name) ?? ""; }
   #|     setProperty(name, value, priority = "") {
+  #|       this.writes.push({ operation: 'set', name: String(name) });
   #|       this.values.set(name, String(value));
   #|       if (priority) this.priorities.set(name, String(priority));
   #|       else this.priorities.delete(name);
   #|     }
   #|     removeProperty(name) {
+  #|       this.writes.push({ operation: 'remove', name: String(name) });
   #|       const previous = this.getPropertyValue(name);
   #|       this.values.delete(name);
   #|       this.priorities.delete(name);
@@ -42,18 +56,31 @@ extern "js" fn install_markdown_comment_browser_test_dom() -> Unit =
   #|       this.isConnected = false;
   #|       this.style = new TestStyle();
   #|       this.clientWidth = 0;
+  #|       this.__offsetWidth = 0;
   #|       this.__offsetHeight = 0;
   #|       this.__hiddenHeights = null;
   #|     }
+  #|     get offsetWidth() { return this.__offsetWidth; }
+  #|     set offsetWidth(value) { this.__offsetWidth = Number(value); }
   #|     get offsetHeight() {
   #|       if (this.__offsetHeight > 0) return this.__offsetHeight;
   #|       const outer = this.parentNode;
   #|       if (!this.__hiddenHeights || outer?.style.getPropertyValue('display') !== 'block') return 0;
-  #|       globalThis.__markdownCommentHiddenMeasureCount += 1;
-  #|       const width = Number.parseInt(outer.style.getPropertyValue('width'), 10);
+  #|       harness.hiddenMeasureCount += 1;
+  #|       const width = Math.trunc(outer.getBoundingClientRect().width);
   #|       return this.__hiddenHeights.get(width) ?? 0;
   #|     }
   #|     set offsetHeight(value) { this.__offsetHeight = Number(value); }
+  #|     getBoundingClientRect() {
+  #|       return {
+  #|         left: 0,
+  #|         right: this.__offsetWidth,
+  #|         top: 0,
+  #|         bottom: this.__offsetHeight,
+  #|         width: this.__offsetWidth,
+  #|         height: this.__offsetHeight,
+  #|       };
+  #|     }
   #|     setAttribute(name, value) { this.attributes.set(name, String(value)); }
   #|     getAttribute(name) { return this.attributes.get(name) ?? ""; }
   #|     closest(selector) {
@@ -86,7 +113,7 @@ extern "js" fn install_markdown_comment_browser_test_dom() -> Unit =
   #|       this.target = null;
   #|       this.targets = [];
   #|       this.disconnectCount = 0;
-  #|       globalThis.__markdownCommentBrowserObservers.push(this);
+  #|       harness.observers.push(this);
   #|     }
   #|     observe(target) {
   #|       this.target ??= target;
@@ -102,25 +129,31 @@ extern "js" fn install_markdown_comment_browser_test_dom() -> Unit =
   #|   };
   #|   globalThis.document = document;
   #|   globalThis.Element = TestElement;
+  #|   globalThis.HTMLElement = TestElement;
   #|   globalThis.ResizeObserver = TestResizeObserver;
   #|   globalThis.requestAnimationFrame = callback => {
-  #|     globalThis.__markdownCommentBrowserFrames.push(callback);
-  #|     return globalThis.__markdownCommentBrowserFrames.length;
+  #|     harness.frames.push(callback);
+  #|     return harness.frames.length;
   #|   };
+  #|   return harness;
   #| }
 
 ///|
-extern "js" fn restore_markdown_comment_browser_test_dom() -> Unit =
-  #| () => {
-  #|   const originals = globalThis.__markdownCommentBrowserOriginals;
-  #|   globalThis.document = originals.document;
-  #|   globalThis.Element = originals.Element;
-  #|   globalThis.ResizeObserver = originals.ResizeObserver;
-  #|   globalThis.requestAnimationFrame = originals.requestAnimationFrame;
-  #|   delete globalThis.__markdownCommentBrowserOriginals;
-  #|   delete globalThis.__markdownCommentBrowserFrames;
-  #|   delete globalThis.__markdownCommentBrowserObservers;
-  #|   delete globalThis.__markdownCommentHiddenMeasureCount;
+extern "js" fn MarkdownCommentBrowserTestHarness::dispose(
+  self : MarkdownCommentBrowserTestHarness,
+) -> Unit =
+  #| harness => {
+  #|   if (harness.restored) return;
+  #|   harness.restored = true;
+  #|   const restore = (name, value) => {
+  #|     if (value === undefined) delete globalThis[name];
+  #|     else globalThis[name] = value;
+  #|   };
+  #|   restore('document', harness.originals.document);
+  #|   restore('Element', harness.originals.Element);
+  #|   restore('HTMLElement', harness.originals.HTMLElement);
+  #|   restore('ResizeObserver', harness.originals.ResizeObserver);
+  #|   restore('requestAnimationFrame', harness.originals.requestAnimationFrame);
   #| }
 
 ///|
@@ -157,26 +190,46 @@ extern "js" fn markdown_comment_test_set_measurement(
   #| }
 
 ///|
-extern "js" fn markdown_comment_test_trigger_resize() -> Unit =
-  #| () => {
-  #|   const observer = globalThis.__markdownCommentBrowserObservers.at(-1);
+extern "js" fn markdown_comment_test_trigger_resize(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> Unit =
+  #| harness => {
+  #|   const observer = harness.observers.at(-1);
   #|   if (!observer) throw new Error("missing ResizeObserver");
   #|   observer.triggerLate();
   #| }
 
 ///|
 extern "js" fn markdown_comment_test_trigger_resize_for(
+  harness : MarkdownCommentBrowserTestHarness,
   element : @rdom.Element,
 ) -> Unit =
-  #| element => {
-  #|   const observer = globalThis.__markdownCommentBrowserObservers.at(-1);
+  #| (harness, element) => {
+  #|   const observer = harness.observers
+  #|     .findLast(candidate => candidate.targets.includes(element));
   #|   if (!observer) throw new Error("missing ResizeObserver");
   #|   observer.triggerLate(element);
   #| }
 
 ///|
-extern "js" fn markdown_comment_test_observes(element : @rdom.Element) -> Bool =
-  #| element => globalThis.__markdownCommentBrowserObservers.at(-1)?.targets.includes(element) === true
+extern "js" fn markdown_comment_test_observes(
+  harness : MarkdownCommentBrowserTestHarness,
+  element : @rdom.Element,
+) -> Bool =
+  #| (harness, element) => harness.observers
+  #|   .some(observer => observer.targets.includes(element))
+
+///|
+extern "js" fn markdown_comment_test_observer_count(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> Int = "harness => harness.observers.length"
+
+///|
+extern "js" fn markdown_comment_test_observer_target_count(
+  harness : MarkdownCommentBrowserTestHarness,
+  index : Int,
+) -> Int =
+  #| (harness, index) => harness.observers[index]?.targets.length ?? 0
 
 ///|
 extern "js" fn markdown_comment_test_mount_offscreen(
@@ -192,17 +245,19 @@ extern "js" fn markdown_comment_test_mount_offscreen(
   #|   viewport.setAttribute('class', 'editor-scrollable');
   #|   viewport.clientWidth = viewportWidth;
   #|   viewport.isConnected = true;
+  #|   viewport.__markdownCommentOuter = outer;
   #|   viewport.appendChild(outer);
   #|   outer.isConnected = true;
+  #|   const pinnedWidth = Math.max(0, viewportWidth - 14);
+  #|   const narrowPinnedWidth = Math.max(0, narrowWidth - 14);
+  #|   outer.offsetWidth = pinnedWidth;
   #|   content.isConnected = true;
   #|   outer.style.setProperty('display', 'none');
   #|   outer.style.setProperty('height', '0px');
-  #|   outer.style.setProperty('width', '100%');
   #|   outer.style.setProperty('top', '7px');
-  #|   outer.style.setProperty('left', '3px');
   #|   content.__hiddenHeights = new Map([
-  #|     [viewportWidth, wideHeight],
-  #|     [narrowWidth, narrowHeight],
+  #|     [pinnedWidth, wideHeight],
+  #|     [narrowPinnedWidth, narrowHeight],
   #|   ]);
   #|   return viewport;
   #| }
@@ -211,7 +266,45 @@ extern "js" fn markdown_comment_test_mount_offscreen(
 extern "js" fn markdown_comment_test_set_viewport_width(
   viewport : @rdom.Element,
   width : Int,
-) -> Unit = "(viewport, width) => { viewport.clientWidth = width; }"
+) -> Unit =
+  #| (viewport, width) => {
+  #|   viewport.clientWidth = width;
+  #|   if (viewport.__markdownCommentOuter) {
+  #|     viewport.__markdownCommentOuter.offsetWidth =
+  #|       Math.max(0, width - 14);
+  #|   }
+  #| }
+
+///|
+extern "js" fn markdown_comment_test_offset_width(
+  element : @rdom.Element,
+) -> Int = "element => Math.trunc(element.offsetWidth)"
+
+///|
+extern "js" fn markdown_comment_test_style(
+  element : @rdom.Element,
+  name : String,
+) -> String = "(element, name) => element.style.getPropertyValue(name)"
+
+///|
+extern "js" fn markdown_comment_test_clear_style_writes(
+  element : @rdom.Element,
+) -> Unit = "element => { element.style.writes.length = 0; }"
+
+///|
+extern "js" fn markdown_comment_test_style_write_count(
+  element : @rdom.Element,
+  name : String,
+) -> Int =
+  #| (element, name) => element.style.writes
+  #|   .filter(write => write.name === name).length
+
+///|
+extern "js" fn markdown_comment_test_set_style(
+  element : @rdom.Element,
+  name : String,
+  value : String,
+) -> Unit = "(element, name, value) => element.style.setProperty(name, value)"
 
 ///|
 extern "js" fn markdown_comment_test_outer_style(
@@ -222,26 +315,36 @@ extern "js" fn markdown_comment_test_outer_style(
   #|   .join(';')
 
 ///|
-extern "js" fn markdown_comment_test_hidden_measure_count() -> Int = "() => globalThis.__markdownCommentHiddenMeasureCount"
+extern "js" fn markdown_comment_test_hidden_measure_count(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> Int = "harness => harness.hiddenMeasureCount"
 
 ///|
-extern "js" fn markdown_comment_test_disconnect_count() -> Int =
-  #| () => globalThis.__markdownCommentBrowserObservers.at(-1)?.disconnectCount ?? 0
+extern "js" fn markdown_comment_test_disconnect_count(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> Int =
+  #| harness => harness.observers
+  #|   .reduce((sum, observer) => sum + observer.disconnectCount, 0)
 
 ///|
-extern "js" fn markdown_comment_test_pending_frame_count() -> Int = "() => globalThis.__markdownCommentBrowserFrames.length"
+extern "js" fn markdown_comment_test_pending_frame_count(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> Int = "harness => harness.frames.length"
 
 ///|
-extern "js" fn markdown_comment_test_flush_frame() -> Unit =
-  #| () => {
-  #|   const callback = globalThis.__markdownCommentBrowserFrames.shift();
+extern "js" fn markdown_comment_test_flush_frame(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> Unit =
+  #| harness => {
+  #|   const callback = harness.frames.shift();
   #|   if (!callback) throw new Error("missing animation frame");
   #|   callback(0);
   #| }
 
 ///|
 test "MarkdownCommentDom creates the stable half-open ViewZone target shape" {
-  install_markdown_comment_browser_test_dom()
+  let harness = install_markdown_comment_browser_test_dom()
+  defer harness.dispose()
   let dom = MarkdownCommentDom(3, 7)
   assert_eq(
     markdown_comment_test_attribute(dom.outer, "class"),
@@ -260,87 +363,109 @@ test "MarkdownCommentDom creates the stable half-open ViewZone target shape" {
       dom.content,
     ),
   )
-  restore_markdown_comment_browser_test_dom()
+}
+
+///|
+test "MarkdownCommentDom pins outer geometry to ViewLines viewport variables" {
+  let harness = install_markdown_comment_browser_test_dom()
+  defer harness.dispose()
+  let dom = MarkdownCommentDom(3, 7)
+  // Simulate the ordinary ViewZone add write that this helper must replace.
+  markdown_comment_test_set_style(dom.outer, "left", "0px")
+  markdown_comment_test_set_style(dom.outer, "width", "100%")
+  dom.pin_to_content_viewport()
+  assert_eq(
+    markdown_comment_test_style(dom.outer, "left"),
+    "var(--moonbit-viewer-rendered-scroll-left, 0px)",
+  )
+  assert_eq(
+    markdown_comment_test_style(dom.outer, "width"),
+    "var(--moonbit-viewer-visible-content-width, 0px)",
+  )
 }
 
 ///|
 test "size observation coalesces and reports positive changed integer heights" {
-  install_markdown_comment_browser_test_dom()
+  let harness = install_markdown_comment_browser_test_dom()
+  defer harness.dispose()
   let dom = MarkdownCommentDom(1, 2)
   let observed : Array[Int] = []
   let lifetime = dom.observe_size(height => observed.push(height))
-  assert_true(markdown_comment_test_observes(dom.content))
+  assert_true(markdown_comment_test_observes(harness, dom.content))
+  assert_eq(markdown_comment_test_observer_count(harness), 1)
+  assert_eq(markdown_comment_test_observer_target_count(harness, 0), 1)
   markdown_comment_test_set_measurement(dom.content, true, 18.9)
-  markdown_comment_test_trigger_resize()
-  markdown_comment_test_trigger_resize()
-  markdown_comment_test_trigger_resize()
-  assert_eq(markdown_comment_test_pending_frame_count(), 1)
+  markdown_comment_test_trigger_resize(harness)
+  markdown_comment_test_trigger_resize(harness)
+  markdown_comment_test_trigger_resize(harness)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 1)
   // The frame reads the latest geometry, not the first observer payload.
   markdown_comment_test_set_measurement(dom.content, true, 27.9)
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_flush_frame(harness)
   assert_eq(observed, [27])
 
-  markdown_comment_test_trigger_resize()
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_trigger_resize(harness)
+  markdown_comment_test_flush_frame(harness)
   assert_eq(observed, [27])
 
   markdown_comment_test_set_measurement(dom.content, true, 31.0)
-  markdown_comment_test_trigger_resize()
-  markdown_comment_test_trigger_resize()
-  assert_eq(markdown_comment_test_pending_frame_count(), 1)
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_trigger_resize(harness)
+  markdown_comment_test_trigger_resize(harness)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 1)
+  markdown_comment_test_flush_frame(harness)
   assert_eq(observed, [27, 31])
   lifetime.dispose()
   lifetime.dispose()
-  assert_eq(markdown_comment_test_disconnect_count(), 1)
-  restore_markdown_comment_browser_test_dom()
+  assert_eq(markdown_comment_test_disconnect_count(harness), 1)
 }
 
 ///|
 test "disconnected zero queued and late observer callbacks are inert" {
-  install_markdown_comment_browser_test_dom()
+  let harness = install_markdown_comment_browser_test_dom()
+  defer harness.dispose()
   let dom = MarkdownCommentDom(5, 6)
   let observed : Array[Int] = []
   let lifetime = dom.observe_size(height => observed.push(height))
 
   markdown_comment_test_set_measurement(dom.content, false, 20.0)
-  markdown_comment_test_trigger_resize()
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_trigger_resize(harness)
+  markdown_comment_test_flush_frame(harness)
   assert_true(observed.is_empty())
 
   markdown_comment_test_set_measurement(dom.content, true, 0.0)
-  markdown_comment_test_trigger_resize()
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_trigger_resize(harness)
+  markdown_comment_test_flush_frame(harness)
   assert_true(observed.is_empty())
 
   markdown_comment_test_set_measurement(dom.content, true, 22.0)
-  markdown_comment_test_trigger_resize()
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_trigger_resize(harness)
+  markdown_comment_test_flush_frame(harness)
   assert_eq(observed, [22])
 
   markdown_comment_test_set_measurement(dom.content, true, 40.0)
-  markdown_comment_test_trigger_resize()
-  assert_eq(markdown_comment_test_pending_frame_count(), 1)
+  markdown_comment_test_trigger_resize(harness)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 1)
   lifetime.dispose()
   lifetime.dispose()
-  assert_eq(markdown_comment_test_disconnect_count(), 1)
+  assert_eq(markdown_comment_test_disconnect_count(harness), 1)
   // The native frame still drains the shared coordinator, whose canceled
   // registration and disposed guard both keep the root callback inert.
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_flush_frame(harness)
   assert_eq(observed, [22])
 
   // Simulate a browser-delivered ResizeObserver callback that was already
   // queued when disconnect ran.
-  markdown_comment_test_trigger_resize()
-  assert_eq(markdown_comment_test_pending_frame_count(), 0)
+  markdown_comment_test_trigger_resize(harness)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 0)
   assert_eq(observed, [22])
-  restore_markdown_comment_browser_test_dom()
 }
 
 ///|
-test "offscreen measurement uses viewport width restores styles and avoids zero feedback" {
-  install_markdown_comment_browser_test_dom()
+test "offscreen measurement retains pinned width and offset and avoids zero feedback" {
+  let harness = install_markdown_comment_browser_test_dom()
+  defer harness.dispose()
   let dom = MarkdownCommentDom(81, 91)
+  dom.pin_to_content_viewport()
   let viewport = markdown_comment_test_mount_offscreen(
     dom.outer,
     dom.content,
@@ -349,39 +474,79 @@ test "offscreen measurement uses viewport width restores styles and avoids zero 
     180,
     154,
   )
+  // The editor viewport is 320px, but the already-pinned Markdown surface
+  // excludes the fixed 14px vertical rail.
+  assert_eq(markdown_comment_test_offset_width(dom.outer), 306)
   let original_style = markdown_comment_test_outer_style(dom.outer)
   let observed : Array[Int] = []
   let observer = dom.observe_size(height => observed.push(height))
-  assert_true(markdown_comment_test_observes(dom.content))
-  assert_true(markdown_comment_test_observes(viewport))
+  let viewport_observer = dom.observe_viewport_width(() => {
+    observer.request_measure()
+  })
+  assert_true(markdown_comment_test_observes(harness, dom.content))
+  assert_true(markdown_comment_test_observes(harness, viewport))
+  assert_eq(markdown_comment_test_observer_count(harness), 2)
+  assert_eq(markdown_comment_test_observer_target_count(harness, 0), 1)
+  assert_eq(markdown_comment_test_observer_target_count(harness, 1), 1)
+  markdown_comment_test_clear_style_writes(dom.outer)
 
   observer.request_measure()
   observer.request_measure()
-  assert_eq(markdown_comment_test_pending_frame_count(), 1)
-  markdown_comment_test_flush_frame()
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 1)
+  markdown_comment_test_flush_frame(harness)
   assert_eq(observed, [96])
-  assert_eq(markdown_comment_test_hidden_measure_count(), 1)
+  assert_eq(markdown_comment_test_hidden_measure_count(harness), 1)
   assert_eq(markdown_comment_test_outer_style(dom.outer), original_style)
+  assert_eq(markdown_comment_test_style_write_count(dom.outer, "width"), 0)
+  assert_eq(markdown_comment_test_style_write_count(dom.outer, "left"), 0)
 
   // The zero-size target callback caused by restoring `display:none` must not
   // enter the forced hidden path again or produce a frame-to-frame loop.
-  markdown_comment_test_trigger_resize_for(dom.content)
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_trigger_resize_for(harness, dom.content)
+  markdown_comment_test_flush_frame(harness)
   assert_eq(observed, [96])
-  assert_eq(markdown_comment_test_hidden_measure_count(), 1)
+  assert_eq(markdown_comment_test_hidden_measure_count(harness), 1)
 
   // A viewport observation is an explicit width invalidation even while the
   // ViewZone remains display:none.
   markdown_comment_test_set_viewport_width(viewport, 180)
-  markdown_comment_test_trigger_resize_for(viewport)
-  markdown_comment_test_flush_frame()
+  markdown_comment_test_trigger_resize_for(harness, viewport)
+  markdown_comment_test_flush_frame(harness)
+  assert_eq(markdown_comment_test_offset_width(dom.outer), 166)
   assert_eq(observed, [96, 154])
-  assert_eq(markdown_comment_test_hidden_measure_count(), 2)
+  assert_eq(markdown_comment_test_hidden_measure_count(harness), 2)
   assert_eq(markdown_comment_test_outer_style(dom.outer), original_style)
+  assert_eq(markdown_comment_test_style_write_count(dom.outer, "width"), 0)
+  assert_eq(markdown_comment_test_style_write_count(dom.outer, "left"), 0)
 
+  // An equal positive width is deduplicated by the shared observer.
+  markdown_comment_test_trigger_resize_for(harness, viewport)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 0)
+
+  // Zero is remembered but not measured. Restoring the same positive width
+  // still invalidates because content may have laid out while the host was
+  // collapsed.
+  markdown_comment_test_set_viewport_width(viewport, 0)
+  markdown_comment_test_trigger_resize_for(harness, viewport)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 0)
+  markdown_comment_test_set_viewport_width(viewport, 180)
+  markdown_comment_test_trigger_resize_for(harness, viewport)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 1)
+  markdown_comment_test_flush_frame(harness)
+  assert_eq(observed, [96, 154])
+  assert_eq(markdown_comment_test_hidden_measure_count(harness), 3)
+  assert_eq(markdown_comment_test_style_write_count(dom.outer, "width"), 0)
+  assert_eq(markdown_comment_test_style_write_count(dom.outer, "left"), 0)
+
+  viewport_observer.dispose()
+  viewport_observer.dispose()
   observer.dispose()
   observer.request_measure()
-  assert_eq(markdown_comment_test_pending_frame_count(), 0)
-  assert_eq(markdown_comment_test_disconnect_count(), 1)
-  restore_markdown_comment_browser_test_dom()
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 0)
+  assert_eq(markdown_comment_test_disconnect_count(harness), 2)
+
+  // Browser-delivered callbacks already queued before disconnect are inert.
+  markdown_comment_test_set_viewport_width(viewport, 240)
+  markdown_comment_test_trigger_resize_for(harness, viewport)
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 0)
 }

--- a/editor/internal/viewer/contrib/markdown_comments/browser/moon.pkg
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbitlang/editor/base/browser" @base_browser,
   "moonbitlang/editor/base/common" @base_common,
   "moonbit-community/rabbita/dom" @rdom,
+  "moonbit-community/rabbita/js",
 }
 
 supported_targets = "js"

--- a/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
@@ -10,6 +10,13 @@ import {
 // Errors
 
 // Types and methods
+pub struct MarkdownCommentDiagramViewports {
+  // private fields
+}
+#alias(new, deprecated)
+pub fn MarkdownCommentDiagramViewports::MarkdownCommentDiagramViewports(@dom.Element, () -> Unit) -> Self
+pub fn MarkdownCommentDiagramViewports::dispose(Self) -> Unit
+
 pub(all) struct MarkdownCommentDom {
   outer : @dom.Element
   content : @dom.Element

--- a/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
@@ -24,12 +24,19 @@ pub(all) struct MarkdownCommentDom {
 #alias(new, deprecated)
 pub fn MarkdownCommentDom::MarkdownCommentDom(Int, Int) -> Self
 pub fn MarkdownCommentDom::observe_size(Self, (Int) -> Unit) -> MarkdownCommentSizeObserver
+pub fn MarkdownCommentDom::observe_viewport_width(Self, () -> Unit) -> MarkdownCommentViewportObserver
+pub fn MarkdownCommentDom::pin_to_content_viewport(Self) -> Unit
 
 pub struct MarkdownCommentSizeObserver {
   // private fields
 }
 pub fn MarkdownCommentSizeObserver::dispose(Self) -> Unit
 pub fn MarkdownCommentSizeObserver::request_measure(Self) -> Unit
+
+pub struct MarkdownCommentViewportObserver {
+  // private fields
+}
+pub fn MarkdownCommentViewportObserver::dispose(Self) -> Unit
 
 // Type aliases
 

--- a/editor/internal/viewer/markdown/diagram_code_block.mbt
+++ b/editor/internal/viewer/markdown/diagram_code_block.mbt
@@ -3,7 +3,7 @@
 /// Unknown, unlabelled, and failed diagram blocks keep the existing fallback.
 fn render_diagram_code_block(code_block : MarkdownCodeBlock) -> String? {
   match code_block.language_id {
-    Some("diago") =>
+    Some("diago") | Some("d2") =>
       render_diago_svg(code_block.code).map(svg => {
         wrap_diagram_svg("diago", svg)
       })

--- a/editor/tests/browser/component/markdown_comments.spec.js
+++ b/editor/tests/browser/component/markdown_comments.spec.js
@@ -9,6 +9,14 @@ const editor = `${host} > .monaco-editor.readonly-editor`;
 const zone = `${editor} .moonbit-viewer-markdown-comment`;
 const content = '.moonbit-viewer-markdown-comment-content';
 const diagram = '.moonbit-viewer-markdown-diagram';
+const diagramViewport =
+  `${diagram}.moonbit-viewer-markdown-diagram-viewport`;
+const diagramContent = '.moonbit-viewer-markdown-diagram-content';
+const diagramControls = '.moonbit-viewer-markdown-diagram-controls';
+const diagramResizeHandle =
+  '.moonbit-viewer-markdown-diagram-resize-handle';
+const editorScrollable =
+  `${editor} .monaco-scrollable-element.editor-scrollable`;
 const imageUrl = 'https://images.example.test/markdown-comment.svg';
 
 const fixtureSvg = `
@@ -54,7 +62,7 @@ async function mountMarkdownComments(page, testInfo) {
   });
   expectMoonBitReportPassed(report, { suite: 'markdown_comments' });
   expect(report.metrics.initialZones).toBe(3);
-  expect(report.metrics.initialDiagrams).toBe(1);
+  expect(report.metrics.initialDiagrams).toBe(2);
   await expect(page.locator(zone)).toHaveCount(3);
   await settle(page);
   return reporter;
@@ -72,6 +80,78 @@ async function state(page) {
   return control(page, 'state');
 }
 
+async function horizontalViewportGeometry(page) {
+  return page.locator(editor).evaluate((root) => {
+    const rect = (node) => {
+      const value = node.getBoundingClientRect();
+      return {
+        top: value.top,
+        bottom: value.bottom,
+        left: value.left,
+        right: value.right,
+        width: value.width,
+        height: value.height,
+      };
+    };
+    const required = (selector, scope = root) => {
+      const node = scope.querySelector(selector);
+      if (!node) throw new Error(`missing horizontal geometry node: ${selector}`);
+      return node;
+    };
+    const scrollable = required(
+      '.monaco-scrollable-element.editor-scrollable',
+    );
+    const rail = required(':scope > .scrollbar.vertical', scrollable);
+    const viewZones = required('.view-zones');
+    const outers = Array.from(
+      root.querySelectorAll('.moonbit-viewer-markdown-comment'),
+    );
+    if (outers.length === 0) {
+      throw new Error('missing Markdown comment outer nodes');
+    }
+    const sourceLine = Array.from(
+      root.querySelectorAll('.view-lines .view-line'),
+    ).find((node) =>
+      node.textContent.includes('horizontal_overflow_sentinel'));
+    if (!sourceLine) throw new Error('missing horizontal overflow source line');
+    const sourceContent =
+      sourceLine.querySelector('.view-line-content') ?? sourceLine;
+    const viewport = required(
+      '.moonbit-viewer-markdown-diagram-viewport',
+    );
+    const toolbar = required(
+      ':scope > .moonbit-viewer-markdown-diagram-controls',
+      viewport,
+    );
+    const transformContent = required(
+      ':scope > .moonbit-viewer-markdown-diagram-content',
+      viewport,
+    );
+    return {
+      scrollable: rect(scrollable),
+      rail: rect(rail),
+      viewZones: rect(viewZones),
+      outers: outers.map(rect),
+      source: rect(sourceContent),
+      diagram: rect(viewport),
+      toolbar: rect(toolbar),
+      diagramTransform: transformContent.style.transform,
+    };
+  });
+}
+
+function expectMarkdownPinnedToVisibleViewport(geometry) {
+  expect(geometry.rail.width).toBeGreaterThan(0);
+  for (const outer of geometry.outers) {
+    expectNear(outer.left, geometry.scrollable.left);
+    expectNear(outer.right, geometry.rail.left);
+    expectNear(
+      outer.width,
+      geometry.rail.left - geometry.scrollable.left,
+    );
+  }
+}
+
 async function zoneRanges(page) {
   return page.locator(zone).evaluateAll((nodes) =>
     nodes.map((node) => [
@@ -79,6 +159,36 @@ async function zoneRanges(page) {
       Number(node.getAttribute('data-end-line')),
     ]),
   );
+}
+
+async function viewportGeometry(locator) {
+  return locator.evaluate((wrapper) => {
+    const transformContent = wrapper.querySelector(
+      ':scope > .moonbit-viewer-markdown-diagram-content',
+    );
+    const svg = transformContent.querySelector(':scope > svg');
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const svgRect = svg.getBoundingClientRect();
+    const transform = new DOMMatrixReadOnly(
+      window.getComputedStyle(transformContent).transform,
+    );
+    return {
+      wrapperHeight: wrapperRect.height,
+      wrapperWidth: wrapperRect.width,
+      inlineHeight: Number.parseFloat(wrapper.style.height),
+      svgHeight: svgRect.height,
+      svgWidth: svgRect.width,
+      scale: transform.a,
+      scaleY: transform.d,
+      translateX: transform.e,
+      translateY: transform.f,
+      transform: transformContent.style.transform,
+    };
+  });
+}
+
+function expectNear(actual, expected, tolerance = 1) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
 }
 
 function relativeLuminance(color) {
@@ -174,7 +284,7 @@ test('public Viewer replaces whole-line source with themed Markdown while model 
     expect(await zoneRanges(page)).toEqual([
       [1, 3],
       [5, 9],
-      [10, 25],
+      [10, 29],
     ]);
 
     const zones = page.locator(zone);
@@ -189,13 +299,58 @@ test('public Viewer replaces whole-line source with themed Markdown while model 
       'let fenced_value = 42',
     );
     await expect(fencedCode.locator('.mtk3')).not.toHaveCount(0);
-    const diagoDiagram = zones
+    const diagoDiagrams = zones
       .nth(2)
       .locator(`${diagram}[data-diagram-language="diago"]`);
-    await expect(diagoDiagram).toHaveCount(1);
-    await expect(diagoDiagram.locator(':scope > svg')).toHaveCount(1);
+    await expect(diagoDiagrams).toHaveCount(2);
+    const diagoDiagram = diagoDiagrams.nth(0);
+    const compactDiagram = diagoDiagrams.nth(1);
+    for (const renderedDiagram of [diagoDiagram, compactDiagram]) {
+      await expect(renderedDiagram).toHaveClass(
+        /moonbit-viewer-markdown-diagram-viewport/,
+      );
+      await expect(
+        renderedDiagram.locator(`:scope > ${diagramContent} > svg`),
+      ).toHaveCount(1);
+      await expect(renderedDiagram.locator(':scope > svg')).toHaveCount(0);
+      await expect(
+        renderedDiagram.locator(`:scope > ${diagramControls} > button`),
+      ).toHaveCount(4);
+      await expect(
+        renderedDiagram.locator(`:scope > ${diagramResizeHandle}`),
+      ).toHaveCount(1);
+      await expect(renderedDiagram).toHaveAttribute(
+        'aria-label',
+        'Interactive Diago diagram',
+      );
+      await expect(renderedDiagram).toHaveAttribute('tabindex', '0');
+    }
+    await expect(
+      diagoDiagram.locator('[aria-label="Toggle pan mode"]'),
+    ).toHaveAttribute('aria-pressed', 'false');
+    await expect(
+      diagoDiagram.locator('[aria-label="Zoom out"]'),
+    ).toHaveCount(1);
+    await expect(
+      diagoDiagram.locator('[aria-label="Zoom in"]'),
+    ).toHaveCount(1);
+    await expect(
+      diagoDiagram.locator('[aria-label="Fit diagram"]'),
+    ).toHaveCount(1);
+    const resizeHandle = diagoDiagram.locator(
+      '[aria-label="Resize diagram"]',
+    );
+    await expect(resizeHandle).toHaveAttribute('role', 'separator');
+    await expect(resizeHandle).toHaveAttribute('tabindex', '0');
+    await expect(resizeHandle).toHaveAttribute(
+      'aria-orientation',
+      'horizontal',
+    );
     const diagramLayout = await diagoDiagram.evaluate((wrapper) => {
-      const svg = wrapper.querySelector(':scope > svg');
+      const transformContent = wrapper.querySelector(
+        ':scope > .moonbit-viewer-markdown-diagram-content',
+      );
+      const svg = transformContent.querySelector(':scope > svg');
       const inner = wrapper.closest(
         '.moonbit-viewer-markdown-comment-content',
       );
@@ -215,7 +370,6 @@ test('public Viewer replaces whole-line source with themed Markdown while model 
         svgWidth: svgRect.width,
         svgAspectRatio: svgRect.width / svgRect.height,
         viewBoxAspectRatio: viewBox.width / viewBox.height,
-        expectedMaxHeight: Math.min(window.innerHeight * 0.5, 480),
         innerClientWidth: inner.clientWidth,
         innerHeight: inner.offsetHeight,
         outerHeight: outerRect.height,
@@ -229,37 +383,45 @@ test('public Viewer replaces whole-line source with themed Markdown while model 
         diagramWithinMeasuredHeight: wrapperRect.bottom <= innerRect.bottom + 1,
         overflowX: window.getComputedStyle(wrapper).overflowX,
         overflowY: window.getComputedStyle(wrapper).overflowY,
+        position: window.getComputedStyle(wrapper).position,
+        boxSizing: window.getComputedStyle(wrapper).boxSizing,
         wrapperMaxWidth: window.getComputedStyle(wrapper).maxWidth,
         svgDisplay: window.getComputedStyle(svg).display,
         svgMaxWidth: window.getComputedStyle(svg).maxWidth,
+        transformOrigin:
+          window.getComputedStyle(transformContent).transformOrigin,
+        preserveAspectRatio: svg.getAttribute('preserveAspectRatio'),
+        hasWidth: svg.hasAttribute('width'),
+        hasHeight: svg.hasAttribute('height'),
       };
     });
     expect(diagramLayout).toMatchObject({
       wrapperWithinContent: true,
       svgWithinWrapper: true,
       diagramWithinMeasuredHeight: true,
-      overflowX: 'auto',
-      overflowY: 'auto',
+      overflowX: 'hidden',
+      overflowY: 'hidden',
+      position: 'relative',
+      boxSizing: 'border-box',
       wrapperMaxWidth: '100%',
       svgDisplay: 'block',
       svgMaxWidth: '100%',
+      transformOrigin: '0px 0px',
+      preserveAspectRatio: 'xMinYMin meet',
+      hasWidth: false,
+      hasHeight: false,
     });
-    expect(diagramLayout.wrapperHeight).toBeGreaterThan(0);
+    expect(diagramLayout.wrapperHeight).toBeGreaterThan(480);
     expect(diagramLayout.svgHeight).toBeGreaterThan(0);
-    expect(
-      Math.abs(
-        diagramLayout.wrapperClientHeight - diagramLayout.expectedMaxHeight,
-      ),
-    ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs(diagramLayout.wrapperHeight - diagramLayout.wrapperClientHeight),
-    ).toBeLessThanOrEqual(1);
-    expect(diagramLayout.wrapperScrollHeight).toBeGreaterThan(
-      diagramLayout.wrapperClientHeight + 1,
+    expectNear(
+      diagramLayout.wrapperHeight,
+      diagramLayout.wrapperClientHeight,
     );
-    expect(diagramLayout.svgHeight).toBeGreaterThan(
-      diagramLayout.wrapperClientHeight + 1,
+    expectNear(
+      diagramLayout.wrapperScrollHeight,
+      diagramLayout.wrapperClientHeight,
     );
+    expectNear(diagramLayout.svgHeight, diagramLayout.wrapperClientHeight);
     expect(
       Math.abs(
         diagramLayout.svgAspectRatio - diagramLayout.viewBoxAspectRatio,
@@ -347,12 +509,12 @@ test('public Viewer replaces whole-line source with themed Markdown while model 
       return {
         start: rect(byRange(1, 3)),
         middle: rect(byRange(5, 9)),
-        eof: rect(byRange(10, 25)),
+        eof: rect(byRange(10, 29)),
         alpha: rect(lineWith('alpha_code_truth')),
         omega: rect(lineWith('omega_code_truth')),
         startHeading: rect(byRange(1, 3).querySelector('h1')),
         eofCode: rect(
-          byRange(10, 25).querySelector('.monaco-tokenized-source'),
+          byRange(10, 29).querySelector('.monaco-tokenized-source'),
         ),
         alphaContent: rect(
           lineWith('alpha_code_truth').querySelector('.view-line-content'),
@@ -374,7 +536,7 @@ test('public Viewer replaces whole-line source with themed Markdown while model 
     expect(
       Math.abs(geometry.eofCode.left - geometry.omegaContent.left),
     ).toBeLessThanOrEqual(1);
-    expect(geometry.visibleLineCount).toBeGreaterThan(3);
+    expect(geometry.visibleLineCount).toBeGreaterThanOrEqual(3);
     expect(geometry.visibleSourceText).not.toContain('///');
     expect(geometry.visibleSourceText).not.toContain('Start comment');
 
@@ -406,58 +568,28 @@ test('public Viewer replaces whole-line source with themed Markdown while model 
     );
     expect(initialState.primaryValue).toContain(imageUrl);
 
-    // The diagram owns wheel input only while it can consume that delta. The
-    // browser keeps native scrolling because the shared listener never calls
-    // preventDefault; the editor's scroll position must stay unchanged.
+    // An interactive viewport has no native diagram scroller. Ordinary wheel
+    // input bubbles to the public Viewer scroll surface without changing its
+    // transform.
+    await diagoDiagram.scrollIntoViewIfNeeded();
+    await settle(page);
     const diagramBox = await diagoDiagram.boundingBox();
     expect(diagramBox).not.toBeNull();
     await page.mouse.move(
       diagramBox.x + diagramBox.width / 2,
-      diagramBox.y + Math.min(100, diagramBox.height / 2),
+      Math.max(20, Math.min(660, diagramBox.y + 100)),
     );
-    const diagramScrollBefore = await diagoDiagram.evaluate(
-      (wrapper) => wrapper.scrollTop,
-    );
+    const diagramBeforeWheel = await viewportGeometry(diagoDiagram);
     const editorScrollBefore = (await state(page)).scrollTop;
     await page.mouse.wheel(0, 160);
     await expect
-      .poll(() => diagoDiagram.evaluate((wrapper) => wrapper.scrollTop))
-      .toBeGreaterThan(diagramScrollBefore);
-    expect(
-      Math.abs((await state(page)).scrollTop - editorScrollBefore),
-    ).toBeLessThanOrEqual(1);
-
-    const boundaryHandoff = await diagoDiagram.evaluate((wrapper) => {
-      const owner = wrapper.closest(
-        '.moonbit-viewer-markdown-comment-content',
-      );
-      wrapper.scrollTop = wrapper.scrollHeight;
-      let bubbled = 0;
-      const observe = (event) => {
-        bubbled += 1;
-        // Observe the handoff before Monaco consumes the synthetic wheel.
-        event.stopPropagation();
-      };
-      owner.addEventListener('wheel', observe);
-      wrapper.dispatchEvent(
-        new WheelEvent('wheel', {
-          bubbles: true,
-          cancelable: true,
-          deltaY: 160,
-        }),
-      );
-      owner.removeEventListener('wheel', observe);
-      return {
-        atBottom:
-          wrapper.scrollTop + wrapper.clientHeight >=
-          wrapper.scrollHeight - 1,
-        bubbled,
-      };
-    });
-    expect(boundaryHandoff).toEqual({ atBottom: true, bubbled: 1 });
-    await diagoDiagram.evaluate((wrapper) => {
-      wrapper.scrollTop = 0;
-    });
+      .poll(async () => (await state(page)).scrollTop)
+      .toBeGreaterThan(editorScrollBefore);
+    const diagramAfterWheel = await viewportGeometry(diagoDiagram);
+    expect(diagramAfterWheel.transform).toBe(diagramBeforeWheel.transform);
+    expect(await diagoDiagram.evaluate((wrapper) => wrapper.scrollTop)).toBe(0);
+    await control(page, 'set_scroll_top', 0);
+    await settle(page);
 
     await control(page, 'set_model_selection');
     await control(page, 'focus');
@@ -572,6 +704,505 @@ test('keeps the Markdown surface distinct from source and fenced code in both th
   }
 });
 
+test('pins Markdown to the visible viewport while long source keeps its horizontal scroll plane', async ({
+  page,
+}, testInfo) => {
+  const reporter = await mountMarkdownComments(page, testInfo);
+  try {
+    const zeroState = await state(page);
+    expect(zeroState.softWrap).toBe(false);
+    expect(zeroState.scrollLeft).toBe(0);
+
+    const zero = await horizontalViewportGeometry(page);
+    expectMarkdownPinnedToVisibleViewport(zero);
+    expect(zeroState.scrollWidth).toBeGreaterThan(zero.scrollable.width + 100);
+    expect(zeroState.contentWidth).toBeGreaterThan(
+      zero.scrollable.width + 100,
+    );
+    expect(zero.viewZones.width).toBeGreaterThan(
+      zero.scrollable.width + 100,
+    );
+
+    const maximumRequest = Math.floor(zeroState.scrollWidth);
+    const middleRequest = Math.max(
+      1,
+      Math.floor((zeroState.scrollWidth - zero.scrollable.width) / 2),
+    );
+    const samples = [{ state: zeroState, geometry: zero }];
+    for (const requested of [middleRequest, maximumRequest]) {
+      await control(page, 'set_scroll_left', requested);
+      await expect
+        .poll(async () => (await state(page)).scrollLeft)
+        .toBeGreaterThan(samples.at(-1).state.scrollLeft);
+      await settle(page);
+      samples.push({
+        state: await state(page),
+        geometry: await horizontalViewportGeometry(page),
+      });
+    }
+
+    for (const sample of samples) {
+      expectMarkdownPinnedToVisibleViewport(sample.geometry);
+      expect(sample.geometry.viewZones.width).toBeGreaterThan(
+        sample.geometry.scrollable.width + 100,
+      );
+      expectNear(
+        sample.geometry.source.left,
+        zero.source.left - sample.state.scrollLeft,
+      );
+      expectNear(sample.geometry.diagram.left, zero.diagram.left);
+      expectNear(sample.geometry.diagram.right, zero.diagram.right);
+      expectNear(sample.geometry.toolbar.right, zero.toolbar.right);
+      expect(sample.geometry.diagramTransform).toBe(zero.diagramTransform);
+      sample.geometry.outers.forEach((outer, index) => {
+        expectNear(outer.height, zero.outers[index].height);
+      });
+    }
+
+    // Widen from the maximum horizontal position so the new maximum is
+    // smaller but remains non-zero. This exercises real scrollLeft clamping,
+    // not merely a resize that increases the available scroll range.
+    const maximumSample = samples.at(-1);
+    await control(page, 'resize', 900);
+    await expect
+      .poll(async () => (await state(page)).scrollLeft)
+      .toBeGreaterThan(0);
+    await expect
+      .poll(async () => (await state(page)).scrollLeft)
+      .toBeLessThan(maximumSample.state.scrollLeft);
+    await settle(page);
+    const resizedState = await state(page);
+    const resized = await horizontalViewportGeometry(page);
+    expect(resizedState.scrollLeft).toBeLessThanOrEqual(
+      Math.max(0, resizedState.scrollWidth - resized.scrollable.width) + 1,
+    );
+    expectMarkdownPinnedToVisibleViewport(resized);
+    expectNear(
+      resized.source.left - resized.scrollable.left + resizedState.scrollLeft,
+      zero.source.left - zero.scrollable.left,
+    );
+    expectNear(
+      resized.diagram.right - resized.toolbar.right,
+      zero.diagram.right - zero.toolbar.right,
+    );
+    expect(resized.diagram.right).toBeLessThanOrEqual(resized.rail.left + 1);
+    expect(
+      resized.outers.some(
+        (outer, index) =>
+          Math.abs(outer.height - maximumSample.geometry.outers[index].height)
+          > 1,
+      ),
+    ).toBe(true);
+
+    // Soft wrap removes the horizontal range and clamps scrollLeft. Toggling
+    // it back restores overflow without changing the Markdown viewport
+    // contract, after which horizontal scrolling can resume.
+    await control(page, 'set_soft_wrap', true);
+    await expect.poll(async () => (await state(page)).softWrap).toBe(true);
+    await expect
+      .poll(async () => (await state(page)).scrollLeft)
+      .toBeLessThan(resizedState.scrollLeft);
+    await settle(page);
+    const wrappedState = await state(page);
+    const wrapped = await horizontalViewportGeometry(page);
+    expect(wrappedState.scrollLeft).toBeLessThanOrEqual(
+      Math.max(0, wrappedState.scrollWidth - wrapped.scrollable.width) + 1,
+    );
+    expectMarkdownPinnedToVisibleViewport(wrapped);
+
+    await control(page, 'set_soft_wrap', false);
+    await expect.poll(async () => (await state(page)).softWrap).toBe(false);
+    await expect
+      .poll(async () => (await state(page)).scrollWidth)
+      .toBeGreaterThan(resized.scrollable.width + 100);
+    await control(page, 'set_scroll_left', middleRequest);
+    await expect
+      .poll(async () => (await state(page)).scrollLeft)
+      .toBeGreaterThan(0);
+    await settle(page);
+    expectMarkdownPinnedToVisibleViewport(
+      await horizontalViewportGeometry(page),
+    );
+  } finally {
+    reporter.dispose();
+  }
+});
+
+test('interactive Diago controls pan zoom fit resize and keep sibling state independent', async ({
+  page,
+}, testInfo) => {
+  const reporter = await mountMarkdownComments(page, testInfo);
+  try {
+    const viewports = page.locator(`${zone} ${diagramViewport}`);
+    await expect(viewports).toHaveCount(2);
+    const large = viewports.nth(0);
+    const compact = viewports.nth(1);
+
+    // Before either diagram has been touched, a host resize recomputes natural
+    // geometry and keeps scale 1. Both controllers observe the same public
+    // Viewer layout but own independent transforms.
+    const compactWide = await viewportGeometry(compact);
+    await control(page, 'resize', 420);
+    await expect
+      .poll(async () => (await viewportGeometry(compact)).wrapperWidth)
+      .toBeLessThan(compactWide.wrapperWidth - 20);
+    const compactNarrow = await viewportGeometry(compact);
+    expectNear(compactNarrow.scale, 1, 0.001);
+    expectNear(compactNarrow.scaleY, 1, 0.001);
+    expectNear(compactNarrow.translateY, 0, 0.01);
+    expect(compactNarrow.wrapperHeight).not.toBe(compactWide.wrapperHeight);
+
+    await large.scrollIntoViewIfNeeded();
+    await settle(page);
+    await control(page, 'set_model_selection');
+    const selectionBeforeInput = (await state(page)).selection;
+    const compactBeforeLargeInput = await viewportGeometry(compact);
+    const initial = await viewportGeometry(large);
+    expectNear(initial.scale, 1, 0.001);
+
+    const pan = large.locator('[aria-label="Toggle pan mode"]');
+    const zoomOut = large.locator('[aria-label="Zoom out"]');
+    const zoomIn = large.locator('[aria-label="Zoom in"]');
+    const fit = large.locator('[aria-label="Fit diagram"]');
+    await zoomIn.focus();
+    const windowWidth = await page.evaluate(() => window.innerWidth);
+    await page.mouse.move(windowWidth - 2, 20);
+    await expect(large.locator(`:scope > ${diagramControls}`)).toHaveCSS(
+      'opacity',
+      '1',
+    );
+    await pan.click();
+    await expect(pan).toHaveAttribute('aria-pressed', 'true');
+    const panBox = await large.boundingBox();
+    expect(panBox).not.toBeNull();
+    const panX = panBox.x + panBox.width * 0.35;
+    const panY = Math.max(30, Math.min(620, panBox.y + 160));
+    await page.mouse.move(panX, panY);
+    await page.mouse.down();
+    await page.mouse.move(panX + 36, panY + 24, { steps: 3 });
+    await page.mouse.up();
+    const plainPanned = await viewportGeometry(large);
+    expectNear(plainPanned.translateX - initial.translateX, 36, 2);
+    expectNear(plainPanned.translateY - initial.translateY, 24, 2);
+    await pan.click();
+    await expect(pan).toHaveAttribute('aria-pressed', 'false');
+
+    // Alt drag pans while the toggle is off. Its >3px single-move threshold is
+    // covered exactly by the reference test; this direct proof uses a clearly
+    // visible gesture.
+    const altPanBox = await large.boundingBox();
+    const altPanX = altPanBox.x + altPanBox.width * 0.35;
+    const altPanY = Math.max(30, Math.min(620, altPanBox.y + 190));
+    await page.keyboard.down('Alt');
+    await page.mouse.move(altPanX, altPanY);
+    await page.mouse.down();
+    await page.mouse.move(altPanX + 28, altPanY - 20, { steps: 2 });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+    const modifierPanned = await viewportGeometry(large);
+    expectNear(modifierPanned.translateX - plainPanned.translateX, 28, 2);
+    expectNear(modifierPanned.translateY - plainPanned.translateY, -20, 2);
+
+    await zoomOut.click();
+    expectNear((await viewportGeometry(large)).scale, 0.8, 0.001);
+    await zoomIn.click();
+    expectNear((await viewportGeometry(large)).scale, 1, 0.001);
+    await fit.click();
+    const fitted = await viewportGeometry(large);
+    expect(fitted.scale).toBeGreaterThan(0);
+    expect(fitted.scale).toBeLessThan(1);
+    const fittedRect = await large.evaluate((wrapper) => {
+      const svg = wrapper.querySelector(
+        ':scope > .moonbit-viewer-markdown-diagram-content > svg',
+      );
+      const viewportRect = wrapper.getBoundingClientRect();
+      const svgRect = svg.getBoundingClientRect();
+      return {
+        left: svgRect.left - viewportRect.left,
+        right: viewportRect.right - svgRect.right,
+        top: svgRect.top - viewportRect.top,
+        bottom: viewportRect.bottom - svgRect.bottom,
+      };
+    });
+    expect(fittedRect.left).toBeGreaterThanOrEqual(15);
+    expect(fittedRect.right).toBeGreaterThanOrEqual(15);
+    expect(fittedRect.top).toBeGreaterThanOrEqual(15);
+    expect(fittedRect.bottom).toBeGreaterThanOrEqual(15);
+
+    await zoomIn.click();
+    const toolbarZoomed = await viewportGeometry(large);
+    expectNear(toolbarZoomed.scale, fitted.scale * 1.25, 0.002);
+    const wheelOwnership = await large.evaluate((wrapper) => {
+      const rect = wrapper.getBoundingClientRect();
+      const dispatch = (init) => {
+        const event = new WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + Math.min(100, rect.height / 2),
+          ...init,
+        });
+        const returned = wrapper.dispatchEvent(event);
+        return { defaultPrevented: event.defaultPrevented, returned };
+      };
+      return {
+        alt: dispatch({ altKey: true, deltaY: -20 }),
+        ctrl: dispatch({ ctrlKey: true, deltaY: -2 }),
+      };
+    });
+    expect(wheelOwnership).toEqual({
+      alt: { defaultPrevented: true, returned: false },
+      ctrl: { defaultPrevented: true, returned: false },
+    });
+    const modifierZoomed = await viewportGeometry(large);
+    expect(modifierZoomed.scale).toBeGreaterThan(toolbarZoomed.scale);
+
+    const clickBox = await large.boundingBox();
+    const clickPosition = {
+      x: clickBox.width * 0.3,
+      y: Math.min(120, clickBox.height * 0.3),
+    };
+    const beforeAltClick = await viewportGeometry(large);
+    await large.click({ position: clickPosition, modifiers: ['Alt'] });
+    const afterAltClick = await viewportGeometry(large);
+    expect(afterAltClick.scale).toBeGreaterThan(beforeAltClick.scale);
+    await large.click({
+      position: clickPosition,
+      modifiers: ['Alt', 'Shift'],
+    });
+    expect((await viewportGeometry(large)).scale).toBeLessThan(
+      afterAltClick.scale,
+    );
+
+    const compactAfterLargeInput = await viewportGeometry(compact);
+    expect(compactAfterLargeInput.transform).toBe(
+      compactBeforeLargeInput.transform,
+    );
+
+    const handle = large.locator(diagramResizeHandle);
+    await handle.scrollIntoViewIfNeeded();
+    await settle(page);
+    const heightBeforePointer = (await viewportGeometry(large)).wrapperHeight;
+    const zoneHeightBeforePointer = await large.evaluate(
+      (wrapper) =>
+        wrapper.closest('.moonbit-viewer-markdown-comment')
+          .getBoundingClientRect().height,
+    );
+    const handleBox = await handle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2,
+      handleBox.y + handleBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2,
+      handleBox.y + handleBox.height / 2 + 60,
+      { steps: 4 },
+    );
+    await page.mouse.up();
+    await expect
+      .poll(async () => (await viewportGeometry(large)).wrapperHeight)
+      .toBeGreaterThan(heightBeforePointer + 55);
+    await expect
+      .poll(() =>
+        large.evaluate(
+          (wrapper) =>
+            wrapper.closest('.moonbit-viewer-markdown-comment')
+              .getBoundingClientRect().height,
+        ),
+      )
+      .toBeGreaterThan(zoneHeightBeforePointer + 55);
+
+    await handle.focus();
+    const heightBeforeKeyboard = (await viewportGeometry(large)).wrapperHeight;
+    await page.keyboard.press('ArrowDown');
+    await expect
+      .poll(async () => (await viewportGeometry(large)).wrapperHeight)
+      .toBeCloseTo(heightBeforeKeyboard + 10, 0);
+    await page.keyboard.press('Shift+ArrowDown');
+    await expect
+      .poll(async () => (await viewportGeometry(large)).wrapperHeight)
+      .toBeCloseTo(heightBeforeKeyboard + 60, 0);
+    await page.keyboard.press('ArrowUp');
+    await expect
+      .poll(async () => (await viewportGeometry(large)).wrapperHeight)
+      .toBeCloseTo(heightBeforeKeyboard + 50, 0);
+
+    // A custom height wins across a later host resize, while prior fit/pan
+    // keeps scale and preserves a visible origin instead of resetting.
+    const beforeResponsiveResize = await viewportGeometry(large);
+    await control(page, 'resize', 620);
+    await expect
+      .poll(async () => (await viewportGeometry(large)).wrapperWidth)
+      .toBeGreaterThan(beforeResponsiveResize.wrapperWidth + 100);
+    const afterResponsiveResize = await viewportGeometry(large);
+    expectNear(
+      afterResponsiveResize.wrapperHeight,
+      beforeResponsiveResize.wrapperHeight,
+      1,
+    );
+    expectNear(afterResponsiveResize.scale, beforeResponsiveResize.scale, 0.002);
+    expect(afterResponsiveResize.transform).not.toBe(
+      beforeResponsiveResize.transform,
+    );
+
+    // A pure horizontal source scroll must not enter the diagram resize or
+    // transform paths. In particular, its caller-selected height is stable.
+    // Bring the long source sentinel into the vertically rendered range so
+    // it contributes the no-wrap horizontal extent used by this gesture.
+    await control(page, 'set_scroll_top', 0);
+    await settle(page);
+    const customHeightBeforeHorizontal = await viewportGeometry(large);
+    await control(page, 'set_scroll_left', 200);
+    await expect
+      .poll(async () => (await state(page)).scrollLeft)
+      .toBeGreaterThan(0);
+    await settle(page);
+    const customHeightAfterHorizontal = await viewportGeometry(large);
+    expectNear(
+      customHeightAfterHorizontal.wrapperHeight,
+      customHeightBeforeHorizontal.wrapperHeight,
+    );
+    expectNear(
+      customHeightAfterHorizontal.inlineHeight,
+      customHeightBeforeHorizontal.inlineHeight,
+    );
+    expect(customHeightAfterHorizontal.transform).toBe(
+      customHeightBeforeHorizontal.transform,
+    );
+    expect((await state(page)).selection).toEqual(selectionBeforeInput);
+  } finally {
+    reporter.dispose();
+  }
+});
+
+test('diagram viewports never cover the editor scrollbar rail and real thumb drag preserves selection', async ({
+  page,
+}, testInfo) => {
+  const reporter = await mountMarkdownComments(page, testInfo);
+  try {
+    const large = page.locator(`${zone} ${diagramViewport}`).first();
+    const scrollable = page.locator(editorScrollable);
+    const verticalBar = scrollable.locator(':scope > .scrollbar.vertical');
+    const slider = verticalBar.locator(':scope > .slider');
+    await expect(verticalBar).toHaveCount(1);
+    await expect(slider).toHaveCount(1);
+
+    // Put the tall diagram behind the entire scrollbar thumb so the hit test
+    // would expose even a one-pixel Markdown overflow into the rail.
+    const desiredScrollTop = await large.evaluate((wrapper) => {
+      const editorRoot = wrapper.closest('.monaco-editor.readonly-editor');
+      const editorRect = editorRoot.getBoundingClientRect();
+      const wrapperRect = wrapper.getBoundingClientRect();
+      const current = Number(
+        globalThis.__markdownCommentsControls.state().scrollTop,
+      );
+      return Math.max(
+        0,
+        Math.round(current + wrapperRect.top - editorRect.top + 20),
+      );
+    });
+    await control(page, 'set_scroll_top', desiredScrollTop);
+    await settle(page);
+    await control(page, 'set_model_selection');
+    const selectionBeforeDrag = (await state(page)).selection;
+
+    const viewportSize = await page.evaluate(() => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }));
+    await page.mouse.move(viewportSize.width - 2, viewportSize.height - 2);
+    await expect(verticalBar).toHaveClass(
+      /(^|\s)invisible(\s|$).*($|\s)fade(\s|$)/,
+      { timeout: 2_500 },
+    );
+    const hiddenPoint = await slider.evaluate((thumb) => {
+      const rect = thumb.getBoundingClientRect();
+      return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+      };
+    });
+    const hiddenHit = await page.evaluate(({ x, y }) => {
+      const node = document.elementFromPoint(x, y);
+      return {
+        hitClass: String(node?.className ?? ''),
+        markdownOuter: Boolean(
+          node?.closest?.('.moonbit-viewer-markdown-comment'),
+        ),
+        markdownDescendant: Boolean(
+          node?.closest?.('.moonbit-viewer-markdown-comment-content'),
+        ),
+        diagramDescendant: Boolean(
+          node?.closest?.('.moonbit-viewer-markdown-diagram-viewport'),
+        ),
+      };
+    }, hiddenPoint);
+    const hiddenPointRelation = await large.evaluate(
+      (wrapper, { x, y }) => {
+        const viewportRect = wrapper.getBoundingClientRect();
+        const outerRect = wrapper
+          .closest('.moonbit-viewer-markdown-comment')
+          .getBoundingClientRect();
+        return {
+          overlapsDiagramRow:
+            y >= viewportRect.top && y <= viewportRect.bottom,
+          atOrBeyondMarkdownRight: x >= outerRect.right - 1,
+        };
+      },
+      hiddenPoint,
+    );
+    expect(hiddenPointRelation).toEqual({
+      overlapsDiagramRow: true,
+      atOrBeyondMarkdownRight: true,
+    });
+    expect(hiddenHit).toMatchObject({
+      markdownOuter: false,
+      markdownDescendant: false,
+      diagramDescendant: false,
+    });
+
+    await scrollable.hover({ position: { x: 20, y: 20 } });
+    await expect(verticalBar).toHaveClass(/(^|\s)visible(\s|$)/);
+    const visiblePoint = await slider.evaluate((thumb) => {
+      const rect = thumb.getBoundingClientRect();
+      return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+      };
+    });
+    const visibleHit = await page.evaluate(({ x, y }) => {
+      const thumb = document.querySelector(
+        '.markdown-comments-host .monaco-scrollable-element.editor-scrollable'
+          + ' > .scrollbar.vertical > .slider',
+      );
+      const hit = document.elementFromPoint(x, y);
+      return {
+        slider: hit === thumb || thumb.contains(hit),
+        hitClass: String(hit?.className ?? ''),
+      };
+    }, visiblePoint);
+    expect(visibleHit.slider).toBe(true);
+
+    const scrollTopBeforeDrag = (await state(page)).scrollTop;
+    await page.mouse.move(visiblePoint.x, visiblePoint.y);
+    await page.mouse.down();
+    await page.mouse.move(visiblePoint.x, visiblePoint.y + 80, { steps: 4 });
+    await page.mouse.up();
+    await expect
+      .poll(async () => (await state(page)).scrollTop)
+      .toBeGreaterThan(scrollTopBeforeDrag);
+    expect((await state(page)).selection).toEqual(selectionBeforeDrag);
+    expect(await page.evaluate(() => document.getSelection()?.toString())).toBe(
+      '',
+    );
+    await expect(slider).not.toHaveClass(/active/);
+  } finally {
+    reporter.dispose();
+  }
+});
+
 test('same-key replacement retains zone identity, reflows, and reconciles add remove move atomically', async ({
   page,
 }, testInfo) => {
@@ -586,6 +1217,29 @@ test('same-key replacement retains zone identity, reflows, and reconciles add re
     expect(oldOuter).not.toBeNull();
     expect(oldContent).not.toBeNull();
     expect(oldHeading).not.toBeNull();
+    const eofContent = page.locator(zone).nth(2).locator(content);
+    const initialDiagram = eofContent.locator(diagramViewport).nth(0);
+    const oldDiagram = await initialDiagram.elementHandle();
+    const oldDiagramContent = await initialDiagram
+      .locator(`:scope > ${diagramContent}`)
+      .elementHandle();
+    const oldPanButton = await initialDiagram
+      .locator('[aria-label="Toggle pan mode"]')
+      .elementHandle();
+    expect(oldDiagram).not.toBeNull();
+    expect(oldDiagramContent).not.toBeNull();
+    expect(oldPanButton).not.toBeNull();
+    const oldPanPressed = await oldPanButton.evaluate((button) =>
+      button.getAttribute('aria-pressed'));
+    await initialDiagram.locator('[aria-label="Zoom in"]').click();
+    const initialResizeHandle = initialDiagram.locator(diagramResizeHandle);
+    await initialResizeHandle.focus();
+    await page.keyboard.press('ArrowDown');
+    const interactedDiagram = await viewportGeometry(initialDiagram);
+    expect(interactedDiagram.scale).toBeGreaterThan(1);
+    await eofContent.evaluate((node) => {
+      node.style.display = 'none';
+    });
     const versionBefore = (await state(page)).primaryVersion;
 
     const updateFrames = await transitionFrames(page, 'same_key_update');
@@ -609,8 +1263,39 @@ test('same-key replacement retains zone identity, reflows, and reconciles add re
     expect(await zoneRanges(page)).toEqual([
       [1, 3],
       [5, 9],
-      [10, 25],
+      [10, 29],
     ]);
+    const replacementDiagrams = eofContent.locator(diagramViewport);
+    await expect(replacementDiagrams).toHaveCount(2);
+    const replacementDiagram = replacementDiagrams.nth(0);
+    const pendingHeight = await replacementDiagram.evaluate(
+      (wrapper) => wrapper.style.height,
+    );
+    expect(pendingHeight).not.toBe('0px');
+    expect(await oldDiagram.evaluate((node) => node.isConnected)).toBe(false);
+    expect(
+      await oldDiagramContent.evaluate((node) => node.isConnected),
+    ).toBe(false);
+    await oldPanButton.evaluate((button) => button.click());
+    expect(
+      await oldPanButton.evaluate((button) =>
+        button.getAttribute('aria-pressed')),
+    ).toBe(oldPanPressed);
+
+    await eofContent.evaluate((node) => {
+      node.style.removeProperty('display');
+    });
+    await expect
+      .poll(async () => (await viewportGeometry(replacementDiagram)).wrapperHeight)
+      .toBeGreaterThan(0);
+    const replacementGeometry = await viewportGeometry(replacementDiagram);
+    expectNear(replacementGeometry.scale, 1, 0.001);
+    expectNear(replacementGeometry.translateY, 0, 0.01);
+    expect(
+      Math.abs(
+        replacementGeometry.wrapperHeight - interactedDiagram.wrapperHeight,
+      ),
+    ).toBeGreaterThan(5);
 
     const wideHeight = await page
       .locator(`${middleSelector} ${content}`)
@@ -741,10 +1426,15 @@ test('offscreen Markdown measures before first reveal and reflows without a scro
   try {
     await control(page, 'offscreen_source');
     await expect(page.locator(zone)).toHaveCount(1);
-    expect(await zoneRanges(page)).toEqual([[81, 91]]);
+    expect(await zoneRanges(page)).toEqual([[81, 97]]);
     const retained = await page.locator(zone).elementHandle();
     expect(retained).not.toBeNull();
     await expect(page.locator(zone)).not.toBeVisible();
+    const offscreenDiagram = page.locator(`${zone} ${diagramViewport}`);
+    await expect(offscreenDiagram).toHaveCount(1);
+    expect(
+      await offscreenDiagram.evaluate((wrapper) => wrapper.style.height),
+    ).toBe('');
 
     // Eighty short visible lines contribute 1440px. The provisional zone is
     // only one 18px line; crossing this threshold proves the still-offscreen
@@ -753,17 +1443,53 @@ test('offscreen Markdown measures before first reveal and reflows without a scro
       .poll(async () => (await state(page)).scrollHeight)
       .toBeGreaterThan(1560);
     const wideHeight = (await state(page)).scrollHeight;
+    const wideState = await state(page);
+    const wideGeometry = await horizontalViewportGeometry(page);
+    expect(wideState.softWrap).toBe(false);
+    expect(wideState.scrollWidth).toBeGreaterThan(
+      wideGeometry.scrollable.width + 100,
+    );
+    expect(wideGeometry.viewZones.width).toBeGreaterThan(
+      wideGeometry.scrollable.width + 100,
+    );
+
+    await control(page, 'set_scroll_left', 300);
+    await expect
+      .poll(async () => (await state(page)).scrollLeft)
+      .toBeGreaterThan(0);
+    await settle(page);
+    const scrolledGeometry = await horizontalViewportGeometry(page);
+    expect(scrolledGeometry.source.left).toBeLessThan(
+      wideGeometry.source.left - 100,
+    );
 
     await control(page, 'resize', 240);
     await expect(page.locator(zone)).not.toBeVisible();
     await expect
+      .poll(async () => (await state(page)).scrollLeft)
+      .toBeGreaterThan(0);
+    await expect
       .poll(async () => (await state(page)).scrollHeight)
-      .toBeGreaterThan(wideHeight + 20);
+      .toBeLessThan(wideHeight - 20);
+    await settle(page);
+    const hiddenNarrowGeometry = await horizontalViewportGeometry(page);
+    expect(hiddenNarrowGeometry.viewZones.width).toBeGreaterThan(
+      hiddenNarrowGeometry.scrollable.width + 100,
+    );
+    expect(
+      await offscreenDiagram.evaluate((wrapper) => wrapper.style.height),
+    ).toBe('');
     const narrowHeight = (await state(page)).scrollHeight;
 
     await control(page, 'scroll_to_bottom');
     await settle(page);
     await expect(page.locator(zone)).toBeVisible();
+    await expect
+      .poll(async () => (await viewportGeometry(offscreenDiagram)).wrapperHeight)
+      .toBeGreaterThan(0);
+    const revealedDiagram = await viewportGeometry(offscreenDiagram);
+    expectNear(revealedDiagram.scale, 1, 0.001);
+    expectNear(revealedDiagram.translateY, 0, 0.01);
     expect(
       await retained.evaluate(
         (node) =>
@@ -771,6 +1497,24 @@ test('offscreen Markdown measures before first reveal and reflows without a scro
           document.querySelector('.moonbit-viewer-markdown-comment'),
       ),
     ).toBe(true);
+    const revealedBounds = await retained.evaluate((outer) => {
+      const root = outer.closest('.monaco-editor.readonly-editor');
+      const scrollable = root.querySelector(
+        '.monaco-scrollable-element.editor-scrollable',
+      );
+      const rail = scrollable.querySelector(':scope > .scrollbar.vertical');
+      const outerRect = outer.getBoundingClientRect();
+      const scrollableRect = scrollable.getBoundingClientRect();
+      const railRect = rail.getBoundingClientRect();
+      return {
+        outerLeft: outerRect.left,
+        outerRight: outerRect.right,
+        scrollableLeft: scrollableRect.left,
+        railLeft: railRect.left,
+      };
+    });
+    expectNear(revealedBounds.outerLeft, revealedBounds.scrollableLeft);
+    expectNear(revealedBounds.outerRight, revealedBounds.railLeft);
     await expect
       .poll(async () =>
         Math.abs((await state(page)).scrollHeight - narrowHeight),
@@ -798,8 +1542,18 @@ test('model detach replacement reattach and Viewer disposal release every render
   try {
     const initialRoot = await page.locator(editor).elementHandle();
     const initialZone = await page.locator(zone).first().elementHandle();
+    const initialDiagram = page.locator(`${zone} ${diagramViewport}`).first();
+    const retainedDiagram = await initialDiagram.elementHandle();
+    const retainedPanButton = await initialDiagram
+      .locator('[aria-label="Toggle pan mode"]')
+      .elementHandle();
     expect(initialRoot).not.toBeNull();
     expect(initialZone).not.toBeNull();
+    expect(retainedDiagram).not.toBeNull();
+    expect(retainedPanButton).not.toBeNull();
+    const retainedPanPressed = await retainedPanButton.evaluate((button) =>
+      button.getAttribute('aria-pressed'));
+    await initialDiagram.locator('[aria-label="Zoom in"]').click();
 
     await control(page, 'detach');
     await settle(page);
@@ -810,6 +1564,27 @@ test('model detach replacement reattach and Viewer disposal release every render
     await expect(page.locator(zone)).toHaveCount(0);
     expect(await initialRoot.evaluate((node) => node.isConnected)).toBe(false);
     expect(await initialZone.evaluate((node) => node.isConnected)).toBe(false);
+    expect(await retainedDiagram.evaluate((node) => node.isConnected)).toBe(
+      false,
+    );
+    expect(
+      await retainedDiagram.evaluate((node) => ({
+        viewport: node.classList.contains(
+          'moonbit-viewer-markdown-diagram-viewport',
+        ),
+        directSvg: Boolean(node.querySelector(':scope > svg')),
+        controls: Boolean(
+          node.querySelector(
+            ':scope > .moonbit-viewer-markdown-diagram-controls',
+          ),
+        ),
+      })),
+    ).toEqual({ viewport: false, directSvg: true, controls: false });
+    await retainedPanButton.evaluate((button) => button.click());
+    expect(
+      await retainedPanButton.evaluate((button) =>
+        button.getAttribute('aria-pressed')),
+    ).toBe(retainedPanPressed);
     expect(await state(page)).toMatchObject({
       attachedKind: 'none',
       attachedValue: '',
@@ -833,6 +1608,7 @@ test('model detach replacement reattach and Viewer disposal release every render
     await control(page, 'reattach_primary');
     await expect(page.locator(zone)).toHaveCount(3);
     await expect(page.locator(zone).first()).toContainText('Start comment');
+    await expect(page.locator(`${zone} ${diagramViewport}`)).toHaveCount(2);
     expect(await replacementRoot.evaluate((node) => node.isConnected)).toBe(false);
     expect(await replacementZone.evaluate((node) => node.isConnected)).toBe(false);
     expect(await state(page)).toMatchObject({
@@ -841,6 +1617,9 @@ test('model detach replacement reattach and Viewer disposal release every render
       replacementAttachedEditors: 0,
     });
     const reattachedZones = await page.locator(zone).elementHandles();
+    const reattachedDiagrams = await page
+      .locator(`${zone} ${diagramViewport}`)
+      .elementHandles();
     expect(
       await reattachedZones[0].evaluate(
         (node, original) => node === original,
@@ -863,6 +1642,16 @@ test('model detach replacement reattach and Viewer disposal release every render
     });
     for (const rendered of reattachedZones) {
       expect(await rendered.evaluate((node) => node.isConnected)).toBe(false);
+    }
+    for (const rendered of reattachedDiagrams) {
+      expect(await rendered.evaluate((node) => node.isConnected)).toBe(false);
+      expect(
+        await rendered.evaluate((node) =>
+          node.classList.contains(
+            'moonbit-viewer-markdown-diagram-viewport',
+          ),
+        ),
+      ).toBe(false);
     }
   } finally {
     reporter.dispose();

--- a/editor/tests/browser/moonbit/component/markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/markdown_comments_scenario.mbt
@@ -9,7 +9,7 @@ fn markdown_comments_initial_source() -> String {
     #|/// # Start comment
     #|/// Start prose with [fixture link](https://example.test/docs).
     #|alpha_code_truth
-    #|let long_neighbor = "soft wrapped source neighbor alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau"
+    #|let long_neighbor = "horizontal_overflow_sentinel alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega"
     #|/// ## Middle comment
     #|/// The **same-key initial phrase** is deliberately long enough to reflow after the public Viewer host becomes narrow.
     #|/// - first item
@@ -28,6 +28,10 @@ fn markdown_comments_initial_source() -> String {
     #|/// svg -> browser: mount
     #|/// ```
     #|///
+    #|/// ```diago
+    #|/// compact -> viewport: fit
+    #|/// ```
+    #|///
     #|/// ![fixture image](https://images.example.test/markdown-comment.svg)
     #|/// EOF paragraph.
   source
@@ -39,7 +43,7 @@ fn markdown_comments_same_key_source() -> String {
     #|/// # Start comment
     #|/// Start prose with [fixture link](https://example.test/docs).
     #|alpha_code_truth
-    #|let long_neighbor = "soft wrapped source neighbor alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau"
+    #|let long_neighbor = "horizontal_overflow_sentinel alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega"
     #|/// ## Middle updated
     #|/// The same-key replacement body is intentionally even longer so width changes produce a visible measured-height transition without changing this block's half-open line range.
     #|/// 1. updated first item
@@ -56,6 +60,10 @@ fn markdown_comments_same_key_source() -> String {
     #|/// parser -> layout: layout
     #|/// layout -> svg: render
     #|/// svg -> browser: mount
+    #|/// ```
+    #|///
+    #|/// ```diago
+    #|/// compact -> viewport: replaced
     #|/// ```
     #|///
     #|/// ![fixture image](https://images.example.test/markdown-comment.svg)
@@ -106,7 +114,13 @@ fn markdown_comments_offscreen_source() -> String {
     if line > 1 {
       source.write_char('\n')
     }
-    source.write_string("offscreen_code_line_\{line}")
+    if line == 10 {
+      source.write_string(
+        "offscreen_horizontal_overflow_sentinel alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega",
+      )
+    } else {
+      source.write_string("offscreen_code_line_\{line}")
+    }
   }
   source.write_string(
     (
@@ -118,6 +132,12 @@ fn markdown_comments_offscreen_source() -> String {
       #|/// - second measured item
       #|/// - third measured item
       #|/// - fourth measured item
+      #|///
+      #|/// ```diago
+      #|/// direction: down
+      #|/// offscreen -> viewport: initialize
+      #|/// viewport -> browser: reveal
+      #|/// ```
       #|///
       #|/// ![fixture image](https://images.example.test/markdown-comment.svg)
       #|/// Final offscreen paragraph.
@@ -162,6 +182,10 @@ fn markdown_comments_state_json(
     "replacementAttachedEditors": replacement
     .get_attached_editor_count()
     .to_json(),
+    "softWrap": viewer.get_options().soft_wrap().to_json(),
+    "scrollLeft": viewer.get_scroll_left().to_json(),
+    "scrollWidth": viewer.get_scroll_width().to_json(),
+    "contentWidth": viewer.get_content_width().to_json(),
     "scrollTop": viewer.get_scroll_top().to_json(),
     "scrollHeight": viewer.get_scroll_height().to_json(),
   }).stringify()
@@ -229,7 +253,7 @@ fn run_markdown_comments_test() -> Unit {
   let viewer = @viewer.Viewer::create(
     host,
     services~,
-    options=ViewerOptions(soft_wrap=true, smooth_scrolling=false),
+    options=ViewerOptions(soft_wrap=false, smooth_scrolling=false),
   )
   viewer.set_model(Some(primary))
   viewer.handle_initialized()
@@ -263,6 +287,11 @@ fn run_markdown_comments_test() -> Unit {
       viewer.handle_initialized()
     },
     () => viewer.set_scroll_top(viewer.get_scroll_height()),
+    top => viewer.set_scroll_top(top.to_double()),
+    left => viewer.set_scroll_left(left.to_double()),
+    enabled => {
+      viewer.update_options(viewer.get_options().with_soft_wrap(enabled))
+    },
     () => viewer.dispose(),
   )
   poll_markdown_comments_ready(ctx, 120)
@@ -275,11 +304,12 @@ fn poll_markdown_comments_ready(
 ) -> Unit {
   let zones = @support.query_count(".moonbit-viewer-markdown-comment")
   let diagrams = @support.query_count(
-    ".markdown-comments-host .moonbit-viewer-markdown-diagram > svg",
+    ".markdown-comments-host .moonbit-viewer-markdown-diagram-content" +
+    " > svg",
   )
   let text = @support.query_text(".markdown-comments-host")
   if zones == 3 &&
-    diagrams == 1 &&
+    diagrams == 2 &&
     text.contains("Start comment") &&
     text.contains("Middle comment") &&
     text.contains("EOF paragraph") &&
@@ -323,12 +353,16 @@ extern "js" fn install_markdown_comments_controls(
   attach_replacement : () -> Unit,
   reattach_primary : () -> Unit,
   scroll_to_bottom : () -> Unit,
+  set_scroll_top : (Int) -> Unit,
+  set_scroll_left : (Int) -> Unit,
+  set_soft_wrap : (Bool) -> Unit,
   dispose_viewer : () -> Unit,
 ) -> Unit =
   #| (host, initialRoot, stateJson, sameKeyUpdate, restructure,
   #|  restoreInitial, foldingSource, offscreenSource, resize,
   #|  setModelSelection, focus, detach, attachReplacement, reattachPrimary,
-  #|  scrollToBottom, disposeViewer) => {
+  #|  scrollToBottom, setScrollTop, setScrollLeft, setSoftWrap,
+  #|  disposeViewer) => {
   #|   const keyLog = [];
   #|   const copyLog = [];
   #|   let disposed = false;
@@ -371,6 +405,9 @@ extern "js" fn install_markdown_comments_controls(
   #|     attach_replacement: attachReplacement,
   #|     reattach_primary: reattachPrimary,
   #|     scroll_to_bottom: scrollToBottom,
+  #|     set_scroll_top: setScrollTop,
+  #|     set_scroll_left: setScrollLeft,
+  #|     set_soft_wrap: setSoftWrap,
   #|     dispose: () => {
   #|       disposeViewer();
   #|       disposed = true;

--- a/editor/viewer/browser/view/codicon/codicon.css
+++ b/editor/viewer/browser/view/codicon/codicon.css
@@ -34,6 +34,22 @@
   content: "\eab6";
 }
 
+.codicon-move:before {
+  content: "\eb22";
+}
+
+.codicon-zoom-out:before {
+  content: "\eb82";
+}
+
+.codicon-zoom-in:before {
+  content: "\eb81";
+}
+
+.codicon-screen-normal:before {
+  content: "\eb4d";
+}
+
 /* The folding icons registered in foldingDecorations.ts:
    folding-expanded = chevron-down, folding-collapsed = chevron-right, and
    the manual variants alias them (registerIcon(...) — Monaco emits these

--- a/editor/viewer/common/config/editor_options.mbt
+++ b/editor/viewer/common/config/editor_options.mbt
@@ -7,9 +7,10 @@
 //
 // Omissions: `glyphMarginDecorationLaneCount` (no glyph-margin lanes),
 // `minimap`/`overviewRuler` cluster, `viewportColumn`,
-// `isWordWrapMinified`/`isViewportWrapping`/`wrappingColumn`, and the
-// scrollbar width/height fields — none are rendered or consumed by the
-// viewer. The viewer has no glyph margin, so `glyph_margin_left`/
+// `isWordWrapMinified`/`isViewportWrapping`/`wrappingColumn`. Scrollbar
+// width/height stay in the reduced shape because viewport-fixed consumers
+// share the actual 14px vertical and 12px horizontal editor geometry. The
+// viewer has no glyph margin, so `glyph_margin_left`/
 // `glyph_margin_width` are always `0` and
 // `content_left = line_numbers_width + decorations_width`.
 

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -27,7 +27,11 @@
  * relayout. The leading edge stays flush with the editor's source rail. */
 .moonbit-viewer-markdown-comment-content {
   box-sizing: border-box;
-  width: 100%;
+  /* ViewZone nodes extend through the editor's 14px overlay scrollbar rail
+   * and its 6px right-side layout allowance. Keep the interactive Markdown
+   * surface left of that 20px strip; the 12px inner padding remains the
+   * visible trailing gap between content and the rail. */
+  width: calc(100% - 20px);
   padding: 6px 12px 8px 0;
   overflow-wrap: anywhere;
   user-select: text;
@@ -113,16 +117,149 @@
   height: auto;
 }
 
-.moonbit-viewer-markdown-comment-content .moonbit-viewer-markdown-diagram {
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-viewport {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
   max-width: 100%;
-  max-height: min(50vh, 480px);
-  overflow: auto;
+  margin-bottom: 1em;
+  overflow: hidden;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px transparent;
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.moonbit-viewer-markdown-comment-content .moonbit-viewer-markdown-diagram > svg {
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-viewport:hover,
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-viewport:focus,
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-viewport:focus-within {
+  box-shadow: inset 0 0 0 1px
+    var(
+      --vscode-editorWidget-border,
+      var(--vscode-widget-border, transparent)
+    );
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-content {
+  transform-origin: 0 0;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-content
+  > svg {
   display: block;
   max-width: 100%;
   height: auto;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-controls {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 100;
+  display: flex;
+  width: auto;
+  gap: 2px;
+  padding: 2px;
+  opacity: 0;
+  border: 1px solid
+    var(--vscode-editorWidget-border, var(--vscode-widget-border, transparent));
+  border-radius: 6px;
+  background: var(
+    --vscode-editorWidget-background,
+    var(--vscode-editor-background)
+  );
+  transition: opacity 0.2s ease-in-out;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-viewport:hover
+  > .moonbit-viewer-markdown-diagram-controls,
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-viewport:focus
+  > .moonbit-viewer-markdown-diagram-controls,
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-viewport:focus-within
+  > .moonbit-viewer-markdown-diagram-controls {
+  opacity: 1;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-controls
+  button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  color: var(--vscode-icon-foreground, var(--vscode-editor-foreground));
+  background: transparent;
+  cursor: pointer;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-controls
+  button:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-controls
+  button.active {
+  color: var(--vscode-focusBorder);
+  background: var(--vscode-toolbar-activeBackground);
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-resize-handle {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 50;
+  height: 10px;
+  background: transparent;
+  cursor: ns-resize;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-resize-handle::after {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  width: 40px;
+  height: 3px;
+  opacity: 0;
+  border-radius: 2px;
+  background: var(
+    --vscode-editorWidget-border,
+    var(--vscode-widget-border, rgb(128 128 128 / 40%))
+  );
+  content: "";
+  transform: translateX(-50%);
+  transition: opacity 0.15s ease-in-out;
+  transition-delay: 0s;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-resize-handle:hover::after {
+  opacity: 1;
+  transition-delay: 0.3s;
+}
+
+.moonbit-viewer-markdown-comment-content
+  .moonbit-viewer-markdown-diagram-resize-handle:focus::after {
+  opacity: 1;
+  transition-delay: 0s;
 }
 
 .moonbit-viewer-markdown-comment-content code,

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -1,10 +1,10 @@
 /* Whole-line Markdown is mounted as ordinary ViewZone content. Projection
- * owns source-line removal; these rules never hide, overlay, or offset model
- * text. The ViewZone owner writes the outer node's position, width, and fixed
- * measured height. */
+ * owns source-line removal; these rules never hide or overlay model text.
+ * ViewZones owns vertical position and measured height, while the Markdown
+ * contribution pins horizontal geometry to the visible editor viewport. */
 .moonbit-viewer-markdown-comment {
   box-sizing: border-box;
-  width: 100%;
+  overflow-x: clip;
   /* The full-scroll-height .view-lines plane is z-index 1. Keep caller-owned
    * Markdown input above it, but below editor cursors (4) and widgets (50+). */
   z-index: 2;
@@ -27,11 +27,8 @@
  * relayout. The leading edge stays flush with the editor's source rail. */
 .moonbit-viewer-markdown-comment-content {
   box-sizing: border-box;
-  /* ViewZone nodes extend through the editor's 14px overlay scrollbar rail
-   * and its 6px right-side layout allowance. Keep the interactive Markdown
-   * surface left of that 20px strip; the 12px inner padding remains the
-   * visible trailing gap between content and the rail. */
-  width: calc(100% - 20px);
+  /* The pinned outer already ends at the vertical scrollbar rail. */
+  width: 100%;
   padding: 6px 12px 8px 0;
   overflow-wrap: anywhere;
   user-select: text;

--- a/editor/viewer/editor_configuration_state.mbt
+++ b/editor/viewer/editor_configuration_state.mbt
@@ -446,8 +446,8 @@ fn EditorConfigurationSnapshot::layout_info(
     decorations_width,
     content_left,
     content_width: self.content_width,
-    horizontal_scrollbar_height: 10.0,
-    vertical_scrollbar_width: 10.0,
+    horizontal_scrollbar_height: @core.editor_horizontal_scrollbar_size,
+    vertical_scrollbar_width: @core.editor_vertical_scrollbar_size,
   }
 }
 

--- a/editor/viewer/markdown_comments_contribution.mbt
+++ b/editor/viewer/markdown_comments_contribution.mbt
@@ -14,11 +14,19 @@ priv struct MarkdownCommentContributionState {
   mut generation : Int
   rendered : Map[String, RenderedMarkdownComment]
   listeners : Array[@base_common.Disposable]
+  mut viewport_observer : @markdown_comments_browser.MarkdownCommentViewportObserver?
+  mut geometry_lease : @base_common.Disposable?
 }
 
 ///|
 fn MarkdownCommentContributionState::MarkdownCommentContributionState() -> MarkdownCommentContributionState {
-  { generation: 0, rendered: Map([]), listeners: [] }
+  {
+    generation: 0,
+    rendered: Map([]),
+    listeners: [],
+    viewport_observer: None,
+    geometry_lease: None,
+  }
 }
 
 ///|
@@ -40,6 +48,59 @@ fn RenderedMarkdownComment::dispose_render_resources(
   self.diagram_viewports.dispose()
   self.rendered_markdown.dispose.dispose()
   self.size_observer.dispose()
+}
+
+///|
+fn MarkdownCommentContributionState::ensure_geometry_lease(
+  self : MarkdownCommentContributionState,
+  view_lines : @view.ViewLines,
+) -> Unit {
+  if self.geometry_lease is None {
+    self.geometry_lease = Some(view_lines.acquire_content_viewport_geometry())
+  }
+}
+
+///|
+fn MarkdownCommentContributionState::dispose_geometry_lease(
+  self : MarkdownCommentContributionState,
+) -> Unit {
+  match self.geometry_lease {
+    Some(lease) => lease.dispose()
+    None => ()
+  }
+  self.geometry_lease = None
+}
+
+///|
+fn MarkdownCommentContributionState::request_all_measures(
+  self : MarkdownCommentContributionState,
+) -> Unit {
+  for _, entry in self.rendered {
+    entry.size_observer.request_measure()
+  }
+}
+
+///|
+fn MarkdownCommentContributionState::ensure_viewport_observer(
+  self : MarkdownCommentContributionState,
+  dom : @markdown_comments_browser.MarkdownCommentDom,
+) -> Unit {
+  if self.viewport_observer is None {
+    self.viewport_observer = Some(
+      dom.observe_viewport_width(() => self.request_all_measures()),
+    )
+  }
+}
+
+///|
+fn MarkdownCommentContributionState::dispose_viewport_observer(
+  self : MarkdownCommentContributionState,
+) -> Unit {
+  match self.viewport_observer {
+    Some(observer) => observer.dispose()
+    None => ()
+  }
+  self.viewport_observer = None
 }
 
 ///|
@@ -141,7 +202,7 @@ fn Viewer::refresh_markdown_comments(
   guard self.markdown_comment_contribution() is Some(state) else { return }
   guard self.get_model() is Some(model) else { return }
   // A headless Viewer has no replacement DOM and must keep source visible.
-  guard self.current_browser_data() is Some(_) else { return }
+  guard self.current_browser_data() is Some(browser) else { return }
   // Reserve this generation before invoking an open provider. Provider code
   // can synchronously mutate or replace the model through an external owner;
   // any nested refresh then invalidates this attempt before it mutates zones.
@@ -154,6 +215,13 @@ fn Viewer::refresh_markdown_comments(
   )
   guard self.markdown_comment_refresh_is_current(state, model, generation) else {
     return
+  }
+  if !blocks.is_empty() {
+    state.ensure_geometry_lease(browser.view.view_lines)
+  } else {
+    // With no surviving consumer, stop width invalidations before disposing
+    // the per-comment observers and removing their zones below.
+    state.dispose_viewport_observer()
   }
   let next : Map[String, @language.MarkdownCommentBlock] = Map([])
   for block in blocks {
@@ -209,6 +277,9 @@ fn Viewer::refresh_markdown_comments(
             height_in_lines=1.0,
           )
           let zone_id = accessor.add_zone(zone)
+          // `add_zone` writes the ordinary scroll-plane `width: 100%`.
+          // Replace it before any observer or renderer can measure the node.
+          dom.pin_to_content_viewport()
           let entry_generation = Ref(generation)
           let size_observer = dom.observe_size(height => {
             self.apply_markdown_comment_height(
@@ -236,6 +307,7 @@ fn Viewer::refresh_markdown_comments(
             generation: entry_generation,
           }
           state.rendered.set(key, entry)
+          state.ensure_viewport_observer(dom)
           size_observer.request_measure()
         }
       }
@@ -246,6 +318,11 @@ fn Viewer::refresh_markdown_comments(
   // generation/source. Never let this older refresh overwrite its ranges.
   guard self.markdown_comment_refresh_is_current(state, model, generation) else {
     return
+  }
+  if state.rendered.is_empty() {
+    // The last geometry consumer is gone only after ViewZones detached its
+    // caller-owned nodes.
+    state.dispose_geometry_lease()
   }
   self.set_hidden_areas(
     markdown_comment_hidden_ranges(blocks),
@@ -297,6 +374,9 @@ fn Viewer::apply_markdown_comment_height(
 fn Viewer::clear_markdown_comment_model_state(self : Viewer) -> Unit {
   guard self.markdown_comment_contribution() is Some(state) else { return }
   state.generation += 1
+  // Stop model-wide invalidation first. Per-comment content/renderer
+  // lifetimes follow, then structural zones, and finally ViewLines geometry.
+  state.dispose_viewport_observer()
   let entries : Array[RenderedMarkdownComment] = []
   for _, entry in state.rendered {
     entries.push(entry)
@@ -316,6 +396,7 @@ fn Viewer::clear_markdown_comment_model_state(self : Viewer) -> Unit {
     None => ()
   }
   state.rendered.clear()
+  state.dispose_geometry_lease()
   self.set_hidden_areas([], source=markdown_comment_hidden_source)
 }
 

--- a/editor/viewer/markdown_comments_contribution.mbt
+++ b/editor/viewer/markdown_comments_contribution.mbt
@@ -27,6 +27,7 @@ priv struct RenderedMarkdownComment {
   zone : @editor_browser.ViewZone
   zone_id : String
   mut rendered_markdown : @browser_markdown.RenderedMarkdown
+  mut diagram_viewports : @markdown_comments_browser.MarkdownCommentDiagramViewports
   size_observer : @markdown_comments_browser.MarkdownCommentSizeObserver
   mut measured_height : Double
   generation : Ref[Int]
@@ -36,6 +37,7 @@ priv struct RenderedMarkdownComment {
 fn RenderedMarkdownComment::dispose_render_resources(
   self : RenderedMarkdownComment,
 ) -> Unit {
+  self.diagram_viewports.dispose()
   self.rendered_markdown.dispose.dispose()
   self.size_observer.dispose()
 }
@@ -178,10 +180,15 @@ fn Viewer::refresh_markdown_comments(
         Some(existing) => {
           existing.generation.val = generation
           if existing.block.markdown != block.markdown {
+            existing.diagram_viewports.dispose()
             existing.rendered_markdown.dispose.dispose()
             existing.rendered_markdown = render_markdown_comment_body(
               model,
               block.markdown,
+              existing.rendered_markdown.element,
+              () => existing.size_observer.request_measure(),
+            )
+            existing.diagram_viewports = MarkdownCommentDiagramViewports(
               existing.rendered_markdown.element,
               () => existing.size_observer.request_measure(),
             )
@@ -214,11 +221,16 @@ fn Viewer::refresh_markdown_comments(
             dom.content,
             () => size_observer.request_measure(),
           )
+          let diagram_viewports = @markdown_comments_browser.MarkdownCommentDiagramViewports(
+            rendered_markdown.element,
+            () => size_observer.request_measure(),
+          )
           let entry : RenderedMarkdownComment = {
             block,
             zone,
             zone_id,
             rendered_markdown,
+            diagram_viewports,
             size_observer,
             measured_height: 0.0,
             generation: entry_generation,

--- a/editor/viewer/markdown_comments_contribution_wbtest.mbt
+++ b/editor/viewer/markdown_comments_contribution_wbtest.mbt
@@ -202,6 +202,25 @@ extern "js" fn markdown_contribution_test_parent(
 extern "js" fn markdown_contribution_test_disconnect_count() -> Int = "() => globalThis.__markdownContributionDisconnectCount"
 
 ///|
+extern "js" fn markdown_contribution_test_active_observer_count() -> Int =
+  #| () => globalThis.__markdownContributionObservers
+  #|   .filter(observer => observer.active).length
+
+///|
+extern "js" fn markdown_contribution_test_active_viewport_observer_count() -> Int =
+  #| () => globalThis.__markdownContributionObservers.filter((observer) => {
+  #|   if (!observer.active) return false;
+  #|   const classes = String(
+  #|     observer.target?.getAttribute?.('class') ?? '',
+  #|   ).split(/\s+/);
+  #|   // The lightweight contribution DOM does not model Element.closest, so
+  #|   // the shared observer can have no target here. Content observers are
+  #|   // still exactly identifiable; the DOM-package fixture separately
+  #|   // verifies that production closest() resolves editor-scrollable.
+  #|   return !classes.includes('moonbit-viewer-markdown-comment-content');
+  #| }).length
+
+///|
 extern "js" fn markdown_contribution_test_trigger_resize(
   target : @rdom.Element,
   height : Int,
@@ -289,6 +308,10 @@ test "Markdown comments replace start middle EOF blocks while preserving model t
       assert_true(state.rendered.contains("1:2"))
       assert_true(state.rendered.contains("3:5"))
       assert_true(state.rendered.contains("6:7"))
+      // Three comments retain independent content observers, but the model
+      // owns exactly one viewport-width observer.
+      assert_eq(markdown_contribution_test_active_observer_count(), 4)
+      assert_eq(markdown_contribution_test_active_viewport_observer_count(), 1)
       for key in ["1:2", "3:5", "6:7"] {
         let entry = state.rendered[key]
         assert_true(entry.zone_id != "")
@@ -460,6 +483,8 @@ test "Markdown comment reconciliation adds removes and moves blocks by stable ra
           removed_outer,
         ),
       )
+      assert_eq(markdown_contribution_test_active_observer_count(), 4)
+      assert_eq(markdown_contribution_test_active_viewport_observer_count(), 1)
       assert_eq(markdown_contribution_test_disconnect_count(), 1)
       assert_true(
         viewer.test_view_model().get_hidden_areas() ==
@@ -655,7 +680,8 @@ test "Markdown comment model detach replacement reattach and Viewer disposal rel
       assert_true(first_view_model.get_hidden_areas() == [])
       assert_eq(first_view_model.get_whitespaces().length(), 0)
       assert_true(markdown_contribution_test_is_detached(first_outer))
-      assert_eq(markdown_contribution_test_disconnect_count(), 1)
+      assert_eq(markdown_contribution_test_active_observer_count(), 0)
+      assert_eq(markdown_contribution_test_disconnect_count(), 2)
 
       // Reattach after the explicit no-model state creates fresh per-model
       // ViewZone/DOM ownership under the same Viewer-lived contribution.
@@ -667,6 +693,8 @@ test "Markdown comment model detach replacement reattach and Viewer disposal rel
       assert_eq(state.rendered.length(), 1)
       assert_false(same_mounted_test_element(first_outer, second_outer))
       assert_true(second_view_model.get_hidden_areas() == [Range(2, 1, 2, 1)])
+      assert_eq(markdown_contribution_test_active_observer_count(), 2)
+      assert_eq(markdown_contribution_test_active_viewport_observer_count(), 1)
 
       // A direct replacement clears the outgoing source/resources before
       // installing a third model's fresh entry.
@@ -679,14 +707,15 @@ test "Markdown comment model detach replacement reattach and Viewer disposal rel
       assert_eq(second_view_model.get_whitespaces().length(), 0)
       assert_true(markdown_contribution_test_is_detached(second_outer))
       assert_false(same_mounted_test_element(second_outer, third_outer))
-      assert_eq(markdown_contribution_test_disconnect_count(), 2)
+      assert_eq(markdown_contribution_test_disconnect_count(), 4)
 
       viewer.dispose()
       assert_eq(state.rendered.length(), 0)
       assert_true(third_view_model.get_hidden_areas() == [])
       assert_eq(third_view_model.get_whitespaces().length(), 0)
       assert_true(markdown_contribution_test_is_detached(third_outer))
-      assert_eq(markdown_contribution_test_disconnect_count(), 3)
+      assert_eq(markdown_contribution_test_active_observer_count(), 0)
+      assert_eq(markdown_contribution_test_disconnect_count(), 6)
       assert_true(viewer.markdown_comment_contribution() is None)
     },
     provider_blocks=[markdown_contribution_block(2, 3, "comment")],
@@ -792,7 +821,8 @@ test "Markdown comment height callbacks ignore zero disconnected stale and dispo
         run_one_mounted_test_frame()
       }
       assert_eq(state.rendered.length(), 0)
-      assert_eq(markdown_contribution_test_disconnect_count(), 1)
+      assert_eq(markdown_contribution_test_active_observer_count(), 0)
+      assert_eq(markdown_contribution_test_disconnect_count(), 2)
       assert_eq(mounted_test_frame_count(), 0)
       markdown_contribution_test_trigger_resize(target, 50, true)
       assert_eq(mounted_test_frame_count(), 0)

--- a/editor/viewer/public_read_api_wbtest.mbt
+++ b/editor/viewer/public_read_api_wbtest.mbt
@@ -312,6 +312,16 @@ test "read API: layout info reduces to gutter + content box" {
     assert_eq(info.content_left, info.line_numbers_width + 26.0)
     assert_eq(info.width, info.content_left + info.content_width)
     assert_eq(info.height, 400.0)
+    assert_eq(
+      info.horizontal_scrollbar_height,
+      @core.editor_horizontal_scrollbar_size,
+    )
+    assert_eq(
+      info.vertical_scrollbar_width,
+      @core.editor_vertical_scrollbar_size,
+    )
+    assert_eq(info.horizontal_scrollbar_height, 12.0)
+    assert_eq(info.vertical_scrollbar_width, 14.0)
     assert_true(info.content_left > 0.0)
     // `showFoldingControls: 'never'` drops the reserve back to the raw
     // `lineDecorationsWidth`.


### PR DESCRIPTION
## Summary

- add an interactive viewport controller for successful direct Diago SVGs in whole-line Markdown comments, with pan, zoom, fit, resize, accessibility, and deterministic disposal
- integrate viewport ownership with the existing Markdown renderer, size observer, ViewZone lifecycle, wheel handoff, and codicon/theme styling
- pin Markdown comment surfaces to the visible editor content viewport while ordinary ViewZones continue to use the horizontal scroll plane
- accept exact lowercase `d2` fences through the existing Diago rendering path
- add pinned reference coverage, public-Viewer browser scenarios, and architecture/harness documentation

## Why

Whole-line Markdown comments inherited the generic ViewZone width. With long unwrapped source lines, that width follows the model scroll plane rather than the visible editor viewport, so diagram content and controls could extend beneath the vertical scrollbar rail. Diagram wrappers also only provided native overflow instead of the intended interactive navigation.

This change keeps generic ViewZone geometry intact, publishes the exact rendered scroll/visible-width snapshot from `ViewLines`, and lets the Markdown contribution pin only its owned surface to that geometry. Height changes continue through the existing generation-checked size observer and ViewZone writer.

## Impact

Rendered Diago diagrams in Markdown comments gain interactive controls and remain bounded by the visible editor area across horizontal scrolling, host resize, soft-wrap changes, offscreen measurement, model replacement, and disposal. Hover and agent-feedback diagrams retain their existing native scrolling behavior. No new public Viewer option or package dependency is introduced.

## Validation

- `MOON_WORK=off moon info --target all`
- `MOON_WORK=off moon fmt`
- `MOON_WORK=off just check`
- `MOON_WORK=off just test`
- `MOON_WORK=off just build`
- focused shared-Markdown tests on JS and native: 11/11 each
- full Playwright suite: 101/101
- `git diff --check`