### PR TITLE
fix(ci): remove redundant desktop checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# A newer PR head supersedes its older checks. Keep main runs complete so every
+# merged commit still receives a full CI result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     name: check (${{ matrix.moonbit-channel }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,15 @@ jobs:
         if: matrix.moonbit-channel == 'stable'
         run: moon fmt --check
 
-      - name: Check
-        # `--deny-warn` on stable only; see the matrix note.
-        run: moon check ${{ matrix.deny-warn }}
+      - name: Check native target
+        # `--deny-warn` on stable only; see the matrix note. Keep the target
+        # explicit because this workspace contains both native and JS packages.
+        run: moon check --target native ${{ matrix.deny-warn }}
+
+      - name: Check JS target
+        # JS-only packages such as the Desktop frontend are skipped by the
+        # native check, even though their modules are root workspace members.
+        run: moon check --target js ${{ matrix.deny-warn }}
 
       - name: Check generated interfaces
         # `moon info` formats abstract types differently across toolchain
@@ -136,10 +142,15 @@ jobs:
             exit 1
           fi
 
-      - name: Test
+      - name: Test native target
         # xvfb: the desktop/Proton windowed tests create real CEF windows (the
         # Linux engine is compiled with CEF_X11), and the runner is headless.
-        run: xvfb-run -a moon test
+        run: xvfb-run -a moon test --target native
+
+      - name: Test JS target
+        # Run JS-only package tests from the same root workspace. These do not
+        # create Proton windows and therefore do not need Xvfb.
+        run: moon test --target js
 
       - name: Cram (offline CLI docs)
         run: moon cram test tests/cram

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,18 @@ concurrency:
 
 jobs:
   check:
-    name: check (${{ matrix.moonbit-channel }})
+    name: check (${{ matrix.moonbit-channel }}, ${{ matrix.target }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
-      # Run both channels independently (fail-fast: false): a stable/nightly
-      # green-red split tells us at a glance whether a failure is a
-      # nightly-toolchain regression or our own bug.
+      # Run both channels and targets independently (fail-fast: false): the
+      # stable/nightly split identifies toolchain regressions, while the
+      # native/JS split lets the two test suites run in parallel.
       fail-fast: false
       matrix:
+        moonbit-channel: [nightly, stable]
+        target: [native, js]
         include:
           # Warnings are denied on stable only. Nightly adds new warnings ahead
           # of anything we could have fixed, so denying them there turns the job
@@ -75,18 +77,21 @@ jobs:
       # desktop/.proton/runtime.json, which Proton's link config prefers over
       # the incomplete checked-in prebuilt.
       - name: Install Proton native build dependencies
+        if: matrix.target == 'native'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             pkg-config libgtk-3-dev libx11-dev xvfb
 
       - name: Cache CEF distribution
+        if: matrix.target == 'native'
         uses: actions/cache@v4
         with:
           path: desktop/.proton/cache
           key: cef-linux-x64-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
       - name: Assemble Proton CEF runtime
+        if: matrix.target == 'native'
         # Proton's link config discovers the assembled runtime by walking up
         # from the proton module root, so once runtime.json exists every moon
         # invocation links it instead of the incomplete checked-in prebuilt.
@@ -121,25 +126,20 @@ jobs:
         # channels, the repo could only ever satisfy it while the two
         # formatters agreed — once they disagree there is no committed form
         # that passes, which is not a state CI should be able to reach.
-        if: matrix.moonbit-channel == 'stable'
+        if: matrix.moonbit-channel == 'stable' && matrix.target == 'native'
         run: moon fmt --check
 
-      - name: Check native target
-        # `--deny-warn` on stable only; see the matrix note. Keep the target
-        # explicit because this workspace contains both native and JS packages.
-        run: moon check --target native ${{ matrix.deny-warn }}
-
-      - name: Check JS target
-        # JS-only packages such as the Desktop frontend are skipped by the
-        # native check, even though their modules are root workspace members.
-        run: moon check --target js ${{ matrix.deny-warn }}
+      - name: Check ${{ matrix.target }} target
+        # `--deny-warn` on stable only; see the matrix note. Keeping the target
+        # explicit also makes each matrix row own one complete check/test pair.
+        run: moon check --target ${{ matrix.target }} ${{ matrix.deny-warn }}
 
       - name: Check generated interfaces
         # `moon info` formats abstract types differently across toolchain
         # versions (`type X` on nightly vs `pub struct X { // private fields }`
         # on stable), and the committed `.mbti` are nightly-generated — so this
         # consistency check is only meaningful on nightly.
-        if: matrix.moonbit-channel == 'nightly'
+        if: matrix.moonbit-channel == 'nightly' && matrix.target == 'native'
         run: |
           moon info
           if [ -n "$(git status --porcelain -- '*.mbti')" ]; then
@@ -151,12 +151,15 @@ jobs:
       - name: Test native target
         # xvfb: the desktop/Proton windowed tests create real CEF windows (the
         # Linux engine is compiled with CEF_X11), and the runner is headless.
+        if: matrix.target == 'native'
         run: xvfb-run -a moon test --target native
 
       - name: Test JS target
         # Run JS-only package tests from the same root workspace. These do not
         # create Proton windows and therefore do not need Xvfb.
+        if: matrix.target == 'js'
         run: moon test --target js
 
       - name: Cram (offline CLI docs)
+        if: matrix.target == 'native'
         run: moon cram test tests/cram

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -162,6 +162,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install NSIS
+        if: github.event_name != 'pull_request'
         shell: pwsh
         run: |
           # Retry up to 3 times: the Chocolatey community feed occasionally
@@ -200,8 +201,16 @@ jobs:
           }
           exit 1
 
+      # Pull requests upload only the portable ZIP, so they do not spend time
+      # installing NSIS or recompressing the same bundle as an installer.
       # Unstamped — no OPENSEEK_CLIENT_TOKEN in CI; see the Linux job's note.
-      - name: Build the Windows app bundle
+      - name: Build the Windows ZIP
+        if: github.event_name == 'pull_request'
+        shell: pwsh
+        run: moon -C desktop run --target native package/windows -- --zip-only
+
+      - name: Build the Windows app bundle and installer
+        if: github.event_name != 'pull_request'
         shell: pwsh
         run: moon -C desktop run --target native package/windows
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -2,7 +2,7 @@ name: Desktop
 
 # Root CI owns workspace-wide formatting, generated-interface checks, and the
 # native/JS check and test matrix. This workflow keeps Proton's macOS release
-# tests and the platform bundle builds.
+# test and the platform bundle builds.
 on:
   push:
     branches: [main]
@@ -19,49 +19,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  desktop-test:
-    name: proton macOS release test (stable)
-    # Keep stable coverage separate; the nightly run shares the macOS artifact
-    # job below. These runtime/window tests need a macOS GUI session, and
-    # --release links with the system toolchain (the debug `tcc` path cannot
-    # resolve the WebKit framework flags). Scope the command to Proton so this
-    # workflow does not repeat root CI's workspace-wide native tests.
-    runs-on: macos-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Check out the Proton submodule
-        run: git submodule update --init desktop/lepus
-
-      - name: Set up MoonBit (stable)
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
-          echo "$HOME/.moon/bin" >> $GITHUB_PATH
-
-      - name: Show MoonBit version
-        run: moon version --all
-
-      - name: Seed MoonBit registry index
-        run: |
-          mkdir -p "$HOME/.moon/registry"
-          for attempt in 1 2 3; do
-            rm -rf "$HOME/.moon/registry/index"
-            if git \
-              -c http.lowSpeedLimit=1000 \
-              -c http.lowSpeedTime=60 \
-              clone --depth 1 https://mooncakes.io/git/index "$HOME/.moon/registry/index"; then
-              exit 0
-            fi
-            sleep $((attempt * 10))
-          done
-          exit 1
-
-      - name: Test Proton runtime (release)
-        run: moon test --target native --release -p justjavac/proton/native
-
   desktop-appimage:
     name: desktop appimage (linux)
     runs-on: ubuntu-latest
@@ -158,9 +115,9 @@ jobs:
           done
           exit 1
 
-      # The stable run is a separate job above. Run nightly here so both
-      # toolchain channels still cover Proton without reserving a third macOS
-      # runner or repeating root CI's workspace-wide native tests.
+      # Exercise Proton's runtime/window path on macOS before packaging. Scope
+      # the command to Proton instead of repeating root CI's workspace-wide
+      # native tests.
       - name: Test Proton runtime (release)
         run: moon test --target native --release -p justjavac/proton/native
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,8 +1,8 @@
 name: Desktop
 
 # Root CI owns workspace-wide formatting, generated-interface checks, and the
-# native/JS check and test matrix. This workflow keeps the Desktop-specific
-# macOS release test and platform bundle builds.
+# native/JS check and test matrix. This workflow keeps Proton's macOS release
+# tests and the platform bundle builds.
 on:
   push:
     branches: [main]
@@ -20,22 +20,15 @@ concurrency:
 
 jobs:
   desktop-test:
-    name: desktop test (release) (${{ matrix.moonbit-channel }})
-    # macOS, not headless Linux: several runtime tests drive a real webview via
-    # app.run(), which needs a GUI session. Proton's own CI skips those tests on
-    # Linux for the same reason. --release links with the system toolchain (the
-    # debug `tcc` path cannot resolve the WebKit/GTK framework flags).
+    name: proton macOS release test (stable)
+    # Keep stable coverage separate; the nightly run shares the macOS artifact
+    # job below. These runtime/window tests need a macOS GUI session, and
+    # --release links with the system toolchain (the debug `tcc` path cannot
+    # resolve the WebKit framework flags). Scope the command to Proton so this
+    # workflow does not repeat root CI's workspace-wide native tests.
     runs-on: macos-latest
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - moonbit-channel: nightly
-            moonbit-version: nightly
-          - moonbit-channel: stable
-            moonbit-version: latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -43,9 +36,9 @@ jobs:
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
 
-      - name: Set up MoonBit (${{ matrix.moonbit-channel }})
+      - name: Set up MoonBit (stable)
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "${{ matrix.moonbit-version }}"
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Show MoonBit version
@@ -66,11 +59,8 @@ jobs:
           done
           exit 1
 
-      - name: Install Lepus codegen tool
-        run: moon -C desktop/lepus install ./cli --bin target/lepus-tools
-
-      - name: Test (release)
-        run: moon -C desktop test --target native --release
+      - name: Test Proton runtime (release)
+        run: moon test --target native --release -p justjavac/proton/native
 
   desktop-appimage:
     name: desktop appimage (linux)
@@ -167,6 +157,12 @@ jobs:
             sleep $((attempt * 10))
           done
           exit 1
+
+      # The stable run is a separate job above. Run nightly here so both
+      # toolchain channels still cover Proton without reserving a third macOS
+      # runner or repeating root CI's workspace-wide native tests.
+      - name: Test Proton runtime (release)
+        run: moon test --target native --release -p justjavac/proton/native
 
       # No --sign or --notarize argument, so the app is only ad-hoc signed,
       # the DMG container is unsigned, and neither artifact is intended for

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,8 +1,8 @@
 name: Desktop
 
-# Kept separate from the root CI (ci.yml): the desktop module is its own
-# MoonBit workspace (desktop/moon.work, with the Proton submodule as members)
-# and is not part of the root moon.work, so the root checks never see it.
+# Root CI owns workspace-wide formatting, generated-interface checks, and the
+# native/JS check and test matrix. This workflow keeps the Desktop-specific
+# macOS release test and platform bundle builds.
 on:
   push:
     branches: [main]
@@ -13,104 +13,6 @@ on:
   pull_request:
 
 jobs:
-  desktop-check:
-    name: desktop check (fmt, check, info) (${{ matrix.moonbit-channel }})
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      # Same split as the root CI (ci.yml): running both channels independently
-      # says at a glance whether a failure is a nightly-toolchain regression or
-      # our own bug. Warnings are denied on stable only — nightly adds new ones
-      # ahead of anything we could have fixed.
-      fail-fast: false
-      matrix:
-        include:
-          - moonbit-channel: nightly
-            moonbit-version: nightly
-            deny-warn: ""
-          - moonbit-channel: stable
-            moonbit-version: latest
-            deny-warn: "--deny-warn"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      # The repository moved from private lepus to public Proton, so the
-      # pinned submodule commit can be fetched without a repository secret.
-      - name: Check out the Proton submodule
-        run: git submodule update --init desktop/lepus
-
-      - name: Set up MoonBit (${{ matrix.moonbit-channel }})
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "${{ matrix.moonbit-version }}"
-          echo "$HOME/.moon/bin" >> $GITHUB_PATH
-
-      - name: Show MoonBit version
-        run: moon version --all
-
-      - name: Seed MoonBit registry index
-        run: |
-          mkdir -p "$HOME/.moon/registry"
-          for attempt in 1 2 3; do
-            rm -rf "$HOME/.moon/registry/index"
-            if git \
-              -c http.lowSpeedLimit=1000 \
-              -c http.lowSpeedTime=60 \
-              clone --depth 1 https://mooncakes.io/git/index "$HOME/.moon/registry/index"; then
-              exit 0
-            fi
-            sleep $((attempt * 10))
-          done
-          exit 1
-
-      - name: Install GTK and WebKitGTK dev packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev
-
-      - name: Install Lepus codegen tool
-        run: moon -C desktop/lepus install ./cli --bin target/lepus-tools
-
-      - name: Check formatting
-        # Scope to this module's own packages: lepus/proton is a workspace
-        # member inside the Proton submodule, so a workspace-wide `fmt --check`
-        # would flag source we don't own.
-        #
-        # Stable only, matching the root CI: the nightly formatter's output
-        # drifts, so gating on it red-lines the build for files nobody touched.
-        if: matrix.moonbit-channel == 'stable'
-        run: moon -C desktop fmt --check . frontend internal package
-
-      - name: Check
-        # `--deny-warn` on stable only; see the matrix note.
-        run: moon -C desktop check --target native ${{ matrix.deny-warn }}
-
-      # The frontend builds to JS; this guards the JS side (and catches native
-      # imports leaking into target-agnostic packages, e.g. a missing
-      # supported_targets) that the native check above cannot see.
-      - name: Check JS target
-        run: moon -C desktop check --target js ${{ matrix.deny-warn }}
-
-      - name: Check generated interfaces
-        # `moon info` formats abstract types differently across toolchain
-        # versions (`type X` on nightly vs `pub struct X { // private fields }`
-        # on stable), and the committed `.mbti` are nightly-generated — so this
-        # consistency check is only meaningful on nightly. Same reasoning as
-        # the root CI's equivalent step.
-        if: matrix.moonbit-channel == 'nightly'
-        run: |
-          moon -C desktop info --target native
-          # The Proton submodule's own .mbti live inside the submodule and are
-          # not tracked as files by this repo, so this pathspec only validates
-          # the desktop module's own generated interfaces.
-          if [ -n "$(git status --porcelain -- '*.mbti')" ]; then
-            git status --short -- '*.mbti'
-            git diff -- '*.mbti'
-            exit 1
-          fi
-
   desktop-test:
     name: desktop test (release) (${{ matrix.moonbit-channel }})
     # macOS, not headless Linux: several runtime tests drive a real webview via
@@ -162,7 +64,7 @@ jobs:
         run: moon -C desktop/lepus install ./cli --bin target/lepus-tools
 
       - name: Test (release)
-        run: moon -C desktop test --release
+        run: moon -C desktop test --target native --release
 
   desktop-appimage:
     name: desktop appimage (linux)

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -12,6 +12,12 @@ on:
   # they lived in ci.yml) rather than enumerate a brittle dependency path list.
   pull_request:
 
+# A newer PR head supersedes its older builds. Keep main runs complete so every
+# merged commit still produces its platform validation and artifacts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   desktop-test:
     name: desktop test (release) (${{ matrix.moonbit-channel }})

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Build the Windows ZIP
         if: github.event_name == 'pull_request'
         shell: pwsh
-        run: moon -C desktop run --target native package/windows -- --zip-only
+        run: moon -C desktop run --target native package/windows -- --target zip
 
       - name: Build the Windows app bundle and installer
         if: github.event_name != 'pull_request'

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -242,10 +242,19 @@ needed, builds the frontend and native host, builds the `openseek` engine from
 the monorepo root, writes `dist/windows-x64/OpenSeek Desktop/`, and creates
 `dist/OpenSeek Desktop-windows-x64.zip`.
 
-The command takes no arguments and always builds every output: the
+Without additional arguments, the command builds every output: the
 `dist/windows-x64/OpenSeek Desktop/` bundle directory, the
 `dist/OpenSeek Desktop-windows-x64.zip` portable zip, and the
 `dist/OpenSeek-Desktop-Setup.exe` NSIS installer.
+
+Pass `--zip-only` when the installer is not needed:
+
+```powershell
+moon -C desktop run --target native package/windows -- --zip-only
+```
+
+This still builds the bundle directory and portable zip, but does not require
+NSIS and does not create `dist/OpenSeek-Desktop-Setup.exe`.
 
 To build the per-user NSIS installer, install NSIS so `makensis.exe` is on
 `PATH`, or extract portable NSIS to

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -247,10 +247,12 @@ Without additional arguments, the command builds every output: the
 `dist/OpenSeek Desktop-windows-x64.zip` portable zip, and the
 `dist/OpenSeek-Desktop-Setup.exe` NSIS installer.
 
-Pass `--zip-only` when the installer is not needed:
+Use repeatable `--target` options to select `app`, `zip`, or `installer`.
+The app bundle is always built; selecting `app` alone skips both distribution
+archives. For example, build only the bundle and portable zip with:
 
 ```powershell
-moon -C desktop run --target native package/windows -- --zip-only
+moon -C desktop run --target native package/windows -- --target zip
 ```
 
 This still builds the bundle directory and portable zip, but does not require

--- a/desktop/package/windows/main.mbt
+++ b/desktop/package/windows/main.mbt
@@ -35,6 +35,13 @@ fn package_command() -> @argparse.Command {
   Command(
     "package/windows",
     about="Build the Windows app bundle, portable zip, and NSIS installer.",
+    flags=[
+      FlagArg(
+        "zip-only",
+        long="zip-only",
+        about="Build the app bundle and portable zip without the NSIS installer",
+      ),
+    ],
   )
 }
 
@@ -279,10 +286,13 @@ async fn build_installer(ws : @packaging.Workspace) -> Unit {
 
 ///|
 async fn main {
-  ignore(package_command().parse())
+  let matches = package_command().parse()
+  let zip_only = matches.flags.get("zip-only").unwrap_or(false)
   let ws = @packaging.locate_workspace()
   @packaging.ensure_cmake(ws)
-  ensure_makensis(ws)
+  if !zip_only {
+    ensure_makensis(ws)
+  }
   let with_wsl_engine = build_outputs(ws)
   println("built openseek engine: \{ws.engine_binary()}")
   if with_wsl_engine {
@@ -292,14 +302,23 @@ async fn main {
   copy_bundle_files(ws, with_wsl_engine~)
   zip_bundle(ws)
   println("generated \{ws.at(ZipPath)}")
-  build_installer(ws)
-  println("generated \{ws.at(InstallerPath)}")
+  if !zip_only {
+    build_installer(ws)
+    println("generated \{ws.at(InstallerPath)}")
+  }
   println("generated \{ws.at(BundleDir)}")
 }
 
 ///|
 test "windows package args accept no mode arguments" {
-  ignore(package_command().parse(argv=[]))
+  let matches = package_command().parse(argv=[])
+  assert_eq(matches.flags.get("zip-only").unwrap_or(false), false)
+}
+
+///|
+test "windows package args accept zip-only mode" {
+  let matches = package_command().parse(argv=["--zip-only"])
+  assert_eq(matches.flags.get("zip-only"), Some(true))
 }
 
 ///|

--- a/desktop/package/windows/main.mbt
+++ b/desktop/package/windows/main.mbt
@@ -31,18 +31,54 @@ const ProgramFilesMakensis : String = "C:/Program Files/NSIS/makensis.exe"
 const AppAssetDir : String = BundleDir + "/assets"
 
 ///|
+priv struct ArtifactPlan {
+  zip : Bool
+  installer : Bool
+} derive(Debug, Eq)
+
+///|
+fn ArtifactPlan::parse(values : ArrayView[String]) -> ArtifactPlan raise {
+  if values.is_empty() {
+    return { zip: true, installer: true }
+  }
+  let mut zip = false
+  let mut installer = false
+  for value in values {
+    match value {
+      "app" => ()
+      "zip" => zip = true
+      "installer" => installer = true
+      value =>
+        raise @packaging.PackageError(
+          "unsupported Windows package target '\{value}'; expected app, zip, or installer",
+        )
+    }
+  }
+  { zip, installer }
+}
+
+///|
 fn package_command() -> @argparse.Command {
   Command(
     "package/windows",
     about="Build the Windows app bundle, portable zip, and NSIS installer.",
-    flags=[
-      FlagArg(
-        "zip-only",
-        long="zip-only",
-        about="Build the app bundle and portable zip without the NSIS installer",
+    options=[
+      OptionArg(
+        "target",
+        action=Append,
+        about="Artifact to produce: app, zip, or installer. Repeatable; defaults to zip and installer.",
       ),
     ],
   )
+}
+
+///|
+fn ArtifactPlan::parse_args(argv? : ArrayView[String]) -> ArtifactPlan raise {
+  let matches = package_command().parse(argv?)
+  match matches.values.get("target") {
+    Some(values) => ArtifactPlan::parse(values)
+    None => ArtifactPlan::parse([])
+  }
 }
 
 ///|
@@ -286,11 +322,11 @@ async fn build_installer(ws : @packaging.Workspace) -> Unit {
 
 ///|
 async fn main {
-  let matches = package_command().parse()
-  let zip_only = matches.flags.get("zip-only").unwrap_or(false)
+  // Parse first: a mistyped target must fail before the build, not after it.
+  let artifacts = ArtifactPlan::parse_args()
   let ws = @packaging.locate_workspace()
   @packaging.ensure_cmake(ws)
-  if !zip_only {
+  if artifacts.installer {
     ensure_makensis(ws)
   }
   let with_wsl_engine = build_outputs(ws)
@@ -300,9 +336,11 @@ async fn main {
   }
   reset_bundle_dirs(ws)
   copy_bundle_files(ws, with_wsl_engine~)
-  zip_bundle(ws)
-  println("generated \{ws.at(ZipPath)}")
-  if !zip_only {
+  if artifacts.zip {
+    zip_bundle(ws)
+    println("generated \{ws.at(ZipPath)}")
+  }
+  if artifacts.installer {
     build_installer(ws)
     println("generated \{ws.at(InstallerPath)}")
   }
@@ -310,39 +348,68 @@ async fn main {
 }
 
 ///|
-test "windows package args accept no mode arguments" {
-  let matches = package_command().parse(argv=[])
-  assert_eq(matches.flags.get("zip-only").unwrap_or(false), false)
+test "windows package args default to zip and installer" {
+  assert_eq(ArtifactPlan::parse_args(argv=[]), { zip: true, installer: true })
 }
 
 ///|
-test "windows package args accept zip-only mode" {
-  let matches = package_command().parse(argv=["--zip-only"])
-  assert_eq(matches.flags.get("zip-only"), Some(true))
+test "windows package target app skips distribution archives" {
+  assert_eq(ArtifactPlan::parse_args(argv=["--target", "app"]), {
+    zip: false,
+    installer: false,
+  })
 }
 
 ///|
-test "windows package args reject removed installer flag" {
-  try package_command().parse(argv=["--installer"]) catch {
-    err =>
-      assert_true(
-        err.to_string().contains("unexpected argument '--installer' found"),
-      )
-  } noraise {
-    _ => fail("expected removed --installer flag to fail")
-  }
+test "windows package target zip skips installer" {
+  assert_eq(ArtifactPlan::parse_args(argv=["--target", "zip"]), {
+    zip: true,
+    installer: false,
+  })
 }
 
 ///|
-test "windows package args reject removed bare mode" {
-  try package_command().parse(argv=["installer"]) catch {
+test "windows package target installer skips zip" {
+  assert_eq(ArtifactPlan::parse_args(argv=["--target", "installer"]), {
+    zip: false,
+    installer: true,
+  })
+}
+
+///|
+test "windows package targets can be repeated" {
+  assert_eq(
+    ArtifactPlan::parse_args(argv=[
+      "--target", "app", "--target", "zip", "--target", "installer",
+    ]),
+    { zip: true, installer: true },
+  )
+}
+
+///|
+test "windows package rejects an unsupported target" {
+  try ArtifactPlan::parse_args(argv=["--target", "msi"]) catch {
     err =>
       assert_true(
         err
         .to_string()
-        .contains("unexpected value 'installer' found; no more were expected"),
+        .contains(
+          "unsupported Windows package target 'msi'; expected app, zip, or installer",
+        ),
       )
   } noraise {
-    _ => fail("expected removed installer mode to fail")
+    _ => fail("expected unsupported Windows package target to fail")
+  }
+}
+
+///|
+test "windows package args reject removed zip-only flag" {
+  try ArtifactPlan::parse_args(argv=["--zip-only"]) catch {
+    err =>
+      assert_true(
+        err.to_string().contains("unexpected argument '--zip-only' found"),
+      )
+  } noraise {
+    _ => fail("expected removed --zip-only flag to fail")
   }
 }


### PR DESCRIPTION
TL;DR: This PR removes redundant checks CI from desktop.yml

## Summary

- run native and JS `moon check` explicitly from the root workspace CI
- run JS tests from the root workspace alongside the existing native/Xvfb tests
- remove the now-redundant `desktop-check` job
- keep the macOS release test and platform packaging jobs in the Desktop workflow

## Why

After `desktop` and Proton became members of the root `moon.work`, the separate Desktop formatting, native check, and interface checks duplicated root CI. However, the root workflow still relied on the native default target, so JS-only packages and tests were skipped.

This makes both targets explicit in root CI while preserving the macOS release test because it exercises a different runner platform and build mode.

## Validation

- `moon check --target js --deny-warn`
- `moon test --target js`
- `moon check --target native --deny-warn`
- `moon fmt --check`
- `moon info`
- parsed both workflow YAML files
- `git diff --check`