### PR TITLE
fix(editor): use tmpdir for native host tests

### DIFF
--- a/editor/internal/shell/server_host_native/native_host_test.mbt
+++ b/editor/internal/shell/server_host_native/native_host_test.mbt
@@ -1,9 +1,13 @@
+// Native filesystem tests use an atomically created directory per test because
+// async tests run in parallel.
+
 ///|
 async test "native host reads root-relative text files" {
-  let root = "_build/native_host_read_test"
-  reset_dir(root)
   @async.with_task_group() <| group => {
-    group.add_defer(() => @fs.rmdir(root, recursive=true))
+    let root = @fs.tmpdir(prefix="openseek-native-host-read")
+    group.add_defer() <| () => {
+      @async.protect_from_cancel(() => @fs.rmdir(root, recursive=true))
+    }
     @fs.mkdir(root + "/src", recursive=true)
     @fs.write_file(
       root + "/src/main.mbt",
@@ -29,10 +33,11 @@ async test "native host reads root-relative text files" {
 
 ///|
 async test "native host resolves one directory level with minted uris" {
-  let root = "_build/native_host_resolve_test"
-  reset_dir(root)
   @async.with_task_group() <| group => {
-    group.add_defer(() => @fs.rmdir(root, recursive=true))
+    let root = @fs.tmpdir(prefix="openseek-native-host-resolve")
+    group.add_defer() <| () => {
+      @async.protect_from_cancel(() => @fs.rmdir(root, recursive=true))
+    }
     @fs.mkdir(root + "/src/lib", recursive=true)
     @fs.mkdir(root + "/_build", recursive=true)
     @fs.write_file(
@@ -111,11 +116,11 @@ fn stat_kind(stats : Array[@workspace.WorkspaceStat], uri : String) -> String {
 
 ///|
 async test "native host polling watch emits changed and deleted" {
-  let root = "_build/native_host_watch_test"
-  reset_dir(root)
   @async.with_task_group() <| group => {
-    group.add_defer(() => @fs.rmdir(root, recursive=true))
-    @fs.mkdir(root, recursive=true)
+    let root = @fs.tmpdir(prefix="openseek-native-host-watch")
+    group.add_defer() <| () => {
+      @async.protect_from_cancel(() => @fs.rmdir(root, recursive=true))
+    }
     @fs.write_file(
       root + "/watched.mbt",
       "pub fn watched { 1 }\n",
@@ -144,13 +149,6 @@ async test "native host polling watch emits changed and deleted" {
     watch.dispose()
     assert_true(events[0] == Changed)
     assert_true(events[1] == Deleted)
-  }
-}
-
-///|
-async fn reset_dir(path : String) -> Unit {
-  if @fs.exists(path) {
-    @fs.rmdir(path, recursive=true)
   }
 }
 


### PR DESCRIPTION
## Summary

- create an atomically allocated temporary directory for each native host filesystem test
- protect recursive cleanup from task cancellation
- remove the shared `_build` fixture roots and their reset function

## Root cause

MoonBit async tests run in parallel. The tests used different fixture directories under the same relative `_build` parent, so a clean test run could have multiple recursive `mkdir` calls race to create `_build`. The losing call surfaced `EEXIST`, producing schedule-dependent native CI failures.

Using `@fs.tmpdir` gives every test a directory that is created atomically and never reused.

## Impact

This removes the native test directory race without changing production code or public APIs.

## Validation

- `moon -C editor check internal/shell/server_host_native --target native`
- `moon -C editor test internal/shell/server_host_native --target native` — 5/5 passed
- repeated the targeted package test 20 times
- `moon -C editor test --target native` — 2695/2695 passed
- `moon -C editor info` — no interface changes