### PR TITLE
feat(editor): expose top-level folding API

### DIFF
--- a/editor/viewer/folding_host.mbt
+++ b/editor/viewer/folding_host.mbt
@@ -29,6 +29,21 @@ fn Viewer::folding_controller(
 }
 
 ///|
+/// Collapses every top-level folding region in the current model.
+///
+/// This is the host-facing mechanism for applying an initial fold policy. It
+/// intentionally supplies no blocked lines, unlike Monaco's
+/// `editor.foldLevel1` action, so the region containing the current selection
+/// is folded as well. The call does nothing when folding is disabled or no
+/// folding model is attached.
+pub fn Viewer::fold_top_level(self : Viewer) -> Unit {
+  guard self.get_options().folding else { return }
+  guard self.folding_controller() is Some(controller) else { return }
+  guard controller.folding_model is Some(folding_model) else { return }
+  @folding_browser.set_collapse_state_at_level(folding_model, 1, true, [])
+}
+
+///|
 /// `onModelChanged` (`folding.ts:227`).
 fn Viewer::folding_on_model_changed(self : Viewer) -> Unit {
   guard self.folding_controller() is Some(controller) else { return }

--- a/editor/viewer/folding_host_wbtest.mbt
+++ b/editor/viewer/folding_host_wbtest.mbt
@@ -17,6 +17,30 @@ test "folding: contribution computes indent regions on model attach" {
 }
 
 ///|
+test "folding: public fold_top_level collapses every outer region only" {
+  with_test_viewer("root\n  child\n    leaf\nnext\n  item\ntail", viewer => {
+    let view_model = viewer.test_view_model()
+    guard viewer.folding_controller() is Some(controller)
+    guard controller.folding_model is Some(folding_model)
+    let regions = folding_model.regions()
+    assert_eq(regions.length(), 3)
+    viewer.set_position(Position(3, 1))
+    viewer.fold_top_level()
+    assert_true(regions.is_collapsed(0))
+    assert_false(regions.is_collapsed(1))
+    assert_true(regions.is_collapsed(2))
+    assert_eq(view_model.line_count(), 3)
+    assert_eq(view_model.lines().get_view_line_content(1), "root")
+    assert_eq(view_model.lines().get_view_line_content(2), "next")
+    assert_eq(view_model.lines().get_view_line_content(3), "tail")
+    // The API does not preserve a blocked selection: folding the containing
+    // outer region snaps the caret to its header.
+    guard viewer.get_selection() is Some(selection)
+    assert_eq(selection.start().line_number, 1)
+  })
+}
+
+///|
 test "folding: toggling a region folds its lines out of the view axis" {
   with_test_viewer("a\n  b\n  c\nd\n  e", viewer => {
     let view_model = viewer.test_view_model()
@@ -97,6 +121,8 @@ test "folding: disabling the option clears folds and detaches the model state" {
     assert_eq(view_model.line_count(), 4)
     assert_true(controller.folding_model is None)
     assert_false(viewer.folding_enabled())
+    viewer.fold_top_level()
+    assert_eq(view_model.line_count(), 4)
   })
 }
 

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -45,6 +45,7 @@ pub fn Viewer::create_decorations_collection(Self, decorations? : Array[@model.M
 pub fn Viewer::delta_decorations(Self, Array[String], Array[@model.ModelDeltaDecoration]) -> Array[String]
 pub fn Viewer::dispose(Self) -> Unit
 pub fn Viewer::focus(Self) -> Unit
+pub fn Viewer::fold_top_level(Self) -> Unit
 pub fn Viewer::get_bottom_for_line_number(Self, Int) -> Double
 pub fn Viewer::get_container_dom_node(Self) -> @dom.Element
 pub fn Viewer::get_content_height(Self) -> Double


### PR DESCRIPTION
## Summary

- expose `Viewer::fold_top_level()` as a host-facing folding operation
- collapse every level-1 folding region without preserving the current selection as a blocked region
- keep the call a safe no-op when folding is disabled or no folding model is attached
- add focused headless coverage and regenerate the Viewer package interface

## Motivation

Hosts need a narrow mechanism to apply default folding once per file-open lifecycle. The open/close policy remains outside the editor; this change only exposes the folding operation already owned by the folding contribution.

## Validation

- `MOON_WORK=off moon test viewer` — 244 passed
- `MOON_WORK=off just test` — 1566 JS and 1053 native tests passed; wasm targets have no test entry
- `MOON_WORK=off just check` — passed with the existing `tree_state.mbt:75` unnecessary-annotation warning
- `MOON_WORK=off moon info`
- `MOON_WORK=off moon fmt`
- `git diff --check`