### PR TITLE
fix: clear deprecated to_repr/Map::default/to_json warnings

### DIFF
--- a/agent/goal_gate_test.mbt
+++ b/agent/goal_gate_test.mbt
@@ -66,7 +66,7 @@ async test "a met goal runs the gate once before the next request" {
       api_url=url,
       tools=Tools([@goal.definition()]),
       on_goal_met=(goal, baseline) => {
-        calls.push((goal, "\{to_repr(baseline)}"))
+        calls.push((goal, "\{Repr(baseline)}"))
         Some("[review] goal-met audit: 0 finding(s) — clean")
       },
     )

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -171,7 +171,7 @@ async fn execute(
       )
     None =>
       @agent_tool.ToolAction::respond(
-        "explore produced no report (\{to_repr(result.terminal())}) — fall back to reading directly.",
+        "explore produced no report (\{Repr(result.terminal())}) — fall back to reading directly.",
         is_error=true,
         brief="explore \{result.subrun_id()} (no report)",
       )

--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -165,7 +165,7 @@ pub impl ToJson for Session with fn to_json(session : Session) -> Json {
     "version": 1,
     "id": session.id(),
     "system_prompt": session.system_prompt(),
-    "events": session.events().to_json(),
+    "events": @json.to_json(session.events()),
   }
 }
 

--- a/agent_subrun/runner_test.mbt
+++ b/agent_subrun/runner_test.mbt
@@ -59,7 +59,7 @@ async test "a spawn failure folds into Failed" {
     emit_event=bracket_collector(events),
   )
   guard events is [SubrunStarted(..), SubrunFinished(status=bracket_status, ..)] else {
-    fail("expected one bracket pair, got \{to_repr(events)}")
+    fail("expected one bracket pair, got \{Repr(events)}")
   }
   guard result.terminal() is Failed(reason) else {
     // Some sandboxes surface spawn refusal as an immediate empty exit:
@@ -108,7 +108,7 @@ async test "a clean exit without a report is NoReport" {
   assert_true(result.value() is None)
   debug_inspect(result.terminal(), content="NoReport")
   guard events is [SubrunStarted(..), SubrunFinished(status="no_report", ..)] else {
-    fail("expected a no_report pair, got \{to_repr(events)}")
+    fail("expected a no_report pair, got \{Repr(events)}")
   }
 }
 
@@ -125,7 +125,7 @@ async test "an observed step exhaustion without a report is MaxSteps" {
   let result = run_script(script, emit_event=bracket_collector(events))
   debug_inspect(result.terminal(), content="MaxSteps")
   guard events is [SubrunStarted(..), SubrunFinished(status="max_steps", ..)] else {
-    fail("expected a max_steps pair, got \{to_repr(events)}")
+    fail("expected a max_steps pair, got \{Repr(events)}")
   }
 }
 
@@ -283,7 +283,7 @@ async test "a run emits a matched started/finished bracket pair" {
         completion_tokens=10
       ),
     ] else {
-    fail("expected exactly one started/finished pair, got \{to_repr(events)}")
+    fail("expected exactly one started/finished pair, got \{Repr(events)}")
   }
   assert_eq(started_id, finished_id)
 }
@@ -305,7 +305,7 @@ async test "a timed-out run still closes its bracket" {
   )
   debug_inspect(result.terminal(), content="TimedOut")
   guard events is [SubrunStarted(..), SubrunFinished(status="timed_out", ..)] else {
-    fail("expected a timed_out pair, got \{to_repr(events)}")
+    fail("expected a timed_out pair, got \{Repr(events)}")
   }
 }
 
@@ -334,7 +334,7 @@ async test "external cancellation closes the bracket before re-raising" {
     let _ = Some(task.wait()) catch { _ => None }
   }
   guard events is [SubrunStarted(..), SubrunFinished(status="cancelled", ..)] else {
-    fail("expected a cancelled pair, got \{to_repr(events)}")
+    fail("expected a cancelled pair, got \{Repr(events)}")
   }
 }
 
@@ -357,7 +357,7 @@ async test "sub-run ids are unique across runs" {
       SubrunStarted(id=second, ..),
       SubrunFinished(id=second_done, ..),
     ] else {
-    fail("expected two pairs, got \{to_repr(events)}")
+    fail("expected two pairs, got \{Repr(events)}")
   }
   assert_true(first != second)
   assert_eq(first, first_done)
@@ -378,7 +378,7 @@ async test "an observed context yield closes with its status" {
   debug_inspect(result.terminal(), content="ContextYield")
   guard events
     is [SubrunStarted(..), SubrunFinished(status="context_yield", ..)] else {
-    fail("expected a context_yield pair, got \{to_repr(events)}")
+    fail("expected a context_yield pair, got \{Repr(events)}")
   }
 }
 
@@ -406,7 +406,7 @@ async test "child_session appends session argv derived from the sub-run id" {
     child_session=ChildSession(root="/tmp/subrun-root", parent="parent-id"),
   )
   guard result.value() is Some(argv) else {
-    fail("expected a captured report, got \{to_repr(result.terminal())}")
+    fail("expected a captured report, got \{Repr(result.terminal())}")
   }
   assert_eq(
     argv,
@@ -442,7 +442,7 @@ async test "child_session's ordinal floor skips persisted ids" {
     ),
   )
   guard result.value() is Some(session_arg) else {
-    fail("expected a captured report, got \{to_repr(result.terminal())}")
+    fail("expected a captured report, got \{Repr(result.terminal())}")
   }
   // $1 is the --session value: parent + the allocated id, at or past the floor.
   assert_eq(session_arg, "resumed-\{result.subrun_id()}")

--- a/agent_tool/goal/internal/decode/README.mbt.md
+++ b/agent_tool/goal/internal/decode/README.mbt.md
@@ -80,7 +80,7 @@ fn decode_error_for_docs(arguments : Json) -> String {
   try @decode.decode(arguments) catch {
     error => @tool_error.failure_message("\{error}")
   } noraise {
-    status => "unexpected success: \{to_repr(status)}"
+    status => "unexpected success: \{Repr(status)}"
   }
 }
 ```

--- a/agent_tool/goal/internal/decode/decode_test.mbt
+++ b/agent_tool/goal/internal/decode/decode_test.mbt
@@ -57,6 +57,6 @@ fn decode_error(arguments : Json) -> String {
   try @decode.decode(arguments) catch {
     error => @tool_error.failure_message("\{error}")
   } noraise {
-    status => "unexpected success: \{to_repr(status)}"
+    status => "unexpected success: \{Repr(status)}"
   }
 }

--- a/cmd/openseek/gate.mbt
+++ b/cmd/openseek/gate.mbt
@@ -86,7 +86,7 @@ fn build_goal_met_gate(
       Some(report) => Some(report.digest())
       None =>
         Some(
-          "[review] unavailable (\{@agent_tool.brief_line("\{to_repr(result.terminal())}", limit=200)}) — treat the met claim as unaudited.",
+          "[review] unavailable (\{@agent_tool.brief_line("\{Repr(result.terminal())}", limit=200)}) — treat the met claim as unaudited.",
         )
     }
   }

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -121,7 +121,7 @@ async fn execute_review(
       )
     None =>
       @agent_tool.ToolAction::respond(
-        "review produced no report (\{@agent_tool.brief_line("\{to_repr(result.terminal())}", limit=200)}) — validate directly instead.",
+        "review produced no report (\{@agent_tool.brief_line("\{Repr(result.terminal())}", limit=200)}) — validate directly instead.",
         is_error=true,
         brief="review \{result.subrun_id()} (no report)",
       )

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -56,7 +56,7 @@ fn main {
         log.error() <?
           {
             "message": "host process error",
-            "error": @debug.render(@debug.to_repr(error)),
+            "error": @debug.render(Repr(error)),
           }
     }
     // A successful `apply_update` swapped the bundle on disk and left a

--- a/editor/base/common/path_reference_test.mbt
+++ b/editor/base/common/path_reference_test.mbt
@@ -121,7 +121,7 @@ test "join" {
     let actual = Posix::join(args)
     if actual != expected {
       failures.push(
-        "posix.join(\{to_repr(args)}) expect=\{expected} actual=\{actual}",
+        "posix.join(\{Repr(args)}) expect=\{expected} actual=\{actual}",
       )
     }
     // For non-Windows specific tests with the Windows join(), we need to try
@@ -131,7 +131,7 @@ test "join" {
     let win_actual_alt = win_actual.replace_all(old="\\", new="/")
     if win_actual != expected && win_actual_alt != expected {
       failures.push(
-        "win32.join(\{to_repr(args)}) expect=\{expected} actual=\{win_actual}",
+        "win32.join(\{Repr(args)}) expect=\{expected} actual=\{win_actual}",
       )
     }
   }
@@ -141,7 +141,7 @@ test "join" {
     let actual_alt = actual.replace_all(old="\\", new="/")
     if actual != expected && actual_alt != expected {
       failures.push(
-        "win32.join(\{to_repr(args)}) expect=\{expected} actual=\{actual}",
+        "win32.join(\{Repr(args)}) expect=\{expected} actual=\{actual}",
       )
     }
   }
@@ -361,7 +361,7 @@ test "resolve" {
     let actual_alt = actual.replace_all(old="\\", new="/")
     if actual != expected && actual_alt != expected {
       failures.push(
-        "win32.resolve(\{to_repr(args)}) expect=\{expected} actual=\{actual}",
+        "win32.resolve(\{Repr(args)}) expect=\{expected} actual=\{actual}",
       )
     }
   }
@@ -376,7 +376,7 @@ test "resolve" {
     let actual = Posix::resolve(args)
     if actual != expected {
       failures.push(
-        "posix.resolve(\{to_repr(args)}) expect=\{expected} actual=\{actual}",
+        "posix.resolve(\{Repr(args)}) expect=\{expected} actual=\{actual}",
       )
     }
   }

--- a/editor/base/common/resources_reference_test.mbt
+++ b/editor/base/common/resources_reference_test.mbt
@@ -465,7 +465,7 @@ fn assert_relative_path(
   let util = if ignore_case { ext_uri_ignore_path_case } else { ext_uri }
   assert_true(
     util.relative_path(u1, u2) == expected_path,
-    msg="from \{u1.to_string()} to \{u2.to_string()}: got \{to_repr(util.relative_path(u1, u2))}, want \{to_repr(expected_path)}",
+    msg="from \{u1.to_string()} to \{u2.to_string()}: got \{Repr(util.relative_path(u1, u2))}, want \{Repr(expected_path)}",
   )
   if expected_path is Some(path) && !ignore_join {
     assert_equal_uri(

--- a/editor/base/common/uri.mbt
+++ b/editor/base/common/uri.mbt
@@ -86,7 +86,7 @@ pub impl Hash for Uri with fn hash_combine(self, hasher) {
 /// Mirrors the `debug.description` label `URI(${this.toString()})`
 /// (uri.ts:421) without touching the `_formatted` cache.
 pub impl Debug for Uri with fn to_repr(self) {
-  to_repr("URI(\{as_formatted(self, false)})")
+  Repr("URI(\{as_formatted(self, false)})")
 }
 
 ///|

--- a/editor/internal/shell/server/server.mbt
+++ b/editor/internal/shell/server/server.mbt
@@ -86,8 +86,8 @@ pub fn RemoteServer::with_language_providers(
     definition_provider,
     references_provider,
     document_symbol_provider,
-    documents: Map::default(),
-    watches: Map::default(),
+    documents: Default::default(),
+    watches: Default::default(),
     document_sync_listener: Ref(None),
   }
 }
@@ -104,8 +104,8 @@ pub fn RemoteServer::new_session(self : RemoteServer) -> RemoteServer {
     definition_provider: self.definition_provider,
     references_provider: self.references_provider,
     document_symbol_provider: self.document_symbol_provider,
-    documents: Map::default(),
-    watches: Map::default(),
+    documents: Default::default(),
+    watches: Default::default(),
     document_sync_listener: self.document_sync_listener,
   }
 }

--- a/editor/internal/shell/server/server_test.mbt
+++ b/editor/internal/shell/server/server_test.mbt
@@ -356,10 +356,10 @@ struct FakeWatchListener {
 ///|
 fn FakeServerHost::new() -> FakeServerHost {
   {
-    files: Map::default(),
-    errors: Map::default(),
-    directories: Map::default(),
-    listeners: Map::default(),
+    files: Default::default(),
+    errors: Default::default(),
+    directories: Default::default(),
+    listeners: Default::default(),
   }
 }
 

--- a/editor/internal/shell/server_host_native/moon_check.mbt
+++ b/editor/internal/shell/server_host_native/moon_check.mbt
@@ -29,8 +29,8 @@ pub fn MoonCheckDiagnostics::MoonCheckDiagnostics(
     publish,
     running: Ref(false),
     dirty: Ref(false),
-    revisions: Map::default(),
-    published: Ref(Map::default()),
+    revisions: Default::default(),
+    published: Ref(Default::default()),
   }
 }
 
@@ -129,7 +129,7 @@ pub fn parse_moon_check_diagnostics(
   raw : String,
 ) -> Map[String, Array[@language.Diagnostic]] {
   let prefix = normalize_host_path(root) + "/"
-  let grouped : Map[String, Array[@language.Diagnostic]] = Map::default()
+  let grouped : Map[String, Array[@language.Diagnostic]] = Default::default()
   for line in raw.split("\n") {
     let trimmed = line.trim(char_set="\r\n ").to_owned()
     if trimmed == "" {

--- a/editor/internal/shell/server_host_native/native_host.mbt
+++ b/editor/internal/shell/server_host_native/native_host.mbt
@@ -282,7 +282,7 @@ priv struct ProtocolSessions {
 
 ///|
 fn ProtocolSessions::new() -> ProtocolSessions {
-  { next_session_id: Ref(0), outboxes: Map::default() }
+  { next_session_id: Ref(0), outboxes: Default::default() }
 }
 
 ///|

--- a/editor/internal/viewer/contrib/folding/browser/folding_model_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model_reference_wbtest.mbt
@@ -151,7 +151,7 @@ fn assert_model_ranges(
     )
   }
   if actual_ranges != expected {
-    fail("\{message}: \{to_repr(actual_ranges)} != \{to_repr(expected)}")
+    fail("\{message}: \{Repr(actual_ranges)} != \{Repr(expected)}")
   }
 }
 
@@ -173,7 +173,7 @@ fn assert_folded_ranges(
     }
   }
   if actual_ranges != expected {
-    fail("\{message}: \{to_repr(actual_ranges)} != \{to_repr(expected)}")
+    fail("\{message}: \{Repr(actual_ranges)} != \{Repr(expected)}")
   }
 }
 
@@ -188,7 +188,7 @@ fn assert_regions_list(
     (r.start_line_number(), r.end_line_number(), r.is_collapsed())
   })
   if mapped != expected {
-    fail("\{message}: \{to_repr(mapped)} != \{to_repr(expected)}")
+    fail("\{message}: \{Repr(mapped)} != \{Repr(expected)}")
   }
 }
 
@@ -208,7 +208,7 @@ fn assert_region_opt(
         region.is_collapsed(),
       )
       if got != expected {
-        fail("\{message}: \{to_repr(got)} != \{to_repr(expected)}")
+        fail("\{message}: \{Repr(got)} != \{Repr(expected)}")
       }
     }
     _ => fail("\{message}: presence mismatch")

--- a/editor/internal/viewer/contrib/folding/browser/folding_ranges_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_ranges_reference_wbtest.mbt
@@ -15,7 +15,7 @@ fn assert_equal_ranges(
   msg : String,
 ) -> Unit raise {
   if range1 != range2 {
-    fail("\{msg}: \{to_repr(range1)} != \{to_repr(range2)}")
+    fail("\{msg}: \{Repr(range1)} != \{Repr(range2)}")
   }
 }
 

--- a/editor/internal/viewer/contrib/folding/browser/hidden_range_model_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/hidden_range_model_reference_wbtest.mbt
@@ -11,7 +11,7 @@ fn assert_hidden_ranges(
 ) -> Unit raise {
   let mapped = actual.map(r => (r.start_line_number, r.end_line_number))
   if mapped != expected {
-    fail("\{message}: \{to_repr(mapped)} != \{to_repr(expected)}")
+    fail("\{message}: \{Repr(mapped)} != \{Repr(expected)}")
   }
 }
 

--- a/editor/internal/viewer/contrib/folding/browser/indent_range_provider_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/indent_range_provider_reference_wbtest.mbt
@@ -124,7 +124,7 @@ fn assert_indent_ranges(
     )
   }
   if actual_ranges != expected {
-    fail("\{to_repr(actual_ranges)} != \{to_repr(expected)}")
+    fail("\{Repr(actual_ranges)} != \{Repr(expected)}")
   }
 }
 
@@ -532,7 +532,7 @@ test "Limit by indent" {
       )
     }
     if actual != expected_ranges {
-      fail("\{message}: \{to_repr(actual)} != \{to_repr(expected_ranges)}")
+      fail("\{message}: \{Repr(actual)} != \{Repr(expected_ranges)}")
     }
     let expected_reported : Int? = if 9 <= max_entries {
       None

--- a/editor/viewer/common/model/interval_tree_reference_test.mbt
+++ b/editor/viewer/common/model/interval_tree_reference_test.mbt
@@ -267,7 +267,7 @@ fn assert_pairs_eq(
   expected : Array[(Int, Int)],
 ) -> Unit raise {
   if actual != expected {
-    fail("got \{to_repr(actual)}, expected \{to_repr(expected)}")
+    fail("got \{Repr(actual)}, expected \{Repr(expected)}")
   }
 }
 

--- a/editor/viewer/common/model/model_decorations_reference_test.mbt
+++ b/editor/viewer/common/model/model_decorations_reference_test.mbt
@@ -108,7 +108,7 @@ fn model_has_decorations(
     )
   })
   if actual != decorations {
-    fail("got \{to_repr(actual)}, expected \{to_repr(decorations)}")
+    fail("got \{Repr(actual)}, expected \{Repr(decorations)}")
   }
 }
 
@@ -142,9 +142,7 @@ fn line_has_decorations(
     .get_line_decorations(line_number)
     .map(d => (d.range.start_column, d.range.end_column, d.options.class_name))
   if actual != decorations {
-    fail(
-      "Line decorations: got \{to_repr(actual)}, expected \{to_repr(decorations)}",
-    )
+    fail("Line decorations: got \{Repr(actual)}, expected \{Repr(decorations)}")
   }
 }
 
@@ -383,7 +381,7 @@ fn assert_range_opt_eq(
   expected : @base_common.Range?,
 ) -> Unit raise {
   if actual != expected {
-    fail("got \{to_repr(actual)}, expected \{to_repr(expected)}")
+    fail("got \{Repr(actual)}, expected \{Repr(expected)}")
   }
 }
 
@@ -393,7 +391,7 @@ fn assert_delta_rows_eq(
   expected : Array[(String, @base_common.Range)],
 ) -> Unit raise {
   if actual != expected {
-    fail("got \{to_repr(actual)}, expected \{to_repr(expected)}")
+    fail("got \{Repr(actual)}, expected \{Repr(expected)}")
   }
 }
 
@@ -608,7 +606,7 @@ test "issue #16922: Clicking on link doesn't seem to do anything" {
   let in_range_class_names = in_range.map(d => d.options.class_name)
   in_range_class_names.sort()
   if in_range_class_names != ["x1", "x2", "x3", "x4"] {
-    fail("got \{to_repr(in_range_class_names)}")
+    fail("got \{Repr(in_range_class_names)}")
   }
 }
 

--- a/editor/viewer/common/model/text_model.mbt
+++ b/editor/viewer/common/model/text_model.mbt
@@ -57,7 +57,7 @@ pub struct TextModel {
 
 ///|
 pub impl Debug for TextModel with fn to_repr(self) {
-  to_repr(
+  Repr(
     "<TextModel \{self.uri.to_string()} v\{self.version} decorations: \{self.decorations.length()}>",
   )
 }

--- a/editor/viewer/common/model/text_model_decorations_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_decorations_wbtest.mbt
@@ -43,7 +43,7 @@ fn assert_names_eq(
   expected : Array[String],
 ) -> Unit raise {
   if actual != expected {
-    fail("got \{to_repr(actual)}, expected \{to_repr(expected)}")
+    fail("got \{Repr(actual)}, expected \{Repr(expected)}")
   }
 }
 
@@ -53,7 +53,7 @@ fn assert_range_opt_eq(
   expected : @base_common.Range?,
 ) -> Unit raise {
   if actual != expected {
-    fail("got \{to_repr(actual)}, expected \{to_repr(expected)}")
+    fail("got \{Repr(actual)}, expected \{Repr(expected)}")
   }
 }
 

--- a/editor/viewer/common/model/text_model_tokens.mbt
+++ b/editor/viewer/common/model/text_model_tokens.mbt
@@ -462,7 +462,7 @@ fn TokenizerWithStateStoreAndTextModel::guess_start_state(
     None =>
       self.base.tokenization_support.initial_state() catch {
         error => {
-          (self.model_state.report_unexpected_error)("\{to_repr(error)}")
+          (self.model_state.report_unexpected_error)("\{Repr(error)}")
           self.base.initial_state_value
         }
       }
@@ -544,7 +544,7 @@ fn safe_tokenize(
   match support {
     Some(tokenization_support) =>
       try tokenization_support.tokenize(text, has_eol, state) catch {
-        error => (model_state.report_unexpected_error)("\{to_repr(error)}")
+        error => (model_state.report_unexpected_error)("\{Repr(error)}")
       } noraise {
         value => result = Some(value)
       }

--- a/editor/viewer/common/model/text_model_tokens_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokens_wbtest.mbt
@@ -39,7 +39,7 @@ fn logging_support(
       TokenizerState("initial")
     },
     tokenize_encoded=(text, has_eol, state) => {
-      calls.push("\{text}:\{has_eol}:\{to_repr(state)}")
+      calls.push("\{text}:\{has_eol}:\{Repr(state)}")
       { tokens: [0, tag_to_metadata(Plain)], end_state: TokenizerState(text) }
     },
   )

--- a/editor/viewer/common/model/tokenizer_syntax_token_backend.mbt
+++ b/editor/viewer/common/model/tokenizer_syntax_token_backend.mbt
@@ -147,8 +147,7 @@ fn TokenizerSyntaxTokenBackend::reset_tokenization(
     match (self.resolve_support)(self.model_state.language_id) {
       Some(candidate) =>
         try candidate.initial_state() catch {
-          error =>
-            (self.model_state.report_unexpected_error)("\{to_repr(error)}")
+          error => (self.model_state.report_unexpected_error)("\{Repr(error)}")
         } noraise {
           _ => support = Some(candidate)
         }
@@ -166,7 +165,7 @@ fn TokenizerSyntaxTokenBackend::reset_tokenization(
         )
       catch {
         error => {
-          (self.model_state.report_unexpected_error)("\{to_repr(error)}")
+          (self.model_state.report_unexpected_error)("\{Repr(error)}")
           None
         }
       } noraise {

--- a/editor/viewer/test_viewer_wbtest.mbt
+++ b/editor/viewer/test_viewer_wbtest.mbt
@@ -518,7 +518,7 @@ test "decoration queries are scoped by editor id like Monaco" {
   )
   let names = viewer.get_line_decorations(1).map(d => d.options.class_name)
   if names != ["model-level"] {
-    fail("got \{to_repr(names)}")
+    fail("got \{Repr(names)}")
   }
 }
 

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -1194,9 +1194,9 @@ fn g(
   let _ : Int = required
   let _ : Int? = optional
   let _ : Int = optional_with_default
-  // `to_repr` (from the prelude `Debug` trait) renders Option via the
+  // `Repr(x)` (from the prelude `Debug` trait) renders Option via the
   // non-deprecated `Show for Repr`, avoiding the deprecated `Show for Option`.
-  "\{positional},\{required},\{to_repr(optional)},\{optional_with_default}"
+  "\{positional},\{required},\{Repr(optional)},\{optional_with_default}"
 }
 
 ///|
@@ -1213,7 +1213,7 @@ Callers still must pass it (as `None`/`Some(...)`).
 ```mbt check
 ///|
 fn with_config(a : Int?, b : Int?, c : Int) -> String {
-  "\{to_repr(a)},\{to_repr(b)},\{c}"
+  "\{Repr(a)},\{Repr(b)},\{c}"
 }
 
 ///|

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -1191,9 +1191,9 @@ fn base_prompt() -> String {
     #|  let _ : Int = required
     #|  let _ : Int? = optional
     #|  let _ : Int = optional_with_default
-    #|  // `to_repr` (from the prelude `Debug` trait) renders Option via the
+    #|  // `Repr(x)` (from the prelude `Debug` trait) renders Option via the
     #|  // non-deprecated `Show for Repr`, avoiding the deprecated `Show for Option`.
-    #|  "\{positional},\{required},\{to_repr(optional)},\{optional_with_default}"
+    #|  "\{positional},\{required},\{Repr(optional)},\{optional_with_default}"
     #|}
     #|
     #|///|
@@ -1210,7 +1210,7 @@ fn base_prompt() -> String {
     #|```mbt check
     #|///|
     #|fn with_config(a : Int?, b : Int?, c : Int) -> String {
-    #|  "\{to_repr(a)},\{to_repr(b)},\{c}"
+    #|  "\{Repr(a)},\{Repr(b)},\{c}"
     #|}
     #|
     #|///|


### PR DESCRIPTION
## Summary
- `moon check --target native/js --deny-warn` (this repo's CI gate) currently fails on 151 deprecation warnings from a current stable toolchain: `to_repr(x)` → `Repr(x)`, `Map::default()` → `Default::default()`, and one `session.events().to_json()` → `@json.to_json(session.events())` migration in `agent_session/json.mbt`.
- Fixes every site across the workspace (mechanical renames, no behavior change). Also drops a couple of now-redundant `@debug.` qualifiers that the `to_repr` → `Repr` rename exposed as `unnecessary_annotation` warnings.
- Bumps the `desktop/lepus` submodule to moonbit-community/proton#64 (`fix/deprecated-to-repr`), which carries the matching fix for the warnings that only show up from proton's own workspace (`cli/*`, not visible from this repo's `moon.work`). That PR is still running CI; will re-point at proton's `main` once it merges.

## Test plan
- [x] `moon check --target native --deny-warn` clean
- [x] `moon check --target js --deny-warn` clean
- [x] `moon fmt --check` clean
- [x] `moon info` shows no `.mbti` diff
- [x] `moon test --target native` — 2763 passed, 0 failed
- [x] `moon test --target js` — 2115 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)