### PR TITLE
feat(shell): trust recoverable git worktree verbs in the source-write sandbox

### DIFF
--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -75,6 +75,43 @@ pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
 }
 
 ///|
+/// Whether a `git worktree` invocation (args in `words[start..end)`, starting at
+/// the verb) is a recoverable write. `add` qualifies with any flags: git
+/// unconditionally refuses an existing non-empty (or file) target — `--force`
+/// only relaxes the branch-checked-out-elsewhere and registered-but-missing-path
+/// safeguards — so it only creates new paths whose content comes from the object
+/// store, and a `-B` branch reset is reflog-recoverable like trusted `reset`.
+/// `remove` qualifies only without force: git then refuses a worktree containing
+/// modified or untracked files, so everything deleted is tracked and clean
+/// (ignored files go silently — the same exposure as trusted `checkout`).
+/// `prune` touches only `$GIT_DIR/worktrees` admin data. Everything else fails
+/// closed: `list` is read-only and runs fine sandboxed, `move` relocates
+/// arbitrary worktree bytes like the excluded `mv`.
+pub fn worktree_args_are_recoverable(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  guard start < end else { return false }
+  match words[start] {
+    "add" | "prune" => true
+    "remove" => {
+      for index in (start + 1)..<end {
+        let arg = words[index]
+        // `--force`, or `-f` possibly clustered (`-ff`). A path named `-f`
+        // after `--` also matches — a conservative false positive that only
+        // drops the command back into the sandbox.
+        if arg == "--force" || short_cluster_has(arg, "f") {
+          return false
+        }
+      }
+      true
+    }
+    _ => false
+  }
+}
+
+///|
 /// Whether a git invocation must be pre-blocked before execution — the
 /// cross-platform guard that does not depend on the runtime sandbox. Conservative
 /// by design: block the git that mutates source but is NOT a recoverable

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -81,12 +81,16 @@ pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
 /// only relaxes the branch-checked-out-elsewhere and registered-but-missing-path
 /// safeguards — so it only creates new paths whose content comes from the object
 /// store, and a `-B` branch reset is reflog-recoverable like trusted `reset`.
-/// `remove` qualifies only without force: git then refuses a worktree containing
+/// `remove` qualifies only bare: git then refuses a worktree containing
 /// modified or untracked files, so everything deleted is tracked and clean
 /// (ignored files go silently — the same exposure as trusted `checkout`).
-/// `prune` touches only `$GIT_DIR/worktrees` admin data. Everything else fails
-/// closed: `list` is read-only and runs fine sandboxed, `move` relocates
-/// arbitrary worktree bytes like the excluded `mv`.
+/// Any option before `--` fails closed, not just `-f`/`--force`: git's option
+/// parser accepts unambiguous long-option abbreviations, so `--fo` forces the
+/// removal too (empirically, git 2.51 destroys a dirty worktree on
+/// `remove --fo`). After `--` every word is a path, so a worktree literally
+/// named `-f` stays removable. `prune` touches only `$GIT_DIR/worktrees` admin
+/// data. Everything else fails closed: `list` is read-only and runs fine
+/// sandboxed, `move` relocates arbitrary worktree bytes like the excluded `mv`.
 pub fn worktree_args_are_recoverable(
   words : Array[String],
   start : Int,
@@ -98,10 +102,10 @@ pub fn worktree_args_are_recoverable(
     "remove" => {
       for index in (start + 1)..<end {
         let arg = words[index]
-        // `--force`, or `-f` possibly clustered (`-ff`). A path named `-f`
-        // after `--` also matches — a conservative false positive that only
-        // drops the command back into the sandbox.
-        if arg == "--force" || short_cluster_has(arg, "f") {
+        if arg == "--" {
+          break
+        }
+        if arg.has_prefix("-") {
           return false
         }
       }

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -107,3 +107,32 @@ test "text_should_preblock mirrors should_preblock on a flat word list" {
   let help = ["git", "apply", "--help"]
   assert_false(@git_policy.text_should_preblock(help, 1, help.length()))
 }
+
+///|
+test "worktree args: add and prune recoverable, remove only without force" {
+  fn recoverable(args : Array[String]) -> Bool {
+    @git_policy.worktree_args_are_recoverable(args, 0, args.length())
+  }
+
+  // `add` in any form: git itself refuses an existing non-empty target, force
+  // included, so nothing existing can be clobbered.
+  assert_true(recoverable(["add", "../wt"]))
+  assert_true(recoverable(["add", "--force", "../wt"]))
+  assert_true(recoverable(["add", "-b", "feat", "../wt", "HEAD"]))
+  assert_true(recoverable(["add", "--detach", "../wt"]))
+  // `remove` without force deletes only tracked, clean content.
+  assert_true(recoverable(["remove", "../wt"]))
+  assert_true(recoverable(["remove", "--", "../wt"]))
+  assert_true(recoverable(["prune"]))
+  assert_true(recoverable(["prune", "-n", "--expire", "1.day"]))
+  // Force remove permanently deletes modified or untracked files.
+  assert_false(recoverable(["remove", "--force", "../wt"]))
+  assert_false(recoverable(["remove", "-f", "../wt"]))
+  assert_false(recoverable(["remove", "-ff", "../wt"]))
+  // Everything else fails closed, including a missing verb.
+  assert_false(recoverable(["list"]))
+  assert_false(recoverable(["lock", "../wt"]))
+  assert_false(recoverable(["move", "../wt", "../wt2"]))
+  assert_false(recoverable(["repair"]))
+  assert_false(recoverable([]))
+}

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -125,10 +125,17 @@ test "worktree args: add and prune recoverable, remove only without force" {
   assert_true(recoverable(["remove", "--", "../wt"]))
   assert_true(recoverable(["prune"]))
   assert_true(recoverable(["prune", "-n", "--expire", "1.day"]))
-  // Force remove permanently deletes modified or untracked files.
+  // Force remove permanently deletes modified or untracked files. Any option
+  // fails closed: git accepts unambiguous long-option abbreviations, so
+  // `--fo`/`--for` force the removal too.
   assert_false(recoverable(["remove", "--force", "../wt"]))
   assert_false(recoverable(["remove", "-f", "../wt"]))
   assert_false(recoverable(["remove", "-ff", "../wt"]))
+  assert_false(recoverable(["remove", "--fo", "../wt"]))
+  assert_false(recoverable(["remove", "--quiet", "../wt"]))
+  // After `--` every word is a path: a worktree named `-f` is a plain,
+  // non-force removal.
+  assert_true(recoverable(["remove", "--", "-f"]))
   // Everything else fails closed, including a missing verb.
   assert_false(recoverable(["list"]))
   assert_false(recoverable(["lock", "../wt"]))

--- a/agent_tool/shell/internal/git_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/git_policy/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub fn text_invocation_writes_from_object_store(Array[String], Int, Int) -> Bool
 
 pub fn text_should_preblock(Array[String], Int, Int) -> Bool
 
+pub fn worktree_args_are_recoverable(Array[String], Int, Int) -> Bool
+
 // Errors
 
 // Types and methods

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -199,7 +199,9 @@ fn trusted_command_class(
 
 ///|
 /// Classify a `git` command for the trusted-source-write path. Trust is granted
-/// only to the recoverable worktree subcommands above, and only when the
+/// only to the recoverable worktree subcommands above plus the recoverable
+/// `git worktree` verbs (`add`/non-force `remove`/`prune`, see
+/// `@git_policy.worktree_args_are_recoverable`), and only when the
 /// invocation cannot reconfigure git to write from somewhere other than the
 /// workspace repo's object store: a custom environment (`GIT_CONFIG_*`,
 /// `env ... git`) or a relocating global option could repoint config (enabling a
@@ -222,6 +224,13 @@ fn trusted_git_command_class(
     }
   }
   if @git_policy.subcommand_writes_from_object_store(invocation.subcommand) {
+    TrustedCommandWrite
+  } else if invocation.subcommand == "worktree" &&
+    @git_policy.worktree_args_are_recoverable(
+      command.argv,
+      invocation.subcommand_index + 1,
+      command.argv.length(),
+    ) {
     TrustedCommandWrite
   } else {
     UntrustedCommand

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1384,7 +1384,8 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
   for
     cmd in [
       "git worktree add ../wt", "git worktree add --force ../wt", "git worktree add -b feat ../wt HEAD",
-      "git worktree remove ../wt", "git worktree prune",
+      "git worktree add .worktrees/feature-x -b feature-x", "git worktree remove ../wt",
+      "git worktree remove .worktrees/feature-x", "git worktree prune",
     ] {
     assert_true(mode_for(cmd) is TrustedSourceWrite)
   }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1393,8 +1393,8 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
   // reconfigured or custom-environment invocation is demoted like any git.
   for
     cmd in [
-      "git worktree remove --force ../wt", "git worktree remove -f ../wt", "git worktree list",
-      "git worktree move ../wt ../wt2", "git worktree", "git -C /tmp/x worktree add ../wt",
+      "git worktree remove --force ../wt", "git worktree remove -f ../wt", "git worktree remove --fo ../wt",
+      "git worktree list", "git worktree move ../wt ../wt2", "git worktree", "git -C /tmp/x worktree add ../wt",
       "GIT_DIR=/tmp/x git worktree add ../wt",
     ] {
     assert_true(mode_for(cmd) is SourceReadOnly)

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -611,6 +611,7 @@ async test "sandbox preblocks common source-writing commands" {
         "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
         "git restore main.mbt", "git reset --hard", "git rm main.mbt", "git stash",
         "git clean -fdn", "git status", "git apply --check patch.diff", "git apply --stat patch.diff",
+        "git worktree add ../wt", "git worktree remove ../wt",
       ] {
       assert_true(
         tree_target(recoverable_git, real_root, Some(real_root)) is None,
@@ -1374,6 +1375,28 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
   }
   // Unknown / plumbing / read-only git is not granted trust (fail closed).
   for cmd in ["git status", "git diff", "git checkout-index -a", "git co -- ."] {
+    assert_true(mode_for(cmd) is SourceReadOnly)
+  }
+  // The recoverable `git worktree` verbs are trusted: `add` only creates new
+  // paths (git refuses an existing non-empty target, force included) filled
+  // from the object store, non-force `remove` deletes only tracked clean
+  // content, and `prune` touches only `$GIT_DIR/worktrees` admin data.
+  for
+    cmd in [
+      "git worktree add ../wt", "git worktree add --force ../wt", "git worktree add -b feat ../wt HEAD",
+      "git worktree remove ../wt", "git worktree prune",
+    ] {
+    assert_true(mode_for(cmd) is TrustedSourceWrite)
+  }
+  // Force remove permanently deletes modified or untracked files; the other
+  // verbs (read-only `list`, byte-moving `move`, ...) fail closed, and a
+  // reconfigured or custom-environment invocation is demoted like any git.
+  for
+    cmd in [
+      "git worktree remove --force ../wt", "git worktree remove -f ../wt", "git worktree list",
+      "git worktree move ../wt ../wt2", "git worktree", "git -C /tmp/x worktree add ../wt",
+      "GIT_DIR=/tmp/x git worktree add ../wt",
+    ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -1749,6 +1749,81 @@ async test "shell allows recoverable git worktree rollback" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "shell allows trusted git worktree add and remove" {
+  @vfs.with_tmpdir(prefix="openseek-shell-git-worktree-", dir => {
+    write_answer_main(dir)
+    let setup_output = run_shell_in_workspace(dir, {
+      "cmd": "git init -q && git config user.email a@b.c && git config user.name t && git add main.mbt && git commit -q -m init",
+      "cwd": dir,
+    })
+    assert_false(setup_output.is_error)
+    // `git worktree add` materializes a fresh checkout from the object store
+    // into a new directory — a trusted source write that runs unsandboxed.
+    let add_output = run_shell_in_workspace(dir, {
+      "cmd": "git worktree add wt -b scratch",
+      "cwd": dir,
+    })
+    assert_false(add_output.is_error)
+    assert_true(add_output.content.contains("<system>exit=0</system>"))
+    assert_answer_main_unchanged("\{dir}/wt")
+    // Removing the clean worktree deletes only tracked, committed content.
+    let remove_output = run_shell_in_workspace(dir, {
+      "cmd": "git worktree remove wt",
+      "cwd": dir,
+    })
+    assert_false(remove_output.is_error)
+    assert_true(remove_output.content.contains("<system>exit=0</system>"))
+    assert_false(@fs.exists("\{dir}/wt"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "shell sandboxes forced git worktree remove" {
+  if !sandbox_exec_usable_for_test() {
+    return
+  }
+  @vfs.with_tmpdir(prefix="openseek-shell-git-worktree-force-", dir => {
+    write_answer_main(dir)
+    let setup_output = run_shell_in_workspace(dir, {
+      "cmd": "git init -q && git config user.email a@b.c && git config user.name t && git add main.mbt && git commit -q -m init",
+      "cwd": dir,
+    })
+    assert_false(setup_output.is_error)
+    // Run the add alone: chained with the sandboxed setup commands above it
+    // would not be granted trust, and here it must actually succeed.
+    let add_output = run_shell_in_workspace(dir, {
+      "cmd": "git worktree add wt -b scratch",
+      "cwd": dir,
+    })
+    assert_true(add_output.content.contains("<system>exit=0</system>"))
+    // An untracked SOURCE file: force remove would permanently delete it, so
+    // the command is not trusted and runs sandboxed, where deleting a source
+    // file is kernel-denied. (Non-source untracked files are not the sandbox's
+    // contract — any sandboxed command may delete those, before or after the
+    // denial fires, so only the source file's survival is deterministic.)
+    @fs.write_file(
+      "\{dir}/wt/extra.mbt",
+      "pub fn extra() -> Int { 7 }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let force_output = run_shell_in_workspace(dir, {
+      "cmd": "git worktree remove --force wt",
+      "cwd": dir,
+    })
+    assert_false(force_output.content.contains("<system>exit=0</system>"))
+    assert_true(
+      force_output.content.contains("source file writes from shell are blocked"),
+    )
+    assert_eq(
+      @fs.read_file("\{dir}/wt/extra.mbt").text(),
+      "pub fn extra() -> Int { 7 }\n",
+    )
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "shell allows trusted moon fmt command" {
   if !sandbox_exec_usable_for_test() {
     return

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -71,9 +71,11 @@ full diagnostics.
   - To try risky or exploratory changes without touching the main checkout,
     use a git worktree inside the workspace. Once per repository, keep the
     parent checkout clean by ignoring the worktree area locally:
-    `grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude`
-    (never stage `.worktrees/` — without the exclude, `git add .` would stage
-    the nested checkout as a gitlink). Then
+    `x=$(git rev-parse --git-path info/exclude) && { grep -qxF '.worktrees/' "$x" 2>/dev/null || echo '.worktrees/' >> "$x"; }`
+    (`--git-path` resolves the exclude file even where `.git` is a file, as
+    in linked worktrees and submodules; never stage `.worktrees/` — without
+    the exclude, `git add .` would stage the nested checkout as a gitlink).
+    Then
     `git worktree add .worktrees/feature-x -b feature-x`, work on the branch
     there, and `git worktree remove .worktrees/feature-x` when done
     (`git worktree prune` cleans stale bookkeeping). Issue each worktree

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -68,6 +68,17 @@ full diagnostics.
     If shell reports that source file writes are blocked, retry compiler
     feedback fixes with line-anchored `edit` (or `multi_edit` for several fixes
     in one file); use `write` only for intentional whole-file replacements.
+  - To try risky or exploratory changes without touching the main checkout,
+    use a git worktree inside the workspace:
+    `git worktree add .worktrees/feature-x -b feature-x`, work on the branch
+    there, and `git worktree remove .worktrees/feature-x` when done
+    (`git worktree prune` cleans stale bookkeeping). Issue each of these as
+    its own shell command, not chained with other commands — only the
+    standalone form is allowed. `add`, non-force `remove`, and `prune` are
+    allowed; `remove --force` is not — commit or discard the worktree's
+    changes with git first, then remove it. Keep worktree paths under
+    `.worktrees/` inside the workspace so their source files get the same
+    tool handling as the rest of the tree.
   - For long-running commands, when the shell tool offers it, set shell's
     `run_in_background: true`: it returns a job id immediately and a notice is
     pushed to you when the job finishes. Never wait with `sleep N && cmd` or by

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -69,13 +69,17 @@ full diagnostics.
     feedback fixes with line-anchored `edit` (or `multi_edit` for several fixes
     in one file); use `write` only for intentional whole-file replacements.
   - To try risky or exploratory changes without touching the main checkout,
-    use a git worktree inside the workspace:
+    use a git worktree inside the workspace. Once per repository, keep the
+    parent checkout clean by ignoring the worktree area locally:
+    `grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude`
+    (never stage `.worktrees/` — without the exclude, `git add .` would stage
+    the nested checkout as a gitlink). Then
     `git worktree add .worktrees/feature-x -b feature-x`, work on the branch
     there, and `git worktree remove .worktrees/feature-x` when done
-    (`git worktree prune` cleans stale bookkeeping). Issue each of these as
-    its own shell command, not chained with other commands — only the
-    standalone form is allowed. `add`, non-force `remove`, and `prune` are
-    allowed; `remove --force` is not — commit or discard the worktree's
+    (`git worktree prune` cleans stale bookkeeping). Issue each worktree
+    command as its own shell command, not chained with other commands — only
+    the standalone form is allowed. `add`, non-force `remove`, and `prune`
+    are allowed; `remove --force` is not — commit or discard the worktree's
     changes with git first, then remove it. Keep worktree paths under
     `.worktrees/` inside the workspace so their source files get the same
     tool handling as the rest of the tree.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -74,13 +74,17 @@ fn default_prompt() -> String {
     #|    feedback fixes with line-anchored `edit` (or `multi_edit` for several fixes
     #|    in one file); use `write` only for intentional whole-file replacements.
     #|  - To try risky or exploratory changes without touching the main checkout,
-    #|    use a git worktree inside the workspace:
+    #|    use a git worktree inside the workspace. Once per repository, keep the
+    #|    parent checkout clean by ignoring the worktree area locally:
+    #|    `grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude`
+    #|    (never stage `.worktrees/` — without the exclude, `git add .` would stage
+    #|    the nested checkout as a gitlink). Then
     #|    `git worktree add .worktrees/feature-x -b feature-x`, work on the branch
     #|    there, and `git worktree remove .worktrees/feature-x` when done
-    #|    (`git worktree prune` cleans stale bookkeeping). Issue each of these as
-    #|    its own shell command, not chained with other commands — only the
-    #|    standalone form is allowed. `add`, non-force `remove`, and `prune` are
-    #|    allowed; `remove --force` is not — commit or discard the worktree's
+    #|    (`git worktree prune` cleans stale bookkeeping). Issue each worktree
+    #|    command as its own shell command, not chained with other commands — only
+    #|    the standalone form is allowed. `add`, non-force `remove`, and `prune`
+    #|    are allowed; `remove --force` is not — commit or discard the worktree's
     #|    changes with git first, then remove it. Keep worktree paths under
     #|    `.worktrees/` inside the workspace so their source files get the same
     #|    tool handling as the rest of the tree.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -73,6 +73,17 @@ fn default_prompt() -> String {
     #|    If shell reports that source file writes are blocked, retry compiler
     #|    feedback fixes with line-anchored `edit` (or `multi_edit` for several fixes
     #|    in one file); use `write` only for intentional whole-file replacements.
+    #|  - To try risky or exploratory changes without touching the main checkout,
+    #|    use a git worktree inside the workspace:
+    #|    `git worktree add .worktrees/feature-x -b feature-x`, work on the branch
+    #|    there, and `git worktree remove .worktrees/feature-x` when done
+    #|    (`git worktree prune` cleans stale bookkeeping). Issue each of these as
+    #|    its own shell command, not chained with other commands — only the
+    #|    standalone form is allowed. `add`, non-force `remove`, and `prune` are
+    #|    allowed; `remove --force` is not — commit or discard the worktree's
+    #|    changes with git first, then remove it. Keep worktree paths under
+    #|    `.worktrees/` inside the workspace so their source files get the same
+    #|    tool handling as the rest of the tree.
     #|  - For long-running commands, when the shell tool offers it, set shell's
     #|    `run_in_background: true`: it returns a job id immediately and a notice is
     #|    pushed to you when the job finishes. Never wait with `sleep N && cmd` or by

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -76,9 +76,11 @@ fn default_prompt() -> String {
     #|  - To try risky or exploratory changes without touching the main checkout,
     #|    use a git worktree inside the workspace. Once per repository, keep the
     #|    parent checkout clean by ignoring the worktree area locally:
-    #|    `grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude`
-    #|    (never stage `.worktrees/` — without the exclude, `git add .` would stage
-    #|    the nested checkout as a gitlink). Then
+    #|    `x=$(git rev-parse --git-path info/exclude) && { grep -qxF '.worktrees/' "$x" 2>/dev/null || echo '.worktrees/' >> "$x"; }`
+    #|    (`--git-path` resolves the exclude file even where `.git` is a file, as
+    #|    in linked worktrees and submodules; never stage `.worktrees/` — without
+    #|    the exclude, `git add .` would stage the nested checkout as a gitlink).
+    #|    Then
     #|    `git worktree add .worktrees/feature-x -b feature-x`, work on the branch
     #|    there, and `git worktree remove .worktrees/feature-x` when done
     #|    (`git worktree prune` cleans stale bookkeeping). Issue each worktree


### PR DESCRIPTION
## What

The shell sandbox was too restrictive for worktree workflows: `git worktree add` fell into the source-write sandbox, where materializing the new checkout is kernel-denied. This PR classifies the recoverable `git worktree` verbs as trusted source writes:

- **`add` (any flags)** — git *unconditionally* refuses an existing non-empty (or file) target; `--force` only relaxes the branch-checked-out-elsewhere and registered-but-missing-path safeguards (verified empirically on git 2.51, including `--force --force`). So `add` only creates new paths whose content comes from the object store. A `-B` branch reset is reflog-recoverable, same as already-trusted `git reset`.
- **`remove` without force** — git refuses a worktree containing modified or untracked files, so everything deleted is tracked and clean. (Ignored files go silently — the same exposure as trusted `checkout`.)
- **`prune`** — touches only `$GIT_DIR/worktrees` admin data.

Everything else fails closed: force `remove` stays sandboxed, `list` is read-only and runs fine sandboxed, `move` relocates arbitrary worktree bytes like the excluded `mv`. The existing gates keep applying: custom environments and reconfiguring global options demote the command, and scratch-lab children remain force-sandboxed.

No preblock changes: unlike custom-env `checkout`, a repointed `worktree add` still cannot overwrite existing source (the non-empty refusal holds regardless of which repo it runs from).

## Tests

- `git_policy` unit tests for the new `worktree_args_are_recoverable` classifier.
- `sandbox_wbtest` classification cases (trusted verbs, force-remove/reconfigured/custom-env demotions, not-preblocked).
- Two e2e tests, written first and confirmed failing pre-change (negative control):
  - add → verify checkout → remove happy path runs unsandboxed and succeeds;
  - forced remove of a dirty worktree runs sandboxed: exit≠0, denial feedback present, and an untracked **source** file survives. The test deliberately pins only source survival — under a partial denial git deletes what it can first, and non-source untracked files are deletable by any sandboxed command anyway; their deletion order is filesystem-dependent (observed flaking on APFS before this was pinned down).
- Full `agent_tool/shell` suite: 123/123 in a fresh worktree (the 5 output-limit failures in the long-lived main checkout are the known pre-existing local flake, also failing there on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)