### PR TITLE
feat(agent_tool): WriteScope containment for the file tools

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -44,6 +44,7 @@
 pub fn definition(
   workspace_root? : String = ".",
   file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="edit",
@@ -113,7 +114,12 @@ pub fn definition(
       "required": ["path", "old_string", "new_string", "start_line"],
     }),
     execute=Async(arguments => {
-      execute_with_workspace(workspace_root, file_state, arguments)
+      execute_with_workspace(
+        workspace_root,
+        file_state,
+        arguments,
+        write_scope?,
+      )
     }),
   )
 }
@@ -123,6 +129,7 @@ async fn execute_with_workspace(
   workspace_root : String,
   file_state : @agent_tool.FileStateMap,
   arguments : Json,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -134,7 +141,19 @@ async fn execute_with_workspace(
     }
   }
   let path = @workspace_path.resolve(workspace_root, input.path)
-  edit_file(input, path~, file_state~)
+  // Containment gate for confined (worker) registries. Previews write
+  // nothing, so they stay readable everywhere; the write itself is gated
+  // again in commit_edit, immediately before the file is touched.
+  if !input.replace_all_preview &&
+    write_scope is Some(scope) &&
+    scope.deny_reason(path) is Some(reason) {
+    return @agent_tool.ToolAction::respond(
+      "error editing \{path}: write blocked: \{reason}",
+      is_error=true,
+      brief="edit \{@agent_tool.brief_basename(path)}",
+    )
+  }
+  edit_file(input, path~, file_state~, write_scope?)
 }
 
 ///|
@@ -142,6 +161,7 @@ async fn edit_file(
   input : @decode.EditInput,
   path~ : String,
   file_state~ : @agent_tool.FileStateMap,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   // Every failure names the file it tried to edit so the viz can show
   // `→ edit · edit <file> 🚩` on the folded call line.
@@ -213,6 +233,7 @@ async fn edit_file(
       summary~,
       ok_brief~,
       file_state~,
+      write_scope?,
     )
   }
   let region = select_edit_region(content, input)
@@ -235,6 +256,7 @@ async fn edit_file(
     summary="ok: replaced 1 occurrence(s) at line \{match_line} in \{path}",
     ok_brief="edited \{@agent_tool.brief_basename(path)}:\{match_line} (1×)",
     file_state~,
+    write_scope?,
   )
 }
 
@@ -616,6 +638,7 @@ async fn commit_edit(
   summary~ : String,
   ok_brief~ : String,
   file_state~ : @agent_tool.FileStateMap,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   if @manifest_error.write_error(path, new_content) is Some(message) {
     return @agent_tool.ToolAction::respond(
@@ -632,6 +655,16 @@ async fn commit_edit(
     )
     is Some(rejection) {
     return rejection
+  }
+  // Containment re-check at the moment of writing: the early gate decided on
+  // filesystem state that awaits ago may have changed (a path component
+  // re-linked underneath the tool).
+  if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
+    return @agent_tool.ToolAction::respond(
+      "error editing \{path}: write blocked: \{reason}",
+      is_error=true,
+      brief=fail_brief,
+    )
   }
   @fs.write_file(path, new_content, create_mode=CreateOrTruncate)
   // A targeted edit preserves most of the file, so provenance depends on

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -1097,3 +1097,58 @@ async test "the expansion estimate does not overflow 32-bit arithmetic" {
     assert_true(preview.content.contains("omitted to keep the array parseable"))
   })
 }
+
+///|
+async test "a write scope confines edit to its allowed paths" {
+  @vfs.with_tmpdir(prefix="edit-scope-", dir => {
+    @vfs.FileSystem({
+      "lib/a.mbt": "pub fn f() -> Int { 1 }\n",
+      "other/b.txt": "hello\n",
+    }).write_to(dir)
+    guard @write_scope.WriteScope::create(root=dir, allowed_paths=["lib"])
+      is Ok(scope) else {
+      fail("expected the scope to build")
+    }
+    let run = match
+      @edit.definition(workspace_root=dir, write_scope=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("edit tool should be async")
+    }
+    guard run({
+        "path": "lib/a.mbt",
+        "old_string": "1",
+        "new_string": "2",
+        "start_line": 1,
+      })
+      is Respond(admitted) else {
+      fail("expected Respond")
+    }
+    assert_false(admitted.is_error)
+    guard run({
+        "path": "other/b.txt",
+        "old_string": "hello",
+        "new_string": "bye",
+        "start_line": 1,
+      })
+      is Respond(blocked) else {
+      fail("expected Respond")
+    }
+    assert_true(blocked.is_error)
+    assert_true(blocked.content.contains("write blocked"))
+    assert_true(@fs.read_file("\{dir}/other/b.txt").text() == "hello\n")
+    // An in-scope link to an out-of-scope file is denied on its resolution.
+    @fs.symlink(target="\{dir}/other/b.txt", "\{dir}/lib/link.txt")
+    guard run({
+        "path": "lib/link.txt",
+        "old_string": "hello",
+        "new_string": "bye",
+        "start_line": 1,
+      })
+      is Respond(via_link) else {
+      fail("expected Respond")
+    }
+    assert_true(via_link.is_error)
+    assert_true(via_link.content.contains("write blocked"))
+    assert_true(@fs.read_file("\{dir}/other/b.txt").text() == "hello\n")
+  })
+}

--- a/agent_tool/edit/moon.pkg
+++ b/agent_tool/edit/moon.pkg
@@ -4,6 +4,7 @@ import {
   "bobzhang/openseek/agent_tool/internal/manifest_error",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/write_scope",
   "bobzhang/openseek/internal/workspace_path",
   "moonbitlang/async",
   "moonbitlang/async/fs",

--- a/agent_tool/edit/pkg.generated.mbti
+++ b/agent_tool/edit/pkg.generated.mbti
@@ -3,10 +3,11 @@ package "bobzhang/openseek/agent_tool/edit"
 
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/internal/write_scope",
 }
 
 // Values
-pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap, write_scope? : @write_scope.WriteScope) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/internal/write_scope/moon.pkg
+++ b/agent_tool/internal/write_scope/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "bobzhang/openseek/internal/workspace_path",
+  "moonbitlang/async/fs",
+  "moonbitlang/x/path",
+}
+
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/internal/write_scope/moon.pkg
+++ b/agent_tool/internal/write_scope/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/internal/workspace_path",
+  "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/x/path",
 }

--- a/agent_tool/internal/write_scope/pkg.generated.mbti
+++ b/agent_tool/internal/write_scope/pkg.generated.mbti
@@ -1,0 +1,21 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/write_scope"
+
+// Values
+
+// Errors
+
+// Types and methods
+pub struct WriteScope {
+  root : String
+  allowed : Array[Array[String]]
+  allowed_display : String
+}
+pub async fn WriteScope::create(root~ : String, allowed_paths? : Array[String]) -> Result[Self, String]
+pub async fn WriteScope::deny_reason(Self, String) -> String?
+pub fn WriteScope::root(Self) -> String
+
+// Type aliases
+
+// Traits
+

--- a/agent_tool/internal/write_scope/write_scope.mbt
+++ b/agent_tool/internal/write_scope/write_scope.mbt
@@ -48,11 +48,7 @@ pub async fn WriteScope::create(
     }
   }
   Ok({
-    // Slash-normalized (Windows realpath returns backslashes) so relative
-    // slicing in `prefix_admits` sees one separator convention.
-    root: @workspace_path.strip_trailing_slash(
-      canonical_root.replace_all(old="\\", new="/"),
-    ),
+    root: @workspace_path.strip_trailing_slash(canonical_root),
     allowed,
     allowed_display: allowed_paths.map(p => p.to_string()).join(", "),
   })
@@ -82,6 +78,16 @@ pub async fn WriteScope::deny_reason(
   self : WriteScope,
   path : String,
 ) -> String? {
+  // On POSIX a backslash is a legal filename byte, but every path helper in
+  // this codebase (and the prefix slicing below) treats it as a separator —
+  // a component literally named `src\x` would resolve as `src/x` and slip
+  // inside an allowed prefix. A confined write has no business targeting
+  // such a name: fail closed instead of normalizing.
+  if backslash_is_hostile(path) {
+    return Some(
+      "path contains a backslash, which this platform treats as a filename byte; confined writes refuse it",
+    )
+  }
   let requested = self.absolutize(path)
   guard resolve_existing_prefix(requested) is Some(resolved) else {
     return Some(
@@ -138,13 +144,17 @@ fn WriteScope::absolutize(self : WriteScope, path : String) -> String {
 /// allowed prefixes, component-wise (`src` never admits `src2`; a path
 /// ABOVE every prefix is not a writable target either).
 fn WriteScope::prefix_admits(self : WriteScope, path : String) -> Bool {
-  // Slash-normalize before slicing: the root is stored normalized, but a
-  // resolved path can arrive backslash-separated on Windows.
-  let path = path.replace_all(old="\\", new="/")
-  let relative = if path == self.root {
+  // Compare on a separator-normalized COPY (the stored root keeps its
+  // canonical realpath spelling): on Windows, realpath returns backslash
+  // separators; on POSIX a backslash is a legal filename byte, so rewriting
+  // it there would let a component literally named `src\x` impersonate
+  // `src/x` inside an allowed prefix.
+  let path = normalize_separators(path)
+  let root = normalize_separators(self.root)
+  let relative = if path == root {
     ""
   } else {
-    path.view(start_offset=self.root.length() + 1).to_owned()
+    path.view(start_offset=root.length() + 1).to_owned()
   }
   let parts = relative.split("/").map(p => p.to_owned()).collect()
   self.allowed.any(prefix => {
@@ -186,6 +196,35 @@ async fn resolve_existing_prefix(path : String) -> String? {
 }
 
 ///|
+/// Path separators for comparison purposes: backslash is a separator only on
+/// Windows; on POSIX it is an ordinary filename byte.
+#cfg(platform="windows")
+fn normalize_separators(path : String) -> String {
+  path.replace_all(old="\\", new="/")
+}
+
+///|
+#cfg(not(platform="windows"))
+fn normalize_separators(path : String) -> String {
+  path
+}
+
+///|
+/// Whether a backslash in `path` must fail closed: true on POSIX (where it is
+/// a filename byte the surrounding path machinery would still treat as a
+/// separator), false on Windows (where it IS the separator and is normalized).
+#cfg(platform="windows")
+fn backslash_is_hostile(_path : String) -> Bool {
+  false
+}
+
+///|
+#cfg(not(platform="windows"))
+fn backslash_is_hostile(path : String) -> Bool {
+  path.contains("\\")
+}
+
+///|
 async fn path_exists_no_follow(path : String) -> Bool {
   let _ = @fs.kind(path, follow_symlink=false) catch {
     error if @async.is_being_cancelled() => raise error
@@ -200,7 +239,7 @@ async fn path_exists_no_follow(path : String) -> Bool {
 /// git or worktree bookkeeping.
 fn validate_prefix(prefix : String) -> Result[Array[String], String] {
   let normalized = @workspace_path.strip_trailing_slash(
-    prefix.replace_all(old="\\", new="/"),
+    normalize_separators(prefix),
   )
   guard normalized != "" else {
     return Err("allowed_paths entries must be non-empty relative paths")

--- a/agent_tool/internal/write_scope/write_scope.mbt
+++ b/agent_tool/internal/write_scope/write_scope.mbt
@@ -37,6 +37,7 @@ pub async fn WriteScope::create(
   allowed_paths? : Array[String] = [],
 ) -> Result[WriteScope, String] {
   let canonical_root = @fs.realpath(root) catch {
+    error if @async.is_being_cancelled() => raise error
     _ => return Err("write scope root does not resolve: \{root}")
   }
   let allowed : Array[Array[String]] = []
@@ -47,7 +48,11 @@ pub async fn WriteScope::create(
     }
   }
   Ok({
-    root: @workspace_path.strip_trailing_slash(canonical_root),
+    // Slash-normalized (Windows realpath returns backslashes) so relative
+    // slicing in `prefix_admits` sees one separator convention.
+    root: @workspace_path.strip_trailing_slash(
+      canonical_root.replace_all(old="\\", new="/"),
+    ),
     allowed,
     allowed_display: allowed_paths.map(p => p.to_string()).join(", "),
   })
@@ -133,6 +138,9 @@ fn WriteScope::absolutize(self : WriteScope, path : String) -> String {
 /// allowed prefixes, component-wise (`src` never admits `src2`; a path
 /// ABOVE every prefix is not a writable target either).
 fn WriteScope::prefix_admits(self : WriteScope, path : String) -> Bool {
+  // Slash-normalize before slicing: the root is stored normalized, but a
+  // resolved path can arrive backslash-separated on Windows.
+  let path = path.replace_all(old="\\", new="/")
   let relative = if path == self.root {
     ""
   } else {
@@ -169,6 +177,7 @@ async fn resolve_existing_prefix(path : String) -> String? {
   }
   guard path_exists_no_follow(prefix) else { return None }
   let real = @fs.realpath(if suffix.is_empty() { path } else { prefix }) catch {
+    error if @async.is_being_cancelled() => raise error
     _ => return None
   }
   let mut resolved = @workspace_path.strip_trailing_slash(real)
@@ -178,7 +187,10 @@ async fn resolve_existing_prefix(path : String) -> String? {
 
 ///|
 async fn path_exists_no_follow(path : String) -> Bool {
-  let _ = @fs.kind(path, follow_symlink=false) catch { _ => return false }
+  let _ = @fs.kind(path, follow_symlink=false) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
   true
 }
 

--- a/agent_tool/internal/write_scope/write_scope.mbt
+++ b/agent_tool/internal/write_scope/write_scope.mbt
@@ -150,7 +150,11 @@ fn WriteScope::prefix_admits(self : WriteScope, path : String) -> Bool {
   // it there would let a component literally named `src\x` impersonate
   // `src/x` inside an allowed prefix.
   let path = normalize_separators(path)
-  let root = normalize_separators(self.root)
+  // Re-strip after normalizing: a Windows drive/UNC root's realpath ends in
+  // a backslash that `strip_trailing_slash` at create time could not see.
+  let root = @workspace_path.strip_trailing_slash(
+    normalize_separators(self.root),
+  )
   let relative = if path == root {
     ""
   } else {
@@ -238,6 +242,15 @@ async fn path_exists_no_follow(path : String) -> Bool {
 /// slash-normalized, no empty/`.`/`..` components, no NUL, and not rooted at
 /// git or worktree bookkeeping.
 fn validate_prefix(prefix : String) -> Result[Array[String], String] {
+  // On POSIX a backslash-bearing prefix could never authorize anything:
+  // deny_reason fails closed on backslash targets, and a slash-spelled
+  // target cannot match a literal-backslash component. Reject it up front
+  // rather than accept a dead entry. (On Windows it normalizes instead.)
+  guard !backslash_is_hostile(prefix) else {
+    return Err(
+      "allowed_paths entries must not contain backslashes on this platform: \{prefix}",
+    )
+  }
   let normalized = @workspace_path.strip_trailing_slash(
     normalize_separators(prefix),
   )

--- a/agent_tool/internal/write_scope/write_scope.mbt
+++ b/agent_tool/internal/write_scope/write_scope.mbt
@@ -1,0 +1,218 @@
+///|
+/// A write-containment scope for confined file tools (worker subagents).
+///
+/// `deny_reason` decides whether a path may be the target of a write-class
+/// operation (write, edit, remove): the lexically normalized request AND its
+/// symlink-resolved location must both stay under the canonical root, and —
+/// when the scope carries `allowed_paths` — both must fall under one of those
+/// component-wise prefixes. Resolution realpaths the nearest EXISTING ancestor
+/// so a symlinked directory cannot smuggle a write out of the root, and a
+/// dangling symlink (final or ancestor) fails closed.
+///
+/// Callers gate once at path resolution for a good early error, and AGAIN
+/// immediately before each write — including revert/rollback writes: the
+/// recheck narrows the check-to-use window; on macOS the worker sandbox
+/// profile backstops what remains (documented TOCTOU residual elsewhere).
+/// Creating parent directories for an admitted target needs no separate gate:
+/// ancestors of an allowed path are implied, and a symlinked ancestor is
+/// already caught by the resolved-location check on the target itself.
+pub struct WriteScope {
+  /// Canonical (realpath'd) absolute root every write must stay under.
+  root : String
+  /// Component-wise relative prefixes; empty means root-only confinement.
+  allowed : Array[Array[String]]
+  /// Human-readable prefix list for deny messages.
+  allowed_display : String
+}
+
+///|
+/// Build a scope from a root directory and optional relative prefixes.
+///
+/// The root must exist (it is canonicalized with realpath so comparisons match
+/// kernel-resolved paths). Prefixes are validated strictly — relative, no
+/// `..`/`.`/empty components, no NUL, and not rooted at `.git` or
+/// `.worktrees` — because they arrive from a model-facing schema.
+pub async fn WriteScope::create(
+  root~ : String,
+  allowed_paths? : Array[String] = [],
+) -> Result[WriteScope, String] {
+  let canonical_root = @fs.realpath(root) catch {
+    _ => return Err("write scope root does not resolve: \{root}")
+  }
+  let allowed : Array[Array[String]] = []
+  for prefix in allowed_paths {
+    match validate_prefix(prefix) {
+      Ok(parts) => allowed.push(parts)
+      Err(reason) => return Err(reason)
+    }
+  }
+  Ok({
+    root: @workspace_path.strip_trailing_slash(canonical_root),
+    allowed,
+    allowed_display: allowed_paths.map(p => p.to_string()).join(", "),
+  })
+}
+
+///|
+/// The canonical root every admitted write stays under.
+pub fn WriteScope::root(self : WriteScope) -> String {
+  self.root
+}
+
+///|
+/// `None` when `path` may be written; otherwise the reason to report.
+///
+/// Two forms of the path are checked against the root and the allowed
+/// prefixes: the fully RESOLVED location (every symlink followed — what the
+/// kernel will actually write), and the REQUESTED form — the final name as
+/// spelled, below its canonicalized parent chain. The dual check means both
+/// the name the caller addressed and the bytes' destination must be in
+/// scope: a link inside an allowed prefix pointing at an out-of-scope file
+/// fails on the resolved side, and an out-of-scope name aliasing an
+/// in-scope file fails on the requested side. Canonicalizing the parent
+/// chain keeps unresolved root spellings (macOS `/tmp`) working. The
+/// verdict depends on live filesystem state, so callers re-run it
+/// immediately before the actual write.
+pub async fn WriteScope::deny_reason(
+  self : WriteScope,
+  path : String,
+) -> String? {
+  let requested = self.absolutize(path)
+  guard resolve_existing_prefix(requested) is Some(resolved) else {
+    return Some(
+      "path does not resolve to a real location under the writable root (dangling or unreadable symlink)",
+    )
+  }
+  let requested_form = match @workspace_path.parent_dir(requested) {
+    Some(parent) =>
+      match resolve_existing_prefix(parent) {
+        Some(real_parent) =>
+          @workspace_path.join_child(
+            real_parent,
+            @workspace_path.path_basename(requested),
+          )
+        None =>
+          return Some(
+            "path does not resolve to a real location under the writable root (dangling or unreadable symlink)",
+          )
+      }
+    None => resolved
+  }
+  guard @workspace_path.is_under_workspace_root(self.root, resolved) else {
+    return Some(
+      "path resolves outside the writable root \{self.root} (through a symlink or ..)",
+    )
+  }
+  guard @workspace_path.is_under_workspace_root(self.root, requested_form) else {
+    return Some("path is outside the writable root \{self.root}")
+  }
+  if self.allowed.is_empty() {
+    return None
+  }
+  guard self.prefix_admits(requested_form) && self.prefix_admits(resolved) else {
+    return Some("path is outside allowed_paths (\{self.allowed_display})")
+  }
+  None
+}
+
+///|
+/// Join a relative path onto the canonical root and normalize lexically.
+/// Absolute paths only normalize; `..` components collapse here, so the
+/// under-root checks that follow see their real ancestry.
+fn WriteScope::absolutize(self : WriteScope, path : String) -> String {
+  let joined = if @path.Path(path).is_absolute() {
+    path
+  } else {
+    "\{self.root}/\{path}"
+  }
+  @path.Path(joined).normalize().to_string()
+}
+
+///|
+/// Whether the root-relative components of `path` sit under one of the
+/// allowed prefixes, component-wise (`src` never admits `src2`; a path
+/// ABOVE every prefix is not a writable target either).
+fn WriteScope::prefix_admits(self : WriteScope, path : String) -> Bool {
+  let relative = if path == self.root {
+    ""
+  } else {
+    path.view(start_offset=self.root.length() + 1).to_owned()
+  }
+  let parts = relative.split("/").map(p => p.to_owned()).collect()
+  self.allowed.any(prefix => {
+    if parts.length() < prefix.length() {
+      return false
+    }
+    for index in 0..<prefix.length() {
+      if parts[index] != prefix[index] {
+        return false
+      }
+    }
+    true
+  })
+}
+
+///|
+/// Resolve `path` against the filesystem: realpath the deepest existing
+/// ancestor (lstat semantics — an existing final symlink resolves through
+/// realpath of the full path) and re-append the not-yet-existing suffix.
+/// `None` means resolution failed — a dangling symlink somewhere on the
+/// path — and the caller must fail closed.
+async fn resolve_existing_prefix(path : String) -> String? {
+  let suffix : Array[String] = []
+  let mut prefix = path
+  while !path_exists_no_follow(prefix) {
+    guard @workspace_path.parent_dir(prefix) is Some(parent) else { break }
+    guard parent != prefix else { break }
+    suffix.push(@workspace_path.path_basename(prefix))
+    prefix = parent
+  }
+  guard path_exists_no_follow(prefix) else { return None }
+  let real = @fs.realpath(if suffix.is_empty() { path } else { prefix }) catch {
+    _ => return None
+  }
+  let mut resolved = @workspace_path.strip_trailing_slash(real)
+  suffix.rev_each(part => resolved = @workspace_path.join_child(resolved, part))
+  Some(resolved)
+}
+
+///|
+async fn path_exists_no_follow(path : String) -> Bool {
+  let _ = @fs.kind(path, follow_symlink=false) catch { _ => return false }
+  true
+}
+
+///|
+/// Validate one model-supplied prefix into components. Strict: relative,
+/// slash-normalized, no empty/`.`/`..` components, no NUL, and not rooted at
+/// git or worktree bookkeeping.
+fn validate_prefix(prefix : String) -> Result[Array[String], String] {
+  let normalized = @workspace_path.strip_trailing_slash(
+    prefix.replace_all(old="\\", new="/"),
+  )
+  guard normalized != "" else {
+    return Err("allowed_paths entries must be non-empty relative paths")
+  }
+  guard !normalized.contains("\u{0}") else {
+    return Err("allowed_paths entry contains a NUL byte")
+  }
+  guard !@path.Path(normalized).is_absolute() && !normalized.has_prefix("/") else {
+    return Err("allowed_paths entries must be relative, got: \{prefix}")
+  }
+  let parts : Array[String] = []
+  for part in normalized.split("/") {
+    let part = part.to_owned()
+    guard part != "" && part != "." && part != ".." else {
+      return Err(
+        "allowed_paths entries must not contain empty, `.`, or `..` components: \{prefix}",
+      )
+    }
+    parts.push(part)
+  }
+  guard parts[0] != ".git" && parts[0] != ".worktrees" else {
+    return Err(
+      "allowed_paths entries must not target git or worktree bookkeeping: \{prefix}",
+    )
+  }
+  Ok(parts)
+}

--- a/agent_tool/internal/write_scope/write_scope_test.mbt
+++ b/agent_tool/internal/write_scope/write_scope_test.mbt
@@ -141,3 +141,16 @@ async test "the scope root is canonical so resolved comparisons match" {
     assert_admits(scope, "\{scope.root()}/src/a.mbt")
   })
 }
+
+///|
+#cfg(not(platform="windows"))
+async test "a POSIX backslash is a filename byte, not a separator" {
+  @vfs.with_tmpdir(prefix="write-scope-backslash-", root => {
+    @vfs.FileSystem({ "src/a.mbt": "a" }).write_to(root)
+    let scope = scope_of(root, allowed_paths=["src"])
+    // A single component literally named `src\outside` is not under `src`;
+    // the surrounding path machinery would treat the backslash as a
+    // separator and smuggle it into the allowed prefix, so it fails closed.
+    assert_denies(scope, "\{root}/src\\outside", because="backslash")
+  })
+}

--- a/agent_tool/internal/write_scope/write_scope_test.mbt
+++ b/agent_tool/internal/write_scope/write_scope_test.mbt
@@ -114,7 +114,7 @@ async test "create validates root and prefixes strictly" {
     assert_true(no_root.contains("does not resolve"))
     for
       bad in [
-        "", ".", "..", "a/../b", "/abs", "a//b", ".git/hooks", ".worktrees/x",
+        "", ".", "..", "a/../b", "/abs", "a//b", ".git/hooks", ".worktrees/x", "src\\generated",
       ] {
       guard @write_scope.WriteScope::create(root~, allowed_paths=[bad])
         is Err(_) else {

--- a/agent_tool/internal/write_scope/write_scope_test.mbt
+++ b/agent_tool/internal/write_scope/write_scope_test.mbt
@@ -114,7 +114,7 @@ async test "create validates root and prefixes strictly" {
     assert_true(no_root.contains("does not resolve"))
     for
       bad in [
-        "", ".", "..", "a/../b", "/abs", "a//b", ".git/hooks", ".worktrees/x", "src\\generated",
+        "", ".", "..", "a/../b", "/abs", "a//b", ".git/hooks", ".worktrees/x",
       ] {
       guard @write_scope.WriteScope::create(root~, allowed_paths=[bad])
         is Err(_) else {
@@ -152,5 +152,13 @@ async test "a POSIX backslash is a filename byte, not a separator" {
     // the surrounding path machinery would treat the backslash as a
     // separator and smuggle it into the allowed prefix, so it fails closed.
     assert_denies(scope, "\{root}/src\\outside", because="backslash")
+    // And a backslash-bearing prefix could never authorize anything here,
+    // so create rejects it (on Windows it is a separator and normalizes).
+    guard @write_scope.WriteScope::create(root~, allowed_paths=[
+        "src\\generated",
+      ])
+      is Err(_) else {
+      fail("expected a backslash prefix rejected on POSIX")
+    }
   })
 }

--- a/agent_tool/internal/write_scope/write_scope_test.mbt
+++ b/agent_tool/internal/write_scope/write_scope_test.mbt
@@ -1,0 +1,143 @@
+///|
+/// Build a scope over `root` or fail the test with the create error.
+async fn scope_of(
+  root : String,
+  allowed_paths? : Array[String] = [],
+) -> @write_scope.WriteScope {
+  match @write_scope.WriteScope::create(root~, allowed_paths~) {
+    Ok(scope) => scope
+    Err(reason) => fail(reason)
+  }
+}
+
+///|
+async fn assert_admits(scope : @write_scope.WriteScope, path : String) -> Unit {
+  match scope.deny_reason(path) {
+    None => ()
+    Some(reason) => fail("expected \{path} admitted, denied: \{reason}")
+  }
+}
+
+///|
+async fn assert_denies(
+  scope : @write_scope.WriteScope,
+  path : String,
+  because~ : String,
+) -> Unit {
+  match scope.deny_reason(path) {
+    Some(reason) => assert_true(reason.contains(because))
+    None => fail("expected \{path} denied (\{because}), was admitted")
+  }
+}
+
+///|
+async test "root-only scope admits inside and denies outside" {
+  @vfs.with_tmpdir(prefix="write-scope-root-", root => {
+    @vfs.FileSystem({ "src/a.mbt": "a", "top.txt": "t" }).write_to(root)
+    let scope = scope_of(root)
+    assert_admits(scope, "\{root}/src/a.mbt")
+    assert_admits(scope, "src/a.mbt")
+    assert_admits(scope, "\{root}/src/newdir/deep/new.mbt")
+    assert_denies(scope, "/etc/hosts", because="outside the writable root")
+    assert_denies(
+      scope,
+      "\{root}/../outside.txt",
+      because="outside the writable root",
+    )
+    // `..` that stays inside the root is fine after normalization.
+    assert_admits(scope, "\{root}/src/../top.txt")
+  })
+}
+
+///|
+async test "allowed prefixes are component-wise" {
+  @vfs.with_tmpdir(prefix="write-scope-prefix-", root => {
+    @vfs.FileSystem({
+      "src/a.mbt": "a",
+      "src2/b.mbt": "b",
+      "docs/notes/n.md": "n",
+    }).write_to(root)
+    let scope = scope_of(root, allowed_paths=["src", "docs/notes"])
+    assert_admits(scope, "\{root}/src/a.mbt")
+    assert_admits(scope, "\{root}/src/sub/new.mbt")
+    assert_admits(scope, "\{root}/docs/notes/n.md")
+    // `src` must not admit `src2`, and a parent of a prefix is not a target.
+    assert_denies(scope, "\{root}/src2/b.mbt", because="allowed_paths")
+    assert_denies(scope, "\{root}/docs/other.md", because="allowed_paths")
+    assert_denies(scope, "\{root}/docs", because="allowed_paths")
+  })
+}
+
+///|
+async test "symlinks cannot smuggle writes out of scope" {
+  @vfs.with_tmpdir(prefix="write-scope-links-", root => {
+    @vfs.FileSystem({
+      "src/real.mbt": "r",
+      "src/inner/i.mbt": "i",
+      "outside_prefix/o.mbt": "o",
+      "victim/v.mbt": "v",
+    }).write_to(root)
+    @vfs.with_tmpdir(prefix="write-scope-elsewhere-", elsewhere => {
+      @vfs.write_text(elsewhere, "target.txt", "x")
+      let scope = scope_of(root, allowed_paths=["src"])
+      // Final-component symlink pointing out of the root: denied on the
+      // resolved location even though the request is lexically in-scope.
+      @fs.symlink(target="\{elsewhere}/target.txt", "\{root}/src/out_link")
+      assert_denies(scope, "\{root}/src/out_link", because="resolves outside")
+      // Ancestor symlink out of the root: a new file beneath it is denied.
+      @fs.symlink(target=elsewhere, "\{root}/src/out_dir")
+      assert_denies(
+        scope,
+        "\{root}/src/out_dir/new.mbt",
+        because="resolves outside",
+      )
+      // In-root but out-of-allowed symlink: root check passes, prefix check
+      // on the resolved location fails.
+      @fs.symlink(target="\{root}/victim/v.mbt", "\{root}/src/in_root_link")
+      assert_denies(scope, "\{root}/src/in_root_link", because="allowed_paths")
+      // Dangling symlink fails closed.
+      @fs.symlink(target="\{root}/missing.mbt", "\{root}/src/dangling")
+      assert_denies(scope, "\{root}/src/dangling", because="does not resolve")
+      // Honest paths keep working alongside the links.
+      assert_admits(scope, "\{root}/src/inner/i.mbt")
+    })
+  })
+}
+
+///|
+async test "create validates root and prefixes strictly" {
+  @vfs.with_tmpdir(prefix="write-scope-validate-", root => {
+    guard @write_scope.WriteScope::create(root="\{root}/missing")
+      is Err(no_root) else {
+      fail("expected missing root rejected")
+    }
+    assert_true(no_root.contains("does not resolve"))
+    for
+      bad in [
+        "", ".", "..", "a/../b", "/abs", "a//b", ".git/hooks", ".worktrees/x",
+      ] {
+      guard @write_scope.WriteScope::create(root~, allowed_paths=[bad])
+        is Err(_) else {
+        fail("expected allowed_paths entry rejected: \{bad}")
+      }
+    }
+    guard @write_scope.WriteScope::create(root~, allowed_paths=[
+        "src", "docs/notes", "a/b/c",
+      ])
+      is Ok(_) else {
+      fail("expected valid prefixes accepted")
+    }
+  })
+}
+
+///|
+async test "the scope root is canonical so resolved comparisons match" {
+  // macOS /tmp is a symlink to /private/tmp: creating the scope from the
+  // un-resolved spelling must still admit realpath'd targets.
+  @vfs.with_tmpdir(prefix="write-scope-canon-", root => {
+    @vfs.FileSystem({ "src/a.mbt": "a" }).write_to(root)
+    let scope = scope_of(root)
+    assert_true(scope.root() == @fs.realpath(root))
+    assert_admits(scope, "\{scope.root()}/src/a.mbt")
+  })
+}

--- a/agent_tool/multi_edit/moon.pkg
+++ b/agent_tool/multi_edit/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/write_scope",
   "bobzhang/openseek/agent_tool/internal/manifest_error",
   "bobzhang/openseek/agent_tool/multi_edit/internal/decode",
   "bobzhang/openseek/internal/workspace_path",

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -11,6 +11,7 @@
 pub fn definition(
   workspace_root? : String = ".",
   file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="multi_edit",
@@ -110,7 +111,12 @@ pub fn definition(
       },
     }),
     execute=Async(arguments => {
-      execute_with_workspace(workspace_root, file_state, arguments)
+      execute_with_workspace(
+        workspace_root,
+        file_state,
+        arguments,
+        write_scope?,
+      )
     }),
   )
 }
@@ -120,6 +126,7 @@ async fn execute_with_workspace(
   workspace_root : String,
   file_state : @agent_tool.FileStateMap,
   arguments : Json,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let args = @decode.decode_args(arguments) catch {
     error =>
@@ -148,6 +155,7 @@ async fn execute_with_workspace(
     args.revert_when_errors_above,
     revert_on_parse_errors=args.revert_on_parse_errors,
     file_state~,
+    write_scope?,
   )
 }
 
@@ -240,6 +248,7 @@ async fn multi_edit_files(
   revert_when_errors_above : Int?,
   revert_on_parse_errors~ : Bool,
   file_state~ : @agent_tool.FileStateMap,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let brief = "multi_edit"
   // Resolve every edit's path up front and key contiguity and grouping on the
@@ -295,11 +304,25 @@ async fn multi_edit_files(
     )
   }
   // Render each file and run the write guard before touching disk, so a guarded
-  // path aborts the whole batch instead of leaving earlier files written.
+  // path aborts the whole batch instead of leaving earlier files written. The
+  // containment gate (confined worker registries) joins the same all-or-nothing
+  // contract: one out-of-scope path rejects the batch with nothing written.
   let writes : Array[PreparedWrite] = []
   for prepared_file in prepared {
     let new_content = apply_plans(prepared_file.content, prepared_file.plans)
-    match @manifest_error.write_error(prepared_file.path, new_content) {
+    let guard_message = match
+      @manifest_error.write_error(prepared_file.path, new_content) {
+      Some(message) => Some(message)
+      None =>
+        if write_scope is Some(scope) {
+          scope
+          .deny_reason(prepared_file.path)
+          .map(reason => "write blocked: \{reason}")
+        } else {
+          None
+        }
+    }
+    match guard_message {
       Some(message) =>
         failures.push({
           file: prepared_file.file,
@@ -333,6 +356,16 @@ async fn multi_edit_files(
     return rejection
   }
   for write in writes {
+    // Containment re-check at the moment of writing: the batch gate above
+    // decided on filesystem state that awaits ago may have changed.
+    if write_scope is Some(scope) &&
+      scope.deny_reason(write.path) is Some(reason) {
+      return @agent_tool.ToolAction::respond(
+        "error multi_editing \{write.path}: write blocked: \{reason}; earlier files in the batch may already be written",
+        is_error=true,
+        brief~,
+      )
+    }
     @fs.write_file(write.path, write.new_content, create_mode=CreateOrTruncate) catch {
       error if @async.is_being_cancelled() => raise error
       error =>
@@ -356,6 +389,7 @@ async fn multi_edit_files(
         first.path,
         writes,
         effective_revert_threshold(revert_when_errors_above),
+        write_scope?,
       )
     None =>
       @agent_tool.ToolAction::respond(
@@ -543,6 +577,7 @@ async fn revert_guarded_response(
   check_path : String,
   writes : Array[PreparedWrite],
   threshold : Int,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let summary = success_summary(writes)
   let kept = @agent_tool.ToolAction::respond(
@@ -562,7 +597,11 @@ async fn revert_guarded_response(
   // Suspicious: the post-batch error count is over the line. Measure the
   // pre-batch baseline by restoring the originals and re-checking, so the guard
   // fires on errors this batch INTRODUCED, not on ones that were already there.
-  let restore_failures = write_files(writes, write => write.original_content)
+  let restore_failures = write_files(
+    writes,
+    write => write.original_content,
+    write_scope?,
+  )
   let before = count_errors_or_none(check_path)
   let before_count = before.map(b => b.error_count).unwrap_or(0)
   let introduced = after.error_count - before_count
@@ -575,7 +614,7 @@ async fn revert_guarded_response(
     )
   } else {
     // False alarm: the errors were mostly pre-existing. Re-apply and keep.
-    let _ = write_files(writes, write => write.new_content)
+    let _ = write_files(writes, write => write.new_content, write_scope?)
     @agent_tool.ToolAction::respond(
       keep_response(summary, after, threshold, introduced~),
       brief=success_brief(writes),
@@ -597,13 +636,20 @@ async fn count_errors_or_none(path : String) -> @auto_check.CheckErrors? {
 /// Write `content(write)` to every file, returning the paths that could not be
 /// written (best effort — a restore/re-apply must not raise mid-rollback). A
 /// non-empty result is surfaced in the revert report so a half-restored tree is
-/// never reported as a clean rollback.
+/// never reported as a clean rollback. The containment scope gates these
+/// restore/re-apply writes too — a path whose resolution changed since the
+/// batch was admitted is skipped and reported rather than written blind.
 async fn write_files(
   writes : Array[PreparedWrite],
   content : (PreparedWrite) -> String,
+  write_scope? : @write_scope.WriteScope,
 ) -> Array[String] {
   let failures : Array[String] = []
   for write in writes {
+    if write_scope is Some(scope) && scope.deny_reason(write.path) is Some(_) {
+      failures.push(write.path)
+      continue
+    }
     @fs.write_file(write.path, content(write), create_mode=CreateOrTruncate) catch {
       error if @async.is_being_cancelled() => raise error
       _ => failures.push(write.path)

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -624,12 +624,22 @@ async fn revert_guarded_response(
       write => write.new_content,
       write_scope?,
     )
-    if restore_failures.length() + reapply_failures.length() > 0 {
-      let stuck = restore_failures + reapply_failures
+    if reapply_failures.length() > 0 {
+      // Final contents are uncertain: these files may still hold their
+      // pre-batch text.
       @agent_tool.ToolAction::respond(
-        "error multi_editing: the batch was kept, but re-applying it did not fully succeed — these files may not hold the batch content: \{stuck.join(", ")}; re-read them before further edits",
+        "error multi_editing: the batch was kept, but re-applying it did not fully succeed — these files may not hold the batch content: \{reapply_failures.join(", ")}; re-read them before further edits",
         is_error=true,
         brief="multi_edit partially re-applied",
+      )
+    } else if restore_failures.length() > 0 {
+      // Every final write landed, so the tree holds the batch — but the
+      // baseline this keep decision compared against was measured with these
+      // files unrestored, so the decision itself deserves the caveat.
+      @agent_tool.ToolAction::respond(
+        keep_response(summary, after, threshold, introduced~) +
+        "\nnote: the pre-batch baseline was measured with \{restore_failures.length()} file(s) unrestored (\{restore_failures.join(", ")}), so the introduced-error count may be understated",
+        brief=success_brief(writes),
       )
     } else {
       @agent_tool.ToolAction::respond(

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -613,12 +613,30 @@ async fn revert_guarded_response(
       brief="multi_edit reverted (\{introduced} new error(s))",
     )
   } else {
-    // False alarm: the errors were mostly pre-existing. Re-apply and keep.
-    let _ = write_files(writes, write => write.new_content, write_scope?)
-    @agent_tool.ToolAction::respond(
-      keep_response(summary, after, threshold, introduced~),
-      brief=success_brief(writes),
+    // False alarm: the errors were mostly pre-existing. Re-apply and keep —
+    // but claim success only when every file actually made it back. A failed
+    // restore skewed the baseline this decision used, and a failed re-apply
+    // (IO fault, or a path whose resolution fell out of scope mid-flight)
+    // leaves a mixed tree; both must reach the model, not vanish into a
+    // success summary.
+    let reapply_failures = write_files(
+      writes,
+      write => write.new_content,
+      write_scope?,
     )
+    if restore_failures.length() + reapply_failures.length() > 0 {
+      let stuck = restore_failures + reapply_failures
+      @agent_tool.ToolAction::respond(
+        "error multi_editing: the batch was kept, but re-applying it did not fully succeed — these files may not hold the batch content: \{stuck.join(", ")}; re-read them before further edits",
+        is_error=true,
+        brief="multi_edit partially re-applied",
+      )
+    } else {
+      @agent_tool.ToolAction::respond(
+        keep_response(summary, after, threshold, introduced~),
+        brief=success_brief(writes),
+      )
+    }
   }
 }
 

--- a/agent_tool/multi_edit/multi_edit_test.mbt
+++ b/agent_tool/multi_edit/multi_edit_test.mbt
@@ -655,3 +655,46 @@ test "multi_edit tool advertises the expected schema" {
   assert_true(text.contains("\"start_line\""))
   assert_true(text.contains("\"end_line\""))
 }
+
+///|
+async test "a write scope rejects the whole batch on one out-of-scope path" {
+  @vfs.with_tmpdir(prefix="multi-edit-scope-", dir => {
+    @vfs.FileSystem({ "lib/a.txt": "aa\n", "other/b.txt": "bb\n" }).write_to(
+      dir,
+    )
+    guard @write_scope.WriteScope::create(root=dir, allowed_paths=["lib"])
+      is Ok(scope) else {
+      fail("expected the scope to build")
+    }
+    let run = match
+      @multi_edit.definition(workspace_root=dir, write_scope=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("multi_edit tool should be async")
+    }
+    guard run({
+        "edits": [
+          {
+            "file": "lib/a.txt",
+            "old_string": "aa",
+            "new_string": "AA",
+            "start_line": 1,
+          },
+          {
+            "file": "other/b.txt",
+            "old_string": "bb",
+            "new_string": "BB",
+            "start_line": 1,
+          },
+        ],
+      })
+      is Respond(output) else {
+      fail("expected Respond")
+    }
+    // All-or-nothing: the out-of-scope member rejects the batch and the
+    // in-scope file stays untouched too.
+    assert_true(output.is_error)
+    assert_true(output.content.contains("write blocked"))
+    assert_true(@fs.read_file("\{dir}/lib/a.txt").text() == "aa\n")
+    assert_true(@fs.read_file("\{dir}/other/b.txt").text() == "bb\n")
+  })
+}

--- a/agent_tool/multi_edit/pkg.generated.mbti
+++ b/agent_tool/multi_edit/pkg.generated.mbti
@@ -3,10 +3,11 @@ package "bobzhang/openseek/agent_tool/multi_edit"
 
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/internal/write_scope",
 }
 
 // Values
-pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap, write_scope? : @write_scope.WriteScope) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/remove/moon.pkg
+++ b/agent_tool/remove/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/write_scope",
   "bobzhang/openseek/agent_tool/remove/internal/decode",
   "bobzhang/openseek/internal/workspace_path",
   "bobzhang/openseek/testkit/filesystem" @vfs,

--- a/agent_tool/remove/pkg.generated.mbti
+++ b/agent_tool/remove/pkg.generated.mbti
@@ -3,10 +3,11 @@ package "bobzhang/openseek/agent_tool/remove"
 
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/internal/write_scope",
 }
 
 // Values
-pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap, write_scope? : @write_scope.WriteScope) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -40,6 +40,7 @@
 pub fn definition(
   workspace_root? : String = ".",
   file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="remove",
@@ -71,7 +72,12 @@ pub fn definition(
       "required": ["path", "reason"],
     }),
     execute=Async(arguments => {
-      execute_with_workspace(workspace_root, file_state, arguments)
+      execute_with_workspace(
+        workspace_root,
+        file_state,
+        arguments,
+        write_scope?,
+      )
     }),
   )
 }
@@ -81,6 +87,7 @@ async fn execute_with_workspace(
   workspace_root : String,
   file_state : @agent_tool.FileStateMap,
   arguments : Json,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -92,7 +99,16 @@ async fn execute_with_workspace(
     }
   }
   let path = @workspace_path.resolve(workspace_root, input.path)
-  remove_file(path, input, file_state)
+  // Containment gate for confined (worker) registries: deletion is a
+  // write-class operation. Re-checked immediately before the delete.
+  if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
+    return @agent_tool.ToolAction::respond(
+      "error removing \{path}: write blocked: \{reason}",
+      is_error=true,
+      brief="remove \{@agent_tool.brief_basename(path)}",
+    )
+  }
+  remove_file(path, input, file_state, write_scope?)
 }
 
 ///|
@@ -100,6 +116,7 @@ async fn remove_file(
   path : String,
   input : @decode.RemoveInput,
   file_state : @agent_tool.FileStateMap,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let fail_brief = "remove \{@agent_tool.brief_basename(path)}"
   fn err(message : String) -> @agent_tool.ToolAction {
@@ -147,6 +164,11 @@ async fn remove_file(
         #|file it created
       ),
     )
+  }
+  // Containment re-check at the moment of deleting: the early gate decided on
+  // filesystem state that awaits ago may have changed underneath the tool.
+  if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
+    return err("write blocked: \{reason}")
   }
   @fs.remove(path)
   // Drop the provenance so a path recreated after this removal is not treated as
@@ -422,5 +444,45 @@ async test "remove rejects a blank reason" {
     )
     assert_true(output.is_error)
     assert_true(@fs.exists(path))
+  })
+}
+
+///|
+async test "a write scope confines remove to its allowed paths" {
+  @vfs.with_tmpdir(prefix="openseek-remove-scope-", dir => {
+    @vfs.FileSystem({ "lib/mine.txt": "m\n", "other/mine.txt": "m\n" }).write_to(
+      dir,
+    )
+    // Both files carry agent-created provenance, so only the scope decides.
+    let state = @agent_tool.FileStateMap::new()
+    state.record_created(
+      "\{dir}/lib/mine.txt",
+      recorded_digest("\{dir}/lib/mine.txt"),
+    )
+    state.record_created(
+      "\{dir}/other/mine.txt",
+      recorded_digest("\{dir}/other/mine.txt"),
+    )
+    guard @write_scope.WriteScope::create(root=dir, allowed_paths=["lib"])
+      is Ok(scope) else {
+      fail("expected the scope to build")
+    }
+    let run = match
+      definition(workspace_root=dir, file_state=state, write_scope=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("remove tool should be async")
+    }
+    guard run({ "path": "other/mine.txt", "reason": "test" })
+      is Respond(blocked) else {
+      fail("expected Respond")
+    }
+    assert_true(blocked.is_error)
+    assert_true(blocked.content.contains("write blocked"))
+    assert_true(@fs.exists("\{dir}/other/mine.txt"))
+    guard run({ "path": "lib/mine.txt", "reason": "test" }) is Respond(admitted) else {
+      fail("expected Respond")
+    }
+    assert_false(admitted.is_error)
+    assert_false(@fs.exists("\{dir}/lib/mine.txt"))
   })
 }

--- a/agent_tool/write/moon.pkg
+++ b/agent_tool/write/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/write_scope",
   "bobzhang/openseek/agent_tool/internal/manifest_error",
   "bobzhang/openseek/agent_tool/write/internal/decode",
   "bobzhang/openseek/internal/workspace_path",

--- a/agent_tool/write/pkg.generated.mbti
+++ b/agent_tool/write/pkg.generated.mbti
@@ -3,10 +3,11 @@ package "bobzhang/openseek/agent_tool/write"
 
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/internal/write_scope",
 }
 
 // Values
-pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateMap, write_scope? : @write_scope.WriteScope) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -32,6 +32,7 @@
 pub fn definition(
   workspace_root? : String = ".",
   file_state? : @agent_tool.FileStateMap = @agent_tool.FileStateMap::new(),
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="write",
@@ -71,7 +72,12 @@ pub fn definition(
       "required": ["path", "content"],
     }),
     execute=Async(arguments => {
-      execute_with_workspace(workspace_root, file_state, arguments)
+      execute_with_workspace(
+        workspace_root,
+        file_state,
+        arguments,
+        write_scope?,
+      )
     }),
   )
 }
@@ -86,6 +92,7 @@ async fn execute_with_workspace(
   workspace_root : String,
   file_state : @agent_tool.FileStateMap,
   arguments : Json,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -97,7 +104,16 @@ async fn execute_with_workspace(
     }
   }
   let path = @workspace_path.resolve(workspace_root, input.path)
-  write_file(input, path~, file_state~)
+  // Containment gate for confined (worker) registries; re-checked below
+  // immediately before the file is written.
+  if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
+    return @agent_tool.ToolAction::respond(
+      "error writing \{path}: write blocked: \{reason}",
+      is_error=true,
+      brief="write \{@agent_tool.brief_basename(path)}",
+    )
+  }
+  write_file(input, path~, file_state~, write_scope?)
 }
 
 ///|
@@ -105,6 +121,7 @@ async fn write_file(
   input : @decode.WriteInput,
   path~ : String,
   file_state~ : @agent_tool.FileStateMap,
+  write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   if @manifest_error.write_error(path, input.content) is Some(message) {
     return @agent_tool.ToolAction::respond(
@@ -161,6 +178,16 @@ async fn write_file(
         )
       }
     }
+  }
+  // Containment re-check at the moment of writing (before parent directories
+  // are created for the target): the early gate decided on filesystem state
+  // that awaits ago may have changed underneath the tool.
+  if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
+    return @agent_tool.ToolAction::respond(
+      "error writing \{path}: write blocked: \{reason}",
+      is_error=true,
+      brief="write \{@agent_tool.brief_basename(path)}",
+    )
   }
   create_parent_dirs(path)
   // Probe before writing so the result can tell the model whether it created a
@@ -786,5 +813,32 @@ async test "write records an overwrite of a pre-existing file as Modified" {
     }
     let _ = run({ "path": path, "content": "new" })
     assert_true(state.get(path) is Some(Modified))
+  })
+}
+
+///|
+async test "a write scope confines write to its allowed paths" {
+  @vfs.with_tmpdir(prefix="openseek-write-scope-", dir => {
+    @vfs.FileSystem({ "lib/keep.txt": "k\n" }).write_to(dir)
+    guard @write_scope.WriteScope::create(root=dir, allowed_paths=["lib"])
+      is Ok(scope) else {
+      fail("expected the scope to build")
+    }
+    let run = match definition(workspace_root=dir, write_scope=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("write tool should be async")
+    }
+    guard run({ "path": "lib/new.txt", "content": "n\n" }) is Respond(admitted) else {
+      fail("expected Respond")
+    }
+    assert_false(admitted.is_error)
+    assert_eq(@fs.read_file("\{dir}/lib/new.txt").text(), "n\n")
+    // Out of scope: blocked before parent directories are even created.
+    guard run({ "path": "other/new.txt", "content": "n\n" }) is Respond(blocked) else {
+      fail("expected Respond")
+    }
+    assert_true(blocked.is_error)
+    assert_true(blocked.content.contains("write blocked"))
+    assert_false(@fs.exists("\{dir}/other"))
   })
 }

--- a/docs/plans/subtask-worker-subagents.md
+++ b/docs/plans/subtask-worker-subagents.md
@@ -1,0 +1,284 @@
+# Plan v3: parallel worker subagents with worktree isolation ("subtask")
+
+Date: 2026-07-31. Status: revised after subal xhigh round-2 (subal-round2.log,
+NO-GO with 3 blockers + majors — all adopted below). v2: subtask-plan-v2.md.
+Threat model unchanged from v2: cooperative (accident prevention + parallel
+correctness), same trust tier as the parent; kernel layer macOS-only.
+
+## Delta summary vs v2 (round-2 findings → resolutions)
+
+- R2-B1 (profile wrong for linked-origin/external siblings; allow-default
+  overclaim) → provision REQUIRES the origin to be the MAIN worktree; profile
+  built from canonical `git rev-parse` outputs + full `git worktree list`
+  enumeration; honest scope language.
+- R2-B2 (in-worktree marker poisons cleanliness) → controller-owned registry
+  under the canonical common git dir; no marker in the worktree.
+- R2-B3 (merge overwrites ignored files) → `--no-overwrite-ignore` + the
+  dedicated git runner's full flag set.
+- R2-MAJORs: scratch_dir launch-path gap (hotfix PR0'), static-guard
+  quantifier flipped, WriteScope resolved-target + component-aware prefixes,
+  mutex keyed by common git dir, reservations live until integrate/abort,
+  reserve-before-provision + rollback, --untracked-files=all + separate -z
+  parsers, submodules from ls-tree of base, staged-diff revalidation,
+  engine-owned integrate_continue/abort, clean-tracked-origin gate,
+  no unconditional prune, PR4 split, residuals restated.
+
+## PR0' (immediate hotfix, independent of this plan): scratch-lab launch gap
+
+`agent_tool/shell/shell.mbt`: `shell()` receives `scratch_dir` (used for its
+own preblock) but omits it at both launch call sites —
+`run_agent_shell_with_tree_precheck(...)` (foreground, ~line 364) and
+`start_background(...)` (~line 307) — although BOTH callees accept
+`scratch_dir?` and forward it to `agent_shell_launch`. Consequences today:
+the K3 force-sandbox of trusted scaffolds (`moon new`) never applies on the
+wired path (kernel backstop inert; lexical guard is sole defense again —
+exactly the K3 blocker), and the second preblock inside each callee runs
+with `scratch_dir=None` (background lab commands would be over-blocked if a
+lab child ever had a bg runtime). Existing test calls `agent_shell_launch`
+directly and cannot see this. Fix: pass `scratch_dir?` at both sites + an
+end-to-end wbtest through `execute_with_workspace` asserting a trusted
+scaffold launches SANDBOXED when a lab is present (and that the lab allow
+reaches the profile). Ship first, alone.
+
+## Provision preconditions (controller, engine-side)
+
+1. Canonical geometry via `git rev-parse --absolute-git-dir
+   --git-common-dir --show-toplevel` (all realpath'd):
+   - workspace_root must equal the toplevel, AND absolute-git-dir must equal
+     common-dir (i.e. the origin is the MAIN worktree, not a linked one).
+     Otherwise: tool error naming the v1 limitation.
+2. Enumerate `git worktree list --porcelain` → every worktree root.
+3. Reserve FIRST: worker slot (semaphore 4) + SubrunBudget slot; every later
+   failure path rolls back provisioned state explicitly (postcondition
+   inspection: branch? dir? admin entry? registry entry?) before the error
+   result.
+4. `base_oid` = rev-parse HEAD (recorded before add; add pins it).
+5. Overlap check against REGISTRY entries in non-terminal states (not just
+   live children): component-aware prefix intersection of `allowed_paths`.
+6. Submodule check: `git ls-tree -r -z <base_oid>` mode-160000 paths vs
+   `allowed_paths` (component-aware); intersection → reject.
+7. info/exclude idempotent `.worktrees/` append.
+8. Under the per-repo mutex (keyed by canonical COMMON git dir; process-local
+   — cross-process is a documented residual):
+   `git worktree add .worktrees/<name> -b openseek/<name>--<nonce>
+   <base_oid>`; resolve the worktree's PRIVATE admin dir via
+   `git -C <wt> rev-parse --absolute-git-dir` (never constructed from name;
+   numeric suffixes exist).
+9. Registry entry (controller-owned, OUTSIDE the worker-writable set):
+   `<common-git-dir>/openseek/subtasks/<branch-nonce>.json` — schema v1:
+   repo identity, name, branch, base_oid, worker root, admin dir,
+   allowed_paths, lifecycle state (provisioned → running → captured|failed →
+   committed → integrated|aborted|kept), parent session, created_at, and
+   later the commit OID. This is the orphan-discovery + reservation record;
+   lifecycle transitions rewrite it atomically (write temp + rename).
+10. Prewarm: copy origin `.mooncakes` when present (immutable snapshot;
+    measure size, skip over a threshold with a note). `_build` never copied.
+11. Launch `run_subrun` (cwd=wt, `subrun worker --dir <wt>`, child_session?,
+    deadline 20 min, steps 100). Child env additions: `GIT_OPTIONAL_LOCKS=0`.
+
+## Worker sandbox profile (macOS kernel layer)
+
+Composed per child from canonical paths (all realpath'd at provision):
+
+- `(allow default)` — retained; scope statement is honest: the kernel layer
+  confines against THIS repository and its sibling worktrees, not the wider
+  filesystem (cooperative model; static guard + WriteScope cover the rest).
+- `(deny file-write* (subpath <common-git-dir>))`
+- `(deny file-write* (subpath <each enumerated worktree root>))` including
+  the origin toplevel; enumeration happens at provision time (a sibling
+  created afterwards is a documented residual).
+- `(allow file-write* (subpath <worker root>))`
+- `(allow file-write* (subpath <worker private admin dir>))` (resolved, not
+  constructed)
+- `(deny file-write* (literal <worker root>/.git))` — the gitfile pointer,
+  last so it wins over the worker-root allow.
+
+Result: moon writes wt/_build + ~/.moon (allowed; ~/.moon sharing is a
+documented residual — moon's own cache locking is trusted); `git status`/
+`diff` work (private index; plus GIT_OPTIONAL_LOCKS=0 keeps status from
+optional index refreshes); `git commit`/ref/config/worktree mutations fail
+(shared object/ref/config writes denied); sibling and origin writes fail.
+Worker mode force-sandboxes EVERY class including Trusted* (K3 mechanism,
+now actually propagated end-to-end per PR0'), foreground AND background.
+
+Static guard (better messages + non-macOS floor): admit a mutating git/moon
+command only when EVERY candidate cwd/target interpretation (cd chains, -C,
+scaffold destinations) is inside the worker root; unknown or mixed →
+blocked with a worker-scope message. Extend denial_output subjects with the
+worker paths so kernel denials self-explain. run_moonbit: worker rooting +
+absolute-cwd outside worker root rejected at decode + worker profile for
+its sandbox. Auto-check stays on; residual stated plainly: auto-check/moon
+prebuild is repository build code running unsandboxed in the child engine,
+same as the parent — we trust repo build rules and accept concurrent
+external writers per worktree (their _build dirs are disjoint).
+
+## WriteScope (PR1 — independently landable)
+
+Shared checker used by edit/multi_edit/write/remove (worker builds all four
+around one instance + one shared FileStateMap, mirroring build_tools):
+
+- Config: canonical root + `allowed_paths` (repo-relative component-wise
+  prefixes; reject absolute, `..`, empty, `.`, NUL, `.git`/`.worktrees`
+  prefixes at decode).
+- Check at use, immediately before each write (and before each rollback
+  write): normalize the REQUESTED path; resolve the nearest existing
+  ancestor via realpath; reject when the resolved target escapes the root;
+  reject when the final component is an existing symlink whose target
+  escapes the root; THEN check BOTH the normalized requested path and the
+  resolved path against `allowed_paths` component-wise (`src` never
+  authorizes `src2`; an in-root symlink into out-of-scope territory fails).
+- TOCTOU window documented; macOS kernel layer backstops it.
+- Tests per subal: component boundaries, `..`, absolute, final/ancestor
+  symlinks, in-root-but-out-of-scope symlink, nonexistent descendants,
+  revalidation on rollback paths, four tools one FileStateMap.
+
+## Capture → validate → commit (controller)
+
+On child exit (any terminal), registry state advances; then:
+
+- Validation (untruncated, byte-preserving): `git status --porcelain=v1 -z
+  --untracked-files=all` and `git diff --name-status -z <base_oid>` with
+  SEPARATE parsers (status reverses rename order vs diff). Every changed/
+  untracked path (both sides of renames, deletes) must pass component-wise
+  `allowed_paths`; wt HEAD must still equal base_oid (profile makes child
+  commits impossible; violation → non-mergeable, kept, listed).
+- Valid + non-empty → controller commits: `git add -A` then REVALIDATE the
+  staged diff (`diff --cached --name-status -z` vs base_oid — background
+  stragglers race the first pass), then commit via the dedicated runner,
+  then verify the commit's tree diff matches. Commit OID → registry.
+- is_error: terminal != Captured, report status "failed", scope violation,
+  or HEAD moved. "partial" → success-with-warning. Evidence display ≤4K
+  (validation never truncates; display does): branch, commit OID, diffstat,
+  child report, provision warnings, cleanup commands for kept trees.
+
+Dedicated git runner (NOT baseline's run_capture): argv-vector spawn,
+per-phase timeouts, merged stdout+stderr diagnostics, NUL-safe capture,
+sanitized env (strip GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE,
+GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES, GIT_CONFIG_*,
+GIT_CEILING_DIRECTORIES), postcondition inspection on failure,
+cancellation reconciliation.
+
+## Integrate (controller; actions on the subtask tool)
+
+`subtask{integrate: <name>}`:
+1. Registry entry must be in `committed`; branch OID must equal the recorded
+   commit; must descend from base_oid.
+2. Origin gate: NO staged changes and NO unstaged tracked changes
+   (`--no-optional-locks status --porcelain=v1 -z`); sole carve-out:
+   gitlink (mode 160000) dirt, which cannot collide (submodule slices were
+   rejected at provision) — documented. Untracked files allowed;
+   `--no-overwrite-ignore` protects ignored ones.
+3. Merge BY EXACT OID: `git -c core.hooksPath=/dev/null merge --no-ff
+   --no-edit --no-gpg-sign --no-autostash --no-rerere-autoupdate
+   --no-overwrite-ignore -m "subtask <name>: <summary line>" <commit-oid>`
+   via the runner, mutex-held.
+4. Clean → post-merge `moon check` summary → targeted `git worktree remove
+   <wt>` + `git branch -d` (no blanket prune) → registry `integrated`.
+5. Conflict → registry `conflicted` + result lists conflicted files; the
+   model edits markers via file tools (origin workspace, parent tools),
+   then `subtask{integrate_continue: <name>}`: controller verifies
+   MERGE_HEAD equals the subtask commit OID, no unresolved entries remain
+   (`ls-files -u`), staged paths ⊆ allowed_paths ∪ conflict set, then
+   commits through the runner. `subtask{integrate_abort: <name>}`: verify
+   MERGE_HEAD belongs to this subtask FIRST, then `merge --abort`,
+   registry back to `committed` (worktree/branch kept).
+
+## Unchanged from v2 (still in force)
+
+Naming (tool `subtask`, kind `worker`, pkg `agent_worker`, branch
+`openseek/<name>--<nonce>`); schema {name, task ≤4000, allowed_paths,
+context? ≤2000} concurrent_safe; child toolset (read unrestricted, worker
+shell, WriteScope file tools, run_moonbit, versioned submit_result; no
+subrun tools); substantial worker system prompt (.mbt.md + dev_build; "do
+not run git commit/worktree — the harness commits; permission errors on
+those are expected"); report v1 {status, summary, verification}; child
+session persistence; viz gate + tests; TUI unchanged; about-text fix;
+budget (SubrunBudget shared backstop + 4-slot semaphore, 20 min, 100
+steps); prompt guidance incl. warning-sweep recipe (partitions =
+allowed_paths; integrate one at a time re-checking after each); dogfood
+eval with negative controls (seeded out-of-scope worker must yield a
+scope-violation error; final verdict from the checker).
+
+## PR sequence (revised)
+
+- PR0' scratch_dir launch-gap hotfix (now).
+- PR1 WriteScope + file-tool wiring (independently landable).
+- PR2 worker sandbox mode: profile builder + force-sandbox propagation +
+  static guard + run_moonbit rooting + denial subjects. Test matrix per
+  subal: linked-origin rejection helper, suffixed admin dirs, external
+  siblings denied, moon check ok, status/diff ok under GIT_OPTIONAL_LOCKS=0,
+  commit/ref/config/worktree mutations fail, common state unchanged
+  (before/after snapshot), fg/bg/trusted/untrusted/run_moonbit paths,
+  no-sandbox platform fallback, e2e lab regression (through
+  execute_with_workspace, not agent_shell_launch).
+- PR3 agent_worker child kind (prompt, capture, dispatch, lifecycle tests).
+- PR4a subtask controller package: geometry/preconditions, registry +
+  lifecycle, mutex, scope parsing/validation, commit/integrate state
+  machine, git runner — tested against real git temp repos including
+  linked-origin, sibling, rename/delete, conflict, abort, rollback cases.
+- PR4b subtask tool: registration ×2, slots, evidence presentation, viz
+  gate + tests.
+- PR5 prompt guidance + regenerate.
+- PR6 dogfood warning-sweep eval.
+
+## Residuals (explicit)
+
+Cooperative-model accepted: direct `openseek` spawn / nesting
+(prompt-forbidden), inherited credentials, no shell merge trust, non-macOS
+= static-guard+WriteScope only (never described as hard confinement),
+auto-check/prebuild = trusted repo build code + concurrent per-worktree
+writers, shared `~/.moon` (moon's own locking trusted), allow-default
+outside the repo on macOS, process-local mutex (single-engine-per-repo
+assumption; two engines on one repo race — registry writes are
+atomic-rename so they fail loudly, not silently), worktree enumeration is
+provision-time (later external siblings undented), TOCTOU between
+WriteScope check and write (kernel backstop on macOS).
+
+## Round-3 outcome (2026-07-31, subal-round3.log)
+
+GO for PR1+PR2; PR #615 confirmed sound; NO-GO only for PR4a as specified.
+PR4a spec amendments to apply when building it (authoritative detail in the
+round-3 log):
+- Provision is ONE mutex-held transaction: registry reconcile → overlap
+  check → create `provisioning` reservation → info/exclude → worktree add;
+  reservation visible before mutex release.
+- Record `origin_head_before` at merge; continue/abort require: registry
+  state `conflicted` for THIS attempt + HEAD == origin_head_before +
+  MERGE_HEAD == recorded worker OID + branch OID unchanged.
+- Registry states: provisioning, running, captured, committing, committed,
+  integrating, conflicted, merged/cleanup_pending; terminals integrated,
+  discarded, no_changes. A `discard` action releases reservations;
+  integrate_abort returns to `committed` WITHOUT releasing.
+- Cross-process: atomic rename ≠ CAS; either add a common-dir lock file or
+  state "cross-process races may be silent".
+- Capture: stop controller-owned bg jobs first; pin validated staged tree
+  OID; verify commit parent == base_oid, commit tree == pinned OID, branch+
+  worktree HEAD == commit, final status snapshot clean; reject NEW
+  mode-160000 entries (embedded repos staged by add -A).
+- Integration gate: reject every staged change; gitlink carve-out only for
+  worktree-only dirt of an existing gitlink whose index entry == HEAD;
+  always `--ignore-submodules=none`.
+- Classify merge outcome by postconditions (MERGE_HEAD, unmerged entries,
+  HEAD), not exit code; crash-after-clean-merge must be recoverable.
+- Merge env: also `-c rerere.enabled=false`; repo/global merge drivers are
+  an accepted-and-stated trusted-repo residual.
+- `git worktree list --porcelain -z`; `rev-parse --path-format=absolute`.
+- WriteScope (PR1): checks cover recursive parent creation and every
+  restore/rollback write; resolved absolute paths convert back to
+  root-relative components before matching; dangling final/ancestor
+  symlinks fail closed.
+- Profile guarantee wording: shared objects/refs/config + origin + siblings
+  protected; worker-private HEAD/index mutation is detected at capture.
+
+## Empirical addendum (2026-07-31, discovered during PR #615 cleanup)
+
+`git worktree remove` FAILS for ANY worktree of this repo — even clean,
+even with the submodule deinit'd — because desktop/lepus is a tracked
+gitlink: git refuses "working trees containing submodules cannot be moved
+or removed" (git 2.5x needs `remove -f -f`, which our trust classifier
+rightly fail-closes on). Consequences: (1) the controller's cleanup must
+use engine-side rm -rf + `git worktree prune` (or -f -f) — never rely on
+plain `worktree remove`; (2) the shipped prompt `.worktrees/` recipe's
+cleanup step cannot complete in this repo under shell policy (remove fails;
+rm -rf of source trees is sandbox-denied) — needs a prompt/policy
+follow-up, tracked separately from this plan.


### PR DESCRIPTION
## Summary
First slice (PR1) of the parallel worker-subagent plan — the full design doc rides along as `docs/plans/subtask-worker-subagents.md` (3 rounds of subal xhigh design review; round 3: GO for PR1+PR2).

- New `agent_tool/internal/write_scope`: one canonical containment checker shared by `edit`, `multi_edit`, `write`, `remove`. A scope = realpath'd root + optional component-wise relative prefixes (`allowed_paths`, the future subtask partition contract).
- Both the requested form (final name below its canonicalized parent chain) and the fully resolved location must pass root+prefix checks: symlinked-dir escapes, in-scope-link-to-out-of-scope-target, out-of-scope aliases of in-scope files, and dangling links all fail closed.
- Tools gate at path resolution and re-check immediately before every write, including multi_edit's restore/re-apply rollback writes. multi_edit stays all-or-nothing (one out-of-scope member rejects the batch, nothing written). Previews stay ungated (no writes).
- No behavior change without a scope — the parameter defaults off everywhere.

## Tests
- Checker matrix: component boundaries (`src` vs `src2`), `..`, absolute paths, final/ancestor/in-root symlink escapes, dangling symlinks, nonexistent descendants, canonical-root spellings (`/tmp` vs `/private/tmp`), strict prefix validation.
- Per-tool containment tests incl. edit-through-symlink and multi_edit batch abort.
- 131/131 across the five packages; repo `moon check` clean (one pre-existing base_prompt warning); `moon fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)