### PR TITLE
feat(shell): worker sandbox mode — kernel-confined write scope per worktree

### DIFF
--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -34,11 +34,12 @@ fn source_write_denied_in_text(
     line.contains("\{subject}:") ||
     line.contains("\{subject}'") ||
     line.contains("\{subject}\"") ||
-    // A subject that is a protected DIRECTORY names every path below it:
-    // `sh: <subject>/seed.txt: Operation not permitted`. Same-line denial
-    // wording is still required by the caller, so a mere mention of a path
-    // under the subject cannot classify on its own.
-    line.contains("\{subject}/") ||
+    // An ABSOLUTE subject that is a protected directory names every path
+    // below it: `sh: <subject>/seed.txt: Operation not permitted`. Only
+    // full-root subjects participate (a bare basename like `repo` would
+    // match unrelated paths such as `/tmp/notrepo/file`); same-line denial
+    // wording is still required by the caller.
+    (subject.has_prefix("/") && line.contains("\{subject}/")) ||
     // MoonBit's own OSError Show output escapes the quotes around the path
     // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
     // followed by `\"`, not a bare quote — run_moonbit's denial shape.

--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -24,6 +24,33 @@ fn source_write_denied_in_text(
   denial_subjects : Array[String],
 ) -> Bool {
 
+  // Whether `line` contains `subject` as a complete path component followed
+  // by a slash — `repo/` at line start or after a non-path character, but
+  // never inside `notrepo/`. Only the character BEFORE the match needs
+  // checking; the trailing slash bounds the other side.
+  fn names_component_bounded(line : StringView, subject : String) -> Bool {
+    let needle = "\{subject}/"
+    let mut from = 0
+    while true {
+      guard line.view(start_offset=from).find(needle) is Some(offset) else {
+        break
+      }
+      let at = from + offset
+      if at == 0 {
+        return true
+      }
+      // A preceding separator means the component IS the subject
+      // (`./repo/`, `/x/repo/`); any word character means the match sits
+      // inside a longer component (`notrepo/`, `not.repo/`).
+      let before = line[at - 1]
+      if !(before is ('a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' | '.')) {
+        return true
+      }
+      from = at + needle.length()
+    }
+    false
+  }
+
   // Whether `line` names `subject` as the object of an error rather than merely
   // containing it as a substring: the tool's own punctuation or quoting follows
   // it, or the line ends with it after a denial's colon.
@@ -34,12 +61,14 @@ fn source_write_denied_in_text(
     line.contains("\{subject}:") ||
     line.contains("\{subject}'") ||
     line.contains("\{subject}\"") ||
-    // An ABSOLUTE subject that is a protected directory names every path
-    // below it: `sh: <subject>/seed.txt: Operation not permitted`. Only
-    // full-root subjects participate (a bare basename like `repo` would
-    // match unrelated paths such as `/tmp/notrepo/file`); same-line denial
-    // wording is still required by the caller.
+    // A subject that is a protected directory names every path below it:
+    // `sh: <subject>/seed.txt: Operation not permitted`. An absolute
+    // subject is inherently anchored; a bare basename (`repo`) matches only
+    // as a COMPLETE leading path component (`repo/file` after a boundary),
+    // so `/tmp/notrepo/file` cannot classify. Same-line denial wording is
+    // still required by the caller.
     (subject.has_prefix("/") && line.contains("\{subject}/")) ||
+    (!subject.has_prefix("/") && names_component_bounded(line, subject)) ||
     // MoonBit's own OSError Show output escapes the quotes around the path
     // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
     // followed by `\"`, not a bare quote — run_moonbit's denial shape.

--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -61,14 +61,6 @@ fn source_write_denied_in_text(
     line.contains("\{subject}:") ||
     line.contains("\{subject}'") ||
     line.contains("\{subject}\"") ||
-    // A subject that is a protected directory names every path below it:
-    // `sh: <subject>/seed.txt: Operation not permitted`. An absolute
-    // subject is inherently anchored; a bare basename (`repo`) matches only
-    // as a COMPLETE leading path component (`repo/file` after a boundary),
-    // so `/tmp/notrepo/file` cannot classify. Same-line denial wording is
-    // still required by the caller.
-    (subject.has_prefix("/") && line.contains("\{subject}/")) ||
-    (!subject.has_prefix("/") && names_component_bounded(line, subject)) ||
     // MoonBit's own OSError Show output escapes the quotes around the path
     // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
     // followed by `\"`, not a bare quote — run_moonbit's denial shape.
@@ -82,6 +74,21 @@ fn source_write_denied_in_text(
       ) &&
       line.has_suffix(subject)
     )
+  }
+
+  // A PROFILE subject that is a protected directory names every path below
+  // it: `sh: <subject>/seed.txt: Operation not permitted`. An absolute
+  // subject is inherently anchored; a bare basename (`repo`) matches only as
+  // a COMPLETE path component after a separator boundary, so
+  // `/tmp/notrepo/file` cannot classify. Applied ONLY to the profile's
+  // denial subjects — protected source suffixes (`.mbt`, `moon.mod`) name
+  // files, and a directory that merely ends like one must not classify.
+  fn line_names_denied_dir(line : StringView, subject : String) -> Bool {
+    if subject.has_prefix("/") {
+      line.contains("\{subject}/")
+    } else {
+      names_component_bounded(line, subject)
+    }
   }
 
   output_text
@@ -98,7 +105,11 @@ fn source_write_denied_in_text(
     (
       protected_source_subjects.any(suffix => line_names_subject(line, suffix)) ||
       denial_subjects.any(subject => {
-        subject != "" && line_names_subject(line, subject)
+        subject != "" &&
+        (
+          line_names_subject(line, subject) ||
+          line_names_denied_dir(line, subject)
+        )
       })
     )
   })

--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -34,6 +34,11 @@ fn source_write_denied_in_text(
     line.contains("\{subject}:") ||
     line.contains("\{subject}'") ||
     line.contains("\{subject}\"") ||
+    // A subject that is a protected DIRECTORY names every path below it:
+    // `sh: <subject>/seed.txt: Operation not permitted`. Same-line denial
+    // wording is still required by the caller, so a mere mention of a path
+    // under the subject cannot classify on its own.
+    line.contains("\{subject}/") ||
     // MoonBit's own OSError Show output escapes the quotes around the path
     // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
     // followed by `\"`, not a bare quote — run_moonbit's denial shape.

--- a/agent_tool/internal/sandbox/denial_output_wbtest.mbt
+++ b/agent_tool/internal/sandbox/denial_output_wbtest.mbt
@@ -40,3 +40,21 @@ test "source-write denial detection in command output" {
   // A source path without any denial wording is not a denial either.
   assert_false(reports([], "compiled keep.mbt: ok"))
 }
+
+///|
+test "directory subjects match below their root, basenames never do" {
+  // An absolute directory subject names every path beneath it.
+  assert_true(
+    source_write_denied_in_text(
+      "sh: /x/repo/seed.txt: Operation not permitted",
+      ["/x/repo"],
+    ),
+  )
+  // A bare basename must not match unrelated paths that merely contain it.
+  assert_false(
+    source_write_denied_in_text(
+      "sh: /tmp/notrepo/file: Operation not permitted",
+      ["repo"],
+    ),
+  )
+}

--- a/agent_tool/internal/sandbox/denial_output_wbtest.mbt
+++ b/agent_tool/internal/sandbox/denial_output_wbtest.mbt
@@ -58,3 +58,23 @@ test "directory subjects match below their root, basenames never do" {
     ),
   )
 }
+
+///|
+test "a basename subject matches as a complete leading component" {
+  // sh reports relative operands relative: `repo/file: Permission denied`.
+  assert_true(
+    source_write_denied_in_text("sh: repo/file: Permission denied", ["repo"]),
+  )
+  // Mid-path occurrences bounded by a slash stay recognized too.
+  assert_true(
+    source_write_denied_in_text("sh: ./repo/file: Operation not permitted", [
+      "repo",
+    ]),
+  )
+  // But never inside another component.
+  assert_false(
+    source_write_denied_in_text("sh: mynotrepo/file: Operation not permitted", [
+      "repo",
+    ]),
+  )
+}

--- a/agent_tool/internal/sandbox/denial_output_wbtest.mbt
+++ b/agent_tool/internal/sandbox/denial_output_wbtest.mbt
@@ -78,3 +78,23 @@ test "a basename subject matches as a complete leading component" {
     ]),
   )
 }
+
+///|
+test "component boundaries hold across word chars and suffix subjects" {
+  // The word chars that drive the boundary set cannot leak a match.
+  assert_false(
+    source_write_denied_in_text("sh: my-repo/file: Operation not permitted", [
+      "repo",
+    ]),
+  )
+  assert_false(
+    source_write_denied_in_text("sh: not.repo/file: Operation not permitted", [
+      "repo",
+    ]),
+  )
+  // Component matching is a profile-subject affordance: a DIRECTORY named
+  // like a protected source suffix must not classify via the suffix list.
+  assert_false(
+    source_write_denied_in_text("sh: foo.mbt/seed: Operation not permitted", []),
+  )
+}

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub(all) enum Command {
 type SandboxedCommand
 pub fn SandboxedCommand::args(Self) -> Array[String]
 pub async fn SandboxedCommand::create_if_available(String, Command, writable_subtree? : String) -> Self?
+pub async fn SandboxedCommand::create_worker_if_available(Command, deny_roots~ : Array[String], worker_root~ : String, worker_admin_dir~ : String) -> Self?
 pub fn SandboxedCommand::output_reports_denial(Self, String) -> Bool
 pub fn SandboxedCommand::program(Self) -> String
 

--- a/agent_tool/internal/sandbox/worker_profile.mbt
+++ b/agent_tool/internal/sandbox/worker_profile.mbt
@@ -1,0 +1,112 @@
+///|
+/// The kernel-enforced write scope of one worker subagent: everything the
+/// repository shares is denied, the worker's own tree is re-allowed.
+///
+/// Rule order is load-bearing (SBPL is last-match-wins):
+///
+///   (allow default)                       — cooperative model: the layer
+///                                           confines against THIS repository
+///                                           and its worktrees, not the wider
+///                                           filesystem
+///   (deny  file-write* <each deny root>)  — canonical common git dir + every
+///                                           enumerated worktree root,
+///                                           including the origin toplevel
+///   (allow file-write* <worker root>)     — the worker's own linked worktree,
+///                                           nested inside a denied root
+///   (allow file-write* <worker admin>)    — the worktree's PRIVATE admin dir
+///                                           (resolved via rev-parse, never
+///                                           constructed), so status/diff can
+///                                           write their index and locks
+///   (deny  file-write* literal <worker root>/.git)
+///                                         — the gitfile pointer, last so it
+///                                           wins over the worker-root allow
+///
+/// Net effect: moon writes `wt/_build` and shared caches; `git status`/`diff`
+/// work; `git commit` and every shared object/ref/config/worktree mutation
+/// fail; sibling and origin writes fail. Worker-private HEAD/index mutation
+/// remains possible by design and is detected at capture time by the
+/// controller.
+priv struct WorkerWriteProfileData {
+  profile : String
+  denial_subjects : Array[String]
+}
+
+///|
+/// Build the worker profile from canonical (realpath'd) inputs. Validation
+/// raises on caller bugs rather than failing open: the worker root must sit
+/// strictly below one of the denied roots (that nesting is what the re-allow
+/// exists to carve out), and no denied root may sit at or below the worker
+/// root (the allow would re-open it wholesale).
+fn worker_write_profile_data(
+  deny_roots : Array[String],
+  worker_root~ : String,
+  worker_admin_dir~ : String,
+) -> WorkerWriteProfileData raise {
+  guard !deny_roots.is_empty() else {
+    fail("worker profile needs at least one denied root")
+  }
+  guard deny_roots.any(root => {
+    @workspace_path.is_under_workspace_root(root, worker_root) &&
+    root != worker_root
+  }) else {
+    fail("worker_root must be nested below a denied root")
+  }
+  for root in deny_roots {
+    if @workspace_path.is_under_workspace_root(worker_root, root) {
+      fail("a denied root sits at or below worker_root: \{root}")
+    }
+  }
+  let profile = StringBuilder()
+  profile <+
+    $|(version 1)
+    $|(allow default)
+    $|
+  let denial_subjects : Array[String] = []
+  for root in deny_roots {
+    profile <+
+      $|(deny file-write* (subpath "\{sbpl_string_escape(root)}"))
+      $|
+    denial_subjects.push(root)
+    let base = @workspace_path.path_basename(root)
+    if base != root {
+      denial_subjects.push(base)
+    }
+  }
+  profile <+
+    $|(allow file-write* (subpath "\{sbpl_string_escape(worker_root)}"))
+    $|(allow file-write* (subpath "\{sbpl_string_escape(worker_admin_dir)}"))
+    $|
+  let gitfile = "\{worker_root}/.git"
+  profile <+
+    $|(deny file-write* (literal "\{sbpl_string_escape(gitfile)}"))
+    $|
+  denial_subjects.push(gitfile)
+  { profile: profile.to_string(), denial_subjects }
+}
+
+///|
+/// Prepare `command` under a worker write profile, or `None` when this
+/// process cannot enforce one (same availability contract as
+/// `create_if_available`). All paths must already be canonical: the caller
+/// (the subtask controller) realpaths them at provision time, and the kernel
+/// matches rules against realpaths.
+pub async fn SandboxedCommand::create_worker_if_available(
+  command : Command,
+  deny_roots~ : Array[String],
+  worker_root~ : String,
+  worker_admin_dir~ : String,
+) -> SandboxedCommand? {
+  // Validate before the availability probe so caller bugs surface on every
+  // platform (see create_if_available).
+  let data = worker_write_profile_data(
+    deny_roots,
+    worker_root~,
+    worker_admin_dir~,
+  )
+  guard sandbox_exec_available() else { return None }
+  let args = match command {
+    Shell(cmd) => sandbox_exec_args(data.profile, cmd)
+    Exec(program, args) => ["-p", data.profile, program, ..args]
+  }
+  Some({ program: SandboxExecPath, args, denial_subjects: data.denial_subjects })
+}

--- a/agent_tool/internal/sandbox/worker_profile.mbt
+++ b/agent_tool/internal/sandbox/worker_profile.mbt
@@ -56,6 +56,21 @@ fn worker_write_profile_data(
       fail("a denied root sits at or below worker_root: \{root}")
     }
   }
+  // The admin allow is a carve-out INSIDE a denied root (the common git
+  // dir's worktrees/<name> subdirectory). A miscomputed admin path that sits
+  // at a denied root — or above one — would re-open shared objects, refs,
+  // and config wholesale, because SBPL is last-match-wins.
+  guard deny_roots.any(root => {
+    @workspace_path.is_under_workspace_root(root, worker_admin_dir) &&
+    root != worker_admin_dir
+  }) else {
+    fail("worker_admin_dir must be nested below a denied root")
+  }
+  for root in deny_roots {
+    if @workspace_path.is_under_workspace_root(worker_admin_dir, root) {
+      fail("worker_admin_dir covers a denied root: \{root}")
+    }
+  }
   let profile = StringBuilder()
   profile <+
     $|(version 1)

--- a/agent_tool/internal/sandbox/worker_profile_test.mbt
+++ b/agent_tool/internal/sandbox/worker_profile_test.mbt
@@ -1,0 +1,136 @@
+///|
+/// Unsandboxed setup helper: run git and require success.
+async fn git_setup(args : Array[String], cwd : String) -> String {
+  let (code, data) = @process.collect_stdout(
+    "git",
+    args,
+    inherit_env=true,
+    cwd=cwd.view(),
+  )
+  guard code == 0 else { fail("git failed in \{cwd}: \{data.text()}") }
+  data.text()
+}
+
+///|
+/// The worker profile, end to end on a real repository with real linked
+/// worktrees: the worker tree is writable, `git status`/`add`-class reads of
+/// its private admin dir work, and every shared surface — origin files, a
+/// sibling worktree, the shared object store (via commit), the gitfile
+/// pointer — is kernel-denied. Guarded on real sandbox availability.
+async test "the worker profile confines writes to the worker tree" {
+  @vfs.with_tmpdir(prefix="openseek-worker-profile-", dir => {
+    // Fixture: a repo with one commit and two linked worktrees.
+    let repo = "\{dir}/repo"
+    @fs.mkdir(repo)
+    let _ = git_setup(["init", "-q"], repo)
+    let _ = git_setup(["config", "user.email", "e2e@test"], repo)
+    let _ = git_setup(["config", "user.name", "e2e"], repo)
+    @vfs.write_text(repo, "seed.txt", "seed\n")
+    let _ = git_setup(["add", "-A"], repo)
+    let _ = git_setup(["commit", "-q", "-m", "base"], repo)
+    let _ = git_setup(
+      ["worktree", "add", "-q", ".worktrees/w1", "-b", "w1"],
+      repo,
+    )
+    let _ = git_setup(
+      ["worktree", "add", "-q", ".worktrees/w2", "-b", "w2"],
+      repo,
+    )
+    let origin = @fs.realpath(repo)
+    let worker_root = @fs.realpath("\{repo}/.worktrees/w1")
+    let sibling = @fs.realpath("\{repo}/.worktrees/w2")
+    let admin_raw = git_setup(["rev-parse", "--absolute-git-dir"], worker_root)
+    let worker_admin_dir = @fs.realpath(admin_raw.trim().to_owned())
+    let common = @fs.realpath("\{origin}/.git")
+    let deny_roots = [common, origin, sibling]
+    async fn probe(cmd : String) -> @sandbox.SandboxedCommand? {
+      @sandbox.SandboxedCommand::create_worker_if_available(
+        Shell(cmd),
+        deny_roots~,
+        worker_root~,
+        worker_admin_dir~,
+      )
+    }
+
+    guard probe(":") is Some(_) else {
+      println("sandbox-exec unavailable; skipping")
+      return
+    }
+    // 1. The worker's own tree is writable.
+    guard probe("printf x > \{worker_root}/scratch.txt") is Some(own) else {
+      fail("probe build failed")
+    }
+    let (own_exit, _) = merged_output_text(own)
+    assert_eq(own_exit, 0)
+    assert_true(@fs.exists("\{worker_root}/scratch.txt"))
+    // 2. Reads of git state through the private admin dir keep working.
+    guard probe("cd \{worker_root} && git status --porcelain") is Some(status) else {
+      fail("probe build failed")
+    }
+    let (status_exit, _) = merged_output_text(status)
+    assert_eq(status_exit, 0)
+    // 3. Origin files survive (the denial is the assertion that matters).
+    guard probe("printf x > \{origin}/seed.txt") is Some(against_origin) else {
+      fail("probe build failed")
+    }
+    let (origin_exit, origin_text) = merged_output_text(against_origin)
+    assert_true(origin_exit != 0)
+    assert_eq(@fs.read_file("\{origin}/seed.txt").text(), "seed\n")
+    assert_true(against_origin.output_reports_denial(origin_text))
+    // 4. A sibling worktree is not writable.
+    guard probe("printf x > \{sibling}/intrude.txt") is Some(against_sibling) else {
+      fail("probe build failed")
+    }
+    let (sibling_exit, _) = merged_output_text(against_sibling)
+    assert_true(sibling_exit != 0)
+    assert_false(@fs.exists("\{sibling}/intrude.txt"))
+    // 5. The gitfile pointer is pinned even though it lives in the allowed
+    // worker root.
+    guard probe("printf y > \{worker_root}/.git") is Some(against_gitfile) else {
+      fail("probe build failed")
+    }
+    let (gitfile_exit, _) = merged_output_text(against_gitfile)
+    assert_true(gitfile_exit != 0)
+    assert_true(
+      @fs.read_file("\{worker_root}/.git").text().has_prefix("gitdir:"),
+    )
+    // 6. Commits cannot land: blob/object writes hit the shared store. The
+    // add/commit chain fails and the branch still holds only the base commit.
+    guard probe("cd \{worker_root} && git add -A && git commit -q -m steal")
+      is Some(against_store) else {
+      fail("probe build failed")
+    }
+    let (commit_exit, _) = merged_output_text(against_store)
+    assert_true(commit_exit != 0)
+    let log = git_setup(["log", "--oneline"], worker_root)
+    assert_eq(log.trim().to_owned().split("\n").count(), 1)
+  })
+}
+
+///|
+/// Caller-bug validation raises instead of failing open.
+async test "worker profile validation rejects impossible geometries" {
+  @vfs.with_tmpdir(prefix="openseek-worker-profile-validate-", dir => {
+    let root = @fs.realpath(dir)
+    // Worker root not nested below any denied root.
+    let outside = @sandbox.SandboxedCommand::create_worker_if_available(
+      Shell(":"),
+      deny_roots=["\{root}/repo"],
+      worker_root="\{root}/elsewhere",
+      worker_admin_dir="\{root}/repo/.git/worktrees/x",
+    ) catch {
+      _ => None
+    }
+    assert_true(outside is None)
+    // A denied root below the worker root would be re-opened wholesale.
+    let reopened = @sandbox.SandboxedCommand::create_worker_if_available(
+      Shell(":"),
+      deny_roots=["\{root}/repo", "\{root}/repo/.worktrees/w1/nested"],
+      worker_root="\{root}/repo/.worktrees/w1",
+      worker_admin_dir="\{root}/repo/.git/worktrees/w1",
+    ) catch {
+      _ => None
+    }
+    assert_true(reopened is None)
+  })
+}

--- a/agent_tool/internal/sandbox/worker_profile_test.mbt
+++ b/agent_tool/internal/sandbox/worker_profile_test.mbt
@@ -132,5 +132,15 @@ async test "worker profile validation rejects impossible geometries" {
       _ => None
     }
     assert_true(reopened is None)
+    // A miscomputed admin dir that IS a denied root would re-open it.
+    let admin_reopens = @sandbox.SandboxedCommand::create_worker_if_available(
+      Shell(":"),
+      deny_roots=["\{root}/repo", "\{root}/repo/.git"],
+      worker_root="\{root}/repo/.worktrees/w1",
+      worker_admin_dir="\{root}/repo/.git",
+    ) catch {
+      _ => None
+    }
+    assert_true(admin_reopens is None)
   })
 }

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
 
-pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, default_timeout_ms? : Int, scratch_dir? : String) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, default_timeout_ms? : Int, scratch_dir? : String, worker_sandbox? : WorkerSandbox) -> @agent_tool.AgentToolDefinition
 
 pub fn source_write_denial_feedback() -> String
 
@@ -20,6 +20,12 @@ pub struct ShellOutput {
   exit_code : Int?
   text : String
   output_limit_reached : Bool
+}
+
+pub(all) struct WorkerSandbox {
+  deny_roots : Array[String]
+  worker_root : String
+  worker_admin_dir : String
 }
 
 // Type aliases

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -61,7 +61,36 @@ async fn agent_shell_launch(
   parsed : @shell_parse.ParseResult,
   cwd? : String,
   scratch_dir? : String,
+  worker_sandbox? : WorkerSandbox,
 ) -> AgentShellLaunch {
+  // Worker mode replaces the whole trust classification: EVERY command —
+  // trusted classes included — launches under the worker write profile, so
+  // the kernel (not the lexical guard) decides what may be written. A
+  // platform without sandbox-exec falls back to unsandboxed execution with
+  // only the static floor — the documented non-macOS posture.
+  if worker_sandbox is Some(scope) {
+    let sandboxed = @sandbox.SandboxedCommand::create_worker_if_available(
+      Shell(cmd),
+      deny_roots=scope.deny_roots,
+      worker_root=scope.worker_root,
+      worker_admin_dir=scope.worker_admin_dir,
+    )
+    return match sandboxed {
+      Some(command) =>
+        {
+          command: { program: command.program(), args: command.args() },
+          sandboxed_command: Some(command),
+        }
+      None =>
+        {
+          command: {
+            program: @platform_shell.program,
+            args: @platform_shell.args(cmd),
+          },
+          sandboxed_command: None,
+        }
+    }
+  }
   let real_workspace_root = @fs.realpath(workspace_root)
   let real_cwd = match cwd {
     Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1680,3 +1680,89 @@ async test "a lone operand is a source with no destination" {
     assert_true(tree_target("mv -f pkg", real_root, Some(real_root)) is None)
   })
 }
+
+///|
+/// Unsandboxed setup helper for worker-mode fixtures: run git, require success.
+async fn worker_git_setup(args : Array[String], cwd : String) -> String {
+  let (code, data) = @process.collect_stdout(
+    "git",
+    args,
+    inherit_env=true,
+    cwd=cwd.view(),
+  )
+  guard code == 0 else { fail("git failed in \{cwd}: \{data.text()}") }
+  data.text()
+}
+
+///|
+/// Worker mode through the WIRED shell entry: every class — including a
+/// trusted git verb — launches under the worker profile, so origin writes,
+/// shared-store writes, and worktree surgery are kernel-denied while the
+/// worker's own tree stays writable. Mirrors the lab regression tests: the
+/// call sites, not `agent_shell_launch`, are what these pin.
+async test "worker mode confines the wired shell to the worker tree" {
+  @vfs.with_tmpdir(prefix="openseek-worker-mode-", dir => {
+    guard @sandbox.SandboxedCommand::create_if_available(dir, Shell(":"))
+      is Some(_) else {
+      println("sandbox-exec unavailable; skipping")
+      return
+    }
+    let repo = "\{dir}/repo"
+    @fs.mkdir(repo)
+    let _ = worker_git_setup(["init", "-q"], repo)
+    let _ = worker_git_setup(["config", "user.email", "e2e@test"], repo)
+    let _ = worker_git_setup(["config", "user.name", "e2e"], repo)
+    @vfs.write_text(repo, "seed.txt", "seed\n")
+    let _ = worker_git_setup(["add", "-A"], repo)
+    let _ = worker_git_setup(["commit", "-q", "-m", "base"], repo)
+    let _ = worker_git_setup(
+      ["worktree", "add", "-q", ".worktrees/w1", "-b", "w1"],
+      repo,
+    )
+    let origin = @fs.realpath(repo)
+    let worker_root = @fs.realpath("\{repo}/.worktrees/w1")
+    let admin_raw = worker_git_setup(
+      ["rev-parse", "--absolute-git-dir"],
+      worker_root,
+    )
+    let scope : WorkerSandbox = {
+      deny_roots: [@fs.realpath("\{origin}/.git"), origin],
+      worker_root,
+      worker_admin_dir: @fs.realpath(admin_raw.trim().to_owned()),
+    }
+    async fn run(cmd : String) -> @agent_tool.ToolAction {
+      execute_with_workspace(
+        worker_root,
+        { "cmd": cmd },
+        read_only=false,
+        default_timeout_ms=30_000,
+        worker_sandbox=scope,
+      )
+    }
+    // The worker's own tree is writable through the tool.
+    guard run("printf x > \{worker_root}/scratch.txt") is Respond(own) else {
+      fail("expected Respond")
+    }
+    assert_false(own.is_error)
+    assert_true(@fs.exists("\{worker_root}/scratch.txt"))
+    // An absolute-path write into the origin is kernel-denied; the seed
+    // survives (the assertion that carries the test).
+    guard run("printf x > \{origin}/seed.txt") is Respond(against_origin) else {
+      fail("expected Respond")
+    }
+    assert_true(against_origin.is_error)
+    assert_eq(@fs.read_file("\{origin}/seed.txt").text(), "seed\n")
+    // A TRUSTED verb is forced onto the sandbox: `git worktree add` would run
+    // unsandboxed in a normal registry, but here its origin write is denied.
+    guard run("git worktree add \{origin}/evil-wt -b evil") is Respond(surgery) else {
+      fail("expected Respond")
+    }
+    assert_true(surgery.is_error)
+    assert_false(@fs.exists("\{origin}/evil-wt"))
+    // Reads of git state keep working.
+    guard run("git status --porcelain") is Respond(status) else {
+      fail("expected Respond")
+    }
+    assert_false(status.is_error)
+  })
+}

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -58,6 +58,7 @@ pub fn definition(
   bg_runtime? : @bgjobs.BgJobRuntime,
   default_timeout_ms? : Int,
   scratch_dir? : String,
+  worker_sandbox? : WorkerSandbox,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="shell",
@@ -119,6 +120,7 @@ pub fn definition(
         bg_runtime?,
         default_timeout_ms?,
         scratch_dir?,
+        worker_sandbox?,
       )
     }),
   )
@@ -173,6 +175,7 @@ async fn execute_with_workspace(
   bg_runtime? : @bgjobs.BgJobRuntime,
   default_timeout_ms? : Int,
   scratch_dir? : String,
+  worker_sandbox? : WorkerSandbox,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error => {
@@ -184,6 +187,23 @@ async fn execute_with_workspace(
     }
   }
   let parsed_command = @shell_parse.parse_for_policy(input.cmd)
+  // Worker mode: the static confinement floor rejects obvious escapes with a
+  // readable explanation before launch; the kernel profile (attached at
+  // launch) is the actual enforcement on platforms that have one.
+  if worker_sandbox is Some(scope) &&
+    worker_confinement_blocks(
+      parsed_command,
+      base_cwd=@workspace_path.resolve_cwd(workspace_root, input.cwd).unwrap_or(
+        workspace_root,
+      ),
+      worker_root=scope.worker_root,
+    )
+    is Some(reason) {
+    return @agent_tool.ToolAction::respond(
+      "blocked in worker mode: \{reason}; your writes are confined to \{scope.worker_root}",
+      is_error=true,
+    )
+  }
   // Read-only (review) mode: refuse the obvious bulk source-rewriters — a
   // source-mutating moon command (fmt / info / test --update) anywhere in the
   // parsed command, including `&&`/`;` chains, pipes, and env prefixes. This is
@@ -219,6 +239,7 @@ async fn execute_with_workspace(
     bg_runtime?,
     default_timeout_ms?,
     scratch_dir?,
+    worker_sandbox?,
   ) catch {
     error =>
       @agent_tool.ToolAction::respond(
@@ -264,6 +285,7 @@ async fn shell(
   cwd : String?,
   workspace_root : String,
   scratch_dir? : String,
+  worker_sandbox? : WorkerSandbox,
   bg_runtime? : @bgjobs.BgJobRuntime,
   default_timeout_ms? : Int,
 ) -> @agent_tool.ToolAction {
@@ -310,6 +332,7 @@ async fn shell(
       cwd,
       workspace_root,
       scratch_dir?,
+      worker_sandbox?,
       bg_runtime?,
     )
   }
@@ -376,6 +399,7 @@ async fn shell(
     foreground_spawn?,
     on_timeout_detach?,
     scratch_dir?,
+    worker_sandbox?,
   )
   let agent_output = match result {
     ShellExecuted(output) => output
@@ -481,6 +505,7 @@ async fn run_agent_shell_with_tree_precheck(
   foreground_spawn? : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution,
   on_timeout_detach? : (@shell_exec.ShellExecution, AgentShellLaunch) -> String,
   scratch_dir? : String,
+  worker_sandbox? : WorkerSandbox,
 ) -> ShellRunResult {
   if preblock_target_outside_lab(
       source_tree_operation_target(parsed_command, cmd, workspace_root, cwd),
@@ -495,6 +520,7 @@ async fn run_agent_shell_with_tree_precheck(
     parsed_command,
     cwd?,
     scratch_dir?,
+    worker_sandbox?,
   )
   match foreground_spawn {
     // Foreground on the shared execution model: spawn on the session group and
@@ -595,6 +621,7 @@ async fn start_background(
   cwd : String?,
   workspace_root : String,
   scratch_dir? : String,
+  worker_sandbox? : WorkerSandbox,
   bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   guard bg_runtime is Some(runtime) else {
@@ -631,6 +658,7 @@ async fn start_background(
     parsed_command,
     cwd?,
     scratch_dir?,
+    worker_sandbox?,
   )
   let id = runtime.start(
     program=launch.command.program,

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -2194,3 +2194,37 @@ async test "worker mode tracks cd forms, pipelines, and symlinked cwds" {
     assert_false(back.is_error)
   })
 }
+
+///|
+/// The review probe that broke the earlier tracker: `cd` into a FILE fails
+/// in sh (cwd unchanged), so the later `&&`-chained `cd ..; cd ..` really
+/// runs from the worker root and escapes. Candidate tracking must know that
+/// only an existing DIRECTORY can become a cwd.
+async test "worker mode blocks the failed-cd-into-file escape chain" {
+  @vfs.with_tmpdir(prefix="openseek-worker-floor3-", dir => {
+    let root = @fs.realpath(dir)
+    @fs.mkdir("\{root}/w")
+    @fs.mkdir("\{root}/w/sub")
+    @fs.write_file("\{root}/w/file", "not a directory", create_mode=CreateNew)
+    @fs.mkdir("\{root}/admin")
+    let scope : @shell.WorkerSandbox = {
+      deny_roots: [root],
+      worker_root: "\{root}/w",
+      worker_admin_dir: "\{root}/admin",
+    }
+    let run = match
+      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("shell tool should be async")
+    }
+    guard run({
+        "cmd": "cd file; cd sub && cd .. && cd .. && touch escaped.txt",
+      })
+      is Respond(output) else {
+      fail("expected Respond")
+    }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("blocked in worker mode"))
+    assert_false(@fs.exists("\{root}/escaped.txt"))
+  })
+}

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -2181,10 +2181,16 @@ async test "worker mode tracks cd forms, pipelines, and symlinked cwds" {
     // An in-tree symlink pointing out of the tree fails the canonical check.
     @fs.symlink(target="/tmp", "\{root}/w/way-out")
     blocked({ "cmd": "pwd", "cwd": "way-out" })
-    // Legitimate in-tree chains stay admitted.
+    // Legitimate in-tree chains stay admitted — including a return to the
+    // worker root through `&&`, where the cd's success is guaranteed for
+    // the chained command.
     guard run({ "cmd": "cd sub && printf ok" }) is Respond(fine) else {
       fail("expected Respond")
     }
     assert_false(fine.is_error)
+    guard run({ "cmd": "cd sub && cd .. && printf ok" }) is Respond(back) else {
+      fail("expected Respond")
+    }
+    assert_false(back.is_error)
   })
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -2228,3 +2228,54 @@ async test "worker mode blocks the failed-cd-into-file escape chain" {
     assert_false(@fs.exists("\{root}/escaped.txt"))
   })
 }
+
+///|
+/// The two cross-model-review escape chains: logical `..` through a symlink
+/// (sh's cd is PWD-textual, so `w/link/..` is `w` even when link resolves
+/// elsewhere in-tree — candidates must track spellings), and a failed cd
+/// whose continuation REJOINS at `;` from the pre-cd cwd (suspended
+/// candidates must merge back). Plus the propagation edges around them.
+async test "worker mode survives logical-cd and failure-rejoin chains" {
+  @vfs.with_tmpdir(prefix="openseek-worker-floor4-", dir => {
+    let root = @fs.realpath(dir)
+    @fs.mkdir("\{root}/w")
+    @fs.mkdir("\{root}/w/sub")
+    @fs.mkdir("\{root}/w/sub/deep")
+    @fs.mkdir("\{root}/admin")
+    let scope : @shell.WorkerSandbox = {
+      deny_roots: [root],
+      worker_root: "\{root}/w",
+      worker_admin_dir: "\{root}/admin",
+    }
+    let run = match
+      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("shell tool should be async")
+    }
+    async fn blocked(cmd : Json) -> Unit {
+      guard run(cmd) is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("blocked in worker mode"))
+    }
+
+    // Symlink + logical `..`: link points DEEP in-tree, so sh's `cd ..`
+    // from the link spelling lands at the worker root and one more `..`
+    // escapes — canonical tracking would predict staying under sub/deep.
+    @fs.symlink(target="\{root}/w/sub/deep", "\{root}/w/link")
+    blocked({ "cmd": "cd link && cd .. && cd .. && touch escaped.txt" })
+    // Failure rejoin at `;`: a cd that fails at runtime skips the `&&`
+    // chain, and the `;` continuation runs from the PRE-cd cwd — which must
+    // still be a candidate for the final `cd ..`.
+    blocked({ "cmd": "cd missing && true; cd .. && touch escaped.txt" })
+    // A cd with no viable destination clears nothing.
+    blocked({ "cmd": "cd missing && cd .. && touch escaped.txt" })
+    // `||` keeps the pre-cd cwd reachable.
+    blocked({ "cmd": "cd sub || cd ..; cd .. && touch escaped.txt" })
+    assert_false(@fs.exists("\{root}/escaped.txt"))
+    // The admitted shapes stay admitted.
+    guard run({ "cmd": "cd link && cd .. && printf ok" }) is Respond(fine) else {
+      fail("expected Respond")
+    }
+    assert_false(fine.is_error)
+  })
+}

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -2269,6 +2269,24 @@ async test "worker mode survives logical-cd and failure-rejoin chains" {
     blocked({ "cmd": "cd missing && true; cd .. && touch escaped.txt" })
     // A cd with no viable destination clears nothing.
     blocked({ "cmd": "cd missing && cd .. && touch escaped.txt" })
+    // The rejoin machinery itself: an EXISTING directory passes scan-time
+    // viability (so the `&&`-clearing fires and suspends the pre-cd cwd),
+    // but exec permission makes the runtime cd fail — the `;` continuation
+    // runs from the suspended cwd, and its `cd ..` must still block.
+    @fs.mkdir("\{root}/w/noexec")
+    let chmod_off = @process.collect_stdout(
+      "chmod",
+      ["000", "\{root}/w/noexec"],
+      inherit_env=true,
+    )
+    assert_eq(chmod_off.0, 0)
+    blocked({ "cmd": "cd noexec && true; cd .. && touch escaped.txt" })
+    let chmod_on = @process.collect_stdout(
+      "chmod",
+      ["755", "\{root}/w/noexec"],
+      inherit_env=true,
+    )
+    assert_eq(chmod_on.0, 0)
     // `||` keeps the pre-cd cwd reachable.
     blocked({ "cmd": "cd sub || cd ..; cd .. && touch escaped.txt" })
     assert_false(@fs.exists("\{root}/escaped.txt"))

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -2143,3 +2143,48 @@ async test "worker mode statically blocks obvious escapes" {
     assert_true(plain.content.contains("hi"))
   })
 }
+
+///|
+/// The floor recognizes cd's full surface and real sh cwd semantics.
+async test "worker mode tracks cd forms, pipelines, and symlinked cwds" {
+  @vfs.with_tmpdir(prefix="openseek-worker-floor2-", dir => {
+    let root = @fs.realpath(dir)
+    @fs.mkdir("\{root}/w")
+    @fs.mkdir("\{root}/w/sub")
+    @fs.mkdir("\{root}/admin")
+    let scope : @shell.WorkerSandbox = {
+      deny_roots: [root],
+      worker_root: "\{root}/w",
+      worker_admin_dir: "\{root}/admin",
+    }
+    let run = match
+      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("shell tool should be async")
+    }
+    async fn blocked(cmd : Json) -> Unit {
+      guard run(cmd) is Respond(output) else { fail("expected Respond") }
+      assert_true(output.is_error)
+      assert_true(output.content.contains("blocked in worker mode"))
+    }
+
+    // `--` and wrapper forms still change the shell's cwd.
+    blocked({ "cmd": "cd -- .. && touch escaped.txt" })
+    blocked({ "cmd": "command cd .. && touch escaped.txt" })
+    // Bare `cd` goes to $HOME; `cd -` is unknowable.
+    blocked({ "cmd": "cd && touch escaped.txt" })
+    blocked({ "cmd": "cd - && touch escaped.txt" })
+    // A `cd` inside a pipeline runs in a subshell: the parent cwd stays at
+    // the worker root, so the second `cd ..` leaves the tree.
+    blocked({ "cmd": "cd sub | true; cd ..; touch escaped.txt" })
+    assert_false(@fs.exists("\{root}/escaped.txt"))
+    // An in-tree symlink pointing out of the tree fails the canonical check.
+    @fs.symlink(target="/tmp", "\{root}/w/way-out")
+    blocked({ "cmd": "pwd", "cwd": "way-out" })
+    // Legitimate in-tree chains stay admitted.
+    guard run({ "cmd": "cd sub && printf ok" }) is Respond(fine) else {
+      fail("expected Respond")
+    }
+    assert_false(fine.is_error)
+  })
+}

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -2096,3 +2096,50 @@ async test "run_in_background without timeout_ms is unaffected by defaults" {
     let _ = bg.stop(jobs[0].id)
   }
 }
+
+///|
+/// The worker-mode static floor: obvious escapes are refused before launch
+/// with a readable explanation, independent of kernel availability; in-tree
+/// commands run normally.
+async test "worker mode statically blocks obvious escapes" {
+  @vfs.with_tmpdir(prefix="openseek-worker-floor-", dir => {
+    let root = @fs.realpath(dir)
+    @fs.mkdir("\{root}/w")
+    @fs.mkdir("\{root}/admin")
+    let scope : @shell.WorkerSandbox = {
+      deny_roots: [root],
+      worker_root: "\{root}/w",
+      worker_admin_dir: "\{root}/admin",
+    }
+    let run = match
+      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
+      Async(execute) => execute
+      Sync(_) => fail("shell tool should be async")
+    }
+    // A cwd outside the worker tree is refused up front.
+    guard run({ "cmd": "pwd", "cwd": "/tmp" }) is Respond(cwd_escape) else {
+      fail("expected Respond")
+    }
+    assert_true(cwd_escape.is_error)
+    assert_true(cwd_escape.content.contains("blocked in worker mode"))
+    // A statically-spelled `cd` out of the tree is refused.
+    guard run({ "cmd": "cd .. && touch escaped.txt" }) is Respond(cd_escape) else {
+      fail("expected Respond")
+    }
+    assert_true(cd_escape.is_error)
+    assert_true(cd_escape.content.contains("blocked in worker mode"))
+    assert_false(@fs.exists("\{root}/escaped.txt"))
+    // `git -C` pointing outside the tree is refused.
+    guard run({ "cmd": "git -C \{root} status" }) is Respond(dash_c) else {
+      fail("expected Respond")
+    }
+    assert_true(dash_c.is_error)
+    assert_true(dash_c.content.contains("blocked in worker mode"))
+    // Ordinary in-tree work is untouched by the floor.
+    guard run({ "cmd": "printf hi" }) is Respond(plain) else {
+      fail("expected Respond")
+    }
+    assert_false(plain.is_error)
+    assert_true(plain.content.contains("hi"))
+  })
+}

--- a/agent_tool/shell/worker_sandbox.mbt
+++ b/agent_tool/shell/worker_sandbox.mbt
@@ -70,11 +70,16 @@ async fn worker_cd_escapes(
       Some(index) if argv[index] == "cd" => {
         match cd_operand(argv, index) {
           CdTo(operand) => {
-            let mut moved : String? = None
-            let mut destination_exists = false
+            // Resolve against EVERY candidate cwd. Each in-tree resolution
+            // is checked; each that is an EXISTING DIRECTORY is a viable
+            // destination (sh's cd fails on anything else — a file or a
+            // missing path never becomes a cwd).
+            let viable : Array[String] = []
+            let mut interpretations = 0
             for cwd in candidates {
               match resolve_worker_operand(cwd, operand) {
                 Some(resolved) => {
+                  interpretations += 1
                   let canonical = canonicalize_if_exists(resolved)
                   let effective = canonical.unwrap_or(
                     @path.Path(resolved).normalize().to_string(),
@@ -84,34 +89,36 @@ async fn worker_cd_escapes(
                     ) {
                     return Some("`cd \{operand}` leaves your worker tree")
                   }
-                  moved = Some(effective)
-                  if canonical is Some(_) {
-                    destination_exists = true
+                  match canonical {
+                    Some(real) =>
+                      if path_is_directory(real) && !viable.contains(effective) {
+                        viable.push(effective)
+                      }
+                    None => ()
                   }
                 }
                 None => ()
               }
             }
-            // Outside a pipeline the destination becomes a candidate. When
-            // the next command is `&&`-chained AND the destination exists,
-            // that command only runs if the cd succeeded, so the pre-cd cwds
-            // drop out (keeping them over-blocks `cd sub && cd ..`); in every
-            // other shape the cd may fail at runtime, so the old cwds stay
-            // candidates too. This is a floor, not an interpreter — the
-            // kernel profile remains the enforcement where one exists.
+            // Candidate propagation (outside a pipeline; a pipeline cd runs
+            // in a subshell and moves nothing). Under `&&`, the chained
+            // command runs only when the cd SUCCEEDED, so its reachable cwds
+            // are exactly the viable destinations — the pre-cd cwds drop
+            // (keeping them over-blocks `cd sub && cd ..`). Under `;`/`||`
+            // the cd may have failed, so the old cwds stay reachable
+            // alongside the viable destinations. This is a floor, not an
+            // interpreter — the kernel profile remains the enforcement where
+            // one exists.
             if !in_pipeline {
               let next_is_and = position + 1 < commands.length() &&
                 commands[position + 1].separator_before == Some("&&")
-              match moved {
-                Some(destination) => {
-                  if next_is_and && destination_exists {
-                    candidates.clear()
-                  }
-                  if !candidates.contains(destination) {
-                    candidates.push(destination)
-                  }
+              if next_is_and && interpretations > 0 && !viable.is_empty() {
+                candidates.clear()
+              }
+              for destination in viable {
+                if !candidates.contains(destination) {
+                  candidates.push(destination)
                 }
-                None => ()
               }
             }
           }
@@ -222,8 +229,7 @@ async fn canonicalize_existing(path : String) -> String {
 }
 
 ///|
-/// `Some(realpath)` when the path exists, `None` otherwise — existence doubles
-/// as the "this cd will succeed" signal for `&&` candidate propagation.
+/// `Some(realpath)` when the path exists, `None` otherwise.
 async fn canonicalize_if_exists(path : String) -> String? {
   Some(@fs.realpath(path)) catch {
     error if @async.is_being_cancelled() => raise error

--- a/agent_tool/shell/worker_sandbox.mbt
+++ b/agent_tool/shell/worker_sandbox.mbt
@@ -35,13 +35,22 @@ async fn worker_confinement_blocks(
   base_cwd~ : String,
   worker_root~ : String,
 ) -> String? {
-  // Containment is decided on canonical paths: an in-tree symlink pointing
-  // elsewhere, or a lexically-inside `a/../..` spelling, must not pass.
-  let canonical_base = canonicalize_existing(base_cwd)
-  guard @workspace_path.is_under_workspace_root(worker_root, canonical_base) else {
+  // Containment is CHECKED on canonical paths (an in-tree symlink pointing
+  // elsewhere must not pass), but cwd TRACKING uses the lexical spelling:
+  // sh's cd is logical — `cd ..` operates on the PWD text, so `w/link/..`
+  // is `w` at runtime even when `link` resolves elsewhere. Mixing the two
+  // (canonical candidates, lexical `..`) mis-predicts sh.
+  guard @workspace_path.is_under_workspace_root(
+    worker_root,
+    canonicalize_existing(base_cwd),
+  ) else {
     return Some("the command runs outside your worker tree (cwd \{base_cwd})")
   }
-  worker_cd_escapes(parsed, base_cwd=canonical_base, worker_root~)
+  worker_cd_escapes(
+    parsed,
+    base_cwd=@path.Path(base_cwd).normalize().to_string(),
+    worker_root~,
+  )
 }
 
 ///|
@@ -56,9 +65,26 @@ async fn worker_cd_escapes(
   worker_root~ : String,
 ) -> String? {
   guard parsed is Simple(commands) else { return None }
+  // Candidates hold LEXICAL cwd spellings (sh's logical cd semantics);
+  // containment checks canonicalize on the spot. `suspended` holds the
+  // pre-cd cwds dropped by an `&&`-clearing: a failed cd skips the `&&`
+  // chain but the shell REJOINS at the next `;`/`||` from the pre-cd cwd,
+  // so those spellings come back into play there.
   let candidates : Array[String] = [base_cwd]
+  let suspended : Array[String] = []
   for position, command in commands {
     let argv = command.argv
+    match command.separator_before {
+      Some(";") | Some("||") => {
+        for old in suspended {
+          if !candidates.contains(old) {
+            candidates.push(old)
+          }
+        }
+        suspended.clear()
+      }
+      _ => ()
+    }
     let in_pipeline = command.separator_before == Some("|") ||
       (
         position + 1 < commands.length() &&
@@ -70,10 +96,12 @@ async fn worker_cd_escapes(
       Some(index) if argv[index] == "cd" => {
         match cd_operand(argv, index) {
           CdTo(operand) => {
-            // Resolve against EVERY candidate cwd. Each in-tree resolution
-            // is checked; each that is an EXISTING DIRECTORY is a viable
-            // destination (sh's cd fails on anything else — a file or a
-            // missing path never becomes a cwd).
+            // Resolve against EVERY candidate cwd. Containment is checked on
+            // the canonicalized location; the LEXICAL spelling is what a
+            // successful cd contributes as a future cwd (sh's `..` is
+            // logical). A resolution is viable only when its canonical
+            // location is an EXISTING DIRECTORY — sh's cd fails on a file or
+            // a missing path, so those never become cwds.
             let viable : Array[String] = []
             let mut interpretations = 0
             for cwd in candidates {
@@ -81,18 +109,16 @@ async fn worker_cd_escapes(
                 Some(resolved) => {
                   interpretations += 1
                   let canonical = canonicalize_if_exists(resolved)
-                  let effective = canonical.unwrap_or(
-                    @path.Path(resolved).normalize().to_string(),
-                  )
-                  if !@workspace_path.is_under_workspace_root(
-                      worker_root, effective,
-                    ) {
+                  guard @workspace_path.is_under_workspace_root(
+                    worker_root,
+                    canonical.unwrap_or(resolved),
+                  ) else {
                     return Some("`cd \{operand}` leaves your worker tree")
                   }
                   match canonical {
                     Some(real) =>
-                      if path_is_directory(real) && !viable.contains(effective) {
-                        viable.push(effective)
+                      if path_is_directory(real) && !viable.contains(resolved) {
+                        viable.push(resolved)
                       }
                     None => ()
                   }
@@ -101,18 +127,24 @@ async fn worker_cd_escapes(
               }
             }
             // Candidate propagation (outside a pipeline; a pipeline cd runs
-            // in a subshell and moves nothing). Under `&&`, the chained
-            // command runs only when the cd SUCCEEDED, so its reachable cwds
-            // are exactly the viable destinations — the pre-cd cwds drop
-            // (keeping them over-blocks `cd sub && cd ..`). Under `;`/`||`
-            // the cd may have failed, so the old cwds stay reachable
-            // alongside the viable destinations. This is a floor, not an
-            // interpreter — the kernel profile remains the enforcement where
-            // one exists.
+            // in a subshell and moves nothing). Under `&&`, the immediately
+            // chained command runs only when the cd SUCCEEDED, so its
+            // reachable cwds are the viable destinations — the pre-cd cwds
+            // move to `suspended` (a failed cd's continuation REJOINS at the
+            // next `;`/`||`, where they merge back; dropping them outright
+            // admitted a real escape). Under `;`/`||` the cd may have failed
+            // in place, so the old cwds stay candidates alongside the
+            // destinations. This is a floor, not an interpreter — the kernel
+            // profile remains the enforcement where one exists.
             if !in_pipeline {
               let next_is_and = position + 1 < commands.length() &&
                 commands[position + 1].separator_before == Some("&&")
               if next_is_and && interpretations > 0 && !viable.is_empty() {
+                for old in candidates {
+                  if !suspended.contains(old) {
+                    suspended.push(old)
+                  }
+                }
                 candidates.clear()
               }
               for destination in viable {

--- a/agent_tool/shell/worker_sandbox.mbt
+++ b/agent_tool/shell/worker_sandbox.mbt
@@ -1,0 +1,108 @@
+///|
+/// The write confinement of a worker subagent's shell, carried from the
+/// subtask controller (which computes the canonical geometry at provision
+/// time) into every launch. When present, shell classification is bypassed:
+/// every command — including classes the normal registry trusts to run
+/// unsandboxed — launches under the worker write profile, which denies the
+/// repository's shared surfaces (`deny_roots`: the canonical common git dir
+/// plus every enumerated worktree root) and re-allows only the worker's own
+/// tree and its private git admin dir. All paths must be canonical
+/// (realpath'd): the kernel matches profile rules against realpaths.
+///
+/// On platforms without sandbox-exec the kernel layer is absent and the
+/// static confinement floor (`worker_confinement_blocks`) is the only guard —
+/// the same best-effort posture as the rest of the sandbox stack there.
+pub(all) struct WorkerSandbox {
+  deny_roots : Array[String]
+  worker_root : String
+  worker_admin_dir : String
+}
+
+///|
+/// The static confinement floor for worker mode: block, before launch, the
+/// command shapes that OBVIOUSLY leave the worker tree, with an explanation a
+/// kernel denial cannot give. Admission requires every resolvable cwd
+/// interpretation to stay inside the worker root: the base cwd, every
+/// statically-spelled `cd` destination, and every `git -C`/`--work-tree`
+/// operand. Anything unresolvable stays admitted — on macOS the kernel
+/// profile is the enforcement; this floor exists for error quality and for
+/// platforms without one.
+fn worker_confinement_blocks(
+  parsed : @shell_parse.ParseResult,
+  base_cwd~ : String,
+  worker_root~ : String,
+) -> String? {
+  if @workspace_path.is_under_workspace_root(worker_root, base_cwd) {
+    worker_cd_escapes(parsed, base_cwd~, worker_root~)
+  } else {
+    Some("the command runs outside your worker tree (cwd \{base_cwd})")
+  }
+}
+
+///|
+/// Scan chained commands for static escapes: `cd <outside>` and
+/// `git -C <outside>` / `--work-tree=<outside>`. Relative operands resolve
+/// against the tracked cwd along the chain; unresolvable operands (command
+/// substitution, variables) stay admitted for the kernel to judge.
+fn worker_cd_escapes(
+  parsed : @shell_parse.ParseResult,
+  base_cwd~ : String,
+  worker_root~ : String,
+) -> String? {
+  guard parsed is Simple(commands) else { return None }
+  let mut cwd = base_cwd
+  for command in commands {
+    let argv = command.argv
+    if argv.length() >= 2 && argv[0] == "cd" && !argv[1].has_prefix("-") {
+      let target = resolve_worker_operand(cwd, argv[1])
+      match target {
+        Some(resolved) => {
+          if !@workspace_path.is_under_workspace_root(worker_root, resolved) {
+            return Some("`cd \{argv[1]}` leaves your worker tree")
+          }
+          cwd = resolved
+        }
+        None => ()
+      }
+    }
+    for index, arg in argv {
+      let operand = if arg == "-C" || arg == "--work-tree" {
+        if index + 1 < argv.length() {
+          Some(argv[index + 1])
+        } else {
+          None
+        }
+      } else if arg.has_prefix("--work-tree=") {
+        arg.view(start_offset="--work-tree=".length()).to_owned() |> Some
+      } else {
+        None
+      }
+      match operand {
+        Some(op) =>
+          match resolve_worker_operand(cwd, op) {
+            Some(resolved) if !@workspace_path.is_under_workspace_root(
+                worker_root, resolved,
+              ) => return Some("`\{arg} \{op}` points outside your worker tree")
+            _ => ()
+          }
+        None => ()
+      }
+    }
+  }
+  None
+}
+
+///|
+/// Lexically resolve one statically-spelled operand against `cwd`; `None`
+/// for shapes only the shell can evaluate (substitutions, variables, `~`).
+fn resolve_worker_operand(cwd : String, operand : String) -> String? {
+  if operand.contains("$") || operand.contains("`") || operand.has_prefix("~") {
+    return None
+  }
+  let joined = if @path.Path(operand).is_absolute() {
+    operand
+  } else {
+    "\{cwd}/\{operand}"
+  }
+  Some(@path.Path(joined).normalize().to_string())
+}

--- a/agent_tool/shell/worker_sandbox.mbt
+++ b/agent_tool/shell/worker_sandbox.mbt
@@ -71,28 +71,46 @@ async fn worker_cd_escapes(
         match cd_operand(argv, index) {
           CdTo(operand) => {
             let mut moved : String? = None
+            let mut destination_exists = false
             for cwd in candidates {
               match resolve_worker_operand(cwd, operand) {
                 Some(resolved) => {
-                  let canonical = canonicalize_existing(resolved)
+                  let canonical = canonicalize_if_exists(resolved)
+                  let effective = canonical.unwrap_or(
+                    @path.Path(resolved).normalize().to_string(),
+                  )
                   if !@workspace_path.is_under_workspace_root(
-                      worker_root, canonical,
+                      worker_root, effective,
                     ) {
                     return Some("`cd \{operand}` leaves your worker tree")
                   }
-                  moved = Some(canonical)
+                  moved = Some(effective)
+                  if canonical is Some(_) {
+                    destination_exists = true
+                  }
                 }
                 None => ()
               }
             }
-            // Outside a pipeline the destination becomes a candidate; the
-            // pre-cd cwds stay candidates because the cd may fail.
+            // Outside a pipeline the destination becomes a candidate. When
+            // the next command is `&&`-chained AND the destination exists,
+            // that command only runs if the cd succeeded, so the pre-cd cwds
+            // drop out (keeping them over-blocks `cd sub && cd ..`); in every
+            // other shape the cd may fail at runtime, so the old cwds stay
+            // candidates too. This is a floor, not an interpreter — the
+            // kernel profile remains the enforcement where one exists.
             if !in_pipeline {
+              let next_is_and = position + 1 < commands.length() &&
+                commands[position + 1].separator_before == Some("&&")
               match moved {
-                Some(destination) =>
+                Some(destination) => {
+                  if next_is_and && destination_exists {
+                    candidates.clear()
+                  }
                   if !candidates.contains(destination) {
                     candidates.push(destination)
                   }
+                }
                 None => ()
               }
             }
@@ -198,8 +216,17 @@ fn resolve_worker_operand(cwd : String, operand : String) -> String? {
 /// lexically-normalized spelling otherwise (a nonexistent directory cannot
 /// be a running process's cwd either).
 async fn canonicalize_existing(path : String) -> String {
-  @fs.realpath(path) catch {
+  canonicalize_if_exists(path).unwrap_or(
+    @path.Path(path).normalize().to_string(),
+  )
+}
+
+///|
+/// `Some(realpath)` when the path exists, `None` otherwise — existence doubles
+/// as the "this cd will succeed" signal for `&&` candidate propagation.
+async fn canonicalize_if_exists(path : String) -> String? {
+  Some(@fs.realpath(path)) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => @path.Path(path).normalize().to_string()
+    _ => None
   }
 }

--- a/agent_tool/shell/worker_sandbox.mbt
+++ b/agent_tool/shell/worker_sandbox.mbt
@@ -22,48 +22,93 @@ pub(all) struct WorkerSandbox {
 /// The static confinement floor for worker mode: block, before launch, the
 /// command shapes that OBVIOUSLY leave the worker tree, with an explanation a
 /// kernel denial cannot give. Admission requires every resolvable cwd
-/// interpretation to stay inside the worker root: the base cwd, every
-/// statically-spelled `cd` destination, and every `git -C`/`--work-tree`
-/// operand. Anything unresolvable stays admitted — on macOS the kernel
-/// profile is the enforcement; this floor exists for error quality and for
-/// platforms without one.
-fn worker_confinement_blocks(
+/// interpretation to stay inside the worker root: the canonicalized base cwd,
+/// every statically-spelled `cd` destination (including `--`, wrapper, bare,
+/// and `-` forms), and every `git -C`/`--work-tree` operand — resolved
+/// against every candidate cwd the chain may be in, since a `cd` may fail at
+/// runtime and a `cd` inside a pipeline runs in a subshell. Truly
+/// unresolvable operands (substitutions, variables) stay admitted — on macOS
+/// the kernel profile is the enforcement; this floor exists for error
+/// quality and for platforms without one.
+async fn worker_confinement_blocks(
   parsed : @shell_parse.ParseResult,
   base_cwd~ : String,
   worker_root~ : String,
 ) -> String? {
-  if @workspace_path.is_under_workspace_root(worker_root, base_cwd) {
-    worker_cd_escapes(parsed, base_cwd~, worker_root~)
-  } else {
-    Some("the command runs outside your worker tree (cwd \{base_cwd})")
+  // Containment is decided on canonical paths: an in-tree symlink pointing
+  // elsewhere, or a lexically-inside `a/../..` spelling, must not pass.
+  let canonical_base = canonicalize_existing(base_cwd)
+  guard @workspace_path.is_under_workspace_root(worker_root, canonical_base) else {
+    return Some("the command runs outside your worker tree (cwd \{base_cwd})")
   }
+  worker_cd_escapes(parsed, base_cwd=canonical_base, worker_root~)
 }
 
 ///|
-/// Scan chained commands for static escapes: `cd <outside>` and
-/// `git -C <outside>` / `--work-tree=<outside>`. Relative operands resolve
-/// against the tracked cwd along the chain; unresolvable operands (command
-/// substitution, variables) stay admitted for the kernel to judge.
-fn worker_cd_escapes(
+/// Scan chained commands for static escapes, tracking the SET of candidate
+/// cwds along the chain: a plain `cd` adds its destination but keeps the old
+/// cwd as a candidate (the `cd` may fail at runtime), and a `cd` that is part
+/// of a pipeline contributes nothing (it runs in a subshell). An operand
+/// escapes when its resolution against ANY candidate leaves the worker root.
+async fn worker_cd_escapes(
   parsed : @shell_parse.ParseResult,
   base_cwd~ : String,
   worker_root~ : String,
 ) -> String? {
   guard parsed is Simple(commands) else { return None }
-  let mut cwd = base_cwd
-  for command in commands {
+  let candidates : Array[String] = [base_cwd]
+  for position, command in commands {
     let argv = command.argv
-    if argv.length() >= 2 && argv[0] == "cd" && !argv[1].has_prefix("-") {
-      let target = resolve_worker_operand(cwd, argv[1])
-      match target {
-        Some(resolved) => {
-          if !@workspace_path.is_under_workspace_root(worker_root, resolved) {
-            return Some("`cd \{argv[1]}` leaves your worker tree")
+    let in_pipeline = command.separator_before == Some("|") ||
+      (
+        position + 1 < commands.length() &&
+        commands[position + 1].separator_before == Some("|")
+      )
+    // The effective command name skips wrappers (`command`, `env`), so
+    // `command cd ..` is still a cwd change.
+    match command.command_index() {
+      Some(index) if argv[index] == "cd" => {
+        match cd_operand(argv, index) {
+          CdTo(operand) => {
+            let mut moved : String? = None
+            for cwd in candidates {
+              match resolve_worker_operand(cwd, operand) {
+                Some(resolved) => {
+                  let canonical = canonicalize_existing(resolved)
+                  if !@workspace_path.is_under_workspace_root(
+                      worker_root, canonical,
+                    ) {
+                    return Some("`cd \{operand}` leaves your worker tree")
+                  }
+                  moved = Some(canonical)
+                }
+                None => ()
+              }
+            }
+            // Outside a pipeline the destination becomes a candidate; the
+            // pre-cd cwds stay candidates because the cd may fail.
+            if !in_pipeline {
+              match moved {
+                Some(destination) =>
+                  if !candidates.contains(destination) {
+                    candidates.push(destination)
+                  }
+                None => ()
+              }
+            }
           }
-          cwd = resolved
+          CdHome =>
+            // Bare `cd` goes to $HOME — never the worker tree.
+            return Some("`cd` (to $HOME) leaves your worker tree")
+          CdBack =>
+            // `cd -` returns to $OLDPWD, which this scan cannot know; the
+            // quantifier is "every interpretation provably inside".
+            return Some("`cd -` targets an unknowable directory")
+          CdUnresolvable => ()
         }
-        None => ()
+        continue
       }
+      _ => ()
     }
     for index, arg in argv {
       let operand = if arg == "-C" || arg == "--work-tree" {
@@ -79,17 +124,57 @@ fn worker_cd_escapes(
       }
       match operand {
         Some(op) =>
-          match resolve_worker_operand(cwd, op) {
-            Some(resolved) if !@workspace_path.is_under_workspace_root(
-                worker_root, resolved,
-              ) => return Some("`\{arg} \{op}` points outside your worker tree")
-            _ => ()
+          for cwd in candidates {
+            match resolve_worker_operand(cwd, op) {
+              Some(resolved) =>
+                if !@workspace_path.is_under_workspace_root(
+                    worker_root,
+                    canonicalize_existing(resolved),
+                  ) {
+                  return Some("`\{arg} \{op}` points outside your worker tree")
+                }
+              None => ()
+            }
           }
         None => ()
       }
     }
   }
   None
+}
+
+///|
+priv enum CdOperand {
+  CdTo(String)
+  CdHome
+  CdBack
+  CdUnresolvable
+}
+
+///|
+/// The destination of a `cd` at `argv[index]`: skip `-P`/`-L` flags and a
+/// `--` separator; a bare `cd` is $HOME; `cd -` is $OLDPWD.
+fn cd_operand(argv : Array[String], index : Int) -> CdOperand {
+  let mut cursor = index + 1
+  while cursor < argv.length() && (argv[cursor] == "-P" || argv[cursor] == "-L") {
+    cursor += 1
+  }
+  if cursor < argv.length() && argv[cursor] == "--" {
+    cursor += 1
+  }
+  if cursor >= argv.length() {
+    return CdHome
+  }
+  let operand = argv[cursor]
+  if operand == "-" {
+    return CdBack
+  }
+  if operand.has_prefix("-") {
+    // An unrecognized option shape; sh would reject or reinterpret it —
+    // nothing this scan can resolve.
+    return CdUnresolvable
+  }
+  CdTo(operand)
 }
 
 ///|
@@ -105,4 +190,16 @@ fn resolve_worker_operand(cwd : String, operand : String) -> String? {
     "\{cwd}/\{operand}"
   }
   Some(@path.Path(joined).normalize().to_string())
+}
+
+///|
+/// Best-effort canonicalization for containment checks: realpath when the
+/// path exists (resolving in-tree symlinks that point elsewhere), the
+/// lexically-normalized spelling otherwise (a nonexistent directory cannot
+/// be a running process's cwd either).
+async fn canonicalize_existing(path : String) -> String {
+  @fs.realpath(path) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => @path.Path(path).normalize().to_string()
+  }
 }


### PR DESCRIPTION
## Summary
PR2 of the worker-subagent plan (`docs/plans/subtask-worker-subagents.md`, landed with #616):
- `create_worker_if_available` builds the worker write profile from canonical geometry: deny common git dir + every enumerated worktree root, re-allow worker root + resolved private admin dir, final literal deny on the gitfile pointer. Impossible geometries raise (no fail-open).
- `@shell.WorkerSandbox`: worker mode bypasses trust classification — every class (trusted verbs included) launches sandboxed, foreground and background. Static confinement floor gives readable pre-launch rejections for obvious escapes and is the documented non-macOS posture.
- Denial recognition extends to directory-rooted subjects (same-line denial wording still required).
- run_moonbit worker rooting deliberately deferred to PR3 (child toolset assembly).

## Tests
- Live kernel probes on a real repo with linked worktrees (profile layer): worker-tree write OK, status OK, origin/sibling/object-store/gitfile writes denied with survival asserted; geometry validation rejections.
- Wired-path e2e (`execute_with_workspace`): trusted `git worktree add` into origin denied; origin redirect denied; in-tree writes and `git status` work.
- Static floor: cwd/cd/-C escapes blocked with the worker-mode message; in-tree commands unaffected.
- Full shell suite 127/127; sandbox package 16/16; repo `moon check` clean (pre-existing base_prompt warning only); `moon fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)