### PR TITLE
fix(prompt): make the guard example total — nightly deny-warn breaker

### DIFF
--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -940,7 +940,7 @@ test "string indexing and utf8 encode/decode" {
   guard b0 is ('\n' | 'h' | 'b' | 'a'..='z') && s is [.. "hello", .. rest] else {
     fail("unexpected string content")
   }
-  guard rest is " world"  // otherwise will crash (guard without else)
+  guard rest is " world" else { fail("unexpected suffix") } // an else keeps the guard total
 
   // In check mode (expression with explicit type), ('\n' : UInt16) is valid.
 

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -937,7 +937,7 @@ fn base_prompt() -> String {
     #|  guard b0 is ('\n' | 'h' | 'b' | 'a'..='z') && s is [.. "hello", .. rest] else {
     #|    fail("unexpected string content")
     #|  }
-    #|  guard rest is " world"  // otherwise will crash (guard without else)
+    #|  guard rest is " world" else { fail("unexpected suffix") } // an else keeps the guard total
     #|
     #|  // In check mode (expression with explicit type), ('\n' : UInt16) is valid.
     #|


### PR DESCRIPTION
## Summary
`check (nightly, native)` is red for every PR: nightly moon emits guard_inexhaustive (0087) for the `guard rest is " world"` example in `prompt/base_prompt.mbt.md` (checked fence), and `--deny-warn` fails the job. The example taught guard-without-else crashing — a shape models would now be warned on themselves — so it gains an `else` and the comment says why. base_prompt is the unselected experimental prompt; generated file regenerated.

Repo `moon check` now clean of warnings; `moon fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)