### PR TITLE
refactor: use core env arguments

### DIFF
--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -268,7 +268,7 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   }
   let (engine, engine_args_prefix) = match explicit_engine {
     Some(engine) => (engine, [])
-    None => default_engine(@sys.get_cli_args())
+    None => default_engine(@env.args())
   }
   {
     api_key,
@@ -479,7 +479,7 @@ test "cli accepts no initial task" {
   assert_true(config.max_steps is None)
   // With no --engine, the engine falls through to re-launching this command
   // (`default_engine` of the process args), not a hardcoded string.
-  let (expected_engine, expected_prefix) = default_engine(@sys.get_cli_args())
+  let (expected_engine, expected_prefix) = default_engine(@env.args())
   assert_eq(config.engine, expected_engine)
   @debug.assert_eq(config.engine_args_prefix, expected_prefix)
   // No --session still converses in a session: a generated per-launch id, so
@@ -673,7 +673,7 @@ async test "engine defaults to this binary; --engine/OPENSEEK_ENGINE override it
   let default_cfg = parse_config(
     cli_command().parse(argv=[], env={ "DEEPSEEK": "k" }),
   )
-  let (expected_engine, expected_prefix) = default_engine(@sys.get_cli_args())
+  let (expected_engine, expected_prefix) = default_engine(@env.args())
   assert_eq(default_cfg.engine, expected_engine)
   @debug.assert_eq(default_cfg.engine_args_prefix, expected_prefix)
   // OPENSEEK_ENGINE is treated as an explicit engine.

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -28,17 +28,94 @@ const ConnectMethod = "host.connect"
 const OpenExternalMethod = "shell.open_external"
 
 ///|
-/// A page attachment waiting for the bridge actor to install it. The reply
-/// makes `host.connect` a finite readiness handshake: success means the
-/// actor has already emitted `agent.connected` to this page.
-priv struct BridgeAttachment {
-  context : @app.AppCommandExtensionContext
-  reply : @async.Queue[Unit]
+/// The typed identity shared by every command and event exposed under
+/// `window.__MoonBit__.openseek`.
+let desktop_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id=ExtensionId,
+  js_namespace=ExtensionNamespace,
+)
+
+///|
+/// The shared API catalog remains JSON-shaped because the browser and relay
+/// transports both feed the same dynamic dispatcher.
+let catalog_commands : Array[@proton_contract.Command[Json, Json]] = @api.method_names().map(fn(
+    name,
+  ) {
+    desktop_contract.command(name)
+  },
+)
+
+///|
+let connect_command : @proton_contract.Command[Json, Json] = desktop_contract.command(
+  ConnectMethod,
+)
+
+///|
+let open_external_command : @proton_contract.Command[Json, Json] = desktop_contract.command(
+  OpenExternalMethod,
+)
+
+///|
+let connected_event : @proton_contract.Event[Json] = desktop_contract.event(
+  "agent.connected",
+)
+
+///|
+/// Proton requires one stable event descriptor per member name. Keep this list
+/// aligned with the frontend listeners in `desktop/frontend/bridge.mbt`.
+let notification_events : Map[String, @proton_contract.Event[Json]] = {
+  "agent.connected": connected_event,
+  "agent.started": desktop_contract.event("agent.started"),
+  "agent.event": desktop_contract.event("agent.event"),
+  "agent.error": desktop_contract.event("agent.error"),
+  "agent.finished": desktop_contract.event("agent.finished"),
+  "agent.durable": desktop_contract.event("agent.durable"),
+  "session.event": desktop_contract.event("session.event"),
+  "session.changed": desktop_contract.event("session.changed"),
+  "workspace.changed": desktop_contract.event("workspace.changed"),
+  "settings.changed": desktop_contract.event("settings.changed"),
+  "skills.changed": desktop_contract.event("skills.changed"),
+  "auth.changed": desktop_contract.event("auth.changed"),
+  "lsp.diagnostics": desktop_contract.event("lsp.diagnostics"),
+  "fs.changed": desktop_contract.event("fs.changed"),
 }
 
 ///|
+/// The page connection and Proton's window lifecycle hook start independently.
+/// Bound the short startup backlog rather than letting either side grow an
+/// unbounded in-memory queue while it waits for the other.
+const PendingNotificationCapacity = 64
+
+///|
+priv enum BridgeControl {
+  PageConnected(@proton.CommandContext, @async.Queue[Unit])
+  WindowReady(@proton.WindowEventEmitter)
+  WindowClosed
+}
+
+///|
+priv struct PageEventTarget {
+  events : @proton.WindowEventEmitter
+}
+
+///|
+async fn PageEventTarget::emit(
+  self : PageEventTarget,
+  notification : @api.Notification,
+) -> Unit {
+  // An undeclared event has no frontend listener either. Ignore it until both
+  // explicit catalogs are updated instead of inventing a runtime route.
+  if notification_events.get(notification.method_) is Some(event) {
+    self.events.emit(event, notification.params)
+  }
+}
+
+///|
+/// Control work that must be ordered with notification delivery. The actor
+/// holds a connect request only until it emits readiness and replies; it never
+/// retains request-scoped state after the command returns.
 priv enum BridgeInput {
-  Attach(BridgeAttachment)
+  Control(BridgeControl)
   Deliver(@api.Notification)
 }
 
@@ -51,7 +128,7 @@ struct DesktopBridgeActor {
   // The desktop page owns one filesystem watcher independently of every
   // remote WebSocket connection.
   host_connection : @host.HostConnection
-  attachments : @async.Queue[BridgeAttachment]
+  controls : @async.Queue[BridgeControl]
 }
 
 ///|
@@ -62,7 +139,7 @@ pub fn DesktopBridgeActor::new(state : @api.ApiState) -> DesktopBridgeActor {
     // A page normally attaches once. A small bounded queue still permits a
     // reload to overlap the old page without allowing abandoned requests to
     // accumulate forever.
-    attachments: Queue(kind=Blocking(4)),
+    controls: Queue(kind=Blocking(8)),
   }
 }
 
@@ -70,54 +147,72 @@ pub fn DesktopBridgeActor::new(state : @api.ApiState) -> DesktopBridgeActor {
 pub fn openseek_extension(
   state : @api.ApiState,
   bridge : DesktopBridgeActor,
-) -> @app.AppCommandExtensionSpec {
-  let descriptors = @api.method_names().map(name => {
-    @app.AppCommandApiDescriptor::new(name)
+) -> @proton_extension.Extension {
+  let command_routes = catalog_commands.map(fn(command) {
+    command.contract_route()
   })
-  descriptors.push(@app.AppCommandApiDescriptor::new(ConnectMethod))
-  descriptors.push(@app.AppCommandApiDescriptor::new(OpenExternalMethod))
-  @app.AppCommandExtensionSpec::new(
-    ExtensionId,
-    ExtensionNamespace,
-    descriptors,
-    context => {
-      for name in @api.method_names() {
-        context.op_async(name, (params : Json) => {
-          @api.dispatch(state, bridge.host_connection, name, params)
-        })
-      }
-      context.op_async(ConnectMethod, (_ : Json) => {
-        bridge.attach(context)
-        Json::empty_object()
+  command_routes.push(connect_command.contract_route())
+  command_routes.push(open_external_command.contract_route())
+  @proton_extension.typed(desktop_contract, command_routes, fn(
+    registrar,
+  ) raise {
+    for command in catalog_commands {
+      let name = command.name()
+      registrar.bind(command, async fn(_, params) {
+        @api.dispatch(state, bridge.host_connection, name, params)
       })
-      context.op_async(OpenExternalMethod, open_external)
-    },
-  )
+    }
+    registrar.bind(connect_command, async fn(context, _) {
+      bridge.connect(context)
+    })
+    registrar.bind(open_external_command, async fn(_, params) {
+      open_external(params)
+    })
+  })
 }
 
 ///|
-async fn DesktopBridgeActor::attach(
+async fn DesktopBridgeActor::connect(
   self : DesktopBridgeActor,
-  context : @app.AppCommandExtensionContext,
-) -> Unit {
+  context : @proton.CommandContext,
+) -> Json {
   let reply : @async.Queue[Unit] = Queue(kind=Blocking(1))
-  self.attachments.put({ context, reply })
+  self.controls.put(PageConnected(context, reply))
   reply.get()
+  Json::empty_object()
 }
 
 ///|
-/// Prefer a pending page attachment over another notification. Once neither
+/// Installs the window-owned event destination used after the connect request
+/// returns. Keeping it separate avoids retaining request-scoped task state.
+pub async fn DesktopBridgeActor::window_ready(
+  self : DesktopBridgeActor,
+  events : @proton.WindowEventEmitter,
+) -> Unit {
+  self.controls.put(WindowReady(events))
+}
+
+///|
+/// Detaches the event destination before the window-owned tasks are released.
+pub async fn DesktopBridgeActor::window_closed(
+  self : DesktopBridgeActor,
+) -> Unit {
+  self.controls.put(WindowClosed)
+}
+
+///|
+/// Prefer pending lifecycle/control work over another notification. Once neither
 /// lane is ready, race their blocking reads; `any` cancels the losing read.
 async fn DesktopBridgeActor::next_input(
   self : DesktopBridgeActor,
   notifications : @async.Queue[@api.Notification],
   host_notifications : @async.Queue[@api.Notification],
 ) -> BridgeInput {
-  if (self.attachments.try_get() catch { _ => None }) is Some(attachment) {
-    return Attach(attachment)
+  if self.controls.try_get() is Some(control) {
+    return Control(control)
   }
   @async.any([
-    () => Attach(self.attachments.get()),
+    () => Control(self.controls.get()),
     () => Deliver(notifications.get()),
     () => Deliver(host_notifications.get()),
   ])
@@ -125,9 +220,9 @@ async fn DesktopBridgeActor::next_input(
 
 ///|
 /// Own the window notification subscription and forward notifications to
-/// the latest attached page. `agent.connected` is emitted while handling
-/// Attach: the engine pump's original event may predate a load or reload,
-/// so this is the page's readiness/resync signal.
+/// the latest attached page. The connect request emits its own readiness event
+/// through its request-scoped sender; later notifications use the window-owned
+/// sender installed by Proton's lifecycle hook.
 pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
   let notifications = self.state.subscribe()
   defer self.state.unsubscribe(notifications)
@@ -143,17 +238,46 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
         host_notifications.put({ method_, params })
       })
     })
-    let mut attached : @app.AppCommandExtensionContext? = None
+    let mut connected = false
+    let mut target : PageEventTarget? = None
+    let pending : Array[@api.Notification] = []
     for ;; {
       match self.next_input(notifications, host_notifications) {
-        Attach({ context, reply }) => {
-          context.emit("agent.connected", Json::empty_object())
-          attached = Some(context)
-          reply.put(())
-        }
+        Control(control) =>
+          match control {
+            PageConnected(context, reply) => {
+              // Serialize readiness before subsequent delivery so the
+              // frontend can use it as the resync boundary.
+              context.emit(connected_event, Json::empty_object())
+              connected = true
+              reply.put(())
+            }
+            WindowReady(events) => {
+              let next_target = PageEventTarget::{ events, }
+              target = Some(next_target)
+              if connected {
+                for notification in pending {
+                  next_target.emit(notification)
+                }
+              }
+              pending.clear()
+            }
+            WindowClosed => {
+              connected = false
+              target = None
+              pending.clear()
+            }
+          }
         Deliver(notification) =>
-          if attached is Some(context) {
-            context.emit(notification.method_, notification.params)
+          if connected {
+            if target is Some(target) {
+              target.emit(notification)
+            } else {
+              if pending.length() == PendingNotificationCapacity {
+                ignore(pending.remove(0))
+              }
+              pending.push(notification)
+            }
           }
       }
     }

--- a/desktop/internal/extension/moon.pkg
+++ b/desktop/internal/extension/moon.pkg
@@ -1,5 +1,7 @@
 import {
-  "justjavac/proton/command" @app,
+  "justjavac/proton",
+  "justjavac/proton/extension" @proton_extension,
+  "justjavac/proton_contract",
   "openseek_desktop/internal/api",
   "openseek_desktop/internal/host",
   "openseek_desktop/internal/platform",

--- a/desktop/internal/extension/pkg.generated.mbti
+++ b/desktop/internal/extension/pkg.generated.mbti
@@ -2,14 +2,14 @@
 package "openseek_desktop/internal/extension"
 
 import {
-  "justjavac/proton/command",
+  "justjavac/proton",
   "openseek_desktop/internal/api",
 }
 
 // Values
 pub const ExtensionId : String = "openseek-desktop"
 
-pub fn openseek_extension(@api.ApiState, DesktopBridgeActor) -> @command.AppCommandExtensionSpec
+pub fn openseek_extension(@api.ApiState, DesktopBridgeActor) -> @justjavac/proton/extension.Extension
 
 // Errors
 
@@ -17,6 +17,8 @@ pub fn openseek_extension(@api.ApiState, DesktopBridgeActor) -> @command.AppComm
 type DesktopBridgeActor
 pub fn DesktopBridgeActor::new(@api.ApiState) -> Self
 pub async fn DesktopBridgeActor::run(Self) -> Unit
+pub async fn DesktopBridgeActor::window_closed(Self) -> Unit
+pub async fn DesktopBridgeActor::window_ready(Self, @proton.WindowEventEmitter) -> Unit
 
 // Type aliases
 

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -58,14 +58,17 @@ fn main {
         height=760,
       )
       .debug_level(1)
-      .extension(
-        @proton_extension.from_command_spec(
-          @extension.openseek_extension(state, bridge),
-        ),
-      )
+      .extension(@extension.openseek_extension(state, bridge))
       // System notifications are an ordinary generated extension now: the
       // frontend posts them and receives `notification.click` with the run id.
       .extension(@notification.extension())
+      // The connect request proves the page can issue commands; this paired
+      // lifecycle supplies the window-owned event destination that remains
+      // valid after that request returns.
+      .window_lifecycle(
+        on_ready=async fn(context) { bridge.window_ready(context.events()) },
+        on_close=async fn(_) { bridge.window_closed() },
+      )
     @async.with_task_group(group => {
       // The bridge actor, engine actor, and host actors run for the app's
       // lifetime — they feed every page/client rather than borrowing a

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -15,6 +15,7 @@ import {
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
   "moonbitlang/editor@0.2.3",
+  "justjavac/proton_contract@0.1.0",
 }
 
 readme = "README.md"

--- a/desktop/moon.pkg
+++ b/desktop/moon.pkg
@@ -2,7 +2,6 @@ import {
   "moonbitlang/async",
   "justjavac/proton",
   "justjavac/proton_ext/notification",
-  "justjavac/proton/extension" @proton_extension,
   "openseek_desktop/internal/api",
   "openseek_desktop/internal/auth",
   "openseek_desktop/internal/engine",


### PR DESCRIPTION
## Summary

- replace the TUI's `@sys.get_cli_args()` calls with `@env.args()`
- move `desktop/lepus` to Proton `main` at `2652522d`, which contains the merged core-env change from [moonbit-community/proton#74](https://github.com/moonbit-community/proton/pull/74)
- migrate OpenSeek Desktop from Proton's removed `AppCommandExtensionContext` / `AppCommandExtensionSpec::new` APIs to typed command contracts and window lifecycle events
- preserve `host.connect` as the readiness boundary and keep later notifications ordered behind `agent.connected`

## Why

MoonBit core now provides process arguments through `@env.args()`. Proton #74 applies the same migration and has been merged into Proton `main`.

Current Proton `main` also removes the old command-extension construction API, so updating the submodule requires the Desktop compatibility migration in this PR.

## Impact

The CLI behavior is unchanged. Desktop commands remain JSON-shaped and keep the existing `window.__MoonBit__.openseek` names. Request-scoped command state is retained only until `host.connect` emits readiness; later events use the window-owned emitter. A bounded startup queue covers the short interval when connection and window lifecycle initialization complete in either order.

## Validation

- `moon info`
- `moon fmt`
- `moon fmt --check`
- `moon check --target js --deny-warn`
- `moon check --target native --deny-warn`
- `moon test --target native` (1881 passed)
- `moon -C desktop run --target native package/macos -- --target app` (generated and ad-hoc signed `OpenSeek Desktop.app`)