### PR TITLE
perf(desktop): speed up local macOS packaging

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -126,7 +126,7 @@ jobs:
       # end-user distribution.
       # Unstamped — no OPENSEEK_CLIENT_TOKEN in CI; see the Linux job's note.
       - name: Build the macOS artifacts
-        run: moon -C desktop run --target native package/macos
+        run: moon -C desktop run --target native package/macos -- --target dmg --target zip
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -406,6 +406,7 @@ timestamp are applied automatically) and notarize:
 #   --apple-id you@example.com --team-id TEAMID --password <app-specific-pw>
 moon run --target native package/macos -- \
   --target dmg \
+  --target zip \
   --sign "Developer ID Application: Your Name (TEAMID)" \
   --notarize openseek
 ```

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -355,13 +355,7 @@ The target machine also needs Microsoft WebView2 Runtime installed.
 
 `package/macos` runs all of the above (including the codegen bootstrap),
 builds the `openseek` engine from the monorepo's `cmd/openseek` source, and
-produces a signed app plus two distribution artifacts:
-
-- `dist/OpenSeek Desktop-macos-arm64.dmg` is for first-time installation. It
-  contains the app and an `/Applications` shortcut so users can install by
-  dragging the app into Applications.
-- `dist/OpenSeek Desktop-macos-arm64.zip` carries the same app for in-app
-  updates.
+produces `dist/OpenSeek Desktop.app` by default:
 
 ```sh
 moon run --target native package/macos
@@ -369,22 +363,29 @@ moon run --target native package/macos
 moon -C desktop run --target native package/macos
 ```
 
-For local testing, build and sign only the app bundle:
+This app-only output keeps the valid ad-hoc signatures written by the linker and
+re-signs the five CEF helpers whose rpaths the packager modifies. It deliberately
+does not seal the outer app bundle or re-sign the bundled MoonBit toolchain.
+This faster output is for development on the build machine, not distribution or
+the in-app updater. Scripts may pass `--target app` to request the same output
+explicitly.
 
-```sh
-moon run --target native package/macos -- --target app
-```
-
-To build the app and a specific distribution artifact, select `dmg` or `zip`:
+To build a distribution artifact, select `dmg` or `zip`:
 
 ```sh
 moon run --target native package/macos -- --target dmg
 moon run --target native package/macos -- --target zip
 ```
 
+- `dist/OpenSeek Desktop-macos-arm64.dmg` is for first-time installation. It
+  contains the app and an `/Applications` shortcut so users can install by
+  dragging the app into Applications.
+- `dist/OpenSeek Desktop-macos-arm64.zip` carries the same app for in-app
+  updates.
+
 `--target` is repeatable. The `dmg` and `zip` targets always include the app
-bundle they package. With no `--target`, the command keeps its release-oriented
-default and produces the app, DMG, and ZIP.
+bundle they package. With no `--target`, the command produces only the local app
+bundle.
 
 The bundled engine is built from the same checkout, so the desktop app and its
 engine never drift out of version with each other.
@@ -394,10 +395,11 @@ The app also contains a read-only MoonBit toolchain seed under
 host initializes a writable copy under the per-user runtime directory before
 setting `MOON_HOME` for the engine.
 
-By default the bundle is ad-hoc signed: it runs on the build machine, but
-it is not a distributable build that Gatekeeper will trust on another machine.
-For distribution, sign with a Developer ID Application identity (hardened
-runtime and a secure timestamp are applied automatically) and notarize:
+The `dmg` or `zip` targets fully ad-hoc sign the app bundle when no identity is
+supplied. Such output runs on the build machine, but it is not a distributable
+build that Gatekeeper will trust on another machine. For distribution, sign
+with a Developer ID Application identity (hardened runtime and a secure
+timestamp are applied automatically) and notarize:
 
 ```sh
 # one-time: xcrun notarytool store-credentials openseek \

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -405,6 +405,7 @@ timestamp are applied automatically) and notarize:
 # one-time: xcrun notarytool store-credentials openseek \
 #   --apple-id you@example.com --team-id TEAMID --password <app-specific-pw>
 moon run --target native package/macos -- \
+  --target dmg \
   --sign "Developer ID Application: Your Name (TEAMID)" \
   --notarize openseek
 ```

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -659,9 +659,20 @@ priv struct ArtifactPlan {
 } derive(Debug, Eq)
 
 ///|
+/// Distribution archives require a sealed outer app bundle even without a
+/// Developer ID identity. App-only output is for local development: its
+/// linker-signed executables stay valid, while only the CEF helpers modified by
+/// `install_name_tool` need a fresh ad-hoc signature.
+fn ArtifactPlan::requires_ad_hoc_bundle_signature(self : ArtifactPlan) -> Bool {
+  self.dmg || self.zip
+}
+
+///|
+/// No explicit target means the fast local app-only build. Selecting either
+/// archive also requests the complete bundle signing that distribution needs.
 fn parse_artifact_plan(values : ArrayView[String]) -> ArtifactPlan raise {
   if values.is_empty() {
-    return { dmg: true, zip: true }
+    return { dmg: false, zip: false }
   }
   let mut dmg = false
   let mut zip = false
@@ -698,12 +709,12 @@ priv struct PackageOptions {
 fn package_command() -> @argparse.Command {
   Command(
     "package/macos",
-    about="Build the macOS app bundle, DMG, and zip archive.",
+    about="Build the macOS app bundle and optional distribution archives.",
     options=[
       OptionArg(
         "target",
         action=Append,
-        about="Artifact to produce: app, dmg, or zip. Repeatable; defaults to dmg and zip.",
+        about="Artifact to produce: app, dmg, or zip. Repeatable; defaults to app.",
       ),
       OptionArg(
         "sign",
@@ -753,12 +764,27 @@ fn parse_package_options(argv? : ArrayView[String]) -> PackageOptions raise {
 }
 
 ///|
-async fn sign_app(ws : @packaging.Workspace, sign : SignConfig) -> Unit {
+/// App-only local output preserves existing linker signatures and signs only
+/// the patched CEF helpers. Archive and Developer ID output retains the full
+/// inside-out bundle signing required for verification and distribution.
+async fn sign_app(
+  ws : @packaging.Workspace,
+  sign : SignConfig,
+  artifacts : ArtifactPlan,
+) -> Unit {
   let entitlements = write_signing_entitlements(ws)
-  let jit_entitlements = write_jit_entitlements(ws)
   guard sign.identity is Some(identity) else {
-    sign_moonbit_seed_binaries(ws, "-", jit_entitlements, distribution=false)
+    if artifacts.requires_ad_hoc_bundle_signature() {
+      let jit_entitlements = write_jit_entitlements(ws)
+      sign_moonbit_seed_binaries(ws, "-", jit_entitlements, distribution=false)
+    }
     sign_cef_helper(ws, "-", entitlements, distribution=false)
+    if !artifacts.requires_ad_hoc_bundle_signature() {
+      println(
+        "kept linker signatures and signed only patched CEF helpers for local app",
+      )
+      return
+    }
     // Do NOT re-sign the bundled CEF runtime. `cef setup` ships it
     // linker-signed (a valid adhoc signature); re-signing with `codesign`
     // replaces that with a plain adhoc signature. The runtime under Resources
@@ -776,6 +802,7 @@ async fn sign_app(ws : @packaging.Workspace, sign : SignConfig) -> Unit {
     )
     return
   }
+  let jit_entitlements = write_jit_entitlements(ws)
   // Real distribution signing: hardened runtime and a secure timestamp are
   // notarization requirements. Sign inside-out: nested executables first, then
   // the bundle, because deprecated `--deep` signs nested code with the wrong
@@ -908,7 +935,7 @@ async fn sign_and_package(
   sign : SignConfig,
   artifacts : ArtifactPlan,
 ) -> Unit {
-  sign_app(ws, sign)
+  sign_app(ws, sign, artifacts)
   if artifacts.dmg {
     create_dmg(ws, sign)
     notarize_if_configured(ws, sign)
@@ -943,11 +970,12 @@ async fn main {
 }
 
 ///|
-test "macos package args default to ad-hoc signing" {
+test "macos package args default to local app-only signing" {
   let options = parse_package_options(argv=[])
   assert_true(options.sign.identity is None)
   assert_true(options.sign.notary_profile is None)
-  assert_eq(options.artifacts, { dmg: true, zip: true })
+  assert_eq(options.artifacts, { dmg: false, zip: false })
+  assert_false(options.artifacts.requires_ad_hoc_bundle_signature())
 }
 
 ///|
@@ -1015,7 +1043,8 @@ test "macos host executable rpath points at bundled proton runtime" {
 ///|
 test "macos package args parse signing and notarization" {
   let options = parse_package_options(argv=[
-    "--sign", "Developer ID Application: Example", "--notarize", "notary",
+    "--target", "dmg", "--sign", "Developer ID Application: Example", "--notarize",
+    "notary",
   ])
   assert_true(
     options.sign.identity is Some("Developer ID Application: Example"),
@@ -1043,12 +1072,14 @@ test "macos notarization requires distribution signing" {
 test "macos package target app skips distribution archives" {
   let options = parse_package_options(argv=["--target", "app"])
   assert_eq(options.artifacts, { dmg: false, zip: false })
+  assert_false(options.artifacts.requires_ad_hoc_bundle_signature())
 }
 
 ///|
 test "macos package target dmg includes the app but skips zip" {
   let options = parse_package_options(argv=["--target", "dmg"])
   assert_eq(options.artifacts, { dmg: true, zip: false })
+  assert_true(options.artifacts.requires_ad_hoc_bundle_signature())
 }
 
 ///|

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -40,7 +40,7 @@ case "${1:-}" in
     artifact="${2:-$default_artifact}"
     if [[ ! -f "$artifact" ]]; then
       echo "artifact not found: $artifact" >&2
-      echo "build it first: moon run ./package/macos -- --sign '...'" >&2
+      echo "build it first: moon run ./package/macos -- --target zip --sign '...'" >&2
       exit 1
     fi
     url="$origin/desktop/releases/v$version/$release_name"


### PR DESCRIPTION
## Summary

- make the macOS packager default to the local app-only artifact
- preserve linker-written ad-hoc signatures and re-sign only the five CEF helper apps modified by `install_name_tool`
- retain complete bundle signing for explicit `dmg`/`zip` targets and Developer ID builds
- make macOS CI and release instructions request their distribution artifacts explicitly
- document the local versus distribution packaging commands and signing behavior

## Why

The previous app-only path still scanned and re-signed the bundled MoonBit toolchain, re-signed the engine, and sealed the outer app bundle. Those operations are needed for distribution archives, but not for a local app running on the build machine.

The prior app-only measurement was 14.93 seconds. After this change, three warm no-change runs took 5.17–5.42 seconds (5.289 seconds mean). Signing the five patched CEF helpers now accounts for about 66 ms total.

## Impact

Running `moon run ./desktop/package/macos` now produces only `OpenSeek Desktop.app` using the faster local signing path. Distribution artifacts remain explicit:

```sh
moon run ./desktop/package/macos -- --target dmg
moon run ./desktop/package/macos -- --target zip
```

App-only output is intentionally not an outer-bundle-sealed distribution artifact and must not be used by the updater. Explicit archive targets still use the complete signing path. The macOS CI job now requests both archive targets explicitly before uploading them.

## Validation

- `moon fmt desktop/package/macos/main.mbt`
- `moon -C desktop info` (no interface changes)
- `moon -C desktop check --target native package/macos`
- `moon -C desktop test --target native package/macos` (13 passed)
- parsed `.github/workflows/desktop.yml` with Ruby YAML
- `bash -n desktop/scripts/publish-release.sh`
- `git diff --check`
- ran the no-argument macOS packager and confirmed it produced the app without DMG/ZIP artifacts
- launched the resulting app through Launch Services and observed its CEF GPU, network, storage, and renderer processes
- verified all five CEF helper app signatures and the bundled executable signatures

Developer ID signing and notarization were not exercised locally because no distribution identity/profile was configured.