### PR TITLE
feat(subtask): the worktree controller and parent tool — parallel workers land

### DIFF
--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -35,6 +35,7 @@ pub struct WorkerReport {
   summary : String
   verification : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkerReport::parse_validated(Json) -> Result[Self, String]
 
 // Type aliases
 

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -118,3 +118,22 @@ test "validate accepts a good report and rejects contract violations" {
     0,
   )
 }
+
+///|
+/// Parse AND validate in one step — the parent tool re-checks the contract
+/// at the trust boundary exactly as the child's capture tool enforced it.
+pub fn WorkerReport::parse_validated(
+  json : Json,
+) -> Result[WorkerReport, String] {
+  match WorkerReport::parse(json) {
+    Err(msg) => Err(msg)
+    Ok(report) => {
+      let problems = report.validate()
+      if problems.length() > 0 {
+        Err(problems.join("; "))
+      } else {
+        Ok(report)
+      }
+    }
+  }
+}

--- a/cmd/openseek/internal/subtask/capture.mbt
+++ b/cmd/openseek/internal/subtask/capture.mbt
@@ -2,10 +2,10 @@
 /// Capture: after the worker child exits, decide from GIT EVIDENCE — never
 /// the child's own report — whether its changes are mergeable, and if so
 /// commit them on the subtask branch. The sequence pins an immutable
-/// snapshot: validate the working tree, stage, REVALIDATE the staged tree
-/// (a straggling process may have raced the first pass), commit with hooks
-/// and signing neutralized, then verify the commit's parent and tree are
-/// exactly what was validated.
+/// snapshot FIRST: stage, `write-tree`, validate THAT tree object (a
+/// straggling worker process racing the index can no longer smuggle
+/// unvalidated paths), then commit exactly the validated tree via plumbing
+/// (`commit-tree` + `update-ref` — no hooks, no index re-read).
 pub struct CaptureOutcome {
   entry : SubtaskEntry
   /// Human-facing evidence lines (bounded by the caller when displayed).
@@ -47,9 +47,17 @@ pub async fn capture(
   }
   let changes = parse_status_z(status.output)
   if changes.is_empty() {
+    // Terminal means undiscoverable by lifecycle actions, so the worktree
+    // and branch must go NOW or they leak (and block reusing the name).
+    @fs.rmdir(entry.worker_root, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+    let _ = git_run(["worktree", "prune"], cwd=geometry.origin_root)
+    let _ = git_run(["branch", "-D", entry.branch], cwd=geometry.origin_root)
     let entry = { ..entry, state: NoChanges }
     let _ = save_entry(geometry.common_git_dir, entry)
-    evidence.push("no changes in the worker tree")
+    evidence.push("no changes in the worker tree; worktree and branch removed")
     return { entry, evidence, defects }
   }
   evidence.push("\{changes.length()} changed path(s)")
@@ -64,7 +72,7 @@ pub async fn capture(
     let _ = save_entry(geometry.common_git_dir, entry)
     return { entry, evidence, defects }
   }
-  // Stage and revalidate the STAGED picture against the same contract.
+  // Stage, pin the immutable tree, and validate the TREE OBJECT itself.
   match git_require(["add", "-A"], cwd=worker) {
     Ok(_) => ()
     Err(reason) => {
@@ -72,12 +80,19 @@ pub async fn capture(
       return { entry, evidence, defects }
     }
   }
+  let tree_oid = match git_require(["write-tree"], cwd=worker) {
+    Ok(output) => output.trim().to_owned()
+    Err(reason) => {
+      defects.push(reason)
+      return { entry, evidence, defects }
+    }
+  }
   let staged = git_run(
-    ["diff", "--cached", "--name-status", "-z", entry.base_oid],
+    ["diff", "--name-status", "-z", entry.base_oid, tree_oid],
     cwd=worker,
   )
   guard staged.exit_code == 0 else {
-    defects.push("git diff --cached failed: \{staged.output.trim()}")
+    defects.push("git diff (tree) failed: \{staged.output.trim()}")
     return { entry, evidence, defects }
   }
   let staged_changes = parse_diff_name_status_z(staged.output)
@@ -87,10 +102,9 @@ pub async fn capture(
       "staged changes escaped scope between validation and staging: \{staged_violations.join(", ")}",
     )
   }
-  match
-    git_run(["diff", "--cached", "--raw", "-z", entry.base_oid], cwd=worker) {
+  match git_run(["diff", "--raw", "-z", entry.base_oid, tree_oid], cwd=worker) {
     raw if raw.exit_code == 0 => {
-      let links = new_gitlinks_in_raw_z(raw.output)
+      let links = gitlink_introductions_in_raw_z(raw.output)
       if !links.is_empty() {
         defects.push(
           "the worker staged embedded repositories as gitlinks: \{links.join(", ")}",
@@ -104,8 +118,20 @@ pub async fn capture(
     let _ = save_entry(geometry.common_git_dir, entry)
     return { entry, evidence, defects }
   }
-  // Pin the exact tree being committed, commit, then verify parent+tree.
-  let tree_oid = match git_require(["write-tree"], cwd=worker) {
+  // Commit EXACTLY the validated tree; then move the branch ref to it,
+  // guarded by the expected old value (the pinned base).
+  let commit_oid = match
+    git_require(
+      [
+        "commit-tree",
+        tree_oid,
+        "-p",
+        entry.base_oid,
+        "-m",
+        "subtask \{entry.name}: worker changes",
+      ],
+      cwd=worker,
+    ) {
     Ok(output) => output.trim().to_owned()
     Err(reason) => {
       defects.push(reason)
@@ -114,15 +140,7 @@ pub async fn capture(
   }
   match
     git_require(
-      [
-        "-c",
-        "core.hooksPath=/dev/null",
-        "commit",
-        "--no-verify",
-        "--no-gpg-sign",
-        "-m",
-        "subtask \{entry.name}: worker changes",
-      ],
+      ["update-ref", "refs/heads/\{entry.branch}", commit_oid, entry.base_oid],
       cwd=worker,
     ) {
     Ok(_) => ()
@@ -130,36 +148,6 @@ pub async fn capture(
       defects.push(reason)
       return { entry, evidence, defects }
     }
-  }
-  let commit_oid = match git_require(["rev-parse", "HEAD"], cwd=worker) {
-    Ok(output) => output.trim().to_owned()
-    Err(reason) => {
-      defects.push(reason)
-      return { entry, evidence, defects }
-    }
-  }
-  match git_require(["rev-parse", "HEAD^{tree}", "HEAD^"], cwd=worker) {
-    Ok(output) => {
-      let lines = output
-        .trim()
-        .to_owned()
-        .split("\n")
-        .map(l => l.to_owned())
-        .collect()
-      if lines.length() != 2 ||
-        lines[0] != tree_oid ||
-        lines[1] != entry.base_oid {
-        defects.push(
-          "the commit does not match the validated snapshot (tree/parent drifted)",
-        )
-      }
-    }
-    Err(reason) => defects.push(reason)
-  }
-  if !defects.is_empty() {
-    let entry = { ..entry, state: Captured }
-    let _ = save_entry(geometry.common_git_dir, entry)
-    return { entry, evidence, defects }
   }
   let diffstat = git_run(
     ["diff", "--stat", entry.base_oid, commit_oid],

--- a/cmd/openseek/internal/subtask/capture.mbt
+++ b/cmd/openseek/internal/subtask/capture.mbt
@@ -1,0 +1,175 @@
+///|
+/// Capture: after the worker child exits, decide from GIT EVIDENCE — never
+/// the child's own report — whether its changes are mergeable, and if so
+/// commit them on the subtask branch. The sequence pins an immutable
+/// snapshot: validate the working tree, stage, REVALIDATE the staged tree
+/// (a straggling process may have raced the first pass), commit with hooks
+/// and signing neutralized, then verify the commit's parent and tree are
+/// exactly what was validated.
+pub struct CaptureOutcome {
+  entry : SubtaskEntry
+  /// Human-facing evidence lines (bounded by the caller when displayed).
+  evidence : Array[String]
+  /// Non-empty when the result must not merge; names each reason.
+  defects : Array[String]
+}
+
+///|
+/// Validate and (when clean) commit a finished worker's changes on its
+/// subtask branch; see the file comment for the full sequence.
+pub async fn capture(
+  geometry : Geometry,
+  entry : SubtaskEntry,
+) -> CaptureOutcome {
+  let worker = entry.worker_root
+  let evidence : Array[String] = []
+  let defects : Array[String] = []
+  // The worker cannot commit (the sandbox denies the shared object store);
+  // a moved HEAD means something abnormal happened — refuse to reason on it.
+  match git_require(["rev-parse", "HEAD"], cwd=worker) {
+    Ok(head) =>
+      if head.trim() != entry.base_oid {
+        defects.push(
+          "worktree HEAD moved from the pinned base (\{head.trim()} != \{entry.base_oid})",
+        )
+      }
+    Err(reason) => defects.push(reason)
+  }
+  let status = git_run(
+    [
+      "status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignore-submodules=none",
+    ],
+    cwd=worker,
+  )
+  guard status.exit_code == 0 else {
+    defects.push("git status failed: \{status.output.trim()}")
+    return { entry, evidence, defects }
+  }
+  let changes = parse_status_z(status.output)
+  if changes.is_empty() {
+    let entry = { ..entry, state: NoChanges }
+    let _ = save_entry(geometry.common_git_dir, entry)
+    evidence.push("no changes in the worker tree")
+    return { entry, evidence, defects }
+  }
+  evidence.push("\{changes.length()} changed path(s)")
+  let violations = scope_violations(changes, entry.allowed_paths)
+  if !violations.is_empty() {
+    defects.push(
+      "out-of-scope changes (allowed: \{entry.allowed_paths.join(", ")}): \{violations.join(", ")}",
+    )
+  }
+  if !defects.is_empty() {
+    let entry = { ..entry, state: Captured }
+    let _ = save_entry(geometry.common_git_dir, entry)
+    return { entry, evidence, defects }
+  }
+  // Stage and revalidate the STAGED picture against the same contract.
+  match git_require(["add", "-A"], cwd=worker) {
+    Ok(_) => ()
+    Err(reason) => {
+      defects.push(reason)
+      return { entry, evidence, defects }
+    }
+  }
+  let staged = git_run(
+    ["diff", "--cached", "--name-status", "-z", entry.base_oid],
+    cwd=worker,
+  )
+  guard staged.exit_code == 0 else {
+    defects.push("git diff --cached failed: \{staged.output.trim()}")
+    return { entry, evidence, defects }
+  }
+  let staged_changes = parse_diff_name_status_z(staged.output)
+  let staged_violations = scope_violations(staged_changes, entry.allowed_paths)
+  if !staged_violations.is_empty() {
+    defects.push(
+      "staged changes escaped scope between validation and staging: \{staged_violations.join(", ")}",
+    )
+  }
+  match
+    git_run(["diff", "--cached", "--raw", "-z", entry.base_oid], cwd=worker) {
+    raw if raw.exit_code == 0 => {
+      let links = new_gitlinks_in_raw_z(raw.output)
+      if !links.is_empty() {
+        defects.push(
+          "the worker staged embedded repositories as gitlinks: \{links.join(", ")}",
+        )
+      }
+    }
+    raw => defects.push("git diff --raw failed: \{raw.output.trim()}")
+  }
+  if !defects.is_empty() {
+    let entry = { ..entry, state: Captured }
+    let _ = save_entry(geometry.common_git_dir, entry)
+    return { entry, evidence, defects }
+  }
+  // Pin the exact tree being committed, commit, then verify parent+tree.
+  let tree_oid = match git_require(["write-tree"], cwd=worker) {
+    Ok(output) => output.trim().to_owned()
+    Err(reason) => {
+      defects.push(reason)
+      return { entry, evidence, defects }
+    }
+  }
+  match
+    git_require(
+      [
+        "-c",
+        "core.hooksPath=/dev/null",
+        "commit",
+        "--no-verify",
+        "--no-gpg-sign",
+        "-m",
+        "subtask \{entry.name}: worker changes",
+      ],
+      cwd=worker,
+    ) {
+    Ok(_) => ()
+    Err(reason) => {
+      defects.push(reason)
+      return { entry, evidence, defects }
+    }
+  }
+  let commit_oid = match git_require(["rev-parse", "HEAD"], cwd=worker) {
+    Ok(output) => output.trim().to_owned()
+    Err(reason) => {
+      defects.push(reason)
+      return { entry, evidence, defects }
+    }
+  }
+  match git_require(["rev-parse", "HEAD^{tree}", "HEAD^"], cwd=worker) {
+    Ok(output) => {
+      let lines = output
+        .trim()
+        .to_owned()
+        .split("\n")
+        .map(l => l.to_owned())
+        .collect()
+      if lines.length() != 2 ||
+        lines[0] != tree_oid ||
+        lines[1] != entry.base_oid {
+        defects.push(
+          "the commit does not match the validated snapshot (tree/parent drifted)",
+        )
+      }
+    }
+    Err(reason) => defects.push(reason)
+  }
+  if !defects.is_empty() {
+    let entry = { ..entry, state: Captured }
+    let _ = save_entry(geometry.common_git_dir, entry)
+    return { entry, evidence, defects }
+  }
+  let diffstat = git_run(
+    ["diff", "--stat", entry.base_oid, commit_oid],
+    cwd=worker,
+  )
+  if diffstat.exit_code == 0 {
+    evidence.push(diffstat.output.trim().to_owned())
+  }
+  let entry = { ..entry, state: Committed, commit_oid: Some(commit_oid) }
+  let _ = save_entry(geometry.common_git_dir, entry)
+  evidence.push("committed \{commit_oid} on \{entry.branch}")
+  { entry, evidence, defects }
+}

--- a/cmd/openseek/internal/subtask/capture.mbt
+++ b/cmd/openseek/internal/subtask/capture.mbt
@@ -46,6 +46,14 @@ pub async fn capture(
     return { entry, evidence, defects }
   }
   let changes = parse_status_z(status.output)
+  if changes.is_empty() && !defects.is_empty() {
+    // A clean tree with a FAILED validation (e.g. HEAD moved off the base)
+    // is abnormal, not a no-op: the worktree may hold the only reference
+    // to whatever happened — keep it and report.
+    let entry = { ..entry, state: Captured }
+    let _ = save_entry(geometry.common_git_dir, entry)
+    return { entry, evidence, defects }
+  }
   if changes.is_empty() {
     // Terminal means undiscoverable by lifecycle actions, so the worktree
     // and branch must go NOW or they leak (and block reusing the name).

--- a/cmd/openseek/internal/subtask/geometry.mbt
+++ b/cmd/openseek/internal/subtask/geometry.mbt
@@ -1,0 +1,91 @@
+///|
+/// The canonical git geometry every subtask operation is decided against.
+/// Resolved ONCE per operation from `git rev-parse` and `git worktree list`
+/// output — never constructed from names (private admin dirs can carry
+/// numeric suffixes; worktrees can live anywhere).
+pub struct Geometry {
+  /// Canonical origin toplevel — must be the MAIN worktree (v1 precondition).
+  origin_root : String
+  /// Canonical common git dir (shared objects/refs/config).
+  common_git_dir : String
+  /// Every registered worktree root, canonicalized, origin included.
+  worktree_roots : Array[String]
+}
+
+///|
+/// Resolve and validate the geometry for `workspace_root`. `Err` names the
+/// violated precondition: the workspace must be a git repository's MAIN
+/// worktree toplevel — a linked worktree's private/common split breaks the
+/// deny-root reasoning, so v1 rejects it outright.
+pub async fn resolve_geometry(
+  workspace_root : String,
+) -> Result[Geometry, String] {
+  let probe = git_run(
+    ["rev-parse", "--show-toplevel", "--absolute-git-dir", "--git-common-dir"],
+    cwd=workspace_root,
+  )
+  guard probe.exit_code == 0 else {
+    return Err("subtask needs a git repository: \{probe.output.trim()}")
+  }
+  let lines = probe.output
+    .trim()
+    .to_owned()
+    .split("\n")
+    .map(l => l.to_owned())
+    .collect()
+  guard lines.length() == 3 else {
+    return Err("unexpected rev-parse output: \{probe.output}")
+  }
+  let toplevel = canonical(lines[0])
+  let git_dir = canonical(lines[1])
+  let common = canonical(absolutize_against(lines[2], toplevel))
+  let workspace = canonical(workspace_root)
+  guard workspace == toplevel else {
+    return Err(
+      "subtask needs the repository toplevel as its workspace (got \{workspace}, toplevel \{toplevel})",
+    )
+  }
+  guard git_dir == common else {
+    return Err(
+      "subtask needs the MAIN worktree — this workspace is a linked worktree (git dir \{git_dir}, common \{common})",
+    )
+  }
+  let listing = git_run(["worktree", "list", "--porcelain", "-z"], cwd=toplevel)
+  guard listing.exit_code == 0 else {
+    return Err("git worktree list failed: \{listing.output.trim()}")
+  }
+  let worktree_roots : Array[String] = []
+  for record in listing.output.split("\u{0}") {
+    let record = record.to_owned()
+    if record.has_prefix("worktree ") {
+      worktree_roots.push(
+        canonical(record.view(start_offset="worktree ".length()).to_owned()),
+      )
+    }
+  }
+  guard !worktree_roots.is_empty() else {
+    return Err("git worktree list reported no worktrees")
+  }
+  Ok({ origin_root: toplevel, common_git_dir: common, worktree_roots })
+}
+
+///|
+/// realpath when possible; lexical normalization otherwise (a nonexistent
+/// path cannot be part of live geometry, but error messages still read).
+async fn canonical(path : String) -> String {
+  let real = @fs.realpath(path) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => path
+  }
+  @workspace_path.strip_trailing_slash(real)
+}
+
+///|
+/// `--git-common-dir` may print a path relative to the cwd of the probe.
+fn absolutize_against(path : String, base : String) -> String {
+  if @path.Path(path).is_absolute() {
+    path
+  } else {
+    "\{base}/\{path}"
+  }
+}

--- a/cmd/openseek/internal/subtask/gitrun.mbt
+++ b/cmd/openseek/internal/subtask/gitrun.mbt
@@ -1,0 +1,64 @@
+///|
+/// The controller's dedicated git runner. Unlike the baseline probe's
+/// `run_capture`, this is built for MUTATION: merged stdout+stderr
+/// diagnostics, per-phase timeouts, byte-preserving output for `-z`
+/// parsing, and a SANITIZED environment — the ambient `GIT_DIR`,
+/// `GIT_WORK_TREE`, `GIT_INDEX_FILE`, object/config overrides a hostile or
+/// merely unusual parent environment might carry are simply not inherited.
+/// Only `PATH` (to find git) and `HOME` (commit identity, global config)
+/// pass through.
+pub struct GitOutcome {
+  exit_code : Int
+  output : String
+}
+
+///|
+/// Run git with `args` in `cwd`, bounded by `timeout_ms`. A timeout cancels
+/// the child and reports exit -1 with a synthetic diagnostic — callers
+/// treat any nonzero exit as the phase failing and inspect postconditions
+/// rather than trusting the code alone.
+pub async fn git_run(
+  args : Array[String],
+  cwd~ : String,
+  timeout_ms? : Int = 30_000,
+) -> GitOutcome {
+  let env : Map[String, String] = Map([])
+  for key in ["PATH", "HOME"] {
+    if @env.get_env_var(key) is Some(value) {
+      env[key] = value
+    }
+  }
+  let outcome = @async.with_timeout_opt(timeout_ms, () => {
+    @process.collect_output_merged(
+      "git",
+      args,
+      extra_env=env,
+      inherit_env=false,
+      cwd=cwd.view(),
+    )
+  }) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => return { exit_code: -1, output: "git spawn failed: \{error}" }
+  }
+  match outcome {
+    Some((exit_code, data)) => { exit_code, output: data.text() }
+    None => { exit_code: -1, output: "git timed out after \{timeout_ms}ms" }
+  }
+}
+
+///|
+/// Run git and require success; `Err` carries the merged diagnostics.
+pub async fn git_require(
+  args : Array[String],
+  cwd~ : String,
+  timeout_ms? : Int = 30_000,
+) -> Result[String, String] {
+  let outcome = git_run(args, cwd~, timeout_ms~)
+  if outcome.exit_code == 0 {
+    Ok(outcome.output)
+  } else {
+    Err(
+      "git \{args.join(" ")} failed (exit \{outcome.exit_code}): \{outcome.output}",
+    )
+  }
+}

--- a/cmd/openseek/internal/subtask/integrate.mbt
+++ b/cmd/openseek/internal/subtask/integrate.mbt
@@ -1,0 +1,351 @@
+///|
+/// Integration: merge a committed subtask branch into the origin, classify
+/// the outcome by POSTCONDITIONS (MERGE_HEAD, unmerged index entries, HEAD)
+/// rather than exit codes, and clean up only what a clean merge proves
+/// redundant. Conflict continuation and abort are controller-owned and
+/// verify the merge in progress belongs to THIS subtask attempt.
+pub struct IntegrateOutcome {
+  entry : SubtaskEntry
+  /// "integrated" | "conflicted" | "refused"
+  result : String
+  detail : Array[String]
+}
+
+///|
+/// The merge flag set: hooks and signing neutralized, no rerere recording
+/// or autostash, ignored files protected, merge by EXACT commit OID.
+fn merge_args(entry : SubtaskEntry, commit_oid : String) -> Array[String] {
+  [
+    "-c",
+    "core.hooksPath=/dev/null",
+    "-c",
+    "rerere.enabled=false",
+    "merge",
+    "--no-ff",
+    "--no-edit",
+    "--no-gpg-sign",
+    "--no-autostash",
+    "--no-overwrite-ignore",
+    "-m",
+    "subtask \{entry.name}: integrate worker changes",
+    commit_oid,
+  ]
+}
+
+///|
+/// Merge a committed subtask into the origin; outcome classified by git
+/// postconditions (integrated | conflicted | refused).
+pub async fn integrate(
+  geometry : Geometry,
+  entry : SubtaskEntry,
+) -> IntegrateOutcome {
+  let origin = geometry.origin_root
+  let mutex = repo_mutex(geometry.common_git_dir)
+  mutex.acquire()
+  let outcome = integrate_locked(geometry, origin, entry)
+  mutex.release()
+  outcome
+}
+
+///|
+async fn integrate_locked(
+  geometry : Geometry,
+  origin : String,
+  entry : SubtaskEntry,
+) -> IntegrateOutcome {
+  guard entry.state is Committed && entry.commit_oid is Some(commit_oid) else {
+    return {
+      entry,
+      result: "refused",
+      detail: ["subtask \{entry.name} is not in a committed state"],
+    }
+  }
+  // The branch must still point at the validated commit, and that commit
+  // must descend from the recorded base.
+  match git_require(["rev-parse", entry.branch], cwd=origin) {
+    Ok(tip) =>
+      if tip.trim() != commit_oid {
+        return {
+          entry,
+          result: "refused",
+          detail: [
+            "branch \{entry.branch} moved (\{tip.trim()} != validated \{commit_oid})",
+          ],
+        }
+      }
+    Err(reason) => return { entry, result: "refused", detail: [reason] }
+  }
+  if git_run(
+      ["merge-base", "--is-ancestor", entry.base_oid, commit_oid],
+      cwd=origin,
+    ).exit_code !=
+    0 {
+    return {
+      entry,
+      result: "refused",
+      detail: ["\{commit_oid} does not descend from the recorded base"],
+    }
+  }
+  // Origin gate: no staged changes, no unstaged changes to tracked files.
+  // Gitlink dirt (a chronically-drifting submodule pointer) is carved out:
+  // submodule slices were rejected at provision, so it cannot collide.
+  let status = git_run(
+    ["status", "--porcelain=v1", "-z", "--ignore-submodules=dirty"],
+    cwd=origin,
+  )
+  guard status.exit_code == 0 else {
+    return {
+      entry,
+      result: "refused",
+      detail: ["git status failed: \{status.output.trim()}"],
+    }
+  }
+  for change in parse_status_z(status.output) {
+    if change.kind != "??" {
+      return {
+        entry,
+        result: "refused",
+        detail: [
+          "the origin has uncommitted tracked changes (\{change.path}); commit or stash them before integrating",
+        ],
+      }
+    }
+  }
+  let head_before = match git_require(["rev-parse", "HEAD"], cwd=origin) {
+    Ok(output) => output.trim().to_owned()
+    Err(reason) => return { entry, result: "refused", detail: [reason] }
+  }
+  let entry = { ..entry, origin_head_before: Some(head_before) }
+  let _ = save_entry(geometry.common_git_dir, entry)
+  let merge = git_run(
+    merge_args(entry, commit_oid),
+    cwd=origin,
+    timeout_ms=120_000,
+  )
+  // Classify by postconditions, not the exit code.
+  let merge_head = git_run(
+    ["rev-parse", "-q", "--verify", "MERGE_HEAD"],
+    cwd=origin,
+  )
+  let unmerged = git_run(["ls-files", "-u", "-z"], cwd=origin)
+  if merge_head.exit_code == 0 {
+    // A merge is in progress: a real conflict handoff only when it is OUR
+    // commit being merged.
+    if merge_head.output.trim() == commit_oid &&
+      unmerged.exit_code == 0 &&
+      unmerged.output != "" {
+      let files : Array[String] = []
+      for
+        change in parse_status_z(
+          git_run(["status", "--porcelain=v1", "-z"], cwd=origin).output,
+        ) {
+        if change.kind.contains("U") && !files.contains(change.path) {
+          files.push(change.path)
+        }
+      }
+      let entry = { ..entry, state: Conflicted }
+      let _ = save_entry(geometry.common_git_dir, entry)
+      return {
+        entry,
+        result: "conflicted",
+        detail: [
+          "merge conflict in: \{files.join(", ")}",
+          "resolve the markers with the file tools, then integrate_continue (or integrate_abort)",
+        ],
+      }
+    }
+    // A foreign or degenerate in-progress merge: abort OUR attempt only if
+    // it is ours; otherwise leave the user's state alone.
+    if merge_head.output.trim() == commit_oid {
+      let _ = git_run(["merge", "--abort"], cwd=origin)
+    }
+    return {
+      entry,
+      result: "refused",
+      detail: ["merge did not complete cleanly: \{merge.output.trim()}"],
+    }
+  }
+  // No merge in progress: either it completed or it never started.
+  let head_after = git_run(["rev-parse", "HEAD"], cwd=origin)
+  if head_after.exit_code == 0 && head_after.output.trim() != head_before {
+    let entry = { ..entry, state: Integrated }
+    let _ = save_entry(geometry.common_git_dir, entry)
+    // The branch's content now lives in origin history: the worktree and
+    // branch are provably redundant — the one auto-clean that is safe.
+    // (`git worktree remove` refuses ANY worktree in repos with tracked
+    // submodules, so removal is rm + prune by design.)
+    @fs.rmdir(entry.worker_root, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+    let _ = git_run(["worktree", "prune"], cwd=origin)
+    let _ = git_run(["branch", "-d", entry.branch], cwd=origin)
+    return {
+      entry,
+      result: "integrated",
+      detail: ["merged \{commit_oid} into \{head_after.output.trim()}"],
+    }
+  }
+  {
+    entry,
+    result: "refused",
+    detail: ["merge did not land: \{merge.output.trim()}"],
+  }
+}
+
+///|
+/// Continue a conflicted integration after the caller resolved the markers:
+/// verify the in-progress merge is THIS attempt, nothing is left unmerged,
+/// and the staged resolution stays inside scope ∪ the conflicted set, then
+/// commit through the controller.
+pub async fn integrate_continue(
+  geometry : Geometry,
+  entry : SubtaskEntry,
+) -> IntegrateOutcome {
+  let origin = geometry.origin_root
+  let mutex = repo_mutex(geometry.common_git_dir)
+  mutex.acquire()
+  let outcome = integrate_continue_locked(geometry, origin, entry)
+  mutex.release()
+  outcome
+}
+
+///|
+async fn integrate_continue_locked(
+  geometry : Geometry,
+  origin : String,
+  entry : SubtaskEntry,
+) -> IntegrateOutcome {
+  guard entry.state is Conflicted && entry.commit_oid is Some(commit_oid) else {
+    return {
+      entry,
+      result: "refused",
+      detail: ["subtask \{entry.name} has no conflicted integration"],
+    }
+  }
+  let merge_head = git_run(
+    ["rev-parse", "-q", "--verify", "MERGE_HEAD"],
+    cwd=origin,
+  )
+  guard merge_head.exit_code == 0 && merge_head.output.trim() == commit_oid else {
+    return {
+      entry,
+      result: "refused",
+      detail: [
+        "no merge of \{commit_oid} is in progress — the conflicted state is stale",
+      ],
+    }
+  }
+  match entry.origin_head_before {
+    Some(before) =>
+      match git_require(["rev-parse", "HEAD"], cwd=origin) {
+        Ok(head) =>
+          if head.trim() != before {
+            return {
+              entry,
+              result: "refused",
+              detail: ["origin HEAD moved during the conflicted window"],
+            }
+          }
+        Err(reason) => return { entry, result: "refused", detail: [reason] }
+      }
+    None => ()
+  }
+  let unmerged = git_run(["ls-files", "-u", "-z"], cwd=origin)
+  if unmerged.exit_code == 0 && unmerged.output != "" {
+    return {
+      entry,
+      result: "refused",
+      detail: ["unresolved conflict entries remain; resolve them all first"],
+    }
+  }
+  match
+    git_require(
+      [
+        "-c", "core.hooksPath=/dev/null", "commit", "--no-verify", "--no-gpg-sign",
+        "--no-edit",
+      ],
+      cwd=origin,
+    ) {
+    Ok(_) => ()
+    Err(reason) => return { entry, result: "refused", detail: [reason] }
+  }
+  let entry = { ..entry, state: Integrated }
+  let _ = save_entry(geometry.common_git_dir, entry)
+  @fs.rmdir(entry.worker_root, recursive=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+  let _ = git_run(["worktree", "prune"], cwd=origin)
+  let _ = git_run(["branch", "-d", entry.branch], cwd=origin)
+  { entry, result: "integrated", detail: ["conflict resolution committed"] }
+}
+
+///|
+/// Abort a conflicted integration: verify ownership first, then restore
+/// the pre-merge state. The subtask returns to `committed` (its branch and
+/// worktree survive) — the reservation is NOT released.
+pub async fn integrate_abort(
+  geometry : Geometry,
+  entry : SubtaskEntry,
+) -> IntegrateOutcome {
+  let origin = geometry.origin_root
+  guard entry.state is Conflicted && entry.commit_oid is Some(commit_oid) else {
+    return {
+      entry,
+      result: "refused",
+      detail: ["subtask \{entry.name} has no conflicted integration"],
+    }
+  }
+  let merge_head = git_run(
+    ["rev-parse", "-q", "--verify", "MERGE_HEAD"],
+    cwd=origin,
+  )
+  guard merge_head.exit_code == 0 && merge_head.output.trim() == commit_oid else {
+    return {
+      entry,
+      result: "refused",
+      detail: ["no merge of \{commit_oid} is in progress"],
+    }
+  }
+  match git_require(["merge", "--abort"], cwd=origin) {
+    Ok(_) => ()
+    Err(reason) => return { entry, result: "refused", detail: [reason] }
+  }
+  let entry = { ..entry, state: Committed }
+  let _ = save_entry(geometry.common_git_dir, entry)
+  {
+    entry,
+    result: "refused",
+    detail: ["merge aborted; the branch and worktree remain"],
+  }
+}
+
+///|
+/// Discard a subtask that will not be integrated: remove its worktree and
+/// branch, release the reservation. Refused while a merge of this subtask
+/// is in progress.
+pub async fn discard(
+  geometry : Geometry,
+  entry : SubtaskEntry,
+) -> Result[Unit, String] {
+  let origin = geometry.origin_root
+  if entry.commit_oid is Some(commit_oid) {
+    let merge_head = git_run(
+      ["rev-parse", "-q", "--verify", "MERGE_HEAD"],
+      cwd=origin,
+    )
+    if merge_head.exit_code == 0 && merge_head.output.trim() == commit_oid {
+      return Err("a merge of this subtask is in progress; abort it first")
+    }
+  }
+  @fs.rmdir(entry.worker_root, recursive=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+  let _ = git_run(["worktree", "prune"], cwd=origin)
+  let _ = git_run(["branch", "-D", entry.branch], cwd=origin)
+  let entry = { ..entry, state: Discarded }
+  let _ = save_entry(geometry.common_git_dir, entry)
+  Ok(())
+}

--- a/cmd/openseek/internal/subtask/integrate.mbt
+++ b/cmd/openseek/internal/subtask/integrate.mbt
@@ -42,9 +42,8 @@ pub async fn integrate(
   let origin = geometry.origin_root
   let mutex = repo_mutex(geometry.common_git_dir)
   mutex.acquire()
-  let outcome = integrate_locked(geometry, origin, entry)
-  mutex.release()
-  outcome
+  defer mutex.release()
+  integrate_locked(geometry, origin, entry)
 }
 
 ///|
@@ -143,7 +142,7 @@ async fn integrate_locked(
           files.push(change.path)
         }
       }
-      let entry = { ..entry, state: Conflicted }
+      let entry = { ..entry, state: Conflicted, conflict_paths: files.copy() }
       let _ = save_entry(geometry.common_git_dir, entry)
       return {
         entry,
@@ -205,9 +204,8 @@ pub async fn integrate_continue(
   let origin = geometry.origin_root
   let mutex = repo_mutex(geometry.common_git_dir)
   mutex.acquire()
-  let outcome = integrate_continue_locked(geometry, origin, entry)
-  mutex.release()
-  outcome
+  defer mutex.release()
+  integrate_continue_locked(geometry, origin, entry)
 }
 
 ///|
@@ -257,6 +255,34 @@ async fn integrate_continue_locked(
       entry,
       result: "refused",
       detail: ["unresolved conflict entries remain; resolve them all first"],
+    }
+  }
+  // The staged resolution may only touch the slice's scope plus the
+  // recorded conflict set — a stray `git add -A` must not smuggle
+  // unrelated changes into the merge commit.
+  let staged = git_run(
+    ["diff", "--cached", "--name-status", "-z", "HEAD"],
+    cwd=origin,
+  )
+  guard staged.exit_code == 0 else {
+    return {
+      entry,
+      result: "refused",
+      detail: ["git diff --cached failed: \{staged.output.trim()}"],
+    }
+  }
+  let permitted = entry.allowed_paths + entry.conflict_paths
+  let strays = scope_violations(
+    parse_diff_name_status_z(staged.output),
+    permitted,
+  )
+  if !strays.is_empty() {
+    return {
+      entry,
+      result: "refused",
+      detail: [
+        "the staged resolution touches paths outside the slice and its conflict set: \{strays.join(", ")}; unstage them first",
+      ],
     }
   }
   match
@@ -316,7 +342,7 @@ pub async fn integrate_abort(
   let _ = save_entry(geometry.common_git_dir, entry)
   {
     entry,
-    result: "refused",
+    result: "aborted",
     detail: ["merge aborted; the branch and worktree remain"],
   }
 }

--- a/cmd/openseek/internal/subtask/lifecycle_test.mbt
+++ b/cmd/openseek/internal/subtask/lifecycle_test.mbt
@@ -1,0 +1,290 @@
+///|
+/// Full-lifecycle tests against REAL git repositories: provision a worktree,
+/// play the worker's part with plain filesystem edits, capture, integrate —
+/// and every refusal edge the state machine promises. These are the
+/// controller's ground-truth tests; the parent tool wires what they prove.
+async fn seed_repo(dir : String) -> String {
+  let repo = "\{dir}/repo"
+  @fs.mkdir(repo)
+  for
+    args in [
+      ["init", "-q"],
+      ["config", "user.email", "e2e@test"],
+      ["config", "user.name", "e2e"],
+    ] {
+    match @subtask.git_require(args, cwd=repo) {
+      Ok(_) => ()
+      Err(reason) => fail(reason)
+    }
+  }
+  @fs.mkdir("\{repo}/lib")
+  @fs.mkdir("\{repo}/other")
+  @vfs.write_text("\{repo}/lib", "a.txt", "alpha\n")
+  @vfs.write_text("\{repo}/other", "b.txt", "beta\n")
+  for args in [["add", "-A"], ["commit", "-q", "-m", "base"]] {
+    match @subtask.git_require(args, cwd=repo) {
+      Ok(_) => ()
+      Err(reason) => fail(reason)
+    }
+  }
+  repo
+}
+
+///|
+async fn must_provision(
+  repo : String,
+  name~ : String,
+  allowed_paths~ : Array[String],
+  nonce~ : String,
+) -> @subtask.Provisioned {
+  match @subtask.provision(repo, name~, allowed_paths~, nonce~) {
+    Ok(provisioned) => provisioned
+    Err(reason) => fail("provision failed: \{reason}")
+  }
+}
+
+///|
+async test "provision, worker edit, capture, integrate — the happy path" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-happy-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let entry = provisioned.entry
+    assert_true(entry.state is Running)
+    assert_true(@fs.exists("\{entry.worker_root}/lib/a.txt"))
+    // The worker's part: an in-scope edit.
+    @vfs.write_text("\{entry.worker_root}/lib", "a.txt", "ALPHA\n")
+    let captured = @subtask.capture(provisioned.geometry, entry)
+    assert_eq(captured.defects, ([] : Array[String]))
+    assert_true(captured.entry.state is Committed)
+    guard captured.entry.commit_oid is Some(_) else {
+      fail("expected a commit oid")
+    }
+    let integrated = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(integrated.result, "integrated")
+    // The change landed in origin history and the worktree is gone.
+    assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "ALPHA\n")
+    assert_false(@fs.exists(entry.worker_root))
+    // The registry records the terminal state.
+    let (entries, skipped) = @subtask.load_entries(
+      provisioned.geometry.common_git_dir,
+    )
+    assert_eq(skipped, ([] : Array[String]))
+    assert_eq(entries.length(), 1)
+    assert_true(entries[0].state is Integrated)
+  })
+}
+
+///|
+async test "out-of-scope worker changes are captured as defects, not merged" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-scope-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let entry = provisioned.entry
+    @vfs.write_text("\{entry.worker_root}/lib", "a.txt", "ALPHA\n")
+    @vfs.write_text("\{entry.worker_root}/other", "b.txt", "INTRUDED\n")
+    let captured = @subtask.capture(provisioned.geometry, entry)
+    assert_true(captured.defects.length() > 0)
+    assert_true(captured.defects[0].contains("other/b.txt"))
+    assert_true(captured.entry.state is Captured)
+    // Nothing was committed; integration refuses.
+    let refused = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(refused.result, "refused")
+    // Origin untouched either way.
+    assert_eq(@fs.read_file("\{repo}/other/b.txt").text(), "beta\n")
+  })
+}
+
+///|
+async test "overlapping reservations and duplicate names refuse at provision" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-overlap-", dir => {
+    let repo = seed_repo(dir)
+    let _ = must_provision(
+      repo,
+      name="first",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    guard @subtask.provision(
+        repo,
+        name="second",
+        allowed_paths=["lib/deep"],
+        nonce="n2",
+      )
+      is Err(overlap) else {
+      fail("expected an overlap refusal")
+    }
+    assert_true(overlap.contains("overlap"))
+    guard @subtask.provision(
+        repo,
+        name="first",
+        allowed_paths=["other"],
+        nonce="n3",
+      )
+      is Err(duplicate) else {
+      fail("expected a duplicate-name refusal")
+    }
+    assert_true(duplicate.contains("already active"))
+    // A DISJOINT slice provisions fine alongside.
+    let _ = must_provision(
+      repo,
+      name="third",
+      allowed_paths=["other"],
+      nonce="n4",
+    )
+  })
+}
+
+///|
+async test "an empty worker tree resolves to no_changes and releases the slice" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-empty-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="noop",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let captured = @subtask.capture(provisioned.geometry, provisioned.entry)
+    assert_true(captured.entry.state is NoChanges)
+    assert_eq(captured.defects, ([] : Array[String]))
+    // The reservation is released: the same slice provisions again.
+    let _ = must_provision(
+      repo,
+      name="retry",
+      allowed_paths=["lib"],
+      nonce="n2",
+    )
+  })
+}
+
+///|
+async test "a conflicting merge hands off, continues after resolution" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-conflict-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let entry = provisioned.entry
+    // Worker changes the file...
+    @vfs.write_text("\{entry.worker_root}/lib", "a.txt", "WORKER\n")
+    let captured = @subtask.capture(provisioned.geometry, entry)
+    assert_true(captured.entry.state is Committed)
+    // ...and the origin advances the SAME line before integration.
+    @vfs.write_text("\{repo}/lib", "a.txt", "ORIGIN\n")
+    for args in [["add", "-A"], ["commit", "-q", "-m", "origin moved"]] {
+      match @subtask.git_require(args, cwd=repo) {
+        Ok(_) => ()
+        Err(reason) => fail(reason)
+      }
+    }
+    let conflicted = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(conflicted.result, "conflicted")
+    assert_true(conflicted.entry.state is Conflicted)
+    assert_true(conflicted.detail[0].contains("lib/a.txt"))
+    // Resolve the markers (the parent model's job, via file tools) and
+    // stage the resolution — then the controller commits.
+    @vfs.write_text("\{repo}/lib", "a.txt", "MERGED\n")
+    match @subtask.git_require(["add", "lib/a.txt"], cwd=repo) {
+      Ok(_) => ()
+      Err(reason) => fail(reason)
+    }
+    let continued = @subtask.integrate_continue(
+      provisioned.geometry,
+      conflicted.entry,
+    )
+    assert_eq(continued.result, "integrated")
+    assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "MERGED\n")
+    assert_false(@fs.exists(entry.worker_root))
+  })
+}
+
+///|
+async test "integrate refuses a dirty tracked origin; abort restores state" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-dirty-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    @vfs.write_text("\{provisioned.entry.worker_root}/lib", "a.txt", "WORKER\n")
+    let captured = @subtask.capture(provisioned.geometry, provisioned.entry)
+    // Dirty the origin's tracked file.
+    @vfs.write_text("\{repo}/other", "b.txt", "dirty\n")
+    let refused = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(refused.result, "refused")
+    assert_true(refused.detail[0].contains("uncommitted tracked changes"))
+    // Clean it; force a conflict; then abort restores the pre-merge state.
+    @vfs.write_text("\{repo}/other", "b.txt", "beta\n")
+    @vfs.write_text("\{repo}/lib", "a.txt", "ORIGIN\n")
+    for args in [["add", "-A"], ["commit", "-q", "-m", "origin moved"]] {
+      match @subtask.git_require(args, cwd=repo) {
+        Ok(_) => ()
+        Err(reason) => fail(reason)
+      }
+    }
+    let conflicted = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(conflicted.result, "conflicted")
+    let aborted = @subtask.integrate_abort(
+      provisioned.geometry,
+      conflicted.entry,
+    )
+    assert_true(aborted.entry.state is Committed)
+    assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "ORIGIN\n")
+    // The branch and worktree survive an abort for a later retry.
+    assert_true(@fs.exists(provisioned.entry.worker_root))
+    // Discard releases everything.
+    match @subtask.discard(provisioned.geometry, aborted.entry) {
+      Ok(_) => ()
+      Err(reason) => fail(reason)
+    }
+    assert_false(@fs.exists(provisioned.entry.worker_root))
+    let retry = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n9",
+    )
+    assert_true(retry.entry.state is Running)
+  })
+}
+
+///|
+async test "provision refuses linked-worktree origins and submodule slices" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-precond-", dir => {
+    let repo = seed_repo(dir)
+    // A linked worktree cannot be the origin.
+    match
+      @subtask.git_require(
+        ["worktree", "add", "-q", "../linked", "-b", "linked"],
+        cwd=repo,
+      ) {
+      Ok(_) => ()
+      Err(reason) => fail(reason)
+    }
+    guard @subtask.provision(
+        "\{dir}/linked",
+        name="x",
+        allowed_paths=["lib"],
+        nonce="n1",
+      )
+      is Err(linked) else {
+      fail("expected the linked-worktree refusal")
+    }
+    assert_true(linked.contains("MAIN worktree"))
+  })
+}

--- a/cmd/openseek/internal/subtask/lifecycle_test.mbt
+++ b/cmd/openseek/internal/subtask/lifecycle_test.mbt
@@ -157,13 +157,16 @@ async test "an empty worker tree resolves to no_changes and releases the slice" 
     let captured = @subtask.capture(provisioned.geometry, provisioned.entry)
     assert_true(captured.entry.state is NoChanges)
     assert_eq(captured.defects, ([] : Array[String]))
-    // The reservation is released: the same slice provisions again.
-    let _ = must_provision(
+    // Cleanup is immediate (terminal entries are undiscoverable), so the
+    // SAME name and slice provision again — with a natural trailing-slash
+    // spelling, which normalization must accept.
+    let again = must_provision(
       repo,
-      name="retry",
-      allowed_paths=["lib"],
+      name="noop",
+      allowed_paths=["lib/"],
       nonce="n2",
     )
+    assert_eq(again.entry.allowed_paths, ["lib"])
   })
 }
 
@@ -195,9 +198,27 @@ async test "a conflicting merge hands off, continues after resolution" {
     assert_true(conflicted.entry.state is Conflicted)
     assert_true(conflicted.detail[0].contains("lib/a.txt"))
     // Resolve the markers (the parent model's job, via file tools) and
-    // stage the resolution — then the controller commits.
+    // stage the resolution — then the controller commits. A stray staged
+    // file outside the slice + conflict set refuses the continue first.
     @vfs.write_text("\{repo}/lib", "a.txt", "MERGED\n")
-    match @subtask.git_require(["add", "lib/a.txt"], cwd=repo) {
+    @vfs.write_text("\{repo}/other", "stray.txt", "stray\n")
+    for args in [["add", "lib/a.txt"], ["add", "other/stray.txt"]] {
+      match @subtask.git_require(args, cwd=repo) {
+        Ok(_) => ()
+        Err(reason) => fail(reason)
+      }
+    }
+    let strayed = @subtask.integrate_continue(
+      provisioned.geometry,
+      conflicted.entry,
+    )
+    assert_eq(strayed.result, "refused")
+    assert_true(strayed.detail[0].contains("other/stray.txt"))
+    match
+      @subtask.git_require(
+        ["restore", "--staged", "--worktree", "other/stray.txt"],
+        cwd=repo,
+      ) {
       Ok(_) => ()
       Err(reason) => fail(reason)
     }
@@ -243,6 +264,7 @@ async test "integrate refuses a dirty tracked origin; abort restores state" {
       provisioned.geometry,
       conflicted.entry,
     )
+    assert_eq(aborted.result, "aborted")
     assert_true(aborted.entry.state is Committed)
     assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "ORIGIN\n")
     // The branch and worktree survive an abort for a later retry.

--- a/cmd/openseek/internal/subtask/moon.pkg
+++ b/cmd/openseek/internal/subtask/moon.pkg
@@ -1,0 +1,17 @@
+import {
+  "bobzhang/openseek/internal/workspace_path",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/process",
+  "moonbitlang/core/json",
+  "moonbitlang/x/path",
+  "moonbitlang/x/sys" @env,
+}
+
+import {
+  "bobzhang/openseek/testkit/filesystem" @vfs,
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -1,0 +1,112 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/openseek/internal/subtask"
+
+import {
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+}
+
+// Values
+pub async fn capture(Geometry, SubtaskEntry) -> CaptureOutcome
+
+pub async fn discard(Geometry, SubtaskEntry) -> Result[Unit, String]
+
+pub async fn git_require(Array[String], cwd~ : String, timeout_ms? : Int) -> Result[String, String]
+
+pub async fn git_run(Array[String], cwd~ : String, timeout_ms? : Int) -> GitOutcome
+
+pub async fn integrate(Geometry, SubtaskEntry) -> IntegrateOutcome
+
+pub async fn integrate_abort(Geometry, SubtaskEntry) -> IntegrateOutcome
+
+pub async fn integrate_continue(Geometry, SubtaskEntry) -> IntegrateOutcome
+
+pub async fn load_entries(String) -> (Array[SubtaskEntry], Array[String])
+
+pub fn new_gitlinks_in_raw_z(String) -> Array[String]
+
+pub fn parse_diff_name_status_z(String) -> Array[Change]
+
+pub fn parse_status_z(String) -> Array[Change]
+
+pub fn paths_overlap(Array[String], Array[String]) -> Bool
+
+pub async fn provision(String, name~ : String, allowed_paths~ : Array[String], nonce~ : String, parent_session? : String) -> Result[Provisioned, String]
+
+pub fn registry_dir(String) -> String
+
+pub async fn resolve_geometry(String) -> Result[Geometry, String]
+
+pub async fn rollback_provision(Geometry, SubtaskEntry) -> Unit
+
+pub async fn save_entry(String, SubtaskEntry) -> Result[Unit, String]
+
+pub fn scope_violations(Array[Change], Array[String]) -> Array[String]
+
+// Errors
+
+// Types and methods
+pub struct CaptureOutcome {
+  entry : SubtaskEntry
+  evidence : Array[String]
+  defects : Array[String]
+}
+
+pub struct Change {
+  path : String
+  kind : String
+} derive(Eq, @debug.Debug)
+
+pub struct Geometry {
+  origin_root : String
+  common_git_dir : String
+  worktree_roots : Array[String]
+}
+
+pub struct GitOutcome {
+  exit_code : Int
+  output : String
+}
+
+pub struct IntegrateOutcome {
+  entry : SubtaskEntry
+  result : String
+  detail : Array[String]
+}
+
+pub struct Provisioned {
+  entry : SubtaskEntry
+  geometry : Geometry
+}
+
+pub struct SubtaskEntry {
+  schema_version : Int
+  name : String
+  nonce : String
+  branch : String
+  state : SubtaskState
+  base_oid : String
+  worker_root : String
+  worker_admin_dir : String
+  allowed_paths : Array[String]
+  parent_session : String?
+  commit_oid : String?
+  origin_head_before : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum SubtaskState {
+  Provisioning
+  Running
+  Captured
+  Committed
+  Conflicted
+  Integrated
+  Discarded
+  NoChanges
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SubtaskState::is_terminal(Self) -> Bool
+
+// Type aliases
+
+// Traits
+

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub async fn git_require(Array[String], cwd~ : String, timeout_ms? : Int) -> Res
 
 pub async fn git_run(Array[String], cwd~ : String, timeout_ms? : Int) -> GitOutcome
 
+pub fn gitlink_introductions_in_raw_z(String) -> Array[String]
+
 pub async fn integrate(Geometry, SubtaskEntry) -> IntegrateOutcome
 
 pub async fn integrate_abort(Geometry, SubtaskEntry) -> IntegrateOutcome
@@ -22,8 +24,6 @@ pub async fn integrate_abort(Geometry, SubtaskEntry) -> IntegrateOutcome
 pub async fn integrate_continue(Geometry, SubtaskEntry) -> IntegrateOutcome
 
 pub async fn load_entries(String) -> (Array[SubtaskEntry], Array[String])
-
-pub fn new_gitlinks_in_raw_z(String) -> Array[String]
 
 pub fn parse_diff_name_status_z(String) -> Array[Change]
 
@@ -92,6 +92,7 @@ pub struct SubtaskEntry {
   parent_session : String?
   commit_oid : String?
   origin_head_before : String?
+  conflict_paths : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) enum SubtaskState {

--- a/cmd/openseek/internal/subtask/provision.mbt
+++ b/cmd/openseek/internal/subtask/provision.mbt
@@ -41,21 +41,21 @@ pub async fn provision(
       "subtask name must be a short lowercase slug ([a-z0-9][a-z0-9-]{0,39}): \{name}",
     )
   }
+  let allowed_paths = match normalize_allowed_paths(allowed_paths) {
+    Ok(normalized) => normalized
+    Err(reason) => return Err(reason)
+  }
   let geometry = match resolve_geometry(workspace_root) {
     Ok(geometry) => geometry
     Err(reason) => return Err(reason)
   }
   let mutex = repo_mutex(geometry.common_git_dir)
   mutex.acquire()
-  let result = provision_locked(
-    geometry,
-    name~,
-    allowed_paths~,
-    nonce~,
-    parent_session?,
-  )
-  mutex.release()
-  result
+  // Block-scoped and sync, so a raise (cancellation included) still
+  // releases; a cached locked mutex would wedge the repository for the
+  // rest of the process.
+  defer mutex.release()
+  provision_locked(geometry, name~, allowed_paths~, nonce~, parent_session?)
 }
 
 ///|
@@ -141,6 +141,7 @@ async fn provision_locked(
     parent_session,
     commit_oid: None,
     origin_head_before: None,
+    conflict_paths: [],
   }
   match save_entry(geometry.common_git_dir, entry) {
     Ok(_) => ()
@@ -251,4 +252,40 @@ test "subtask names are strict slugs" {
     long.write_char('a')
   }
   assert_false(is_valid_name(long.to_string()))
+}
+
+///|
+/// Normalize model-supplied prefixes into the one spelling BOTH enforcement
+/// layers use: trailing slashes stripped (a natural `lib/` must not become
+/// `lib` + an empty component that rejects everything), no absolute, empty,
+/// `.`/`..`, or backslash components.
+fn normalize_allowed_paths(
+  allowed_paths : Array[String],
+) -> Result[Array[String], String] {
+  let normalized : Array[String] = []
+  for prefix in allowed_paths {
+    let mut cleaned = prefix.trim().to_owned()
+    while cleaned.has_suffix("/") {
+      cleaned = cleaned.view(end_offset=cleaned.length() - 1).to_owned()
+    }
+    guard cleaned != "" && !cleaned.has_prefix("/") else {
+      return Err(
+        "allowed_paths entries must be non-empty relative prefixes: \{prefix}",
+      )
+    }
+    guard !cleaned.contains("\\") else {
+      return Err("allowed_paths entries must use forward slashes: \{prefix}")
+    }
+    for part in cleaned.split("/") {
+      guard !(part.to_owned() is ("" | "." | "..")) else {
+        return Err(
+          "allowed_paths entries must not contain empty, `.`, or `..` components: \{prefix}",
+        )
+      }
+    }
+    if !normalized.contains(cleaned) {
+      normalized.push(cleaned)
+    }
+  }
+  Ok(normalized)
 }

--- a/cmd/openseek/internal/subtask/provision.mbt
+++ b/cmd/openseek/internal/subtask/provision.mbt
@@ -1,0 +1,254 @@
+///|
+/// Provisioning: one MUTEX-HELD transaction from registry reconciliation to
+/// a live worktree with a visible reservation. The mutex is keyed per
+/// canonical common git dir (process-local — the single-engine-per-repo
+/// assumption is a documented residual), so two concurrent subtask calls
+/// cannot both observe "no overlap" and launch overlapping workers.
+let repo_mutexes : Map[String, @async.Mutex] = Map([])
+
+///|
+fn repo_mutex(common_git_dir : String) -> @async.Mutex {
+  match repo_mutexes.get(common_git_dir) {
+    Some(mutex) => mutex
+    None => {
+      let mutex = @async.Mutex()
+      repo_mutexes[common_git_dir] = mutex
+      mutex
+    }
+  }
+}
+
+///|
+/// Everything a launched worker (and its later capture/integrate) needs.
+pub struct Provisioned {
+  entry : SubtaskEntry
+  geometry : Geometry
+}
+
+///|
+/// Provision a worktree for `name` with `allowed_paths`, or explain why
+/// not. On any failure after partial creation, the transaction rolls back
+/// what it made (worktree, branch, registry entry) before returning.
+pub async fn provision(
+  workspace_root : String,
+  name~ : String,
+  allowed_paths~ : Array[String],
+  nonce~ : String,
+  parent_session? : String,
+) -> Result[Provisioned, String] {
+  guard is_valid_name(name) else {
+    return Err(
+      "subtask name must be a short lowercase slug ([a-z0-9][a-z0-9-]{0,39}): \{name}",
+    )
+  }
+  let geometry = match resolve_geometry(workspace_root) {
+    Ok(geometry) => geometry
+    Err(reason) => return Err(reason)
+  }
+  let mutex = repo_mutex(geometry.common_git_dir)
+  mutex.acquire()
+  let result = provision_locked(
+    geometry,
+    name~,
+    allowed_paths~,
+    nonce~,
+    parent_session?,
+  )
+  mutex.release()
+  result
+}
+
+///|
+async fn provision_locked(
+  geometry : Geometry,
+  name~ : String,
+  allowed_paths~ : Array[String],
+  nonce~ : String,
+  parent_session? : String,
+) -> Result[Provisioned, String] {
+  let origin = geometry.origin_root
+  // 1. Reservation check against every non-terminal registry entry.
+  let (entries, _) = load_entries(geometry.common_git_dir)
+  for existing in entries {
+    if existing.state.is_terminal() {
+      continue
+    }
+    if existing.name == name {
+      return Err(
+        "a subtask named \{name} is already active (state \{Repr(existing.state)}); pick another name or integrate/discard it first",
+      )
+    }
+    if paths_overlap(existing.allowed_paths, allowed_paths) {
+      return Err(
+        "allowed_paths overlap active subtask \{existing.name} (\{existing.allowed_paths.join(", ")}); partitions must be disjoint — integrate or discard it first",
+      )
+    }
+  }
+  // 2. Base is pinned BEFORE the worktree exists and passed to git
+  //    explicitly, so a HEAD move between steps cannot skew evidence.
+  let base_oid = match git_require(["rev-parse", "HEAD"], cwd=origin) {
+    Ok(output) => output.trim().to_owned()
+    Err(reason) => return Err(reason)
+  }
+  // 3. Submodule slices are rejected from the PINNED tree, not the checkout.
+  match git_require(["ls-tree", "-r", "-z", base_oid], cwd=origin) {
+    Ok(listing) =>
+      for record in listing.split("\u{0}") {
+        let record = record.to_owned()
+        guard record.contains(" 160000 ") || record.has_prefix("160000 ") else {
+          continue
+        }
+        guard record.split("\t").last() is Some(path) else { continue }
+        let gitlink = path.to_owned()
+        if scope_violations([{ path: gitlink, kind: "gitlink" }], allowed_paths).is_empty() {
+          return Err(
+            "allowed_paths cover the submodule \{gitlink}; submodule slices are not supported (v1)",
+          )
+        }
+      }
+    Err(reason) => return Err(reason)
+  }
+  // 4. Keep .worktrees/ out of status noise, idempotently.
+  let exclude = "\{geometry.common_git_dir}/info/exclude"
+  let existing_exclude = @fs.read_file(exclude).text() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ""
+  }
+  if !existing_exclude.split("\n").any(line => line == ".worktrees/") {
+    @fs.write_file(
+      exclude,
+      "\{existing_exclude}\{if existing_exclude == "" || existing_exclude.has_suffix("\n") { "" } else { "\n" }}.worktrees/\n",
+      create_mode=CreateOrTruncate,
+    ) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  // 5. Reservation becomes visible BEFORE the worktree exists: a crash
+  //    between the two leaves a Provisioning entry naming what to clean.
+  let branch = "openseek/\{name}--\{nonce}"
+  let worker_root_spelled = "\{origin}/.worktrees/\{name}"
+  let mut entry : SubtaskEntry = {
+    schema_version: 1,
+    name,
+    nonce,
+    branch,
+    state: Provisioning,
+    base_oid,
+    worker_root: worker_root_spelled,
+    worker_admin_dir: "",
+    allowed_paths,
+    parent_session,
+    commit_oid: None,
+    origin_head_before: None,
+  }
+  match save_entry(geometry.common_git_dir, entry) {
+    Ok(_) => ()
+    Err(reason) => return Err(reason)
+  }
+  // 6. The worktree itself, pinned to the recorded base.
+  match
+    git_require(
+      ["worktree", "add", ".worktrees/\{name}", "-b", branch, base_oid],
+      cwd=origin,
+      timeout_ms=60_000,
+    ) {
+    Ok(_) => ()
+    Err(reason) => {
+      let _ = rollback_provision(geometry, entry)
+      return Err(reason)
+    }
+  }
+  // 7. Canonicalize what git actually made; resolve the PRIVATE admin dir
+  //    from inside the worktree (numeric suffixes exist — never construct).
+  let worker_root = canonical(worker_root_spelled)
+  let admin = match
+    git_require(["rev-parse", "--absolute-git-dir"], cwd=worker_root) {
+    Ok(output) => canonical(output.trim().to_owned())
+    Err(reason) => {
+      let _ = rollback_provision(geometry, entry)
+      return Err(reason)
+    }
+  }
+  entry = { ..entry, worker_root, worker_admin_dir: admin, state: Running }
+  match save_entry(geometry.common_git_dir, entry) {
+    Ok(_) => ()
+    Err(reason) => {
+      let _ = rollback_provision(geometry, entry)
+      return Err(reason)
+    }
+  }
+  // 8. Prewarm the dependency cache when the origin has one: registry
+  //    snapshots are immutable, and a worker without them pays a full
+  //    re-download before its first moon command.
+  copy_mooncakes(origin, worker_root)
+  Ok({ entry, geometry })
+}
+
+///|
+/// Undo a partial provision: worktree directory, bookkeeping, branch, and
+/// registry entry, in that order, each best-effort.
+pub async fn rollback_provision(
+  geometry : Geometry,
+  entry : SubtaskEntry,
+) -> Unit {
+  @fs.rmdir(entry.worker_root, recursive=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+  let _ = git_run(["worktree", "prune"], cwd=geometry.origin_root)
+  let _ = git_run(["branch", "-D", entry.branch], cwd=geometry.origin_root)
+  let dir = registry_dir(geometry.common_git_dir)
+  @fs.remove("\{dir}/\{entry.name}--\{entry.nonce}.json") catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+}
+
+///|
+fn is_valid_name(name : String) -> Bool {
+  guard name.length() >= 1 && name.length() <= 40 else { return false }
+  for index, ch in name {
+    let ok = ch is ('a'..='z' | '0'..='9') || (ch == '-' && index > 0)
+    if !ok {
+      return false
+    }
+  }
+  true
+}
+
+///|
+/// Best-effort recursive copy of `.mooncakes` (immutable registry
+/// snapshots). Failure is fine — the worker just pays the download.
+async fn copy_mooncakes(origin : String, worker_root : String) -> Unit {
+  let source = "\{origin}/.mooncakes"
+  guard (@fs.exists(source) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => false
+  }) else {
+    return
+  }
+  let _ = @process.run(
+    "cp",
+    ["-R", source, "\{worker_root}/.mooncakes"],
+    inherit_env=true,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => 1
+  }
+}
+
+///|
+test "subtask names are strict slugs" {
+  assert_true(is_valid_name("fix-warnings"))
+  assert_true(is_valid_name("a1"))
+  assert_false(is_valid_name("-leading"))
+  assert_false(is_valid_name("Upper"))
+  assert_false(is_valid_name("has space"))
+  assert_false(is_valid_name(""))
+  let long = StringBuilder()
+  for _ in 0..<41 {
+    long.write_char('a')
+  }
+  assert_false(is_valid_name(long.to_string()))
+}

--- a/cmd/openseek/internal/subtask/registry.mbt
+++ b/cmd/openseek/internal/subtask/registry.mbt
@@ -41,6 +41,7 @@ pub struct SubtaskEntry {
   parent_session : String?
   commit_oid : String?
   origin_head_before : String?
+  conflict_paths : Array[String]
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|
@@ -165,6 +166,7 @@ fn sample_entry() -> SubtaskEntry {
     parent_session: Some("run-1"),
     commit_oid: None,
     origin_head_before: None,
+    conflict_paths: [],
   }
 }
 

--- a/cmd/openseek/internal/subtask/registry.mbt
+++ b/cmd/openseek/internal/subtask/registry.mbt
@@ -109,11 +109,23 @@ pub async fn load_entries(
         continue
       }
     }
-    let parsed : SubtaskEntry = @json.from_json(@json.parse(text)) catch {
+    let json = @json.parse(text) catch {
       _ => {
         skipped.push(name)
         continue
       }
+    }
+    let parsed : SubtaskEntry = @json.from_json(json) catch {
+      _ =>
+        // Entries written before `conflict_paths` existed decode with the
+        // field defaulted rather than being skipped: a skipped ACTIVE entry
+        // would hide its reservation from provisioning.
+        @json.from_json(with_default_conflict_paths(json)) catch {
+          _ => {
+            skipped.push(name)
+            continue
+          }
+        }
     }
     if parsed.schema_version == registry_schema_version {
       entries.push(parsed)
@@ -190,4 +202,20 @@ test "path overlap is component-wise in both directions" {
   assert_true(paths_overlap(["a", "b"], ["c", "b/d"]))
   assert_false(paths_overlap(["src"], ["src2"]))
   assert_false(paths_overlap(["a/b"], ["a/c"]))
+}
+
+///|
+fn with_default_conflict_paths(json : Json) -> Json {
+  match json {
+    Object(map) => {
+      // Mutating the matched map mutates the parsed value in place; the
+      // original handle is returned rather than re-wrapped (Json's
+      // constructors are read-only outside core).
+      if !map.contains("conflict_paths") {
+        map["conflict_paths"] = ([] : Array[String]).to_json()
+      }
+      json
+    }
+    other => other
+  }
 }

--- a/cmd/openseek/internal/subtask/registry.mbt
+++ b/cmd/openseek/internal/subtask/registry.mbt
@@ -1,0 +1,191 @@
+///|
+/// The controller-owned lifecycle record of one subtask, stored OUTSIDE any
+/// worker-writable path at `<common-git-dir>/openseek/subtasks/<file>.json`.
+/// It is simultaneously the orphan-discovery record (a later session can
+/// enumerate the directory) and the path RESERVATION: entries in
+/// non-terminal states hold their `allowed_paths` against overlapping
+/// launches until integrated, discarded, or found empty.
+///
+/// Writes go through temp-file + rename: atomic against torn reads, NOT a
+/// cross-process lock — two engines driving one repository can still race
+/// silently (documented residual; the single-engine-per-repo assumption).
+pub(all) enum SubtaskState {
+  Provisioning
+  Running
+  Captured
+  Committed
+  Conflicted
+  Integrated
+  Discarded
+  NoChanges
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+/// Terminal states hold no path reservation.
+pub fn SubtaskState::is_terminal(self : SubtaskState) -> Bool {
+  self is (Integrated | Discarded | NoChanges)
+}
+
+///|
+/// One subtask's durable lifecycle record; see the file comment.
+pub struct SubtaskEntry {
+  schema_version : Int
+  name : String
+  nonce : String
+  branch : String
+  state : SubtaskState
+  base_oid : String
+  worker_root : String
+  worker_admin_dir : String
+  allowed_paths : Array[String]
+  parent_session : String?
+  commit_oid : String?
+  origin_head_before : String?
+} derive(Debug, Eq, ToJson, FromJson)
+
+///|
+let registry_schema_version : Int = 1
+
+///|
+/// Where entries live under the canonical common git dir.
+pub fn registry_dir(common_git_dir : String) -> String {
+  "\{common_git_dir}/openseek/subtasks"
+}
+
+///|
+fn entry_path(common_git_dir : String, entry : SubtaskEntry) -> String {
+  "\{registry_dir(common_git_dir)}/\{entry.name}--\{entry.nonce}.json"
+}
+
+///|
+/// Persist `entry` atomically (temp + rename in the registry directory).
+pub async fn save_entry(
+  common_git_dir : String,
+  entry : SubtaskEntry,
+) -> Result[Unit, String] {
+  let dir = registry_dir(common_git_dir)
+  @fs.mkdir(dir, recursive=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+  let target = entry_path(common_git_dir, entry)
+  let temp = "\{target}.tmp"
+  @fs.write_file(
+    temp,
+    entry.to_json().stringify(),
+    create_mode=CreateOrTruncate,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => return Err("could not write registry entry: \{error}")
+  }
+  @fs.rename(temp, target) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => return Err("could not commit registry entry: \{error}")
+  }
+  Ok(())
+}
+
+///|
+/// Load every parseable entry. Unparseable files are skipped (a foreign or
+/// future-schema record must not wedge provisioning) but their NAMES are
+/// reported alongside so a caller can surface them.
+pub async fn load_entries(
+  common_git_dir : String,
+) -> (Array[SubtaskEntry], Array[String]) {
+  let entries : Array[SubtaskEntry] = []
+  let skipped : Array[String] = []
+  let dir = registry_dir(common_git_dir)
+  let names = @fs.readdir(dir) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return (entries, skipped)
+  }
+  for name in names {
+    guard name.has_suffix(".json") else { continue }
+    let text = @fs.read_file("\{dir}/\{name}").text() catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => {
+        skipped.push(name)
+        continue
+      }
+    }
+    let parsed : SubtaskEntry = @json.from_json(@json.parse(text)) catch {
+      _ => {
+        skipped.push(name)
+        continue
+      }
+    }
+    if parsed.schema_version == registry_schema_version {
+      entries.push(parsed)
+    } else {
+      skipped.push(name)
+    }
+  }
+  (entries, skipped)
+}
+
+///|
+/// Component-wise prefix overlap between two allowed-path sets: `src`
+/// overlaps `src/lexer` and `src`, never `src2`.
+pub fn paths_overlap(a : Array[String], b : Array[String]) -> Bool {
+  fn components(prefix : String) -> Array[String] {
+    prefix.split("/").map(part => part.to_owned()).collect()
+  }
+
+  fn one_covers(shorter : Array[String], longer : Array[String]) -> Bool {
+    guard shorter.length() <= longer.length() else { return false }
+    for index in 0..<shorter.length() {
+      if shorter[index] != longer[index] {
+        return false
+      }
+    }
+    true
+  }
+
+  a.any(left => {
+    b.any(right => {
+      let l = components(left)
+      let r = components(right)
+      one_covers(l, r) || one_covers(r, l)
+    })
+  })
+}
+
+///|
+fn sample_entry() -> SubtaskEntry {
+  {
+    schema_version: 1,
+    name: "fix-warnings",
+    nonce: "ab12cd",
+    branch: "openseek/fix-warnings--ab12cd",
+    state: Running,
+    base_oid: "0123456789abcdef0123456789abcdef01234567",
+    worker_root: "/repo/.worktrees/fix-warnings",
+    worker_admin_dir: "/repo/.git/worktrees/fix-warnings",
+    allowed_paths: ["lib", "cmd/tool"],
+    parent_session: Some("run-1"),
+    commit_oid: None,
+    origin_head_before: None,
+  }
+}
+
+///|
+test "registry entry round-trips and states classify" {
+  let entry = sample_entry()
+  let parsed : SubtaskEntry = @json.from_json(entry.to_json()) catch {
+    e => fail("round-trip failed: \{e}")
+  }
+  assert_eq(parsed, entry)
+  assert_false(Running.is_terminal())
+  assert_false(Conflicted.is_terminal())
+  assert_true(Integrated.is_terminal())
+  assert_true(NoChanges.is_terminal())
+}
+
+///|
+test "path overlap is component-wise in both directions" {
+  assert_true(paths_overlap(["src"], ["src/lexer"]))
+  assert_true(paths_overlap(["src/lexer"], ["src"]))
+  assert_true(paths_overlap(["a", "b"], ["c", "b/d"]))
+  assert_false(paths_overlap(["src"], ["src2"]))
+  assert_false(paths_overlap(["a/b"], ["a/c"]))
+}

--- a/cmd/openseek/internal/subtask/scope.mbt
+++ b/cmd/openseek/internal/subtask/scope.mbt
@@ -98,10 +98,11 @@ pub fn scope_violations(
 }
 
 ///|
-/// Paths of NEW gitlink (mode 160000) entries in the staged diff — an
-/// embedded repository `git add -A` swallowed as a pointer. Detected from
-/// `git diff --cached --raw -z` records (`:000000 160000 ... A NUL path`).
-pub fn new_gitlinks_in_raw_z(output : String) -> Array[String] {
+/// Paths that TRANSITION INTO gitlink mode (160000) in a raw -z diff — an
+/// embedded repository swallowed as a pointer, whether added over nothing
+/// (`:000000 160000 ... A`) or replacing a regular file (`:100644 160000
+/// ... T`). Pre-existing gitlinks (source already 160000) pass.
+pub fn gitlink_introductions_in_raw_z(output : String) -> Array[String] {
   let links : Array[String] = []
   let fields = output.split("\u{0}").map(f => f.to_owned()).collect()
   let mut index = 0
@@ -115,7 +116,7 @@ pub fn new_gitlinks_in_raw_z(output : String) -> Array[String] {
         .split(" ")
         .map(p => p.to_owned())
         .collect()
-      if parts.length() >= 5 && parts[1] == "160000" && parts[0] == "000000" {
+      if parts.length() >= 5 && parts[1] == "160000" && parts[0] != "160000" {
         links.push(fields[index + 1])
       }
       index += 2
@@ -162,7 +163,9 @@ test "scope violations are component-wise over every side" {
 }
 
 ///|
-test "new gitlinks are detected from raw -z records" {
-  let raw = ":000000 160000 0000000 abc1234 A\u{0}vendor/embedded\u{0}:000000 100644 0000000 def5678 A\u{0}lib/file.txt\u{0}"
-  assert_eq(new_gitlinks_in_raw_z(raw), ["vendor/embedded"])
+test "gitlink introductions are detected from raw -z records" {
+  let raw = ":000000 160000 0000000 abc1234 A\u{0}vendor/embedded\u{0}:000000 100644 0000000 def5678 A\u{0}lib/file.txt\u{0}:100644 160000 aaa1111 bbb2222 T\u{0}lib/swapped\u{0}:160000 160000 ccc3333 ddd4444 M\u{0}vendor/existing\u{0}"
+  assert_eq(gitlink_introductions_in_raw_z(raw), [
+    "vendor/embedded", "lib/swapped",
+  ])
 }

--- a/cmd/openseek/internal/subtask/scope.mbt
+++ b/cmd/openseek/internal/subtask/scope.mbt
@@ -1,0 +1,168 @@
+///|
+/// Untruncated, NUL-delimited change parsing and component-wise scope
+/// validation — the controller's ground truth about what a worker touched.
+/// `git status --porcelain=v1 -z` and `git diff --name-status -z` need
+/// SEPARATE parsers: status prints `XY rename_target NUL rename_source`,
+/// diff prints `Rnnn NUL source NUL target`.
+
+///|
+/// One changed path with how it changed. Renames yield TWO records (source
+/// and target) — both sides must be in scope for the change to merge.
+pub struct Change {
+  path : String
+  kind : String
+} derive(Debug, Eq)
+
+///|
+/// Parse `git status --porcelain=v1 -z --untracked-files=all` output.
+pub fn parse_status_z(output : String) -> Array[Change] {
+  let changes : Array[Change] = []
+  let fields = output.split("\u{0}").map(f => f.to_owned()).collect()
+  let mut index = 0
+  while index < fields.length() {
+    let record = fields[index]
+    if record.length() < 4 {
+      index += 1
+      continue
+    }
+    let xy = record.view(end_offset=2).to_owned()
+    let path = record.view(start_offset=3).to_owned()
+    changes.push({ path, kind: xy.trim().to_owned() })
+    // A rename/copy consumes the NEXT field as its source path.
+    if xy.contains("R") || xy.contains("C") {
+      if index + 1 < fields.length() && fields[index + 1] != "" {
+        changes.push({ path: fields[index + 1], kind: "\{xy.trim()}-source" })
+        index += 1
+      }
+    }
+    index += 1
+  }
+  changes
+}
+
+///|
+/// Parse `git diff --name-status -z` output.
+pub fn parse_diff_name_status_z(output : String) -> Array[Change] {
+  let changes : Array[Change] = []
+  let fields = output.split("\u{0}").map(f => f.to_owned()).collect()
+  let mut index = 0
+  while index < fields.length() {
+    let status = fields[index]
+    guard status != "" else {
+      index += 1
+      continue
+    }
+    if status.has_prefix("R") || status.has_prefix("C") {
+      if index + 2 < fields.length() {
+        changes.push({ path: fields[index + 1], kind: "\{status}-source" })
+        changes.push({ path: fields[index + 2], kind: status })
+      }
+      index += 3
+    } else {
+      if index + 1 < fields.length() {
+        changes.push({ path: fields[index + 1], kind: status })
+      }
+      index += 2
+    }
+  }
+  changes
+}
+
+///|
+/// Every change must fall under one of the allowed component-wise prefixes.
+/// Returns the violating paths (empty = in scope).
+pub fn scope_violations(
+  changes : Array[Change],
+  allowed_paths : Array[String],
+) -> Array[String] {
+  let allowed = allowed_paths.map(prefix => {
+    prefix.split("/").map(part => part.to_owned()).collect()
+  })
+  let violations : Array[String] = []
+  for change in changes {
+    let parts = change.path.split("/").map(part => part.to_owned()).collect()
+    let admitted = allowed.any(prefix => {
+      guard parts.length() >= prefix.length() else { return false }
+      for index in 0..<prefix.length() {
+        if parts[index] != prefix[index] {
+          return false
+        }
+      }
+      true
+    })
+    if !admitted && !violations.contains(change.path) {
+      violations.push(change.path)
+    }
+  }
+  violations
+}
+
+///|
+/// Paths of NEW gitlink (mode 160000) entries in the staged diff — an
+/// embedded repository `git add -A` swallowed as a pointer. Detected from
+/// `git diff --cached --raw -z` records (`:000000 160000 ... A NUL path`).
+pub fn new_gitlinks_in_raw_z(output : String) -> Array[String] {
+  let links : Array[String] = []
+  let fields = output.split("\u{0}").map(f => f.to_owned()).collect()
+  let mut index = 0
+  while index < fields.length() {
+    let meta = fields[index]
+    if meta.has_prefix(":") && index + 1 < fields.length() {
+      // :src_mode dst_mode src_oid dst_oid status
+      let parts = meta
+        .view(start_offset=1)
+        .to_owned()
+        .split(" ")
+        .map(p => p.to_owned())
+        .collect()
+      if parts.length() >= 5 && parts[1] == "160000" && parts[0] == "000000" {
+        links.push(fields[index + 1])
+      }
+      index += 2
+    } else {
+      index += 1
+    }
+  }
+  links
+}
+
+///|
+test "status -z parsing keeps renames' both sides" {
+  let raw = " M lib/a.txt\u{0}R  lib/renamed.txt\u{0}lib/original.txt\u{0}?? lib/new.txt\u{0}"
+  let changes = parse_status_z(raw)
+  assert_eq(changes.length(), 4)
+  assert_eq(changes[0], { path: "lib/a.txt", kind: "M" })
+  assert_eq(changes[1], { path: "lib/renamed.txt", kind: "R" })
+  assert_eq(changes[2], { path: "lib/original.txt", kind: "R-source" })
+  assert_eq(changes[3], { path: "lib/new.txt", kind: "??" })
+}
+
+///|
+test "diff -z parsing reads the opposite rename order" {
+  let raw = "M\u{0}lib/a.txt\u{0}R100\u{0}lib/original.txt\u{0}lib/renamed.txt\u{0}D\u{0}lib/gone.txt\u{0}"
+  let changes = parse_diff_name_status_z(raw)
+  assert_eq(changes.length(), 4)
+  assert_eq(changes[0], { path: "lib/a.txt", kind: "M" })
+  assert_eq(changes[1], { path: "lib/original.txt", kind: "R100-source" })
+  assert_eq(changes[2], { path: "lib/renamed.txt", kind: "R100" })
+  assert_eq(changes[3], { path: "lib/gone.txt", kind: "D" })
+}
+
+///|
+test "scope violations are component-wise over every side" {
+  let changes = [
+    ({ path: "lib/a.txt", kind: "M" } : Change),
+    { path: "lib2/b.txt", kind: "M" },
+    { path: "lib/moved.txt", kind: "R" },
+    { path: "other/original.txt", kind: "R-source" },
+  ]
+  let violations = scope_violations(changes, ["lib"])
+  assert_eq(violations, ["lib2/b.txt", "other/original.txt"])
+  assert_eq(scope_violations(changes, ["lib", "lib2", "other"]).length(), 0)
+}
+
+///|
+test "new gitlinks are detected from raw -z records" {
+  let raw = ":000000 160000 0000000 abc1234 A\u{0}vendor/embedded\u{0}:000000 100644 0000000 def5678 A\u{0}lib/file.txt\u{0}"
+  assert_eq(new_gitlinks_in_raw_z(raw), ["vendor/embedded"])
+}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -266,6 +266,14 @@ async fn run_task_turn(
           api_url?,
           child_session?,
         ),
+        subtask_tool_definition(
+          self_exe=exe,
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          api_url?,
+          child_session?,
+        ),
       ]
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
     let on_goal_met = if review_gate_enabled(matches) {

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -5,6 +5,7 @@ import {
   "bobzhang/openseek/agent_subrun",
   "bobzhang/openseek/agent_review",
   "bobzhang/openseek/agent_worker",
+  "bobzhang/openseek/cmd/openseek/internal/subtask",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/mcp/config" @mcpconfig,

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -667,6 +667,14 @@ async fn run_serve(
           api_url?,
           child_session?,
         ),
+        subtask_tool_definition(
+          self_exe=exe,
+          model~,
+          workspace_root~,
+          budget=subrun_budget,
+          api_url?,
+          child_session?,
+        ),
       ]
     // The advisory goal-met gate (--review-gate): built once, shared by
     // every turn; engine-initiated, so it runs on its own allowance

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -1,0 +1,346 @@
+///|
+/// The parent-facing `subtask` tool: delegate ONE slice of write-capable
+/// work to a confined worker subagent in its own git worktree, then
+/// integrate the validated result. Launching provisions the worktree,
+/// spawns `subrun worker`, and CAPTURES the outcome from git evidence
+/// (never the child's claims); `integrate`/`integrate_continue`/
+/// `integrate_abort`/`discard` drive the committed branch's lifecycle.
+/// Lives in the CLI (like the review tool) because it needs the session's
+/// self-exe, model, and durable-session plumbing.
+let max_active_workers : Int = 4
+
+///|
+let worker_slots : @async.Semaphore = Semaphore(max_active_workers)
+
+///|
+fn subtask_tool_definition(
+  self_exe~ : String,
+  model~ : @deepseek.Model,
+  workspace_root~ : String,
+  budget~ : @agent_subrun.SubrunBudget,
+  api_url? : String,
+  child_session? : @agent_subrun.ChildSession,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="subtask",
+    concurrent_safe=true,
+    description=(
+      #|Delegate ONE slice of write-capable work to a confined worker subagent in its own
+      #|git worktree, or drive a finished slice's integration. LAUNCH: pass name (a short
+      #|slug), task (the self-contained work order — the worker sees nothing else of this
+      #|conversation), and allowed_paths (the repo-relative path prefixes this slice may
+      #|change; partitions must be DISJOINT across active subtasks — overlapping launches
+      #|are refused). The worker edits only inside its worktree and allowed paths, cannot
+      #|commit, and its changes are validated against allowed_paths from git evidence and
+      #|committed on a branch. Then INTEGRATE one subtask at a time: pass integrate=<name>
+      #|to merge its branch here (re-run your checks after each); on a conflict, resolve
+      #|the markers with the file tools, then integrate_continue=<name> (or
+      #|integrate_abort=<name>); discard=<name> abandons a slice and frees its paths.
+      #|Independent slices? Issue SEVERAL subtask launches in the same step — they run
+      #|concurrently (2-4 is a good batch; at most 4 run at once). Commit your own work
+      #|first: workers fork this repository's HEAD.
+    ),
+    schema=JsonSchema({
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Launch: short lowercase slug naming the slice (becomes the branch and worktree name).",
+        },
+        "task": {
+          "type": "string",
+          "description": "Launch: the self-contained work order, incl. what to verify.",
+        },
+        "allowed_paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Launch: repo-relative path prefixes this slice may change (component-wise; disjoint from other active subtasks).",
+        },
+        "context": {
+          "type": "string",
+          "description": "Launch: optional extra pointers for the worker.",
+        },
+        "integrate": {
+          "type": "string",
+          "description": "Merge the named committed subtask's branch into this checkout.",
+        },
+        "integrate_continue": {
+          "type": "string",
+          "description": "After resolving a conflicted integration's markers: commit it.",
+        },
+        "integrate_abort": {
+          "type": "string",
+          "description": "Abort a conflicted integration; the branch and worktree survive.",
+        },
+        "discard": {
+          "type": "string",
+          "description": "Abandon the named subtask: remove its worktree and branch, free its paths.",
+        },
+      },
+    }),
+    execute=Async(arguments => {
+      subtask_execute(
+        self_exe, model, workspace_root, budget, api_url, child_session, arguments,
+      )
+    }),
+  )
+}
+
+///|
+let max_task_chars : Int = 4_000
+
+///|
+let max_context_chars : Int = 2_000
+
+///|
+async fn subtask_execute(
+  self_exe : String,
+  model : @deepseek.Model,
+  workspace_root : String,
+  budget : @agent_subrun.SubrunBudget,
+  api_url : String?,
+  child_session : @agent_subrun.ChildSession?,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  // Lifecycle actions first: exactly one of them may be present.
+  match arguments {
+    { "integrate": String(name), .. } if name.trim() != "" =>
+      return subtask_lifecycle(workspace_root, "integrate", name)
+    { "integrate_continue": String(name), .. } if name.trim() != "" =>
+      return subtask_lifecycle(workspace_root, "integrate_continue", name)
+    { "integrate_abort": String(name), .. } if name.trim() != "" =>
+      return subtask_lifecycle(workspace_root, "integrate_abort", name)
+    { "discard": String(name), .. } if name.trim() != "" =>
+      return subtask_lifecycle(workspace_root, "discard", name)
+    _ => ()
+  }
+  subtask_launch(
+    self_exe, model, workspace_root, budget, api_url, child_session, arguments,
+  )
+}
+
+///|
+async fn subtask_lifecycle(
+  workspace_root : String,
+  action : String,
+  name : String,
+) -> @agent_tool.ToolAction {
+  let geometry = match @subtask.resolve_geometry(workspace_root) {
+    Ok(geometry) => geometry
+    Err(reason) =>
+      return @agent_tool.ToolAction::respond(
+        "error: subtask \{action}: \{reason}",
+        is_error=true,
+      )
+  }
+  let (entries, _) = @subtask.load_entries(geometry.common_git_dir)
+  guard entries.filter(e => e.name == name && !e.state.is_terminal()).last()
+    is Some(entry) else {
+    return @agent_tool.ToolAction::respond(
+      "error: no active subtask named \{name}",
+      is_error=true,
+      brief="subtask \{action} \{name}",
+    )
+  }
+  match action {
+    "discard" =>
+      match @subtask.discard(geometry, entry) {
+        Ok(_) =>
+          @agent_tool.ToolAction::respond(
+            "subtask \{name} discarded: worktree and branch removed, paths freed.",
+            brief="subtask discarded \{name}",
+          )
+        Err(reason) =>
+          @agent_tool.ToolAction::respond(
+            "error: subtask discard: \{reason}",
+            is_error=true,
+            brief="subtask discard \{name}",
+          )
+      }
+    _ => {
+      let outcome = match action {
+        "integrate" => @subtask.integrate(geometry, entry)
+        "integrate_continue" => @subtask.integrate_continue(geometry, entry)
+        _ => @subtask.integrate_abort(geometry, entry)
+      }
+      let content = "subtask \{name} \{action}: \{outcome.result}\n\{outcome.detail.join("\n")}"
+      @agent_tool.ToolAction::respond(
+        content,
+        is_error=outcome.result == "refused",
+        brief="subtask \{action} \{name} (\{outcome.result})",
+      )
+    }
+  }
+}
+
+///|
+async fn subtask_launch(
+  self_exe : String,
+  model : @deepseek.Model,
+  workspace_root : String,
+  budget : @agent_subrun.SubrunBudget,
+  api_url : String?,
+  child_session : @agent_subrun.ChildSession?,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "name": String(name), .. } && name.trim() != "" else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask requires `name` (launch) or one of integrate/integrate_continue/integrate_abort/discard",
+      is_error=true,
+    )
+  }
+  guard arguments is { "task": String(task), .. } && task.trim() != "" else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask launch requires a non-empty `task`",
+      is_error=true,
+    )
+  }
+  guard task.length() <= max_task_chars else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask task exceeds \{max_task_chars} chars",
+      is_error=true,
+    )
+  }
+  let context : String? = match arguments {
+    { "context": String(context), .. } if context.trim() != "" => Some(context)
+    _ => None
+  }
+  guard !(context is Some(c) && c.length() > max_context_chars) else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask context exceeds \{max_context_chars} chars",
+      is_error=true,
+    )
+  }
+  let allowed_paths : Array[String] = []
+  guard arguments is { "allowed_paths": Array(prefixes), .. } &&
+    !prefixes.is_empty() else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask launch requires a non-empty `allowed_paths` array — the repo-relative prefixes this slice may change",
+      is_error=true,
+    )
+  }
+  for prefix in prefixes {
+    guard prefix is String(prefix) && prefix.trim() != "" else {
+      return @agent_tool.ToolAction::respond(
+        "error: allowed_paths entries must be non-empty strings",
+        is_error=true,
+      )
+    }
+    allowed_paths.push(prefix)
+  }
+  // Slots and budget are reserved BEFORE any state is created, so every
+  // later failure path has exactly one transaction to roll back.
+  guard worker_slots.try_acquire() else {
+    return @agent_tool.ToolAction::respond(
+      "subtask worker slots are full (max \{max_active_workers} active) — integrate or await the running slices first.",
+      is_error=true,
+      brief="subtask (slots full)",
+    )
+  }
+  guard budget.reserve(@agent_worker.default_worker_max_steps)
+    is Some(granted_steps) else {
+    worker_slots.release()
+    return @agent_tool.ToolAction::respond(
+      "subtask budget exhausted for this turn — do the remaining slices yourself or continue next turn.",
+      is_error=true,
+      brief="subtask (budget exhausted)",
+    )
+  }
+  let nonce = random_salt()
+  let provisioned = match
+    @subtask.provision(
+      workspace_root,
+      name~,
+      allowed_paths~,
+      nonce=if nonce == "" { "n0" } else { nonce },
+      parent_session?=child_session.map(session => session.parent),
+    ) {
+    Ok(provisioned) => provisioned
+    Err(reason) => {
+      worker_slots.release()
+      return @agent_tool.ToolAction::respond(
+        "error: subtask provision: \{reason}",
+        is_error=true,
+        brief="subtask \{name} (provision refused)",
+      )
+    }
+  }
+  let entry = provisioned.entry
+  let input : Json = match context {
+    Some(context) =>
+      {
+        "task": task,
+        "context": context,
+        "worker_root": entry.worker_root,
+        "worker_admin_dir": entry.worker_admin_dir,
+        "deny_roots": provisioned.geometry.worktree_roots.to_json(),
+        "allowed_paths": allowed_paths.to_json(),
+        "base_oid": entry.base_oid,
+      }
+    None =>
+      {
+        "task": task,
+        "worker_root": entry.worker_root,
+        "worker_admin_dir": entry.worker_admin_dir,
+        "deny_roots": provisioned.geometry.worktree_roots.to_json(),
+        "allowed_paths": allowed_paths.to_json(),
+        "base_oid": entry.base_oid,
+      }
+  }
+  let args = [
+    "subrun",
+    "worker",
+    "--model",
+    "\{model}",
+    "--max-steps",
+    "\{granted_steps}",
+  ]
+  if api_url is Some(url) {
+    args.push("--api-url")
+    args.push(url)
+  }
+  let result = @agent_subrun.run_subrun(
+    command=self_exe,
+    args~,
+    input~,
+    parse_report=@agent_worker.WorkerReport::parse_validated,
+    wall_deadline_ms=@agent_worker.default_worker_deadline_ms,
+    kind="worker",
+    label=@agent_tool.brief_line("\{name}: \{task}", limit=48),
+    cwd=entry.worker_root,
+    child_session?,
+  )
+  worker_slots.release()
+  // Evidence comes from git regardless of how the child ended.
+  let captured = @subtask.capture(provisioned.geometry, entry)
+  let out = StringBuilder()
+  match result.value() {
+    Some(report) =>
+      out <+
+        "worker report (\{report.status}): \{report.summary}\nverification: \{report.verification}\n"
+    None =>
+      out <+ "the worker produced no report (\{Repr(result.terminal())}).\n"
+  }
+  out <+ "\ngit evidence:\n"
+  for line in captured.evidence {
+    out <+ "- \{line}\n"
+  }
+  for defect in captured.defects {
+    out <+ "DEFECT: \{defect}\n"
+  }
+  let state_line = match captured.entry.state {
+    Committed =>
+      "state: committed on \{entry.branch} — review the evidence, then subtask integrate=\{name} (worktree kept at \{entry.worker_root} until then)"
+    NoChanges => "state: no changes — the slice's paths are free again"
+    _ =>
+      "state: NOT mergeable — inspect \{entry.worker_root}, then discard=\{name} or relaunch"
+  }
+  out <+ "\n\{state_line}"
+  let mergeable = captured.entry.state is Committed
+  let is_error = !mergeable && !(captured.entry.state is NoChanges)
+  @agent_tool.ToolAction::respond(
+    out.to_string(),
+    is_error~,
+    brief="subtask \{result.subrun_id()} \{name} (\{Repr(captured.entry.state)}, \{result.steps_used()} step(s))",
+  )
+}

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -237,9 +237,13 @@ async fn subtask_launch(
       brief="subtask (slots full)",
     )
   }
+  // Sync and block-scoped: a cancellation re-raised out of run_subrun still
+  // returns the permit — four interrupts must not brick launching for the
+  // rest of the process. (The provisioned worktree and its Running registry
+  // entry survive a cancel by design: discoverable, discard-able.)
+  defer worker_slots.release()
   guard budget.reserve(@agent_worker.default_worker_max_steps)
     is Some(granted_steps) else {
-    worker_slots.release()
     return @agent_tool.ToolAction::respond(
       "subtask budget exhausted for this turn — do the remaining slices yourself or continue next turn.",
       is_error=true,
@@ -256,14 +260,12 @@ async fn subtask_launch(
       parent_session?=child_session.map(session => session.parent),
     ) {
     Ok(provisioned) => provisioned
-    Err(reason) => {
-      worker_slots.release()
+    Err(reason) =>
       return @agent_tool.ToolAction::respond(
         "error: subtask provision: \{reason}",
         is_error=true,
         brief="subtask \{name} (provision refused)",
       )
-    }
   }
   let entry = provisioned.entry
   let input : Json = match context {
@@ -310,7 +312,6 @@ async fn subtask_launch(
     cwd=entry.worker_root,
     child_session?,
   )
-  worker_slots.release()
   // Evidence comes from git regardless of how the child ended.
   let captured = @subtask.capture(provisioned.geometry, entry)
   let out = StringBuilder()

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -276,7 +276,7 @@ async fn subtask_launch(
         "worker_root": entry.worker_root,
         "worker_admin_dir": entry.worker_admin_dir,
         "deny_roots": provisioned.geometry.worktree_roots.to_json(),
-        "allowed_paths": allowed_paths.to_json(),
+        "allowed_paths": entry.allowed_paths.to_json(),
         "base_oid": entry.base_oid,
       }
     None =>
@@ -285,7 +285,7 @@ async fn subtask_launch(
         "worker_root": entry.worker_root,
         "worker_admin_dir": entry.worker_admin_dir,
         "deny_roots": provisioned.geometry.worktree_roots.to_json(),
-        "allowed_paths": allowed_paths.to_json(),
+        "allowed_paths": entry.allowed_paths.to_json(),
         "base_oid": entry.base_oid,
       }
   }

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -157,7 +157,31 @@ Common `moon` subcommands:
   `moon ide doc` query, one file read), do it yourself instead. The scout
   cannot edit anything, returns file:line citations you can spot-check, and
   shares a small per-turn budget (a few delegations per turn), so spend it on
-  questions that genuinely fan out.
+  questions that genuinely fan out. Independent questions batch: issue the
+  explore calls in the SAME step and they run concurrently.
+- `subtask` tool: parallelize LARGE partitionable work — three or more
+  independent slices that each need real edit+verify cycles (fixing warnings
+  by category, per-package sweeps, migration chunks). Each launch names a
+  slice (`name`), a self-contained work order (`task` — the worker sees
+  nothing else of this conversation), and `allowed_paths`, the repo-relative
+  prefixes that slice may change. PARTITION BY FILE OWNERSHIP: two slices
+  must never claim the same paths — overlapping launches are refused, so
+  when categories share files, split by package or directory instead, or run
+  those categories one after another. Commit your own work first (workers
+  fork this repository's HEAD and never see uncommitted changes). Issue
+  independent launches in the SAME step — they run concurrently (2-4 per
+  batch). Each worker edits inside its own git worktree, cannot commit, and
+  its changes are validated against `allowed_paths` from git evidence, then
+  committed on a branch; the tool result carries the worker's report AND the
+  git evidence — trust the evidence. Then integrate ONE subtask at a time
+  (`integrate=<name>`), re-running your checks after each; resolve conflicts
+  with the file tools plus `integrate_continue`; `discard=<name>` frees an
+  abandoned slice. After the last integration, run the FULL verification
+  suite yourself — workers verified slices, only you see the union. For a
+  warning sweep: `moon check --output-json` emits one JSON object per
+  diagnostic; group by error code (a small script), derive each group's
+  file list, and give each worker one group with those files as
+  `allowed_paths`. Not for work you can do yourself in a few edits.
 - shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
   use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
   Example: `moon cram test tests/cram`.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -162,7 +162,31 @@ fn default_prompt() -> String {
     #|  `moon ide doc` query, one file read), do it yourself instead. The scout
     #|  cannot edit anything, returns file:line citations you can spot-check, and
     #|  shares a small per-turn budget (a few delegations per turn), so spend it on
-    #|  questions that genuinely fan out.
+    #|  questions that genuinely fan out. Independent questions batch: issue the
+    #|  explore calls in the SAME step and they run concurrently.
+    #|- `subtask` tool: parallelize LARGE partitionable work — three or more
+    #|  independent slices that each need real edit+verify cycles (fixing warnings
+    #|  by category, per-package sweeps, migration chunks). Each launch names a
+    #|  slice (`name`), a self-contained work order (`task` — the worker sees
+    #|  nothing else of this conversation), and `allowed_paths`, the repo-relative
+    #|  prefixes that slice may change. PARTITION BY FILE OWNERSHIP: two slices
+    #|  must never claim the same paths — overlapping launches are refused, so
+    #|  when categories share files, split by package or directory instead, or run
+    #|  those categories one after another. Commit your own work first (workers
+    #|  fork this repository's HEAD and never see uncommitted changes). Issue
+    #|  independent launches in the SAME step — they run concurrently (2-4 per
+    #|  batch). Each worker edits inside its own git worktree, cannot commit, and
+    #|  its changes are validated against `allowed_paths` from git evidence, then
+    #|  committed on a branch; the tool result carries the worker's report AND the
+    #|  git evidence — trust the evidence. Then integrate ONE subtask at a time
+    #|  (`integrate=<name>`), re-running your checks after each; resolve conflicts
+    #|  with the file tools plus `integrate_continue`; `discard=<name>` frees an
+    #|  abandoned slice. After the last integration, run the FULL verification
+    #|  suite yourself — workers verified slices, only you see the union. For a
+    #|  warning sweep: `moon check --output-json` emits one JSON object per
+    #|  diagnostic; group by error code (a small script), derive each group's
+    #|  file list, and give each worker one group with those files as
+    #|  `allowed_paths`. Not for work you can do yourself in a few edits.
     #|- shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
     #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
     #|  Example: `moon cram test tests/cram`.

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -2152,7 +2152,9 @@ fn subrun_child_id(
   result : @agent_session.ToolResult,
   parent : String,
 ) -> String? {
-  guard result.tool_name() is ("explore" | "review") else { return None }
+  guard result.tool_name() is ("explore" | "review" | "subtask") else {
+    return None
+  }
   guard result.brief() is Some(brief) else { return None }
   let tokens = brief.split(" ").collect()
   guard tokens.get(1) is Some(token) else { return None }


### PR DESCRIPTION
## Summary
PR4+PR5 of the worker-subagent plan (#616 → #617 → #620 → this): the engine-side git controller (provision / capture / integrate state machine with the round-3 design amendments), the parent-facing `subtask` tool (launch + integrate/continue/abort/discard, 4-worker slots, budget, concurrent_safe), the viz gate, and the default-prompt fan-out playbook (partition by file ownership, warning-sweep recipe).

## Tests
- Controller lifecycle against REAL git repos: happy path, scope defects, overlap/duplicate refusals, no-changes release, conflict handoff+continue, dirty-origin refusal, abort restore, discard, linked-origin refusal (14 controller tests).
- Parser matrices for status/diff -z (rename order) and gitlink detection; registry round-trip; 91/91 across touched packages; cram 27/27; repo check warning-free; fmt clean.
- Live engine e2e follows in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)