### PR TITLE
prompt(worker): formatting is part of a slice's verification

### DIFF
--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -17,10 +17,12 @@ fn worker_system_prompt() -> String {
     #|  seems to require touching something outside it, STOP and report that in
     #|  `submit_result` (status partial or failed) instead of working around it.
     #|- Do NOT run `git commit`, `git add`, `git worktree`, branch or config
-    #|  surgery, or any git mutation: the shared git state is denied and the
-    #|  HARNESS commits your changes after validating them. Permission errors on
-    #|  such commands are expected, not bugs to route around. Reading git state
-    #|  (`git status`, `git diff`) works and is encouraged.
+    #|  surgery: the shared git state is denied and the HARNESS commits your
+    #|  changes after validating them. Permission errors on such commands are
+    #|  expected, not bugs to route around. Reading git state (`git status`,
+    #|  `git diff`) works and is encouraged, and WORKING-TREE-ONLY commands
+    #|  (`git restore <path>`, `git checkout -- <path>`) are fine — they write
+    #|  only files inside your worktree.
     #|- Never spawn another engine or delegate further; your slice is yours.
     #|
     #|Working discipline (the same discipline as the main agent):
@@ -46,8 +48,9 @@ fn worker_system_prompt() -> String {
     #|  and an unformatted fix fails there even when every check passes. Then
     #|  look at `git status`: formatting may touch files OUTSIDE your allowed
     #|  paths when the repository carries pre-existing drift — revert those
-    #|  (`git restore <path>`) and keep your own files formatted; a single
-    #|  out-of-scope reformat makes your whole result unmergeable.
+    #|  (`git restore <path>`, one of the permitted working-tree-only commands)
+    #|  and keep your own files formatted; a single out-of-scope reformat makes
+    #|  your whole result unmergeable.
     #|
     #|Reporting (`submit_result`, exactly once with schema_version 1, never a
     #|plain-text finish):

--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -42,6 +42,12 @@ fn worker_system_prompt() -> String {
     #|  unmergeable.
     #|- `moon test` what your changes could plausibly break; name what you ran
     #|  and what it said in your verification.
+    #|- Before submitting, run `moon fmt` — repositories gate CI on formatting,
+    #|  and an unformatted fix fails there even when every check passes. Then
+    #|  look at `git status`: formatting may touch files OUTSIDE your allowed
+    #|  paths when the repository carries pre-existing drift — revert those
+    #|  (`git restore <path>`) and keep your own files formatted; a single
+    #|  out-of-scope reformat makes your whole result unmergeable.
     #|
     #|Reporting (`submit_result`, exactly once with schema_version 1, never a
     #|plain-text finish):

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -37,6 +37,12 @@ Working discipline (the same discipline as the main agent):
   unmergeable.
 - `moon test` what your changes could plausibly break; name what you ran
   and what it said in your verification.
+- Before submitting, run `moon fmt` — repositories gate CI on formatting,
+  and an unformatted fix fails there even when every check passes. Then
+  look at `git status`: formatting may touch files OUTSIDE your allowed
+  paths when the repository carries pre-existing drift — revert those
+  (`git restore <path>`) and keep your own files formatted; a single
+  out-of-scope reformat makes your whole result unmergeable.
 
 Reporting (`submit_result`, exactly once with schema_version 1, never a
 plain-text finish):

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -12,10 +12,12 @@ The confinement, plainly:
   seems to require touching something outside it, STOP and report that in
   `submit_result` (status partial or failed) instead of working around it.
 - Do NOT run `git commit`, `git add`, `git worktree`, branch or config
-  surgery, or any git mutation: the shared git state is denied and the
-  HARNESS commits your changes after validating them. Permission errors on
-  such commands are expected, not bugs to route around. Reading git state
-  (`git status`, `git diff`) works and is encouraged.
+  surgery: the shared git state is denied and the HARNESS commits your
+  changes after validating them. Permission errors on such commands are
+  expected, not bugs to route around. Reading git state (`git status`,
+  `git diff`) works and is encouraged, and WORKING-TREE-ONLY commands
+  (`git restore <path>`, `git checkout -- <path>`) are fine — they write
+  only files inside your worktree.
 - Never spawn another engine or delegate further; your slice is yours.
 
 Working discipline (the same discipline as the main agent):
@@ -41,8 +43,9 @@ Working discipline (the same discipline as the main agent):
   and an unformatted fix fails there even when every check passes. Then
   look at `git status`: formatting may touch files OUTSIDE your allowed
   paths when the repository carries pre-existing drift — revert those
-  (`git restore <path>`) and keep your own files formatted; a single
-  out-of-scope reformat makes your whole result unmergeable.
+  (`git restore <path>`, one of the permitted working-tree-only commands)
+  and keep your own files formatted; a single out-of-scope reformat makes
+  your whole result unmergeable.
 
 Reporting (`submit_result`, exactly once with schema_version 1, never a
 plain-text finish):

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -177,7 +177,9 @@ Common `moon` subcommands:
   (`integrate=<name>`), re-running your checks after each; resolve conflicts
   with the file tools plus `integrate_continue`; `discard=<name>` frees an
   abandoned slice. After the last integration, run the FULL verification
-  suite yourself — workers verified slices, only you see the union. For a
+  suite yourself — including the repository's format gate (`moon fmt`
+  and a clean `moon fmt --check`) — workers verified slices, only you
+  see the union. For a
   warning sweep: `moon check --output-json` emits one JSON object per
   diagnostic; group by error code (a small script), derive each group's
   file list, and give each worker one group with those files as

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -182,7 +182,9 @@ fn default_prompt() -> String {
     #|  (`integrate=<name>`), re-running your checks after each; resolve conflicts
     #|  with the file tools plus `integrate_continue`; `discard=<name>` frees an
     #|  abandoned slice. After the last integration, run the FULL verification
-    #|  suite yourself — workers verified slices, only you see the union. For a
+    #|  suite yourself — including the repository's format gate (`moon fmt`
+    #|  and a clean `moon fmt --check`) — workers verified slices, only you
+    #|  see the union. For a
     #|  warning sweep: `moon check --output-json` emits one JSON object per
     #|  diagnostic; group by error code (a small script), derive each group's
     #|  file list, and give each worker one group with those files as


### PR DESCRIPTION
Production-sweep lesson (moonbitlang/office.mbt PRs 309/310): correct fixes, red CI on `moon fmt --check`. The worker prompt now requires `moon fmt` before submit with the out-of-scope-revert protocol (pre-existing drift outside `allowed_paths` must not ride along), and the parent playbook's post-integration gate names the format check. Prompt-only; generated files regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)