### PR TITLE
fix(desktop): forward terminal events to webview

### DIFF
--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -78,6 +78,10 @@ let notification_events : Map[String, @proton_contract.Event[Json]] = {
   "auth.changed": desktop_contract.event("auth.changed"),
   "lsp.diagnostics": desktop_contract.event("lsp.diagnostics"),
   "fs.changed": desktop_contract.event("fs.changed"),
+  // PTY output and exit notifications originate from the connection-owned
+  // terminal pump, but still need explicit Proton descriptors to reach xterm.
+  "terminal.output": desktop_contract.event("terminal.output"),
+  "terminal.exit": desktop_contract.event("terminal.exit"),
 }
 
 ///|


### PR DESCRIPTION
## Summary

- register `terminal.output` and `terminal.exit` in the native Proton event catalog
- preserve the existing connection-owned terminal pump and frontend decoding paths

## Root cause

The PTY process started successfully and produced output, while the frontend already subscribed to both terminal notifications. The native extension's explicit Proton event catalog omitted those two descriptors, so `PageEventTarget::emit` silently discarded the output and exit notifications before they reached xterm. This left running shells displayed as blank terminal tabs.

## User impact

Terminal prompts and subsequent PTY output now reach the desktop webview, and shell exit notifications are delivered instead of leaving stale tabs.

## Validation

- `moon check internal/extension --target native`
- `moon test frontend --target js` (301 passed)
- `moon test --target native`
- `moon info`
- `moon fmt`

The existing local 0.1.5 version and nightly-toolchain changes were intentionally excluded from this PR.