### PR TITLE
fix(shell): avoid sandbox profile argv limit

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -39,18 +39,17 @@ let default_hard_timeout_ms : Int = 1_800_000
 /// the session group in a spawn closure, so the runtime is not generic and can be
 /// an optional tool argument.
 pub struct BgJobRuntime {
-  // Spawn a `ShellExecution` on the captured session group: (program, args, cwd,
-  // inline-preview budget, spill path) -> execution. Captured so the runtime type
-  // is not generic.
-  priv spawn_exec : async (String, Array[String], String?, Int, String?) -> @shell_exec.ShellExecution
+  // Spawn a `ShellExecution` on the captured session group: (command, cwd,
+  // inline-preview budget, spill path) -> execution. Captured so the runtime
+  // type is not generic.
+  priv spawn_exec : async (@shell_exec.ProcessCommand, String?, Int, String?) -> @shell_exec.ShellExecution
   // Spawn a *retained* foreground execution (may be detached on timeout):
   // file-backed with a large hard cap, but still killed on exceeding the inline
   // cap so a timed command that floods output is an immediate output-limit error;
   // `background()` clears that kill so a detached-under-the-limit job keeps
   // growing. The `String?` is the spill path.
   priv spawn_foreground_retained_exec : async (
-    String,
-    Array[String],
+    @shell_exec.ProcessCommand,
     String?,
     Int,
     String?,
@@ -133,14 +132,13 @@ pub fn[X] BgJobRuntime::new(
 ) -> BgJobRuntime {
   let group = scope.group()
   {
-    spawn_exec: (program, args, cwd, max_output_chars, spill_path) => {
+    spawn_exec: (process_command, cwd, max_output_chars, spill_path) => {
       // Background retention: inline preview up to the budget, full output to
       // the spill file, and the hard-cap watchdog so a flooding job is killed
       // (and surfaced) rather than left burning CPU with its output dropped.
       @shell_exec.ShellExecution::start(
         scope,
-        program~,
-        args~,
+        command=process_command,
         cwd?,
         inline_cap=max_output_chars,
         hard_cap=hard_output_cap,
@@ -149,8 +147,7 @@ pub fn[X] BgJobRuntime::new(
       )
     },
     spawn_foreground_retained_exec: (
-      program,
-      args,
+      process_command,
       cwd,
       max_output_chars,
       spill_path,
@@ -159,8 +156,7 @@ pub fn[X] BgJobRuntime::new(
       // `background()`), the job is still bounded in output like any other.
       @shell_exec.ShellExecution::start(
         scope,
-        program~,
-        args~,
+        command=process_command,
         cwd?,
         inline_cap=max_output_chars,
         hard_cap=hard_output_cap,
@@ -198,8 +194,7 @@ fn BgJobRuntime::next_id(self : BgJobRuntime) -> String {
 /// distinct `fg-<n>.out` spill file.
 pub async fn BgJobRuntime::spawn_foreground_retained(
   self : BgJobRuntime,
-  program : String,
-  args : Array[String],
+  command : @shell_exec.ProcessCommand,
   cwd : String?,
   max_output_chars : Int,
 ) -> @shell_exec.ShellExecution {
@@ -209,7 +204,7 @@ pub async fn BgJobRuntime::spawn_foreground_retained(
     "\{dir}/fg-\{index}.out"
   })
   (self.spawn_foreground_retained_exec)(
-    program, args, cwd, max_output_chars, spill_path,
+    command, cwd, max_output_chars, spill_path,
   )
 }
 
@@ -230,7 +225,13 @@ pub async fn BgJobRuntime::start(
   // the job id and its `<id>.out` file never diverge.
   let id = self.next_id()
   let spill_path = self.spill_dir.map(dir => "\{dir}/\{id}.out")
-  let exec = (self.spawn_exec)(program, args, cwd, max_output_chars, spill_path)
+  let process_command = match sandboxed_command {
+    Some(command) => @shell_exec.ProcessCommand::sandboxed(command)
+    None => @shell_exec.ProcessCommand::plain(program, args)
+  }
+  let exec = (self.spawn_exec)(
+    process_command, cwd, max_output_chars, spill_path,
+  )
   self.register(id, exec, command~, cwd?, sandboxed_command?)
   id
 }
@@ -245,10 +246,15 @@ pub fn BgJobRuntime::adopt(
   exec : @shell_exec.ShellExecution,
   command~ : String,
   cwd? : String,
-  sandboxed_command? : @sandbox.SandboxedCommand,
 ) -> String {
   let id = self.next_id()
-  self.register(id, exec, command~, cwd?, sandboxed_command?)
+  self.register(
+    id,
+    exec,
+    command~,
+    cwd?,
+    sandboxed_command?=exec.sandboxed_command(),
+  )
   id
 }
 
@@ -492,9 +498,10 @@ async test "adopt registers an already-running execution as a job" {
   @async.with_task_group(group => {
     let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
     let rt = BgJobRuntime::new(scope)
-    let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
-      "30",
-    ])
+    let exec = @shell_exec.ShellExecution::start(
+      scope,
+      command=@shell_exec.ProcessCommand::plain("sleep", ["30"]),
+    )
     let id = rt.adopt(exec, command="sleep 30")
     @async.sleep(50)
     assert_true(rt.snapshot(id).unwrap().status is Running)
@@ -621,7 +628,11 @@ async test "an adopted job keeps its original wall-clock deadline" {
     let rt = BgJobRuntime::new(AgentTaskScope(group), hard_timeout_ms=150)
     // The execution starts OUTSIDE the registry (a foreground command) and
     // burns most of its lifetime before being adopted on detach.
-    let exec = rt.spawn_foreground_retained("sh", ["-c", "sleep 5"], None, 200)
+    let exec = rt.spawn_foreground_retained(
+      @shell_exec.ProcessCommand::plain("sh", ["-c", "sleep 5"]),
+      None,
+      200,
+    )
     @async.sleep(120)
     let _ = exec.background()
     let id = rt.adopt(exec, command="sleep 5")

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -15,13 +15,13 @@ import {
 pub struct BgJobRuntime {
   // private fields
 }
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
-pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
+pub async fn BgJobRuntime::spawn_foreground_retained(Self, @shell_exec.ProcessCommand, String?, Int) -> @shell_exec.ShellExecution
 pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
 pub async fn BgJobRuntime::wait_exit(Self, String, Int) -> Bool

--- a/agent_tool/internal/sandbox/README.mbt.md
+++ b/agent_tool/internal/sandbox/README.mbt.md
@@ -4,10 +4,10 @@ The source-write sandbox as one prepared-command capability. `shell`,
 `run_moonbit`, `bgjobs`, and `shell_output` share one macOS `sandbox-exec`
 integration: describe command intent with the `Shell` or `Exec` variants of
 `Command`,
-prepare an opaque `SandboxedCommand`, run its program and arguments, then ask
-that same value to judge the output. Everything SBPL-specific — profile text,
-denial subjects, escaping, the `sandbox-exec` path, and the availability probe
-— stays behind the API.
+prepare an opaque `SandboxedCommand`, prepare its spawn arguments in the task group that
+owns the process, then ask that same value to judge the output. Everything
+SBPL-specific — profile text, denial subjects, escaping, the `sandbox-exec`
+path, profile-file lifetime, and the availability probe — stays behind the API.
 
 This package does not own workspace path manipulation or protection-policy
 predicates. Generic lexical operations live in `internal/workspace_path`,
@@ -27,20 +27,22 @@ async test "prepare, run, and classify a shell command" {
     ".",
     Shell(shell_text),
   )
-  let (program, args) = match prepared {
-    Some(command) => (command.program(), command.args())
-    // Enforcement is unavailable outside macOS and inside some nested
-    // sandboxes. Running without it is an explicit caller policy decision.
-    None => (@platform_shell.program, @platform_shell.args(shell_text))
-  }
-  let (exit_code, output) = @process.collect_output_merged(program, args)
-  let output = output.text()
-  assert_eq(exit_code, 0)
-  assert_eq(output.trim(), "sandbox-ready")
-  if prepared is Some(command) {
-    // Classify with the same value that supplied the executed program/argv.
-    assert_false(command.output_reports_denial(output))
-  }
+  @async.with_task_group(group => {
+    let (program, args) = match prepared {
+      Some(command) => command.prepare_for_spawn(group)
+      // Enforcement is unavailable outside macOS and inside some nested
+      // sandboxes. Running without it is an explicit caller policy decision.
+      None => (@platform_shell.program, @platform_shell.args(shell_text))
+    }
+    let (exit_code, output) = @process.collect_output_merged(program, args)
+    let output = output.text()
+    assert_eq(exit_code, 0)
+    assert_eq(output.trim(), "sandbox-ready")
+    if prepared is Some(command) {
+      // Classify with the same value that supplied the executed program/argv.
+      assert_false(command.output_reports_denial(output))
+    }
+  })
 }
 ```
 
@@ -61,7 +63,9 @@ command runs.
 shell involved — the shape `run_moonbit` uses to run `moon` directly. Both
 produce the same opaque `SandboxedCommand`. Its executable, arguments, and
 denial subjects travel together because classification is meaningful only for
-output produced by that prepared invocation.
+output produced by that prepared invocation. `prepare_for_spawn(group)` writes
+the SBPL to a short-lived file, passes only its path through argv, and
+registers the file's removal on the same group before returning.
 
 `writable_subtree` re-allows one directory tree — a scratch lab for a
 read-only subagent, `run_moonbit`'s throwaway build dir — via a

--- a/agent_tool/internal/sandbox/capability.mbt
+++ b/agent_tool/internal/sandbox/capability.mbt
@@ -13,18 +13,12 @@ pub(all) enum Command {
 /// denial subjects stay together so output is always classified against the
 /// profile that produced it.
 struct SandboxedCommand {
-  /// Executable to spawn for this prepared invocation. It is the first half of
-  /// the process command and must be passed together with `args`. When sandbox
-  /// enforcement is available, this is the platform's `sandbox-exec` binary.
-  program : String
-  /// Companion argument vector for `program`: the generated profile followed
-  /// by either the platform-shell invocation or the requested `Exec`
-  /// program/argv. For example, `Shell("moon check")` prepares approximately
-  /// `program = "/usr/bin/sandbox-exec"` with
-  /// `args = ["-p", "<profile>", "sh", "-c", "moon check"]` on macOS.
-  args : Array[String]
+  /// Original command, kept tokenized until it is prepared for spawn.
+  command : Command
+  /// SBPL source. It is deliberately not placed in argv or written yet.
+  profile : String
   /// Protected paths and basenames derived from the same profile encoded in
-  /// `args`, retained so denial reporting cannot use metadata from another run.
+  /// `profile`, retained so denial reporting cannot use metadata from another run.
   denial_subjects : Array[String]
 }
 
@@ -80,13 +74,9 @@ pub async fn SandboxedCommand::create_if_available(
     real_root,
     writable_lab?=subtree,
   )
-  let args = match command {
-    Shell(cmd) => sandbox_exec_args(data.profile, cmd)
-    Exec(program, args) => ["-p", data.profile, program, ..args]
-  }
   Some({
-    program: SandboxExecPath,
-    args,
+    command,
+    profile: data.profile,
     // Copied: the profile cache hands out its own array, and this command must
     // keep classifying with the subjects of the profile it actually runs under.
     denial_subjects: data.denial_subjects.copy(),
@@ -94,15 +84,18 @@ pub async fn SandboxedCommand::create_if_available(
 }
 
 ///|
-/// The executable of this prepared invocation.
-pub fn SandboxedCommand::program(self : SandboxedCommand) -> String {
-  self.program
-}
-
-///|
-/// A copy of this prepared invocation's argument vector.
-pub fn SandboxedCommand::args(self : SandboxedCommand) -> Array[String] {
-  self.args.copy()
+/// Prepare this command for one execution owned by `group`.
+///
+/// The profile file is created only when execution starts, then registered on
+/// the same group before its path is returned. The group removes it after every
+/// child has terminated, so callers never receive or forward a cleanup action.
+pub async fn[X] SandboxedCommand::prepare_for_spawn(
+  self : SandboxedCommand,
+  group : @async.TaskGroup[X],
+) -> (String, Array[String]) {
+  let profile_file = SandboxProfileFile::create(self.profile)
+  group.add_defer(() => profile_file.remove())
+  (SandboxExecPath, profile_file.arguments(self.command))
 }
 
 ///|

--- a/agent_tool/internal/sandbox/capability_test.mbt
+++ b/agent_tool/internal/sandbox/capability_test.mbt
@@ -1,5 +1,5 @@
 ///|
-/// Run a prepared command and materialize its merged output as text — the same
+/// Run a prepared command and collect its merged output as text — the same
 /// consumption pattern real callers use, so the tests exercise the capability
 /// exactly as shipped.
 async fn merged_output_text(
@@ -8,10 +8,10 @@ async fn merged_output_text(
   @async.with_task_group() <| group => {
     let (reader, writer) = @process.read_from_process()
     defer reader.close()
-    let args = command.args()
+    let (program, args) = command.prepare_for_spawn(group)
     let child = @process.spawn(
       group,
-      command.program(),
+      program,
       args,
       stdout=writer,
       stderr=writer,
@@ -87,13 +87,19 @@ async test "exec command produces the argv shape without a shell" {
       is Some(command) else {
       return
     }
-    assert_eq(command.program(), "/usr/bin/sandbox-exec")
-    let args = command.args()
-    // [-p, <profile>, moon, check, --target, native]
-    assert_eq(args[0], "-p")
-    assert_eq(args[2], "moon")
-    assert_eq(args[3], "check")
-    assert_eq(args.length(), 6)
+    let mut profile_path = ""
+    @async.with_task_group(group => {
+      let (program, args) = command.prepare_for_spawn(group)
+      assert_eq(program, "/usr/bin/sandbox-exec")
+      // [-f, <profile-path>, moon, check, --target, native]
+      assert_eq(args[0], "-f")
+      profile_path = args[1]
+      assert_true(@fs.exists(profile_path))
+      assert_eq(args[2], "moon")
+      assert_eq(args[3], "check")
+      assert_eq(args.length(), 6)
+    })
+    assert_false(@fs.exists(profile_path))
   })
 }
 

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "bobzhang/openseek/agent_tool/internal/sandbox"
 
+import {
+  "moonbitlang/async",
+}
+
 // Values
 
 // Errors
@@ -12,11 +16,10 @@ pub(all) enum Command {
 }
 
 type SandboxedCommand
-pub fn SandboxedCommand::args(Self) -> Array[String]
 pub async fn SandboxedCommand::create_if_available(String, Command, writable_subtree? : String) -> Self?
 pub async fn SandboxedCommand::create_worker_if_available(Command, deny_roots~ : Array[String], worker_root~ : String, worker_admin_dir~ : String) -> Self?
 pub fn SandboxedCommand::output_reports_denial(Self, String) -> Bool
-pub fn SandboxedCommand::program(Self) -> String
+pub async fn[X] SandboxedCommand::prepare_for_spawn(Self, @async.TaskGroup[X]) -> (String, Array[String])
 
 // Type aliases
 

--- a/agent_tool/internal/sandbox/sandbox_exec.mbt
+++ b/agent_tool/internal/sandbox/sandbox_exec.mbt
@@ -8,16 +8,66 @@ const SandboxExecPath : String = "/usr/bin/sandbox-exec"
 let sandbox_exec_available_cache : Ref[Bool?] = { val: None }
 
 ///|
-/// Build the argument vector passed to `SandboxExecPath` to interpret `cmd`
-/// under an inline SBPL `profile`.
+/// One private SBPL file owned by an execution task group.
 ///
-/// The returned vector has the shape
-/// `[-p, profile, @platform_shell.program, ..@platform_shell.args(cmd)]`.
-/// Therefore `cmd` is shell text, not an executable path or a pre-tokenized
-/// argument vector. This function does not validate the profile or probe
-/// availability.
-fn sandbox_exec_args(profile : String, cmd : String) -> Array[String] {
-  ["-p", profile, @platform_shell.program, ..@platform_shell.args(cmd)]
+/// The profile must stay present until `sandbox-exec` exits: removing it just
+/// after spawning races the new process opening `-f`. `prepare_for_spawn`
+/// therefore registers its removal on the task group before returning its path.
+priv struct SandboxProfileFile {
+  directory : String
+  path : String
+}
+
+///|
+/// Write `profile` outside argv so a large source tree cannot make process
+/// creation fail with `E2BIG`. The containing directory is private and unique;
+/// the file itself is created with owner-only permissions.
+async fn SandboxProfileFile::create(profile : String) -> SandboxProfileFile {
+  let directory = @fs.tmpdir(prefix="openseek-sandbox-profile-")
+  let path = "\{directory}/profile.sb"
+  try {
+    @fs.write_file(path, profile, create_mode=CreateNew, permission=0o600)
+    { directory, path }
+  } catch {
+    error => {
+      // Creation may be cancelled after the directory exists. Shield this
+      // small removal so a cancelled tool call does not leak profile text.
+      @async.protect_from_cancel(() => {
+        @fs.rmdir(directory, recursive=true) catch {
+          _ => ()
+        }
+      })
+      raise error
+    }
+  }
+}
+
+///|
+/// Build the argument vector passed to `SandboxExecPath`.
+///
+/// `Shell(cmd)` remains shell text, while `Exec(program, args)` stays an
+/// already-tokenized invocation. In both cases argv contains only the short
+/// profile path, never the potentially megabyte-sized SBPL source.
+fn SandboxProfileFile::arguments(
+  self : SandboxProfileFile,
+  command : Command,
+) -> Array[String] {
+  match command {
+    Shell(cmd) =>
+      ["-f", self.path, @platform_shell.program, ..@platform_shell.args(cmd)]
+    Exec(program, args) => ["-f", self.path, program, ..args]
+  }
+}
+
+///|
+/// Remove the private profile directory. Removal is idempotent and best-effort
+/// because the child has already exited when production callers invoke it.
+async fn SandboxProfileFile::remove(self : SandboxProfileFile) -> Unit {
+  @async.protect_from_cancel(() => {
+    @fs.rmdir(self.directory, recursive=true) catch {
+      _ => ()
+    }
+  })
 }
 
 ///|
@@ -69,24 +119,28 @@ async fn probe_sandbox_exec_available() -> Bool {
     $|(version 1)
     $|(allow default)
     $|(deny file-write* (literal "\{sbpl_string_escape(blocked_path)}"))
-  let noop_exit = run_probe_exit(
-    SandboxExecPath,
-    sandbox_exec_args(probe_profile, PlatformNoopCommand),
-  )
-  if noop_exit != Some(0) {
-    cleanup_sandbox_probe(probe_dir, blocked_path)
-    return false
-  }
-  let write_exit = run_probe_exit(
-    SandboxExecPath,
-    sandbox_exec_args(
-      probe_profile,
-      "printf probe > \{shell_quote(blocked_path)}",
-    ),
-  )
-  let denied = write_exit != Some(0) && !@fs.exists(blocked_path)
-  cleanup_sandbox_probe(probe_dir, blocked_path)
-  denied
+  @async.with_task_group(probe_group => {
+    probe_group.add_defer(() => cleanup_sandbox_probe(probe_dir, blocked_path))
+    let profile_file = SandboxProfileFile::create(probe_profile) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => return false
+    }
+    probe_group.add_defer(() => profile_file.remove())
+    let noop_exit = run_probe_exit(
+      SandboxExecPath,
+      profile_file.arguments(Shell(PlatformNoopCommand)),
+    )
+    if noop_exit != Some(0) {
+      return false
+    }
+    let write_exit = run_probe_exit(
+      SandboxExecPath,
+      profile_file.arguments(
+        Shell("printf probe > \{shell_quote(blocked_path)}"),
+      ),
+    )
+    write_exit != Some(0) && !@fs.exists(blocked_path)
+  })
 }
 
 ///|
@@ -122,6 +176,8 @@ async fn cleanup_sandbox_probe(
   probe_dir : String,
   blocked_path : String,
 ) -> Unit {
-  ignore(@fs.remove(blocked_path) catch { _ => () })
-  ignore(@fs.rmdir(probe_dir) catch { _ => () })
+  @async.protect_from_cancel(() => {
+    ignore(@fs.remove(blocked_path) catch { _ => () })
+    ignore(@fs.rmdir(probe_dir) catch { _ => () })
+  })
 }

--- a/agent_tool/internal/sandbox/sandbox_wbtest.mbt
+++ b/agent_tool/internal/sandbox/sandbox_wbtest.mbt
@@ -10,6 +10,32 @@ test "sandbox source write profile regex covers source and manifests" {
 }
 
 ///|
+/// A profile larger than macOS's observed 1 MiB argv limit still launches:
+/// only its short file path is passed to `sandbox-exec`.
+async test "sandbox profile file avoids the argv size limit" {
+  guard sandbox_exec_available() else { return }
+  let profile = StringBuilder()
+  profile <+
+    $|(version 1)
+    $|(allow default)
+    $|
+  for _ in 0..<70_000 {
+    profile <+ "(allow file-read*)\n"
+  }
+  let profile = profile.to_string()
+  assert_true(profile.length() > 1_048_576)
+  let profile_file = SandboxProfileFile::create(profile)
+  let args = profile_file.arguments(Shell(PlatformNoopCommand))
+  assert_eq(args[0], "-f")
+  assert_eq(args[1], profile_file.path)
+  assert_true(@fs.exists(profile_file.path))
+  let exit_code = run_probe_exit(SandboxExecPath, args)
+  profile_file.remove()
+  assert_false(@fs.exists(profile_file.path))
+  assert_eq(exit_code, Some(0))
+}
+
+///|
 /// Pins the emitted SBPL byte for byte. The `contains` assertions elsewhere
 /// would not notice a lost trailing newline, and
 /// `source_write_readonly_profile_data` appends the lab rule straight onto this

--- a/agent_tool/internal/sandbox/worker_profile.mbt
+++ b/agent_tool/internal/sandbox/worker_profile.mbt
@@ -119,9 +119,5 @@ pub async fn SandboxedCommand::create_worker_if_available(
     worker_admin_dir~,
   )
   guard sandbox_exec_available() else { return None }
-  let args = match command {
-    Shell(cmd) => sandbox_exec_args(data.profile, cmd)
-    Exec(program, args) => ["-p", data.profile, program, ..args]
-  }
-  Some({ program: SandboxExecPath, args, denial_subjects: data.denial_subjects })
+  Some({ command, profile: data.profile, denial_subjects: data.denial_subjects })
 }

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -253,26 +253,29 @@ async fn execute(
     // workspace root (e.g. `workspace_root=/tmp`, where `@fs.tmpdir` lands
     // under it) the shared deny would otherwise block moon's own generated
     // `snippet.mbt`.
-    let sandboxed_command = @sandbox.SandboxedCommand::create_if_available(
-      workspace_root,
-      Exec("moon", moon_argv),
-      writable_subtree=dir,
-    )
-    let (prog, argv) = match sandboxed_command {
-      Some(command) => (command.program(), command.args())
-      None => ("moon", moon_argv)
-    }
-    let result = @async.with_timeout_opt(RunTimeoutMs, () => {
-      let exit_code = @process.run(
-        prog,
-        argv,
-        cwd=run_cwd.unwrap_or("."),
-        inherit_env=true,
-        stdin=@process.redirect_from_file(empty_stdin),
-        stdout=@process.redirect_to_file(log, append=true),
-        stderr=@process.redirect_to_file(log, append=true),
+    let (result, sandboxed_command) = @async.with_task_group(execution_group => {
+      let sandboxed_command = @sandbox.SandboxedCommand::create_if_available(
+        workspace_root,
+        Exec("moon", moon_argv),
+        writable_subtree=dir,
       )
-      (exit_code, read_capped(log))
+      let (prog, argv) = match sandboxed_command {
+        Some(command) => command.prepare_for_spawn(execution_group)
+        None => ("moon", moon_argv)
+      }
+      let result = @async.with_timeout_opt(RunTimeoutMs, () => {
+        let exit_code = @process.run(
+          prog,
+          argv,
+          cwd=run_cwd.unwrap_or("."),
+          inherit_env=true,
+          stdin=@process.redirect_from_file(empty_stdin),
+          stdout=@process.redirect_to_file(log, append=true),
+          stderr=@process.redirect_to_file(log, append=true),
+        )
+        (exit_code, read_capped(log))
+      })
+      (result, sandboxed_command)
     })
     // A "not permitted" line naming a protected source path in a sandboxed run
     // is the source-write policy firing, not an environment fault: explain it

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -16,17 +16,8 @@ priv enum SourceWriteMode {
 }
 
 ///|
-priv struct ProcessCommand {
-  program : String
-  args : Array[String]
-}
-
-///|
 priv struct AgentShellLaunch {
-  command : ProcessCommand
-  // `Some` exactly when `command` was prepared under the source-write sandbox.
-  // It stays intact so output is judged against the profile that produced it.
-  sandboxed_command : @sandbox.SandboxedCommand?
+  command : @shell_exec.ProcessCommand
 }
 
 ///|
@@ -77,17 +68,13 @@ async fn agent_shell_launch(
     )
     return match sandboxed {
       Some(command) =>
-        {
-          command: { program: command.program(), args: command.args() },
-          sandboxed_command: Some(command),
-        }
+        { command: @shell_exec.ProcessCommand::sandboxed(command) }
       None =>
         {
-          command: {
-            program: @platform_shell.program,
-            args: @platform_shell.args(cmd),
-          },
-          sandboxed_command: None,
+          command: @shell_exec.ProcessCommand::plain(
+            @platform_shell.program,
+            @platform_shell.args(cmd),
+          ),
         }
     }
   }
@@ -145,17 +132,13 @@ async fn agent_shell_launch(
   match (mode, sandboxed_command) {
     (TrustedSourceWrite, _) | (_, None) =>
       {
-        command: {
-          program: @platform_shell.program,
-          args: @platform_shell.args(cmd),
-        },
-        sandboxed_command: None,
+        command: @shell_exec.ProcessCommand::plain(
+          @platform_shell.program,
+          @platform_shell.args(cmd),
+        ),
       }
     (SourceReadOnly, Some(command)) =>
-      {
-        command: { program: command.program(), args: command.args() },
-        sandboxed_command: Some(command),
-      }
+      { command: @shell_exec.ProcessCommand::sandboxed(command) }
   }
 }
 

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1532,7 +1532,7 @@ async test "a scratch lab forces trusted source-writes onto the sandbox" {
     @shell_parse.parse_for_policy("moon new \{lab}/probe"),
     cwd=lab,
   )
-  assert_true(without.sandboxed_command is None)
+  assert_true(without.command.sandboxed_command() is None)
   // With the lab wired, the same command is sandboxed instead — the
   // profile allows lab writes, the kernel denies workspace writes.
   let with_lab = agent_shell_launch(
@@ -1542,7 +1542,7 @@ async test "a scratch lab forces trusted source-writes onto the sandbox" {
     cwd=lab,
     scratch_dir=lab,
   )
-  assert_true(with_lab.sandboxed_command is Some(_))
+  assert_true(with_lab.command.sandboxed_command() is Some(_))
   @fs.rmdir(ws, recursive=true)
   @fs.rmdir(lab, recursive=true)
 }

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -365,24 +365,19 @@ async fn shell(
   // keeps a full record if detached — the foreground output-limit is still
   // enforced at display via `over_inline_cap` and the spill is discarded
   // when the command finishes in the foreground.
-  let foreground_spawn : (async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution)? = bg_runtime.map(runtime => {
-      (program, args, cwd, max) => {
-        runtime.spawn_foreground_retained(program, args, cwd, max)
+  let foreground_spawn : (async (@shell_exec.ProcessCommand, String?, Int) -> @shell_exec.ShellExecution)? = bg_runtime.map(runtime => {
+      (command, cwd, max) => {
+        runtime.spawn_foreground_retained(command, cwd, max)
       }
     },
   )
   // Detach-on-timeout: move a command that outlives its timeout to the background
   // instead of killing it — the model keeps watching it with shell_output /
   // shell_stop rather than losing it.
-  let on_timeout_detach : ((@shell_exec.ShellExecution, AgentShellLaunch) -> String)? = bg_runtime.map(runtime => {
-      (exec, launch) => {
+  let on_timeout_detach : ((@shell_exec.ShellExecution) -> String)? = bg_runtime.map(runtime => {
+      exec => {
         let _ = exec.background()
-        runtime.adopt(
-          exec,
-          command=input.cmd,
-          cwd?,
-          sandboxed_command?=launch.sandboxed_command,
-        )
+        runtime.adopt(exec, command=input.cmd, cwd?)
       }
     },
   )
@@ -502,8 +497,8 @@ async fn run_agent_shell_with_tree_precheck(
   cwd? : String,
   max_output_chars~ : Int,
   timeout_ms~ : Int,
-  foreground_spawn? : async (String, Array[String], String?, Int) -> @shell_exec.ShellExecution,
-  on_timeout_detach? : (@shell_exec.ShellExecution, AgentShellLaunch) -> String,
+  foreground_spawn? : async (@shell_exec.ProcessCommand, String?, Int) -> @shell_exec.ShellExecution,
+  on_timeout_detach? : (@shell_exec.ShellExecution) -> String,
   scratch_dir? : String,
   worker_sandbox? : WorkerSandbox,
 ) -> ShellRunResult {
@@ -528,12 +523,7 @@ async fn run_agent_shell_with_tree_precheck(
     // await, so a timeout must stop it here — not leak it — and a turn
     // cancellation must too (the catch stops it before re-raising).
     Some(spawn) => {
-      let exec = spawn(
-        launch.command.program,
-        launch.command.args,
-        cwd,
-        max_output_chars,
-      )
+      let exec = spawn(launch.command, cwd, max_output_chars)
       let finished = @async.with_timeout_opt(timeout_ms, () => {
         exec.wait_or_invalid()
       }) catch {
@@ -545,7 +535,7 @@ async fn run_agent_shell_with_tree_precheck(
       match finished {
         None =>
           match on_timeout_detach {
-            Some(detach) => ShellDetached(detach(exec, launch))
+            Some(detach) => ShellDetached(detach(exec))
             None => {
               let _ = exec.stop()
               ShellTimedOut
@@ -574,17 +564,15 @@ async fn run_agent_shell_with_tree_precheck(
     // the per-call collection path, with the same timeout wrapping as before.
     None => {
       let collected = @async.with_timeout_opt(timeout_ms, () => {
-        collect_process_output(
-          launch.command.program,
-          launch.command.args,
-          cwd?,
-          max_output_chars~,
-        )
+        collect_process_output(launch.command, cwd?, max_output_chars~)
       })
       match collected {
         None => ShellTimedOut
         Some(output) =>
-          ShellExecuted({ output, sandboxed_command: launch.sandboxed_command })
+          ShellExecuted({
+            output,
+            sandboxed_command: launch.command.sandboxed_command(),
+          })
       }
     }
   }
@@ -608,7 +596,7 @@ fn agent_shell_output_from_exec(
       // memory-only one was killed at it (truncated, hard cap == inline cap).
       output_limit_reached: exec.over_inline_cap() || exec.output_truncated(),
     },
-    sandboxed_command: launch.sandboxed_command,
+    sandboxed_command: launch.command.sandboxed_command(),
   }
 }
 
@@ -661,12 +649,12 @@ async fn start_background(
     worker_sandbox?,
   )
   let id = runtime.start(
-    program=launch.command.program,
-    args=launch.command.args,
+    program=@platform_shell.program,
+    args=@platform_shell.args(input.cmd),
     command=input.cmd,
     cwd?,
     max_output_chars=input.max_output_chars,
-    sandboxed_command?=launch.sandboxed_command,
+    sandboxed_command?=launch.command.sandboxed_command(),
   )
   @agent_tool.ToolAction::respond(
     "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
@@ -715,8 +703,10 @@ pub async fn collect_shell_output(
   max_output_chars? : Int = @decode.default_max_output_chars,
 ) -> ShellOutput {
   collect_process_output(
-    @platform_shell.program,
-    @platform_shell.args(cmd),
+    @shell_exec.ProcessCommand::plain(
+      @platform_shell.program,
+      @platform_shell.args(cmd),
+    ),
     cwd?,
     max_output_chars~,
   )
@@ -724,13 +714,13 @@ pub async fn collect_shell_output(
 
 ///|
 async fn collect_process_output(
-  program : String,
-  args : Array[String],
+  command : @shell_exec.ProcessCommand,
   cwd? : String,
   max_output_chars~ : Int,
 ) -> ShellOutput {
   let (reader, writer) = @process.read_from_process()
   @async.with_task_group() <| group => {
+    let (program, args) = command.prepare_for_spawn(group)
     defer reader.close()
     let process = @process.spawn(
       group,

--- a/agent_tool/shell_exec/README.mbt.md
+++ b/agent_tool/shell_exec/README.mbt.md
@@ -57,8 +57,10 @@ error instead of silently presenting replacement characters as success.
 
 ## L1 — `ShellExecution`: process + sink + status
 
-`ShellExecution::start` spawns the child on the session task group (so session
-teardown cancels it) and starts a monitor task. The monitor's design point:
+`ShellExecution::start` creates one private execution task group beneath the
+session task group, so session teardown still cancels it. That private group
+owns the process, its monitor, and any temporary sandbox profile; the profile
+is removed only after the process and monitor stop. The monitor's design point:
 **draining the pipe and awaiting the exit are decoupled.** Coupling them (read
 to EOF, then wait) hangs forever when the child exits but a descendant it
 spawned still holds the pipe open — so a concurrent reader drains bytes while

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -45,6 +45,9 @@ fn ExecStatus::is_terminal(self : ExecStatus) -> Bool {
 pub struct ShellExecution {
   priv sink : ShellOutputSink
   priv process : @process.Process
+  // Preserved after launch so a detached job classifies output against the
+  // exact sandbox profile that its process used.
+  priv sandboxed_command : @sandbox.SandboxedCommand?
   priv mut status : ExecStatus
   // Set before the child is cancelled (by `stop`, or by the output-limit kill)
   // so the monitor reports `Killed` rather than the kill signal's exit code.
@@ -72,13 +75,23 @@ pub struct ShellExecution {
 }
 
 ///|
-/// Spawn `program args` on the session group with stdout+stderr merged into a
-/// fresh sink, start a monitor task, and return the live execution. `spill_path`,
-/// when set, is where the sink writes full output once it exceeds `inline_cap`.
+/// Startup handoff from an execution's private task group to its caller.
+priv enum ExecutionStart {
+  Started(ShellExecution)
+  Failed(Error)
+}
+
+///|
+/// Spawn `program args` in a private child task group with stdout+stderr merged
+/// into a fresh sink, then return the live execution. `spill_path`, when set, is
+/// where the sink writes full output once it exceeds `inline_cap`.
+///
+/// A sandbox profile is registered with that same group's defer stack. The
+/// group therefore removes it only after its process and monitor have both
+/// terminated, including for detached background jobs and cancellation.
 pub async fn[X] ShellExecution::start(
   scope : @agent_runtime.AgentTaskScope[X],
-  program~ : String,
-  args~ : Array[String],
+  command~ : ProcessCommand,
   cwd? : String,
   inline_cap? : Int = default_inline_cap,
   hard_cap? : Int = default_hard_cap,
@@ -86,34 +99,55 @@ pub async fn[X] ShellExecution::start(
   kill_when_full? : Bool = false,
   kill_at_hard_cap? : Bool = false,
 ) -> ShellExecution {
-  let group = scope.group()
+  let session_group = scope.group()
+  let sandboxed_command = command.sandboxed_command()
   let sink = ShellOutputSink::new(inline_cap~, hard_cap~, spill_path?)
-  let (reader, writer) = @process.read_from_process()
-  let process = @process.spawn(
-    group,
-    program,
-    args,
-    stdout=writer,
-    stderr=writer,
-    cwd?=cwd.map(cwd => cwd.view()),
-    cancel_handler=@process.hard_cancel(),
-    no_wait=true,
-  )
-  let exec = {
-    sink,
-    process,
-    status: Running,
-    cancel_requested: false,
-    kill_when_full,
-    kill_at_hard_cap,
-    killed_by_output_limit: false,
-    started_at_ms: @env.now().reinterpret_as_int64(),
-    killed_by_time_limit: false,
+  let started : @async.Queue[ExecutionStart] = Queue(kind=Unbounded)
+  session_group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
+    @async.with_task_group(execution_group => {
+      let mut start_reported = false
+      try {
+        let (program, args) = command.prepare_for_spawn(execution_group)
+        let (reader, writer) = @process.read_from_process()
+        let process = @process.spawn(
+          execution_group,
+          program,
+          args,
+          stdout=writer,
+          stderr=writer,
+          cwd?=cwd.map(cwd => cwd.view()),
+          cancel_handler=@process.hard_cancel(),
+          no_wait=true,
+        )
+        let exec = {
+          sink,
+          process,
+          sandboxed_command,
+          status: Running,
+          cancel_requested: false,
+          kill_when_full,
+          kill_at_hard_cap,
+          killed_by_output_limit: false,
+          started_at_ms: @env.now().reinterpret_as_int64(),
+          killed_by_time_limit: false,
+        }
+        started.put(Started(exec))
+        start_reported = true
+        exec.monitor(reader, process)
+      } catch {
+        error => {
+          if !start_reported {
+            ignore(started.try_put(Failed(error)) catch { _ => false })
+          }
+          raise error
+        }
+      }
+    })
   }
-  group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
-    exec.monitor(reader, process)
+  match started.get() {
+    Started(exec) => exec
+    Failed(error) => raise error
   }
-  exec
 }
 
 ///|
@@ -227,6 +261,14 @@ pub async fn ShellExecution::stop(self : ShellExecution) -> Bool {
 pub fn ShellExecution::request_stop(self : ShellExecution) -> Unit {
   self.cancel_requested = true
   self.process.cancel()
+}
+
+///|
+/// Prepared sandbox metadata for the exact process owned by this execution.
+pub fn ShellExecution::sandboxed_command(
+  self : ShellExecution,
+) -> @sandbox.SandboxedCommand? {
+  self.sandboxed_command
 }
 
 ///|
@@ -399,9 +441,10 @@ async fn poll_exec_terminal(exec : ShellExecution, ticks? : Int = 200) -> Unit {
 #cfg(not(platform="windows"))
 async test "execution runs to completion and captures output" {
   @async.with_task_group(group => {
-    let exec = ShellExecution::start(AgentTaskScope(group), program="sh", args=[
-      "-c", "printf hello",
-    ])
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      command=ProcessCommand::plain("sh", ["-c", "printf hello"]),
+    )
     poll_exec_terminal(exec)
     assert_true(exec.status() is Exited(0))
     assert_true(exec.head().contains("hello"))
@@ -413,9 +456,10 @@ async test "execution runs to completion and captures output" {
 #cfg(not(platform="windows"))
 async test "execution records a non-zero exit code" {
   @async.with_task_group(group => {
-    let exec = ShellExecution::start(AgentTaskScope(group), program="sh", args=[
-      "-c", "exit 3",
-    ])
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      command=ProcessCommand::plain("sh", ["-c", "exit 3"]),
+    )
     poll_exec_terminal(exec)
     assert_true(exec.status() is Exited(3))
     assert_true(exec.exit_code() is Some(3))
@@ -423,12 +467,55 @@ async test "execution records a non-zero exit code" {
 }
 
 ///|
+/// Startup errors must cross the private task-group handoff instead of leaving
+/// the caller waiting on an empty queue.
+#cfg(not(platform="windows"))
+async test "execution reports a spawn failure" {
+  @async.with_task_group(group => {
+    let failed = try {
+      ignore(
+        ShellExecution::start(
+          AgentTaskScope(group),
+          command=ProcessCommand::plain("/openseek/no-such-executable", []),
+        ),
+      )
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(failed)
+  })
+}
+
+///|
+/// A sandboxed execution retains the metadata used to classify its output.
+#cfg(not(platform="windows"))
+async test "execution retains its sandbox command" {
+  let workspace = @fs.tmpdir(prefix="openseek-exec-profile-owner-")
+  guard @sandbox.SandboxedCommand::create_if_available(workspace, Shell(":"))
+    is Some(command) else {
+    @fs.rmdir(workspace, recursive=true)
+    return
+  }
+  @async.with_task_group(group => {
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      command=ProcessCommand::sandboxed(command),
+    )
+    assert_true(exec.sandboxed_command() is Some(_))
+    poll_exec_terminal(exec)
+  })
+  @fs.rmdir(workspace, recursive=true)
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "stop and request_stop terminate a running execution" {
   @async.with_task_group(group => {
-    let exec = ShellExecution::start(AgentTaskScope(group), program="sleep", args=[
-      "30",
-    ])
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      command=ProcessCommand::plain("sleep", ["30"]),
+    )
     @async.sleep(50)
     assert_true(exec.status() is Running)
     assert_true(exec.stop())
@@ -441,9 +528,10 @@ async test "stop and request_stop terminate a running execution" {
 #cfg(not(platform="windows"))
 async test "request_stop synchronously terminates a running execution" {
   @async.with_task_group(group => {
-    let exec = ShellExecution::start(AgentTaskScope(group), program="sleep", args=[
-      "30",
-    ])
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      command=ProcessCommand::plain("sleep", ["30"]),
+    )
     @async.sleep(50)
     assert_true(exec.status() is Running)
     exec.request_stop()
@@ -456,9 +544,10 @@ async test "request_stop synchronously terminates a running execution" {
 #cfg(not(platform="windows"))
 async test "background flips to Backgrounded and keeps running" {
   @async.with_task_group(group => {
-    let exec = ShellExecution::start(AgentTaskScope(group), program="sleep", args=[
-      "30",
-    ])
+    let exec = ShellExecution::start(
+      AgentTaskScope(group),
+      command=ProcessCommand::plain("sleep", ["30"]),
+    )
     @async.sleep(50)
     assert_true(exec.background())
     assert_true(exec.status() is Backgrounded)
@@ -473,8 +562,7 @@ async test "kill_when_full stops a runaway once the sink fills" {
   @async.with_task_group(group => {
     let exec = ShellExecution::start(
       AgentTaskScope(group),
-      program="sh",
-      args=["-c", "yes"],
+      command=ProcessCommand::plain("sh", ["-c", "yes"]),
       inline_cap=100,
       hard_cap=100,
       kill_when_full=true,
@@ -492,8 +580,7 @@ async test "large output spills and read_all returns the full output" {
     let path = "/tmp/openseek-exec-spill.out"
     let exec = ShellExecution::start(
       AgentTaskScope(group),
-      program="sh",
-      args=["-c", "seq 1 5000"],
+      command=ProcessCommand::plain("sh", ["-c", "seq 1 5000"]),
       inline_cap=100,
       hard_cap=1000000,
       spill_path=path,

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -103,6 +103,12 @@ pub async fn[X] ShellExecution::start(
   let sandboxed_command = command.sandboxed_command()
   let sink = ShellOutputSink::new(inline_cap~, hard_cap~, spill_path?)
   let started : @async.Queue[ExecutionStart] = Queue(kind=Unbounded)
+  // The caller owns the startup handoff. If it is cancelled before accepting
+  // an execution, closing the queue makes the starter's `put` fail inside
+  // `execution_group`; group teardown then cancels any process already spawned
+  // and removes its sandbox profile. A value already delivered to `get` is
+  // still returned before cancellation propagates, so ownership is not lost.
+  defer started.close()
   session_group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
     @async.with_task_group(execution_group => {
       let mut start_reported = false

--- a/agent_tool/shell_exec/moon.pkg
+++ b/agent_tool/shell_exec/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_tool/internal/sandbox",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -3,6 +3,8 @@ package "bobzhang/openseek/agent_tool/shell_exec"
 
 import {
   "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_tool/internal/sandbox",
+  "moonbitlang/async",
   "moonbitlang/core/debug",
 }
 
@@ -18,6 +20,12 @@ pub enum ExecStatus {
   Exited(Int)
   Killed
 } derive(Eq, @debug.Debug)
+
+type ProcessCommand
+pub fn ProcessCommand::plain(String, Array[String]) -> Self
+pub async fn[X] ProcessCommand::prepare_for_spawn(Self, @async.TaskGroup[X]) -> (String, Array[String])
+pub fn ProcessCommand::sandboxed(@sandbox.SandboxedCommand) -> Self
+pub fn ProcessCommand::sandboxed_command(Self) -> @sandbox.SandboxedCommand?
 
 pub struct ShellExecution {
   // private fields
@@ -35,9 +43,10 @@ pub fn ShellExecution::over_inline_cap(Self) -> Bool
 pub async fn ShellExecution::read_all(Self) -> String
 pub async fn ShellExecution::read_tail(Self, Int) -> String
 pub fn ShellExecution::request_stop(Self) -> Unit
+pub fn ShellExecution::sandboxed_command(Self) -> @sandbox.SandboxedCommand?
 pub fn ShellExecution::seq(Self) -> Int
 pub fn ShellExecution::size(Self) -> Int
-pub async fn[X] ShellExecution::start(@agent_runtime.AgentTaskScope[X], program~ : String, args~ : Array[String], cwd? : String, inline_cap? : Int, hard_cap? : Int, spill_path? : String, kill_when_full? : Bool, kill_at_hard_cap? : Bool) -> Self
+pub async fn[X] ShellExecution::start(@agent_runtime.AgentTaskScope[X], command~ : ProcessCommand, cwd? : String, inline_cap? : Int, hard_cap? : Int, spill_path? : String, kill_when_full? : Bool, kill_at_hard_cap? : Bool) -> Self
 pub fn ShellExecution::started_at_ms(Self) -> Int64
 pub fn ShellExecution::status(Self) -> ExecStatus
 pub async fn ShellExecution::stop(Self) -> Bool

--- a/agent_tool/shell_exec/process_command.mbt
+++ b/agent_tool/shell_exec/process_command.mbt
@@ -1,0 +1,55 @@
+///|
+/// One command to spawn, either plain or backed by a prepared source-write
+/// sandbox command.
+///
+/// Keeping these together ensures the task group that prepares a sandbox
+/// profile also owns the process that uses it.
+struct ProcessCommand {
+  command : ProcessCommandKind
+}
+
+///|
+priv enum ProcessCommandKind {
+  Plain(String, Array[String])
+  Sandboxed(@sandbox.SandboxedCommand)
+}
+
+///|
+/// Construct an ordinary process command with no sandbox profile to own.
+pub fn ProcessCommand::plain(
+  program : String,
+  args : Array[String],
+) -> ProcessCommand {
+  { command: Plain(program, args) }
+}
+
+///|
+/// Construct the exact process command represented by `sandboxed_command`.
+pub fn ProcessCommand::sandboxed(
+  sandboxed_command : @sandbox.SandboxedCommand,
+) -> ProcessCommand {
+  { command: Sandboxed(sandboxed_command) }
+}
+
+///|
+/// Prepare program and argv inside the task group that will own the process.
+pub async fn[X] ProcessCommand::prepare_for_spawn(
+  self : ProcessCommand,
+  group : @async.TaskGroup[X],
+) -> (String, Array[String]) {
+  match self.command {
+    Plain(program, args) => (program, args.copy())
+    Sandboxed(command) => command.prepare_for_spawn(group)
+  }
+}
+
+///|
+/// Prepared sandbox command, when this process owns a temporary SBPL file.
+pub fn ProcessCommand::sandboxed_command(
+  self : ProcessCommand,
+) -> @sandbox.SandboxedCommand? {
+  match self.command {
+    Plain(_, _) => None
+    Sandboxed(command) => Some(command)
+  }
+}


### PR DESCRIPTION
<img width="705" height="206" alt="image" src="https://github.com/user-attachments/assets/e1b8a65b-93ff-442f-8d9f-4cb1b6812d13" />


## Summary

- write generated SBPL profiles to private temporary files and invoke `sandbox-exec -f` instead of passing the full profile through argv
- prepare each profile only when the command is spawned and bind cleanup to the execution task group
- keep the executable, argv, and sandbox denial metadata together across foreground execution, background jobs, and detach-on-timeout
- add regressions for profiles larger than 1 MiB, profile cleanup, and spawn-startup error propagation

## Root cause

The shell sandbox passed the generated SBPL profile as one `sandbox-exec -p` argument. In repositories with many source directories, that profile can exceed macOS `ARG_MAX`, so even a short command such as `pwd` fails at process creation with `Argument list too long`.

Using `sandbox-exec -f <profile-file>` keeps argv small regardless of repository size. The profile file is registered with the same async task group that owns the process and monitor, so it remains available through startup and is removed after the execution terminates or is cancelled.

## Validation

- `moon check --target native`
- `moon test agent_tool/internal/sandbox --target native`
- `moon test agent_tool/shell_exec --target native`
- `moon test agent_tool/bgjobs --target native`
- `moon test agent_tool/shell --target native`
- `moon test agent_tool/run_moonbit --target native`
- `moon test agent_tool/shell_output --target native`
- `moon test agent_tool/shell_stop --target native`
- `moon test --target native -q`
- `git diff --check origin/main...HEAD`

The final test run left no `openseek-sandbox-profile-*` directories behind.