### PR TITLE
feat(subtask): one call, many slices — parallelism by construction

### DIFF
--- a/cmd/openseek/internal/subtask/lifecycle_test.mbt
+++ b/cmd/openseek/internal/subtask/lifecycle_test.mbt
@@ -310,3 +310,39 @@ async test "provision refuses linked-worktree origins and submodule slices" {
     assert_true(linked.contains("MAIN worktree"))
   })
 }
+
+///|
+/// Two disjoint slices provisioned back-to-back both go live — the shape a
+/// one-call `slices` fan-out relies on (the tool layer runs these
+/// concurrently; here the controller-level invariant is what matters).
+async test "disjoint slices coexist as active reservations" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-fanout-", dir => {
+    let repo = seed_repo(dir)
+    let a = must_provision(
+      repo,
+      name="slice-a",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let b = must_provision(
+      repo,
+      name="slice-b",
+      allowed_paths=["other"],
+      nonce="n2",
+    )
+    assert_true(a.entry.state is Running)
+    assert_true(b.entry.state is Running)
+    assert_true(@fs.exists("\{a.entry.worker_root}/lib/a.txt"))
+    assert_true(@fs.exists("\{b.entry.worker_root}/other/b.txt"))
+    // Both reservations are visible; a third overlapping slice is refused.
+    guard @subtask.provision(
+        repo,
+        name="slice-c",
+        allowed_paths=["lib/deep"],
+        nonce="n3",
+      )
+      is Err(_) else {
+      fail("expected the overlapping third slice to be refused")
+    }
+  })
+}

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -110,4 +110,3 @@ pub fn SubtaskState::is_terminal(Self) -> Bool
 // Type aliases
 
 // Traits
-

--- a/cmd/openseek/pkg.generated.mbti
+++ b/cmd/openseek/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "bobzhang/openseek/cmd/openseek"
 // Type aliases
 
 // Traits
-

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -47,7 +47,8 @@ fn subtask_tool_definition(
       "properties": {
         "slices": {
           "type": "array",
-          "description": "Parallel launch: several {name, task, allowed_paths, context?} slices run CONCURRENTLY from this one call. Their allowed_paths must be disjoint from each other and from any active subtask.",
+          "description": "Parallel launch: several {name, task, allowed_paths, context?} slices run CONCURRENTLY from this one call (at most 4 — the worker-slot cap). Their allowed_paths must be disjoint from each other and from any active subtask.",
+          "maxItems": 4,
           "items": {
             "type": "object",
             "properties": {
@@ -141,6 +142,15 @@ async fn subtask_execute(
       guard !entries.is_empty() else {
         return @agent_tool.ToolAction::respond(
           "error: subtask `slices` must not be empty",
+          is_error=true,
+        )
+      }
+      // Refuse rather than silently drop: slots are taken with
+      // try_acquire, so entries past the cap would fail as "slots full"
+      // while the call still looked accepted.
+      guard entries.length() <= max_active_workers else {
+        return @agent_tool.ToolAction::respond(
+          "error: subtask `slices` accepts at most \{max_active_workers} slices per call (got \{entries.length()}) — send the rest in a follow-up call once these integrate",
           is_error=true,
         )
       }
@@ -299,25 +309,33 @@ async fn subtask_launch_many(
       })
     }
   })
-  let out = StringBuilder()
+  // A compact status line PER SLICE comes first: four full reports can
+  // exceed the loop's per-tool-result clamp, and a truncated tail would
+  // otherwise erase later slices' state and next steps entirely.
+  let summary = StringBuilder()
+  let detail = StringBuilder()
   let mut any_error = false
   let briefs : Array[String] = []
   for index, spec in specs {
-    out <+ "## \{spec.name}\n"
+    let (status, errored) = match results.get(index) {
+      Some(Respond(output)) => (slice_status_line(output), output.is_error)
+      _ => ("no result", true)
+    }
+    if errored {
+      any_error = true
+    }
+    briefs.push(spec.name)
+    summary <+ "- \{spec.name}: \{status}\n"
+    detail <+ "## \{spec.name}\n"
     match results.get(index) {
-      Some(Respond(output)) => {
-        out <+ "\{output.content}\n\n"
-        if output.is_error {
-          any_error = true
-        }
-        briefs.push(spec.name)
-      }
-      _ => {
-        out <+ "(no result)\n\n"
-        any_error = true
-      }
+      Some(Respond(output)) => detail <+ "\{output.content}\n\n"
+      _ => detail <+ "(no result)\n\n"
     }
   }
+  let out = StringBuilder()
+  out <+
+    "\{specs.length()} slice(s) launched concurrently:\n\{summary.to_string()}\n"
+  out <+ "\{detail.to_string()}"
   @agent_tool.ToolAction::respond(
     out.to_string(),
     is_error=any_error,
@@ -455,4 +473,18 @@ async fn subtask_launch_one(
     is_error~,
     brief="subtask \{result.subrun_id()} \{name} (\{Repr(captured.entry.state)}, \{result.steps_used()} step(s))",
   )
+}
+
+///|
+/// The one-line state of a finished slice, recovered from its rendered
+/// result: the `state:` line the single-slice renderer emits, or a
+/// truncated first line as a fallback.
+fn slice_status_line(output : @agent_tool.ToolOutput) -> String {
+  for line in output.content.split("\n") {
+    let line = line.to_owned()
+    if line.has_prefix("state: ") {
+      return @agent_tool.brief_line(line, limit=120)
+    }
+  }
+  @agent_tool.brief_line(output.content, limit=120)
 }

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -36,16 +36,35 @@ fn subtask_tool_definition(
       #|to merge its branch here (re-run your checks after each); on a conflict, resolve
       #|the markers with the file tools, then integrate_continue=<name> (or
       #|integrate_abort=<name>); discard=<name> abandons a slice and frees its paths.
-      #|Independent slices? Issue SEVERAL subtask launches in the same step — they run
-      #|concurrently (2-4 is a good batch; at most 4 run at once). Commit your own work
-      #|first: workers fork this repository's HEAD.
+      #|PARALLELISM: to run several slices at once, pass them as `slices`: an ARRAY of
+      #|{name, task, allowed_paths, context?} objects in ONE call — they are launched
+      #|concurrently and reported together (2-4 per call; at most 4 run at once). Prefer
+      #|this over issuing separate calls, which the loop can only overlap when they land
+      #|in the same step. Commit your own work first: workers fork this repository's HEAD.
     ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
+        "slices": {
+          "type": "array",
+          "description": "Parallel launch: several {name, task, allowed_paths, context?} slices run CONCURRENTLY from this one call. Their allowed_paths must be disjoint from each other and from any active subtask.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "task": { "type": "string" },
+              "allowed_paths": {
+                "type": "array",
+                "items": { "type": "string" },
+              },
+              "context": { "type": "string" },
+            },
+            "required": ["name", "task", "allowed_paths"],
+          },
+        },
         "name": {
           "type": "string",
-          "description": "Launch: short lowercase slug naming the slice (becomes the branch and worktree name).",
+          "description": "Single launch: short lowercase slug naming the slice (becomes the branch and worktree name).",
         },
         "task": {
           "type": "string",
@@ -114,8 +133,40 @@ async fn subtask_execute(
       return subtask_lifecycle(workspace_root, "discard", name)
     _ => ()
   }
-  subtask_launch(
-    self_exe, model, workspace_root, budget, api_url, child_session, arguments,
+  // `slices` launches several confined workers CONCURRENTLY from one call;
+  // a bare name/task/allowed_paths object is the single-slice form.
+  let specs : Array[LaunchSpec] = []
+  match arguments {
+    { "slices": Array(entries), .. } => {
+      guard !entries.is_empty() else {
+        return @agent_tool.ToolAction::respond(
+          "error: subtask `slices` must not be empty",
+          is_error=true,
+        )
+      }
+      for entry in entries {
+        match decode_launch(entry) {
+          Ok(spec) => specs.push(spec)
+          Err(reason) =>
+            return @agent_tool.ToolAction::respond(
+              "error: \{reason}",
+              is_error=true,
+            )
+        }
+      }
+    }
+    _ =>
+      match decode_launch(arguments) {
+        Ok(spec) => specs.push(spec)
+        Err(reason) =>
+          return @agent_tool.ToolAction::respond(
+            "error: \{reason}",
+            is_error=true,
+          )
+      }
+  }
+  subtask_launch_many(
+    self_exe, model, workspace_root, budget, api_url, child_session, specs,
   )
 }
 
@@ -174,60 +225,120 @@ async fn subtask_lifecycle(
 }
 
 ///|
-async fn subtask_launch(
+/// One decoded launch request.
+priv struct LaunchSpec {
+  name : String
+  task : String
+  context : String?
+  allowed_paths : Array[String]
+}
+
+///|
+/// Decode one launch object (the tool's own arguments, or one element of
+/// `slices`). `Err` carries the model-facing message.
+fn decode_launch(spec : Json) -> Result[LaunchSpec, String] {
+  guard spec is { "name": String(name), .. } && name.trim() != "" else {
+    return Err(
+      "subtask requires `name` (launch), `slices` (parallel launch), or one of integrate/integrate_continue/integrate_abort/discard",
+    )
+  }
+  guard spec is { "task": String(task), .. } && task.trim() != "" else {
+    return Err("subtask launch requires a non-empty `task` for \{name}")
+  }
+  guard task.length() <= max_task_chars else {
+    return Err("subtask task for \{name} exceeds \{max_task_chars} chars")
+  }
+  let context : String? = match spec {
+    { "context": String(context), .. } if context.trim() != "" => Some(context)
+    _ => None
+  }
+  guard !(context is Some(c) && c.length() > max_context_chars) else {
+    return Err("subtask context for \{name} exceeds \{max_context_chars} chars")
+  }
+  let allowed_paths : Array[String] = []
+  guard spec is { "allowed_paths": Array(prefixes), .. } && !prefixes.is_empty() else {
+    return Err(
+      "subtask launch \{name} requires a non-empty `allowed_paths` array — the repo-relative prefixes this slice may change",
+    )
+  }
+  for prefix in prefixes {
+    guard prefix is String(prefix) && prefix.trim() != "" else {
+      return Err("allowed_paths entries must be non-empty strings (\{name})")
+    }
+    allowed_paths.push(prefix)
+  }
+  Ok({ name, task, context, allowed_paths })
+}
+
+///|
+/// Launch every slice CONCURRENTLY and render one combined result. This is
+/// the structural answer to a real dogfood finding: batching several
+/// `subtask` calls into one assistant message parallelizes them, but that
+/// is advisory — in a production sweep the model serialized 2 of 3 fan-outs
+/// and paid ~2.7x the wall-clock. One call carrying N slices cannot be
+/// serialized by accident.
+async fn subtask_launch_many(
   self_exe : String,
   model : @deepseek.Model,
   workspace_root : String,
   budget : @agent_subrun.SubrunBudget,
   api_url : String?,
   child_session : @agent_subrun.ChildSession?,
-  arguments : Json,
+  specs : Array[LaunchSpec],
 ) -> @agent_tool.ToolAction {
-  guard arguments is { "name": String(name), .. } && name.trim() != "" else {
-    return @agent_tool.ToolAction::respond(
-      "error: subtask requires `name` (launch) or one of integrate/integrate_continue/integrate_abort/discard",
-      is_error=true,
-    )
-  }
-  guard arguments is { "task": String(task), .. } && task.trim() != "" else {
-    return @agent_tool.ToolAction::respond(
-      "error: subtask launch requires a non-empty `task`",
-      is_error=true,
-    )
-  }
-  guard task.length() <= max_task_chars else {
-    return @agent_tool.ToolAction::respond(
-      "error: subtask task exceeds \{max_task_chars} chars",
-      is_error=true,
-    )
-  }
-  let context : String? = match arguments {
-    { "context": String(context), .. } if context.trim() != "" => Some(context)
-    _ => None
-  }
-  guard !(context is Some(c) && c.length() > max_context_chars) else {
-    return @agent_tool.ToolAction::respond(
-      "error: subtask context exceeds \{max_context_chars} chars",
-      is_error=true,
-    )
-  }
-  let allowed_paths : Array[String] = []
-  guard arguments is { "allowed_paths": Array(prefixes), .. } &&
-    !prefixes.is_empty() else {
-    return @agent_tool.ToolAction::respond(
-      "error: subtask launch requires a non-empty `allowed_paths` array — the repo-relative prefixes this slice may change",
-      is_error=true,
-    )
-  }
-  for prefix in prefixes {
-    guard prefix is String(prefix) && prefix.trim() != "" else {
-      return @agent_tool.ToolAction::respond(
-        "error: allowed_paths entries must be non-empty strings",
-        is_error=true,
-      )
+  let results : Map[Int, @agent_tool.ToolAction] = Map([])
+  @async.with_task_group(scope => {
+    for index, spec in specs {
+      scope.spawn_bg(() => {
+        results.set(
+          index,
+          subtask_launch_one(
+            self_exe, model, workspace_root, budget, api_url, child_session, spec,
+          ),
+        )
+      })
     }
-    allowed_paths.push(prefix)
+  })
+  let out = StringBuilder()
+  let mut any_error = false
+  let briefs : Array[String] = []
+  for index, spec in specs {
+    out <+ "## \{spec.name}\n"
+    match results.get(index) {
+      Some(Respond(output)) => {
+        out <+ "\{output.content}\n\n"
+        if output.is_error {
+          any_error = true
+        }
+        briefs.push(spec.name)
+      }
+      _ => {
+        out <+ "(no result)\n\n"
+        any_error = true
+      }
+    }
   }
+  @agent_tool.ToolAction::respond(
+    out.to_string(),
+    is_error=any_error,
+    brief="subtask \{specs.length()} slices (\{briefs.join(", ")})",
+  )
+}
+
+///|
+async fn subtask_launch_one(
+  self_exe : String,
+  model : @deepseek.Model,
+  workspace_root : String,
+  budget : @agent_subrun.SubrunBudget,
+  api_url : String?,
+  child_session : @agent_subrun.ChildSession?,
+  spec : LaunchSpec,
+) -> @agent_tool.ToolAction {
+  let name = spec.name
+  let task = spec.task
+  let context = spec.context
+  let allowed_paths = spec.allowed_paths
   // Slots and budget are reserved BEFORE any state is created, so every
   // later failure path has exactly one transaction to roll back.
   guard worker_slots.try_acquire() else {

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -296,7 +296,7 @@ async fn subtask_launch_many(
   child_session : @agent_subrun.ChildSession?,
   specs : Array[LaunchSpec],
 ) -> @agent_tool.ToolAction {
-  let results : Map[Int, @agent_tool.ToolAction] = Map([])
+  let results : Map[Int, SliceOutcome] = Map([])
   @async.with_task_group(scope => {
     for index, spec in specs {
       scope.spawn_bg(() => {
@@ -318,8 +318,9 @@ async fn subtask_launch_many(
   let briefs : Array[String] = []
   for index, spec in specs {
     let (status, errored) = match results.get(index) {
-      Some(Respond(output)) => (slice_status_line(output), output.is_error)
-      _ => ("no result", true)
+      Some(outcome) =>
+        (outcome.status, outcome.action is Respond(output) && output.is_error)
+      None => ("no result", true)
     }
     if errored {
       any_error = true
@@ -328,7 +329,7 @@ async fn subtask_launch_many(
     summary <+ "- \{spec.name}: \{status}\n"
     detail <+ "## \{spec.name}\n"
     match results.get(index) {
-      Some(Respond(output)) => detail <+ "\{output.content}\n\n"
+      Some({ action: Respond(output), .. }) => detail <+ "\{output.content}\n\n"
       _ => detail <+ "(no result)\n\n"
     }
   }
@@ -344,6 +345,15 @@ async fn subtask_launch_many(
 }
 
 ///|
+/// One finished slice: its rendered result plus the AUTHORITATIVE status
+/// the controller derived from git evidence — carried as data so a batch
+/// summary can never re-derive it from worker-authored prose.
+priv struct SliceOutcome {
+  action : @agent_tool.ToolAction
+  status : String
+}
+
+///|
 async fn subtask_launch_one(
   self_exe : String,
   model : @deepseek.Model,
@@ -352,7 +362,7 @@ async fn subtask_launch_one(
   api_url : String?,
   child_session : @agent_subrun.ChildSession?,
   spec : LaunchSpec,
-) -> @agent_tool.ToolAction {
+) -> SliceOutcome {
   let name = spec.name
   let task = spec.task
   let context = spec.context
@@ -360,11 +370,14 @@ async fn subtask_launch_one(
   // Slots and budget are reserved BEFORE any state is created, so every
   // later failure path has exactly one transaction to roll back.
   guard worker_slots.try_acquire() else {
-    return @agent_tool.ToolAction::respond(
-      "subtask worker slots are full (max \{max_active_workers} active) — integrate or await the running slices first.",
-      is_error=true,
-      brief="subtask (slots full)",
-    )
+    return {
+      action: @agent_tool.ToolAction::respond(
+        "subtask worker slots are full (max \{max_active_workers} active) — integrate or await the running slices first.",
+        is_error=true,
+        brief="subtask (slots full)",
+      ),
+      status: "not launched: worker slots full",
+    }
   }
   // Sync and block-scoped: a cancellation re-raised out of run_subrun still
   // returns the permit — four interrupts must not brick launching for the
@@ -373,11 +386,14 @@ async fn subtask_launch_one(
   defer worker_slots.release()
   guard budget.reserve(@agent_worker.default_worker_max_steps)
     is Some(granted_steps) else {
-    return @agent_tool.ToolAction::respond(
-      "subtask budget exhausted for this turn — do the remaining slices yourself or continue next turn.",
-      is_error=true,
-      brief="subtask (budget exhausted)",
-    )
+    return {
+      action: @agent_tool.ToolAction::respond(
+        "subtask budget exhausted for this turn — do the remaining slices yourself or continue next turn.",
+        is_error=true,
+        brief="subtask (budget exhausted)",
+      ),
+      status: "not launched: per-turn subtask budget exhausted",
+    }
   }
   let nonce = random_salt()
   let provisioned = match
@@ -390,11 +406,14 @@ async fn subtask_launch_one(
     ) {
     Ok(provisioned) => provisioned
     Err(reason) =>
-      return @agent_tool.ToolAction::respond(
-        "error: subtask provision: \{reason}",
-        is_error=true,
-        brief="subtask \{name} (provision refused)",
-      )
+      return {
+        action: @agent_tool.ToolAction::respond(
+          "error: subtask provision: \{reason}",
+          is_error=true,
+          brief="subtask \{name} (provision refused)",
+        ),
+        status: "not launched: \{@agent_tool.brief_line(reason, limit=100)}",
+      }
   }
   let entry = provisioned.entry
   let input : Json = match context {
@@ -468,23 +487,12 @@ async fn subtask_launch_one(
   out <+ "\n\{state_line}"
   let mergeable = captured.entry.state is Committed
   let is_error = !mergeable && !(captured.entry.state is NoChanges)
-  @agent_tool.ToolAction::respond(
-    out.to_string(),
-    is_error~,
-    brief="subtask \{result.subrun_id()} \{name} (\{Repr(captured.entry.state)}, \{result.steps_used()} step(s))",
-  )
-}
-
-///|
-/// The one-line state of a finished slice, recovered from its rendered
-/// result: the `state:` line the single-slice renderer emits, or a
-/// truncated first line as a fallback.
-fn slice_status_line(output : @agent_tool.ToolOutput) -> String {
-  for line in output.content.split("\n") {
-    let line = line.to_owned()
-    if line.has_prefix("state: ") {
-      return @agent_tool.brief_line(line, limit=120)
-    }
+  {
+    action: @agent_tool.ToolAction::respond(
+      out.to_string(),
+      is_error~,
+      brief="subtask \{result.subrun_id()} \{name} (\{Repr(captured.entry.state)}, \{result.steps_used()} step(s))",
+    ),
+    status: state_line,
   }
-  @agent_tool.brief_line(output.content, limit=120)
 }

--- a/cmd/tui/internal/command_context/pkg.generated.mbti
+++ b/cmd/tui/internal/command_context/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub struct ShellCommand {
 // Type aliases
 
 // Traits
-

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -49,4 +49,3 @@ pub struct UsageInfo {
 // Type aliases
 
 // Traits
-

--- a/cmd/tui/pkg.generated.mbti
+++ b/cmd/tui/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn tui_ui_options() -> Array[@argparse.OptionArg]
 // Type aliases
 
 // Traits
-

--- a/cmd/viz_app/pkg.generated.mbti
+++ b/cmd/viz_app/pkg.generated.mbti
@@ -19,4 +19,3 @@ type Theme derive(Eq)
 // Type aliases
 
 // Traits
-

--- a/cmd/viz_server/pkg.generated.mbti
+++ b/cmd/viz_server/pkg.generated.mbti
@@ -11,4 +11,3 @@ type Reply
 // Type aliases
 
 // Traits
-

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -168,9 +168,10 @@ Common `moon` subcommands:
   must never claim the same paths — overlapping launches are refused, so
   when categories share files, split by package or directory instead, or run
   those categories one after another. Commit your own work first (workers
-  fork this repository's HEAD and never see uncommitted changes). Issue
-  independent launches in the SAME step — they run concurrently (2-4 per
-  batch). Each worker edits inside its own git worktree, cannot commit, and
+  fork this repository's HEAD and never see uncommitted changes). Launch
+  independent slices with ONE call carrying a `slices` array (2-4 per
+  call): that runs them concurrently by construction, where separate calls
+  overlap only when they happen to land in the same step. Each worker edits inside its own git worktree, cannot commit, and
   its changes are validated against `allowed_paths` from git evidence, then
   committed on a branch; the tool result carries the worker's report AND the
   git evidence — trust the evidence. Then integrate ONE subtask at a time

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -173,9 +173,10 @@ fn default_prompt() -> String {
     #|  must never claim the same paths — overlapping launches are refused, so
     #|  when categories share files, split by package or directory instead, or run
     #|  those categories one after another. Commit your own work first (workers
-    #|  fork this repository's HEAD and never see uncommitted changes). Issue
-    #|  independent launches in the SAME step — they run concurrently (2-4 per
-    #|  batch). Each worker edits inside its own git worktree, cannot commit, and
+    #|  fork this repository's HEAD and never see uncommitted changes). Launch
+    #|  independent slices with ONE call carrying a `slices` array (2-4 per
+    #|  call): that runs them concurrently by construction, where separate calls
+    #|  overlap only when they happen to land in the same step. Each worker edits inside its own git worktree, cannot commit, and
     #|  its changes are validated against `allowed_paths` from git evidence, then
     #|  committed on a branch; the tool result carries the worker's report AND the
     #|  git evidence — trust the evidence. Then integrate ONE subtask at a time

--- a/prompt/pkg.generated.mbti
+++ b/prompt/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn system_prompt_for_model(@deepseek.Model) -> String
 // Type aliases
 
 // Traits
-


### PR DESCRIPTION
## Why
Measured in the mbtexcel production sweep: same-step batching is advisory, and the model doesn't reliably do it. Across three real fan-outs it batched once (4 workers in step 20, 267s wall) and serialized twice (one worker per step, e.g. sr-1→step 6, sr-2→step 7 …). On the worst run that cost **~2.7×**: 1315s of worker time serialized where a 483s overlap was available.

## What
`subtask` accepts `slices` — an array of `{name, task, allowed_paths, context?}` — launched concurrently from one call and reported together. Parallelism no longer depends on model batching behavior. Single-slice form unchanged; decode shared; each slice keeps its own slot/budget reservation, provisioning transaction, evidence capture, and error state (one bad slice doesn't sink the batch). Tool description and default prompt teach `slices` first.

## Tests
84/84 across the CLI + controller packages, including a new controller invariant test that disjoint slices coexist as active reservations while an overlapping third is refused. Repo check/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)