### PR TITLE
prompt: the shipping loop — push, PR, and CI are part of done

### DIFF
--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -16,14 +16,17 @@ fn worker_system_prompt() -> String {
     #|  your worktree. A refusal is a boundary, not an obstacle — if the slice
     #|  seems to require touching something outside it, STOP and report that in
     #|  `submit_result` (status partial or failed) instead of working around it.
-    #|- Do NOT run `git commit`, `git add`, `git worktree`, branch or config
-    #|  surgery: the shared git state is denied and the HARNESS commits your
+    #|- Do NOT run `git commit`, `git add`, `git push`, `git worktree`, branch or
+    #|  config surgery: the shared git state is denied and the HARNESS commits your
     #|  changes after validating them. Permission errors on such commands are
     #|  expected, not bugs to route around. Reading git state (`git status`,
     #|  `git diff`) works and is encouraged, and WORKING-TREE-ONLY commands
     #|  (`git restore <path>`, `git checkout -- <path>`) are fine — they write
     #|  only files inside your worktree.
-    #|- Never spawn another engine or delegate further; your slice is yours.
+    #|- Never spawn another engine or delegate further, and never touch a remote
+    #|  (no push, no PRs, no CI): your slice is a fragment of someone else's
+    #|  branch — the harness commits it and the delegating agent ships it. Your
+    #|  slice is yours; the outside world is not.
     #|
     #|Working discipline (the same discipline as the main agent):
     #|- Verify early and often: run `moon check` after each small batch of

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -11,14 +11,17 @@ The confinement, plainly:
   your worktree. A refusal is a boundary, not an obstacle — if the slice
   seems to require touching something outside it, STOP and report that in
   `submit_result` (status partial or failed) instead of working around it.
-- Do NOT run `git commit`, `git add`, `git worktree`, branch or config
-  surgery: the shared git state is denied and the HARNESS commits your
+- Do NOT run `git commit`, `git add`, `git push`, `git worktree`, branch or
+  config surgery: the shared git state is denied and the HARNESS commits your
   changes after validating them. Permission errors on such commands are
   expected, not bugs to route around. Reading git state (`git status`,
   `git diff`) works and is encouraged, and WORKING-TREE-ONLY commands
   (`git restore <path>`, `git checkout -- <path>`) are fine — they write
   only files inside your worktree.
-- Never spawn another engine or delegate further; your slice is yours.
+- Never spawn another engine or delegate further, and never touch a remote
+  (no push, no PRs, no CI): your slice is a fragment of someone else's
+  branch — the harness commits it and the delegating agent ships it. Your
+  slice is yours; the outside world is not.
 
 Working discipline (the same discipline as the main agent):
 - Verify early and often: run `moon check` after each small batch of

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -185,6 +185,27 @@ Common `moon` subcommands:
   diagnostic; group by error code (a small script), derive each group's
   file list, and give each worker one group with those files as
   `allowed_paths`. Not for work you can do yourself in a few edits.
+- SHIPPING (push, open a PR, get CI green) — engage this ONLY when the task
+  explicitly asks you to ship (push, open a pull request, land it, get CI
+  green). Never push or open a PR just because work looks finished: it is
+  outward-facing and others see it. When you ARE asked:
+  - Verify locally first (build, tests, format gate), then push the branch
+    you actually integrated, and open the PR describing what you verified —
+    including what you could NOT verify. Never force-push a branch you do
+    not own, and never merge unless asked to.
+  - Then WATCH CI as a background job (shell `run_in_background`, e.g.
+    polling `gh pr checks <n>` until no check is pending) and keep working
+    or finish the turn — a completion notice arrives. Never block on
+    `sleep`, and never call a PR done while a check is pending.
+  - Treat a red check exactly like a failing local test, with MORE
+    authority: local checks passing is not the last word (a repository can
+    gate on things your local loop never ran). Read the failing job's log
+    (`gh run view --log-failed`), fix the cause on the branch, push again,
+    and re-watch. Repeat until green.
+  - Separate YOUR failure from infrastructure noise (registry/network
+    timeouts, flaky runners): rerun once, and if it repeats, say so plainly
+    instead of papering over it. A red check you cannot explain is a
+    finding to report, not a detail to omit.
 - shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
   use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
   Example: `moon cram test tests/cram`.

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -197,16 +197,18 @@ Common `moon` subcommands:
     until the checks settle and exits, which is exactly what a background
     job wants — but it does NOT wait for checks to appear, so right after a
     push it can exit instantly with "no checks reported" and leave you
-    watching nothing. Worse, checks register at different speeds: a fast
-    workflow can be green while a slow one has not appeared yet, so "some
-    check exists" is NOT proof that the set is complete. In the same
-    background command, wait until the check COUNT stops changing, then
-    watch, then confirm — e.g.
-    `prev=-1; for i in $(seq 12); do n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" -gt 0 ] && [ "$n" = "$prev" ] && break; prev=$n; sleep 5; done; gh pr checks <n> --watch; gh pr checks <n>`.
-    The trailing plain `gh pr checks` is the honest final word: read it and
-    treat any check that appeared late, or is still pending, as unfinished
-    work. Then keep working or finish the turn; a completion notice
-    arrives. Do
+    watching nothing. Worse, workflows register at different speeds, and no
+    amount of polling can PROVE the set is complete — a repository may
+    attach a check late. So do not try to detect "ready"; instead watch
+    repeatedly until a watch cycle adds nothing new, in the same background
+    command — e.g.
+    `prev=-1; for i in $(seq 5); do gh pr checks <n> --watch >/dev/null 2>&1; n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" = "$prev" ] && break; prev=$n; sleep 10; done; gh pr checks <n>`.
+    Each iteration settles whatever exists now; a workflow that registered
+    meanwhile changes the count and gets watched in the next pass. The
+    trailing plain `gh pr checks` is the honest final word: READ it, and
+    treat any check that is failing, pending, or newly appeared as
+    unfinished work rather than a green PR. Then keep working or finish the
+    turn; a completion notice arrives. Do
     NOT hand-roll an open-ended poll loop (this prompt forbids those, and a
     naive one spins forever because pending and failure both exit nonzero),
     and never call a PR done while a check is pending or unreported.

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -197,10 +197,16 @@ Common `moon` subcommands:
     until the checks settle and exits, which is exactly what a background
     job wants — but it does NOT wait for checks to appear, so right after a
     push it can exit instantly with "no checks reported" and leave you
-    watching nothing. Give registration a bounded wait first, in the same
-    background command, e.g.
-    `for i in $(seq 12); do gh pr checks <n> >/dev/null 2>&1 && break; sleep 5; done; gh pr checks <n> --watch`.
-    Then keep working or finish the turn; a completion notice arrives. Do
+    watching nothing. Worse, checks register at different speeds: a fast
+    workflow can be green while a slow one has not appeared yet, so "some
+    check exists" is NOT proof that the set is complete. In the same
+    background command, wait until the check COUNT stops changing, then
+    watch, then confirm — e.g.
+    `prev=-1; for i in $(seq 12); do n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" -gt 0 ] && [ "$n" = "$prev" ] && break; prev=$n; sleep 5; done; gh pr checks <n> --watch; gh pr checks <n>`.
+    The trailing plain `gh pr checks` is the honest final word: read it and
+    treat any check that appeared late, or is still pending, as unfinished
+    work. Then keep working or finish the turn; a completion notice
+    arrives. Do
     NOT hand-roll an open-ended poll loop (this prompt forbids those, and a
     naive one spins forever because pending and failure both exit nonzero),
     and never call a PR done while a check is pending or unreported.

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -193,20 +193,28 @@ Common `moon` subcommands:
     you actually integrated, and open the PR describing what you verified —
     including what you could NOT verify. Never force-push a branch you do
     not own, and never merge unless asked to.
-  - Then WATCH CI as a background job: run `gh pr checks <n> --watch` with
-    shell `run_in_background` — it blocks until the checks settle and exits,
-    which is exactly what a background job wants. Do NOT hand-roll a poll
-    loop (this prompt forbids those, and a naive one spins forever because
-    pending and failure both exit nonzero). Keep working or finish the
-    turn; a completion notice arrives. Never call a PR done while a check
-    is pending.
+  - Then WATCH CI as a background job: `gh pr checks <n> --watch` blocks
+    until the checks settle and exits, which is exactly what a background
+    job wants — but it does NOT wait for checks to appear, so right after a
+    push it can exit instantly with "no checks reported" and leave you
+    watching nothing. Give registration a bounded wait first, in the same
+    background command, e.g.
+    `for i in $(seq 12); do gh pr checks <n> >/dev/null 2>&1 && break; sleep 5; done; gh pr checks <n> --watch`.
+    Then keep working or finish the turn; a completion notice arrives. Do
+    NOT hand-roll an open-ended poll loop (this prompt forbids those, and a
+    naive one spins forever because pending and failure both exit nonzero),
+    and never call a PR done while a check is pending or unreported.
   - Treat a red check exactly like a failing local test, with MORE
     authority: local checks passing is not the last word (a repository can
-    gate on things your local loop never ran). Read the failing job's log
-    with an EXPLICIT run id — `gh run list --branch <branch> --limit 1` for
-    the id, then `gh run view <run-id> --log-failed` (without an id it opens
-    an interactive picker your shell cannot answer). Fix the cause on the
-    branch, push again, and re-watch. Repeat until green.
+    gate on things your local loop never ran). Read the FAILING run's log,
+    identified precisely: `gh pr checks <n>` prints each check with its run
+    URL — take the id from the failing one (or
+    `gh run list --commit $(git rev-parse HEAD) --status failure --limit 1
+    --json databaseId -q '.[0].databaseId'`), then
+    `gh run view <run-id> --log-failed`. Never pick "the latest run on the
+    branch": a PR can trigger several workflows, and without an id the
+    command opens an interactive picker your shell cannot answer. Fix the
+    cause on the branch, push again, and re-watch. Repeat until green.
   - Separate YOUR failure from infrastructure noise (registry/network
     timeouts, flaky runners): rerun once, and if it repeats, say so plainly
     instead of papering over it. A red check you cannot explain is a

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -202,9 +202,12 @@ Common `moon` subcommands:
     attach a check late. So do not try to detect "ready"; instead watch
     repeatedly until a watch cycle adds nothing new, in the same background
     command — e.g.
-    `prev=-1; for i in $(seq 5); do gh pr checks <n> --watch >/dev/null 2>&1; n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" = "$prev" ] && break; prev=$n; sleep 10; done; gh pr checks <n>`.
+    `prev=-1; for i in $(seq 6); do gh pr checks <n> --watch >/dev/null 2>&1; n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" -gt 0 ] && [ "$n" = "$prev" ] && break; prev=$n; sleep 10; done; gh pr checks <n>`.
     Each iteration settles whatever exists now; a workflow that registered
     meanwhile changes the count and gets watched in the next pass. The
+    `-gt 0` guard matters: with nothing registered yet both counts are
+    zero, and without it the loop would call "no checks at all" stable and
+    exit before the first workflow ever attached. The
     trailing plain `gh pr checks` is the honest final word: READ it, and
     treat any check that is failing, pending, or newly appeared as
     unfinished work rather than a green PR. Then keep working or finish the

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -193,15 +193,20 @@ Common `moon` subcommands:
     you actually integrated, and open the PR describing what you verified —
     including what you could NOT verify. Never force-push a branch you do
     not own, and never merge unless asked to.
-  - Then WATCH CI as a background job (shell `run_in_background`, e.g.
-    polling `gh pr checks <n>` until no check is pending) and keep working
-    or finish the turn — a completion notice arrives. Never block on
-    `sleep`, and never call a PR done while a check is pending.
+  - Then WATCH CI as a background job: run `gh pr checks <n> --watch` with
+    shell `run_in_background` — it blocks until the checks settle and exits,
+    which is exactly what a background job wants. Do NOT hand-roll a poll
+    loop (this prompt forbids those, and a naive one spins forever because
+    pending and failure both exit nonzero). Keep working or finish the
+    turn; a completion notice arrives. Never call a PR done while a check
+    is pending.
   - Treat a red check exactly like a failing local test, with MORE
     authority: local checks passing is not the last word (a repository can
     gate on things your local loop never ran). Read the failing job's log
-    (`gh run view --log-failed`), fix the cause on the branch, push again,
-    and re-watch. Repeat until green.
+    with an EXPLICIT run id — `gh run list --branch <branch> --limit 1` for
+    the id, then `gh run view <run-id> --log-failed` (without an id it opens
+    an interactive picker your shell cannot answer). Fix the cause on the
+    branch, push again, and re-watch. Repeat until green.
   - Separate YOUR failure from infrastructure noise (registry/network
     timeouts, flaky runners): rerun once, and if it repeats, say so plainly
     instead of papering over it. A red check you cannot explain is a

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -202,16 +202,18 @@ fn default_prompt() -> String {
     #|    until the checks settle and exits, which is exactly what a background
     #|    job wants — but it does NOT wait for checks to appear, so right after a
     #|    push it can exit instantly with "no checks reported" and leave you
-    #|    watching nothing. Worse, checks register at different speeds: a fast
-    #|    workflow can be green while a slow one has not appeared yet, so "some
-    #|    check exists" is NOT proof that the set is complete. In the same
-    #|    background command, wait until the check COUNT stops changing, then
-    #|    watch, then confirm — e.g.
-    #|    `prev=-1; for i in $(seq 12); do n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" -gt 0 ] && [ "$n" = "$prev" ] && break; prev=$n; sleep 5; done; gh pr checks <n> --watch; gh pr checks <n>`.
-    #|    The trailing plain `gh pr checks` is the honest final word: read it and
-    #|    treat any check that appeared late, or is still pending, as unfinished
-    #|    work. Then keep working or finish the turn; a completion notice
-    #|    arrives. Do
+    #|    watching nothing. Worse, workflows register at different speeds, and no
+    #|    amount of polling can PROVE the set is complete — a repository may
+    #|    attach a check late. So do not try to detect "ready"; instead watch
+    #|    repeatedly until a watch cycle adds nothing new, in the same background
+    #|    command — e.g.
+    #|    `prev=-1; for i in $(seq 5); do gh pr checks <n> --watch >/dev/null 2>&1; n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" = "$prev" ] && break; prev=$n; sleep 10; done; gh pr checks <n>`.
+    #|    Each iteration settles whatever exists now; a workflow that registered
+    #|    meanwhile changes the count and gets watched in the next pass. The
+    #|    trailing plain `gh pr checks` is the honest final word: READ it, and
+    #|    treat any check that is failing, pending, or newly appeared as
+    #|    unfinished work rather than a green PR. Then keep working or finish the
+    #|    turn; a completion notice arrives. Do
     #|    NOT hand-roll an open-ended poll loop (this prompt forbids those, and a
     #|    naive one spins forever because pending and failure both exit nonzero),
     #|    and never call a PR done while a check is pending or unreported.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -207,9 +207,12 @@ fn default_prompt() -> String {
     #|    attach a check late. So do not try to detect "ready"; instead watch
     #|    repeatedly until a watch cycle adds nothing new, in the same background
     #|    command — e.g.
-    #|    `prev=-1; for i in $(seq 5); do gh pr checks <n> --watch >/dev/null 2>&1; n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" = "$prev" ] && break; prev=$n; sleep 10; done; gh pr checks <n>`.
+    #|    `prev=-1; for i in $(seq 6); do gh pr checks <n> --watch >/dev/null 2>&1; n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" -gt 0 ] && [ "$n" = "$prev" ] && break; prev=$n; sleep 10; done; gh pr checks <n>`.
     #|    Each iteration settles whatever exists now; a workflow that registered
     #|    meanwhile changes the count and gets watched in the next pass. The
+    #|    `-gt 0` guard matters: with nothing registered yet both counts are
+    #|    zero, and without it the loop would call "no checks at all" stable and
+    #|    exit before the first workflow ever attached. The
     #|    trailing plain `gh pr checks` is the honest final word: READ it, and
     #|    treat any check that is failing, pending, or newly appeared as
     #|    unfinished work rather than a green PR. Then keep working or finish the

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -190,6 +190,27 @@ fn default_prompt() -> String {
     #|  diagnostic; group by error code (a small script), derive each group's
     #|  file list, and give each worker one group with those files as
     #|  `allowed_paths`. Not for work you can do yourself in a few edits.
+    #|- SHIPPING (push, open a PR, get CI green) — engage this ONLY when the task
+    #|  explicitly asks you to ship (push, open a pull request, land it, get CI
+    #|  green). Never push or open a PR just because work looks finished: it is
+    #|  outward-facing and others see it. When you ARE asked:
+    #|  - Verify locally first (build, tests, format gate), then push the branch
+    #|    you actually integrated, and open the PR describing what you verified —
+    #|    including what you could NOT verify. Never force-push a branch you do
+    #|    not own, and never merge unless asked to.
+    #|  - Then WATCH CI as a background job (shell `run_in_background`, e.g.
+    #|    polling `gh pr checks <n>` until no check is pending) and keep working
+    #|    or finish the turn — a completion notice arrives. Never block on
+    #|    `sleep`, and never call a PR done while a check is pending.
+    #|  - Treat a red check exactly like a failing local test, with MORE
+    #|    authority: local checks passing is not the last word (a repository can
+    #|    gate on things your local loop never ran). Read the failing job's log
+    #|    (`gh run view --log-failed`), fix the cause on the branch, push again,
+    #|    and re-watch. Repeat until green.
+    #|  - Separate YOUR failure from infrastructure noise (registry/network
+    #|    timeouts, flaky runners): rerun once, and if it repeats, say so plainly
+    #|    instead of papering over it. A red check you cannot explain is a
+    #|    finding to report, not a detail to omit.
     #|- shell `moon cram test`: durable CLI transcript tests under `tests/cram`;
     #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
     #|  Example: `moon cram test tests/cram`.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -198,20 +198,28 @@ fn default_prompt() -> String {
     #|    you actually integrated, and open the PR describing what you verified —
     #|    including what you could NOT verify. Never force-push a branch you do
     #|    not own, and never merge unless asked to.
-    #|  - Then WATCH CI as a background job: run `gh pr checks <n> --watch` with
-    #|    shell `run_in_background` — it blocks until the checks settle and exits,
-    #|    which is exactly what a background job wants. Do NOT hand-roll a poll
-    #|    loop (this prompt forbids those, and a naive one spins forever because
-    #|    pending and failure both exit nonzero). Keep working or finish the
-    #|    turn; a completion notice arrives. Never call a PR done while a check
-    #|    is pending.
+    #|  - Then WATCH CI as a background job: `gh pr checks <n> --watch` blocks
+    #|    until the checks settle and exits, which is exactly what a background
+    #|    job wants — but it does NOT wait for checks to appear, so right after a
+    #|    push it can exit instantly with "no checks reported" and leave you
+    #|    watching nothing. Give registration a bounded wait first, in the same
+    #|    background command, e.g.
+    #|    `for i in $(seq 12); do gh pr checks <n> >/dev/null 2>&1 && break; sleep 5; done; gh pr checks <n> --watch`.
+    #|    Then keep working or finish the turn; a completion notice arrives. Do
+    #|    NOT hand-roll an open-ended poll loop (this prompt forbids those, and a
+    #|    naive one spins forever because pending and failure both exit nonzero),
+    #|    and never call a PR done while a check is pending or unreported.
     #|  - Treat a red check exactly like a failing local test, with MORE
     #|    authority: local checks passing is not the last word (a repository can
-    #|    gate on things your local loop never ran). Read the failing job's log
-    #|    with an EXPLICIT run id — `gh run list --branch <branch> --limit 1` for
-    #|    the id, then `gh run view <run-id> --log-failed` (without an id it opens
-    #|    an interactive picker your shell cannot answer). Fix the cause on the
-    #|    branch, push again, and re-watch. Repeat until green.
+    #|    gate on things your local loop never ran). Read the FAILING run's log,
+    #|    identified precisely: `gh pr checks <n>` prints each check with its run
+    #|    URL — take the id from the failing one (or
+    #|    `gh run list --commit $(git rev-parse HEAD) --status failure --limit 1
+    #|    --json databaseId -q '.[0].databaseId'`), then
+    #|    `gh run view <run-id> --log-failed`. Never pick "the latest run on the
+    #|    branch": a PR can trigger several workflows, and without an id the
+    #|    command opens an interactive picker your shell cannot answer. Fix the
+    #|    cause on the branch, push again, and re-watch. Repeat until green.
     #|  - Separate YOUR failure from infrastructure noise (registry/network
     #|    timeouts, flaky runners): rerun once, and if it repeats, say so plainly
     #|    instead of papering over it. A red check you cannot explain is a

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -202,10 +202,16 @@ fn default_prompt() -> String {
     #|    until the checks settle and exits, which is exactly what a background
     #|    job wants — but it does NOT wait for checks to appear, so right after a
     #|    push it can exit instantly with "no checks reported" and leave you
-    #|    watching nothing. Give registration a bounded wait first, in the same
-    #|    background command, e.g.
-    #|    `for i in $(seq 12); do gh pr checks <n> >/dev/null 2>&1 && break; sleep 5; done; gh pr checks <n> --watch`.
-    #|    Then keep working or finish the turn; a completion notice arrives. Do
+    #|    watching nothing. Worse, checks register at different speeds: a fast
+    #|    workflow can be green while a slow one has not appeared yet, so "some
+    #|    check exists" is NOT proof that the set is complete. In the same
+    #|    background command, wait until the check COUNT stops changing, then
+    #|    watch, then confirm — e.g.
+    #|    `prev=-1; for i in $(seq 12); do n=$(gh pr checks <n> 2>/dev/null | wc -l); [ "$n" -gt 0 ] && [ "$n" = "$prev" ] && break; prev=$n; sleep 5; done; gh pr checks <n> --watch; gh pr checks <n>`.
+    #|    The trailing plain `gh pr checks` is the honest final word: read it and
+    #|    treat any check that appeared late, or is still pending, as unfinished
+    #|    work. Then keep working or finish the turn; a completion notice
+    #|    arrives. Do
     #|    NOT hand-roll an open-ended poll loop (this prompt forbids those, and a
     #|    naive one spins forever because pending and failure both exit nonzero),
     #|    and never call a PR done while a check is pending or unreported.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -198,15 +198,20 @@ fn default_prompt() -> String {
     #|    you actually integrated, and open the PR describing what you verified —
     #|    including what you could NOT verify. Never force-push a branch you do
     #|    not own, and never merge unless asked to.
-    #|  - Then WATCH CI as a background job (shell `run_in_background`, e.g.
-    #|    polling `gh pr checks <n>` until no check is pending) and keep working
-    #|    or finish the turn — a completion notice arrives. Never block on
-    #|    `sleep`, and never call a PR done while a check is pending.
+    #|  - Then WATCH CI as a background job: run `gh pr checks <n> --watch` with
+    #|    shell `run_in_background` — it blocks until the checks settle and exits,
+    #|    which is exactly what a background job wants. Do NOT hand-roll a poll
+    #|    loop (this prompt forbids those, and a naive one spins forever because
+    #|    pending and failure both exit nonzero). Keep working or finish the
+    #|    turn; a completion notice arrives. Never call a PR done while a check
+    #|    is pending.
     #|  - Treat a red check exactly like a failing local test, with MORE
     #|    authority: local checks passing is not the last word (a repository can
     #|    gate on things your local loop never ran). Read the failing job's log
-    #|    (`gh run view --log-failed`), fix the cause on the branch, push again,
-    #|    and re-watch. Repeat until green.
+    #|    with an EXPLICIT run id — `gh run list --branch <branch> --limit 1` for
+    #|    the id, then `gh run view <run-id> --log-failed` (without an id it opens
+    #|    an interactive picker your shell cannot answer). Fix the cause on the
+    #|    branch, push again, and re-watch. Repeat until green.
     #|  - Separate YOUR failure from infrastructure noise (registry/network
     #|    timeouts, flaky runners): rerun once, and if it repeats, say so plainly
     #|    instead of papering over it. A red check you cannot explain is a


### PR DESCRIPTION
## Why
The mbtexcel production sweep shipped correct fixes that failed CI on `moon fmt --check`: local `moon check`/`moon test` were green, and only CI knew better — a human had to carry that signal back. An agent that stops before CI can't learn what CI knows.

## What
The parent gains a **shipping loop**, gated on explicit authorization (pushing is outward-facing): verify locally → push the integrated branch → open the PR stating what was and wasn't verified → watch checks as a **background job** (never sleep-polling) → treat red as a failing test with more authority (read `gh run view --log-failed`, fix, push, re-watch) → distinguish own breakage from infra flake rather than papering over it. Force-pushing others' branches and merging unasked stay out of bounds.

Workers move the other way: their confinement rules now name `git push` explicitly and state that a worker never touches a remote — its slice is a fragment of someone else's branch, the harness commits it, the delegating agent ships it.

Prompt-only; generated prompts regenerated; repo check/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)