### PR TITLE
feat(desktop): add device page link

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2534,6 +2534,30 @@ button.secondary:not(:disabled):hover {
   background: var(--surface-2);
 }
 
+/* A Device page is navigation, so it remains an anchor while matching the
+   secondary controls beside it. The desktop's delegated link handler opens it
+   in the system browser instead of navigating the app frame. */
+a.setting-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--ink);
+  padding: 6px 12px;
+  font-size: 12px;
+  line-height: 1.2;
+  text-decoration: none;
+}
+a.setting-link:hover {
+  background: var(--surface-2);
+}
+a.setting-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* The accent-filled call to action, button.secondary's counterpart:
    Save API key, the self-update controls, modal confirms. As a
    sidebar-button it keeps the sidebar's geometry, only the fill. */
@@ -3419,6 +3443,7 @@ button.danger:not(:disabled):hover {
   }
   button.secondary,
   button.primary:not(.sidebar-button),
+  a.setting-link,
   .portal-menu-item,
   .portal-button-link,
   .modal-actions button {

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1853,7 +1853,17 @@ fn remote_access_rows(
           rows.push(
             setting_row(
               "Device page",
-              [],
+              [
+                // The shared external-link listener keeps the desktop webview
+                // in place and hands this URL to the system browser.
+                @html.a(
+                  class="setting-link",
+                  href=url,
+                  target=Blank,
+                  rel="noopener noreferrer",
+                  [icon(icon_link_external), @html.span("Open")],
+                ),
+              ],
               desc="\{name} — open \{url} in a signed-in browser.",
             ),
           )
@@ -1895,6 +1905,29 @@ fn remote_access_rows(
     rows.push(setting_row("Problem", [], desc=message))
   }
   rows
+}
+
+///|
+#warnings("-alert_unstable")
+test "remote access device page renders an external link" {
+  let model = {
+    ..test_model(),
+    remote_access: Some({
+      server_url: Some("https://relay.example"),
+      connected: true,
+      managed_by_env: false,
+      user_login: Some("octocat"),
+      device_name: Some("My Mac"),
+      device_url: Some("https://relay.example/d/d_abc/"),
+    }),
+  }
+  let rendered = @html.div(remote_access_rows(test_dispatch(), model))
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("href=\"https://relay.example/d/d_abc/\""))
+  assert_true(markup.contains("target=\"_blank\""))
+  assert_true(markup.contains("rel=\"noopener noreferrer\""))
+  assert_true(markup.contains("class=\"setting-link\""))
+  assert_true(markup.contains("<span>Open</span>"))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- add an Open control beside the Remote access Device page row
- route the device URL through the existing safe external-link behavior so the desktop frame stays in place
- style the link as a secondary Settings control with hover, keyboard-focus, and mobile touch states
- cover the rendered URL, target, rel attributes, class, and label

## User impact

Signed-in desktop users can open their registered device page directly from Settings instead of copying the URL from the description.

## Validation

- `moon check desktop/frontend --target js --deny-warn`
- `moon test desktop/frontend --target js --deny-warn` (302 passed)
- `moon build desktop/frontend/desktop --target js --release --deny-warn`
- `moon -C desktop run --target native package/macos` (local arm64 app bundle built successfully)
- `git diff --check`
