### PR TITLE
refactor(desktop): rename the app to SeekMoon

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: OpenSeek-Desktop-linux-x86_64
-          path: desktop/dist/OpenSeek-Desktop-linux-x86_64.AppImage
+          name: SeekMoon-linux-x86_64
+          path: desktop/dist/SeekMoon-linux-x86_64.AppImage
           if-no-files-found: error
 
   desktop-macos:
@@ -131,10 +131,10 @@ jobs:
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: OpenSeek-Desktop-macos-arm64
+          name: SeekMoon-macos-arm64
           path: |
-            desktop/dist/OpenSeek Desktop-macos-arm64.zip
-            desktop/dist/OpenSeek Desktop-macos-arm64.dmg
+            desktop/dist/SeekMoon-macos-arm64.zip
+            desktop/dist/SeekMoon-macos-arm64.dmg
           if-no-files-found: error
 
   desktop-windows:
@@ -224,6 +224,6 @@ jobs:
       - name: Upload Windows app artifact
         uses: actions/upload-artifact@v4
         with:
-          name: OpenSeek-Desktop-windows-x64
-          path: desktop/dist/OpenSeek Desktop-windows-x64.zip
+          name: SeekMoon-windows-x64
+          path: desktop/dist/SeekMoon-windows-x64.zip
           if-no-files-found: error

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,4 +1,4 @@
-# OpenSeek Desktop
+# SeekMoon
 
 A [Lepus](https://github.com/moonbit-community/lepus) + [Rabbita](https://mooncakes.io/docs/moonbit-community/rabbita) desktop client for the OpenSeek agent, written in MoonBit.
 
@@ -221,7 +221,7 @@ bundle — for example, on macOS:
 
 ```sh
 moon run --target native package/macos
-open "dist/OpenSeek Desktop.app"
+open "dist/SeekMoon.app"
 ```
 
 (Use `package/linux` for the AppImage or `package/windows` for the Windows
@@ -243,13 +243,13 @@ moon -C desktop run --target native package/windows
 
 It builds the Lepus codegen tool if needed, installs WebView2 SDK headers if
 needed, builds the frontend and native host, builds the `openseek` engine from
-the monorepo root, writes `dist/windows-x64/OpenSeek Desktop/`, and creates
-`dist/OpenSeek Desktop-windows-x64.zip`.
+the monorepo root, writes `dist/windows-x64/SeekMoon/`, and creates
+`dist/SeekMoon-windows-x64.zip`.
 
 Without additional arguments, the command builds every output: the
-`dist/windows-x64/OpenSeek Desktop/` bundle directory, the
-`dist/OpenSeek Desktop-windows-x64.zip` portable zip, and the
-`dist/OpenSeek-Desktop-Setup.exe` NSIS installer.
+`dist/windows-x64/SeekMoon/` bundle directory, the
+`dist/SeekMoon-windows-x64.zip` portable zip, and the
+`dist/SeekMoon-Setup.exe` NSIS installer.
 
 Use repeatable `--target` options to select `app`, `zip`, or `installer`.
 The app bundle is always built; selecting `app` alone skips both distribution
@@ -260,14 +260,14 @@ moon -C desktop run --target native package/windows -- --target zip
 ```
 
 This still builds the bundle directory and portable zip, but does not require
-NSIS and does not create `dist/OpenSeek-Desktop-Setup.exe`.
+NSIS and does not create `dist/SeekMoon-Setup.exe`.
 
 To build the per-user NSIS installer, install NSIS so `makensis.exe` is on
 `PATH`, or extract portable NSIS to
 `desktop/dist/tools/nsis-3.12/makensis.exe`.
 
 The installer installs under
-`%LOCALAPPDATA%\Programs\OpenSeek Desktop`, creates Start Menu shortcuts,
+`%LOCALAPPDATA%\Programs\SeekMoon`, creates Start Menu shortcuts,
 offers optional desktop-shortcut and launch-after-install checkboxes, and
 registers an HKCU uninstall entry, so it does not require administrator
 privileges.
@@ -331,7 +331,7 @@ cd desktop
 For a runnable development bundle, place these files together:
 
 ```text
-dist/windows-x64/OpenSeek Desktop/
+dist/windows-x64/SeekMoon/
   openseek-desktop.exe
   openseek.exe
   assets/index.html
@@ -355,7 +355,7 @@ The target machine also needs Microsoft WebView2 Runtime installed.
 
 `package/macos` runs all of the above (including the codegen bootstrap),
 builds the `openseek` engine from the monorepo's `cmd/openseek` source, and
-produces `dist/OpenSeek Desktop.app` by default:
+produces `dist/SeekMoon.app` by default:
 
 ```sh
 moon run --target native package/macos
@@ -377,10 +377,10 @@ moon run --target native package/macos -- --target dmg
 moon run --target native package/macos -- --target zip
 ```
 
-- `dist/OpenSeek Desktop-macos-arm64.dmg` is for first-time installation. It
+- `dist/SeekMoon-macos-arm64.dmg` is for first-time installation. It
   contains the app and an `/Applications` shortcut so users can install by
   dragging the app into Applications.
-- `dist/OpenSeek Desktop-macos-arm64.zip` carries the same app for in-app
+- `dist/SeekMoon-macos-arm64.zip` carries the same app for in-app
   updates.
 
 `--target` is repeatable. The `dmg` and `zip` targets always include the app
@@ -424,7 +424,7 @@ for distribution.
 
 `package/linux` runs the same build steps (including the codegen
 bootstrap), builds the `openseek` engine from the monorepo's `cmd/openseek`
-source, and produces `dist/OpenSeek-Desktop-linux-x86_64.AppImage`:
+source, and produces `dist/SeekMoon-linux-x86_64.AppImage`:
 
 ```sh
 moon run --target native package/linux

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -11295,7 +11295,7 @@ test "an unavailable startup update reports why without offering Update" {
     result=CheckFound(
       version="0.2.0",
       installable=false,
-      unavailable_reason=Some("Move OpenSeek Desktop.app to Applications."),
+      unavailable_reason=Some("Move SeekMoon.app to Applications."),
     ),
     explicit=false,
   )
@@ -11308,7 +11308,7 @@ test "an unavailable startup update reports why without offering Update" {
     assert_eq(result.notifications.length(), 1)
     inspect(
       result.notifications[0].message,
-      content="Move OpenSeek Desktop.app to Applications.",
+      content="Move SeekMoon.app to Applications.",
     )
     assert_eq(result.notification_seq, 1)
   }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -122,7 +122,7 @@ fn conversation_title(conv : Conversation) -> String {
   }
   let task = conv.task.trim().to_owned()
   if task.is_empty() {
-    "OpenSeek Desktop"
+    "SeekMoon"
   } else {
     task
   }
@@ -247,7 +247,7 @@ fn console_session_rows(
       if console.roster.is_empty() {
         rows.push(
           dim_row(
-            "No devices yet — open OpenSeek Desktop and sign in under Settings → Remote access.",
+            "No devices yet — open SeekMoon and sign in under Settings → Remote access.",
           ),
         )
       }

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -10,7 +10,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
     />
-    <title>OpenSeek Desktop</title>
+    <title>SeekMoon</title>
     <!-- The embedded code viewer's styles, assembled from the editor dependency
          by the packager (see build_viewer_stylesheet). -->
     <link rel="stylesheet" href="viewer.css" />

--- a/desktop/installer/openseek-desktop.nsi
+++ b/desktop/installer/openseek-desktop.nsi
@@ -9,23 +9,23 @@ SetOverwrite on
 !endif
 
 !ifndef SOURCE_DIR
-!define SOURCE_DIR "dist\windows-x64\OpenSeek Desktop"
+!define SOURCE_DIR "dist\windows-x64\SeekMoon"
 !endif
 
 !ifndef OUTPUT_DIR
 !define OUTPUT_DIR "dist"
 !endif
 
-!define APP_NAME "OpenSeek Desktop"
+!define APP_NAME "SeekMoon"
 !define APP_PUBLISHER "OpenSeek"
 !define APP_EXE "openseek-desktop.exe"
-!define APP_UNINSTALL_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenSeek Desktop"
+!define APP_UNINSTALL_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\SeekMoon"
 
 !include "MUI2.nsh"
 
 Name "${APP_NAME}"
-OutFile "${OUTPUT_DIR}\OpenSeek-Desktop-Setup.exe"
-InstallDir "$LOCALAPPDATA\Programs\OpenSeek Desktop"
+OutFile "${OUTPUT_DIR}\SeekMoon-Setup.exe"
+InstallDir "$LOCALAPPDATA\Programs\SeekMoon"
 BrandingText "${APP_NAME}"
 
 VIProductVersion "${APP_VERSION}.0"
@@ -50,7 +50,7 @@ VIAddVersionKey "LegalCopyright" "${APP_PUBLISHER}"
 
 !insertmacro MUI_LANGUAGE "English"
 
-Section "OpenSeek Desktop" SecInstall
+Section "SeekMoon" SecInstall
   SetShellVarContext current
   SetOutPath "$INSTDIR"
   SectionIn RO
@@ -63,8 +63,8 @@ Section "OpenSeek Desktop" SecInstall
   WriteUninstaller "$INSTDIR\Uninstall.exe"
 
   CreateDirectory "$SMPROGRAMS\OpenSeek"
-  CreateShortcut "$SMPROGRAMS\OpenSeek\OpenSeek Desktop.lnk" "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
-  CreateShortcut "$SMPROGRAMS\OpenSeek\Uninstall OpenSeek Desktop.lnk" "$INSTDIR\Uninstall.exe"
+  CreateShortcut "$SMPROGRAMS\OpenSeek\SeekMoon.lnk" "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
+  CreateShortcut "$SMPROGRAMS\OpenSeek\Uninstall SeekMoon.lnk" "$INSTDIR\Uninstall.exe"
 
   WriteRegStr HKCU "${APP_UNINSTALL_KEY}" "DisplayName" "${APP_NAME}"
   WriteRegStr HKCU "${APP_UNINSTALL_KEY}" "DisplayVersion" "${APP_VERSION}"
@@ -78,15 +78,15 @@ SectionEnd
 
 Section /o "Desktop Shortcut" SecDesktopShortcut
   SetShellVarContext current
-  CreateShortcut "$DESKTOP\OpenSeek Desktop.lnk" "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
+  CreateShortcut "$DESKTOP\SeekMoon.lnk" "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
 SectionEnd
 
 Section "Uninstall"
   SetShellVarContext current
 
-  Delete "$DESKTOP\OpenSeek Desktop.lnk"
-  Delete "$SMPROGRAMS\OpenSeek\OpenSeek Desktop.lnk"
-  Delete "$SMPROGRAMS\OpenSeek\Uninstall OpenSeek Desktop.lnk"
+  Delete "$DESKTOP\SeekMoon.lnk"
+  Delete "$SMPROGRAMS\OpenSeek\SeekMoon.lnk"
+  Delete "$SMPROGRAMS\OpenSeek\Uninstall SeekMoon.lnk"
   RMDir "$SMPROGRAMS\OpenSeek"
 
   DeleteRegKey HKCU "${APP_UNINSTALL_KEY}"

--- a/desktop/internal/host/runtime.mbt
+++ b/desktop/internal/host/runtime.mbt
@@ -4,7 +4,7 @@
 /// signed bundle is read-only by convention (and may be mounted read-only under
 /// app translocation), and writing next to the binary also breaks when a
 /// repackage replaces the bundle under a running instance. Uses
-/// `~/Library/Application Support/OpenSeek Desktop` where that layout exists
+/// `~/Library/Application Support/SeekMoon` where that layout exists
 /// (macOS) and `~/.openseek-desktop` elsewhere.
 async fn app_runtime_dir() -> String? {
   guard @home.dir() is Some(home) else { return None }
@@ -14,7 +14,7 @@ async fn app_runtime_dir() -> String? {
     _ => false
   }
   let dir = if app_support_exists {
-    app_support.join("OpenSeek Desktop")
+    app_support.join("SeekMoon")
   } else {
     home_path.join(".openseek-desktop")
   }

--- a/desktop/internal/update/apply_wbtest.mbt
+++ b/desktop/internal/update/apply_wbtest.mbt
@@ -7,7 +7,7 @@ async test "bundle replacement checks the containing directory" {
       @fs.chmod(root, 0o700)
       @fs.rmdir(root, recursive=true)
     })
-    let bundle = "\{root}/OpenSeek Desktop.app"
+    let bundle = "\{root}/SeekMoon.app"
     @fs.mkdir(bundle)
     @debug.assert_eq(bundle_replacement_failure(bundle), None)
     @fs.chmod(root, 0o500)
@@ -27,7 +27,7 @@ async test "an unavailable destination stops apply before any mutation" {
       @fs.chmod(root, 0o700)
       @fs.rmdir(root, recursive=true)
     })
-    let bundle = "\{root}/OpenSeek Desktop.app"
+    let bundle = "\{root}/SeekMoon.app"
     let staged = "\{root}/Staged.app"
     let aside = aside_path(bundle)
     @fs.mkdir(bundle)

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -117,7 +117,7 @@ pub async fn check_for_update(
 ///|
 /// The actionable explanation shared by the capability check and the final
 /// apply-time check when the running bundle's directory cannot be changed.
-const BundleReplacementFailureMessage : String = "OpenSeek cannot replace the app in its current location. Move OpenSeek Desktop.app to Applications, reopen it, and try again."
+const BundleReplacementFailureMessage : String = "OpenSeek cannot replace the app in its current location. Move SeekMoon.app to Applications, reopen it, and try again."
 
 ///|
 /// Why `bundle_path` cannot be renamed within its current directory. Rename

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -51,12 +51,7 @@ fn main {
     // requests at all (a proton:// page's http fetches stall inside CEF's
     // network service). Remote browsers use the same method catalog over the
     // relay WebSocket instead (docs/remote-protocol.md).
-    let app = @proton.asset(
-        "OpenSeek Desktop",
-        frontend_entry,
-        width=1120,
-        height=760,
-      )
+    let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760)
       .debug_level(1)
       .extension(@extension.openseek_extension(state, bridge))
       // System notifications are an ordinary generated extension now: the

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -23,7 +23,7 @@ readme = "README.md"
 
 license = "Apache-2.0"
 
-description = "OpenSeek Desktop — a Proton + Rabbita desktop client for the OpenSeek agent."
+description = "SeekMoon — a Proton + Rabbita desktop client for the OpenSeek agent."
 
 options(
   "--moonbit-unstable-prebuild": "native_link_config.mjs",

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -386,7 +386,7 @@ pub fn absolute_path(path : String) -> String {
 }
 
 ///|
-const CmakeUnavailableMessage : String = "CMake is required to package OpenSeek Desktop, but `cmake --version` could not be run. Install CMake and ensure `cmake` is on PATH, then rerun the package command. On macOS with Homebrew, run `brew install cmake`."
+const CmakeUnavailableMessage : String = "CMake is required to package SeekMoon, but `cmake --version` could not be run. Install CMake and ensure `cmake` is on PATH, then rerun the package command. On macOS with Homebrew, run `brew install cmake`."
 
 ///|
 /// Verify CMake can be launched before a packager performs any build or
@@ -762,13 +762,16 @@ test "workspace derives absolute paths from an absolute root" {
 }
 
 ///|
+// The bundle names carry no spaces, but a checkout path still can, so the
+// space this pins is in the workspace root.
 test "workspace path join preserves spaces and nested segments" {
-  let ws : Workspace = { root: "/w", invoked_from_repo_root: false }
+  let ws : Workspace = {
+    root: "/My Checkouts/w",
+    invoked_from_repo_root: false,
+  }
   assert_eq(
-    ws.at(
-      "dist/OpenSeek Desktop.app/Contents/Resources/toolchains/moonbit/macos-arm64",
-    ),
-    "/w/dist/OpenSeek Desktop.app/Contents/Resources/toolchains/moonbit/macos-arm64",
+    ws.at("dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64"),
+    "/My Checkouts/w/dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64",
   )
   assert_false(ws.invoked_from_repo_root())
 }

--- a/desktop/package/linux/main.mbt
+++ b/desktop/package/linux/main.mbt
@@ -1,8 +1,8 @@
 ///|
-const AppDirPath : String = "dist/OpenSeek-Desktop.AppDir"
+const AppDirPath : String = "dist/SeekMoon.AppDir"
 
 ///|
-const AppImagePath : String = "dist/OpenSeek-Desktop-linux-x86_64.AppImage"
+const AppImagePath : String = "dist/SeekMoon-linux-x86_64.AppImage"
 
 ///|
 const UsrBinPath : String = AppDirPath + "/usr/bin"
@@ -131,7 +131,7 @@ fn desktop_entry_source() -> String {
   let source =
     #|[Desktop Entry]
     #|Type=Application
-    #|Name=OpenSeek Desktop
+    #|Name=SeekMoon
     #|Exec=openseek-desktop-bin
     #|Icon=openseek-desktop
     #|Categories=Development;

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -1,14 +1,14 @@
 ///|
-const AppPath : String = "dist/OpenSeek Desktop.app"
+const AppPath : String = "dist/SeekMoon.app"
 
 ///|
-const ZipPath : String = "dist/OpenSeek Desktop-macos-arm64.zip"
+const ZipPath : String = "dist/SeekMoon-macos-arm64.zip"
 
 ///|
-const DmgPath : String = "dist/OpenSeek Desktop-macos-arm64.dmg"
+const DmgPath : String = "dist/SeekMoon-macos-arm64.dmg"
 
 ///|
-const DmgStagingPath : String = "dist/OpenSeek Desktop-dmg-root"
+const DmgStagingPath : String = "dist/SeekMoon-dmg-root"
 
 ///|
 const ContentsPath : String = AppPath + "/Contents"
@@ -39,7 +39,7 @@ const ProtonRuntimePath : String = ResourcesPath + "/proton"
 const CefProcessName : String = "cef_process"
 
 ///|
-const HelperExecutableBaseName : String = "OpenSeek Desktop Helper"
+const HelperExecutableBaseName : String = "SeekMoon Helper"
 
 ///|
 const HelperProtonRPath : String = "@loader_path/../../../../Resources/proton/lib"
@@ -67,7 +67,7 @@ const AppBundleIdentifier : String = "community.moonbit.proton.openseek-desktop"
 const HelperBundleIdentifier : String = AppBundleIdentifier + ".helper"
 
 ///|
-const SigningEntitlementsPath : String = "dist/OpenSeek Desktop.entitlements"
+const SigningEntitlementsPath : String = "dist/SeekMoon.entitlements"
 
 ///|
 /// Entitlements for the bundled `moonrun`: it JIT-compiles wasm, so under the
@@ -382,12 +382,12 @@ fn info_plist_source() -> String {
     $|<plist version="1.0">
     $|<dict>
     $|  <key>CFBundleDevelopmentRegion</key><string>en</string>
-    $|  <key>CFBundleDisplayName</key><string>OpenSeek Desktop</string>
+    $|  <key>CFBundleDisplayName</key><string>SeekMoon</string>
     $|  <key>CFBundleExecutable</key><string>openseek-desktop</string>
     $|  <key>CFBundleIconFile</key><string>AppIcon</string>
     $|  <key>CFBundleIdentifier</key><string>\{AppBundleIdentifier}</string>
     $|  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
-    $|  <key>CFBundleName</key><string>OpenSeek Desktop</string>
+    $|  <key>CFBundleName</key><string>SeekMoon</string>
     $|  <key>CFBundlePackageType</key><string>APPL</string>
     $|  <key>CFBundleShortVersionString</key><string>\{@version.AppVersion}</string>
     $|  <key>CFBundleVersion</key><string>\{@version.AppVersion}</string>
@@ -860,7 +860,7 @@ async fn create_dmg(ws : @packaging.Workspace, sign : SignConfig) -> Unit {
   // conventional /Applications shortcut used by drag-to-install DMGs.
   @packaging.run_checked(
     "ditto",
-    [AppPath, DmgStagingPath + "/OpenSeek Desktop.app"],
+    [AppPath, DmgStagingPath + "/SeekMoon.app"],
     dir=ws.dir(),
   )
   @packaging.run_checked(
@@ -873,7 +873,7 @@ async fn create_dmg(ws : @packaging.Workspace, sign : SignConfig) -> Unit {
     [
       "create",
       "-volname",
-      "OpenSeek Desktop",
+      "SeekMoon",
       "-srcfolder",
       DmgStagingPath,
       "-format",
@@ -1004,14 +1004,14 @@ test "macos helper plist describes cef helper app" {
 test "macos renderer helper plist uses cef helper variant name" {
   let helper = cef_helper_variants()[4]
   let plist = helper_info_plist_source(helper)
-  assert_eq(helper.executable_name(), "OpenSeek Desktop Helper (Renderer)")
+  assert_eq(helper.executable_name(), "SeekMoon Helper (Renderer)")
   assert_eq(
     helper.executable_path(),
-    "dist/OpenSeek Desktop.app/Contents/Frameworks/OpenSeek Desktop Helper (Renderer).app/Contents/MacOS/OpenSeek Desktop Helper (Renderer)",
+    "dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Renderer).app/Contents/MacOS/SeekMoon Helper (Renderer)",
   )
   assert_true(
     plist.contains(
-      "<key>CFBundleExecutable</key><string>OpenSeek Desktop Helper (Renderer)</string>",
+      "<key>CFBundleExecutable</key><string>SeekMoon Helper (Renderer)</string>",
     ),
   )
   assert_true(
@@ -1026,7 +1026,7 @@ test "macos base helper path points at chromium helper executable name" {
   let helper = cef_helper_variants()[0]
   assert_eq(
     helper.executable_path(),
-    "dist/OpenSeek Desktop.app/Contents/Frameworks/OpenSeek Desktop Helper.app/Contents/MacOS/OpenSeek Desktop Helper",
+    "dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper.app/Contents/MacOS/SeekMoon Helper",
   )
 }
 

--- a/desktop/package/windows/main.mbt
+++ b/desktop/package/windows/main.mbt
@@ -7,16 +7,16 @@ const WslEngineBinary : String = "_build/wsl_engine/native/release/build/bobzhan
 const BundledWslEngineName : String = "openseek-linux"
 
 ///|
-const BundleDir : String = "dist/windows-x64/OpenSeek Desktop"
+const BundleDir : String = "dist/windows-x64/SeekMoon"
 
 ///|
-const ZipPath : String = "dist/OpenSeek Desktop-windows-x64.zip"
+const ZipPath : String = "dist/SeekMoon-windows-x64.zip"
 
 ///|
 const InstallerScript : String = "installer/openseek-desktop.nsi"
 
 ///|
-const InstallerPath : String = "dist/OpenSeek-Desktop-Setup.exe"
+const InstallerPath : String = "dist/SeekMoon-Setup.exe"
 
 ///|
 const LocalMakensis : String = "dist/tools/nsis-3.12/makensis.exe"

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -30,10 +30,10 @@ fi
 
 # The artifact publishes under the release naming convention: the
 # `<platform>` infix is the manifest `platforms` key clients look
-# themselves up by, and the name must pass the server's URL path guard
-# (no spaces — hence the rename from the dist zip).
-release_name="OpenSeek-Desktop-macos-arm64.zip"
-default_artifact="$desktop_dir/dist/OpenSeek Desktop-macos-arm64.zip"
+# themselves up by. The name has no spaces, so it passes the server's URL
+# path guard and the dist zip uploads under its own basename.
+release_name="SeekMoon-macos-arm64.zip"
+default_artifact="$desktop_dir/dist/$release_name"
 
 case "${1:-}" in
   upload)


### PR DESCRIPTION
Renames the desktop app's product name from `OpenSeek Desktop` to `SeekMoon`.

The old name carried a space, and that space leaked into every artifact path
derived from it — the `.app` bundle, the DMG/ZIP names, the Windows bundle
directory and install dir, the CI `path:` entries, the macOS Application
Support directory. Each one needed quoting, and the release upload path needed
a *second*, hyphenated spelling of the name just to satisfy the server's URL
path guard. `SeekMoon` has no space, so all of that collapses.

## What changed

- **Display name** — window title, `index.html` `<title>`, the empty-task
  fallback label, the remote-access hint, the Linux `.desktop` `Name=`,
  `CFBundleName` / `CFBundleDisplayName`, NSIS `APP_NAME`, `moon.mod`
  description.
- **Artifact paths** — `dist/SeekMoon.app`, `SeekMoon-macos-arm64.{zip,dmg}`,
  `SeekMoon-windows-x64.zip`, `SeekMoon-Setup.exe`,
  `SeekMoon-linux-x86_64.AppImage`, `SeekMoon.AppDir`,
  `dist/windows-x64/SeekMoon/`, `SeekMoon Helper (*)`.
- **Install/runtime locations** — `%LOCALAPPDATA%\Programs\SeekMoon`, the HKCU
  uninstall key, `~/Library/Application Support/SeekMoon`.
- **CI + release** — upload-artifact names and paths; `publish-release.sh` now
  derives `default_artifact` from `release_name` instead of keeping two
  spellings of the same file.

Left alone deliberately: the MoonBit module name `openseek_desktop` and its
package paths, the `openseek-desktop.exe` / `openseek-desktop-bin` executable
names, `openseek-desktop.log`, the `OPENSEEK_DESKTOP_*` environment variables,
the `community.moonbit.proton.openseek-desktop` bundle identifier, and
`~/.openseek-desktop`. Those are code identity rather than the product name,
none of them contain whitespace, and renaming them would be a large mechanical
churn with no payoff for this change.

## Behavioral notes worth a second opinion

1. **macOS state directory moves.** `~/Library/Application Support/OpenSeek
   Desktop` becomes `.../SeekMoon`. Existing installs will start from a fresh
   runtime dir — launch logs, sessions, `auth.json`, and the writable MoonBit
   toolchain copy all live there. No migration is included in this PR; say the
   word if you want one (copy-on-first-launch from the old path).
2. **In-place updates keep the old bundle name.** `apply_staged` moves the
   staged app onto the *running* bundle's path, so a machine running
   `OpenSeek Desktop.app` that auto-updates keeps that filename with SeekMoon
   inside. Only a fresh DMG/installer run produces `SeekMoon.app`.
3. **Release upload path changes.** New versions upload to
   `…/desktop/releases/vX.Y.Z/SeekMoon-macos-arm64.zip`. Already-published
   manifests keep pointing at their existing URLs, so shipped clients are
   unaffected.

## Verification

- `moon check --target native` — clean
- `moon test --target native -p …/package/internal/packaging -p …/package/macos
  -p …/internal/update -p …/internal/host` — 38 passed
- `moon test --target js -p …/frontend` — 302 passed
- `moon fmt`
- `moon run --target native package/macos` — builds `dist/SeekMoon.app`.
  Checked `CFBundleName` / `CFBundleDisplayName` are `SeekMoon`, the five
  renamed CEF helpers are present and signed, and every `CFBundleExecutable`
  resolves. `codesign -v --deep` reports the same unsealed-outer-bundle notice
  as the pre-rename bundle, which is what the app-only target documents. The
  app was not launched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

