### PR TITLE
chore(desktop): upgrade moonbitlang/editor to 0.4.0

### DIFF
--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -416,9 +416,7 @@ test "symbol_item resolves a jump target only when the symbol has a path" {
     range~,
   )
   assert_true(placed.path is Some("src/main.mbt"))
-  assert_true(
-    placed.range is Some(placed_range) && placed_range.equals_range(range),
-  )
+  assert_true(placed.range is Some(placed_range) && placed_range == range)
   // The reference anchors at the range's (one-based) start line.
   assert_eq(placed.detail, "src/main.mbt:5")
   let unplaced = symbol_item("parse_hover", container=None, path="", range~)
@@ -520,8 +518,7 @@ test "decode_symbols parses rows and skips malformed ones" {
   assert_eq(items[0].detail, "Lsp · a/b.mbt:5")
   // The zero-based wire range arrives as one-based viewer coordinates.
   assert_true(
-    items[0].range is Some(range) &&
-    range.equals_range(@common.Range::Range(5, 3, 5, 14)),
+    items[0].range is Some(range) && range == @common.Range::Range(5, 3, 5, 14),
   )
   assert_true(decode_symbols("not json") is None)
 }

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -298,7 +298,7 @@ fn show_file_in_viewer(
         viewer.set_selection(
           @core.Selection::from_positions(
             range.get_start_position(),
-            range.get_end_position(),
+            @common.Position(range.end_line_number, range.end_column),
           ),
         )
       }

--- a/desktop/frontend/fileeditor/feedback/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/feedback/pkg.generated.mbti
@@ -11,12 +11,17 @@ import {
 // Errors
 
 // Types and methods
+pub(all) struct AgentFeedbackAddedEvent {
+  feedback : @agent_feedback_api.AgentFeedback
+  has_existing_feedback_for_file : Bool
+}
+
 type DesktopFeedbackService
 pub fn DesktopFeedbackService::DesktopFeedbackService() -> Self
 pub fn DesktopFeedbackService::add_feedback(Self, @common.Uri, @common.Range, String, kind? : @agent_feedback_api.AgentFeedbackKind, state? : @agent_feedback_api.AgentFeedbackState) -> @agent_feedback_api.AgentFeedback
 pub fn DesktopFeedbackService::agent_feedback_handle(Self) -> @agent_feedback_api.AgentFeedbackHandle
 pub fn DesktopFeedbackService::clear_feedback(Self, @common.Uri) -> Unit
-pub fn DesktopFeedbackService::on_did_add_feedback(Self, (@agent_feedback_api.AgentFeedbackAddedEvent) -> Unit) -> @common.Disposable
+pub fn DesktopFeedbackService::on_did_add_feedback(Self, (AgentFeedbackAddedEvent) -> Unit) -> @common.Disposable
 pub fn DesktopFeedbackService::remove_feedback(Self, @common.Uri, String) -> Unit
 pub fn DesktopFeedbackService::set_feedback_enabled(Self, @common.Uri, Bool) -> Unit
 

--- a/desktop/frontend/fileeditor/feedback/service.mbt
+++ b/desktop/frontend/fileeditor/feedback/service.mbt
@@ -4,6 +4,16 @@
 // snapshots cannot observe later mutations.
 
 ///|
+/// The payload for a newly accepted item. Desktop declares it because the
+/// event is Desktop's own: `agent_feedback_api` exposes only what the Viewer
+/// consumes, and the editor package keeps its equivalent private to the
+/// viewer's feedback contribution.
+pub(all) struct AgentFeedbackAddedEvent {
+  feedback : @agent_feedback_api.AgentFeedback
+  has_existing_feedback_for_file : Bool
+}
+
+///|
 /// The Desktop-owned backing for the public agent-feedback capability consumed
 /// by the Viewer. The Viewer sees only `AgentFeedbackHandle`; Desktop keeps the
 /// concrete store so it can enable comments and turn accepted user feedback
@@ -13,9 +23,7 @@ struct DesktopFeedbackService {
     @agent_feedback_api.AgentFeedbackChangeEvent,
   ]
   did_change_navigation : @common.Emitter[@common.Uri]
-  did_add_feedback : @common.Emitter[
-    @agent_feedback_api.AgentFeedbackAddedEvent,
-  ]
+  did_add_feedback : @common.Emitter[AgentFeedbackAddedEvent]
   items_by_resource : Map[String, Array[@agent_feedback_api.AgentFeedback]]
   navigation_anchor_by_resource : Map[String, String]
   enabled_resources : Map[String, Bool]
@@ -78,7 +86,7 @@ pub fn DesktopFeedbackService::agent_feedback_handle(
 /// Desktop turns the accepted item into a composer chip.
 pub fn DesktopFeedbackService::on_did_add_feedback(
   self : DesktopFeedbackService,
-  listener : (@agent_feedback_api.AgentFeedbackAddedEvent) -> Unit,
+  listener : (AgentFeedbackAddedEvent) -> Unit,
 ) -> @common.Disposable {
   self.did_add_feedback.event(listener)
 }

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -173,17 +173,13 @@ fn hover_range(
     @jsonx.json_int(reply, "start_character") is Some(start_character) &&
     @jsonx.json_int(reply, "end_line") is Some(end_line) &&
     @jsonx.json_int(reply, "end_character") is Some(end_character) else {
-    let origin = snapshot.get_position_at(0)
-    return @common.Range::from_positions(origin, origin)
+    return snapshot.range_of(@common.OffsetRange::empty_at(0))
   }
   // The reply carries 0-based LSP positions; shift to the viewer's 1-based
   // line/column, then round-trip through offsets so the range stays clamped.
   let start = snapshot.get_offset_at(start_line + 1, start_character + 1)
   let end = snapshot.get_offset_at(end_line + 1, end_character + 1)
-  @common.Range::from_positions(
-    snapshot.get_position_at(start),
-    snapshot.get_position_at(end),
-  )
+  snapshot.range_of(@common.OffsetRange(start, end))
 }
 
 ///|

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -15,7 +15,7 @@ import {
   "justjavac/proton_ext@0.1.7",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
-  "moonbitlang/editor@0.2.3",
+  "moonbitlang/editor@0.4.0",
   "justjavac/proton_contract@0.1.0",
 }
 


### PR DESCRIPTION
`moon add moonbitlang/editor --upgrade` takes the dependency from **0.2.3 to
0.4.0**. That is a breaking jump — the tree does not compile on the bump alone.
Four pieces of API the desktop used are gone in 0.4.0:

| Removed | Replacement |
| --- | --- |
| `agent_feedback_api.AgentFeedbackAddedEvent` | desktop declares its own (below) |
| `TextSnapshot::get_position_at` | `snapshot.range_of(OffsetRange)` |
| `Range::get_end_position` | built from `Range`'s `pub(all)` fields |
| `Range::equals_range` | `==` — `Range` now derives `Eq` |

## The feedback event

0.4.0 did not delete `AgentFeedbackAddedEvent`; it made it **private** to
`internal/viewer/contrib/agent_feedback`. `agent_feedback_api` now exposes only
what the Viewer consumes.

That matches what the desktop code already said about its own use of it:

> This host-only event is intentionally separate from `AgentFeedbackHandle`:
> the Viewer consumes the handle while Desktop turns the accepted item into a
> composer chip.

So `DesktopFeedbackService` now declares the two-field payload itself rather
than reaching into the editor's internals. Consumers only ever read
`.feedback`, so nothing downstream changed.

## The other three

`hover_range` used to go offsets → positions → range; `range_of` does exactly
that in one call, and keeps the clamping the comment there describes.
`get_end_position` and `equals_range` are mechanical.

## Packaging CSS list

`packaging.mbt` carries an explicit *"re-sync this list on an editor version
bump"* note on `viewer_css_sources()`. Checked: all twenty stylesheets and the
codicon font still resolve at their existing paths under the 0.4.0 package, and
the stylesheet-assembly test passes. The list is unchanged.

## Verification

- `moon check` clean on `js` and `native`, at the repo root and in `desktop/`
- `moon test --target js` — 738 passed
- `moon test --target native` — 1907 passed

## One note on `moon info`

AGENTS.md asks for `moon info && moon fmt` as a last step. Running `moon info`
here rewrote **122 unrelated `.mbti` files** across the whole repo and dirtied
the `desktop/lepus` submodule — every one of those diffs was a stripped
trailing blank line, i.e. drift between the local toolchain
(`moon 0.1.20260731`) and whatever generated the committed files. Those were
all reverted; this PR carries only the one interface that genuinely changed,
`desktop/frontend/fileeditor/feedback/pkg.generated.mbti`. Worth fixing
separately so `moon info` can be run cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
