### PR TITLE
feat: enable moonbit toolchain fallback

### DIFF
--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1294,27 +1294,22 @@ async fn add_moonbit_path_for_native_engine(
   config : RunConfig,
   runtime_dir : @path.Path?,
 ) -> Unit {
-  let moon_home = @moonbit.prepare_bundled_home(config.engine, runtime_dir?)
-  let moon_bin_dir = moon_home.join("bin")
-  let moon = moon_bin_dir.join("moon")
-  let moon_exe = moon_bin_dir.join("moon.exe")
-  // The agent tools spawn `moon` by name, so prepend the bundled bin to the
-  // path variable (updating `Path` in place on Windows — see
-  // `@env.prepend_path_entry`). Deliberately do not set `MOON_HOME` (it would
-  // redirect registry/cache lookup into the bundled payload) and drop any
-  // ambient `MOON_HOME` the launching shell exported: moon prefers it over
-  // the executable-relative home and would otherwise run the bundled binary
-  // against the user's (possibly missing or incompatible) MoonBit home.
-  let path = @env.prepend_path_entry(env, moon_bin_dir.to_string())
-  env.remove("MOON_HOME")
+  // The agent tools spawn `moon` by name, so prepend the resolved toolchain's
+  // bin to the path variable (updating `Path` in place on Windows — see
+  // `@env.prepend_path_entry`). `MOON_HOME` passes through untouched: moon
+  // finds its compiler assets relative to its own executable, and the
+  // variable's actual cargo — registry credentials and caches — must keep
+  // working (`moon publish`) inside spawned sessions.
+  // An unavailable toolchain fails the spawn: a session whose `moon` would
+  // break in confusing ways downstream is worth less than a clear error
+  // naming the cause now.
+  let toolchain = @moonbit.resolve_toolchain(config.engine, runtime_dir?)
+  toolchain.apply_to_env(env)
   @xlog.debug() <?
     {
       "event": "desktop_engine_moonbit_path",
-      "moon_home": moon_home.to_string(),
-      "moon_bin_dir": moon_bin_dir.to_string(),
-      "moon_exists": @fsx.exists(moon),
-      "moon_exe_exists": @fsx.exists(moon_exe),
-      "path_prefix": first_path_entry(Some(path)),
+      "bin_dir": toolchain.bin_dir.to_string(),
+      "path_prefix": first_path_entry(path_env_value(env)),
     }
 }
 
@@ -2109,8 +2104,8 @@ async fn prepare_fake_moonbit_seed(
   seed : @path.Path,
   version~ : String,
 ) -> Unit {
-  write_fake_file(seed.join("bin/moon"))
-  write_fake_file(seed.join("bin/moonc"))
+  write_fake_executable(seed.join("bin/moon"))
+  write_fake_executable(seed.join("bin/moonc"))
   write_fake_file(seed.join("lib/core/moon.mod"))
   @fs.write_file(
     seed.join(".openseek-moonbit-seed-version").to_string(),
@@ -2142,6 +2137,19 @@ async fn prepare_fake_bundled_moonbit_home(
 async fn write_fake_file(path : @path.Path) -> Unit {
   @fsx.ensure_dir(path.dirname())
   @fs.write_file(path.to_string(), "", create_mode=CreateOrTruncate)
+}
+
+///|
+/// The resolver only assembles a toolchain around a regular executable `moon`,
+/// and initialization executes `moonc`, so both fakes must carry the bit.
+async fn write_fake_executable(path : @path.Path) -> Unit {
+  @fsx.ensure_dir(path.dirname())
+  @fs.write_file(
+    path.to_string(),
+    "",
+    create_mode=CreateOrTruncate,
+    permission=0o755,
+  )
 }
 
 ///|

--- a/desktop/internal/fsx/fsx.mbt
+++ b/desktop/internal/fsx/fsx.mbt
@@ -4,6 +4,27 @@ pub async fn exists(path : @path.Path) -> Bool {
 }
 
 ///|
+/// True when `path` names a regular executable file — the right probe for
+/// "can I spawn this binary". `can_execute` alone is not enough: X_OK on a
+/// directory means searchable, so a directory shadowing a binary's name
+/// would pass it. Sequenced as two statements — async calls joined with
+/// `&&` are evaluated eagerly, and `kind` raises on a missing path. Probe
+/// errors (an ENOTDIR from a file-shaped ancestor, a race with deletion)
+/// mean "not a usable executable" — a probe answers a question, it does not
+/// propagate the filesystem's mood.
+pub async fn is_executable_file(path : @path.Path) -> Bool {
+  try {
+    if !@fs.can_execute(path.to_string()) {
+      return false
+    }
+    @fs.kind(path.to_string()) is Regular
+  } catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => false
+  }
+}
+
+///|
 pub async fn try_read_text(path : @path.Path) -> String? {
   Some(@fs.read_file(path.to_string()).text()) catch {
     error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/fsx/pkg.generated.mbti
+++ b/desktop/internal/fsx/pkg.generated.mbti
@@ -14,6 +14,8 @@ pub async fn exists(@path.Path) -> Bool
 
 pub async fn is_dir(@path.Path) -> Bool
 
+pub async fn is_executable_file(@path.Path) -> Bool
+
 pub async fn read_text(@path.Path) -> String
 
 pub async fn read_text_if_exists(@path.Path) -> String?
@@ -43,4 +45,3 @@ pub fn DirectoryEntry::name(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -34,11 +34,22 @@ const MaxModuleRoots = 6
 const MaxSymbolResults = 50
 
 ///|
-/// One resolved way to launch a toolchain binary: the bundled one with its
-/// complete child environment, or a bare name found on PATH (`env` absent).
+/// One resolved way to launch the selected toolchain's `moon` binary with its
+/// complete child environment.
 priv struct ToolSpawnConfig {
   command : String
   env : Map[String, String]?
+}
+
+///|
+/// Cached outcome of the one-shot toolchain resolution. `ToolUnavailable` is
+/// a diagnosed terminal state — the reason was already logged — so later
+/// language requests answer empty instead of retrying or spawning an ambient
+/// `moon` whose provenance is unknown.
+priv enum ToolSpawnResolution {
+  ToolUnresolved
+  ToolUnavailable
+  ToolResolved(ToolSpawnConfig)
 }
 
 ///|
@@ -50,9 +61,8 @@ priv struct MoonCliState {
   engine : String
   runtime_dir : @path.Path?
   // Resolved on first use; concurrent first requests may both resolve, which
-  // is benign — `prepare_bundled_home` serializes itself and the results are
-  // identical.
-  mut command : ToolSpawnConfig?
+  // is benign — bundled preparation serializes itself and the results agree.
+  mut command : ToolSpawnResolution
   // Module root → the files the last `moon check` reported diagnostics on.
   // The next run pushes an empty array for any file that dropped out, the
   // wire's "squiggles fixed" signal. Bounded by the module roots touched in
@@ -69,7 +79,7 @@ fn MoonCliState::new(
   {
     engine,
     runtime_dir,
-    command: None,
+    command: ToolUnresolved,
     published: Map([]),
     diagnostics: Queue(kind=DiscardOldest(256)),
   }
@@ -87,24 +97,39 @@ async fn MoonCliState::forward_diagnostics(
 }
 
 ///|
-async fn MoonCliState::resolve_command(self : MoonCliState) -> ToolSpawnConfig {
-  if self.command is Some(config) {
-    return config
+async fn MoonCliState::resolve_command(self : MoonCliState) -> ToolSpawnConfig? {
+  match self.command {
+    ToolResolved(config) => return Some(config)
+    ToolUnavailable => return None
+    ToolUnresolved => ()
   }
-  let config = if @moonbit.bundled_moon(
-      self.engine,
-      runtime_dir?=self.runtime_dir,
-    )
-    is Some(path) {
-    {
-      command: path.to_string(),
-      env: Some(@moonbit.bundled_tool_env(path.dirname())),
+  let toolchain = @moonbit.resolve_toolchain(
+    self.engine,
+    runtime_dir?=self.runtime_dir,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    @moonbit.ToolchainUnavailable as unavailable => {
+      @xlog.warn() <?
+        {
+          "event": "desktop_moon_cli_toolchain_unavailable",
+          "reason": "\{unavailable}",
+        }
+      self.command = ToolUnavailable
+      return None
     }
-  } else {
-    { command: "moon", env: None }
+    error => {
+      @xlog.warn() <?
+        { "event": "desktop_moon_cli_toolchain_error", "error": "\{error}" }
+      self.command = ToolUnavailable
+      return None
+    }
   }
-  self.command = Some(config)
-  config
+  let config = {
+    command: toolchain.moon.to_string(),
+    env: Some(toolchain.tool_env()),
+  }
+  self.command = ToolResolved(config)
+  Some(config)
 }
 
 ///|
@@ -117,7 +142,7 @@ async fn MoonCliState::run_moon(
   args : Array[String],
   cwd : String,
 ) -> (Int, String, String)? {
-  let config = self.resolve_command()
+  guard self.resolve_command() is Some(config) else { return None }
   @async.with_timeout_opt(MoonCliTimeoutMs, () => {
     // An empty-file stdin keeps any accidentally interactive tool from
     // waiting on the host's inherited stdin, mirroring the engine's tool

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -101,24 +101,24 @@ async fn resolve_moonide_request(
 }
 
 ///|
-fn moonide_spawn_config_from_bundled(
-  bundled : @path.Path?,
-) -> MoonIdeSpawnConfig {
-  match bundled {
-    Some(path) =>
-      {
-        executable: path.to_string(),
-        extra_env: Some(@moonbit.bundled_tool_env(path.dirname())),
-      }
-    None => { executable: "moon", extra_env: None }
-  }
-}
-
-///|
+/// Diagnostics win over fallback: every anomaly — a resolution error, no
+/// toolchain anywhere, or a toolchain without a usable `moon` — surfaces to
+/// the caller as a [HostError] naming the cause, instead of spawning
+/// whatever `moon` the ambient environment happens to serve.
 async fn moonide_spawn_config(state : HostState) -> MoonIdeSpawnConfig {
-  moonide_spawn_config_from_bundled(
-    @moonbit.bundled_moon(state.engine, runtime_dir?=state.runtime_dir),
-  )
+  let toolchain = @moonbit.resolve_toolchain(
+    state.engine,
+    runtime_dir?=state.runtime_dir,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    @moonbit.ToolchainUnavailable as unavailable =>
+      raise HostError("\{unavailable}")
+    error => raise HostError("could not resolve a MoonBit toolchain: \{error}")
+  }
+  {
+    executable: toolchain.moon.to_string(),
+    extra_env: Some(toolchain.tool_env()),
+  }
 }
 
 ///|
@@ -395,14 +395,4 @@ test "physical Moon IDE results keep the lexical attached workspace identity" {
   assert_true(
     moonide_client_path(lexical, physical, "/private/projects/project") is None,
   )
-}
-
-///|
-test "Moon IDE spawn config prefers bundled moon and falls back to PATH" {
-  let bundled = moonide_spawn_config_from_bundled(Some(Path("/tool/bin/moon")))
-  assert_eq(bundled.executable, "/tool/bin/moon")
-  assert_true(bundled.extra_env is Some(_))
-  let fallback = moonide_spawn_config_from_bundled(None)
-  assert_eq(fallback.executable, "moon")
-  assert_true(fallback.extra_env is None)
 }

--- a/desktop/internal/moonbit/moon.pkg
+++ b/desktop/internal/moonbit/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "openseek_desktop/internal/env",
   "openseek_desktop/internal/fsx",
+  "openseek_desktop/internal/home",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -1,7 +1,11 @@
 ///|
+/// Environment overrides for running the payload's own tools during
+/// preparation. The payload's `moon`/`moonc` locate their compiler assets
+/// relative to their own executables, so a path prepend is all they need;
+/// `MOON_HOME` stays whatever the user has (it holds registry credentials
+/// and caches, not the toolchain).
 fn moonbit_process_env(moon_home : @path.Path) -> Map[String, String] {
   {
-    "MOON_HOME": moon_home.to_string(),
     "PATH": @env.prepend_to_path_env(
       moonbit_bin_dir(moon_home).to_string(),
       @env.get("PATH"),
@@ -35,32 +39,6 @@ async fn prepare_tool_stdin(
   }
   @fs.write_file(path.to_string(), "", create_mode=CreateOrTruncate)
   @process.redirect_from_file(path.to_string())
-}
-
-///|
-async fn get_moonc_version(
-  moon_home : @path.Path,
-  runtime_dir : @path.Path?,
-) -> String {
-  let moonc = moonbit_compiler_command(moon_home)
-  let child_stdin = prepare_tool_stdin(runtime_dir, moonc)
-  let (code, output) = @process.collect_output_merged(
-    moonc.to_string(),
-    ["-v"],
-    inherit_env=true,
-    extra_env=moonbit_process_env(moon_home),
-    stdin=child_stdin,
-  )
-  if code != 0 {
-    fail(
-      "failed to read bundled MoonBit compiler version: \{output.text().trim()}",
-    )
-  }
-  match [..output.text().trim().split(" ")] {
-    [['v', .. version], ..] => version.to_owned()
-    [version, ..] => version.to_owned()
-    [] => ""
-  }
 }
 
 ///|
@@ -131,11 +109,15 @@ async fn copy_moonbit_seed_dir(
 }
 
 ///|
+/// Build the copied seed's core bundles against the version packaging already
+/// verified with `moonc -v`. The seed version stamp is authoritative here: it
+/// is written only after extraction, executable-bit normalization, and the
+/// compiler-version check have all succeeded.
 async fn initialize_moonbit(
   moon_home : @path.Path,
+  version : String,
   runtime_dir : @path.Path?,
 ) -> Unit {
-  let version = get_moonc_version(moon_home, runtime_dir)
   @xlog.debug() <?
     {
       "event": "desktop_moonbit_initialize",
@@ -196,6 +178,9 @@ async fn prepared_bundled_moonbit_payload(
   }
   prepare_payload_lock.acquire()
   defer prepare_payload_lock.release()
+  guard bundled_moonbit_seed_version(seed_dir) is Some(version) else {
+    return None
+  }
   @xlog.debug() <?
     {
       "event": "desktop_moonbit_prepare_payload",
@@ -204,8 +189,7 @@ async fn prepared_bundled_moonbit_payload(
       "moon_exists": @fsx.exists(moonbit_command(moon_home)),
       "moonc_exists": @fsx.exists(moonbit_compiler_command(moon_home)),
     }
-  if bundled_moonbit_seed_version(seed_dir) is Some(version) &&
-    is_moonbit_bundled(moon_home, version) {
+  if is_moonbit_bundled(moon_home, version) {
     @xlog.debug() <?
       {
         "event": "desktop_moonbit_prepare_payload_reuse",
@@ -223,7 +207,7 @@ async fn prepared_bundled_moonbit_payload(
     }
   @fsx.remove_if_exists(moon_home)
   copy_moonbit_seed_dir(seed_dir, moon_home)
-  initialize_moonbit(moon_home, runtime_dir)
+  initialize_moonbit(moon_home, version, runtime_dir)
   @xlog.debug() <?
     {
       "event": "desktop_moonbit_prepare_payload_complete",
@@ -233,100 +217,6 @@ async fn prepared_bundled_moonbit_payload(
       "moonc_exists": @fsx.exists(moonbit_compiler_command(moon_home)),
     }
   Some(moon_home)
-}
-
-///|
-pub async fn prepare_bundled_home(
-  engine_command : String,
-  runtime_dir? : @path.Path,
-) -> @path.Path {
-  @xlog.debug() <?
-    {
-      "event": "desktop_moonbit_prepare_home",
-      "engine_command": engine_command,
-      "runtime_dir": runtime_dir.map(dir => dir.to_string()).unwrap_or(""),
-    }
-  guard bundled_moonbit_seed_dir(engine_command) is Some(seed_dir) else {
-    fail("bundled MoonBit toolchain seed not found")
-  }
-  guard prepared_bundled_moonbit_payload(seed_dir~, runtime_dir?)
-    is Some(moon_home) else {
-    fail("failed to prepare bundled MoonBit toolchain")
-  }
-  @xlog.debug() <?
-    {
-      "event": "desktop_moonbit_prepare_home_complete",
-      "engine_command": engine_command,
-      "seed_dir": seed_dir.to_string(),
-      "moon_home": moon_home.to_string(),
-    }
-  moon_home
-}
-
-///|
-/// A complete child environment (pass with `inherit_env=false`) for spawning a
-/// binary out of the bundled toolchain: the current environment with `bin_dir`
-/// prepended to the path variable and any ambient `MOON_HOME` dropped — moon
-/// tools prefer `MOON_HOME` over their executable-relative home, so one
-/// exported by the launching shell would run the bundled binary against an
-/// unrelated toolchain home. Mirrors the engine's child environment. Windows
-/// blocks commonly spell the key `Path`; update the spelling that already
-/// exists and drop any duplicates, so the child sees exactly one path variable.
-pub fn bundled_tool_env(bin_dir : @path.Path) -> Map[String, String] {
-  let env = @sys.get_env_vars()
-  @env.prepend_path_entry(env, bin_dir.to_string()) |> ignore
-  env.remove("MOON_HOME")
-  env
-}
-
-///|
-/// Path to the `moon` CLI shipped in the bundled MoonBit toolchain, or `None`
-/// when there is no bundled seed — a dev run of the bare host binary, where
-/// the caller deliberately falls back to `moon` on PATH. Packaged hosts
-/// always execute the prepared per-user copy, so every language service
-/// shares one toolchain; the home is the one the engine prepares, so once a
-/// conversation has run this is a cheap existence check.
-pub async fn bundled_moon(
-  engine_command : String,
-  runtime_dir? : @path.Path,
-) -> @path.Path? {
-  let moon_home = prepare_bundled_home(engine_command, runtime_dir?) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
-  }
-  let moon = moonbit_command(moon_home)
-  if @fsx.exists(moon) {
-    Some(moon)
-  } else {
-    None
-  }
-}
-
-///|
-async test "prepare bundled home raises when seed is missing" {
-  let dir = @fs.tmpdir(prefix="openseek-moonbit-missing-seed-")
-  let engine = @path.Path(dir).join("engine").to_string()
-  try prepare_bundled_home(engine) catch {
-    Failure::Failure(message) => {
-      @fs.rmdir(dir, recursive=true) catch {
-        _ => ()
-      }
-      assert_true(message.contains("bundled MoonBit toolchain seed not found"))
-    }
-    error => {
-      @fs.rmdir(dir, recursive=true) catch {
-        _ => ()
-      }
-      raise error
-    }
-  } noraise {
-    _ => {
-      @fs.rmdir(dir, recursive=true) catch {
-        _ => ()
-      }
-      fail("missing seed prepared successfully")
-    }
-  }
 }
 
 ///|

--- a/desktop/internal/moonbit/pkg.generated.mbti
+++ b/desktop/internal/moonbit/pkg.generated.mbti
@@ -6,15 +6,19 @@ import {
 }
 
 // Values
-pub async fn bundled_moon(String, runtime_dir? : @path.Path) -> @path.Path?
-
-pub fn bundled_tool_env(@path.Path) -> Map[String, String]
-
-pub async fn prepare_bundled_home(String, runtime_dir? : @path.Path) -> @path.Path
+pub async fn resolve_toolchain(String, runtime_dir? : @path.Path) -> ResolvedToolchain
 
 // Errors
+pub suberror ToolchainUnavailable
+pub impl Show for ToolchainUnavailable
 
 // Types and methods
+pub struct ResolvedToolchain {
+  bin_dir : @path.Path
+  moon : @path.Path
+}
+pub fn ResolvedToolchain::apply_to_env(Self, Map[String, String]) -> Unit
+pub fn ResolvedToolchain::tool_env(Self) -> Map[String, String]
 
 // Type aliases
 

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -24,19 +24,12 @@ fn bin_sibling_toolchain_dir(
 }
 
 ///|
-async fn executable_exists(root : @path.Path, name : String) -> Bool {
-  @fs.exists(root.join("bin").join(name).to_string()) ||
-  @fs.exists(root.join("bin").join("\{name}.exe").to_string())
-}
-
-///|
-async fn moonbit_seed_looks_complete(path : @path.Path) -> Bool {
-  executable_exists(path, "moon") &&
-  executable_exists(path, "moonc") &&
-  @fs.exists(path.join("lib/core/moon.mod").to_string())
-}
-
-///|
+/// A seed is detected by the version stamp packaging writes as its final
+/// step — after extracting the binary and core archives and verifying the
+/// staged compiler answers `moonc -v` with the expected version. The stamp's
+/// presence therefore already asserts a complete seed; re-probing individual
+/// files here would re-litigate what packaging proved, and the sealed app
+/// bundle guards integrity from there.
 async fn bundled_moonbit_seed_dir(engine_command : String) -> @path.Path? {
   let command_dir = @path.Path(engine_command).dirname().resolve()
   let candidates = [
@@ -48,16 +41,16 @@ async fn bundled_moonbit_seed_dir(engine_command : String) -> @path.Path? {
     bin_sibling_toolchain_dir(command_dir, "macos-arm64"),
   ]
   for candidate in candidates {
-    let complete = moonbit_seed_looks_complete(candidate)
+    let version = bundled_moonbit_seed_version(candidate)
     @xlog.debug() <?
       {
         "event": "desktop_moonbit_seed_candidate",
         "engine_command": engine_command,
         "command_dir": command_dir.to_string(),
         "candidate": candidate.to_string(),
-        "complete": complete,
+        "seed_version": version,
       }
-    if complete {
+    if version is Some(_) {
       @xlog.debug() <?
         {
           "event": "desktop_moonbit_seed_selected",
@@ -155,8 +148,8 @@ fn moonbit_wasm_gc_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
 }
 
 ///|
-/// Lay a fake seed under `root`: the two executables and the core manifest
-/// `moonbit_seed_looks_complete` probes for.
+/// Lay a fake completed seed under `root`, including the version stamp that
+/// packaging writes only after it has verified the extracted toolchain.
 async fn write_fake_seed(root : @path.Path) -> Unit {
   @fs.mkdir(root.join("bin").to_string(), recursive=true)
   @fs.mkdir(root.join("lib/core").to_string(), recursive=true)
@@ -175,6 +168,11 @@ async fn write_fake_seed(root : @path.Path) -> Unit {
     "{}",
     create_mode=CreateOrTruncate,
   )
+  @fs.write_file(
+    root.join(MoonbitSeedVersionFile).to_string(),
+    "test-version",
+    create_mode=CreateOrTruncate,
+  )
 }
 
 ///|
@@ -182,7 +180,7 @@ async fn write_fake_seed(root : @path.Path) -> Unit {
 /// (`<input>/bin/openseek` beside `<input>/toolchains/`), unlike the Linux
 /// AppImage and the Windows bundle, which put the engine straight into the
 /// directory holding `toolchains/`. Both shapes must resolve, or the engine
-/// never spawns — `prepare_bundled_home` raises before it.
+/// never spawns — `resolve_toolchain` raises before it.
 async test "the seed is found beside the engine and one level above it" {
   let tmp = @path.Path(@fs.tmpdir(prefix="openseek-moonbit-seed-layout-"))
   // macOS: `<input>/bin/openseek` with `<input>/toolchains/…`.

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -1,0 +1,150 @@
+///|
+/// Where a usable MoonBit toolchain's executable lives, probed once at
+/// resolution. `moon` serves the engine tools and every host language request.
+/// Everything else a moon command needs (`moonc`, `lib/core`, `include`) is
+/// moon's own business: moon locates its compiler assets relative to its own
+/// executable, so handing children the right binary is the whole job.
+/// `MOON_HOME` is never read or written — it holds the user's registry
+/// identity (`credentials.json`) and caches, not the toolchain, and plays
+/// no part in which moon binary runs.
+pub struct ResolvedToolchain {
+  bin_dir : @path.Path
+  moon : @path.Path
+}
+
+///|
+/// Assemble the toolchain living at `bin_dir`, `None` when the directory
+/// does not hold the binary the desktop spawns (a usable `moon`). All
+/// executable probing happens here, once. Only the current
+/// platform's name counts: the suffix rejects a directory holding just
+/// `moon.exe` (a Windows install leaking into a foreign-platform search),
+/// where command lookup for `moon` would never resolve and accepting the
+/// directory would shadow a valid `~/.moon/bin` later in the chain.
+async fn toolchain_at(bin_dir : @path.Path) -> ResolvedToolchain? {
+  let moon = bin_dir.join("moon" + ExecutableSuffix)
+  guard @fsx.is_executable_file(moon) else { return None }
+  Some({ bin_dir, moon })
+}
+
+///|
+/// No usable MoonBit toolchain on this machine: nothing bundled, and the
+/// external search found no directory holding an executable `moon`.
+/// Consumers must fail their operation rather than substitute a toolchain
+/// from ambient state.
+pub suberror ToolchainUnavailable
+
+///|
+/// The canonical description used verbatim in consumer logs and surfaced
+/// errors, so every report of an unavailable toolchain reads the same.
+pub impl Show for ToolchainUnavailable with fn output(_self, logger) {
+  logger.write_string(
+    "no MoonBit toolchain found: nothing bundled, and no usable moon on PATH or in ~/.moon/bin",
+  )
+}
+
+///|
+/// Locate the MoonBit toolchain the desktop hands to engines and the LSP
+/// pool: the bundled seed's prepared payload when the app ships one,
+/// otherwise the first external toolchain found. Raises
+/// [ToolchainUnavailable] when the machine has none; a bundled seed that
+/// fails to prepare raises a plain failure — that is the app's own artifact
+/// breaking, not machine configuration.
+pub async fn resolve_toolchain(
+  engine_command : String,
+  runtime_dir? : @path.Path,
+) -> ResolvedToolchain {
+  if bundled_moonbit_seed_dir(engine_command) is Some(seed_dir) {
+    guard prepared_bundled_moonbit_payload(seed_dir~, runtime_dir?)
+      is Some(payload) else {
+      fail("failed to prepare bundled MoonBit toolchain")
+    }
+    guard toolchain_at(moonbit_bin_dir(payload)) is Some(toolchain) else {
+      fail("bundled MoonBit toolchain payload is not a complete toolchain")
+    }
+    return toolchain
+  }
+  external_toolchain(path_env?=@env.get("PATH"), home_dir?=@home.dir())
+}
+
+///|
+/// The external search chain: the path variable's entries in order, then
+/// `~/.moon/bin`. The path scan mirrors the shell's own command lookup —
+/// which moon binary runs is the path's decision, and `MOON_HOME` plays no
+/// part in it, so the resolver never reads the variable. The default
+/// install location is probed last as a rescue for environments whose path
+/// variable is bare (Finder or launchd launches): it is a constant, not an
+/// environment variable, so it survives the stripped launchd environment
+/// that hides the terminal's configuration.
+async fn external_toolchain(
+  path_env? : String,
+  home_dir? : @path.Path,
+) -> ResolvedToolchain {
+  if path_env is Some(path_value) {
+    for entry in path_value.split(@env.path_sep) {
+      if entry.is_empty() {
+        continue
+      }
+      let bin_dir = @path.Path(entry.to_owned())
+      // A relative entry only means something from the resolver's own
+      // working directory; children spawn elsewhere, so it must not be
+      // selected or re-exported.
+      if !bin_dir.is_absolute() {
+        @xlog.debug() <?
+          {
+            "event": "desktop_moonbit_path_entry_relative",
+            "entry": entry.to_owned(),
+          }
+        continue
+      }
+      if toolchain_at(bin_dir) is Some(toolchain) {
+        @xlog.debug() <?
+          {
+            "event": "desktop_moonbit_external_toolchain",
+            "source": "path",
+            "bin_dir": bin_dir.to_string(),
+          }
+        return toolchain
+      }
+    }
+  }
+  if home_dir is Some(home) {
+    let bin_dir = home.join(".moon").join("bin")
+    if toolchain_at(bin_dir) is Some(toolchain) {
+      @xlog.debug() <?
+        {
+          "event": "desktop_moonbit_external_toolchain",
+          "source": "home_default",
+          "bin_dir": bin_dir.to_string(),
+        }
+      return toolchain
+    }
+  }
+  raise ToolchainUnavailable
+}
+
+///|
+/// Prepend the toolchain's bin directory to `env`'s path variable (updating
+/// `Path` in place on Windows — see `@env.prepend_path_entry`). `MOON_HOME`
+/// is deliberately left alone: moon reads the user's registry identity
+/// (`credentials.json`) and caches from it, while compiler assets resolve
+/// relative to the moon executable itself — scrubbing or rewriting the
+/// variable buys no isolation and breaks `moon login` / `moon publish` in
+/// spawned sessions.
+pub fn ResolvedToolchain::apply_to_env(
+  self : ResolvedToolchain,
+  env : Map[String, String],
+) -> Unit {
+  @env.prepend_path_entry(env, self.bin_dir.to_string()) |> ignore
+}
+
+///|
+/// A complete child environment (pass with `inherit_env=false`) for spawning
+/// a binary out of this toolchain: the current environment with the
+/// toolchain's environment policy applied.
+pub fn ResolvedToolchain::tool_env(
+  self : ResolvedToolchain,
+) -> Map[String, String] {
+  let env = @sys.get_env_vars()
+  self.apply_to_env(env)
+  env
+}

--- a/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
@@ -1,0 +1,155 @@
+///|
+async fn remove_toolchain_test_tree(root : @path.Path) -> Unit {
+  @fs.rmdir(root.to_string(), recursive=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+}
+
+///|
+/// Runs `body` against a fresh temporary root and removes the tree on both
+/// exit paths — `defer` cannot run the async removal, so the try/catch
+/// split lives here once instead of in every test.
+async fn with_toolchain_test_tree(body : async (@path.Path) -> Unit) -> Unit {
+  let root = @path.Path(@fs.tmpdir(prefix="openseek-moonbit-external-"))
+  body(root) catch {
+    error => {
+      remove_toolchain_test_tree(root)
+      raise error
+    }
+  }
+  remove_toolchain_test_tree(root)
+}
+
+///|
+/// A complete fake toolchain: the resolver only assembles one around the
+/// executable the desktop spawns — `moon`.
+async fn touch_fake_toolchain(bin_dir : @path.Path) -> Unit {
+  @fs.write_file(
+    bin_dir.join("moon" + ExecutableSuffix).to_string(),
+    "",
+    create_mode=CreateOrTruncate,
+    permission=0o755,
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a non-executable moon file does not count" {
+  with_toolchain_test_tree(async fn(root) {
+    let path_bin = root.join("pathdir")
+    let home_bin = root.join("home").join(".moon").join("bin")
+    @fs.mkdir(path_bin.to_string(), recursive=true)
+    @fs.mkdir(home_bin.to_string(), recursive=true)
+    @fs.write_file(
+      path_bin.join("moon").to_string(),
+      "",
+      create_mode=CreateOrTruncate,
+    )
+    touch_fake_toolchain(home_bin)
+    let toolchain = external_toolchain(
+      path_env=path_bin.to_string(),
+      home_dir=root.join("home"),
+    )
+    assert_eq(toolchain.bin_dir.to_string(), home_bin.to_string())
+  })
+}
+
+///|
+async test "a directory named moon does not count" {
+  with_toolchain_test_tree(async fn(root) {
+    let path_bin = root.join("pathdir")
+    let home_bin = root.join("home").join(".moon").join("bin")
+    @fs.mkdir(
+      path_bin.join("moon" + ExecutableSuffix).to_string(),
+      recursive=true,
+    )
+    @fs.mkdir(home_bin.to_string(), recursive=true)
+    touch_fake_toolchain(home_bin)
+    let toolchain = external_toolchain(
+      path_env=path_bin.to_string(),
+      home_dir=root.join("home"),
+    )
+    assert_eq(toolchain.bin_dir.to_string(), home_bin.to_string())
+  })
+}
+
+///|
+async test "an executable moon is a usable toolchain" {
+  with_toolchain_test_tree(async fn(root) {
+    let bin_dir = root.join("bin")
+    @fs.mkdir(bin_dir.to_string(), recursive=true)
+    @fs.write_file(
+      bin_dir.join("moon" + ExecutableSuffix).to_string(),
+      "",
+      create_mode=CreateOrTruncate,
+      permission=0o755,
+    )
+    assert_true(toolchain_at(bin_dir) is Some(_))
+  })
+}
+
+///|
+async test "a file-shaped path entry does not abort the scan" {
+  with_toolchain_test_tree(async fn(root) {
+    let not_a_dir = root.join("notdir")
+    let home_bin = root.join("home").join(".moon").join("bin")
+    @fs.write_file(not_a_dir.to_string(), "", create_mode=CreateOrTruncate)
+    @fs.mkdir(home_bin.to_string(), recursive=true)
+    touch_fake_toolchain(home_bin)
+    let toolchain = external_toolchain(
+      path_env=not_a_dir.to_string(),
+      home_dir=root.join("home"),
+    )
+    assert_eq(toolchain.bin_dir.to_string(), home_bin.to_string())
+  })
+}
+
+///|
+async test "path scan wins over the default install" {
+  with_toolchain_test_tree(async fn(root) {
+    let home_bin = root.join("home").join(".moon").join("bin")
+    let path_bin = root.join("pathdir")
+    @fs.mkdir(home_bin.to_string(), recursive=true)
+    @fs.mkdir(path_bin.to_string(), recursive=true)
+    touch_fake_toolchain(home_bin)
+    touch_fake_toolchain(path_bin)
+    let toolchain = external_toolchain(
+      path_env=path_bin.to_string(),
+      home_dir=root.join("home"),
+    )
+    assert_eq(toolchain.bin_dir.to_string(), path_bin.to_string())
+  })
+}
+
+///|
+async test "no toolchain anywhere raises ToolchainUnavailable" {
+  with_toolchain_test_tree(async fn(root) {
+    let bare_bin = root.join("bare")
+    @fs.mkdir(bare_bin.to_string(), recursive=true)
+    try
+      external_toolchain(
+        path_env=bare_bin.to_string(),
+        home_dir=root.join("home"),
+      )
+    catch {
+      ToolchainUnavailable => ()
+      error => raise error
+    } noraise {
+      _ => fail("resolved without any toolchain present")
+    }
+  })
+}
+
+///|
+/// The environment policy is a path prepend and nothing else — in
+/// particular the ambient `MOON_HOME` must survive untouched, or spawned
+/// sessions lose the user's registry credentials.
+async test "toolchain env policy leaves MOON_HOME alone" {
+  let env : Map[String, String] = { "MOON_HOME": "/custom", "PATH": "/usr/bin" }
+  { bin_dir: Path("/found/bin"), moon: Path("/found/bin/moon") }.apply_to_env(
+    env,
+  )
+  assert_eq(env.get("MOON_HOME"), Some("/custom"))
+  assert_true(env.get("PATH").unwrap_or("").has_prefix("/found/bin"))
+}

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -105,6 +105,13 @@ fn PackageOptions::parse(argv? : ArrayView[String]) -> PackageOptions raise {
   if notary_profile is Some(_) && !artifacts.dmg {
     raise @packaging.PackageError("--notarize requires --target dmg")
   }
+  // A Developer ID signature marks distributable output. Require an explicit
+  // archive target instead of signing only the intermediate app bundle.
+  if identity is Some(_) && !artifacts.dmg && !artifacts.zip {
+    raise @packaging.PackageError(
+      "--sign requires a distribution target (--target dmg or --target zip)",
+    )
+  }
   {
     artifacts,
     sign: { identity, notary_profile },
@@ -226,6 +233,8 @@ async fn @packaging.Workspace::stage_package_inputs(
     ["+x", PackageBinDir + "/openseek"],
     dir=self.dir(),
   )
+  // Proton applies the static `bundle.sign.binaries` list to both ad-hoc and
+  // Developer ID signing, so every macOS app must stage these seed binaries.
   let target = @moonbit.moonbit_macos_arm64_toolchain()
   @moonbit.stage_moonbit_toolchain_seed(
     self,
@@ -306,4 +315,16 @@ test "macOS packaging combines optional archive targets" {
     "--target", "app", "--target", "zip", "--target", "dmg",
   ])
   @debug.assert_eq(options.artifacts, { dmg: true, zip: true })
+}
+
+///|
+test "macOS signing requires a distribution target" {
+  try PackageOptions::parse(argv=["--sign", "Developer ID"]) catch {
+    error =>
+      assert_true(
+        error.to_string().contains("--sign requires a distribution target"),
+      )
+  } noraise {
+    _ => fail("expected --sign without a distribution target to fail")
+  }
 }


### PR DESCRIPTION
This PR allows desktop to resolve MoonBit toolchain according to PATH/MOON_HOME. This used to be explicitly forbidden because we don't want user to be able to use a non-bundled MoonBit toolchain.

Now we want to speed up the desktop dev experience, and therefore we allow this fallback specifically so that devs can skip bundling the MoonBit toolchain when in dev mode.

This does not speed up dev build