### PR TITLE
Integrate editor 0.4.4 and Moon IDE navigation

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -44,6 +44,10 @@ priv struct ViewerHost {
   // first run reports `cwd`). `None` when the viewer shows a notice or
   // nothing.
   mut relative : @pathx.Relative?
+  // The active host/workspace route for Definition/References targets and
+  // cross-file Peek previews. Cleared together with the document so a late
+  // navigation request can never reopen a previous conversation's file.
+  mut navigation : NavigationContext?
   // Monotonic model version; the viewer treats a new version as a new
   // document.
   mut version : Int
@@ -60,6 +64,7 @@ let viewer_state : ViewerHost = {
   services: None,
   absolute: None,
   relative: None,
+  navigation: None,
   version: 0,
   view_states: Map([]),
 }
@@ -106,7 +111,14 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
         is Some(host) {
         register_tokenizers()
         register_hover_provider()
-        let services = DesktopViewerServices()
+        let services = DesktopViewerServices(
+          navigation_location_opener((owner, path, range) => {
+            scheduler.add(
+              dispatch(OpenNavigationLocation(owner~, path~, range~)),
+            )
+          }),
+          navigation_text_model_resolver(),
+        )
         viewer_state.services = Some(services)
         let viewer = @viewer.Viewer::create(
           host,
@@ -200,7 +212,8 @@ pub fn request_viewer_remeasure() -> @cmd.Cmd {
 /// brings the incoming document back to its saved position instead of the
 /// top — the Monaco save/restore-view-state contract around `set_model`.
 fn show_file_in_viewer(
-  channel : @interop.ChannelId,
+  owner : @interop.ConversationKey,
+  workspace : @pathx.Absolute?,
   name : String,
   content : String,
   absolute? : @pathx.Absolute,
@@ -219,7 +232,7 @@ fn show_file_in_viewer(
     // (withheld binary/oversized file) has no file behind it, so its inert
     // scheme never parses as a model path and hover stays off.
     let uri = match absolute {
-      Some(absolute) => model_uri_of(channel, absolute)
+      Some(absolute) => model_uri_of(owner.channel, absolute)
       None => app_uri("openseek-notice", "/" + name)
     }
     // Whether anything needs redrawing is decided here, against the document
@@ -264,6 +277,11 @@ fn show_file_in_viewer(
     // along for comments filed on this document (see `ViewerHost::relative`).
     viewer_state.absolute = absolute
     viewer_state.relative = relative
+    viewer_state.navigation = match (absolute, relative) {
+      (Some(absolute), Some(relative)) =>
+        navigation_context_for_file(owner, workspace, absolute, relative)
+      _ => None
+    }
     // Commenting (select → inline input → composer chip) is for real files;
     // a notice document has nothing behind it to comment on.
     if viewer_state.services is Some(services) {
@@ -321,6 +339,7 @@ fn clear_viewer() -> @cmd.Cmd {
     if viewer_state.viewer is Some(viewer) {
       viewer_state.absolute = None
       viewer_state.relative = None
+      viewer_state.navigation = None
       viewer.set_model(None)
     }
   })
@@ -335,6 +354,7 @@ fn clear_document() -> @cmd.Cmd {
     if viewer_state.viewer is Some(viewer) {
       viewer_state.absolute = None
       viewer_state.relative = None
+      viewer_state.navigation = None
       viewer.set_model(None)
     }
   })

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -86,6 +86,7 @@ fn register_tokenizers() -> Unit {
   |> ignore
   @languages.languages.set_tokens_provider("json", @lang_json.JsonTokenizer())
   |> ignore
+  install_moonbit_markdown_comment_provider()
 }
 
 ///|

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -221,6 +221,31 @@ fn decode_file_content(text : String) -> FileContent? {
 }
 
 ///|
+/// Read one file for a cross-resource Peek preview without entering the tab
+/// state machine. This deliberately reuses the same `fs.read_file` wire op
+/// and decoder as ordinary file opening, so binary/oversized policy and
+/// workspace containment stay identical. Failures are unavailable previews,
+/// not panel errors, and therefore return `None` to the resolver.
+async fn read_file_snapshot(
+  owner : @interop.ConversationKey,
+  path : @pathx.Relative,
+  workspace~ : @pathx.Absolute?,
+) -> FileContent? {
+  let payload = @js.Object::new()
+  payload["session"] = owner.session
+  payload["path"] = path.0
+  @interop.set_workspace(payload, workspace)
+  let reply = @interop.bridge_request(
+    owner.channel,
+    "fs.read_file",
+    payload.to_value(),
+  ) catch {
+    _ => return None
+  }
+  decode_file_content(@interop.reply_json_text(reply))
+}
+
+///|
 /// Stat the open tabs' files and fold the signatures back as `StatsLoaded`.
 /// Best-effort: a failed call is dropped — the next change push retries.
 fn stat_files(

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -179,7 +179,7 @@ fn hover_range(
   // line/column, then round-trip through offsets so the range stays clamped.
   let start = snapshot.get_offset_at(start_line + 1, start_character + 1)
   let end = snapshot.get_offset_at(end_line + 1, end_character + 1)
-  snapshot.range_of(@common.OffsetRange(start, end))
+  snapshot.range_of(@common.OffsetRange::from_to(start, end))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/markdown_comments.mbt
+++ b/desktop/frontend/fileeditor/markdown_comments.mbt
@@ -1,0 +1,103 @@
+// MoonBit documentation comments and item separators are anchored by the
+// formatter's top-level `///|` marker. The reusable Viewer stays
+// language-neutral, so OpenSeek supplies this small language adapter.
+
+///|
+priv struct MoonBitMarkdownCommentProvider {}
+
+///|
+impl @language.MarkdownCommentProvider for MoonBitMarkdownCommentProvider with fn provide_markdown_comments(
+  _self,
+  model,
+) {
+  moonbit_markdown_comments_in_snapshot(model.snapshot())
+}
+
+///|
+fn install_moonbit_markdown_comment_provider() -> Unit {
+  @languages.languages.register_markdown_comment_provider(
+    @language.LanguageId("moonbit"),
+    MoonBitMarkdownCommentProvider::{  },
+    foldable=true,
+  )
+  |> ignore
+}
+
+///|
+/// Returns anchored MoonBit documentation and item-separator blocks. Every
+/// `///|` marker becomes a Markdown horizontal rule; text after the marker is
+/// the first documentation line, and consecutive `///` lines form the body.
+fn moonbit_markdown_comments_in_snapshot(
+  snapshot : @model.TextSnapshot,
+) -> Array[@language.MarkdownCommentBlock] {
+  let blocks : Array[@language.MarkdownCommentBlock] = []
+  let line_count = snapshot.line_count()
+  let mut line_number = 1
+  while line_number <= line_count {
+    guard moonbit_markdown_comment_anchor_content(
+        snapshot.get_line_content(line_number),
+      )
+      is Some(anchor_content) else {
+      line_number += 1
+      continue
+    }
+    let start_line_number = line_number
+    line_number += 1
+    let contents : Array[String] = []
+    if anchor_content != "" {
+      contents.push(anchor_content)
+    }
+    while line_number <= line_count {
+      match
+        moonbit_markdown_comment_line_content(
+          snapshot.get_line_content(line_number),
+        ) {
+        Some(content) => {
+          contents.push(content)
+          line_number += 1
+        }
+        None => break
+      }
+    }
+    blocks.push({
+      line_range: @common.LineRange(start_line_number, line_number),
+      markdown: if contents.is_empty() {
+        "---"
+      } else {
+        (
+          $|---
+          $|
+          $|\{contents.join("\n")}
+        )
+      },
+    })
+  }
+  blocks
+}
+
+///|
+/// Returns marker-line documentation, or `Some("")` for a bare separator.
+fn moonbit_markdown_comment_anchor_content(line : String) -> String? {
+  if !line.has_prefix("///|") {
+    return None
+  }
+  let mut content_start = 4
+  if content_start < line.length() && line[content_start].to_int() == 32 {
+    content_start += 1
+  }
+  Some(line.unsafe_substring(start=content_start, end=line.length()))
+}
+
+///|
+/// Strips exactly `///` and at most one following ASCII space. A following
+/// `///|` starts a new block rather than extending the current one.
+fn moonbit_markdown_comment_line_content(line : String) -> String? {
+  if line.has_prefix("///|") || !line.has_prefix("///") {
+    return None
+  }
+  let mut content_start = 3
+  if content_start < line.length() && line[content_start].to_int() == 32 {
+    content_start += 1
+  }
+  Some(line.unsafe_substring(start=content_start, end=line.length()))
+}

--- a/desktop/frontend/fileeditor/markdown_comments_wbtest.mbt
+++ b/desktop/frontend/fileeditor/markdown_comments_wbtest.mbt
@@ -1,0 +1,38 @@
+///|
+test "MoonBit Markdown comments include separators and marker-line text" {
+  let blocks = moonbit_markdown_comments_in_snapshot(
+    @model.TextSnapshot(
+      (
+        #|///| File summary
+        #|/// More detail.
+        #|fn first() -> Unit {}
+        #|///|
+        #|fn second() -> Unit {}
+        #|
+      ),
+    ),
+  )
+  assert_eq(blocks.length(), 2)
+  assert_eq(blocks[0].line_range, @common.LineRange(1, 3))
+  assert_eq(blocks[0].markdown, "---\n\nFile summary\nMore detail.")
+  assert_eq(blocks[1].line_range, @common.LineRange(4, 5))
+  assert_eq(blocks[1].markdown, "---")
+}
+
+///|
+test "MoonBit Markdown comments do not merge adjacent item markers" {
+  let blocks = moonbit_markdown_comments_in_snapshot(
+    @model.TextSnapshot(
+      (
+        #|///|
+        #|///| Next
+        #|/// body
+        #|
+      ),
+    ),
+  )
+  assert_eq(blocks.length(), 2)
+  assert_eq(blocks[0].line_range, @common.LineRange(1, 2))
+  assert_eq(blocks[1].line_range, @common.LineRange(2, 4))
+  assert_eq(blocks[1].markdown, "---\n\nNext\nbody")
+}

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -14,6 +14,7 @@ import {
   "moonbitlang/editor/viewer/common/languages",
   "moonbitlang/editor/viewer/common/markers",
   "moonbitlang/editor/viewer/common/model",
+  "moonbitlang/editor/viewer/common/navigation_api",
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/syntax/lang_javascript",
   "moonbitlang/editor/syntax/lang_json",

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -1,0 +1,317 @@
+// Definition, References, and Peek integration for the embedded Viewer.
+// The language queries go directly to the host's `moonide.*` operations;
+// moon-lsp is deliberately not part of this path. Viewer owns the UI and
+// request lifecycle, while Desktop owns routing, file opening, and preview
+// model leases.
+
+///|
+/// The active workspace identity needed by cross-resource navigation. The
+/// root is host-confirmed: either the attached workspace supplied by `Ctx`,
+/// or the root reconstructed from the absolute/relative pair returned by
+/// `fs.read_file`.
+priv struct NavigationContext {
+  owner : @interop.ConversationKey
+  root : @pathx.Absolute
+} derive(Eq)
+
+///|
+/// Reconstruct the workspace root from one file's host-resolved absolute path
+/// and its workspace-relative name. Separators are normalized so a Windows
+/// host and URI-derived path compare in the same form. This is lexical only;
+/// both values came from the same successful, workspace-contained read.
+fn navigation_root_from_file(
+  absolute : @pathx.Absolute,
+  relative : @pathx.Relative,
+) -> @pathx.Absolute? {
+  let path = @pathx.normalize(absolute.0)
+  let name = @pathx.normalize(relative.0)
+  guard !name.is_empty() else { return None }
+  let suffix = "/" + name
+  guard path.strip_suffix(suffix) is Some(root) else { return None }
+  if root.is_empty() {
+    Some(Absolute("/"))
+  } else {
+    Some(Absolute(root.to_owned()))
+  }
+}
+
+///|
+/// Choose the root for the document now on screen. An explicit workspace is
+/// accepted only when it maps the absolute file back to the exact relative
+/// name; otherwise the host-returned file pair wins (important for canonical
+/// paths behind symlinked workspace hints).
+fn navigation_context_for_file(
+  owner : @interop.ConversationKey,
+  workspace : @pathx.Absolute?,
+  absolute : @pathx.Absolute,
+  relative : @pathx.Relative,
+) -> NavigationContext? {
+  let root = match workspace {
+    Some(root) if absolute.relative_to(root~) == Some(relative) => Some(root)
+    _ => navigation_root_from_file(absolute, relative)
+  }
+  root.map(root => { owner, root })
+}
+
+///|
+/// One implementation serves both editor provider traits. The model URI is
+/// the complete route: it names the absolute file and the local/remote host.
+priv struct MoonIdeNavigationProvider {}
+
+///|
+impl @language.DefinitionProvider for MoonIdeNavigationProvider with fn provide_definition(
+  _self,
+  model,
+  position,
+  token,
+) {
+  if token.is_cancellation_requested() || model.language_id != "moonbit" {
+    return []
+  }
+  guard model_uri_path(model.uri) is Some(path) &&
+    model_uri_channel(model.uri) is Some(channel) else {
+    return []
+  }
+  let locations = request_moon_ide_locations(
+    channel,
+    "moonide.definition",
+    path,
+    position.line_number,
+    position.column,
+  ) catch {
+    _ => return []
+  }
+  if token.is_cancellation_requested() {
+    []
+  } else {
+    locations
+  }
+}
+
+///|
+impl @language.ReferencesProvider for MoonIdeNavigationProvider with fn provide_references(
+  _self,
+  model,
+  position,
+  token,
+) {
+  if token.is_cancellation_requested() || model.language_id != "moonbit" {
+    return []
+  }
+  guard model_uri_path(model.uri) is Some(path) &&
+    model_uri_channel(model.uri) is Some(channel) else {
+    return []
+  }
+  let locations = request_moon_ide_locations(
+    channel,
+    "moonide.references",
+    path,
+    position.line_number,
+    position.column,
+  ) catch {
+    _ => return []
+  }
+  if token.is_cancellation_requested() {
+    []
+  } else {
+    locations
+  }
+}
+
+///|
+/// Register both navigation providers on the process-wide language registry.
+/// The returned handles are retained by `DesktopViewerServices` for the full
+/// lifetime of the one mounted Viewer.
+fn register_moon_ide_navigation_providers() -> Array[@common.Disposable] {
+  let provider = MoonIdeNavigationProvider::{  }
+  [
+    @languages.languages.register_definition_provider(
+      @language.LanguageSelector::LanguageId("moonbit"),
+      provider,
+    ),
+    @languages.languages.register_references_provider(
+      @language.LanguageSelector::LanguageId("moonbit"),
+      provider,
+    ),
+  ]
+}
+
+///|
+async fn request_moon_ide_locations(
+  channel : @interop.ChannelId,
+  op : String,
+  path : @pathx.Absolute,
+  line : Int,
+  column : Int,
+) -> Array[@language.Location] {
+  let payload = @js.Object::new()
+  payload["path"] = path.0
+  payload["line"] = line
+  payload["column"] = column
+  let reply = @interop.bridge_request(channel, op, payload.to_value())
+  decode_moon_ide_locations(@interop.reply_json_text(reply), channel)
+}
+
+///|
+/// Decode the host-normalized location reply. Every coordinate is already a
+/// one-based protocol position, so no client-side column conversion or
+/// LSP-style shifting occurs here.
+fn decode_moon_ide_locations(
+  text : String,
+  channel : @interop.ChannelId,
+) -> Array[@language.Location] {
+  let json = @json.parse(text) catch { _ => return [] }
+  guard json is Object(reply) && reply.get("locations") is Some(Array(items)) else {
+    return []
+  }
+  let result : Array[@language.Location] = []
+  for item in items {
+    guard item is Object(fields) &&
+      @jsonx.json_text(fields, "path") is Some(path) &&
+      !path.is_empty() &&
+      @jsonx.json_int(fields, "start_line") is Some(start_line) &&
+      @jsonx.json_int(fields, "start_column") is Some(start_column) &&
+      @jsonx.json_int(fields, "end_line") is Some(end_line) &&
+      @jsonx.json_int(fields, "end_column") is Some(end_column) else {
+      continue
+    }
+    guard start_line > 0 &&
+      start_column > 0 &&
+      end_line > 0 &&
+      end_column > 0 &&
+      (
+        end_line > start_line ||
+        (end_line == start_line && end_column >= start_column)
+      ) else {
+      continue
+    }
+    result.push(@language.Location::{
+      uri: model_uri_of(channel, Absolute(path)),
+      range: @common.Range::Range(
+        start_line, start_column, end_line, end_column,
+      ),
+    })
+  }
+  result
+}
+
+///|
+/// Desktop opens navigation targets in its current tab group. `Side` is not
+/// accepted because the file panel has no second editor group; returning
+/// false lets Viewer preserve its current state and report that limitation.
+fn navigation_location_opener(
+  open_location : (@interop.ConversationKey, @pathx.Relative, @common.Range) -> Unit,
+) -> @navigation_api.LocationOpenerHandle {
+  LocationOpenerHandle(open=request => {
+    guard request.mode is Current else { return false }
+    guard viewer_state.navigation is Some(context) else { return false }
+    guard model_uri_channel(request.location.uri) == Some(context.owner.channel) &&
+      model_uri_path(request.location.uri) is Some(absolute) &&
+      absolute.relative_to(root=context.root) is Some(relative) &&
+      !relative.is_root() else {
+      return false
+    }
+    open_location(context.owner, relative, request.location.range)
+    true
+  })
+}
+
+///|
+fn navigation_text_model_resolver() -> @navigation_api.TextModelResolverHandle {
+  TextModelResolverHandle(resolve=(resource, token) => {
+    resolve_navigation_preview(resource, token)
+  })
+}
+
+///|
+/// Resolve one cross-file Peek model through OpenSeek's existing safe
+/// workspace read. Each request owns one fresh readonly model; the returned
+/// reference disposes it when Viewer's last use of that request ends. No LSP
+/// document cache or development-shell protocol is involved.
+async fn resolve_navigation_preview(
+  resource : @common.Uri,
+  token : @language.CancellationToken,
+) -> @navigation_api.TextModelReference? noraise {
+  if token.is_cancellation_requested() {
+    return None
+  }
+  guard viewer_state.navigation is Some(context) else { return None }
+  guard model_uri_channel(resource) == Some(context.owner.channel) &&
+    model_uri_path(resource) is Some(absolute) &&
+    absolute.relative_to(root=context.root) is Some(relative) &&
+    !relative.is_root() else {
+    return None
+  }
+  let file = read_file_snapshot(
+    context.owner,
+    relative,
+    workspace=Some(context.root),
+  ) catch {
+    _ => return None
+  }
+  if token.is_cancellation_requested() ||
+    viewer_state.navigation != Some(context) {
+    return None
+  }
+  guard file is Some(Content(content~, absolute=loaded, sig~)) &&
+    loaded == absolute else {
+    return None
+  }
+  let name = basename(relative)
+  let model = @model.TextModel(
+    resource,
+    name,
+    language_id(name),
+    1,
+    sig,
+    content,
+  )
+  Some(
+    TextModelReference(model, release=() => {
+      if !model.is_disposed() {
+        model.dispose()
+      }
+    }),
+  )
+}
+
+///|
+test "navigation root follows host absolute and workspace-relative paths" {
+  assert_true(
+    navigation_root_from_file(
+      Absolute("/ws/project/src/main.mbt"),
+      Relative("src/main.mbt"),
+    ) ==
+    Some(Absolute("/ws/project")),
+  )
+  assert_true(
+    navigation_root_from_file(
+      Absolute("C:\\ws\\project\\src\\main.mbt"),
+      Relative("src/main.mbt"),
+    ) ==
+    Some(Absolute("C:/ws/project")),
+  )
+  assert_true(
+    navigation_root_from_file(
+      Absolute("/other/src/main.mbt"),
+      Relative("lib/main.mbt"),
+    )
+    is None,
+  )
+}
+
+///|
+test "moon ide locations stay one based and channel routed" {
+  let reply =
+    #|{"locations":[{"path":"/ws/lib.mbt","start_line":2,"start_column":3,"end_line":2,"end_column":9},{"path":"/ws/bad.mbt","start_line":0,"start_column":1,"end_line":1,"end_column":1}]}
+  let locations = decode_moon_ide_locations(
+    reply,
+    @interop.ChannelId::Remote("device"),
+  )
+  assert_eq(locations.length(), 1)
+  assert_true(
+    model_uri_channel(locations[0].uri) == Some(Remote("device")) &&
+    model_uri_path(locations[0].uri) == Some(Absolute("/ws/lib.mbt")) &&
+    locations[0].range == @common.Range::Range(2, 3, 2, 9),
+  )
+}

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -82,6 +82,7 @@ pub(all) enum Msg {
   FilesIndexed(owner~ : @interop.ConversationKey, files~ : Array[@pathx.Relative], truncated~ : Bool)
   FileIndexFailed(owner~ : @interop.ConversationKey)
   FileSelected(path~ : @pathx.Relative, name~ : String)
+  OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
   FileLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, name~ : String, file~ : FileContent, range~ : @common.Range?, annotation~ : String?)
   FileFailed(owner~ : @interop.ConversationKey, message~ : String)
   FsChanged

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -287,6 +287,14 @@ pub(all) enum Msg {
   // A file row was clicked: read it and show it in the viewer. `name` is the
   // entry's display name, kept for the viewer's title and language guess.
   FileSelected(path~ : @pathx.Relative, name~ : String)
+  // A Definition/References result accepted by the Viewer's location opener.
+  // Carry the captured owner so a conversation switch that races the async
+  // request cannot open the target in the next workspace.
+  OpenNavigationLocation(
+    owner~ : @interop.ConversationKey,
+    path~ : @pathx.Relative,
+    range~ : @common.Range
+  )
   // `file` is the decoded reply (content + address, or a withheld-file
   // case). `range`, when present, is a jumped-to symbol's one-based range,
   // revealed in the viewer once the file loads and — unless empty —

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -44,7 +44,8 @@ fn show_tab(dispatch : @cmd.Emit[Msg], ctx : Ctx, tab : Tab) -> @cmd.Cmd {
       )
     TabLoaded(content~, absolute~, ..) => {
       let show = show_file_in_viewer(
-        ctx.owner.channel,
+        ctx.owner,
+        ctx.workspace,
         tab.name,
         content,
         absolute~,
@@ -616,6 +617,12 @@ pub fn update(
       }
     FileSelected(path~, name~) =>
       open_or_activate(dispatch, state, ctx, path, name, range=None)
+    OpenNavigationLocation(owner~, path~, range~) =>
+      if state.owner == Some(owner) && ctx.owner == owner {
+        open_file(dispatch, state, ctx, path, range=Some(range))
+      } else {
+        (@cmd.none, state)
+      }
     FileLoaded(owner~, path~, name~, file~, range~, annotation~) =>
       // A stale read — the conversation switched, or the tab was closed
       // while the read was in flight — must not resurrect state.
@@ -647,7 +654,8 @@ pub fn update(
             // — so only the viewer shows.
             Content(content~, absolute~, ..) => {
               let show = show_file_in_viewer(
-                ctx.owner.channel,
+                ctx.owner,
+                ctx.workspace,
                 name,
                 content,
                 absolute~,

--- a/desktop/frontend/fileeditor/viewer_services.mbt
+++ b/desktop/frontend/fileeditor/viewer_services.mbt
@@ -6,15 +6,30 @@ priv struct DesktopViewerServices {
   viewer_services : @viewer.ViewerServices
   markers : @markers.MarkerService
   feedback : @feedback.DesktopFeedbackService
+  // Retaining the registry handles keeps ownership explicit. The desktop
+  // mounts exactly one Viewer for the page lifetime; a future page teardown
+  // can dispose these without reaching into the process-wide registry.
+  _navigation_registrations : Array[@common.Disposable]
 }
 
 ///|
-fn DesktopViewerServices::DesktopViewerServices() -> DesktopViewerServices {
+fn DesktopViewerServices::DesktopViewerServices(
+  location_opener : @navigation_api.LocationOpenerHandle,
+  text_model_resolver : @navigation_api.TextModelResolverHandle,
+) -> DesktopViewerServices {
   let markers = @markers.MarkerService(schedule=@base_browser.queue_microtask)
   let feedback = @feedback.DesktopFeedbackService()
+  let navigation_registrations = register_moon_ide_navigation_providers()
   let viewer_services = @viewer.ViewerServices(
     markers=@markers.MarkerStore(markers.marker_service_handle()),
     agent_feedback=feedback.agent_feedback_handle(),
+    location_opener~,
+    text_model_resolver~,
   )
-  { viewer_services, markers, feedback }
+  {
+    viewer_services,
+    markers,
+    feedback,
+    _navigation_registrations: navigation_registrations,
+  }
 }

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -40,6 +40,8 @@ impl Show for PayloadError with fn output(self, logger) {
 /// self-update staging state. Filesystem watches are connection-owned below,
 /// because two clients may watch different workspaces at the same time.
 struct HostState {
+  engine : String
+  runtime_dir : @path.Path?
   lsp : LspPoolActor
   updates : UpdateState
 }
@@ -75,7 +77,12 @@ pub fn new_host_state(
   if runtime_dir is Some(dir) {
     @lsp.enable_traffic_log(dir.join("lsp.log").to_string())
   }
-  { lsp, updates: new_update_state(runtime_dir, executable) }
+  {
+    engine,
+    runtime_dir,
+    lsp,
+    updates: new_update_state(runtime_dir, executable),
+  }
 }
 
 ///|
@@ -244,6 +251,14 @@ pub async fn host_op(
           workspace_symbols_op(state.lsp, decode_payload(payload)),
         ),
       )
+    "moonide.definition" =>
+      Some(
+        ToJson::to_json(moonide_definition_op(state, decode_payload(payload))),
+      )
+    "moonide.references" =>
+      Some(
+        ToJson::to_json(moonide_references_op(state, decode_payload(payload))),
+      )
     "fs.browse" =>
       Some(ToJson::to_json(browse_directory_op(decode_payload(payload))))
     _ => None
@@ -258,8 +273,9 @@ pub fn host_method_names() -> Array[String] {
     "fs.read_file", "fs.read_directory", "fs.list_files", "fs.stat_files", "fs.watch",
     "fs.unwatch", "fs.browse", "terminal.open", "terminal.input", "terminal.resize",
     "terminal.ack", "terminal.close", "lsp.open", "lsp.hover", "lsp.workspace_symbols",
-    "skills.catalog", "skills.installed", "skills.install", "skills.uninstall", "update.check",
-    "update.download", "update.apply", "app.list", "app.launch", "git.branch", "host.open_path",
+    "moonide.definition", "moonide.references", "skills.catalog", "skills.installed",
+    "skills.install", "skills.uninstall", "update.check", "update.download", "update.apply",
+    "app.list", "app.launch", "git.branch", "host.open_path",
   ]
 }
 
@@ -272,4 +288,11 @@ test "host catalog advertises the complete terminal surface" {
     ] {
     assert_true(methods.contains(method_))
   }
+}
+
+///|
+test "host catalog advertises Moon IDE navigation" {
+  let methods = host_method_names()
+  assert_true(methods.contains("moonide.definition"))
+  assert_true(methods.contains("moonide.references"))
 }

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -21,6 +21,7 @@ import {
   "moonbitlang/core/encoding/base64",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
+  "moonbitlang/core/string",
   "moonbitlang/x/path",
   "tonyfettes/xlog",
 }

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -1,0 +1,407 @@
+// Host-owned Moon IDE navigation. These operations are deliberately separate
+// from the persistent moon-lsp pool: each request invokes the checked-out
+// workspace through `moon ide`, whose package/build-index semantics are the
+// source of truth for definition and reference locations.
+
+///|
+priv enum MoonIdeQuery {
+  Definition
+  References
+}
+
+///|
+priv struct MoonIdeRequest {
+  lexical_workspace : @path.Path
+  physical_workspace : @path.Path
+  relative_path : String
+  line : Int
+  column : Int
+}
+
+///|
+priv struct MoonIdeSpawnConfig {
+  executable : String
+  extra_env : Map[String, String]?
+}
+
+///|
+fn MoonIdeQuery::subcommand(self : MoonIdeQuery) -> String {
+  match self {
+    Definition => "peek-def"
+    References => "find-references"
+  }
+}
+
+///|
+/// The argv handed directly to the process API — never a shell string. `path`
+/// has already been reduced to a workspace-relative address, so an absolute
+/// client path cannot choose cwd or escape through the CLI.
+fn MoonIdeQuery::args(
+  self : MoonIdeQuery,
+  path : String,
+  line : Int,
+  column : Int,
+) -> Array[String] {
+  ["ide", self.subcommand(), "--loc", "\{path}:\{line}:\{column}", "--json"]
+}
+
+///|
+/// Resolve an already-absolute physical path below `workspace` to the CLI's
+/// normalized relative form. Normalizing before the containment check closes
+/// lexical `..` escapes; the async owner additionally canonicalizes both paths
+/// with `realpath` before calling this helper.
+fn moonide_relative_path(workspace : @path.Path, absolute : String) -> String? {
+  let candidate = @path.Path(absolute)
+  guard candidate.is_absolute() else { return None }
+  let root = workspace.normalize().to_string()
+  let candidate = candidate.normalize().to_string()
+  guard @pathx.relative_to(candidate, root~) is Some(relative) &&
+    !relative.is_empty() else {
+    return None
+  }
+  Some(relative)
+}
+
+///|
+/// Establish both workspace identities: the attached lexical spelling used by
+/// existing client models, and the canonical physical root used for security,
+/// CLI cwd, and relative locations. The engine helper requires an absolute
+/// path, chooses the deepest attached workspace, and rejects symlink escapes.
+async fn resolve_moonide_request(
+  payload : MoonIdeNavigationPayload,
+) -> MoonIdeRequest {
+  guard payload.line > 0 && payload.column > 0 else {
+    raise PayloadError("line and column must be positive one-based integers")
+  }
+  guard @engine.attached_workspace_dir(payload.path) is Some(attached) else {
+    raise HostError("path is outside every attached workspace")
+  }
+  let lexical_workspace = attached.normalize()
+  let workspace_text = @fs.realpath(lexical_workspace.to_string()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => raise HostError("attached workspace is unavailable")
+  }
+  let path_text = @fs.realpath(payload.path) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => raise HostError("navigation path is unavailable")
+  }
+  let physical_workspace = @path.Path(workspace_text).normalize()
+  guard moonide_relative_path(physical_workspace, path_text)
+    is Some(relative_path) else {
+    raise HostError("path is outside its attached workspace")
+  }
+  {
+    lexical_workspace,
+    physical_workspace,
+    relative_path,
+    line: payload.line,
+    column: payload.column,
+  }
+}
+
+///|
+fn moonide_spawn_config_from_bundled(
+  bundled : @path.Path?,
+) -> MoonIdeSpawnConfig {
+  match bundled {
+    Some(path) =>
+      {
+        executable: path.to_string(),
+        extra_env: Some(@moonbit.bundled_tool_env(path.dirname())),
+      }
+    None => { executable: "moon", extra_env: None }
+  }
+}
+
+///|
+async fn moonide_spawn_config(state : HostState) -> MoonIdeSpawnConfig {
+  moonide_spawn_config_from_bundled(
+    @moonbit.bundled_moon(state.engine, runtime_dir?=state.runtime_dir),
+  )
+}
+
+///|
+fn positive_position(text : StringView) -> (Int, Int)? {
+  guard [..text.split(":")] is [line_text, column_text] else { return None }
+  let line = @string.parse_int(line_text) catch { _ => return None }
+  let column = @string.parse_int(column_text) catch { _ => return None }
+  if line > 0 && column > 0 {
+    Some((line, column))
+  } else {
+    None
+  }
+}
+
+///|
+/// Parse Moon IDE's compact, one-based `line:column-line:column` range.
+/// Reversed and non-positive ranges are malformed rows.
+fn parse_moonide_range(text : String) -> (Int, Int, Int, Int)? {
+  guard [..text.split("-")] is [start_text, end_text] else { return None }
+  guard positive_position(start_text) is Some((start_line, start_column)) &&
+    positive_position(end_text) is Some((end_line, end_column)) else {
+    return None
+  }
+  guard end_line > start_line ||
+    (end_line == start_line && end_column >= start_column) else {
+    return None
+  }
+  Some((start_line, start_column, end_line, end_column))
+}
+
+///|
+/// Normalize one CLI result into an absolute candidate. Current Moon IDE emits
+/// absolute paths, but accepting relative output against the physical cwd is
+/// harmless. This helper deliberately makes no security decision: the owner
+/// follows `realpath` and checks the physical workspace afterwards.
+fn moonide_result_path(physical_workspace : @path.Path, raw : String) -> String {
+  let raw_path = @path.Path(raw)
+  let candidate = if raw_path.is_absolute() {
+    raw_path.normalize()
+  } else {
+    physical_workspace.join(raw_path).normalize()
+  }
+  candidate.to_string()
+}
+
+///|
+/// Decode the stable Moon IDE JSON shape (`null` or `[{path, range}]`). A bad
+/// document is an operation failure; bad individual rows are omitted so one
+/// stale compiler location cannot poison the other valid navigation targets.
+fn parse_moonide_output(
+  output : String,
+  physical_workspace : @path.Path,
+) -> MoonIdeLocationsReply raise HostError {
+  let json = @json.parse(output) catch {
+    _ => raise HostError("moon ide returned malformed JSON")
+  }
+  let items = match json {
+    Null => return { locations: [] }
+    Array(items) => items
+    _ => raise HostError("moon ide returned an unexpected JSON value")
+  }
+  let locations : Array[MoonIdeLocation] = []
+  for item in items {
+    guard item is Object(fields) &&
+      fields.get("path") is Some(String(path)) &&
+      fields.get("range") is Some(String(range)) else {
+      continue
+    }
+    guard parse_moonide_range(range)
+      is Some((start_line, start_column, end_line, end_column)) else {
+      continue
+    }
+    let path = moonide_result_path(physical_workspace, path)
+    locations.push({ path, start_line, start_column, end_line, end_column })
+  }
+  { locations, }
+}
+
+///|
+/// Map one already-canonical result from the physical security identity back
+/// to the attached workspace's lexical spelling. This keeps model URIs aligned
+/// with `fs.read_file` even when the attached root itself is a symlink.
+fn moonide_client_path(
+  lexical_workspace : @path.Path,
+  physical_workspace : @path.Path,
+  physical_result : String,
+) -> String? {
+  guard moonide_relative_path(physical_workspace, physical_result)
+    is Some(relative) else {
+    return None
+  }
+  Some(lexical_workspace.join(Path(relative)).normalize().to_string())
+}
+
+///|
+/// Follow result symlinks and retain only files physically beneath the exact
+/// canonical workspace that owned the request. A safe result is mapped back
+/// to the lexical attached root before crossing the wire. Unreadable/stale
+/// paths are dropped, while line and column numbers pass through unchanged.
+async fn canonical_moonide_locations(
+  reply : MoonIdeLocationsReply,
+  lexical_workspace : @path.Path,
+  physical_workspace : @path.Path,
+) -> MoonIdeLocationsReply {
+  let locations : Array[MoonIdeLocation] = []
+  for location in reply.locations {
+    let canonical = @fs.realpath(location.path) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => continue
+    }
+    guard moonide_client_path(lexical_workspace, physical_workspace, canonical)
+      is Some(path) else {
+      continue
+    }
+    locations.push({
+      path,
+      start_line: location.start_line,
+      start_column: location.start_column,
+      end_line: location.end_line,
+      end_column: location.end_column,
+    })
+  }
+  { locations, }
+}
+
+///|
+async fn moonide_navigation_op(
+  state : HostState,
+  query : MoonIdeQuery,
+  payload : MoonIdeNavigationPayload,
+) -> MoonIdeLocationsReply {
+  let request = resolve_moonide_request(payload)
+  let config = moonide_spawn_config(state)
+  let args = query.args(request.relative_path, request.line, request.column)
+  let (code, stdout, stderr) = @process.collect_output(
+    config.executable,
+    args,
+    extra_env?=config.extra_env,
+    inherit_env=config.extra_env is None,
+    cwd=request.physical_workspace.to_string(),
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise HostError("could not run moon ide: \{error}")
+  }
+  if code != 0 {
+    let stderr = (stderr.text() catch { _ => "" }).trim().to_owned()
+    let stdout = (stdout.text() catch { _ => "" }).trim().to_owned()
+    let detail = if !stderr.is_empty() { stderr } else { stdout }
+    raise HostError(
+      if detail.is_empty() {
+        "moon ide \{query.subcommand()} exited with code \{code}"
+      } else {
+        detail
+      },
+    )
+  }
+  let output = stdout.text() catch {
+    _ => raise HostError("moon ide returned non-text output")
+  }
+  canonical_moonide_locations(
+    parse_moonide_output(output, request.physical_workspace),
+    request.lexical_workspace,
+    request.physical_workspace,
+  )
+}
+
+///|
+async fn moonide_definition_op(
+  state : HostState,
+  payload : MoonIdeNavigationPayload,
+) -> MoonIdeLocationsReply {
+  moonide_navigation_op(state, Definition, payload)
+}
+
+///|
+async fn moonide_references_op(
+  state : HostState,
+  payload : MoonIdeNavigationPayload,
+) -> MoonIdeLocationsReply {
+  moonide_navigation_op(state, References, payload)
+}
+
+///|
+test "Moon IDE commands use relative one-based locations without a shell" {
+  assert_eq(Definition.args("src/main.mbt", 12, 5), [
+    "ide", "peek-def", "--loc", "src/main.mbt:12:5", "--json",
+  ])
+  assert_eq(References.args("src/main.mbt", 12, 5), [
+    "ide", "find-references", "--loc", "src/main.mbt:12:5", "--json",
+  ])
+}
+
+///|
+test "Moon IDE relative paths normalize in-root paths and reject escapes" {
+  let workspace = @path.Path("/workspace")
+  assert_eq(
+    moonide_relative_path(workspace, "/workspace/src/../main.mbt"),
+    Some("main.mbt"),
+  )
+  assert_true(moonide_relative_path(workspace, "/outside/main.mbt") is None)
+  assert_true(
+    moonide_relative_path(workspace, "/workspace/../../outside.mbt") is None,
+  )
+  assert_true(moonide_relative_path(workspace, "relative.mbt") is None)
+  assert_true(moonide_relative_path(workspace, "/workspace") is None)
+}
+
+///|
+test "Moon IDE parser expands ranges before physical security filtering" {
+  let workspace = @path.Path("/workspace")
+  let reply = parse_moonide_output(
+    (
+      #|[
+      #|  {"path":"/workspace/src/a.mbt","range":"2:3-4:5"},
+      #|  {"path":"src/b.mbt","range":"7:8-7:12"},
+      #|  {"path":"/other/c.mbt","range":"1:1-1:2"},
+      #|  {"path":"../escape.mbt","range":"1:1-1:2"},
+      #|  {"path":"/workspace/bad.mbt","range":"0:1-1:2"},
+      #|  {"path":"/workspace/reversed.mbt","range":"3:4-2:1"},
+      #|  {"path":"/workspace/missing-range.mbt"}
+      #|]
+    ),
+    workspace,
+  )
+  assert_eq(ToJson::to_json(reply), {
+    "locations": [
+      {
+        "path": "/workspace/src/a.mbt",
+        "start_line": 2,
+        "start_column": 3,
+        "end_line": 4,
+        "end_column": 5,
+      },
+      {
+        "path": "/workspace/src/b.mbt",
+        "start_line": 7,
+        "start_column": 8,
+        "end_line": 7,
+        "end_column": 12,
+      },
+      {
+        "path": "/other/c.mbt",
+        "start_line": 1,
+        "start_column": 1,
+        "end_line": 1,
+        "end_column": 2,
+      },
+      {
+        "path": "/escape.mbt",
+        "start_line": 1,
+        "start_column": 1,
+        "end_line": 1,
+        "end_column": 2,
+      },
+    ],
+  })
+  assert_true(parse_moonide_output("null", workspace).locations.is_empty())
+}
+
+///|
+test "physical Moon IDE results keep the lexical attached workspace identity" {
+  let lexical = @path.Path("/attached/project-link")
+  let physical = @path.Path("/private/projects/project")
+  assert_eq(
+    moonide_client_path(
+      lexical, physical, "/private/projects/project/src/main.mbt",
+    ),
+    Some("/attached/project-link/src/main.mbt"),
+  )
+  assert_true(
+    moonide_client_path(lexical, physical, "/private/projects/other/main.mbt")
+    is None,
+  )
+  assert_true(
+    moonide_client_path(lexical, physical, "/private/projects/project") is None,
+  )
+}
+
+///|
+test "Moon IDE spawn config prefers bundled moon and falls back to PATH" {
+  let bundled = moonide_spawn_config_from_bundled(Some(Path("/tool/bin/moon")))
+  assert_eq(bundled.executable, "/tool/bin/moon")
+  assert_true(bundled.extra_env is Some(_))
+  let fallback = moonide_spawn_config_from_bundled(None)
+  assert_eq(fallback.executable, "moon")
+  assert_true(fallback.extra_env is None)
+}

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -272,6 +272,36 @@ priv struct LspHoverPayload {
 } derive(FromJson)
 
 ///|
+/// A source position for Moon IDE navigation. `line` and `column` are positive,
+/// one-based numbers which the host passes to `moon ide --loc` unchanged.
+/// `path` is absolute and is accepted only when it belongs to an attached
+/// workspace.
+priv struct MoonIdeNavigationPayload {
+  path : String
+  line : Int
+  column : Int
+} derive(FromJson)
+
+///|
+/// One Moon IDE navigation result. The host validates the CLI path against the
+/// physical workspace, then maps it back under the attached workspace's
+/// lexical spelling. Its compact range becomes explicit numeric fields while
+/// line and column values retain the coordinates emitted by Moon IDE.
+priv struct MoonIdeLocation {
+  path : String
+  start_line : Int
+  start_column : Int
+  end_line : Int
+  end_column : Int
+} derive(ToJson)
+
+///|
+/// Shared reply shape for `moonide.definition` and `moonide.references`.
+priv struct MoonIdeLocationsReply {
+  locations : Array[MoonIdeLocation]
+} derive(ToJson)
+
+///|
 /// `lsp_open` tells the host the editor is now showing the file at absolute
 /// `path`, so the language server opens/syncs it and starts publishing
 /// diagnostics. The reply carries whatever the server has already reported;

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -280,6 +280,27 @@ pub fn bundled_tool_env(bin_dir : @path.Path) -> Map[String, String] {
 }
 
 ///|
+/// Path to `moon` in the bundled MoonBit toolchain, or `None` when the host is
+/// running without a packaged seed. Bare development hosts deliberately use
+/// that absence to fall back to `moon` on PATH; packaged hosts always execute
+/// the prepared per-user copy so Moon IDE and moon-lsp share one toolchain.
+pub async fn bundled_moon(
+  engine_command : String,
+  runtime_dir? : @path.Path,
+) -> @path.Path? {
+  let moon_home = prepare_bundled_home(engine_command, runtime_dir?) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return None
+  }
+  let moon = moonbit_command(moon_home)
+  if @fsx.exists(moon) {
+    Some(moon)
+  } else {
+    None
+  }
+}
+
+///|
 /// Path to the `moon-lsp` shipped in the bundled MoonBit toolchain, or `None`
 /// when there is no bundled seed (a dev run of the bare host binary, where the
 /// caller falls back to `moon-lsp` on PATH). This shares the home the engine

--- a/desktop/internal/moonbit/pkg.generated.mbti
+++ b/desktop/internal/moonbit/pkg.generated.mbti
@@ -6,6 +6,8 @@ import {
 }
 
 // Values
+pub async fn bundled_moon(String, runtime_dir? : @path.Path) -> @path.Path?
+
 pub async fn bundled_moon_lsp(String, runtime_dir? : @path.Path) -> @path.Path?
 
 pub fn bundled_tool_env(@path.Path) -> Map[String, String]

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -15,7 +15,7 @@ import {
   "justjavac/proton_ext@0.1.7",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
-  "moonbitlang/editor@0.4.2",
+  "moonbitlang/editor@0.4.4",
   "justjavac/proton_contract@0.1.0",
 }
 

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -15,7 +15,7 @@ import {
   "justjavac/proton_ext@0.1.7",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
-  "moonbitlang/editor@0.4.0",
+  "moonbitlang/editor@0.4.2",
   "justjavac/proton_contract@0.1.0",
 }
 

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -47,9 +47,11 @@ fn viewer_css_sources() -> Array[String] {
     "viewer/browser/view_parts/decorations/decorations.css", "viewer/browser/view_parts/view_cursors/view_cursors.css",
     "viewer/browser/view_parts/margin/margin.css", "viewer/browser/view_parts/margin/lines_decorations.css",
     "viewer/browser/view_parts/view_lines/tokens.css", "viewer/browser/view_parts/view_lines/markers.css",
-    "viewer/contrib/folding/browser/folding.css", "viewer/contrib/hover/hover.css",
-    "viewer/contrib/quick_diff/browser/quick_diff.css", "viewer/contrib/agent_feedback/browser/agent_feedback.css",
-    "viewer/contrib/markdown_comments/browser/markdown_comments.css",
+    "viewer/contrib/folding/browser/folding.css", "viewer/contrib/contextmenu/browser/contextmenu.css",
+    "viewer/contrib/definition/browser/definition.css", "viewer/contrib/references/browser/references.css",
+    "viewer/contrib/hover/hover.css", "viewer/contrib/quick_diff/browser/quick_diff.css",
+    "viewer/contrib/agent_feedback/browser/agent_feedback.css", "internal/viewer/browser/markdown/diagram_viewport.css",
+    "viewer/contrib/markdown_comments/browser/markdown_comments.css", "internal/viewer/browser/markdown_document/markdown_document.css",
   ]
 }
 

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -24,7 +24,15 @@
   --vscode-widget-border: #313131;
   --vscode-widget-shadow: rgb(0 0 0 / 36%);
   --vscode-shadow-hover: rgb(0 0 0 / 36%);
+  --vscode-shadow-lg: 0 0 12px rgb(0 0 0 / 36%);
+  --vscode-cornerRadius-medium: 2px;
   --vscode-cornerRadius-large: 4px;
+  --vscode-menu-background: #1f1f1f;
+  --vscode-menu-foreground: #cccccc;
+  --vscode-menu-selectionBackground: #0078d4;
+  --vscode-menu-selectionForeground: #ffffff;
+  --vscode-menu-separatorBackground: #cccccc33;
+  --vscode-menu-border: transparent;
 
   --vscode-editor-background: #1f1f1f;
   --vscode-editor-foreground: #cccccc;
@@ -33,6 +41,8 @@
   --vscode-editor-selectionBackground: #264f78;
   --vscode-editor-hoverHighlightBackground: #264f7840;
   --vscode-editor-rangeHighlightBackground: #ffffff0b;
+  --vscode-editor-symbolHighlightBackground: #ea5c0055;
+  --vscode-editor-symbolHighlightBorder: transparent;
   /* editor.foldBackground = transparent(editor.selectionBackground, 0.3),
      editor.foldPlaceholderForeground = #808080,
      editorGutter.foldingControlForeground = iconForeground
@@ -56,6 +66,19 @@
   --vscode-editorError-foreground: #f14c4c;
   --vscode-editorInfo-foreground: #59a4f9;
   --vscode-editorHint-foreground: #eeeeeeb3;
+  --vscode-peekView-border: #59a4f9;
+  --vscode-peekViewTitle-background: #252526;
+  --vscode-peekViewTitleLabel-foreground: #ffffff;
+  --vscode-peekViewTitleDescription-foreground: #ccccccb3;
+  --vscode-peekViewResult-background: #252526;
+  --vscode-peekViewResult-lineForeground: #bbbbbb;
+  --vscode-peekViewResult-fileForeground: #ffffff;
+  --vscode-peekViewResult-selectionBackground: #3399ff33;
+  --vscode-peekViewResult-selectionForeground: #ffffff;
+  --vscode-peekViewEditor-background: #001f33;
+  --vscode-peekViewEditorGutter-background: #001f33;
+  --vscode-peekViewEditor-matchHighlightBackground: #ff8f0099;
+  --vscode-peekViewEditor-matchHighlightBorder: transparent;
 
   /* editorError/Warning/Info/Hint.border are null in VS Code's normal (non-HC)
      themes, so they stay unset here too — the visible squiggle is the runtime
@@ -77,6 +100,7 @@
   --vscode-input-background: #313131;
   --vscode-input-foreground: #cccccc;
   --vscode-input-border: #3c3c3c;
+  --vscode-inputValidation-infoBorder: #007acc;
   --vscode-button-background: #0078d4;
   --vscode-button-foreground: #ffffff;
   --vscode-button-hoverBackground: #026ec1;
@@ -148,7 +172,15 @@
   --vscode-widget-border: #e5e5e5;
   --vscode-widget-shadow: rgb(0 0 0 / 16%);
   --vscode-shadow-hover: rgb(0 0 0 / 16%);
+  --vscode-shadow-lg: 0 0 12px rgb(0 0 0 / 16%);
+  --vscode-cornerRadius-medium: 2px;
   --vscode-cornerRadius-large: 4px;
+  --vscode-menu-background: #ffffff;
+  --vscode-menu-foreground: #3b3b3b;
+  --vscode-menu-selectionBackground: #005fb8;
+  --vscode-menu-selectionForeground: #ffffff;
+  --vscode-menu-separatorBackground: #3b3b3b33;
+  --vscode-menu-border: #cecece;
 
   --vscode-editor-background: #ffffff;
   --vscode-editor-foreground: #3b3b3b;
@@ -157,6 +189,8 @@
   --vscode-editor-selectionBackground: #add6ff;
   --vscode-editor-hoverHighlightBackground: #add6ff26;
   --vscode-editor-rangeHighlightBackground: #fdff0033;
+  --vscode-editor-symbolHighlightBackground: #ea5c0055;
+  --vscode-editor-symbolHighlightBorder: transparent;
   /* See the Dark Modern block above (folding colors). */
   --vscode-editor-foldBackground: #add6ff4d;
   --vscode-editor-foldPlaceholderForeground: #808080;
@@ -174,6 +208,19 @@
   --vscode-editorError-foreground: #e51400;
   --vscode-editorInfo-foreground: #0063d3;
   --vscode-editorHint-foreground: #6c6c6c;
+  --vscode-peekView-border: #0063d3;
+  --vscode-peekViewTitle-background: #f3f3f3;
+  --vscode-peekViewTitleLabel-foreground: #000000;
+  --vscode-peekViewTitleDescription-foreground: #616161;
+  --vscode-peekViewResult-background: #f3f3f3;
+  --vscode-peekViewResult-lineForeground: #646465;
+  --vscode-peekViewResult-fileForeground: #1e1e1e;
+  --vscode-peekViewResult-selectionBackground: #3399ff33;
+  --vscode-peekViewResult-selectionForeground: #6c6c6c;
+  --vscode-peekViewEditor-background: #f2f8fc;
+  --vscode-peekViewEditorGutter-background: #f2f8fc;
+  --vscode-peekViewEditor-matchHighlightBackground: #f5d802de;
+  --vscode-peekViewEditor-matchHighlightBorder: transparent;
 
   /* See the Dark Modern block above. */
   --vscode-editorUnnecessaryCode-opacity: 0.47;
@@ -190,6 +237,7 @@
   --vscode-input-background: #ffffff;
   --vscode-input-foreground: #3b3b3b;
   --vscode-input-border: #cecece;
+  --vscode-inputValidation-infoBorder: #007acc;
   --vscode-button-background: #005fb8;
   --vscode-button-foreground: #ffffff;
   --vscode-button-hoverBackground: #0258a8;

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -473,6 +473,23 @@ Notification:
 |---|---|
 | `lsp.diagnostics` | `{path, diagnostics}` — same array shape as `lsp.open`'s reply |
 
+### moonide.* — workspace navigation
+
+Both methods accept an absolute source `path` plus positive, one-based `line`
+and `column` numbers. The host passes those values unchanged to `moon ide
+--loc`, after resolving the path to its attached workspace, and runs the
+bundled `moon` from that workspace root (`moon` on `PATH` only for a bare
+development host without a packaged toolchain seed). Result paths are
+canonicalized for physical containment, then mapped back under the attached
+workspace's lexical root so they match existing file/model identities. The
+CLI's line and column values are returned unchanged; malformed or
+workspace-escaping locations are omitted.
+
+| method | params | result |
+|---|---|---|
+| `moonide.definition` | `{path, line, column}` (absolute path; positive 1-based position) | `{locations: [{path, start_line, start_column, end_line, end_column}]}` — absolute paths under the attached lexical workspace root, with Moon IDE's numeric ranges |
+| `moonide.references` | `{path, line, column}` (absolute path; positive 1-based position) | `{locations: [{path, start_line, start_column, end_line, end_column}]}` — absolute paths under the attached lexical workspace root, with Moon IDE's numeric ranges |
+
 ### skills.*
 
 | method | params | result |
@@ -617,7 +634,7 @@ changed and why:
   to close exact reconnect ownership (including a zero-commit abnormal exit).
   Full-message events overwrite partial deltas within one step.
 - **Route/op names unified** under dotted namespaces (`agent.*`,
-  `session.*`, `workspace.*`, `git.*`, `fs.*`, `lsp.*`, `skills.*`,
+  `session.*`, `workspace.*`, `git.*`, `fs.*`, `lsp.*`, `moonide.*`, `skills.*`,
   `update.*`, `app.*`, `host.*`), shared verbatim by the bridge and the
   WebSocket.
 - **Most in-band sentinels were removed from the wire**: request `cwd` and


### PR DESCRIPTION
## Summary

- adapt the desktop viewer to `moonbitlang/editor` 0.4.4, including the current API, CSS/theme assets, and Markdown comment rendering
- implement Definition and References providers through host RPC operations backed by `moon ide peek-def --json` and `moon ide find-references --json`
- expose Go to Definition, Peek Definition, and Peek References through the editor's shared navigation UI
- keep the macOS packager aligned with the dependency-owned viewer assets

## Data flow

The editor requests Definition or References from the OpenSeek provider. The desktop frontend routes the request to the owning host, the host invokes the bundled Moon IDE command, and the decoded locations return to the editor's normal navigation and Peek controllers.

This path is intentionally independent of LSP. Moon IDE positions are passed through unchanged for now; scalar-to-UTF-16 conversion belongs in Moon IDE. Hover, diagnostics, and LSP-session removal are explicitly out of scope.

## Dependency

Depends on moonbitlang/editor#125, which fixes embedded codicon loading and bumps the editor package to 0.4.4.

Until that PR is merged and 0.4.4 is published to Mooncakes, this draft's GitHub Actions are expected to stop during dependency resolution with `no version satisfies requirement 0.4.4`. Local validation used the editor #125 worktree as a temporary workspace dependency.

## Validation

- `moon check --target js`
- `moon check --target native`
- `moon test --target js` (`2676 passed`)
- `moon test --target native` (`3205 passed`)
- `moon fmt --check`
- `moon info` with no non-blank generated-interface drift
- `moon -C desktop run --target native package/macos`
- packaged App asset checks for the relative codicon URL, folding glyphs, Moon IDE provider code, arm64 binaries, and strict CEF helper signature
