### PR TITLE
feat(agent_worker): raise worker step ceiling to 300, wall deadline to 45min

### DIFF
--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -4,15 +4,21 @@
 // the generated `.mbt`.
 
 ///|
-/// Step ceiling requested for one worker child. Same reasoning as explore's:
-/// a truncated child burns its allowance and returns nothing, so the ceiling
-/// is generous and the prompt's answer-early rule is what bounds real cost.
-pub let default_worker_max_steps : Int = 100
+/// Step ceiling requested for one worker child. Sized from real sweep
+/// workloads, not the scout's Q&A profile: an edit+verify worker spends
+/// 2-3 steps per fix cluster, and package-sized slices complete at ~80-100
+/// steps — the old ceiling of 100 truncated the overflow tail in two
+/// consecutive production sweeps. 300 is ~3x the observed completion
+/// envelope; the wall deadline below is the hang guard, and the prompt's
+/// answer-early rule is what bounds real cost.
+pub let default_worker_max_steps : Int = 300
 
 ///|
-/// Wall deadline for one worker child: real edit+verify loops run moon
-/// check/test repeatedly, so a worker gets twice the scout's ten minutes.
-pub let default_worker_deadline_ms : Int = 1_200_000
+/// Wall deadline for one worker child. Observed sweep pace is ~6-8s/step,
+/// so the step ceiling above spends at most ~30-40 minutes of steady
+/// progress; 45 minutes keeps the deadline from truncating a worker the
+/// step ceiling would allow, while still cutting off a hung child.
+pub let default_worker_deadline_ms : Int = 2_700_000
 
 ///|
 /// The geometry and work order a worker child receives from the subtask

--- a/docs/plans/subtask-worker-subagents.md
+++ b/docs/plans/subtask-worker-subagents.md
@@ -74,7 +74,9 @@ reaches the profile). Ship first, alone.
 10. Prewarm: copy origin `.mooncakes` when present (immutable snapshot;
     measure size, skip over a threshold with a note). `_build` never copied.
 11. Launch `run_subrun` (cwd=wt, `subrun worker --dir <wt>`, child_session?,
-    deadline 20 min, steps 100). Child env additions: `GIT_OPTIONAL_LOCKS=0`.
+    deadline 45 min, steps 300 — resized 2026-08-04 after two sweeps
+    truncated workers at the original 100). Child env additions:
+    `GIT_OPTIONAL_LOCKS=0`.
 
 ## Worker sandbox profile (macOS kernel layer)
 
@@ -193,8 +195,8 @@ subrun tools); substantial worker system prompt (.mbt.md + dev_build; "do
 not run git commit/worktree — the harness commits; permission errors on
 those are expected"); report v1 {status, summary, verification}; child
 session persistence; viz gate + tests; TUI unchanged; about-text fix;
-budget (SubrunBudget shared backstop + 4-slot semaphore, 20 min, 100
-steps); prompt guidance incl. warning-sweep recipe (partitions =
+budget (SubrunBudget shared backstop + 4-slot semaphore, 45 min, 300
+steps since 2026-08-04); prompt guidance incl. warning-sweep recipe (partitions =
 allowed_paths; integrate one at a time re-checking after each); dogfood
 eval with negative controls (seeded out-of-scope worker must yield a
 scope-violation error; final verdict from the checker).


### PR DESCRIPTION
The worker step ceiling of 100 was inherited from the explore scout's Q&A sizing rationale and has now truncated edit+verify workers in two consecutive mbtexcel production sweeps (2026-07-31: 2 of 4 workers; 2026-08-04: 1 of 4 truncated at 100 with 28 warnings left, plus a 99-step near-miss completion).

Empirics from the 2026-08-04 sweep: package-sized slices complete at ~80-100 steps, ~6-8s/step, so workers hit the step ceiling at roughly half the 20-minute wall budget — the backstop bound real work while the guard never fired.

- `default_worker_max_steps` 100 → 300 (~3x the observed completion envelope)
- `default_worker_deadline_ms` 20min → 45min (steps spend at most ~30-40min of steady progress, so the deadline only fires on a genuine hang)

`SubrunBudget` is a per-turn call-count allowance (reserve returns the full requested ceiling), so raising the per-worker number cannot starve fan-out.

Follow-up (separate PR): a `continue` path so the parent can relaunch a fresh worker on the kept worktree after truncation instead of mopping up in its own context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)