### PR TITLE
feat(subtask): continue=<name> — resume a truncated slice with a fresh worker on its kept worktree

### DIFF
--- a/cmd/openseek/internal/subtask/capture.mbt
+++ b/cmd/openseek/internal/subtask/capture.mbt
@@ -24,13 +24,21 @@ pub async fn capture(
   let worker = entry.worker_root
   let evidence : Array[String] = []
   let defects : Array[String] = []
+  // The pin this capture measures HEAD against and stacks its commit on. A
+  // first capture pins the recorded base; a RESUMED slice's worktree
+  // legitimately sits at the previous capture's commit (update-ref moved
+  // the checked-out branch), so later captures pin that commit instead.
+  let pin = match entry.commit_oid {
+    Some(prior) => prior
+    None => entry.base_oid
+  }
   // The worker cannot commit (the sandbox denies the shared object store);
   // a moved HEAD means something abnormal happened — refuse to reason on it.
   match git_require(["rev-parse", "HEAD"], cwd=worker) {
     Ok(head) =>
-      if head.trim() != entry.base_oid {
+      if head.trim() != pin {
         defects.push(
-          "worktree HEAD moved from the pinned base (\{head.trim()} != \{entry.base_oid})",
+          "worktree HEAD moved from the pinned base (\{head.trim()} != \{pin})",
         )
       }
     Err(reason) => defects.push(reason)
@@ -52,6 +60,15 @@ pub async fn capture(
     // to whatever happened — keep it and report.
     let entry = { ..entry, state: Captured }
     let _ = save_entry(geometry.common_git_dir, entry)
+    return { entry, evidence, defects }
+  }
+  if changes.is_empty() && entry.commit_oid is Some(prior) {
+    // A resumed worker that added nothing new: the prior capture still
+    // stands. The terminal cleanup below would delete the branch holding
+    // already-validated work — keep everything and report instead.
+    let entry = { ..entry, state: Committed }
+    let _ = save_entry(geometry.common_git_dir, entry)
+    evidence.push("no additional changes since the prior capture \{prior}")
     return { entry, evidence, defects }
   }
   if changes.is_empty() {
@@ -127,14 +144,14 @@ pub async fn capture(
     return { entry, evidence, defects }
   }
   // Commit EXACTLY the validated tree; then move the branch ref to it,
-  // guarded by the expected old value (the pinned base).
+  // guarded by the expected old value (the pin).
   let commit_oid = match
     git_require(
       [
         "commit-tree",
         tree_oid,
         "-p",
-        entry.base_oid,
+        pin,
         "-m",
         "subtask \{entry.name}: worker changes",
       ],
@@ -148,7 +165,7 @@ pub async fn capture(
   }
   match
     git_require(
-      ["update-ref", "refs/heads/\{entry.branch}", commit_oid, entry.base_oid],
+      ["update-ref", "refs/heads/\{entry.branch}", commit_oid, pin],
       cwd=worker,
     ) {
     Ok(_) => ()

--- a/cmd/openseek/internal/subtask/capture.mbt
+++ b/cmd/openseek/internal/subtask/capture.mbt
@@ -65,10 +65,24 @@ pub async fn capture(
   if changes.is_empty() && entry.commit_oid is Some(prior) {
     // A resumed worker that added nothing new: the prior capture still
     // stands. The terminal cleanup below would delete the branch holding
-    // already-validated work — keep everything and report instead.
-    let entry = { ..entry, state: Committed }
+    // already-validated work — keep everything and report instead. "Still
+    // stands" is verified, not assumed: an externally moved branch must
+    // surface now, not as a later integrate refusal.
+    match git_require(["rev-parse", "refs/heads/\{entry.branch}"], cwd=worker) {
+      Ok(tip) if tip.trim() == prior => {
+        let entry = { ..entry, state: Committed }
+        let _ = save_entry(geometry.common_git_dir, entry)
+        evidence.push("no additional changes since the prior capture \{prior}")
+        return { entry, evidence, defects }
+      }
+      Ok(tip) =>
+        defects.push(
+          "branch \{entry.branch} moved externally (\{tip.trim()} != prior capture \{prior})",
+        )
+      Err(reason) => defects.push(reason)
+    }
+    let entry = { ..entry, state: Captured }
     let _ = save_entry(geometry.common_git_dir, entry)
-    evidence.push("no additional changes since the prior capture \{prior}")
     return { entry, evidence, defects }
   }
   if changes.is_empty() {

--- a/cmd/openseek/internal/subtask/integrate.mbt
+++ b/cmd/openseek/internal/subtask/integrate.mbt
@@ -33,6 +33,25 @@ fn merge_args(entry : SubtaskEntry, commit_oid : String) -> Array[String] {
 }
 
 ///|
+/// Re-read the caller's entry from the registry: the tool layer loaded its
+/// snapshot BEFORE any mutex was taken, and a concurrent continue may have
+/// advanced the state since (e.g. Committed → Running with a live child).
+/// Operating on the stale snapshot would merge or delete under that child.
+/// A missing record falls back to the snapshot — the state guards at each
+/// call site then decide.
+async fn reload_entry(
+  common_git_dir : String,
+  entry : SubtaskEntry,
+) -> SubtaskEntry {
+  let (entries, _) = load_entries(common_git_dir)
+  match
+    entries.filter(e => e.name == entry.name && e.nonce == entry.nonce).last() {
+    Some(fresh) => fresh
+    None => entry
+  }
+}
+
+///|
 /// Merge a committed subtask into the origin; outcome classified by git
 /// postconditions (integrated | conflicted | refused).
 pub async fn integrate(
@@ -52,6 +71,7 @@ async fn integrate_locked(
   origin : String,
   entry : SubtaskEntry,
 ) -> IntegrateOutcome {
+  let entry = reload_entry(geometry.common_git_dir, entry)
   guard entry.state is Committed && entry.commit_oid is Some(commit_oid) else {
     return {
       entry,
@@ -214,6 +234,7 @@ async fn integrate_continue_locked(
   origin : String,
   entry : SubtaskEntry,
 ) -> IntegrateOutcome {
+  let entry = reload_entry(geometry.common_git_dir, entry)
   guard entry.state is Conflicted && entry.commit_oid is Some(commit_oid) else {
     return {
       entry,
@@ -316,6 +337,10 @@ pub async fn integrate_abort(
   entry : SubtaskEntry,
 ) -> IntegrateOutcome {
   let origin = geometry.origin_root
+  let mutex = repo_mutex(geometry.common_git_dir)
+  mutex.acquire()
+  defer mutex.release()
+  let entry = reload_entry(geometry.common_git_dir, entry)
   guard entry.state is Conflicted && entry.commit_oid is Some(commit_oid) else {
     return {
       entry,
@@ -356,6 +381,14 @@ pub async fn discard(
   entry : SubtaskEntry,
 ) -> Result[Unit, String] {
   let origin = geometry.origin_root
+  // Discard stays the destructive escape hatch for ANY non-terminal state
+  // (it is the documented recovery for a crashed or cancelled child), but
+  // it serializes with the other lifecycle actions and acts on the fresh
+  // record, never a stale snapshot.
+  let mutex = repo_mutex(geometry.common_git_dir)
+  mutex.acquire()
+  defer mutex.release()
+  let entry = reload_entry(geometry.common_git_dir, entry)
   if entry.commit_oid is Some(commit_oid) {
     let merge_head = git_run(
       ["rev-parse", "-q", "--verify", "MERGE_HEAD"],

--- a/cmd/openseek/internal/subtask/lifecycle_test.mbt
+++ b/cmd/openseek/internal/subtask/lifecycle_test.mbt
@@ -430,3 +430,94 @@ async test "resume_running refuses unknown names and running slices" {
     assert_true(running.contains("Running"))
   })
 }
+
+///|
+/// The repair half of continue: a defective re-capture preserves the prior
+/// commit_oid, resume admits the Captured state, and once the intrusion is
+/// reverted the idle re-capture returns to Committed on the SAME commit.
+async test "captured defects repair through resume and re-capture" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-repair-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let entry = provisioned.entry
+    @vfs.write_text("\{entry.worker_root}/lib", "a.txt", "ALPHA\n")
+    let first = @subtask.capture(provisioned.geometry, entry)
+    assert_true(first.entry.state is Committed)
+    guard first.entry.commit_oid is Some(commit1) else {
+      fail("expected a first commit")
+    }
+    // A resumed worker strays out of scope: the re-capture is defective but
+    // must keep the prior commit pinned.
+    @vfs.write_text("\{entry.worker_root}/other", "b.txt", "INTRUDED\n")
+    let defective = @subtask.capture(provisioned.geometry, first.entry)
+    assert_true(defective.defects.length() > 0)
+    assert_true(defective.entry.state is Captured)
+    assert_eq(defective.entry.commit_oid, Some(commit1))
+    // Captured is continuable; the repair worker reverts the intrusion.
+    let resumed = match
+      @subtask.resume_running(provisioned.geometry, "fix-lib") {
+      Ok(resumed) => resumed
+      Err(reason) => fail("resume_running refused a Captured slice: \{reason}")
+    }
+    @vfs.write_text("\{resumed.worker_root}/other", "b.txt", "beta\n")
+    let repaired = @subtask.capture(provisioned.geometry, resumed)
+    assert_eq(repaired.defects, ([] : Array[String]))
+    assert_true(repaired.entry.state is Committed)
+    assert_eq(repaired.entry.commit_oid, Some(commit1))
+    let integrated = @subtask.integrate(provisioned.geometry, repaired.entry)
+    assert_eq(integrated.result, "integrated")
+    assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "ALPHA\n")
+    assert_eq(@fs.read_file("\{repo}/other/b.txt").text(), "beta\n")
+  })
+}
+
+///|
+/// The integration-safety gates: a Conflicted slice and a gone worktree
+/// both refuse resume — continue must never race a half-done merge or
+/// relaunch into a deleted tree.
+async test "resume_running refuses conflicted slices and gone worktrees" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-resume-gates-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let entry = provisioned.entry
+    @vfs.write_text("\{entry.worker_root}/lib", "a.txt", "WORKER\n")
+    let captured = @subtask.capture(provisioned.geometry, entry)
+    assert_true(captured.entry.state is Committed)
+    // Origin advances the same line: integration conflicts.
+    @vfs.write_text("\{repo}/lib", "a.txt", "ORIGIN\n")
+    for args in [["add", "-A"], ["commit", "-q", "-m", "origin moved"]] {
+      match @subtask.git_require(args, cwd=repo) {
+        Ok(_) => ()
+        Err(reason) => fail(reason)
+      }
+    }
+    let conflicted = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(conflicted.result, "conflicted")
+    guard @subtask.resume_running(provisioned.geometry, "fix-lib")
+      is Err(midmerge) else {
+      fail("expected a conflicted-state refusal")
+    }
+    assert_true(midmerge.contains("Conflicted"))
+    // Abort the merge, then delete the worktree out from under the entry.
+    let aborted = @subtask.integrate_abort(
+      provisioned.geometry,
+      conflicted.entry,
+    )
+    assert_eq(aborted.result, "aborted")
+    @fs.rmdir(entry.worker_root, recursive=true)
+    guard @subtask.resume_running(provisioned.geometry, "fix-lib") is Err(gone) else {
+      fail("expected a gone-worktree refusal")
+    }
+    assert_true(gone.contains("gone"))
+  })
+}

--- a/cmd/openseek/internal/subtask/lifecycle_test.mbt
+++ b/cmd/openseek/internal/subtask/lifecycle_test.mbt
@@ -459,6 +459,10 @@ async test "captured defects repair through resume and re-capture" {
     assert_true(defective.entry.state is Captured)
     assert_eq(defective.entry.commit_oid, Some(commit1))
     // Captured is continuable; the repair worker reverts the intrusion.
+    // other/b.txt is TRACKED (seeded in the base commit) and commit1's
+    // tree holds it at "beta" — restoring that content makes the worktree
+    // status clean again, which is what routes the re-capture through the
+    // idle guard below.
     let resumed = match
       @subtask.resume_running(provisioned.geometry, "fix-lib") {
       Ok(resumed) => resumed
@@ -519,5 +523,36 @@ async test "resume_running refuses conflicted slices and gone worktrees" {
       fail("expected a gone-worktree refusal")
     }
     assert_true(gone.contains("gone"))
+  })
+}
+
+///|
+/// The stale-snapshot gate: lifecycle actions re-read the registry under
+/// the repo mutex, so an entry object captured BEFORE a concurrent
+/// continue flipped the slice to Running cannot merge or discard under the
+/// live child.
+async test "integrate refuses a stale snapshot of a resumed slice" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-stale-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    @vfs.write_text("\{provisioned.entry.worker_root}/lib", "a.txt", "ALPHA\n")
+    let captured = @subtask.capture(provisioned.geometry, provisioned.entry)
+    assert_true(captured.entry.state is Committed)
+    // A continue flips the slice to Running on disk; the caller still
+    // holds the Committed snapshot.
+    match @subtask.resume_running(provisioned.geometry, "fix-lib") {
+      Ok(_) => ()
+      Err(reason) => fail("resume_running failed: \{reason}")
+    }
+    let refused = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(refused.result, "refused")
+    assert_true(refused.detail[0].contains("not in a committed state"))
+    // The worktree survives for the (simulated) live child.
+    assert_true(@fs.exists(provisioned.entry.worker_root))
   })
 }

--- a/cmd/openseek/internal/subtask/lifecycle_test.mbt
+++ b/cmd/openseek/internal/subtask/lifecycle_test.mbt
@@ -346,3 +346,87 @@ async test "disjoint slices coexist as active reservations" {
     }
   })
 }
+
+///|
+/// The resume path's controller half: capture is re-entrant. A second
+/// capture after further edits stacks a child commit on the same branch; a
+/// second capture with nothing new leaves the prior commit standing instead
+/// of tripping the no-changes cleanup (which would delete validated work).
+async test "capture is re-entrant: resumed work stacks on the same branch" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-resume-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    let entry = provisioned.entry
+    @vfs.write_text("\{entry.worker_root}/lib", "a.txt", "ALPHA\n")
+    let first = @subtask.capture(provisioned.geometry, entry)
+    assert_eq(first.defects, ([] : Array[String]))
+    assert_true(first.entry.state is Committed)
+    guard first.entry.commit_oid is Some(commit1) else {
+      fail("expected a first commit")
+    }
+    // Resume finds the entry continuable and flips it back to Running.
+    let resumed = match
+      @subtask.resume_running(provisioned.geometry, "fix-lib") {
+      Ok(resumed) => resumed
+      Err(reason) => fail("resume_running failed: \{reason}")
+    }
+    assert_true(resumed.state is Running)
+    assert_eq(resumed.commit_oid, Some(commit1))
+    // A resumed worker that adds nothing: the prior capture must stand and
+    // the worktree and branch must survive.
+    let idle = @subtask.capture(provisioned.geometry, resumed)
+    assert_eq(idle.defects, ([] : Array[String]))
+    assert_true(idle.entry.state is Committed)
+    assert_eq(idle.entry.commit_oid, Some(commit1))
+    assert_true(@fs.exists(entry.worker_root))
+    // A resumed worker that adds more work: the second capture stacks a
+    // commit whose parent is the first capture's commit.
+    @vfs.write_text("\{entry.worker_root}/lib", "c.txt", "GAMMA\n")
+    let second = @subtask.capture(provisioned.geometry, idle.entry)
+    assert_eq(second.defects, ([] : Array[String]))
+    assert_true(second.entry.state is Committed)
+    guard second.entry.commit_oid is Some(commit2) else {
+      fail("expected a second commit")
+    }
+    assert_true(commit1 != commit2)
+    match @subtask.git_require(["rev-parse", "\{commit2}^"], cwd=repo) {
+      Ok(parent) => assert_eq(parent.trim().to_owned(), commit1)
+      Err(reason) => fail(reason)
+    }
+    // Integration lands BOTH captures' work.
+    let integrated = @subtask.integrate(provisioned.geometry, second.entry)
+    assert_eq(integrated.result, "integrated")
+    assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "ALPHA\n")
+    assert_eq(@fs.read_file("\{repo}/lib/c.txt").text(), "GAMMA\n")
+  })
+}
+
+///|
+/// resume_running refuses what it must: unknown names, and states without a
+/// kept worktree (a Running slice may still have a live child).
+async test "resume_running refuses unknown names and running slices" {
+  @vfs.with_tmpdir(prefix="openseek-subtask-resume-refuse-", dir => {
+    let repo = seed_repo(dir)
+    let provisioned = must_provision(
+      repo,
+      name="fix-lib",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    guard @subtask.resume_running(provisioned.geometry, "nope") is Err(unknown) else {
+      fail("expected an unknown-name refusal")
+    }
+    assert_true(unknown.contains("no active subtask"))
+    // Freshly provisioned means Running — a child may still be live.
+    guard @subtask.resume_running(provisioned.geometry, "fix-lib")
+      is Err(running) else {
+      fail("expected a running-state refusal")
+    }
+    assert_true(running.contains("Running"))
+  })
+}

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -37,6 +37,8 @@ pub fn registry_dir(String) -> String
 
 pub async fn resolve_geometry(String) -> Result[Geometry, String]
 
+pub async fn resume_running(Geometry, String) -> Result[SubtaskEntry, String]
+
 pub async fn rollback_provision(Geometry, SubtaskEntry) -> Unit
 
 pub async fn save_entry(String, SubtaskEntry) -> Result[Unit, String]

--- a/cmd/openseek/internal/subtask/provision.mbt
+++ b/cmd/openseek/internal/subtask/provision.mbt
@@ -207,6 +207,41 @@ pub async fn rollback_provision(
 }
 
 ///|
+/// Flip the active slice `name` back to Running for a resume relaunch, or
+/// explain why not. Only a kept-worktree state — Committed (a truncated
+/// worker's validated partial) or Captured (a defective capture awaiting
+/// repair) — can host a fresh worker; capture() then measures the resumed
+/// run against the entry's prior commit and stacks its commit on it.
+pub async fn resume_running(
+  geometry : Geometry,
+  name : String,
+) -> Result[SubtaskEntry, String] {
+  let (entries, _) = load_entries(geometry.common_git_dir)
+  guard entries.filter(e => e.name == name && !e.state.is_terminal()).last()
+    is Some(entry) else {
+    return Err("no active subtask named \{name}")
+  }
+  guard entry.state is (Committed | Captured) else {
+    return Err(
+      "subtask \{name} is \{Repr(entry.state)} — only a captured or committed slice with a kept worktree can be continued",
+    )
+  }
+  guard (@fs.exists(entry.worker_root) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => false
+  }) else {
+    return Err(
+      "subtask \{name}'s worktree is gone (\{entry.worker_root}); discard it and launch a fresh slice",
+    )
+  }
+  let entry = { ..entry, state: Running }
+  match save_entry(geometry.common_git_dir, entry) {
+    Ok(_) => Ok(entry)
+    Err(reason) => Err(reason)
+  }
+}
+
+///|
 fn is_valid_name(name : String) -> Bool {
   guard name.length() >= 1 && name.length() <= 40 else { return false }
   for index, ch in name {

--- a/cmd/openseek/internal/subtask/provision.mbt
+++ b/cmd/openseek/internal/subtask/provision.mbt
@@ -216,6 +216,15 @@ pub async fn resume_running(
   geometry : Geometry,
   name : String,
 ) -> Result[SubtaskEntry, String] {
+  // The same mutex provision and integrate hold: a continue racing an
+  // in-flight integrate must observe its OUTCOME state (Conflicted refuses
+  // below; Integrated is terminal; a clean merge removed the worktree),
+  // never the pre-merge Committed. A cancelled continue still leaks a
+  // Running entry whose branch holds validated work (capture never ran) —
+  // that residual mirrors the launch-cancel one and only discard clears it.
+  let mutex = repo_mutex(geometry.common_git_dir)
+  mutex.acquire()
+  defer mutex.release()
   let (entries, _) = load_entries(geometry.common_git_dir)
   guard entries.filter(e => e.name == name && !e.state.is_terminal()).last()
     is Some(entry) else {

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -529,8 +529,12 @@ async fn run_worker_slice(
     Committed =>
       "state: committed on \{entry.branch} — review the evidence, then subtask integrate=\{name}; if the task is unfinished, continue=\{name} with the remainder (worktree kept at \{entry.worker_root} until then)"
     NoChanges => "state: no changes — the slice's paths are free again"
+    Captured =>
+      "state: NOT mergeable (captured with defects) — inspect \{entry.worker_root}; continue=\{name} with a corrective task can repair it, or discard=\{name}"
     _ =>
-      "state: NOT mergeable — inspect \{entry.worker_root}; continue=\{name} with a corrective task can repair it, or discard=\{name}"
+      // Early capture failures leave the registry entry Running, which
+      // continue refuses — only discard applies here.
+      "state: NOT mergeable — inspect \{entry.worker_root}, then discard=\{name} or relaunch"
   }
   out <+ "\n\{state_line}"
   let mergeable = captured.entry.state is Committed

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -36,6 +36,10 @@ fn subtask_tool_definition(
       #|to merge its branch here (re-run your checks after each); on a conflict, resolve
       #|the markers with the file tools, then integrate_continue=<name> (or
       #|integrate_abort=<name>); discard=<name> abandons a slice and frees its paths.
+      #|CONTINUE: continue=<name> plus a fresh task (the remainder work order)
+      #|relaunches a NEW worker on a truncated or NOT-mergeable slice's kept worktree;
+      #|its cumulative changes are re-captured on the same branch — prefer this over
+      #|finishing a truncated slice yourself.
       #|PARALLELISM: to run several slices at once, pass them as `slices`: an ARRAY of
       #|{name, task, allowed_paths, context?} objects in ONE call — they are launched
       #|concurrently and reported together (2-4 per call; at most 4 run at once). Prefer
@@ -96,6 +100,10 @@ fn subtask_tool_definition(
           "type": "string",
           "description": "Abandon the named subtask: remove its worktree and branch, free its paths.",
         },
+        "continue": {
+          "type": "string",
+          "description": "Relaunch a fresh worker on the named slice's kept worktree to finish or repair it. Requires `task` (the remainder work order); accepts `context`. New work is captured cumulatively on the same branch.",
+        },
       },
     }),
     execute=Async(arguments => {
@@ -124,6 +132,11 @@ async fn subtask_execute(
 ) -> @agent_tool.ToolAction {
   // Lifecycle actions first: exactly one of them may be present.
   match arguments {
+    { "continue": String(name), .. } if name.trim() != "" =>
+      return subtask_continue(
+        self_exe, model, workspace_root, budget, api_url, child_session, arguments,
+        name,
+      )
     { "integrate": String(name), .. } if name.trim() != "" =>
       return subtask_lifecycle(workspace_root, "integrate", name)
     { "integrate_continue": String(name), .. } if name.trim() != "" =>
@@ -415,7 +428,42 @@ async fn subtask_launch_one(
         status: "not launched: \{@agent_tool.brief_line(reason, limit=100)}",
       }
   }
-  let entry = provisioned.entry
+  run_worker_slice(
+    self_exe,
+    model,
+    api_url,
+    child_session,
+    provisioned.geometry,
+    provisioned.entry,
+    name,
+    task,
+    context,
+    // Resolved BEFORE the worktree existed, so the worker's own root is
+    // naturally absent from this deny list.
+    provisioned.geometry.worktree_roots,
+    granted_steps,
+  )
+}
+
+///|
+/// Run one worker child against a provisioned or resumed slice and capture
+/// the outcome from git evidence. `deny_roots` is the caller's concern:
+/// launch passes the pre-worktree geometry (the worker's own root is
+/// naturally absent); continue passes a fresh resolve with the slice's own
+/// root filtered out.
+async fn run_worker_slice(
+  self_exe : String,
+  model : @deepseek.Model,
+  api_url : String?,
+  child_session : @agent_subrun.ChildSession?,
+  geometry : @subtask.Geometry,
+  entry : @subtask.SubtaskEntry,
+  name : String,
+  task : String,
+  context : String?,
+  deny_roots : Array[String],
+  granted_steps : Int,
+) -> SliceOutcome {
   let input : Json = match context {
     Some(context) =>
       {
@@ -423,7 +471,7 @@ async fn subtask_launch_one(
         "context": context,
         "worker_root": entry.worker_root,
         "worker_admin_dir": entry.worker_admin_dir,
-        "deny_roots": provisioned.geometry.worktree_roots.to_json(),
+        "deny_roots": deny_roots.to_json(),
         "allowed_paths": entry.allowed_paths.to_json(),
         "base_oid": entry.base_oid,
       }
@@ -432,7 +480,7 @@ async fn subtask_launch_one(
         "task": task,
         "worker_root": entry.worker_root,
         "worker_admin_dir": entry.worker_admin_dir,
-        "deny_roots": provisioned.geometry.worktree_roots.to_json(),
+        "deny_roots": deny_roots.to_json(),
         "allowed_paths": entry.allowed_paths.to_json(),
         "base_oid": entry.base_oid,
       }
@@ -461,7 +509,7 @@ async fn subtask_launch_one(
     child_session?,
   )
   // Evidence comes from git regardless of how the child ended.
-  let captured = @subtask.capture(provisioned.geometry, entry)
+  let captured = @subtask.capture(geometry, entry)
   let out = StringBuilder()
   match result.value() {
     Some(report) =>
@@ -479,10 +527,10 @@ async fn subtask_launch_one(
   }
   let state_line = match captured.entry.state {
     Committed =>
-      "state: committed on \{entry.branch} — review the evidence, then subtask integrate=\{name} (worktree kept at \{entry.worker_root} until then)"
+      "state: committed on \{entry.branch} — review the evidence, then subtask integrate=\{name}; if the task is unfinished, continue=\{name} with the remainder (worktree kept at \{entry.worker_root} until then)"
     NoChanges => "state: no changes — the slice's paths are free again"
     _ =>
-      "state: NOT mergeable — inspect \{entry.worker_root}, then discard=\{name} or relaunch"
+      "state: NOT mergeable — inspect \{entry.worker_root}; continue=\{name} with a corrective task can repair it, or discard=\{name}"
   }
   out <+ "\n\{state_line}"
   let mergeable = captured.entry.state is Committed
@@ -495,4 +543,98 @@ async fn subtask_launch_one(
     ),
     status: state_line,
   }
+}
+
+///|
+/// `continue=<name>`: relaunch a fresh worker on an existing slice's kept
+/// worktree — the recovery path for a worker that hit its step ceiling
+/// (state Committed, task unfinished) or captured NOT-mergeable (state
+/// Captured). The slice keeps its name, branch, reservation, and base; the
+/// new child receives the remainder work order and capture() stacks its
+/// validated changes on the same branch.
+async fn subtask_continue(
+  self_exe : String,
+  model : @deepseek.Model,
+  workspace_root : String,
+  budget : @agent_subrun.SubrunBudget,
+  api_url : String?,
+  child_session : @agent_subrun.ChildSession?,
+  arguments : Json,
+  name : String,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "task": String(task), .. } && task.trim() != "" else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask continue=\{name} requires a `task` — the remainder work order for the fresh worker",
+      is_error=true,
+      brief="subtask continue \{name}",
+    )
+  }
+  guard task.length() <= max_task_chars else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask task for \{name} exceeds \{max_task_chars} chars",
+      is_error=true,
+      brief="subtask continue \{name}",
+    )
+  }
+  let parent_context : String? = match arguments {
+    { "context": String(context), .. } if context.trim() != "" => Some(context)
+    _ => None
+  }
+  guard !(parent_context is Some(c) && c.length() > max_context_chars) else {
+    return @agent_tool.ToolAction::respond(
+      "error: subtask context for \{name} exceeds \{max_context_chars} chars",
+      is_error=true,
+      brief="subtask continue \{name}",
+    )
+  }
+  let geometry = match @subtask.resolve_geometry(workspace_root) {
+    Ok(geometry) => geometry
+    Err(reason) =>
+      return @agent_tool.ToolAction::respond(
+        "error: subtask continue: \{reason}",
+        is_error=true,
+        brief="subtask continue \{name}",
+      )
+  }
+  guard worker_slots.try_acquire() else {
+    return @agent_tool.ToolAction::respond(
+      "subtask worker slots are full (max \{max_active_workers} active) — integrate or await the running slices first.",
+      is_error=true,
+      brief="subtask continue (slots full)",
+    )
+  }
+  defer worker_slots.release()
+  guard budget.reserve(@agent_worker.default_worker_max_steps)
+    is Some(granted_steps) else {
+    return @agent_tool.ToolAction::respond(
+      "subtask budget exhausted for this turn — do the remaining work yourself or continue next turn.",
+      is_error=true,
+      brief="subtask continue (budget exhausted)",
+    )
+  }
+  let entry = match @subtask.resume_running(geometry, name) {
+    Ok(entry) => entry
+    Err(reason) =>
+      return @agent_tool.ToolAction::respond(
+        "error: subtask continue: \{reason}",
+        is_error=true,
+        brief="subtask continue \{name}",
+      )
+  }
+  // The fresh geometry lists the slice's own worktree; the worker must not
+  // be denied its own root.
+  let deny_roots = geometry.worktree_roots.filter(root => {
+    root != entry.worker_root
+  })
+  let preamble = "RESUMED SLICE: a previous worker already worked this slice; its validated progress is already present in your worktree files. Verify the current state first, then do only what the task still requires."
+  let context = Some(
+    match parent_context {
+      Some(context) => "\{preamble}\n\{context}"
+      None => preamble
+    },
+  )
+  run_worker_slice(
+    self_exe, model, api_url, child_session, geometry, entry, name, task, context,
+    deny_roots, granted_steps,
+  ).action
 }

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -177,7 +177,10 @@ Common `moon` subcommands:
   git evidence — trust the evidence. Then integrate ONE subtask at a time
   (`integrate=<name>`), re-running your checks after each; resolve conflicts
   with the file tools plus `integrate_continue`; `discard=<name>` frees an
-  abandoned slice. After the last integration, run the FULL verification
+  abandoned slice. A slice that stopped at its step ceiling or captured
+  NOT-mergeable keeps its worktree: `continue=<name>` with a remainder work
+  order relaunches a fresh worker there — prefer that over finishing the
+  slice yourself. After the last integration, run the FULL verification
   suite yourself — including the repository's format gate (`moon fmt`
   and a clean `moon fmt --check`) — workers verified slices, only you
   see the union. For a

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -182,7 +182,10 @@ fn default_prompt() -> String {
     #|  git evidence — trust the evidence. Then integrate ONE subtask at a time
     #|  (`integrate=<name>`), re-running your checks after each; resolve conflicts
     #|  with the file tools plus `integrate_continue`; `discard=<name>` frees an
-    #|  abandoned slice. After the last integration, run the FULL verification
+    #|  abandoned slice. A slice that stopped at its step ceiling or captured
+    #|  NOT-mergeable keeps its worktree: `continue=<name>` with a remainder work
+    #|  order relaunches a fresh worker there — prefer that over finishing the
+    #|  slice yourself. After the last integration, run the FULL verification
     #|  suite yourself — including the repository's format gate (`moon fmt`
     #|  and a clean `moon fmt --check`) — workers verified slices, only you
     #|  see the union. For a


### PR DESCRIPTION
Companion to #637. Both mbtexcel production sweeps had workers truncate at the step ceiling; the designed degraded path made the PARENT mop up the remainder in its own context. This adds the structural fix: `subtask continue=<name>` + a remainder `task` relaunches a new worker child on the slice's kept worktree.

**Controller — capture() is now re-entrant.** The pin used for the worktree HEAD check, the `commit-tree` parent, and the `update-ref` expected-old is `entry.commit_oid ?? base_oid`. Without this, a second capture (a) false-flags "HEAD moved" (the worktree is checked out on the branch that update-ref moved) and (b) is refused by the update-ref old-value guard. Scope validation still diffs the full base→tree span, so cumulative changes stay inside `allowed_paths`. An empty re-capture with a prior commit stays `Committed` — the old `NoChanges` cleanup would have **deleted the branch holding validated work**. New `resume_running()` gates the state transition (only Committed/Captured with a surviving worktree; Running and Conflicted refuse).

**Tool** — `run_worker_slice` extracted and shared by launch and continue. The one behavioral subtlety: continue resolves geometry fresh, which now lists the slice's own worktree, so its own root is filtered out of `deny_roots` (at launch it was naturally absent — geometry resolved before `worktree add`). Slot + budget reservation identical to launch; the worker context gets a resumed-slice preamble telling it to verify current state before doing the remainder.

**Tests** — lifecycle: stacked captures chain parents (`commit2^ == commit1`) and integrate lands both; idle re-capture preserves branch + worktree; `resume_running` refusal edges. 17/17 controller tests green; repo-wide `moon check --deny-warn` and `moon fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)