### PR TITLE
feat(desktop): add release flag to package commands

### DIFF
--- a/.github/workflows/desktop-staging-release.yml
+++ b/.github/workflows/desktop-staging-release.yml
@@ -112,6 +112,7 @@ jobs:
           OPENSEEK_CLIENT_TOKEN: ${{ secrets.OPENSEEK_CLIENT_TOKEN }}
         run: |
           moon -C desktop run --target native --release package/macos -- \
+            --release \
             --target dmg \
             --target zip \
             --sign "$MACOS_SIGNING_IDENTITY" \

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -70,7 +70,7 @@ jobs:
       # extractable credential. A stamped bundle requires a manual build
       # with the secret in the environment.
       - name: Build the AppImage
-        run: moon -C desktop run --target native package/linux
+        run: moon -C desktop run --target native package/linux -- --release
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
@@ -126,7 +126,7 @@ jobs:
       # end-user distribution.
       # Unstamped — no OPENSEEK_CLIENT_TOKEN in CI; see the Linux job's note.
       - name: Build the macOS artifacts
-        run: moon -C desktop run --target native package/macos -- --target dmg --target zip
+        run: moon -C desktop run --target native package/macos -- --release --target dmg --target zip
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
@@ -214,12 +214,12 @@ jobs:
       - name: Build the Windows ZIP
         if: github.event_name == 'pull_request'
         shell: pwsh
-        run: moon -C desktop run --target native package/windows -- --target zip
+        run: moon -C desktop run --target native package/windows -- --release --target zip
 
       - name: Build the Windows app bundle and installer
         if: github.event_name != 'pull_request'
         shell: pwsh
-        run: moon -C desktop run --target native package/windows
+        run: moon -C desktop run --target native package/windows -- --release
 
       - name: Upload Windows app artifact
         uses: actions/upload-artifact@v4

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -206,13 +206,15 @@ restage, clean, and rebuild until the submodule tree stays clean.
 Then build the frontend bundle and the native binary:
 
 ```sh
-moon build frontend/desktop --target js --release
-cp ../_build/js/release/build/openseek_desktop/frontend/desktop/desktop.js frontend.js
-moon build . --target native --release         # build the native binary
+moon build frontend/desktop --target js
+cp ../_build/js/debug/build/openseek_desktop/frontend/desktop/desktop.js frontend.js
+moon build . --target native         # build the native binary
 ```
 
 The native binary is written to
-`_build/native/release/build/openseek_desktop/openseek_desktop.exe`.
+`_build/native/debug/build/openseek_desktop/openseek_desktop.exe`. Add
+`--release` to each build command for optimized output; those artifacts use the
+corresponding `_build/*/release/` directories.
 
 ## Run during development
 
@@ -231,7 +233,8 @@ packaged layout, so running the bare `openseek_desktop` binary unbundled — or
 pointing it at an `openseek` on `PATH` — is not supported. To iterate on the UI,
 rebuild the frontend bundle and re-run the package command; the engine and seed
 are rebuilt and re-staged from the same checkout, so the app never drifts out of
-version with them.
+version with them. Package commands build debug MoonBit artifacts by default;
+pass `--release` after `--` when you need optimized artifacts.
 
 ## Bootstrap desktop submodules on Windows
 
@@ -245,6 +248,9 @@ It builds the Lepus codegen tool if needed, installs WebView2 SDK headers if
 needed, builds the frontend and native host, builds the `openseek` engine from
 the monorepo root, writes `dist/windows-x64/SeekMoon/`, and creates
 `dist/SeekMoon-windows-x64.zip`.
+
+This development command builds debug MoonBit artifacts. Add `-- --release`
+for an optimized bundle and archives.
 
 Without additional arguments, the command builds every output: the
 `dist/windows-x64/SeekMoon/` bundle directory, the
@@ -355,7 +361,7 @@ The target machine also needs Microsoft WebView2 Runtime installed.
 
 `package/macos` runs all of the above (including the codegen bootstrap),
 builds the `openseek` engine from the monorepo's `cmd/openseek` source, and
-produces `dist/SeekMoon.app` by default:
+produces `dist/SeekMoon.app` from debug MoonBit artifacts by default:
 
 ```sh
 moon run --target native package/macos
@@ -368,13 +374,14 @@ re-signs the five CEF helpers whose rpaths the packager modifies. It deliberatel
 does not seal the outer app bundle or re-sign the bundled MoonBit toolchain.
 This faster output is for development on the build machine, not distribution or
 the in-app updater. Scripts may pass `--target app` to request the same output
-explicitly.
+explicitly. Pass `--release` after `--` to build the frontend, host, and engine
+as optimized release artifacts.
 
 To build a distribution artifact, select `dmg` or `zip`:
 
 ```sh
-moon run --target native package/macos -- --target dmg
-moon run --target native package/macos -- --target zip
+moon run --target native package/macos -- --release --target dmg
+moon run --target native package/macos -- --release --target zip
 ```
 
 - `dist/SeekMoon-macos-arm64.dmg` is for first-time installation. It
@@ -405,6 +412,7 @@ timestamp are applied automatically) and notarize:
 # one-time: xcrun notarytool store-credentials openseek \
 #   --apple-id you@example.com --team-id TEAMID --password <app-specific-pw>
 moon run --target native package/macos -- \
+  --release \
   --target dmg \
   --target zip \
   --sign "Developer ID Application: Your Name (TEAMID)" \
@@ -424,12 +432,19 @@ for distribution.
 
 `package/linux` runs the same build steps (including the codegen
 bootstrap), builds the `openseek` engine from the monorepo's `cmd/openseek`
-source, and produces `dist/SeekMoon-linux-x86_64.AppImage`:
+source, and produces `dist/SeekMoon-linux-x86_64.AppImage`. It builds debug
+MoonBit artifacts by default:
 
 ```sh
 moon run --target native package/linux
 # or, from the monorepo root:
 moon -C desktop run --target native package/linux
+```
+
+For an optimized AppImage, pass the package flag after Moon's `--` separator:
+
+```sh
+moon run --target native package/linux -- --release
 ```
 
 Build requirements: `pkg-config` plus the GTK3 and WebKitGTK dev packages

--- a/desktop/package/browser/main.mbt
+++ b/desktop/package/browser/main.mbt
@@ -3,8 +3,8 @@
 const BrowserDistDir : String = "dist/browser"
 
 ///|
-/// The release JS bundle emitted by the root MoonBit workspace.
-const BrowserBundleArtifact : String = "_build/js/release/build/openseek_desktop/frontend/browser/browser.js"
+/// The browser JS bundle's path below its selected debug/release directory.
+const BrowserBundleArtifact : String = "build/openseek_desktop/frontend/browser/browser.js"
 
 ///|
 /// Build and stage every browser asset behind one MoonBit packaging command.
@@ -13,12 +13,25 @@ const BrowserBundleArtifact : String = "_build/js/release/build/openseek_desktop
 /// packager. Production runs inside a Linux x64 Docker build; the other
 /// selections keep the same command usable by the supported desktop hosts.
 async fn main {
+  let matches = @argparse.Command(
+    "package/browser",
+    about="Build and stage the browser frontend assets.",
+    flags=[
+      FlagArg(
+        "release",
+        about="Build optimized release artifacts instead of debug artifacts.",
+      ),
+    ],
+  ).parse()
+  let release = matches.flags.get("release").unwrap_or(false)
+  let release_args = if release { ["--release"] } else { [] }
+  let mode = if release { "release" } else { "debug" }
   let ws = @packaging.locate_workspace()
   @packaging.remove_path_if_exists(ws.at(BrowserDistDir))
   @packaging.ensure_dir(ws.at(BrowserDistDir))
   @packaging.run_checked(
     "moon",
-    ["build", "frontend/browser", "--target", "js", "--release"],
+    ["build", "frontend/browser", "--target", "js", ..release_args],
     dir=ws.dir(),
   )
   @packaging.build_viewer_stylesheet(ws)
@@ -39,7 +52,7 @@ async fn main {
     ws.at(BrowserDistDir + "/index.html"),
   )
   @packaging.copy_file(
-    ws.repo_at(BrowserBundleArtifact),
+    ws.repo_at("_build/js/\{mode}/\{BrowserBundleArtifact}"),
     ws.at(BrowserDistDir + "/browser.js"),
   )
   @packaging.copy_file(ws.at("app.css"), ws.at(BrowserDistDir + "/app.css"))

--- a/desktop/package/browser/moon.pkg
+++ b/desktop/package/browser/moon.pkg
@@ -2,6 +2,7 @@ import {
   "openseek_desktop/package/internal/packaging",
   "openseek_desktop/package/internal/xterm_assets",
   "moonbitlang/async",
+  "moonbitlang/core/argparse",
   "tonyfettes/platform",
 }
 

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -4,11 +4,8 @@
 const FrontendPackage : String = "frontend/desktop"
 
 ///|
-/// The JS bundle `moon build frontend/desktop --target js --release` emits.
-/// Build
-/// output lands in the monorepo root's `_build` (the single root moon.work
-/// owns the build directory), so this resolves via `repo_at`, not `at`.
-const FrontendBundleArtifact : String = "_build/js/release/build/openseek_desktop/frontend/desktop/desktop.js"
+/// The JS bundle's path below MoonBit's target/profile build directory.
+const FrontendBundleArtifact : String = "build/openseek_desktop/frontend/desktop/desktop.js"
 
 ///|
 /// The stable path the host and packagers read the frontend bundle from.
@@ -71,13 +68,13 @@ const CodiconFontOutput : String = "codicon.ttf"
 const NativePackage : String = "."
 
 ///|
-const NativeBinary : String = "_build/native/release/build/openseek_desktop/openseek_desktop.exe"
+const NativeBinary : String = "build/openseek_desktop/openseek_desktop.exe"
 
 ///|
 const EnginePackage : String = "cmd/openseek"
 
 ///|
-const EngineBinary : String = "_build/native/release/build/bobzhang/openseek/cmd/openseek/openseek.exe"
+const EngineBinary : String = "build/bobzhang/openseek/cmd/openseek/openseek.exe"
 
 ///|
 /// Raised when a packaging helper cannot complete a filesystem, build, or
@@ -158,17 +155,19 @@ fn join_path(base : String, relative : String) -> String {
 }
 
 ///|
-/// Return the release-mode native desktop host binary path under the monorepo
-/// root, where the single root moon.work places all build output.
-pub fn Workspace::native_binary(self : Workspace) -> String {
-  self.repo_at(NativeBinary)
+/// Return the selected-mode native desktop host binary path under the
+/// monorepo root, where the single root moon.work places all build output.
+pub fn Workspace::native_binary(self : Workspace, release~ : Bool) -> String {
+  let mode = if release { "release" } else { "debug" }
+  self.repo_at("_build/native/\{mode}/\{NativeBinary}")
 }
 
 ///|
-/// Return the release-mode openseek engine binary path under the monorepo
+/// Return the selected-mode openseek engine binary path under the monorepo
 /// root.
-pub fn Workspace::engine_binary(self : Workspace) -> String {
-  self.repo_at(EngineBinary)
+pub fn Workspace::engine_binary(self : Workspace, release~ : Bool) -> String {
+  let mode = if release { "release" } else { "debug" }
+  self.repo_at("_build/native/\{mode}/\{EngineBinary}")
 }
 
 ///|
@@ -418,15 +417,20 @@ pub async fn run_checked(
 }
 
 ///|
-/// Build the frontend package and copy the generated JS bundle to the stable
-/// `frontend.js` path the host and packagers consume.
-pub async fn build_frontend_bundle(ws : Workspace) -> Unit {
+/// Build the frontend package in the selected mode and copy the generated
+/// JS bundle to the stable `frontend.js` path the host and packagers consume.
+pub async fn build_frontend_bundle(ws : Workspace, release~ : Bool) -> Unit {
+  let release_args = if release { ["--release"] } else { [] }
   run_checked(
     "moon",
-    ["build", FrontendPackage, "--target", "js", "--release"],
+    ["build", FrontendPackage, "--target", "js", ..release_args],
     dir=ws.dir(),
   )
-  copy_file(ws.repo_at(FrontendBundleArtifact), ws.at(FrontendBundleOutput))
+  let mode = if release { "release" } else { "debug" }
+  copy_file(
+    ws.repo_at("_build/js/\{mode}/\{FrontendBundleArtifact}"),
+    ws.at(FrontendBundleOutput),
+  )
   build_viewer_stylesheet(ws)
 }
 
@@ -535,13 +539,13 @@ async fn restore_client_token(ws : Workspace, original : String?) -> Unit {
 }
 
 ///|
-/// Build the native desktop host in release mode. When the packaging
-/// machine sets OPENSEEK_CLIENT_TOKEN, the token is stamped into the host
-/// source for the build and the committed source is restored afterwards —
-/// even when the build fails — so the token reaches the binary but never
-/// the repository.
+/// Build the native desktop host in the selected mode. When the packaging
+/// machine sets OPENSEEK_CLIENT_TOKEN, the token is stamped into the host source
+/// for the build and the committed source is restored afterwards — even when
+/// the build fails — so the token reaches the binary but never the repository.
 pub async fn build_native_host(
   ws : Workspace,
+  release~ : Bool,
   extra_args? : Array[String] = [],
   extra_env? : Map[String, String] = Map([]),
   disable_mimalloc? : Bool = false,
@@ -582,9 +586,10 @@ pub async fn build_native_host(
     build_env[name] = value
   }
   build_env["PROTON_NATIVE_DIST"] = runtime_dist
+  let release_args = if release { ["--release"] } else { [] }
   run_checked(
     "moon",
-    ["build", NativePackage, "--target", "native", "--release"] + extra_args,
+    ["build", NativePackage, "--target", "native", ..release_args, ..extra_args],
     dir=ws.dir(),
     extra_env=build_env,
   ) catch {
@@ -679,15 +684,17 @@ async fn restore_mimalloc(swap : MimallocSwap?) -> Unit {
 /// always matches the checkout instead of whatever happens to be on PATH.
 pub async fn build_engine(
   ws : Workspace,
+  release~ : Bool,
   extra_env? : Map[String, String] = Map([]),
 ) -> Unit {
+  let release_args = if release { ["--release"] } else { [] }
   run_checked(
     "moon",
-    ["build", EnginePackage, "--target", "native", "--release"],
+    ["build", EnginePackage, "--target", "native", ..release_args],
     dir=ws.repo(),
     extra_env~,
   )
-  let engine_binary = ws.engine_binary()
+  let engine_binary = ws.engine_binary(release~)
   if !@asyncfs.exists(engine_binary) {
     raise PackageError("openseek engine binary not found: \{engine_binary}")
   }
@@ -750,6 +757,23 @@ test "workspace path join preserves spaces and nested segments" {
   assert_eq(
     ws.at("dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64"),
     "/My Checkouts/w/dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64",
+  )
+}
+
+///|
+test "package build paths select debug or release" {
+  let ws : Workspace = { root: "/abs/repo/desktop" }
+  assert_eq(
+    ws.native_binary(release=false),
+    "/abs/repo/_build/native/debug/build/openseek_desktop/openseek_desktop.exe",
+  )
+  assert_eq(
+    ws.engine_binary(release=false),
+    "/abs/repo/_build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.exe",
+  )
+  assert_eq(
+    ws.native_binary(release=true),
+    "/abs/repo/_build/native/release/build/openseek_desktop/openseek_desktop.exe",
   )
 }
 

--- a/desktop/package/internal/packaging/pkg.generated.mbti
+++ b/desktop/package/internal/packaging/pkg.generated.mbti
@@ -6,11 +6,11 @@ pub fn absolute_path(String) -> String
 
 pub async fn assemble_cef_runtime(Workspace, String, extra_env? : Map[String, String]) -> Unit
 
-pub async fn build_engine(Workspace, extra_env? : Map[String, String]) -> Unit
+pub async fn build_engine(Workspace, release~ : Bool, extra_env? : Map[String, String]) -> Unit
 
-pub async fn build_frontend_bundle(Workspace) -> Unit
+pub async fn build_frontend_bundle(Workspace, release~ : Bool) -> Unit
 
-pub async fn build_native_host(Workspace, extra_args? : Array[String], extra_env? : Map[String, String], disable_mimalloc? : Bool) -> Unit
+pub async fn build_native_host(Workspace, release~ : Bool, extra_args? : Array[String], extra_env? : Map[String, String], disable_mimalloc? : Bool) -> Unit
 
 pub async fn build_viewer_stylesheet(Workspace) -> Unit
 
@@ -52,8 +52,8 @@ pub impl Show for PackageError
 type Workspace
 pub fn Workspace::at(Self, String) -> String
 pub fn Workspace::dir(Self) -> String
-pub fn Workspace::engine_binary(Self) -> String
-pub fn Workspace::native_binary(Self) -> String
+pub fn Workspace::engine_binary(Self, release~ : Bool) -> String
+pub fn Workspace::native_binary(Self, release~ : Bool) -> String
 pub fn Workspace::repo(Self) -> String
 pub fn Workspace::repo_at(Self, String) -> String
 

--- a/desktop/package/linux/main.mbt
+++ b/desktop/package/linux/main.mbt
@@ -19,7 +19,10 @@ const AppImageToolCache : String = "dist/tools/appimagetool"
 const AppImageToolUrl : String = "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
 
 ///|
-async fn build_outputs(ws : @packaging.Workspace) -> @xterm_assets.Assets {
+async fn build_outputs(
+  ws : @packaging.Workspace,
+  release~ : Bool,
+) -> @xterm_assets.Assets {
   // Assemble the CEF runtime first so the native host links against it.
   @packaging.assemble_cef_runtime(ws, @packaging.posix_proton_cli())
   // Then replace the assembled dist's libproton with one built from the
@@ -29,13 +32,13 @@ async fn build_outputs(ws : @packaging.Workspace) -> @xterm_assets.Assets {
     ("lib/libproton.so", "lib/libproton.so"),
     ("bin/cef_process", "bin/cef_process"),
   ])
-  @packaging.build_frontend_bundle(ws)
+  @packaging.build_frontend_bundle(ws, release~)
   let terminal_assets = @xterm_assets.build(
     ws,
     @xterm_assets.linux_x64_target(),
   )
-  @packaging.build_native_host(ws)
-  @packaging.build_engine(ws)
+  @packaging.build_native_host(ws, release~)
+  @packaging.build_engine(ws, release~)
   terminal_assets
 }
 
@@ -52,9 +55,10 @@ async fn reset_bundle_dirs(ws : @packaging.Workspace) -> Unit {
 async fn copy_bundle_files(
   ws : @packaging.Workspace,
   terminal_assets : @xterm_assets.Assets,
+  release~ : Bool,
 ) -> Unit {
-  let native_binary = ws.native_binary()
-  let engine_binary = ws.engine_binary()
+  let native_binary = ws.native_binary(release~)
+  let engine_binary = ws.engine_binary(release~)
   if !@asyncfs.exists(native_binary) {
     raise @packaging.PackageError("native binary not found: \{native_binary}")
   }
@@ -216,12 +220,23 @@ async fn build_appimage(ws : @packaging.Workspace, tool : String) -> Unit {
 
 ///|
 async fn main {
+  let matches = @argparse.Command(
+    "package/linux",
+    about="Build the Linux AppImage.",
+    flags=[
+      FlagArg(
+        "release",
+        about="Build optimized release artifacts instead of debug artifacts.",
+      ),
+    ],
+  ).parse()
+  let release = matches.flags.get("release").unwrap_or(false)
   let ws = @packaging.locate_workspace()
   @packaging.ensure_cmake(ws)
-  let terminal_assets = build_outputs(ws)
-  println("built openseek engine: \{ws.engine_binary()}")
+  let terminal_assets = build_outputs(ws, release~)
+  println("built openseek engine: \{ws.engine_binary(release~)}")
   reset_bundle_dirs(ws)
-  copy_bundle_files(ws, terminal_assets)
+  copy_bundle_files(ws, terminal_assets, release~)
   write_bundle_metadata(ws)
   let tool = ensure_appimagetool(ws)
   build_appimage(ws, tool)

--- a/desktop/package/linux/moon.pkg
+++ b/desktop/package/linux/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs" @asyncfs,
   "moonbitlang/async/process",
+  "moonbitlang/core/argparse",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -150,7 +150,10 @@ fn CefHelperVariant::executable_path(self : CefHelperVariant) -> String {
 }
 
 ///|
-async fn build_outputs(ws : @packaging.Workspace) -> @xterm_assets.Assets {
+async fn build_outputs(
+  ws : @packaging.Workspace,
+  release~ : Bool,
+) -> @xterm_assets.Assets {
   let env = { "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion }
   let host_env = {
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
@@ -178,15 +181,20 @@ async fn build_outputs(ws : @packaging.Workspace) -> @xterm_assets.Assets {
     ],
     extra_env=env,
   )
-  @packaging.build_frontend_bundle(ws)
+  @packaging.build_frontend_bundle(ws, release~)
   let terminal_assets = @xterm_assets.build(
     ws,
     @xterm_assets.macos_arm64_target(),
   )
   // Build the host without mimalloc: its static malloc/free override crashes
   // against CEF's PartitionAlloc default zone on the first `@fs.realpath`.
-  @packaging.build_native_host(ws, extra_env=host_env, disable_mimalloc=true)
-  @packaging.build_engine(ws, extra_env=env)
+  @packaging.build_native_host(
+    ws,
+    release~,
+    extra_env=host_env,
+    disable_mimalloc=true,
+  )
+  @packaging.build_engine(ws, release~, extra_env=env)
   terminal_assets
 }
 
@@ -208,9 +216,10 @@ async fn reset_bundle_dirs(ws : @packaging.Workspace) -> Unit {
 async fn copy_bundle_files(
   ws : @packaging.Workspace,
   terminal_assets : @xterm_assets.Assets,
+  release~ : Bool,
 ) -> Unit {
-  let native_binary = ws.native_binary()
-  let engine_binary = ws.engine_binary()
+  let native_binary = ws.native_binary(release~)
+  let engine_binary = ws.engine_binary(release~)
   if !@asyncfs.exists(native_binary) {
     raise @packaging.PackageError("native binary not found: \{native_binary}")
   }
@@ -653,6 +662,7 @@ priv struct SignConfig {
 priv struct PackageOptions {
   artifacts : ArtifactPlan
   sign : SignConfig
+  release : Bool
 }
 
 ///|
@@ -660,6 +670,12 @@ fn package_command() -> @argparse.Command {
   Command(
     "package/macos",
     about="Build the macOS app bundle and optional distribution archives.",
+    flags=[
+      FlagArg(
+        "release",
+        about="Build optimized release artifacts instead of debug artifacts.",
+      ),
+    ],
     options=[
       OptionArg(
         "target",
@@ -710,7 +726,7 @@ fn parse_package_options(argv? : ArrayView[String]) -> PackageOptions raise {
   if sign.notary_profile is Some(_) && !artifacts.dmg {
     raise @packaging.PackageError("--notarize requires --target dmg")
   }
-  { artifacts, sign }
+  { artifacts, sign, release: matches.flags.get("release").unwrap_or(false) }
 }
 
 ///|
@@ -901,10 +917,10 @@ async fn main {
   let options = parse_package_options()
   let ws = @packaging.locate_workspace()
   @packaging.ensure_cmake(ws)
-  let terminal_assets = build_outputs(ws)
-  println("built openseek engine: \{ws.engine_binary()}")
+  let terminal_assets = build_outputs(ws, release=options.release)
+  println("built openseek engine: \{ws.engine_binary(release=options.release)}")
   reset_bundle_dirs(ws)
-  copy_bundle_files(ws, terminal_assets)
+  copy_bundle_files(ws, terminal_assets, release=options.release)
   write_bundle_metadata(ws)
   sign_and_package(ws, options.sign, options.artifacts)
   println("generated \{ws.at(AppPath)}")
@@ -925,6 +941,7 @@ test "macos package args default to local app-only signing" {
   assert_true(options.sign.identity is None)
   assert_true(options.sign.notary_profile is None)
   assert_eq(options.artifacts, { dmg: false, zip: false })
+  assert_false(options.release)
   assert_false(options.artifacts.requires_ad_hoc_bundle_signature())
 }
 
@@ -993,13 +1010,14 @@ test "macos host executable rpath points at bundled proton runtime" {
 ///|
 test "macos package args parse signing and notarization" {
   let options = parse_package_options(argv=[
-    "--target", "dmg", "--sign", "Developer ID Application: Example", "--notarize",
-    "notary",
+    "--release", "--target", "dmg", "--sign", "Developer ID Application: Example",
+    "--notarize", "notary",
   ])
   assert_true(
     options.sign.identity is Some("Developer ID Application: Example"),
   )
   assert_true(options.sign.notary_profile is Some("notary"))
+  assert_true(options.release)
 }
 
 ///|

--- a/desktop/package/windows/main.mbt
+++ b/desktop/package/windows/main.mbt
@@ -54,6 +54,12 @@ fn package_command() -> @argparse.Command {
   Command(
     "package/windows",
     about="Build the Windows app bundle, portable zip, and NSIS installer.",
+    flags=[
+      FlagArg(
+        "release",
+        about="Build optimized release artifacts instead of debug artifacts.",
+      ),
+    ],
     options=[
       OptionArg(
         "target",
@@ -65,8 +71,9 @@ fn package_command() -> @argparse.Command {
 }
 
 ///|
-fn ArtifactPlan::parse_args(argv? : ArrayView[String]) -> ArtifactPlan raise {
-  let matches = package_command().parse(argv?)
+fn ArtifactPlan::from_matches(
+  matches : @argparse.Matches,
+) -> ArtifactPlan raise {
   match matches.values.get("target") {
     Some(values) => ArtifactPlan::parse(values)
     None => ArtifactPlan::parse([])
@@ -91,7 +98,10 @@ async fn run_powershell(ws : @packaging.Workspace, script : String) -> Unit {
 ///|
 /// Build everything the bundle needs. CEF replaces WebView2, so no WebView2
 /// SDK headers are fetched.
-async fn build_outputs(ws : @packaging.Workspace) -> @xterm_assets.Assets {
+async fn build_outputs(
+  ws : @packaging.Workspace,
+  release~ : Bool,
+) -> @xterm_assets.Assets {
   // Assemble the CEF runtime first so the native host links against it.
   @packaging.assemble_cef_runtime(ws, @packaging.windows_proton_cli())
   // Then replace the assembled dist's proton library with one built from the
@@ -103,13 +113,13 @@ async fn build_outputs(ws : @packaging.Workspace) -> @xterm_assets.Assets {
     ("bin/Release/cef_process.exe", "bin/cef_process.exe"),
     ("lib/Release/proton.lib", "lib/proton.lib"),
   ])
-  @packaging.build_frontend_bundle(ws)
+  @packaging.build_frontend_bundle(ws, release~)
   let terminal_assets = @xterm_assets.build(
     ws,
     @xterm_assets.windows_x64_target(),
   )
-  @packaging.build_native_host(ws, extra_args=["--warn-list", "-20"])
-  @packaging.build_engine(ws)
+  @packaging.build_native_host(ws, release~, extra_args=["--warn-list", "-20"])
+  @packaging.build_engine(ws, release~)
   terminal_assets
 }
 
@@ -125,9 +135,10 @@ async fn reset_bundle_dirs(ws : @packaging.Workspace) -> Unit {
 async fn copy_bundle_files(
   ws : @packaging.Workspace,
   terminal_assets : @xterm_assets.Assets,
+  release~ : Bool,
 ) -> Unit {
-  let native_binary = ws.native_binary()
-  let engine_binary = ws.engine_binary()
+  let native_binary = ws.native_binary(release~)
+  let engine_binary = ws.engine_binary(release~)
   let bundled_engine = BundleDir + "/openseek.exe"
   if !@asyncfs.exists(native_binary) {
     raise @packaging.PackageError("native binary not found: \{native_binary}")
@@ -270,16 +281,18 @@ async fn build_installer(ws : @packaging.Workspace) -> Unit {
 ///|
 async fn main {
   // Parse first: a mistyped target must fail before the build, not after it.
-  let artifacts = ArtifactPlan::parse_args()
+  let matches = package_command().parse()
+  let artifacts = ArtifactPlan::from_matches(matches)
+  let release = matches.flags.get("release").unwrap_or(false)
   let ws = @packaging.locate_workspace()
   @packaging.ensure_cmake(ws)
   if artifacts.installer {
     ensure_makensis(ws)
   }
-  let terminal_assets = build_outputs(ws)
-  println("built openseek engine: \{ws.engine_binary()}")
+  let terminal_assets = build_outputs(ws, release~)
+  println("built openseek engine: \{ws.engine_binary(release~)}")
   reset_bundle_dirs(ws)
-  copy_bundle_files(ws, terminal_assets)
+  copy_bundle_files(ws, terminal_assets, release~)
   if artifacts.zip {
     zip_bundle(ws)
     println("generated \{ws.at(ZipPath)}")
@@ -293,12 +306,24 @@ async fn main {
 
 ///|
 test "windows package args default to zip and installer" {
-  assert_eq(ArtifactPlan::parse_args(argv=[]), { zip: true, installer: true })
+  let matches = package_command().parse(argv=[])
+  let artifacts = ArtifactPlan::from_matches(matches)
+  assert_eq(artifacts, { zip: true, installer: true })
+  assert_false(matches.flags.get("release").unwrap_or(false))
+}
+
+///|
+test "windows package args accept release" {
+  let matches = package_command().parse(argv=["--release", "--target", "app"])
+  let artifacts = ArtifactPlan::from_matches(matches)
+  assert_eq(artifacts, { zip: false, installer: false })
+  assert_true(matches.flags.get("release").unwrap_or(false))
 }
 
 ///|
 test "windows package target app skips distribution archives" {
-  assert_eq(ArtifactPlan::parse_args(argv=["--target", "app"]), {
+  let matches = package_command().parse(argv=["--target", "app"])
+  assert_eq(ArtifactPlan::from_matches(matches), {
     zip: false,
     installer: false,
   })
@@ -306,33 +331,28 @@ test "windows package target app skips distribution archives" {
 
 ///|
 test "windows package target zip skips installer" {
-  assert_eq(ArtifactPlan::parse_args(argv=["--target", "zip"]), {
-    zip: true,
-    installer: false,
-  })
+  let matches = package_command().parse(argv=["--target", "zip"])
+  assert_eq(ArtifactPlan::from_matches(matches), { zip: true, installer: false })
 }
 
 ///|
 test "windows package target installer skips zip" {
-  assert_eq(ArtifactPlan::parse_args(argv=["--target", "installer"]), {
-    zip: false,
-    installer: true,
-  })
+  let matches = package_command().parse(argv=["--target", "installer"])
+  assert_eq(ArtifactPlan::from_matches(matches), { zip: false, installer: true })
 }
 
 ///|
 test "windows package targets can be repeated" {
-  assert_eq(
-    ArtifactPlan::parse_args(argv=[
-      "--target", "app", "--target", "zip", "--target", "installer",
-    ]),
-    { zip: true, installer: true },
-  )
+  let matches = package_command().parse(argv=[
+    "--target", "app", "--target", "zip", "--target", "installer",
+  ])
+  assert_eq(ArtifactPlan::from_matches(matches), { zip: true, installer: true })
 }
 
 ///|
 test "windows package rejects an unsupported target" {
-  try ArtifactPlan::parse_args(argv=["--target", "msi"]) catch {
+  let matches = package_command().parse(argv=["--target", "msi"])
+  try ArtifactPlan::from_matches(matches) catch {
     err =>
       assert_true(
         err
@@ -348,7 +368,7 @@ test "windows package rejects an unsupported target" {
 
 ///|
 test "windows package args reject removed zip-only flag" {
-  try ArtifactPlan::parse_args(argv=["--zip-only"]) catch {
+  try package_command().parse(argv=["--zip-only"]) catch {
     err =>
       assert_true(
         err.to_string().contains("unexpected argument '--zip-only' found"),

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -40,7 +40,7 @@ case "${1:-}" in
     artifact="${2:-$default_artifact}"
     if [[ ! -f "$artifact" ]]; then
       echo "artifact not found: $artifact" >&2
-      echo "build it first: moon run ./package/macos -- --target zip --sign '...'" >&2
+      echo "build it first: moon run ./package/macos -- --release --target zip --sign '...'" >&2
       exit 1
     fi
     url="$origin/desktop/releases/v$version/$release_name"


### PR DESCRIPTION
```
haoxiang@Haoxiangs-MacBook-Pro openseek % time moon run ./desktop/package/macos
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] cmake --version
cmake version 4.4.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] moon install --target-dir target/proton-cli-build ./lepus/cli --bin target/proton-tools
Finished. moon: no work to do
Success: Installed `proton_cli` to `target/proton-tools/proton_cli`
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/proton-tools/proton_cli -C /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/lepus cef setup
warning: proton_cli 0.1.12 is available (current 0.1.11). Set PROTON_NO_UPDATE_CHECK=1 to disable this check.
[INFO] Assembling Proton runtime: /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/lepus/.proton/runtimes/darwin-arm64/proton-0.1.13_cef-147.0.14+g76d2442+chromium-147.0.7727.138
/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/lepus/.proton/runtimes/darwin-arm64/proton-0.1.13_cef-147.0.14+g76d2442+chromium-147.0.7727.138
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] cmake -S /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/lepus/native -B /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/proton-native/build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DPROTON_WITH_ENGINE=ON -DPROTON_ENGINE_ROOT=/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/lepus/.proton/cache/cef/darwin-arm64/cef_binary_147.0.14+g76d2442+chromium-147.0.7727.138_macosarm64_minimal
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/proton-native/build
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] cmake --build /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/proton-native/build --config Release
[ 13%] Built target proton_cef_loader
[ 90%] Built target proton
[100%] Built target cef_process
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] moon build frontend/desktop --target js
Finished. moon: no work to do
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] tar -xzf /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/cache/xterm-5.5.0.tgz -C /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/work/xterm --strip-components=1
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] tar -xzf /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/cache/addon-fit-0.10.0.tgz -C /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/work/fit --strip-components=1
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] tar -xzf /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/cache/esbuild-darwin-arm64-0.28.1.tgz -C /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/work/esbuild --strip-components=1
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/work/esbuild/bin/esbuild /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/work/entry.js --bundle --format=iife --platform=browser --minify --outfile=/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/target/vendor-xterm/dist/xterm.js

  target/vendor-xterm/dist/xterm.js  283.8kb

⚡ Done in 17ms
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] cc -c /tmp/openseek-disable-mimalloc-.34863.fd62bfdf/empty.c -o /Users/haoxiang/Library/MoonBit/lib/libmoonbitrun.o
Disabled mimalloc for the host build: /Users/haoxiang/Library/MoonBit/lib/libmoonbitrun.o
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] moon build . --target native
Finished. moon: no work to do
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek] moon build cmd/openseek --target native
Finished. moon: no work to do
built openseek engine: /Users/haoxiang/.codex/worktrees/e35c/openseek/_build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.exe
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Resources/assets] cp -R /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/fonts /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Resources/assets/fonts
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Resources] cp -R /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/lepus/.proton/runtimes/darwin-arm64/proton-0.1.13_cef-147.0.14+g76d2442+chromium-147.0.7727.138 /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Resources/proton
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper.app/Contents/MacOS/SeekMoon Helper
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] install_name_tool -add_rpath @loader_path/../../../../Resources/proton/lib /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper.app/Contents/MacOS/SeekMoon Helper
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Alerts).app/Contents/MacOS/SeekMoon Helper (Alerts)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] install_name_tool -add_rpath @loader_path/../../../../Resources/proton/lib /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Alerts).app/Contents/MacOS/SeekMoon Helper (Alerts)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (GPU).app/Contents/MacOS/SeekMoon Helper (GPU)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] install_name_tool -add_rpath @loader_path/../../../../Resources/proton/lib /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (GPU).app/Contents/MacOS/SeekMoon Helper (GPU)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Plugin).app/Contents/MacOS/SeekMoon Helper (Plugin)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] install_name_tool -add_rpath @loader_path/../../../../Resources/proton/lib /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Plugin).app/Contents/MacOS/SeekMoon Helper (Plugin)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Renderer).app/Contents/MacOS/SeekMoon Helper (Renderer)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] install_name_tool -add_rpath @loader_path/../../../../Resources/proton/lib /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Renderer).app/Contents/MacOS/SeekMoon Helper (Renderer)
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] tar -xzf dist/tools/moonbit/moonbit-darwin-aarch64-0.10.5+001eef869-nightly.tar.gz -C dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] tar -xzf dist/tools/moonbit/core-0.10.5+001eef869-nightly.tar.gz -C dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/lib
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moon
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moonc
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moondoc
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moonfmt
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moonrun
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/internal/tcc
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moon-ide
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moon-lsp
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/mooncake
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/mooninfo
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moon-cram
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moonlex.wasm
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moon-wasm-opt
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moonyacc.wasm
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/Resources/toolchains/moonbit/macos-arm64/bin/moon_cove_report
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] chmod +x dist/SeekMoon.app/Contents/MacOS/openseek-desktop dist/SeekMoon.app/Contents/MacOS/openseek
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] codesign --force --entitlements /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.entitlements --sign - /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper.app
/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper.app: replacing existing signature
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] codesign --force --entitlements /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.entitlements --sign - /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Alerts).app
/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Alerts).app: replacing existing signature
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] codesign --force --entitlements /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.entitlements --sign - /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (GPU).app
/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (GPU).app: replacing existing signature
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] codesign --force --entitlements /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.entitlements --sign - /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Plugin).app
/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Plugin).app: replacing existing signature
$ [/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop] codesign --force --entitlements /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.entitlements --sign - /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Renderer).app
/Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app/Contents/Frameworks/SeekMoon Helper (Renderer).app: replacing existing signature
kept linker signatures and signed only patched CEF helpers for local app
generated /Users/haoxiang/.codex/worktrees/e35c/openseek/desktop/dist/SeekMoon.app
moon run ./desktop/package/macos  1.59s user 2.65s system 68% cpu 6.146 total
```

## Summary

- make the browser, Linux, macOS, and Windows package commands build debug MoonBit artifacts by default
- add an explicit `--release` package flag and pass it through labelled `release` arguments to frontend, native host, engine, and artifact-path selection
- update distribution CI, release instructions, and packaging documentation to opt into release builds explicitly
- preserve the latest `main` behavior that removes Windows WSL packaging support

## Why

The package commands previously hard-coded `moon build --release` and release-only artifact paths. That made the normal packaging flow unsuitable for fast local debug builds and could not select the matching debug artifact directory.

## Validation

- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon test desktop/package/internal/packaging --target native --deny-warn` (7/7)
- `moon test desktop/package/macos --target native --deny-warn` (13/13)
- `moon test desktop/package/windows --target native --deny-warn` (8/8)
- `moon run desktop/package/{browser,linux,macos,windows} --target native -- --help`
- `moon fmt --check`
- parsed `.github/workflows/desktop.yml` with Ruby YAML
- `bash -n desktop/scripts/publish-release.sh`
- `git diff --check origin/main...HEAD`

Full platform packaging was not run locally.