### PR TITLE
ci: schedule daily desktop staging releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -76,14 +76,23 @@ jobs:
 
             # The macOS packager uses this version for both the visible release
             # version and CFBundleVersion, whose third component is at most two digits.
-            major_version="${BASH_REMATCH[1]}"
-            minor_version="${BASH_REMATCH[2]}"
-            patch_version="${BASH_REMATCH[3]}"
-            if (( 10#$patch_version >= 99 )); then
-              echo "::error::Cannot auto-increment staging version '$current_version': patch component is already 99"
+            major_version=$((10#${BASH_REMATCH[1]}))
+            minor_version=$((10#${BASH_REMATCH[2]}))
+            patch_version=$((10#${BASH_REMATCH[3]}))
+            if (( patch_version < 99 )); then
+              patch_version=$((patch_version + 1))
+            elif (( minor_version < 99 )); then
+              minor_version=$((minor_version + 1))
+              patch_version=0
+            elif (( major_version < 9999 )); then
+              major_version=$((major_version + 1))
+              minor_version=0
+              patch_version=0
+            else
+              echo "::error::Cannot auto-increment maximum staging version '$current_version'"
               exit 1
             fi
-            release_version="$((10#$major_version)).$((10#$minor_version)).$((10#$patch_version + 1))"
+            release_version="$major_version.$minor_version.$patch_version"
           else
             release_version="$MANUAL_RELEASE_VERSION"
           fi

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -65,7 +65,25 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
-            release_version="0.1.$(TZ=Asia/Shanghai date +%Y%m%d)"
+            current_version="$(
+              curl -fsSL "$OPENSEEK_API_ORIGIN/desktop/releases/latest.json" |
+                jq -er '.version | strings'
+            )"
+            if [[ ! "$current_version" =~ ^([0-9]{1,4})\.([0-9]{1,2})\.([0-9]{1,2})$ ]]; then
+              echo "::error::Published staging version '$current_version' is not an Apple-compatible three-part version"
+              exit 1
+            fi
+
+            # The macOS packager uses this version for both the visible release
+            # version and CFBundleVersion, whose third component is at most two digits.
+            major_version="${BASH_REMATCH[1]}"
+            minor_version="${BASH_REMATCH[2]}"
+            patch_version="${BASH_REMATCH[3]}"
+            if (( 10#$patch_version >= 99 )); then
+              echo "::error::Cannot auto-increment staging version '$current_version': patch component is already 99"
+              exit 1
+            fi
+            release_version="$((10#$major_version)).$((10#$minor_version)).$((10#$patch_version + 1))"
           else
             release_version="$MANUAL_RELEASE_VERSION"
           fi

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -3,9 +3,10 @@ name: Desktop release
 run-name: Desktop ${{ github.event_name == 'schedule' && 'staging' || inputs.channel }} v${{ github.event_name == 'schedule' && 'daily' || inputs.version }} by @${{ github.actor }}
 
 on:
-  # GitHub cron is UTC; 04:00 UTC is 12:00 in Asia/Shanghai.
+  # GitHub cron is UTC; these run at 12:00 and 18:30 in Asia/Shanghai.
   schedule:
     - cron: "0 4 * * *"
+    - cron: "30 10 * * *"
   workflow_dispatch:
     inputs:
       channel:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,8 +1,11 @@
 name: Desktop release
 
-run-name: Desktop ${{ inputs.channel }} v${{ inputs.version }} by @${{ github.actor }}
+run-name: Desktop ${{ github.event_name == 'schedule' && 'staging' || inputs.channel }} v${{ github.event_name == 'schedule' && 'daily' || inputs.version }} by @${{ github.actor }}
 
 on:
+  # GitHub cron is UTC; 04:00 UTC is 12:00 in Asia/Shanghai.
+  schedule:
+    - cron: "0 4 * * *"
   workflow_dispatch:
     inputs:
       channel:
@@ -21,7 +24,7 @@ on:
 # A release must finish as one upload/publish transaction. A second dispatch
 # waits instead of cancelling a run that may already have uploaded its archive.
 concurrency:
-  group: desktop-${{ inputs.channel }}-release
+  group: desktop-${{ github.event_name == 'schedule' && 'staging' || inputs.channel }}-release
   cancel-in-progress: false
 
 permissions:
@@ -36,10 +39,9 @@ jobs:
     env:
       APPLE_TEAM_ID: NYZ3LQ5QWC
       MACOS_SIGNING_IDENTITY: "Developer ID Application: Haoxiang Fei (NYZ3LQ5QWC)"
-      NOTARY_PROFILE: openseek-${{ inputs.channel }}
-      OPENSEEK_API_ORIGIN: ${{ inputs.channel == 'staging' && 'https://openseek-api-staging.moonbitlang.cn' || 'https://openseek-api.moonbitlang.cn' }}
-      RELEASE_CHANNEL: ${{ inputs.channel }}
-      RELEASE_VERSION: ${{ inputs.version }}
+      NOTARY_PROFILE: openseek-${{ github.event_name == 'schedule' && 'staging' || inputs.channel }}
+      OPENSEEK_API_ORIGIN: ${{ (github.event_name == 'schedule' || inputs.channel == 'staging') && 'https://openseek-api-staging.moonbitlang.cn' || 'https://openseek-api.moonbitlang.cn' }}
+      RELEASE_CHANNEL: ${{ github.event_name == 'schedule' && 'staging' || inputs.channel }}
 
     steps:
       - name: Checkout main
@@ -54,6 +56,21 @@ jobs:
         with:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
+
+      - name: Resolve release version
+        id: release
+        shell: bash
+        env:
+          MANUAL_RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+            release_version="0.1.$(TZ=Asia/Shanghai date +%Y%m%d)"
+          else
+            release_version="$MANUAL_RELEASE_VERSION"
+          fi
+          echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          echo "version=$release_version" >> "$GITHUB_OUTPUT"
 
       # Stamp only this runner's checkout; the source branch is not modified.
       - name: Stamp release version
@@ -137,7 +154,7 @@ jobs:
       - name: Upload signed artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: SeekMoon-macos-arm64-v${{ inputs.version }}
+          name: SeekMoon-macos-arm64-v${{ steps.release.outputs.version }}
           path: |
             desktop/dist/SeekMoon-macos-arm64.zip
             desktop/dist/SeekMoon-macos-arm64.dmg
@@ -146,7 +163,7 @@ jobs:
 
       # Upload verifies the server-computed digest before publish atomically
       # switches the selected channel's latest.json to this version.
-      - name: Publish to ${{ inputs.channel }}
+      - name: Publish release
         shell: bash
         env:
           OPENSEEK_DEPLOY_TOKEN: ${{ secrets.OPENSEEK_DEPLOY_TOKEN }}
@@ -156,7 +173,7 @@ jobs:
             desktop/dist/SeekMoon-macos-arm64.dmg
           desktop/scripts/publish-release.sh publish "v$RELEASE_VERSION"
 
-      - name: Verify ${{ inputs.channel }} manifest
+      - name: Verify release manifest
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- run the unified Desktop release workflow every day at 04:00 and 10:30 UTC / 12:00 and 18:30 Asia/Shanghai
- make scheduled runs staging-only and resolve the next version from the published staging `latest.json`
- increment the patch component and carry into minor and major at `99`, while respecting Apple's `CFBundleVersion` component limits
- keep manual staging/stable dispatch behavior unchanged, including the explicit version input
- propagate the resolved version to version stamping and the uploaded GitHub Actions artifact name

No Desktop source or updater changes are required. Scheduled releases keep one three-part version that is also valid as the macOS `CFBundleVersion`.

## Checks

- workflow YAML parsed successfully
- both `0 4 * * *` and `30 10 * * *` schedules verified
- ShellCheck passed for the edited Bash resolver
- live staging manifest resolved `0.1.9` to `0.1.10`
- rollover cases resolved `0.1.99` to `0.2.0` and `0.99.99` to `1.0.0`
- maximum `9999.99.99` exited with the expected error
- manual dispatch resolver path remains unchanged
- `git diff --check`
