### PR TITLE
fix(desktop): upgrade Proton integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "desktop/lepus"]
 	path = desktop/lepus
 	url = https://github.com/moonbit-community/proton.git
-	branch = haoxiang/openseek-desktop-proton-modroot-fix
+	branch = main
 [submodule "editor/codemirror"]
 	path = editor/codemirror
 	url = https://code.haverbeke.berlin/codemirror/dev.git

--- a/desktop/frontend/external_links.mbt
+++ b/desktop/frontend/external_links.mbt
@@ -69,8 +69,9 @@ fn open_external_link(dispatch : @cmd.Emit[Msg], url : String) -> @cmd.Cmd {
 ///|
 /// Install one delegated capture listener and return its identity for removal.
 /// Browser pages preserve ordinary navigation but force safe external targets
-/// into a new tab. Proton pages prevent every anchor navigation (so the app
-/// frame cannot escape) and emit only allowlisted external schemes.
+/// into a new tab. Pages with the injected Desktop bridge prevent every anchor
+/// navigation (so the app frame cannot escape) and emit only allowlisted
+/// external schemes.
 extern "js" fn add_external_link_capture(
   on_external : (String) -> Unit,
 ) -> @js.Value =
@@ -88,7 +89,7 @@ extern "js" fn add_external_link_capture(
   #|     const supported = destination.protocol === "http:" ||
   #|       destination.protocol === "https:" ||
   #|       destination.protocol === "mailto:";
-  #|     if (globalThis.location?.protocol === "proton:") {
+  #|     if (globalThis.__MoonBit__?.openseek) {
   #|       event.preventDefault();
   #|       if (supported) onExternal(destination.href);
   #|       return;

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -18,17 +18,6 @@ impl Show for BridgeError with fn output(self, logger) {
 }
 
 ///|
-/// Whether this page is the desktop webview (served from `proton://app/`,
-/// where the `__MoonBit__` bridge is injected) as opposed to a browser.
-pub fn using_proton_bridge() -> Bool {
-  guard js_prop(@js.globalThis, "location") is Some(location) else {
-    return false
-  }
-  (@js.Cast::into((location.get_with_string("protocol") : @js.Value)) : String?)
-  is Some("proton:")
-}
-
-///|
 /// `globalThis.__MoonBit__.openseek`, once the proton bridge is injected.
 pub fn openseek_api() -> @js.Value? {
   guard moonbit_bridge_root() is Some(root) else { return None }
@@ -127,7 +116,7 @@ pub fn bridge_error_is_definite(error : Error) -> Bool {
   match error {
     BridgeError(_) => false
     @js.Error_(value) =>
-      using_proton_bridge() || browser_rpc_error_is_definite(value)
+      openseek_api() is Some(_) || browser_rpc_error_is_definite(value)
     _ => false
   }
 }

--- a/desktop/frontend/interop/channel.mbt
+++ b/desktop/frontend/interop/channel.mbt
@@ -54,7 +54,7 @@ pub fn ChannelId::from_uri_authority(authority : String) -> ChannelId? {
 /// local host. `None` in a browser — the console at `/` holds no channel
 /// until it fetches the device roster and connects each device.
 pub fn page_channel() -> ChannelId? {
-  if using_proton_bridge() {
+  if openseek_api() is Some(_) {
     Some(Local)
   } else {
     None

--- a/desktop/frontend/interop/pkg.generated.mbti
+++ b/desktop/frontend/interop/pkg.generated.mbti
@@ -39,8 +39,6 @@ pub fn set_trimmed(@js.Object, String, String) -> Unit
 
 pub fn set_workspace(@js.Object, @pathx.Absolute?) -> Unit
 
-pub fn using_proton_bridge() -> Bool
-
 pub fn viewport_width() -> Int?
 
 pub fn ws_close(ChannelId) -> Unit

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1356,6 +1356,7 @@ fn initial_model() -> Model {
   // browser console, the device (`?device=`, minted by the relay's redirect
   // off the retired `/d/<id>/` routes); the first conversation lands there.
   let preselect_workspace = @interop.page_query_param("workspace")
+  let is_desktop = @interop.openseek_api() is Some(_)
   {
     // The desktop window's one channel; a browser page starts empty and
     // fills `devices` from the fetched roster (`apply_roster`).
@@ -1382,10 +1383,10 @@ fn initial_model() -> Model {
     host_settings_revision: -1,
     deferred_host_settings: None,
     legacy_cleanup_pending: false,
-    is_desktop: @interop.using_proton_bridge(),
+    is_desktop,
     // Every browser page is the console: it signs in against the relay and
     // fetches the device roster before any channel opens.
-    console: if @interop.using_proton_bridge() {
+    console: if is_desktop {
       None
     } else {
       Some(

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -148,7 +148,9 @@ pub async fn self_update_unavailable_reason(bundle_path~ : String) -> String? {
   if team_identifier(bundle_path) is Some(_) {
     bundle_replacement_failure(bundle_path)
   } else {
-    Some("The running OpenSeek bundle is not Developer ID signed.")
+    Some(
+      "Update is not available because current application is not signed with Developer ID",
+    )
   }
 }
 

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -53,10 +53,12 @@ fn main {
     // relay WebSocket instead (docs/remote-protocol.md).
     let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760)
       .debug_level(1)
-      .extension(@extension.openseek_extension(state, bridge))
+      // Both command extensions are deliberately exposed to the configured
+      // entry page; registration alone does not grant renderer access.
+      .expose(@extension.openseek_extension(state, bridge))
       // System notifications are an ordinary generated extension now: the
       // frontend posts them and receives `notification.click` with the run id.
-      .extension(@notification.extension())
+      .expose(@notification.extension())
       // The connect request proves the page can issue commands; this paired
       // lifecycle supplies the window-owned event destination that remains
       // valid after that request returns.

--- a/moon.work
+++ b/moon.work
@@ -7,5 +7,7 @@ members = [
   "./desktop",
   "./desktop/lepus/config",
   "./desktop/lepus/extensions",
+  "./desktop/lepus/rsa",
+  "./desktop/lepus/updater",
   "./desktop/lepus/proton",
 ]


### PR DESCRIPTION
## Summary

- track Proton main at `54768675` (Proton 0.1.14) and add its RSA/updater workspace modules
- expose the OpenSeek and notification command extensions to the configured renderer
- detect Desktop through the injected `globalThis.__MoonBit__.openseek` API instead of the retired `proton:` URL scheme
- report a clearer reason when local ad-hoc builds cannot self-update

## Root cause

Current Proton serves packaged assets from `https://proton.localhost/` and separates extension registration from renderer exposure. OpenSeek was still identifying Desktop pages through `location.protocol === "proton:"` and registering command extensions without exposing them. That misclassified the packaged app as the browser console, causing the sign-in check to hit the local asset origin and return HTTP 404.

The older Proton gitlink also predates the shared CEF cache and the current 0.1.14 module/API layout.

## Impact

Packaged Desktop builds now use Proton's current renderer permission model, select the local Desktop channel from the injected API, preserve external-link containment, and reuse Proton's shared CEF cache across worktrees.

## Validation

- `moon -C desktop check --target js --deny-warn`
- `moon -C desktop check --target native --deny-warn`
- `moon -C desktop test --target js --deny-warn` — 784 passed
- `moon -C desktop test --target native --release --deny-warn` — 2012 passed
- `moon -C desktop run --target native package/macos`
- strict signature verification for the main executable and all five CEF helper bundles
- packaged macOS UI smoke test: Desktop loaded normally without the sign-in HTTP 404
