### PR TITLE
feat(desktop): add terminal toggle shortcut

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -17,10 +17,27 @@ pub fn boot() -> Unit {
       },
       // The narrow-layout flag must track the window: rotating a phone or
       // resizing a desktop window across the breakpoint re-lays the app out.
+      // Ctrl+` follows the terminal buttons' existing toggle path, so the
+      // shortcut works from the composer, editor, and terminal itself.
       subscriptions=(emit, _) => {
         @sub.batch([
           @sub.on_resize(
             emit.map(viewport => ViewportResized(width=viewport.width)),
+          ),
+          @sub.on_key_down(
+            @cmd.Emit((keyboard : @keyboard.Keyboard) => {
+              if keyboard.code() == "Backquote" &&
+                keyboard.ctrl_key() &&
+                !keyboard.shift_key() &&
+                !keyboard.alt_key() &&
+                !keyboard.meta_key() &&
+                !keyboard.is_composing() &&
+                !keyboard.repeat() {
+                emit(Terminal(ToggleTerminal))
+              } else {
+                @cmd.none
+              }
+            }),
           ),
           external_link_subscription(emit.map(url => ExternalLinkClicked(url))),
         ])

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -25,7 +25,7 @@ pub fn boot() -> Unit {
             emit.map(viewport => ViewportResized(width=viewport.width)),
           ),
           @sub.on_key_down(
-            @cmd.Emit((keyboard : @keyboard.Keyboard) => {
+            @cmd.Emit((keyboard : @rabbita/common.Keyboard) => {
               if keyboard.code() == "Backquote" &&
                 keyboard.ctrl_key() &&
                 !keyboard.shift_key() &&

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/core/string",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/common" @keyboard,
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -4,7 +4,7 @@ import {
   "moonbitlang/core/string",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
-  "moonbit-community/rabbita/common" @keyboard,
+  "moonbit-community/rabbita/common" @rabbita/common,
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",

--- a/desktop/frontend/terminal/view.mbt
+++ b/desktop/frontend/terminal/view.mbt
@@ -85,7 +85,7 @@ pub fn panel_view(
   items.push(
     @html.button(
       class="terminal-close",
-      title="Hide terminal",
+      title="Hide terminal (Ctrl+`)",
       on_click=dispatch(ToggleTerminal),
       "✕",
     ),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2551,9 +2551,9 @@ fn topbar_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         "panel-toggle"
       },
       title=if model.terminal_panel.open {
-        "Hide terminal"
+        "Hide terminal (Ctrl+`)"
       } else {
-        "Show terminal"
+        "Show terminal (Ctrl+`)"
       },
       on_click=dispatch(Terminal(ToggleTerminal)),
       icon(icon_terminal),


### PR DESCRIPTION
Considering that we may or may not want to make keybindings configurable, this PR keep the keybinding handling centralized in boot.mbt so that it remains flexible to possible future evolutions, like adding a `KeyEvent -> Msg` map.

## Summary

- add a global Ctrl+Backquote shortcut that follows the existing terminal toggle path
- ignore shifted/alternate modifiers, key repeats, and IME composition
- show the shortcut in the terminal toggle tooltips

## Why

The integrated terminal previously required a pointer click to open or hide. This makes it accessible from the composer, editor, and terminal itself without changing terminal lifecycle behavior.

## Validation

- JS tests: 745/745 passed
- native tests: 1920/1920 passed
- JS and native checks passed with `--deny-warn`
- formatting and `git diff --check` passed
- built and signed the local macOS `SeekMoon.app`
- verified in the real app that the first shortcut opens and focuses the terminal and the second closes it while xterm has focus
