### PR TITLE
feat(desktop): auto-fold MoonBit source outlines

### DIFF
--- a/desktop/frontend/fileeditor/auto_fold_policy_wbtest.mbt
+++ b/desktop/frontend/fileeditor/auto_fold_policy_wbtest.mbt
@@ -1,0 +1,41 @@
+///|
+fn auto_fold_policy_model(
+  display_name : String,
+  language_id : String,
+) -> @model.TextModel {
+  @model.TextModel(
+    try! @common.Uri::from(
+      scheme="inmemory",
+      authority="auto-fold-policy",
+      path="/fixture",
+    ),
+    display_name,
+    language_id,
+    1,
+    "revision-1",
+    "root\n  child",
+  )
+}
+
+///|
+test "auto-fold policy is limited to ordinary MoonBit source files" {
+  assert_true(
+    should_auto_fold_top_level(auto_fold_policy_model("main.mbt", "moonbit")),
+  )
+  assert_false(
+    should_auto_fold_top_level(
+      auto_fold_policy_model("pkg.generated.mbti", "moonbit"),
+    ),
+  )
+  assert_false(
+    should_auto_fold_top_level(
+      auto_fold_policy_model("README.mbt.md", "moonbit"),
+    ),
+  )
+  assert_false(
+    should_auto_fold_top_level(auto_fold_policy_model("source", "moonbit")),
+  )
+  assert_false(
+    should_auto_fold_top_level(auto_fold_policy_model("main.mbt", "plaintext")),
+  )
+}

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -271,6 +271,14 @@ fn show_file_in_viewer(
         viewer_state.view_states.get(rel.0) is Some(saved) {
         viewer.restore_view_state(Some(saved))
       }
+      // Match the reference workbench's host policy: ordinary `.mbt` files
+      // open as a top-level outline. `set_model` computes folding ranges
+      // synchronously, so this is stable initialization state rather than a
+      // delayed render effect. Keeping it in the fresh-model branch leaves
+      // folding interactions on the current model entirely user-controlled.
+      if should_auto_fold_top_level(text_model) {
+        viewer.fold_top_level()
+      }
     }
     // Gate incoming diagnostics to the file now on screen (a notice document,
     // with no absolute path, takes no diagnostics). The relative name rides
@@ -324,6 +332,16 @@ fn show_file_in_viewer(
       viewer.reveal_range_in_center(range)
     }
   })
+}
+
+///|
+/// Whether Desktop applies the reference workbench's initial outline policy.
+///
+/// Only ordinary MoonBit `.mbt` source files opt in. Interfaces, literate
+/// documents, extensionless sources, and other languages stay expanded.
+fn should_auto_fold_top_level(text_model : @model.TextModel) -> Bool {
+  text_model.get_language_id() == "moonbit" &&
+  text_model.display_name.has_suffix(".mbt")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- apply the reference editor workbench's auto-fold policy when OpenSeek installs a fresh ordinary `.mbt` model
- preserve user-controlled folding while the same model remains active
- keep `.mbti`, `.mbt.md`, extensionless sources, and other languages expanded
- cover the host policy boundary with a white-box regression test

## Why

OpenSeek's in-tree Viewer already implements `fold_top_level()`, including MoonBit function outlines and top-level license/comment runs. The desktop file editor installed and restored models but never invoked that host policy, so OpenSeek opened those files fully expanded.

## User impact

Ordinary MoonBit source files now open with the same outline presentation as the editor workbench. File-header license blocks collapse to their first line, top-level function bodies collapse while signatures remain visible, and subsequent folding interactions on the active model remain user-controlled.

## Validation

- `moon test desktop/frontend/fileeditor --target js` — 44/44 passed
- `just check`
- `just test` — native 3068/3068, JS 2468/2468, cram 27/27
- `just build`