### PR TITLE
feat(shell): trust recoverable git rebase forms

### DIFF
--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -66,12 +66,86 @@ pub fn global_option_reconfigures(arg : String) -> Bool {
 /// a tracked file recoverable from it — reviewable through git, never sourced from
 /// an external file or stdin. Excluded: `mv` (moves arbitrary worktree bytes onto
 /// the destination) and `clean` (deletes UNTRACKED files with no object-store
-/// copy — permanent). `rm` stays: it only deletes tracked files.
+/// copy — permanent). `rm` stays: it only deletes tracked files. `rebase` also
+/// writes from the object store but is trusted only in the argument forms
+/// admitted by `rebase_args_are_recoverable`, so it is not listed here.
 pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
   match subcommand {
     "checkout" | "switch" | "restore" | "reset" | "stash" | "rm" => true
     _ => false
   }
+}
+
+///|
+/// Whether `subcommand` writes the worktree from the object store: the
+/// unconditionally recoverable writers plus `rebase`, whose recoverable forms
+/// are gated by `rebase_args_are_recoverable`. Used by the custom-environment
+/// pre-blocks — any of these, repointed via `GIT_DIR`/`GIT_CONFIG_*`/`env`,
+/// could write workspace source from a different repository regardless of its
+/// arguments.
+pub fn subcommand_is_object_store_writer(subcommand : String) -> Bool {
+  subcommand == "rebase" || subcommand_writes_from_object_store(subcommand)
+}
+
+///|
+/// Whether a `git rebase` invocation's arguments (in `words[start..end)`) keep
+/// it a recoverable object-store write: replayed content materializes from
+/// commits, the pre-rebase tip stays reachable via `ORIG_HEAD` and the reflog,
+/// a dirty tree is refused up front (or stashed recoverably with
+/// `--autostash`), and git refuses to overwrite untracked files during replay.
+///
+/// Unlike the checkout guard this is an ALLOWLIST that fails closed on any
+/// unrecognized token: rebase's option surface is large and includes command
+/// runners (`--exec`, `-i`, `--edit-todo`, a `--strategy` resolved from the
+/// exec path), and git accepts unambiguous long-option abbreviations, so only
+/// exact known-safe tokens qualify — the in-progress verbs
+/// (`--continue`/`--abort`/`--skip`/`--quit`), base selection
+/// (`--onto <ref>`/`--onto=<ref>`/`--keep-base`,
+/// `--fork-point`/`--no-fork-point`), `--autostash`/`--no-autostash`, and
+/// positional revisions. Everything else falls through to the sandbox.
+///
+/// `--continue` does resume a rebase started outside the agent, including the
+/// remaining todo steps of a user-started interactive rebase; those steps are
+/// the user's own, and the agent cannot author any because the interactive
+/// forms are pre-blocked (`should_preblock`).
+pub fn rebase_args_are_recoverable(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  let mut index = start
+  while index < end {
+    match words[index] {
+      "--continue"
+      | "--abort"
+      | "--skip"
+      | "--quit"
+      | "--keep-base"
+      | "--fork-point"
+      | "--no-fork-point"
+      | "--autostash"
+      | "--no-autostash" => index += 1
+      // The `--onto` value is a committish resolved from the object store; git
+      // consumes the next word whatever it looks like, and a non-revision fails
+      // resolution before anything is written.
+      "--onto" => {
+        if index + 1 >= end {
+          return false
+        }
+        index += 2
+      }
+      arg =>
+        if arg.has_prefix("--onto=") {
+          index += 1
+        } else if arg.has_prefix("-") && arg != "-" {
+          return false
+        } else {
+          // A positional upstream/branch revision (`-` is the previous branch).
+          index += 1
+        }
+    }
+  }
+  true
 }
 
 ///|
@@ -121,9 +195,11 @@ pub fn worktree_args_are_recoverable(
 /// by design: block the git that mutates source but is NOT a recoverable
 /// object-store write — store feeders (`apply`/`am`/`update-index`/`read-tree`/
 /// `fast-import`), `mv` (moves arbitrary worktree bytes), non-dry-run `clean`
-/// (permanently deletes untracked files), and any object-store writer that is
-/// reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). The recoverable
-/// writers (`checkout`/`switch`/`restore`/`reset`/`stash`/`rm`) and read-only git
+/// (permanently deletes untracked files), rebase's command-running forms
+/// (`-i`/`--exec`/`--edit-todo`/a merge strategy), and any object-store writer
+/// that is reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). The
+/// recoverable writers (`checkout`/`switch`/`restore`/`reset`/`stash`/`rm`,
+/// rebase in its `rebase_args_are_recoverable` forms) and read-only git
 /// are not pre-blocked; they run (trusted, or sandboxed where they cannot harm).
 pub fn should_preblock(argv : Array[String], arg_start : Int) -> Bool {
   guard parse(argv, arg_start) is Some(invocation) else { return false }
@@ -151,8 +227,8 @@ pub fn text_should_preblock(
 }
 
 ///|
-/// Whether the git subcommand found in `words[start..end)` is a recoverable
-/// object-store writer (checkout/switch/restore/reset/stash/rm). The text path
+/// Whether the git subcommand found in `words[start..end)` is an object-store
+/// writer (checkout/switch/restore/reset/stash/rm, or rebase). The text path
 /// uses this to decide whether a custom environment before `git` (which it cannot
 /// see in `words[start..]`) makes the writer unsafe and must be pre-blocked.
 pub fn text_invocation_writes_from_object_store(
@@ -162,7 +238,7 @@ pub fn text_invocation_writes_from_object_store(
 ) -> Bool {
   match text_subcommand_index(words, start, end) {
     Some(subcommand_index) =>
-      subcommand_writes_from_object_store(words[subcommand_index])
+      subcommand_is_object_store_writer(words[subcommand_index])
     None => false
   }
 }
@@ -193,6 +269,12 @@ fn preblock_for_subcommand(
     "checkout" | "switch" | "restore" =>
       region_reconfigures(words, global_start, subcommand_index) ||
       overwrites_untracked_from_tree(words, args_start, end)
+    // rebase replays object-store commits (recoverable via ORIG_HEAD/reflog),
+    // but its command-running forms execute arbitrary commands and must never
+    // run; a reconfigured rebase is unsafe like the other writers.
+    "rebase" =>
+      region_reconfigures(words, global_start, subcommand_index) ||
+      rebase_args_run_external_commands(words, args_start, end)
     // The other recoverable writers are only unsafe when reconfigured.
     subcommand =>
       subcommand_writes_from_object_store(subcommand) &&
@@ -252,6 +334,65 @@ fn short_cluster_has(arg : String, flag : String) -> Bool {
   !arg.has_prefix("--") &&
   arg != "-" &&
   arg.contains(flag)
+}
+
+///|
+/// Whether a `git rebase` invocation's arguments (in `words[start..end)`)
+/// request running external commands: `-i`/`--interactive` (sequence-editor
+/// driven, `exec` todo lines), `--edit-todo` (opens the todo in an editor),
+/// `-x`/`--exec` (a shell command per commit), or a merge strategy
+/// (`-s`/`--strategy` resolves a `git-merge-<s>` executable from the exec
+/// path; `-X`/`--strategy-option` is grouped with it conservatively). These
+/// are pre-blocked cross-platform: on a platform without `sandbox-exec` they
+/// would otherwise run arbitrary commands. Long options match by prefix
+/// because git accepts unambiguous abbreviations (`--exe=cmd` runs the
+/// command; an ambiguous prefix such as `--e` just errors in git, so
+/// over-matching is harmless in a pre-block); short options match inside
+/// clusters and attached-value forms (`-iv`, `-xcmd`). The scan stops at `--`:
+/// past it every word is a revision, and a revision cannot begin with a dash.
+fn rebase_args_run_external_commands(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  for index in start..<end {
+    let arg = words[index]
+    if arg == "--" {
+      return false
+    }
+    if rebase_arg_runs_external_commands(arg) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+fn rebase_arg_runs_external_commands(arg : String) -> Bool {
+  if arg.has_prefix("--") {
+    return long_option_selects(arg, "--interactive") ||
+      long_option_selects(arg, "--exec") ||
+      long_option_selects(arg, "--edit-todo") ||
+      long_option_selects(arg, "--strategy") ||
+      long_option_selects(arg, "--strategy-option")
+  }
+  short_cluster_has(arg, "i") ||
+  short_cluster_has(arg, "x") ||
+  short_cluster_has(arg, "s") ||
+  short_cluster_has(arg, "X")
+}
+
+///|
+/// Whether `arg` selects the long option `full`, accepting git's
+/// unambiguous-abbreviation forms and an attached value: for
+/// `full == "--exec"`, the args `--exec`, `--exe`, and `--exe=cmd` all match.
+/// The name must extend past the bare `--` terminator, which never matches.
+fn long_option_selects(arg : String, full : String) -> Bool {
+  let name = match [..arg.split("=")] {
+    [name, _, ..] => name.to_owned()
+    _ => arg
+  }
+  name.length() > 2 && full.has_prefix(name)
 }
 
 ///|

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -20,8 +20,107 @@ test "object-store-write classification excludes mv and plumbing" {
   for sub in ["checkout", "switch", "restore", "reset", "stash", "rm"] {
     assert_true(@git_policy.subcommand_writes_from_object_store(sub))
   }
-  for sub in ["mv", "clean", "apply", "am", "status", "checkout-index", "co"] {
+  // rebase is deliberately absent: its recoverable forms are gated by args
+  // (`rebase_args_are_recoverable`), never trusted by name alone.
+  for
+    sub in [
+      "mv", "clean", "apply", "am", "status", "checkout-index", "co", "rebase",
+    ] {
     assert_false(@git_policy.subcommand_writes_from_object_store(sub))
+  }
+  // The custom-environment pre-blocks treat rebase as an object-store writer:
+  // repointed via GIT_DIR/GIT_CONFIG_* it could write source from another repo.
+  assert_true(@git_policy.subcommand_is_object_store_writer("rebase"))
+  assert_true(@git_policy.subcommand_is_object_store_writer("checkout"))
+  assert_false(@git_policy.subcommand_is_object_store_writer("apply"))
+  assert_false(@git_policy.subcommand_is_object_store_writer("clean"))
+}
+
+///|
+test "rebase args: plain and in-progress forms recoverable, rest fails closed" {
+  fn recoverable(args : Array[String]) -> Bool {
+    @git_policy.rebase_args_are_recoverable(args, 0, args.length())
+  }
+
+  // Plain rebases and the in-progress verbs: replayed content comes from the
+  // object store and the pre-rebase tip stays in ORIG_HEAD/the reflog.
+  assert_true(recoverable([]))
+  assert_true(recoverable(["main"]))
+  assert_true(recoverable(["origin/main", "feature"]))
+  assert_true(recoverable(["-"]))
+  assert_true(recoverable(["--onto", "main", "feature~3", "feature"]))
+  assert_true(recoverable(["--onto=main", "feature"]))
+  assert_true(recoverable(["--keep-base", "main"]))
+  assert_true(recoverable(["--fork-point", "main"]))
+  assert_true(recoverable(["--no-fork-point", "main"]))
+  assert_true(recoverable(["--autostash", "main"]))
+  assert_true(recoverable(["--no-autostash", "main"]))
+  assert_true(recoverable(["--continue"]))
+  assert_true(recoverable(["--abort"]))
+  assert_true(recoverable(["--skip"]))
+  assert_true(recoverable(["--quit"]))
+  // Allowlist polarity: anything not an exact known-safe token fails closed —
+  // rebase's surface includes command runners, and git accepts unambiguous
+  // long-option abbreviations, so `--cont` is as untrusted as `--exec`.
+  assert_false(recoverable(["-i", "main"]))
+  assert_false(recoverable(["--interactive", "main"]))
+  assert_false(recoverable(["--exec", "ls", "main"]))
+  assert_false(recoverable(["-x", "ls", "main"]))
+  assert_false(recoverable(["--edit-todo"]))
+  assert_false(recoverable(["--strategy=ours", "main"]))
+  assert_false(recoverable(["--root"]))
+  assert_false(recoverable(["--rebase-merges", "main"]))
+  assert_false(recoverable(["--stat", "main"]))
+  assert_false(recoverable(["--cont"]))
+  assert_false(recoverable(["--onto"]))
+  assert_false(recoverable(["--", "main"]))
+}
+
+///|
+test "should_preblock: rebase command-running and reconfigured forms" {
+  // Blocked: forms that execute external commands (interactive/todo editing,
+  // `--exec`, a merge strategy) — including abbreviations, short clusters, and
+  // attached values — plus any reconfigured rebase.
+  for
+    cmd in [
+      ["git", "rebase", "-i", "main"],
+      ["git", "rebase", "--interactive", "main"],
+      ["git", "rebase", "--int", "main"],
+      ["git", "rebase", "-iv", "main"],
+      ["git", "rebase", "--exec", "ls", "main"],
+      ["git", "rebase", "--exec=ls", "main"],
+      ["git", "rebase", "--exe=ls", "main"],
+      ["git", "rebase", "-x", "ls", "main"],
+      ["git", "rebase", "-xls", "main"],
+      ["git", "rebase", "--edit-todo"],
+      ["git", "rebase", "-s", "ours", "main"],
+      ["git", "rebase", "--strategy=ours", "main"],
+      ["git", "rebase", "-Xtheirs", "main"],
+      ["git", "rebase", "--strategy-option", "theirs", "main"],
+      ["git", "-c", "sequence.editor=x", "rebase", "--continue"],
+      ["git", "-C", "/tmp/x", "rebase", "--abort"],
+      ["git", "--work-tree=/tmp/x", "rebase", "main"],
+    ] {
+    assert_true(@git_policy.should_preblock(cmd, 1))
+  }
+  // Not blocked: the recoverable forms (they run trusted) and the
+  // merely-unrecognized forms (they run sandboxed, where the profile denies
+  // any source write). `--stat`/`--empty` must not false-positive against the
+  // `--strategy`/`--exec` abbreviation prefixes.
+  for
+    cmd in [
+      ["git", "rebase", "main"],
+      ["git", "rebase", "--onto", "main", "feature~3", "feature"],
+      ["git", "rebase", "--continue"],
+      ["git", "rebase", "--abort"],
+      ["git", "rebase", "--autostash", "main"],
+      ["git", "rebase", "--root"],
+      ["git", "rebase", "--rebase-merges", "main"],
+      ["git", "rebase", "--stat", "main"],
+      ["git", "rebase", "--empty=drop", "main"],
+      ["git", "rebase", "--help"],
+    ] {
+    assert_false(@git_policy.should_preblock(cmd, 1))
   }
 }
 

--- a/agent_tool/shell/internal/git_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/git_policy/pkg.generated.mbti
@@ -6,7 +6,11 @@ pub fn global_option_reconfigures(String) -> Bool
 
 pub fn parse(Array[String], Int) -> Invocation?
 
+pub fn rebase_args_are_recoverable(Array[String], Int, Int) -> Bool
+
 pub fn should_preblock(Array[String], Int) -> Bool
+
+pub fn subcommand_is_object_store_writer(String) -> Bool
 
 pub fn subcommand_writes_from_object_store(String) -> Bool
 
@@ -27,4 +31,3 @@ pub struct Invocation {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -230,7 +230,9 @@ fn trusted_command_class(
 /// Classify a `git` command for the trusted-source-write path. Trust is granted
 /// only to the recoverable worktree subcommands above plus the recoverable
 /// `git worktree` verbs (`add`/non-force `remove`/`prune`, see
-/// `@git_policy.worktree_args_are_recoverable`), and only when the
+/// `@git_policy.worktree_args_are_recoverable`) and the recoverable `rebase`
+/// forms (an exact-token allowlist, see
+/// `@git_policy.rebase_args_are_recoverable`), and only when the
 /// invocation cannot reconfigure git to write from somewhere other than the
 /// workspace repo's object store: a custom environment (`GIT_CONFIG_*`,
 /// `env ... git`) or a relocating global option could repoint config (enabling a
@@ -253,6 +255,13 @@ fn trusted_git_command_class(
     }
   }
   if @git_policy.subcommand_writes_from_object_store(invocation.subcommand) {
+    TrustedCommandWrite
+  } else if invocation.subcommand == "rebase" &&
+    @git_policy.rebase_args_are_recoverable(
+      command.argv,
+      invocation.subcommand_index + 1,
+      command.argv.length(),
+    ) {
     TrustedCommandWrite
   } else if invocation.subcommand == "worktree" &&
     @git_policy.worktree_args_are_recoverable(
@@ -3082,7 +3091,7 @@ fn git_must_preblock(
   has_custom_env &&
   (match @git_policy.parse(argv, arg_start) {
     Some(invocation) =>
-      @git_policy.subcommand_writes_from_object_store(invocation.subcommand)
+      @git_policy.subcommand_is_object_store_writer(invocation.subcommand)
     None => false
   })
 }

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -570,7 +570,9 @@ async test "sandbox preblocks common source-writing commands" {
         "git clean -e -n -fd", "git -c filter.f.smudge=cmd checkout -- .", "git -C /tmp/x checkout -- .",
         "git checkout -f other", "git restore --source=HEAD~1 -- main.mbt", "GIT_DIR=/tmp/x git checkout -- main.mbt",
         "env GIT_WORK_TREE=. git restore main.mbt", "git checkout HEAD~1 -- main.mbt",
-        "git restore -s HEAD~1 main.mbt",
+        "git restore -s HEAD~1 main.mbt", "git rebase -i main", "git rebase --exec ls main",
+        "git rebase -s ours main", "git rebase --edit-todo", "git -c sequence.editor=x rebase --continue",
+        "GIT_DIR=/tmp/x git rebase main",
       ] {
       assert_true(
         is_some_path(
@@ -611,7 +613,8 @@ async test "sandbox preblocks common source-writing commands" {
         "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
         "git restore main.mbt", "git reset --hard", "git rm main.mbt", "git stash",
         "git clean -fdn", "git status", "git apply --check patch.diff", "git apply --stat patch.diff",
-        "git worktree add ../wt", "git worktree remove ../wt",
+        "git worktree add ../wt", "git worktree remove ../wt", "git rebase main",
+        "git rebase --continue", "git rebase --onto main feature~3 feature", "git rebase --rebase-merges main",
       ] {
       assert_true(
         tree_target(recoverable_git, real_root, Some(real_root)) is None,
@@ -1397,6 +1400,38 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
       "git worktree remove --force ../wt", "git worktree remove -f ../wt", "git worktree remove --fo ../wt",
       "git worktree list", "git worktree move ../wt ../wt2", "git worktree", "git -C /tmp/x worktree add ../wt",
       "GIT_DIR=/tmp/x git worktree add ../wt",
+    ] {
+    assert_true(mode_for(cmd) is SourceReadOnly)
+  }
+}
+
+///|
+test "sandbox trusts restricted rebase forms, demotes the rest" {
+  // The recoverable rebase forms are trusted source writers: replayed content
+  // materializes from the object store, the pre-rebase tip stays in
+  // ORIG_HEAD/the reflog, and git refuses to overwrite untracked files during
+  // replay. Conflict resolution still flows through `edit` + sandboxed
+  // `git add`, so this opens no source-editing channel outside the tools.
+  for
+    cmd in [
+      "git rebase", "git rebase main", "git rebase origin/main feature", "git rebase --onto main feature~3 feature",
+      "git rebase --keep-base main", "git rebase --autostash main", "git rebase --fork-point main",
+      "git rebase --continue", "git rebase --abort", "git rebase --skip", "git rebase --quit",
+      "cd pkg && git rebase --continue",
+    ] {
+    assert_true(mode_for(cmd) is TrustedSourceWrite)
+  }
+  // Anything not an exact known-safe token fails closed to the sandbox (git
+  // accepts unambiguous long-option abbreviations, and rebase's surface
+  // includes command runners), as do reconfigured or custom-environment
+  // invocations. The command-running forms are additionally pre-blocked
+  // (`should_preblock`) as the cross-platform floor.
+  for
+    cmd in [
+      "git rebase --rebase-merges main", "git rebase --root", "git rebase --cont",
+      "git rebase -i main", "git rebase --exec ls main", "git rebase -s ours main",
+      "git -c sequence.editor=x rebase main", "git -C /tmp/x rebase --abort", "FOO=bar git rebase main",
+      "env GIT_DIR=/tmp/x git rebase --continue",
     ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }


### PR DESCRIPTION
## Summary

Extends the shell tool's trusted-source-write git policy to `rebase`, classified **by form, not by name** — the same model used for `checkout` (safe forms trusted, dangerous forms pre-blocked).

- **Trusted (unsandboxed)**: an exact-token allowlist (`rebase_args_are_recoverable`) admits plain rebases, `--onto <ref>`/`--onto=<ref>`/`--keep-base`, `--fork-point`/`--no-fork-point`, `--autostash`/`--no-autostash`, positional revisions, and the in-progress verbs `--continue`/`--abort`/`--skip`/`--quit`. These satisfy the existing trust invariant: every worktree write materializes from the object store, the pre-rebase tip stays reachable via `ORIG_HEAD`/the reflog, git refuses to start on a dirty tree and refuses to overwrite untracked files during replay.
- **Fail closed to the sandbox**: anything not exactly known-safe (`--rebase-merges`, `--root`, abbreviations like `--cont`, …). Allowlist polarity is deliberate — opposite of the checkout guard — because rebase's option surface is large, includes command runners, and git accepts unambiguous long-option abbreviations.
- **Pre-blocked cross-platform**: the command-running forms — `-i`/`--interactive`, `-x`/`--exec`, `--edit-todo`, `-s`/`--strategy`/`-X` — including abbreviation prefixes (`--exe=cmd`), short clusters (`-iv`), and attached values (`-xcmd`). On a platform without `sandbox-exec` these previously ran unguarded (`git rebase --exec 'anything'` on Linux); now they are blocked before execution.
- **Custom-environment rebase** joins the object-store-writer pre-block on both the argv and TooComplex text paths (`subcommand_is_object_store_writer`): a repointed `GIT_DIR`/`GIT_CONFIG_*` could write workspace source from a different repository.

Conflict resolution still flows through `edit` + sandboxed `git add`, so trusting rebase opens no source-editing channel outside the tools — the object store only contains history plus edit-tool-authored content (store feeders remain pre-blocked).

## Testing

- `moon test -p agent_tool/shell/internal/git_policy`: 24/24
- `moon test -p agent_tool/shell`: 228/228
- `moon check --deny-warn` clean, `moon fmt` applied, `moon info` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)