### PR TITLE
fix(desktop): watch only active file editor paths

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -42,7 +42,57 @@ fn bridge_msg(
       diagnostics_msg(channel, payload).map(msg => {
         FromDevice(channel, FilePanel(msg))
       })
-    "fs.changed" => Some(FromDevice(channel, FilePanel(FsChanged)))
+    "fs.changed" => {
+      let session = @jsonx.json_text(payload, "session")
+      let changes : Array[@fileeditor.FileChange]? = if @jsonx.json_bool(
+          payload, "baseline",
+        ).unwrap_or(false) {
+        None
+      } else if payload.get("events") is Some(Array(items)) {
+        let decoded : Array[@fileeditor.FileChange] = []
+        for item in items {
+          if item is Object(fields) &&
+            @jsonx.json_text(fields, "kind") is Some(kind_) &&
+            @jsonx.json_text(fields, "path") is Some(path) {
+            match kind_ {
+              "modify" =>
+                decoded.push(@fileeditor.Modified(@pathx.Relative(path)))
+              "create" =>
+                decoded.push(@fileeditor.Created(@pathx.Relative(path)))
+              "remove" =>
+                decoded.push(@fileeditor.Removed(@pathx.Relative(path)))
+              "rename" =>
+                if @jsonx.json_text(fields, "old_path") is Some(old) {
+                  decoded.push(
+                    @fileeditor.Renamed(
+                      old=@pathx.Relative(old),
+                      new=@pathx.Relative(path),
+                    ),
+                  )
+                }
+              _ => ()
+            }
+          }
+        }
+        Some(decoded)
+      } else {
+        // An older host sent only `{root}`; preserve its coarse refresh.
+        None
+      }
+      Some(FromDevice(channel, FilePanel(FsChanged(session~, changes~))))
+    }
+    "fs.watch_failed" =>
+      if @jsonx.json_text(payload, "session") is Some(session) &&
+        @jsonx.json_text(payload, "message") is Some(message) {
+        Some(
+          FromDevice(
+            channel,
+            FilePanel(FileWatchFailed(owner={ channel, session }, message~)),
+          ),
+        )
+      } else {
+        None
+      }
     "terminal.output" =>
       terminal_output_msg(channel, payload).map(msg => Terminal(msg))
     "terminal.exit" =>
@@ -215,7 +265,8 @@ fn proton_event_methods() -> Array[String] {
     "agent.connected", "agent.started", "agent.event", "agent.error", "agent.finished",
     "agent.durable", "session.event", "session.changed", "workspace.changed", "settings.changed",
     "skills.changed", "update.download_progress", "update.downloaded", "update.download_failed",
-    "auth.changed", "lsp.diagnostics", "fs.changed", "terminal.output", "terminal.exit",
+    "auth.changed", "lsp.diagnostics", "fs.changed", "fs.watch_failed", "terminal.output",
+    "terminal.exit",
   ]
 }
 
@@ -277,7 +328,57 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
   let channel : @interop.ChannelId = Remote("d1")
   assert_true(
     bridge_msg(channel, "fs.changed", Map([]))
-    is Some(FromDevice(Remote("d1"), FilePanel(_))),
+    is Some(
+      FromDevice(Remote("d1"), FilePanel(FsChanged(session=None, changes=None)))
+    ),
+  )
+  assert_true(
+    bridge_msg(channel, "fs.changed", {
+      "session": Json::string("s-1"),
+      "baseline": Json::boolean(false),
+      "events": Json::array([
+        { "kind": "modify", "path": "src/main.mbt" },
+        { "kind": "rename", "path": "src/new.mbt", "old_path": "src/old.mbt" },
+      ]),
+    })
+    is Some(
+      FromDevice(
+        Remote("d1"),
+        FilePanel(
+          FsChanged(
+            session=Some("s-1"),
+            changes=Some(
+              [
+                Modified(Relative("src/main.mbt")),
+                Renamed(
+                  old=Relative("src/old.mbt"),
+                  new=Relative("src/new.mbt")
+                ),
+              ]
+            )
+          )
+        )
+      )
+    ),
+  )
+  assert_true(proton_event_methods().contains("fs.watch_failed"))
+  assert_true(
+    bridge_msg(channel, "fs.watch_failed", {
+      "session": Json::string("s-1"),
+      "root": Json::string("/work/project"),
+      "message": Json::string("File watching stopped"),
+    })
+    is Some(
+      FromDevice(
+        Remote("d1"),
+        FilePanel(
+          FileWatchFailed(
+            owner={ channel: Remote("d1"), session: "s-1" },
+            message="File watching stopped"
+          )
+        )
+      )
+    ),
   )
   // A remote device's relay registration is its host's business.
   assert_true(bridge_msg(channel, "auth.changed", Map([])) is None)

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -294,17 +294,16 @@ fn decode_file_stats(text : String) -> Array[FileStat]? {
 
 ///|
 /// Point the host's workspace watcher at `session`'s workspace, or park it
-/// (`fs.unwatch`) when the panel no longer needs one. Fire-and-forget:
-/// there is no reply worth folding, and a failure just means no live
-/// updates until the next reconciliation re-sends.
+/// (`fs.unwatch`) when the panel no longer needs one. Parking is best-effort,
+/// but a rejected watch is surfaced because it means live updates are off.
 fn watch_workspace(
+  dispatch : @cmd.Emit[Msg],
   channel~ : @interop.ChannelId,
-  session : String,
-  workspace~ : @pathx.Absolute?,
+  watched : WatchedPaths?,
 ) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
+  @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      if session.is_empty() {
+      if watched is None {
         let _ : @js.Value = @interop.bridge_request_in_order(
           channel,
           "fs.unwatch",
@@ -312,16 +311,28 @@ fn watch_workspace(
         ) catch {
           _ => return
         }
-      } else {
+      } else if watched is Some(watched) {
         let payload = @js.Object::new()
-        payload["session"] = session
-        @interop.set_workspace(payload, workspace)
+        payload["session"] = watched.owner.session
+        payload["files"] = watched.files.map(path => path.0)
+        payload["directories"] = watched.directories.map(path => path.0)
+        @interop.set_workspace(payload, watched.workspace)
         let _ : @js.Value = @interop.bridge_request_in_order(
           channel,
           "fs.watch",
           payload.to_value(),
         ) catch {
-          _ => return
+          error => {
+            scheduler.add(
+              dispatch(
+                FileWatchFailed(
+                  owner=watched.owner,
+                  message="File watching failed: \{@interop.bridge_error_text(error)}",
+                ),
+              ),
+            )
+            return
+          }
         }
       }
     })

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -39,6 +39,13 @@ pub(all) struct Ctx {
   narrow : Bool
 }
 
+pub(all) enum FileChange {
+  Modified(@pathx.Relative)
+  Created(@pathx.Relative)
+  Removed(@pathx.Relative)
+  Renamed(old~ : @pathx.Relative, new~ : @pathx.Relative)
+} derive(Eq)
+
 pub(all) enum FileContent {
   Binary
   Oversized
@@ -85,7 +92,8 @@ pub(all) enum Msg {
   OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
   FileLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, name~ : String, file~ : FileContent, range~ : @common.Range?, annotation~ : String?)
   FileFailed(owner~ : @interop.ConversationKey, message~ : String)
-  FsChanged
+  FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
+  FsChanged(session~ : String?, changes~ : Array[FileChange]?)
   StatsLoaded(owner~ : @interop.ConversationKey, stats~ : Array[FileStat])
   DiagnosticsLoaded(owner~ : @interop.ConversationKey, absolute~ : @pathx.Absolute, diagnostics~ : Json)
   DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @pathx.Absolute, diagnostics~ : Json)
@@ -106,7 +114,8 @@ pub(all) struct State {
   open : Bool
   owner : @interop.ConversationKey?
   tree_open : Bool
-  watching : @interop.ConversationKey?
+  watching : WatchedPaths?
+  watch_error : String?
   expanded : Array[@pathx.Relative]
   loading : Array[@pathx.Relative]
   children : Map[@pathx.Relative, Array[FileEntry]]
@@ -142,6 +151,13 @@ pub(all) enum TreeLayout {
 } derive(Eq)
 pub fn TreeLayout::parse(String) -> Self
 pub fn TreeLayout::wire(Self) -> String
+
+pub(all) struct WatchedPaths {
+  owner : @interop.ConversationKey
+  workspace : @pathx.Absolute?
+  files : Array[@pathx.Relative]
+  directories : Array[@pathx.Relative]
+} derive(Eq)
 
 // Type aliases
 

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -89,6 +89,28 @@ pub(all) struct FileStat {
 }
 
 ///|
+/// One concrete filesystem event from the host watcher. Paths are relative
+/// to the conversation workspace. A rename keeps both names so the file tree
+/// and any open tab at either address can be reconciled.
+pub(all) enum FileChange {
+  Modified(@pathx.Relative)
+  Created(@pathx.Relative)
+  Removed(@pathx.Relative)
+  Renamed(old~ : @pathx.Relative, new~ : @pathx.Relative)
+} derive(Eq)
+
+///|
+/// The exact watcher configuration most recently sent to one host connection:
+/// every open tab plus the root/expanded directories whose immediate children
+/// the file tree needs to keep current.
+pub(all) struct WatchedPaths {
+  owner : @interop.ConversationKey
+  workspace : @pathx.Absolute?
+  files : Array[@pathx.Relative]
+  directories : Array[@pathx.Relative]
+} derive(Eq)
+
+///|
 /// The workspace file index behind the filter's fuzzy matching: every file
 /// under the workspace (the host walks it recursively, pruning churn
 /// directories and capping the count). Requested lazily on the first
@@ -122,10 +144,14 @@ pub(all) struct State {
   // is shown. A panel preference, not per-conversation state, so it
   // survives conversation switches.
   tree_open : Bool
-  // The conversation whose workspace the host's file watcher currently
-  // follows (`None` = parked). Keeping the channel here lets `sync` explicitly
-  // retire the previous host's watcher before placing the next one.
-  watching : @interop.ConversationKey?
+  // The paths the host's watcher currently follows (`None` = parked). Keeping
+  // the full configuration makes opening/closing a tab or expanding/collapsing
+  // a directory replace the watch even when the conversation did not change.
+  watching : WatchedPaths?
+  // A watcher can fail after `fs.watch` has already replied. Keep that
+  // failure separate from directory/file requests so a later successful
+  // directory listing does not hide the loss of live updates.
+  watch_error : String?
   // Directory paths the user has expanded, and those with a `read_directory`
   // in flight; plain arrays since a workspace tree is small.
   expanded : Array[@pathx.Relative]
@@ -165,6 +191,7 @@ pub fn State::empty() -> State {
     owner: None,
     tree_open: true,
     watching: None,
+    watch_error: None,
     expanded: [],
     loading: [],
     children: Map([]),
@@ -311,10 +338,13 @@ pub(all) enum Msg {
     annotation~ : String?
   )
   FileFailed(owner~ : @interop.ConversationKey, message~ : String)
-  // The host's coarse "something changed under the watched workspace" push.
-  // Carries no paths — the handler re-stats the open tabs and re-lists the
-  // expanded directories to find out what moved.
-  FsChanged
+  // An `fs.watch` request rejection or an asynchronous watcher failure. The
+  // owner fences both paths against a conversation switch.
+  FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
+  // A new watcher sends `changes=None` once it is attached, requesting a full
+  // baseline reconciliation. Later pushes contain the exact debounced events.
+  // `session` is absent only for compatibility with an older host.
+  FsChanged(session~ : String?, changes~ : Array[FileChange]?)
   // A `stat_files` reply: each open tab's current mtime signature (`""` =
   // the file is gone). `owner` says which conversation it answers, like
   // every other reply.

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -188,17 +188,77 @@ pub fn open_file(
 }
 
 ///|
+/// Whether this event can change the file currently addressed by `path`.
+/// Structural directory events cover every descendant; a content modification
+/// applies only to the exact file returned by the watcher.
+fn FileChange::touches(self : FileChange, path : @pathx.Relative) -> Bool {
+  match self {
+    Modified(changed) => changed == path
+    Created(changed) | Removed(changed) => @pathx.contains(changed.0, path.0)
+    Renamed(old~, new~) =>
+      @pathx.contains(old.0, path.0) || @pathx.contains(new.0, path.0)
+  }
+}
+
+///|
+/// The directory containing `path`; a root-level entry belongs to `""`.
+fn FileChange::parent(path : @pathx.Relative) -> @pathx.Relative {
+  let segments = [..path.0.split("/")]
+  ignore(segments.pop())
+  Relative(segments.join("/"))
+}
+
+///|
+/// Listed directories whose immediate rows may have changed. A created or
+/// renamed destination is included too so a directory that disappeared and
+/// later returned does not reuse stale cached children.
+fn FileChange::relist_candidates(self : FileChange) -> Array[@pathx.Relative] {
+  match self {
+    Modified(_) => []
+    Created(path) => [FileChange::parent(path), path]
+    Removed(path) => [FileChange::parent(path)]
+    Renamed(old~, new~) =>
+      [FileChange::parent(old), FileChange::parent(new), new]
+  }
+}
+
+///|
+fn FileChange::changes_file_list(self : FileChange) -> Bool {
+  !(self is Modified(_))
+}
+
+///|
 /// Reconcile the host's workspace watcher with what the panel needs: follow
 /// the active session while the panel is open or tabs remain open in the
 /// background (their staleness must keep being tracked for the reopen), park
 /// it otherwise. Wraps every `sync` exit so the bookkeeping cannot be missed.
-fn with_watch(state : State, ctx : Ctx, cmd : @cmd.Cmd) -> (State, @cmd.Cmd) {
-  let want = if (state.open || !state.tabs.is_empty()) &&
-    !ctx.owner.session.is_empty() {
-    Some(ctx.owner)
-  } else {
-    None
+fn State::watched_paths(self : State, ctx : Ctx) -> WatchedPaths? {
+  if (!self.open && self.tabs.is_empty()) || ctx.owner.session.is_empty() {
+    return None
   }
+  let files = self.tabs.map(tab => tab.path)
+  files.sort_by((left, right) => left.0.lexical_compare(right.0))
+  let directories : Array[@pathx.Relative] = []
+  if self.open {
+    directories.push(@pathx.Relative::root())
+    for directory in self.expanded {
+      if !directories.contains(directory) {
+        directories.push(directory)
+      }
+    }
+    directories.sort_by((left, right) => left.0.lexical_compare(right.0))
+  }
+  Some({ owner: ctx.owner, workspace: ctx.workspace, files, directories })
+}
+
+///|
+fn with_watch(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  cmd : @cmd.Cmd,
+) -> (State, @cmd.Cmd) {
+  let want = state.watched_paths(ctx)
   if state.watching == want {
     (state, cmd)
   } else {
@@ -206,21 +266,20 @@ fn with_watch(state : State, ctx : Ctx, cmd : @cmd.Cmd) -> (State, @cmd.Cmd) {
     // A watcher is host-local. Moving across channels must explicitly retire
     // the old host; placing a new watch on another socket cannot replace it.
     if state.watching is Some(current) &&
-      (want is None || (want is Some(next) && current.channel != next.channel)) {
+      (
+        want is None ||
+        (want is Some(next) && current.owner.channel != next.owner.channel)
+      ) {
       commands.push(
-        watch_workspace(channel=current.channel, "", workspace=None),
+        watch_workspace(dispatch, channel=current.owner.channel, None),
       )
     }
     if want is Some(next) {
       commands.push(
-        watch_workspace(
-          channel=next.channel,
-          next.session,
-          workspace=ctx.workspace,
-        ),
+        watch_workspace(dispatch, channel=next.owner.channel, Some(next)),
       )
     }
-    ({ ..state, watching: want }, @cmd.batch(commands))
+    ({ ..state, watching: want, watch_error: None }, @cmd.batch(commands))
   }
 }
 
@@ -297,8 +356,8 @@ pub fn sync(
         open: state.open,
         owner: Some(ctx.owner),
         tree_open: state.tree_open,
-        // What the host actually watches doesn't change with the reroot;
-        // `with_watch` re-points it against this record on the way out.
+        // Preserve the last host configuration long enough for `with_watch`
+        // to retire or replace it on the way out.
         watching: state.watching,
         remembered,
         tabs,
@@ -309,7 +368,7 @@ pub fn sync(
   }
   // A closed panel re-roots (above) and keeps the watcher placed, but the
   // tree itself can wait for the reopen.
-  guard state.open else { return with_watch(state, ctx, reroot_cmd) }
+  guard state.open else { return with_watch(dispatch, state, ctx, reroot_cmd) }
   // Load as soon as there is a conversation: the workspace directory is a pure
   // function of the session id, so the host can list it without waiting for a
   // run to report `cwd` (it reports an empty workspace until the first turn
@@ -317,11 +376,12 @@ pub fn sync(
   if ctx.owner.session.is_empty() ||
     state.children.contains("") ||
     state.loading.contains("") {
-    return with_watch(state, ctx, reroot_cmd)
+    return with_watch(dispatch, state, ctx, reroot_cmd)
   }
   let loading = state.loading.copy()
   loading.push("")
   with_watch(
+    dispatch,
     { ..state, loading, },
     ctx,
     @cmd.batch([
@@ -686,45 +746,70 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
-    FsChanged => {
-      guard state.owner is Some(owner) else { return (@cmd.none, state) }
-      // Something under the watched workspace moved. Find out what: one
-      // batched stat for the open tabs, and a re-list of the root plus every
-      // expanded directory already on screen (marked loading so a burst of
-      // pushes cannot stack duplicate lists; the watcher already debounces).
-      let cmds = []
-      if !state.tabs.is_empty() {
-        cmds.push(
-          stat_files(
-            dispatch,
-            owner,
-            state.tabs.map(tab => tab.path),
-            workspace=ctx.workspace,
-          ),
-        )
-      }
-      let relist : Array[@pathx.Relative] = []
-      if state.children.contains("") && !state.loading.contains("") {
-        relist.push(@pathx.Relative::root())
-      }
-      for dir in state.expanded {
-        if state.children.contains(dir) && !state.loading.contains(dir) {
-          relist.push(dir)
+    FsChanged(session~, changes~) =>
+      if state.owner is Some(owner) &&
+        (session is None || session == Some(owner.session)) {
+        // A baseline checks the whole selection after watcher replacement.
+        // Concrete batches stat only affected tabs and re-list only directories
+        // whose immediate children changed.
+        let cmds = []
+        let stat_paths : Array[@pathx.Relative] = []
+        let relist : Array[@pathx.Relative] = []
+        let mut refresh_index = false
+        if changes is Some(changes) {
+          for change in changes {
+            for tab in state.tabs {
+              if change.touches(tab.path) && !stat_paths.contains(tab.path) {
+                stat_paths.push(tab.path)
+              }
+            }
+            for directory in change.relist_candidates() {
+              if !relist.contains(directory) &&
+                state.children.contains(directory) &&
+                (directory.is_root() || state.expanded.contains(directory)) &&
+                !state.loading.contains(directory) {
+                relist.push(directory)
+              }
+            }
+            if change.changes_file_list() {
+              refresh_index = true
+            }
+          }
+        } else {
+          for tab in state.tabs {
+            stat_paths.push(tab.path)
+          }
+          if state.children.contains("") && !state.loading.contains("") {
+            relist.push(@pathx.Relative::root())
+          }
+          for directory in state.expanded {
+            if state.children.contains(directory) &&
+              !state.loading.contains(directory) {
+              relist.push(directory)
+            }
+          }
+          refresh_index = true
         }
+        if !stat_paths.is_empty() {
+          cmds.push(
+            stat_files(dispatch, owner, stat_paths, workspace=ctx.workspace),
+          )
+        }
+        let loading = state.loading.copy()
+        for directory in relist {
+          loading.push(directory)
+          cmds.push(
+            read_directory(dispatch, owner, directory, workspace=ctx.workspace),
+          )
+        }
+        // Only structural events can change the fuzzy index's path list.
+        if refresh_index && !(state.index is IndexEmpty) {
+          cmds.push(list_files(dispatch, owner, workspace=ctx.workspace))
+        }
+        (@cmd.batch(cmds), { ..state, loading, })
+      } else {
+        (@cmd.none, state)
       }
-      let loading = state.loading.copy()
-      for dir in relist {
-        loading.push(dir)
-        cmds.push(read_directory(dispatch, owner, dir, workspace=ctx.workspace))
-      }
-      // The fuzzy filter's index goes stale with the tree; rebuild it if
-      // anyone has ever needed it (the reply just replaces the old list, so
-      // the filter keeps showing the previous matches meanwhile).
-      if !(state.index is IndexEmpty) {
-        cmds.push(list_files(dispatch, owner, workspace=ctx.workspace))
-      }
-      (@cmd.batch(cmds), { ..state, loading, })
-    }
     StatsLoaded(owner~, stats~) =>
       if state.owner != Some(owner) {
         (@cmd.none, state)
@@ -803,6 +888,12 @@ pub fn update(
         (@cmd.none, state)
       } else {
         (@cmd.none, { ..state, error: Some(message) })
+      }
+    FileWatchFailed(owner~, message~) =>
+      if state.owner != Some(owner) {
+        (@cmd.none, state)
+      } else {
+        (@cmd.none, { ..state, watch_error: Some(message) })
       }
     // Owned by the main package's update: the comment becomes a composer
     // chip there, which then clears the editor bubble through
@@ -1132,7 +1223,7 @@ test "a closed panel still re-roots when the conversation switches" {
   let state = {
     ..open_state(),
     open: false,
-    watching: Some(test_ctx().owner),
+    watching: open_state().watched_paths(test_ctx()),
     tabs: [loaded_tab("a.mbt", "a.mbt")],
     active: Some(Relative("a.mbt")),
   }
@@ -1158,7 +1249,15 @@ test "a closed panel still re-roots when the conversation switches" {
   assert_true(restored.tabs[0].state is TabLoading)
   assert_true(restored.active is Some(Relative("a.mbt")))
   assert_true(
-    restored.watching is Some({ channel: Local, session: "desktop-test" }),
+    restored.watching
+    is Some(
+      {
+        owner: { channel: Local, session: "desktop-test" },
+        workspace: None,
+        files: [Relative("a.mbt")],
+        directories: [],
+      }
+    ),
   )
   // Reopening is what reads the restored active tab (the command is opaque;
   // the tab stays TabLoading until the reply lands).
@@ -1267,7 +1366,7 @@ test "a deleted tab whose file reappears reloads on the next stats" {
 }
 
 ///|
-test "FsChanged re-lists the root and expanded, already-listed directories" {
+test "watcher baseline re-lists the root and expanded, listed directories" {
   let emit = test_emit()
   let children : Map[@pathx.Relative, Array[FileEntry]] = Map([])
   children[Relative("")] = []
@@ -1277,35 +1376,124 @@ test "FsChanged re-lists the root and expanded, already-listed directories" {
     children,
     expanded: [Relative("src"), Relative("never-listed")],
   }
-  let (_, next) = update(emit, FsChanged, state, test_ctx())
+  let baseline = FsChanged(session=Some("desktop-test"), changes=None)
+  let (_, next) = update(emit, baseline, state, test_ctx())
   // Both known directories are marked in flight; the never-listed one is
   // left to its own first expansion.
   assert_true(next.loading.contains(Relative("")))
   assert_true(next.loading.contains(Relative("src")))
   assert_false(next.loading.contains(Relative("never-listed")))
   // A second push while the lists are in flight stacks nothing.
-  let (_, again) = update(emit, FsChanged, next, test_ctx())
+  let (_, again) = update(emit, baseline, next, test_ctx())
   assert_eq(again.loading.length(), next.loading.length())
+}
+
+///|
+test "concrete watcher events refresh only affected listed directories" {
+  let emit = test_emit()
+  let children : Map[@pathx.Relative, Array[FileEntry]] = Map([])
+  children[Relative("")] = []
+  children[Relative("src")] = []
+  children[Relative("docs")] = []
+  let state = {
+    ..open_state(),
+    children,
+    expanded: [Relative("src"), Relative("docs")],
+  }
+  let message = FsChanged(
+    session=Some("desktop-test"),
+    changes=Some([Created(Relative("src/new.mbt"))]),
+  )
+  let (_, first) = update(emit, message, state, test_ctx())
+  assert_true(first.loading == [Relative("src")])
+  // Rabbita purity: the same message and model produce the same state.
+  let (_, second) = update(emit, message, state, test_ctx())
+  assert_true(first.loading == second.loading)
+  // A late batch from the previous conversation is ignored.
+  let (_, stale) = update(
+    emit,
+    FsChanged(
+      session=Some("previous-session"),
+      changes=Some([Created(Relative("docs/new.md"))]),
+    ),
+    state,
+    test_ctx(),
+  )
+  assert_true(stale.loading.is_empty())
 }
 
 ///|
 test "sync reconciles the watcher with the panel and its tabs" {
   let emit = test_emit()
   // Open panel: watch the active session.
-  let (watched, _) = sync(emit, open_state(), test_ctx())
-  assert_true(watched.watching == Some(test_ctx().owner))
-  // Closed panel with tabs still open: keep watching (staleness tracking).
-  let closed = {
+  let (watched, _) = sync(
+    emit,
+    { ..open_state(), watch_error: Some("old watcher failure") },
+    test_ctx(),
+  )
+  assert_true(
+    watched.watching
+    is Some(
+      {
+        owner: { session: "desktop-test", .. },
+        workspace: None,
+        files: [],
+        directories: [Relative("")],
+      }
+    ),
+  )
+  // Issuing a new watch attempt retires the previous failure.
+  assert_true(watched.watch_error is None)
+  // Opening a tab or expanding a directory replaces the same conversation's
+  // watcher with the new exact selection.
+  let selected = {
     ..watched,
-    open: false,
     tabs: [loaded_tab("a.mbt", "a.mbt")],
-    children: Map([]),
-    loading: [],
+    expanded: [Relative("src")],
   }
+  let (replaced, _) = sync(emit, selected, test_ctx())
+  assert_true(
+    replaced.watching
+    is Some(
+      {
+        files: [Relative("a.mbt")],
+        directories: [Relative(""), Relative("src")],
+        ..,
+      }
+    ),
+  )
+  // Closed panel with tabs still open: keep watching (staleness tracking).
+  let closed = { ..replaced, open: false, children: Map([]), loading: [] }
   let (still, _) = sync(emit, closed, test_ctx())
-  assert_true(still.watching == Some(test_ctx().owner))
+  assert_true(
+    still.watching is Some({ files: [Relative("a.mbt")], directories: [], .. }),
+  )
   // Closed panel, no tabs: park the watcher.
   let empty_panel = { ..still, tabs: [] }
   let (parked, _) = sync(emit, empty_panel, test_ctx())
   assert_true(parked.watching is None)
+}
+
+///|
+test "watcher failures are visible only in their owning conversation" {
+  let emit = test_emit()
+  let owner = test_ctx().owner
+  let (_, failed) = update(
+    emit,
+    FileWatchFailed(owner~, message="File watching stopped"),
+    open_state(),
+    test_ctx(),
+  )
+  assert_true(failed.watch_error is Some("File watching stopped"))
+  let other : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Remote("other"),
+    session: owner.session,
+  }
+  let (_, unchanged) = update(
+    emit,
+    FileWatchFailed(owner=other, message="stale failure"),
+    failed,
+    test_ctx(),
+  )
+  assert_true(unchanged.watch_error is Some("File watching stopped"))
 }

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -175,6 +175,12 @@ fn viewer_notice(state : State) -> @html.Html {
 /// edge.
 fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html {
   let entries = visible_entries(state)
+  // Losing the watcher is more important than a request-local failure: live
+  // updates remain disabled even if a later directory request succeeds.
+  let visible_error = match state.watch_error {
+    Some(message) => Some(message)
+    None => state.error
+  }
   // The filter's query, rebuilt here only to split each row's path into
   // matched/unmatched sections for highlighting — the rows themselves were
   // already ranked by `visible_entries`.
@@ -224,12 +230,12 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
     @html.div(class="file-tree", tree_children),
     // Rendered even while empty so the row's slot in the pane is stable.
     @html.div(
-      class=if state.error is Some(_) {
+      class=if visible_error is Some(_) {
         "file-panel-error"
       } else {
         "file-panel-error empty"
       },
-      match state.error {
+      match visible_error {
         Some(message) => message
         None => ""
       },

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1091,7 +1091,8 @@ priv enum DeviceMsg {
   // A scheduled reconnect attempt came due. Dropped harmlessly when the
   // device was removed or re-added in the meantime.
   ReconnectDue(websocket_epoch~ : Int)
-  // A file-panel-scoped host push (`fs.changed`, `lsp.diagnostics`),
+  // A file-panel-scoped host push (`fs.changed`, `fs.watch_failed`,
+  // `lsp.diagnostics`),
   // stamped with its channel: the panel serves the focused conversation,
   // so a background device's filesystem noise is dropped at the arm.
   FilePanel(@fileeditor.Msg)

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -81,6 +81,7 @@ let notification_events : Map[String, @proton_contract.Event[Json]] = {
   "auth.changed": desktop_contract.event("auth.changed"),
   "lsp.diagnostics": desktop_contract.event("lsp.diagnostics"),
   "fs.changed": desktop_contract.event("fs.changed"),
+  "fs.watch_failed": desktop_contract.event("fs.watch_failed"),
   // PTY output and exit notifications originate from the connection-owned
   // terminal pump, but still need explicit Proton descriptors to reach xterm.
   "terminal.output": desktop_contract.event("terminal.output"),

--- a/desktop/internal/host/fs_watch.mbt
+++ b/desktop/internal/host/fs_watch.mbt
@@ -1,12 +1,13 @@
-// The workspace file watcher behind the editor panel's live updates. The
-// Each client connection points its own actor at the active conversation's
+// The workspace file watcher behind the editor panel's live updates. Each
+// client connection points its own actor at the active conversation's
 // workspace through `fs.watch` (and parks it with `fs.unwatch`); the actor
-// runs one recursive `@fs.Watcher` on that root and pushes a coarse
-// `fs.changed` notification back to that connection on every change.
+// runs one recursive `@fs.Watcher` pruned to the file editor's current open
+// files and listed directories. It pushes concrete `fs.changed` events back
+// to that connection on every change, or an
+// `fs.watch_failed` notification when the accepted watcher cannot keep
+// running.
 // `FsWatchActor` owns both the desired-root mailbox and the active watcher
-// resource. The watcher reports no paths — the frontend re-stats its open
-// tabs (`fs.stat_files`) and re-lists its expanded directories to find out
-// what moved.
+// resource.
 
 ///|
 /// One ordered actor request. Resolution happens inside the actor, after the
@@ -24,6 +25,110 @@ priv enum FsWatchRequest {
 /// preferable to silently applying them out of order.
 priv struct FsWatchActor {
   requests : @async.Queue[FsWatchRequest]
+}
+
+///|
+/// The resolved watch address plus the conversation that requested it. The
+/// session travels with asynchronous failures so a late notification cannot
+/// be shown in the next conversation.
+priv struct FsWatchTarget {
+  session : String
+  root : String
+  interest : WatchInterest
+}
+
+///|
+/// The immutable selection captured by one watcher. `paths` contains every
+/// explicitly selected file/directory and its ancestors. `directories`
+/// additionally keeps each selected directory's immediate children so create,
+/// remove, and rename events can be discovered without descending further.
+priv struct WatchInterest {
+  legacy_full_tree : Bool
+  paths : Set[String]
+  directories : Set[String]
+}
+
+///|
+fn WatchInterest::WatchInterest(
+  payload : WatchWorkspacePayload,
+) -> WatchInterest {
+  let interest = {
+    legacy_full_tree: payload.files is None && payload.directories is None,
+    paths: Set([]),
+    directories: Set([]),
+  }
+  if payload.files is Some(files) {
+    for path in files {
+      interest.remember(path)
+    }
+  }
+  if payload.directories is Some(directories) {
+    for path in directories {
+      interest.directories.add(path)
+      interest.remember(path)
+    }
+  }
+  interest
+}
+
+///|
+/// Retain `path` and each directory needed to reach it from the watch root.
+fn WatchInterest::remember(self : WatchInterest, path : String) -> Unit {
+  let mut prefix = ""
+  for segment in path.split("/") {
+    if !segment.is_empty() {
+      prefix = if prefix.is_empty() {
+        segment.to_owned()
+      } else {
+        "\{prefix}/\{segment}"
+      }
+      self.paths.add(prefix)
+    }
+  }
+}
+
+///|
+/// Subtrees omitted by recursive snapshots and legacy full-tree watchers.
+/// Explicit watcher selections do not use this policy: an opened file must
+/// remain watchable even under one of these conventional directory names.
+fn ignored_watch_path(path : String) -> Bool {
+  match [..path.split("/")] {
+    [
+      ..,
+      ".git"
+      | "target"
+      | "_build"
+      | "node_modules"
+      | ".mooncakes"
+      | ".repos",
+    ] => true
+    _ => false
+  }
+}
+
+///|
+/// Keep selected paths, their ancestors, and one level below every selected
+/// directory. A child directory is opened so its own create/remove can be
+/// observed, but its descendants are ignored unless that directory is also
+/// selected or leads to an opened file.
+fn WatchInterest::ignores(self : WatchInterest, path : String) -> Bool {
+  if self.legacy_full_tree {
+    return ignored_watch_path(path)
+  }
+  if self.paths.contains(path) {
+    return false
+  }
+  for directory in self.directories {
+    if directory.is_empty() {
+      if !path.contains("/") {
+        return false
+      }
+    } else if path.strip_prefix("\{directory}/") is Some(rest) &&
+      !rest.contains("/") {
+      return false
+    }
+  }
+  true
 }
 
 ///|
@@ -61,8 +166,8 @@ async fn FsWatchActor::unwatch(self : FsWatchActor) -> Unit {
 /// chosen its next state.
 async fn FsWatchRequest::apply(
   self : FsWatchRequest,
-  current : String?,
-) -> String? {
+  current : FsWatchTarget?,
+) -> FsWatchTarget? {
   match self {
     Unwatch(reply~) => {
       reply.put(None)
@@ -77,7 +182,11 @@ async fn FsWatchRequest::apply(
         ) {
         Some(root) => {
           reply.put(None)
-          Some(root.to_string())
+          Some({
+            session: payload.session,
+            root: root.to_string(),
+            interest: WatchInterest(payload),
+          })
         }
         None => {
           reply.put(Some("path is outside the conversation workspace"))
@@ -88,40 +197,31 @@ async fn FsWatchRequest::apply(
 }
 
 ///|
-/// Subtrees the watcher never descends into. Build output and package
-/// caches churn constantly and would both flood the debouncer and — on the
-/// kqueue backend, which holds one file descriptor per watched node — burn
-/// the process's fd budget on a big workspace. `path` is relative to the
-/// watch root and `/`-separated; pruning a directory prunes everything
-/// under it, so matching the leaf segment is enough.
-fn ignored_watch_path(path : String) -> Bool {
-  match [..path.split("/")] {
-    [
-      ..,
-      ".git"
-      | "target"
-      | "_build"
-      | "node_modules"
-      | ".mooncakes"
-      | ".repos",
-    ] => true
-    _ => false
-  }
-}
-
-///|
-/// Watch `root` until cancelled, pushing one coarse `fs_changed` per
-/// debounced change burst. The `Watcher` itself coalesces events (20ms
-/// quiet / 200ms max delay), so a build storm emits a trickle, not a flood.
+/// Watch one target until cancelled. Construction scans only the selected
+/// paths; once attached, the baseline closes the replacement race and later
+/// notifications preserve `Watcher::wait`'s concrete debounced events.
 async fn watch_root(
-  root : String,
+  target : FsWatchTarget,
   emit : async (FsChangedPayload) -> Unit,
 ) -> Unit {
-  let watcher = @fs.Watcher::Watcher(root, ignored_paths=ignored_watch_path)
+  let watcher = @fs.Watcher::Watcher(target.root, ignored_paths=path => {
+    target.interest.ignores(path)
+  })
   defer watcher.close()
+  emit({
+    session: target.session,
+    root: target.root,
+    baseline: true,
+    events: [],
+  })
   for ;; {
-    watcher.wait_any()
-    emit({ root, })
+    let events = watcher.wait()
+    emit({
+      session: target.session,
+      root: target.root,
+      baseline: false,
+      events: events.map(FsEventPayload::from_event),
+    })
   }
 }
 
@@ -129,36 +229,49 @@ async fn watch_root(
 /// The actor loop: hold one watcher on the latest requested root, swapping when a
 /// new request arrives. Each watcher runs in a child task group whose body
 /// blocks on the next request — `return_immediately` then cancels the
-/// blocked `wait_any` deterministically (`Watcher::close` alone is not
+/// blocked `wait` deterministically (`Watcher::close` alone is not
 /// documented to wake it). A missing root (workspace directories are
 /// created lazily on the first run) is polled until it appears, so the
-/// watcher attaches by itself once the first run creates the directory. The
-/// watcher task is `allow_failure` so a watcher error (say, fd exhaustion
-/// on a huge tree) degrades to "no live updates" instead of tearing down
-/// the connection.
+/// watcher attaches by itself once the first run creates the directory.
+/// Watcher failures are logged and pushed to the file editor instead of being
+/// silently discarded. Cancellation is different: replacing or parking a
+/// watcher deliberately cancels the old child, so that error must propagate
+/// as cancellation and must not reach the UI.
 async fn FsWatchActor::run(
   self : FsWatchActor,
-  emit : async (FsChangedPayload) -> Unit,
+  emit_changed : async (FsChangedPayload) -> Unit,
+  emit_failed : async (FsWatchFailedPayload) -> Unit,
 ) -> Unit {
-  let mut root : String? = None
+  let mut root : FsWatchTarget? = None
   for ;; {
     root = self.requests.get().apply(root)
     guard root is Some(target) else { continue }
     let request = @async.with_task_group(group => {
-      group.spawn_bg(allow_failure=true, () => {
-        if !@fs.exists(target) {
-          for ;; {
-            @async.sleep(2000)
-            if @fs.exists(target) {
-              break
+      group.spawn_bg(() => {
+        try {
+          if !@fs.exists(target.root) {
+            for ;; {
+              @async.sleep(2000)
+              if @fs.exists(target.root) {
+                break
+              }
             }
           }
-          // The root just appeared (the first run created it) — tell the
-          // panel before the watcher attaches, so it re-lists the tree it
-          // showed as empty.
-          emit({ root: target })
+          watch_root(target, emit_changed)
+        } catch {
+          error if @async.is_being_cancelled() => raise error
+          error => {
+            let message = "File watching stopped: \{error}"
+            @xlog.warn(category="filesystem") <?
+              {
+                "event": "watch_failed",
+                "session": target.session,
+                "root": target.root,
+                "error": "\{error}",
+              }
+            emit_failed({ session: target.session, root: target.root, message })
+          }
         }
-        watch_root(target, emit)
       })
       let next = self.requests.get()
       group.return_immediately(next)
@@ -171,19 +284,42 @@ async fn FsWatchActor::run(
 // The watcher's pruning rules and the stat op's wire shapes.
 
 ///|
-test "ignored_watch_path prunes cache and build subtrees at any depth" {
-  assert_true(ignored_watch_path(".git"))
-  assert_true(ignored_watch_path("sub/project/.git"))
-  assert_true(ignored_watch_path("target"))
-  assert_true(ignored_watch_path("deps/node_modules"))
-  assert_true(ignored_watch_path("editor/_build"))
-  assert_true(ignored_watch_path(".mooncakes"))
-  assert_true(ignored_watch_path(".repos"))
-  // Only whole segments match — a file merely named like a cache dir stays.
-  assert_false(ignored_watch_path("targets"))
-  assert_false(ignored_watch_path("src/main.mbt"))
-  assert_false(ignored_watch_path("git/notes.md"))
-  assert_false(ignored_watch_path(""))
+test "watch interest retains selected files, listed children, and ancestors" {
+  let payload : WatchWorkspacePayload = {
+    session: "s-1",
+    workspace: None,
+    files: Some(["src/main.mbt", "node_modules/pkg/index.js"]),
+    directories: Some(["", "docs"]),
+  }
+  let interest = WatchInterest(payload)
+  // Root rows and one level under an expanded directory stay observable.
+  assert_false(interest.ignores("README.md"))
+  assert_false(interest.ignores("src"))
+  assert_false(interest.ignores("docs/guide.md"))
+  assert_false(interest.ignores("docs/reference"))
+  assert_true(interest.ignores("docs/reference/deep.md"))
+  // An opened file and all of its ancestors override conventional churn
+  // directory names without admitting their unrelated siblings.
+  assert_false(interest.ignores("src/main.mbt"))
+  assert_true(interest.ignores("src/other.mbt"))
+  assert_false(interest.ignores("node_modules"))
+  assert_false(interest.ignores("node_modules/pkg"))
+  assert_false(interest.ignores("node_modules/pkg/index.js"))
+  assert_true(interest.ignores("node_modules/other/index.js"))
+}
+
+///|
+test "legacy watch payloads retain the recursive blacklist" {
+  let payload : WatchWorkspacePayload = {
+    session: "s-1",
+    workspace: None,
+    files: None,
+    directories: None,
+  }
+  let interest = WatchInterest(payload)
+  assert_true(interest.legacy_full_tree)
+  assert_true(interest.ignores("deps/node_modules"))
+  assert_false(interest.ignores("src/main.mbt"))
 }
 
 ///|
@@ -206,9 +342,18 @@ test "stat_files payload decodes with and without a workspace hint" {
   assert_eq(payload.session, "s-1")
   assert_true(payload.paths == ["a.mbt", "src/b.mbt"])
   assert_true(payload.workspace is Some("/work/project"))
+  let selected : WatchWorkspacePayload = @json.from_json({
+    "session": "s-2",
+    "files": ["src/main.mbt"],
+    "directories": ["", "src"],
+  })
+  assert_true(selected.files is Some(["src/main.mbt"]))
+  assert_true(selected.directories is Some(["", "src"]))
   let bare : WatchWorkspacePayload = @json.from_json({ "session": "s-2" })
   assert_eq(bare.session, "s-2")
   assert_true(bare.workspace is None)
+  assert_true(bare.files is None)
+  assert_true(bare.directories is None)
 }
 
 ///|

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -134,9 +134,10 @@ pub async fn HostConnection::run(
         }
       })
     })
-    self.fs_watch.run(async fn(push) {
-      emit("fs.changed", ToJson::to_json(push))
-    })
+    self.fs_watch.run(
+      async fn(push) { emit("fs.changed", ToJson::to_json(push)) },
+      async fn(failure) { emit("fs.watch_failed", ToJson::to_json(failure)) },
+    )
   })
 }
 

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -45,4 +45,3 @@ type HostState
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -250,15 +250,80 @@ priv struct WatchWorkspacePayload {
   session : String
   // The conversation's workspace, when it has one (see `fs.read_directory`).
   workspace : String?
+  // Current clients send both arrays. Their absence retains the older
+  // recursive-watch behavior for protocol compatibility; present arrays are
+  // an explicit selection, including when one of them is empty.
+  files : Array[String]?
+  directories : Array[String]?
 } derive(FromJson)
 
 ///|
-/// The `fs_changed` push: something under `root` changed. Coarse by design —
-/// the watcher reports no paths, so the frontend re-stats its open tabs and
-/// re-lists its expanded directories itself.
+/// One concrete event from `Watcher::wait`. Rename uses `path` for the new
+/// name and `old_path` for the old one; the other kinds omit `old_path`.
+priv struct FsEventPayload {
+  kind_ : String
+  path : String
+  old_path : String?
+} derive(ToJson(fields(kind_(rename="kind"))))
+
+///|
+/// A filesystem change batch. A new watcher emits `baseline=true` once it is
+/// attached, telling the frontend to stat/re-list everything in its selection;
+/// later batches carry the exact debounced events.
 priv struct FsChangedPayload {
+  session : String
   root : String
+  baseline : Bool
+  events : Array[FsEventPayload]
 } derive(ToJson)
+
+///|
+fn FsEventPayload::from_event(event : @fs.FsEvent) -> FsEventPayload {
+  match event {
+    Modify(path) => { kind_: "modify", path, old_path: None }
+    Create(path) => { kind_: "create", path, old_path: None }
+    Remove(path) => { kind_: "remove", path, old_path: None }
+    Rename(old~, new~) => { kind_: "rename", path: new, old_path: Some(old) }
+  }
+}
+
+///|
+test "filesystem events keep their concrete kind and paths on the wire" {
+  assert_eq(
+    ToJson::to_json(
+      FsEventPayload::from_event(Rename(old="src/old.mbt", new="src/new.mbt")),
+    ),
+    { "kind": "rename", "path": "src/new.mbt", "old_path": "src/old.mbt" },
+  )
+  assert_eq(ToJson::to_json(FsEventPayload::from_event(Modify("README.md"))), {
+    "kind": "modify",
+    "path": "README.md",
+  })
+}
+
+///|
+/// A watcher that was accepted but could not attach, or later stopped while
+/// reading filesystem events. `session` lets the frontend discard a failure
+/// that raced a conversation switch.
+priv struct FsWatchFailedPayload {
+  session : String
+  root : String
+  message : String
+} derive(ToJson)
+
+///|
+test "filesystem watcher failures retain their conversation on the wire" {
+  let payload : FsWatchFailedPayload = {
+    session: "s-1",
+    root: "/work/project",
+    message: "File watching stopped: too many open files",
+  }
+  assert_eq(ToJson::to_json(payload), {
+    "session": "s-1",
+    "root": "/work/project",
+    "message": "File watching stopped: too many open files",
+  })
+}
 
 ///|
 /// `hover` asks a language server for hover at a zero-based

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -417,15 +417,22 @@ filesystem for the workspace picker.
 | `fs.read_directory` | `{session, path, workspace?}` (`""` = workspace root) | `{entries: [{name, is_dir}]}`, directories first |
 | `fs.list_files` | `{session, workspace?}` | `{files: […], truncated}` — recursive snapshot for the fuzzy finder |
 | `fs.stat_files` | `{session, paths, workspace?}` | `{stats: [{path, sig}]}` — `sig` is the opaque mtime signature `"{seconds}:{nanos}"`; `""` means the file is missing, retained for client compatibility |
-| `fs.watch` | `{session, workspace?}` | `{}` — points the single workspace watcher at this conversation |
-| `fs.unwatch` | `{}` | `{}` — stops watching (the panel closed) |
+| `fs.watch` | `{session, workspace?, files?, directories?}` | `{}` — replaces the single workspace watcher with the open files and listed directories; each directory keeps its immediate children observable |
+| `fs.unwatch` | `{}` | `{}` — stops watching when the panel is closed and it has no open tabs |
 | `fs.browse` | `{path?}` (absent = home; leading `~` expands) | `{path, parent?, entries}` — subdirectory names, sorted, dotfiles skipped |
 
 Notification:
 
 | method | params |
 |---|---|
-| `fs.changed` | `{root}` — coarse by design; the client re-stats its open tabs and re-lists expanded directories |
+| `fs.changed` | `{session, root, baseline, events: [{kind, path, old_path?}]}` — `baseline=true` follows watcher attachment; later batches use `modify` / `create` / `remove` / `rename` events with workspace-relative paths |
+| `fs.watch_failed` | `{session, root, message}` — the accepted watcher could not attach or later stopped; clients should fence the failure by session |
+
+`files` and `directories` are optional only for compatibility with older
+clients. When both are absent the host retains the previous pruned recursive
+watch; current clients always send both arrays, including empty arrays. A
+watcher replacement emits a baseline after it has scanned the selected paths,
+so the client can reconcile changes that raced the replacement.
 
 ### terminal.* — connection-scoped PTYs
 


### PR DESCRIPTION
## Summary

- limit the Desktop file watcher to open files plus the root and expanded directories needed by the file tree
- forward concrete modify/create/remove/rename events and emit a baseline after watcher replacement
- refresh only affected tabs and listed directories while retaining compatibility with older clients
- surface watcher setup and runtime failures in the file editor instead of silently dropping them

## Root cause

The recursive macOS watcher retained a file descriptor for every observed node. Large workspaces could exceed the GUI process's low file-descriptor soft limit, and the watcher task used `allow_failure=true`, so losing live updates was silent.

This change fixes the resource usage at its source rather than raising the process limit.

## Validation

- `moon check --deny-warn`
- `moon check --target js --deny-warn`
- `cd desktop && moon test internal/host` (22 passed)
- `cd desktop && moon test --target js frontend` (305 passed)
- `moon fmt`
- `git diff --check`