### PR TITLE
fix(desktop): stop terminal pump on shutdown

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -227,6 +227,7 @@ jobs:
       # successful production build.
       - name: Test Windows terminal
         shell: pwsh
+        timeout-minutes: 5
         run: moon -C desktop test internal/terminal --target native
 
       # Pull requests upload only the portable ZIP, so they do not spend time

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -116,6 +116,9 @@ pub async fn HostConnection::run(
   emit : async (String, Json) -> Unit,
 ) -> Unit {
   @async.with_task_group(group => {
+    // Closing the request queue is the terminal pump's normal connection-end
+    // signal. It must not be tied to the page-reload session sweep below.
+    defer self.terminal.shutdown()
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(self.terminal, async fn(push) {
         match push {

--- a/desktop/internal/terminal/launcher_wbtest.mbt
+++ b/desktop/internal/terminal/launcher_wbtest.mbt
@@ -36,8 +36,8 @@ async test "a default session launches a live platform shell" {
     })
     close_terminal(state, id~)
     // Windows keeps ConPTY's output pipe open after cmd.exe alone is killed.
-    // Requiring `Exited` proves terminal close also releases the PTY handles
-    // and wakes the session reader instead of merely signalling the child.
+    // Requiring `Exited` proves terminal close also cancels the pending pipe
+    // read, allowing the session to reach its final PTY cleanup.
     @async.with_timeout(5000, () => {
       for ;; {
         if pushes.get() is Exited(..) {

--- a/desktop/internal/terminal/launcher_wbtest.mbt
+++ b/desktop/internal/terminal/launcher_wbtest.mbt
@@ -7,6 +7,7 @@
 async test "a default session launches a live platform shell" {
   @async.with_task_group(group => {
     let state = new_terminal_state()
+    defer state.shutdown()
     let pushes : @async.Queue[TerminalPush] = Queue(kind=Unbounded)
     group.spawn_bg(allow_failure=true, () => {
       run_terminal_pump(state, async fn(push) { pushes.put(push) })
@@ -34,7 +35,6 @@ async test "a default session launches a live platform shell" {
       }
     })
     close_terminal(state, id~)
-    group.return_immediately(())
   })
 }
 
@@ -44,6 +44,7 @@ async test "a default session launches a live platform shell" {
 async test "a session whose cwd does not exist fails while opening" {
   @async.with_task_group(group => {
     let state = new_terminal_state()
+    defer state.shutdown()
     let pushes : @async.Queue[TerminalPush] = Queue(kind=Unbounded)
     group.spawn_bg(allow_failure=true, () => {
       run_terminal_pump(state, async fn(push) { pushes.put(push) })
@@ -61,6 +62,5 @@ async test "a session whose cwd does not exist fails while opening" {
       _ => false
     }
     assert_true(failed)
-    group.return_immediately(())
   })
 }

--- a/desktop/internal/terminal/launcher_wbtest.mbt
+++ b/desktop/internal/terminal/launcher_wbtest.mbt
@@ -35,6 +35,16 @@ async test "a default session launches a live platform shell" {
       }
     })
     close_terminal(state, id~)
+    // Windows keeps ConPTY's output pipe open after cmd.exe alone is killed.
+    // Requiring `Exited` proves terminal close also releases the PTY handles
+    // and wakes the session reader instead of merely signalling the child.
+    @async.with_timeout(5000, () => {
+      for ;; {
+        if pushes.get() is Exited(..) {
+          break
+        }
+      }
+    })
   })
 }
 

--- a/desktop/internal/terminal/pkg.generated.mbti
+++ b/desktop/internal/terminal/pkg.generated.mbti
@@ -30,8 +30,8 @@ pub(all) enum TerminalPush {
 }
 
 type TerminalState
+pub fn TerminalState::shutdown(Self) -> Unit
 
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/terminal/pump.mbt
+++ b/desktop/internal/terminal/pump.mbt
@@ -27,6 +27,25 @@ pub async fn run_terminal_pump(
 }
 
 ///|
+/// POSIX closes the PTY slave when the child dies, which wakes the reader and
+/// lets the session drain before its deferred `Pty::close` runs.
+#cfg(not(platform="windows"))
+async fn TerminalSession::close_when_requested(self : TerminalSession) -> Unit {
+  self.close_requested.get()
+  let cancel = @process.hard_cancel()
+  cancel(self.pty.pid())
+}
+
+///|
+/// Windows ConPTY keeps its output pipe open after the child dies. Close the
+/// whole PTY so the pending reader is released as well as the child process.
+#cfg(platform="windows")
+async fn TerminalSession::close_when_requested(self : TerminalSession) -> Unit {
+  self.close_requested.get()
+  self.pty.close()
+}
+
+///|
 /// One session's lifetime: spawn the PTY child, answer the opener, then loop
 /// reading output until the child exits (or `close_terminal` requests it),
 /// pausing whenever the flow-control debt passes the high watermark.
@@ -86,15 +105,9 @@ async fn run_session(
       state.sessions.remove(request.id)
       pty.close()
     }
-    // `Pty::cancel` uses the process package's five-second graceful timeout on
-    // Unix. A terminal close is an explicit immediate operation, so a
-    // session-owned task applies the cross-platform hard cancellation handler
-    // while the normal reader and waiter continue to drain and reap the child.
-    group.spawn_bg(no_wait=true, () => {
-      session.close_requested.get()
-      let cancel = @process.hard_cancel()
-      cancel(pty.pid())
-    })
+    // The session owns the platform-specific difference between killing a
+    // POSIX child and closing a Windows ConPTY to wake its output reader.
+    group.spawn_bg(no_wait=true, () => session.close_when_requested())
     request.reply.put(Ok(()))
     @xlog.debug() <?
       {
@@ -111,6 +124,10 @@ async fn run_session(
       // A closed master reports the child's exit as EIO on macOS rather
       // than a clean EOF; both end the session the same way.
       let n = reader.read(buf) catch {
+        // On Windows, `close_terminal` closes the PTY to wake this read, which
+        // the async stream reports as cancellation. It is normal EOF for this
+        // session, not cancellation of the task that owns it.
+        _ if session.closing => 0
         error if @async.is_being_cancelled() => raise error
         _ => 0
       }

--- a/desktop/internal/terminal/pump.mbt
+++ b/desktop/internal/terminal/pump.mbt
@@ -1,23 +1,26 @@
 // The pump that owns every PTY child: spawned in the host services' task
 // group (like the LSP and watcher pumps), it consumes `open_terminal`
-// requests and runs one task per session. Closing the window cancels the
-// group, which cancels every session task; each task's `defer` then releases
-// its PTY, so no child outlives the app.
+// requests and runs one task per session. The connection owner shuts down the
+// terminal state before its group ends, waking this pump and closing every
+// session; each session's `defer` then releases its PTY.
 
 ///|
 /// Read PTY output in chunks this large; a typical child burst fits in one.
 const ReadChunkBytes = 16384
 
 ///|
-/// Run terminal sessions until cancelled, forwarding every session's pushes
-/// through `emit`.
+/// Run terminal sessions until the state shuts down or this task is cancelled,
+/// forwarding every session's pushes through `emit`.
 pub async fn run_terminal_pump(
   state : TerminalState,
   emit : async (TerminalPush) -> Unit,
 ) -> Unit {
   @async.with_task_group(group => {
     for ;; {
-      let request = state.requests.get()
+      let request = state.requests.get() catch {
+        TerminalPumpClosed => return
+        error => raise error
+      }
       group.spawn_bg(allow_failure=true, () => run_session(state, request, emit))
     }
   })
@@ -34,7 +37,12 @@ async fn run_session(
 ) -> Unit {
   @async.with_task_group(group => {
     if request.connection_generation != state.connection_generation {
-      request.reply.put(Err("terminal open was cancelled by reconnect"))
+      let message = if state.closed {
+        "terminal service is closed"
+      } else {
+        "terminal open was cancelled by reconnect"
+      }
+      request.reply.put(Err(message))
       return
     }
     let pty = @pty.spawn(
@@ -55,7 +63,12 @@ async fn run_session(
     // Spawning suspends, so a reconnect can invalidate the request while the
     // child is being created. Close it before publishing a stale session.
     if request.connection_generation != state.connection_generation {
-      request.reply.put(Err("terminal open was cancelled by reconnect"))
+      let message = if state.closed {
+        "terminal service is closed"
+      } else {
+        "terminal open was cancelled by reconnect"
+      }
+      request.reply.put(Err(message))
       pty.close()
       return
     }

--- a/desktop/internal/terminal/pump.mbt
+++ b/desktop/internal/terminal/pump.mbt
@@ -30,19 +30,28 @@ pub async fn run_terminal_pump(
 /// POSIX closes the PTY slave when the child dies, which wakes the reader and
 /// lets the session drain before its deferred `Pty::close` runs.
 #cfg(not(platform="windows"))
-async fn TerminalSession::close_when_requested(self : TerminalSession) -> Unit {
+async fn TerminalSession::close_when_requested(
+  self : TerminalSession,
+  _output_task : @async.Task[Unit],
+) -> Unit {
   self.close_requested.get()
   let cancel = @process.hard_cancel()
   cancel(self.pty.pid())
 }
 
 ///|
-/// Windows ConPTY keeps its output pipe open after the child dies. Close the
-/// whole PTY so the pending reader is released as well as the child process.
+/// Windows ConPTY keeps its output pipe open after the child dies. Cancelling
+/// the task that submitted the synchronous pipe read lets async call
+/// `CancelSynchronousIo`; closing the HANDLE from this different task does not
+/// wake that read reliably.
 #cfg(platform="windows")
-async fn TerminalSession::close_when_requested(self : TerminalSession) -> Unit {
+async fn TerminalSession::close_when_requested(
+  self : TerminalSession,
+  output_task : @async.Task[Unit],
+) -> Unit {
   self.close_requested.get()
-  self.pty.close()
+  self.pty.cancel()
+  output_task.cancel()
 }
 
 ///|
@@ -105,9 +114,6 @@ async fn run_session(
       state.sessions.remove(request.id)
       pty.close()
     }
-    // The session owns the platform-specific difference between killing a
-    // POSIX child and closing a Windows ConPTY to wake its output reader.
-    group.spawn_bg(no_wait=true, () => session.close_when_requested())
     request.reply.put(Ok(()))
     @xlog.debug() <?
       {
@@ -118,32 +124,40 @@ async fn run_session(
         // The directory passed directly to the platform process spawn.
         "cwd": request.cwd,
       }
-    let reader = pty.reader()
-    let buf : FixedArray[Byte] = FixedArray::make(ReadChunkBytes, b'\x00')
-    for ;; {
-      // A closed master reports the child's exit as EIO on macOS rather
-      // than a clean EOF; both end the session the same way.
-      let n = reader.read(buf) catch {
-        // On Windows, `close_terminal` closes the PTY to wake this read, which
-        // the async stream reports as cancellation. It is normal EOF for this
-        // session, not cancellation of the task that owns it.
-        _ if session.closing => 0
-        error if @async.is_being_cancelled() => raise error
-        _ => 0
+    let output_task = group.spawn(allow_failure=true, () => {
+      let reader = pty.reader()
+      let buf : FixedArray[Byte] = FixedArray::make(ReadChunkBytes, b'\x00')
+      for ;; {
+        // A closed master reports the child's exit as EIO on macOS rather
+        // than a clean EOF; both end the session the same way.
+        let n = reader.read(buf) catch {
+          // Cancelling the Windows output task aborts its synchronous pipe
+          // read. Treat that requested shutdown as EOF for this session.
+          _ if session.closing => 0
+          error if @async.is_being_cancelled() => raise error
+          _ => 0
+        }
+        if n <= 0 {
+          break
+        }
+        let sequence = session.next_output_sequence
+        session.next_output_sequence = sequence + 1
+        // Record the debt before emitting: the webview can acknowledge as soon
+        // as it receives the event, including before this task resumes.
+        session.unacked_chunks[sequence] = n
+        session.unacked += n
+        emit(Output(id=request.id, sequence~, data=Bytes::from_array(buf[:n])))
+        while session.unacked >= HighWatermark && !session.closing {
+          session.cond.wait()
+        }
       }
-      if n <= 0 {
-        break
-      }
-      let sequence = session.next_output_sequence
-      session.next_output_sequence = sequence + 1
-      // Record the debt before emitting: the webview can acknowledge as soon
-      // as it receives the event, including before this task resumes.
-      session.unacked_chunks[sequence] = n
-      session.unacked += n
-      emit(Output(id=request.id, sequence~, data=Bytes::from_array(buf[:n])))
-      while session.unacked >= HighWatermark && !session.closing {
-        session.cond.wait()
-      }
+    })
+    // The session owns the platform-specific difference between waiting for a
+    // POSIX PTY EOF and cancelling a Windows synchronous pipe read.
+    group.spawn_bg(no_wait=true, () => session.close_when_requested(output_task))
+    output_task.wait() catch {
+      _ if session.closing => ()
+      error => raise error
     }
     let code = pty.wait() catch {
       error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -186,9 +186,9 @@ pub fn ack_terminal(state : TerminalState, id~ : Int, sequence~ : Int) -> Unit {
 }
 
 ///|
-/// Request a session's shutdown. Its task kills the child immediately, then
-/// the existing read/wait path emits `Exited` and releases the PTY. Unknown
-/// ids are a no-op (the session already exited).
+/// Request a session's shutdown. Its task stops the child immediately and, on
+/// Windows, closes the ConPTY handles so a pending reader wakes; the existing
+/// wait path then emits `Exited`. Unknown ids are a no-op (already exited).
 pub fn close_terminal(state : TerminalState, id~ : Int) -> Unit {
   guard state.sessions.get(id) is Some(session) else { return }
   guard !session.closing else { return }

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -11,6 +11,13 @@ pub suberror TerminalError {
 }
 
 ///|
+/// The request queue uses this private error only to wake and stop its pump.
+/// Callers instead receive `TerminalError` from their individual reply queue.
+priv suberror TerminalPumpClosed {
+  TerminalPumpClosed
+}
+
+///|
 /// One push from a terminal session to the webview. `Output` carries raw PTY
 /// bytes (chunk boundaries may split UTF-8 sequences, so the wire encoding
 /// must stay byte-transparent); `Exited` reports the child's exit code after
@@ -73,6 +80,9 @@ struct TerminalState {
   requests : @async.Queue[OpenRequest]
   sessions : Map[Int, TerminalSession]
   mut next_id : Int
+  /// Once closed, this state cannot serve another connection. Page reconnects
+  /// use `close_all_terminals` instead and leave the pump available.
+  mut closed : Bool
   /// Incremented by the connect handshake so opens from an older page cannot
   /// publish a session after that page has gone away.
   mut connection_generation : Int
@@ -84,6 +94,7 @@ pub fn new_terminal_state() -> TerminalState {
     requests: Queue(kind=Unbounded),
     sessions: Map([]),
     next_id: 1,
+    closed: false,
     connection_generation: 0,
   }
 }
@@ -93,7 +104,8 @@ pub fn new_terminal_state() -> TerminalState {
 /// running. Without `command`, POSIX launches `$SHELL -l` and Windows launches
 /// `%COMSPEC%`; with it, that argv runs directly in the session's PTY instead.
 /// Requires `run_terminal_pump` to be running (the host services' task
-/// group), otherwise the call waits until it is.
+/// group), otherwise the call waits until it is. A permanently shut down state
+/// rejects the request instead of leaving its caller parked.
 pub async fn open_terminal(
   state : TerminalState,
   cwd~ : String,
@@ -101,6 +113,7 @@ pub async fn open_terminal(
   rows~ : Int,
   command? : Array[String],
 ) -> Int {
+  guard !state.closed else { raise TerminalError("terminal service is closed") }
   let argv = session_argv(command?)
   let id = state.next_id
   state.next_id = id + 1
@@ -113,7 +126,10 @@ pub async fn open_terminal(
     cols,
     rows,
     reply,
-  })
+  }) catch {
+    TerminalPumpClosed => raise TerminalError("terminal service is closed")
+    error => raise error
+  }
   match reply.get() {
     Ok(_) => id
     Err(message) => raise TerminalError(message)
@@ -195,4 +211,23 @@ pub fn close_all_terminals(state : TerminalState) -> Unit {
   for id in state.sessions.keys().to_array() {
     close_terminal(state, id~)
   }
+}
+
+///|
+/// Permanently stop this connection's terminal subsystem. Pending open calls
+/// are rejected before the request queue closes, so neither they nor an idle
+/// pump remain parked. Repeated shutdown calls are harmless.
+pub fn TerminalState::shutdown(self : TerminalState) -> Unit {
+  guard !self.closed else { return }
+  self.closed = true
+  close_all_terminals(self)
+  // A request still in this queue has an opener blocked on its private reply.
+  // Close that reply explicitly before removing the pump's only route to it.
+  while (self.requests.try_get() catch { _ => None }) is Some(request) {
+    request.reply.close(
+      error=TerminalError("terminal service is closed"),
+      clear=true,
+    )
+  }
+  self.requests.close(error=TerminalPumpClosed, clear=true)
 }

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -187,8 +187,9 @@ pub fn ack_terminal(state : TerminalState, id~ : Int, sequence~ : Int) -> Unit {
 
 ///|
 /// Request a session's shutdown. Its task stops the child immediately and, on
-/// Windows, closes the ConPTY handles so a pending reader wakes; the existing
-/// wait path then emits `Exited`. Unknown ids are a no-op (already exited).
+/// Windows, cancels the task that issued the blocking ConPTY read; the async
+/// I/O layer can then interrupt that exact read before the session closes its
+/// handles and emits `Exited`. Unknown ids are a no-op (already exited).
 pub fn close_terminal(state : TerminalState, id~ : Int) -> Unit {
   guard state.sessions.get(id) is Some(session) else { return }
   guard !session.closing else { return }

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -38,6 +38,7 @@ async fn wait_for_exit(pushes : @async.Queue[@terminal.TerminalPush]) -> Unit {
 async test "terminal session round-trips output and reports exit" {
   @async.with_task_group(group => {
     let state = @terminal.new_terminal_state()
+    defer state.shutdown()
     let pushes = new_push_queue()
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
@@ -50,7 +51,6 @@ async test "terminal session round-trips output and reports exit" {
     @terminal.resize_terminal(state, id~, cols=100, rows=30)
     @terminal.close_terminal(state, id~)
     @async.with_timeout(5000, () => wait_for_exit(pushes))
-    group.return_immediately(())
   })
 }
 
@@ -59,18 +59,19 @@ async test "terminal session round-trips output and reports exit" {
 async test "terminal session runs in the requested directory" {
   @async.with_task_group(group => {
     let state = @terminal.new_terminal_state()
+    defer state.shutdown()
     let pushes = new_push_queue()
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
     })
-    let id = @terminal.open_terminal(state, cwd="/tmp", cols=80, rows=24, command=[
-      "/bin/sh", "-c", "pwd",
-    ])
+    ignore(
+      @terminal.open_terminal(state, cwd="/tmp", cols=80, rows=24, command=[
+        "/bin/sh", "-c", "pwd",
+      ]),
+    )
     // /tmp is a symlink to /private/tmp on macOS; match the suffix.
     @async.with_timeout(5000, () => wait_for_output(pushes, "tmp"))
     @async.with_timeout(5000, () => wait_for_exit(pushes))
-    ignore(id)
-    group.return_immediately(())
   })
 }
 
@@ -80,6 +81,7 @@ async test "terminal session runs in the requested directory" {
 async test "a missing program fails while opening the session" {
   @async.with_task_group(group => {
     let state = @terminal.new_terminal_state()
+    defer state.shutdown()
     let pushes = new_push_queue()
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
@@ -94,7 +96,6 @@ async test "a missing program fails while opening the session" {
       _ => false
     }
     assert_true(failed)
-    group.return_immediately(())
   })
 }
 
@@ -112,12 +113,61 @@ async test "an empty command is rejected before spawning" {
 }
 
 ///|
+/// Shutdown is the pump's normal stop signal. In particular, an idle pump
+/// blocked on its request queue must let its owning task group finish.
+async test "shutdown wakes an idle terminal pump" {
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let state = @terminal.new_terminal_state()
+      let pushes = new_push_queue()
+      group.spawn_bg(allow_failure=true, () => {
+        @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
+      })
+      @async.pause()
+      state.shutdown()
+    })
+  })
+}
+
+///|
+/// An opener may already be waiting on its private reply when the connection
+/// ends. Shutdown must reject that call, and all later opens, without a pump.
+async test "shutdown rejects pending and later terminal opens" {
+  @async.with_task_group(group => {
+    let state = @terminal.new_terminal_state()
+    let pending_rejected : @async.Queue[Bool] = Queue(kind=Blocking(1))
+    group.spawn_bg(allow_failure=true, () => {
+      let rejected = try {
+        let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
+        false
+      } catch {
+        @terminal.TerminalError("terminal service is closed") => true
+        _ => false
+      }
+      pending_rejected.put(rejected)
+    })
+    @async.pause()
+    state.shutdown()
+    assert_true(@async.with_timeout(5000, () => pending_rejected.get()))
+    let later_rejected = try {
+      let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
+      false
+    } catch {
+      @terminal.TerminalError("terminal service is closed") => true
+      _ => false
+    }
+    assert_true(later_rejected)
+  })
+}
+
+///|
 /// `close_all_terminals` (the connect handshake's sweep) retires every live
 /// session; each one still reports its exit.
 #cfg(not(platform="windows"))
 async test "close_all_terminals retires every live session" {
   @async.with_task_group(group => {
     let state = @terminal.new_terminal_state()
+    defer state.shutdown()
     let pushes = new_push_queue()
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
@@ -135,7 +185,6 @@ async test "close_all_terminals retires every live session" {
     })
     exited.sort()
     assert_eq(exited, [first, second])
-    group.return_immediately(())
   })
 }
 
@@ -146,6 +195,7 @@ async test "close_all_terminals retires every live session" {
 async test "close_all_terminals cancels queued opens from an older page" {
   @async.with_task_group(group => {
     let state = @terminal.new_terminal_state()
+    defer state.shutdown()
     let pushes = new_push_queue()
     let cancelled : @async.Queue[Bool] = Queue(kind=Blocking(1))
     group.spawn_bg(allow_failure=true, () => {
@@ -168,7 +218,6 @@ async test "close_all_terminals cancels queued opens from an older page" {
     })
     let was_cancelled = @async.with_timeout(5000, () => cancelled.get())
     assert_true(was_cancelled)
-    group.return_immediately(())
   })
 }
 
@@ -180,6 +229,7 @@ async test "close_all_terminals cancels queued opens from an older page" {
 async test "duplicate acknowledgements release an output chunk only once" {
   @async.with_task_group(group => {
     let state = @terminal.new_terminal_state()
+    defer state.shutdown()
     let pushes = new_push_queue()
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
@@ -219,7 +269,6 @@ async test "duplicate acknowledgements release an output chunk only once" {
     assert_true(resumed is Some(Output(id=output_id, ..)) && output_id == id)
     @terminal.close_terminal(state, id~)
     @async.with_timeout(5000, () => wait_for_exit(pushes))
-    group.return_immediately(())
   })
 }
 


### PR DESCRIPTION
## Summary

- add an idempotent terminal-state shutdown operation that rejects pending opens and closes the pump request queue
- stop the connection-owned terminal pump from `HostConnection::run` while leaving page-reload terminal cleanup reusable
- replace forced task-group cancellation in terminal tests with owner-driven shutdown and add regression coverage

## Root cause

`run_terminal_pump` waited forever on `state.requests.get()`. Terminal tests ended by cancelling the outer task group with `return_immediately`, which could leave the nested pump task group parked and trigger the native test deadlock. Closing terminal sessions alone did not close the request queue or wake the idle pump.

## Validation

- `moon fmt --check`
- `moon check --target native --deny-warn`
- `moon test --target native` (3168 passed)
- original cwd test and shutdown regressions repeated 20 times
- `moon info desktop/internal/terminal`
- `git diff --check`