### PR TITLE
fix(editor): reduce Markdown document type scale

### DIFF
--- a/editor/internal/viewer/browser/markdown_document/markdown_document.css
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.css
@@ -35,7 +35,7 @@
   box-sizing: border-box;
   min-height: 100%;
   padding: 16px 24px 64px;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1.6;
   overflow-wrap: anywhere;
 }

--- a/editor/tests/browser/component/markdown_document.spec.js
+++ b/editor/tests/browser/component/markdown_document.spec.js
@@ -311,15 +311,15 @@ test('uses a restrained, stable Markdown type scale', async ({ page }) => {
     }
   });
 
-  await expect(page.locator(article)).toHaveCSS('font-size', '16px');
-  await expect(page.locator(`${article} h1`)).toHaveCSS('font-size', '28px');
-  await expect(page.locator(`${article} h1`)).toHaveCSS('line-height', '33.6px');
+  await expect(page.locator(article)).toHaveCSS('font-size', '14px');
+  await expect(page.locator(`${article} h1`)).toHaveCSS('font-size', '24.5px');
+  await expect(page.locator(`${article} h1`)).toHaveCSS('line-height', '29.4px');
   for (const [level, fontSize] of [
-    [2, '22px'],
-    [3, '18px'],
-    [4, '16px'],
-    [5, '16px'],
-    [6, '16px'],
+    [2, '19.25px'],
+    [3, '15.75px'],
+    [4, '14px'],
+    [5, '14px'],
+    [6, '14px'],
   ]) {
     await expect(
       page.locator(`[data-type-scale-probe="${level}"]`),


### PR DESCRIPTION
## Summary

- reduce the readonly Markdown document base font size from 16px to 14px
- preserve the existing heading scale and editor-owned code font size
- update the browser regression assertions for the resulting type scale

## Why

OpenSeek presents Markdown beside compact 12–13px editor and workbench UI. The fixed 16px Markdown base made prose and headings look oversized in the desktop file editor. A 14px base keeps the document readable while fitting the surrounding interface more naturally.

## User impact

Markdown documents render with a denser, better-balanced prose and heading scale. Code blocks remain aligned with the configured editor typography.

## Validation

- `just editor-test` (wasm 1022, JS 1722, native 1148 tests passed)
- `just editor-test-browser` (140 tests passed)
- `moon info`
- `moon fmt`
- visually verified `README.mbt.md` in the editor reference shell