### PR TITLE
feat(desktop): native-view browser preview

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -769,6 +769,201 @@ html.is-resizing * {
   user-select: none !important;
 }
 
+/* ---------- dock: browser tabs, launcher, file picker ---------- */
+/* The active tab's kind is a class on .editor (mode-file / mode-browser /
+   mode-picker / mode-launcher); every body part below the strip is always
+   rendered and CSS shows exactly one, so no imperative host is re-keyed. */
+.editor.mode-browser .viewer-breadcrumb,
+.editor.mode-browser .editor-body,
+.editor.mode-launcher .viewer-breadcrumb,
+.editor.mode-launcher .editor-body {
+  display: none;
+}
+/* The picker reuses the file chrome (tree + viewer area); the overlay
+   covers whatever document the viewer last showed. */
+.editor.mode-picker .viewer-stack::after {
+  content: "Select a file to open";
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--surface);
+  color: var(--ink-2);
+  font-size: 13px;
+}
+/* The strip's new-tab button and its launcher popup. The tabsbar anchors
+   the popup; the full-screen transparent backdrop catches the click away
+   (reusing the topbar launcher's backdrop). */
+.editor-tabsbar {
+  position: relative;
+}
+.tab-add {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+}
+.tab-add:hover {
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+}
+.tab-add.hidden {
+  display: none;
+}
+.dock-menu {
+  position: absolute;
+  top: calc(100% - 6px);
+  left: 12px;
+  min-width: 260px;
+  padding: 5px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-pop);
+  z-index: 31;
+}
+/* The empty strip's centered launcher pane, same rows as the popup. */
+.dock-launcher {
+  display: none;
+}
+.editor.mode-launcher .dock-launcher {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  align-items: center;
+  justify-content: center;
+}
+.dock-launcher-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 280px;
+}
+.dock-launcher-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 9px 11px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+.dock-launcher-row:hover {
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+}
+.dock-launcher-row .icon {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+}
+.dock-launcher-name {
+  font-weight: 550;
+}
+.dock-launcher-hint {
+  margin-left: auto;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+/* The browser chrome: toolbar + failure line + the pane the native web
+   contents view overlays. The pane element renders nothing itself — the
+   host places the view over its measured rectangle. */
+.browser-chrome {
+  display: none;
+}
+.editor.mode-browser .browser-chrome {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+}
+.browser-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--line);
+}
+.browser-nav-button {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+}
+.browser-nav-button:hover {
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+}
+.browser-nav-button.loading .icon svg {
+  animation: browser-reload-spin 1s linear infinite;
+}
+@keyframes browser-reload-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.icon.rotate-left svg {
+  transform: rotate(-90deg);
+}
+.icon.rotate-right svg {
+  transform: rotate(90deg);
+}
+.browser-address {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 5px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--ink);
+  font-size: 13px;
+}
+.browser-address:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.browser-failure {
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--line);
+  color: var(--del);
+  font-size: 12px;
+}
+.browser-failure.hidden {
+  display: none;
+}
+.browser-pane {
+  flex: 1 1 auto;
+  min-height: 0;
+  background: var(--surface-2);
+}
+
 /* The filter line rides the panel's bottom edge like an Emacs
    minibuffer: one flat row, a hairline above it, a borderless input. */
 .file-tree-header {

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -484,6 +484,11 @@ fn wire_proton_events(
       bridge_msg(Local, notification)
     })
   }
+  // Native view events describe this window's own browser tabs. Like
+  // `notification.click` below, the event is window-local: it has no
+  // `NotificationKind` because the shared wire catalog must never carry it
+  // to a relay client, which has no native views.
+  on("openseek.browser.event", browser_event_msg)
   // Emitted by the notification extension when the user clicks a system
   // notification; the payload is the run id this frontend stamped on it.
   // Desktop-only by nature.

--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -1,0 +1,274 @@
+// The dock's browser tabs, host side: every command here talks to the
+// desktop window's native web contents views over the bridge-local
+// `browser.*` ops, and the pane-geometry plumbing keeps the active view
+// glued to the `browser-pane` element the frontend renders. Views exist
+// only in the desktop window (`ChannelId::Local`); the routing in update
+// never sends a remote console here.
+
+///|
+/// The placeholder element the active page's native view overlays. The view
+/// is z-ordered above all HTML, so this element renders nothing — it only
+/// donates its rectangle.
+const BrowserPaneId = "browser-pane"
+
+///|
+/// One bridge-local browser op. Geometry calls (`quiet=true`) fail silently
+/// — they are continuous best-effort placement, and a failure just means
+/// the view is gone or not yet created; the next sync pass reconverges.
+/// Ordered on purpose: Proton may dispatch two fire-and-forget requests
+/// into the host in either order, while browser ops are sequences —
+/// create-then-place, bounds-before-visibility — whose inversion shows on
+/// screen.
+fn[Payload : ToJson] browser_op(
+  dispatch : @cmd.Emit[Msg],
+  command : @commands.Command[Payload, @protocol.EmptyReply],
+  payload : Payload,
+  quiet~ : Bool,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let _ : @protocol.EmptyReply = @interop.bridge_request_in_order(
+        @interop.ChannelId::Local,
+        command,
+        payload,
+      ) catch {
+        error => {
+          if !quiet {
+            scheduler.add(
+              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
+            )
+          }
+          return
+        }
+      }
+    })
+  })
+}
+
+///|
+/// Create page `id`'s native view loading `url`. The view starts hidden;
+/// the pane sync shows and places it after the next measurement.
+fn browser_open(dispatch : @cmd.Emit[Msg], id : Int, url : String) -> @cmd.Cmd {
+  browser_op(dispatch, @commands.browser_open, { id, url }, quiet=false)
+}
+
+///|
+fn browser_navigate(
+  dispatch : @cmd.Emit[Msg],
+  id : Int,
+  url : String,
+) -> @cmd.Cmd {
+  browser_op(dispatch, @commands.browser_navigate, { id, url }, quiet=false)
+}
+
+///|
+/// A history op on whatever Browser tab is active — a no-op when none is,
+/// or while a blank tab has no view yet.
+fn browser_history_for_active(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  command : @commands.Command[@protocol.BrowserIdPayload, @protocol.EmptyReply],
+) -> @cmd.Cmd {
+  guard @dock.active_browser(model.dock) is Some(id) &&
+    @preview.page(model.preview, id) is Some(page) &&
+    page.url is Some(_) else {
+    return @cmd.none
+  }
+  browser_op(dispatch, command, { id, }, quiet=false)
+}
+
+///|
+fn browser_set_bounds(
+  dispatch : @cmd.Emit[Msg],
+  id : Int,
+  rect : @preview.Rect,
+) -> @cmd.Cmd {
+  browser_op(
+    dispatch,
+    @commands.browser_set_bounds,
+    { id, x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    quiet=true,
+  )
+}
+
+///|
+fn browser_set_visible(
+  dispatch : @cmd.Emit[Msg],
+  id : Int,
+  visible : Bool,
+) -> @cmd.Cmd {
+  browser_op(
+    dispatch,
+    @commands.browser_set_visible,
+    { id, visible },
+    quiet=true,
+  )
+}
+
+///|
+fn browser_close_view(dispatch : @cmd.Emit[Msg], id : Int) -> @cmd.Cmd {
+  browser_op(dispatch, @commands.browser_close, { id, }, quiet=true)
+}
+
+///|
+/// The browser pane's current on-screen rectangle in CSS pixels — the same
+/// coordinate space as the window's logical view bounds while the zoom is
+/// 100% (a known constraint of the native-view design).
+fn browser_pane_rect() -> @preview.Rect? {
+  guard @dom.document().get_element_by_id(BrowserPaneId).to_option()
+    is Some(element) else {
+    return None
+  }
+  let rect = element.get_bounding_client_rect()
+  Some({
+    x: rect.get_x().to_int(),
+    y: rect.get_y().to_int(),
+    width: rect.get_width().to_int(),
+    height: rect.get_height().to_int(),
+  })
+}
+
+///|
+/// Measure the pane after the render it reacts to has committed, and report
+/// the rectangle back into the update loop.
+fn measure_browser_pane(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    scheduler => {
+      match browser_pane_rect() {
+        Some(rect) => scheduler.add(dispatch(BrowserPaneMeasured(rect~)))
+        None => ()
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+let browser_pane_watched : Ref[Bool] = Ref(false)
+
+///|
+/// Watch the pane element's size, once. Size changes that never pass
+/// through the model — a window resize, the editor-width drag — reshape the
+/// pane without any message, so the element's own ResizeObserver is the
+/// signal; position-only shifts (the sidebar toggling) are model-driven and
+/// covered by the geometry signature in `sync_browser_view`.
+fn watch_browser_pane(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    scheduler => {
+      guard !browser_pane_watched.val else { return }
+      guard @dom.document().get_element_by_id(BrowserPaneId).to_option()
+        is Some(element) else {
+        return
+      }
+      guard @interop.js_prop(@js.globalThis, "ResizeObserver") is Some(ctor) else {
+        return
+      }
+      browser_pane_watched.val = true
+      let on_resize = (_entries : @js.Value) => {
+        match browser_pane_rect() {
+          Some(rect) => scheduler.add(dispatch(BrowserPaneMeasured(rect~)))
+          None => ()
+        }
+      }
+      let observer : @js.Value = ctor.new([@js.Value::cast_from(on_resize)])
+      let _ : @js.Value = observer.apply_with_string("observe", [
+        @js.Value::cast_from(element),
+      ])
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+/// Focus the address bar — the blank tab a launcher's Browser row opens is
+/// for typing into.
+fn focus_browser_address() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      match
+        @dom.document().get_element_by_id(@preview.AddressInputId).to_option() {
+        Some(element) => {
+          let _ : @js.Value = @js.Cast::from(element).apply_with_string(
+            "focus",
+            ([] : Array[@js.Value]),
+          )
+        }
+        None => ()
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+/// Decode one `browser.event` notification into the preview subsystem's
+/// message. Unknown kinds and malformed payloads drop.
+fn browser_event_msg(payload : Map[String, Json]) -> Msg? {
+  guard @jsonx.json_int(payload, "id") is Some(id) &&
+    @jsonx.json_text(payload, "kind") is Some(kind) else {
+    return None
+  }
+  match kind {
+    "navigated" =>
+      @jsonx.json_text(payload, "url").map(url => {
+        Preview(@preview.Msg::Navigated(id~, url~))
+      })
+    "loading" =>
+      @jsonx.json_bool(payload, "loading").map(loading => {
+        Preview(@preview.Msg::LoadingChanged(id~, loading~))
+      })
+    "title" =>
+      @jsonx.json_text(payload, "title").map(title => {
+        Preview(@preview.Msg::TitleUpdated(id~, title~))
+      })
+    "load_failed" =>
+      // CEF reports ERR_ABORTED (-3) whenever a load is superseded — a new
+      // navigation, an in-page form submit — not when anything actually
+      // failed. It can even arrive after the superseding navigation
+      // cleared the failure state, leaving a stale banner over a healthy
+      // page; the canonical CEF load-error handler ignores it, so do we.
+      if @jsonx.json_int(payload, "code") is Some(-3) {
+        None
+      } else {
+        match
+          (@jsonx.json_text(payload, "url"), @jsonx.json_text(payload, "text")) {
+          (Some(url), Some(text)) =>
+            Some(Preview(@preview.Msg::LoadFailed(id~, url~, text~)))
+          _ => None
+        }
+      }
+    _ => None
+  }
+}
+
+///|
+test "browser event decode drops ERR_ABORTED but keeps real failures" {
+  let aborted : Map[String, Json] = {
+    "id": Json::number(1),
+    "kind": "load_failed",
+    "url": "https://www.baidu.com/s?wd=x",
+    "code": Json::number(-3),
+    "text": "ERR_ABORTED",
+  }
+  assert_true(browser_event_msg(aborted) is None)
+  let refused : Map[String, Json] = {
+    "id": Json::number(1),
+    "kind": "load_failed",
+    "url": "http://127.0.0.1:5173/",
+    "code": Json::number(-102),
+    "text": "ERR_CONNECTION_REFUSED",
+  }
+  assert_true(
+    browser_event_msg(refused)
+    is Some(Preview(LoadFailed(id=1, url="http://127.0.0.1:5173/", ..))),
+  )
+  let navigated : Map[String, Json] = {
+    "id": Json::number(2),
+    "kind": "navigated",
+    "url": "https://www.google.com/",
+  }
+  assert_true(
+    browser_event_msg(navigated)
+    is Some(Preview(Navigated(id=2, url="https://www.google.com/"))),
+  )
+}

--- a/desktop/frontend/dock/dock_test.mbt
+++ b/desktop/frontend/dock/dock_test.mbt
@@ -1,0 +1,223 @@
+// State-transition tests for the strip machine: opening, activating,
+// closing, and how a conversation switch parks and restores a strip. The
+// dock is command-free, so every assertion is on the returned state.
+
+///|
+fn owner(session : String) -> @interop.ConversationKey {
+  { channel: @interop.ChannelId::Local, session }
+}
+
+///|
+fn file_tab(path : String) -> @dock.DockTab {
+  @dock.DockTab::File(path=@pathx.Relative(path))
+}
+
+///|
+test "open_file appends in order and activates" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+  assert_true(state.tabs == [file_tab("a.mbt"), file_tab("b.mbt")])
+  assert_true(state.active == Some(file_tab("b.mbt")))
+  assert_true(
+    @dock.file_paths(state) ==
+    [@pathx.Relative("a.mbt"), @pathx.Relative("b.mbt")],
+  )
+  assert_true(@dock.active_file(state) == Some(@pathx.Relative("b.mbt")))
+}
+
+///|
+test "open_file re-activates an existing tab without duplicating it" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+  assert_true(state.tabs == [file_tab("a.mbt"), file_tab("b.mbt")])
+  assert_true(state.active == Some(file_tab("a.mbt")))
+}
+
+///|
+test "TogglePanel flips the panel" {
+  let state = @dock.update(@dock.TogglePanel, @dock.State::empty())
+  assert_true(state.open)
+  let state = @dock.update(@dock.TogglePanel, state)
+  assert_true(!state.open)
+}
+
+///|
+test "TabActivated switches to a present tab and ignores an absent one" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+  let activated = @dock.update(@dock.TabActivated(file_tab("a.mbt")), state)
+  assert_true(activated.active == Some(file_tab("a.mbt")))
+  // Idempotent: activating the active tab changes nothing.
+  let again = @dock.update(@dock.TabActivated(file_tab("a.mbt")), activated)
+  assert_true(again == activated)
+  let ghost = @dock.update(@dock.TabActivated(file_tab("ghost.mbt")), state)
+  assert_true(ghost == state)
+}
+
+///|
+test "closing the active tab activates the right neighbor, else the left" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+    |> @dock.open_file(@pathx.Relative("c.mbt"))
+  // Close the middle tab while it is active: the right neighbor wins.
+  let state = @dock.update(@dock.TabActivated(file_tab("b.mbt")), state)
+  let state = @dock.update(@dock.TabClosed(file_tab("b.mbt")), state)
+  assert_true(state.tabs == [file_tab("a.mbt"), file_tab("c.mbt")])
+  assert_true(state.active == Some(file_tab("c.mbt")))
+  // Close the last tab while it is active: the left neighbor wins.
+  let state = @dock.update(@dock.TabClosed(file_tab("c.mbt")), state)
+  assert_true(state.tabs == [file_tab("a.mbt")])
+  assert_true(state.active == Some(file_tab("a.mbt")))
+  // Close the only tab: the strip empties and nothing is active.
+  let state = @dock.update(@dock.TabClosed(file_tab("a.mbt")), state)
+  assert_true(state.tabs.is_empty())
+  assert_true(state.active is None)
+}
+
+///|
+test "closing a background tab keeps the active tab" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+  let state = @dock.update(@dock.TabClosed(file_tab("a.mbt")), state)
+  assert_true(state.tabs == [file_tab("b.mbt")])
+  assert_true(state.active == Some(file_tab("b.mbt")))
+  // Idempotent: closing an already-closed tab changes nothing.
+  let again = @dock.update(@dock.TabClosed(file_tab("a.mbt")), state)
+  assert_true(again == state)
+}
+
+///|
+test "sync parks the strip and restores it when the conversation returns" {
+  let first = owner("alpha")
+  let second = owner("beta")
+  let state = @dock.sync(@dock.State::empty(), first)
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+  let state = @dock.update(@dock.TabActivated(file_tab("a.mbt")), state)
+  // Switch away: the strip parks and the panel starts empty.
+  let away = @dock.sync(state, second)
+  assert_true(away.owner == Some(second))
+  assert_true(away.tabs.is_empty())
+  assert_true(away.active is None)
+  // A same-owner sync is a no-op.
+  assert_true(@dock.sync(away, second) == away)
+  // Switch back: identities and the active tab return.
+  let back = @dock.sync(away, first)
+  assert_true(back.tabs == [file_tab("a.mbt"), file_tab("b.mbt")])
+  assert_true(back.active == Some(file_tab("a.mbt")))
+}
+
+///|
+test "sync does not park a strip owned by an empty session" {
+  let scratch = owner("")
+  let real = owner("alpha")
+  let state = @dock.sync(@dock.State::empty(), scratch)
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+  let moved = @dock.sync(state, real)
+  assert_true(moved.tabs.is_empty())
+  // Returning to the empty session restores nothing.
+  let back = @dock.sync(moved, scratch)
+  assert_true(back.tabs.is_empty())
+  assert_true(back.active is None)
+}
+
+///|
+test "open_browser appends and re-activates without duplicating" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_browser(7)
+  assert_true(state.tabs == [file_tab("a.mbt"), @dock.DockTab::Browser(id=7)])
+  assert_true(state.active == Some(@dock.DockTab::Browser(id=7)))
+  assert_true(@dock.active_browser(state) == Some(7))
+  assert_true(@dock.active_file(state) is None)
+  // Files projection skips non-file tabs.
+  assert_true(@dock.file_paths(state) == [@pathx.Relative("a.mbt")])
+  let again = @dock.open_browser(state, 7)
+  assert_true(again.tabs == state.tabs)
+}
+
+///|
+test "open_picker keeps at most one picker tab" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_picker
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+    |> @dock.open_picker
+  assert_true(
+    state.tabs ==
+    [file_tab("a.mbt"), @dock.DockTab::FilePicker, file_tab("b.mbt")],
+  )
+  assert_true(state.active == Some(@dock.DockTab::FilePicker))
+}
+
+///|
+test "resolve_pick replaces the picker in place with a fresh file" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_picker
+  let state = @dock.resolve_pick(state, @pathx.Relative("b.mbt"))
+  assert_true(state.tabs == [file_tab("a.mbt"), file_tab("b.mbt")])
+  assert_true(state.active == Some(file_tab("b.mbt")))
+}
+
+///|
+test "resolve_pick activates an already-open file and closes the picker" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_file(@pathx.Relative("b.mbt"))
+    |> @dock.open_picker
+  let state = @dock.resolve_pick(state, @pathx.Relative("a.mbt"))
+  assert_true(state.tabs == [file_tab("a.mbt"), file_tab("b.mbt")])
+  assert_true(state.active == Some(file_tab("a.mbt")))
+}
+
+///|
+test "resolve_pick without a picker is a plain open" {
+  let state = @dock.State::empty() |> @dock.open_file(@pathx.Relative("a.mbt"))
+  let state = @dock.resolve_pick(state, @pathx.Relative("b.mbt"))
+  assert_true(state.tabs == [file_tab("a.mbt"), file_tab("b.mbt")])
+  assert_true(state.active == Some(file_tab("b.mbt")))
+}
+
+///|
+test "closing the picker activates a neighbor like any tab" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_picker
+  let state = @dock.update(TabClosed(@dock.DockTab::FilePicker), state)
+  assert_true(state.tabs == [file_tab("a.mbt")])
+  assert_true(state.active == Some(file_tab("a.mbt")))
+}
+
+///|
+test "menu toggles, closes with the panel, and never parks" {
+  let state = @dock.State::empty() |> @dock.open_browser(1)
+  let state = @dock.update(MenuToggled, state)
+  assert_true(state.menu_open)
+  assert_false(@dock.close_menu(state).menu_open)
+  let toggled = @dock.update(TogglePanel, state)
+  assert_false(toggled.menu_open)
+  // A conversation switch drops the popup with the strip it rode on.
+  let state = @dock.sync(state, owner("s1"))
+  assert_false(state.menu_open)
+}
+
+///|
+test "park and restore keeps browser and picker tabs" {
+  let state = @dock.sync(@dock.State::empty(), owner("s1"))
+    |> @dock.open_browser(3)
+    |> @dock.open_picker
+  let state = @dock.sync(state, owner("s2"))
+  assert_true(state.tabs.is_empty())
+  let state = @dock.sync(state, owner("s1"))
+  assert_true(
+    state.tabs == [@dock.DockTab::Browser(id=3), @dock.DockTab::FilePicker],
+  )
+  assert_true(state.active == Some(@dock.DockTab::FilePicker))
+}

--- a/desktop/frontend/dock/moon.pkg
+++ b/desktop/frontend/dock/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/interop",
+}
+
+supported_targets = "js"

--- a/desktop/frontend/dock/pkg.generated.mbti
+++ b/desktop/frontend/dock/pkg.generated.mbti
@@ -1,0 +1,81 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/dock"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/internal/pathx",
+}
+
+// Values
+pub fn active_browser(State) -> Int?
+
+pub fn active_file(State) -> @pathx.Relative?
+
+pub fn close_menu(State) -> State
+
+pub fn file_paths(State) -> Array[@pathx.Relative]
+
+pub fn launcher_pane(LauncherActions) -> @html.Html
+
+pub fn open_browser(State, Int) -> State
+
+pub fn open_file(State, @pathx.Relative) -> State
+
+pub fn open_picker(State) -> State
+
+pub fn resolve_pick(State, @pathx.Relative) -> State
+
+pub fn sync(State, @interop.ConversationKey) -> State
+
+pub fn tabs_bar(@cmd.Emit[Msg], State, Array[TabChip], LauncherActions) -> @html.Html
+
+pub fn update(Msg, State) -> State
+
+// Errors
+
+// Types and methods
+pub(all) enum DockTab {
+  File(path~ : @pathx.Relative)
+  Browser(id~ : Int)
+  FilePicker
+} derive(Eq)
+
+pub(all) struct LauncherActions {
+  browser : @cmd.Cmd?
+  files : @cmd.Cmd
+}
+
+pub(all) enum Msg {
+  TogglePanel
+  TabActivated(DockTab)
+  TabClosed(DockTab)
+  MenuToggled
+}
+
+pub(all) struct RememberedStrip {
+  tabs : Array[DockTab]
+  active : DockTab?
+} derive(Eq)
+
+pub(all) struct State {
+  open : Bool
+  owner : @interop.ConversationKey?
+  tabs : Array[DockTab]
+  active : DockTab?
+  menu_open : Bool
+  remembered : Map[@interop.ConversationKey, RememberedStrip]
+} derive(Eq)
+pub fn State::empty() -> Self
+
+pub(all) struct TabChip {
+  tab : DockTab
+  label : String
+  title : String
+  missing : Bool
+}
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/dock/state.mbt
+++ b/desktop/frontend/dock/state.mbt
@@ -1,0 +1,96 @@
+// The right panel's dock: one mixed tab strip whose entries may be of
+// different kinds (files today; browser pages and other viewers later). The
+// dock owns strip membership, order, and the active tab — the single source
+// of truth the root update projects into the content subsystems (fileeditor
+// receives the open-file list through its `Ctx`). Document state never lives
+// here: a `File` tab is only an identity, and its content stays in the
+// fileeditor package's document table.
+
+///|
+/// One strip entry. Adding a tab kind later (subagent viewer, review pane)
+/// is a new variant plus its body view — the strip machine itself does not
+/// change.
+pub(all) enum DockTab {
+  File(path~ : @pathx.Relative)
+  // A browser page, rendered by a host-owned native web contents view; the
+  // id keys the `preview` package's page state and the host's view. Page
+  // ids are global, so a parked strip's tabs keep naming their pages.
+  Browser(id~ : Int)
+  // The transient open-a-file tab (at most one): the file view's tree with
+  // a pick-a-file placeholder. Picking a file replaces it in place.
+  FilePicker
+} derive(Eq)
+
+///|
+/// A conversation's parked strip: identities and the active tab only,
+/// mirroring how fileeditor used to park its tab set. Restoring never brings
+/// content back by itself — the content subsystems reload on demand.
+pub(all) struct RememberedStrip {
+  tabs : Array[DockTab]
+  active : DockTab?
+} derive(Eq)
+
+///|
+/// The dock's state. Invariant: `active` is `None` exactly when `tabs` is
+/// empty (an empty strip shows the panel's placeholder body; from M2 on, the
+/// launcher menu).
+pub(all) struct State {
+  // Whether the right panel is expanded. The panel is always rendered (the
+  // viewer host element must stay put) and merely hidden by CSS when closed.
+  open : Bool
+  // Which conversation the live strip belongs to; `None` before the first
+  // sync. Switching conversations parks the strip under this key.
+  owner : @interop.ConversationKey?
+  // The strip, in opening order, and the tab whose body is on screen.
+  tabs : Array[DockTab]
+  active : DockTab?
+  // Whether the strip's `+` launcher menu popup is open. Transient UI, never
+  // parked with a strip.
+  menu_open : Bool
+  // Strips parked by conversation switches, restored when their conversation
+  // returns to the screen.
+  remembered : Map[@interop.ConversationKey, RememberedStrip]
+} derive(Eq)
+
+///|
+pub fn State::empty() -> State {
+  {
+    open: false,
+    owner: None,
+    tabs: [],
+    active: None,
+    menu_open: false,
+    remembered: Map([]),
+  }
+}
+
+///|
+/// The strip's file paths, in strip order — the projection the root update
+/// hands to fileeditor's `Ctx` for its stat/watch/reload sweeps.
+pub fn file_paths(state : State) -> Array[@pathx.Relative] {
+  let paths : Array[@pathx.Relative] = []
+  for tab in state.tabs {
+    if tab is File(path~) {
+      paths.push(path)
+    }
+  }
+  paths
+}
+
+///|
+/// The active tab's file path, when the active tab is a file.
+pub fn active_file(state : State) -> @pathx.Relative? {
+  match state.active {
+    Some(File(path~)) => Some(path)
+    _ => None
+  }
+}
+
+///|
+/// The active tab's browser page id, when the active tab is a browser page.
+pub fn active_browser(state : State) -> Int? {
+  match state.active {
+    Some(Browser(id~)) => Some(id)
+    _ => None
+  }
+}

--- a/desktop/frontend/dock/update.mbt
+++ b/desktop/frontend/dock/update.mbt
@@ -1,0 +1,150 @@
+// The strip machine. `update` is pure and command-free: the cross-package
+// effects of a strip transition (showing a document, clearing the viewer,
+// mounting hosts) are the root update's to command — it compares `active`
+// before and after and drives the content subsystems accordingly.
+
+///|
+pub(all) enum Msg {
+  // Show or hide the whole right panel.
+  TogglePanel
+  // A tab in the strip was clicked: put its body on screen.
+  TabActivated(DockTab)
+  // A tab's close button was clicked. Closing the active tab activates its
+  // right neighbor, else its left, else none.
+  TabClosed(DockTab)
+  // Open or close the strip's `+` launcher menu popup. The rows themselves
+  // dispatch root messages (opening a tab crosses packages), and the root
+  // closes the menu with `close_menu` as part of handling them.
+  MenuToggled
+}
+
+///|
+fn tab_index(state : State, tab : DockTab) -> Int? {
+  state.tabs.search_by(entry => entry == tab)
+}
+
+///|
+pub fn update(msg : Msg, state : State) -> State {
+  match msg {
+    TogglePanel => { ..state, open: !state.open, menu_open: false }
+    MenuToggled => { ..state, menu_open: !state.menu_open }
+    TabActivated(tab) =>
+      if tab_index(state, tab) is Some(_) {
+        { ..state, active: Some(tab) }
+      } else {
+        state
+      }
+    TabClosed(tab) =>
+      match tab_index(state, tab) {
+        Some(index) => {
+          let tabs = state.tabs.filter(entry => entry != tab)
+          let active = if state.active == Some(tab) {
+            // The right neighbor inherits the screen; at the strip's end,
+            // the left one.
+            match tabs.get(index) {
+              Some(next) => Some(next)
+              None => if index > 0 { tabs.get(index - 1) } else { None }
+            }
+          } else {
+            state.active
+          }
+          { ..state, tabs, active }
+        }
+        None => state
+      }
+  }
+}
+
+///|
+/// Open `path`'s file tab (appending one if it is not in the strip yet) and
+/// make it active — the strip half of a tree click or a chip jump.
+pub fn open_file(state : State, path : @pathx.Relative) -> State {
+  let tab = DockTab::File(path~)
+  let tabs = if tab_index(state, tab) is Some(_) {
+    state.tabs
+  } else {
+    let tabs = state.tabs.copy()
+    tabs.push(tab)
+    tabs
+  }
+  { ..state, tabs, active: Some(tab) }
+}
+
+///|
+/// Close the `+` launcher menu — the root's half of handling a menu row
+/// click, whose real work (allocating a page, opening the picker) crosses
+/// packages.
+pub fn close_menu(state : State) -> State {
+  { ..state, menu_open: false }
+}
+
+///|
+/// Open browser page `id`'s tab (appending one if it is not in the strip
+/// yet) and make it active. The caller owns the id: allocating the page and
+/// asking the host for its native view are the browser subsystem's business.
+pub fn open_browser(state : State, id : Int) -> State {
+  let tab = DockTab::Browser(id~)
+  let tabs = if tab_index(state, tab) is Some(_) {
+    state.tabs
+  } else {
+    let tabs = state.tabs.copy()
+    tabs.push(tab)
+    tabs
+  }
+  { ..state, tabs, active: Some(tab) }
+}
+
+///|
+/// Open the transient file-picker tab, re-activating the existing one — at
+/// most one lives in the strip.
+pub fn open_picker(state : State) -> State {
+  let tabs = if tab_index(state, FilePicker) is Some(_) {
+    state.tabs
+  } else {
+    let tabs = state.tabs.copy()
+    tabs.push(FilePicker)
+    tabs
+  }
+  { ..state, tabs, active: Some(FilePicker) }
+}
+
+///|
+/// A file was picked while the picker tab is in the strip: the picker is
+/// replaced in place by that file's tab — unless the file is already open,
+/// in which case its existing tab activates and the picker closes. Without
+/// a picker this is a plain `open_file`.
+pub fn resolve_pick(state : State, path : @pathx.Relative) -> State {
+  guard tab_index(state, FilePicker) is Some(picker_index) else {
+    return open_file(state, path)
+  }
+  let file = DockTab::File(path~)
+  if tab_index(state, file) is Some(_) {
+    let tabs = state.tabs.filter(entry => !(entry is FilePicker))
+    { ..state, tabs, active: Some(file) }
+  } else {
+    let tabs = state.tabs.copy()
+    tabs[picker_index] = file
+    { ..state, tabs, active: Some(file) }
+  }
+}
+
+///|
+/// Reconcile the strip with the active conversation: when the conversation
+/// changed, park the current strip under its owner and restore the new
+/// conversation's parked strip (or an empty one). Pure — reloading the
+/// restored documents is the content subsystems' business, driven by their
+/// own sync against the fresh projection.
+pub fn sync(state : State, owner : @interop.ConversationKey) -> State {
+  if state.owner == Some(owner) {
+    return state
+  }
+  let remembered = state.remembered.copy()
+  if state.owner is Some(previous) && !previous.session.is_empty() {
+    remembered[previous] = { tabs: state.tabs, active: state.active }
+  }
+  let (tabs, active) = match remembered.get(owner) {
+    Some(parked) => (parked.tabs.copy(), parked.active)
+    None => ([], (None : DockTab?))
+  }
+  { ..state, owner: Some(owner), tabs, active, menu_open: false, remembered }
+}

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -1,0 +1,169 @@
+// The strip's view: the tab bar riding the top of the right panel, with the
+// whole-panel toggle at its right edge. The dock renders identities only —
+// labels and per-tab decorations come in as `TabChip` view-models computed
+// by the root view from the owning subsystem's state, so the dock never
+// reads document tables.
+
+///|
+/// The sidebar-right codicon for the panel toggle, from Microsoft's
+/// vscode-codicons (CC BY 4.0), embedded unmodified.
+let icon_layout_sidebar_right : String =
+  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M12.5 1C13.881 1 15 2.119 15 3.5V12.5C15 13.881 13.881 15 12.5 15H3.5C2.119 15 1 13.881 1 12.5V3.5C1 2.119 2.119 1 3.5 1H12.5ZM9 14V2H3.5C2.672 2 2 2.672 2 3.5V12.5C2 13.328 2.672 14 3.5 14H9Z"/></svg>
+
+///|
+/// The add codicon (CC BY 4.0): the strip's new-tab button.
+let icon_add : String =
+  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/></svg>
+
+///|
+/// The folder codicon (CC BY 4.0): the launcher's Files row.
+let icon_folder : String =
+  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M2 4.5V6H5.58579C5.71839 6 5.84557 5.94732 5.93934 5.85355L7.29289 4.5L5.93934 3.14645C5.84557 3.05268 5.71839 3 5.58579 3H3.5C2.67157 3 2 3.67157 2 4.5ZM1 4.5C1 3.11929 2.11929 2 3.5 2H5.58579C5.98361 2 6.36514 2.15804 6.64645 2.43934L8.20711 4H12.5C13.8807 4 15 5.11929 15 6.5V11.5C15 12.8807 13.8807 14 12.5 14H3.5C2.11929 14 1 12.8807 1 11.5V4.5ZM2 7V11.5C2 12.3284 2.67157 13 3.5 13H12.5C13.3284 13 14 12.3284 14 11.5V6.5C14 5.67157 13.3284 5 12.5 5H8.20711L6.64645 6.56066C6.36514 6.84197 5.98361 7 5.58579 7H2Z"/></svg>
+
+///|
+/// A simple globe for the launcher's Browser row (drawn here, not a
+/// codicon): a circle with one meridian and the equator.
+let icon_globe : String =
+  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor"><circle cx="8" cy="8" r="6"/><ellipse cx="8" cy="8" rx="2.6" ry="6"/><path d="M2 8h12"/></svg>
+
+///|
+/// An icon's SVG markup injected into a fixed-size span. The markup is a
+/// trusted compile-time constant, never user input, so the XSS alert on
+/// `inner_html` does not apply.
+#warnings("-alert_xss_vulnerable")
+fn icon(markup : String) -> @html.Html {
+  @html.span(
+    class="icon",
+    attrs=@html.Attrs::build().inner_html(markup).aria_hidden("true"),
+    ([] : Array[@html.Html]),
+  )
+}
+
+///|
+/// One strip entry as the root view presents it: the tab's identity plus the
+/// decorations only the owning subsystem knows — the label text, the hover
+/// title, and whether the tab's backing content is missing (a deleted file),
+/// which styles the tab.
+pub(all) struct TabChip {
+  tab : DockTab
+  label : String
+  title : String
+  missing : Bool
+}
+
+///|
+/// What the launcher's rows can open, as root-owned commands — opening a
+/// tab allocates state in other packages, so the dock only emits. A `None`
+/// browser action hides that row (a remote console has no native views to
+/// host pages with).
+pub(all) struct LauncherActions {
+  browser : @cmd.Cmd?
+  files : @cmd.Cmd
+}
+
+///|
+/// The launcher rows shared by the empty-strip pane and the `+` popup: the
+/// kinds of tab the dock can open.
+fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
+  let rows : Array[@html.Html] = []
+  if actions.browser is Some(open_browser) {
+    rows.push(
+      @html.button(class="dock-launcher-row", on_click=open_browser, [
+        icon(icon_globe),
+        @html.span(class="dock-launcher-name", "Browser"),
+        @html.span(class="dock-launcher-hint", "Open a page in a tab"),
+      ]),
+    )
+  }
+  rows.push(
+    @html.button(class="dock-launcher-row", on_click=actions.files, [
+      icon(icon_folder),
+      @html.span(class="dock-launcher-name", "Files"),
+      @html.span(class="dock-launcher-hint", "Open a file from the workspace"),
+    ]),
+  )
+  rows
+}
+
+///|
+/// The empty strip's body: a centered launcher menu of the tab kinds the
+/// dock can open (Codex-style). Always rendered — CSS shows it only while
+/// the strip is empty — so the panel's child order stays structural.
+pub fn launcher_pane(actions : LauncherActions) -> @html.Html {
+  @html.div(class="dock-launcher", [
+    @html.div(class="dock-launcher-menu", launcher_rows(actions)),
+  ])
+}
+
+///|
+/// The panel's top bar: the open tabs, the `+` launcher popup, and the
+/// whole-panel toggle riding the right edge. Always rendered so the panel's
+/// child order stays structural. Clicking a tab activates it; the `×`
+/// closes it without activating (the close click must not bubble into the
+/// tab's own handler).
+pub fn tabs_bar(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  chips : Array[TabChip],
+  actions : LauncherActions,
+) -> @html.Html {
+  let tabs : Array[@html.Html] = []
+  for chip in chips {
+    let mut classes = "editor-tab"
+    if state.active == Some(chip.tab) {
+      classes = classes + " active"
+    }
+    if chip.missing {
+      classes = classes + " deleted"
+    }
+    let tab = chip.tab
+    tabs.push(
+      @html.div(
+        class=classes,
+        title=chip.title,
+        on_click=dispatch(TabActivated(tab)),
+        [
+          @html.span(class="tab-name", chip.label),
+          @html.button(
+            class="tab-close",
+            title="Close",
+            attrs=@html.Attrs::build().on_click(event => {
+              event.stop_propagation()
+              dispatch(TabClosed(tab))
+            }),
+            "×",
+          ),
+        ],
+      ),
+    )
+  }
+  // With an empty strip the body already is the launcher, so the `+` hides
+  // (by class, keeping the child order structural). The popup and its
+  // backdrop are conditional, appended after every stable child.
+  let children : Array[@html.Html] = [
+    @html.div(class="editor-tabs", tabs),
+    @html.button(
+      class=if chips.is_empty() { "tab-add hidden" } else { "tab-add" },
+      title="New tab",
+      on_click=dispatch(MenuToggled),
+      icon(icon_add),
+    ),
+    @html.button(
+      class="panel-toggle",
+      title="Hide panel",
+      on_click=dispatch(TogglePanel),
+      icon(icon_layout_sidebar_right),
+    ),
+  ]
+  if state.menu_open {
+    children.push(
+      @html.div(
+        class="launcher-backdrop",
+        on_click=dispatch(MenuToggled),
+        @html.nothing,
+      ),
+    )
+    children.push(@html.div(class="dock-menu", launcher_rows(actions)))
+  }
+  @html.div(class="editor-tabsbar", children)
+}

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -10,19 +10,33 @@ import {
 }
 
 // Values
+pub fn activate(@cmd.Emit[Msg], State, Ctx, @pathx.Relative) -> (@cmd.Cmd, State)
+
 pub fn basename(@pathx.Relative) -> String
+
+pub fn body_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
+
+pub fn breadcrumb_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
+
+pub fn close_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, next~ : @pathx.Relative?, was_active~ : Bool) -> (@cmd.Cmd, State)
+
+pub fn editor_classes(State, Ctx) -> String
 
 pub fn mount_cmds(@cmd.Emit[Msg]) -> @cmd.Cmd
 
-pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, range~ : @common.Range?, annotation? : String) -> (@cmd.Cmd, State)
+pub fn open_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, name~ : String, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
 
-pub fn panel_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
+pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
+
+pub fn panel_toggle_cmds(@cmd.Emit[Msg], State, Ctx, opening~ : Bool) -> @cmd.Cmd
 
 pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, @pathx.Relative, String, range~ : @common.Range?, annotation? : String, workspace~ : @pathx.Absolute?) -> @cmd.Cmd
 
 pub fn remove_editor_feedback(ModelUri, String) -> @cmd.Cmd
 
 pub fn request_viewer_remeasure() -> @cmd.Cmd
+
+pub fn resize_handle_view() -> @html.Html
 
 pub fn sync(@cmd.Emit[Msg], State, Ctx) -> (State, @cmd.Cmd)
 
@@ -37,7 +51,16 @@ pub(all) struct Ctx {
   dark_mode : Bool
   tree_layout : TreeLayout
   narrow : Bool
+  panel_open : Bool
+  open_files : Array[@pathx.Relative]
+  active_file : @pathx.Relative?
 }
+
+pub(all) struct Doc {
+  name : String
+  state : TabState
+  stale : Bool
+} derive(Eq)
 
 pub(all) enum FileChange {
   Modified(@pathx.Relative)
@@ -73,12 +96,9 @@ pub struct ModelUri(String)
 pub fn ModelUri::of(@interop.ChannelId, @pathx.Absolute) -> Self
 
 pub(all) enum Msg {
-  ToggleFilePanel
   RevealDirectory(@pathx.Relative)
   HighlightCleared(@pathx.Relative)
   ToggleTree
-  TabActivated(@pathx.Relative)
-  TabClosed(@pathx.Relative)
   DirToggle(@pathx.Relative)
   FileFilterChanged(String)
   TreeKeyMove(delta~ : Int)
@@ -100,18 +120,7 @@ pub(all) enum Msg {
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
 }
 
-pub(all) struct RememberedTab {
-  path : @pathx.Relative
-  name : String
-} derive(Eq)
-
-pub(all) struct RememberedTabs {
-  entries : Array[RememberedTab]
-  active : @pathx.Relative?
-} derive(Eq)
-
 pub(all) struct State {
-  open : Bool
   owner : @interop.ConversationKey?
   tree_open : Bool
   watching : WatchedPaths?
@@ -119,9 +128,7 @@ pub(all) struct State {
   expanded : Array[@pathx.Relative]
   loading : Array[@pathx.Relative]
   children : Map[@pathx.Relative, Array[FileEntry]]
-  tabs : Array[Tab]
-  active : @pathx.Relative?
-  remembered : Map[@interop.ConversationKey, RememberedTabs]
+  docs : Map[@pathx.Relative, Doc]
   highlighted : @pathx.Relative?
   filter : String
   index : FileIndex
@@ -129,13 +136,6 @@ pub(all) struct State {
   error : String?
 } derive(Eq)
 pub fn State::empty() -> Self
-
-pub(all) struct Tab {
-  path : @pathx.Relative
-  name : String
-  state : TabState
-  stale : Bool
-} derive(Eq)
 
 pub(all) enum TabState {
   TabLoading

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -52,32 +52,16 @@ pub(all) enum TabState {
 } derive(Eq)
 
 ///|
-/// One open file in the editor's tab strip. Identified by its
-/// workspace-relative `path`; the strip's order is the order files were
-/// opened.
-pub(all) struct Tab {
-  path : @pathx.Relative
+/// One open file's document record, keyed by its workspace-relative path in
+/// `State.docs`. Which files are open — and in what order — is the dock
+/// strip's business; this table only holds what each open file's document
+/// looks like.
+pub(all) struct Doc {
   name : String
   state : TabState
-  // The file changed on disk while the tab was in the background; reloaded
+  // The file changed on disk while its tab was in the background; reloaded
   // on activation rather than eagerly, so a build storm costs one read.
   stale : Bool
-} derive(Eq)
-
-///|
-/// A conversation's tab set, remembered across conversation switches. Only
-/// identities — content would pin up to 1MiB per tab for conversations not
-/// on screen — so restoring reloads the active tab and marks the rest for
-/// load-on-activation.
-pub(all) struct RememberedTab {
-  path : @pathx.Relative
-  name : String
-} derive(Eq)
-
-///|
-pub(all) struct RememberedTabs {
-  entries : Array[RememberedTab]
-  active : @pathx.Relative?
 } derive(Eq)
 
 ///|
@@ -129,16 +113,15 @@ pub(all) enum FileIndex {
 } derive(Eq)
 
 ///|
-/// The editor side-panel's state: a lazily-loaded file tree of the active
-/// conversation's workspace and the files open in the embedded viewer's tab
-/// strip. Keyed entirely by workspace-relative paths; `owner` records which
-/// channel's conversation the cached tree belongs to, so switching either
-/// channel or session swaps it (parking the open tabs in `remembered`) rather
-/// than showing another host's files.
+/// The file subsystem's state: a lazily-loaded file tree of the active
+/// conversation's workspace and the document table behind the dock's open
+/// file tabs. Keyed entirely by workspace-relative paths; `owner` records
+/// which channel's conversation the cached tree and documents belong to, so
+/// switching either channel or session swaps them rather than showing
+/// another host's files. Strip membership, order, the active tab, and the
+/// parked per-conversation strips all live in the dock package — the open
+/// file list arrives through `Ctx`.
 pub(all) struct State {
-  // Whether the panel column is expanded; the column is always rendered (so
-  // the viewer host element stays put) and merely hidden by CSS when closed.
-  open : Bool
   owner : @interop.ConversationKey?
   // Whether the file-tree pane (the toggleable column right of the viewer)
   // is shown. A panel preference, not per-conversation state, so it
@@ -158,13 +141,10 @@ pub(all) struct State {
   loading : Array[@pathx.Relative]
   // Listed directories' entries, keyed by the directory's relative path.
   children : Map[@pathx.Relative, Array[FileEntry]]
-  // The open files, in strip order, and which of them the viewer shows.
-  // `active: None` leaves the viewer on its placeholder.
-  tabs : Array[Tab]
-  active : @pathx.Relative?
-  // Tab sets parked by conversation switches, keyed by their full host-local
-  // identity, restored when that conversation returns to the screen.
-  remembered : Map[@interop.ConversationKey, RememberedTabs]
+  // Each open file's document, keyed by workspace-relative path. The key set
+  // mirrors the dock strip's file tabs (`Ctx.open_files`): the root update
+  // adds an entry when it opens a tab and drops it when the tab closes.
+  docs : Map[@pathx.Relative, Doc]
   // The directory a breadcrumb click most recently revealed, flashed in the
   // tree until `HighlightCleared` fires.
   highlighted : @pathx.Relative?
@@ -187,7 +167,6 @@ pub(all) struct State {
 ///|
 pub fn State::empty() -> State {
   {
-    open: false,
     owner: None,
     tree_open: true,
     watching: None,
@@ -195,9 +174,7 @@ pub fn State::empty() -> State {
     expanded: [],
     loading: [],
     children: Map([]),
-    tabs: [],
-    active: None,
-    remembered: Map([]),
+    docs: Map([]),
     highlighted: None,
     filter: "",
     index: IndexEmpty,
@@ -250,13 +227,17 @@ pub(all) struct Ctx {
   // share one full-width pane (CSS shows exactly one), so opening a file
   // closes the tree — a drill-down — instead of showing both side by side.
   narrow : Bool
+  // The dock's projection, recomputed by the root each dispatch: whether the
+  // right panel is expanded, which files the strip holds (in strip order —
+  // the stat/watch/reload sweeps run over this list), and which file tab is
+  // active (`None` while no file tab is on screen).
+  panel_open : Bool
+  open_files : Array[@pathx.Relative]
+  active_file : @pathx.Relative?
 }
 
 ///|
 pub(all) enum Msg {
-  // Show or hide the editor side-panel. Opening it loads the active
-  // conversation's workspace root if it has not been listed yet.
-  ToggleFilePanel
   // A breadcrumb segment was clicked: switch back to the (always-rooted)
   // tree and reveal this directory — expanding whatever ancestors are
   // needed to show it, then scrolling to and flashing it. `""` (the leading
@@ -267,13 +248,6 @@ pub(all) enum Msg {
   HighlightCleared(@pathx.Relative)
   // Show or hide the file-tree pane (the column right of the viewer).
   ToggleTree
-  // A tab in the strip was clicked: show that file in the viewer.
-  TabActivated(@pathx.Relative)
-  // A tab's close button was clicked. Closing the active tab activates its
-  // right neighbor, else its left, else none (the viewer falls back to the
-  // placeholder, and the tree pane is forced open so the panel is never
-  // empty).
-  TabClosed(@pathx.Relative)
   // Expand or collapse a directory row in the file tree; the first expansion
   // lazily lists the directory through the host.
   DirToggle(@pathx.Relative)

--- a/desktop/frontend/fileeditor/tree_nav.mbt
+++ b/desktop/frontend/fileeditor/tree_nav.mbt
@@ -170,7 +170,6 @@ fn scroll_cursor_after_render(path : @pathx.Relative) -> @cmd.Cmd {
 fn nav_state() -> State {
   {
     ..State::empty(),
-    open: true,
     owner: Some(test_ctx().owner),
     children: Map::from_array([
       (
@@ -224,35 +223,37 @@ test "Enter toggles a directory under the cursor and opens a file" {
     nav_state(),
     test_ctx(),
   )
+  // A file under the cursor re-dispatches `FileSelected` for the root to
+  // intercept (the command is opaque); the table itself is untouched.
   let (_, opened) = update(emit, TreeKeyAccept, on_file, test_ctx())
-  assert_true(opened.active is Some(Relative("main.mbt")))
-  assert_eq(opened.tabs.length(), 1)
+  assert_true(opened == on_file)
 }
 
 ///|
-test "Enter with no cursor opens a non-blank filter's top match" {
+test "Enter with no cursor acts only on a non-blank filter" {
   let emit = test_emit()
+  // The top match's open is an opaque re-dispatch; the state is untouched
+  // either way.
   let state = { ..nav_state(), filter: "lib" }
   let (_, opened) = update(emit, TreeKeyAccept, state, test_ctx())
-  assert_true(opened.active is Some(Relative("src/lib.mbt")))
-  // A blank filter with no cursor has nothing to act on.
+  assert_true(opened == state)
   let (_, untouched) = update(emit, TreeKeyAccept, nav_state(), test_ctx())
-  assert_true(untouched.active is None)
+  assert_true(untouched == nav_state())
 }
 
 ///|
 test "Escape clears the filter first, then closes the tree" {
   let emit = test_emit()
-  let state = {
-    ..nav_state(),
-    filter: "lib",
-    tabs: [loaded_tab("main.mbt", "main.mbt")],
-    active: Some(Relative("main.mbt")),
+  let viewing : Ctx = {
+    ..test_ctx(),
+    open_files: [Relative("main.mbt")],
+    active_file: Some(Relative("main.mbt")),
   }
-  let (_, cleared) = update(emit, TreeKeyDismiss, state, test_ctx())
+  let state = { ..nav_state(), filter: "lib" }
+  let (_, cleared) = update(emit, TreeKeyDismiss, state, viewing)
   assert_eq(cleared.filter, "")
   assert_true(cleared.tree_open)
-  let (_, closed) = update(emit, TreeKeyDismiss, cleared, test_ctx())
+  let (_, closed) = update(emit, TreeKeyDismiss, cleared, viewing)
   assert_false(closed.tree_open)
   // With no file open the tree is unconditional; Escape leaves it alone.
   let (_, kept) = update(emit, TreeKeyDismiss, nav_state(), test_ctx())
@@ -283,16 +284,18 @@ test "the fuzzy filter matches the workspace index, best score first" {
 }
 
 ///|
-test "Enter opens the index's top match even when unlisted" {
+test "Enter resolves the index's top match even when unlisted" {
   let emit = test_emit()
   let state = {
     ..nav_state(),
     filter: "lib",
     index: IndexReady(files=[Relative("deep/lib.mbt")], truncated=false),
   }
+  // The open itself is an opaque `FileSelected` re-dispatch for the root to
+  // intercept; the resolution (an index row synthesizes a file entry) is
+  // what `visible_entries` covers above, so here the state stays untouched.
   let (_, opened) = update(emit, TreeKeyAccept, state, test_ctx())
-  assert_true(opened.active is Some(Relative("deep/lib.mbt")))
-  assert_eq(opened.tabs[0].name, "lib.mbt")
+  assert_true(opened == state)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -17,18 +17,18 @@ pub fn mount_cmds(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 }
 
 ///|
-fn tab_index(state : State, path : @pathx.Relative) -> Int? {
-  state.tabs.search_by(tab => tab.path == path)
-}
-
-///|
-/// The command that puts `tab`'s document on screen: its content (scroll
+/// The command that puts `path`'s document on screen: its content (scroll
 /// restored to where the tab was left), a withheld/deleted notice, or — for
-/// a tab whose content is not loaded yet — a fresh read, whose `FileLoaded`
-/// does the showing. A MoonBit file also re-syncs diagnostics, matching what
-/// its first load did.
-fn show_tab(dispatch : @cmd.Emit[Msg], ctx : Ctx, tab : Tab) -> @cmd.Cmd {
-  let show = match tab.state {
+/// a document whose content is not loaded yet — a fresh read, whose
+/// `FileLoaded` does the showing. A MoonBit file also re-syncs diagnostics,
+/// matching what its first load did.
+fn show_tab(
+  dispatch : @cmd.Emit[Msg],
+  ctx : Ctx,
+  path : @pathx.Relative,
+  doc : Doc,
+) -> @cmd.Cmd {
+  let show = match doc.state {
     TabLoading =>
       // Covers both "a read is already in flight" (a duplicate reply is
       // folded idempotently) and "parked since a conversation restore, never
@@ -37,8 +37,8 @@ fn show_tab(dispatch : @cmd.Emit[Msg], ctx : Ctx, tab : Tab) -> @cmd.Cmd {
       read_file(
         dispatch,
         ctx.owner,
-        tab.path,
-        tab.name,
+        path,
+        doc.name,
         range=None,
         workspace=ctx.workspace,
       )
@@ -46,13 +46,13 @@ fn show_tab(dispatch : @cmd.Emit[Msg], ctx : Ctx, tab : Tab) -> @cmd.Cmd {
       let show = show_file_in_viewer(
         ctx.owner,
         ctx.workspace,
-        tab.name,
+        doc.name,
         content,
         absolute~,
-        relative=tab.path,
+        relative=path,
         restore_scroll=true,
       )
-      if language_id(tab.name) == "moonbit" {
+      if language_id(doc.name) == "moonbit" {
         @cmd.batch([show, request_diagnostics(dispatch, ctx.owner, absolute)])
       } else {
         show
@@ -63,17 +63,17 @@ fn show_tab(dispatch : @cmd.Emit[Msg], ctx : Ctx, tab : Tab) -> @cmd.Cmd {
     // drops back to no document underneath it.
     TabBinary | TabOversized | TabDeleted => clear_document()
   }
-  // A tab that went stale in the background (or was deleted and reappeared)
-  // shows what it has and reloads in the same breath; the reply lands with
-  // the scroll kept in place.
-  if tab.stale && !(tab.state is TabLoading) {
+  // A document that went stale in the background (or was deleted and
+  // reappeared) shows what it has and reloads in the same breath; the reply
+  // lands with the scroll kept in place.
+  if doc.stale && !(doc.state is TabLoading) {
     @cmd.batch([
       show,
       read_file(
         dispatch,
         ctx.owner,
-        tab.path,
-        tab.name,
+        path,
+        doc.name,
         range=None,
         workspace=ctx.workspace,
       ),
@@ -84,54 +84,52 @@ fn show_tab(dispatch : @cmd.Emit[Msg], ctx : Ctx, tab : Tab) -> @cmd.Cmd {
 }
 
 ///|
-/// Open `path` in a tab (appending one if it is not open yet) and make it
-/// active. A plain activation of an already-open tab shows what the tab has,
-/// exactly like a tab-strip click; everything else reads the file — so a
-/// jump's `range`/`annotation` ride the reply to be revealed on arrival.
-fn open_or_activate(
+/// Open `path`'s document — the file half of a tree click, a chip jump, or
+/// a dock activation of a not-yet-open file. The dock half (which tab is in
+/// the strip and active) has already happened in the root update, so
+/// `ctx.active_file` names this path; `had_active` says whether a file tab
+/// was on screen before the transition (gaining the first one reveals the
+/// breadcrumb row, which needs a viewer remeasure). A plain re-open of an
+/// already-loaded document shows what the table has, exactly like a
+/// tab-strip click; everything else reads the file — so a jump's
+/// `range`/`annotation` ride the reply to be revealed on arrival.
+pub fn open_document(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
   path : @pathx.Relative,
-  name : String,
+  name~ : String,
   range~ : @common.Range?,
   annotation? : String,
+  had_active~ : Bool,
 ) -> (@cmd.Cmd, State) {
   // The plain-activation case must not rely on the read's reply to switch
   // the document: `FileLoaded`'s identical-content dedup assumes the reply's
   // document is the one on screen, so a re-read of an unchanged file would
   // skip the redraw and leave the previous tab's document showing. Withheld
-  // and deleted tabs still fall through to the read — a tree click is the
-  // explicit re-open that refreshes them (see `TabState`).
+  // and deleted documents still fall through to the read — a tree click is
+  // the explicit re-open that refreshes them (see `TabState`).
   if range is None &&
     annotation is None &&
-    tab_index(state, path) is Some(index) &&
-    !(state.tabs[index].state is (TabBinary | TabOversized | TabDeleted)) {
-    let show = show_tab(dispatch, ctx, state.tabs[index])
+    state.docs.get(path) is Some(doc) &&
+    !(doc.state is (TabBinary | TabOversized | TabDeleted)) {
+    let show = show_tab(dispatch, ctx, path, doc)
     // Gaining the first active tab reveals the breadcrumb row, and the
     // narrow drill-down closing the tree reveals a viewer that was last
     // measured while hidden — both need a remeasure alongside the show.
-    let cmd = if state.active is None || (state.tree_open && ctx.narrow) {
+    let cmd = if !had_active || (state.tree_open && ctx.narrow) {
       @cmd.batch([show, request_viewer_remeasure()])
     } else {
       show
     }
     return (
       cmd,
-      {
-        ..state,
-        active: Some(path),
-        error: None,
-        tree_open: state.tree_open && !ctx.narrow,
-      },
+      { ..state, error: None, tree_open: state.tree_open && !ctx.narrow },
     )
   }
-  let tabs = if tab_index(state, path) is Some(_) {
-    state.tabs
-  } else {
-    let tabs = state.tabs.copy()
-    tabs.push({ path, name, state: TabLoading, stale: false })
-    tabs
+  let docs = state.docs.copy()
+  if !docs.contains(path) {
+    docs[path] = { name, state: TabLoading, stale: false }
   }
   let read = read_file(
     dispatch,
@@ -145,28 +143,22 @@ fn open_or_activate(
   // Gaining the first active tab reveals the breadcrumb row, and the narrow
   // drill-down closing the tree reveals a hidden-measured viewer — either
   // way the viewer must remeasure before the reply's document lands.
-  let cmd = if state.active is None || (state.tree_open && ctx.narrow) {
+  let cmd = if !had_active || (state.tree_open && ctx.narrow) {
     @cmd.batch([read, request_viewer_remeasure()])
   } else {
     read
   }
   (
     cmd,
-    {
-      ..state,
-      tabs,
-      active: Some(path),
-      error: None,
-      tree_open: state.tree_open && !ctx.narrow,
-    },
+    { ..state, docs, error: None, tree_open: state.tree_open && !ctx.narrow },
   )
 }
 
 ///|
-/// Open (or refocus) the panel on `path` — the tail of a composer chip's or
-/// transcript chip's jump, after the main package has relativized the raw
-/// path. Ensures the viewer is mounted, since the jump may be what opens the
-/// panel.
+/// Open (or refocus) `path`'s document for a composer chip's or transcript
+/// chip's jump, after the main package has relativized the raw path and
+/// opened the dock tab. Ensures the viewer is mounted, since the jump may be
+/// what opens the panel.
 pub fn open_file(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -174,17 +166,109 @@ pub fn open_file(
   path : @pathx.Relative,
   range~ : @common.Range?,
   annotation? : String,
+  had_active~ : Bool,
 ) -> (@cmd.Cmd, State) {
-  let (cmd, state) = open_or_activate(
+  let (cmd, state) = open_document(
     dispatch,
     state,
     ctx,
     path,
-    basename(path),
+    name=basename(path),
     range~,
     annotation?,
+    had_active~,
   )
-  (@cmd.batch([mount_cmds(dispatch), cmd]), { ..state, open: true })
+  (@cmd.batch([mount_cmds(dispatch), cmd]), state)
+}
+
+///|
+/// Show `path`'s document after the dock switched its active tab to it — a
+/// tab-strip click. The document is expected in the table; a missing entry
+/// (a stale click racing a close) is a no-op.
+pub fn activate(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  path : @pathx.Relative,
+) -> (@cmd.Cmd, State) {
+  guard state.docs.get(path) is Some(doc) else { return (@cmd.none, state) }
+  let show = show_tab(dispatch, ctx, path, doc)
+  // The narrow drill-down closing the tree reveals a viewer that was last
+  // measured while hidden; it must remeasure with the show.
+  let cmd = if state.tree_open && ctx.narrow {
+    @cmd.batch([show, request_viewer_remeasure()])
+  } else {
+    show
+  }
+  (cmd, { ..state, error: None, tree_open: state.tree_open && !ctx.narrow })
+}
+
+///|
+/// Drop `path`'s document after its dock tab closed. `next`, when the closed
+/// tab owned the screen, is the file the dock promoted (`None` when the
+/// strip emptied — the viewer falls back to the placeholder, and the tree is
+/// forced open so the panel is never a dead pane). The closed document's
+/// parked scroll is forgotten after the neighbor's show re-parks the
+/// outgoing document.
+pub fn close_document(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  path : @pathx.Relative,
+  next~ : @pathx.Relative?,
+  was_active~ : Bool,
+) -> (@cmd.Cmd, State) {
+  let docs = state.docs.copy()
+  docs.remove(path)
+  guard was_active else { return (forget_view_state(path), { ..state, docs, }) }
+  match next {
+    Some(next_path) =>
+      if docs.get(next_path) is Some(doc) {
+        (
+          @cmd.batch([
+            show_tab(dispatch, ctx, next_path, doc),
+            forget_view_state(path),
+          ]),
+          { ..state, docs, },
+        )
+      } else {
+        (forget_view_state(path), { ..state, docs, })
+      }
+    // The last tab: fall back to the placeholder and force the tree open so
+    // the panel is never a dead pane. Losing the active tab also hides the
+    // breadcrumb row, so the viewer must remeasure.
+    None =>
+      (
+        @cmd.batch([
+          clear_document(),
+          forget_view_state(path),
+          request_viewer_remeasure(),
+        ]),
+        { ..state, docs, tree_open: true },
+      )
+  }
+}
+
+///|
+/// The commands a panel-visibility toggle needs: the mount set always, plus
+/// — when opening — a read for an active document that was restored while
+/// the panel was closed and never read (it sits at `TabLoading`; opening is
+/// what makes it worth showing, and a duplicate of an in-flight read folds
+/// idempotently).
+pub fn panel_toggle_cmds(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  opening~ : Bool,
+) -> @cmd.Cmd {
+  let cmds = [mount_cmds(dispatch)]
+  if opening &&
+    ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.state is TabLoading {
+    cmds.push(show_tab(dispatch, ctx, path, doc))
+  }
+  @cmd.batch(cmds)
 }
 
 ///|
@@ -239,18 +323,17 @@ fn FileChange::moonbit_relevant(self : FileChange) -> Bool {
 }
 
 ///|
-/// The diagnostics request for the active tab when it is a loaded MoonBit
-/// file, or `None` when it is anything else — the shared trigger behind the
-/// stats, watcher, and run-finish re-check paths.
+/// The diagnostics request for the active file when it is a loaded MoonBit
+/// document, or `None` when it is anything else — the shared trigger behind
+/// the stats, watcher, and run-finish re-check paths.
 fn active_moonbit_diagnostics(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
-  tabs : Array[Tab],
+  docs : Map[@pathx.Relative, Doc],
   active : @pathx.Relative?,
 ) -> @cmd.Cmd? {
   guard active is Some(active) &&
-    tabs.search_by(tab => tab.path == active) is Some(index) &&
-    tabs[index] is { name, state: TabLoaded(absolute~, ..), .. } &&
+    docs.get(active) is Some({ name, state: TabLoaded(absolute~, ..), .. }) &&
     language_id(name) == "moonbit" else {
     return None
   }
@@ -277,18 +360,20 @@ fn moonbit_check_input(path : @pathx.Relative) -> Bool {
 }
 
 ///|
-/// Reconcile the host's workspace watcher with what the panel needs: follow
-/// the active session while the panel is open or tabs remain open in the
-/// background (their staleness must keep being tracked for the reopen), park
-/// it otherwise. Wraps every `sync` exit so the bookkeeping cannot be missed.
+/// The exact selection the host should watch: the open files (the dock
+/// strip's projection — their staleness must keep being tracked even while
+/// the panel is closed, for the reopen) plus the root and expanded
+/// directories the tree keeps on screen while the panel is open. `None`
+/// parks the watcher.
 fn State::watched_paths(self : State, ctx : Ctx) -> WatchedPaths? {
-  if (!self.open && self.tabs.is_empty()) || ctx.owner.session.is_empty() {
+  if (!ctx.panel_open && ctx.open_files.is_empty()) ||
+    ctx.owner.session.is_empty() {
     return None
   }
-  let files = self.tabs.map(tab => tab.path)
+  let files = ctx.open_files.copy()
   files.sort_by((left, right) => left.0.lexical_compare(right.0))
   let directories : Array[@pathx.Relative] = []
-  if self.open {
+  if ctx.panel_open {
     directories.push(@pathx.Relative::root())
     for directory in self.expanded {
       if !directories.contains(directory) {
@@ -333,17 +418,18 @@ fn with_watch(
 }
 
 ///|
-/// Reconcile the panel with the active conversation after every message:
-/// swap the tab set and tree when the conversation changed (parking the old
-/// conversation's tabs in `remembered`, restoring the new one's), list the
-/// workspace root once its path is known, and keep the host's file watcher
-/// pointed at the right workspace. The main update runs this post-dispatch,
-/// so no conversation-switching handler has to re-root the panel itself.
-/// The re-root happens whether the panel is open or closed — hidden tabs
-/// and the watcher must always agree on the session — while listing the
-/// tree waits for an open panel. A no-op unless something is actually due,
-/// so it never re-fires while a request is in flight or the tree is already
-/// current.
+/// Reconcile the file subsystem with the active conversation after every
+/// message: rebuild the document table and drop the tree cache when the
+/// conversation changed (the dock parks/restores strip identities; this side
+/// re-seeds documents from the fresh `Ctx` projection), list the workspace
+/// root once its path is known, and keep the host's file watcher pointed at
+/// the right workspace. The main update runs this post-dispatch — after the
+/// dock's own sync, so the projection is already the new conversation's.
+/// The re-root happens whether the panel is open or closed — hidden
+/// documents and the watcher must always agree on the session — while
+/// listing the tree waits for an open panel. A no-op unless something is
+/// actually due, so it never re-fires while a request is in flight or the
+/// tree is already current.
 pub fn sync(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -352,48 +438,35 @@ pub fn sync(
   // When the active conversation changes, drop the cached tree *and* the
   // viewer's open document — the viewer is imperative state outside the
   // model, so it would otherwise keep showing the previous conversation's
-  // file. The open tabs are parked by conversation key and restored (identities
-  // only: the active one reloads now, the rest load on activation) when
-  // their conversation returns. This runs even while the panel is closed:
-  // `with_watch` follows `ctx.owner` whenever tabs remain, so leaving the
-  // tabs rooted in the previous conversation would have the next fs_changed
-  // stat their paths against the new conversation's workspace — marking
-  // hidden tabs deleted/stale for files that never moved.
+  // file. The dock has already parked the outgoing strip and restored this
+  // conversation's; the document table is rebuilt from the projection —
+  // identities only, every entry `TabLoading` until a read lands. This runs
+  // even while the panel is closed: `with_watch` follows `ctx.owner`
+  // whenever open files remain, so leaving the documents rooted in the
+  // previous conversation would have the next fs_changed stat their paths
+  // against the new conversation's workspace — marking hidden documents
+  // deleted/stale for files that never moved.
   let (state, reroot_cmd) = if state.owner == Some(ctx.owner) {
     (state, @cmd.none)
   } else {
-    let remembered = state.remembered.copy()
-    if state.owner is Some(owner) && !owner.session.is_empty() {
-      remembered[owner] = {
-        entries: state.tabs.map(tab => { path: tab.path, name: tab.name }),
-        active: state.active,
+    let docs : Map[@pathx.Relative, Doc] = Map([])
+    for path in ctx.open_files {
+      docs[path] = {
+        name: basename(path),
+        state: TabState::TabLoading,
+        stale: false,
       }
     }
-    let (tabs, active) = match remembered.get(ctx.owner) {
-      Some(parked) =>
-        (
-          parked.entries.map(entry => {
-            path: entry.path,
-            name: entry.name,
-            state: TabState::TabLoading,
-            stale: false,
-          }),
-          parked.active,
-        )
-      None => ([], (None : @pathx.Relative?))
-    }
     let cmds = [clear_viewer()]
-    // A hidden panel's restored active tab is not worth a read yet; it stays
-    // TabLoading and `ToggleFilePanel` reads it on reopen.
-    if state.open &&
-      active is Some(path) &&
-      tabs.search_by(tab => tab.path == path) is Some(index) {
+    // A hidden panel's restored active document is not worth a read yet; it
+    // stays TabLoading and the panel-open toggle reads it on reopen.
+    if ctx.panel_open && ctx.active_file is Some(path) && docs.contains(path) {
       cmds.push(
         read_file(
           dispatch,
           ctx.owner,
           path,
-          tabs[index].name,
+          basename(path),
           range=None,
           workspace=ctx.workspace,
         ),
@@ -402,22 +475,21 @@ pub fn sync(
     (
       {
         ..State::empty(),
-        open: state.open,
         owner: Some(ctx.owner),
         tree_open: state.tree_open,
         // Preserve the last host configuration long enough for `with_watch`
         // to retire or replace it on the way out.
         watching: state.watching,
-        remembered,
-        tabs,
-        active,
+        docs,
       },
       @cmd.batch(cmds),
     )
   }
   // A closed panel re-roots (above) and keeps the watcher placed, but the
   // tree itself can wait for the reopen.
-  guard state.open else { return with_watch(dispatch, state, ctx, reroot_cmd) }
+  guard ctx.panel_open else {
+    return with_watch(dispatch, state, ctx, reroot_cmd)
+  }
   // Load as soon as there is a conversation: the workspace directory is a pure
   // function of the session id, so the host can list it without waiting for a
   // run to report `cwd` (it reports an empty workspace until the first turn
@@ -453,21 +525,6 @@ pub fn update(
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
   match msg {
-    ToggleFilePanel => {
-      // Loading the tree is left to `sync`. A re-root while the panel was
-      // closed leaves the restored active tab unread (TabLoading); opening
-      // is what makes it worth showing, so read it now (a duplicate of an
-      // in-flight read folds idempotently).
-      let opening = !state.open
-      let cmds = [mount_cmds(dispatch)]
-      if opening &&
-        state.active is Some(path) &&
-        tab_index(state, path) is Some(index) &&
-        state.tabs[index].state is TabLoading {
-        cmds.push(show_tab(dispatch, ctx, state.tabs[index]))
-      }
-      (@cmd.batch(cmds), { ..state, open: opening })
-    }
     ToggleTree => {
       // The docked panel takes its height from the viewer, and the viewer
       // cannot see a CSS change on its own. Opening also puts the keyboard
@@ -479,69 +536,6 @@ pub fn update(
       }
       (@cmd.batch(cmds), { ..state, tree_open: opening })
     }
-    TabActivated(path) =>
-      if state.active == Some(path) {
-        (@cmd.none, state)
-      } else if tab_index(state, path) is Some(index) {
-        let show = show_tab(dispatch, ctx, state.tabs[index])
-        // The narrow drill-down closing the tree reveals a viewer that was
-        // last measured while hidden; it must remeasure with the show.
-        let cmd = if state.tree_open && ctx.narrow {
-          @cmd.batch([show, request_viewer_remeasure()])
-        } else {
-          show
-        }
-        (
-          cmd,
-          {
-            ..state,
-            active: Some(path),
-            error: None,
-            tree_open: state.tree_open && !ctx.narrow,
-          },
-        )
-      } else {
-        (@cmd.none, state)
-      }
-    TabClosed(path) =>
-      if tab_index(state, path) is Some(index) {
-        let tabs = state.tabs.filter(tab => tab.path != path)
-        if state.active == Some(path) {
-          // The right neighbor inherits the screen; at the strip's end, the
-          // left one. The closed tab's parked scroll is forgotten after the
-          // neighbor's show re-parks the outgoing (closed) document.
-          let next = match tabs.get(index) {
-            Some(tab) => Some(tab)
-            None => if index > 0 { tabs.get(index - 1) } else { None }
-          }
-          match next {
-            Some(tab) =>
-              (
-                @cmd.batch([
-                  show_tab(dispatch, ctx, tab),
-                  forget_view_state(path),
-                ]),
-                { ..state, tabs, active: Some(tab.path) },
-              )
-            // The last tab: fall back to the placeholder and force the tree
-            // open so the panel is never a dead pane. Losing the active tab
-            // also hides the breadcrumb row, so the viewer must remeasure.
-            None =>
-              (
-                @cmd.batch([
-                  clear_document(),
-                  forget_view_state(path),
-                  request_viewer_remeasure(),
-                ]),
-                { ..state, tabs, active: None, tree_open: true },
-              )
-          }
-        } else {
-          (forget_view_state(path), { ..state, tabs, })
-        }
-      } else {
-        (@cmd.none, state)
-      }
     RevealDirectory(path) =>
       if path.is_root() {
         (@cmd.none, { ..state, tree_open: true, highlighted: None })
@@ -651,12 +645,10 @@ pub fn update(
           if entry.is_dir {
             update(dispatch, DirToggle(entry.path), state, ctx)
           } else {
-            update(
-              dispatch,
-              FileSelected(path=entry.path, name=entry.name),
-              state,
-              ctx,
-            )
+            // Opening a file is the dock strip's business: re-dispatch the
+            // same message a tree click produces, which the root update
+            // intercepts (see `FileSelected`).
+            (dispatch(FileSelected(path=entry.path, name=entry.name)), state)
           }
         None => (@cmd.none, state)
       }
@@ -664,7 +656,7 @@ pub fn update(
     TreeKeyDismiss =>
       if !state.filter.trim().is_empty() {
         (@cmd.none, { ..state, filter: "", cursor: None })
-      } else if state.active is Some(_) {
+      } else if ctx.active_file is Some(_) {
         // Close the panel like ToggleTree; with no file open the tree is
         // unconditional (see panel_view), so there is nothing to close into.
         (request_viewer_remeasure(), { ..state, tree_open: false })
@@ -724,36 +716,37 @@ pub fn update(
       } else {
         (@cmd.none, { ..state, index: IndexEmpty })
       }
-    FileSelected(path~, name~) =>
-      open_or_activate(dispatch, state, ctx, path, name, range=None)
-    OpenNavigationLocation(owner~, path~, range~) =>
-      if state.owner == Some(owner) && ctx.owner == owner {
-        open_file(dispatch, state, ctx, path, range=Some(range))
-      } else {
-        (@cmd.none, state)
-      }
+    // Owned by the main package's update: which dock tab a tree click opens
+    // is the strip's business, so the root intercepts this (the
+    // `EditorCommentAdded` pattern), opens/activates the dock tab, and calls
+    // `open_document`. Reaching this arm means the root didn't intercept it;
+    // changing nothing is the safe answer.
+    FileSelected(..) => (@cmd.none, state)
+    // Intercepted by the root for the same reason: a navigation jump opens
+    // a dock tab before the document loads.
+    OpenNavigationLocation(..) => (@cmd.none, state)
     FileLoaded(owner~, path~, name~, file~, range~, annotation~) =>
       // A stale read — the conversation switched, or the tab was closed
       // while the read was in flight — must not resurrect state.
       if state.owner != Some(owner) {
         (@cmd.none, state)
-      } else if tab_index(state, path) is Some(index) {
-        let previous = state.tabs[index].state
-        let tab_state = match file {
+      } else if state.docs.get(path) is Some(doc) {
+        let previous = doc.state
+        let doc_state = match file {
           Content(content~, absolute~, sig~) =>
             TabState::TabLoaded(content~, absolute~, sig~)
           Binary => TabBinary
           Oversized => TabOversized
         }
-        let tabs = state.tabs.copy()
-        tabs[index] = { ..tabs[index], name, state: tab_state, stale: false }
+        let docs = state.docs.copy()
+        docs[path] = { name, state: doc_state, stale: false }
         // Only the tab on screen touches the viewer; a background load just
         // settles into its tab for the next activation. No content
         // comparison happens here: whether anything actually needs redrawing
         // is the show command's call, made against what the viewer really
         // displays (see `show_file_in_viewer`) — this side would only be
         // guessing from the tab cache.
-        let cmd = if state.active == Some(path) {
+        let cmd = if ctx.active_file == Some(path) {
           match file {
             // A real MoonBit file also gets a diagnostics request: the host
             // runs `moon check` over the file's module and returns its
@@ -791,13 +784,13 @@ pub fn update(
         } else {
           @cmd.none
         }
-        (cmd, { ..state, tabs, })
+        (cmd, { ..state, docs, })
       } else {
         (@cmd.none, state)
       }
     RunSettled(owner~) =>
       if state.owner == Some(owner) &&
-        active_moonbit_diagnostics(dispatch, owner, state.tabs, state.active)
+        active_moonbit_diagnostics(dispatch, owner, state.docs, ctx.active_file)
         is Some(recheck) {
         (recheck, state)
       } else {
@@ -807,8 +800,9 @@ pub fn update(
       if state.owner is Some(owner) &&
         (session is None || session == Some(owner.session)) {
         // A baseline checks the whole selection after watcher replacement.
-        // Concrete batches stat only affected tabs and re-list only directories
-        // whose immediate children changed.
+        // Concrete batches stat only affected open files (the dock strip's
+        // projection) and re-list only directories whose immediate children
+        // changed.
         let cmds = []
         let stat_paths : Array[@pathx.Relative] = []
         let relist : Array[@pathx.Relative] = []
@@ -819,9 +813,9 @@ pub fn update(
             if change.moonbit_relevant() {
               moonbit_changed = true
             }
-            for tab in state.tabs {
-              if change.touches(tab.path) && !stat_paths.contains(tab.path) {
-                stat_paths.push(tab.path)
+            for path in ctx.open_files {
+              if change.touches(path) && !stat_paths.contains(path) {
+                stat_paths.push(path)
               }
             }
             for directory in change.relist_candidates() {
@@ -837,8 +831,8 @@ pub fn update(
             }
           }
         } else {
-          for tab in state.tabs {
-            stat_paths.push(tab.path)
+          for path in ctx.open_files {
+            stat_paths.push(path)
           }
           if state.children.contains("") && !state.loading.contains("") {
             relist.push(@pathx.Relative::root())
@@ -856,7 +850,12 @@ pub fn update(
             stat_files(dispatch, owner, stat_paths, workspace=ctx.workspace),
           )
         } else if moonbit_changed &&
-          active_moonbit_diagnostics(dispatch, owner, state.tabs, state.active)
+          active_moonbit_diagnostics(
+            dispatch,
+            owner,
+            state.docs,
+            ctx.active_file,
+          )
           is Some(recheck) {
           // A MoonBit change that touched no open tab still moves the
           // module's diagnostics (a sibling file's edit can break or fix the
@@ -884,30 +883,27 @@ pub fn update(
       if state.owner != Some(owner) {
         (@cmd.none, state)
       } else {
-        let tabs = state.tabs.copy()
+        let docs = state.docs.copy()
         let cmds = []
         // Whether the loop below already reloads the active tab — that path
         // re-requests diagnostics on its own.
         let mut active_reloading = false
         for stat in stats {
-          guard tabs.search_by(tab => tab.path == stat.path) is Some(index) else {
-            continue
-          }
-          let tab = tabs[index]
+          guard docs.get(stat.path) is Some(doc) else { continue }
           guard stat.sig is Some(current_sig) else {
             // The file is gone. The tab stays as the user's bookmark; the
             // notice replaces the document if it is the one on screen.
-            if !(tab.state is TabDeleted) {
-              tabs[index] = { ..tab, state: TabDeleted, stale: false }
-              // The notice overlay renders from the tab's new state; the
-              // viewer only needs its stale document dropped.
-              if state.active == Some(tab.path) {
+            if !(doc.state is TabDeleted) {
+              docs[stat.path] = { ..doc, state: TabDeleted, stale: false }
+              // The notice overlay renders from the document's new state;
+              // the viewer only needs its stale document dropped.
+              if ctx.active_file == Some(stat.path) {
                 cmds.push(clear_document())
               }
             }
             continue
           }
-          let changed = match tab.state {
+          let changed = match doc.state {
             // The loaded baseline says whether the disk moved on.
             TabLoaded(sig~, ..) => sig != current_sig
             // A deleted file whose signature came back: it reappeared.
@@ -915,31 +911,31 @@ pub fn update(
             // A read is already in flight; its reply carries a fresh
             // signature anyway.
             TabLoading => false
-            // Withheld tabs carry no baseline to compare against (see
+            // Withheld documents carry no baseline to compare against (see
             // `TabState`); they refresh on explicit re-open instead.
             TabBinary | TabOversized => false
           }
           if changed {
-            if state.active == Some(tab.path) {
+            if ctx.active_file == Some(stat.path) {
               // The document on screen reloads eagerly (scroll kept —
-              // `FileLoaded` sees the previous content). The tab keeps its
-              // loaded state so that restore has its baseline.
+              // `FileLoaded` sees the previous content). The document keeps
+              // its loaded state so that restore has its baseline.
               active_reloading = true
               cmds.push(
                 read_file(
                   dispatch,
                   owner,
-                  tab.path,
-                  tab.name,
+                  stat.path,
+                  doc.name,
                   range=None,
                   workspace=ctx.workspace,
                 ),
               )
             } else {
-              // Background tabs just remember they are behind; activation
-              // reloads them. A build storm therefore costs one read, not
-              // one per open tab.
-              tabs[index] = { ..tab, stale: true }
+              // Background documents just remember they are behind;
+              // activation reloads them. A build storm therefore costs one
+              // read, not one per open tab.
+              docs[stat.path] = { ..doc, stale: true }
             }
           }
         }
@@ -948,14 +944,14 @@ pub fn update(
         // `moon check` behind `lsp_open` only runs when asked, unlike the
         // resident server it replaced. One re-check per (debounced) change
         // burst covers that: the reload above brings its own request, so
-        // only an active tab the stats left untouched needs the explicit
+        // only an active file the stats left untouched needs the explicit
         // refresh. Its check's pushes update the other open tabs too.
         if !active_reloading &&
-          active_moonbit_diagnostics(dispatch, owner, tabs, state.active)
+          active_moonbit_diagnostics(dispatch, owner, docs, ctx.active_file)
           is Some(recheck) {
           cmds.push(recheck)
         }
-        (@cmd.batch(cmds), { ..state, tabs, })
+        (@cmd.batch(cmds), { ..state, docs, })
       }
     DiagnosticsLoaded(owner~, absolute~, diagnostics~) =>
       if state.owner == Some(owner) {
@@ -989,9 +985,10 @@ pub fn update(
   }
 }
 
-// State-transition tests for the tab strip: opening, activating, closing,
-// and how a conversation switch parks and restores a tab set. Commands are
-// opaque, so the tests assert on the returned state only.
+// State-transition tests for the document table: opening documents, how
+// replies settle into the table, disk-change sweeps, and how a conversation
+// switch re-roots the table from the dock's projection. Commands are opaque,
+// so the tests assert on the returned state only.
 
 ///|
 fn test_emit() -> @cmd.Emit[Msg] {
@@ -1006,212 +1003,174 @@ fn test_ctx() -> Ctx {
     dark_mode: false,
     tree_layout: BottomPanel,
     narrow: false,
+    panel_open: true,
+    open_files: [],
+    active_file: None,
   }
 }
 
 ///|
-fn open_state() -> State {
-  { ..State::empty(), open: true, owner: Some(test_ctx().owner) }
+fn owned_state() -> State {
+  { ..State::empty(), owner: Some(test_ctx().owner) }
 }
 
 ///|
-fn loaded_tab(path : String, name : String) -> Tab {
+fn loaded_doc(path : String) -> Doc {
   {
-    path: Relative(path),
-    name,
+    name: basename(Relative(path)),
     state: TabLoaded(content="", absolute=Absolute("/work/" + path), sig="1:0"),
     stale: false,
   }
 }
 
 ///|
-test "FileSelected opens tabs in click order and activates the last" {
+test "open_document seeds a loading entry and re-open keeps cached content" {
   let emit = test_emit()
-  let (_, one) = update(
+  let (_, one) = open_document(
     emit,
-    FileSelected(path=Relative("a.mbt"), name="a.mbt"),
-    open_state(),
-    test_ctx(),
+    owned_state(),
+    {
+      ..test_ctx(),
+      open_files: [Relative("a.mbt")],
+      active_file: Some(Relative("a.mbt")),
+    },
+    Relative("a.mbt"),
+    name="a.mbt",
+    range=None,
+    had_active=false,
   )
-  let (_, two) = update(
+  assert_true(
+    one.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
+  )
+  // A plain re-open of a loaded document keeps the cached state — the show
+  // command redraws from the table, never waiting on a re-read's reply.
+  let docs = one.docs.copy()
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  let (_, again) = open_document(
     emit,
-    FileSelected(path=Relative("src/b.mbt"), name="b.mbt"),
-    one,
-    test_ctx(),
+    { ..one, docs, },
+    {
+      ..test_ctx(),
+      open_files: [Relative("a.mbt")],
+      active_file: Some(Relative("a.mbt")),
+    },
+    Relative("a.mbt"),
+    name="a.mbt",
+    range=None,
+    had_active=true,
   )
-  assert_eq(two.tabs.length(), 2)
-  assert_true(two.tabs[0].path == Relative("a.mbt"))
-  assert_true(two.tabs[1].path == Relative("src/b.mbt"))
-  assert_true(two.active is Some(Relative("src/b.mbt")))
-  // Re-selecting an open file refocuses its tab, never a duplicate.
-  let (_, again) = update(
-    emit,
-    FileSelected(path=Relative("a.mbt"), name="a.mbt"),
-    two,
-    test_ctx(),
+  assert_true(
+    again.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
   )
-  assert_eq(again.tabs.length(), 2)
-  assert_true(again.active is Some(Relative("a.mbt")))
 }
 
 ///|
-test "narrow ctx: opening or activating a file closes the tree pane" {
+test "narrow ctx: opening or activating a document closes the tree pane" {
   let emit = test_emit()
-  let narrow : Ctx = { ..test_ctx(), narrow: true }
-  let start = { ..open_state(), tree_open: true }
+  let narrow : Ctx = {
+    ..test_ctx(),
+    narrow: true,
+    open_files: [Relative("a.mbt")],
+    active_file: Some(Relative("a.mbt")),
+  }
+  let start = { ..owned_state(), tree_open: true }
   // A fresh open drills down into the viewer.
-  let (_, opened) = update(
+  let (_, opened) = open_document(
     emit,
-    FileSelected(path=Relative("a.mbt"), name="a.mbt"),
     start,
     narrow,
+    Relative("a.mbt"),
+    name="a.mbt",
+    range=None,
+    had_active=false,
   )
   assert_false(opened.tree_open)
-  // Back to the tree (the breadcrumb toggle), then activating an open tab
-  // drills down again.
+  // Back to the tree, then activating an open document drills down again.
   let (_, tree) = update(emit, ToggleTree, opened, narrow)
   assert_true(tree.tree_open)
-  let (_, activated) = update(
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  let (_, activated) = activate(
     emit,
-    FileSelected(path=Relative("a.mbt"), name="a.mbt"),
-    { ..tree, tabs: [loaded_tab("a.mbt", "a.mbt")], active: None },
+    { ..tree, docs, },
     narrow,
+    Relative("a.mbt"),
   )
   assert_false(activated.tree_open)
   // The wide layout keeps the pane open alongside the viewer.
-  let (_, wide) = update(
+  let (_, wide) = open_document(
     emit,
-    FileSelected(path=Relative("b.mbt"), name="b.mbt"),
     start,
-    test_ctx(),
+    {
+      ..test_ctx(),
+      open_files: [Relative("b.mbt")],
+      active_file: Some(Relative("b.mbt")),
+    },
+    Relative("b.mbt"),
+    name="b.mbt",
+    range=None,
+    had_active=false,
   )
   assert_true(wide.tree_open)
 }
 
 ///|
-/// The bug this guards against: re-selecting an already-loaded file from the
-/// tree used to only issue a re-read and leave the document switch to the
-/// `FileLoaded` reply — whose identical-content dedup then skipped the
-/// redraw, leaving the previous tab's document on screen. A plain tree click
-/// on an open tab now shows the cached content directly (like a tab-strip
-/// click), so the tab must keep its loaded state rather than dropping back
-/// to `TabLoading` for a read.
-test "re-selecting a loaded file switches to its cached content" {
+test "activate without a document entry is a no-op" {
   let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [loaded_tab("a.mbt", "a.mbt"), loaded_tab("b.mbt", "b.mbt")],
-    active: Some(Relative("b.mbt")),
-  }
-  let (_, next) = update(
+  let (_, same) = activate(
     emit,
-    FileSelected(path=Relative("a.mbt"), name="a.mbt"),
+    owned_state(),
+    test_ctx(),
+    Relative("gone.mbt"),
+  )
+  assert_true(same == owned_state())
+}
+
+///|
+test "close_document drops the entry and forces the tree open on the last one" {
+  let emit = test_emit()
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  docs[Relative("b.mbt")] = loaded_doc("b.mbt")
+  let state = { ..owned_state(), docs, tree_open: false }
+  // Closing the active document with a neighbor left: the entry goes, the
+  // tree stays as it was.
+  let (_, one) = close_document(
+    emit,
     state,
     test_ctx(),
+    Relative("a.mbt"),
+    next=Some(Relative("b.mbt")),
+    was_active=true,
   )
-  assert_true(next.active is Some(Relative("a.mbt")))
-  assert_true(next.tabs[0].state is TabLoaded(..))
-  assert_eq(next.tabs.length(), 2)
-}
-
-///|
-test "TabActivated switches only to an existing tab" {
-  let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [loaded_tab("a.mbt", "a.mbt"), loaded_tab("b.mbt", "b.mbt")],
-    active: Some(Relative("a.mbt")),
-  }
-  let (_, next) = update(
+  assert_false(one.docs.contains(Relative("a.mbt")))
+  assert_true(one.docs.contains(Relative("b.mbt")))
+  assert_false(one.tree_open)
+  // Closing the last document: the viewer falls back to the placeholder and
+  // the tree is forced open so the panel is never a dead pane.
+  let (_, last) = close_document(
     emit,
-    TabActivated(Relative("b.mbt")),
-    state,
+    one,
     test_ctx(),
+    Relative("b.mbt"),
+    next=None,
+    was_active=true,
   )
-  assert_true(next.active is Some(Relative("b.mbt")))
-  // An unknown path (a stale click racing a close) changes nothing.
-  let (_, stray) = update(
-    emit,
-    TabActivated(Relative("gone.mbt")),
-    next,
-    test_ctx(),
-  )
-  assert_true(stray.active is Some(Relative("b.mbt")))
-  // Re-activating the active tab is idempotent.
-  let (_, same) = update(
-    emit,
-    TabActivated(Relative("b.mbt")),
-    stray,
-    test_ctx(),
-  )
-  assert_true(same.active is Some(Relative("b.mbt")))
-  assert_eq(same.tabs.length(), 2)
+  assert_true(last.docs.is_empty())
+  assert_true(last.tree_open)
 }
 
 ///|
-test "closing the active tab activates the right neighbor, else the left" {
+test "FileLoaded settles content into its document, active or not" {
   let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [
-      loaded_tab("a.mbt", "a.mbt"),
-      loaded_tab("b.mbt", "b.mbt"),
-      loaded_tab("c.mbt", "c.mbt"),
-    ],
-    active: Some(Relative("b.mbt")),
-  }
-  // Middle tab closed: the right neighbor inherits the screen.
-  let (_, next) = update(emit, TabClosed(Relative("b.mbt")), state, test_ctx())
-  assert_eq(next.tabs.length(), 2)
-  assert_true(next.active is Some(Relative("c.mbt")))
-  // Rightmost tab closed: the left neighbor inherits.
-  let (_, next) = update(emit, TabClosed(Relative("c.mbt")), next, test_ctx())
-  assert_true(next.active is Some(Relative("a.mbt")))
-}
-
-///|
-test "closing a background tab keeps the active one" {
-  let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [loaded_tab("a.mbt", "a.mbt"), loaded_tab("b.mbt", "b.mbt")],
-    active: Some(Relative("b.mbt")),
-  }
-  let (_, next) = update(emit, TabClosed(Relative("a.mbt")), state, test_ctx())
-  assert_eq(next.tabs.length(), 1)
-  assert_true(next.active is Some(Relative("b.mbt")))
-}
-
-///|
-test "closing the last tab clears the viewer and forces the tree open" {
-  let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tree_open: false,
-    tabs: [loaded_tab("a.mbt", "a.mbt")],
-    active: Some(Relative("a.mbt")),
-  }
-  let (_, next) = update(emit, TabClosed(Relative("a.mbt")), state, test_ctx())
-  assert_eq(next.tabs.length(), 0)
-  assert_true(next.active is None)
-  assert_true(next.tree_open)
-}
-
-///|
-test "FileLoaded settles content into its tab, active or not" {
-  let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [
-      {
-        path: Relative("a.mbt"),
-        name: "a.mbt",
-        state: TabLoading,
-        stale: false,
-      },
-      loaded_tab("b.mbt", "b.mbt"),
-    ],
-    active: Some(Relative("b.mbt")),
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = { name: "a.mbt", state: TabLoading, stale: false }
+  docs[Relative("b.mbt")] = loaded_doc("b.mbt")
+  let state = { ..owned_state(), docs, }
+  let ctx = {
+    ..test_ctx(),
+    open_files: [Relative("a.mbt"), Relative("b.mbt")],
+    active_file: Some(Relative("b.mbt")),
   }
   let (_, next) = update(
     emit,
@@ -1228,11 +1187,13 @@ test "FileLoaded settles content into its tab, active or not" {
       annotation=None,
     ),
     state,
-    test_ctx(),
+    ctx,
   )
-  assert_true(next.tabs[0].state is TabLoaded(content="fn main {}", ..))
-  assert_true(next.active is Some(Relative("b.mbt")))
-  // A reply for a closed tab (or another conversation) is dropped.
+  assert_true(
+    next.docs.get(Relative("a.mbt"))
+    is Some({ state: TabLoaded(content="fn main {}", ..), .. }),
+  )
+  // A reply for a closed document (or another conversation) is dropped.
   let (_, stray) = update(
     emit,
     FileLoaded(
@@ -1244,9 +1205,9 @@ test "FileLoaded settles content into its tab, active or not" {
       annotation=None,
     ),
     next,
-    test_ctx(),
+    ctx,
   )
-  assert_eq(stray.tabs.length(), 2)
+  assert_true(stray.docs.length() == 2)
   let (_, other) = update(
     emit,
     FileLoaded(
@@ -1261,79 +1222,89 @@ test "FileLoaded settles content into its tab, active or not" {
       annotation=None,
     ),
     stray,
-    test_ctx(),
+    ctx,
   )
-  assert_true(other.tabs[0].state is TabLoaded(..))
+  assert_true(
+    other.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
+  )
 }
 
 ///|
-test "sync parks the outgoing conversation's tabs and restores them later" {
+test "sync re-roots the document table from the dock's projection" {
   let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [loaded_tab("a.mbt", "a.mbt"), loaded_tab("b.mbt", "b.mbt")],
-    active: Some(Relative("a.mbt")),
-    tree_open: false,
-  }
-  // Switch away: the tab set parks under its full conversation identity.
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("old.mbt")] = loaded_doc("old.mbt")
+  let state = { ..owned_state(), docs, tree_open: false }
+  // Switch conversations: the dock restored a two-file strip for the new
+  // one; the table re-seeds from it, identities only.
   let other : Ctx = {
     ..test_ctx(),
     owner: {
       channel: @interop.ChannelId::Remote("other"),
       session: "desktop-test",
     },
+    open_files: [Relative("a.mbt"), Relative("b.mbt")],
+    active_file: Some(Relative("a.mbt")),
   }
-  let (parked, _) = sync(emit, state, other)
-  assert_true(parked.owner is Some({ channel: Remote("other"), .. }))
-  assert_eq(parked.tabs.length(), 0)
-  assert_true(parked.remembered.contains(test_ctx().owner))
+  let (rerooted, _) = sync(emit, state, other)
+  assert_true(rerooted.owner is Some({ channel: Remote("other"), .. }))
+  assert_false(rerooted.docs.contains(Relative("old.mbt")))
+  assert_true(
+    rerooted.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
+  )
+  assert_true(
+    rerooted.docs.get(Relative("b.mbt")) is Some({ state: TabLoading, .. }),
+  )
   // The pane-visibility preference follows the panel, not the conversation.
-  assert_false(parked.tree_open)
-  // Switch back: identities return, contents reload lazily (the tabs are
-  // TabLoading until read replies land).
-  let (restored, _) = sync(emit, parked, test_ctx())
-  assert_eq(restored.tabs.length(), 2)
-  assert_true(restored.tabs[0].path == Relative("a.mbt"))
-  assert_true(restored.tabs[0].state is TabLoading)
-  assert_true(restored.active is Some(Relative("a.mbt")))
+  assert_false(rerooted.tree_open)
 }
 
 ///|
-/// The bug this guards against: with the panel closed but tabs remaining,
-/// switching conversations used to skip the re-root while `with_watch`
+/// The bug this guards against: with the panel closed but files remaining
+/// open, switching conversations used to skip the re-root while the watcher
 /// followed the new session — the next fs_changed then stat'ed the old
-/// conversation's paths against the new workspace, marking hidden tabs
+/// conversation's paths against the new workspace, marking hidden documents
 /// deleted or stale for files that never moved.
 test "a closed panel still re-roots when the conversation switches" {
   let emit = test_emit()
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
   let state = {
-    ..open_state(),
-    open: false,
-    watching: open_state().watched_paths(test_ctx()),
-    tabs: [loaded_tab("a.mbt", "a.mbt")],
-    active: Some(Relative("a.mbt")),
+    ..owned_state(),
+    docs,
+    watching: Some({
+      owner: test_ctx().owner,
+      workspace: None,
+      files: [Relative("a.mbt")],
+      directories: [],
+    }),
   }
+  // The new conversation has nothing open and the panel is closed.
   let other : Ctx = {
     ..test_ctx(),
     owner: {
       channel: @interop.ChannelId::Remote("other"),
       session: "desktop-test",
     },
+    panel_open: false,
   }
   let (parked, _) = sync(emit, state, other)
   assert_true(parked.owner is Some({ channel: Remote("other"), .. }))
-  assert_false(parked.open)
-  assert_eq(parked.tabs.length(), 0)
-  assert_true(parked.remembered.contains(test_ctx().owner))
+  assert_true(parked.docs.is_empty())
   // Nothing left to track in the new conversation, so the watcher parks.
   assert_true(parked.watching is None)
-  // Switching back restores the identities — still hidden, not read yet —
-  // and the watcher follows the tabs again.
-  let (restored, _) = sync(emit, parked, test_ctx())
-  assert_false(restored.open)
-  assert_eq(restored.tabs.length(), 1)
-  assert_true(restored.tabs[0].state is TabLoading)
-  assert_true(restored.active is Some(Relative("a.mbt")))
+  // Switching back (still closed) re-seeds the table and the watcher
+  // follows the open files again.
+  let back : Ctx = {
+    ..test_ctx(),
+    panel_open: false,
+    open_files: [Relative("a.mbt")],
+    active_file: Some(Relative("a.mbt")),
+  }
+  let (restored, _) = sync(emit, parked, back)
+  assert_true(
+    restored.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
+  )
   assert_true(
     restored.watching
     is Some(
@@ -1345,16 +1316,12 @@ test "a closed panel still re-roots when the conversation switches" {
       }
     ),
   )
-  // Reopening is what reads the restored active tab (the command is opaque;
-  // the tab stays TabLoading until the reply lands).
-  let (_, reopened) = update(emit, ToggleFilePanel, restored, test_ctx())
-  assert_true(reopened.open)
 }
 
 ///|
 test "ToggleTree flips the pane and RevealDirectory forces it open" {
   let emit = test_emit()
-  let (_, closed) = update(emit, ToggleTree, open_state(), test_ctx())
+  let (_, closed) = update(emit, ToggleTree, owned_state(), test_ctx())
   assert_false(closed.tree_open)
   let (_, revealed) = update(
     emit,
@@ -1369,44 +1336,54 @@ test "ToggleTree flips the pane and RevealDirectory forces it open" {
 ///|
 test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [
-      loaded_tab("a.mbt", "a.mbt"),
-      loaded_tab("b.mbt", "b.mbt"),
-      loaded_tab("c.mbt", "c.mbt"),
-    ],
-    active: Some(Relative("a.mbt")),
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  docs[Relative("b.mbt")] = loaded_doc("b.mbt")
+  docs[Relative("c.mbt")] = loaded_doc("c.mbt")
+  let state = { ..owned_state(), docs, }
+  let ctx = {
+    ..test_ctx(),
+    open_files: [Relative("a.mbt"), Relative("b.mbt"), Relative("c.mbt")],
+    active_file: Some(Relative("a.mbt")),
   }
   let (_, next) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, stats=[
-      // The active file changed: reloaded eagerly, so its tab stays loaded
-      // (the baseline the scroll-keeping reload compares against).
+      // The active file changed: reloaded eagerly, so its document stays
+      // loaded (the baseline the scroll-keeping reload compares against).
       { path: Relative("a.mbt"), sig: Some("9:0") },
       // A background file changed: only marked stale.
       { path: Relative("b.mbt"), sig: Some("9:0") },
-      // Deleted: the tab flips to the deleted notice state.
+      // Deleted: the document flips to the deleted notice state.
       { path: Relative("c.mbt"), sig: None },
     ]),
     state,
-    test_ctx(),
+    ctx,
   )
-  assert_true(next.tabs[0].state is TabLoaded(..))
-  assert_false(next.tabs[0].stale)
-  assert_true(next.tabs[1].stale)
-  assert_true(next.tabs[2].state is TabDeleted)
-  // An unchanged signature is a no-op.
+  assert_true(
+    next.docs.get(Relative("a.mbt"))
+    is Some({ state: TabLoaded(..), stale: false, .. }),
+  )
+  assert_true(next.docs.get(Relative("b.mbt")) is Some({ stale: true, .. }))
+  assert_true(
+    next.docs.get(Relative("c.mbt")) is Some({ state: TabDeleted, .. }),
+  )
+  // An unchanged signature on a background file still compares against the
+  // loaded baseline.
+  let solo : Map[@pathx.Relative, Doc] = Map([])
+  solo[Relative("b.mbt")] = loaded_doc("b.mbt")
   let (_, same) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, stats=[
       { path: Relative("b.mbt"), sig: Some("9:0") },
     ]),
-    { ..next, tabs: [loaded_tab("b.mbt", "b.mbt")], active: None },
-    test_ctx(),
+    { ..next, docs: solo },
+    { ..ctx, active_file: None },
   )
-  assert_true(same.tabs[0].state is TabLoaded(sig="1:0", ..))
-  assert_true(same.tabs[0].stale) // "9:0" != baseline "1:0" -> stale
+  assert_true(
+    same.docs.get(Relative("b.mbt"))
+    is Some({ state: TabLoaded(sig="1:0", ..), stale: true, .. }),
+  )
   // A reply from another conversation is dropped.
   let (_, other) = update(
     emit,
@@ -1418,37 +1395,32 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
       stats=[{ path: Relative("a.mbt"), sig: None }],
     ),
     state,
-    test_ctx(),
+    ctx,
   )
-  assert_true(other.tabs[0].state is TabLoaded(..))
+  assert_true(
+    other.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
+  )
 }
 
 ///|
-test "a deleted tab whose file reappears reloads on the next stats" {
+test "a deleted document whose file reappears reloads on the next stats" {
   let emit = test_emit()
-  let state = {
-    ..open_state(),
-    tabs: [
-      {
-        path: Relative("a.mbt"),
-        name: "a.mbt",
-        state: TabDeleted,
-        stale: false,
-      },
-    ],
-    active: None,
-  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = { name: "a.mbt", state: TabDeleted, stale: false }
+  let state = { ..owned_state(), docs, }
   let (_, next) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, stats=[
       { path: Relative("a.mbt"), sig: Some("3:0") },
     ]),
     state,
-    test_ctx(),
+    { ..test_ctx(), open_files: [Relative("a.mbt")] },
   )
   // Background reappearance: stale, reloaded on activation.
-  assert_true(next.tabs[0].state is TabDeleted)
-  assert_true(next.tabs[0].stale)
+  assert_true(
+    next.docs.get(Relative("a.mbt"))
+    is Some({ state: TabDeleted, stale: true, .. }),
+  )
 }
 
 ///|
@@ -1458,7 +1430,7 @@ test "watcher baseline re-lists the root and expanded, listed directories" {
   children[Relative("")] = []
   children[Relative("src")] = []
   let state = {
-    ..open_state(),
+    ..owned_state(),
     children,
     expanded: [Relative("src"), Relative("never-listed")],
   }
@@ -1482,7 +1454,7 @@ test "concrete watcher events refresh only affected listed directories" {
   children[Relative("src")] = []
   children[Relative("docs")] = []
   let state = {
-    ..open_state(),
+    ..owned_state(),
     children,
     expanded: [Relative("src"), Relative("docs")],
   }
@@ -1524,12 +1496,12 @@ test "moonbit-relevant changes cover sources, interfaces, and manifests" {
 }
 
 ///|
-test "sync reconciles the watcher with the panel and its tabs" {
+test "sync reconciles the watcher with the panel and its open files" {
   let emit = test_emit()
   // Open panel: watch the active session.
   let (watched, _) = sync(
     emit,
-    { ..open_state(), watch_error: Some("old watcher failure") },
+    { ..owned_state(), watch_error: Some("old watcher failure") },
     test_ctx(),
   )
   assert_true(
@@ -1545,14 +1517,11 @@ test "sync reconciles the watcher with the panel and its tabs" {
   )
   // Issuing a new watch attempt retires the previous failure.
   assert_true(watched.watch_error is None)
-  // Opening a tab or expanding a directory replaces the same conversation's
+  // Opening a file or expanding a directory replaces the same conversation's
   // watcher with the new exact selection.
-  let selected = {
-    ..watched,
-    tabs: [loaded_tab("a.mbt", "a.mbt")],
-    expanded: [Relative("src")],
-  }
-  let (replaced, _) = sync(emit, selected, test_ctx())
+  let selected_ctx = { ..test_ctx(), open_files: [Relative("a.mbt")] }
+  let selected = { ..watched, expanded: [Relative("src")] }
+  let (replaced, _) = sync(emit, selected, selected_ctx)
   assert_true(
     replaced.watching
     is Some(
@@ -1563,15 +1532,19 @@ test "sync reconciles the watcher with the panel and its tabs" {
       }
     ),
   )
-  // Closed panel with tabs still open: keep watching (staleness tracking).
-  let closed = { ..replaced, open: false, children: Map([]), loading: [] }
-  let (still, _) = sync(emit, closed, test_ctx())
+  // Closed panel with files still open: keep watching (staleness tracking).
+  let still_ctx = {
+    ..test_ctx(),
+    panel_open: false,
+    open_files: [Relative("a.mbt")],
+  }
+  let closed = { ..replaced, children: Map([]), loading: [] }
+  let (still, _) = sync(emit, closed, still_ctx)
   assert_true(
     still.watching is Some({ files: [Relative("a.mbt")], directories: [], .. }),
   )
-  // Closed panel, no tabs: park the watcher.
-  let empty_panel = { ..still, tabs: [] }
-  let (parked, _) = sync(emit, empty_panel, test_ctx())
+  // Closed panel, nothing open: park the watcher.
+  let (parked, _) = sync(emit, still, { ..test_ctx(), panel_open: false })
   assert_true(parked.watching is None)
 }
 
@@ -1582,7 +1555,7 @@ test "watcher failures are visible only in their owning conversation" {
   let (_, failed) = update(
     emit,
     FileWatchFailed(owner~, message="File watching stopped"),
-    open_state(),
+    owned_state(),
     test_ctx(),
   )
   assert_true(failed.watch_error is Some("File watching stopped"))

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1,17 +1,12 @@
-// The editor part's views: the panel (tree-or-file pane hosting the embedded
-// viewer), its breadcrumb header, and the file-tree rows. Rendered by the
-// main package's `view` through `panel_view`, with dispatches pre-mapped to
-// this package's `Msg`.
+// The file subsystem's views: the viewer/tree body, the breadcrumb header,
+// and the file-tree rows. The dock package renders the panel's tab strip;
+// the root view assembles `div.editor` from the dock's parts and these, with
+// dispatches pre-mapped to this package's `Msg`.
 
 ///|
-/// The sidebar-right codicon for the panel toggle, from Microsoft's
+/// The folder codicon for the tree-pane toggle, from Microsoft's
 /// vscode-codicons (CC BY 4.0), embedded unmodified — mirrors the main
 /// package's icon set, which is not importable from here.
-let icon_layout_sidebar_right : String =
-  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M12.5 1C13.881 1 15 2.119 15 3.5V12.5C15 13.881 13.881 15 12.5 15H3.5C2.119 15 1 13.881 1 12.5V3.5C1 2.119 2.119 1 3.5 1H12.5ZM9 14V2H3.5C2.672 2 2 2.672 2 3.5V12.5C2 13.328 2.672 14 3.5 14H9Z"/></svg>
-
-///|
-/// The folder codicon for the tree-pane toggle (same provenance as above).
 let icon_folder : String =
   #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M2 4.5V6H5.58579C5.71839 6 5.84557 5.94732 5.93934 5.85355L7.29289 4.5L5.93934 3.14645C5.84557 3.05268 5.71839 3 5.58579 3H3.5C2.67157 3 2 3.67157 2 4.5ZM1 4.5C1 3.11929 2.11929 2 3.5 2H5.58579C5.98361 2 6.36514 2.15804 6.64645 2.43934L8.20711 4H12.5C13.8807 4 15 5.11929 15 6.5V11.5C15 12.8807 13.8807 14 12.5 14H3.5C2.11929 14 1 12.8807 1 11.5V4.5ZM2 7V11.5C2 12.3284 2.67157 13 3.5 13H12.5C13.3284 13 14 12.3284 14 11.5V6.5C14 5.67157 13.3284 5 12.5 5H8.20711L6.64645 6.56066C6.36514 6.84197 5.98361 7 5.58579 7H2Z"/></svg>
 
@@ -29,15 +24,49 @@ fn icon(markup : String) -> @html.Html {
 }
 
 ///|
-/// The editor part: a tab strip of open files over the embedded viewer, with
-/// the workspace tree (filterable, expandable, always rooted at the
-/// workspace root) as a toggleable pane on the viewer's right. The whole
-/// part is always rendered so the viewer's host element (`viewer-host`)
-/// stays put across renders and screen switches; CSS hides the tree pane
-/// when toggled off and collapses the whole pane to zero width when the
-/// panel is closed. The children's order is structural — rabbita diffs by
-/// index, so every part renders unconditionally.
-pub fn panel_view(
+/// The `div.editor` class list the root view wraps the panel's parts in:
+/// tree visibility and the Settings-chosen dock layout are both classes, not
+/// structure, so every state renders the same children in the same order and
+/// the viewer host is never re-keyed. With no file open the breadcrumb row
+/// hides (see `breadcrumb_view`) and takes the tree toggle with it, so the
+/// tree must show regardless of the toggle's state — the panel is otherwise
+/// a dead pane.
+pub fn editor_classes(state : State, ctx : Ctx) -> String {
+  let tree_visible = state.tree_open || ctx.active_file is None
+  let mut classes = "editor"
+  if tree_visible {
+    classes = classes + " tree-open"
+  }
+  if ctx.tree_layout is RightSidebar {
+    classes = classes + " tree-right"
+  }
+  classes
+}
+
+///|
+/// A grab strip on the editor's left edge for drag-to-resize. Absolutely
+/// positioned, so it is not a grid item and never disturbs the pane's
+/// children; its drag is wired imperatively (see editor_resize.mbt). Always
+/// rendered (CSS hides it while the panel is closed) so its position among
+/// the editor's children — and thus the never-re-keyed viewer host — stays
+/// stable.
+pub fn resize_handle_view() -> @html.Html {
+  @html.div(
+    attrs=@html.Attrs::build().id(ResizeHandleId).class("editor-resize-handle"),
+    ([] : Array[@html.Html]),
+  )
+}
+
+///|
+/// The viewer-plus-tree body under the strip and breadcrumb: the embedded
+/// viewer with its notice overlay, and the workspace tree (filterable,
+/// expandable, always rooted at the workspace root) as a toggleable pane on
+/// the viewer's right. Always rendered so the viewer's host element
+/// (`viewer-host`) stays put across renders and screen switches; CSS hides
+/// the tree pane when toggled off and collapses the whole panel to zero
+/// width when it is closed. The children's order is structural — rabbita
+/// diffs by index, so every part renders unconditionally.
+pub fn body_view(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
@@ -56,107 +85,28 @@ pub fn panel_view(
       .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
     ([] : Array[@html.Html]),
   )
-  // A grab strip on the editor's left edge for drag-to-resize. Absolutely
-  // positioned, so it is not a grid item and never disturbs the pane's
-  // children; its drag is wired imperatively (see editor_resize.mbt). Always
-  // rendered (CSS hides it while the panel is closed) so its position among
-  // the editor's children — and thus the never-re-keyed viewer host — stays
-  // stable.
-  let resize_handle = @html.div(
-    attrs=@html.Attrs::build().id(ResizeHandleId).class("editor-resize-handle"),
-    ([] : Array[@html.Html]),
-  )
-  // With no file open the breadcrumb row hides (see `viewer_breadcrumb`) and
-  // takes the tree toggle with it, so the tree must show regardless of the
-  // toggle's state — the panel is otherwise a dead pane.
-  let tree_visible = state.tree_open || state.active is None
-  // The dock layout is a class, not structure: both layouts render the same
-  // children in the same order (CSS flips the body's flex direction), so
-  // switching in Settings never re-keys the viewer host.
-  let mut classes = "editor"
-  if tree_visible {
-    classes = classes + " tree-open"
-  }
-  if ctx.tree_layout is RightSidebar {
-    classes = classes + " tree-right"
-  }
-  @html.div(class=classes, [
-    resize_handle,
-    tabs_bar(dispatch, state),
-    viewer_breadcrumb(dispatch, state),
-    @html.div(class="editor-body", [
-      @html.div(class="viewer-stack", [viewer_host, viewer_notice(state)]),
-      tree_pane(dispatch, state, ctx),
-    ]),
+  @html.div(class="editor-body", [
+    @html.div(class="viewer-stack", [viewer_host, viewer_notice(state, ctx)]),
+    tree_pane(dispatch, state, ctx),
   ])
 }
 
 ///|
-/// The editor's top bar, aligned with the topbar: the open-file tabs, with
-/// the whole-panel toggle riding the right edge (the topbar only shows the
-/// open toggle while the panel is closed). Always rendered so the editor's
-/// child order stays structural. Clicking a tab activates it; the `×`
-/// closes it without activating (the close click must not bubble into the
-/// tab's own handler).
-fn tabs_bar(dispatch : @cmd.Emit[Msg], state : State) -> @html.Html {
-  let tabs : Array[@html.Html] = []
-  for tab in state.tabs {
-    let mut classes = "editor-tab"
-    if state.active == Some(tab.path) {
-      classes = classes + " active"
-    }
-    if tab.state is TabDeleted {
-      classes = classes + " deleted"
-    }
-    tabs.push(
-      @html.div(
-        class=classes,
-        title=tab.path.0,
-        on_click=dispatch(TabActivated(tab.path)),
-        [
-          @html.span(class="tab-name", tab.name),
-          @html.button(
-            class="tab-close",
-            title="Close",
-            attrs=@html.Attrs::build().on_click(event => {
-              event.stop_propagation()
-              dispatch(TabClosed(tab.path))
-            }),
-            "×",
-          ),
-        ],
-      ),
-    )
-  }
-  @html.div(class="editor-tabsbar", [
-    @html.div(class="editor-tabs", tabs),
-    @html.button(
-      class="panel-toggle",
-      title="Hide panel",
-      on_click=dispatch(ToggleFilePanel),
-      icon(icon_layout_sidebar_right),
-    ),
-  ])
-}
-
-///|
-/// The notice covering the viewer while the active tab has no document to
+/// The notice covering the viewer while the active document has nothing to
 /// show — a deleted, binary, or oversized file. Plain panel chrome laid
 /// over the (cleared) viewer, so a notice never renders as a highlighted
 /// source document. Always in the DOM; blank and hidden otherwise.
-fn viewer_notice(state : State) -> @html.Html {
-  let text = match state.active {
+fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
+  let text = match ctx.active_file {
     Some(path) =>
-      match state.tabs.search_by(tab => tab.path == path) {
-        Some(index) => {
-          let tab = state.tabs[index]
-          match tab.state {
-            TabDeleted => "\{tab.name} was deleted on disk."
-            TabBinary => "\{tab.name} is a binary file and cannot be previewed."
-            TabOversized => "\{tab.name} is too large to preview."
+      match state.docs.get(path) {
+        Some(doc) =>
+          match doc.state {
+            TabDeleted => "\{doc.name} was deleted on disk."
+            TabBinary => "\{doc.name} is a binary file and cannot be previewed."
+            TabOversized => "\{doc.name} is too large to preview."
             TabLoading | TabLoaded(..) => ""
           }
-        }
         None => ""
       }
     None => ""
@@ -205,7 +155,7 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
     }
   } else {
     let rows = entries.map(pair => {
-      tree_row(dispatch, state, pair.0, pair.1, fuzzy~)
+      tree_row(dispatch, state, ctx, pair.0, pair.1, fuzzy~)
     })
     // Own up to a capped index: matches may simply be missing.
     if fuzzy is Some(_) && state.index is IndexReady(truncated=true, ..) {
@@ -340,7 +290,7 @@ fn crumb_link(
 }
 
 ///|
-/// The breadcrumb row under the tab bar: the active tab's path as
+/// The breadcrumb row under the tab bar: the active file's path as
 /// `dir › dir › file` (the file segment emphasized) behind a leading
 /// "Workspace" crumb. Every crumb but the last reveals that ancestor
 /// directory in the tree pane when clicked (opening the pane if needed).
@@ -348,9 +298,13 @@ fn crumb_link(
 /// bar's panel toggle. With no file open the whole row hides (via CSS — it
 /// stays in the DOM so the editor's child order, and thus the viewer host,
 /// is never re-keyed) and the tree shows unconditionally in its place.
-fn viewer_breadcrumb(dispatch : @cmd.Emit[Msg], state : State) -> @html.Html {
+pub fn breadcrumb_view(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
   let crumbs : Array[@html.Html] = []
-  match state.active {
+  match ctx.active_file {
     Some(path) => {
       crumbs.push(crumb_link(dispatch, "Workspace", @pathx.Relative::root()))
       let segments = path_segments(path)
@@ -368,7 +322,7 @@ fn viewer_breadcrumb(dispatch : @cmd.Emit[Msg], state : State) -> @html.Html {
     None => crumbs.push(@html.span(class="crumb crumb-file", "Workspace"))
   }
   @html.div(
-    class=if state.active is None {
+    class=if ctx.active_file is None {
       "viewer-breadcrumb hidden"
     } else {
       "viewer-breadcrumb"
@@ -395,6 +349,7 @@ fn viewer_breadcrumb(dispatch : @cmd.Emit[Msg], state : State) -> @html.Html {
 fn tree_row(
   dispatch : @cmd.Emit[Msg],
   state : State,
+  ctx : Ctx,
   entry : FileEntry,
   depth : Int,
   fuzzy~ : @fuzzy_match.Query?,
@@ -446,7 +401,7 @@ fn tree_row(
       None => @html.span(class="tree-name", entry.name)
     }
     @html.div(
-      class=(if state.active == Some(entry.path) {
+      class=(if ctx.active_file == Some(entry.path) {
           "tree-row tree-file selected"
         } else {
           "tree-row tree-file"

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -79,11 +79,12 @@ extern "js" fn js_ordered_method_promise(
   #| })()
 
 ///|
-/// Call one host method in the page's issue order. The file-panel watcher is
-/// the only current user: `watch(A)` followed by `unwatch` is desired state,
-/// not two independent queries, so Proton must not reorder their entry into
-/// the connection's actor. Remote requests use the same call site; their
-/// socket reader additionally preserves these two methods' wire order.
+/// Call one host method in the page's issue order, for callers whose
+/// requests are desired state rather than independent queries: the
+/// file-panel watcher (`watch(A)` then `unwatch`) and the browser view ops
+/// (create-then-place, bounds-before-visibility). Proton must not reorder
+/// their entry into the connection's actor. Remote requests use the same
+/// call site; their socket reader additionally preserves wire order.
 pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   channel : ChannelId,
   command : @commands.Command[Payload, Reply],

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -837,11 +837,25 @@ priv struct Model {
   // host, not a conversation or workspace, so this catalog is probed once
   // and kept while the frontend runs.
   launcher : Launcher
-  // The editor side-panel: the active conversation's file tree and the file
-  // shown in the embedded viewer. Rooted at `active().cwd`; rebuilt when the
-  // active conversation changes. Owned by the `fileeditor` package; this
-  // model only carries its state and routes `FileEditor` messages to it.
+  // The right panel's dock: the mixed tab strip's membership, order, active
+  // tab, and per-conversation parked strips. Owned by the `dock` package;
+  // the projection (open files, active file, panel visibility) feeds
+  // `file_ctx` every dispatch.
+  dock : @dock.State
+  // The file subsystem behind the dock's file tabs: the active
+  // conversation's file tree and the document table the embedded viewer
+  // shows from. Rooted at `active().cwd`; rebuilt when the active
+  // conversation changes. Owned by the `fileeditor` package; this model only
+  // carries its state and routes `FileEditor` messages to it.
   file_panel : @fileeditor.State
+  // The browser subsystem behind the dock's Browser tabs: per-page address
+  // state, keyed by page-global ids that only grow. The pages themselves
+  // are native web contents views the desktop host owns.
+  preview : @preview.State
+  // What the host has been told about the active page's native view: which
+  // view is visible, at which bounds, and the geometry signature the last
+  // measurement was requested for (see `sync_browser_view`).
+  browser_pane : BrowserPane
   // The integrated terminal. Each tab retains the device channel that owns
   // its PTY, so the desktop uses Local while a browser uses its relay-backed
   // Remote channel without session-id collisions between devices.
@@ -889,6 +903,32 @@ priv struct RemoteAccess {
 priv struct Launcher {
   open : Bool
   apps : LauncherApps
+} derive(Eq)
+
+///|
+/// The host-side presentation of the active Browser tab's native view, as
+/// last commanded: `shown`/`rect` echo the `browser.set_visible`/
+/// `browser.set_bounds` already sent, and `geo` is the model-geometry
+/// signature the last pane measurement was requested under — the damping
+/// that keeps the per-dispatch sync pass from measuring forever.
+priv struct BrowserPane {
+  shown : Int?
+  rect : @preview.Rect?
+  geo : BrowserGeometry?
+} derive(Eq)
+
+///|
+/// Every model-driven input of the browser pane's placement. When any of
+/// these change while a view should be on screen, the pane is re-measured;
+/// sizes that change without the model (window resize, the width drag) are
+/// caught by the pane element's ResizeObserver instead.
+priv struct BrowserGeometry {
+  // Which view should be visible (`desired_browser_view`), or none.
+  desired : Int?
+  sidebar_open : Bool
+  narrow : Bool
+  terminal_open : Bool
+  tree_layout : @fileeditor.TreeLayout
 } derive(Eq)
 
 ///|
@@ -1204,11 +1244,34 @@ priv enum Msg {
   LauncherFailed(String)
   // Launch one detected app (by its id) on the active conversation's workspace.
   LaunchApp(String)
-  // The editor side-panel's own messages (tree, viewer, diagnostics,
-  // comments), routed to the `fileeditor` package's update. The one
-  // exception is `EditorCommentAdded`, which this update intercepts: the
-  // comment becomes a chip on the composer draft, which only the app model
-  // knows about.
+  // The right panel's strip messages (panel toggle, tab activate/close),
+  // routed to the `dock` package's pure strip machine; this update then
+  // drives the content subsystems from the transition (see the `Dock` arm).
+  Dock(@dock.Msg)
+  // The browser subsystem's pure messages: address drafts and the host's
+  // `browser.event` view events, routed to the `preview` package.
+  Preview(@preview.Msg)
+  // The dock launcher's rows: open a blank Browser tab (with the address
+  // bar focused) or the transient FilePicker tab. Both close the `+` menu.
+  BrowserTabRequested
+  FilePickerRequested
+  // The browser toolbar, acting on whatever Browser tab is active — the
+  // messages carry no id so a stale click cannot outlive a tab switch.
+  BrowserAddressEdited(String)
+  BrowserNavigateSubmitted
+  BrowserBack
+  BrowserForward
+  BrowserReload
+  BrowserOpenExternal
+  // The browser pane's on-screen rectangle, reported after a render by the
+  // measurer or the pane's ResizeObserver; drives view bounds/visibility.
+  BrowserPaneMeasured(rect~ : @preview.Rect)
+  // The file subsystem's own messages (tree, viewer, diagnostics,
+  // comments), routed to the `fileeditor` package's update. Two exceptions
+  // this update intercepts: `EditorCommentAdded` (the comment becomes a chip
+  // on the composer draft, which only the app model knows about) and
+  // `FileSelected` (which dock tab a tree click opens is the strip's
+  // business).
   FileEditor(@fileeditor.Msg)
   // The integrated terminal panel's own messages, routed to the `terminal`
   // package's update.
@@ -1587,7 +1650,10 @@ fn initial_model() -> Model {
     symbol_search: None,
     symbol_search_generation: 0,
     launcher: { open: false, apps: AppsNotFetched },
+    dock: @dock.State::empty(),
     file_panel: @fileeditor.State::empty(),
+    preview: @preview.State::empty(),
+    browser_pane: { shown: None, rect: None, geo: None },
     terminal_panel: @terminal.State::empty(),
     notifications: [],
     notification_seq: 0,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -15,11 +15,13 @@ import {
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",
+  "openseek_desktop/frontend/dock",
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/terminal",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/markdown",
   "openseek_desktop/frontend/mention_context",
+  "openseek_desktop/frontend/preview",
   "openseek_desktop/frontend/transcript",
 }
 

--- a/desktop/frontend/preview/moon.pkg
+++ b/desktop/frontend/preview/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+}
+
+supported_targets = "js"

--- a/desktop/frontend/preview/pkg.generated.mbti
+++ b/desktop/frontend/preview/pkg.generated.mbti
@@ -1,0 +1,79 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/preview"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+}
+
+// Values
+pub const AddressInputId : String = "browser-address-input"
+
+pub fn close_page(State, Int) -> State
+
+pub fn failure_view(PageState) -> @html.Html
+
+pub fn host_of(String) -> String?
+
+pub fn is_loopback(String) -> Bool
+
+pub fn is_web_url(String) -> Bool
+
+pub fn navigate(State, Int, String) -> State
+
+pub fn normalize_url(String) -> String?
+
+pub fn open_page(State, url? : String) -> (State, Int)
+
+pub fn page(State, Int) -> PageState?
+
+pub fn page_label(PageState) -> String
+
+pub fn toolbar_view(PageState, ToolbarActions) -> @html.Html
+
+pub fn update(Msg, State) -> State
+
+// Errors
+
+// Types and methods
+pub(all) enum Msg {
+  InputChanged(id~ : Int, value~ : String)
+  Navigated(id~ : Int, url~ : String)
+  LoadingChanged(id~ : Int, loading~ : Bool)
+  TitleUpdated(id~ : Int, title~ : String)
+  LoadFailed(id~ : Int, url~ : String, text~ : String)
+}
+
+pub(all) struct PageState {
+  url : String?
+  input : String
+  title : String
+  loading : Bool
+  failure : String?
+} derive(Eq)
+
+pub(all) struct Rect {
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+} derive(Eq)
+
+pub(all) struct State {
+  pages : Map[Int, PageState]
+  next_id : Int
+} derive(Eq)
+pub fn State::empty() -> Self
+
+pub(all) struct ToolbarActions {
+  input : @cmd.Emit[String]
+  submit : @cmd.Cmd
+  back : @cmd.Cmd
+  forward : @cmd.Cmd
+  reload : @cmd.Cmd
+  open_external : @cmd.Cmd
+}
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/preview/preview_test.mbt
+++ b/desktop/frontend/preview/preview_test.mbt
@@ -1,0 +1,256 @@
+// State-transition and address-lexing tests for the browser subsystem. The
+// package is command-free — navigation side effects live in the root — so
+// every assertion is on returned state or parsed text.
+
+///|
+test "open_page allocates growing ids and blank tabs have no url" {
+  let (state, first) = @preview.open_page(@preview.State::empty())
+  let (state, second) = @preview.open_page(state, url="http://127.0.0.1:5173/")
+  assert_eq(first, 1)
+  assert_eq(second, 2)
+  let blank = @preview.page(state, first).unwrap()
+  assert_true(blank.url is None)
+  assert_eq(blank.input, "")
+  assert_false(blank.loading)
+  let routed = @preview.page(state, second).unwrap()
+  assert_true(routed.url == Some("http://127.0.0.1:5173/"))
+  assert_eq(routed.input, "http://127.0.0.1:5173/")
+  assert_true(routed.loading)
+}
+
+///|
+test "close_page drops only its page" {
+  let (state, first) = @preview.open_page(@preview.State::empty())
+  let (state, second) = @preview.open_page(state)
+  let state = @preview.close_page(state, first)
+  assert_true(@preview.page(state, first) is None)
+  assert_true(@preview.page(state, second) is Some(_))
+  // Ids never regress: the next page cannot collide with a parked strip's
+  // closed id.
+  let (state, third) = @preview.open_page(state)
+  assert_eq(third, 3)
+  ignore(state)
+}
+
+///|
+test "navigate commits url, mirrors the draft, clears the failure" {
+  let (state, id) = @preview.open_page(@preview.State::empty())
+  let state = @preview.update(
+    @preview.Msg::LoadFailed(id~, url="http://x/", text="boom"),
+    state,
+  )
+  let state = @preview.navigate(state, id, "http://127.0.0.1:8080/")
+  let page = @preview.page(state, id).unwrap()
+  assert_true(page.url == Some("http://127.0.0.1:8080/"))
+  assert_eq(page.input, "http://127.0.0.1:8080/")
+  assert_true(page.loading)
+  assert_true(page.failure is None)
+}
+
+///|
+test "update applies host events and is idempotent" {
+  let (state, id) = @preview.open_page(
+    @preview.State::empty(),
+    url="http://localhost:5173/",
+  )
+  let msgs : Array[@preview.Msg] = [
+    Navigated(id~, url="http://localhost:5173/app"),
+    TitleUpdated(id~, title="Dev Server"),
+    LoadingChanged(id~, loading=false),
+  ]
+  let mut current = state
+  for msg in msgs {
+    current = @preview.update(msg, current)
+    // Idempotence: applying the same event twice settles on the same state.
+    assert_true(@preview.update(msg, current) == current)
+  }
+  let page = @preview.page(current, id).unwrap()
+  assert_true(page.url == Some("http://localhost:5173/app"))
+  assert_eq(page.input, "http://localhost:5173/app")
+  assert_eq(page.title, "Dev Server")
+  assert_false(page.loading)
+}
+
+///|
+test "a new document drops the title; a fragment jump keeps it" {
+  let (state, id) = @preview.open_page(
+    @preview.State::empty(),
+    url="https://example.com/docs",
+  )
+  let titled = @preview.update(
+    @preview.Msg::TitleUpdated(id~, title="Docs"),
+    state,
+  )
+  // Same document, new anchor: the page never reloads, so no `TitleUpdated`
+  // is coming and the title must survive.
+  let anchored = @preview.update(
+    @preview.Msg::Navigated(id~, url="https://example.com/docs#install"),
+    titled,
+  )
+  assert_eq(@preview.page_label(@preview.page(anchored, id).unwrap()), "Docs")
+  // A different document is a different page: labelling it "Docs" until some
+  // title arrives (a failed load reports none) would name the wrong site.
+  let moved = @preview.update(
+    @preview.Msg::Navigated(id~, url="https://other.test/x"),
+    anchored,
+  )
+  assert_eq(
+    @preview.page_label(@preview.page(moved, id).unwrap()),
+    "other.test",
+  )
+  // The address bar's own commit follows the same rule.
+  let typed = @preview.navigate(titled, id, "https://example.com/guide")
+  assert_eq(
+    @preview.page_label(@preview.page(typed, id).unwrap()),
+    "example.com",
+  )
+}
+
+///|
+test "a failure for a superseded URL never reaches the page" {
+  let (state, id) = @preview.open_page(
+    @preview.State::empty(),
+    url="http://localhost:5173/",
+  )
+  // The user moves on before the old load's error is reported.
+  let moved = @preview.navigate(state, id, "https://example.com/")
+  let late = @preview.update(
+    @preview.Msg::LoadFailed(
+      id~,
+      url="http://localhost:5173/",
+      text="ERR_CONNECTION_REFUSED",
+    ),
+    moved,
+  )
+  assert_true(late == moved)
+  // The current URL's own failure still shows.
+  let failed = @preview.update(
+    @preview.Msg::LoadFailed(
+      id~,
+      url="https://example.com/",
+      text="ERR_NAME_NOT_RESOLVED",
+    ),
+    moved,
+  )
+  let page = @preview.page(failed, id).unwrap()
+  assert_true(page.failure is Some(_))
+  assert_false(page.loading)
+}
+
+///|
+test "events for unknown pages are dropped" {
+  let state = @preview.State::empty()
+  let next = @preview.update(
+    @preview.Msg::TitleUpdated(id=7, title="ghost"),
+    state,
+  )
+  assert_true(next == state)
+}
+
+///|
+test "load failure records and navigation label falls back sensibly" {
+  let (state, id) = @preview.open_page(
+    @preview.State::empty(),
+    url="http://localhost:5173/",
+  )
+  let state = @preview.update(
+    @preview.Msg::LoadFailed(id~, url="http://localhost:5173/", text="refused"),
+    state,
+  )
+  let page = @preview.page(state, id).unwrap()
+  assert_false(page.loading)
+  assert_true(page.failure is Some(_))
+  assert_eq(@preview.page_label(page), "localhost")
+  let titled = @preview.update(
+    @preview.Msg::TitleUpdated(id~, title="Docs"),
+    state,
+  )
+  assert_eq(@preview.page_label(@preview.page(titled, id).unwrap()), "Docs")
+  let (blank_state, blank) = @preview.open_page(state)
+  assert_eq(
+    @preview.page_label(@preview.page(blank_state, blank).unwrap()),
+    "New Tab",
+  )
+}
+
+///|
+test "host_of strips scheme, userinfo, and port" {
+  assert_true(@preview.host_of("http://localhost:5173/x") == Some("localhost"))
+  assert_true(
+    @preview.host_of("https://User@Example.COM:8443?q=1") == Some("example.com"),
+  )
+  assert_true(@preview.host_of("http://[::1]:3000/") == Some("[::1]"))
+  assert_true(@preview.host_of("http://127.0.0.1") == Some("127.0.0.1"))
+  assert_true(@preview.host_of("ftp://x/") is None)
+  assert_true(@preview.host_of("not a url") is None)
+}
+
+///|
+test "is_web_url accepts http(s) with a host only" {
+  assert_true(@preview.is_web_url("http://127.0.0.1:5173/"))
+  assert_true(@preview.is_web_url("https://github.com/moonbit"))
+  assert_true(@preview.is_web_url("HTTPS://Example.COM/x"))
+  assert_false(@preview.is_web_url("mailto:someone@example.com"))
+  assert_false(@preview.is_web_url("file:///etc/passwd"))
+  assert_false(@preview.is_web_url("vscode://open?x=1"))
+  assert_false(@preview.is_web_url("not a url"))
+  // A bare scheme or hostless URL is not a page the host would load.
+  assert_false(@preview.is_web_url("http://"))
+  assert_false(@preview.is_web_url("https:///path"))
+}
+
+///|
+test "is_loopback routes only this machine's hosts" {
+  assert_true(@preview.is_loopback("http://localhost:5173/"))
+  assert_true(@preview.is_loopback("http://127.0.0.1:8080/path"))
+  assert_true(@preview.is_loopback("https://127.1.2.3/"))
+  assert_true(@preview.is_loopback("http://[::1]:3000/"))
+  assert_false(@preview.is_loopback("https://github.com/"))
+  assert_false(@preview.is_loopback("https://localhost.evil.com/"))
+  assert_false(@preview.is_loopback("mailto:someone@example.com"))
+  // A `127.`-prefixed DNS name is somebody else's machine: only a dotted
+  // quad in 127/8 is loopback, so these keep the https default.
+  assert_false(@preview.is_loopback("https://127.example.com/"))
+  assert_false(@preview.is_loopback("https://127.com/"))
+  assert_false(@preview.is_loopback("https://127.0.0.1.evil.com/"))
+  assert_false(@preview.is_loopback("https://127.0.0.256/"))
+  assert_true(
+    @preview.normalize_url("127.example.com") == Some("https://127.example.com"),
+  )
+}
+
+///|
+test "normalize_url prefixes bare hosts and rejects foreign schemes" {
+  assert_true(
+    @preview.normalize_url("http://example.com/x") ==
+    Some("http://example.com/x"),
+  )
+  assert_true(
+    @preview.normalize_url("  https://example.com  ") ==
+    Some("https://example.com"),
+  )
+  assert_true(
+    @preview.normalize_url("localhost:5173") == Some("http://localhost:5173"),
+  )
+  assert_true(
+    @preview.normalize_url("127.0.0.1:8080/app") ==
+    Some("http://127.0.0.1:8080/app"),
+  )
+  assert_true(
+    @preview.normalize_url("example.com/docs") ==
+    Some("https://example.com/docs"),
+  )
+  // A path colon is not a scheme; a scheme colon is.
+  assert_true(
+    @preview.normalize_url("example.com/a:b") == Some("https://example.com/a:b"),
+  )
+  assert_true(@preview.normalize_url("javascript:alert(1)") is None)
+  assert_true(@preview.normalize_url("mailto:x@y.z") is None)
+  assert_true(@preview.normalize_url("ftp://host/") is None)
+  assert_true(@preview.normalize_url("") is None)
+  assert_true(@preview.normalize_url("two words") is None)
+  // A committed draft must be a URL the host will load: a bare scheme or a
+  // hostless path normalizes to nothing rather than stranding the tab.
+  assert_true(@preview.normalize_url("http://") is None)
+  assert_true(@preview.normalize_url("/docs") is None)
+}

--- a/desktop/frontend/preview/state.mbt
+++ b/desktop/frontend/preview/state.mbt
@@ -1,0 +1,121 @@
+// The browser subsystem behind the dock's `Browser` tabs: per-page address
+// state only. Every page is rendered by a native web contents view the host
+// owns; this model mirrors what the host reports (URL, title, load state) so
+// the toolbar and tab chips can render without asking the host anything.
+
+///|
+/// A rectangle in CSS pixels — the browser pane's placement, which at 100%
+/// zoom equals the window-logical bounds a native view takes.
+pub(all) struct Rect {
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+} derive(Eq)
+
+///|
+/// One browser page's state. `url` is `None` until the first navigation —
+/// a blank tab has no native view yet (the host creates it on the first
+/// `browser.open`), so nothing covers the pane while the address bar waits
+/// for input.
+pub(all) struct PageState {
+  // The last URL this page was sent to (optimistic) or reported at (from a
+  // `Navigated` event). `None` = blank tab, no native view exists.
+  url : String?
+  // The address bar's draft. Mirrors `url` after a navigation; edited
+  // freely in between.
+  input : String
+  // The page title from the host's `TitleUpdated` events; empty until one
+  // arrives.
+  title : String
+  loading : Bool
+  // The last load failure's description, cleared by the next navigation.
+  failure : String?
+} derive(Eq)
+
+///|
+/// The browser subsystem's state: every live page keyed by its dock tab id.
+/// Ids are page-global (never per conversation) so parked strips can keep
+/// referring to their pages, and only ever grow.
+pub(all) struct State {
+  pages : Map[Int, PageState]
+  next_id : Int
+} derive(Eq)
+
+///|
+pub fn State::empty() -> State {
+  { pages: Map([]), next_id: 1 }
+}
+
+///|
+/// Allocate a page. A blank tab starts without a URL; a routed link opens
+/// with one (the caller also asks the host to create the native view then).
+pub fn open_page(state : State, url? : String) -> (State, Int) {
+  let id = state.next_id
+  let pages = state.pages.copy()
+  pages[id] = {
+    url,
+    input: url.unwrap_or(""),
+    title: "",
+    loading: url is Some(_),
+    failure: None,
+  }
+  ({ pages, next_id: id + 1 }, id)
+}
+
+///|
+pub fn close_page(state : State, id : Int) -> State {
+  let pages = state.pages.copy()
+  pages.remove(id)
+  { ..state, pages, }
+}
+
+///|
+pub fn page(state : State, id : Int) -> PageState? {
+  state.pages.get(id)
+}
+
+///|
+/// Point the page at `url`: it becomes the page's target, the draft mirrors
+/// it, and the previous failure clears. The title survives only a
+/// same-document jump — a new document's title has to be reported by the
+/// host, and nothing guarantees one ever is (a failed load carries no title
+/// at all), so keeping the old one would leave the previous site's name
+/// labelling the new page indefinitely. Dropped, `page_label` falls back to
+/// the destination's host until a `TitleUpdated` lands.
+fn PageState::commit_url(self : PageState, url : String) -> PageState {
+  let title = if self.url is Some(current) &&
+    document_of(current) == document_of(url) {
+    self.title
+  } else {
+    ""
+  }
+  { ..self, url: Some(url), input: url, title, failure: None }
+}
+
+///|
+/// Commit a navigation optimistically. The caller sends the matching
+/// `browser.open`/`browser.navigate` to the host.
+pub fn navigate(state : State, id : Int, url : String) -> State {
+  guard state.pages.get(id) is Some(previous) else { return state }
+  let pages = state.pages.copy()
+  pages[id] = { ..previous.commit_url(url), loading: true }
+  { ..state, pages, }
+}
+
+///|
+/// The tab chip's label: the page title once one arrived, else the URL's
+/// host, else a blank-tab placeholder.
+pub fn page_label(page : PageState) -> String {
+  if !page.title.is_empty() {
+    return page.title
+  }
+  match page.url {
+    Some(url) =>
+      match host_of(url) {
+        Some(host) => host
+        None => url
+      }
+    None => "New Tab"
+  }
+}

--- a/desktop/frontend/preview/update.mbt
+++ b/desktop/frontend/preview/update.mbt
@@ -1,0 +1,50 @@
+// The browser subsystem's pure message machine. Everything here mirrors
+// either a keystroke in the address bar or a view event the host reported;
+// the commands that talk to the host (open/navigate/back/close and the
+// bounds sync) are the root update's business.
+
+///|
+pub(all) enum Msg {
+  // The address bar's draft changed.
+  InputChanged(id~ : Int, value~ : String)
+  // Host view events, decoded from `browser.event` notifications.
+  Navigated(id~ : Int, url~ : String)
+  LoadingChanged(id~ : Int, loading~ : Bool)
+  TitleUpdated(id~ : Int, title~ : String)
+  LoadFailed(id~ : Int, url~ : String, text~ : String)
+}
+
+///|
+pub fn update(msg : Msg, state : State) -> State {
+  fn patch(id : Int, apply : (PageState) -> PageState) -> State {
+    guard state.pages.get(id) is Some(page) else { return state }
+    let pages = state.pages.copy()
+    pages[id] = apply(page)
+    { ..state, pages, }
+  }
+
+  match msg {
+    InputChanged(id~, value~) => patch(id, page => { ..page, input: value })
+    // The committed URL replaces the draft: the bar names what the pane
+    // shows, exactly like a browser's address bar after a navigation. A
+    // navigation the page started itself (a link click, a redirect) arrives
+    // only here, so it goes through the same commit as a typed one.
+    Navigated(id~, url~) => patch(id, page => page.commit_url(url))
+    LoadingChanged(id~, loading~) => patch(id, page => { ..page, loading, })
+    TitleUpdated(id~, title~) => patch(id, page => { ..page, title, })
+    // A failure for a URL the page has already left behind is not this
+    // page's failure to show: a superseded load can report its error after
+    // the replacing navigation committed (the same lateness that makes
+    // ERR_ABORTED unusable — see `browser_event_msg`), and the banner would
+    // then sit over a healthy page for good. Dropping it costs nothing:
+    // `loading` is driven by its own event, so the new load still ends.
+    LoadFailed(id~, url~, text~) =>
+      patch(id, page => {
+        if page.url == Some(url) {
+          { ..page, loading: false, failure: Some("\{url}: \{text}") }
+        } else {
+          page
+        }
+      })
+  }
+}

--- a/desktop/frontend/preview/url.mbt
+++ b/desktop/frontend/preview/url.mbt
@@ -1,0 +1,197 @@
+// Address handling: the small, purely lexical slice of URL parsing the
+// browser tabs need — enough to normalize what the user typed, name a page
+// by its host, and route web links into the dock. Pages themselves are
+// navigated by the native view, which does the real parsing.
+
+///|
+fn ascii_lower(text : String) -> String {
+  let buf = StringBuilder::new()
+  for ch in text {
+    buf.write_char(ch.to_ascii_lowercase())
+  }
+  buf.to_string()
+}
+
+///|
+/// The authority part of an http(s) URL: everything between `scheme://` and
+/// the first `/`, `?`, or `#`. `None` for any other scheme.
+fn authority_of(url : String) -> String? {
+  let lower = ascii_lower(url)
+  let offset = if lower.has_prefix("http://") {
+    "http://".length()
+  } else if lower.has_prefix("https://") {
+    "https://".length()
+  } else {
+    return None
+  }
+  let buf = StringBuilder::new()
+  for ch in url.view(start_offset=offset) {
+    if ch == '/' || ch == '?' || ch == '#' {
+      break
+    }
+    buf.write_char(ch)
+  }
+  Some(buf.to_string())
+}
+
+///|
+/// The lowercased host of an http(s) URL: the authority minus any userinfo
+/// and port. An IPv6 literal keeps its brackets (`[::1]`).
+pub fn host_of(url : String) -> String? {
+  guard authority_of(url) is Some(authority) else { return None }
+  let host_port = match authority.split("@").collect() {
+    [.., after] => after.to_owned()
+    [] => authority
+  }
+  if host_port.has_prefix("[") {
+    // An IPv6 literal's colons are not a port separator.
+    let buf = StringBuilder::new()
+    for ch in host_port {
+      buf.write_char(ch)
+      if ch == ']' {
+        break
+      }
+    }
+    return Some(ascii_lower(buf.to_string()))
+  }
+  match host_port.split(":").collect() {
+    [host, ..] => Some(ascii_lower(host.to_owned()))
+    [] => Some(ascii_lower(host_port))
+  }
+}
+
+///|
+/// Whether the URL is a web page — the only thing a Browser tab's native
+/// view can host. Anything else (mailto:, file:, vscode:, …) belongs to the
+/// system's own handler. A bare scheme (`http://`) is not a page: the host
+/// rejects hostless URLs, and rejecting them here keeps the page state from
+/// committing a URL no view will ever load.
+pub fn is_web_url(url : String) -> Bool {
+  host_of(url) is Some(host) && !host.is_empty()
+}
+
+///|
+/// The document a URL names: everything before its `#fragment`. Two URLs
+/// sharing a document differ only in the anchor a same-document jump
+/// scrolls to, which never reloads the page.
+fn document_of(url : String) -> String {
+  let buf = StringBuilder::new()
+  for ch in url {
+    if ch == '#' {
+      break
+    }
+    buf.write_char(ch)
+  }
+  buf.to_string()
+}
+
+///|
+/// One decimal IPv4 octet's value, or `None` when the text is not one.
+fn octet_value(text : StringView) -> Int? {
+  guard all_digits(text) && text.length() <= 3 else { return None }
+  let mut value = 0
+  for ch in text {
+    value = value * 10 + (ch.to_int() - '0'.to_int())
+  }
+  if value <= 255 {
+    Some(value)
+  } else {
+    None
+  }
+}
+
+///|
+/// Whether the host is a dotted-quad address in 127/8. Matching the `127.`
+/// prefix textually would be wrong: `127.example.com` and `127.com` are
+/// ordinary DNS names that resolve to whatever their owner points them at,
+/// and calling them loopback would send them plaintext.
+fn is_loopback_ipv4(host : String) -> Bool {
+  match host.split(".").collect() {
+    [first, second, third, fourth] =>
+      octet_value(first) == Some(127) &&
+      octet_value(second) is Some(_) &&
+      octet_value(third) is Some(_) &&
+      octet_value(fourth) is Some(_)
+    _ => false
+  }
+}
+
+///|
+/// Whether an http(s) URL points at this machine — these force the plain
+/// `http://` scheme when the address bar completes a bare host.
+pub fn is_loopback(url : String) -> Bool {
+  match host_of(url) {
+    Some("localhost") | Some("[::1]") => true
+    Some(host) => is_loopback_ipv4(host)
+    None => false
+  }
+}
+
+///|
+/// Whether the text is one or more digits — the shape that distinguishes a
+/// `localhost:5173` port from a `mailto:someone` scheme.
+fn all_digits(text : StringView) -> Bool {
+  let mut seen_digit = false
+  for ch in text {
+    if ch < '0' || ch > '9' {
+      return false
+    }
+    seen_digit = true
+  }
+  seen_digit
+}
+
+///|
+/// The draft's first segment — everything before the path, query, or
+/// fragment — where a scheme or port would live.
+fn head_of(text : String) -> String {
+  let buf = StringBuilder::new()
+  for ch in text {
+    if ch == '/' || ch == '?' || ch == '#' {
+      break
+    }
+    buf.write_char(ch)
+  }
+  buf.to_string()
+}
+
+///|
+/// What the address bar's draft navigates to: an explicit http(s) URL as
+/// typed; a bare host (with an optional `:port` and path) gets a scheme
+/// prefixed — `http://` for loopback hosts, `https://` otherwise. Anything
+/// else (other schemes, spaces, empty, a hostless URL) is not navigable —
+/// the result must pass `is_web_url`, so a committed draft is always one
+/// the host will accept.
+pub fn normalize_url(input : String) -> String? {
+  let trimmed = input.trim().to_owned()
+  if trimmed.is_empty() {
+    return None
+  }
+  for ch in trimmed {
+    if ch == ' ' || ch == '\t' {
+      return None
+    }
+  }
+  let lower = ascii_lower(trimmed)
+  let candidate = if lower.has_prefix("http://") || lower.has_prefix("https://") {
+    trimmed
+  } else {
+    // A colon before any slash is either a port (digits) or a foreign scheme.
+    match head_of(trimmed).split(":").collect() {
+      [_] => ()
+      [_, port] if all_digits(port) => ()
+      _ => return None
+    }
+    let candidate = "http://" + trimmed
+    if is_loopback(candidate) {
+      candidate
+    } else {
+      "https://" + trimmed
+    }
+  }
+  if is_web_url(candidate) {
+    Some(candidate)
+  } else {
+    None
+  }
+}

--- a/desktop/frontend/preview/view.mbt
+++ b/desktop/frontend/preview/view.mbt
@@ -1,0 +1,116 @@
+// The browser toolbar riding the top of the pane while a Browser tab is
+// active: history buttons, the address bar, and open-in-system-browser. The
+// page itself is a native web contents view the host overlays on the pane
+// below — this package renders chrome only.
+
+///|
+/// The element id the root focuses when a blank tab opens.
+pub const AddressInputId = "browser-address-input"
+
+///|
+/// The up arrow codicon from Microsoft's vscode-codicons (CC BY 4.0),
+/// embedded unmodified; the toolbar's back/forward rotate it by CSS so the
+/// history buttons keep the exact codicon geometry.
+let icon_arrow_up : String =
+  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M13.854 7.14576L8.85401 2.14576C8.65901 1.95076 8.34201 1.95076 8.14701 2.14576L3.14601 7.14576C2.95101 7.34076 2.95101 7.65776 3.14601 7.85276C3.34101 8.04776 3.65801 8.04776 3.85301 7.85276L7.99901 3.70676V13.4998C7.99901 13.7758 8.22301 13.9998 8.49901 13.9998C8.77501 13.9998 8.99901 13.7758 8.99901 13.4998V3.70676L13.145 7.85276C13.243 7.95076 13.371 7.99876 13.499 7.99876C13.627 7.99876 13.755 7.94976 13.853 7.85276C14.048 7.65776 14.048 7.34076 13.853 7.14576H13.854Z"/></svg>
+
+///|
+/// The sync codicon (CC BY 4.0), the reload button.
+let icon_sync : String =
+  #|<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M14 3.5V6.5C14 6.78 13.78 7 13.5 7H10.5C10.22 7 9.99999 6.78 9.99999 6.5C9.99999 6.22 10.22 6 10.5 6H12.58C11.78 4.17 10.01 3 7.99999 3C5.77999 3 3.79999 4.5 3.18999 6.64C3.12999 6.86 2.92999 7 2.70999 7C2.65999 7 2.61999 7 2.56999 6.98C2.29999 6.9 2.14999 6.63 2.22999 6.36C2.95999 3.79 5.32999 2 7.99999 2C10.05 2 11.91 3.02 13 4.69V3.5C13 3.22 13.22 3 13.5 3C13.78 3 14 3.22 14 3.5ZM13.42 9.02C13.16 8.95 12.88 9.1 12.8 9.37C12.19 11.51 10.22 13.01 7.98999 13.01C5.97999 13.01 4.20999 11.84 3.40999 10.01H5.48999C5.76999 10.01 5.98999 9.79 5.98999 9.51C5.98999 9.23 5.76999 9.01 5.48999 9.01H2.48999C2.20999 9.01 1.98999 9.23 1.98999 9.51V12.51C1.98999 12.79 2.20999 13.01 2.48999 13.01C2.76999 13.01 2.98999 12.79 2.98999 12.51V11.32C4.07999 12.98 5.93999 14.01 7.98999 14.01C10.66 14.01 13.03 12.22 13.76 9.65C13.84 9.38 13.68 9.11 13.41 9.03L13.42 9.02Z"/></svg>
+
+///|
+/// The link-external codicon (CC BY 4.0), the open-in-system-browser button.
+let icon_link_external : String =
+  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M15 9.5V12.5C15 13.879 13.879 15 12.5 15H3.5C2.121 15 1 13.879 1 12.5V3.5C1 2.121 2.121 1 3.5 1H6.5C6.776 1 7 1.224 7 1.5C7 1.776 6.776 2 6.5 2H3.5C2.673 2 2 2.673 2 3.5V12.5C2 13.327 2.673 14 3.5 14H12.5C13.327 14 14 13.327 14 12.5V9.5C14 9.224 14.224 9 14.5 9C14.776 9 15 9.224 15 9.5ZM14.5 1H9.5C9.224 1 9 1.224 9 1.5C9 1.776 9.224 2 9.5 2H13.293L9.147 6.146C8.952 6.341 8.952 6.658 9.147 6.853C9.245 6.951 9.373 6.999 9.501 6.999C9.629 6.999 9.757 6.95 9.855 6.853L14.001 2.707V6.5C14.001 6.776 14.225 7 14.501 7C14.777 7 15.001 6.776 15.001 6.5V1.5C15.001 1.224 14.777 1 14.501 1H14.5Z"/></svg>
+
+///|
+/// An icon's SVG markup injected into a fixed-size span. The markup is a
+/// trusted compile-time constant, never user input, so the XSS alert on
+/// `inner_html` does not apply.
+#warnings("-alert_xss_vulnerable")
+fn icon(markup : String, rotate? : String) -> @html.Html {
+  let class = match rotate {
+    Some(direction) => "icon rotate-\{direction}"
+    None => "icon"
+  }
+  @html.span(
+    class~,
+    attrs=@html.Attrs::build().inner_html(markup).aria_hidden("true"),
+    ([] : Array[@html.Html]),
+  )
+}
+
+///|
+/// What the toolbar can ask the app to do. Navigation and history are host
+/// commands, so the root update owns them; this view only emits.
+pub(all) struct ToolbarActions {
+  input : @cmd.Emit[String]
+  submit : @cmd.Cmd
+  back : @cmd.Cmd
+  forward : @cmd.Cmd
+  reload : @cmd.Cmd
+  open_external : @cmd.Cmd
+}
+
+///|
+/// The active page's toolbar. Always rendered (the panel's child order is
+/// structural); CSS hides it while the active tab is not a Browser tab.
+pub fn toolbar_view(page : PageState, actions : ToolbarActions) -> @html.Html {
+  let children : Array[@html.Html] = [
+    @html.button(
+      class="browser-nav-button",
+      title="Back",
+      on_click=actions.back,
+      icon(icon_arrow_up, rotate="left"),
+    ),
+    @html.button(
+      class="browser-nav-button",
+      title="Forward",
+      on_click=actions.forward,
+      icon(icon_arrow_up, rotate="right"),
+    ),
+    @html.button(
+      class=if page.loading {
+        "browser-nav-button loading"
+      } else {
+        "browser-nav-button"
+      },
+      title="Reload",
+      on_click=actions.reload,
+      icon(icon_sync),
+    ),
+    @html.input(
+      input_type=@html.InputType::Text,
+      value=page.input,
+      placeholder="Enter a URL",
+      on_input=actions.input,
+      attrs=@html.Attrs::build()
+        .id(AddressInputId)
+        .class("browser-address")
+        .on_keydown(event => {
+          match event.key() {
+            "Enter" => actions.submit
+            _ => @cmd.none
+          }
+        }),
+    ),
+    @html.button(
+      class="browser-nav-button",
+      title="Open in system browser",
+      on_click=actions.open_external,
+      icon(icon_link_external),
+    ),
+  ]
+  @html.div(class="browser-toolbar", children)
+}
+
+///|
+/// The failure banner under the toolbar: the last load error, or nothing.
+/// Always rendered so the pane below never shifts index.
+pub fn failure_view(page : PageState) -> @html.Html {
+  match page.failure {
+    Some(text) => @html.div(class="browser-failure", text)
+    None => @html.div(class="browser-failure hidden", "")
+  }
+}

--- a/desktop/frontend/symbol_search.mbt
+++ b/desktop/frontend/symbol_search.mbt
@@ -803,8 +803,10 @@ test "accepting a symbol opens the editor at its file and returns to chat" {
   let (_, accepted) = update(dispatch, SymbolSearchAccept, ready)
   assert_true(accepted.symbol_search is None)
   assert_true(accepted.screen is Chat)
-  assert_true(accepted.file_panel.open)
-  assert_true(accepted.file_panel.active is Some(Relative("src/main.mbt")))
+  assert_true(accepted.dock.open)
+  assert_true(
+    @dock.active_file(accepted.dock) is Some(Relative("src/main.mbt")),
+  )
   // Reopening over an already-open panel reuses the same open/reveal path.
   let (_, reopened) = update(dispatch, SymbolSearchOpen, accepted)
   guard reopened.symbol_search is Some(next_search) else {
@@ -821,8 +823,10 @@ test "accepting a symbol opens the editor at its file and returns to chat" {
     reopened,
   )
   let (_, picked) = update(dispatch, SymbolSearchPick(0), next_ready)
-  assert_true(picked.file_panel.open)
-  assert_true(picked.file_panel.active is Some(Relative("src/render.mbt")))
+  assert_true(picked.dock.open)
+  assert_true(
+    @dock.active_file(picked.dock) is Some(Relative("src/render.mbt")),
+  )
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -557,27 +557,48 @@ fn open_editor_at(
     session: conv.session_id,
   }
   let femit = dispatch.map(msg => FileEditor(msg))
-  // Re-root only when the panel's cached tree belongs to another
-  // conversation; otherwise `sync_file_panel`'s post-dispatch pass would
-  // see a session mismatch and wipe the tab/`open` set below.
+  // Park/restore the strip for a conversation switch up front, and re-root
+  // the file subsystem when its cached tree belongs to another conversation;
+  // otherwise `sync_file_panel`'s post-dispatch pass would see a session
+  // mismatch and wipe the freshly opened tab below. A re-rooted document
+  // table is seeded from the restored strip (identities only), exactly like
+  // `@fileeditor.sync`'s own re-root.
+  let dock = @dock.sync(model.dock, owner)
   let panel = if model.file_panel.owner == Some(owner) {
     model.file_panel
   } else {
-    { ..@fileeditor.State::empty(), owner: Some(owner) }
+    let docs : Map[@pathx.Relative, @fileeditor.Doc] = Map([])
+    for open_path in @dock.file_paths(dock) {
+      docs[open_path] = {
+        name: @fileeditor.basename(open_path),
+        state: TabLoading,
+        stale: false,
+      }
+    }
+    { ..@fileeditor.State::empty(), owner: Some(owner), docs }
   }
   guard conversation_relative(conv, path) is Some(relative) else {
     return (
       @fileeditor.mount_cmds(femit),
       {
         ..model,
+        dock: { ..dock, open: true },
         file_panel: {
           ..panel,
-          open: true,
           error: Some("\{path} is outside the conversation workspace"),
         },
       },
     )
   }
+  let had_active = @dock.active_file(dock) is Some(_)
+  // An explicit open while the picker is the active tab fulfills it, the
+  // same as a pick from its tree.
+  let dock = if dock.active is Some(FilePicker) {
+    { ..@dock.resolve_pick(dock, relative), open: true }
+  } else {
+    { ..@dock.open_file(dock, relative), open: true }
+  }
+  let model = { ..model, dock, file_panel: panel }
   let (cmd, panel) = @fileeditor.open_file(
     femit,
     panel,
@@ -585,6 +606,7 @@ fn open_editor_at(
     relative,
     range~,
     annotation?,
+    had_active~,
   )
   (cmd, { ..model, file_panel: panel })
 }
@@ -834,6 +856,11 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     dark_mode: model.theme.is_dark(model.system_dark),
     tree_layout: model.tree_layout,
     narrow: model.narrow,
+    // The dock's projection: strip membership and the active tab are the
+    // dock's truth, handed to the file subsystem read-only.
+    panel_open: model.dock.open,
+    open_files: @dock.file_paths(model.dock),
+    active_file: @dock.active_file(model.dock),
   }
 }
 
@@ -875,19 +902,129 @@ fn sync_terminal_panel(
 }
 
 ///|
-/// Reconcile the file panel with the active conversation after every message
-/// (see `@fileeditor.sync`). Centralizing it here keeps every
+/// Reconcile the dock strip, then the file subsystem, with the active
+/// conversation after every message (see `@dock.sync` /
+/// `@fileeditor.sync`). Order matters: the dock parks/restores the strip
+/// first, so the file sync sees the fresh projection and re-roots its
+/// document table from it. Centralizing it here keeps every
 /// conversation-switching handler from having to re-root the panel itself.
 fn sync_file_panel(
   dispatch : @cmd.Emit[Msg],
   model : Model,
 ) -> (Model, @cmd.Cmd) {
+  let conv = model.active()
+  let dock = @dock.sync(model.dock, {
+    channel: model.focused,
+    session: conv.session_id,
+  })
+  let model = { ..model, dock, }
   let (panel, cmd) = @fileeditor.sync(
     dispatch.map(msg => FileEditor(msg)),
     model.file_panel,
     file_ctx(model),
   )
   ({ ..model, file_panel: panel }, cmd)
+}
+
+///|
+/// Whether a full-screen surface is drawn over the window. Every overlay
+/// `view.mbt` appends after the shell (see its trailing `children.push`
+/// block) belongs here: native views z-order above all HTML, so an overlay
+/// this predicate forgets renders with the browser pane punched through it,
+/// swallowing the clicks that land there.
+fn covering_overlay(model : Model) -> Bool {
+  model.workspace_picker is Some(_) ||
+  model.archive_confirm is Some(_) ||
+  model.symbol_search is Some(_) ||
+  model.update_ux is ConfirmingRestart(_) ||
+  // Best effort: with the bridge gone the hide op may not deliver.
+  model.bridge_state() is BridgeLost(_)
+}
+
+///|
+/// Which browser page's native view belongs on screen: the active Browser
+/// tab's, once it has a URL (a blank tab has no view yet) — and only while
+/// the pane is actually visible and uncovered. Native views z-order above
+/// all HTML, so anything the frontend draws over the pane area — the `+`
+/// launcher popup, the narrow layout's sidebar drawer, the topbar app
+/// launcher's backdrop, and every `covering_overlay` — must hide the view
+/// rather than fight it.
+fn desired_browser_view(model : Model) -> Int? {
+  guard model.is_desktop &&
+    model.screen is Chat &&
+    model.dock.open &&
+    !model.dock.menu_open &&
+    !model.launcher.open &&
+    !(model.narrow && model.sidebar_open) &&
+    !covering_overlay(model) else {
+    return None
+  }
+  guard @dock.active_browser(model.dock) is Some(id) &&
+    @preview.page(model.preview, id) is Some(page) &&
+    page.url is Some(_) else {
+    return None
+  }
+  Some(id)
+}
+
+///|
+fn browser_geometry(model : Model) -> BrowserGeometry {
+  {
+    desired: desired_browser_view(model),
+    sidebar_open: model.sidebar_open,
+    narrow: model.narrow,
+    terminal_open: model.terminal_panel.open,
+    tree_layout: model.tree_layout,
+  }
+}
+
+///|
+/// Reconcile the native view with the pane after every message. Hiding is
+/// immediate; showing waits for a fresh pane measurement (the measured
+/// rectangle comes back as `BrowserPaneMeasured`, which sends the bounds
+/// and then the visibility flip). The geometry signature keeps this pass
+/// from re-measuring when nothing placement-relevant changed — including
+/// after the measurement message itself, which never alters the signature.
+fn sync_browser_view(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+) -> (Model, @cmd.Cmd) {
+  let pane = model.browser_pane
+  match desired_browser_view(model) {
+    None =>
+      match pane.shown {
+        Some(old) =>
+          (
+            { ..model, browser_pane: { shown: None, rect: None, geo: None } },
+            browser_set_visible(dispatch, old, false),
+          )
+        None =>
+          if pane.geo is Some(_) {
+            // A measurement was requested but the view left the screen
+            // before it landed; forget it so a later show re-measures.
+            (
+              { ..model, browser_pane: { shown: None, rect: None, geo: None } },
+              @cmd.none,
+            )
+          } else {
+            (model, @cmd.none)
+          }
+      }
+    Some(_) => {
+      let geo = browser_geometry(model)
+      if pane.geo == Some(geo) {
+        (model, @cmd.none)
+      } else {
+        (
+          { ..model, browser_pane: { ..pane, geo: Some(geo) } },
+          @cmd.batch([
+            watch_browser_pane(dispatch),
+            measure_browser_pane(dispatch),
+          ]),
+        )
+      }
+    }
+  }
 }
 
 ///|
@@ -970,7 +1107,8 @@ fn update(
   let model = close_stale_symbol_search(model)
   let (model, panel_cmd) = sync_file_panel(dispatch, model)
   let (model, terminal_cmd) = sync_terminal_panel(dispatch, model)
-  (@cmd.batch([cmd, panel_cmd, terminal_cmd]), model)
+  let (model, browser_cmd) = sync_browser_view(dispatch, model)
+  (@cmd.batch([cmd, panel_cmd, terminal_cmd, browser_cmd]), model)
 }
 
 ///|
@@ -1158,6 +1296,53 @@ fn update_msg(
         @fileeditor.remove_editor_feedback(resource, feedback_id),
         model.replace_conversation({ ..conv, mentions, }),
       )
+    }
+    // Intercepted like the comment above: which dock tab a tree click opens
+    // is the strip's business. The dock opens (or re-activates) the tab,
+    // then the file subsystem loads and shows the document against the
+    // fresh projection.
+    FileEditor(FileSelected(path~, name~)) => {
+      let had_active = @dock.active_file(model.dock) is Some(_)
+      // A pick made from the active FilePicker tab fulfills it: the picker
+      // is replaced in place (or the already-open tab activates and the
+      // picker closes). Any other tree click opens tabs as before.
+      let dock = if model.dock.active is Some(FilePicker) {
+        @dock.resolve_pick(model.dock, path)
+      } else {
+        @dock.open_file(model.dock, path)
+      }
+      let model = { ..model, dock, }
+      let (cmd, panel) = @fileeditor.open_document(
+        dispatch.map(msg => FileEditor(msg)),
+        model.file_panel,
+        file_ctx(model),
+        path,
+        name~,
+        range=None,
+        had_active~,
+      )
+      (cmd, { ..model, file_panel: panel })
+    }
+    // Intercepted for the same reason: a navigation jump (go-to-definition,
+    // a reference pick) opens a dock tab before the document loads. The
+    // owner stamp rejects a reply that outlived a conversation switch.
+    FileEditor(OpenNavigationLocation(owner~, path~, range~)) => {
+      guard model.file_panel.owner == Some(owner) &&
+        file_ctx(model).owner == owner else {
+        return (@cmd.none, model)
+      }
+      let had_active = @dock.active_file(model.dock) is Some(_)
+      let dock = @dock.open_file(model.dock, path)
+      let model = { ..model, dock, }
+      let (cmd, panel) = @fileeditor.open_file(
+        dispatch.map(msg => FileEditor(msg)),
+        model.file_panel,
+        file_ctx(model),
+        path,
+        range=Some(range),
+        had_active~,
+      )
+      (cmd, { ..model, file_panel: panel })
     }
     CompletionAccept =>
       if model.completion is Some(menu) && menu.current() is Some(item) {
@@ -1495,11 +1680,19 @@ fn update_msg(
       // so any resize while a document is up remeasures it — same-side
       // resizes included (a rotation changes the host without crossing the
       // breakpoint).
-      let cmd = if model.file_panel.open && model.file_panel.active is Some(_) {
-        @fileeditor.request_viewer_remeasure()
+      let cmds = if model.dock.open && @dock.active_file(model.dock) is Some(_) {
+        [@fileeditor.request_viewer_remeasure()]
       } else {
-        @cmd.none
+        []
       }
+      // A horizontal resize can move the right-anchored browser pane
+      // without resizing it (`--editor-width` is fixed pixels after a
+      // drag): its ResizeObserver stays silent and the geometry signature
+      // never changes, so the resize itself must trigger the re-measure.
+      if desired_browser_view(model) is Some(_) {
+        cmds.push(measure_browser_pane(dispatch))
+      }
+      let cmd = @cmd.batch(cmds)
       if narrow == model.narrow {
         (cmd, model)
       } else {
@@ -2141,6 +2334,218 @@ fn update_msg(
       )
       (cmd, { ..model, file_panel: panel })
     }
+    Dock(msg) => {
+      // The strip machine is pure; the cross-package effects of the
+      // transition — showing or dropping documents, mounting hosts — are
+      // commanded here off the before/after difference.
+      let before = model.dock
+      let dock = @dock.update(msg, before)
+      let model = { ..model, dock, }
+      let femit = dispatch.map(msg => FileEditor(msg))
+      match msg {
+        TogglePanel =>
+          (
+            @fileeditor.panel_toggle_cmds(
+              femit,
+              model.file_panel,
+              file_ctx(model),
+              opening=dock.open,
+            ),
+            model,
+          )
+        MenuToggled =>
+          // Pure UI state; the browser sync pass hides the native view
+          // while the popup would overlap it.
+          (@cmd.none, model)
+        TabActivated(_) =>
+          if dock.active != before.active &&
+            @dock.active_file(dock) is Some(path) {
+            let cmds : Array[@cmd.Cmd] = []
+            if @dock.active_file(before) is None {
+              // The file body was CSS-hidden behind the browser pane or
+              // the picker overlay; the viewer must re-measure its host on
+              // return.
+              cmds.push(@fileeditor.request_viewer_remeasure())
+            }
+            let (cmd, panel) = @fileeditor.activate(
+              femit,
+              model.file_panel,
+              file_ctx(model),
+              path,
+            )
+            cmds.push(cmd)
+            (@cmd.batch(cmds), { ..model, file_panel: panel })
+          } else {
+            (@cmd.none, model)
+          }
+        TabClosed(tab) =>
+          // A stale close (racing another close) leaves the strip — and so
+          // the document table — untouched.
+          if before.tabs.search_by(entry => entry == tab) is Some(_) {
+            // When the closed tab was on screen and a file tab inherits it,
+            // its document must be shown; a file close routes through
+            // close_document (which also drops the document), the other
+            // kinds activate directly.
+            let next_file = @dock.active_file(dock)
+            let was_active = before.active == Some(tab)
+            match tab {
+              File(path~) => {
+                let (cmd, panel) = @fileeditor.close_document(
+                  femit,
+                  model.file_panel,
+                  file_ctx(model),
+                  path,
+                  next=next_file,
+                  was_active~,
+                )
+                (cmd, { ..model, file_panel: panel })
+              }
+              Browser(id~) => {
+                let cmds : Array[@cmd.Cmd] = [browser_close_view(dispatch, id)]
+                let model = {
+                  ..model,
+                  preview: @preview.close_page(model.preview, id),
+                }
+                if was_active && next_file is Some(path) {
+                  cmds.push(@fileeditor.request_viewer_remeasure())
+                  let (cmd, panel) = @fileeditor.activate(
+                    femit,
+                    model.file_panel,
+                    file_ctx(model),
+                    path,
+                  )
+                  cmds.push(cmd)
+                  (@cmd.batch(cmds), { ..model, file_panel: panel })
+                } else {
+                  (@cmd.batch(cmds), model)
+                }
+              }
+              FilePicker =>
+                if was_active && next_file is Some(path) {
+                  let (cmd, panel) = @fileeditor.activate(
+                    femit,
+                    model.file_panel,
+                    file_ctx(model),
+                    path,
+                  )
+                  (cmd, { ..model, file_panel: panel })
+                } else {
+                  (@cmd.none, model)
+                }
+            }
+          } else {
+            (@cmd.none, model)
+          }
+      }
+    }
+    Preview(msg) =>
+      (@cmd.none, { ..model, preview: @preview.update(msg, model.preview) })
+    BrowserTabRequested => {
+      let (preview, id) = @preview.open_page(model.preview)
+      let dock = @dock.close_menu(@dock.open_browser(model.dock, id))
+      (focus_browser_address(), { ..model, preview, dock })
+    }
+    FilePickerRequested => {
+      let dock = @dock.close_menu(@dock.open_picker(model.dock))
+      (@cmd.none, { ..model, dock, })
+    }
+    BrowserAddressEdited(value) =>
+      match @dock.active_browser(model.dock) {
+        Some(id) =>
+          (
+            @cmd.none,
+            {
+              ..model,
+              preview: @preview.update(
+                @preview.Msg::InputChanged(id~, value~),
+                model.preview,
+              ),
+            },
+          )
+        None => (@cmd.none, model)
+      }
+    BrowserNavigateSubmitted => {
+      guard @dock.active_browser(model.dock) is Some(id) &&
+        @preview.page(model.preview, id) is Some(page) &&
+        @preview.normalize_url(page.input) is Some(url) else {
+        return (@cmd.none, model)
+      }
+      // A blank tab's first navigation creates the native view; later ones
+      // navigate the existing view.
+      let (cmd, pane) = if page.url is Some(_) {
+        // `browser.navigate` builds the view back when it is gone — a create
+        // the host refused, or one a reload's `close_all` swept — and a
+        // rebuilt view arrives hidden at a placeholder size. No view op is
+        // acknowledged, so the cached placement may describe a view that
+        // never existed; forgetting it has the next sync measure and place
+        // whatever the host actually has now.
+        (
+          browser_navigate(dispatch, id, url),
+          { shown: None, rect: None, geo: None },
+        )
+      } else {
+        // The blank tab's own placement is already absent (a page without a
+        // URL is never the desired view), so the create needs no reset.
+        (browser_open(dispatch, id, url), model.browser_pane)
+      }
+      (
+        cmd,
+        {
+          ..model,
+          preview: @preview.navigate(model.preview, id, url),
+          browser_pane: pane,
+        },
+      )
+    }
+    BrowserBack =>
+      (
+        browser_history_for_active(dispatch, model, @commands.browser_back),
+        model,
+      )
+    BrowserForward =>
+      (
+        browser_history_for_active(dispatch, model, @commands.browser_forward),
+        model,
+      )
+    BrowserReload =>
+      (
+        browser_history_for_active(dispatch, model, @commands.browser_reload),
+        model,
+      )
+    BrowserOpenExternal => {
+      guard @dock.active_browser(model.dock) is Some(id) &&
+        @preview.page(model.preview, id) is Some(page) &&
+        page.url is Some(url) else {
+        return (@cmd.none, model)
+      }
+      (open_external_link(dispatch, url), model)
+    }
+    BrowserPaneMeasured(rect~) => {
+      // A rectangle for a view that already left the screen (or a zero
+      // rectangle from the observer watching a hidden pane) is stale.
+      guard desired_browser_view(model) is Some(id) &&
+        rect.width > 0 &&
+        rect.height > 0 else {
+        return (@cmd.none, model)
+      }
+      let pane = model.browser_pane
+      let cmds : Array[@cmd.Cmd] = []
+      if pane.rect != Some(rect) || pane.shown != Some(id) {
+        cmds.push(browser_set_bounds(dispatch, id, rect))
+      }
+      if pane.shown != Some(id) {
+        // Bounds land before visibility so the view never flashes at its
+        // previous place.
+        if pane.shown is Some(old) {
+          cmds.push(browser_set_visible(dispatch, old, false))
+        }
+        cmds.push(browser_set_visible(dispatch, id, true))
+      }
+      (
+        @cmd.batch(cmds),
+        { ..model, browser_pane: { ..pane, shown: Some(id), rect: Some(rect) } },
+      )
+    }
     Terminal(msg) => {
       // Host-originated replies and notifications can already be queued when
       // a WebSocket closes. Their terminal ids belong to the dead connection,
@@ -2177,7 +2582,47 @@ fn update_msg(
       }
     }
     HostActionFailed(message) => model.notify_error(dispatch, message)
-    ExternalLinkClicked(url) => (open_external_link(dispatch, url), model)
+    ExternalLinkClicked(url) =>
+      // Web links open in the dock's Browser tabs by default — the
+      // toolbar's open-external button hands the page to the system
+      // browser when its chrome or logins are needed. Non-web schemes
+      // (mailto:, vscode:, …) and remote consoles (no native views) keep
+      // the external path. A same-URL tab already in this strip
+      // re-activates instead of duplicating.
+      //
+      // Only from Chat: the capture listener behind this message is a
+      // document-wide one, so it also reports anchors on the other screens,
+      // where the dock is not rendered at all — routing there would open a
+      // tab nobody can see. Settings' device-page link is the clearest
+      // case: it names a URL to open in a browser the user is signed in to,
+      // which a native view (with its own cookie jar) is not.
+      if model.is_desktop && model.screen is Chat && @preview.is_web_url(url) {
+        // The scan is over this strip's tabs, not the global page map: a
+        // parked conversation may hold the same URL, and matching its page
+        // first would shadow this strip's own tab forever.
+        let reuse = for tab in model.dock.tabs {
+          if tab is Browser(id~) &&
+            @preview.page(model.preview, id) is Some(page) &&
+            page.url == Some(url) {
+            break Some(id)
+          }
+        } nobreak {
+          None
+        }
+        match reuse {
+          Some(id) => {
+            let dock = { ..@dock.open_browser(model.dock, id), open: true }
+            (@cmd.none, { ..model, dock, })
+          }
+          None => {
+            let (preview, id) = @preview.open_page(model.preview, url~)
+            let dock = { ..@dock.open_browser(model.dock, id), open: true }
+            (browser_open(dispatch, id, url), { ..model, preview, dock })
+          }
+        }
+      } else {
+        (open_external_link(dispatch, url), model)
+      }
     FromDevice(channel, msg) => update_device_msg(dispatch, channel, msg, model)
   }
 }
@@ -11066,8 +11511,10 @@ test "JumpToMention opens the editor panel and selects the mention's file" {
     mentions: [mention],
   })
   let (_, next) = update(dispatch, JumpToMention(0), model)
-  assert_true(next.file_panel.open)
-  assert_true(next.file_panel.active is Some(Relative("src/main.mbt")))
+  assert_true(next.dock.open)
+  assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
+  // The document table follows the strip: the jumped-to file has an entry.
+  assert_true(next.file_panel.docs.contains(Relative("src/main.mbt")))
 }
 
 ///|
@@ -11079,8 +11526,8 @@ test "JumpToMention is a no-op for a chip without a resolved location" {
     mentions: [mention],
   })
   let (_, next) = update(dispatch, JumpToMention(0), model)
-  assert_false(next.file_panel.open)
-  assert_true(next.file_panel.active is None)
+  assert_false(next.dock.open)
+  assert_true(next.dock.active is None)
 }
 
 ///|
@@ -11131,7 +11578,7 @@ test "chip jumps relativize legacy absolute paths against the roots" {
     ),
     model,
   )
-  assert_true(next.file_panel.active is Some(Relative("src/main.mbt")))
+  assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
   // Before the first run reports cwd, the attached workspace serves as root.
   let model = test_model().replace_conversation({
     ..test_conversation(),
@@ -11146,7 +11593,7 @@ test "chip jumps relativize legacy absolute paths against the roots" {
     ),
     model,
   )
-  assert_true(next.file_panel.active is Some(Relative("src/main.mbt")))
+  assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
   // An absolute path outside every root cannot be opened; the panel says so
   // instead of sending the host a bogus read.
   let (_, outside) = update(
@@ -11158,7 +11605,7 @@ test "chip jumps relativize legacy absolute paths against the roots" {
     ),
     model,
   )
-  assert_true(outside.file_panel.active is None)
+  assert_true(outside.dock.active is None)
   assert_true(outside.file_panel.error is Some(_))
 }
 
@@ -11166,21 +11613,28 @@ test "chip jumps relativize legacy absolute paths against the roots" {
 test "RevealDirectory(\"\") opens the tree pane without a highlight" {
   let dispatch = test_dispatch()
   let model = test_model()
+  let owner : @interop.ConversationKey = {
+    channel: Local,
+    session: "desktop-test",
+  }
+  let dock = {
+    ..@dock.open_file(model.dock, Relative("README.md")),
+    open: true,
+    owner: Some(owner),
+  }
   let panel = {
     ..model.file_panel,
-    open: true,
-    owner: Some({ channel: Local, session: "desktop-test" }),
+    owner: Some(owner),
     tree_open: false,
-    active: Some(Relative("README.md")),
     highlighted: Some(Relative("src")),
   }
   let (_, next) = update(
     dispatch,
     FileEditor(RevealDirectory(@pathx.Relative::root())),
-    { ..model, file_panel: panel },
+    { ..model, dock, file_panel: panel },
   )
   // The active tab stays put — revealing the tree must not close the file.
-  assert_true(next.file_panel.active is Some(Relative("README.md")))
+  assert_true(@dock.active_file(next.dock) is Some(Relative("README.md")))
   assert_true(next.file_panel.tree_open)
   assert_true(next.file_panel.highlighted is None)
 }
@@ -11191,7 +11645,6 @@ test "RevealDirectory expands an uncached ancestor and highlights the target" {
   let model = test_model()
   let panel = {
     ..model.file_panel,
-    open: true,
     owner: Some({ channel: Local, session: "desktop-test" }),
   }
   let (_, next) = update(
@@ -11213,7 +11666,6 @@ test "RevealDirectory on an already-cached ancestor needs no reload" {
   ])
   let panel = {
     ..model.file_panel,
-    open: true,
     owner: Some({ channel: Local, session: "desktop-test" }),
     children,
   }
@@ -12599,4 +13051,284 @@ test "auth status payloads decode by shape" {
     device: None,
   })
   assert_true(signed_out.user_login is None)
+}
+
+///|
+/// Test-only: a desktop-shaped model (browser tabs exist only where the
+/// native views do), after one settling dispatch so the per-conversation
+/// sync passes have claimed their owners — as any real first message has
+/// long done before a tab can open.
+fn desktop_model() -> Model {
+  let model = { ..test_model(), is_desktop: true }
+  let (_, model) = update(test_dispatch(), TranscriptPinned(true), model)
+  model
+}
+
+///|
+test "launcher rows open a blank browser tab and the picker, closing the menu" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(dispatch, Dock(TogglePanel), model)
+  let (_, model) = update(dispatch, Dock(MenuToggled), model)
+  assert_true(model.dock.menu_open)
+  let (_, model) = update(dispatch, BrowserTabRequested, model)
+  assert_false(model.dock.menu_open)
+  assert_true(@dock.active_browser(model.dock) == Some(1))
+  let page = @preview.page(model.preview, 1).unwrap()
+  assert_true(page.url is None)
+  assert_false(page.loading)
+  let (_, model) = update(dispatch, FilePickerRequested, model)
+  assert_true(model.dock.active == Some(@dock.DockTab::FilePicker))
+  assert_true(
+    model.dock.tabs == [@dock.DockTab::Browser(id=1), @dock.DockTab::FilePicker],
+  )
+}
+
+///|
+test "a tree pick fulfills the active picker in place" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(dispatch, Dock(TogglePanel), model)
+  let (_, model) = update(dispatch, FilePickerRequested, model)
+  let (_, model) = update(
+    dispatch,
+    FileEditor(FileSelected(path=Relative("src/main.mbt"), name="main.mbt")),
+    model,
+  )
+  assert_true(
+    model.dock.tabs == [@dock.DockTab::File(path=Relative("src/main.mbt"))],
+  )
+  assert_true(@dock.active_file(model.dock) == Some(Relative("src/main.mbt")))
+}
+
+///|
+test "web links open (and reuse) a dock browser tab; other schemes do not" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  assert_true(model.dock.open)
+  assert_true(@dock.active_browser(model.dock) == Some(1))
+  assert_true(
+    @preview.page(model.preview, 1).unwrap().url ==
+    Some("http://127.0.0.1:5173/"),
+  )
+  // The same URL re-activates the existing tab instead of duplicating.
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  assert_eq(model.dock.tabs.length(), 1)
+  assert_eq(model.preview.pages.length(), 1)
+  // External sites are web pages too: they get their own tab.
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("https://github.com/moonbit"),
+    model,
+  )
+  assert_eq(model.dock.tabs.length(), 2)
+  assert_true(@dock.active_browser(model.dock) == Some(2))
+  // A non-web scheme keeps the system handler: no tab appears.
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("mailto:someone@example.com"),
+    model,
+  )
+  assert_eq(model.dock.tabs.length(), 2)
+  // So does a link clicked on another screen, where the dock is not on
+  // screen to show a tab — Settings' device-page link wants the browser the
+  // user is signed in to anyway.
+  let (_, settings) = update(
+    dispatch,
+    ExternalLinkClicked("https://openseek.test/d/abc"),
+    { ..model, screen: Settings },
+  )
+  assert_eq(settings.dock.tabs.length(), 2)
+  assert_eq(settings.preview.pages.length(), 2)
+}
+
+///|
+test "same-URL reuse scans this strip, not the global page map" {
+  let dispatch = test_dispatch()
+  let url = "http://127.0.0.1:5173/"
+  // Another conversation's parked strip already holds this URL: its page
+  // sits in the global map with no tab in this strip. It must not shadow
+  // this strip's own tab.
+  let (foreign, _) = @preview.open_page(@preview.State::empty(), url~)
+  let model = { ..desktop_model(), preview: foreign }
+  let (_, model) = update(dispatch, ExternalLinkClicked(url), model)
+  assert_eq(model.dock.tabs.length(), 1)
+  assert_eq(model.preview.pages.length(), 2)
+  // A repeat click re-activates this strip's tab instead of stacking a
+  // duplicate per click.
+  let (_, model) = update(dispatch, ExternalLinkClicked(url), model)
+  assert_eq(model.dock.tabs.length(), 1)
+  assert_eq(model.preview.pages.length(), 2)
+}
+
+///|
+test "a remote console routes loopback links to the system browser too" {
+  let dispatch = test_dispatch()
+  // test_model is desktop-shaped except for the flag; without native views
+  // the dock must not grow browser tabs.
+  let model = test_model()
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  assert_true(model.dock.tabs.is_empty())
+  assert_true(model.preview.pages.is_empty())
+}
+
+///|
+test "submitting the address bar normalizes the draft and commits it" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(dispatch, Dock(TogglePanel), model)
+  let (_, model) = update(dispatch, BrowserTabRequested, model)
+  let (_, model) = update(
+    dispatch,
+    BrowserAddressEdited("localhost:5173"),
+    model,
+  )
+  let (_, model) = update(dispatch, BrowserNavigateSubmitted, model)
+  let page = @preview.page(model.preview, 1).unwrap()
+  assert_true(page.url == Some("http://localhost:5173"))
+  assert_eq(page.input, "http://localhost:5173")
+  assert_true(page.loading)
+  // A non-navigable draft changes nothing — including a bare scheme, which
+  // the host would reject after the URL had already been committed.
+  let (_, edited) = update(dispatch, BrowserAddressEdited("two words"), model)
+  let (_, unchanged) = update(dispatch, BrowserNavigateSubmitted, edited)
+  assert_true(
+    @preview.page(unchanged.preview, 1).unwrap().url ==
+    Some("http://localhost:5173"),
+  )
+  let (_, edited) = update(dispatch, BrowserAddressEdited("http://"), unchanged)
+  let (_, still) = update(dispatch, BrowserNavigateSubmitted, edited)
+  assert_true(
+    @preview.page(still.preview, 1).unwrap().url ==
+    Some("http://localhost:5173"),
+  )
+}
+
+///|
+test "navigating an already-placed tab re-places its view" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700 }
+  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  assert_true(model.browser_pane.shown == Some(1))
+  // The host may have rebuilt the view under `browser.navigate` (nothing
+  // acknowledges the ops that placed the old one), and a rebuilt view is
+  // hidden at a placeholder size. Keeping the placement would leave the tab
+  // blank until an unrelated resize, so the submission drops it…
+  let (_, edited) = update(
+    dispatch,
+    BrowserAddressEdited("https://github.com/moonbit"),
+    model,
+  )
+  let (_, navigated) = update(dispatch, BrowserNavigateSubmitted, edited)
+  assert_true(navigated.browser_pane.shown is None)
+  assert_true(navigated.browser_pane.rect is None)
+  // …and the re-measure it provokes places the view again.
+  let (_, replaced) = update(dispatch, BrowserPaneMeasured(rect~), navigated)
+  assert_true(replaced.browser_pane.shown == Some(1))
+  assert_true(replaced.browser_pane.rect == Some(rect))
+}
+
+///|
+test "pane measurements place the active view and idempotently settle" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700 }
+  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  assert_true(model.browser_pane.shown == Some(1))
+  assert_true(model.browser_pane.rect == Some(rect))
+  let (_, again) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  assert_true(again == model)
+  // A zero-size measurement (the observer firing against a hidden pane)
+  // never places the view.
+  let zero : @preview.Rect = { x: 0, y: 0, width: 0, height: 0 }
+  let (_, still) = update(dispatch, BrowserPaneMeasured(rect=zero), model)
+  assert_true(still.browser_pane.rect == Some(rect))
+}
+
+///|
+test "the launcher popup and tab close both retire the shown view" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700 }
+  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  assert_true(model.browser_pane.shown == Some(1))
+  // The popup overlaps the pane, so the native view must hide under it.
+  let (_, covered) = update(dispatch, Dock(MenuToggled), model)
+  assert_true(covered.browser_pane.shown is None)
+  // Closing the tab drops the page and the placement.
+  let (_, closed) = update(
+    dispatch,
+    Dock(TabClosed(@dock.DockTab::Browser(id=1))),
+    model,
+  )
+  assert_true(closed.browser_pane.shown is None)
+  assert_true(@preview.page(closed.preview, 1) is None)
+  assert_true(closed.dock.tabs.is_empty())
+}
+
+///|
+test "full-screen modals hide the native view and closing restores it" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700 }
+  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  assert_true(model.browser_pane.shown == Some(1))
+  // The workspace picker's modal covers the pane; native views z-order
+  // above HTML, so the view must hide first.
+  let (_, covered) = update(dispatch, PickWorkspace(Local), model)
+  assert_true(covered.workspace_picker is Some(_))
+  assert_true(covered.browser_pane.shown is None)
+  // Closing the modal re-measures; the next measurement re-places the view.
+  let (_, closed) = update(dispatch, WorkspacePickerClose, covered)
+  let (_, restored) = update(dispatch, BrowserPaneMeasured(rect~), closed)
+  assert_true(restored.browser_pane.shown == Some(1))
+  // The topbar app launcher's click-away backdrop covers the pane too.
+  let (_, launched) = update(dispatch, ToggleLauncher, restored)
+  assert_true(launched.browser_pane.shown is None)
+  // So do the other two surfaces `view.mbt` appends beside the picker: the
+  // archive-discard confirmation and the workspace-symbol palette.
+  let (_, archiving) = update_dev(
+    dispatch,
+    ArchiveNeedsForce(session="desktop-test", message="dirty"),
+    restored,
+  )
+  assert_true(archiving.archive_confirm is Some(_))
+  assert_true(archiving.browser_pane.shown is None)
+  let (_, searching) = update(dispatch, SymbolSearchOpen, restored)
+  assert_true(searching.symbol_search is Some(_))
+  assert_true(searching.browser_pane.shown is None)
 }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2615,12 +2615,12 @@ fn topbar_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // panel is closed; an open panel carries the toggle at the right edge of
   // its breadcrumb instead, keeping this bar uncrowded. Both spots hug the
   // window's right edge, so the toggle stays put as the panel opens/closes.
-  if !model.file_panel.open {
+  if !model.dock.open {
     items.push(
       @html.button(
         class="panel-toggle",
         title="Show panel",
-        on_click=dispatch(FileEditor(ToggleFilePanel)),
+        on_click=dispatch(Dock(TogglePanel)),
         icon(icon_layout_sidebar_right),
       ),
     )
@@ -2706,6 +2706,107 @@ fn console_gate_view(
 }
 
 ///|
+/// The right panel: the dock's strip over the file subsystem's breadcrumb
+/// and viewer/tree body, in the exact child order the old fileeditor panel
+/// rendered — the order is structural (rabbita diffs by index) and the
+/// viewer host must never be re-keyed. The strip renders identities only;
+/// labels and the deleted styling come from the document table.
+fn dock_panel_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  let femit = dispatch.map(msg => FileEditor(msg))
+  let ctx = file_ctx(model)
+  let chips : Array[@dock.TabChip] = model.dock.tabs.map(tab => {
+    match tab {
+      File(path~) => {
+        let (label, missing) = match model.file_panel.docs.get(path) {
+          Some(doc) => (doc.name, doc.state is TabDeleted)
+          None => (@fileeditor.basename(path), false)
+        }
+        { tab, label, title: path.0, missing }
+      }
+      Browser(id~) => {
+        let (label, title) = match @preview.page(model.preview, id) {
+          Some(page) => {
+            let label = @preview.page_label(page)
+            (label, page.url.unwrap_or(label))
+          }
+          None => ("New Tab", "New Tab")
+        }
+        { tab, label, title, missing: false }
+      }
+      FilePicker =>
+        {
+          tab,
+          label: "Open File",
+          title: "Open a workspace file",
+          missing: false,
+        }
+    }
+  })
+  let actions : @dock.LauncherActions = {
+    // Browser tabs need this window's native views; a remote console has
+    // none, so its launcher offers files only.
+    browser: if model.is_desktop {
+      Some(dispatch(BrowserTabRequested))
+    } else {
+      None
+    },
+    files: dispatch(FilePickerRequested),
+  }
+  // The active tab's kind as a class: every body part below is rendered
+  // permanently and CSS shows exactly one, so no host is ever re-keyed.
+  let mode = match model.dock.active {
+    None => "mode-launcher"
+    Some(Browser(_)) => "mode-browser"
+    Some(FilePicker) => "mode-picker"
+    Some(File(_)) => "mode-file"
+  }
+  // The toolbar always renders (structural child order); it shows the
+  // active Browser page's state, or a blank placeholder while CSS hides it.
+  let active_page : @preview.PageState = match
+    @dock.active_browser(model.dock) {
+    Some(id) =>
+      match @preview.page(model.preview, id) {
+        Some(page) => page
+        None => blank_browser_page()
+      }
+    None => blank_browser_page()
+  }
+  let toolbar_actions : @preview.ToolbarActions = {
+    input: dispatch.map(value => BrowserAddressEdited(value)),
+    submit: dispatch(BrowserNavigateSubmitted),
+    back: dispatch(BrowserBack),
+    forward: dispatch(BrowserForward),
+    reload: dispatch(BrowserReload),
+    open_external: dispatch(BrowserOpenExternal),
+  }
+  @html.div(
+    class=@fileeditor.editor_classes(model.file_panel, ctx) + " " + mode,
+    [
+      @fileeditor.resize_handle_view(),
+      @dock.tabs_bar(dispatch.map(msg => Dock(msg)), model.dock, chips, actions),
+      @fileeditor.breadcrumb_view(femit, model.file_panel, ctx),
+      @fileeditor.body_view(femit, model.file_panel, ctx),
+      @html.div(class="browser-chrome", [
+        @preview.toolbar_view(active_page, toolbar_actions),
+        @preview.failure_view(active_page),
+        // The placeholder the active page's native view overlays; it only
+        // donates its rectangle (measured after render / by ResizeObserver).
+        @html.div(
+          attrs=@html.Attrs::build().id("browser-pane").class("browser-pane"),
+          ([] : Array[@html.Html]),
+        ),
+      ]),
+      @dock.launcher_pane(actions),
+    ],
+  )
+}
+
+///|
+fn blank_browser_page() -> @preview.PageState {
+  { url: None, input: "", title: "", loading: false, failure: None }
+}
+
+///|
 fn view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // A browser page is gated on the relay session: until `/v1/auth/me`
   // answers signed-in, the console frame — sidebar, composer, overlays —
@@ -2735,7 +2836,7 @@ fn view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // chat; on the Skills page it stays collapsed, but the editor column (and the
   // viewer host inside it) is still rendered so the attached viewer is never
   // torn down.
-  let panel_open = model.file_panel.open && model.screen is Chat
+  let panel_open = model.dock.open && model.screen is Chat
   let mut content_class = if panel_open {
     "content panel-open"
   } else {
@@ -2748,11 +2849,7 @@ fn view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     sidebar_view(dispatch, model),
     @html.div(class=content_class, [
       @html.main_(content),
-      @fileeditor.panel_view(
-        dispatch.map(msg => FileEditor(msg)),
-        model.file_panel,
-        file_ctx(model),
-      ),
+      dock_panel_view(dispatch, model),
       // Keep the stable emulator host mounted while the panel is hidden; its
       // imperative xterm instances retain their screens and scrollback.
       @terminal.panel_view(

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -342,3 +342,54 @@ pub let shell_open_external : Command[
   @protocol.ExternalLinkPayload,
   @protocol.OpenExternalReply,
 ] = Command("shell.open_external")
+// The dock's browser-tab commands. Like `host.connect` and
+// `shell.open_external`, they are bound window-only: the native web
+// contents views live in the desktop window, so a relay browser has
+// nothing to command.
+
+///|
+pub let browser_open : Command[
+  @protocol.BrowserOpenPayload,
+  @protocol.EmptyReply,
+] = Command("browser.open")
+
+///|
+pub let browser_navigate : Command[
+  @protocol.BrowserOpenPayload,
+  @protocol.EmptyReply,
+] = Command("browser.navigate")
+
+///|
+pub let browser_back : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply] = Command(
+  "browser.back",
+)
+
+///|
+pub let browser_forward : Command[
+  @protocol.BrowserIdPayload,
+  @protocol.EmptyReply,
+] = Command("browser.forward")
+
+///|
+pub let browser_reload : Command[
+  @protocol.BrowserIdPayload,
+  @protocol.EmptyReply,
+] = Command("browser.reload")
+
+///|
+pub let browser_set_bounds : Command[
+  @protocol.BrowserBoundsPayload,
+  @protocol.EmptyReply,
+] = Command("browser.set_bounds")
+
+///|
+pub let browser_set_visible : Command[
+  @protocol.BrowserVisiblePayload,
+  @protocol.EmptyReply,
+] = Command("browser.set_visible")
+
+///|
+pub let browser_close : Command[
+  @protocol.BrowserIdPayload,
+  @protocol.EmptyReply,
+] = Command("browser.close")

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -33,6 +33,22 @@ pub let auth_disconnect : Command[@protocol.EmptyPayload, @protocol.AuthStatusPa
 
 pub let auth_status : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
 
+pub let browser_back : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+
+pub let browser_close : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+
+pub let browser_forward : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+
+pub let browser_navigate : Command[@protocol.BrowserOpenPayload, @protocol.EmptyReply]
+
+pub let browser_open : Command[@protocol.BrowserOpenPayload, @protocol.EmptyReply]
+
+pub let browser_reload : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+
+pub let browser_set_bounds : Command[@protocol.BrowserBoundsPayload, @protocol.EmptyReply]
+
+pub let browser_set_visible : Command[@protocol.BrowserVisiblePayload, @protocol.EmptyReply]
+
 pub let extension_contract : @proton_contract.ExtensionContract
 
 pub let fs_browse : Command[@protocol.BrowseDirectoryPayload, @protocol.BrowseDirectoryReply]

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -1,0 +1,322 @@
+// The native half of the dock's Browser tabs: one web contents view per
+// page, owned by the window and driven by bridge-local ops. Like
+// `shell.open_external`, none of these commands join the shared API catalog
+// — a relay browser has no native views to command. View events flow back
+// to the page as `browser.event` notifications through the bridge actor.
+
+///|
+/// The registry of native browser views. The window handle arrives with
+/// Proton's window lifecycle and every view hangs off it by name, so this
+/// holds no view map of its own — `WindowHandle::find_view` is the truth.
+struct BrowserViews {
+  mut window : @proton.WindowHandle?
+}
+
+///|
+pub fn BrowserViews::new() -> BrowserViews {
+  { window: None }
+}
+
+///|
+pub fn BrowserViews::window_ready(
+  self : BrowserViews,
+  window : @proton.WindowHandle,
+) -> Unit {
+  self.window = Some(window)
+}
+
+///|
+pub fn BrowserViews::window_closed(self : BrowserViews) -> Unit {
+  self.window = None
+}
+
+///|
+/// Drop every browser view. A reloaded page allocates ids from scratch, so
+/// views of the previous page must not survive its `host.connect`.
+fn BrowserViews::close_all(self : BrowserViews) -> Unit {
+  guard self.window is Some(window) else { return }
+  for view in window.views() {
+    if browser_view_id(view.id()) is Some(_) {
+      window.remove_view(view.id()) catch {
+        _ => ()
+      }
+    }
+  }
+}
+
+///|
+fn view_name(id : Int) -> String {
+  "browser-\{id}"
+}
+
+///|
+/// The page id a view name encodes, or `None` for views that are not
+/// browser tabs. The inverse of `view_name`.
+pub fn browser_view_id(name : String) -> Int? {
+  guard name.strip_prefix("browser-") is Some(digits) && !digits.is_empty() else {
+    return None
+  }
+  Some(@string.parse_int(digits, base=10)) catch {
+    _ => None
+  }
+}
+
+///|
+/// A view event as the `browser.event` notification payload the frontend
+/// decodes.
+pub fn view_event_json(id : Int, event : @proton.ViewEvent) -> Json {
+  match event {
+    Navigated(url~) =>
+      { "id": id.to_json(), "kind": "navigated", "url": url.to_json() }
+    LoadingChanged(is_loading~) =>
+      { "id": id.to_json(), "kind": "loading", "loading": is_loading.to_json() }
+    TitleUpdated(title~) =>
+      { "id": id.to_json(), "kind": "title", "title": title.to_json() }
+    LoadFailed(url~, error_code~, error_text~) =>
+      {
+        "id": id.to_json(),
+        "kind": "load_failed",
+        "url": url.to_json(),
+        "code": error_code.to_json(),
+        "text": error_text.to_json(),
+      }
+  }
+}
+
+///|
+priv suberror BrowserViewError {
+  BrowserViewError(String)
+}
+
+///|
+impl Show for BrowserViewError with fn output(self, logger) {
+  match self {
+    BrowserViewError(message) => logger.write_string(message)
+  }
+}
+
+///|
+/// Browser views navigate to web pages only — never local files or the
+/// app's own scheme. Schemes are case-insensitive (RFC 3986), and the
+/// frontend passes URLs as typed, so the check lowercases before matching.
+fn allowed_page_url(url : String) -> Bool {
+  let buf = StringBuilder::new()
+  for ch in url {
+    buf.write_char(ch.to_ascii_lowercase())
+  }
+  let lower = buf.to_string()
+  if lower.strip_prefix("https://") is Some(rest) {
+    !rest.is_empty()
+  } else if lower.strip_prefix("http://") is Some(rest) {
+    !rest.is_empty()
+  } else {
+    false
+  }
+}
+
+///|
+fn BrowserViews::attached_window(
+  self : BrowserViews,
+) -> @proton.WindowHandle raise BrowserViewError {
+  guard self.window is Some(window) else {
+    raise BrowserViewError("The desktop window is not ready")
+  }
+  window
+}
+
+///|
+fn BrowserViews::view(
+  self : BrowserViews,
+  id : Int,
+) -> @proton.ViewHandle raise BrowserViewError {
+  guard self.attached_window().view(view_name(id)) is Some(view) else {
+    raise BrowserViewError("Unknown browser view \{id}")
+  }
+  view
+}
+
+///|
+/// Point page `id`'s native view at `url`, creating the view if it does not
+/// exist yet. A fresh view starts hidden at a placeholder size; the frontend
+/// shows and places it with the `browser.set_bounds`/`browser.set_visible`
+/// that follow its next pane measurement. `browser.open` and
+/// `browser.navigate` share this create-if-missing semantic on purpose: the
+/// frontend commits a page's URL optimistically, so if the creating call was
+/// rejected (or raced a reload's `close_all`), the next navigation must be
+/// able to build the view rather than strand the tab.
+fn BrowserViews::open(
+  self : BrowserViews,
+  payload : @protocol.BrowserOpenPayload,
+) -> @protocol.EmptyReply raise {
+  guard allowed_page_url(payload.url) else {
+    raise BrowserViewError("Blocked non-web page URL")
+  }
+  let window = self.attached_window()
+  match window.view(view_name(payload.id)) {
+    Some(view) => view.load_url(payload.url)
+    None =>
+      ignore(
+        window.add_view(
+          view_name(payload.id),
+          @proton.view(payload.url, width=800, height=600, visible=false),
+        ),
+      )
+  }
+  Acknowledged
+}
+
+///|
+fn BrowserViews::back(
+  self : BrowserViews,
+  payload : @protocol.BrowserIdPayload,
+) -> @protocol.EmptyReply raise {
+  self.view(payload.id).back()
+  Acknowledged
+}
+
+///|
+fn BrowserViews::forward(
+  self : BrowserViews,
+  payload : @protocol.BrowserIdPayload,
+) -> @protocol.EmptyReply raise {
+  self.view(payload.id).forward()
+  Acknowledged
+}
+
+///|
+fn BrowserViews::reload(
+  self : BrowserViews,
+  payload : @protocol.BrowserIdPayload,
+) -> @protocol.EmptyReply raise {
+  self.view(payload.id).reload()
+  Acknowledged
+}
+
+///|
+fn BrowserViews::set_bounds(
+  self : BrowserViews,
+  payload : @protocol.BrowserBoundsPayload,
+) -> @protocol.EmptyReply raise {
+  self
+  .view(payload.id)
+  .set_bounds(
+    x=payload.x,
+    y=payload.y,
+    width=payload.width,
+    height=payload.height,
+  )
+  Acknowledged
+}
+
+///|
+fn BrowserViews::set_visible(
+  self : BrowserViews,
+  payload : @protocol.BrowserVisiblePayload,
+) -> @protocol.EmptyReply raise {
+  self.view(payload.id).set_visible(payload.visible)
+  Acknowledged
+}
+
+///|
+fn BrowserViews::close(
+  self : BrowserViews,
+  payload : @protocol.BrowserIdPayload,
+) -> @protocol.EmptyReply raise {
+  // Closing a view that is already gone is not an error: the close raced a
+  // page reload's `close_all`.
+  guard self.window is Some(window) else { return Acknowledged }
+  if window.view(view_name(payload.id)) is Some(_) {
+    window.remove_view(view_name(payload.id))
+  }
+  Acknowledged
+}
+
+///|
+/// The dock's browser-tab endpoints, kept beside their handlers so the two
+/// cannot drift. All of them are window-only like `shell.open_external`:
+/// the native web contents views live in this window, so a relay browser
+/// has nothing to command. `browser.navigate` deliberately binds the same
+/// create-if-missing handler as `browser.open`.
+fn browser_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
+  [
+    @endpoint.Endpoint::window(@commands.browser_open, (_, payload) => {
+      views.open(payload)
+    }),
+    @endpoint.Endpoint::window(@commands.browser_navigate, (_, payload) => {
+      views.open(payload)
+    }),
+    @endpoint.Endpoint::window(@commands.browser_back, (_, payload) => {
+      views.back(payload)
+    }),
+    @endpoint.Endpoint::window(@commands.browser_forward, (_, payload) => {
+      views.forward(payload)
+    }),
+    @endpoint.Endpoint::window(@commands.browser_reload, (_, payload) => {
+      views.reload(payload)
+    }),
+    @endpoint.Endpoint::window(@commands.browser_set_bounds, (_, payload) => {
+      views.set_bounds(payload)
+    }),
+    @endpoint.Endpoint::window(@commands.browser_set_visible, (_, payload) => {
+      views.set_visible(payload)
+    }),
+    @endpoint.Endpoint::window(@commands.browser_close, (_, payload) => {
+      views.close(payload)
+    }),
+  ]
+}
+
+///|
+test "browser ops are absent from the relay method catalog" {
+  let state = @api.ApiState::new(engine="unused")
+  let connection = @host.HostConnection::new()
+  let catalog = @api.endpoints(state, connection)
+  for endpoint in browser_endpoints(BrowserViews::new()) {
+    let name = endpoint.name()
+    assert_false(catalog.iter().any(shared => shared.name() == name))
+  }
+}
+
+///|
+test "browser ops refuse to run without a window; close tolerates it" {
+  // The ops refuse to run without a window, which is the earliest failure
+  // a headless test can observe.
+  fn raises(run : () -> @protocol.EmptyReply raise) -> Bool {
+    let _ = run() catch { _ => return true }
+    false
+  }
+
+  let views = BrowserViews::new()
+  assert_true(raises(() => views.open({ id: 1, url: "http://x/" })))
+  assert_true(raises(() => views.back({ id: 1 })))
+  assert_true(raises(() => views.forward({ id: 1 })))
+  assert_true(raises(() => views.reload({ id: 1 })))
+  assert_true(
+    raises(() => views.set_bounds({ id: 1, x: 0, y: 0, width: 10, height: 10 })),
+  )
+  assert_true(raises(() => views.set_visible({ id: 1, visible: true })))
+  // Closing with no window (or no view) is deliberately not an error:
+  // the close raced a page reload's `close_all`.
+  assert_true(views.close({ id: 1 }) is Acknowledged)
+}
+
+///|
+test "view names round-trip and reject foreign views" {
+  assert_true(browser_view_id("browser-3") == Some(3))
+  assert_true(browser_view_id("browser-42") == Some(42))
+  assert_true(browser_view_id("browser-") is None)
+  assert_true(browser_view_id("sidebar") is None)
+  assert_true(browser_view_id("browser-x") is None)
+}
+
+///|
+test "browser page urls are web-only" {
+  assert_true(allowed_page_url("http://127.0.0.1:5173/"))
+  assert_true(allowed_page_url("https://github.com/"))
+  assert_true(allowed_page_url("HTTPS://Example.COM/x"))
+  assert_true(allowed_page_url("HTTP://LOCALHOST:5173/"))
+  assert_false(allowed_page_url("proton://app/"))
+  assert_false(allowed_page_url("file:///etc/passwd"))
+  assert_false(allowed_page_url("javascript:alert(1)"))
+  assert_false(allowed_page_url("about:blank"))
+}

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -133,6 +133,16 @@ let terminal_exit_event : @proton_contract.Event[@protocol.TerminalExitPayload] 
 )
 
 ///|
+/// The one window-local event: native browser view events (navigation,
+/// title, load state), pumped in by `App::on_view_event` through
+/// `DesktopBridgeActor::notify_browser_event`. It deliberately has no
+/// `NotificationKind` — the shared wire catalog must never carry it to a
+/// relay client, which has no native views.
+let browser_event : @proton_contract.Event[Json] = @commands.extension_contract.event(
+  "browser.event",
+)
+
+///|
 /// The page connection and Proton's window lifecycle hook start independently.
 /// Bound the short startup backlog rather than letting either side grow an
 /// unbounded in-memory queue while it waits for the other.
@@ -146,6 +156,15 @@ priv enum BridgeControl {
 }
 
 ///|
+/// What the actor delivers to the attached page: a hub notification from
+/// the shared catalog, or this window's own browser view event — which has
+/// a Proton descriptor but deliberately no place in the wire catalog.
+priv enum PageNotification {
+  Hub(@protocol.Notification)
+  BrowserEvent(Json)
+}
+
+///|
 priv struct PageEventTarget {
   events : @proton.WindowEventEmitter
 }
@@ -153,38 +172,42 @@ priv struct PageEventTarget {
 ///|
 async fn PageEventTarget::emit(
   self : PageEventTarget,
-  notification : @protocol.Notification,
+  notification : PageNotification,
 ) -> Unit {
   // Matching the closed enum keeps each Proton descriptor paired with the
   // payload type that belongs to that event.
   match notification {
-    AgentConnected(payload) => self.events.emit(connected_event, payload)
-    AgentStarted(payload) => self.events.emit(started_event, payload)
-    AgentEvent(payload) => self.events.emit(agent_event, payload)
-    AgentError(payload) => self.events.emit(agent_error_event, payload)
-    AgentFinished(payload) => self.events.emit(finished_event, payload)
-    AgentDurable(payload) => self.events.emit(durable_event, payload)
-    SessionEvent(payload) => self.events.emit(session_event, payload)
-    SessionChanged(payload) => self.events.emit(session_changed_event, payload)
-    WorkspaceChanged(payload) =>
+    Hub(AgentConnected(payload)) => self.events.emit(connected_event, payload)
+    Hub(AgentStarted(payload)) => self.events.emit(started_event, payload)
+    Hub(AgentEvent(payload)) => self.events.emit(agent_event, payload)
+    Hub(AgentError(payload)) => self.events.emit(agent_error_event, payload)
+    Hub(AgentFinished(payload)) => self.events.emit(finished_event, payload)
+    Hub(AgentDurable(payload)) => self.events.emit(durable_event, payload)
+    Hub(SessionEvent(payload)) => self.events.emit(session_event, payload)
+    Hub(SessionChanged(payload)) =>
+      self.events.emit(session_changed_event, payload)
+    Hub(WorkspaceChanged(payload)) =>
       self.events.emit(workspace_changed_event, payload)
-    WorktreeChanged(payload) =>
+    Hub(WorktreeChanged(payload)) =>
       self.events.emit(worktree_changed_event, payload)
-    SettingsChanged(payload) =>
+    Hub(SettingsChanged(payload)) =>
       self.events.emit(settings_changed_event, payload)
-    SkillsChanged => self.events.emit(skills_changed_event, NoPayload)
-    UpdateDownloadProgress(payload) =>
+    Hub(SkillsChanged) => self.events.emit(skills_changed_event, NoPayload)
+    Hub(UpdateDownloadProgress(payload)) =>
       self.events.emit(update_progress_event, payload)
-    UpdateDownloaded(payload) =>
+    Hub(UpdateDownloaded(payload)) =>
       self.events.emit(update_downloaded_event, payload)
-    UpdateDownloadFailed(payload) =>
+    Hub(UpdateDownloadFailed(payload)) =>
       self.events.emit(update_failed_event, payload)
-    AuthChanged(payload) => self.events.emit(auth_changed_event, payload)
-    LspDiagnostics(payload) => self.events.emit(diagnostics_event, payload)
-    FsChanged(payload) => self.events.emit(fs_changed_event, payload)
-    FsWatchFailed(payload) => self.events.emit(fs_watch_failed_event, payload)
-    TerminalOutput(payload) => self.events.emit(terminal_output_event, payload)
-    TerminalExit(payload) => self.events.emit(terminal_exit_event, payload)
+    Hub(AuthChanged(payload)) => self.events.emit(auth_changed_event, payload)
+    Hub(LspDiagnostics(payload)) => self.events.emit(diagnostics_event, payload)
+    Hub(FsChanged(payload)) => self.events.emit(fs_changed_event, payload)
+    Hub(FsWatchFailed(payload)) =>
+      self.events.emit(fs_watch_failed_event, payload)
+    Hub(TerminalOutput(payload)) =>
+      self.events.emit(terminal_output_event, payload)
+    Hub(TerminalExit(payload)) => self.events.emit(terminal_exit_event, payload)
+    BrowserEvent(payload) => self.events.emit(browser_event, payload)
   }
 }
 
@@ -194,7 +217,7 @@ async fn PageEventTarget::emit(
 /// retains request-scoped state after the command returns.
 priv enum BridgeInput {
   Control(BridgeControl)
-  Deliver(@protocol.Notification)
+  Deliver(PageNotification)
 }
 
 ///|
@@ -207,6 +230,10 @@ struct DesktopBridgeActor {
   // remote WebSocket connection.
   host_connection : @host.HostConnection
   controls : @async.Queue[BridgeControl]
+  // Window-local browser view events that must reach this page without
+  // touching the process-wide hub — a relay client has no native views, so
+  // it must never see them.
+  browser_events : @async.Queue[Json]
 }
 
 ///|
@@ -218,17 +245,34 @@ pub fn DesktopBridgeActor::new(state : @api.ApiState) -> DesktopBridgeActor {
     // reload to overlap the old page without allowing abandoned requests to
     // accumulate forever.
     controls: Queue(kind=Blocking(8)),
+    browser_events: Queue(kind=Blocking(64)),
   }
+}
+
+///|
+/// Queue a window-local browser view event for the attached page. The
+/// delivery rules (declared descriptor, connect-then-window-ready ordering,
+/// the bounded startup backlog) are the actor loop's, same as hub
+/// notifications.
+pub async fn DesktopBridgeActor::notify_browser_event(
+  self : DesktopBridgeActor,
+  params : Json,
+) -> Unit {
+  self.browser_events.put(params)
 }
 
 ///|
 pub fn openseek_extension(
   state : @api.ApiState,
   bridge : DesktopBridgeActor,
+  views : BrowserViews,
 ) -> @proton_extension.Extension {
   let endpoints = @api.endpoints(state, bridge.host_connection)
   endpoints.push(
     @endpoint.Endpoint::window(@commands.host_connect, async fn(context, _) {
+      // A reloaded page allocates browser ids from scratch; the previous
+      // page's native views must not survive its attachment.
+      views.close_all()
       bridge.connect(context)
     }),
   )
@@ -240,6 +284,9 @@ pub fn openseek_extension(
       open_external(payload)
     }),
   )
+  for endpoint in browser_endpoints(views) {
+    endpoints.push(endpoint)
+  }
   @proton_extension.typed(
     @commands.extension_contract,
     endpoints.map(endpoint => endpoint.route()),
@@ -296,8 +343,9 @@ async fn DesktopBridgeActor::next_input(
   }
   @async.any([
     () => Control(self.controls.get()),
-    () => Deliver(notifications.get()),
-    () => Deliver(host_notifications.get()),
+    () => Deliver(Hub(notifications.get())),
+    () => Deliver(Hub(host_notifications.get())),
+    () => Deliver(BrowserEvent(self.browser_events.get())),
   ])
 }
 
@@ -323,7 +371,7 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
     })
     let mut connected = false
     let mut target : PageEventTarget? = None
-    let pending : Array[@protocol.Notification] = []
+    let pending : Array[PageNotification] = []
     for ;; {
       match self.next_input(notifications, host_notifications) {
         Control(control) =>

--- a/desktop/internal/extension/moon.pkg
+++ b/desktop/internal/extension/moon.pkg
@@ -9,6 +9,7 @@ import {
   "openseek_desktop/internal/platform",
   "openseek_desktop/internal/protocol",
   "moonbitlang/async",
+  "moonbitlang/core/string",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/extension/pkg.generated.mbti
+++ b/desktop/internal/extension/pkg.generated.mbti
@@ -7,13 +7,23 @@ import {
 }
 
 // Values
-pub fn openseek_extension(@api.ApiState, DesktopBridgeActor) -> @justjavac/proton/extension.Extension
+pub fn browser_view_id(String) -> Int?
+
+pub fn openseek_extension(@api.ApiState, DesktopBridgeActor, BrowserViews) -> @justjavac/proton/extension.Extension
+
+pub fn view_event_json(Int, @proton.ViewEvent) -> Json
 
 // Errors
 
 // Types and methods
+type BrowserViews
+pub fn BrowserViews::new() -> Self
+pub fn BrowserViews::window_closed(Self) -> Unit
+pub fn BrowserViews::window_ready(Self, @proton.WindowHandle) -> Unit
+
 type DesktopBridgeActor
 pub fn DesktopBridgeActor::new(@api.ApiState) -> Self
+pub async fn DesktopBridgeActor::notify_browser_event(Self, Json) -> Unit
 pub async fn DesktopBridgeActor::run(Self) -> Unit
 pub async fn DesktopBridgeActor::window_closed(Self) -> Unit
 pub async fn DesktopBridgeActor::window_ready(Self, @proton.WindowEventEmitter) -> Unit

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -248,6 +248,32 @@ pub(all) struct MoonIdeNavigationPayload {
 pub(all) struct ExternalLinkPayload {
   url : String
 } derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct BrowserOpenPayload {
+  id : Int
+  url : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct BrowserIdPayload {
+  id : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct BrowserBoundsPayload {
+  id : Int
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct BrowserVisiblePayload {
+  id : Int
+  visible : Bool
+} derive(Debug, Eq, FromJson, ToJson)
 // Notification payloads.
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -84,6 +84,28 @@ pub(all) struct BrowseDirectoryReply {
   entries : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) struct BrowserBoundsPayload {
+  id : Int
+  x : Int
+  y : Int
+  width : Int
+  height : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct BrowserIdPayload {
+  id : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct BrowserOpenPayload {
+  id : Int
+  url : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct BrowserVisiblePayload {
+  id : Int
+  visible : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
 pub(all) struct CancelPayload {
   run_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -50,6 +50,9 @@ fn main {
       app_version~,
     )
     let bridge = @extension.DesktopBridgeActor::new(state)
+    // The dock's browser tabs: native web contents views, owned by the
+    // window and commanded over bridge-local `browser.*` ops.
+    let views = @extension.BrowserViews::new()
     let relay = @remote.RelayActor::new(state, announce=device => {
       log.info() <? { "message": "relay registered", "device": device }
     })
@@ -63,17 +66,37 @@ fn main {
       .debug_level(1)
       // Both command extensions are deliberately exposed to the configured
       // entry page; registration alone does not grant renderer access.
-      .expose(@extension.openseek_extension(state, bridge))
+      .expose(@extension.openseek_extension(state, bridge, views))
       // System notifications are an ordinary generated extension now: the
       // frontend posts them and receives `notification.click` with the run id.
       .expose(@notification.extension())
       // The connect request proves the page can issue commands; this paired
       // lifecycle supplies the window-owned event destination that remains
-      // valid after that request returns.
+      // valid after that request returns — and the window handle the browser
+      // views hang off.
       .window_lifecycle(
-        on_ready=async fn(context) { bridge.window_ready(context.events()) },
-        on_close=async fn(_) { bridge.window_closed() },
+        on_ready=async fn(context) {
+          views.window_ready(context.handle())
+          bridge.window_ready(context.events())
+        },
+        on_close=async fn(_) {
+          views.window_closed()
+          bridge.window_closed()
+        },
       )
+      // Browser view events reach the page as `browser.event` notifications;
+      // views that are not browser tabs are not the frontend's business.
+      .on_view_event(async fn(view, event) noraise {
+        match @extension.browser_view_id(view.id()) {
+          Some(id) =>
+            bridge.notify_browser_event(@extension.view_event_json(id, event)) catch {
+              // Only cancellation can interrupt the queue put — the app is
+              // shutting down, so the event has nowhere to go anyway.
+              _ => ()
+            }
+          None => ()
+        }
+      })
     @async.with_task_group(group => {
       // The bridge actor, engine actor, and host actors run for the app's
       // lifetime — they feed every page/client rather than borrowing a

--- a/docs/plans/sidebar-dock.md
+++ b/docs/plans/sidebar-dock.md
@@ -1,0 +1,565 @@
+# Sidebar Dock: Mixed Tab Strip For Editor, Browser, And Future Views
+
+## Goal
+
+Rebuild the right-hand panel as a dock whose single tab strip mixes
+heterogeneous tabs — files (the existing editor), browser preview pages (new),
+and future kinds such as subagent viewers — in the style of the Codex desktop
+client. P1 ships the dock refactor plus an iframe-backed browser scaffold; the
+browser engine is later swapped for a native CEF browser view upstreamed in
+proton (P2) without reworking the dock. The editor's current behavior must not
+regress.
+
+## Accepted Design
+
+### Strip ownership
+
+- A new `desktop/frontend/dock/` package owns the strip as the single source
+  of truth: `tabs : Array[DockTab]` (strip order) plus `active : DockTab?`,
+  with the invariant that `active` is `None` exactly when the strip is
+  empty. An empty strip renders the launcher menu — that is a view branch on
+  `tabs.is_empty()`, not a stored mode.
+
+  ```
+  enum DockTab {
+    File(path~ : @pathx.Relative)   // document state stays in fileeditor
+    Browser(id~ : Int)              // page state lives in preview
+    FilePicker                      // transient open-a-file tab; at most one
+    // future: Subagent(id~ : ...)
+  }
+  ```
+
+- `FilePicker` is the one transient tab kind (Codex's "open file" tab): the
+  launcher's Files row opens it, or re-activates the existing one — at most
+  one lives in the strip. Its body shows the workspace tree with a
+  pick-a-file placeholder. Choosing a file replaces the picker in place with
+  that file's `File` tab; if the file is already open, the existing `File`
+  tab is activated and the picker closes. It closes like any tab and holds
+  no document state, so park/restore treats it as a plain strip entry.
+- Clicking the file pane's own tree (visible beside the viewer when a
+  `File` tab is active) keeps today's rule: open the path's tab or
+  re-activate it if already open.
+- No projection/reconciliation design: `fileeditor` stops owning any strip
+  state. Two owners of membership with one owner of order is a standing bug
+  source; the strip is hoisted wholesale instead.
+- `fileeditor` is demoted to a document subsystem: it keeps the per-path
+  document table (content, mtime signature, staleness), the file tree, LSP,
+  and the watcher. The list of open files flows in one direction — the root
+  update projects `Array[@pathx.Relative]` out of the dock strip into
+  `fileeditor.Ctx` for stat/watch/reload sweeps. Nothing flows back.
+- `TabActivated` / `TabClosed` move from `fileeditor.Msg` to the dock's `Msg`;
+  a tree click (`FileSelected`) becomes an intent the root update turns into a
+  dock open-tab message.
+
+### Rendering: hosts stay mounted, CSS switches
+
+- Every tab-kind host is rendered permanently and hidden by CSS — never
+  unmounted. This is load-bearing: the editor viewer, xterm, and iframes are
+  imperative hosts under Rabbita's positional diffing, and an iframe that
+  leaves the DOM (or is reparented) reloads its document unconditionally.
+- File tabs share the one editor viewer host, exactly as today.
+- The `FilePicker` tab reuses the file view's chrome — the tree stays, the
+  viewer area shows an open-a-file placeholder; no new host.
+- Each `Browser(id)` tab owns one iframe element (`browser-host-<id>`),
+  attached imperatively on first use (the terminal package's pattern) inside
+  one stable container. Inactive iframes are CSS-hidden, never detached.
+- The dock view renders the strip and the body: active `File` embeds the
+  fileeditor viewer + tree, active `Browser` embeds the preview toolbar + that
+  tab's iframe, and an empty strip renders the launcher menu.
+- P2 forward-compatibility: each `Browser` tab later maps to one native CEF
+  browser view; the dock still only decides which tab is visible and where its
+  bounds are. The strip machine does not change.
+
+### Conversation switch: per-conversation strips, keep-alive iframes
+
+- The whole strip is parked and restored per `ConversationKey`, generalizing
+  fileeditor's `remembered` machinery (which moves into the dock): a
+  remembered strip is the ordered `Array[DockTab]` identities plus the active
+  tab. Agent-opened pages belong to their conversation, same as files.
+- Semantics and implementation are deliberately split: parking drops file
+  content (cheap to re-read, a pure function of the path) but browser iframes
+  are keyed by their global id and stay mounted across parks, so returning to
+  a conversation does not reload its pages. A page's value is its live state
+  (scroll, form, SPA memory), which no re-navigation can reproduce.
+- Live iframes are capped (LRU, initial cap 8). An evicted tab keeps its strip
+  entry and reloads its URL on next activation.
+
+### Preview package (browser subsystem, P1 = iframe)
+
+- `desktop/frontend/preview/` owns per-page state:
+
+  ```
+  struct PageState { url : String, input : String }  // input = address draft
+  struct State { pages : Map[Int, PageState], next_id : Int }
+  ```
+
+- Toolbar: address bar (auto-prefix `http://`, recognizes localhost), reload
+  (imperative `src` reset), open-in-system-browser. Tab label shows the host
+  (`localhost:5173`) with a generic globe icon.
+- No back/forward in the iframe phase. The joint session history is shared by
+  the top page and every live iframe (including hidden background tabs whose
+  SPAs push entries), `history.back()` targets whichever frame owns the
+  adjacent entry with no API to scope or introspect it, button enablement
+  cannot be computed, and a cross-origin iframe's current URL is unreadable so
+  the address bar would lie after navigating. A self-maintained URL stack is
+  worse: in-page navigations are invisible to the embedder, so the stack
+  diverges immediately and "back" destroys real history. Full navigation
+  (`GoBack`/`CanGoBack`/`OnAddressChange`) arrives with the native view in P2.
+- No favicon fetching: the app page is a `proton://` origin and its http(s)
+  subresource fetches silently hang inside CEF's network service (known bug);
+  an `<img>` pointed at a site's favicon would hit the same stall.
+- Non-localhost input warns that external sites usually refuse framing
+  (`X-Frame-Options`/`frame-ancestors` denials are undetectable from the
+  embedder — the frame just stays blank) instead of letting the user hit a
+  silent white pane.
+
+### Entry points and routing
+
+- `ExternalLinkClicked` in the root update splits: web (`http(s)`) URLs
+  open (or re-activate a same-URL) Browser tab in the dock; non-web
+  schemes (`mailto:`, `vscode:`, …) and remote consoles keep the
+  open-in-system-browser path, and the toolbar's open-external button
+  hands any page to the system browser on demand. The capture-phase
+  listener in `external_links.mbt` is unchanged — the decision lives in
+  update. (The original iframe-era split was by host — loopback only —
+  for the XFO reasons below; native views render external sites fine, so
+  the default flipped once M2 shipped.)
+- The split is by host, not scheme, because `http(s)` says nothing about
+  whether the target permits framing: most external sites an agent links
+  (GitHub, Google, docs) send `X-Frame-Options`/`frame-ancestors` denials, a
+  denial is invisible to the embedder (the load event fires, the pane stays
+  blank), and probing response headers first is impossible — http(s) fetches
+  from the proton:// origin are exactly the requests that hang in CEF.
+  Loopback hosts are both the target scenario (dev servers) and in practice
+  never frame-blocking. The predicate is one function — widening it (say to
+  private-LAN hosts) is a one-line change — and P2's native view flips the
+  default so external links open in the dock too.
+- Opening tabs is launcher-driven, Codex-style: with an empty strip the dock
+  body is a centered launcher menu of the kinds the dock can open; with tabs
+  present, the strip's `+` opens the same menu as an anchored popup. P1
+  rows: Browser (opens a blank Browser tab with the address bar focused) and
+  Files (see below). Future kinds — review, subagent viewers — become new
+  rows without changing the mechanism. Per-row keyboard shortcuts are M3
+  polish. Every row must open its result in the sidebar — which is why
+  there is no Terminal row: the terminal deliberately lives in the bottom
+  dock, and a sidebar launcher entry that pops a panel elsewhere would
+  mislead.
+- The Files row opens the `FilePicker` tab, re-activating the existing one
+  if the strip already has it. A fuzzy quick-open (Cmd-P style) can later
+  complement this path.
+- No tab drag-reorder in P1 (positional vdom diffing makes a DnD strip a
+  project of its own).
+- The terminal keeps its bottom dock and separate toggle; it joins neither
+  the strip nor the launcher menu. If a sidebar terminal is ever wanted, it
+  arrives as a `DockTab::Terminal` variant with its own launcher row — the
+  dock design does not block it.
+
+### Layout mechanics
+
+- The drag-to-resize handle (CSS custom property `--editor-width`, handle
+  element, clamp bounds in `index.html`'s grid) is hoisted from `fileeditor`
+  to the dock package unchanged in behavior — it always resized the whole
+  panel, so ownership follows the panel.
+- Narrow layout keeps the existing semantics: one full-width pane; the file
+  view keeps its tree-drill-down behavior, the browser view fills the pane.
+- Rabbita discipline throughout: pure `update`, plain-data models, imperative
+  DOM only inside named hosts, idempotence tests for every new message.
+
+## Milestones
+
+- **M0 — iframe probe (gates M2).** A minimal proton app proving whether an
+  `<iframe src="http://localhost:...">` subframe navigation loads under a
+  `proton://` page at all. The known CEF hang was diagnosed for fetch/XHR/
+  EventSource from the proton origin; subframe navigation is unverified.
+  Deliberately out of scope for the probe: in-iframe WebSocket/HMR and
+  WebGPU — verified later against real dev servers if it ever matters.
+  Record the result in this document.
+
+  **Result (2026-08-03): FAILED — the iframe scaffold is not viable.** Probe
+  harness: untracked `probe_iframe/` module (add `./probe_iframe` to
+  `moon.work`, `PROTON_NATIVE_DIST=<assembled dist> moon build probe_iframe
+  --target native`, run against a local logging HTTP server). Findings, each
+  verified against the server's request log plus `PROTON_NATIVE_LOG` traces:
+  - `<iframe src="http://127.0.0.1:...">` under a `proton://` page: the
+    request never reaches the server (30 s), and the parent frame's
+    `load_end` never fires — the subframe navigation stalls exactly like the
+    known fetch/XHR hang.
+  - The same iframe under a `file://` host page also never issues the
+    request, so the stall is not proton-scheme registration; it hits
+    renderer-initiated http requests from any non-http document origin.
+  - Renderer-initiated **top-level** navigation from the proton:// page
+    (`location.href = "http://127.0.0.1:..."`) also vanishes — no request,
+    no `load_start`. So no "navigate the pane" workaround exists either.
+  - Controls proving the rest of the stack is healthy: a browser-initiated
+    top-level http load (host-side `load_url`, proton `url` entry) loads the
+    document, an `<img>` subresource, an in-page `fetch`, and the favicon
+    instantly; and a same-origin `proton://` iframe loads normally
+    (`status=200`). Iframe machinery and the network service are both fine —
+    only proton-origin-initiated http traffic is swallowed.
+  - Consequence: M2 ships the launcher/dock UI over the placeholder pane;
+    real page rendering arrives with P2's native CEF browser view, which
+    navigates browser-initiated — precisely the path the probe proved works.
+
+  **Addendum (2026-08-04): an http:// parent page revives the iframe.**
+  Probed: a top-level `http://127.0.0.1:18923/` page embedding an iframe
+  from a *different* loopback port (18924) loads instantly under CEF, and
+  in-iframe fetch works — the swallow only hits renderer-initiated http
+  requests from non-http document origins. And proton's runtime already
+  supports exposing the bridge to an http origin: `BridgeConfig.dev_origins`
+  → wire `origin_policy: { mode: "app_and_dev_origins", dev_origins }` →
+  enforced renderer-side in `cef_common/bridge_policy.c`. Our pinned lepus
+  gates it behind dev mode (`PROTON_DEV`, `bridge_page_policy_for_entry`),
+  but upstream main removed that gate in the 0.1.14 chain (fd15942,
+  2026-07-31; field renamed `entry_origin`): a production `Url` entry now
+  gets the bridge at its origin unconditionally — no upstream PR needed,
+  only a submodule bump (our pin 2652522 is 24 commits behind 744615c).
+  Remaining costs of this route: the host static server (the loopback OAuth
+  listener is prior art), entry/packaging adjustments, a persisted port
+  (origin changes wipe localStorage), and the residual iframe limits stay
+  (external sites still XFO-refuse framing — routing stays loopback-only;
+  no back/forward). Decision pending: pursue this as the P1 browser host,
+  or keep the placeholder-pane plan and leave real rendering to P2 — see
+  the P2 section: upstream is building the native view right now.
+
+  **Addendum (2026-08-05): `https://proton.localhost` does NOT open the
+  network.** After the lepus bump to 0.1.14/upstream main (asset entries
+  now serve from the intercepted `https://proton.localhost` origin — a
+  domain-bound CEF scheme factory registered for the (https,
+  proton.localhost) pair in `native/src/engine/cef_common/scheme.c`; no
+  real server, no TLS), the probe was rerun in asset mode
+  (`probe_iframe/assets/ws_probe.html` + the logging WS server). Verdict:
+  all four renderer-initiated real-network vectors from that origin —
+  `fetch`, `<img>`, `<iframe src="http://127.0.0.1:…">`, and
+  `new WebSocket("ws://…")` — are still swallowed (zero server hits;
+  main-frame `load_end` never fires), while a same-origin subframe loads
+  normally (status=200 control). The https label buys secure context and
+  a stable origin, not network access. Consequences: the "asset-entry
+  page + loopback WS" hybrid is dead, M2 iframes cannot ride the asset
+  origin, and M1.5's real loopback-http origin remains the only working
+  path.
+- **M1 — strip hoist.** The dock package plus the fileeditor demotion, as a
+  pure behavior-preserving refactor: after M1 the app renders and behaves
+  identically to today (file tabs only), with dock and fileeditor each under
+  their own blackbox tests. The empty panel keeps today's tree-plus-
+  placeholder body; the launcher arrives with M2.
+
+  **Status (2026-08-03): DONE.** `desktop/frontend/dock/` (state/update/
+  view + 8 blackbox tests) owns `open`/`tabs`/`active`/`remembered`;
+  fileeditor demoted to the document table (`docs : Map[Relative, Doc]`,
+  strip fields and `ToggleFilePanel`/`TabActivated`/`TabClosed` removed,
+  `Ctx` carries the projection); root update wires `Dock(...)`, intercepts
+  `FileSelected`, and syncs dock-then-fileeditor; root view assembles
+  `div.editor` from dock strip + fileeditor breadcrumb/body (child order
+  unchanged). `moon -C desktop check --deny-warn` clean on js and native;
+  js suite 743/743 (dock 8, fileeditor 36, root 302 included); interface
+  diffs match the API diff below. Not yet committed.
+- **M1.5 — transport unification (unlocks M2's iframes).** The user chose
+  the full version of the http-parent route: instead of bridging proton://
+  to an http origin, the window itself moves onto `http://127.0.0.1:<port>/`
+  and the in-process `__MoonBit__` bridge is deleted — the desktop window
+  becomes the same JSON-RPC WebSocket client a relay browser is
+  (docs/remote-protocol.md is updated as the contract).
+
+  **Status (2026-08-04): DONE (code + tests; live E2E is the user's).**
+  - Pre-probe: WS-from-http-origin under CEF verified with the probe_iframe
+    `url` harness + a hand-rolled WS server — handshake (with
+    `Origin: http://127.0.0.1:<port>`), both frame directions, all instant.
+  - Host: `internal/remote/local.mbt` `LocalServer` (loopback bind with
+    persisted-port preference, static bundle serving with traversal-proof
+    routes, `/ws` upgrade guarded by a per-launch entropy token + exact
+    Origin match) feeding the same `WsClientActor` as the relay;
+    `local_ops.mbt` carries the loopback-only methods (`shell.open_external`
+    moved from the extension, new `notification.show`); the delivery filter
+    (`notification_for_client`) now also gates `notification.click` to
+    loopback. `main.mbt` builds the window with `@proton.url` on
+    `LocalServer::entry_url()`, pumps native notification clicks into the
+    hub, and drops the whole extension/window-lifecycle wiring;
+    `internal/extension/` is deleted and the `proton_ext`/`proton_contract`
+    deps removed. Port persists via `internal/host/local_port.mbt`
+    (`local_http.json`) so the origin — and localStorage UI prefs — survive
+    relaunches. No lepus bump needed: `Url` entries need no bridge at all.
+  - Frontend: `bridge_request`/`bridge_request_in_order` collapse to
+    `ws_request`; `ws_connect` takes the channel (`Local` → same-origin
+    `/ws?token=` from the entry query); the proton install/event-wiring
+    half of bridge.mbt is gone; `BridgeUnavailable` died with it (loss =
+    `ChannelDown`×3); system notifications post over the wire; the shell
+    executables name their identity (`boot(desktop~)` →
+    `initial_model(desktop~)`) replacing every runtime protocol sniff —
+    including the external-link capture listener, which now takes the flag
+    instead of testing `location.protocol` (else the desktop window would
+    have opened externals as CEF popups).
+  - Validation: js 741/741, native 1911/1911, `moon build --target native`
+    links, both checks warning-free; mbti diffs are exactly the intended
+    surface (interop −5 proton fns, `ws_connect(ChannelId, …)`,
+    `boot(desktop~)`, host +port persistence, remote +LocalServer/extras).
+  - Deliberate cost: the old `proton://app/` origin's localStorage is
+    unreachable — legacy client-held engine keys (pre-host-store builds)
+    can no longer migrate and users coming from very old builds re-enter
+    them in Settings; UI prefs reset once.
+- **M2 — browser tabs.** The preview package, iframe hosts, link routing,
+  address bar, and the launcher (empty-strip pane, `+` popup menu, the
+  `FilePicker` tab). With M1.5 in, the window is an http origin, so real
+  iframes are live again: loopback-host framing works (M0 addendum);
+  external sites still XFO-refuse and route to the system browser.
+
+  **Status (2026-08-05): DONE (code + tests; live E2E is the user's) — on
+  native views, not iframes, per the P2 probe verdict below.**
+  - Host: `internal/extension/browser_views.mbt` owns the views. Eight
+    bridge-local ops (`browser.open/navigate/back/forward/reload/
+    set_bounds/set_visible/close`), registered beside `shell.open_external`
+    and tested absent from the relay catalog — a remote browser has no
+    native views to command. Views hang off the `WindowHandle` by name
+    (`browser-<id>`, no shadow map); `window_lifecycle.on_ready` hands the
+    handle over, `host.connect` closes stale views on page reload, and
+    `App::on_view_event` pumps Navigated/Loading/Title/LoadFailed into a
+    new window-local notification lane on `DesktopBridgeActor`
+    (`notify`) so `browser.event` reaches only this window, never the hub.
+  - Frontend: new `frontend/preview/` package (page table keyed by
+    page-global growing ids; URL lexing: `normalize_url` scheme
+    prefixing, `is_loopback`, `host_of`; toolbar + failure-banner views).
+    `@dock` gained `Browser(id~)`/`FilePicker` variants, the `+` menu
+    (`MenuToggled`, backdrop popup) and `open_browser`/`open_picker`/
+    `resolve_pick` transitions. The root wires it all in
+    `browser_ops.mbt` + new update arms; toolbar messages carry no id —
+    they act on the active tab, so a stale click cannot outlive a switch.
+  - Blank tabs defer view creation: a launcher-opened tab has `url: None`
+    and no native view until the first submit (`browser.open`); the pane
+    shows the focused address bar instead of a white page.
+  - Bounds/visibility sync: the view is placed over a `#browser-pane`
+    placeholder measured after render; a per-dispatch `sync_browser_view`
+    pass re-measures when a model-geometry signature changes (panel/menu/
+    sidebar/narrow/terminal/screen), and the pane's ResizeObserver catches
+    sizes the model never sees (window resize, `--editor-width` drag).
+    Bounds land before the visibility flip. The view hides under anything
+    the frontend must draw over the pane — the `+` popup, the narrow
+    sidebar drawer — because native views z-order above all HTML.
+  - Rendering: the panel keeps one structural child list; the active kind
+    is a class (`mode-file/browser/picker/launcher`) and CSS shows exactly
+    one body, so no imperative host is ever re-keyed. The picker reuses
+    the file chrome with a CSS overlay (`mode-picker .viewer-stack::after`)
+    over whatever the viewer last showed; fileeditor is untouched.
+  - Routing (Open Question resolved): loopback links open (or re-activate
+    a same-URL tab in the current strip); external links initially kept
+    the system browser. Flipped 2026-08-05 after first live use: all web
+    links now default to the dock (`is_web_url`), with the toolbar's
+    open-external button as the system-browser escape hatch; non-web
+    schemes stay external. On a remote console (`is_desktop` false) the
+    Browser launcher row hides and every link keeps the system-browser
+    path.
+  - Validation: js 2537/2537, native 3173/3173, deny-warn clean both
+    targets, native binary links. Known deferred costs: zoom ≠ 100 breaks
+    the CSS-px↔logical-pt mapping (unhandled), toasts can overlap the
+    view corner (transient, accepted), parked strips keep views alive
+    with no LRU cap yet (M3).
+  - Post-review hardening (same branch): browser ops ride the ordered
+    bridge path (`bridge_request_in_order` — Proton may otherwise reorder
+    fire-and-forget requests, inverting bounds-before-visibility);
+    `ViewportResized` re-measures the pane (a horizontal window resize
+    moves the right-anchored pane without resizing it, invisible to both
+    the ResizeObserver and the geometry signature); the workspace-picker
+    and update-restart modals hide the view (`desired_browser_view`);
+    host URL validation is scheme-case-insensitive. Round 2:
+    `browser.navigate` is create-if-missing (a rejected or racing create
+    used to strand the tab — the optimistically committed URL routed
+    every later submission to a view that never existed), the frontend
+    refuses hostless drafts (`is_web_url`/`normalize_url` require a
+    non-empty host), same-URL link reuse scans the current strip rather
+    than the global page map (a parked conversation's page shadowed the
+    strip's own tab, duplicating on every click), and the topbar app
+    launcher + bridge-lost overlay joined the visibility predicate.
+    DEFERRED, needs upstream lepus: pages'
+    `target="_blank"`/`window.open` popups are cancelled by the pinned
+    view client with no event — common links silently no-op inside a
+    Browser tab. Upstream must surface an on-before-popup event (cancel
+    the native popup, report the URL) so the host can route it into a
+    dock tab.
+- **M3 — polish.** Remembered strips including browser tabs, iframe LRU
+  keep-alive, narrow layout pass.
+
+## M1 Wiring Decisions (settled at implementation start)
+
+- `@dock.State = { open, tabs : Array[DockTab], active : DockTab?, owner :
+  ConversationKey?, remembered : Map[ConversationKey, RememberedStrip] }`;
+  `RememberedStrip = { tabs, active }`. The panel-visibility `open` flag moves
+  here from fileeditor (the panel is the dock now). M1's `DockTab` has only
+  `File(path~)`; `Browser`/`FilePicker` arrive with M2 so no unreachable view
+  arms exist in a behavior-preserving refactor.
+- `@dock.Msg = TogglePanel | TabActivated(DockTab) | TabClosed(DockTab)`;
+  `update` is the pure strip machine (close picks right neighbor, else left,
+  else None). Pure helpers: `open_file(state, path)` (append-or-activate),
+  `sync(state, owner)` (park/restore per conversation, pure — document
+  reloads stay fileeditor's), `file_paths(state)` (the projection).
+- Root orchestrates cross-package effects by comparing `dock.active` before/
+  after a dock message: activation change → `@fileeditor.activate(path)` /
+  clear; a close also drops the closed path's document + parked view state;
+  panel-open toggle → mount commands + read-active-if-loading. The tree click
+  (`FileSelected`) is intercepted in the root update (the
+  `EditorCommentAdded` pattern): dock appends/activates the tab, fileeditor
+  loads the document.
+- fileeditor demotion: `State` loses `open`/`tabs`/`active`/`remembered`;
+  gains `docs : Map[@pathx.Relative, Doc]` with `Doc = { name, state :
+  TabState, stale }` (TabState and its constructors keep their names — only
+  strip membership moves out). `Ctx` gains `panel_open : Bool`, `open_files :
+  Array[@pathx.Relative]`, `active_file : @pathx.Relative?` — all projected
+  from the dock by the root each dispatch. The watcher condition becomes
+  `ctx.panel_open || !ctx.open_files.is_empty()`.
+- Post-dispatch sync order matters: `@dock.sync` first (strip parked/
+  restored), then `@fileeditor.sync` sees the fresh projection and re-roots
+  the document table (docs rebuilt as `TabLoading` from `ctx.open_files`,
+  active read issued when the panel is open).
+- View split keeps today's DOM exactly: the root view builds `div.editor`
+  from dock parts (`resize_handle_view`, `tabs_bar`) followed by fileeditor
+  parts (breadcrumb, body). `tabs_bar` takes root-computed
+  `TabChip = { tab, label, title, missing }` view-models so the dock never
+  reads document state (labels/deleted-style come from fileeditor's table).
+- Deviation settled while implementing: `editor_resize.mbt` STAYS in
+  fileeditor for now — its drag shares `drag_size`/`end_drag`/root-style
+  refs with the tree resizer and re-measures the viewer (`mounted_viewer`),
+  all fileeditor internals. The CSS contract (`--editor-width`, element ids)
+  is unchanged and the dock owns panel visibility; moving the file is
+  mechanical if a later milestone wants it.
+
+## Target Files And Surfaces
+
+- New `desktop/frontend/dock/`: strip state machine (`state.mbt`,
+  `update.mbt`, `view.mbt`, resize), blackbox tests for open/activate/close/
+  park/restore/LRU transitions.
+- New `desktop/frontend/preview/`: page state, toolbar view, iframe host
+  attach/reload commands, URL normalization; blackbox tests.
+- `desktop/frontend/fileeditor/state.mbt`, `update.mbt`, `view.mbt`,
+  `editor_panel.mbt`: remove `tabs`/`active`/`remembered` and the strip view;
+  keep the document table, tree, LSP, watcher; `Ctx` gains the projected
+  open-file list.
+- `desktop/frontend/fileeditor/editor_resize.mbt`: moves to the dock package;
+  CSS contract (`--editor-width`, clamp bounds) unchanged.
+- `desktop/frontend/model.mbt`: `dock : @dock.State` and
+  `preview : @preview.State` join `file_panel : @fileeditor.State`.
+- `desktop/frontend/update.mbt`: root wiring (`Dock(...)`, `Preview(...)`
+  wraps), `file_ctx` projection, the `ExternalLinkClicked` split, and the
+  conversation-switch park/restore call moving from fileeditor sync to dock
+  sync.
+- `desktop/frontend/view.mbt`: the right panel renders the dock view; topbar
+  toggles unchanged.
+- `desktop/app.css`, `desktop/index.html`: strip styles, stacked hidden
+  hosts, grid variable ownership.
+- Generated `pkg.generated.mbti` files for the touched frontend packages.
+
+## API And Interface Diff
+
+- New public packages `@dock` (opaque `State`, `pub(all) enum DockTab`,
+  `Msg`, `update`/`sync`/`panel_view`) and `@preview` (opaque `State`, `Msg`,
+  toolbar/view entry points), following the one-package-per-component
+  convention.
+- `@fileeditor.State` loses `tabs`, `active`, `remembered`;
+  `RememberedTab(s)` move to the dock generalized over `DockTab`;
+  `@fileeditor.Msg` loses `TabActivated`/`TabClosed`; `Ctx` gains the open
+  file list.
+- The root package stays private; no host/extension or wire-protocol changes
+  in P1 (the iframe needs no new ops).
+
+## Open Questions
+
+- ~~M2 scope under the placeholder outcome~~ — resolved with M2 (2026-08-05):
+  loopback links open real Browser tabs (native views render them).
+  External links briefly stayed in the system browser; flipped the same
+  day after first live use — all web links default to the dock, with the
+  toolbar's open-external button as the escape hatch.
+- Whether the dock's open state and active tab persist across app restart
+  (decide at M3; the `TreeLayoutStorageKey` pattern is available).
+- LRU cap value (initial 8) — revisit once real memory numbers exist.
+
+## Deferred (P2): Native Browser View
+
+The iframe is a scaffold. The endgame — matching the Codex client, which uses
+Electron's `WebContentsView` — is a proton-upstream API creating per-tab CEF
+browsers as native child views of the main window: bounds synced from the
+panel rect over a bridge op, navigation events (`OnAddressChange`, title,
+loading) pumped back for the address bar, persistent cookie storage
+(cache_path) so logins survive restarts, `window.open` routed to the system
+browser. Known costs accepted in advance: per-platform native work (macOS
+first), native views z-order above all HTML (constrain or temporarily hide
+overlays), and focus/shortcut handoff between the page and the app. The dock
+and preview state machines carry over unchanged; only the host behind each
+`Browser` tab swaps.
+
+**Upstream is building exactly this (found 2026-08-04).** Branch
+`origin/feat/web-contents-view` in moonbit-community/proton (last commit
+2026-08-04, active): `ViewHandle` (set_bounds/set_visible/set_z_order,
+load_url/load_html, back/forward/reload/stop, eval, devtools, close),
+`App::on_view_event` with `ViewEvent::LoadingChanged / Navigated /
+TitleUpdated / LoadFailed` — the address bar's whole wishlist — engines for
+macOS, Windows, and Linux, an e2e scenario, and example
+`52_web_contents_view` reworked into "a built-in browser demo". Not merged
+to main yet; API may still churn; a bump requires a runtime rebuild (native
+ABI additions). When it lands, the dock's `Browser` tab host can skip the
+iframe entirely.
+
+**Merged and probe-verified (2026-08-05).** `feat/web-contents-view` merged
+to lepus main as PR #80 (cf2f7e7); submodule bumped to d19a843 and the
+darwin-arm64 runtime dist reassembled (same `proton-0.1.14` name, new view
+ABI — a stale dist fails at link/probe, so `cef setup` must rerun on every
+bump). Probe (`probe_iframe view http://127.0.0.1:18931/`):
+`web_contents_view_supported=true`; from inside the view, page load, fetch,
+and a WebSocket handshake + frame round-trip all hit the probe server —
+the view is a real network-served browser, no request-swallow disease — and
+`on_view_event` delivered Navigated / LoadingChanged / TitleUpdated.
+Facade surface: `App::window_lifecycle(on_ready)` → `WindowHandle` →
+`add_view/remove_view/view/views`, runtime-managed; bounds are window
+logical coordinates that match host-page CSS px at zoom 100 (the 52
+example positions a view against a CSS sidebar with raw numbers).
+Consequence for M2: build `Browser` tabs on native views NOW and skip the
+iframe scaffold — frontend keeps tab strip + address bar, sends the browser
+ops (open/navigate/back/forward/reload/set-bounds/close) to the host, which
+owns the ViewHandles and streams view events back for the address bar.
+Iframes remain the fallback only if a per-platform view bug appears. Known
+costs unchanged: views z-order above ALL HTML (hide or shrink the view when
+frontend overlays/popovers must cover the content area), zoom ≠ 100 breaks
+the CSS-px↔logical-pt bounds mapping (pin zoom or scale bounds).
+
+**Decision (2026-08-05): M2 builds directly on origin/main.** With native
+views verified, the http-origin migration is no longer a prerequisite for
+the dock: main already carries the view-ABI lepus (PR #650 pinned the
+submodule past the web-contents-view merge and added the rsa/updater
+workspace members), and views are host-created, so they work under the
+bridge transport exactly as well. PR #639 (loopback-http window, bridge
+deletion) is parked as a draft — its remaining rationale is transport
+unification with the browser console (the window-as-WS-client architecture
+is impossible on the asset origin, where renderer WebSockets are swallowed)
+— to be revisited after the dock ships. PR #640 (this dock hoist) is
+retargeted to main and proceeds. M2's frontend↔host channel is therefore
+the existing proton bridge ops, not loopback WS local ops; the op names and
+event shapes stay as designed so a later #639 revival only swaps the
+carrier.
+
+## Next Implementation Step
+
+M0 (failed → probed to native views), M1 (strip hoist, PR #657 on main),
+M1.5 (transport unification, PR #639 — parked), and M2 (native-view
+Browser tabs + launcher + FilePicker, statused above) are done. Next:
+the user's live E2E pass over M2 (open a dev-server link from a
+transcript, blank-tab flow, tab switching under drag/sidebar/terminal
+reflows, picker round-trip), then M3 — remembered strips including
+browser tabs across restart, the view LRU cap, the narrow layout pass,
+and per-row launcher shortcuts.
+
+## Validation Plan
+
+- Dock strip machine: blackbox tests covering open/activate/close ordering,
+  same-URL reuse, the launcher-on-empty-strip invariant, `FilePicker`
+  open/dedupe/replace-in-place/close transitions (including picking an
+  already-open file), park/restore round-trips per conversation, LRU
+  eviction order, and idempotence of every new message.
+- Fileeditor: existing tests keep passing with strip fields removed; document
+  table sweeps driven by the projected open-file list get their own cases.
+- Root update: idempotence tests for the `ExternalLinkClicked` split and the
+  conversation-switch park/restore path.
+- M1 exit criterion: no user-visible behavior change (file tabs, tree,
+  resize, narrow layout, conversation switch all as today).
+- Run `moon -C desktop check --target native --deny-warn` and
+  `moon -C desktop check --target js --deny-warn`; focused package tests,
+  then the full desktop test suite.
+- Run `moon -C desktop fmt` and default-target `moon -C desktop info`; review
+  generated interface diffs against the API diff above.
+- User-run E2E on the packaged app: open files, switch conversations, open a
+  localhost preview from a transcript link, verify no reload on switch-back,
+  evict past the LRU cap, narrow layout.


### PR DESCRIPTION
The right panel becomes a dock with one mixed tab strip: file tabs and built-in browser tabs, plus a launcher (`+`) for opening either.

- `frontend/dock` now owns the tab strip; `fileeditor` is demoted to a document subsystem fed by the dock's projection.
- Browser tabs are real pages on host-owned CEF web contents views, driven over bridge-local `browser.*` ops; the view overlays a measured `#browser-pane` placeholder and hides under anything the frontend draws over it.
- Links in the conversation open in a dock browser tab by default (same-URL reuse per strip); the toolbar has an open-in-system-browser button; non-web schemes and remote consoles keep the system path.

Known gap (plan doc): in-page `target="_blank"` popups silently no-op until proton exposes an on-before-popup event.

Details: `docs/plans/sidebar-dock.md`. Validation: js 2542/2542, native 3178/3178, deny-warn clean; live E2E in progress.

Replaces #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
