### PR TITLE
ci(desktop): cache CEF distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,10 @@ jobs:
         if: matrix.target == 'native'
         uses: actions/cache@v4
         with:
-          path: desktop/lepus/.proton/cache
-          key: cef-lepus-linux-x64-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
+          # Proton shares downloaded CEF distributions between projects here,
+          # then copies the selected version into the project-local runtime.
+          path: ~/.proton/cache/cef
+          key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
       - name: Assemble Proton CEF runtime
         if: matrix.target == 'native'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
 
+      # `cef setup` reads and populates Proton's shared user-level cache.
+      - name: Cache CEF distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.proton/cache/cef
+          key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
+
       # Stamp only this runner's checkout; the source branch is not modified.
       - name: Stamp release version
         shell: bash

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -31,6 +31,13 @@ jobs:
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
 
+      # `cef setup` reads and populates Proton's shared user-level cache.
+      - name: Cache CEF distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.proton/cache/cef
+          key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
+
       - name: Set up MoonBit (nightly)
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- nightly
@@ -91,6 +98,13 @@ jobs:
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
 
+      # `cef setup` reads and populates Proton's shared user-level cache.
+      - name: Cache CEF distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.proton/cache/cef
+          key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
+
       - name: Set up MoonBit (nightly)
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- nightly
@@ -148,6 +162,13 @@ jobs:
 
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
+
+      # `cef setup` reads and populates Proton's shared user-level cache.
+      - name: Cache CEF distribution
+        uses: actions/cache@v4
+        with:
+          path: ~/.proton/cache/cef
+          key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
       - name: Set up MoonBit (nightly)
         shell: pwsh


### PR DESCRIPTION
## Summary

- cache Proton's shared user-level CEF directory in root native CI
- enable the same cache for Linux, macOS, and Windows desktop packaging
- reuse the cache in the signed macOS release workflow
- isolate cache entries by runner OS, architecture, and Proton's pinned CEF definitions

## Why

The pinned Proton version stores downloaded CEF distributions under `~/.proton/cache/cef` and copies the selected distribution into each project-local runtime. Root CI still cached the old project-local directory, while the platform packaging jobs downloaded CEF without an Actions cache.

## Validation

- parsed the three modified workflow files with Ruby YAML
- `git diff --check`
