### PR TITLE
ci(desktop): keep PR CEF caches read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config libgtk-3-dev libx11-dev xvfb
 
-      - name: Cache CEF distribution
+      # Pull requests may restore the default branch's cache, but their own
+      # merge-ref caches are private to that PR and cannot warm other branches.
+      - name: Restore CEF distribution
         if: matrix.target == 'native'
-        uses: actions/cache@v4
+        id: cef-cache
+        uses: actions/cache/restore@v4
         with:
           # Proton shares downloaded CEF distributions between projects here,
           # then copies the selected version into the project-local runtime.
@@ -120,6 +123,19 @@ jobs:
           cmake --build desktop/target/proton-native/build --config Release
           cp desktop/target/proton-native/build/lib/libproton.so "$dist/lib/libproton.so"
           nm -D "$dist/lib/libproton.so" | grep -q proton_runtime_set_menu_json
+
+      # The stable/native main job is the sole Linux writer. PR jobs remain
+      # restore-only, and nightly does not race stable to reserve the same key.
+      - name: Save CEF distribution
+        if: >-
+          github.event_name == 'push' &&
+          matrix.moonbit-channel == 'stable' &&
+          matrix.target == 'native' &&
+          steps.cef-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.proton/cache/cef
+          key: ${{ steps.cef-cache.outputs.cache-primary-key }}
 
       - name: Check formatting
         # Stable only, for the same reason as `--deny-warn` below. `moon fmt` is

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -31,9 +31,11 @@ jobs:
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
 
-      # `cef setup` reads and populates Proton's shared user-level cache.
-      - name: Cache CEF distribution
-        uses: actions/cache@v4
+      # Root CI's stable/native main job owns the Linux cache. This packaging
+      # job restores it without creating a workflow- or PR-private duplicate.
+      - name: Restore CEF distribution
+        id: cef-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
@@ -98,9 +100,11 @@ jobs:
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
 
-      # `cef setup` reads and populates Proton's shared user-level cache.
-      - name: Cache CEF distribution
-        uses: actions/cache@v4
+      # Pull requests restore the default-branch cache without writing a
+      # merge-ref cache that no other PR can use.
+      - name: Restore CEF distribution
+        id: cef-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
@@ -142,6 +146,16 @@ jobs:
       - name: Build the macOS artifacts
         run: moon -C desktop run --target native package/macos -- --release --target dmg --target zip
 
+      # Only a trusted push to main publishes the cache shared by later PRs.
+      - name: Save CEF distribution
+        if: >-
+          github.event_name == 'push' &&
+          steps.cef-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.proton/cache/cef
+          key: ${{ steps.cef-cache.outputs.cache-primary-key }}
+
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -163,9 +177,11 @@ jobs:
       - name: Check out the Proton submodule
         run: git submodule update --init desktop/lepus
 
-      # `cef setup` reads and populates Proton's shared user-level cache.
-      - name: Cache CEF distribution
-        uses: actions/cache@v4
+      # Pull requests restore the default-branch cache without writing a
+      # merge-ref cache that no other PR can use.
+      - name: Restore CEF distribution
+        id: cef-cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
@@ -242,6 +258,16 @@ jobs:
         if: github.event_name != 'pull_request'
         shell: pwsh
         run: moon -C desktop run --target native package/windows -- --release
+
+      # Only a trusted push to main publishes the cache shared by later PRs.
+      - name: Save CEF distribution
+        if: >-
+          github.event_name == 'push' &&
+          steps.cef-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.proton/cache/cef
+          key: ${{ steps.cef-cache.outputs.cache-primary-key }}
 
       - name: Upload Windows app artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- restore CEF caches without scheduling a post-job save in pull request runs
- make root CI's stable/native main job the sole Linux cache writer
- let the macOS and Windows Desktop jobs save their platform caches only on trusted pushes to main
- keep the Linux AppImage job restore-only so it does not race root CI for the same key

## Why

GitHub scopes caches written by `pull_request` runs to `refs/pull/<number>/merge`. Those entries cannot warm the default branch or sibling pull requests, so each cold PR run uploaded a private CEF cache of roughly 340 MB that other PRs could not use. Concurrent jobs also raced to reserve the same cache key.

The split `actions/cache/restore` and `actions/cache/save` flow makes pull requests consumers of the default-branch cache while trusted main jobs remain the only publishers.

This PR intentionally does not cache or otherwise change the `libproton` CMake build.

## Validation

- parsed `.github/workflows/ci.yml`, `.github/workflows/desktop.yml`, and `.github/workflows/desktop-release.yml` with Ruby YAML
- `git diff --check`
