### PR TITLE
ci(release): upload and verify the dmg installer artifact

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -152,6 +152,8 @@ jobs:
           OPENSEEK_DEPLOY_TOKEN: ${{ secrets.OPENSEEK_DEPLOY_TOKEN }}
         run: |
           desktop/scripts/publish-release.sh upload
+          desktop/scripts/publish-release.sh upload \
+            desktop/dist/SeekMoon-macos-arm64.dmg
           desktop/scripts/publish-release.sh publish "v$RELEASE_VERSION"
 
       - name: Verify ${{ inputs.channel }} manifest
@@ -162,22 +164,33 @@ jobs:
           archive="desktop/dist/SeekMoon-macos-arm64.zip"
           archive_sha256="$(shasum -a 256 "$archive" | cut -d' ' -f1)"
           archive_url="$OPENSEEK_API_ORIGIN/desktop/releases/v$RELEASE_VERSION/SeekMoon-macos-arm64.zip"
+          dmg="desktop/dist/SeekMoon-macos-arm64.dmg"
+          dmg_sha256="$(shasum -a 256 "$dmg" | cut -d' ' -f1)"
+          dmg_url="$OPENSEEK_API_ORIGIN/desktop/releases/v$RELEASE_VERSION/SeekMoon-macos-arm64.dmg"
 
+          # The updater installs from the bare platform key; the `-dmg`
+          # entry is the manual installer the web console links to.
           jq -e \
             --arg version "$RELEASE_VERSION" \
             --arg url "$archive_url" \
             --arg sha256 "$archive_sha256" \
+            --arg dmg_url "$dmg_url" \
+            --arg dmg_sha256 "$dmg_sha256" \
             '.version == $version and
               .platforms["macos-arm64"].url == $url and
-              .platforms["macos-arm64"].sha256 == $sha256' \
+              .platforms["macos-arm64"].sha256 == $sha256 and
+              .platforms["macos-arm64-dmg"].url == $dmg_url and
+              .platforms["macos-arm64-dmg"].sha256 == $dmg_sha256' \
             <<< "$manifest"
 
           {
             echo "## Desktop $RELEASE_CHANNEL release"
             echo
             echo "- Version: \`$RELEASE_VERSION\`"
-            echo "- Artifact: $archive_url"
-            echo "- SHA-256: \`$archive_sha256\`"
+            echo "- Updater ZIP: $archive_url"
+            echo "- ZIP SHA-256: \`$archive_sha256\`"
+            echo "- Installer DMG: $dmg_url"
+            echo "- DMG SHA-256: \`$dmg_sha256\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove signing keychain

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -931,7 +931,7 @@ async fn main {
   if options.artifacts.zip {
     println("generated \{ws.at(ZipPath)}")
     println(
-      "release with scripts/publish-release.sh — it uploads the zip to openseek-api and publishes the version",
+      "release with scripts/publish-release.sh — upload each distribution artifact before publishing the version",
     )
   }
 }

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -28,21 +28,20 @@ if [[ -z "$version" ]]; then
   exit 1
 fi
 
-# The artifact publishes under the release naming convention: the
-# `<platform>` infix is the manifest `platforms` key clients look
-# themselves up by. The name has no spaces, so it passes the server's URL
-# path guard and the dist zip uploads under its own basename.
-release_name="SeekMoon-macos-arm64.zip"
-default_artifact="$desktop_dir/dist/$release_name"
+# The default remains the ZIP consumed by the in-app updater. An explicit
+# artifact, such as the DMG offered for manual installation, uploads under
+# its own basename so both files can coexist under the same version.
+default_artifact="$desktop_dir/dist/SeekMoon-macos-arm64.zip"
 
 case "${1:-}" in
   upload)
     artifact="${2:-$default_artifact}"
     if [[ ! -f "$artifact" ]]; then
       echo "artifact not found: $artifact" >&2
-      echo "build it first: moon run ./package/macos -- --release --target zip --sign '...'" >&2
+      echo "build it first: moon run ./package/macos -- --release --target dmg --target zip --sign '...'" >&2
       exit 1
     fi
+    release_name="$(basename "$artifact")"
     url="$origin/desktop/releases/v$version/$release_name"
     echo "uploading $artifact"
     echo "       to $url"


### PR DESCRIPTION
## Summary
- The desktop release workflow already builds a signed, notarized DMG, but only the updater ZIP was uploaded to openseek-api — the DMG never left the runner.
- Upload the DMG alongside the ZIP before publishing, and extend the manifest verification to assert both `platforms["macos-arm64"]` (updater ZIP) and `platforms["macos-arm64-dmg"]` (manual installer) entries with their sha256.
- `publish-release.sh upload` accepts an explicit artifact and uploads it under its own basename, so both files coexist under one version; the packager's post-build hint follows suit.

## Server-side counterpart
openseek-api publishes DMGs under the `<platform>-dmg` manifest key (moonbitlang/openseek-api@124d87f), and the homepage's download cards prefer that entry over the archive (moonbitlang/openseek-api@8639c6a).

## Rollout note
Run this release flow only after the updated openseek-api is deployed — the verification step requires the `-dmg` manifest entry, which older servers never emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)